### PR TITLE
fix(lite): managed Postgres via Unix socket, never TCP 5432 (#108)

### DIFF
--- a/internal/cli/db.go
+++ b/internal/cli/db.go
@@ -66,7 +66,7 @@ func newDBResetCommand() *cobra.Command {
 // dropDevDatabase drops the isolated dev database, terminating any open
 // connections (Postgres 13+ WITH FORCE), via the maintenance database.
 func dropDevDatabase(ctx context.Context, cmd *cobra.Command) error {
-	conn, err := pgx.Connect(ctx, devMaintenanceURL)
+	conn, err := pgx.Connect(ctx, devDSNs().maintenance)
 	if err != nil {
 		return fmt.Errorf("connecting to Postgres (is it up?): %w", err)
 	}

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -701,7 +701,7 @@ func devMigrate(cmd *cobra.Command) error {
 	if err != nil {
 		return fmt.Errorf("loading embedded migrations: %w", err)
 	}
-	m, err := migrate.NewWithSourceInstance("iofs", src, devMigrateURL)
+	m, err := migrate.NewWithSourceInstance("iofs", src, devDSNs().migrate)
 	if err != nil {
 		return fmt.Errorf("initializing migrator: %w", err)
 	}
@@ -715,7 +715,7 @@ func devMigrate(cmd *cobra.Command) error {
 // ensureDevDatabase creates the isolated leoflow_dev database if it does not yet
 // exist, so the dev experience never shares the product's "leoflow" database.
 func ensureDevDatabase(ctx context.Context, cmd *cobra.Command) error {
-	conn, err := pgx.Connect(ctx, devMaintenanceURL)
+	conn, err := pgx.Connect(ctx, devDSNs().maintenance)
 	if err != nil {
 		return fmt.Errorf("connecting to Postgres (is it up?): %w", err)
 	}
@@ -983,7 +983,7 @@ func sharedServerEnv(host string, port int, adminHash, adminEmail string) []stri
 		"LEOFLOW_LOGS_DIR=" + filepath.Join(liteDevDir(), "logs"),
 		"LEOFLOW_UI_INSTANCE_NAME=" + devInstanceName,
 		"LEOFLOW_UI_EDITION=lite",
-		"LEOFLOW_DATABASE_URL=" + devDatabaseURL,
+		"LEOFLOW_DATABASE_URL=" + devDSNs().database,
 		"LEOFLOW_REDIS_URL=" + devRedisURL,
 		"LEOFLOW_AUTH_JWT_SECRET=" + devJWTSecret,
 		// Lite is a local, single-user tool: a 1-hour token (the server default)

--- a/internal/cli/dsn.go
+++ b/internal/cli/dsn.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// dsnSet holds the three Postgres DSNs Lite needs: the dedicated dev database,
+// the maintenance database used only to CREATE it, and the golang-migrate
+// (pgx5) variant of the dev database.
+type dsnSet struct {
+	database    string
+	maintenance string
+	migrate     string
+}
+
+// buildDSNs returns the Lite DSNs for the active datastore. With an empty
+// socketDir it returns the Docker datastore's TCP localhost:5432 connections
+// (the default). With a managed socketDir it returns Unix-socket DSNs
+// (host=<socketDir>, trust auth, no TCP) — so the managed cluster is reached
+// only through its own per-user socket and a foreign Postgres bound to 5432 can
+// never be connected to or mistaken for ours.
+func buildDSNs(socketDir string) dsnSet {
+	if socketDir == "" {
+		return dsnSet{database: devDatabaseURL, maintenance: devMaintenanceURL, migrate: devMigrateURL}
+	}
+	q := "?host=" + socketDir + "&sslmode=disable"
+	return dsnSet{
+		database:    "postgres://leoflow@/" + devDBName + q,
+		maintenance: "postgres://leoflow@/postgres" + q,
+		migrate:     "pgx5://leoflow@/" + devDBName + q,
+	}
+}
+
+// devDSNs resolves the Lite DSNs for the current run. It auto-detects a live
+// managed cluster by its socket file under ~/.leoflow/pgdata, so every entry
+// point (the lite runner, reset-password, db reset) connects consistently
+// without threading the --postgres choice through each of them.
+func devDSNs() dsnSet {
+	return buildDSNs(managedSocketDir())
+}
+
+// managedSocketDir returns the managed Postgres data dir when its Unix socket is
+// live there (cluster up), or "" otherwise (Docker datastore, or not started).
+func managedSocketDir() string {
+	_, dataDir, err := managedPGPaths()
+	if err != nil {
+		return ""
+	}
+	if _, statErr := os.Stat(filepath.Join(dataDir, ".s.PGSQL.5432")); statErr == nil {
+		return dataDir
+	}
+	return ""
+}

--- a/internal/cli/dsn_test.go
+++ b/internal/cli/dsn_test.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildDSNsDockerDefault: with no managed socket dir, the Lite DSNs are the
+// Docker datastore's TCP localhost:5432 connections (the default path, unchanged).
+func TestBuildDSNsDockerDefault(t *testing.T) {
+	d := buildDSNs("")
+	if d.database != devDatabaseURL || d.maintenance != devMaintenanceURL || d.migrate != devMigrateURL {
+		t.Fatalf("empty socket dir must yield the TCP DSN consts, got %+v", d)
+	}
+}
+
+// TestBuildDSNsManagedSocket: with a managed socket dir, every DSN connects over
+// that Unix socket (host=<dir>) and never over TCP localhost:5432 — so a foreign
+// Postgres bound to 5432 can never be reached or mistaken for ours.
+func TestBuildDSNsManagedSocket(t *testing.T) {
+	dir := "/home/u/.leoflow/pgdata"
+	d := buildDSNs(dir)
+	for label, dsn := range map[string]string{"database": d.database, "maintenance": d.maintenance, "migrate": d.migrate} {
+		if !strings.Contains(dsn, "host="+dir) {
+			t.Errorf("%s DSN %q must select the unix socket via host=%s", label, dsn, dir)
+		}
+		if strings.Contains(dsn, "localhost:5432") || strings.Contains(dsn, "@localhost") {
+			t.Errorf("%s DSN %q must not use TCP localhost", label, dsn)
+		}
+	}
+	if !strings.HasPrefix(d.migrate, "pgx5://") {
+		t.Errorf("migrate DSN must keep the pgx5 scheme, got %q", d.migrate)
+	}
+	if !strings.Contains(d.database, "/leoflow_dev") || !strings.Contains(d.maintenance, "/postgres") {
+		t.Errorf("DSNs target the wrong databases: %+v", d)
+	}
+}

--- a/internal/cli/managed_postgres.go
+++ b/internal/cli/managed_postgres.go
@@ -33,11 +33,12 @@ func managedPGPaths() (binDir, dataDir string, err error) {
 }
 
 // startManagedPostgres downloads the relocatable PostgreSQL if needed, initdb's a
-// per-user data dir on first run, and starts it listening on localhost:5432 — the
-// same address the Docker datastore used, so dev-DB creation, migrations, and the
-// server connect unchanged. Idempotent: an already-running cluster is left as is.
-// trust auth is safe here: it binds loopback only on a local single-user machine,
-// the same threat model as the Docker datastore's well-known password.
+// per-user data dir on first run, and starts it on a Unix socket in that data dir
+// (TCP disabled) — so dev-DB creation, migrations, and the server reach it only
+// through the per-user socket and never collide with, or connect to, a foreign
+// Postgres bound to localhost:5432. Idempotent: an already-running cluster is
+// left as is. trust auth is safe here: the socket lives in the user's own
+// ~/.leoflow, the same single-user threat model as the Docker datastore.
 func startManagedPostgres(ctx context.Context, cmd *cobra.Command) error {
 	out := cmd.OutOrStdout()
 	h, herr := os.UserHomeDir()
@@ -55,8 +56,10 @@ func startManagedPostgres(ctx context.Context, cmd *cobra.Command) error {
 	}
 	dataDir := filepath.Join(root, "pgdata")
 
-	// Already accepting connections? leave it (idempotent across lite runs).
-	if exec.CommandContext(ctx, filepath.Join(binDir, "pg_isready"), "-h", "127.0.0.1", "-p", "5432").Run() == nil { //nolint:gosec // managed binary + fixed args
+	// Our cluster already accepting connections on its socket? leave it (idempotent
+	// across lite runs). Probing the socket dir — not 127.0.0.1 — means a foreign
+	// Postgres on 5432 is never mistaken for ours.
+	if exec.CommandContext(ctx, filepath.Join(binDir, "pg_isready"), "-h", dataDir, "-p", "5432").Run() == nil { //nolint:gosec // managed binary + fixed args
 		devPrintln(out, "▸ managed Postgres already running")
 		return nil
 	}
@@ -74,9 +77,12 @@ func startManagedPostgres(ctx context.Context, cmd *cobra.Command) error {
 	if mkErr := os.MkdirAll(filepath.Dir(logFile), 0o750); mkErr != nil {
 		return fmt.Errorf("creating postgres log dir: %w", mkErr)
 	}
+	// listen_addresses= (empty) disables TCP; -k keeps the Unix socket in dataDir
+	// (named .s.PGSQL.5432 from -p). No shell here, so an empty -c value is the
+	// reliable way to turn TCP off — "-h ''" would pass literal quote characters.
 	start := exec.CommandContext(ctx, filepath.Join(binDir, "pg_ctl"), //nolint:gosec // managed binary + fixed args
 		"-D", dataDir, "-l", logFile, "-w", "-t", "30",
-		"-o", "-p 5432 -h 127.0.0.1 -k "+dataDir, "start")
+		"-o", "-p 5432 -k "+dataDir+" -c listen_addresses=", "start")
 	start.Stdout, start.Stderr = io.Discard, cmd.ErrOrStderr()
 	if rerr := start.Run(); rerr != nil {
 		return fmt.Errorf("starting managed Postgres (see %s): %w", logFile, rerr)

--- a/internal/cli/reset_password.go
+++ b/internal/cli/reset_password.go
@@ -46,7 +46,7 @@ func runResetPassword(cmd *cobra.Command, userEmail string) error {
 	}
 
 	ctx := cmdContext(cmd)
-	pg, err := storage.NewPostgres(ctx, config.DatabaseSection{URL: devDatabaseURL})
+	pg, err := storage.NewPostgres(ctx, config.DatabaseSection{URL: devDSNs().database})
 	if err != nil {
 		return fmt.Errorf("connecting to the Lite database (is Postgres up? start `leoflow lite`): %w", err)
 	}


### PR DESCRIPTION
## Problem

`leoflow lite --postgres managed` (Fase 2) probed and connected on `localhost:5432`. A foreign Postgres already on 5432 (e.g. a Docker-based Leoflow, a system PG) was treated as ours — the idempotency probe skipped starting our cluster and the run **migrated/created `leoflow_dev` in the foreign database**. Confirmed on a host (`.142`) running a real Docker Leoflow: managed mode would have touched the live DB.

This was the pre-requisite flagged in the #107 review before managed can become the default.

## Fix

The managed cluster now listens **only on a Unix socket** in its per-user data dir (`listen_addresses=`, TCP off). Connections go through that socket (`host=<dataDir>`):

- `buildDSNs` returns socket DSNs for every Lite entry point — server, migrate, dev-DB creation, `reset-password`, `db reset` — auto-detected by the live socket file (no need to thread the `--postgres` choice through each).
- The idempotency probe targets the socket dir, not `127.0.0.1`, so a foreign PG on 5432 is never mistaken for ours.
- Collision is impossible by construction; the foreign DB is unreachable.

The **Docker datastore is unchanged** (TCP `localhost:5432`).

## Validation (Lima, arm64)

| Scenario | Result |
|---|---|
| Foreign Postgres squatting on 5432 (sentinel row) + `--postgres managed` | managed uses its own socket, migrates into its own db, **foreign DB untouched** (sentinel=42, no `leoflow_dev`), login 200 |
| `--postgres docker` (default) | 1 Docker PG, migrate OK, login 200 over TCP — no regression |

Unit test pins socket-vs-TCP DSN selection. `go test`, `golangci-lint` (0 issues), coverage 79.0% all green locally.

Closes #108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)