### PR TITLE
feat(onboarding): interactive setup wizard on remote install + clearer CLI

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -17,9 +17,18 @@ trusted internal network — see [Editions](editions.md).
 curl -fsSL https://raw.githubusercontent.com/neochaotic/leoflow/main/install.sh | sh
 ```
 
-This installs the binaries to `~/.leoflow/bin`, **adds them to your PATH**, and
-runs `leoflow setup` — which fetches a managed Python + the editor, creates your
-workspace (`~/leoflow`), and prints your **admin password once**:
+This installs the binaries to a directory on your `PATH` (e.g. `/usr/local/bin`)
+and runs the **setup wizard**, which asks a few questions — press Enter to accept
+each `[default]`:
+
+- **Where your DAGs live** (workspace) — default `~/leoflow`
+- **How tasks run**: `local` (each task as a process on this machine — simple, no
+  Docker, recommended) or `cluster` (real pod-per-task on a local mini-Kubernetes
+  — mirrors Production, needs Docker)
+- **Admin email** — default `admin@leoflow.local`
+
+It then fetches a managed Python + the editor, creates your workspace, and prints
+your **admin password once** (`sudo leoflow lite reset-password` resets it):
 
 ```
 ── Leoflow Lite admin (save this — it is shown only once) ──
@@ -27,11 +36,10 @@ workspace (`~/leoflow`), and prints your **admin password once**:
   password: tiger98
 ```
 
-Save that password. Then load the new PATH (or open a new terminal):
-
-```bash
-source ~/.bashrc        # or ~/.zshrc
-```
+(Piping non-interactively, or re-running with an existing config, skips the
+questions and uses the defaults — which are always printed, so you are never
+guessing.) If the installer added a PATH line to your shell profile, open a new
+terminal (or `source` it); installing to `/usr/local/bin` needs no reload.
 
 ## 2 · Run it
 

--- a/install.sh
+++ b/install.sh
@@ -164,7 +164,15 @@ if [ "${LEOFLOW_NO_SETUP:-}" = "1" ]; then
 	info "skipping setup (LEOFLOW_NO_SETUP=1); run '${INSTALL_DIR}/leoflow setup' when ready"
 else
 	info "running 'leoflow setup'..."
-	"${INSTALL_DIR}/leoflow" setup
+	# Attach the controlling terminal so the interactive setup wizard (where your
+	# DAGs live, how tasks run, the admin login) can prompt even under `curl | sh`,
+	# where stdin is the piped script, not a TTY. With no terminal (CI) or
+	# LEOFLOW_NONINTERACTIVE=1, fall back to non-interactive defaults.
+	if [ "${LEOFLOW_NONINTERACTIVE:-}" != "1" ] && [ -r /dev/tty ]; then
+		"${INSTALL_DIR}/leoflow" setup </dev/tty
+	else
+		"${INSTALL_DIR}/leoflow" setup
+	fi
 fi
 
 printf '\n'

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -122,7 +122,18 @@ type devOptions struct {
 // has no project yet — so a fresh install runs with a bare `leoflow lite`.
 func resolveLiteProject(cmd *cobra.Command, args []string) (string, error) {
 	if len(args) == 1 {
-		return args[0], nil
+		p := args[0]
+		// An explicit argument must be an existing project dir. Without this check a
+		// typo like `leoflow lite uninstall` was swallowed as a project path and
+		// failed later with a cryptic "open uninstall/leoflow.yaml". Fail clearly.
+		if _, err := os.Stat(filepath.Join(p, "leoflow.yaml")); err != nil {
+			return "", fmt.Errorf("no Leoflow project at %q (no leoflow.yaml).\n"+
+				"  - run `leoflow lite` with no argument to use your workspace (%s)\n"+
+				"  - run `leoflow init %s` to create a project there\n"+
+				"  - for other actions see `leoflow --help` (e.g. `leoflow uninstall`)",
+				p, defaultWorkspace(cmd), p)
+		}
+		return p, nil
 	}
 	dir := defaultWorkspace(cmd)
 	if _, err := os.Stat(filepath.Join(dir, "leoflow.yaml")); errors.Is(err, os.ErrNotExist) {

--- a/internal/cli/lite_project_test.go
+++ b/internal/cli/lite_project_test.go
@@ -36,9 +36,15 @@ type nopWriter struct{}
 func (nopWriter) Write(p []byte) (int, error) { return len(p), nil }
 
 func TestResolveLiteProjectExplicitArg(t *testing.T) {
-	got, err := resolveLiteProject(bareCmd(), []string{"/some/dag"})
-	if err != nil || got != "/some/dag" {
-		t.Errorf("explicit arg = (%q,%v), want /some/dag", got, err)
+	// An explicit argument must point at a real project (a dir with leoflow.yaml);
+	// a non-project arg now errors clearly instead of being swallowed as a path.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "leoflow.yaml"), []byte("dag_id: x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveLiteProject(bareCmd(), []string{dir})
+	if err != nil || got != dir {
+		t.Errorf("explicit project arg = (%q,%v), want %q", got, err, dir)
 	}
 }
 

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -64,14 +64,19 @@ func gatherLiteConfig(interactive bool, in *bufio.Reader, out io.Writer, def lit
 	}
 	_, _ = fmt.Fprintln(out, "\nLeoflow Lite setup — press Enter to accept each [default].") //nolint:errcheck // best-effort
 	s := def
-	s.Workspace = promptLine(in, out, "Workspace directory (your DAG projects)", def.Workspace)
-	_, _ = fmt.Fprintln(out, "  Executor: 'subprocess' = local use (fast, no Docker); 'k8s' = mini-cluster for development (k3d, needs Docker).") //nolint:errcheck // best-effort
+	s.Workspace = promptLine(in, out, "Where should your DAGs live (workspace)", def.Workspace)
+	// Run mode, in plain language — not the internal "subprocess|k8s" jargon a
+	// first-timer can't answer. The named choices map to the executor below.
+	_, _ = fmt.Fprintln(out, "\n  How should tasks run?")                                                                           //nolint:errcheck // best-effort
+	_, _ = fmt.Fprintln(out, "    local    — each task runs as a process on this machine; simple, fast, no Docker (recommended)")   //nolint:errcheck // best-effort
+	_, _ = fmt.Fprintln(out, "    cluster  — real pod-per-task on a local mini-Kubernetes (k3d); mirrors Production, needs Docker") //nolint:errcheck // best-effort
 	for {
-		s.Executor = promptLine(in, out, "Executor (subprocess|k8s)", def.Executor)
-		if s.Executor == "subprocess" || s.Executor == "k8s" {
+		choice := strings.ToLower(promptLine(in, out, "Run mode (local|cluster)", executorLabel(def.Executor)))
+		if executor, ok := executorFromChoice(choice); ok {
+			s.Executor = executor
 			break
 		}
-		_, _ = fmt.Fprintln(out, "  please type 'subprocess' or 'k8s'") //nolint:errcheck // best-effort
+		_, _ = fmt.Fprintln(out, "  please type 'local' or 'cluster'") //nolint:errcheck // best-effort
 	}
 	if p, err := strconv.Atoi(promptLine(in, out, "UI port", strconv.Itoa(def.Port))); err == nil && p > 0 {
 		s.Port = p
@@ -85,6 +90,27 @@ func gatherLiteConfig(interactive bool, in *bufio.Reader, out io.Writer, def lit
 // a ModeCharDevice check would wrongly treat as interactive.
 func isInteractive(f *os.File) bool {
 	return term.IsTerminal(int(f.Fd()))
+}
+
+// executorLabel maps the internal executor value to the user-facing run-mode name
+// shown in the wizard ("local"/"cluster"), so users never see "subprocess|k8s".
+func executorLabel(executor string) string {
+	if executor == "k8s" {
+		return "cluster"
+	}
+	return "local"
+}
+
+// executorFromChoice maps a run-mode answer to the internal executor, accepting
+// both the friendly names and the legacy raw values. Returns ok=false otherwise.
+func executorFromChoice(choice string) (string, bool) {
+	switch choice {
+	case "local", "subprocess":
+		return "subprocess", true
+	case "cluster", "k8s", "kubernetes":
+		return "k8s", true
+	}
+	return "", false
 }
 
 // newSetupCommand bootstraps the managed runtime: a usable Python 3.11 (the
@@ -258,7 +284,11 @@ func printSetupSummary(out io.Writer, lc liteSettings, generatedPassword string)
 	}
 	_, _ = fmt.Fprintln(out, "\n  SECURITY: Lite uses a short, human-friendly password and is meant for local/")     //nolint:errcheck // best-effort terminal output
 	_, _ = fmt.Fprintln(out, "  trusted use only. Run it on an internal network or VPN — never expose it publicly.") //nolint:errcheck // best-effort terminal output
-	_, _ = fmt.Fprintf(out, "\n  ready. Next: `leoflow lite %s/<your-dag>`\n", lc.Workspace)                         //nolint:errcheck // best-effort terminal output
+	// AAA close: tell the dev exactly what to do next, with what it does.
+	devPrintln(out, "\n  ✓ You're all set!")
+	devPrintf(out, "\n      Start Leoflow Lite:        leoflow lite\n"+
+		"        (opens the UI, scaffolds a starter DAG in %s if empty, and hot-reloads on save)\n"+
+		"      Reach it from your network: leoflow lite --host 0.0.0.0\n", lc.Workspace)
 }
 
 // liteConfigExists reports whether ~/.leoflow/config.yaml is already present.

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -55,7 +56,11 @@ func runUninstall(cmd *cobra.Command, yes, purge bool) error {
 		workspace = c.Workspace
 	}
 
-	devPrintf(out, "This will remove the Leoflow installation:\n  %s  (binaries, config, Python, Monaco)\n", root)
+	binDir := installBinDir()
+	devPrintf(out, "This will remove the Leoflow installation:\n  %s  (config, managed Python, Monaco, sources)\n", root)
+	if binDir != "" {
+		devPrintf(out, "  the leoflow binaries in %s\n", binDir)
+	}
 	if purge {
 		if workspace != "" {
 			devPrintf(out, "  %s  (your DAG workspace)\n", workspace)
@@ -77,6 +82,10 @@ func runUninstall(cmd *cobra.Command, yes, purge bool) error {
 		return fmt.Errorf("removing %s: %w", root, rerr)
 	}
 	devPrintf(out, "✓ removed %s\n", root)
+	// Remove the binaries too — install.sh places them on a PATH dir (e.g.
+	// /usr/local/bin), NOT under ~/.leoflow, so removing the home alone left a
+	// working `leoflow` behind.
+	removeBinariesIn(out, installBinDir())
 	if purge && workspace != "" {
 		if rerr := os.RemoveAll(workspace); rerr != nil {
 			devPrintf(out, "  ! could not remove workspace %s: %v\n", workspace, rerr)
@@ -84,8 +93,39 @@ func runUninstall(cmd *cobra.Command, yes, purge bool) error {
 			devPrintf(out, "✓ removed workspace %s\n", workspace)
 		}
 	}
-	devPrintln(out, "Done. Remove the 'export PATH=\"$HOME/.leoflow/bin:$PATH\"' line from your shell profile if you added it.")
+	devPrintln(out, "Done. If install.sh added a 'leoflow' PATH line to your shell profile, remove it.")
 	return nil
+}
+
+// installBinDir is the directory the running leoflow binary lives in — where
+// install.sh placed the binaries (/usr/local/bin, ~/.local/bin, or ~/.leoflow/bin).
+func installBinDir() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	return filepath.Dir(exe)
+}
+
+// removeBinariesIn deletes the leoflow binaries from dir (leoflow last — it is the
+// running process; on Linux unlinking a running binary is safe). A removal failure
+// (e.g. /usr/local/bin without sudo) is reported, not fatal, so ~/.leoflow is still
+// cleaned.
+func removeBinariesIn(out io.Writer, dir string) {
+	if dir == "" {
+		return
+	}
+	for _, name := range []string{"leoflow-server", "leoflow-agent", "leoflow"} {
+		p := filepath.Join(dir, name)
+		if _, err := os.Stat(p); err != nil {
+			continue
+		}
+		if err := os.Remove(p); err != nil {
+			devPrintf(out, "  ! could not remove %s: %v (remove it manually, e.g. `sudo rm %s`)\n", p, err, p)
+		} else {
+			devPrintf(out, "✓ removed %s\n", p)
+		}
+	}
 }
 
 // confirmUninstall reads a yes/no from stdin; anything but yes/y (and any EOF on

--- a/internal/cli/uninstall_test.go
+++ b/internal/cli/uninstall_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,50 @@ import (
 
 	"github.com/spf13/cobra"
 )
+
+// TestRemoveBinariesIn covers the uninstall fix: the leoflow binaries (which
+// install.sh puts on a PATH dir like /usr/local/bin, not under ~/.leoflow) must be
+// removed, while unrelated files in the same dir are left untouched.
+func TestRemoveBinariesIn(t *testing.T) {
+	dir := t.TempDir()
+	for _, n := range []string{"leoflow", "leoflow-server", "leoflow-agent", "other-tool"} {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	removeBinariesIn(&bytes.Buffer{}, dir)
+	for _, n := range []string{"leoflow", "leoflow-server", "leoflow-agent"} {
+		if _, err := os.Stat(filepath.Join(dir, n)); !os.IsNotExist(err) {
+			t.Errorf("%s should have been removed", n)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, "other-tool")); err != nil {
+		t.Error("unrelated binaries must be left untouched")
+	}
+	removeBinariesIn(&bytes.Buffer{}, "") // empty dir is a no-op, must not panic
+}
+
+// TestResolveLiteProjectRejectsNonProjectArg covers the CLI clarity fix: an
+// explicit `leoflow lite <arg>` that is not a project (e.g. the `leoflow lite
+// uninstall` typo) fails with an actionable message, not a cryptic leoflow.yaml error.
+func TestResolveLiteProjectRejectsNonProjectArg(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.SetOut(io.Discard)
+
+	if _, err := resolveLiteProject(cmd, []string{"uninstall"}); err == nil {
+		t.Fatal("a non-project argument should error")
+	} else if !strings.Contains(err.Error(), "no Leoflow project") || !strings.Contains(err.Error(), "leoflow uninstall") {
+		t.Errorf("error should be actionable, got: %v", err)
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "leoflow.yaml"), []byte("dag_id: x\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := resolveLiteProject(cmd, []string{dir}); err != nil || got != dir {
+		t.Errorf("existing project: got (%q, %v), want (%q, nil)", got, err, dir)
+	}
+}
 
 // uninstallCmd builds a command with the given stdin and captured output.
 func uninstallCmd(stdin string) (*cobra.Command, *bytes.Buffer) {


### PR DESCRIPTION
Make the install/onboarding **inform the user and behave predictably** — the "I'm lost, I don't know any config like the workspace" gap.

## Changes
- **Wizard actually prompts on `curl | sh`.** The wizard already existed but was skipped because under a pipe stdin isn't a TTY. `install.sh` now runs `leoflow setup </dev/tty`, so it asks (workspace, run mode, admin email) with defaults; falls back to defaults with no terminal or `LEOFLOW_NONINTERACTIVE=1`.
- **Plain-language run mode.** Instead of `subprocess|k8s`, the wizard asks **local** (each task as a process on this machine — simple, no Docker, recommended) vs **cluster** (real pod-per-task on a local mini-Kubernetes — mirrors Production, needs Docker). Values still map to `subprocess`/`k8s`.
- **AAA next step.** Setup closes with a clear "✓ You're all set — run `leoflow lite`" (and `--host 0.0.0.0` for the LAN).
- **`leoflow uninstall` removes the binaries too.** install.sh moved them to a PATH dir (`/usr/local/bin`), so removing `~/.leoflow` alone left a working `leoflow` behind — it now deletes `leoflow`/`leoflow-server`/`leoflow-agent` from the install dir.
- **`leoflow lite <non-project-arg>`** (e.g. the `leoflow lite uninstall` typo) now fails with an actionable message instead of a cryptic `open uninstall/leoflow.yaml`.
- **Docs:** quickstart documents the wizard, the `~/leoflow` default, the run modes, and reset/uninstall.

## Tests
`TestRemoveBinariesIn`, `TestResolveLiteProjectRejectsNonProjectArg`, updated `TestResolveLiteProjectExplicitArg`; existing `gatherLiteConfig`/setup tests still green.

`go test ./...` exit 0 · `golangci-lint` 0 issues. (Wizard text in English; chat-only Portuguese.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)