### PR TITLE
fix(lite): acceptance batch — login, scheduler, logs, dagRun delete, IDE leak

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -154,7 +154,7 @@ func run() error {
 	handler := api.NewServer(api.Dependencies{
 		Logger:        tel.Logger,
 		Authenticator: authn,
-		RateLimiter:   auth.NewRateLimiter(5, time.Minute),
+		RateLimiter:   auth.NewRateLimiter(loginRateLimit(cfg), time.Minute),
 		Registry:      tel.Registry,
 		Metrics:       tel.Metrics,
 		Tracer:        tel.Tracer,
@@ -310,6 +310,16 @@ const podNamespace = "leoflow"
 
 // agentTokenTTL is how long a dispatched task's agent identity token stays valid.
 const agentTokenTTL = 24 * time.Hour
+
+// loginRateLimit returns the per-minute failed-login cap with a safe floor: a
+// missing or nonsensical (<=0) config value falls back to the conservative
+// default rather than 0, which would lock every user out.
+func loginRateLimit(cfg *config.ServerConfig) int {
+	if cfg.Auth.LoginRateLimitPerMinute > 0 {
+		return cfg.Auth.LoginRateLimitPerMinute
+	}
+	return 5
+}
 
 // inlineStateSink adapts the scheduler store to the inline runner's StateSink,
 // recording inline http_api task transitions.

--- a/internal/agent/dial.go
+++ b/internal/agent/dial.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"time"
 
 	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
 	"google.golang.org/grpc"
@@ -96,9 +97,43 @@ func (s *grpcLogSink) Send(line *agentv1.LogLine) error {
 	return s.stream.Send(line)
 }
 
-// Close signals the control plane that no more log lines will be sent.
+// logDrainTimeout bounds how long Close waits for the server to acknowledge the
+// streamed lines. It must be generous enough for normal delivery but finite: a
+// task must never hang because log shipping stalls.
+const logDrainTimeout = 5 * time.Second
+
+// Close signals the control plane that no more log lines will be sent, then
+// waits (briefly) for the server to consume them. The drain is essential:
+// stream.Send only QUEUES a line into the gRPC transport, and CloseSend merely
+// half-closes; without waiting for the RPC to complete, the agent returns and
+// the deferred conn.Close() tears the connection down before the queued lines
+// are flushed — so a short task's logs never arrive and the attempt's log file
+// stays empty. Draining (Recv to EOF) blocks until the server has consumed every
+// line, guaranteeing delivery.
+//
+// The wait is bounded by logDrainTimeout: log delivery is best-effort and must
+// never hang the task. If the control plane stalls, Close returns and the caller
+// closes the connection — losing at most the tail of the logs, never the task.
 func (s *grpcLogSink) Close() error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.stream.CloseSend()
+	err := s.stream.CloseSend()
+	s.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			if _, rerr := s.stream.Recv(); rerr != nil {
+				return // EOF (clean) or any error: the drain is over
+			}
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(logDrainTimeout):
+		// The server did not finish in time; do not hang the task on it.
+	}
+	return nil
 }

--- a/internal/agent/logship_e2e_test.go
+++ b/internal/agent/logship_e2e_test.go
@@ -1,0 +1,100 @@
+package agent_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/neochaotic/leoflow/internal/agent"
+	"github.com/neochaotic/leoflow/internal/logs"
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+)
+
+// logServer is a minimal StreamLogs server that persists received lines to a real
+// DiskSink, mirroring the control plane's write path (recv until EOF, then flush
+// on Close).
+type logServer struct {
+	agentv1.UnimplementedAgentServiceServer
+	sink *logs.DiskSink
+	ref  logs.Ref
+}
+
+func (s *logServer) StreamLogs(stream grpc.BidiStreamingServer[agentv1.LogLine, agentv1.LogAck]) error {
+	w, err := s.sink.Open(s.ref)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = w.Close() }() // flushes the buffered lines to disk
+	for {
+		line, rerr := stream.Recv()
+		if errors.Is(rerr, io.EOF) {
+			return nil
+		}
+		if rerr != nil {
+			return rerr
+		}
+		_ = w.WriteEvent(logs.Event{Time: line.GetTime().AsTime(), Stream: line.GetStream(), Message: line.GetMessage()})
+	}
+}
+
+// TestLogSinkDeliversBeforeClose is the regression guard for the empty-task-log
+// bug: the agent's log sink must guarantee that every line it sent is actually
+// persisted by the time Close() returns. The agent closes its gRPC connection
+// immediately after Close(); if Close only half-closed the stream (CloseSend)
+// without draining the server's response, a short task's queued lines were torn
+// down with the connection and never reached disk — a 0-byte log file. Close must
+// block until the server has consumed and flushed every line.
+func TestLogSinkDeliversBeforeClose(t *testing.T) {
+	dir := t.TempDir()
+	ref := logs.Ref{TenantID: "tn", DagID: "leoflow", RunID: "run1", TaskID: "hello", TryNumber: 1}
+
+	lis := bufconn.Listen(1 << 20)
+	srv := grpc.NewServer()
+	agentv1.RegisterAgentServiceServer(srv, &logServer{sink: logs.NewDiskSink(dir), ref: ref})
+	go func() { _ = srv.Serve(lis) }()
+	defer srv.Stop()
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) { return lis.DialContext(ctx) }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	client := agentv1.NewAgentServiceClient(conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	sink, err := agent.OpenLogSink(ctx, client)
+	if err != nil {
+		t.Fatalf("OpenLogSink: %v", err)
+	}
+	if serr := sink.Send(&agentv1.LogLine{Time: timestamppb.Now(), Stream: "stdout", Message: "HELLO_FROM_TASK", LineNumber: 1}); serr != nil {
+		t.Fatalf("Send: %v", serr)
+	}
+	// Close must block until the line is delivered + flushed server-side.
+	if cerr := sink.Close(); cerr != nil {
+		t.Fatalf("Close: %v", cerr)
+	}
+	// The agent tears the connection down right after Close — exactly the moment
+	// that used to lose the line.
+	_ = conn.Close()
+
+	data, err := os.ReadFile(filepath.Join(dir, "tn", "leoflow", "run1", "hello", "1.log"))
+	if err != nil {
+		t.Fatalf("reading the persisted log: %v", err)
+	}
+	if !strings.Contains(string(data), "HELLO_FROM_TASK") {
+		t.Fatalf("log line was not persisted before Close returned; file=%q", string(data))
+	}
+}

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -25,8 +25,13 @@ type tokenResponse struct {
 // authTokenHandler issues a JWT for valid credentials, rate-limited per client IP.
 func authTokenHandler(authn auth.Authenticator, limiter *auth.RateLimiter, ttlSeconds int) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if !limiter.Allow(c.ClientIP()) {
-			AbortProblem(c, http.StatusTooManyRequests, "rate limited", "too many login attempts")
+		// Peek the limiter up front but DON'T count this attempt yet: only failed
+		// logins consume the budget (recorded below). This is what keeps a user who
+		// mistypes a couple times — or whose SPA re-fetches a token — from getting
+		// locked out the instant they finally send the right password.
+		if limiter.Blocked(c.ClientIP()) {
+			AbortProblem(c, http.StatusTooManyRequests, "rate limited",
+				"too many failed login attempts; wait about a minute and try again")
 			return
 		}
 		var req tokenRequest
@@ -48,6 +53,7 @@ func authTokenHandler(authn auth.Authenticator, limiter *auth.RateLimiter, ttlSe
 		})
 		if err != nil {
 			if errors.Is(err, auth.ErrInvalidCredentials) {
+				limiter.Allow(c.ClientIP()) // count the failure toward the lockout budget
 				AbortProblem(c, http.StatusUnauthorized, "unauthorized", "invalid credentials")
 				return
 			}

--- a/internal/api/auth_handler_test.go
+++ b/internal/api/auth_handler_test.go
@@ -1,0 +1,72 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+)
+
+// credAuthn issues a token only for password "right"; anything else is invalid
+// credentials. It lets the rate-limit tests distinguish a successful login from
+// a failed one (fakeAuthn ignores the password).
+type credAuthn struct{}
+
+func (credAuthn) IssueToken(_ context.Context, c auth.Credentials) (string, error) {
+	if c.Password == "right" {
+		return "jwt", nil
+	}
+	return "", auth.ErrInvalidCredentials
+}
+
+func (credAuthn) Authenticate(context.Context, string) (*auth.User, error) {
+	return &auth.User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}, nil
+}
+
+func rateLimitedServer(limit int) *gin.Engine {
+	return NewServer(Dependencies{
+		Logger: discardLogger(), Authenticator: credAuthn{},
+		RateLimiter: auth.NewRateLimiter(limit, time.Minute),
+		CORSOrigins: []string{"*"}, TokenTTLSecs: 3600,
+	})
+}
+
+func TestLoginRateLimitCountsOnlyFailures(t *testing.T) {
+	good := `{"username":"admin@leoflow.local","password":"right"}`
+	bad := `{"username":"admin@leoflow.local","password":"wrong"}`
+
+	t.Run("successful logins never consume the budget", func(t *testing.T) {
+		srv := rateLimitedServer(2) // tiny budget; successes must still all pass
+		for i := 0; i < 6; i++ {
+			if code := do(srv, http.MethodPost, "/auth/token", good).Code; code != http.StatusOK {
+				t.Fatalf("successful login %d = %d, want 200 (a success must not count)", i, code)
+			}
+		}
+	})
+
+	t.Run("mistype a few times then get it right is NOT locked", func(t *testing.T) {
+		srv := rateLimitedServer(3)
+		for i := 0; i < 2; i++ {
+			if code := do(srv, http.MethodPost, "/auth/token", bad).Code; code != http.StatusUnauthorized {
+				t.Fatalf("wrong attempt %d = %d, want 401", i, code)
+			}
+		}
+		if code := do(srv, http.MethodPost, "/auth/token", good).Code; code != http.StatusOK {
+			t.Fatalf("correct password after mistypes = %d, want 200 (must not be locked)", code)
+		}
+	})
+
+	t.Run("repeated failures still lock (anti-brute-force intact)", func(t *testing.T) {
+		srv := rateLimitedServer(3)
+		for i := 0; i < 3; i++ {
+			do(srv, http.MethodPost, "/auth/token", bad)
+		}
+		if code := do(srv, http.MethodPost, "/auth/token", good).Code; code != http.StatusTooManyRequests {
+			t.Fatalf("after exhausting the budget with failures, login = %d, want 429", code)
+		}
+	})
+}

--- a/internal/api/auth_login.go
+++ b/internal/api/auth_login.go
@@ -49,10 +49,25 @@ var loginPageTemplate = template.Must(template.New("login").Parse(`<!doctype htm
        method: 'POST', headers: {'Content-Type':'application/json'},
        body: JSON.stringify({username: f.username.value, password: f.password.value})
      });
-     if (!r.ok) { document.getElementById('e').textContent = 'Invalid credentials'; return; }
+     if (!r.ok) {
+       document.getElementById('e').textContent = r.status === 429
+         ? 'Too many attempts — wait about a minute, then try again.'
+         : 'Invalid credentials';
+       return;
+     }
      const data = await r.json();
      const secure = location.protocol === 'https:' ? '; secure' : '';
      document.cookie = '_token=' + data.access_token + '; path=/; samesite=lax' + secure;
+     // Ask the browser to remember the credentials. A fetch-based login (no
+     // native form navigation) does not trigger the "save password?" prompt on
+     // its own; the Credential Management API does. Best-effort, guarded.
+     if (window.PasswordCredential) {
+       try {
+         await navigator.credentials.store(new PasswordCredential({
+           id: f.username.value, name: f.username.value, password: f.password.value
+         }));
+       } catch (_) { /* unsupported or denied: fall through */ }
+     }
      window.location.replace(next);
    } catch (_) { document.getElementById('e').textContent = 'Sign-in failed'; }
  });

--- a/internal/api/auth_login_test.go
+++ b/internal/api/auth_login_test.go
@@ -44,6 +44,31 @@ func TestLoginPageIsPublicHTML(t *testing.T) {
 	}
 }
 
+func TestLoginPageLetsBrowserSaveCredentials(t *testing.T) {
+	body := anonGet(loginServer(), "/api/v2/auth/login").Body.String()
+	// Autofill on load needs the standard autocomplete tokens.
+	for _, want := range []string{`autocomplete="username"`, `autocomplete="current-password"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("login form missing %s", want)
+		}
+	}
+	// A fetch login does not trigger the browser "save password?" prompt by
+	// itself; the Credential Management API does. Without this the user has to
+	// retype the password every session.
+	if !strings.Contains(body, "navigator.credentials.store") || !strings.Contains(body, "PasswordCredential") {
+		t.Error("login page should store credentials via the Credential Management API so the browser can save them")
+	}
+}
+
+func TestLoginPageDistinguishesRateLimit(t *testing.T) {
+	body := anonGet(loginServer(), "/api/v2/auth/login").Body.String()
+	// A 429 must NOT show "Invalid credentials" — that makes a rate-limited user
+	// retry and dig the hole deeper. The page must tell them to wait.
+	if !strings.Contains(body, "429") || !strings.Contains(body, "wait") {
+		t.Errorf("login page should handle 429 with a 'wait' message, not 'Invalid credentials':\n%s", body)
+	}
+}
+
 func TestLoginPageSanitizesNext(t *testing.T) {
 	// Open-redirect targets collapse to "/".
 	for _, bad := range []string{"//evil.com", "https://evil.com", "javascript:alert(1)"} {

--- a/internal/api/ide_page.html
+++ b/internal/api/ide_page.html
@@ -119,8 +119,15 @@ async function openFile(path) {
     const { content } = await api.read(path);
     current = path;
     pathEl.textContent = path;
+    // Dispose the previous model before swapping in the new one. Monaco models are
+    // NOT garbage-collected — they live in the editor's model registry until
+    // disposed — so creating one per file-open without disposing leaks the full
+    // text buffer + tokenization + undo stack each time. Opening files across a
+    // few tabs then exhausts memory and freezes the browser.
+    const previous = editor.getModel();
     const model = monaco.editor.createModel(content, languageFor(path));
     editor.setModel(model);
+    if (previous) previous.dispose();
     setStatus("opened " + path);
     document.querySelectorAll("#tree .node").forEach((n) =>
       n.classList.toggle("active", n.dataset.path === path));

--- a/internal/api/ide_test.go
+++ b/internal/api/ide_test.go
@@ -169,6 +169,13 @@ func TestIDEPageServed(t *testing.T) {
 			t.Errorf("/ide page missing marker %q", marker)
 		}
 	}
+	// Guard the Monaco model-leak fix: opening a file must dispose the previous
+	// model (models are not GC'd), or every open leaks a buffer and a few tabs
+	// freeze the browser. Verified live: without dispose, getModels() grew 1->16
+	// over 15 opens; with it, stayed at 1.
+	if !strings.Contains(body, ".dispose()") {
+		t.Error("/ide page must dispose the previous Monaco model on file open (memory leak otherwise)")
+	}
 }
 
 func TestIDEMonacoNotProvisioned404(t *testing.T) {

--- a/internal/api/resources.go
+++ b/internal/api/resources.go
@@ -35,6 +35,7 @@ type DagRunRepository interface {
 	GetDagRun(ctx context.Context, tenant, dagID, runID string) (domain.DagRun, error)
 	CreateDagRun(ctx context.Context, tenant, dagID string, run domain.DagRun) (domain.DagRun, error)
 	SetDagRunState(ctx context.Context, tenant, dagID, runID, state string) error
+	DeleteDagRun(ctx context.Context, tenant, dagID, runID string) error
 }
 
 // TaskInstanceRepository reads task instances, clears them for re-run, and sets
@@ -185,6 +186,20 @@ func deleteDagHandler(repo DagRepository) gin.HandlerFunc {
 			err = repo.ClearDagHistory(c.Request.Context(), tenantOf(c), dagID)
 		}
 		if err != nil {
+			handleRepoError(c, err)
+			return
+		}
+		c.Status(http.StatusNoContent)
+	}
+}
+
+// deleteDagRunHandler implements DELETE /api/v2/dags/{dag_id}/dagRuns/{run_id},
+// mirroring Airflow: it removes a single run (task instances and XCom cascade)
+// and returns 204, or 404 when the run does not exist. The UI's "delete run"
+// action calls this; without the route it 404'd as "API route not found".
+func deleteDagRunHandler(repo DagRunRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if err := repo.DeleteDagRun(c.Request.Context(), tenantOf(c), c.Param("dag_id"), c.Param("dag_run_id")); err != nil {
 			handleRepoError(c, err)
 			return
 		}
@@ -699,9 +714,34 @@ func taskInstanceActionHandler(tasks TaskInstanceRepository, logs LogReader, xco
 			serveTaskTries(c, tasks, runs, versions, strings.TrimPrefix(action, "tries"))
 			return
 		}
+		// The SPA also addresses sub-resources under an explicit map_index, e.g.
+		// "{map_index}/tries" — the attempts list for one instance, requested right
+		// after a Clear (captured live from the 3.2 UI). The leading integer is the
+		// map_index (-1 for the single unmapped instance); route the sub-resource.
+		// TODO(#103): this handles only "{map_index}/tries" and serveTaskTries
+		// ignores the map_index. Correct while tasks are unmapped (map_index always
+		// -1); generalize the {map_index}/{subresource} routing + filter by
+		// map_index before dynamic task mapping lands.
+		if slash := strings.IndexByte(action, '/'); slash > 0 {
+			if _, err := strconv.Atoi(action[:slash]); err == nil {
+				if sub := action[slash+1:]; sub == "tries" || strings.HasPrefix(sub, "tries/") {
+					serveTaskTries(c, tasks, runs, versions, strings.TrimPrefix(sub, "tries"))
+					return
+				}
+			}
+		}
+		if action == "" {
+			// A bare path is the single (unmapped) instance.
+			serveSingleTaskInstance(c, tasks, runs, versions, specs, -1)
+			return
+		}
 		mapIndex, err := strconv.Atoi(action)
 		if err != nil {
-			AbortProblem(c, http.StatusBadRequest, "bad request", "map_index must be an integer")
+			// Not a map_index and not a known sub-resource. Say so honestly: the old
+			// "map_index must be an integer" 400 was misleading for an action that
+			// was never a map_index (e.g. a sub-resource the UI added).
+			AbortProblem(c, http.StatusNotFound, "not found",
+				fmt.Sprintf("unsupported task instance action %q", action))
 			return
 		}
 		serveSingleTaskInstance(c, tasks, runs, versions, specs, mapIndex)
@@ -821,6 +861,7 @@ func registerResources(r gin.IRouter, deps Dependencies) {
 		g.POST("", RequirePermission("execute", "dag"), createDagRunHandler(deps.DagRuns, deps.Audit))
 		g.GET("/:dag_run_id", RequirePermission("read", "dag_run"), getDagRunHandler(deps.DagRuns))
 		g.PATCH("/:dag_run_id", RequirePermission("write", "dag_run"), patchDagRunHandler(deps.DagRuns, deps.Audit))
+		g.DELETE("/:dag_run_id", RequirePermission("write", "dag_run"), deleteDagRunHandler(deps.DagRuns))
 	}
 	if deps.Tasks != nil {
 		r.GET("/api/v2/dags/:dag_id/dagRuns/:dag_run_id/taskInstances",

--- a/internal/api/resources_taskinstance_test.go
+++ b/internal/api/resources_taskinstance_test.go
@@ -26,9 +26,16 @@ func TestServeSingleTaskInstance(t *testing.T) {
 	if rec := authGet(srv, http.MethodGet, tiBase+"/ghost/0", ""); rec.Code != http.StatusNotFound {
 		t.Errorf("ghost/0 = %d, want 404", rec.Code)
 	}
-	// A non-integer map_index is a 400 (not a 500/panic).
-	if rec := authGet(srv, http.MethodGet, tiBase+"/extract/banana", ""); rec.Code != http.StatusBadRequest {
-		t.Errorf("extract/banana = %d, want 400", rec.Code)
+	// A segment that is neither a map_index nor a known sub-resource is a clear
+	// 404 "unsupported action" — NOT the old misleading "map_index must be an
+	// integer" 400, which mislabeled UI sub-resources (e.g. "{map_index}/tries")
+	// as a bad map_index.
+	rec := authGet(srv, http.MethodGet, tiBase+"/extract/banana", "")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("extract/banana = %d, want 404", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "map_index must be an integer") {
+		t.Errorf("unknown action must not be reported as a map_index error: %s", rec.Body.String())
 	}
 }
 

--- a/internal/api/resources_test.go
+++ b/internal/api/resources_test.go
@@ -100,6 +100,15 @@ func (f *fakeRunRepo) SetDagRunState(_ context.Context, _, _, runID, state strin
 	}
 	return nil
 }
+func (f *fakeRunRepo) DeleteDagRun(_ context.Context, _, _, runID string) error {
+	for i := range f.runs {
+		if f.runs[i].RunID == runID {
+			f.runs = append(f.runs[:i], f.runs[i+1:]...)
+			return nil
+		}
+	}
+	return domain.ErrNotFound
+}
 func (f *fakeRunRepo) CreateDagRun(_ context.Context, _, dagID string, run domain.DagRun) (domain.DagRun, error) {
 	run.DagID = dagID
 	return run, nil
@@ -310,6 +319,28 @@ func authGet(srv *gin.Engine, method, path, body string) *httptest.ResponseRecor
 	return rec
 }
 
+func TestDeleteDagRun(t *testing.T) {
+	admin := &auth.User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}
+	runs := &fakeRunRepo{runs: []domain.DagRun{{DagID: "etl", RunID: "r1", State: domain.DagRunStateSuccess}}}
+	srv := NewServer(Dependencies{
+		Logger: discardLogger(), Authenticator: &fakeAuthn{user: admin},
+		RateLimiter: auth.NewRateLimiter(100, time.Minute), CORSOrigins: []string{"*"}, TokenTTLSecs: 3600,
+		DagRuns: runs,
+	})
+	// The UI's "delete run" must succeed (204), not 404 as "API route not found".
+	rec := authGet(srv, http.MethodDelete, "/api/v2/dags/etl/dagRuns/r1", "")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("DELETE existing run = %d, want 204; body=%q", rec.Code, rec.Body.String())
+	}
+	if len(runs.runs) != 0 {
+		t.Errorf("run was not removed: %+v", runs.runs)
+	}
+	// A missing run is a clean 404, not a silent 204.
+	if rec := authGet(srv, http.MethodDelete, "/api/v2/dags/etl/dagRuns/nope", ""); rec.Code != http.StatusNotFound {
+		t.Errorf("DELETE missing run = %d, want 404", rec.Code)
+	}
+}
+
 func TestListDagRunsStateFilter(t *testing.T) {
 	// The "failed runs" widget filters with ?state=failed; the handler must honor
 	// it (it previously ignored the filter and returned every run).
@@ -518,6 +549,36 @@ func TestClearAcceptsAirflowTupleTaskIDs(t *testing.T) {
 	if rec := authGet(srv, http.MethodPost, "/api/v2/dags/etl/clearTaskInstances",
 		`{"dag_run_id":"r1","task_ids":["extract"]}`); rec.Code != http.StatusOK {
 		t.Errorf("string task_ids should still bind, got %d", rec.Code)
+	}
+}
+
+// TestTaskInstanceActionMapIndexSubresources is a CONTRACT test against the real
+// Airflow 3.2 SPA, captured live from a browser: right after a Clear, the UI
+// requests the attempts list as "{map_index}/tries" (e.g. "-1/tries"). The
+// catch-all only knew "tries"/"tries/{n}", so "-1/tries" fell through to
+// strconv.Atoi and 400'd with the misleading "map_index must be an integer".
+// This asserts the real URL shape works and that a genuinely unknown action gets
+// a clear 404 — never that misleading 400.
+func TestTaskInstanceActionMapIndexSubresources(t *testing.T) {
+	srv := authedServer()
+	base := "/api/v2/dags/etl/dagRuns/r1/taskInstances/extract"
+
+	// The exact shape the SPA sends after a Clear (was a 400 in the wild).
+	if rec := authGet(srv, http.MethodGet, base+"/-1/tries", ""); rec.Code != http.StatusOK {
+		t.Errorf("GET {map_index}/tries = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	// The bare map_index still returns the single instance (the fake's TI is at
+	// map_index 0).
+	if rec := authGet(srv, http.MethodGet, base+"/0", ""); rec.Code != http.StatusOK {
+		t.Errorf("GET {map_index} = %d, want 200", rec.Code)
+	}
+	// A genuinely unknown action must NOT masquerade as a map_index error.
+	rec := authGet(srv, http.MethodGet, base+"/dependencies", "")
+	if strings.Contains(rec.Body.String(), "map_index must be an integer") {
+		t.Errorf("unknown action misreported as a map_index error: %s", rec.Body.String())
+	}
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("unknown action = %d, want 404", rec.Code)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -132,7 +132,7 @@ func NewServer(deps Dependencies) *gin.Engine {
 		r.GET("/static/*filepath", static)
 		r.HEAD("/static/*filepath", static)
 	}
-	r.NoRoute(uiNoRoute(deps.UI))
+	r.NoRoute(uiNoRoute(deps.UI, deps.Authenticator, deps.DevNoAuth))
 
 	return r
 }

--- a/internal/api/ui.go
+++ b/internal/api/ui.go
@@ -2,9 +2,12 @@ package api
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/neochaotic/leoflow/internal/auth"
 )
 
 // supportedMenuItems are the Airflow 3.2.1 UI menu sections Leoflow backs. The
@@ -127,7 +130,7 @@ func uiMenusHandler() gin.HandlerFunc {
 // writes). An unmatched /api path is a 404. Any other GET falls back to the SPA
 // shell so the React router can handle client-side routes; without a UI server,
 // or for non-GET, it is a 404.
-func uiNoRoute(uiSrv UIServer) gin.HandlerFunc {
+func uiNoRoute(uiSrv UIServer, authn auth.Authenticator, devNoAuth bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		path := c.Request.URL.Path
 		switch {
@@ -144,9 +147,35 @@ func uiNoRoute(uiSrv UIServer) gin.HandlerFunc {
 			return
 		}
 		if uiSrv != nil && c.Request.Method == http.MethodGet {
+			// Gate the SPA shell: an unauthenticated visitor must NOT see the
+			// app rendered behind the login screen. Without this, the SPA shell
+			// loads, mounts the authenticated layout, and fires its data calls
+			// (which 401) before redirecting — flashing the whole UI and lighting
+			// the log with 401s. Redirecting here keeps the shell off-screen until
+			// there is a valid session. Skipped under dev no-auth.
+			if !devNoAuth && !shellSessionValid(c, authn) {
+				c.Redirect(http.StatusFound, "/api/v2/auth/login?next="+url.QueryEscape(path))
+				return
+			}
 			uiSrv.Index(c.Writer, "/")
 			return
 		}
 		AbortProblem(c, http.StatusNotFound, "not found", "no such resource")
 	}
+}
+
+// shellSessionValid reports whether the request carries a token (bearer or the
+// _token cookie) that authenticates — the same check JWTAuth applies to data
+// routes, reused to gate the SPA shell so the gate and the data plane agree on
+// what "logged in" means.
+func shellSessionValid(c *gin.Context, authn auth.Authenticator) bool {
+	if authn == nil {
+		return false
+	}
+	for _, token := range candidateTokens(c) {
+		if _, err := authn.Authenticate(c.Request.Context(), token); err == nil {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/api/ui_test.go
+++ b/internal/api/ui_test.go
@@ -174,26 +174,46 @@ func TestUINoRouteDegradesGracefully(t *testing.T) {
 	}
 }
 
-func TestUnauthenticatedCanLoadSPAButNotData(t *testing.T) {
+func TestUnauthenticatedShellRedirectsToLogin(t *testing.T) {
 	srv := uiServer()
-	anon := func(path string) int {
+	anon := func(path string) *httptest.ResponseRecorder {
 		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, http.NoBody)
-		rec := httptest.NewRecorder() // no Authorization header
+		rec := httptest.NewRecorder() // no Authorization header, no cookie
 		srv.ServeHTTP(rec, req)
-		return rec.Code
+		return rec
 	}
-	// The static SPA (shell + assets + pre-login config) must load anonymously,
-	// or the browser can never reach the login screen.
-	for _, p := range []string{"/", "/dags/etl/grid", "/static/VERSION", "/ui/config"} {
-		if code := anon(p); code != http.StatusOK {
-			t.Errorf("anonymous GET %s = %d, want 200 (public SPA)", p, code)
+	// The app shell must NOT render for an unauthenticated visitor: rendering it
+	// flashes the whole logged-in UI before bouncing to login (and lights the log
+	// with 401s). Shell routes redirect straight to the login page instead.
+	for _, p := range []string{"/", "/dags/etl/grid"} {
+		rec := anon(p)
+		if rec.Code != http.StatusFound {
+			t.Errorf("anonymous shell GET %s = %d, want 302 to login", p, rec.Code)
+		}
+		if loc := rec.Header().Get("Location"); !strings.HasPrefix(loc, "/api/v2/auth/login") {
+			t.Errorf("anonymous shell GET %s -> %q, want /api/v2/auth/login", p, loc)
 		}
 	}
-	// The data planes stay gated.
+	// Static assets and the pre-login config stay public — the login page and the
+	// SPA bundle it loads after sign-in must be fetchable without a token.
+	for _, p := range []string{"/static/VERSION", "/ui/config"} {
+		if rec := anon(p); rec.Code != http.StatusOK {
+			t.Errorf("anonymous GET %s = %d, want 200 (public)", p, rec.Code)
+		}
+	}
+	// Data planes stay gated with 401 (API calls, not a redirect).
 	for _, p := range []string{"/api/v2/version", "/ui/auth/me"} {
-		if code := anon(p); code != http.StatusUnauthorized {
-			t.Errorf("anonymous GET %s = %d, want 401 (gated data)", p, code)
+		if rec := anon(p); rec.Code != http.StatusUnauthorized {
+			t.Errorf("anonymous GET %s = %d, want 401 (gated data)", p, rec.Code)
 		}
+	}
+	// With a session cookie, the gate lets the shell through.
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/dags/etl/grid", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: authTokenCookie, Value: "valid"})
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "<div id=\"root\"") {
+		t.Errorf("cookie-authenticated shell = %d, want 200 SPA shell", rec.Code)
 	}
 }
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -125,6 +125,33 @@ func TestRateLimiter(t *testing.T) {
 	}
 }
 
+func TestRateLimiterBlockedIsAPeek(t *testing.T) {
+	now := time.Now()
+	r := NewRateLimiter(2, time.Minute)
+	r.now = func() time.Time { return now }
+	// Blocked must NOT consume budget: peeking any number of times keeps the key
+	// usable. This lets the handler reject over-limit callers up front while only
+	// counting actual failures.
+	for i := 0; i < 10; i++ {
+		if r.Blocked("ip") {
+			t.Fatal("peek must not count toward the limit")
+		}
+	}
+	r.Allow("ip")
+	if r.Blocked("ip") {
+		t.Error("one recorded event must not block (limit 2)")
+	}
+	r.Allow("ip")
+	if !r.Blocked("ip") {
+		t.Error("reaching the limit must block")
+	}
+	// The window resets the block.
+	now = now.Add(time.Minute + time.Second)
+	if r.Blocked("ip") {
+		t.Error("a new window must not be blocked")
+	}
+}
+
 func TestMintUserTokenRoundTrips(t *testing.T) {
 	const secret = "dev-insecure-jwt-secret-change-me"
 	token, err := MintUserToken(secret, time.Hour, User{

--- a/internal/auth/ratelimit.go
+++ b/internal/auth/ratelimit.go
@@ -30,6 +30,21 @@ func NewRateLimiter(limit int, window time.Duration) *RateLimiter {
 	}
 }
 
+// Blocked reports whether key has already reached its limit in the current
+// window, WITHOUT recording an attempt (a peek). The login handler uses it to
+// reject an over-limit caller up front while calling Allow only for actual
+// failures — so a successful login never consumes the budget and a user who
+// mistypes a few times is not locked out the moment they finally get it right.
+func (r *RateLimiter) Blocked(key string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	st, ok := r.buckets[key]
+	if !ok || r.now().After(st.resetAt) {
+		return false
+	}
+	return st.count >= r.limit
+}
+
 // Allow records an event for key and reports whether it is within the limit.
 func (r *RateLimiter) Allow(key string) bool {
 	r.mu.Lock()

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -332,6 +332,9 @@ func validateDAGFile(path string) error {
 	if err := spec.ValidateInlineExecution(domain.DefaultInlineMaxDurationSeconds); err != nil {
 		return fmt.Errorf("produced %s is invalid: %w", path, err)
 	}
+	if err := spec.ValidateSchedule(); err != nil {
+		return fmt.Errorf("produced %s is invalid: %w", path, err)
+	}
 	return nil
 }
 

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -51,12 +51,19 @@ const (
 	devRedisURL   = "redis://localhost:6379/0"
 	// taskSDKVersion matches the task image (runtime/Dockerfile); the dev venv
 	// installs it so dag.py's `from airflow.sdk import ...` resolves.
-	taskSDKVersion  = "apache-airflow-task-sdk==1.2.1"
-	devJWTSecret    = "dev-insecure-jwt-secret-change-me"
-	devSecretKey    = "dev-insecure-secret-key-32bytes!"
-	devAdminUser    = "admin@leoflow.local"
-	devPollInterval = 750 * time.Millisecond
-	devReadyTimeout = 30 * time.Second
+	taskSDKVersion = "apache-airflow-task-sdk==1.2.1"
+	devJWTSecret   = "dev-insecure-jwt-secret-change-me"
+	devSecretKey   = "dev-insecure-secret-key-32bytes!"
+	// liteTokenTTLSeconds is the lite session lifetime: 30 days. Lite is a local
+	// single-user tool, so the server's 1-hour default just means surprise
+	// re-logins mid-session.
+	liteTokenTTLSeconds = 30 * 24 * 60 * 60
+	// liteLoginRateLimit is the per-minute failed-login cap for Lite — generous,
+	// because locking out the single local user is pure friction, not security.
+	liteLoginRateLimit = 30
+	devAdminUser       = "admin@leoflow.local"
+	devPollInterval    = 750 * time.Millisecond
+	devReadyTimeout    = 30 * time.Second
 	// Dev uses ports distinct from the demo/production defaults (8080/9090/9091)
 	// so a `leoflow dev` and a demo control plane can run side by side without
 	// colliding. --port overrides the HTTP port; the gRPC and metrics ports derive
@@ -944,6 +951,15 @@ func sharedServerEnv(host string, port int, adminHash, adminEmail string) []stri
 		"LEOFLOW_DATABASE_URL=" + devDatabaseURL,
 		"LEOFLOW_REDIS_URL=" + devRedisURL,
 		"LEOFLOW_AUTH_JWT_SECRET=" + devJWTSecret,
+		// Lite is a local, single-user tool: a 1-hour token (the server default)
+		// expires mid-session and silently bounces the user to a re-login they did
+		// not ask for. Mint 30-day sessions so signing in is a once-a-month event,
+		// not an hourly tax.
+		fmt.Sprintf("LEOFLOW_AUTH_JWT_TOKEN_TTL_SECONDS=%d", liteTokenTTLSeconds),
+		// A local single-user tool should not lock you out for fat-fingering the
+		// password a few times (only failures count, but the production default of
+		// 5/min is still tight here). Be generous.
+		fmt.Sprintf("LEOFLOW_AUTH_LOGIN_RATE_LIMIT_PER_MINUTE=%d", liteLoginRateLimit),
 		"LEOFLOW_SECRET_KEY=" + devSecretKey,
 		"LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS=true",
 	}

--- a/internal/cli/dev_test.go
+++ b/internal/cli/dev_test.go
@@ -365,6 +365,18 @@ func TestSharedServerEnvAuthModes(t *testing.T) {
 			t.Errorf("real-auth env missing %q", must)
 		}
 	}
+	// Lite mints 30-day sessions (not the server's 1h default) so the user is not
+	// silently logged out mid-session.
+	for _, env := range []string{noAdmin, withAdmin} {
+		if !strings.Contains(env, "LEOFLOW_AUTH_JWT_TOKEN_TTL_SECONDS=2592000") {
+			t.Errorf("lite env missing 30-day token TTL; got:\n%s", env)
+		}
+		// A local single-user tool gets a generous login rate limit so fat-fingering
+		// the password does not lock the user out.
+		if !strings.Contains(env, "LEOFLOW_AUTH_LOGIN_RATE_LIMIT_PER_MINUTE=30") {
+			t.Errorf("lite env missing generous login rate limit; got:\n%s", env)
+		}
+	}
 }
 
 func TestLiteEditorEnv(t *testing.T) {

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -143,6 +143,11 @@ type AuthSection struct {
 	// default and the server logs a prominent warning when it is on. NEVER set
 	// this in production (LEOFLOW_AUTH_DEV_NO_AUTH).
 	DevNoAuth bool `mapstructure:"dev_no_auth"`
+	// LoginRateLimitPerMinute caps failed /auth/token attempts per client IP per
+	// minute (anti-brute-force). Only failures count, so a successful login never
+	// consumes budget. Lite raises this well above the production default because
+	// it is a local single-user tool where lockouts are pure friction.
+	LoginRateLimitPerMinute int `mapstructure:"login_rate_limit_per_minute"`
 }
 
 // JWTSection configures JWT issuance and validation.
@@ -186,6 +191,7 @@ var serverDefaults = map[string]any{
 	"auth.provider":                             "jwt",
 	"auth.jwt.secret":                           "",
 	"auth.jwt.token_ttl_seconds":                3600,
+	"auth.login_rate_limit_per_minute":          5,
 	"scheduler.loop_interval_ms":                1000,
 	"scheduler.enabled":                         true,
 	"executor.http.inline_max_duration_seconds": 300,

--- a/internal/domain/schedule.go
+++ b/internal/domain/schedule.go
@@ -1,0 +1,51 @@
+package domain
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/robfig/cron/v3"
+)
+
+// cronlessSchedules are Airflow string schedules that are valid but are NOT cron
+// expressions (they select a non-cron timetable). Leoflow does not cron-schedule
+// them, but they must still register, so they are accepted at compile and skipped
+// — not flagged as malformed — by the scheduler.
+var cronlessSchedules = map[string]bool{"@once": true, "@continuous": true}
+
+// IsCronlessSchedule reports whether expr is empty (manual-only) or a recognized
+// non-cron Airflow schedule. Such a schedule is valid but is never run on a cron,
+// so callers skip cron handling for it without treating it as an error.
+func IsCronlessSchedule(expr string) bool {
+	e := strings.ToLower(strings.TrimSpace(expr))
+	return e == "" || cronlessSchedules[e]
+}
+
+// IsOnceSchedule reports whether expr is Airflow's "@once" — a DAG that runs
+// exactly one time (on first scheduler sight) and never again.
+func IsOnceSchedule(expr string) bool {
+	return strings.EqualFold(strings.TrimSpace(expr), "@once")
+}
+
+// ValidateSchedule checks that a DAG's cron schedule is parseable. An empty or
+// absent schedule (manual-only) and the recognized non-cron Airflow schedules
+// (@once, @continuous) are valid. A malformed cron expression — a 4-field cron,
+// a typo — is rejected here so it fails loudly at compile time; otherwise the
+// scheduler silently can't parse it and the DAG simply never runs, with no error
+// surfaced anywhere (the worst failure mode). The parser is robfig/cron's
+// ParseStandard, the same one the scheduler uses, so what validates here is
+// exactly what the scheduler can run (see scheduler/cron.go).
+func (d *DAGSpec) ValidateSchedule() error {
+	if d.Schedule == nil {
+		return nil
+	}
+	expr := strings.TrimSpace(*d.Schedule)
+	if IsCronlessSchedule(expr) {
+		return nil
+	}
+	if _, err := cron.ParseStandard(expr); err != nil {
+		return fmt.Errorf("invalid schedule %q: %v; Leoflow supports standard 5-field cron "+
+			`(e.g. "*/3 * * * *" for every 3 minutes), the @hourly/@daily/@weekly/@monthly/@yearly presets, and @once`, expr, err)
+	}
+	return nil
+}

--- a/internal/domain/schedule_test.go
+++ b/internal/domain/schedule_test.go
@@ -1,0 +1,45 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateSchedule(t *testing.T) {
+	str := func(s string) *string { return &s }
+	cases := []struct {
+		name     string
+		schedule *string
+		wantErr  bool
+	}{
+		{"nil is manual-only, valid", nil, false},
+		{"empty is manual-only, valid", str(""), false},
+		{"blank is manual-only, valid", str("   "), false},
+		{"valid 5-field cron", str("*/3 * * * *"), false},
+		{"every-minute cron", str("*/1 * * * *"), false},
+		{"@daily preset", str("@daily"), false},
+		{"@hourly preset", str("@hourly"), false},
+		// Valid Airflow non-cron schedules must register (not be blocked at compile)
+		// even though Leoflow does not cron-schedule them.
+		{"@once is a valid Airflow schedule", str("@once"), false},
+		{"@continuous is a valid Airflow schedule", str("@continuous"), false},
+		{"@once is case-insensitive", str("@Once"), false},
+		// The exact bug a user hit: a 4-field cron. It must FAIL loudly at
+		// compile, not be silently ignored by the scheduler.
+		{"4-field cron is rejected", str("*/3 * * *"), true},
+		{"garbage is rejected", str("not a cron"), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := &DAGSpec{DagID: "d", Schedule: tc.schedule}
+			err := spec.ValidateSchedule()
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("ValidateSchedule(%v) err=%v, wantErr=%v", tc.schedule, err, tc.wantErr)
+			}
+			// A rejection must name the offending expression so the user can fix it.
+			if tc.wantErr && tc.schedule != nil && !strings.Contains(err.Error(), strings.TrimSpace(*tc.schedule)) {
+				t.Errorf("error %q should quote the bad schedule %q", err, *tc.schedule)
+			}
+		})
+	}
+}

--- a/internal/executor/subprocess_test.go
+++ b/internal/executor/subprocess_test.go
@@ -48,11 +48,15 @@ func writeScript(t *testing.T, body string) string {
 // agent asynchronously, so its side effects land shortly after Execute returns).
 func waitForFile(t *testing.T, path string) []byte {
 	t.Helper()
-	for i := 0; i < 100; i++ {
+	// Generous deadline: the executor spawns the agent asynchronously, and under
+	// parallel `go test ./...` with coverage instrumentation that side effect can
+	// land well after Execute returns. Poll up to 10s (returns as soon as the file
+	// appears) so the test is not flaky under load — a fixed 2s wait was.
+	for i := 0; i < 200; i++ {
 		if data, err := os.ReadFile(path); err == nil {
 			return data
 		}
-		time.Sleep(20 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 	}
 	t.Fatalf("file %s never appeared", path)
 	return nil

--- a/internal/scheduler/cron.go
+++ b/internal/scheduler/cron.go
@@ -6,6 +6,16 @@ import (
 	"github.com/robfig/cron/v3"
 )
 
+// scheduleParseable reports whether expr is a cron schedule the scheduler can
+// run (the same ParseStandard check nextScheduledRun applies). It lets the
+// caller distinguish "not due yet" from "can never be due because the
+// expression is malformed", so the latter can be surfaced instead of silently
+// ignored.
+func scheduleParseable(expr string) bool {
+	_, err := cron.ParseStandard(expr)
+	return err == nil
+}
+
 // nextScheduledRun returns the logical date of the next due run for a cron
 // expression given the latest run's logical date (nil if the DAG never ran) and
 // the current time. due is false when nothing is due yet or the expression is

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -84,15 +84,20 @@ type Scheduler struct {
 	inline      InlineRunner
 	lastTick    atomic.Int64 // unix-nano of the last loop iteration; 0 = not yet ticked
 	leading     atomic.Bool  // true only while this instance holds leadership and ticks
+	// warnedSchedules dedupes the "unparseable schedule" warning per DAG (keyed by
+	// the offending expression) so a bad cron logs once, not every tick. Accessed
+	// only from the single-threaded tick (createDueRuns), so it needs no lock.
+	warnedSchedules map[string]string
 }
 
 // NewScheduler builds a Scheduler over the given store, ticking every interval.
 func NewScheduler(store Store, logger *slog.Logger, interval time.Duration) *Scheduler {
 	return &Scheduler{
-		store:       store,
-		logger:      logger,
-		interval:    interval,
-		stepTimeout: defaultStepTimeout(interval),
+		store:           store,
+		logger:          logger,
+		interval:        interval,
+		stepTimeout:     defaultStepTimeout(interval),
+		warnedSchedules: map[string]string{},
 	}
 }
 
@@ -235,20 +240,51 @@ func (s *Scheduler) createDueRuns(ctx context.Context) error {
 	}
 	now := time.Now().UTC()
 	for _, d := range dags {
+		if domain.IsOnceSchedule(d.Schedule) {
+			// @once: fire exactly one run on first sight, then never again. Once the
+			// run exists, the DAG's LastLogical is non-nil and this is skipped.
+			if d.LastLogical == nil {
+				s.createScheduledRun(ctx, d.DagID, now)
+			}
+			continue
+		}
+		if domain.IsCronlessSchedule(d.Schedule) {
+			// Manual-only or @continuous: nothing to cron-schedule — skip quietly.
+			continue
+		}
+		// A non-empty but unparseable schedule (a 4-field cron, a typo) would
+		// otherwise be swallowed silently: nextScheduledRun returns "not due" and
+		// the DAG never runs, with nothing logged. Surface it (once per bad
+		// expression) so the operator sees why a scheduled DAG sits idle. Compile
+		// validation (domain.ValidateSchedule) catches this earlier; this is the
+		// backstop for DAGs registered before the fix.
+		if !scheduleParseable(d.Schedule) {
+			if s.warnedSchedules[d.DagID] != d.Schedule {
+				s.logger.Warn("DAG has an unparseable cron schedule; it will not run on a schedule until fixed",
+					"dag", d.DagID, "schedule", d.Schedule)
+				s.warnedSchedules[d.DagID] = d.Schedule
+			}
+			continue
+		}
 		logical, due := nextScheduledRun(d.Schedule, d.LastLogical, now)
 		if !due {
 			continue
 		}
-		if err := s.store.CreateScheduledRun(ctx, d.DagID, logical); err != nil {
-			// Isolate per DAG: one DAG's creation failure must not block run
-			// creation for every other scheduled DAG this tick.
-			s.logger.Error("creating scheduled run", "dag", d.DagID, "error", err)
-			s.record("create_run_error")
-			continue
-		}
-		s.record("create_run")
+		s.createScheduledRun(ctx, d.DagID, logical)
 	}
 	return nil
+}
+
+// createScheduledRun creates one scheduled run for a DAG, isolating per-DAG
+// failures: a single DAG's creation error is logged and metered but never blocks
+// run creation for the other scheduled DAGs in this tick.
+func (s *Scheduler) createScheduledRun(ctx context.Context, dagID string, logical time.Time) {
+	if err := s.store.CreateScheduledRun(ctx, dagID, logical); err != nil {
+		s.logger.Error("creating scheduled run", "dag", dagID, "error", err)
+		s.record("create_run_error")
+		return
+	}
+	s.record("create_run")
 }
 
 func (s *Scheduler) advance(ctx context.Context, run RunState) error {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log/slog"
@@ -181,6 +182,55 @@ func TestStepNoScheduledRunWhenNotDue(t *testing.T) {
 	}
 	if len(store.createdRuns) != 0 {
 		t.Errorf("no run should be created when not due, got %v", store.createdRuns)
+	}
+}
+
+func TestStepOnceScheduleFiresExactlyOnce(t *testing.T) {
+	// @once with no prior run -> create exactly one run.
+	store := newFakeStore()
+	store.scheduled = []ScheduledDAG{{DagID: "once_dag", Schedule: "@once"}}
+	if err := newScheduler(store).Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.createdRuns) != 1 || store.createdRuns[0] != "once_dag" {
+		t.Errorf("@once with no prior run should create exactly one run, got %v", store.createdRuns)
+	}
+
+	// @once that has ALREADY run (LastLogical set) -> create nothing more.
+	ran := time.Now().UTC().Add(-time.Hour)
+	store2 := newFakeStore()
+	store2.scheduled = []ScheduledDAG{{DagID: "once_dag", Schedule: "@once", LastLogical: &ran}}
+	if err := newScheduler(store2).Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store2.createdRuns) != 0 {
+		t.Errorf("@once that already ran must not run again, got %v", store2.createdRuns)
+	}
+}
+
+func TestStepWarnsOnUnparseableScheduleAndCreatesNoRun(t *testing.T) {
+	store := newFakeStore()
+	// A 4-field cron (the real bug): the scheduler must not silently ignore it.
+	store.scheduled = []ScheduledDAG{{DagID: "etl", Schedule: "*/3 * * *"}}
+	var buf bytes.Buffer
+	s := NewScheduler(store, slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})), time.Millisecond)
+
+	if err := s.Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.createdRuns) != 0 {
+		t.Errorf("a bad schedule must create no run, got %v", store.createdRuns)
+	}
+	if !strings.Contains(buf.String(), "unparseable") || !strings.Contains(buf.String(), "*/3 * * *") {
+		t.Errorf("expected a WARN naming the bad schedule, got: %q", buf.String())
+	}
+	// A second tick with the same bad schedule must not re-warn (deduped).
+	buf.Reset()
+	if err := s.Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "unparseable") {
+		t.Errorf("the warning should be deduped per expression, but it logged again: %q", buf.String())
 	}
 }
 

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -34,6 +34,8 @@ type Querier interface {
 	CreateUser(ctx context.Context, arg CreateUserParams) (pgtype.UUID, error)
 	DeleteConnection(ctx context.Context, arg DeleteConnectionParams) (int64, error)
 	DeleteDag(ctx context.Context, arg DeleteDagParams) (int64, error)
+	// Removes one run; its task_instances and XCom rows cascade (ON DELETE CASCADE).
+	DeleteDagRun(ctx context.Context, arg DeleteDagRunParams) (int64, error)
 	DeleteExpiredXComIndex(ctx context.Context) error
 	DeleteImportError(ctx context.Context, arg DeleteImportErrorParams) error
 	DeleteVariable(ctx context.Context, arg DeleteVariableParams) (int64, error)

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -6,6 +6,10 @@ RETURNING *;
 -- name: GetDagRun :one
 SELECT * FROM dag_runs WHERE dag_id = $1 AND run_id = $2;
 
+-- name: DeleteDagRun :execrows
+-- Removes one run; its task_instances and XCom rows cascade (ON DELETE CASCADE).
+DELETE FROM dag_runs WHERE dag_id = $1 AND run_id = $2;
+
 -- name: ListDagRunsByDag :many
 SELECT * FROM dag_runs
 WHERE dag_id = $1

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -269,6 +269,24 @@ func (q *Queries) CreateTaskInstance(ctx context.Context, arg CreateTaskInstance
 	return i, err
 }
 
+const deleteDagRun = `-- name: DeleteDagRun :execrows
+DELETE FROM dag_runs WHERE dag_id = $1 AND run_id = $2
+`
+
+type DeleteDagRunParams struct {
+	DagID pgtype.UUID `json:"dag_id"`
+	RunID string      `json:"run_id"`
+}
+
+// Removes one run; its task_instances and XCom rows cascade (ON DELETE CASCADE).
+func (q *Queries) DeleteDagRun(ctx context.Context, arg DeleteDagRunParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteDagRun, arg.DagID, arg.RunID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const failTaskInstanceIfActive = `-- name: FailTaskInstanceIfActive :exec
 UPDATE task_instances
 SET state = 'failed', ended_at = now(), error_message = $2

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -178,6 +178,24 @@ func (r *Repository) GetDagRun(ctx context.Context, tenant, dagID, runID string)
 	return mapDagRun(run, dagID), nil
 }
 
+// DeleteDagRun removes one run (and, by cascade, its task instances and XCom).
+// It returns domain.ErrNotFound when no run with that id exists for the DAG, so
+// the API can answer 404 rather than a silent 204 for a bad id.
+func (r *Repository) DeleteDagRun(ctx context.Context, tenant, dagID, runID string) error {
+	dag, err := r.resolveDag(ctx, tenant, dagID)
+	if err != nil {
+		return err
+	}
+	n, err := r.q.DeleteDagRun(ctx, queries.DeleteDagRunParams{DagID: dag.ID, RunID: runID})
+	if err != nil {
+		return fmt.Errorf("deleting dag run: %w", err)
+	}
+	if n == 0 {
+		return domain.ErrNotFound
+	}
+	return nil
+}
+
 // CreateDagRun inserts a new run for a DAG at its current version.
 func (r *Repository) CreateDagRun(ctx context.Context, tenant, dagID string, run domain.DagRun) (domain.DagRun, error) {
 	dag, err := r.resolveDag(ctx, tenant, dagID)

--- a/scripts/e2e-lite-login.sh
+++ b/scripts/e2e-lite-login.sh
@@ -106,9 +106,16 @@ grep -q "monaco" "$HOME_DIR/ide.html" && grep -q "/api/v2/ide/tree" "$HOME_DIR/i
   || fail "/ide page missing expected markers"
 pass "/ide editor page served"
 
+# An unauthenticated visitor must NOT be served the app shell — the gate
+# redirects to the login page (no flash of the logged-in UI before bouncing).
+code="$(curl -s -o /dev/null -w '%{http_code}' "${BASE}/")"
+[ "$code" = "302" ] || fail "unauthenticated / returned $code (want 302 to login)"
+pass "unauthenticated shell redirects to login (gate)"
+
 # The IDE entry button is injected into the UI shell, with its inline SVG icon
-# (regression guard for #88 — the icon must not silently vanish).
-curl -s "${BASE}/" > "$HOME_DIR/home.html"
+# (regression guard for #88 — the icon must not silently vanish). The shell is
+# now behind the login gate, so request it WITH the token.
+curl -s "${AUTH[@]}" "${BASE}/" > "$HOME_DIR/home.html"
 grep -q "leoflow-ide-button" "$HOME_DIR/home.html" \
   && grep -q 'href="/ide"' "$HOME_DIR/home.html" \
   && grep -q "<svg" "$HOME_DIR/home.html" \


### PR DESCRIPTION
Fixes found during m900 acceptance testing of Lite. All changes are TDD; every
user-facing fix was validated in a **real headless browser** (Chromium via
Playwright) against a fresh Lite install on a Lima VM — not just at the API.

## Login (the "tá um saco logar" cluster)
- **Rate-limit lockout (root cause of "can't log in"):** `/auth/token` counted *every* attempt against a hardcoded 5/min/IP, so mistyping a stale password a few times returned 429 even with the correct one. Now counts **only failed** logins (a success is free), the limit is **configurable** with a generous Lite default, and the login page shows a distinct "wait a minute" message on 429 instead of "invalid credentials". *Browser-validated: 4 wrong + correct → 200; 10 successes → no lockout.*
- **SPA auth gate:** an unauthenticated visitor was served the full app shell (flash of the logged-in UI + a wall of 401s) before bouncing to login. Now the shell redirects to the login page when there's no valid session. *Browser-validated.*
- **30-day Lite session token** (was the 1h server default → silent mid-session logout). *Validated: `expires_in=2592000`.*
- **Browser credential save** via the Credential Management API (secure context: HTTPS/localhost).

## Scheduler
- **Invalid cron no longer silently swallowed:** a malformed expression (e.g. a 4-field `*/3 * * *`) is rejected at **compile** (loud import error in the IDE/UI) instead of the DAG just never running; the scheduler also warns once as a backstop.
- **`@once` implemented:** fires exactly one run on first sight, then never again. *Lima-validated: 0 → 1 → 1.*

## API
- **`DELETE /api/v2/dags/{dag_id}/dagRuns/{run_id}`** registered (was 404 "route not found" — the UI's delete-run failed).
- **`taskInstances/{map_index}/tries`** routed (the shape the SPA sends after a Clear, captured live). Genuinely unknown actions now return an honest **404**, not the misleading "map_index must be an integer" 400. General routing follow-up: #103. *Browser-validated: clear → `-1/tries` → 200.*

## Logs (regression)
- **Empty task logs fixed:** the agent's gRPC log sink only `CloseSend`'d before the connection was torn down, so a short task's queued lines never reached the server (0-byte log file). It now **drains the stream** before closing, **bounded by a 5s timeout** so log shipping can never hang the task. *Browser-validated: the `print` renders in the UI Logs tab. e2e contract test added.*

## IDE
- **Monaco model leak fixed:** the editor created a model per file-open and never disposed the previous one (models aren't GC'd), so a few tabs exhausted memory and froze the browser. Now disposes the outgoing model. *Browser-validated: getModels() went 1→16 over 15 opens before, 1→1 after.*

## Tests / CI
- TDD throughout; contract tests anchored to the **real** Airflow 3.2 SPA payloads (per #98), e.g. the post-Clear `{map_index}/tries` shape and log delivery on Close.
- Fixed a flaky subprocess-executor test (fixed 2s wait → poll up to 10s) that failed under parallel test + coverage load.

Coverage stays above the floor; `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)