### PR TITLE
fix(lite): root/non-root collisions — reconcile admin, per-user paths, reset without root

### DIFF
--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -730,6 +730,18 @@ func devHome() (string, error) {
 	return d, nil
 }
 
+// liteDevDir is the per-user Lite scratch dir (~/.leoflow/dev) for state that must
+// never be shared between users: the compiled dag.json and task logs. A global
+// /tmp path is owned by whoever ran Lite first and then denies every other user
+// (the root-vs-non-root "permission denied" trap). Best-effort: it falls back to a
+// temp dir only if the home cannot be resolved.
+func liteDevDir() string {
+	if h, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(h, ".leoflow", "dev")
+	}
+	return os.TempDir()
+}
+
 // venvPython returns the Python interpreter inside the dev venv under home,
 // honoring the platform layout (bin on Unix, Scripts on Windows).
 func venvPython(home string) string {
@@ -945,7 +957,11 @@ func sharedServerEnv(host string, port int, adminHash, adminEmail string) []stri
 		// "connection refused to :4317" every export interval. Prometheus metrics
 		// (scraped, not pushed) stay on.
 		"LEOFLOW_OBSERVABILITY_OTEL_ENABLED=false",
-		"LEOFLOW_LOGS_DIR=" + filepath.Join(os.TempDir(), "leoflow-dev-logs"),
+		// Per-user, under ~/.leoflow — NOT a shared /tmp path. A global
+		// /tmp/leoflow-dev-logs is created by whoever runs Lite first and then
+		// rejects every other user with "permission denied" (root vs non-root). The
+		// user's own .leoflow dir never collides.
+		"LEOFLOW_LOGS_DIR=" + filepath.Join(liteDevDir(), "logs"),
 		"LEOFLOW_UI_INSTANCE_NAME=" + devInstanceName,
 		"LEOFLOW_UI_EDITION=lite",
 		"LEOFLOW_DATABASE_URL=" + devDatabaseURL,
@@ -1160,7 +1176,7 @@ func devWatchPaths(dir string, cfg *domain.LeoflowConfig) []string {
 // stamps a fresh dev version so a hot reload never collides with the previous
 // registration (dag_versions is unique per dag_id + version).
 func devCompileAndRegister(ctx context.Context, cmd *cobra.Command, dir string, opts compileOptions, token string, afterCompile func() error, uiURL string) error {
-	opts.output = filepath.Join(os.TempDir(), "leoflow-dev-dag.json")
+	opts.output = filepath.Join(liteDevDir(), "dag.json")
 	opts.dagVersion = fmt.Sprintf("dev-%d", time.Now().UnixNano())
 	//nolint:contextcheck // runCompile derives its context from cmd; ctx here is used for registration.
 	if cerr := runCompile(cmd, dir, opts); cerr != nil {
@@ -1171,7 +1187,7 @@ func devCompileAndRegister(ctx context.Context, cmd *cobra.Command, dir string, 
 			return aerr
 		}
 	}
-	data, err := os.ReadFile(opts.output) //nolint:gosec // path is leoflow-controlled under TempDir
+	data, err := os.ReadFile(opts.output) //nolint:gosec // path is leoflow-controlled under ~/.leoflow
 	if err != nil {
 		return fmt.Errorf("reading compiled dag.json: %w", err)
 	}

--- a/internal/cli/dev_test.go
+++ b/internal/cli/dev_test.go
@@ -376,6 +376,14 @@ func TestSharedServerEnvAuthModes(t *testing.T) {
 		if !strings.Contains(env, "LEOFLOW_AUTH_LOGIN_RATE_LIMIT_PER_MINUTE=30") {
 			t.Errorf("lite env missing generous login rate limit; got:\n%s", env)
 		}
+		// Logs go under the per-user ~/.leoflow, NOT a shared /tmp path that
+		// collides across users (root vs non-root permission-denied trap).
+		if !strings.Contains(env, filepath.Join(".leoflow", "dev", "logs")) {
+			t.Errorf("logs dir must be per-user under ~/.leoflow/dev/logs; got:\n%s", env)
+		}
+		if strings.Contains(env, "leoflow-dev-logs") {
+			t.Errorf("logs dir must not use the shared /tmp path; got:\n%s", env)
+		}
 	}
 }
 

--- a/internal/cli/reset_password.go
+++ b/internal/cli/reset_password.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/user"
@@ -13,17 +12,19 @@ import (
 	"github.com/neochaotic/leoflow/internal/storage"
 )
 
-// newResetPasswordCommand resets the Lite admin password. It is root-gated: a
-// password reset is a privileged local recovery operation.
+// newResetPasswordCommand resets the Lite admin password. Lite is a per-user
+// install (the database and ~/.leoflow config belong to the user who ran it), so
+// this runs as that user — NOT root. Running it under sudo would resolve HOME to
+// /root and miss the user's config; run it as the same user as `leoflow lite`.
 func newResetPasswordCommand() *cobra.Command {
 	var userEmail string
 	cmd := &cobra.Command{
 		Use:   "reset-password",
-		Short: "Reset the Leoflow Lite admin password (requires sudo/root).",
+		Short: "Reset the Leoflow Lite admin password.",
 		Long: "reset-password generates a new admin password, updates it in the Lite " +
-			"database, and shows it once. It must run as root (a privileged local " +
-			"recovery operation): `sudo leoflow lite reset-password`. The Lite Postgres " +
-			"must be reachable (start `leoflow lite` if it is not).",
+			"database, and shows it once. Run it as the same user as `leoflow lite` " +
+			"(no sudo). The Lite Postgres must be reachable (start `leoflow lite` if it " +
+			"is not).",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runResetPassword(cmd, userEmail)
@@ -34,9 +35,6 @@ func newResetPasswordCommand() *cobra.Command {
 }
 
 func runResetPassword(cmd *cobra.Command, userEmail string) error {
-	if os.Geteuid() != 0 {
-		return errors.New("reset-password must run as root — try `sudo leoflow lite reset-password`")
-	}
 	out := cmd.OutOrStdout()
 	home := invokingUserHome()
 	cfg := loadUserConfig(home)

--- a/internal/cli/reset_password_test.go
+++ b/internal/cli/reset_password_test.go
@@ -70,15 +70,16 @@ func TestInvokingUserHome(t *testing.T) {
 	})
 }
 
-func TestResetPasswordRequiresRoot(t *testing.T) {
-	if os.Geteuid() == 0 {
-		t.Skip("running as root; the non-root refusal path cannot be exercised")
-	}
+func TestResetPasswordDoesNotRequireRoot(t *testing.T) {
+	// Lite is a per-user install, so reset-password must run as the normal user —
+	// never demand root (the old `sudo` requirement was a catch-22: without sudo it
+	// refused, and under sudo HOME became /root and it missed the user's config).
+	// With no Postgres in a unit test it fails on the DB connection — but it must
+	// NEVER fail with a "must run as root" refusal.
 	cmd := newResetPasswordCommand()
 	cmd.SetArgs([]string{})
 	cmd.SilenceUsage, cmd.SilenceErrors = true, true
-	err := cmd.Execute()
-	if err == nil || !strings.Contains(err.Error(), "must run as root") {
-		t.Fatalf("err = %v, want a root-required error", err)
+	if err := cmd.Execute(); err != nil && strings.Contains(err.Error(), "must run as root") {
+		t.Fatalf("reset-password must not require root anymore; got: %v", err)
 	}
 }

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -207,7 +207,7 @@ func runSetup(cmd *cobra.Command, workspaceFlag string, dryRun bool) error {
 		lc = gatherLiteConfig(interactive, bufio.NewReader(os.Stdin), out, def)
 	} else {
 		lc = loadManifestSettings(leoflowHome, def)
-		_, _ = fmt.Fprintln(out, "\n  already configured (~/.leoflow/config.yaml) — keeping your settings.\n  change the admin with `sudo leoflow lite reset-password`.") //nolint:errcheck // best-effort terminal output
+		_, _ = fmt.Fprintln(out, "\n  already configured (~/.leoflow/config.yaml) — keeping your settings.\n  change the admin with `leoflow lite reset-password`.") //nolint:errcheck // best-effort terminal output
 	}
 
 	_, _ = fmt.Fprintf(out, "\n  workspace  %s\n  executor   %s\n  port       %d\n  admin      %s\n", lc.Workspace, lc.Executor, lc.Port, lc.AdminEmail) //nolint:errcheck // best-effort terminal output
@@ -318,9 +318,9 @@ func printSetupSummary(out io.Writer, lc liteSettings, generatedPassword string)
 	p := newPalette(colorEnabled(out))
 	if generatedPassword != "" {
 		_, _ = fmt.Fprintf(out, "\n  %s── Leoflow Lite admin (save this — it is shown only once) ──%s\n    user:     %s\n    password: %s%s%s\n", p.bold, p.reset, lc.AdminEmail, p.bold, generatedPassword, p.reset) //nolint:errcheck // best-effort terminal output
-		_, _ = fmt.Fprintln(out, "    (forgot it? `sudo leoflow lite reset-password`)")                                                                                                                               //nolint:errcheck // best-effort terminal output
+		_, _ = fmt.Fprintln(out, "    (forgot it? `leoflow lite reset-password`)")                                                                                                                                    //nolint:errcheck // best-effort terminal output
 	} else {
-		_, _ = fmt.Fprintln(out, "\n  admin already configured (~/.leoflow/config.yaml); reset with `sudo leoflow lite reset-password`.") //nolint:errcheck // best-effort terminal output
+		_, _ = fmt.Fprintln(out, "\n  admin already configured (~/.leoflow/config.yaml); reset with `leoflow lite reset-password`.") //nolint:errcheck // best-effort terminal output
 	}
 	_, _ = fmt.Fprintln(out, "\n  SECURITY: Lite uses a short, human-friendly password and is meant for local/")     //nolint:errcheck // best-effort terminal output
 	_, _ = fmt.Fprintln(out, "  trusted use only. Run it on an internal network or VPN — never expose it publicly.") //nolint:errcheck // best-effort terminal output

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -174,7 +174,11 @@ func TestStepCreatesDueScheduledRun(t *testing.T) {
 }
 
 func TestStepNoScheduledRunWhenNotDue(t *testing.T) {
-	recent := time.Now().UTC().Add(-1 * time.Minute)
+	// last == now, so the next @hourly slot is strictly after now and the DAG is
+	// not due. Using now-1min was clock-dependent: when the test ran within a
+	// minute after the top of the hour, the just-passed hour boundary fell inside
+	// [last, now] and the DAG became "due", flaking CI (it ran at 02:01).
+	recent := time.Now().UTC()
 	store := newFakeStore()
 	store.scheduled = []ScheduledDAG{{DagID: "etl", Schedule: "@hourly", LastLogical: &recent}}
 	if err := newScheduler(store).Step(context.Background()); err != nil {

--- a/internal/storage/bootstrap_integration_test.go
+++ b/internal/storage/bootstrap_integration_test.go
@@ -62,41 +62,49 @@ func TestPasswordRecoveryLoginIntegration(t *testing.T) {
 	}
 }
 
-// TestBootstrapAdminHashIntegration checks the hash-only admin bootstrap used by
-// Leoflow Lite: the stored hash must accept the password (login compatibility),
-// and a second bootstrap must be a no-op once a user exists.
-func TestBootstrapAdminHashIntegration(t *testing.T) {
+// TestBootstrapAdminHashReconcilesIntegration is the reality-anchored guard for
+// the "can't log in against a stale DB" bug: BootstrapAdminHash must RECONCILE an
+// existing admin to the configured hash (config is Lite's source of truth), so
+// the password the setup printed always logs in — even when the database already
+// has an admin from a previous install — without anyone wiping Docker volumes.
+func TestBootstrapAdminHashReconcilesIntegration(t *testing.T) {
 	repo, _, ctx := openRepo(t)
 	const email = "admin@leoflow.local"
-	const pw = "river82"
 
-	hash, err := auth.HashPassword(pw)
+	h1, err := auth.HashPassword("first-pw-1")
 	if err != nil {
-		t.Fatalf("hash: %v", err)
+		t.Fatal(err)
+	}
+	if _, err := repo.BootstrapAdminHash(ctx, "default", email, h1); err != nil {
+		t.Fatalf("first bootstrap: %v", err)
+	}
+	if _, s1, ferr := repo.FindUserByLogin(ctx, "default", email); ferr != nil || !auth.VerifyPassword(s1, "first-pw-1") {
+		t.Fatalf("first bootstrap did not set the hash (err=%v)", ferr)
 	}
 
-	created, err := repo.BootstrapAdminHash(ctx, "default", email, hash)
+	// A second bootstrap with a DIFFERENT hash (the stale-DB case: a new install's
+	// config over an old admin) must RESET the admin to the new hash and report
+	// "not newly created".
+	h2, err := auth.HashPassword("second-pw-2")
 	if err != nil {
-		t.Fatalf("BootstrapAdminHash: %v", err)
+		t.Fatal(err)
 	}
-	if created {
-		// The hash setup persisted must verify the password the user wrote down.
-		_, storedHash, ferr := repo.FindUserByLogin(ctx, "default", email)
-		if ferr != nil {
-			t.Fatalf("loading admin: %v", ferr)
-		}
-		if !auth.VerifyPassword(storedHash, pw) {
-			t.Error("stored hash does not verify the bootstrap password")
-		}
-	}
-
-	// Idempotent: bootstrapping again is a no-op while a user exists.
-	again, err := repo.BootstrapAdminHash(ctx, "default", email, hash)
+	again, err := repo.BootstrapAdminHash(ctx, "default", email, h2)
 	if err != nil {
 		t.Fatalf("second BootstrapAdminHash: %v", err)
 	}
 	if again {
-		t.Error("second BootstrapAdminHash must be a no-op when users exist")
+		t.Error("reconcile must return false (it updated an existing admin, did not create one)")
+	}
+	_, s2, ferr := repo.FindUserByLogin(ctx, "default", email)
+	if ferr != nil {
+		t.Fatalf("load admin: %v", ferr)
+	}
+	if !auth.VerifyPassword(s2, "second-pw-2") {
+		t.Error("bootstrap did not reconcile the admin to the new config hash — stale-DB login would fail")
+	}
+	if auth.VerifyPassword(s2, "first-pw-1") {
+		t.Error("old password still verifies after reconcile")
 	}
 }
 

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -567,21 +567,31 @@ func (r *Repository) SetUserPassword(ctx context.Context, tenant, email, hash st
 	return n > 0, nil
 }
 
-// BootstrapAdminHash is BootstrapAdmin given a precomputed bcrypt hash, so a
-// caller (e.g. Leoflow Lite) can provision the admin without the plaintext
-// password ever reaching the control plane. It is a no-op when users exist.
+// BootstrapAdminHash provisions the Lite admin from a precomputed bcrypt hash
+// (so the plaintext never reaches the control plane). It RECONCILES: if the admin
+// already exists, its password is reset to this hash. The Lite config
+// (admin_password_hash) is the source of truth, so the password the setup printed
+// always logs in — even against a pre-existing or stale database — without anyone
+// having to wipe Docker volumes. The only sanctioned way to change the password,
+// `reset-password`, also writes the config, so the two never drift. Returns true
+// only when the admin was newly created (false when an existing one was
+// reconciled). See cmd/leoflow-server bootstrapAdmin.
 func (r *Repository) BootstrapAdminHash(ctx context.Context, tenant, email, hash string) (bool, error) {
 	tid, err := r.tenantID(ctx, tenant)
 	if err != nil {
 		return false, err
 	}
-	n, err := r.q.CountUsers(ctx, tid)
+	// Reconcile an existing admin to the configured hash.
+	updated, err := r.q.UpdateUserPassword(ctx, queries.UpdateUserPasswordParams{
+		Name: tenant, Email: email, PasswordHash: strPtr(hash),
+	})
 	if err != nil {
-		return false, fmt.Errorf("counting users: %w", err)
+		return false, fmt.Errorf("reconciling admin password: %w", err)
 	}
-	if n > 0 {
+	if updated > 0 {
 		return false, nil
 	}
+	// No such admin yet — create it and grant the admin role.
 	uid, err := r.q.CreateUser(ctx, queries.CreateUserParams{TenantID: tid, Email: email, PasswordHash: strPtr(hash)})
 	if err != nil {
 		return false, fmt.Errorf("creating admin user: %w", err)


### PR DESCRIPTION
Follow-up to #104, from continued m900 acceptance testing: a **non-root install layered over prior `sudo` runs** couldn't log in, its DAGs failed, and `reset-password` was a catch-22. Root cause across all of them: Lite kept state in **shared/ambient locations that collide between users**. This scopes state per-user and makes the config the source of truth. Validated in a real non-root install on a Lima VM (incl. a deliberately root-owned `/tmp` trap + a stale DB).

## Reconcile the admin to the config (login always works)
`BootstrapAdminHash` was create-if-absent, so against a pre-existing database the password the setup printed was never applied → login failed, and users resorted to wiping Docker volumes. It now **reconciles**: on boot the admin's password is set to the configured hash (the Lite config is the source of truth; `reset-password` also writes it, so they never drift).
- *Validated:* stale DB with an old admin + a new config hash → login with the new password returns **200**, no wipe.
- Integration test `TestBootstrapAdminHashReconcilesIntegration` (the stale-DB scenario).

## Per-user paths (no shared /tmp)
The dev `dag.json` and task logs moved from a global `/tmp/leoflow-dev-*` (owned by whoever ran Lite first → `permission denied` for every other user, root vs non-root) to the per-user `~/.leoflow/dev`.
- *Validated:* with a root-owned `/tmp/leoflow-dev-logs` present, a non-root run has **0 permission errors**, the task log lands under `~/.leoflow/dev/logs` and renders, and `/tmp` stays untouched.

## reset-password without root
Lite is a per-user install (the DB and `~/.leoflow` belong to the user), so `reset-password` runs as that user — the `os.Geteuid()!=0` gate was a catch-22 (without `sudo` it refused; under `sudo`, HOME became `/root` and it missed the config). Removed the gate and the `sudo` hints in setup.

## Tests / CI
TDD; the test that codified the old "must run as root" was flipped to assert the new contract, and the bootstrap test now asserts reconcile (not no-op). Coverage above floor; lint clean.

## Deferred (tracked, not blockers now that reconcile + per-user paths fix login & DAGs)
- Per-user Docker volume namespacing (`COMPOSE_PROJECT_NAME=leoflow-$(id -u)`)
- Fresh install resets the datastore but preserves the workspace (user authorized wiping DB+logs on install; migrate/backup later)
- `uv` instead of pip for the dev venv (the ~2-min first-run step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)