### PR TITLE
fix(lite): per-user datastore volume + uninstall resets it (keep workspace)

### DIFF
--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -620,6 +620,7 @@ func devComposeUp(ctx context.Context, cmd *cobra.Command, o devOptions) error {
 	devPrintln(cmd.OutOrStdout(), "▸ starting dependencies (docker compose) …")
 	var captured bytes.Buffer
 	up := exec.CommandContext(ctx, "docker", "compose", "-f", o.composeFile, "up", "-d", "--wait") //nolint:gosec // operator-supplied compose file on the dev CLI
+	up.Env = append(os.Environ(), "COMPOSE_PROJECT_NAME="+liteComposeProject())                    // per-user datastore (no root/non-root volume sharing)
 	up.Stdout = cmd.OutOrStdout()
 	// Tee stderr so the user still sees compose progress while we inspect it to
 	// translate a port-allocation failure into an actionable message.
@@ -740,6 +741,20 @@ func liteDevDir() string {
 		return filepath.Join(h, ".leoflow", "dev")
 	}
 	return os.TempDir()
+}
+
+// liteComposeProject is the docker compose project name for this user's Lite
+// datastore: leoflow-<uid>. Per-user, so root and an unprivileged user get
+// SEPARATE Postgres/Redis volumes instead of silently sharing one — the
+// root-vs-non-root data collision where a stale admin from a prior `sudo` run
+// blocked a fresh login. The host ports (5432/6379) stay shared, so only one
+// instance runs at a time, which is fine for a local single-user tool. Must be
+// set identically on every compose invocation (up and uninstall's down).
+func liteComposeProject() string {
+	if uid := os.Getuid(); uid >= 0 { // -1 on platforms without getuid (Windows); Lite is linux/darwin
+		return "leoflow-" + strconv.Itoa(uid)
+	}
+	return "leoflow"
 }
 
 // venvPython returns the Python interpreter inside the dev venv under home,

--- a/internal/cli/dev_test.go
+++ b/internal/cli/dev_test.go
@@ -387,6 +387,16 @@ func TestSharedServerEnvAuthModes(t *testing.T) {
 	}
 }
 
+func TestLiteComposeProjectIsPerUser(t *testing.T) {
+	p := liteComposeProject()
+	// Per-user (leoflow-<uid>) so root and an unprivileged user never share a
+	// Postgres/Redis volume — the root-vs-non-root data collision where a stale
+	// admin from a prior `sudo` run blocked a fresh login.
+	if !strings.HasPrefix(p, "leoflow-") || p == "leoflow" {
+		t.Errorf("liteComposeProject = %q, want a per-user leoflow-<uid>", p)
+	}
+}
+
 func TestLiteEditorEnv(t *testing.T) {
 	env := strings.Join(liteEditorEnv("/home/u/proj", "/home/u/.leoflow"), "\n")
 	if !strings.Contains(env, "LEOFLOW_UI_WORKSPACE=/home/u/proj") {

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -15,26 +15,27 @@ import (
 	"github.com/neochaotic/leoflow/internal/config"
 )
 
-// newUninstallCommand removes the Leoflow installation (~/.leoflow). It confirms
-// first (unless --yes); --purge additionally removes the DAG workspace and the
-// Docker datastore volumes.
+// newUninstallCommand removes the Leoflow installation (~/.leoflow) and this
+// user's Docker datastore volumes, so a reinstall starts fresh. It preserves the
+// DAG workspace unless --purge. Confirms first unless --yes.
 func newUninstallCommand() *cobra.Command {
 	var yes, purge bool
 	cmd := &cobra.Command{
 		Use:   "uninstall",
-		Short: "Remove the Leoflow installation (~/.leoflow).",
+		Short: "Remove the Leoflow installation (~/.leoflow) and datastore.",
 		Long: "uninstall removes the managed Leoflow home (~/.leoflow): the binaries, config, " +
-			"managed Python, Monaco assets, and local dev state. It does NOT remove your DAG " +
-			"workspace or Docker datastore volumes unless you pass --purge. It asks for confirmation " +
-			"unless --yes is given. (To upgrade instead, just re-run install.sh — it replaces the " +
-			"binaries and keeps your config.)",
+			"managed Python, Monaco assets, and local dev state. It also drops this user's Docker " +
+			"datastore volumes (Postgres/Redis) so a reinstall starts clean. It KEEPS your DAG " +
+			"workspace unless you pass --purge. It asks for confirmation unless --yes is given. " +
+			"(To upgrade instead, just re-run install.sh — it replaces the binaries and keeps your " +
+			"config and datastore.)",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runUninstall(cmd, yes, purge)
 		},
 	}
 	cmd.Flags().BoolVar(&yes, "yes", false, "skip the confirmation prompt")
-	cmd.Flags().BoolVar(&purge, "purge", false, "also remove the DAG workspace and Docker datastore volumes (destructive)")
+	cmd.Flags().BoolVar(&purge, "purge", false, "also remove the DAG workspace (the datastore volumes are removed by default)")
 	return cmd
 }
 
@@ -61,11 +62,9 @@ func runUninstall(cmd *cobra.Command, yes, purge bool) error {
 	if binDir != "" {
 		devPrintf(out, "  the leoflow binaries in %s\n", binDir)
 	}
-	if purge {
-		if workspace != "" {
-			devPrintf(out, "  %s  (your DAG workspace)\n", workspace)
-		}
-		devPrintln(out, "  Docker datastore volumes: leoflow_pgdata, leoflow_redisdata")
+	devPrintln(out, "  the Docker datastore volumes (Postgres/Redis) — a reinstall then starts fresh")
+	if purge && workspace != "" {
+		devPrintf(out, "  %s  (your DAG workspace — only with --purge)\n", workspace)
 	}
 
 	if !yes && !confirmUninstall(cmd) {
@@ -73,11 +72,11 @@ func runUninstall(cmd *cobra.Command, yes, purge bool) error {
 		return nil
 	}
 
-	if purge {
-		// Best-effort: stop datastores and drop their volumes before deleting the
-		// compose file that defines them.
-		composeDownVolumes(cmd, filepath.Join(root, "docker-compose.yaml"))
-	}
+	// Always drop this user's datastore volumes so a reinstall starts clean — the
+	// stale-admin/old-runs trap. The DAG workspace is preserved (only --purge
+	// removes it). Targets the per-user compose project by name, so it works
+	// regardless of which compose file Lite used.
+	composeDownVolumes(cmd)
 	if rerr := os.RemoveAll(root); rerr != nil {
 		return fmt.Errorf("removing %s: %w", root, rerr)
 	}
@@ -141,19 +140,35 @@ func confirmUninstall(cmd *cobra.Command) bool {
 	return answer == "yes" || answer == "y"
 }
 
-// composeDownVolumes best-effort stops the datastores and removes their volumes
-// via the managed compose file, if both Docker and the file are present.
-func composeDownVolumes(cmd *cobra.Command, composeFile string) {
-	if _, err := os.Stat(composeFile); err != nil {
-		return
-	}
+// composeDownVolumes best-effort tears down this user's Lite datastore — the
+// per-user compose project's containers and named volumes — so a reinstall starts
+// fresh. It targets the project by NAME (-p leoflow-<uid>), independent of which
+// compose file `leoflow lite` used (a checkout's docker-compose.dev.yaml, the
+// managed ~/.leoflow one, or --compose), and then removes the project's volumes
+// directly (a file-less `down` does not know the volume definitions to drop). All
+// best-effort: an already-gone datastore is fine.
+func composeDownVolumes(cmd *cobra.Command) {
 	if _, err := exec.LookPath("docker"); err != nil {
 		return
 	}
-	c := exec.CommandContext(cmdContext(cmd), "docker", "compose", "-f", composeFile, "down", "-v") //nolint:gosec // fixed args, managed compose path
-	c.Stdout, c.Stderr = cmd.OutOrStdout(), cmd.ErrOrStderr()
-	if err := c.Run(); err != nil {
-		// Best-effort: a missing/already-down stack is fine; the files are removed next.
-		devPrintf(cmd.OutOrStdout(), "  ! docker compose down (datastores may already be gone): %v\n", err)
+	ctx := cmdContext(cmd)
+	project := liteComposeProject()
+	down := exec.CommandContext(ctx, "docker", "compose", "-p", project, "down", "--remove-orphans") //nolint:gosec // fixed args + derived project name
+	down.Stdout, down.Stderr = io.Discard, io.Discard
+	_ = down.Run() //nolint:errcheck // best-effort: containers may already be gone; volume rm below is the real cleanup
+	// Remove the project's named volumes (prefix "<project>_"; the trailing "_"
+	// avoids matching a different uid like leoflow-5011_*).
+	out, err := exec.CommandContext(ctx, "docker", "volume", "ls", "-q", "--filter", "name="+project+"_").Output() //nolint:gosec // derived project name
+	if err != nil {
+		return
+	}
+	removed := 0
+	for _, v := range strings.Fields(string(out)) {
+		if exec.CommandContext(ctx, "docker", "volume", "rm", v).Run() == nil { //nolint:gosec // volume name from docker's own listing
+			removed++
+		}
+	}
+	if removed > 0 {
+		devPrintf(cmd.OutOrStdout(), "  ✓ removed %d Lite datastore volume(s)\n", removed)
 	}
 }

--- a/internal/cli/uninstall_test.go
+++ b/internal/cli/uninstall_test.go
@@ -90,6 +90,19 @@ func TestUninstallRemovesHomeWithYes(t *testing.T) {
 	}
 }
 
+func TestUninstallRemovesDatastoreByDefault(t *testing.T) {
+	seedHome(t)
+	cmd, out := uninstallCmd("no\n") // decline, just to capture the announced plan
+	if err := runUninstall(cmd, false, false); err != nil {
+		t.Fatalf("uninstall (no --purge): %v", err)
+	}
+	// Default uninstall drops this user's datastore volumes so a reinstall starts
+	// fresh (the stale-admin / old-runs trap); the workspace is kept unless --purge.
+	if !strings.Contains(out.String(), "datastore") {
+		t.Errorf("default uninstall must announce removing the datastore volumes; got:\n%s", out.String())
+	}
+}
+
 func TestUninstallAbortsWithoutConfirmation(t *testing.T) {
 	home := seedHome(t)
 	cmd, out := uninstallCmd("no\n") // user declines


### PR DESCRIPTION
Completes the root/non-root isolation started in #105 (reconcile-admin handled the *login* symptom; this isolates the *data* and makes a reinstall clean). Validated on a Lima VM as a non-root user.

## #88 — per-user Docker volume
The compose project is now `COMPOSE_PROJECT_NAME=leoflow-$(id -u)`, so root and an unprivileged user get **separate** Postgres/Redis volumes instead of silently sharing one (the data half of the root-vs-non-root collision). Set identically on `up` (lite) and on uninstall's teardown.
- *Validated:* a non-root run creates `leoflow-<uid>_leoflow_pgdata` / `_redisdata`.

## #90 — uninstall resets the datastore, keeps the workspace
`leoflow uninstall` now drops **this user's datastore volumes by default** (so a reinstall starts fresh instead of inheriting a stale admin / old runs), while **keeping the DAG workspace** — only `--purge` removes that. The teardown targets the project **by name** and removes its volumes directly, so it works regardless of which compose file Lite used (a checkout's `docker-compose.dev.yaml`, the managed `~/.leoflow` one, or `--compose`). *(My first cut keyed off a fixed `~/.leoflow/docker-compose.yaml` path and silently left volumes behind when Lite had used a different file — caught and fixed in validation.)*
- *Validated:* uninstall removes the `leoflow-<uid>` volumes and the workspace `dag.py` survives.

Host ports stay shared (5432/6379), so one Lite instance runs at a time — fine for a local single-user tool. Coverage above floor; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)