### PR TITLE
fix(api): cookie fallback for the login flash/refresh bug + recovery test

### DIFF
--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -133,18 +133,24 @@ func JWTAuth(authn auth.Authenticator) gin.HandlerFunc {
 			c.Next()
 			return
 		}
-		token := tokenFromRequest(c)
-		if token == "" {
+		tokens := candidateTokens(c)
+		if len(tokens) == 0 {
 			AbortProblem(c, http.StatusUnauthorized, "unauthorized", "missing bearer token")
 			return
 		}
-		user, err := authn.Authenticate(c.Request.Context(), token)
-		if err != nil {
-			AbortProblem(c, http.StatusUnauthorized, "unauthorized", "invalid token")
-			return
+		// Try each candidate (bearer, then cookie) and accept the first that
+		// validates. The cookie is a real fallback even when a bearer is present:
+		// on a full-page refresh the Airflow UI loses its in-memory token and may
+		// send a stale/empty bearer, but a valid _token cookie still authenticates
+		// — otherwise the invalid bearer 401s and the UI bounces to login.
+		for _, token := range tokens {
+			if user, err := authn.Authenticate(c.Request.Context(), token); err == nil {
+				c.Set(contextKeyUser, user)
+				c.Next()
+				return
+			}
 		}
-		c.Set(contextKeyUser, user)
-		c.Next()
+		AbortProblem(c, http.StatusUnauthorized, "unauthorized", "invalid token")
 	}
 }
 
@@ -156,16 +162,20 @@ func bearerToken(header string) string {
 	return ""
 }
 
-// tokenFromRequest extracts the JWT from the Authorization header, falling back
-// to the Airflow UI's _token cookie so cookie-only requests authenticate too.
-func tokenFromRequest(c *gin.Context) string {
+// candidateTokens returns the JWTs to try authenticating, in order: the
+// Authorization bearer first, then the Airflow UI's _token cookie. Both are
+// returned (not just the first present) so JWTAuth can fall back to the cookie
+// when the bearer is stale/invalid — the SPA-refresh case — rather than failing
+// on the bearer alone.
+func candidateTokens(c *gin.Context) []string {
+	var tokens []string
 	if t := bearerToken(c.GetHeader("Authorization")); t != "" {
-		return t
+		tokens = append(tokens, t)
 	}
-	if cookie, err := c.Request.Cookie(authTokenCookie); err == nil {
-		return cookie.Value
+	if cookie, err := c.Request.Cookie(authTokenCookie); err == nil && cookie.Value != "" {
+		tokens = append(tokens, cookie.Value)
 	}
-	return ""
+	return tokens
 }
 
 // UserFromContext returns the authenticated user stored by JWTAuth.

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -8,7 +8,59 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/neochaotic/leoflow/internal/auth"
 )
+
+// tokenAuthn authenticates exactly one token value; anything else is invalid. It
+// lets a test distinguish a stale bearer from a valid session cookie.
+type tokenAuthn struct{ valid string }
+
+func (tokenAuthn) IssueToken(context.Context, auth.Credentials) (string, error) { return "", nil }
+func (a tokenAuthn) Authenticate(_ context.Context, token string) (*auth.User, error) {
+	if token == a.valid {
+		return &auth.User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}, nil
+	}
+	return nil, auth.ErrInvalidToken
+}
+
+// TestJWTAuthFallsBackToCookieWhenBearerInvalid covers the SPA-refresh login bug:
+// the Airflow UI loses its in-memory token on refresh and may send a stale/empty
+// bearer while a valid session lives in the _token cookie. JWTAuth must try the
+// bearer AND fall back to the cookie, accepting whichever validates — otherwise an
+// invalid bearer short-circuits to 401 and the UI bounces to login ("flash").
+func TestJWTAuthFallsBackToCookieWhenBearerInvalid(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	run := func(setup func(*http.Request)) int {
+		r := gin.New()
+		r.Use(JWTAuth(tokenAuthn{valid: "good"}))
+		r.GET("/ui/auth/me", func(c *gin.Context) { c.Status(http.StatusOK) })
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/ui/auth/me", http.NoBody)
+		setup(req)
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		return rec.Code
+	}
+	cases := []struct {
+		name  string
+		setup func(*http.Request)
+		want  int
+	}{
+		{"stale bearer + valid cookie -> cookie wins", func(r *http.Request) {
+			r.Header.Set("Authorization", "Bearer stale-or-undefined")
+			r.AddCookie(&http.Cookie{Name: authTokenCookie, Value: "good"})
+		}, http.StatusOK},
+		{"valid bearer", func(r *http.Request) { r.Header.Set("Authorization", "Bearer good") }, http.StatusOK},
+		{"valid cookie only", func(r *http.Request) { r.AddCookie(&http.Cookie{Name: authTokenCookie, Value: "good"}) }, http.StatusOK},
+		{"invalid bearer, no cookie", func(r *http.Request) { r.Header.Set("Authorization", "Bearer bad") }, http.StatusUnauthorized},
+		{"nothing", func(*http.Request) {}, http.StatusUnauthorized},
+	}
+	for _, c := range cases {
+		if got := run(c.setup); got != c.want {
+			t.Errorf("%s: got %d, want %d", c.name, got, c.want)
+		}
+	}
+}
 
 // TestDevBypassAuthInjectsAdmin verifies the dev-only auth bypass: a protected
 // data-plane route is reachable with NO token, and the request carries an admin

--- a/internal/storage/bootstrap_integration_test.go
+++ b/internal/storage/bootstrap_integration_test.go
@@ -3,10 +3,64 @@
 package storage_test
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/neochaotic/leoflow/internal/auth"
 )
+
+// TestPasswordRecoveryLoginIntegration is the end-to-end recovery flow behind
+// `leoflow lite reset-password`: after a reset, the admin must be able to LOG IN
+// with the new password (issue a token), and the old password must stop working.
+// This guards the real recovery scenario, not just the DB hash update.
+func TestPasswordRecoveryLoginIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	const email = "admin@leoflow.local"
+	const oldPW, newPW = "old-secret-1", "new-secret-2"
+
+	oldHash, err := auth.HashPassword(oldPW)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Ensure the admin exists (creates it on a fresh tenant; a no-op otherwise),
+	// then force a known starting password — robust whether or not the DB already
+	// has an admin (BootstrapAdminHash only seeds an empty tenant).
+	if _, err := repo.BootstrapAdminHash(ctx, "default", email, oldHash); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	if ok, err := repo.SetUserPassword(ctx, "default", email, oldHash); err != nil || !ok {
+		t.Fatalf("seed starting password: ok=%v err=%v", ok, err)
+	}
+
+	authn := auth.NewJWTAuthenticator(repo, "recovery-test-secret", time.Hour)
+	login := func(pw string) error {
+		_, e := authn.IssueToken(context.Background(), auth.Credentials{Tenant: "default", Username: email, Password: pw})
+		return e
+	}
+
+	// Sanity: the original password logs in.
+	if err := login(oldPW); err != nil {
+		t.Fatalf("login with original password failed: %v", err)
+	}
+
+	// Recover: reset to a new password (what reset-password does).
+	newHash, err := auth.HashPassword(newPW)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok, err := repo.SetUserPassword(ctx, "default", email, newHash); err != nil || !ok {
+		t.Fatalf("reset password: ok=%v err=%v", ok, err)
+	}
+
+	// The new password now logs in; the old one no longer does.
+	if err := login(newPW); err != nil {
+		t.Errorf("login with the reset password failed (recovery broken): %v", err)
+	}
+	if err := login(oldPW); err == nil {
+		t.Error("old password still logs in after reset")
+	}
+}
 
 // TestBootstrapAdminHashIntegration checks the hash-only admin bootstrap used by
 // Leoflow Lite: the stored hash must accept the password (login compatibility),


### PR DESCRIPTION
## The bug
On a full-page refresh, the Airflow UI flashed the dashboard then bounced to login — even with a valid session. Reported as "pisca o painel logado e volta", and it happened regardless of credentials.

## Root cause (reproduced, not guessed)
The Airflow SPA holds its JWT in memory and sends it as `Authorization: Bearer`. On refresh that in-memory token is gone, so the SPA sends a **stale/empty bearer** while a valid session still lives in the **`_token` cookie**. `JWTAuth` authenticated only the *first* token from `tokenFromRequest` (the bearer when present) — so an **invalid bearer short-circuited to 401** and never tried the cookie → bounce.

Reproduced headlessly on a VM (no browser, no release):
| call | before | after |
|---|---|---|
| `/ui/auth/me` invalid bearer + valid cookie | **401** | **200** |
| `Bearer undefined` + valid cookie | 401 | 200 |
| valid bearer / cookie only | 200 | 200 |
| invalid bearer, no cookie / nothing | 401 | 401 |

## Fix
`JWTAuth` now collects candidate tokens (bearer, then `_token` cookie) and accepts whichever **validates** — so the cookie is a real fallback even when a stale bearer is present. No public API change.

## Tests
- `TestJWTAuthFallsBackToCookieWhenBearerInvalid` (unit) — the refresh matrix above.
- `TestPasswordRecoveryLoginIntegration` (integration) — the `reset-password` recovery flow end-to-end: after a reset you can **log in with the new password** and the **old one stops working** (verified against real Postgres).

## Validation
Unit suite `go test ./...` exit 0 · `golangci-lint` 0 issues · cookie fix validated end-to-end on a VM with a built server · recovery test passing against real Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)