### PR TITLE
fix(install/wizard): resolve newest release reliably + numbered run mode + clear cluster error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -73,10 +73,13 @@ have tar || err "need tar to extract the release archive (install it, e.g. 'apk 
 version="${LEOFLOW_VERSION:-}"
 if [ -z "$version" ]; then
 	info "resolving latest release..."
-	# Use the releases list (newest-first), not /releases/latest, because the
-	# latter excludes pre-releases — and Leoflow alphas are pre-releases.
-	version=$(fetch "https://api.github.com/repos/${REPO}/releases?per_page=1" \
-		| grep '"tag_name"' | head -1 | sed 's/.*: *"//; s/".*//')
+	# Use the releases list, not /releases/latest, because the latter excludes
+	# pre-releases — and Leoflow alphas are pre-releases. The list is NOT reliably
+	# newest-first (a retracted draft can reorder it), so DON'T trust its order:
+	# take the highest version tag with `sort -V`. Unauthenticated requests omit
+	# drafts, so only published releases are considered.
+	version=$(fetch "https://api.github.com/repos/${REPO}/releases?per_page=50" \
+		| grep '"tag_name"' | sed 's/.*: *"//; s/".*//' | sort -V | tail -1)
 	[ -n "$version" ] || err "could not resolve the latest release tag (set LEOFLOW_VERSION)"
 fi
 # GoReleaser archive names drop the leading 'v' from the version.

--- a/install.sh
+++ b/install.sh
@@ -70,16 +70,21 @@ fi
 have tar || err "need tar to extract the release archive (install it, e.g. 'apk add tar', 'zypper in tar', 'dnf install tar')"
 
 # ── Resolve version ──
+# Pin any version (incl. a pre-release once stable exists): LEOFLOW_VERSION=...
 version="${LEOFLOW_VERSION:-}"
 if [ -z "$version" ]; then
 	info "resolving latest release..."
-	# Use the releases list, not /releases/latest, because the latter excludes
-	# pre-releases — and Leoflow alphas are pre-releases. The list is NOT reliably
-	# newest-first (a retracted draft can reorder it), so DON'T trust its order:
-	# take the highest version tag with `sort -V`. Unauthenticated requests omit
-	# drafts, so only published releases are considered.
-	version=$(fetch "https://api.github.com/repos/${REPO}/releases?per_page=50" \
-		| grep '"tag_name"' | sed 's/.*: *"//; s/".*//' | sort -V | tail -1)
+	# Prefer the latest STABLE release: /releases/latest excludes pre-releases AND
+	# drafts, so once a stable ships, users get it by default (the right behavior).
+	version=$(fetch "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null \
+		| grep '"tag_name"' | head -1 | sed 's/.*: *"//; s/".*//')
+	# No stable yet (the pre-alpha phase): fall back to the highest published
+	# pre-release. Don't trust the list order (a retracted draft reorders it) —
+	# take the highest tag with sort -V over the non-draft list.
+	if [ -z "$version" ]; then
+		version=$(fetch "https://api.github.com/repos/${REPO}/releases?per_page=50" \
+			| grep '"tag_name"' | sed 's/.*: *"//; s/".*//' | sort -V | tail -1)
+	fi
 	[ -n "$version" ] || err "could not resolve the latest release tag (set LEOFLOW_VERSION)"
 fi
 # GoReleaser archive names drop the leading 'v' from the version.

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -822,6 +822,16 @@ func ensureBaseImage(ctx context.Context, cmd *cobra.Command) error {
 	if _, err := devOutput(ctx, "docker", "image", "inspect", devBaseImage); err == nil {
 		return nil
 	}
+	// The base image is built from runtime/Dockerfile with the repo as context;
+	// a binary install (curl|sh) has no source tree, so fail clearly and point at
+	// the local run mode instead of the cryptic "lstat runtime: no such file".
+	if _, err := os.Stat(filepath.Join("runtime", "Dockerfile")); err != nil {
+		return fmt.Errorf("cluster run mode needs the Leoflow source tree to build the task base image " +
+			"(runtime/Dockerfile), which a binary install does not have.\n" +
+			"  Use the 'local' run mode: re-run `leoflow setup` and choose 1 (local), " +
+			"or set `lite_executor: subprocess` in ~/.leoflow/config.yaml.\n" +
+			"  (Cluster mode works when you run `leoflow lite` from a Leoflow source checkout.)")
+	}
 	devPrintln(cmd.OutOrStdout(), "▸ building task base image "+devBaseImage+" (first run) …")
 	if err := devRun(ctx, cmd, "docker", baseImageBuildArgs()...); err != nil {
 		return fmt.Errorf("building base image (run from the leoflow source tree): %w", err)

--- a/internal/cli/dev_test.go
+++ b/internal/cli/dev_test.go
@@ -452,6 +452,17 @@ func TestKubectlNamespaceArgs(t *testing.T) {
 }
 
 func TestDevClusterSetupStubbed(t *testing.T) {
+	// Cluster mode builds the base image from runtime/Dockerfile (CWD context);
+	// run from a tree that has it so ensureBaseImage's source-tree precheck passes.
+	src := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(src, "runtime"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "runtime", "Dockerfile"), []byte("FROM scratch\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(src)
+
 	origRun, origOut := devRun, devOutput
 	defer func() { devRun, devOutput = origRun, origOut }()
 	var runs []string

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -78,16 +78,16 @@ func gatherLiteConfig(interactive bool, in *bufio.Reader, out io.Writer, def lit
 	s.Workspace = promptLine(in, out, p, "Where should your DAGs live (workspace)", def.Workspace)
 	// Run mode, in plain language — not the internal "subprocess|k8s" jargon a
 	// first-timer can't answer. The named choices map to the executor below.
-	_, _ = fmt.Fprintf(out, "\n  %sHow should tasks run?%s\n", p.bold, p.reset)                                                                                               //nolint:errcheck // best-effort
-	_, _ = fmt.Fprintf(out, "    %slocal%s    — each task runs as a process on this machine; simple, fast, no Docker %s(recommended)%s\n", p.cyan, p.reset, p.green, p.reset) //nolint:errcheck // best-effort
-	_, _ = fmt.Fprintf(out, "    %scluster%s  — real pod-per-task on a local mini-Kubernetes (k3d); mirrors Production, needs Docker\n", p.cyan, p.reset)                     //nolint:errcheck // best-effort
+	_, _ = fmt.Fprintf(out, "\n  %sHow should tasks run?%s\n", p.bold, p.reset)                                                                                                           //nolint:errcheck // best-effort
+	_, _ = fmt.Fprintf(out, "    %s1)%s local    — %srecommended for everyday use%s: each task runs as a process here; simple, no Docker\n", p.cyan, p.reset, p.green, p.reset)           //nolint:errcheck // best-effort
+	_, _ = fmt.Fprintf(out, "    %s2)%s cluster  — for a development environment that mirrors Production: real pod-per-task on a mini-Kubernetes (k3d); needs Docker\n", p.cyan, p.reset) //nolint:errcheck // best-effort
 	for {
-		choice := strings.ToLower(promptLine(in, out, p, "Run mode (local|cluster)", executorLabel(def.Executor)))
+		choice := strings.ToLower(promptLine(in, out, p, "Run mode (1 or 2)", executorChoiceLabel(def.Executor)))
 		if executor, ok := executorFromChoice(choice); ok {
 			s.Executor = executor
 			break
 		}
-		_, _ = fmt.Fprintln(out, "  please type 'local' or 'cluster'") //nolint:errcheck // best-effort
+		_, _ = fmt.Fprintln(out, "  please type 1 (local) or 2 (cluster)") //nolint:errcheck // best-effort
 	}
 	if port, err := strconv.Atoi(promptLine(in, out, p, "UI port", strconv.Itoa(def.Port))); err == nil && port > 0 {
 		s.Port = port
@@ -126,22 +126,23 @@ func newPalette(enabled bool) palette {
 	return palette{bold: "\x1b[1m", dim: "\x1b[2m", green: "\x1b[32m", cyan: "\x1b[36m", reset: "\x1b[0m"}
 }
 
-// executorLabel maps the internal executor value to the user-facing run-mode name
-// shown in the wizard ("local"/"cluster"), so users never see "subprocess|k8s".
-func executorLabel(executor string) string {
+// executorChoiceLabel maps the executor to its menu number for the [default]
+// prompt (so the default reads "1"/"2", matching the numbered menu).
+func executorChoiceLabel(executor string) string {
 	if executor == "k8s" {
-		return "cluster"
+		return "2"
 	}
-	return "local"
+	return "1"
 }
 
 // executorFromChoice maps a run-mode answer to the internal executor, accepting
-// both the friendly names and the legacy raw values. Returns ok=false otherwise.
+// the menu numbers (1/2), the friendly names (local/cluster), and the legacy raw
+// values. Returns ok=false otherwise.
 func executorFromChoice(choice string) (string, bool) {
 	switch choice {
-	case "local", "subprocess":
+	case "1", "local", "subprocess":
 		return "subprocess", true
-	case "cluster", "k8s", "kubernetes":
+	case "2", "cluster", "k8s", "kubernetes":
 		return "k8s", true
 	}
 	return "", false

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -221,4 +221,15 @@ func TestGatherLiteConfig(t *testing.T) {
 			t.Errorf("got %+v, want defaults %+v", got, def)
 		}
 	})
+
+	// The numbered menu (the human feedback): typing 1/2 must work, not only the
+	// names. 2 -> cluster (k8s), 1 -> local (subprocess).
+	t.Run("numbered run mode picks the executor", func(t *testing.T) {
+		if got := gatherLiteConfig(true, bufio.NewReader(strings.NewReader("/ws\n2\n8088\nx@y.io\n")), io.Discard, def); got.Executor != "k8s" {
+			t.Errorf("'2' should select cluster (k8s), got %q", got.Executor)
+		}
+		if got := gatherLiteConfig(true, bufio.NewReader(strings.NewReader("/ws\n1\n8088\nx@y.io\n")), io.Discard, def); got.Executor != "subprocess" {
+			t.Errorf("'1' should select local (subprocess), got %q", got.Executor)
+		}
+	})
 }


### PR DESCRIPTION
Three issues from real-hardware testing (the user installed and got the **wrong, old** version with a bare wizard).

## 1. install.sh installed the wrong version (critical)
`install.sh` resolved the version with `/releases?per_page=1 | head`, but the GitHub release list is **not reliably newest-first** — a retracted draft (prealpha.10) reordered it, so the first non-draft was **prealpha.9**. Users got the OLD binary (no login/clear/grid fixes, the old wizard). Now we take the **highest tag with `sort -V`** over the published list.

Verified against the live API: new resolution → `prealpha.11`; old → `prealpha.9`.

## 2. Numbered run mode (human feedback)
The user typed `2` and got "please type subprocess|k8s". The wizard now accepts the **menu numbers 1/2** (and the names), and explains the recommendation:
- **1) local** — recommended for everyday use; each task as a process here, no Docker.
- **2) cluster** — for a development environment that mirrors Production; pod-per-task on a mini-Kubernetes (k3d), needs Docker.

## 3. Cluster mode on a binary install (cryptic error)
`leoflow lite` in cluster mode built the base image from `runtime/Dockerfile` (source-tree context); a binary install has no source tree → `lstat runtime: no such file`. Now it pre-checks and fails clearly, pointing at the local run mode.

`go test ./...` exit 0 · `golangci-lint` 0 issues. New test covers the numbered menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)