### PR TITLE
feat(lite): default --postgres to managed (Docker-free by default)

### DIFF
--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -363,7 +363,7 @@ func newLiteCommand() *cobra.Command {
 	cmd.Flags().StringVar(&o.serverBin, "server-bin", "", "leoflow-server binary (default: PATH, then ./bin)")
 	cmd.Flags().StringVar(&o.agentBin, "agent-bin", "", "leoflow-agent binary (default: PATH, then ./bin)")
 	cmd.Flags().BoolVar(&o.noUp, "no-up", false, "skip docker compose (Postgres already running); the dev DB + venv are still provisioned")
-	cmd.Flags().StringVar(&o.postgres, "postgres", datastoreDocker, "Postgres backend: 'docker' (default) or 'managed' (relocatable PG under ~/.leoflow, no Docker — experimental, Fase 2)")
+	cmd.Flags().StringVar(&o.postgres, "postgres", datastoreManaged, "Postgres backend: 'managed' (default; relocatable PG under ~/.leoflow on a Unix socket, no Docker) or 'docker'")
 	cmd.AddCommand(newLiteProvisionCommand())
 	cmd.AddCommand(newResetPasswordCommand())
 	return cmd

--- a/internal/cli/lite_postgres_default_test.go
+++ b/internal/cli/lite_postgres_default_test.go
@@ -1,0 +1,17 @@
+package cli
+
+import "testing"
+
+// TestLitePostgresDefaultIsManaged pins the promoted default: `leoflow lite` uses
+// the managed relocatable Postgres (Docker-free datastore) unless --postgres
+// docker is passed. Promotion is safe now that managed PG is socket-only (no 5432
+// collision) and Lite is Redis-free (ADR 0026).
+func TestLitePostgresDefaultIsManaged(t *testing.T) {
+	f := newLiteCommand().Flags().Lookup("postgres")
+	if f == nil {
+		t.Fatal("--postgres flag not defined")
+	}
+	if f.DefValue != datastoreManaged {
+		t.Errorf("--postgres default = %q, want %q", f.DefValue, datastoreManaged)
+	}
+}


### PR DESCRIPTION
Promotes managed relocatable Postgres to the default datastore for `leoflow lite` (pre-reqs in: socket-only #108/#111, Redis-free #112). `--postgres docker` stays. Validated on Lima: no flag → managed on a Unix socket, 0 Docker containers, login 200; unit test pins the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)