### PR TITLE
fix(lite): reliable install + run across distros, and graceful conflict handling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,25 @@ jobs:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
 
   # ─────────────────────────────────────────────────────────────────────
+  # Lint the GitHub Actions workflows themselves (actionlint). A malformed
+  # workflow can silently fail to trigger or break a release; catching schema and
+  # expression errors here keeps the CI/release workflows valid before they merge.
+  # ─────────────────────────────────────────────────────────────────────
+  workflow-lint:
+    name: Lint workflows (actionlint)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - name: actionlint
+        run: |
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+          "$(go env GOPATH)/bin/actionlint" -color
+
+  # ─────────────────────────────────────────────────────────────────────
   # Tests (ADR 0011: TDD with coverage floor per phase)
   # ─────────────────────────────────────────────────────────────────────
   test:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,3 +67,68 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EXPIRES_AT: ${{ env.EXPIRES_AT }}
+
+  # ── Faithful install smoke: run the REAL `curl | sh` of the just-published
+  # release in a clean container per distro and verify the binary plus the managed
+  # CPython actually run. This catches install-path bugs (PATH, checksum, tar, the
+  # relocatable CPython, glibc/musl) — the class of failure that previously only
+  # surfaced on real machines. GoReleaser publishes pre-releases (publicly
+  # downloadable, so `curl | sh` works here); if ANY distro fails, the `gate` job
+  # below retracts the release to a draft. Net effect: a release only survives if
+  # it installs cleanly on every supported distro ("só corta se passar").
+  install-smoke:
+    name: Install smoke (${{ matrix.image }})
+    needs: release
+    runs-on: ubuntu-latest
+    container: ${{ matrix.image }}
+    defaults:
+      run:
+        shell: sh # Alpine ships busybox sh, not bash; keep every distro on sh.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { image: "debian:12", prep: "apt-get update -qq && apt-get install -y -qq curl ca-certificates tar" }
+          - { image: "ubuntu:24.04", prep: "apt-get update -qq && apt-get install -y -qq curl ca-certificates tar" }
+          - { image: "fedora:41", prep: "dnf install -y -q tar curl --allowerasing" }
+          - { image: "quay.io/rockylinux/rockylinux:9", prep: "dnf install -y -q tar curl --allowerasing" }
+          - { image: "opensuse/leap:15", prep: "zypper -n in -y curl tar gzip" }
+          - { image: "archlinux:latest", prep: "pacman -Sy --noconfirm curl tar" }
+          - { image: "alpine:3.20", prep: "apk add --no-cache curl tar" }
+    steps:
+      - name: Install prerequisites (curl + tar)
+        run: ${{ matrix.prep }}
+
+      - name: Install Leoflow via the published install.sh
+        env:
+          LEOFLOW_VERSION: ${{ github.ref_name }} # pin to the just-pushed tag
+        run: curl -fsSL "https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/install.sh" | sh
+
+      - name: Verify the binary and managed CPython run
+        run: |
+          set -eu
+          leoflow version
+          "$HOME/.leoflow/python/bin/python3.11" --version
+
+  # ── Release gate: if the install smoke failed on any distro, retract the
+  # pre-release to a draft so `curl | sh` (which resolves the newest public
+  # release) stops handing users a broken build. Runs always() so it can act on a
+  # smoke failure; on success it leaves the published pre-release untouched.
+  gate:
+    name: Gate release on install smoke
+    needs: [release, install-smoke]
+    if: always() && needs.release.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retract release to draft on smoke failure
+        if: needs.install-smoke.result != 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          echo "::error::install smoke failed on at least one distro; retracting ${GITHUB_REF_NAME} to a draft."
+          gh release edit "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" --draft
+          exit 1
+      - name: Confirm release passed the install gate
+        if: needs.install-smoke.result == 'success'
+        run: echo "install smoke passed on all distros; ${GITHUB_REF_NAME} stays published."

--- a/install.sh
+++ b/install.sh
@@ -64,6 +64,11 @@ else
 	err "need curl or wget to download Leoflow"
 fi
 
+# tar extracts the release archive (tar -xzf below). Minimal images (e.g. openSUSE
+# Leap) ship without it; check up front so we fail with a clear, actionable
+# message instead of a raw "tar: command not found" mid-install.
+have tar || err "need tar to extract the release archive (install it, e.g. 'apk add tar', 'zypper in tar', 'dnf install tar')"
+
 # ── Resolve version ──
 version="${LEOFLOW_VERSION:-}"
 if [ -z "$version" ]; then

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -14,6 +15,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -57,19 +59,41 @@ const (
 	devReadyTimeout = 30 * time.Second
 	// Dev uses ports distinct from the demo/production defaults (8080/9090/9091)
 	// so a `leoflow dev` and a demo control plane can run side by side without
-	// colliding. --port overrides the HTTP port; gRPC/metrics are fixed for dev.
-	devDefaultPort     = 8088
-	devGRPCBindAddr    = ":9099"
-	devMetricsBindAddr = ":9098"
+	// colliding. --port overrides the HTTP port; the gRPC and metrics ports derive
+	// from it (devGRPCPort/devMetricsPort) so multiple Lite instances can coexist.
+	devDefaultPort = 8088
+	// The gRPC and metrics ports are offset from the HTTP --port so that distinct
+	// --port values yield distinct gRPC/metrics ports (letting two Lite instances
+	// run on one host). The offsets preserve the historical defaults: the default
+	// HTTP port 8088 maps to gRPC 9099 and metrics 9098.
+	devGRPCPortOffset    = 1011
+	devMetricsPortOffset = 1010
 	// Cluster-mode (default) runs real pod-per-task on a dedicated k3d cluster,
 	// fully isolated from any product/demo cluster. Pods dial the host control
 	// plane's gRPC; host.docker.internal resolves to the host on Docker Desktop.
-	devClusterName  = "leoflow-dev"
-	devNamespace    = "leoflow"
-	devPyVersion    = "3.11"
-	devBaseImage    = "leoflow-base:py3.11"
-	devHostGRPCAddr = "host.docker.internal:9099"
+	devClusterName = "leoflow-dev"
+	devNamespace   = "leoflow"
+	devPyVersion   = "3.11"
+	devBaseImage   = "leoflow-base:py3.11"
 )
+
+// devGRPCPort derives the gRPC port from the HTTP --port; see devGRPCPortOffset.
+func devGRPCPort(httpPort int) int { return httpPort + devGRPCPortOffset }
+
+// devMetricsPort derives the metrics port from the HTTP --port.
+func devMetricsPort(httpPort int) int { return httpPort + devMetricsPortOffset }
+
+// devGRPCBindAddr is the gRPC listen address for the given HTTP --port.
+func devGRPCBindAddr(httpPort int) string { return fmt.Sprintf(":%d", devGRPCPort(httpPort)) }
+
+// devMetricsBindAddr is the metrics listen address for the given HTTP --port.
+func devMetricsBindAddr(httpPort int) string { return fmt.Sprintf(":%d", devMetricsPort(httpPort)) }
+
+// devHostGRPCAddr is the address task pods dial back for gRPC (cluster mode),
+// derived from the HTTP --port; host.docker.internal resolves to the host.
+func devHostGRPCAddr(httpPort int) string {
+	return fmt.Sprintf("host.docker.internal:%d", devGRPCPort(httpPort))
+}
 
 const (
 	ansiReset = "\x1b[0m"
@@ -445,6 +469,11 @@ func runDev(cmd *cobra.Command, dir string, o devOptions) error {
 	defer stop()
 
 	warnIfExposed(out, o.host, o.adminHash)
+	// Fail fast on a port conflict (a second Lite instance, or another service on
+	// the HTTP/gRPC/metrics ports) with a clear message, before starting Docker.
+	if perr := preflightDevPorts(ctx, o.host, o.port); perr != nil {
+		return perr
+	}
 	if uerr := bringUpDependencies(ctx, cmd, &o); uerr != nil {
 		return uerr
 	}
@@ -571,10 +600,57 @@ func devClusterSetup(ctx context.Context, cmd *cobra.Command, dir string, o devO
 // server; the dev's own database lives inside it, isolated by name).
 func devComposeUp(ctx context.Context, cmd *cobra.Command, o devOptions) error {
 	devPrintln(cmd.OutOrStdout(), "▸ starting dependencies (docker compose) …")
+	var captured bytes.Buffer
 	up := exec.CommandContext(ctx, "docker", "compose", "-f", o.composeFile, "up", "-d", "--wait") //nolint:gosec // operator-supplied compose file on the dev CLI
-	up.Stdout, up.Stderr = cmd.OutOrStdout(), cmd.ErrOrStderr()
+	up.Stdout = cmd.OutOrStdout()
+	// Tee stderr so the user still sees compose progress while we inspect it to
+	// translate a port-allocation failure into an actionable message.
+	up.Stderr = io.MultiWriter(cmd.ErrOrStderr(), &captured)
 	if err := up.Run(); err != nil {
-		return fmt.Errorf("docker compose up (is Docker running?): %w", err)
+		return composeUpError(err, captured.String())
+	}
+	return nil
+}
+
+// composeUpError turns a `docker compose up` failure into an actionable message.
+// A port-allocation failure — a foreign Postgres/Redis already bound to 5432/6379,
+// the common real-world conflict — produces a cryptic raw Docker error, so it is
+// translated; any other failure keeps the generic "is Docker running?" hint.
+func composeUpError(err error, output string) error {
+	low := strings.ToLower(output)
+	if strings.Contains(low, "already allocated") || strings.Contains(low, "address already in use") || strings.Contains(low, "port is already") {
+		return fmt.Errorf("a database/cache port is already in use — another Postgres or Redis is bound to 5432/6379. Stop it, or run `leoflow lite --no-up` to point at your own datastores (LEOFLOW_DATABASE_URL/LEOFLOW_REDIS_URL): %w", err)
+	}
+	return fmt.Errorf("docker compose up (is Docker running?): %w", err)
+}
+
+// preflightDevPorts checks that the HTTP, gRPC, and metrics ports Lite needs are
+// free, failing with a clear message that names the busy port — turning the
+// server's deep "bind: address already in use" into actionable advice before
+// anything starts. Best-effort: a port freed between the check and the bind still
+// surfaces the server's own error. The gRPC/metrics ports derive from the HTTP
+// --port, so picking a different --port sidesteps a conflict.
+func preflightDevPorts(ctx context.Context, host string, port int) error {
+	bindHost := host
+	if bindHost == "" || bindHost == "0.0.0.0" {
+		bindHost = "127.0.0.1"
+	}
+	checks := []struct {
+		role string
+		addr string
+		num  int
+	}{
+		{"the HTTP/UI server", net.JoinHostPort(bindHost, strconv.Itoa(port)), port},
+		{"the agent gRPC server", fmt.Sprintf(":%d", devGRPCPort(port)), devGRPCPort(port)},
+		{"the metrics endpoint", fmt.Sprintf(":%d", devMetricsPort(port)), devMetricsPort(port)},
+	}
+	var lc net.ListenConfig
+	for _, c := range checks {
+		ln, err := lc.Listen(ctx, "tcp", c.addr)
+		if err != nil {
+			return fmt.Errorf("port %d is already in use (needed for %s); another Leoflow Lite may be running — stop it, or pass --port to pick a free port", c.num, c.role)
+		}
+		_ = ln.Close() //nolint:errcheck // best-effort probe; closing frees the port for the real bind
 	}
 	return nil
 }
@@ -835,8 +911,12 @@ func resolveBinary(explicit, name string) (string, error) {
 func sharedServerEnv(host string, port int, adminHash, adminEmail string) []string {
 	env := []string{
 		fmt.Sprintf("LEOFLOW_SERVER_HTTP_ADDR=%s:%d", resolveBindHost(host, adminHash), port),
-		"LEOFLOW_SERVER_GRPC_ADDR=" + devGRPCBindAddr,
-		"LEOFLOW_SERVER_METRICS_ADDR=" + devMetricsBindAddr,
+		"LEOFLOW_SERVER_GRPC_ADDR=" + devGRPCBindAddr(port),
+		"LEOFLOW_SERVER_METRICS_ADDR=" + devMetricsBindAddr(port),
+		// Lite has no OTLP collector locally; disabling the exporter avoids a noisy
+		// "connection refused to :4317" every export interval. Prometheus metrics
+		// (scraped, not pushed) stay on.
+		"LEOFLOW_OBSERVABILITY_OTEL_ENABLED=false",
 		"LEOFLOW_LOGS_DIR=" + filepath.Join(os.TempDir(), "leoflow-dev-logs"),
 		"LEOFLOW_UI_INSTANCE_NAME=" + devInstanceName,
 		"LEOFLOW_UI_EDITION=lite",
@@ -937,7 +1017,7 @@ func subprocessServerEnv(host string, port int, agentBin, workDir, venvPython, a
 	return append(sharedServerEnv(host, port, adminHash, adminEmail),
 		"LEOFLOW_EXECUTOR_TYPE=subprocess",
 		"LEOFLOW_EXECUTOR_AGENT_PATH="+agentBin,
-		"LEOFLOW_EXECUTOR_AGENT_CONTROL_PLANE_ADDR=127.0.0.1"+devGRPCBindAddr,
+		"LEOFLOW_EXECUTOR_AGENT_CONTROL_PLANE_ADDR=127.0.0.1"+devGRPCBindAddr(port),
 		"LEOFLOW_EXECUTOR_SUBPROCESS_WORKDIR="+workDir,
 		"LEOFLOW_PYTHON="+venvPython,
 	)
@@ -950,7 +1030,7 @@ func clusterServerEnv(host string, port int, kubeconfig, adminHash, adminEmail s
 	return append(sharedServerEnv(host, port, adminHash, adminEmail),
 		"LEOFLOW_EXECUTOR_TYPE=kubernetes",
 		"KUBECONFIG="+kubeconfig,
-		"LEOFLOW_EXECUTOR_AGENT_CONTROL_PLANE_ADDR="+devHostGRPCAddr,
+		"LEOFLOW_EXECUTOR_AGENT_CONTROL_PLANE_ADDR="+devHostGRPCAddr(port),
 		// The dev k3d cluster's local-path provisioner rejects RWX; it is
 		// single-node, so RWO is sufficient for a run's sequential pods (ADR 0022).
 		"LEOFLOW_EXECUTOR_DEFAULTS_STAGING_ACCESS_MODE=ReadWriteOnce",

--- a/internal/cli/dev_test.go
+++ b/internal/cli/dev_test.go
@@ -324,9 +324,20 @@ func TestServerEnvBuilders(t *testing.T) {
 		}
 	}
 	clu := strings.Join(clusterServerEnv("127.0.0.1", 8088, "/home/u/.leoflow/dev/kubeconfig", "", ""), "\n")
-	for _, must := range []string{"LEOFLOW_EXECUTOR_TYPE=kubernetes", "KUBECONFIG=/home/u/.leoflow/dev/kubeconfig", "LEOFLOW_EXECUTOR_AGENT_CONTROL_PLANE_ADDR=" + devHostGRPCAddr} {
+	for _, must := range []string{"LEOFLOW_EXECUTOR_TYPE=kubernetes", "KUBECONFIG=/home/u/.leoflow/dev/kubeconfig", "LEOFLOW_EXECUTOR_AGENT_CONTROL_PLANE_ADDR=" + devHostGRPCAddr(8088)} {
 		if !strings.Contains(clu, must) {
 			t.Errorf("clusterServerEnv missing %q", must)
+		}
+	}
+	// gRPC/metrics derive from --port so two Lite instances coexist: a different
+	// --port must yield different gRPC/metrics ports (and OTel is off in Lite).
+	if !strings.Contains(sub, "LEOFLOW_OBSERVABILITY_OTEL_ENABLED=false") {
+		t.Error("Lite env should disable the OTLP exporter (no local collector)")
+	}
+	alt := strings.Join(subprocessServerEnv("127.0.0.1", 8090, "/bin/agent", "/proj", "/venv/py", "", ""), "\n")
+	for _, must := range []string{"LEOFLOW_SERVER_GRPC_ADDR=:9101", "LEOFLOW_SERVER_METRICS_ADDR=:9100", "127.0.0.1:9101"} {
+		if !strings.Contains(alt, must) {
+			t.Errorf("--port 8090 should offset gRPC/metrics, missing %q", must)
 		}
 	}
 	// Both carry the shared settings (isolated DB + LITE badge).

--- a/internal/cli/lite_conflict_test.go
+++ b/internal/cli/lite_conflict_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestPreflightDevPorts: a busy HTTP port is reported clearly (naming the port),
+// while free ports pass. This turns "bind: address already in use" deep in the
+// server into an actionable message before anything starts.
+func TestPreflightDevPorts(t *testing.T) {
+	ctx := context.Background()
+	// Grab a free port, then hold it so the preflight sees it as busy.
+	var lc net.ListenConfig
+	ln, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+	busy := ln.Addr().(*net.TCPAddr).Port
+
+	if err := preflightDevPorts(ctx, "127.0.0.1", busy); err == nil {
+		t.Fatal("expected an error for a busy HTTP port")
+	} else if !strings.Contains(err.Error(), strconv.Itoa(busy)) || !strings.Contains(err.Error(), "--port") {
+		t.Errorf("error should name the busy port and suggest --port, got: %v", err)
+	}
+
+	// A free port range passes (use a high base unlikely to collide in CI).
+	if err := preflightDevPorts(ctx, "127.0.0.1", 18088); err != nil {
+		t.Errorf("free ports should pass, got: %v", err)
+	}
+}
+
+// TestComposeUpError translates the cryptic Docker port-allocation failure into a
+// clear "another Postgres/Redis is on 5432/6379, use --no-up" message, while
+// keeping the generic hint for other failures.
+func TestComposeUpError(t *testing.T) {
+	base := errString("exit status 1")
+	portErr := composeUpError(base, "Error response from daemon: ... Bind for 0.0.0.0:5432 failed: port is already allocated")
+	if !strings.Contains(portErr.Error(), "--no-up") || !strings.Contains(strings.ToLower(portErr.Error()), "postgres") {
+		t.Errorf("port-allocation failure should mention --no-up and Postgres/Redis, got: %v", portErr)
+	}
+	other := composeUpError(base, "Cannot connect to the Docker daemon")
+	if !strings.Contains(other.Error(), "is Docker running?") {
+		t.Errorf("non-port failure should keep the generic hint, got: %v", other)
+	}
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }

--- a/internal/executor/subprocess.go
+++ b/internal/executor/subprocess.go
@@ -51,7 +51,11 @@ func agentEnv(req Request) []string {
 // A non-zero exit is therefore NOT a synchronous error; only a failure to start
 // is. The process is reaped in the background.
 func (e *SubprocessExecutor) Execute(ctx context.Context, req Request) error {
-	cmd := exec.CommandContext(ctx, e.agentPath) //nolint:gosec // dev-only executor running the trusted agent binary
+	// WithoutCancel detaches the agent from the dispatch context: like a pod, it
+	// must run to completion and report its own terminal state over gRPC. Binding
+	// it to ctx would SIGKILL the agent when the dispatch ctx is canceled (surfacing
+	// as "signal: killed" and a falsely failed task), mirroring the inline runner.
+	cmd := exec.CommandContext(context.WithoutCancel(ctx), e.agentPath) //nolint:gosec // dev-only executor running the trusted agent binary
 	cmd.Env = append(os.Environ(), agentEnv(req)...)
 	cmd.Dir = e.workDir
 	// Surface the agent's own diagnostics (it logs to stderr); otherwise an agent

--- a/internal/executor/subprocess_test.go
+++ b/internal/executor/subprocess_test.go
@@ -77,6 +77,26 @@ func TestSubprocessExecuteRunsInWorkDir(t *testing.T) {
 	}
 }
 
+func TestSubprocessExecuteSurvivesContextCancel(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash agent stub is POSIX-only")
+	}
+	// The agent must outlive the dispatch context, exactly like a Kubernetes pod
+	// outlives the request that created it. Binding the process to the dispatch
+	// ctx (exec.CommandContext(ctx, ...)) SIGKILLs the agent the moment that ctx
+	// is canceled — surfacing as "signal: killed" and a falsely failed task even
+	// for a trivial task that already did its work.
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "marker")
+	e := NewSubprocessExecutor(writeScript(t, "sleep 0.3; echo ran > "+marker), discardLogger())
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := e.Execute(ctx, Request{TaskID: "t"}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	cancel()               // the dispatch context ends immediately; the agent must keep running
+	waitForFile(t, marker) // never appears if cancellation killed the agent mid-run
+}
+
 func TestSubprocessExecuteLaunchesAsync(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("bash agent stub is POSIX-only")


### PR DESCRIPTION
## What & why

Faithful multi-distro install/run testing (clean containers per distro + full `leoflow lite` e2e + conflict scenarios) surfaced a set of real, reproducible issues — the class that previously only showed up on users' machines. This fixes all of them and adds a CI gate so they can't regress.

### Fixes
- **Task `signal: killed`** — the subprocess executor bound the agent to the dispatch context; cancellation SIGKILLed it mid-run (a falsely failed task). Detached with `context.WithoutCancel`, mirroring the inline runner.
- **Two Lite instances collided** — gRPC `:9099`/metrics `:9098` were hardcoded. Now derived from `--port` (default 8088 → 9099/9098 preserved), so instances coexist.
- **OTLP noise** — Lite has no local collector; the exporter logged `connection refused to :4317` every interval. Disabled in Lite (Prometheus metrics stay on).
- **Port conflict UX** — a busy HTTP/gRPC/metrics port now fails fast with a message naming the port + suggesting `--port`.
- **Foreign Postgres/Redis** — a cryptic Docker `port is already allocated` (wrapped in a misleading `(is Docker running?)`) is now translated to an actionable message pointing at `--no-up`.
- **`install.sh` assumed `tar`** — now preflighted with a clear, distro-aware error.

### CI gate
- `install-smoke`: real `curl | sh` of the published pre-release in a clean container per distro (**debian, ubuntu, fedora, rocky, opensuse, arch, alpine**), verifying the binary + managed CPython run.
- `gate`: retracts the release to a draft if any distro fails → **a release only survives if it installs cleanly everywhere**.

## Validation
- Install matrix: 6 distros locally (glibc + musl), Arch added in CI (amd64).
- Full `leoflow lite` e2e: compose → venv → Task SDK import → readyz → DAG registered.
- Behavioral validation on a VM with built binaries: OTel noise = 0, `signal: killed` = 0, two instances coexist (8090 + 8092), clean messages for port/compose conflicts.
- `go test ./...` exit 0, `golangci-lint run ./...` 0 issues, coverage 78.4% (floor 78%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)