### PR TITLE
fix(scheduler): TI heartbeat reaper — companion safety net for agent-side crashes (#128)

### DIFF
--- a/internal/agentrpc/server.go
+++ b/internal/agentrpc/server.go
@@ -44,6 +44,10 @@ type Store interface {
 	TaskSpec(ctx context.Context, id auth.AgentIdentity) (TaskSpec, error)
 	// ReportState records a state transition reported by the agent.
 	ReportState(ctx context.Context, id auth.AgentIdentity, state domain.TaskState, exitCode int, errMsg string) error
+	// RecordHeartbeat stamps last_heartbeat_at on the identified TI so the
+	// scheduler's heartbeat reaper (#128) can tell live tasks from agent-lost
+	// ones. The state guard inside the SQL skips already-terminal rows.
+	RecordHeartbeat(ctx context.Context, id auth.AgentIdentity) error
 }
 
 // XComService stores and retrieves XCom values for the agent.
@@ -142,10 +146,20 @@ func (s *Server) ReportState(ctx context.Context, req *agentv1.ReportStateReques
 	return &agentv1.ReportStateResponse{Acknowledged: true}, nil
 }
 
-// Heartbeat returns the server clock so the agent can detect skew.
+// Heartbeat stamps the per-TI liveness signal (#128) and returns the server
+// clock so the agent can detect skew. A storage error stamping the heartbeat
+// is logged but does not fail the RPC — failing the call would risk the
+// agent terminating itself unnecessarily on a transient DB blip. The
+// scheduler reaper would, in the worst case, fail the TI as agent_lost on
+// the next tick; correct under "do no harm" (ADR 0031).
 func (s *Server) Heartbeat(ctx context.Context, _ *agentv1.HeartbeatRequest) (*agentv1.HeartbeatResponse, error) {
-	if _, err := s.identify(ctx); err != nil {
+	id, err := s.identify(ctx)
+	if err != nil {
 		return nil, err
+	}
+	if hbErr := s.store.RecordHeartbeat(ctx, *id); hbErr != nil {
+		slog.Warn("recording heartbeat",
+			"ti", id.TaskInstanceID, "run", id.RunID, "task", id.TaskID, "error", hbErr)
 	}
 	return &agentv1.HeartbeatResponse{ServerTime: timestamppb.New(s.now())}, nil
 }

--- a/internal/agentrpc/server_test.go
+++ b/internal/agentrpc/server_test.go
@@ -20,10 +20,12 @@ import (
 
 // fakeStore records ReportState calls and serves a fixed task spec.
 type fakeStore struct {
-	spec      TaskSpec
-	specErr   error
-	reported  []reportedState
-	reportErr error
+	spec         TaskSpec
+	specErr      error
+	reported     []reportedState
+	reportErr    error
+	heartbeats   []auth.AgentIdentity
+	heartbeatErr error
 }
 
 type reportedState struct {
@@ -40,6 +42,11 @@ func (s *fakeStore) TaskSpec(context.Context, auth.AgentIdentity) (TaskSpec, err
 func (s *fakeStore) ReportState(_ context.Context, id auth.AgentIdentity, st domain.TaskState, exit int, msg string) error {
 	s.reported = append(s.reported, reportedState{id, st, exit, msg})
 	return s.reportErr
+}
+
+func (s *fakeStore) RecordHeartbeat(_ context.Context, id auth.AgentIdentity) error {
+	s.heartbeats = append(s.heartbeats, id)
+	return s.heartbeatErr
 }
 
 func testIdentity() auth.AgentIdentity {
@@ -360,6 +367,40 @@ func (w *fakeSinkWriter) WriteEvent(ev logs.Event) error {
 	return nil
 }
 func (w *fakeSinkWriter) Close() error { return nil }
+
+// TestHeartbeatRecordsLivenessOnStore: the Heartbeat RPC stamps
+// last_heartbeat_at via store.RecordHeartbeat so the scheduler's heartbeat
+// reaper (#128) can distinguish live tasks from agent-lost ones. The RPC
+// must still succeed when the store stamp fails (transient DB blip) — see
+// the comment on Server.Heartbeat: failing the call would risk the agent
+// terminating itself unnecessarily.
+func TestHeartbeatRecordsLivenessOnStore(t *testing.T) {
+	store := &fakeStore{}
+	srv, authn := newServer(store)
+	if _, err := srv.Heartbeat(ctxWithToken(t, authn), &agentv1.HeartbeatRequest{}); err != nil {
+		t.Fatalf("Heartbeat: %v", err)
+	}
+	if len(store.heartbeats) != 1 {
+		t.Fatalf("heartbeats recorded = %d, want 1", len(store.heartbeats))
+	}
+	got := store.heartbeats[0]
+	if got.TaskInstanceID != "ti-1" || got.RunID != "run-1" || got.TaskID != "extract" {
+		t.Errorf("heartbeat identity = %+v, want the testIdentity", got)
+	}
+}
+
+// TestHeartbeatSucceedsWhenStoreFails pins the resilience contract: a
+// transient DB error inside RecordHeartbeat must not surface as an RPC error
+// to the agent. Otherwise the agent could terminate itself on a DB blip.
+// The scheduler reaper would in the worst case fail the TI as agent_lost on
+// the next tick — correct under "do no harm" (ADR 0031).
+func TestHeartbeatSucceedsWhenStoreFails(t *testing.T) {
+	store := &fakeStore{heartbeatErr: errors.New("db transient blip")}
+	srv, authn := newServer(store)
+	if _, err := srv.Heartbeat(ctxWithToken(t, authn), &agentv1.HeartbeatRequest{}); err != nil {
+		t.Errorf("Heartbeat must not surface a transient store error to the agent; got %v", err)
+	}
+}
 
 func TestRegisterAndHeartbeatReturnServerTime(t *testing.T) {
 	srv, a := newServer(&fakeStore{})

--- a/internal/agentrpc/tls_test.go
+++ b/internal/agentrpc/tls_test.go
@@ -81,6 +81,7 @@ func (tlsFakeStore) TaskSpec(context.Context, auth.AgentIdentity) (agentrpc.Task
 func (tlsFakeStore) ReportState(context.Context, auth.AgentIdentity, domain.TaskState, int, string) error {
 	return nil
 }
+func (tlsFakeStore) RecordHeartbeat(context.Context, auth.AgentIdentity) error { return nil }
 
 type tlsNoXCom struct{}
 

--- a/internal/scheduler/heartbeat_reap.go
+++ b/internal/scheduler/heartbeat_reap.go
@@ -1,0 +1,103 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"runtime/debug"
+	"time"
+)
+
+// AgentLostCandidate is one task instance in `running` whose agent may have
+// gone silent, with the timestamp of its most recent heartbeat. The reaper
+// compares the gap from this stamp to "now" against a stall threshold; a
+// non-zero gap larger than the threshold means the agent is presumed gone
+// and the TI is failed with reason "agent_lost".
+type AgentLostCandidate struct {
+	TaskInstanceID string
+	DagRunID       string
+	DagID          string
+	TaskID         string
+	LastHeartbeat  time.Time
+}
+
+// IsAgentLost reports whether the agent has been silent long enough to be
+// declared lost. A zero LastHeartbeat (never reported) is treated as alive,
+// not lost — the TI may be inline (no agent ever exists), or simply has not
+// completed its first interval yet. The reaper only fires on TIs that did
+// heartbeat at least once and then went silent; this is the "do no harm"
+// rule of ADR 0031. Future timestamps (clock skew) are treated as alive.
+func IsAgentLost(c AgentLostCandidate, threshold time.Duration, now time.Time) bool {
+	if c.LastHeartbeat.IsZero() {
+		return false
+	}
+	return now.Sub(c.LastHeartbeat) >= threshold
+}
+
+// HeartbeatReapStore is the slice of scheduler.Store the TI heartbeat reaper
+// needs. The full scheduler.Store embeds this interface so production wires
+// through one type; unit tests fake just this surface.
+type HeartbeatReapStore interface {
+	// ListAgentLostCandidates returns every `running` TI whose last heartbeat
+	// is non-null (it has heartbeated at least once). The reaper applies the
+	// threshold per candidate so the SQL stays simple and the decision is
+	// purely in Go.
+	ListAgentLostCandidates(ctx context.Context) ([]AgentLostCandidate, error)
+	// MarkTaskAgentLost transitions one TI to `failed` with
+	// error_message='agent_lost'. The WHERE state='running' guard makes this
+	// idempotent: a second call on a now-failed TI is a no-op.
+	MarkTaskAgentLost(ctx context.Context, taskInstanceID string) error
+}
+
+// agentLostReaper is the scheduler-internal worker that fails TIs whose agent
+// went silent. Invoked once per scheduler tick, leader-only. Mirrors the
+// shape of orphanReaper deliberately so the two reapers share the same
+// resilience invariants: panic-safe, per-candidate isolated, metered.
+type agentLostReaper struct {
+	store     HeartbeatReapStore
+	logger    *slog.Logger
+	threshold time.Duration
+	recorder  Recorder
+}
+
+func newAgentLostReaper(store HeartbeatReapStore, logger *slog.Logger, threshold time.Duration, rec Recorder) *agentLostReaper {
+	return &agentLostReaper{store: store, logger: logger, threshold: threshold, recorder: rec}
+}
+
+// run lists every candidate, fails the stale ones, returns any infra-level
+// list error so the caller can log it. Per-TI failures are isolated; a panic
+// at any point is recovered so the scheduler tick stays alive.
+func (r *agentLostReaper) run(ctx context.Context) error {
+	defer func() {
+		if rec := recover(); rec != nil {
+			r.logger.Error("agent-lost reaper panic recovered", "panic", rec, "stack", string(debug.Stack()))
+			r.record("agent_lost_panic")
+		}
+	}()
+	candidates, err := r.store.ListAgentLostCandidates(ctx)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	for _, c := range candidates {
+		if !IsAgentLost(c, r.threshold, now) {
+			continue
+		}
+		if ferr := r.store.MarkTaskAgentLost(ctx, c.TaskInstanceID); ferr != nil {
+			r.logger.Error("marking task agent-lost",
+				"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID, "error", ferr)
+			r.record("agent_lost_error")
+			continue
+		}
+		r.logger.Warn("task agent silent past threshold; failing as agent_lost",
+			"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID,
+			"last_heartbeat", c.LastHeartbeat)
+		r.record("agent_lost")
+	}
+	return nil
+}
+
+func (r *agentLostReaper) record(decision string) {
+	if r.recorder != nil {
+		r.recorder.RecordSchedulerDecision(decision)
+	}
+}

--- a/internal/scheduler/heartbeat_reap_test.go
+++ b/internal/scheduler/heartbeat_reap_test.go
@@ -1,0 +1,146 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestIsAgentLost: the pure decision returns true iff the gap between the
+// candidate's last heartbeat and now reaches the threshold. A zero
+// LastHeartbeat (never reported) is treated as still alive — the TI may be
+// inline (no agent) or fresh — so this reaper only fires on TIs that *did*
+// heartbeat at least once and then went silent. The "do no harm" rule
+// (ADR 0031): a positive observable signal is required.
+func TestIsAgentLost(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	const threshold = 90 * time.Second
+
+	tests := []struct {
+		name string
+		last time.Time
+		want bool
+	}{
+		{"fresh heartbeat is alive", now.Add(-1 * time.Second), false},
+		{"exactly at threshold is lost", now.Add(-90 * time.Second), true},
+		{"well past threshold is lost", now.Add(-10 * time.Minute), true},
+		{"future heartbeat (clock skew) is alive", now.Add(1 * time.Second), false},
+		{"zero heartbeat is alive (never reported, out of scope)", time.Time{}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := IsAgentLost(AgentLostCandidate{LastHeartbeat: tc.last}, threshold, now)
+			if got != tc.want {
+				t.Errorf("IsAgentLost(last=%v) = %v, want %v", tc.last, got, tc.want)
+			}
+		})
+	}
+}
+
+// fakeHeartbeatStore is the minimal store the reaper needs in unit tests.
+type fakeHeartbeatStore struct {
+	candidates []AgentLostCandidate
+	listErr    error
+	failed     []string
+	failErr    error
+}
+
+func (f *fakeHeartbeatStore) ListAgentLostCandidates(context.Context) ([]AgentLostCandidate, error) {
+	return f.candidates, f.listErr
+}
+
+func (f *fakeHeartbeatStore) MarkTaskAgentLost(_ context.Context, tiID string) error {
+	if f.failErr != nil {
+		return f.failErr
+	}
+	f.failed = append(f.failed, tiID)
+	return nil
+}
+
+// TestReapAgentLost_MarksStaleTIs covers the success path: only candidates
+// older than the threshold get failed; fresh ones are left alone. This is
+// the contract that makes "stuck dag_run because one TI's agent died"
+// recoverable without manual intervention.
+func TestReapAgentLost_MarksStaleTIs(t *testing.T) {
+	now := time.Now().UTC()
+	store := &fakeHeartbeatStore{candidates: []AgentLostCandidate{
+		{TaskInstanceID: "fresh-ti", LastHeartbeat: now.Add(-1 * time.Second)},
+		{TaskInstanceID: "stale-ti", LastHeartbeat: now.Add(-5 * time.Minute)},
+	}}
+	rec := &capturingRecorder{}
+	r := newAgentLostReaper(store, reapTestLogger(), 90*time.Second, rec)
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run err = %v", err)
+	}
+	if len(store.failed) != 1 || store.failed[0] != "stale-ti" {
+		t.Errorf("failed = %v, want [stale-ti]", store.failed)
+	}
+	if got := rec.count("agent_lost"); got != 1 {
+		t.Errorf("agent_lost decisions = %d, want 1", got)
+	}
+}
+
+// TestReapAgentLost_ListErrorSurfaces: a list failure is returned so the
+// caller can log it (the scheduler's reapHeartbeatLossesIfLeader treats this
+// as a "next tick will try again" condition). It must NEVER panic.
+func TestReapAgentLost_ListErrorSurfaces(t *testing.T) {
+	r := newAgentLostReaper(&fakeHeartbeatStore{listErr: errors.New("db down")},
+		reapTestLogger(), 90*time.Second, nil)
+	if err := r.run(context.Background()); err == nil {
+		t.Error("expected list error to be returned")
+	}
+}
+
+// TestReapAgentLost_PerTIErrorIsolated: a failure on one TI does not stall
+// the rest of the candidate set — same isolation pattern as the run reaper
+// and advanceSafely.
+func TestReapAgentLost_PerTIErrorIsolated(t *testing.T) {
+	now := time.Now().UTC()
+	store := &fakeHeartbeatStore{
+		candidates: []AgentLostCandidate{
+			{TaskInstanceID: "a", LastHeartbeat: now.Add(-5 * time.Minute)},
+			{TaskInstanceID: "b", LastHeartbeat: now.Add(-5 * time.Minute)},
+		},
+		failErr: errors.New("write failed"),
+	}
+	r := newAgentLostReaper(store, reapTestLogger(), 90*time.Second, nil)
+	if err := r.run(context.Background()); err != nil {
+		t.Errorf("run err = %v, want nil (per-TI errors isolated)", err)
+	}
+}
+
+// panicHeartbeatStore is the resilience pin — any panic in the store layer
+// must be recovered. The scheduler must never die.
+type panicHeartbeatStore struct {
+	panicOnList bool
+	panicOnFail bool
+}
+
+func (p *panicHeartbeatStore) ListAgentLostCandidates(context.Context) ([]AgentLostCandidate, error) {
+	if p.panicOnList {
+		panic("boom: ListAgentLostCandidates")
+	}
+	return []AgentLostCandidate{{TaskInstanceID: "doomed", LastHeartbeat: time.Now().Add(-1 * time.Hour)}}, nil
+}
+func (p *panicHeartbeatStore) MarkTaskAgentLost(context.Context, string) error {
+	if p.panicOnFail {
+		panic("boom: MarkTaskAgentLost")
+	}
+	return nil
+}
+
+func TestReapAgentLost_PanicInListDoesNotCrash(t *testing.T) {
+	r := newAgentLostReaper(&panicHeartbeatStore{panicOnList: true}, reapTestLogger(), 90*time.Second, nil)
+	if err := r.run(context.Background()); err != nil {
+		t.Errorf("panic in list must be recovered; got error %v", err)
+	}
+}
+
+func TestReapAgentLost_PanicInMarkDoesNotCrash(t *testing.T) {
+	r := newAgentLostReaper(&panicHeartbeatStore{panicOnFail: true}, reapTestLogger(), 90*time.Second, nil)
+	if err := r.run(context.Background()); err != nil {
+		t.Errorf("panic in MarkTaskAgentLost must be recovered; got error %v", err)
+	}
+}

--- a/internal/scheduler/resilience_test.go
+++ b/internal/scheduler/resilience_test.go
@@ -97,6 +97,10 @@ func (f *flakyStore) ListReapCandidates(context.Context) ([]ReapCandidate, error
 	return nil, nil
 }
 func (f *flakyStore) ReapRun(context.Context, string) error { return nil }
+func (f *flakyStore) ListAgentLostCandidates(context.Context) ([]AgentLostCandidate, error) {
+	return nil, nil
+}
+func (f *flakyStore) MarkTaskAgentLost(context.Context, string) error { return nil }
 
 func (f *flakyStore) snapshotMaterialized() []string {
 	f.mu.Lock()

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -51,6 +51,10 @@ type Store interface {
 	// ReapStore methods drive the orphan reaper (#120): they list running runs
 	// that have gone quiet and fail them so the dashboard counter is correct.
 	ReapStore
+	// HeartbeatReapStore methods drive the TI heartbeat reaper (#128): they
+	// list `running` task instances whose agent has gone silent and fail them
+	// as `agent_lost` so the dashboard counter recovers from agent-side crashes.
+	HeartbeatReapStore
 }
 
 // Recorder records scheduler metrics. observability.Metrics implements it.
@@ -82,18 +86,25 @@ type InlineRunner interface {
 // that a real orphan is reaped before the operator looks at the dashboard.
 const defaultOrphanThreshold = 5 * time.Minute
 
+// defaultAgentLostThreshold is how long a running TI may go without an agent
+// heartbeat before the TI reaper declares the agent lost. 90 s is 6x the
+// default agent heartbeat interval (15 s, see cmd/leoflow-agent/main.go),
+// tolerating a handful of missed pings before failing the task.
+const defaultAgentLostThreshold = 90 * time.Second
+
 // Scheduler advances dag runs by applying the planning rules each tick.
 type Scheduler struct {
-	store           Store
-	logger          *slog.Logger
-	interval        time.Duration
-	stepTimeout     time.Duration
-	recorder        Recorder
-	dispatcher      Dispatcher
-	inline          InlineRunner
-	orphanThreshold time.Duration
-	lastTick        atomic.Int64 // unix-nano of the last loop iteration; 0 = not yet ticked
-	leading         atomic.Bool  // true only while this instance holds leadership and ticks
+	store              Store
+	logger             *slog.Logger
+	interval           time.Duration
+	stepTimeout        time.Duration
+	recorder           Recorder
+	dispatcher         Dispatcher
+	inline             InlineRunner
+	orphanThreshold    time.Duration
+	agentLostThreshold time.Duration
+	lastTick           atomic.Int64 // unix-nano of the last loop iteration; 0 = not yet ticked
+	leading            atomic.Bool  // true only while this instance holds leadership and ticks
 	// warnedSchedules dedupes the "unparseable schedule" warning per DAG (keyed by
 	// the offending expression) so a bad cron logs once, not every tick. Accessed
 	// only from the single-threaded tick (createDueRuns), so it needs no lock.
@@ -103,12 +114,13 @@ type Scheduler struct {
 // NewScheduler builds a Scheduler over the given store, ticking every interval.
 func NewScheduler(store Store, logger *slog.Logger, interval time.Duration) *Scheduler {
 	return &Scheduler{
-		store:           store,
-		logger:          logger,
-		interval:        interval,
-		stepTimeout:     defaultStepTimeout(interval),
-		orphanThreshold: defaultOrphanThreshold,
-		warnedSchedules: map[string]string{},
+		store:              store,
+		logger:             logger,
+		interval:           interval,
+		stepTimeout:        defaultStepTimeout(interval),
+		orphanThreshold:    defaultOrphanThreshold,
+		agentLostThreshold: defaultAgentLostThreshold,
+		warnedSchedules:    map[string]string{},
 	}
 }
 
@@ -116,6 +128,11 @@ func NewScheduler(store Store, logger *slog.Logger, interval time.Duration) *Sch
 // declare a running dag run orphaned (optional; mainly for tests). The default
 // is defaultOrphanThreshold.
 func (s *Scheduler) SetOrphanThreshold(d time.Duration) { s.orphanThreshold = d }
+
+// SetAgentLostThreshold overrides the silence window the TI heartbeat reaper
+// uses to declare a task's agent lost (optional; mainly for tests). The default
+// is defaultAgentLostThreshold.
+func (s *Scheduler) SetAgentLostThreshold(d time.Duration) { s.agentLostThreshold = d }
 
 // defaultStepTimeout bounds how long one scheduling tick may run before it is
 // canceled so the loop can recover, rather than hang forever on a stuck query.
@@ -233,18 +250,25 @@ func (s *Scheduler) Step(ctx context.Context) error {
 	return createErr
 }
 
-// reapOrphansIfLeader runs the orphan reaper exactly once per tick, only on the
-// leader: reaping writes state and we want one writer at a time across the
-// fleet. A list error is logged (not returned) because it should not stall the
-// rest of the loop — the reaper is a backstop, not on the critical path.
+// reapOrphansIfLeader runs both reapers (run-level orphans + TI-level
+// agent-lost) exactly once per tick, only on the leader: reaping writes state
+// and we want one writer at a time across the fleet. A list error is logged
+// (not returned) because it should not stall the rest of the loop — the
+// reapers are backstops, not on the critical path. The two reapers are
+// independent: a failure in one does not prevent the other from running.
 func (s *Scheduler) reapOrphansIfLeader(ctx context.Context) {
 	if !s.leading.Load() {
 		return
 	}
-	r := newOrphanReaper(s.store, s.logger, s.orphanThreshold, s.recorder)
-	if err := r.run(ctx); err != nil {
+	runReaper := newOrphanReaper(s.store, s.logger, s.orphanThreshold, s.recorder)
+	if err := runReaper.run(ctx); err != nil {
 		s.logger.Error("orphan reaper", "error", err)
 		s.record("orphan_list_error")
+	}
+	tiReaper := newAgentLostReaper(s.store, s.logger, s.agentLostThreshold, s.recorder)
+	if err := tiReaper.run(ctx); err != nil {
+		s.logger.Error("agent-lost reaper", "error", err)
+		s.record("agent_lost_list_error")
 	}
 }
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -19,17 +19,19 @@ type transition struct {
 }
 
 type fakeStore struct {
-	runs        []RunState
-	materialize []string
-	transitions []transition
-	retried     []transition
-	runStates   map[string]domain.DagRunState
-	scheduled   []ScheduledDAG
-	createdRuns []string
-	notes       map[string]string
-	reapCands   []ReapCandidate
-	reaped      []string
-	createErr   bool
+	runs            []RunState
+	materialize     []string
+	transitions     []transition
+	retried         []transition
+	runStates       map[string]domain.DagRunState
+	scheduled       []ScheduledDAG
+	createdRuns     []string
+	notes           map[string]string
+	reapCands       []ReapCandidate
+	reaped          []string
+	createErr       bool
+	agentLostCands  []AgentLostCandidate
+	agentLostMarked []string
 }
 
 func newFakeStore(runs ...RunState) *fakeStore {
@@ -75,6 +77,13 @@ func (f *fakeStore) ListReapCandidates(context.Context) ([]ReapCandidate, error)
 }
 func (f *fakeStore) ReapRun(_ context.Context, runID string) error {
 	f.reaped = append(f.reaped, runID)
+	return nil
+}
+func (f *fakeStore) ListAgentLostCandidates(context.Context) ([]AgentLostCandidate, error) {
+	return f.agentLostCands, nil
+}
+func (f *fakeStore) MarkTaskAgentLost(_ context.Context, tiID string) error {
+	f.agentLostMarked = append(f.agentLostMarked, tiID)
 	return nil
 }
 

--- a/internal/storage/agent_store.go
+++ b/internal/storage/agent_store.go
@@ -65,6 +65,22 @@ func (s *ExecutionStore) ReportState(ctx context.Context, id auth.AgentIdentity,
 	return s.q.ReportTaskResult(ctx, params)
 }
 
+// RecordHeartbeat stamps last_heartbeat_at on the agent's TI so the
+// scheduler's heartbeat reaper (#128) can tell a live task from one whose
+// agent has gone silent. The SQL guard skips terminal rows — a late
+// heartbeat after a terminal report is a no-op, not a regression.
+func (s *ExecutionStore) RecordHeartbeat(ctx context.Context, id auth.AgentIdentity) error {
+	rid, err := parseUUID(id.RunID)
+	if err != nil {
+		return err
+	}
+	return s.q.RecordTaskHeartbeat(ctx, queries.RecordTaskHeartbeatParams{
+		DagRunID:  rid,
+		TaskID:    id.TaskID,
+		TryNumber: toInt32(id.TryNumber),
+	})
+}
+
 // FailTask marks a task instance failed by its ID, but only while it is still
 // active (scheduled/queued/running), so it never clobbers a terminal state. It
 // implements executor.FailureReporter for the pod reconciler.

--- a/internal/storage/heartbeat_reap_integration_test.go
+++ b/internal/storage/heartbeat_reap_integration_test.go
@@ -1,0 +1,155 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/config"
+	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/scheduler"
+	"github.com/neochaotic/leoflow/internal/storage"
+)
+
+// openExec extends the openRepo helper with an ExecutionStore over the same
+// pool, so the heartbeat write path can be exercised end-to-end.
+func openExec(t *testing.T) (*storage.Repository, *storage.SchedulerStore, *storage.ExecutionStore, context.Context) {
+	t.Helper()
+	url := os.Getenv("DATABASE_URL")
+	if url == "" {
+		t.Skip("DATABASE_URL must point at a migrated database for integration tests")
+	}
+	ctx := context.Background()
+	pg, err := storage.NewPostgres(ctx, config.DatabaseSection{URL: url})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pg.Close)
+	return storage.NewRepository(pg), storage.NewSchedulerStore(pg), storage.NewExecutionStore(pg), ctx
+}
+
+// TestHeartbeatRoundTripIntegration is the end-to-end contract for the
+// per-TI liveness signal (#128): the agent's RecordHeartbeat call stamps
+// last_heartbeat_at, and the scheduler's ListAgentLostCandidates picks the
+// TI up only after the stamp is older than the threshold. The "do no harm"
+// rule of ADR 0031 is the load-bearing assertion here — a fresh heartbeat
+// must keep the TI off the candidate list.
+func TestHeartbeatRoundTripIntegration(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("hb_roundtrip_%d", time.Now().UnixNano())
+	tasks := []domain.TaskSpec{{TaskID: "t", Type: domain.TaskTypePython}}
+	registerSpec(t, repo, ctx, dagID, tasks)
+	if _, err := repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+		RunID: "r1", State: domain.DagRunStateRunning, RunType: "manual", LogicalDate: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	runUUID := resolveRunUUID(t, sched, ctx, dagID)
+	if err := sched.MaterializeTasks(ctx, runUUID, tasks); err != nil {
+		t.Fatalf("MaterializeTasks: %v", err)
+	}
+	if err := sched.ApplyTransition(ctx, runUUID, "t", domain.TaskStateRunning); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-heartbeat: TI has no last_heartbeat_at, so it is OUT of the
+	// candidate set (the SQL filters on IS NOT NULL).
+	cands, err := sched.ListAgentLostCandidates(ctx)
+	if err != nil {
+		t.Fatalf("ListAgentLostCandidates: %v", err)
+	}
+	if findAgentLostCandidate(cands, runUUID) != nil {
+		t.Errorf("pre-heartbeat TI must not be a candidate (last_heartbeat_at is NULL)")
+	}
+
+	// Agent heartbeats — the column is stamped.
+	if err := exec.RecordHeartbeat(ctx, auth.AgentIdentity{
+		RunID: runUUID, TaskID: "t", TryNumber: 1,
+	}); err != nil {
+		t.Fatalf("RecordHeartbeat: %v", err)
+	}
+
+	// Post-heartbeat: the TI is now a candidate (it has heartbeated). Whether
+	// it gets reaped is a Go-side decision based on the threshold — the SQL
+	// only filters on "has heartbeated at all".
+	cands, err = sched.ListAgentLostCandidates(ctx)
+	if err != nil {
+		t.Fatalf("ListAgentLostCandidates: %v", err)
+	}
+	c := findAgentLostCandidate(cands, runUUID)
+	if c == nil {
+		t.Fatalf("post-heartbeat TI must appear as a candidate; got %+v", cands)
+	}
+	if c.LastHeartbeat.IsZero() {
+		t.Errorf("candidate LastHeartbeat must be the stamped time, got zero")
+	}
+	if c.TaskID != "t" || c.DagID != dagID {
+		t.Errorf("candidate identity = %+v, want task=t dag=%s", c, dagID)
+	}
+}
+
+// TestMarkTaskAgentLostIntegration: marking a TI as agent_lost transitions
+// it to `failed` with the right error_message and is idempotent (a second
+// call on a now-failed TI is a no-op thanks to the WHERE state='running'
+// guard — defense in depth against late terminal reports).
+func TestMarkTaskAgentLostIntegration(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("hb_mark_%d", time.Now().UnixNano())
+	tasks := []domain.TaskSpec{{TaskID: "t", Type: domain.TaskTypePython}}
+	registerSpec(t, repo, ctx, dagID, tasks)
+	if _, err := repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+		RunID: "r1", State: domain.DagRunStateRunning, RunType: "manual", LogicalDate: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	runUUID := resolveRunUUID(t, sched, ctx, dagID)
+	if err := sched.MaterializeTasks(ctx, runUUID, tasks); err != nil {
+		t.Fatalf("MaterializeTasks: %v", err)
+	}
+	if err := sched.ApplyTransition(ctx, runUUID, "t", domain.TaskStateRunning); err != nil {
+		t.Fatal(err)
+	}
+	if err := exec.RecordHeartbeat(ctx, auth.AgentIdentity{
+		RunID: runUUID, TaskID: "t", TryNumber: 1,
+	}); err != nil {
+		t.Fatalf("RecordHeartbeat: %v", err)
+	}
+
+	cands, _ := sched.ListAgentLostCandidates(ctx)
+	c := findAgentLostCandidate(cands, runUUID)
+	if c == nil {
+		t.Fatalf("expected candidate after heartbeat")
+	}
+
+	// Reap.
+	if err := sched.MarkTaskAgentLost(ctx, c.TaskInstanceID); err != nil {
+		t.Fatalf("MarkTaskAgentLost: %v", err)
+	}
+
+	// The TI is now failed and out of the candidate set.
+	tis, _ := repo.TaskInstancesForRuns(ctx, "default", dagID, []string{"r1"})
+	if len(tis) != 1 || tis[0].State != domain.TaskStateFailed {
+		t.Errorf("after MarkTaskAgentLost, TI state = %+v, want failed", tis)
+	}
+
+	// Second call is a no-op (WHERE state='running' updates zero rows).
+	if err := sched.MarkTaskAgentLost(ctx, c.TaskInstanceID); err != nil {
+		t.Errorf("second MarkTaskAgentLost must be a no-op; got %v", err)
+	}
+}
+
+// findAgentLostCandidate returns the candidate matching the run uuid (a
+// single-TI test set), or nil.
+func findAgentLostCandidate(cands []scheduler.AgentLostCandidate, runUUID string) *scheduler.AgentLostCandidate {
+	for i := range cands {
+		if cands[i].DagRunID == runUUID {
+			return &cands[i]
+		}
+	}
+	return nil
+}

--- a/internal/storage/queries/models.go
+++ b/internal/storage/queries/models.go
@@ -328,6 +328,7 @@ type TaskInstance struct {
 	Hostname        *string            `json:"hostname"`
 	Note            *string            `json:"note"`
 	ScheduledAt     pgtype.Timestamptz `json:"scheduled_at"`
+	LastHeartbeatAt pgtype.Timestamptz `json:"last_heartbeat_at"`
 }
 
 type TaskStateHistory struct {

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -62,6 +62,13 @@ type Querier interface {
 	// run_id is the dag_run's UUID (StagingClaimName uses it), so join on dag_runs.id,
 	// which is globally unique. run_state is NULL only when the run row is truly gone.
 	ListActiveStagingVolumes(ctx context.Context) ([]ListActiveStagingVolumesRow, error)
+	// Lists running TIs that have heartbeated at least once and whose latest
+	// heartbeat is non-null, alongside enough identity to log + observe.
+	// The "non-null" filter is the safety guarantee: a TI that never heartbeated
+	// is either inline (no agent ever exists) or fresh — out of scope for this
+	// reaper. The LIMIT bounds a single tick's reap work even after a large
+	// outage; the rest are picked up on the next tick.
+	ListAgentLostCandidates(ctx context.Context) ([]ListAgentLostCandidatesRow, error)
 	ListAuditLogs(ctx context.Context, arg ListAuditLogsParams) ([]ListAuditLogsRow, error)
 	// All of a tenant's connections WITH the encrypted password, for delivering
 	// credentials to task pods (ADR 0021). Never use this for UI/API responses,
@@ -101,7 +108,18 @@ type Querier interface {
 	// parameter across an UPDATE-inside-WITH and the outer UPDATE.
 	MarkRunOrphanedTaskInstances(ctx context.Context, dagRunID pgtype.UUID) error
 	MarkStagingDeleted(ctx context.Context, arg MarkStagingDeletedParams) error
+	// Fails a TI whose agent went silent. The WHERE state='running' guard
+	// prevents overwriting a TI the agent's last terminal report finally
+	// delivered between our list and our write (defense in depth — a late
+	// report wins over the reaper). Idempotent on a second call.
+	MarkTaskAgentLost(ctx context.Context, id pgtype.UUID) (int64, error)
 	RecordStagingVolume(ctx context.Context, arg RecordStagingVolumeParams) error
+	// Stamps last_heartbeat_at on the active TI of an attempt. Bounded by the
+	// (dag_run_id, task_id, try_number) tuple to match the agent's identity. The
+	// state IN guard avoids stamping a heartbeat on a TI the scheduler already
+	// transitioned to terminal between the agent's last heartbeat and now — a
+	// terminal TI must stay terminal even if a late heartbeat arrives.
+	RecordTaskHeartbeat(ctx context.Context, arg RecordTaskHeartbeatParams) error
 	RecordXCom(ctx context.Context, arg RecordXComParams) error
 	RemoveFavorite(ctx context.Context, arg RemoveFavoriteParams) error
 	// $3 is cast to task_state in every usage: without the cast Postgres deduces an

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -244,6 +244,50 @@ SET state = 'failed',
 WHERE dag_run_id = $1
   AND state IN ('scheduled', 'queued', 'running');
 
+-- name: RecordTaskHeartbeat :exec
+-- Stamps last_heartbeat_at on the active TI of an attempt. Bounded by the
+-- (dag_run_id, task_id, try_number) tuple to match the agent's identity. The
+-- state IN guard avoids stamping a heartbeat on a TI the scheduler already
+-- transitioned to terminal between the agent's last heartbeat and now — a
+-- terminal TI must stay terminal even if a late heartbeat arrives.
+UPDATE task_instances
+SET last_heartbeat_at = now()
+WHERE dag_run_id = $1
+  AND task_id = $2
+  AND try_number = $3
+  AND state IN ('queued', 'running');
+
+-- name: ListAgentLostCandidates :many
+-- Lists running TIs that have heartbeated at least once and whose latest
+-- heartbeat is non-null, alongside enough identity to log + observe.
+-- The "non-null" filter is the safety guarantee: a TI that never heartbeated
+-- is either inline (no agent ever exists) or fresh — out of scope for this
+-- reaper. The LIMIT bounds a single tick's reap work even after a large
+-- outage; the rest are picked up on the next tick.
+SELECT ti.id AS task_instance_id,
+       ti.dag_run_id AS dag_run_id,
+       d.dag_id AS dag_id_text,
+       ti.task_id AS task_id,
+       ti.last_heartbeat_at AS last_heartbeat_at
+FROM task_instances ti
+JOIN dag_runs dr ON dr.id = ti.dag_run_id
+JOIN dags d ON d.id = dr.dag_id
+WHERE ti.state = 'running'
+  AND ti.last_heartbeat_at IS NOT NULL
+ORDER BY ti.last_heartbeat_at
+LIMIT 100;
+
+-- name: MarkTaskAgentLost :execrows
+-- Fails a TI whose agent went silent. The WHERE state='running' guard
+-- prevents overwriting a TI the agent's last terminal report finally
+-- delivered between our list and our write (defense in depth — a late
+-- report wins over the reaper). Idempotent on a second call.
+UPDATE task_instances
+SET state = 'failed',
+    ended_at = now(),
+    error_message = 'agent_lost: no heartbeat within the threshold — see #128'
+WHERE id = $1 AND state = 'running';
+
 -- name: MarkRunOrphanedRun :execrows
 -- Fails an orphaned dag run. The `state = 'running'` guard makes the reap a
 -- safety net, never a takeover: a competing finalizer (the normal scheduler

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -217,7 +217,7 @@ func (q *Queries) CreateScheduledRunByDagID(ctx context.Context, arg CreateSched
 const createTaskInstance = `-- name: CreateTaskInstance :one
 INSERT INTO task_instances (tenant_id, dag_run_id, task_id, operator, max_tries, state, try_number)
 VALUES ($1, $2, $3, $4, $5, $6, 1)
-RETURNING id, tenant_id, dag_run_id, task_id, map_index, try_number, max_tries, state, pool, operator, queued_at, started_at, ended_at, duration_seconds, pod_name, node_name, exit_code, error_message, log_url, hostname, note, scheduled_at
+RETURNING id, tenant_id, dag_run_id, task_id, map_index, try_number, max_tries, state, pool, operator, queued_at, started_at, ended_at, duration_seconds, pod_name, node_name, exit_code, error_message, log_url, hostname, note, scheduled_at, last_heartbeat_at
 `
 
 type CreateTaskInstanceParams struct {
@@ -265,6 +265,7 @@ func (q *Queries) CreateTaskInstance(ctx context.Context, arg CreateTaskInstance
 		&i.Hostname,
 		&i.Note,
 		&i.ScheduledAt,
+		&i.LastHeartbeatAt,
 	)
 	return i, err
 }
@@ -488,6 +489,61 @@ func (q *Queries) ListActiveDagRuns(ctx context.Context) ([]DagRun, error) {
 	return items, nil
 }
 
+const listAgentLostCandidates = `-- name: ListAgentLostCandidates :many
+SELECT ti.id AS task_instance_id,
+       ti.dag_run_id AS dag_run_id,
+       d.dag_id AS dag_id_text,
+       ti.task_id AS task_id,
+       ti.last_heartbeat_at AS last_heartbeat_at
+FROM task_instances ti
+JOIN dag_runs dr ON dr.id = ti.dag_run_id
+JOIN dags d ON d.id = dr.dag_id
+WHERE ti.state = 'running'
+  AND ti.last_heartbeat_at IS NOT NULL
+ORDER BY ti.last_heartbeat_at
+LIMIT 100
+`
+
+type ListAgentLostCandidatesRow struct {
+	TaskInstanceID  pgtype.UUID        `json:"task_instance_id"`
+	DagRunID        pgtype.UUID        `json:"dag_run_id"`
+	DagIDText       string             `json:"dag_id_text"`
+	TaskID          string             `json:"task_id"`
+	LastHeartbeatAt pgtype.Timestamptz `json:"last_heartbeat_at"`
+}
+
+// Lists running TIs that have heartbeated at least once and whose latest
+// heartbeat is non-null, alongside enough identity to log + observe.
+// The "non-null" filter is the safety guarantee: a TI that never heartbeated
+// is either inline (no agent ever exists) or fresh — out of scope for this
+// reaper. The LIMIT bounds a single tick's reap work even after a large
+// outage; the rest are picked up on the next tick.
+func (q *Queries) ListAgentLostCandidates(ctx context.Context) ([]ListAgentLostCandidatesRow, error) {
+	rows, err := q.db.Query(ctx, listAgentLostCandidates)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListAgentLostCandidatesRow{}
+	for rows.Next() {
+		var i ListAgentLostCandidatesRow
+		if err := rows.Scan(
+			&i.TaskInstanceID,
+			&i.DagRunID,
+			&i.DagIDText,
+			&i.TaskID,
+			&i.LastHeartbeatAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listDagRunsByDag = `-- name: ListDagRunsByDag :many
 SELECT id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note FROM dag_runs
 WHERE dag_id = $1
@@ -633,7 +689,7 @@ func (q *Queries) ListScheduledDags(ctx context.Context) ([]ListScheduledDagsRow
 }
 
 const listTaskInstancesByRun = `-- name: ListTaskInstancesByRun :many
-SELECT id, tenant_id, dag_run_id, task_id, map_index, try_number, max_tries, state, pool, operator, queued_at, started_at, ended_at, duration_seconds, pod_name, node_name, exit_code, error_message, log_url, hostname, note, scheduled_at FROM task_instances
+SELECT id, tenant_id, dag_run_id, task_id, map_index, try_number, max_tries, state, pool, operator, queued_at, started_at, ended_at, duration_seconds, pod_name, node_name, exit_code, error_message, log_url, hostname, note, scheduled_at, last_heartbeat_at FROM task_instances
 WHERE dag_run_id = $1
 ORDER BY task_id
 `
@@ -670,6 +726,7 @@ func (q *Queries) ListTaskInstancesByRun(ctx context.Context, dagRunID pgtype.UU
 			&i.Hostname,
 			&i.Note,
 			&i.ScheduledAt,
+			&i.LastHeartbeatAt,
 		); err != nil {
 			return nil, err
 		}
@@ -716,6 +773,51 @@ WHERE dag_run_id = $1
 // parameter across an UPDATE-inside-WITH and the outer UPDATE.
 func (q *Queries) MarkRunOrphanedTaskInstances(ctx context.Context, dagRunID pgtype.UUID) error {
 	_, err := q.db.Exec(ctx, markRunOrphanedTaskInstances, dagRunID)
+	return err
+}
+
+const markTaskAgentLost = `-- name: MarkTaskAgentLost :execrows
+UPDATE task_instances
+SET state = 'failed',
+    ended_at = now(),
+    error_message = 'agent_lost: no heartbeat within the threshold — see #128'
+WHERE id = $1 AND state = 'running'
+`
+
+// Fails a TI whose agent went silent. The WHERE state='running' guard
+// prevents overwriting a TI the agent's last terminal report finally
+// delivered between our list and our write (defense in depth — a late
+// report wins over the reaper). Idempotent on a second call.
+func (q *Queries) MarkTaskAgentLost(ctx context.Context, id pgtype.UUID) (int64, error) {
+	result, err := q.db.Exec(ctx, markTaskAgentLost, id)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const recordTaskHeartbeat = `-- name: RecordTaskHeartbeat :exec
+UPDATE task_instances
+SET last_heartbeat_at = now()
+WHERE dag_run_id = $1
+  AND task_id = $2
+  AND try_number = $3
+  AND state IN ('queued', 'running')
+`
+
+type RecordTaskHeartbeatParams struct {
+	DagRunID  pgtype.UUID `json:"dag_run_id"`
+	TaskID    string      `json:"task_id"`
+	TryNumber int32       `json:"try_number"`
+}
+
+// Stamps last_heartbeat_at on the active TI of an attempt. Bounded by the
+// (dag_run_id, task_id, try_number) tuple to match the agent's identity. The
+// state IN guard avoids stamping a heartbeat on a TI the scheduler already
+// transitioned to terminal between the agent's last heartbeat and now — a
+// terminal TI must stay terminal even if a late heartbeat arrives.
+func (q *Queries) RecordTaskHeartbeat(ctx context.Context, arg RecordTaskHeartbeatParams) error {
+	_, err := q.db.Exec(ctx, recordTaskHeartbeat, arg.DagRunID, arg.TaskID, arg.TryNumber)
 	return err
 }
 
@@ -988,7 +1090,7 @@ const updateTaskInstanceState = `-- name: UpdateTaskInstanceState :one
 UPDATE task_instances
 SET state = $2, started_at = $3, ended_at = $4
 WHERE id = $1
-RETURNING id, tenant_id, dag_run_id, task_id, map_index, try_number, max_tries, state, pool, operator, queued_at, started_at, ended_at, duration_seconds, pod_name, node_name, exit_code, error_message, log_url, hostname, note, scheduled_at
+RETURNING id, tenant_id, dag_run_id, task_id, map_index, try_number, max_tries, state, pool, operator, queued_at, started_at, ended_at, duration_seconds, pod_name, node_name, exit_code, error_message, log_url, hostname, note, scheduled_at, last_heartbeat_at
 `
 
 type UpdateTaskInstanceStateParams struct {
@@ -1029,6 +1131,7 @@ func (q *Queries) UpdateTaskInstanceState(ctx context.Context, arg UpdateTaskIns
 		&i.Hostname,
 		&i.Note,
 		&i.ScheduledAt,
+		&i.LastHeartbeatAt,
 	)
 	return i, err
 }

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -295,6 +295,46 @@ func (s *SchedulerStore) ReapRun(ctx context.Context, runID string) error {
 	return nil
 }
 
+// ListAgentLostCandidates returns every `running` TI with a non-null
+// last_heartbeat_at, for the scheduler's TI heartbeat reaper (#128). The
+// reaper applies the threshold per row so the SQL stays simple.
+func (s *SchedulerStore) ListAgentLostCandidates(ctx context.Context) ([]scheduler.AgentLostCandidate, error) {
+	rows, err := s.q.ListAgentLostCandidates(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing agent-lost candidates: %w", err)
+	}
+	out := make([]scheduler.AgentLostCandidate, 0, len(rows))
+	for _, r := range rows {
+		var last time.Time
+		if r.LastHeartbeatAt.Valid {
+			last = r.LastHeartbeatAt.Time.UTC()
+		}
+		out = append(out, scheduler.AgentLostCandidate{
+			TaskInstanceID: uuidToString(r.TaskInstanceID),
+			DagRunID:       uuidToString(r.DagRunID),
+			DagID:          r.DagIDText,
+			TaskID:         r.TaskID,
+			LastHeartbeat:  last,
+		})
+	}
+	return out, nil
+}
+
+// MarkTaskAgentLost transitions one TI to `failed` with the agent_lost
+// reason. The WHERE state='running' guard makes this idempotent and prevents
+// a late terminal report being overwritten — if the row already moved, we
+// touch zero rows and return nil.
+func (s *SchedulerStore) MarkTaskAgentLost(ctx context.Context, taskInstanceID string) error {
+	tid, err := parseUUID(taskInstanceID)
+	if err != nil {
+		return err
+	}
+	if _, err := s.q.MarkTaskAgentLost(ctx, tid); err != nil {
+		return fmt.Errorf("marking task agent-lost: %w", err)
+	}
+	return nil
+}
+
 // ListActiveStagingVolumes returns active staging volumes joined with their DAG
 // run's state (empty when the run row is gone), for the GC (ADR 0022).
 func (s *SchedulerStore) ListActiveStagingVolumes(ctx context.Context) ([]domain.StagingVolumeState, error) {

--- a/migrations/015_ti_heartbeat.down.sql
+++ b/migrations/015_ti_heartbeat.down.sql
@@ -1,0 +1,8 @@
+-- 015_ti_heartbeat.down.sql
+
+BEGIN;
+
+DROP INDEX IF EXISTS idx_ti_running_heartbeat;
+ALTER TABLE task_instances DROP COLUMN IF EXISTS last_heartbeat_at;
+
+COMMIT;

--- a/migrations/015_ti_heartbeat.up.sql
+++ b/migrations/015_ti_heartbeat.up.sql
@@ -1,0 +1,18 @@
+-- 015_ti_heartbeat.up.sql
+-- Per-task-instance liveness signal for the agent heartbeat reaper (#128).
+-- The scheduler's run-level reaper (#120) intentionally leaves any run with an
+-- active TI alone to avoid killing legitimately-slow tasks; this column closes
+-- the companion gap "the agent went silent mid-task".
+
+BEGIN;
+
+ALTER TABLE task_instances
+    ADD COLUMN last_heartbeat_at TIMESTAMPTZ;
+
+-- Partial index: the reaper only ever scans TIs in `running` whose heartbeat
+-- is stale, so the index is narrow and write traffic on settled TIs is
+-- unaffected.
+CREATE INDEX idx_ti_running_heartbeat ON task_instances(last_heartbeat_at)
+    WHERE state = 'running';
+
+COMMIT;


### PR DESCRIPTION
## Summary
The run-level orphan reaper (#120, merged in PR #126) intentionally never touches a run with an active task instance, to avoid killing legitimately slow tasks. This left one shape uncovered: a TI stuck in \`running\` because its **agent died** (pod evicted, node OOMs, network partition, agent crash). The run never finalizes, and the dashboard counter stays stuck.

This PR adds the companion safety net: a per-TI heartbeat reaper that fails task instances whose agent has been silent past a threshold.

Closes #128.

## How
- **Migration 015** adds \`last_heartbeat_at TIMESTAMPTZ\` to \`task_instances\` plus a narrow partial index (\`WHERE state = 'running'\`) for the reap query.
- **agentrpc.Server.Heartbeat** now persists the timestamp via the new \`Store.RecordHeartbeat\` method. A store-side failure is **logged but does NOT surface as an RPC error** — failing the call would risk the agent terminating itself on a transient DB blip, and the scheduler reaper would in the worst case fail the TI as agent_lost on the next tick (correct under ADR 0031 \"do no harm\").
- **\`scheduler.IsAgentLost\`** is the pure decision, table-tested for fresh / at-threshold / past / clock-skew / **zero (never reported, out of scope)**.
- **\`scheduler.agentLostReaper\`** mirrors \`orphanReaper\` exactly: panic-safe, per-TI isolated, metered (\`agent_lost\`, \`agent_lost_error\`, \`agent_lost_list_error\`, \`agent_lost_panic\`), capped at LIMIT 100/tick.
- **\`Scheduler.Step\`** now runs both reapers, leader-only, after the planning + create phases. The two reapers are **independent**: a failure in one does not prevent the other.
- **Default threshold 90 s** — 6× the agent's 15 s heartbeat interval (\`cmd/leoflow-agent/main.go:70\`). Configurable via \`SetAgentLostThreshold\`.

## The \"do no harm\" guarantee
A TI is only considered when **last_heartbeat_at IS NOT NULL** in SQL **and** the time-gap exceeds the threshold in Go. This excludes:
- Inline http_api tasks (no agent ever exists; will never be reaped by this reaper).
- Brand-new TIs that have not completed their first heartbeat interval yet.

Inline-task orphan recovery is a separate concern, intentionally out of scope.

## Tests
- **Unit** (\`internal/scheduler/heartbeat_reap_test.go\`): table-driven \`IsAgentLost\`, MarksStaleTIs, ListErrorSurfaces, PerTIErrorIsolated, PanicInListDoesNotCrash, PanicInMarkDoesNotCrash.
- **Agent RPC** (\`internal/agentrpc/server_test.go\`): \`TestHeartbeatRecordsLivenessOnStore\` (the column is stamped), \`TestHeartbeatSucceedsWhenStoreFails\` (transient DB error never surfaces to agent).
- **Integration** (\`internal/storage/heartbeat_reap_integration_test.go\`, CI \`integration\` job): \`TestHeartbeatRoundTripIntegration\` (pre-heartbeat TI is NOT a candidate; post-heartbeat IS), \`TestMarkTaskAgentLostIntegration\` (transition + idempotency).

## Test plan
- [x] \`go test ./...\` — green
- [x] \`go vet -tags integration ./internal/storage/...\` — clean
- [x] \`golangci-lint run ./...\` v2.12.2 — 0 issues
- [ ] CI integration job — runs against real Postgres 16
- [ ] Manual: trigger a Lite run, kill the agent process mid-task, wait 90 s → TI flips to \`failed (agent_lost)\`, run finalizes naturally on the next tick.

## Architecture
This is the second layer of the two-layer safety net documented in ADR 0031. Combined with PR #126, the matrix:

| Failure shape | Caught by |
|---|---|
| Scheduler crash mid-finalization (TIs settled, run stuck) | Run reaper (#120, PR #126) |
| Agent dies mid-task (TI stuck running, agent silent) | TI heartbeat reaper (#128, this PR) |

Both reapers honour the same \"do no harm\" rule and the same resilience invariants (leader-only, panic-safe, per-candidate isolated, bounded batch, metered).

## Related
- #120 (PR #126) — Run reaper (merged).
- #127 — Async dispatch (open).
- #129 — Catchup correctness (open).
- #130 — Leader-overlap test coverage (open).
- ADR 0031 — Scheduler architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)