### PR TITLE
fix(lite): .17 robustness — datastore auto-select, per-install isolation, free-port, uninstall symmetry

### DIFF
--- a/cmd/leoflow-agent/main.go
+++ b/cmd/leoflow-agent/main.go
@@ -52,6 +52,13 @@ func run() int {
 		hostname = "unknown"
 	}
 
+	returnPath, cleanupReturn, rverr := agent.NewReturnValuePath()
+	if rverr != nil {
+		slog.Error("preparing return-value path", "error", rverr)
+		return 1
+	}
+	defer func() { _ = cleanupReturn() }() //nolint:errcheck // best-effort cleanup of the per-task temp dir on exit
+
 	runner := &agent.Runner{
 		Client:            client,
 		Cmd:               agent.NewExecRunner(),
@@ -59,7 +66,7 @@ func run() int {
 		Hostname:          hostname,
 		Version:           version,
 		Env:               os.Environ(),
-		ReturnPath:        agent.ReturnValuePath,
+		ReturnPath:        returnPath,
 		HeartbeatInterval: 15 * time.Second,
 	}
 	if rerr := runner.Run(ctx); rerr != nil {

--- a/cmd/leoflow-server/disk_test.go
+++ b/cmd/leoflow-server/disk_test.go
@@ -1,0 +1,17 @@
+package main
+
+import "testing"
+
+// TestLowDisk pins the datastore low-disk threshold check used by the janitor.
+func TestLowDisk(t *testing.T) {
+	const threshold = 1 << 30 // 1 GiB
+	if !lowDisk(500<<20, threshold) {
+		t.Error("500 MiB free must be flagged low")
+	}
+	if lowDisk(2<<30, threshold) {
+		t.Error("2 GiB free must not be flagged low")
+	}
+	if lowDisk(threshold, threshold) {
+		t.Error("exactly the threshold is not below it")
+	}
+}

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -114,7 +114,7 @@ func run() error {
 	}
 	defer grpcSrv.GracefulStop()
 
-	startCleanup(ctx, storage.NewXComIndex(pg), logSink, tel.Logger)
+	startCleanup(ctx, storage.NewXComIndex(pg), logSink, cfg.Logs.Dir, tel.Logger)
 
 	var schedulerHealth api.Heartbeater
 	podDispatch := false
@@ -394,10 +394,15 @@ const cleanupInterval = time.Hour
 // logRetention is how long task logs are kept before garbage collection.
 const logRetention = 30 * 24 * time.Hour
 
-// startCleanup runs a periodic janitor that purges expired XCom index rows and
-// prunes old log files. The operations are idempotent, so it is safe on every
-// replica.
-func startCleanup(ctx context.Context, idx *storage.XComIndex, sink *logs.DiskSink, logger *slog.Logger) {
+// lowDiskWarnBytes is the free-space threshold below which the janitor warns: the
+// embedded datastore (managed Postgres + logs) lives on this filesystem, and a
+// full disk makes Postgres fail writes with a cryptic error.
+const lowDiskWarnBytes = 1 << 30 // 1 GiB
+
+// startCleanup runs a periodic janitor that purges expired XCom index rows,
+// prunes old log files, and warns on low disk for the datastore dir. The
+// operations are idempotent, so it is safe on every replica.
+func startCleanup(ctx context.Context, idx *storage.XComIndex, sink *logs.DiskSink, dataDir string, logger *slog.Logger) {
 	go func() {
 		t := time.NewTicker(cleanupInterval)
 		defer t.Stop()
@@ -413,10 +418,26 @@ func startCleanup(ctx context.Context, idx *storage.XComIndex, sink *logs.DiskSi
 					if err := sink.Prune(time.Now(), logRetention); err != nil {
 						logger.Error("pruning old logs", "error", err)
 					}
+					if free, derr := dirFreeBytes(dataDir); derr == nil && lowDisk(free, lowDiskWarnBytes) {
+						logger.Warn("low disk space for the datastore", "dir", dataDir,
+							"free_mb", free/(1<<20), "threshold_mb", uint64(lowDiskWarnBytes)/(1<<20))
+					}
 				})
 			}
 		}
 	}()
+}
+
+// lowDisk reports whether free is below the threshold (both in bytes).
+func lowDisk(free, threshold uint64) bool { return free < threshold }
+
+// dirFreeBytes returns the bytes available on the filesystem holding dir.
+func dirFreeBytes(dir string) (uint64, error) {
+	var st syscall.Statfs_t
+	if err := syscall.Statfs(dir, &st); err != nil {
+		return 0, fmt.Errorf("statfs %s: %w", dir, err)
+	}
+	return st.Bavail * uint64(st.Bsize), nil
 }
 
 // safeCycle runs one iteration of a periodic background loop, recovering any

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -437,7 +437,7 @@ func dirFreeBytes(dir string) (uint64, error) {
 	if err := syscall.Statfs(dir, &st); err != nil {
 		return 0, fmt.Errorf("statfs %s: %w", dir, err)
 	}
-	return st.Bavail * uint64(st.Bsize), nil
+	return st.Bavail * uint64(st.Bsize), nil //nolint:gosec // G115: a filesystem block size is never negative
 }
 
 // safeCycle runs one iteration of a periodic background loop, recovering any

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: leoflow
       POSTGRES_DB: leoflow
     ports:
-      - "5432:5432"
+      - "${LEOFLOW_DB_PORT:-5432}:5432"
     volumes:
       - leoflow_pgdata:/var/lib/postgresql/data
     healthcheck:

--- a/docs/adr/0029-lite-datastore-default-docker.md
+++ b/docs/adr/0029-lite-datastore-default-docker.md
@@ -1,10 +1,17 @@
 # ADR 0029: Lite Datastore Default — Docker Postgres (Managed PG is the Opt-In)
 
-**Status:** Accepted
+**Status:** Superseded by [ADR 0030](0030-lite-datastore-auto-select.md)
 **Date:** 2026-05-27
 **Deciders:** Project founder
 **Refines:** ADR 0027 (Product Editions), ADR 0026 (Lite Datastore — XCom on Postgres)
 **Relates:** ADR 0015 (Kubernetes as the sole container execution path)
+
+> **Superseded (2026-05-27):** this ADR made Docker the default and the managed PG
+> an explicit opt-in flag. ADR 0030 keeps both backends but makes the choice
+> **automatic** (`--postgres auto`): Docker Postgres when Docker is present, the
+> managed relocatable PG when it is absent — so the Docker-free path is the default
+> behavior on a Docker-free host, not a hidden flag. See
+> [ADR 0030](0030-lite-datastore-auto-select.md).
 
 ## Context
 

--- a/docs/adr/0029-lite-datastore-default-docker.md
+++ b/docs/adr/0029-lite-datastore-default-docker.md
@@ -1,0 +1,62 @@
+# ADR 0029: Lite Datastore Default — Docker Postgres (Managed PG is the Opt-In)
+
+**Status:** Accepted
+**Date:** 2026-05-27
+**Deciders:** Project founder
+**Refines:** ADR 0027 (Product Editions), ADR 0026 (Lite Datastore — XCom on Postgres)
+**Relates:** ADR 0015 (Kubernetes as the sole container execution path)
+
+## Context
+
+Fase 2 / prealpha.16 promoted the **managed relocatable Postgres** (a theseus-rs
+build under `~/.leoflow`, on a Unix socket) to Lite's **default** datastore, for a
+"Docker-free out of the box" story (ADR 0027 described Lite's datastore as
+"embedded managed Postgres, no Docker").
+
+Testing the default on real and minimal hosts exposed a portability problem: the
+relocatable build **dynamically links a chain of system libraries it does not
+bundle** — ICU, Kerberos/GSSAPI, zstd, lz4, libxml2, … . On full distros (Ubuntu,
+Fedora, …) these are present, so it works; on **minimal hosts (Alpine/musl, slim
+containers)** they are absent and the server dies on a loader error. Installing a
+couple of packages is not enough (the chain is ~a dozen libs, version-matched);
+the proper fix (bundle the chain or a lean PG build) is non-trivial (#97).
+
+Two facts make Docker the better default:
+
+1. Lite's **default executor is k3d**, which already **requires Docker**. So a
+   typical `leoflow lite` user already has Docker — and where Docker exists, the
+   Docker Postgres (`postgres:16`) "just works" (its lib chain is baked into the
+   image by apk at build time).
+2. The "Docker-free out of the box" promise was only **partial** anyway, because
+   the default executor needed Docker regardless.
+
+## Decision
+
+**Lite's default datastore is Docker Postgres** (`postgres:16` via `docker
+compose`). The **managed relocatable Postgres is the opt-in** (`--postgres
+managed`) for a Docker-free datastore — recommended on full distros; on minimal
+hosts a pre-flight fails loud and points back to `--postgres docker`.
+
+This **does not reintroduce a Docker executor** and does not contradict ADR 0015:
+the control plane still imports **no Docker SDK** and runs tasks only via the
+Kubernetes (k3d) or subprocess executors. Docker here runs **only a Postgres
+container via the `docker` CLI** — the datastore, not task execution.
+
+ADR 0026 is unaffected: Lite remains **Redis-free** with **XCom stored in
+Postgres**, whichever Postgres (Docker or managed) it connects to.
+
+## Consequences
+
+- **Robust default:** the default `leoflow lite` works wherever Docker runs (the
+  common case, aligned with the k3d executor default) — no relocatable-PG lib
+  fragility on the default path.
+- **Managed PG stays, hardened:** `--postgres managed` is the Docker-free opt-in,
+  with the .17 fixes (locale-independent initdb, socket-only via postgresql.conf,
+  socket-path guard, and a `postgres --version` pre-flight that fails loud with a
+  clear `--postgres docker` fallback).
+- **Self-contained managed runtime (#97) is no longer a default-path blocker** —
+  it becomes a quality improvement for the opt-in path.
+- **Editions framing updated:** ADR 0027's "Lite datastore: embedded managed, no
+  Docker" is refined here to "Docker Postgres by default; managed (relocatable,
+  no-Docker) as opt-in." The no-Docker datastore remains achievable, just not the
+  default.

--- a/docs/adr/0030-lite-datastore-auto-select.md
+++ b/docs/adr/0030-lite-datastore-auto-select.md
@@ -1,0 +1,78 @@
+# ADR 0030: Lite Datastore Auto-Selects — Docker Postgres, or a Managed PG When Docker Is Absent
+
+**Status:** Accepted
+**Date:** 2026-05-27
+**Deciders:** Project founder
+**Supersedes:** ADR 0029 (Lite Datastore Default — Docker)
+**Refines:** ADR 0026 (Lite Datastore — XCom on Postgres, no Redis), ADR 0027 (Product Editions)
+**Relates:** ADR 0015 (Kubernetes as the sole container execution path)
+
+## Context
+
+prealpha.16 made the **managed relocatable Postgres** Lite's default; real-host
+testing exposed its portability cost (it dynamically links an unbundled chain of
+system libraries — ICU, Kerberos, zstd, lz4, libxml2 — that is absent on minimal
+hosts like Alpine/musl). ADR 0029 reacted by making **Docker Postgres the default**
+and demoting the managed PG to an explicit opt-in (`--postgres managed`).
+
+Two problems remained with the opt-in framing:
+
+1. **The Docker-free path was undiscoverable.** A user on a Docker-free host who
+   runs `leoflow lite` got a Docker error, with no hint that a flag would make it
+   work without Docker.
+2. **It was asymmetric with the executor.** The executor already resolves `auto`
+   (k3d when Docker is present, else subprocess). The datastore did not — yet the
+   two track the *same* host capability (Docker present or not).
+
+A managed runtime is also already Lite's established pattern: `leoflow setup`
+downloads a pinned, checksum-verified **managed CPython** so the user installs no
+Python. Provisioning a managed Postgres when Docker is absent is the same pattern —
+"Leoflow brings its own runtimes; you install nothing."
+
+## Decision
+
+**Lite's `--postgres` flag defaults to `auto`**, resolved for the host:
+
+- **Docker present** → the Docker `postgres:16` (via `docker compose`). This is the
+  realistic case, since Lite's default executor (k3d) already needs Docker.
+- **Docker absent** → a **managed relocatable Postgres** downloaded under
+  `~/.leoflow`, on a per-user Unix socket (no Docker). So `leoflow lite` runs on a
+  Docker-free host with **nothing to install** — paired with the `subprocess`
+  executor that the `auto` executor already selects when Docker is absent.
+
+`auto` mirrors `resolveExecutor`, so the datastore and executor resolve from one
+host probe. Either backend can be forced (`--postgres docker|managed`). On a minimal
+host (Alpine/musl, slim container) the managed build's pre-flight (`postgres
+--version`) **fails loud** with a clear message pointing at installing Docker — the
+fragility is contained to the fallback and never silent.
+
+Connection wiring is unchanged: `devDSNs` already auto-detects a live managed
+cluster by its socket file (`~/.leoflow/pgdata/.s.PGSQL.5432`) and otherwise returns
+the Docker TCP DSNs, so every entry point (the lite runner, reset-password, db
+reset) connects consistently without threading the choice through each.
+
+Lite stays **Redis-free** (ADR 0026), grounded on durability (Postgres XCom
+survives a restart) and a single datastore; Redis remains a Production-scale
+concern. This introduces **no Docker executor** and does not contradict ADR 0015:
+the control plane imports no Docker SDK and runs tasks only via Kubernetes (k3d) or
+subprocess. The k3d path **requires Docker to host the cluster**, but Docker is only
+k3d's substrate, never an executor.
+
+## Consequences
+
+- **Docker-free out of the box, where possible:** `curl … | sh && leoflow lite`
+  runs on a clean Docker-free Ubuntu/macOS host (managed PG + subprocess), with no
+  flag and nothing else installed.
+- **Real pods need Docker:** a Docker-free host gets the `subprocess` executor only
+  (no isolation, dev-only); the k3d pod-per-task path requires Docker. This is made
+  explicit in the docs and in the run-time message printed by `autoDatastore` /
+  `autoExecutor`.
+- **Fragility is contained:** the managed build can still fail on minimal hosts, but
+  only on the fallback path and with a loud, actionable error. Hardening the managed
+  runtime to run anywhere (bundling its lib chain) stays a quality follow-up (#97),
+  not a default-path blocker.
+- **Symmetry:** datastore and executor both resolve `auto` from one Docker probe, so
+  the two never disagree about the host.
+- **Editions framing updated:** ADR 0027's "embedded managed, no Docker" and ADR
+  0029's "Docker default, managed opt-in" are replaced here by "Postgres,
+  auto-selected: Docker when present, managed (Docker-free) otherwise."

--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -32,4 +32,5 @@ The *why* behind Leoflow's design. ADRs are immutable once accepted.
 - [ADR 0027: Product Editions — Executors and Delivery](adr/0027-product-editions-executors-delivery.md)
 - [ADR 0028: Release & Versioning for the Two Editions (One Tag, Two Co-Versioned Artifacts)](adr/0028-release-versioning-two-editions.md)
 - [ADR 0029: Lite Datastore Default — Docker Postgres (Managed PG is the Opt-In)](adr/0029-lite-datastore-default-docker.md)
+- [ADR 0030: Lite Datastore Auto-Selects — Docker Postgres, or a Managed PG When Docker Is Absent](adr/0030-lite-datastore-auto-select.md)
 <!-- END ADR INDEX -->

--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -31,4 +31,5 @@ The *why* behind Leoflow's design. ADRs are immutable once accepted.
 - [ADR 0026: Lite Datastore — XCom on Postgres, No Redis](adr/0026-lite-datastore-no-redis.md)
 - [ADR 0027: Product Editions — Executors and Delivery](adr/0027-product-editions-executors-delivery.md)
 - [ADR 0028: Release & Versioning for the Two Editions (One Tag, Two Co-Versioned Artifacts)](adr/0028-release-versioning-two-editions.md)
+- [ADR 0029: Lite Datastore Default — Docker Postgres (Managed PG is the Opt-In)](adr/0029-lite-datastore-default-docker.md)
 <!-- END ADR INDEX -->

--- a/docs/editions.md
+++ b/docs/editions.md
@@ -15,10 +15,10 @@ DAG once and it runs on either.
 | Install | one command (`curl … \| sh`) on one machine | Helm chart on your cluster |
 | Command | `leoflow lite` | the deployed control plane |
 | Auth | a single local **admin** login (password shown once at setup) | enterprise: SSO/OIDC, full RBAC, multi-tenant |
-| Executors | a local **k3d** mini-cluster (real pods) or **subprocess** (dev-only, unsandboxed) | **Kubernetes only**, at scale |
+| Executors | a local **k3d** mini-cluster (real pods, **requires Docker** to host the cluster) or **subprocess** (dev-only, unsandboxed, no Docker) | **Kubernetes only**, at scale |
 | Deploy | edit + hot-reload | GitOps: `leoflow compile` in CI → immutable image + `dag.json` |
 | Intended use | local, small, or **light production** projects on a **trusted/internal network** | teams and production workloads at scale |
-| Datastores | Postgres via Docker (default) or **embedded** managed (`--postgres managed`, Docker-free); **no Redis** | **external** managed Postgres + Redis |
+| Datastores | **Postgres, auto-selected**: the Docker `postgres:16` when Docker is present, else an **embedded managed** Postgres (downloaded under `~/.leoflow`, no Docker); **no Redis** | **external** managed Postgres + Redis |
 
 ## Leoflow Lite
 
@@ -39,21 +39,29 @@ Lite also includes a small built-in **[web editor](lite-web-editor.md)** (Monaco
 with Python/YAML highlighting) so you can edit DAG projects from the browser — a
 Lite-only convenience; Production teams use their own editor and the GitOps flow.
 
-### No Docker, no Redis
+### Datastore (auto-selected), no Redis
 
-Lite runs its whole control plane on an **embedded managed Postgres** (a pinned,
-checksum-verified relocatable build under `~/.leoflow`, on a local Unix socket).
-It needs **no Redis** — scheduler locks use Postgres advisory locks and XCom is
-stored in Postgres — and **no Docker** for the datastore. The Postgres-backed
-XCom is *durable* (it survives a restart), which suits light production; very
-high XCom throughput is where you would move to the Production edition. (See
-[ADR 0026](adr/0026-lite-datastore-no-redis.md).)
+Lite's datastore is **Postgres, chosen automatically for the host**: when Docker is
+present it uses the `postgres:16` container; when it is not, it falls back to an
+**embedded managed Postgres** (a pinned, checksum-verified relocatable build
+downloaded under `~/.leoflow`, on a local Unix socket) — so `leoflow lite` runs on
+a **Docker-free host with nothing to install**, the same way `leoflow setup` already
+provisions a managed Python. (Force either with `--postgres docker|managed`; on a
+minimal host such as Alpine/musl the managed build may lack system libraries and
+fails loud, pointing at Docker.)
 
-For task isolation, Lite's container path is a local **k3d** mini-cluster, not
-the Docker socket: a Docker-socket executor is **equivalent to host root** (a DAG
-could escape to the machine), so it was rejected on security grounds. `subprocess`
-exists only as an explicitly unsandboxed, dev-only escape hatch. (See
-[ADR 0027](adr/0027-product-editions-executors-delivery.md).)
+Either way Lite needs **no Redis** — scheduler locks use Postgres advisory locks and
+XCom is stored in Postgres. The Postgres-backed XCom is *durable* (it survives a
+restart), which suits light production, and a single datastore is simpler to
+operate; Redis is a Production-scale concern (multi-node locking, high XCom
+throughput). (See [ADR 0026](adr/0026-lite-datastore-no-redis.md).)
+
+For task execution, the **k3d** path runs real pods and therefore **requires Docker
+to host the cluster** — but Docker is only the *substrate* of k3d, never an executor:
+Lite talks to the Kubernetes API, and a Docker-socket executor was rejected because
+it is **equivalent to host root** (a DAG could escape to the machine). `subprocess`
+runs tasks directly on the host (no Docker, no isolation) as an explicitly dev-only
+escape hatch. (See [ADR 0027](adr/0027-product-editions-executors-delivery.md).)
 
 Pre-alpha Lite builds also **expire** (~90 days) and refuse to run past it — a
 reminder that Lite is for iterating locally, not for durable deployments.

--- a/docs/editions.md
+++ b/docs/editions.md
@@ -18,7 +18,7 @@ DAG once and it runs on either.
 | Executors | a local **k3d** mini-cluster (real pods) or **subprocess** (dev-only, unsandboxed) | **Kubernetes only**, at scale |
 | Deploy | edit + hot-reload | GitOps: `leoflow compile` in CI → immutable image + `dag.json` |
 | Intended use | local, small, or **light production** projects on a **trusted/internal network** | teams and production workloads at scale |
-| Datastores | **embedded** managed Postgres; **no Redis, no Docker** | **external** managed Postgres + Redis |
+| Datastores | Postgres via Docker (default) or **embedded** managed (`--postgres managed`, Docker-free); **no Redis** | **external** managed Postgres + Redis |
 
 ## Leoflow Lite
 

--- a/internal/agent/command.go
+++ b/internal/agent/command.go
@@ -7,14 +7,26 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 )
 
-// ReturnValuePath is where the Python helper writes a task's return value.
-const ReturnValuePath = "/tmp/leoflow_return_value.json"
-
 const maxRetryAttempts = 5
+
+// NewReturnValuePath returns a unique, agent-owned path for this task's return
+// value, plus a cleanup. The agent runs one task per process, so a per-process
+// temp dir keeps concurrent tasks and other users from ever sharing a single
+// /tmp/leoflow_return_value.json (which collided — permission denied across uids,
+// clobbered across parallel tasks). The runtime is pointed here via the
+// LEOFLOW_RETURN_VALUE_PATH env the runner injects.
+func NewReturnValuePath() (path string, cleanup func() error, err error) {
+	dir, derr := os.MkdirTemp("", "leoflow-rv-")
+	if derr != nil {
+		return "", nil, fmt.Errorf("creating return-value dir: %w", derr)
+	}
+	return filepath.Join(dir, "return_value.json"), func() error { return os.RemoveAll(dir) }, nil
+}
 
 // BuildCommand returns the argv to execute the user's task for the given
 // operator. http_api tasks are executed by the control plane, not the agent.

--- a/internal/agent/returnvalue_test.go
+++ b/internal/agent/returnvalue_test.go
@@ -1,0 +1,71 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+)
+
+// TestNewReturnValuePathUnique: each task gets its own return-value path under a
+// fresh temp dir (no shared /tmp/leoflow_return_value.json), and cleanup removes it.
+func TestNewReturnValuePathUnique(t *testing.T) {
+	p1, c1, err := NewReturnValuePath()
+	if err != nil {
+		t.Fatalf("NewReturnValuePath: %v", err)
+	}
+	defer func() { _ = c1() }()
+	p2, c2, err := NewReturnValuePath()
+	if err != nil {
+		t.Fatalf("NewReturnValuePath: %v", err)
+	}
+	if p1 == p2 {
+		t.Errorf("two tasks must get distinct paths, both %q", p1)
+	}
+	if strings.HasPrefix(p1, "/tmp/leoflow_return_value.json") {
+		t.Errorf("must not use the shared global path, got %q", p1)
+	}
+	if err := c2(); err != nil {
+		t.Errorf("cleanup: %v", err)
+	}
+	if _, serr := os.Stat(p2); !os.IsNotExist(serr) {
+		t.Errorf("cleanup must remove the return-value dir, stat err = %v", serr)
+	}
+}
+
+// TestBuildEnvInjectsReturnValuePath: the runner tells the runtime where to write
+// the return value (the agent's per-task path), and injects nothing when there is
+// no return path.
+func TestBuildEnvInjectsReturnValuePath(t *testing.T) {
+	r := newRunner(&fakeClient{}, &fakeCmd{}, &recordingSink{})
+	r.ReturnPath = "/run/task-42/return_value.json"
+	env, err := r.buildEnv(context.Background(), &agentv1.TaskSpec{})
+	if err != nil {
+		t.Fatalf("buildEnv: %v", err)
+	}
+	if !contains(env, "LEOFLOW_RETURN_VALUE_PATH=/run/task-42/return_value.json") {
+		t.Errorf("buildEnv must inject the per-task return path, got %v", env)
+	}
+
+	r.ReturnPath = ""
+	env2, err := r.buildEnv(context.Background(), &agentv1.TaskSpec{})
+	if err != nil {
+		t.Fatalf("buildEnv: %v", err)
+	}
+	for _, kv := range env2 {
+		if strings.HasPrefix(kv, "LEOFLOW_RETURN_VALUE_PATH=") {
+			t.Errorf("must not inject a return path when none is set, got %q", kv)
+		}
+	}
+}
+
+func contains(env []string, want string) bool {
+	for _, kv := range env {
+		if kv == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -109,6 +109,12 @@ func (r *Runner) buildEnv(ctx context.Context, spec *agentv1.TaskSpec) ([]string
 		xcom = append(xcom, XComEnvVar(param, resp.GetValue()))
 	}
 	env := mergeEnv(r.Env, spec.GetEnvironment(), xcom)
+	if r.ReturnPath != "" {
+		// Tell the runtime to write the return value to the agent's per-task path,
+		// not the shared global default — so concurrent tasks and other users never
+		// collide on /tmp/leoflow_return_value.json.
+		env = append(env, "LEOFLOW_RETURN_VALUE_PATH="+r.ReturnPath)
+	}
 	return append(env, r.secretsEnv(ctx)...), nil
 }
 

--- a/internal/cli/datastore.go
+++ b/internal/cli/datastore.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// defaultDevDBPort is the host port Lite's Docker Postgres prefers; if it is busy
+// (a foreign Postgres, another install) Lite picks the next free one.
+const defaultDevDBPort = 5432
+
+// leoflowHome returns the per-user Leoflow home (~/.leoflow) — the install
+// identity that scopes the datastore to this user.
+func leoflowHome() (string, error) {
+	h, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home dir: %w", err)
+	}
+	return filepath.Join(h, ".leoflow"), nil
+}
+
+// projectName derives a stable, per-install docker compose project name from the
+// Leoflow home path: leoflow-<12 hex>. It is DERIVED (a pure function of the
+// path), never stored — so it is recomputed identically on every run and after a
+// reinstall at the same HOME, which is what lets `leoflow lite` reconnect to the
+// same Docker volume (the datastore's identity) instead of orphaning it. Two
+// users (different HOME) get different names, so their datastores never share or
+// clobber, and `uninstall` targets exactly this install's container and volume.
+func projectName(leoflowRoot string) string {
+	sum := sha256.Sum256([]byte(leoflowRoot))
+	return "leoflow-" + hex.EncodeToString(sum[:])[:12]
+}
+
+// devProjectName is projectName for the current user's Leoflow home.
+func devProjectName() string {
+	root, err := leoflowHome()
+	if err != nil {
+		return "leoflow"
+	}
+	return projectName(root)
+}
+
+// composeEnv returns the environment for `docker compose` (up and down) so it runs
+// under this install's per-user project name — isolating its container and volume
+// from other users/installs, and letting uninstall target exactly this install's
+// datastore — and publishes Postgres on the resolved host port (the compose
+// interpolates LEOFLOW_DB_PORT).
+func composeEnv() []string {
+	return append(os.Environ(),
+		"COMPOSE_PROJECT_NAME="+devProjectName(),
+		fmt.Sprintf("LEOFLOW_DB_PORT=%d", devDBPort(liteDevDir())),
+	)
+}
+
+// portFree reports whether the loopback TCP port can be bound right now.
+func portFree(port int) bool {
+	var lc net.ListenConfig
+	ln, err := lc.Listen(context.Background(), "tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+	if err != nil {
+		return false
+	}
+	_ = ln.Close() //nolint:errcheck // probe only; the port is free if it bound
+	return true
+}
+
+// firstFreePort returns the first bindable loopback port at or above start,
+// scanning a bounded window so a pathological host fails fast rather than hanging.
+func firstFreePort(start int) int {
+	for p := start; p < start+100; p++ {
+		if portFree(p) {
+			return p
+		}
+	}
+	return start
+}
+
+// resolveDevDBPort returns the host port for this install's Docker Postgres,
+// persisting it under devDir so every entry point (the lite runner,
+// reset-password, db reset — separate processes) agrees on it. A persisted port
+// is reused unconditionally (our own container holds it; it is not "free"); only
+// on first run is a free port picked via pick. The port is just the host mapping
+// — the datastore's identity is the project/volume (see projectName) — so a
+// reinstall that re-picks a port still reconnects to the same volume.
+func resolveDevDBPort(devDir string, pick func() int) (int, error) {
+	pf := filepath.Join(devDir, "db-port")
+	if p, ok := readPort(pf); ok {
+		return p, nil
+	}
+	p := pick()
+	if err := os.MkdirAll(devDir, 0o750); err != nil {
+		return 0, fmt.Errorf("creating dev state dir %s: %w", devDir, err)
+	}
+	if err := os.WriteFile(pf, []byte(strconv.Itoa(p)), 0o600); err != nil {
+		return 0, fmt.Errorf("persisting db port to %s: %w", pf, err)
+	}
+	return p, nil
+}
+
+// devDBPort reads the persisted host port for this install's Docker Postgres,
+// defaulting to defaultDevDBPort when none is recorded (a source checkout or an
+// explicit --compose, where the port is whatever the compose file maps).
+func devDBPort(devDir string) int {
+	if p, ok := readPort(filepath.Join(devDir, "db-port")); ok {
+		return p
+	}
+	return defaultDevDBPort
+}
+
+// readPort reads a positive integer port from a file, if present and valid.
+func readPort(path string) (int, bool) {
+	b, err := os.ReadFile(path) //nolint:gosec // path derived from the per-user Leoflow home
+	if err != nil {
+		return 0, false
+	}
+	p, err := strconv.Atoi(strings.TrimSpace(string(b)))
+	if err != nil || p <= 0 {
+		return 0, false
+	}
+	return p, true
+}

--- a/internal/cli/datastore_test.go
+++ b/internal/cli/datastore_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestProjectNameStableAndDistinct: the project name is a pure function of the
+// install path — identical on every call (so a reinstall at the same HOME
+// reconnects to the same volume) and distinct per path (so two users never share
+// or clobber a datastore).
+func TestProjectNameStableAndDistinct(t *testing.T) {
+	a1 := projectName("/home/alice/.leoflow")
+	a2 := projectName("/home/alice/.leoflow")
+	b := projectName("/home/bob/.leoflow")
+	if a1 != a2 {
+		t.Errorf("project name must be deterministic: %q != %q", a1, a2)
+	}
+	if a1 == b {
+		t.Errorf("different install paths must yield different project names, both %q", a1)
+	}
+	if !strings.HasPrefix(a1, "leoflow-") || len(a1) != len("leoflow-")+12 {
+		t.Errorf("project name %q must be leoflow-<12 hex>", a1)
+	}
+	validProjectChar := func(r rune) bool {
+		return r == '-' || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+	}
+	for _, r := range a1 {
+		if !validProjectChar(r) {
+			t.Errorf("project name %q must be a valid docker compose project (lowercase/digits/-)", a1)
+		}
+	}
+}
+
+// TestResolveDevDBPortPersistsAndReuses: the first call picks a port and persists
+// it; later calls reuse the persisted port even if pick would choose another (the
+// running container holds it) — so separate processes agree.
+func TestResolveDevDBPortPersistsAndReuses(t *testing.T) {
+	dir := t.TempDir()
+	got, err := resolveDevDBPort(dir, func() int { return 5455 })
+	if err != nil || got != 5455 {
+		t.Fatalf("first resolve = (%d, %v), want (5455, nil)", got, err)
+	}
+	if b, _ := os.ReadFile(filepath.Join(dir, "db-port")); strings.TrimSpace(string(b)) != "5455" {
+		t.Errorf("port not persisted, db-port = %q", string(b))
+	}
+	again, err := resolveDevDBPort(dir, func() int { return 9999 })
+	if err != nil || again != 5455 {
+		t.Errorf("second resolve must reuse persisted port, got (%d, %v), want 5455", again, err)
+	}
+}
+
+// TestDevDBPortDefault: with no persisted port (source checkout / explicit
+// --compose), the DSNs fall back to the standard 5432.
+func TestDevDBPortDefault(t *testing.T) {
+	if p := devDBPort(t.TempDir()); p != defaultDevDBPort {
+		t.Errorf("devDBPort with no db-port = %d, want %d", p, defaultDevDBPort)
+	}
+}
+
+// TestFirstFreePortSkipsBusy: a bound port is skipped and the next free one is
+// returned.
+func TestFirstFreePortSkipsBusy(t *testing.T) {
+	var lc net.ListenConfig
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Skipf("cannot listen on loopback: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	busy := ln.Addr().(*net.TCPAddr).Port
+	got := firstFreePort(busy)
+	if got <= busy {
+		t.Errorf("firstFreePort(%d) = %d, must skip the bound port", busy, got)
+	}
+	if !portFree(got) {
+		t.Errorf("firstFreePort returned a port that is not free: %d", got)
+	}
+}

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -296,12 +296,20 @@ func bringUpDependencies(ctx context.Context, cmd *cobra.Command, o *devOptions)
 		//nolint:contextcheck // stop runs at shutdown with a fresh context; the run's ctx is already canceled
 		return func() { stopManagedPostgres(cmd) }, nil
 	}
-	// Docker datastore: only Postgres (Lite needs no Redis).
+	// Docker datastore: only Postgres (Lite needs no Redis). Pick a host port that
+	// is free (so a foreign Postgres on 5432 — system or another project — never
+	// conflicts; Lite stays isolated rather than adopting it). The port is
+	// persisted so reset-password / db reset agree with the running server.
+	port, perr := resolveDevDBPort(liteDevDir(), func() int { return firstFreePort(defaultDevDBPort) })
+	if perr != nil {
+		return noop, perr
+	}
 	cf, err := resolveComposeFile(o.composeFile)
 	if err != nil {
 		return noop, err
 	}
 	o.composeFile = cf
+	devPrintf(cmd.OutOrStdout(), "▸ Postgres (Docker) on localhost:%d  [project %s]\n", port, devProjectName())
 	return noop, devComposeUp(ctx, cmd, *o, "postgres")
 }
 
@@ -639,12 +647,15 @@ func devClusterSetup(ctx context.Context, cmd *cobra.Command, dir string, o devO
 
 // devComposeUp starts the named local datastore services via docker compose. Lite
 // brings up only Postgres (it is Redis-free — ADR 0026); the dev's own database
-// lives inside it, isolated by name.
+// lives inside it, isolated by name. The compose runs under a per-install project
+// name (so two users/installs never share or clobber a container/volume) and on
+// the resolved host port (LEOFLOW_DB_PORT, which the compose interpolates).
 func devComposeUp(ctx context.Context, cmd *cobra.Command, o devOptions, services ...string) error {
 	devPrintln(cmd.OutOrStdout(), "▸ starting dependencies (docker compose) …")
 	var captured bytes.Buffer
 	args := append([]string{"compose", "-f", o.composeFile, "up", "-d", "--wait"}, services...)
 	up := exec.CommandContext(ctx, "docker", args...) //nolint:gosec // operator-supplied compose file on the dev CLI
+	up.Env = composeEnv()
 	up.Stdout = cmd.OutOrStdout()
 	// Tee stderr so the user still sees compose progress while we inspect it to
 	// translate a port-allocation failure into an actionable message.

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -363,7 +363,7 @@ func newLiteCommand() *cobra.Command {
 	cmd.Flags().StringVar(&o.serverBin, "server-bin", "", "leoflow-server binary (default: PATH, then ./bin)")
 	cmd.Flags().StringVar(&o.agentBin, "agent-bin", "", "leoflow-agent binary (default: PATH, then ./bin)")
 	cmd.Flags().BoolVar(&o.noUp, "no-up", false, "skip docker compose (Postgres already running); the dev DB + venv are still provisioned")
-	cmd.Flags().StringVar(&o.postgres, "postgres", datastoreManaged, "Postgres backend: 'managed' (default; relocatable PG under ~/.leoflow on a Unix socket, no Docker) or 'docker'")
+	cmd.Flags().StringVar(&o.postgres, "postgres", datastoreDocker, "Postgres backend: 'docker' (default; postgres:16 via docker compose) or 'managed' (relocatable PG under ~/.leoflow on a Unix socket, no Docker — best on full distros; minimal hosts may lack its system libs)")
 	cmd.AddCommand(newLiteProvisionCommand())
 	cmd.AddCommand(newResetPasswordCommand())
 	return cmd

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -117,7 +117,7 @@ type devOptions struct {
 	serverBin   string
 	agentBin    string
 	noUp        bool
-	postgres    string // "docker" (default) or "managed" (relocatable PG, no Docker)
+	postgres    string // "auto" (default), "docker", or "managed" (relocatable PG, no Docker)
 	// Resolved from ~/.leoflow/config.yaml (written by `leoflow setup`), not flags.
 	adminHash  string
 	adminEmail string
@@ -275,19 +275,17 @@ func friendlyResolves() bool {
 	return err == nil && len(addrs) > 0
 }
 
-// bringUpDependencies starts Lite's datastores and returns a cleanup func the
-// caller defers (a no-op for the Docker path, which leaves its containers up
-// across runs; a managed-Postgres stop for the managed path, which this run owns).
+// bringUpDependencies starts Lite's datastore and returns a cleanup func the
+// caller defers. It resolves the "auto" --postgres for the host first (Docker
+// Postgres when Docker is present, else a managed relocatable PG), then: the
+// Docker path is a no-op cleanup (its container is left up across runs); the
+// managed path returns a stop, since this run owns the cluster.
 func bringUpDependencies(ctx context.Context, cmd *cobra.Command, o *devOptions) (func(), error) {
 	noop := func() {}
 	if o.noUp {
 		return noop, nil
 	}
-	cf, err := resolveComposeFile(o.composeFile)
-	if err != nil {
-		return noop, err
-	}
-	o.composeFile = cf
+	o.postgres = autoDatastore(cmd, o.postgres)
 	if o.postgres == datastoreManaged {
 		// Managed relocatable Postgres, no Docker at all: Lite is Redis-free (XCom
 		// on Postgres, in-process log tailer — ADR 0026), so nothing comes up via
@@ -299,6 +297,11 @@ func bringUpDependencies(ctx context.Context, cmd *cobra.Command, o *devOptions)
 		return func() { stopManagedPostgres(cmd) }, nil
 	}
 	// Docker datastore: only Postgres (Lite needs no Redis).
+	cf, err := resolveComposeFile(o.composeFile)
+	if err != nil {
+		return noop, err
+	}
+	o.composeFile = cf
 	return noop, devComposeUp(ctx, cmd, *o, "postgres")
 }
 
@@ -363,7 +366,7 @@ func newLiteCommand() *cobra.Command {
 	cmd.Flags().StringVar(&o.serverBin, "server-bin", "", "leoflow-server binary (default: PATH, then ./bin)")
 	cmd.Flags().StringVar(&o.agentBin, "agent-bin", "", "leoflow-agent binary (default: PATH, then ./bin)")
 	cmd.Flags().BoolVar(&o.noUp, "no-up", false, "skip docker compose (Postgres already running); the dev DB + venv are still provisioned")
-	cmd.Flags().StringVar(&o.postgres, "postgres", datastoreDocker, "Postgres backend: 'docker' (default; postgres:16 via docker compose) or 'managed' (relocatable PG under ~/.leoflow on a Unix socket, no Docker — best on full distros; minimal hosts may lack its system libs)")
+	cmd.Flags().StringVar(&o.postgres, "postgres", datastoreAuto, "Postgres backend: 'auto' (default; the Docker postgres:16 when Docker is present, else a managed relocatable PG under ~/.leoflow on a Unix socket, no Docker), 'docker', or 'managed' (best on full distros; minimal hosts may lack its system libs)")
 	cmd.AddCommand(newLiteProvisionCommand())
 	cmd.AddCommand(newResetPasswordCommand())
 	return cmd

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -354,7 +354,7 @@ func newLiteCommand() *cobra.Command {
 			return runDev(cmd, dir, o)
 		},
 	}
-	cmd.Flags().StringVar(&o.executor, "executor", "k8s", "execution mode: 'k8s' (dedicated k3d cluster, real pods) or 'subprocess' (host, fast, unsandboxed)")
+	cmd.Flags().StringVar(&o.executor, "executor", "auto", "execution mode: 'auto' (default; k3d if Docker is present, else subprocess), 'k8s' (dedicated k3d cluster, real pods), or 'subprocess' (host, fast, unsandboxed)")
 	cmd.Flags().IntVar(&o.port, "port", devDefaultPort, "HTTP/UI port (dev default 8088, distinct from the demo's 8080)")
 	cmd.Flags().StringVar(&o.host, "host", "127.0.0.1", "address to bind the UI/API to; use 0.0.0.0 to reach it from your internal network/VPN (insecure — see the warning)")
 	cmd.Flags().StringVar(&o.image, "image", "leoflow-dev:local", "placeholder image recorded in dag.json (subprocess mode only)")
@@ -528,9 +528,13 @@ func runDev(cmd *cobra.Command, dir string, o devOptions) error {
 		return berr
 	}
 
+	// "auto" (the default) uses k3d when Docker is present, else the unsandboxed
+	// subprocess executor so `leoflow lite` still runs without Docker.
+	o.executor = autoExecutor(cmd, o.executor)
+
 	// Mode-specific setup: the env the control plane runs with and the per-reload
-	// build/register strategy. Cluster-mode (default) runs real pods on a
-	// dedicated k3d cluster; subprocess runs unsandboxed on the host (fast loop).
+	// build/register strategy. k8s runs real pods on a dedicated k3d cluster;
+	// subprocess runs unsandboxed on the host (fast loop).
 	var serverEnv []string
 	var makeReload func(token string) func() error
 	if o.executor == "subprocess" {

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -661,7 +661,10 @@ func composeUpError(err error, output string) error {
 	if strings.Contains(low, "already allocated") || strings.Contains(low, "address already in use") || strings.Contains(low, "port is already") {
 		return fmt.Errorf("the Postgres port 5432 is already in use — another Postgres is bound to it. Stop it, run `leoflow lite --postgres managed` (a private, socket-only Postgres), or `leoflow lite --no-up` to point at your own (LEOFLOW_DATABASE_URL): %w", err)
 	}
-	return fmt.Errorf("docker compose up (is Docker running?): %w", err)
+	if strings.Contains(low, "unknown command") || strings.Contains(low, "is not a docker command") || strings.Contains(low, "compose") && strings.Contains(low, "not found") {
+		return fmt.Errorf("the Docker Compose v2 plugin is not installed (the `docker compose` subcommand is missing). Install it, or run `leoflow lite --postgres managed` for a Docker-free Postgres: %w", err)
+	}
+	return fmt.Errorf("docker compose up (is Docker running, with the Compose v2 plugin?): %w", err)
 }
 
 // preflightDevPorts checks that the HTTP, gRPC, and metrics ports Lite needs are

--- a/internal/cli/dsn.go
+++ b/internal/cli/dsn.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -14,30 +15,44 @@ type dsnSet struct {
 	migrate     string
 }
 
-// buildDSNs returns the Lite DSNs for the active datastore. With an empty
-// socketDir it returns the Docker datastore's TCP localhost:5432 connections
-// (the default). With a managed socketDir it returns Unix-socket DSNs
-// (host=<socketDir>, trust auth, no TCP) — so the managed cluster is reached
-// only through its own per-user socket and a foreign Postgres bound to 5432 can
-// never be connected to or mistaken for ours.
-func buildDSNs(socketDir string) dsnSet {
-	if socketDir == "" {
-		return dsnSet{database: devDatabaseURL, maintenance: devMaintenanceURL, migrate: devMigrateURL}
+// devDSNs resolves the Lite DSNs for the current run. A live managed cluster
+// (detected by its socket file under ~/.leoflow/pgdata) is reached over its Unix
+// socket; otherwise the Docker datastore is reached over TCP on the persisted
+// host port (ADR 0030 auto-selects which backend). Every entry point (the lite
+// runner, reset-password, db reset) calls this, so they connect consistently
+// without threading the choice through each.
+func devDSNs() dsnSet {
+	if sock := managedSocketDir(); sock != "" {
+		return socketDSNs(sock)
 	}
+	return tcpDSNs(devDBPort(liteDevDir()))
+}
+
+// tcpDSNs builds the Docker datastore DSNs for the given host port. The host port
+// is dynamic (Lite picks a free one when 5432 is taken — see resolveDevDBPort), so
+// the DSNs must track it rather than hard-code 5432.
+func tcpDSNs(port int) dsnSet {
+	url := func(db string) string {
+		return fmt.Sprintf("postgres://leoflow:leoflow@localhost:%d/%s?sslmode=disable", port, db)
+	}
+	return dsnSet{
+		database:    url(devDBName),
+		maintenance: url("postgres"),
+		migrate:     fmt.Sprintf("pgx5://leoflow:leoflow@localhost:%d/%s?sslmode=disable", port, devDBName),
+	}
+}
+
+// socketDSNs builds the managed-cluster DSNs over its per-user Unix socket
+// (host=<socketDir>, trust auth, no TCP) — so the managed cluster is reached only
+// through its own socket and a foreign Postgres bound to 5432 is never connected
+// to or mistaken for ours.
+func socketDSNs(socketDir string) dsnSet {
 	q := "?host=" + socketDir + "&sslmode=disable"
 	return dsnSet{
 		database:    "postgres://leoflow@/" + devDBName + q,
 		maintenance: "postgres://leoflow@/postgres" + q,
 		migrate:     "pgx5://leoflow@/" + devDBName + q,
 	}
-}
-
-// devDSNs resolves the Lite DSNs for the current run. It auto-detects a live
-// managed cluster by its socket file under ~/.leoflow/pgdata, so every entry
-// point (the lite runner, reset-password, db reset) connects consistently
-// without threading the --postgres choice through each of them.
-func devDSNs() dsnSet {
-	return buildDSNs(managedSocketDir())
 }
 
 // managedSocketDir returns the managed Postgres data dir when its Unix socket is

--- a/internal/cli/dsn_test.go
+++ b/internal/cli/dsn_test.go
@@ -5,21 +5,40 @@ import (
 	"testing"
 )
 
-// TestBuildDSNsDockerDefault: with no managed socket dir, the Lite DSNs are the
-// Docker datastore's TCP localhost:5432 connections (the default path, unchanged).
-func TestBuildDSNsDockerDefault(t *testing.T) {
-	d := buildDSNs("")
-	if d.database != devDatabaseURL || d.maintenance != devMaintenanceURL || d.migrate != devMigrateURL {
-		t.Fatalf("empty socket dir must yield the TCP DSN consts, got %+v", d)
+// TestTCPDSNsTrackThePort: the Docker DSNs are built on the given host port (Lite
+// picks a free one when 5432 is taken), targeting the dedicated dev database and
+// the maintenance "postgres" db, with the migrate DSN on the pgx5 scheme.
+func TestTCPDSNsTrackThePort(t *testing.T) {
+	d := tcpDSNs(5433)
+	for label, dsn := range map[string]string{"database": d.database, "maintenance": d.maintenance, "migrate": d.migrate} {
+		if !strings.Contains(dsn, "localhost:5433") {
+			t.Errorf("%s DSN %q must use the resolved host port 5433", label, dsn)
+		}
+	}
+	if !strings.HasPrefix(d.migrate, "pgx5://") {
+		t.Errorf("migrate DSN must keep the pgx5 scheme, got %q", d.migrate)
+	}
+	if !strings.Contains(d.database, "/leoflow_dev") || !strings.Contains(d.maintenance, "/postgres") {
+		t.Errorf("DSNs target the wrong databases: %+v", d)
 	}
 }
 
-// TestBuildDSNsManagedSocket: with a managed socket dir, every DSN connects over
-// that Unix socket (host=<dir>) and never over TCP localhost:5432 — so a foreign
+// TestTCPDSNsDefaultPortMatchesConsts pins the invariant that the default-port
+// (5432) DSNs equal the documented consts — so nothing regressed when the port
+// became dynamic.
+func TestTCPDSNsDefaultPortMatchesConsts(t *testing.T) {
+	d := tcpDSNs(defaultDevDBPort)
+	if d.database != devDatabaseURL || d.maintenance != devMaintenanceURL || d.migrate != devMigrateURL {
+		t.Fatalf("tcpDSNs(%d) must equal the 5432 consts, got %+v", defaultDevDBPort, d)
+	}
+}
+
+// TestSocketDSNsUseTheSocket: with a managed socket dir, every DSN connects over
+// that Unix socket (host=<dir>) and never over TCP localhost — so a foreign
 // Postgres bound to 5432 can never be reached or mistaken for ours.
-func TestBuildDSNsManagedSocket(t *testing.T) {
+func TestSocketDSNsUseTheSocket(t *testing.T) {
 	dir := "/home/u/.leoflow/pgdata"
-	d := buildDSNs(dir)
+	d := socketDSNs(dir)
 	for label, dsn := range map[string]string{"database": d.database, "maintenance": d.maintenance, "migrate": d.migrate} {
 		if !strings.Contains(dsn, "host="+dir) {
 			t.Errorf("%s DSN %q must select the unix socket via host=%s", label, dsn, dir)
@@ -30,8 +49,5 @@ func TestBuildDSNsManagedSocket(t *testing.T) {
 	}
 	if !strings.HasPrefix(d.migrate, "pgx5://") {
 		t.Errorf("migrate DSN must keep the pgx5 scheme, got %q", d.migrate)
-	}
-	if !strings.Contains(d.database, "/leoflow_dev") || !strings.Contains(d.maintenance, "/postgres") {
-		t.Errorf("DSNs target the wrong databases: %+v", d)
 	}
 }

--- a/internal/cli/lite_conflict_test.go
+++ b/internal/cli/lite_conflict_test.go
@@ -43,8 +43,12 @@ func TestComposeUpError(t *testing.T) {
 	if !strings.Contains(portErr.Error(), "--no-up") || !strings.Contains(strings.ToLower(portErr.Error()), "postgres") {
 		t.Errorf("port-allocation failure should mention --no-up and Postgres, got: %v", portErr)
 	}
+	noCompose := composeUpError(base, "docker: 'compose' is not a docker command.")
+	if !strings.Contains(noCompose.Error(), "Compose v2") || !strings.Contains(noCompose.Error(), "--postgres managed") {
+		t.Errorf("missing-compose-plugin should point at the Compose v2 plugin and --postgres managed, got: %v", noCompose)
+	}
 	other := composeUpError(base, "Cannot connect to the Docker daemon")
-	if !strings.Contains(other.Error(), "is Docker running?") {
+	if !strings.Contains(other.Error(), "is Docker running") {
 		t.Errorf("non-port failure should keep the generic hint, got: %v", other)
 	}
 }

--- a/internal/cli/lite_executor_test.go
+++ b/internal/cli/lite_executor_test.go
@@ -1,0 +1,24 @@
+package cli
+
+import "testing"
+
+// TestResolveExecutor pins the auto-detect default: `leoflow lite` (executor
+// "auto") uses k3d when Docker is available, else falls back to the subprocess
+// executor so Lite still runs Docker-free; an explicit choice is honored.
+func TestResolveExecutor(t *testing.T) {
+	cases := []struct {
+		flag   string
+		docker bool
+		want   string
+	}{
+		{"auto", true, "k8s"},
+		{"auto", false, "subprocess"},
+		{"k8s", false, "k8s"},
+		{"subprocess", true, "subprocess"},
+	}
+	for _, c := range cases {
+		if got := resolveExecutor(c.flag, c.docker); got != c.want {
+			t.Errorf("resolveExecutor(%q, %v) = %q, want %q", c.flag, c.docker, got, c.want)
+		}
+	}
+}

--- a/internal/cli/lite_postgres_default_test.go
+++ b/internal/cli/lite_postgres_default_test.go
@@ -2,16 +2,36 @@ package cli
 
 import "testing"
 
-// TestLitePostgresDefaultIsDocker pins the default datastore: `leoflow lite` uses
-// the Docker postgres:16 (robust wherever Docker runs — and the default executor
-// already needs Docker), with the relocatable managed PG available as the
-// Docker-free opt-in via --postgres managed.
-func TestLitePostgresDefaultIsDocker(t *testing.T) {
+// TestLitePostgresDefaultIsAuto pins the default datastore selection: `leoflow
+// lite` resolves the Postgres backend for the host — the Docker postgres:16 when
+// Docker is present (the realistic case, since the k3d executor needs Docker
+// too), else the managed relocatable PG (Docker-free), with both forceable.
+func TestLitePostgresDefaultIsAuto(t *testing.T) {
 	f := newLiteCommand().Flags().Lookup("postgres")
 	if f == nil {
 		t.Fatal("--postgres flag not defined")
 	}
-	if f.DefValue != datastoreDocker {
-		t.Errorf("--postgres default = %q, want %q", f.DefValue, datastoreDocker)
+	if f.DefValue != datastoreAuto {
+		t.Errorf("--postgres default = %q, want %q", f.DefValue, datastoreAuto)
+	}
+}
+
+// TestResolveDatastore: "auto" picks Docker when Docker is available, else the
+// managed relocatable PG; an explicit value is returned unchanged.
+func TestResolveDatastore(t *testing.T) {
+	cases := []struct {
+		flag     string
+		dockerOK bool
+		want     string
+	}{
+		{datastoreAuto, true, datastoreDocker},
+		{datastoreAuto, false, datastoreManaged},
+		{datastoreDocker, false, datastoreDocker},
+		{datastoreManaged, true, datastoreManaged},
+	}
+	for _, c := range cases {
+		if got := resolveDatastore(c.flag, c.dockerOK); got != c.want {
+			t.Errorf("resolveDatastore(%q, dockerOK=%v) = %q, want %q", c.flag, c.dockerOK, got, c.want)
+		}
 	}
 }

--- a/internal/cli/lite_postgres_default_test.go
+++ b/internal/cli/lite_postgres_default_test.go
@@ -2,16 +2,16 @@ package cli
 
 import "testing"
 
-// TestLitePostgresDefaultIsManaged pins the promoted default: `leoflow lite` uses
-// the managed relocatable Postgres (Docker-free datastore) unless --postgres
-// docker is passed. Promotion is safe now that managed PG is socket-only (no 5432
-// collision) and Lite is Redis-free (ADR 0026).
-func TestLitePostgresDefaultIsManaged(t *testing.T) {
+// TestLitePostgresDefaultIsDocker pins the default datastore: `leoflow lite` uses
+// the Docker postgres:16 (robust wherever Docker runs — and the default executor
+// already needs Docker), with the relocatable managed PG available as the
+// Docker-free opt-in via --postgres managed.
+func TestLitePostgresDefaultIsDocker(t *testing.T) {
 	f := newLiteCommand().Flags().Lookup("postgres")
 	if f == nil {
 		t.Fatal("--postgres flag not defined")
 	}
-	if f.DefValue != datastoreManaged {
-		t.Errorf("--postgres default = %q, want %q", f.DefValue, datastoreManaged)
+	if f.DefValue != datastoreDocker {
+		t.Errorf("--postgres default = %q, want %q", f.DefValue, datastoreDocker)
 	}
 }

--- a/internal/cli/managed_postgres.go
+++ b/internal/cli/managed_postgres.go
@@ -8,14 +8,16 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/neochaotic/leoflow/internal/setup"
 )
 
-// Datastore backends for Lite's Postgres. Docker is the default; managed runs a
-// relocatable PostgreSQL under ~/.leoflow with no Docker (Fase 2, behind a flag).
+// Datastore backends for Lite's Postgres. Managed (a relocatable PostgreSQL under
+// ~/.leoflow on a Unix socket, no Docker) is the default; Docker is opt-in via
+// --postgres docker.
 const (
 	datastoreDocker  = "docker"
 	datastoreManaged = "managed"
@@ -55,6 +57,9 @@ func startManagedPostgres(ctx context.Context, cmd *cobra.Command) error {
 		return fmt.Errorf("installing managed Postgres: %w", err)
 	}
 	dataDir := filepath.Join(root, "pgdata")
+	if serr := checkSocketPathLen(dataDir); serr != nil {
+		return serr
+	}
 
 	// Our cluster already accepting connections on its socket? leave it (idempotent
 	// across lite runs). Probing the socket dir — not 127.0.0.1 — means a foreign
@@ -66,10 +71,30 @@ func startManagedPostgres(ctx context.Context, cmd *cobra.Command) error {
 	if _, serr := os.Stat(filepath.Join(dataDir, "PG_VERSION")); os.IsNotExist(serr) {
 		devPrintln(out, "▸ initializing managed Postgres data dir …")
 		id := exec.CommandContext(ctx, filepath.Join(binDir, "initdb"), //nolint:gosec // managed binary + fixed args
-			"-D", dataDir, "-U", "leoflow", "-A", "trust", "--encoding=UTF8")
+			"-D", dataDir, "-U", "leoflow", "-A", "trust", "--encoding=UTF8", "--locale=C")
+		// Force a valid, deterministic locale: a host (e.g. an SSH session from
+		// macOS forwarding LC_CTYPE=UTF-8) may export a locale initdb rejects on
+		// Linux ("invalid locale settings"). --locale=C pins the cluster; the
+		// sanitized env keeps initdb itself from choking on the inherited one.
+		id.Env = pgLocaleEnv(os.Environ())
 		id.Stdout, id.Stderr = io.Discard, cmd.ErrOrStderr()
 		if rerr := id.Run(); rerr != nil {
-			return fmt.Errorf("initdb: %w", rerr)
+			return fmt.Errorf("initdb (see the locale note if it mentions LANG/LC_*): %w", rerr)
+		}
+		// Pin the socket-only listener in postgresql.conf rather than via pg_ctl -o:
+		// the conf parser quotes paths natively, so a data dir with spaces works and
+		// we avoid the fragile space-split of an -o option string.
+		confPath := filepath.Join(dataDir, "postgresql.conf")
+		cf, oerr := os.OpenFile(confPath, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // path derived from our per-user data dir
+		if oerr != nil {
+			return fmt.Errorf("opening %s: %w", confPath, oerr)
+		}
+		if _, werr := cf.WriteString(managedPGConfLines(dataDir)); werr != nil {
+			_ = cf.Close() //nolint:errcheck // already returning an error
+			return fmt.Errorf("writing managed Postgres config: %w", werr)
+		}
+		if cerr := cf.Close(); cerr != nil {
+			return fmt.Errorf("closing %s: %w", confPath, cerr)
 		}
 	}
 	devPrintln(out, "▸ starting managed Postgres (no Docker) …")
@@ -77,12 +102,11 @@ func startManagedPostgres(ctx context.Context, cmd *cobra.Command) error {
 	if mkErr := os.MkdirAll(filepath.Dir(logFile), 0o750); mkErr != nil {
 		return fmt.Errorf("creating postgres log dir: %w", mkErr)
 	}
-	// listen_addresses= (empty) disables TCP; -k keeps the Unix socket in dataDir
-	// (named .s.PGSQL.5432 from -p). No shell here, so an empty -c value is the
-	// reliable way to turn TCP off — "-h ''" would pass literal quote characters.
+	// Socket-only listener (no TCP) is configured in postgresql.conf at initdb
+	// time, so pg_ctl needs no -o options carrying the data-dir path.
 	start := exec.CommandContext(ctx, filepath.Join(binDir, "pg_ctl"), //nolint:gosec // managed binary + fixed args
-		"-D", dataDir, "-l", logFile, "-w", "-t", "30",
-		"-o", "-p 5432 -k "+dataDir+" -c listen_addresses=", "start")
+		"-D", dataDir, "-l", logFile, "-w", "-t", "30", "start")
+	start.Env = pgLocaleEnv(os.Environ())
 	start.Stdout, start.Stderr = io.Discard, cmd.ErrOrStderr()
 	if rerr := start.Run(); rerr != nil {
 		return fmt.Errorf("starting managed Postgres (see %s): %w", logFile, rerr)
@@ -104,6 +128,51 @@ func stopManagedPostgres(cmd *cobra.Command) {
 	c := exec.CommandContext(context.Background(), filepath.Join(binDir, "pg_ctl"), "-D", dataDir, "stop", "-m", "fast") //nolint:gosec // managed binary + fixed args
 	c.Stdout, c.Stderr = io.Discard, io.Discard
 	_ = c.Run() //nolint:errcheck // best-effort stop on shutdown
+}
+
+// maxUnixSocketPath is a conservative cap on the managed Postgres socket path.
+// The OS sun_path limit is ~104 (macOS) to ~108 (Linux); we guard below it so a
+// deep HOME fails with a clear message instead of a cryptic Postgres error.
+const maxUnixSocketPath = 100
+
+// managedPGConfLines are the socket-only settings appended to postgresql.conf at
+// initdb time: TCP off, the Unix socket in the per-user data dir, port 5432 (so
+// the socket file is .s.PGSQL.5432). The data dir is single-quoted, so a path
+// with spaces is parsed correctly (unlike a space-split pg_ctl -o string).
+func managedPGConfLines(dataDir string) string {
+	return "\n# Leoflow Lite: socket-only datastore (no TCP), socket in the data dir.\n" +
+		"listen_addresses = ''\n" +
+		"unix_socket_directories = '" + dataDir + "'\n" +
+		"port = 5432\n"
+}
+
+// checkSocketPathLen fails loud when the managed Postgres Unix socket path would
+// exceed the OS limit (e.g. a deeply nested HOME / service account), pointing at
+// the workaround instead of letting Postgres emit a cryptic socket error.
+func checkSocketPathLen(dataDir string) error {
+	sock := filepath.Join(dataDir, ".s.PGSQL.5432")
+	if len(sock) > maxUnixSocketPath {
+		return fmt.Errorf("managed Postgres socket path is too long (%d > %d chars): %s\n"+
+			"  your home directory is too deeply nested for a Unix socket.\n"+
+			"  use `leoflow lite --postgres docker`, or set a shorter HOME",
+			len(sock), maxUnixSocketPath, sock)
+	}
+	return nil
+}
+
+// pgLocaleEnv returns env with any inherited LANG/LC_* removed and a valid,
+// deterministic LANG=C / LC_ALL=C forced, so initdb and pg_ctl never inherit a
+// locale Linux rejects — e.g. an SSH session from macOS forwards LC_CTYPE=UTF-8,
+// which is invalid on glibc and made initdb fail ("invalid locale settings").
+func pgLocaleEnv(base []string) []string {
+	out := make([]string, 0, len(base)+2)
+	for _, kv := range base {
+		if strings.HasPrefix(kv, "LANG=") || strings.HasPrefix(kv, "LC_") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, "LANG=C", "LC_ALL=C")
 }
 
 // detectLibc reports the host libc ("glibc"/"musl" on linux, "" on darwin) so the

--- a/internal/cli/managed_postgres.go
+++ b/internal/cli/managed_postgres.go
@@ -60,6 +60,17 @@ func startManagedPostgres(ctx context.Context, cmd *cobra.Command) error {
 	if serr := checkSocketPathLen(dataDir); serr != nil {
 		return serr
 	}
+	// Pre-flight: the relocatable Postgres dynamically links a chain of system
+	// libraries it does not bundle (ICU, Kerberos, zstd, lz4, libxml2, …). On a
+	// minimal host (Alpine/musl, slim containers) some are absent and the server
+	// dies with a cryptic loader error. Probe the `postgres` binary — it has the
+	// widest dependency set, wider than initdb — and fail with an actionable
+	// message before the confusing startup error.
+	if verr := exec.CommandContext(ctx, filepath.Join(binDir, "postgres"), "--version").Run(); verr != nil { //nolint:gosec // managed binary + fixed arg
+		return fmt.Errorf("the managed Postgres can't run on this host — it needs system libraries (ICU, Kerberos) that are missing here (common on Alpine/musl and slim containers): %w\n"+
+			"  use `leoflow lite --postgres docker` (recommended; works everywhere).\n"+
+			"  installing the libs may help if the versions match (Debian/Ubuntu: `apt-get install libicu-dev libgssapi-krb5-2`; Alpine: `apk add icu-libs krb5-libs` — but the bundled build may need exact versions)", verr)
+	}
 
 	// Our cluster already accepting connections on its socket? leave it (idempotent
 	// across lite runs). Probing the socket dir — not 127.0.0.1 — means a foreign

--- a/internal/cli/managed_postgres.go
+++ b/internal/cli/managed_postgres.go
@@ -15,13 +15,45 @@ import (
 	"github.com/neochaotic/leoflow/internal/setup"
 )
 
-// Datastore backends for Lite's Postgres. Managed (a relocatable PostgreSQL under
-// ~/.leoflow on a Unix socket, no Docker) is the default; Docker is opt-in via
-// --postgres docker.
+// Datastore backends for Lite's Postgres. The default is "auto": Docker Postgres
+// when Docker is present (the realistic case, since the k3d executor needs Docker
+// too), else a managed relocatable PostgreSQL under ~/.leoflow on a Unix socket —
+// so `leoflow lite` runs on a Docker-free host with nothing to install. Either can
+// be forced explicitly.
 const (
+	datastoreAuto    = "auto"
 	datastoreDocker  = "docker"
 	datastoreManaged = "managed"
 )
+
+// resolveDatastore maps the --postgres flag to a concrete backend: "auto" picks
+// the Docker Postgres when Docker is available, else the managed relocatable PG
+// (Docker-free); any explicit value is returned unchanged. It mirrors
+// resolveExecutor so the datastore and executor track the same host capability.
+func resolveDatastore(flag string, dockerOK bool) string {
+	if flag != datastoreAuto {
+		return flag
+	}
+	if dockerOK {
+		return datastoreDocker
+	}
+	return datastoreManaged
+}
+
+// autoDatastore resolves an "auto" --postgres at run time (detecting Docker) and
+// prints which backend it chose; a non-auto value is returned unchanged.
+func autoDatastore(cmd *cobra.Command, flag string) string {
+	if flag != datastoreAuto {
+		return flag
+	}
+	mode := resolveDatastore(datastoreAuto, dockerAvailable())
+	if mode == datastoreManaged {
+		devPrintln(cmd.OutOrStdout(), "▸ no Docker detected — using a managed Postgres (downloaded under ~/.leoflow, no Docker). Install Docker for the postgres:16 container instead.")
+	} else {
+		devPrintln(cmd.OutOrStdout(), "▸ Docker detected — using the Docker Postgres (postgres:16). Pass --postgres managed for a Docker-free Postgres.")
+	}
+	return mode
+}
 
 // managedPGPaths returns the managed Postgres bin dir and data dir, both per-user
 // under ~/.leoflow (so root and an unprivileged user never share a cluster).

--- a/internal/cli/managed_postgres.go
+++ b/internal/cli/managed_postgres.go
@@ -79,7 +79,7 @@ func startManagedPostgres(ctx context.Context, cmd *cobra.Command) error {
 		id.Env = pgLocaleEnv(os.Environ())
 		id.Stdout, id.Stderr = io.Discard, cmd.ErrOrStderr()
 		if rerr := id.Run(); rerr != nil {
-			return fmt.Errorf("initdb (see the locale note if it mentions LANG/LC_*): %w", rerr)
+			return fmt.Errorf("initdb failed%s: %w", managedPGHint, rerr)
 		}
 		// Pin the socket-only listener in postgresql.conf rather than via pg_ctl -o:
 		// the conf parser quotes paths natively, so a data dir with spaces works and
@@ -109,7 +109,7 @@ func startManagedPostgres(ctx context.Context, cmd *cobra.Command) error {
 	start.Env = pgLocaleEnv(os.Environ())
 	start.Stdout, start.Stderr = io.Discard, cmd.ErrOrStderr()
 	if rerr := start.Run(); rerr != nil {
-		return fmt.Errorf("starting managed Postgres (see %s): %w", logFile, rerr)
+		return fmt.Errorf("starting managed Postgres (see %s)%s: %w", logFile, managedPGHint, rerr)
 	}
 	return nil
 }
@@ -129,6 +129,11 @@ func stopManagedPostgres(cmd *cobra.Command) {
 	c.Stdout, c.Stderr = io.Discard, io.Discard
 	_ = c.Run() //nolint:errcheck // best-effort stop on shutdown
 }
+
+// managedPGHint is appended to managed-Postgres startup failures: if the
+// relocatable build can't run on this host (very old glibc, musl, locale), the
+// Docker datastore is the escape hatch.
+const managedPGHint = " — if the managed Postgres can't run on this host (very old glibc, musl, or a locale issue), use `leoflow lite --postgres docker`"
 
 // maxUnixSocketPath is a conservative cap on the managed Postgres socket path.
 // The OS sun_path limit is ~104 (macOS) to ~108 (Linux); we guard below it so a
@@ -178,8 +183,47 @@ func pgLocaleEnv(base []string) []string {
 // detectLibc reports the host libc ("glibc"/"musl" on linux, "" on darwin) so the
 // matching relocatable PostgreSQL build is selected.
 func detectLibc() string {
+	return hostProbe().Libc
+}
+
+// dockerAvailable reports whether Docker is usable on this host, used to resolve
+// the "auto" executor (k3d when present, else subprocess).
+func dockerAvailable() bool {
+	return hostProbe().Docker
+}
+
+// hostProbe runs the shared environment detection once per call site.
+func hostProbe() setup.Report {
 	return setup.Detect(setup.Probe{
 		GOOS: runtime.GOOS, GOARCH: runtime.GOARCH,
 		LookPath: exec.LookPath, Stat: os.Stat, Getwd: os.Getwd,
-	}).Libc
+	})
+}
+
+// autoExecutor resolves an "auto" --executor at run time (detecting Docker) and
+// prints which path it chose; a non-auto value is returned unchanged.
+func autoExecutor(cmd *cobra.Command, flag string) string {
+	if flag != "auto" {
+		return flag
+	}
+	mode := resolveExecutor("auto", dockerAvailable())
+	if mode == "subprocess" {
+		devPrintln(cmd.OutOrStdout(), "⚠ no Docker detected — running tasks via the subprocess executor (no isolation, dev-only). Install Docker for pod-per-task (k3d), or pass --executor k8s.")
+	} else {
+		devPrintln(cmd.OutOrStdout(), "▸ Docker detected — using the k3d executor (pod-per-task). Pass --executor subprocess for a no-Docker run.")
+	}
+	return mode
+}
+
+// resolveExecutor maps the --executor flag to a concrete mode: "auto" picks k3d
+// when Docker is available, else the subprocess executor (Docker-free); any
+// explicit value is returned unchanged.
+func resolveExecutor(flag string, dockerOK bool) string {
+	if flag != "auto" {
+		return flag
+	}
+	if dockerOK {
+		return "k8s"
+	}
+	return "subprocess"
 }

--- a/internal/cli/managed_postgres_test.go
+++ b/internal/cli/managed_postgres_test.go
@@ -3,8 +3,67 @@ package cli
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
+
+// TestManagedPGConfLinesQuotesDataDir: the socket/TCP settings go into
+// postgresql.conf (not the space-split pg_ctl -o), so a data dir with spaces is
+// single-quoted and parsed correctly; TCP is off and the socket lives in dataDir.
+func TestManagedPGConfLinesQuotesDataDir(t *testing.T) {
+	conf := managedPGConfLines("/home/jo doe/.leoflow/pgdata")
+	for _, want := range []string{
+		"listen_addresses = ''",
+		"unix_socket_directories = '/home/jo doe/.leoflow/pgdata'",
+		"port = 5432",
+	} {
+		if !strings.Contains(conf, want) {
+			t.Errorf("conf missing %q:\n%s", want, conf)
+		}
+	}
+}
+
+// TestCheckSocketPathLen fails loud (clear message) when the Unix socket path
+// would exceed the OS limit (~108), instead of letting Postgres emit a cryptic
+// "socket path too long" — e.g. a deeply nested HOME (service accounts).
+func TestCheckSocketPathLen(t *testing.T) {
+	if err := checkSocketPathLen("/home/u/.leoflow/pgdata"); err != nil {
+		t.Errorf("normal path should pass, got %v", err)
+	}
+	long := "/" + strings.Repeat("nested/", 20) + ".leoflow/pgdata"
+	err := checkSocketPathLen(long)
+	if err == nil || !strings.Contains(err.Error(), "socket path") {
+		t.Errorf("a too-long path must fail with a clear 'socket path' error, got %v", err)
+	}
+}
+
+// TestPGLocaleEnvForcesValidLocale guards the initdb locale regression: a macOS
+// SSH session forwards LC_CTYPE=UTF-8, which is NOT a valid locale on Linux and
+// made `initdb` fail ("invalid locale settings"), breaking the managed-PG default
+// on a fresh `leoflow lite`. pgLocaleEnv must strip any inherited LANG/LC_* and
+// force a deterministic, valid LANG=C / LC_ALL=C, while preserving other vars.
+func TestPGLocaleEnvForcesValidLocale(t *testing.T) {
+	got := pgLocaleEnv([]string{"PATH=/usr/bin", "LC_CTYPE=UTF-8", "LANG=C.UTF-8", "LC_ALL=", "HOME=/h"})
+	has := func(s string) bool {
+		for _, kv := range got {
+			if kv == s {
+				return true
+			}
+		}
+		return false
+	}
+	for _, kv := range got {
+		if strings.HasPrefix(kv, "LC_CTYPE=") || kv == "LANG=C.UTF-8" {
+			t.Errorf("inherited locale var must be stripped, got %q", kv)
+		}
+	}
+	if !has("LANG=C") || !has("LC_ALL=C") {
+		t.Errorf("must force LANG=C and LC_ALL=C, got %v", got)
+	}
+	if !has("PATH=/usr/bin") || !has("HOME=/h") {
+		t.Errorf("non-locale vars must be preserved, got %v", got)
+	}
+}
 
 // TestManagedPGPaths pins the per-user managed-Postgres layout the rest of the
 // lifecycle depends on: the bin dir and data dir both live under ~/.leoflow so

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -25,9 +25,10 @@ func newUninstallCommand() *cobra.Command {
 		Short: "Remove the Leoflow installation (~/.leoflow).",
 		Long: "uninstall removes the managed Leoflow home (~/.leoflow): the binaries, config, " +
 			"managed Python, Monaco assets, and local dev state. It does NOT remove your DAG " +
-			"workspace or Docker datastore volumes unless you pass --purge. It asks for confirmation " +
-			"unless --yes is given. (To upgrade instead, just re-run install.sh — it replaces the " +
-			"binaries and keeps your config.)",
+			"workspace or your datastore (the managed Postgres data in ~/.leoflow/pgdata and this " +
+			"install's Docker volume) unless you pass --purge — so a reinstall keeps your data. It " +
+			"asks for confirmation unless --yes is given. (To upgrade instead, just re-run install.sh " +
+			"— it replaces the binaries and keeps your config.)",
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runUninstall(cmd, yes, purge)
@@ -65,7 +66,9 @@ func runUninstall(cmd *cobra.Command, yes, purge bool) error {
 		if workspace != "" {
 			devPrintf(out, "  %s  (your DAG workspace)\n", workspace)
 		}
-		devPrintln(out, "  Docker datastore volume: leoflow_pgdata (and any legacy leoflow_redisdata)")
+		devPrintln(out, "  your datastore: the managed Postgres data (~/.leoflow/pgdata) AND this install's Docker volume")
+	} else {
+		devPrintln(out, "  (keeping your datastore — the managed pgdata and the Docker volume — and your DAG workspace; pass --purge to remove them)")
 	}
 
 	if !yes && !confirmUninstall(cmd) {
@@ -73,15 +76,13 @@ func runUninstall(cmd *cobra.Command, yes, purge bool) error {
 		return nil
 	}
 
-	if purge {
-		// Best-effort: stop datastores and drop their volumes before deleting the
-		// compose file that defines them.
-		composeDownVolumes(cmd, filepath.Join(root, "docker-compose.yaml"))
+	if rerr := removeLeoflowHome(cmd, root, purge); rerr != nil {
+		return rerr
 	}
-	if rerr := os.RemoveAll(root); rerr != nil {
-		return fmt.Errorf("removing %s: %w", root, rerr)
+	devPrintf(out, "✓ removed the Leoflow install at %s\n", root)
+	if !purge {
+		devPrintln(out, "  (kept your datastore for a future reinstall — `leoflow uninstall --purge` removes it)")
 	}
-	devPrintf(out, "✓ removed %s\n", root)
 	// Remove the binaries too — install.sh places them on a PATH dir (e.g.
 	// /usr/local/bin), NOT under ~/.leoflow, so removing the home alone left a
 	// working `leoflow` behind.
@@ -141,6 +142,53 @@ func confirmUninstall(cmd *cobra.Command) bool {
 	return answer == "yes" || answer == "y"
 }
 
+// removeLeoflowHome removes the Leoflow home, stopping a running managed Postgres
+// first (so no orphaned process points at a half-removed data dir). With purge it
+// also drops this install's Docker volume and removes the datastore; without it,
+// the datastore (managed pgdata / the Docker volume) is preserved for a reinstall.
+func removeLeoflowHome(cmd *cobra.Command, root string, purge bool) error {
+	stopManagedPostgres(cmd)
+	if purge {
+		// Best-effort: stop the Docker datastore and drop this install's volume
+		// before deleting the compose file that defines it.
+		composeDownVolumes(cmd, filepath.Join(root, "docker-compose.yaml"))
+		if err := os.RemoveAll(root); err != nil {
+			return fmt.Errorf("removing %s: %w", root, err)
+		}
+		return nil
+	}
+	if err := removeHomeExcept(root, "pgdata"); err != nil {
+		return fmt.Errorf("removing %s: %w", root, err)
+	}
+	return nil
+}
+
+// removeHomeExcept deletes everything under root except the entry named keep — the
+// datastore (managed pgdata), preserved on a plain uninstall so a reinstall at the
+// same HOME reconnects to its data (symmetric with the Docker volume, which a plain
+// uninstall also leaves intact). If keep is absent (e.g. a Docker-only install),
+// root is emptied and removed entirely.
+func removeHomeExcept(root, keep string) error {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return err
+	}
+	kept := false
+	for _, e := range entries {
+		if e.Name() == keep {
+			kept = true
+			continue
+		}
+		if rerr := os.RemoveAll(filepath.Join(root, e.Name())); rerr != nil {
+			return rerr
+		}
+	}
+	if !kept {
+		return os.Remove(root)
+	}
+	return nil
+}
+
 // composeDownVolumes best-effort stops the datastores and removes their volumes
 // via the managed compose file, if both Docker and the file are present.
 func composeDownVolumes(cmd *cobra.Command, composeFile string) {
@@ -151,6 +199,9 @@ func composeDownVolumes(cmd *cobra.Command, composeFile string) {
 		return
 	}
 	c := exec.CommandContext(cmdContext(cmd), "docker", "compose", "-f", composeFile, "down", "-v") //nolint:gosec // fixed args, managed compose path
+	// Run under this install's project name so `down -v` removes exactly this
+	// install's container and volume, never a co-resident user's.
+	c.Env = composeEnv()
 	c.Stdout, c.Stderr = cmd.OutOrStdout(), cmd.ErrOrStderr()
 	if err := c.Run(); err != nil {
 		// Best-effort: a missing/already-down stack is fine; the files are removed next.

--- a/internal/cli/uninstall_test.go
+++ b/internal/cli/uninstall_test.go
@@ -137,3 +137,47 @@ func TestUninstallWired(t *testing.T) {
 		t.Error("`leoflow uninstall` should be registered on the root command")
 	}
 }
+
+// TestRemoveHomeExceptPreservesDatastore: a plain uninstall keeps the datastore
+// (pgdata) for a reinstall while removing everything else under the home.
+func TestRemoveHomeExceptPreservesDatastore(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "pgdata", "PG_VERSION"), "16")
+	mustWrite(t, filepath.Join(root, "postgres", "bin", "postgres"), "x")
+	mustWrite(t, filepath.Join(root, "config.yaml"), "admin: x")
+	if err := removeHomeExcept(root, "pgdata"); err != nil {
+		t.Fatalf("removeHomeExcept: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "pgdata", "PG_VERSION")); err != nil {
+		t.Errorf("pgdata must be preserved on a plain uninstall: %v", err)
+	}
+	for _, gone := range []string{"config.yaml", "postgres"} {
+		if _, err := os.Stat(filepath.Join(root, gone)); !os.IsNotExist(err) {
+			t.Errorf("%s must be removed, stat err = %v", gone, err)
+		}
+	}
+}
+
+// TestRemoveHomeExceptRemovesRootWhenNoDatastore: a Docker-only install (no
+// managed pgdata) has its home removed entirely — its data lives in the Docker
+// volume, which a plain uninstall also leaves intact (it does not run down -v).
+func TestRemoveHomeExceptRemovesRootWhenNoDatastore(t *testing.T) {
+	root := filepath.Join(t.TempDir(), ".leoflow")
+	mustWrite(t, filepath.Join(root, "postgres", "bin", "postgres"), "x")
+	if err := removeHomeExcept(root, "pgdata"); err != nil {
+		t.Fatalf("removeHomeExcept: %v", err)
+	}
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Errorf("home must be removed entirely when there is no datastore to keep, stat err = %v", err)
+	}
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/runtime/python/README.md
+++ b/runtime/python/README.md
@@ -4,9 +4,10 @@ The Python helper baked into every Leoflow task base image. It runs the user's
 task callable inside the container and bridges data flow with the control plane:
 
 - `python -m leoflow_runtime <module:callable>` imports and calls the task,
-  writing a non-`None` return value to `/tmp/leoflow_return_value.json`. The
-  `leoflow-agent` reads that file and pushes it as the task's `return_value`
-  XCom.
+  writing a non-`None` return value to the path in `LEOFLOW_RETURN_VALUE_PATH`
+  (the `leoflow-agent` sets this to a unique per-task file; it falls back to
+  `/tmp/leoflow_return_value.json` only when unset). The agent reads that file
+  and pushes it as the task's `return_value` XCom.
 - `leoflow_runtime.xcom_pull("name")` returns an upstream XCom the agent injected
   as `LEOFLOW_XCOM_<NAME>`.
 


### PR DESCRIPTION
## Summary
Hardening batch for **Leoflow Lite** (prealpha .17). Resolves the real-machine issues found while testing on Lima/.142, converging the datastore story and fixing several first-run/lifecycle rough edges. All changes are scoped to Lite (CLI/datastore/uninstall); the `/api/v2/` surface and the executor model (ADR 0015) are untouched.

## What's in it (8 commits)
- **Datastore auto-select (ADR 0030, supersedes 0029):** `--postgres auto` — Docker `postgres:16` when Docker is present, else a managed relocatable Postgres under `~/.leoflow` (Docker-free), mirroring `--executor auto`. Lite stays Redis-free (durability + single datastore; Redis is a Production-scale concern).
- **Per-install isolation + free host port:** the Docker datastore runs under a project name derived from the `~/.leoflow` path (`leoflow-<hash>`) so users/installs never share or clobber a volume; the host port is auto-picked (first free from 5432) so a foreign Postgres on 5432 is sidestepped, not adopted. Port persisted in `~/.leoflow/dev/db-port`.
- **Uninstall symmetry:** a plain `uninstall` preserves the datastore for **both** backends (keep `pgdata`, no `down -v`); `--purge` removes both. `down -v` runs under this install's project name (targets exactly its volume); a running managed PG is stopped first.
- Earlier in the batch: per-task XCom return path, locale-independent managed initdb (socket-only via postgresql.conf, socket-path guard, `postgres --version` pre-flight), `--executor auto`, low-disk warning, and a clear Compose-v2-plugin-missing error.

## Validation (Lima, real machine)
- `auto` datastore both ways: **with Docker** → Docker PG + k3d, **without Docker** → managed PG + subprocess — login + XCom run **success** both.
- 5432 occupied by a foreign Postgres → Lite binds **5433**, isolated project/volume `leoflow-<hash>`, foreign PG untouched, login + run success.
- Acceptance pass: install paths, first-run UX, smoke/e2e, task logs non-empty, DELETE dagRun (204→404), UI login (200, 0 console errors). **No regressions.**
- Example suite: compile **13/13**; run **8/13** on subprocess (incl. networked). The 4 failures are **pre-existing** and tracked separately: #115 (dynamic task-mapping args), #116 (dev venv deps not refreshed on project/dep change) — neither caused by this batch.

## ADRs
0030 (new, supersedes 0029); refines 0026/0027; ADR 0015 explicitly unaffected (no Docker SDK, no Docker executor — `go mod why github.com/docker/docker` confirms it's not in the build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)