### PR TITLE
draft(production): Helm hardening + chart-test CI + deployment guide

### DIFF
--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -1,0 +1,104 @@
+# DRAFT (Production track) — Helm chart CI. Mirrors the Lite install gate, but for
+# Kubernetes: lint + schema (every PR touching helm/**), then a real kind cluster
+# install with a pod-per-task smoke. Triggered manually (workflow_dispatch) and on
+# helm/** changes so it stays dormant until the Production front opens.
+#
+# TODO before enabling as a required gate:
+#   - SHA-pin the helm/kind/azure actions (ADR 0014 supply chain).
+#   - Flesh out the pod-per-task smoke (build a tiny DAG image, `kind load`, register
+#     via POST /api/v2/dags/:id/versions, trigger a run, assert the task pod succeeds).
+name: Chart test (DRAFT)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths: ["helm/**", ".github/workflows/chart-test.yaml"]
+
+permissions:
+  contents: read
+
+jobs:
+  # Fast, always-runnable: chart syntax + rendered-manifest schema.
+  lint:
+    name: helm lint + kubeconform
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: azure/setup-helm@v4 # TODO: pin to SHA
+        with:
+          version: v3.16.2
+      - name: helm lint
+        run: helm lint helm/leoflow
+      - name: Render + validate manifests (kubeconform)
+        run: |
+          curl -fsSL https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz \
+            | tar xz -C /usr/local/bin kubeconform
+          # Render with the Production toggles ON so the new templates are validated too.
+          helm template leoflow helm/leoflow \
+            --set autoscaling.enabled=true \
+            --set podDisruptionBudget.enabled=true \
+            --set networkPolicy.enabled=true \
+            --set database.url=postgres://x \
+            --set redis.url=redis://x \
+            --set auth.jwtSecret=x \
+            | kubeconform -strict -summary -ignore-missing-schemas \
+                -schema-location default \
+                -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+
+  # Real cluster: install the chart on kind against ephemeral Postgres + Redis and
+  # smoke the control plane. The pod-per-task run is the milestone to complete.
+  kind-e2e:
+    name: kind install + smoke
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: "1.26.3"
+          cache: true
+
+      - uses: helm/kind-action@v1 # TODO: pin to SHA
+        with:
+          cluster_name: leoflow-ci
+
+      - name: Build + load the control-plane image into kind
+        run: |
+          docker build -t leoflow-server:ci -f deploy/Dockerfile .
+          kind load docker-image leoflow-server:ci --name leoflow-ci
+          # Migration image (golang-migrate + migrations).
+          docker build -t leoflow-migrate:ci -f deploy/Dockerfile.migrate .
+          kind load docker-image leoflow-migrate:ci --name leoflow-ci
+
+      - name: Ephemeral Postgres + Redis
+        run: |
+          kubectl create namespace leoflow
+          kubectl -n leoflow apply -f .github/ci/kind-datastores.yaml  # TODO: add this manifest (bare pg + redis + services)
+          kubectl -n leoflow rollout status deploy/postgres --timeout=120s
+          kubectl -n leoflow rollout status deploy/redis --timeout=120s
+
+      - name: helm install
+        run: |
+          helm install leoflow helm/leoflow -n leoflow \
+            --set image.repository=leoflow-server --set image.tag=ci \
+            --set migrations.image.repository=leoflow-migrate --set migrations.image.tag=ci \
+            --set database.url='postgres://leoflow:leoflow@postgres:5432/leoflow?sslmode=disable' \
+            --set redis.url='redis://redis:6379/0' \
+            --set auth.jwtSecret=ci-secret \
+            --set bootstrap.password=ci-admin \
+            --wait --timeout 180s
+          kubectl -n leoflow rollout status deploy/leoflow --timeout=120s
+
+      - name: Smoke — readyz + RBAC for pod-per-task
+        run: |
+          kubectl -n leoflow port-forward svc/leoflow 8080:8080 &
+          sleep 5
+          curl -fsS http://127.0.0.1:8080/readyz
+          # The control plane must be allowed to create task pods in its namespace.
+          kubectl -n leoflow auth can-i create pods \
+            --as=system:serviceaccount:leoflow:leoflow
+
+      # TODO (Production milestone): build a sample DAG image, `kind load` it,
+      #   POST /api/v2/dags/:id/versions, trigger a DagRun, and assert the task pod
+      #   reaches Succeeded — the K8s analog of the Lite e2e. This is the real gate.

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -19,7 +19,7 @@ Leoflow is a product two kinds of people use, with very different effort:
 
 | Role | What they do | Effort |
 |---|---|---|
-| **Platform operator** (once) | Provision a K8s cluster, Postgres, Redis; set a handful of values; `helm install`. | Real infra work — but a **paved road**: sane defaults, BYO-or-quickstart datastores, one install command, and an install gate (see *Testing in CI* below) so it works on first try. |
+| **Platform operator** (once) | Provision a K8s cluster, point at their **own (managed) Postgres + Redis**; set a handful of values; `helm install`. | Real infra work — but a **paved road**: sane defaults, bring-your-own datastores, one install command, and an install gate (see *Testing in CI* below) so it works on first try. |
 | **DAG author** (daily) | Write `dag.py` + `leoflow.yaml`; push. CI builds the image and registers it. | **Only build DAGs.** No cluster, no YAML plumbing — the [CI/CD examples](deploy.md) + the [`examples/`](https://github.com/neochaotic/leoflow/tree/main/examples) starters are copy-paste. |
 
 The design goal is not "zero infra" — a production platform always needs a cluster
@@ -38,6 +38,27 @@ and the author's loop **as close to "just write the DAG" as possible**.
 | `Secret` | inline DB / Redis / JWT / bootstrap credentials (skipped with `existingSecret`) |
 | `Job` (hook) | `golang-migrate` before install/upgrade |
 | `Ingress` | optional |
+
+### Datastores: bring your own
+
+The chart **bundles no database or cache by design** — you point it at your own.
+This is deliberate, not a gap:
+
+- **Postgres is the system of record** (DagRuns, TaskInstances, users, connections,
+  variables). Durability, backups, PITR, and HA are the operator's call, so it must
+  be a **managed/owned Postgres** — RDS, Cloud SQL, AlloyDB, or your own cluster —
+  never a pod bundled in this chart.
+- **Redis holds XCom + scheduler locks** (ADR 0006/0009). Also bring your own
+  (ElastiCache, Memorystore, or self-managed); it is less durability-critical than
+  Postgres but still operator-owned.
+- Wire both via `database.url`/`redis.url`, or — preferred — `existingSecret` so
+  credentials never sit in plaintext values. With all creds in existing Secrets the
+  chart creates no Secret of its own.
+
+!!! warning "Bundled datastores are for throwaway trials only"
+    The ephemeral Postgres/Redis in the chart-test CI (kind, see *Testing in CI*
+    below) exist only to exercise an install. Never run production on an in-cluster
+    database pod — there is no backup or failover story there.
 
 ### High availability
 

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -13,6 +13,19 @@ and a thin agent (ADR 0004) reports state back over gRPC. Two things are deliver
 on independent tracks — **the platform** (this chart) and **the DAGs** (immutable
 images, see [CI/CD & deploy](deploy.md)). Keep them separate.
 
+## Who does what
+
+Leoflow is a product two kinds of people use, with very different effort:
+
+| Role | What they do | Effort |
+|---|---|---|
+| **Platform operator** (once) | Provision a K8s cluster, Postgres, Redis; set a handful of values; `helm install`. | Real infra work — but a **paved road**: sane defaults, BYO-or-quickstart datastores, one install command, and an install gate (see *Testing in CI* below) so it works on first try. |
+| **DAG author** (daily) | Write `dag.py` + `leoflow.yaml`; push. CI builds the image and registers it. | **Only build DAGs.** No cluster, no YAML plumbing — the [CI/CD examples](deploy.md) + the [`examples/`](https://github.com/neochaotic/leoflow/tree/main/examples) starters are copy-paste. |
+
+The design goal is not "zero infra" — a production platform always needs a cluster
+and datastores. The goal is to make the operator's setup **as small as possible**
+and the author's loop **as close to "just write the DAG" as possible**.
+
 ## 1 · The chart
 
 `helm/leoflow/` deploys the control plane. See the [chart README](https://github.com/neochaotic/leoflow/tree/main/helm/leoflow) for the full values reference.

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -1,0 +1,119 @@
+# Production deployment (draft)
+
+!!! note "Production is a near-term goal, not yet for testing"
+    Leoflow proves itself in **[Lite](operating-modes.md)** first. This guide is the
+    **design + best-practice reference** for the Production edition: how the Helm
+    chart is structured, how it is published and tested, and how it fits a GitOps
+    delivery. The hardening templates and the chart-test workflow it describes ship
+    **disabled by default** until the Production front opens.
+
+Production runs the Go control plane on real Kubernetes with the **pod-per-task**
+executor (ADR 0002, ADR 0015): the scheduler creates one pod per `TaskInstance`,
+and a thin agent (ADR 0004) reports state back over gRPC. Two things are delivered
+on independent tracks — **the platform** (this chart) and **the DAGs** (immutable
+images, see [CI/CD & deploy](deploy.md)). Keep them separate.
+
+## 1 · The chart
+
+`helm/leoflow/` deploys the control plane. See the [chart README](https://github.com/neochaotic/leoflow/tree/main/helm/leoflow) for the full values reference.
+
+| Resource | Purpose |
+|---|---|
+| `Deployment` | `leoflow-server` (HTTP `8080`, metrics `9090`, agent gRPC `9091`) |
+| `Service` | ClusterIP for http / metrics / grpc |
+| `ServiceAccount` + `Role`/`RoleBinding` | lets the control plane create/watch/delete **task pods** and read their logs in `taskNamespace` |
+| `Secret` | inline DB / Redis / JWT / bootstrap credentials (skipped with `existingSecret`) |
+| `Job` (hook) | `golang-migrate` before install/upgrade |
+| `Ingress` | optional |
+
+### High availability
+
+`replicaCount > 1` is safe: the scheduler **leader-elects** (ADR 0009), so extra
+replicas serve the API/UI while exactly one scheduler is active. Pair it with the
+hardening toggles below.
+
+### Hardening toggles (draft, off by default)
+
+| Values key | Resource | Notes |
+|---|---|---|
+| `autoscaling.enabled` | `HorizontalPodAutoscaler` | safe with leader election (scales API/UI) |
+| `podDisruptionBudget.enabled` | `PodDisruptionBudget` | keep the API available across node drains |
+| `networkPolicy.enabled` | `NetworkPolicy` | trust boundary: clients → HTTP, Prometheus → metrics, **task pods → gRPC**; egress to Postgres/Redis/kube-apiserver/DNS |
+| `metrics.serviceMonitor.enabled` | `ServiceMonitor` | Prometheus Operator scrape of `/metrics` (ADR 0010) |
+| `agentTLS.enabled` | — | mTLS for the agent ↔ control-plane gRPC (cert-manager; issue #58) |
+
+## 2 · Publishing the chart
+
+Ride the same supply-chain pipeline as the binaries (ADR 0014):
+
+- Package and push as an **OCI artifact** to GHCR: `helm push leoflow-<v>.tgz oci://ghcr.io/neochaotic/charts`.
+- **Sign with cosign** and attach an SBOM, like the release images.
+- Keep the chart `version` (SemVer) **decoupled** from `appVersion` (the server image tag).
+- Publish on release tags so a chart version maps to a tested server build.
+
+## 3 · Testing in CI
+
+Mirror the Lite install gate, layered cheapest → most faithful (`.github/workflows/chart-test.yaml`, draft):
+
+```mermaid
+flowchart LR
+  L["helm lint + kubeconform<br/>(every helm/** PR)"] --> CT["chart-testing<br/>install matrix"]
+  CT --> K["kind: install + pod-per-task smoke<br/>(the gate)"]
+```
+
+1. **`helm lint` + `kubeconform`** — chart syntax and rendered-manifest schema (with the CRD catalog for `ServiceMonitor`). Seconds.
+2. **`chart-testing` (ct)** — install with a values matrix (default / HA / network-policy-on).
+3. **kind, as the gate** — install the chart on a real [kind](https://kind.sigs.k8s.io/) cluster against ephemeral Postgres + Redis, then run a **pod-per-task smoke**: register a DAG image, trigger a `DagRun`, assert the task pod reaches `Succeeded`.
+
+!!! tip "Why the kind smoke is the gate"
+    The risky, scenario-specific part is the control plane **creating task pods**
+    and the agent **dialing gRPC back** (plus RBAC, image pulls, the per-run staging
+    volume — ADR 0022). Unit tests can't cover it; kind can. This is the K8s analog
+    of the Lite cross-distro install gate. Don't test against a managed cloud cluster
+    in CI — kind is faithful to the pod-per-task model and far cheaper.
+
+## 4 · The GitOps delivery
+
+Two independent flows — do not couple them:
+
+```mermaid
+flowchart TB
+  subgraph Platform
+    G1[chart + values in git] --> A[Argo CD / Flux] --> CP[control plane on K8s]
+  end
+  subgraph DAGs
+    G2[dag.py + leoflow.yaml in git] --> CI[leoflow compile --build] --> IM[push image] --> REG[POST /api/v2/dags/:id/versions]
+  end
+  CP -. registers .- REG
+```
+
+- **Platform** — the chart + environment `values` live in git; **Argo CD** (or Flux)
+  syncs the control-plane release. Pin the chart version in the `Application`; promote
+  staging → prod by PR. Argo CD *deploys Leoflow* — it is complementary, not a competitor.
+- **DAGs** — each DAG is its own **immutable image + `dag.json`** (ADR 0003), built and
+  registered in CI (see [CI/CD & deploy](deploy.md)). The runtime is pinned in the
+  image, so there is no dependency drift between authoring and execution.
+
+## 5 · How this compares to Kubeflow / Argo
+
+Separate the **engine delivery** from the **workflow delivery**:
+
+| | Engine | Workflow / DAG |
+|---|---|---|
+| **Argo Workflows** | controller + CRDs | each run is a `Workflow` **CRD** (pod-per-step) |
+| **Argo CD** | — (it *is* the deployer) | **GitOps** sync of manifests |
+| **Kubeflow Pipelines** | KFP over Argo | Python pipeline **compiled to Argo YAML** |
+| **Leoflow (Production)** | **Helm chart** (Go control plane) | **immutable image + `dag.json`**, registered via API |
+
+Leoflow keeps the pod-per-task model Argo Workflows got right, but the source of
+truth for a DAG is a **versioned image**, not a mutable CRD in etcd — and the UI/API
+contract is **Airflow 3.2.x** (ADR 0007). In one line: *Argo Workflows underneath,
+Airflow on top, no GIL in the middle.*
+
+## Best practices, summarized
+
+- Publish the chart as a **signed OCI artifact** via the existing release pipeline.
+- Make the **kind pod-per-task smoke the release gate** for the chart.
+- Run **two GitOps flows**: Argo CD for the platform, image+API for DAGs.
+- In prod values, enable **`agentTLS`** (mTLS), **`networkPolicy`**, **`podDisruptionBudget`**, and the **`serviceMonitor`**; size with **`autoscaling`** + `resources`.
+- **SHA-pin** every action and **trivy-scan** the rendered manifests (ADR 0014).

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -66,6 +66,20 @@ or set `migrations.enabled=false` to migrate out of band.
 | `migrations.enabled` | `true` | golang-migrate hook Job |
 | `ingress.enabled` | `false` | HTTP ingress |
 
+## Production hardening (draft)
+
+Off by default; opt in per environment. See the full
+[Production deployment guide](../../docs/production-deployment.md) for publishing,
+CI (kind pod-per-task gate), and the GitOps delivery model.
+
+| Key | Resource | Notes |
+|---|---|---|
+| `autoscaling.enabled` | `HorizontalPodAutoscaler` | safe with the leader-elected scheduler |
+| `podDisruptionBudget.enabled` | `PodDisruptionBudget` | keep the API available across node drains |
+| `networkPolicy.enabled` | `NetworkPolicy` | clients → HTTP, Prometheus → metrics, task pods → gRPC |
+| `metrics.serviceMonitor.enabled` | `ServiceMonitor` | Prometheus Operator scrape of `/metrics` |
+| `agentTLS.enabled` | — | mTLS for the agent ↔ control-plane gRPC (cert-manager, #58) |
+
 ## Validate
 
 ```bash

--- a/helm/leoflow/templates/hpa.yaml
+++ b/helm/leoflow/templates/hpa.yaml
@@ -1,0 +1,42 @@
+{{- /*
+DRAFT (Production track) — HorizontalPodAutoscaler for the control plane.
+Safe because the scheduler leader-elects (ADR 0009): scaling the Deployment adds
+API/UI replicas while exactly one scheduler stays active. Disabled by default.
+*/ -}}
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "leoflow.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "leoflow.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "leoflow.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- with .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+    {{- with .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/leoflow/templates/networkpolicy.yaml
+++ b/helm/leoflow/templates/networkpolicy.yaml
@@ -1,0 +1,60 @@
+{{- /*
+DRAFT (Production track) — NetworkPolicy for the control plane. In our scenario
+the trust boundary is: clients/ingress hit HTTP; Prometheus scrapes metrics; and
+TASK PODS dial the gRPC port back (the pod-per-task agent, ADR 0002/0004). Egress
+must reach Postgres, Redis, the Kubernetes API (to create task pods), and DNS.
+
+This is a STARTING POINT — NetworkPolicy is environment-specific (CNI must
+enforce it). Defaults are permissive on egress (DNS + all) so enabling it does not
+silently break the control plane; tighten `egress` per your cluster. Disabled by
+default.
+*/ -}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "leoflow.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "leoflow.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "leoflow.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # HTTP/UI + gRPC (task pods dial back). Restrict sources via networkPolicy.ingressFrom.
+    - ports:
+        - port: {{ .Values.ports.http }}
+          protocol: TCP
+        - port: {{ .Values.ports.grpc }}
+          protocol: TCP
+      {{- with .Values.networkPolicy.ingressFrom }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.networkPolicy.metricsFrom }}
+    # Metrics scrape (e.g. the Prometheus pods' namespace/labels).
+    - ports:
+        - port: {{ $.Values.ports.metrics }}
+          protocol: TCP
+      from:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+  egress:
+    # DNS is always required for service discovery.
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    {{- with .Values.networkPolicy.egress }}
+    {{- toYaml . | nindent 4 }}
+    {{- else }}
+    # Default: allow all other egress (Postgres, Redis, kube-apiserver). Tighten
+    # by setting networkPolicy.egress to explicit rules for your data stores + API.
+    - {}
+    {{- end }}
+{{- end }}

--- a/helm/leoflow/templates/pdb.yaml
+++ b/helm/leoflow/templates/pdb.yaml
@@ -1,0 +1,24 @@
+{{- /*
+DRAFT (Production track) — PodDisruptionBudget so voluntary disruptions (node
+drains, upgrades) keep enough control-plane replicas serving the API. Disabled by
+default; set replicaCount > 1 (HA, leader-elected) before enabling.
+*/ -}}
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "leoflow.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "leoflow.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "leoflow.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/leoflow/templates/servicemonitor.yaml
+++ b/helm/leoflow/templates/servicemonitor.yaml
@@ -1,0 +1,29 @@
+{{- /*
+DRAFT (Production track) — Prometheus Operator ServiceMonitor so the control
+plane's /metrics (ADR 0010) is scraped automatically. Requires the
+monitoring.coreos.com CRDs (kube-prometheus-stack). Disabled by default.
+*/ -}}
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "leoflow.fullname" . }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "leoflow.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "leoflow.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval | default "30s" }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout | default "10s" }}
+{{- end }}

--- a/helm/leoflow/values.yaml
+++ b/helm/leoflow/values.yaml
@@ -134,3 +134,41 @@ securityContext:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+# ── Production hardening (DRAFT) — all OFF by default; opt in per environment. ──
+
+# HorizontalPodAutoscaler. Safe with the leader-elected scheduler (ADR 0009):
+# extra replicas serve the API/UI while one scheduler stays active.
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 6
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: ""
+  behavior: {}
+
+# PodDisruptionBudget so node drains/upgrades keep the API available (needs
+# replicaCount > 1). Set one of minAvailable / maxUnavailable.
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  maxUnavailable: ""
+
+# NetworkPolicy for the control plane (requires a CNI that enforces it). See the
+# template header — egress defaults to permissive so enabling it never silently
+# breaks DB/Redis/kube-apiserver access; tighten per environment.
+networkPolicy:
+  enabled: false
+  ingressFrom: []   # e.g. [{namespaceSelector: {}}] to allow same-namespace clients + task pods
+  metricsFrom: []   # e.g. [{namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: monitoring}}}]
+  egress: []        # explicit egress rules; empty = allow-all (besides DNS, always allowed)
+
+# Prometheus Operator ServiceMonitor for /metrics (ADR 0010). Requires the
+# kube-prometheus-stack CRDs.
+metrics:
+  serviceMonitor:
+    enabled: false
+    namespace: ""           # defaults to the release namespace
+    interval: 30s
+    scrapeTimeout: 10s
+    additionalLabels: {}    # e.g. {release: kube-prometheus-stack} to match the Prometheus selector


### PR DESCRIPTION
**DRAFT — Production track.** Not for merge yet; this is the staged groundwork for when the Production edition opens. Everything ships **disabled by default** (non-breaking) so it can land safely ahead of time.

## What's here

### Helm hardening (off by default)
- `templates/hpa.yaml` — `HorizontalPodAutoscaler` (safe with the leader-elected scheduler, ADR 0009).
- `templates/pdb.yaml` — `PodDisruptionBudget`.
- `templates/networkpolicy.yaml` — `NetworkPolicy` (trust boundary: clients → HTTP, Prometheus → metrics, **task pods → gRPC**; permissive egress default to avoid silently breaking DB/Redis/kube-apiserver).
- `templates/servicemonitor.yaml` — Prometheus Operator `ServiceMonitor` for `/metrics` (ADR 0010).
- `values.yaml` — `autoscaling` / `podDisruptionBudget` / `networkPolicy` / `metrics.serviceMonitor`, all `enabled: false`.
- (mTLS already exists via `agentTLS`, #58.)

### CI
- `.github/workflows/chart-test.yaml` — `helm lint` + `kubeconform` now; **kind install + pod-per-task smoke** as the gate to flesh out (the K8s analog of the Lite install gate). Triggers on `helm/**` PRs + manual.

### Docs
- `docs/production-deployment.md` — chart/HA/hardening, signed OCI publishing, layered CI, two-flow GitOps (Argo CD for the platform, image+API for DAGs), Kubeflow/Argo comparison, best practices.
- Pointer + toggles table in `helm/leoflow/README.md`.

## TODO before this becomes a real gate
- SHA-pin the helm/kind/azure actions (ADR 0014).
- Add `.github/ci/kind-datastores.yaml` and complete the pod-per-task smoke (build a sample DAG image, `kind load`, `POST /versions`, trigger a run, assert the task pod `Succeeded`).

## Validated offline
`helm lint` clean · all four new templates render with toggles on · `actionlint` clean · pre-commit gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)