### PR TITLE
fix(api): clear tuple task_ids + client-cancel 499 + 4xx/5xx error logging

### DIFF
--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -16,7 +16,11 @@ import (
 const (
 	contextKeyUser      = "leoflow.user"
 	contextKeyRequestID = "leoflow.request_id"
-	headerRequestID     = "X-Request-Id"
+	// contextKeyProblemDetail carries the AbortProblem detail so StructuredLogger
+	// can surface WHY a 4xx/5xx happened — otherwise a failing request is logged
+	// only as a status code, with no cause (an observability blind spot).
+	contextKeyProblemDetail = "leoflow.problem_detail"
+	headerRequestID         = "X-Request-Id"
 )
 
 // RequestID assigns a request id (honoring an inbound X-Request-Id) and echoes it.
@@ -51,13 +55,28 @@ func StructuredLogger(logger *slog.Logger) gin.HandlerFunc {
 		if path == "" {
 			path = c.Request.URL.Path
 		}
-		logger.Info("http request",
+		status := c.Writer.Status()
+		attrs := []any{
 			"method", c.Request.Method,
 			"path", path,
-			"status", c.Writer.Status(),
+			"status", status,
 			"duration_ms", time.Since(start).Milliseconds(),
 			"request_id", c.GetString(contextKeyRequestID),
-		)
+		}
+		// Surface the cause on failures so a 4xx/5xx is diagnosable from the log,
+		// not just a status code. 5xx is a server fault (ERROR); 4xx is a rejected
+		// request (WARN). Below 400 stays INFO.
+		if detail := c.GetString(contextKeyProblemDetail); detail != "" {
+			attrs = append(attrs, "detail", detail)
+		}
+		switch {
+		case status >= 500:
+			logger.Error("http request", attrs...)
+		case status >= 400:
+			logger.Warn("http request", attrs...)
+		default:
+			logger.Info("http request", attrs...)
+		}
 	}
 }
 

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -1,7 +1,10 @@
 package api
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,6 +14,44 @@ import (
 
 	"github.com/neochaotic/leoflow/internal/auth"
 )
+
+// TestStructuredLoggerSurfacesErrorDetail is the observability guard the escaped
+// 400/500 regressions exposed: a failing request must log its CAUSE and the right
+// level (5xx=ERROR, 4xx=WARN), not just a bare status code.
+func TestStructuredLoggerSurfacesErrorDetail(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	r := gin.New()
+	r.Use(StructuredLogger(logger))
+	r.GET("/bad", func(c *gin.Context) {
+		AbortProblem(c, http.StatusBadRequest, "bad request", "cannot unmarshal array into Go struct field clearRequest.task_ids of type string")
+	})
+	r.GET("/boom", func(c *gin.Context) {
+		AbortProblem(c, http.StatusInternalServerError, "server error", "scanning task instances: db exploded")
+	})
+	r.GET("/ok", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	do := func(p string) map[string]any {
+		buf.Reset()
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, p, http.NoBody))
+		var m map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+			t.Fatalf("log line not JSON: %q", buf.String())
+		}
+		return m
+	}
+	if m := do("/bad"); m["level"] != "WARN" || !strings.Contains(m["detail"].(string), "task_ids") {
+		t.Errorf("4xx must log WARN + cause, got %v", m)
+	}
+	if m := do("/boom"); m["level"] != "ERROR" || !strings.Contains(m["detail"].(string), "db exploded") {
+		t.Errorf("5xx must log ERROR + cause, got %v", m)
+	}
+	if m := do("/ok"); m["level"] != "INFO" {
+		t.Errorf("2xx stays INFO, got %v", m)
+	}
+}
 
 // tokenAuthn authenticates exactly one token value; anything else is invalid. It
 // lets a test distinguish a stale bearer from a valid session cookie.

--- a/internal/api/problem.go
+++ b/internal/api/problem.go
@@ -14,6 +14,13 @@ type Problem struct {
 
 // AbortProblem writes an RFC 7807 problem response and stops the handler chain.
 func AbortProblem(c *gin.Context, status int, title, detail string) {
+	// Record the cause so StructuredLogger can log WHY this failed (4xx/5xx are
+	// otherwise logged as a bare status code).
+	if detail != "" {
+		c.Set(contextKeyProblemDetail, detail)
+	} else {
+		c.Set(contextKeyProblemDetail, title)
+	}
 	c.Header("Content-Type", "application/problem+json")
 	c.AbortWithStatusJSON(status, Problem{
 		Type:     "about:blank",

--- a/internal/api/resources.go
+++ b/internal/api/resources.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -103,9 +104,21 @@ func tenantOf(c *gin.Context) string {
 	return "default"
 }
 
+// statusClientClosedRequest (499, nginx convention) marks a request the client
+// aborted before the server finished — not a server fault.
+const statusClientClosedRequest = 499
+
 func handleRepoError(c *gin.Context, err error) {
 	if errors.Is(err, ErrNotFound) {
 		AbortProblem(c, http.StatusNotFound, "not found", err.Error())
+		return
+	}
+	// A canceled/timed-out context means the client went away (the UI routinely
+	// supersedes in-flight grid requests). That is NOT a server error — mapping it
+	// to 500 produced spurious ti_summaries 500s under rapid refresh. Report 499 so
+	// it logs as a client-side 4xx, not a server fault.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		AbortProblem(c, statusClientClosedRequest, "client closed request", err.Error())
 		return
 	}
 	AbortProblem(c, http.StatusInternalServerError, "internal error", err.Error())
@@ -368,16 +381,50 @@ func listTaskInstancesHandler(repo TaskInstanceRepository, runs DagRunRepository
 	}
 }
 
+// clearTaskIDs accepts the Airflow UI's task_ids, where each element is either a
+// task id string OR a [task_id, map_index] tuple (mapped tasks). Lite is unmapped,
+// so the map index is dropped. Without this, the real UI payload (e.g.
+// [["hello", -1]]) fails to bind and the clear request 400s.
+type clearTaskIDs []string
+
+// UnmarshalJSON decodes each task_ids element as a string or a [task_id, map_index] tuple.
+func (t *clearTaskIDs) UnmarshalJSON(b []byte) error {
+	var raw []json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	out := make([]string, 0, len(raw))
+	for _, el := range raw {
+		var s string
+		if json.Unmarshal(el, &s) == nil {
+			out = append(out, s)
+			continue
+		}
+		var tuple []json.RawMessage
+		if err := json.Unmarshal(el, &tuple); err != nil || len(tuple) == 0 {
+			return fmt.Errorf("task_ids element must be a string or [task_id, map_index] tuple")
+		}
+		var id string
+		if err := json.Unmarshal(tuple[0], &id); err != nil {
+			return fmt.Errorf("task_ids tuple task id: %w", err)
+		}
+		out = append(out, id)
+	}
+	*t = out
+	return nil
+}
+
 type clearRequest struct {
-	TaskIDs           []string `json:"task_ids"`
-	DagRunID          string   `json:"dag_run_id"`
-	OnlyFailed        *bool    `json:"only_failed"`
-	ResetDagRuns      *bool    `json:"reset_dag_runs"`
-	DryRun            *bool    `json:"dry_run"`
-	IncludeUpstream   bool     `json:"include_upstream"`
-	IncludeDownstream bool     `json:"include_downstream"`
-	IncludePast       bool     `json:"include_past"`
-	IncludeFuture     bool     `json:"include_future"`
+	TaskIDs           clearTaskIDs `json:"task_ids"`
+	DagRunID          string       `json:"dag_run_id"`
+	OnlyFailed        *bool        `json:"only_failed"`
+	OnlyRunning       *bool        `json:"only_running"`
+	ResetDagRuns      *bool        `json:"reset_dag_runs"`
+	DryRun            *bool        `json:"dry_run"`
+	IncludeUpstream   bool         `json:"include_upstream"`
+	IncludeDownstream bool         `json:"include_downstream"`
+	IncludePast       bool         `json:"include_past"`
+	IncludeFuture     bool         `json:"include_future"`
 }
 
 func clearTaskInstancesHandler(repo TaskInstanceRepository, runs DagRunRepository, versions DagVersionLister, specs DagSpecReader, audit AuditWriter) gin.HandlerFunc {
@@ -423,14 +470,15 @@ func clearTaskInstancesHandler(repo TaskInstanceRepository, runs DagRunRepositor
 // include_upstream/downstream is set (needs the spec); otherwise returns them
 // unchanged. An empty task list (clear-the-whole-run) is left empty.
 func expandClearTasks(c *gin.Context, specs DagSpecReader, body clearRequest) []string {
-	if specs == nil || len(body.TaskIDs) == 0 || (!body.IncludeUpstream && !body.IncludeDownstream) {
-		return body.TaskIDs
+	seeds := []string(body.TaskIDs)
+	if specs == nil || len(seeds) == 0 || (!body.IncludeUpstream && !body.IncludeDownstream) {
+		return seeds
 	}
 	spec, err := specs.GetCurrentSpec(c.Request.Context(), tenantOf(c), c.Param("dag_id"))
 	if err != nil {
-		return body.TaskIDs
+		return seeds
 	}
-	return expandTaskIDs(spec.Tasks, body.TaskIDs, body.IncludeUpstream, body.IncludeDownstream)
+	return expandTaskIDs(spec.Tasks, seeds, body.IncludeUpstream, body.IncludeDownstream)
 }
 
 // clearTargetRuns resolves which runs a clear applies to: just the named run, or

--- a/internal/api/resources_test.go
+++ b/internal/api/resources_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -493,6 +494,57 @@ func TestTaskInstancesAndClear(t *testing.T) {
 	rec := authGet(srv, http.MethodPost, "/api/v2/dags/etl/clearTaskInstances", `{"task_ids":["extract"],"dag_run_id":"r1"}`)
 	if rec.Code != http.StatusOK {
 		t.Errorf("clear = %d, want 200", rec.Code)
+	}
+}
+
+// TestClearAcceptsAirflowTupleTaskIDs is a CONTRACT test against the REAL Airflow
+// 3.2 UI payload: the SPA sends task_ids as [task_id, map_index] tuples (captured
+// from the bundle as task_ids:[[...]]), not plain strings. The clear endpoint must
+// accept that shape. The prior []string DTO 400'd on it — and the older tests used
+// our own invented `["extract"]` shape, so they never caught the mismatch (issue
+// #98). This test posts the real shape, so it fails if the contract breaks again.
+func TestClearAcceptsAirflowTupleTaskIDs(t *testing.T) {
+	srv := authedServer()
+	// Real Airflow shape: each task_ids element is a [task_id, map_index] tuple.
+	rec := authGet(srv, http.MethodPost, "/api/v2/dags/etl/clearTaskInstances",
+		`{"dag_run_id":"r1","task_ids":[["extract",-1]],"dry_run":true}`)
+	if rec.Code == http.StatusBadRequest {
+		t.Fatalf("the real Airflow tuple payload must bind, not 400: %s", rec.Body.String())
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("clear (tuple task_ids) = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	// Backward compatibility: plain-string task_ids still bind.
+	if rec := authGet(srv, http.MethodPost, "/api/v2/dags/etl/clearTaskInstances",
+		`{"dag_run_id":"r1","task_ids":["extract"]}`); rec.Code != http.StatusOK {
+		t.Errorf("string task_ids should still bind, got %d", rec.Code)
+	}
+}
+
+// TestHandleRepoErrorClientCancel guards the ti_summaries 500 regression: a
+// canceled/timed-out context means the client aborted (the UI supersedes in-flight
+// grid requests), which must map to 499 (client closed), not a 500 server fault.
+func TestHandleRepoErrorClientCancel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"client canceled", context.Canceled, statusClientClosedRequest},
+		{"deadline exceeded", context.DeadlineExceeded, statusClientClosedRequest},
+		{"wrapped cancel", errors.Join(errors.New("task instances for runs"), context.Canceled), statusClientClosedRequest},
+		{"not found", ErrNotFound, http.StatusNotFound},
+		{"real server error", errors.New("db exploded"), http.StatusInternalServerError},
+	}
+	for _, tc := range cases {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", http.NoBody)
+		handleRepoError(c, tc.err)
+		if w.Code != tc.want {
+			t.Errorf("%s: got %d, want %d", tc.name, w.Code, tc.want)
+		}
 	}
 }
 


### PR DESCRIPTION
Two real API regressions surfaced by testing Lite on real hardware, plus the observability gap that made them invisible. **All diagnoses anchored to the real Airflow contract / real behavior — not self-made fixtures** (see #98).

## Fixes
- **`clearTaskInstances` 400 → fixed.** The Airflow 3.2 UI sends `task_ids` as `[task_id, map_index]` **tuples** (`[["hello", -1]]`, captured from the SPA bundle), but `clearRequest.TaskIDs` was `[]string` → the real payload never bound → clear 400'd on every click. Now accepts both string and tuple forms (+ `only_running`). **Contract test posts the real tuple shape** — the prior test used our own `["extract"]` and never caught it.
- **`ti_summaries` 500 (the "eternal running" grid) → fixed.** `handleRepoError` mapped every non-NotFound error to 500, including `context.Canceled` — which just means the client aborted (the UI supersedes in-flight grid requests under rapid refresh). The run actually finalizes `success` in the DB; the 500s broke the grid's refresh, so it showed stale "running". Now maps client-cancel to **499**.
- **4xx/5xx error logging.** `AbortProblem` records its detail; `StructuredLogger` logs 5xx at ERROR / 4xx at WARN with the cause. Failing requests were logged only as a bare status code — this is what cracked both bugs and guards future regressions.

## Not bugs (clarified during diagnosis)
- IDE button: present (floating bottom-right), not in the sidebar.
- Empty task log: the starter `hello` task only `return`s; log capture works (verified a `print()` task ships stdout + the Airflow SDK logger).

## Tests
- `TestClearAcceptsAirflowTupleTaskIDs` (contract: real tuple payload).
- `TestHandleRepoErrorClientCancel` (cancel/deadline → 499; NotFound → 404; real error → 500).
- `TestStructuredLoggerSurfacesErrorDetail` (5xx=ERROR, 4xx=WARN, +detail).

## Validation
`go test ./...` exit 0 · `golangci-lint` 0 issues · validated end-to-end on a VM: clear with tuples → 200 (was 400), task log captures stdout + SDK logs, run finalizes success.

Follow-ups: the pre-login flash (client-side, cosmetic) and the test-effectiveness audit (#98).

🤖 Generated with [Claude Code](https://claude.com/claude-code)