### PR TITLE
fix(api,lite): duplicate dagRun returns 409, dev venv refreshes deps on project switch

### DIFF
--- a/internal/api/resources.go
+++ b/internal/api/resources.go
@@ -114,6 +114,10 @@ func handleRepoError(c *gin.Context, err error) {
 		AbortProblem(c, http.StatusNotFound, "not found", err.Error())
 		return
 	}
+	if errors.Is(err, domain.ErrConflict) {
+		AbortProblem(c, http.StatusConflict, "conflict", err.Error())
+		return
+	}
 	// A canceled/timed-out context means the client went away (the UI routinely
 	// supersedes in-flight grid requests). That is NOT a server error — mapping it
 	// to 500 produced spurious ti_summaries 500s under rapid refresh. Report 499 so

--- a/internal/api/resources_test.go
+++ b/internal/api/resources_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -596,6 +597,8 @@ func TestHandleRepoErrorClientCancel(t *testing.T) {
 		{"deadline exceeded", context.DeadlineExceeded, statusClientClosedRequest},
 		{"wrapped cancel", errors.Join(errors.New("task instances for runs"), context.Canceled), statusClientClosedRequest},
 		{"not found", ErrNotFound, http.StatusNotFound},
+		{"conflict (duplicate run)", domain.ErrConflict, http.StatusConflict},
+		{"wrapped conflict", fmt.Errorf("creating dag run: %w", domain.ErrConflict), http.StatusConflict},
 		{"real server error", errors.New("db exploded"), http.StatusInternalServerError},
 	}
 	for _, tc := range cases {

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -15,6 +15,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -847,16 +848,66 @@ func ensureDevVenv(ctx context.Context, cmd *cobra.Command, home, runtimeSrc str
 			return "", fmt.Errorf("creating dev venv with %s (the managed CPython bundles venv; a system python3 may need its python3-venv package): %w", base, e)
 		}
 	}
+	// Runtime + Airflow SDK: install once, gated by the runtime being importable, so
+	// reruns are fast. (No project deps here — those are tracked separately below.)
 	check := exec.CommandContext(ctx, py, "-c", "import leoflow_runtime") //nolint:gosec // py is the managed venv interpreter
 	if check.Run() != nil {
 		devPrintln(cmd.OutOrStdout(), "▸ installing task runtime + Airflow SDK into the dev venv …")
-		install := exec.CommandContext(ctx, py, venvPipArgs(runtimeSrc, deps)...) //nolint:gosec // py is the managed venv interpreter
+		install := exec.CommandContext(ctx, py, venvPipArgs(runtimeSrc, nil)...) //nolint:gosec // py is the managed venv interpreter
 		install.Stdout, install.Stderr = cmd.OutOrStdout(), cmd.ErrOrStderr()
 		if e := install.Run(); e != nil {
-			return "", fmt.Errorf("installing dev venv packages: %w", e)
+			return "", fmt.Errorf("installing dev venv runtime: %w", e)
+		}
+	}
+	// Project deps: (re)install when the active project's declared dependencies
+	// change — gating only on the runtime above meant switching projects, or
+	// editing `dependencies:`, never refreshed the venv (#116). Additive: extra
+	// packages from a previous project are harmless.
+	if len(deps) > 0 && !devDepsUpToDate(home, deps) {
+		devPrintln(cmd.OutOrStdout(), "▸ installing project dependencies into the dev venv …")
+		install := exec.CommandContext(ctx, py, venvDepsArgs(deps)...) //nolint:gosec // py is the managed venv interpreter
+		install.Stdout, install.Stderr = cmd.OutOrStdout(), cmd.ErrOrStderr()
+		if e := install.Run(); e != nil {
+			return "", fmt.Errorf("installing project dependencies: %w", e)
+		}
+		if e := writeDevDepsMarker(home, deps); e != nil {
+			return "", fmt.Errorf("recording installed project deps: %w", e)
 		}
 	}
 	return py, nil
+}
+
+// venvDepsArgs is the pip invocation that installs just the project's declared
+// dependencies into the dev venv.
+func venvDepsArgs(deps []string) []string {
+	return append([]string{"-m", "pip", "install", "-q"}, deps...)
+}
+
+// devDepsMarkerPath is the file recording which project dependencies the dev venv
+// currently has installed.
+func devDepsMarkerPath(home string) string { return filepath.Join(home, "venv", ".leoflow-deps") }
+
+// devDepsSignature is an order-independent canonical form of a dependency list, so
+// reordering `dependencies:` does not force a needless reinstall.
+func devDepsSignature(deps []string) string {
+	s := append([]string(nil), deps...)
+	sort.Strings(s)
+	return strings.Join(s, "\n")
+}
+
+// devDepsUpToDate reports whether the dev venv already has exactly these project
+// deps installed (per the marker written by the last successful install).
+func devDepsUpToDate(home string, deps []string) bool {
+	b, err := os.ReadFile(devDepsMarkerPath(home)) //nolint:gosec // path derived from the per-user dev home
+	if err != nil {
+		return false
+	}
+	return string(b) == devDepsSignature(deps)
+}
+
+// writeDevDepsMarker records the project deps just installed into the dev venv.
+func writeDevDepsMarker(home string, deps []string) error {
+	return os.WriteFile(devDepsMarkerPath(home), []byte(devDepsSignature(deps)), 0o600)
 }
 
 // devRun and devOutput run external dev tools (k3d/docker/kubectl). They are

--- a/internal/cli/dev_venv_test.go
+++ b/internal/cli/dev_venv_test.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDevDepsSignatureOrderIndependent: the canonical signature ignores ordering,
+// so a leoflow.yaml that just reorders `dependencies:` does not force a needless
+// reinstall.
+func TestDevDepsSignatureOrderIndependent(t *testing.T) {
+	a := devDepsSignature([]string{"requests==2.31.0", "duckdb==1.4.4"})
+	b := devDepsSignature([]string{"duckdb==1.4.4", "requests==2.31.0"})
+	if a != b {
+		t.Errorf("signature must be order-independent: %q != %q", a, b)
+	}
+	c := devDepsSignature([]string{"requests==2.31.0"})
+	if a == c {
+		t.Errorf("a different dep set must yield a different signature: both %q", a)
+	}
+}
+
+// TestDevDepsRoundtrip: after writeDevDepsMarker, devDepsUpToDate is true for the
+// same deps and false when the deps change — which is what gates the reinstall
+// when switching projects or editing dependencies (#116).
+func TestDevDepsRoundtrip(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "venv"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if devDepsUpToDate(home, []string{"x"}) {
+		t.Errorf("an absent marker must report not up-to-date")
+	}
+	if err := writeDevDepsMarker(home, []string{"requests==2.31.0", "duckdb==1.4.4"}); err != nil {
+		t.Fatal(err)
+	}
+	if !devDepsUpToDate(home, []string{"duckdb==1.4.4", "requests==2.31.0"}) {
+		t.Errorf("same deps (any order) must report up-to-date after a successful install")
+	}
+	if devDepsUpToDate(home, []string{"requests==2.31.0"}) {
+		t.Errorf("a different dep set must report not up-to-date (forces reinstall on project switch)")
+	}
+}

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -4,3 +4,7 @@ import "errors"
 
 // ErrNotFound is returned when a requested resource does not exist.
 var ErrNotFound = errors.New("resource not found")
+
+// ErrConflict is returned when a write conflicts with an existing resource (e.g.
+// a duplicate dag run for the same logical date). The API maps it to 409.
+var ErrConflict = errors.New("resource already exists")

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/neochaotic/leoflow/internal/auth"
@@ -49,6 +50,21 @@ func toInt32(n int) int32 {
 func mapNotFound(err error) error {
 	if errors.Is(err, pgx.ErrNoRows) {
 		return domain.ErrNotFound
+	}
+	return err
+}
+
+// pgUniqueViolation is the Postgres SQLSTATE for a unique-constraint violation.
+const pgUniqueViolation = "23505"
+
+// mapConflict translates a Postgres unique-constraint violation into
+// domain.ErrConflict (which the API maps to 409), leaving other errors as is — so
+// a duplicate write (e.g. a second dag run for the same logical date) surfaces as
+// a clean conflict rather than a raw 500.
+func mapConflict(err error) error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == pgUniqueViolation {
+		return domain.ErrConflict
 	}
 	return err
 }
@@ -213,7 +229,7 @@ func (r *Repository) CreateDagRun(ctx context.Context, tenant, dagID string, run
 		Note:         strPtr(run.Note),
 	})
 	if err != nil {
-		return domain.DagRun{}, fmt.Errorf("creating dag run: %w", err)
+		return domain.DagRun{}, fmt.Errorf("creating dag run: %w", mapConflict(err))
 	}
 	// The trigger's audit entry is written by the API handler, where the acting
 	// user is known (so the Audit Log shows the owner).

--- a/internal/storage/repository_test.go
+++ b/internal/storage/repository_test.go
@@ -1,0 +1,32 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// TestMapConflict: a Postgres unique-constraint violation (SQLSTATE 23505) maps to
+// domain.ErrConflict (so the API returns 409 for a duplicate run); other errors,
+// including a different SQLSTATE, pass through unchanged.
+func TestMapConflict(t *testing.T) {
+	unique := &pgconn.PgError{Code: "23505", Message: "duplicate key value violates unique constraint"}
+	if got := mapConflict(unique); !errors.Is(got, domain.ErrConflict) {
+		t.Errorf("23505 must map to ErrConflict, got %v", got)
+	}
+	if got := mapConflict(fmt.Errorf("wrapped: %w", unique)); !errors.Is(got, domain.ErrConflict) {
+		t.Errorf("wrapped 23505 must map to ErrConflict, got %v", got)
+	}
+	other := &pgconn.PgError{Code: "23503", Message: "foreign key violation"}
+	if got := mapConflict(other); errors.Is(got, domain.ErrConflict) {
+		t.Errorf("a non-unique SQLSTATE must NOT map to ErrConflict, got %v", got)
+	}
+	plain := errors.New("connection refused")
+	if got := mapConflict(plain); errors.Is(got, domain.ErrConflict) {
+		t.Errorf("a non-pg error must not map to ErrConflict, got %v", got)
+	}
+}


### PR DESCRIPTION
Two pre-existing bugs found in the .17 acceptance pass; both have TDD coverage.

## #118 — duplicate dagRun → 500 (chaos finding)
Second POST to `/dags/{id}/dagRuns` with the same logical_date hit the unique constraint and surfaced the raw DB error as **500**. Now: `mapConflict` translates Postgres SQLSTATE 23505 to `domain.ErrConflict`, and `handleRepoError` returns **409 Conflict** (matches Airflow). Unit tests on the handler table and the storage mapper.

## #116 — dev venv didn't refresh deps when the project (or its deps) changed
`ensureDevVenv` gated the project-deps install on `import leoflow_runtime` failing, so it ran only on first venv creation. Switching projects (or adding a dep) never refreshed → tasks failed with `ModuleNotFoundError`. Runtime install stays gated; project deps now tracked by an order-independent signature in `.leoflow-deps` and (re)installed when it drifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)