### PR TITLE
fix(agent): task-start/end framing — logs are never empty in the UI (#119)

### DIFF
--- a/internal/agent/framing_test.go
+++ b/internal/agent/framing_test.go
@@ -1,0 +1,93 @@
+package agent
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+)
+
+// linesSink captures whole LogLine values so a framing test can assert message,
+// level, and stream (capSink only records the message + line number).
+type linesSink struct{ ls []*agentv1.LogLine }
+
+func (s *linesSink) Send(l *agentv1.LogLine) error { s.ls = append(s.ls, l); return nil }
+func (s *linesSink) Close() error                  { return nil }
+
+// TestEmitTaskStarted writes a synthetic "▸ task started" line at INFO with
+// stream "agent" — so the UI's Logs panel is never empty even for a task that
+// calls no print() (#119).
+func TestEmitTaskStarted(t *testing.T) {
+	s := &linesSink{}
+	emitTaskStarted(s)
+	if len(s.ls) != 1 {
+		t.Fatalf("emitTaskStarted must send exactly 1 line, got %d", len(s.ls))
+	}
+	l := s.ls[0]
+	if !strings.Contains(l.GetMessage(), "task started") {
+		t.Errorf("message must mark the start, got %q", l.GetMessage())
+	}
+	if l.GetLevel() != agentv1.LogLevel_LOG_LEVEL_INFO {
+		t.Errorf("start framing should be INFO, got %v", l.GetLevel())
+	}
+	if l.GetStream() != "agent" {
+		t.Errorf("framing must use stream=%q so the UI logger column shows task.agent, got %q", "agent", l.GetStream())
+	}
+}
+
+// TestEmitTaskEndedSuccess writes an INFO "✓ task succeeded in <dur>" line on a
+// clean exit, so the panel always shows the terminal state.
+func TestEmitTaskEndedSuccess(t *testing.T) {
+	s := &linesSink{}
+	emitTaskEnded(s, 0, nil, 1234*time.Millisecond)
+	if len(s.ls) != 1 {
+		t.Fatalf("emitTaskEnded must send exactly 1 line, got %d", len(s.ls))
+	}
+	l := s.ls[0]
+	if !strings.Contains(l.GetMessage(), "succeeded") || !strings.Contains(l.GetMessage(), "1.234s") {
+		t.Errorf("success message must say succeeded with the duration, got %q", l.GetMessage())
+	}
+	if l.GetLevel() != agentv1.LogLevel_LOG_LEVEL_INFO {
+		t.Errorf("success framing should be INFO, got %v", l.GetLevel())
+	}
+}
+
+// TestEmitTaskEndedFailureWithCause writes an ERROR line with the exit code and
+// the wrapping cause, so a failing task always shows the reason — even when the
+// user task printed nothing before the failure.
+func TestEmitTaskEndedFailureWithCause(t *testing.T) {
+	s := &linesSink{}
+	emitTaskEnded(s, 2, errors.New("boom"), 500*time.Millisecond)
+	if len(s.ls) != 1 {
+		t.Fatalf("emitTaskEnded must send exactly 1 line, got %d", len(s.ls))
+	}
+	l := s.ls[0]
+	for _, want := range []string{"failed", "exit 2", "boom", "500ms"} {
+		if !strings.Contains(l.GetMessage(), want) {
+			t.Errorf("failure message must mention %q, got %q", want, l.GetMessage())
+		}
+	}
+	if l.GetLevel() != agentv1.LogLevel_LOG_LEVEL_ERROR {
+		t.Errorf("failure framing should be ERROR, got %v", l.GetLevel())
+	}
+}
+
+// TestEmitTaskEndedFailureNoCause covers a non-zero exit with no Go-level error
+// (the subprocess exited badly but Cmd.Run returned nil): still ERROR, still
+// mentions the exit code and duration.
+func TestEmitTaskEndedFailureNoCause(t *testing.T) {
+	s := &linesSink{}
+	emitTaskEnded(s, 7, nil, 100*time.Millisecond)
+	if len(s.ls) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(s.ls))
+	}
+	l := s.ls[0]
+	if !strings.Contains(l.GetMessage(), "failed") || !strings.Contains(l.GetMessage(), "exit 7") {
+		t.Errorf("non-zero exit without cause must still be flagged failed with the exit code, got %q", l.GetMessage())
+	}
+	if l.GetLevel() != agentv1.LogLevel_LOG_LEVEL_ERROR {
+		t.Errorf("non-zero exit framing should be ERROR, got %v", l.GetLevel())
+	}
+}

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -155,9 +155,14 @@ func (r *Runner) execute(ctx context.Context, argv, env []string) error {
 		go r.heartbeat(runCtx, cancel)
 	}
 
+	// Frame the run so a task with no print() still has visible logs in the UI —
+	// matching real Airflow, which always emits start/end framing (#119).
+	start := time.Now()
+	emitTaskStarted(r.Sink)
 	exitCode, runErr := r.Cmd.Run(runCtx, argv, env, stdout, stderr)
 	stdout.flush()
 	stderr.flush()
+	emitTaskEnded(r.Sink, exitCode, runErr, time.Since(start))
 	if cerr := r.Sink.Close(); cerr != nil {
 		slog.Warn("closing log stream", "error", cerr)
 	}
@@ -309,6 +314,48 @@ func (w *logWriter) flush() {
 	if len(w.buf) > 0 {
 		w.emit(w.buf)
 		w.buf = nil
+	}
+}
+
+// emitTaskStarted writes a synthetic start-of-task event to the log sink, so the
+// UI's Logs panel always shows at least one line — even for a task that calls no
+// print(). Best-effort; a sink error is logged but not propagated (the task
+// itself is what matters).
+func emitTaskStarted(sink LogSink) {
+	if err := sink.Send(&agentv1.LogLine{
+		Time:    timestamppb.Now(),
+		Level:   agentv1.LogLevel_LOG_LEVEL_INFO,
+		Message: "▸ task started",
+		Stream:  "agent",
+	}); err != nil {
+		slog.Warn("emitting task-started log", "error", err)
+	}
+}
+
+// emitTaskEnded writes a synthetic end-of-task event with the run duration and
+// either a success marker or the exit code + cause. Pairs with emitTaskStarted to
+// guarantee the Logs panel is never empty for a completed task (#119).
+func emitTaskEnded(sink LogSink, exitCode int, cause error, duration time.Duration) {
+	d := duration.Round(time.Millisecond)
+	var msg string
+	level := agentv1.LogLevel_LOG_LEVEL_INFO
+	if cause == nil && exitCode == 0 {
+		msg = fmt.Sprintf("✓ task succeeded in %s", d)
+	} else {
+		level = agentv1.LogLevel_LOG_LEVEL_ERROR
+		if cause != nil {
+			msg = fmt.Sprintf("✗ task failed (exit %d) in %s: %s", exitCode, d, cause.Error())
+		} else {
+			msg = fmt.Sprintf("✗ task failed (exit %d) in %s", exitCode, d)
+		}
+	}
+	if err := sink.Send(&agentv1.LogLine{
+		Time:    timestamppb.Now(),
+		Level:   level,
+		Message: msg,
+		Stream:  "agent",
+	}); err != nil {
+		slog.Warn("emitting task-ended log", "error", err)
 	}
 }
 

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -174,8 +174,17 @@ func TestRunnerHappyPath(t *testing.T) {
 	if !strings.Contains(je, "AIRFLOW_CONN_MY_DB=postgres://u:p@h/db") {
 		t.Errorf("env missing AIRFLOW_CONN_MY_DB: %v", env)
 	}
-	if len(sink.lines) != 2 || sink.lines[0] != "line one" {
-		t.Errorf("log lines = %v, want two captured lines", sink.lines)
+	// The agent frames a run with synthetic start/end events (#119) so a task
+	// with no print() still has visible logs, so the captured stream is:
+	//   ["▸ task started", "line one", "line two", "✓ task succeeded in <dur>"]
+	if len(sink.lines) != 4 || sink.lines[1] != "line one" || sink.lines[2] != "line two" {
+		t.Errorf("log lines = %v, want framing + 'line one' + 'line two' + framing", sink.lines)
+	}
+	if !strings.Contains(sink.lines[0], "task started") {
+		t.Errorf("first line must be the start framing, got %q", sink.lines[0])
+	}
+	if !strings.Contains(sink.lines[3], "succeeded") {
+		t.Errorf("last line must be the success framing, got %q", sink.lines[3])
 	}
 	if !sink.closed {
 		t.Error("log sink should be closed after the command exits")

--- a/internal/api/resources.go
+++ b/internal/api/resources.go
@@ -114,6 +114,10 @@ func handleRepoError(c *gin.Context, err error) {
 		AbortProblem(c, http.StatusNotFound, "not found", err.Error())
 		return
 	}
+	if errors.Is(err, domain.ErrConflict) {
+		AbortProblem(c, http.StatusConflict, "conflict", err.Error())
+		return
+	}
 	// A canceled/timed-out context means the client went away (the UI routinely
 	// supersedes in-flight grid requests). That is NOT a server error — mapping it
 	// to 500 produced spurious ti_summaries 500s under rapid refresh. Report 499 so

--- a/internal/api/resources_test.go
+++ b/internal/api/resources_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -596,6 +597,8 @@ func TestHandleRepoErrorClientCancel(t *testing.T) {
 		{"deadline exceeded", context.DeadlineExceeded, statusClientClosedRequest},
 		{"wrapped cancel", errors.Join(errors.New("task instances for runs"), context.Canceled), statusClientClosedRequest},
 		{"not found", ErrNotFound, http.StatusNotFound},
+		{"conflict (duplicate run)", domain.ErrConflict, http.StatusConflict},
+		{"wrapped conflict", fmt.Errorf("creating dag run: %w", domain.ErrConflict), http.StatusConflict},
 		{"real server error", errors.New("db exploded"), http.StatusInternalServerError},
 	}
 	for _, tc := range cases {

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -15,6 +15,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -847,16 +848,66 @@ func ensureDevVenv(ctx context.Context, cmd *cobra.Command, home, runtimeSrc str
 			return "", fmt.Errorf("creating dev venv with %s (the managed CPython bundles venv; a system python3 may need its python3-venv package): %w", base, e)
 		}
 	}
+	// Runtime + Airflow SDK: install once, gated by the runtime being importable, so
+	// reruns are fast. (No project deps here — those are tracked separately below.)
 	check := exec.CommandContext(ctx, py, "-c", "import leoflow_runtime") //nolint:gosec // py is the managed venv interpreter
 	if check.Run() != nil {
 		devPrintln(cmd.OutOrStdout(), "▸ installing task runtime + Airflow SDK into the dev venv …")
-		install := exec.CommandContext(ctx, py, venvPipArgs(runtimeSrc, deps)...) //nolint:gosec // py is the managed venv interpreter
+		install := exec.CommandContext(ctx, py, venvPipArgs(runtimeSrc, nil)...) //nolint:gosec // py is the managed venv interpreter
 		install.Stdout, install.Stderr = cmd.OutOrStdout(), cmd.ErrOrStderr()
 		if e := install.Run(); e != nil {
-			return "", fmt.Errorf("installing dev venv packages: %w", e)
+			return "", fmt.Errorf("installing dev venv runtime: %w", e)
+		}
+	}
+	// Project deps: (re)install when the active project's declared dependencies
+	// change — gating only on the runtime above meant switching projects, or
+	// editing `dependencies:`, never refreshed the venv (#116). Additive: extra
+	// packages from a previous project are harmless.
+	if len(deps) > 0 && !devDepsUpToDate(home, deps) {
+		devPrintln(cmd.OutOrStdout(), "▸ installing project dependencies into the dev venv …")
+		install := exec.CommandContext(ctx, py, venvDepsArgs(deps)...) //nolint:gosec // py is the managed venv interpreter
+		install.Stdout, install.Stderr = cmd.OutOrStdout(), cmd.ErrOrStderr()
+		if e := install.Run(); e != nil {
+			return "", fmt.Errorf("installing project dependencies: %w", e)
+		}
+		if e := writeDevDepsMarker(home, deps); e != nil {
+			return "", fmt.Errorf("recording installed project deps: %w", e)
 		}
 	}
 	return py, nil
+}
+
+// venvDepsArgs is the pip invocation that installs just the project's declared
+// dependencies into the dev venv.
+func venvDepsArgs(deps []string) []string {
+	return append([]string{"-m", "pip", "install", "-q"}, deps...)
+}
+
+// devDepsMarkerPath is the file recording which project dependencies the dev venv
+// currently has installed.
+func devDepsMarkerPath(home string) string { return filepath.Join(home, "venv", ".leoflow-deps") }
+
+// devDepsSignature is an order-independent canonical form of a dependency list, so
+// reordering `dependencies:` does not force a needless reinstall.
+func devDepsSignature(deps []string) string {
+	s := append([]string(nil), deps...)
+	sort.Strings(s)
+	return strings.Join(s, "\n")
+}
+
+// devDepsUpToDate reports whether the dev venv already has exactly these project
+// deps installed (per the marker written by the last successful install).
+func devDepsUpToDate(home string, deps []string) bool {
+	b, err := os.ReadFile(devDepsMarkerPath(home)) //nolint:gosec // path derived from the per-user dev home
+	if err != nil {
+		return false
+	}
+	return string(b) == devDepsSignature(deps)
+}
+
+// writeDevDepsMarker records the project deps just installed into the dev venv.
+func writeDevDepsMarker(home string, deps []string) error {
+	return os.WriteFile(devDepsMarkerPath(home), []byte(devDepsSignature(deps)), 0o600)
 }
 
 // devRun and devOutput run external dev tools (k3d/docker/kubectl). They are

--- a/internal/cli/dev_venv_test.go
+++ b/internal/cli/dev_venv_test.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDevDepsSignatureOrderIndependent: the canonical signature ignores ordering,
+// so a leoflow.yaml that just reorders `dependencies:` does not force a needless
+// reinstall.
+func TestDevDepsSignatureOrderIndependent(t *testing.T) {
+	a := devDepsSignature([]string{"requests==2.31.0", "duckdb==1.4.4"})
+	b := devDepsSignature([]string{"duckdb==1.4.4", "requests==2.31.0"})
+	if a != b {
+		t.Errorf("signature must be order-independent: %q != %q", a, b)
+	}
+	c := devDepsSignature([]string{"requests==2.31.0"})
+	if a == c {
+		t.Errorf("a different dep set must yield a different signature: both %q", a)
+	}
+}
+
+// TestDevDepsRoundtrip: after writeDevDepsMarker, devDepsUpToDate is true for the
+// same deps and false when the deps change — which is what gates the reinstall
+// when switching projects or editing dependencies (#116).
+func TestDevDepsRoundtrip(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, "venv"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if devDepsUpToDate(home, []string{"x"}) {
+		t.Errorf("an absent marker must report not up-to-date")
+	}
+	if err := writeDevDepsMarker(home, []string{"requests==2.31.0", "duckdb==1.4.4"}); err != nil {
+		t.Fatal(err)
+	}
+	if !devDepsUpToDate(home, []string{"duckdb==1.4.4", "requests==2.31.0"}) {
+		t.Errorf("same deps (any order) must report up-to-date after a successful install")
+	}
+	if devDepsUpToDate(home, []string{"requests==2.31.0"}) {
+		t.Errorf("a different dep set must report not up-to-date (forces reinstall on project switch)")
+	}
+}

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -4,3 +4,7 @@ import "errors"
 
 // ErrNotFound is returned when a requested resource does not exist.
 var ErrNotFound = errors.New("resource not found")
+
+// ErrConflict is returned when a write conflicts with an existing resource (e.g.
+// a duplicate dag run for the same logical date). The API maps it to 409.
+var ErrConflict = errors.New("resource already exists")

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/neochaotic/leoflow/internal/auth"
@@ -49,6 +50,21 @@ func toInt32(n int) int32 {
 func mapNotFound(err error) error {
 	if errors.Is(err, pgx.ErrNoRows) {
 		return domain.ErrNotFound
+	}
+	return err
+}
+
+// pgUniqueViolation is the Postgres SQLSTATE for a unique-constraint violation.
+const pgUniqueViolation = "23505"
+
+// mapConflict translates a Postgres unique-constraint violation into
+// domain.ErrConflict (which the API maps to 409), leaving other errors as is — so
+// a duplicate write (e.g. a second dag run for the same logical date) surfaces as
+// a clean conflict rather than a raw 500.
+func mapConflict(err error) error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == pgUniqueViolation {
+		return domain.ErrConflict
 	}
 	return err
 }
@@ -213,7 +229,7 @@ func (r *Repository) CreateDagRun(ctx context.Context, tenant, dagID string, run
 		Note:         strPtr(run.Note),
 	})
 	if err != nil {
-		return domain.DagRun{}, fmt.Errorf("creating dag run: %w", err)
+		return domain.DagRun{}, fmt.Errorf("creating dag run: %w", mapConflict(err))
 	}
 	// The trigger's audit entry is written by the API handler, where the acting
 	// user is known (so the Audit Log shows the owner).

--- a/internal/storage/repository_test.go
+++ b/internal/storage/repository_test.go
@@ -1,0 +1,32 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// TestMapConflict: a Postgres unique-constraint violation (SQLSTATE 23505) maps to
+// domain.ErrConflict (so the API returns 409 for a duplicate run); other errors,
+// including a different SQLSTATE, pass through unchanged.
+func TestMapConflict(t *testing.T) {
+	unique := &pgconn.PgError{Code: "23505", Message: "duplicate key value violates unique constraint"}
+	if got := mapConflict(unique); !errors.Is(got, domain.ErrConflict) {
+		t.Errorf("23505 must map to ErrConflict, got %v", got)
+	}
+	if got := mapConflict(fmt.Errorf("wrapped: %w", unique)); !errors.Is(got, domain.ErrConflict) {
+		t.Errorf("wrapped 23505 must map to ErrConflict, got %v", got)
+	}
+	other := &pgconn.PgError{Code: "23503", Message: "foreign key violation"}
+	if got := mapConflict(other); errors.Is(got, domain.ErrConflict) {
+		t.Errorf("a non-unique SQLSTATE must NOT map to ErrConflict, got %v", got)
+	}
+	plain := errors.New("connection refused")
+	if got := mapConflict(plain); errors.Is(got, domain.ErrConflict) {
+		t.Errorf("a non-pg error must not map to ErrConflict, got %v", got)
+	}
+}


### PR DESCRIPTION
Closes #119.

## Root cause
The agent (`internal/agent/runner.go::execute`) shipped only the user's stdout/stderr to the per-task log file via `logWriter`. There was **no framing** of its own — no "task started", no "task succeeded/failed" line. The #80 fix made sure user stdout reached the file; tasks that print are fine, but a task with **no `print()`** left the file empty, so the UI's Logs panel showed only the wrapper `::group::Log message source details / sources=[...]` with no events after `::endgroup::` — visually broken. Real Airflow always emits framing; Leoflow never did. **Not a .17 regression — #80 stopped at "stdout reaches the file" and the framing gap was invisible until a printless task was opened.**

## Fix
The agent emits two synthetic `LogLine` events on the same `Sink` as stdout/stderr (stream=`agent` → UI's logger column shows `task.agent`):
- `▸ task started` (INFO) at the start
- `✓ task succeeded in <dur>` (INFO) or `✗ task failed (exit N) in <dur>: <cause>` (ERROR) at the end

The UI renders them as ordinary content events — zero UI change.

## Verification
- Unit: `TestEmitTaskStarted`, `TestEmitTaskEndedSuccess`, `TestEmitTaskEndedFailureWithCause`, `TestEmitTaskEndedFailureNoCause` (level, message, stream).
- Existing: `TestRunnerHappyPath` updated to expect framing + user lines.
- **e2e on Lima** (subprocess executor): a `silent` task with `pass  # no print` runs → API log payload now has **4 events** (was 2): the `::group::`/`::endgroup::` wrappers + `▸ task started` (info) + `✓ task succeeded in 727ms` (info). `start_framing_present: True`, `end_framing_present: True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)