### PR TITLE
fix(scheduler): async dispatch via bounded worker pool (#127)

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -587,7 +587,7 @@ func startScheduler(ctx context.Context, cfg *config.ServerConfig, pg *storage.P
 		MaxSeconds:  cfg.Executor.HTTP.InlineMaxDurationSeconds,
 		UserAgent:   cfg.Executor.HTTP.UserAgent,
 	}))
-	podDispatch := setupDispatch(ctx, cfg, sched, execStore, authn, store, logger)
+	podDispatch := setupDispatch(ctx, cfg, sched, execStore, authn, store, logger, metrics)
 	leader := scheduler.NewLeader(leaderPool)
 	go func() {
 		defer leaderPool.Close()
@@ -721,11 +721,11 @@ func serve(s *http.Server, errCh chan<- error) {
 // setupDispatch wires the pod-path executor selected by executor.type onto the
 // scheduler and returns whether pod dispatch is active. "subprocess" runs the
 // agent on the host (dev only); "kubernetes" (default) launches task pods.
-func setupDispatch(ctx context.Context, cfg *config.ServerConfig, sched *scheduler.Scheduler, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, store *storage.SchedulerStore, logger *slog.Logger) bool {
+func setupDispatch(ctx context.Context, cfg *config.ServerConfig, sched *scheduler.Scheduler, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, store *storage.SchedulerStore, logger *slog.Logger, metrics *observability.Metrics) bool {
 	if cfg.Executor.Type == "subprocess" {
-		return setupSubprocessDispatch(cfg, sched, execStore, authn, logger)
+		return setupSubprocessDispatch(cfg, sched, execStore, authn, logger, store, metrics) //nolint:contextcheck // buffered worker deliberately detaches from caller ctx
 	}
-	return setupK8sDispatch(ctx, cfg, sched, execStore, authn, store, logger)
+	return setupK8sDispatch(ctx, cfg, sched, execStore, authn, store, logger, metrics) //nolint:contextcheck // buffered worker deliberately detaches from caller ctx
 }
 
 // resolveAgentControlAddr returns the address task agents dial back, defaulting
@@ -739,19 +739,19 @@ func resolveAgentControlAddr(cfg *config.ServerConfig) string {
 
 // setupSubprocessDispatch wires the dev-only subprocess executor (ADR 0023): it
 // runs the agent on the host with no isolation, so it is gated to dev use.
-func setupSubprocessDispatch(cfg *config.ServerConfig, sched *scheduler.Scheduler, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, logger *slog.Logger) bool {
+func setupSubprocessDispatch(cfg *config.ServerConfig, sched *scheduler.Scheduler, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, logger *slog.Logger, sink dispatch.FailureSink, metrics *observability.Metrics) bool {
 	subExec := executor.NewSubprocessExecutor(cfg.Executor.AgentPath, logger)
 	subExec.SetWorkDir(cfg.Executor.SubprocessWorkDir)
 	dispatcher := dispatch.NewDispatcher(subExec, execStore, authn, resolveAgentControlAddr(cfg), agentTokenTTL)
 	dispatcher.SetPlatformDefaults(platformDefaults(cfg.Executor.Defaults))
-	sched.SetDispatcher(dispatcher)
+	sched.SetDispatcher(wrapBuffered(dispatcher, sink, logger, metrics, cfg.Scheduler.Dispatch))
 	logger.Warn("subprocess dispatch enabled (dev only; user code runs unsandboxed)")
 	return true
 }
 
 // setupK8sDispatch wires the production pod-per-task executor; it is a no-op
 // (only inline http_api tasks run) when no Kubernetes client is available.
-func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *scheduler.Scheduler, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, store *storage.SchedulerStore, logger *slog.Logger) bool {
+func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *scheduler.Scheduler, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, store *storage.SchedulerStore, logger *slog.Logger, metrics *observability.Metrics) bool {
 	cs, perr := buildK8sClient()
 	if perr != nil {
 		logger.Warn("pod dispatch disabled; only inline http_api tasks will run", "error", perr)
@@ -763,11 +763,32 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 	dispatcher := dispatch.NewDispatcher(podExec, execStore, authn, controlAddr, agentTokenTTL)
 	dispatcher.SetAgentTLSCAConfigMap(cfg.Executor.AgentTLSCAConfigMap)
 	dispatcher.SetPlatformDefaults(platformDefaults(cfg.Executor.Defaults))
-	sched.SetDispatcher(dispatcher)
+	sched.SetDispatcher(wrapBuffered(dispatcher, store, logger, metrics, cfg.Scheduler.Dispatch)) //nolint:contextcheck // buffered worker deliberately detaches from caller ctx
 	startReconciler(ctx, cs, execStore, logger)
 	startStagingGC(ctx, cs, store, logger)
 	logger.Info("pod dispatch enabled", "namespace", podNamespace, "agent_control_plane_addr", controlAddr)
 	return true
+}
+
+// wrapBuffered returns the dispatcher to plug into the scheduler. When
+// BufferSize > 0 the inner dispatcher is fronted by the worker pool (#127);
+// when BufferSize == 0 the inner dispatcher is used directly (Lite). The
+// caller passes a FailureSink (typically the SchedulerStore) so worker-side
+// dispatch failures fail the TI with a clear reason instead of leaving it
+// stuck `queued`.
+func wrapBuffered(inner dispatch.Inner, sink dispatch.FailureSink, logger *slog.Logger, metrics *observability.Metrics, cfg config.DispatchSection) scheduler.Dispatcher {
+	if cfg.BufferSize <= 0 {
+		// Passthrough: keep the inner dispatcher exposed verbatim so the
+		// scheduler sees the same surface it always did in Lite.
+		return inner
+	}
+	bd := dispatch.NewBuffered(inner, sink, logger, metrics, dispatch.BufferConfig{
+		BufferSize: cfg.BufferSize,
+		Workers:    cfg.Workers,
+	})
+	logger.Info("buffered dispatch enabled (async pool)",
+		"buffer_size", cfg.BufferSize, "workers", cfg.Workers)
+	return bd
 }
 
 // platformDefaults maps the executor.defaults config (L0 task defaults, ADR

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -158,8 +158,25 @@ type JWTSection struct {
 
 // SchedulerSection configures the scheduler loop.
 type SchedulerSection struct {
-	LoopIntervalMS int  `mapstructure:"loop_interval_ms"`
-	Enabled        bool `mapstructure:"enabled"`
+	LoopIntervalMS int             `mapstructure:"loop_interval_ms"`
+	Enabled        bool            `mapstructure:"enabled"`
+	Dispatch       DispatchSection `mapstructure:"dispatch"`
+}
+
+// DispatchSection sizes the BufferedDispatcher (#127). BufferSize=0 keeps the
+// scheduler tick synchronous with the inner dispatcher — the right shape for
+// Lite (subprocess fork is microseconds). BufferSize>0 enables the worker
+// pool — the right shape for Pro (Kubernetes API calls add real latency).
+// The defaults are set per-edition by configsetup so the user does not have
+// to think about this; an operator can still tune the knobs.
+type DispatchSection struct {
+	// BufferSize is the depth of the queued-dispatches channel. 0 disables the
+	// pool (synchronous passthrough). A full channel returns ErrAtCapacity to
+	// the scheduler, which leaves the TI scheduled for the next tick.
+	BufferSize int `mapstructure:"buffer_size"`
+	// Workers is the number of goroutines draining the queue. Ignored when
+	// BufferSize <= 0; otherwise floored to 1.
+	Workers int `mapstructure:"workers"`
 }
 
 // ObservabilitySection configures logging, metrics, and tracing.
@@ -190,13 +207,18 @@ var serverDefaults = map[string]any{
 	// Empty by default: no Redis configured selects the embedded edition (Lite —
 	// XCom on Postgres, in-process log tailer, ADR 0026). Production sets this
 	// explicitly via the Helm chart (external Redis).
-	"redis.url":                                 "",
-	"auth.provider":                             "jwt",
-	"auth.jwt.secret":                           "",
-	"auth.jwt.token_ttl_seconds":                3600,
-	"auth.login_rate_limit_per_minute":          5,
-	"scheduler.loop_interval_ms":                1000,
-	"scheduler.enabled":                         true,
+	"redis.url":                        "",
+	"auth.provider":                    "jwt",
+	"auth.jwt.secret":                  "",
+	"auth.jwt.token_ttl_seconds":       3600,
+	"auth.login_rate_limit_per_minute": 5,
+	"scheduler.loop_interval_ms":       1000,
+	"scheduler.enabled":                true,
+	// Default: synchronous dispatch (BufferSize=0). Safe and zero-overhead for
+	// Lite. Pro deployments should set buffer_size>=1 + workers>=1 in their
+	// values.yaml so K8s API latency does not stretch the tick (#127, ADR 0031).
+	"scheduler.dispatch.buffer_size":            0,
+	"scheduler.dispatch.workers":                0,
 	"executor.http.inline_max_duration_seconds": 300,
 	"executor.http.inline_concurrency_limit":    256,
 	"executor.http.user_agent":                  "leoflow/0.1",

--- a/internal/config/server_test.go
+++ b/internal/config/server_test.go
@@ -23,9 +23,12 @@ func TestLoadServerAppliesDefaults(t *testing.T) {
 		"token_ttl":         {c.Auth.JWT.TokenTTLSeconds, 3600},
 		"loop_interval_ms":  {c.Scheduler.LoopIntervalMS, 1000},
 		"scheduler.enabled": {c.Scheduler.Enabled, true},
-		"otel.enabled":      {c.Observability.OTel.Enabled, true},
-		"log_level":         {c.Observability.LogLevel, "info"},
-		"log_format":        {c.Observability.LogFormat, "json"},
+		// Default is sync passthrough (#127): Pro deployments opt in via values.yaml.
+		"scheduler.dispatch.buffer_size": {c.Scheduler.Dispatch.BufferSize, 0},
+		"scheduler.dispatch.workers":     {c.Scheduler.Dispatch.Workers, 0},
+		"otel.enabled":                   {c.Observability.OTel.Enabled, true},
+		"log_level":                      {c.Observability.LogLevel, "info"},
+		"log_format":                     {c.Observability.LogFormat, "json"},
 	}
 	for name, c := range checks {
 		if c.got != c.want {

--- a/internal/dispatch/buffered.go
+++ b/internal/dispatch/buffered.go
@@ -1,0 +1,189 @@
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"runtime/debug"
+	"sync"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// ErrAtCapacity is returned by BufferedDispatcher.Dispatch when the buffered
+// queue cannot accept another request. The scheduler treats it exactly like a
+// transient inner-dispatcher error: log + metric + leave the TI scheduled so
+// the next tick re-tries. It is the backpressure signal that bounds tick
+// latency under load (ADR 0031: tick rate decoupled from executor latency).
+var ErrAtCapacity = errors.New("dispatch buffer at capacity; will retry next tick")
+
+// Inner is the underlying synchronous dispatcher BufferedDispatcher wraps —
+// matches scheduler.Dispatcher exactly so production wires through one type.
+type Inner interface {
+	Dispatch(ctx context.Context, runID, dagID string, task domain.TaskSpec) error
+}
+
+// FailureSink lets a worker report that an asynchronously-dispatched task
+// failed inside the inner dispatcher, so the scheduler can fail the TI with a
+// clear reason. Without this callback a `queued` TI whose dispatch failed
+// would sit forever (no reaper targets `queued`; ADR 0031 #128 only targets
+// `running`).
+type FailureSink interface {
+	MarkTaskDispatchFailed(ctx context.Context, runID, taskID, reason string) error
+}
+
+// MetricsRecorder records dispatch-pool observability signals.
+type MetricsRecorder interface {
+	RecordDispatchQueueDepth(depth int)
+	RecordDispatchAtCapacity()
+	RecordDispatchLatencySeconds(seconds float64)
+	RecordDispatchInnerError()
+}
+
+// BufferConfig sizes the BufferedDispatcher's worker pool. BufferSize=0 means
+// "passthrough sync" (Lite mode, zero overhead): no goroutines spawned, no
+// channel, the inner dispatcher is called inline. Any BufferSize>0 spawns
+// max(Workers, 1) worker goroutines and a buffered channel of BufferSize
+// slots.
+type BufferConfig struct {
+	BufferSize int
+	Workers    int
+}
+
+// dispatchRequest carries one queued dispatch from the scheduler to a worker.
+// runID, dagID, task are the same arguments the synchronous interface takes;
+// ctx is the scheduler's caller context — the worker uses a derived
+// background context so a cancellation of the caller does not abandon work
+// the scheduler already considers "accepted".
+type dispatchRequest struct {
+	runID, dagID string
+	task         domain.TaskSpec
+}
+
+// BufferedDispatcher fronts a synchronous Inner dispatcher with a bounded
+// worker pool, so the scheduler tick is never blocked by a slow remote API
+// call. ADR 0031: two-phase scheduler — planning sync, dispatch async.
+type BufferedDispatcher struct {
+	inner   Inner
+	sink    FailureSink
+	logger  *slog.Logger
+	metrics MetricsRecorder
+	cfg     BufferConfig
+	queue   chan dispatchRequest
+	wg      sync.WaitGroup
+	closed  chan struct{}
+	once    sync.Once
+}
+
+// NewBuffered constructs a BufferedDispatcher. BufferSize=0 returns a
+// passthrough that is byte-for-byte equivalent to using the inner dispatcher
+// directly (Lite path). BufferSize>0 spawns the worker pool.
+func NewBuffered(inner Inner, sink FailureSink, logger *slog.Logger, metrics MetricsRecorder, cfg BufferConfig) *BufferedDispatcher {
+	b := &BufferedDispatcher{
+		inner:   inner,
+		sink:    sink,
+		logger:  logger,
+		metrics: metrics,
+		cfg:     cfg,
+		closed:  make(chan struct{}),
+	}
+	if cfg.BufferSize <= 0 {
+		return b
+	}
+	workers := cfg.Workers
+	if workers <= 0 {
+		workers = 1
+	}
+	b.queue = make(chan dispatchRequest, cfg.BufferSize)
+	for i := 0; i < workers; i++ {
+		b.wg.Add(1)
+		go b.worker()
+	}
+	return b
+}
+
+// Dispatch hands a task off to the inner dispatcher. In passthrough mode the
+// inner call happens inline. In buffered mode the request is enqueued non-
+// blockingly: success returns nil immediately (the scheduler then records the
+// TI as `queued`); a full channel returns ErrAtCapacity (the scheduler treats
+// it as a transient failure and leaves the TI scheduled).
+func (b *BufferedDispatcher) Dispatch(ctx context.Context, runID, dagID string, task domain.TaskSpec) error {
+	if b.queue == nil {
+		return b.inner.Dispatch(ctx, runID, dagID, task)
+	}
+	select {
+	case b.queue <- dispatchRequest{runID: runID, dagID: dagID, task: task}:
+		if b.metrics != nil {
+			b.metrics.RecordDispatchQueueDepth(len(b.queue))
+		}
+		return nil
+	default:
+		if b.metrics != nil {
+			b.metrics.RecordDispatchAtCapacity()
+		}
+		return ErrAtCapacity
+	}
+}
+
+// Close stops accepting new dispatches, drains the in-flight queue, and waits
+// for every worker to finish. Calling Close more than once is safe.
+func (b *BufferedDispatcher) Close() {
+	b.once.Do(func() {
+		if b.queue != nil {
+			close(b.queue)
+		}
+		close(b.closed)
+	})
+	b.wg.Wait()
+}
+
+// worker drains the queue, calling the inner dispatcher and reporting failures
+// via the sink so the scheduler can fail the TI. A panic in the inner
+// dispatcher is recovered so one poison task never kills the worker
+// goroutine (ADR 0031 "the scheduler must never die" extends to the workers).
+func (b *BufferedDispatcher) worker() {
+	defer b.wg.Done()
+	for req := range b.queue {
+		b.dispatchOne(req)
+	}
+}
+
+// dispatchOne calls the inner dispatcher with full panic isolation; a panic
+// is reported via the sink as a dispatch failure so the scheduler can fail
+// the TI rather than leaving it stuck `queued`.
+func (b *BufferedDispatcher) dispatchOne(req dispatchRequest) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			b.logger.Error("dispatch worker panic recovered",
+				"run", req.runID, "dag", req.dagID, "task", req.task.TaskID,
+				"panic", rec, "stack", string(debug.Stack()))
+			b.reportFailure(req, "dispatch_failed: worker panic")
+		}
+	}()
+	// Use a background context: the caller's ctx may already be canceled by
+	// the time the worker picks the request up (a long tick has rolled over),
+	// but we already accepted responsibility for this dispatch — abandoning it
+	// would leave a `queued` TI without a runner. The inner dispatcher's own
+	// timeout protects against hanging.
+	if err := b.inner.Dispatch(context.Background(), req.runID, req.dagID, req.task); err != nil { //nolint:contextcheck // worker intentionally detaches from the caller's ctx
+		b.logger.Error("dispatch failed in worker",
+			"run", req.runID, "dag", req.dagID, "task", req.task.TaskID, "error", err)
+		if b.metrics != nil {
+			b.metrics.RecordDispatchInnerError()
+		}
+		b.reportFailure(req, "dispatch_failed: "+err.Error())
+	}
+}
+
+// reportFailure marks the TI failed via the sink if one is configured. A sink
+// error is logged but cannot itself be propagated — the worker has already
+// done all it can.
+func (b *BufferedDispatcher) reportFailure(req dispatchRequest, reason string) {
+	if b.sink == nil {
+		return
+	}
+	if err := b.sink.MarkTaskDispatchFailed(context.Background(), req.runID, req.task.TaskID, reason); err != nil { //nolint:contextcheck // worker intentionally uses a fresh context for the failure report
+		b.logger.Error("reporting dispatch failure",
+			"run", req.runID, "task", req.task.TaskID, "error", err)
+	}
+}

--- a/internal/dispatch/buffered_test.go
+++ b/internal/dispatch/buffered_test.go
@@ -1,0 +1,224 @@
+package dispatch_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/dispatch"
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// recordingInner is a scheduler.Dispatcher fake that records every call. It is
+// the dispatcher the BufferedDispatcher wraps in tests.
+type recordingInner struct {
+	mu        sync.Mutex
+	calls     []string
+	err       error
+	delay     time.Duration
+	callCount atomic.Int64
+}
+
+func (r *recordingInner) Dispatch(_ context.Context, _, _ string, task domain.TaskSpec) error {
+	r.callCount.Add(1)
+	if r.delay > 0 {
+		time.Sleep(r.delay)
+	}
+	r.mu.Lock()
+	r.calls = append(r.calls, task.TaskID)
+	r.mu.Unlock()
+	return r.err
+}
+
+func (r *recordingInner) seen() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.calls...)
+}
+
+// recordingSink records dispatch-failure callbacks the worker makes when the
+// inner dispatcher returns an error in async mode.
+type recordingSink struct {
+	mu      sync.Mutex
+	failed  []failedDispatch
+	failErr error
+}
+
+type failedDispatch struct {
+	runID, taskID, reason string
+}
+
+func (r *recordingSink) MarkTaskDispatchFailed(_ context.Context, runID, taskID, reason string) error {
+	r.mu.Lock()
+	r.failed = append(r.failed, failedDispatch{runID, taskID, reason})
+	r.mu.Unlock()
+	return r.failErr
+}
+
+func (r *recordingSink) snapshot() []failedDispatch {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]failedDispatch(nil), r.failed...)
+}
+
+// TestBuffered_Passthrough_BufferSizeZero pins the Lite contract: BufferSize=0
+// means no goroutines, no channel — the call goes straight to the inner
+// dispatcher and the result (including errors) bubbles up unchanged. This is
+// the zero-overhead path Lite relies on.
+func TestBuffered_Passthrough_BufferSizeZero(t *testing.T) {
+	inner := &recordingInner{}
+	d := dispatch.NewBuffered(inner, nil, discardLogger(), nil, dispatch.BufferConfig{BufferSize: 0, Workers: 0})
+	defer d.Close()
+	err := d.Dispatch(context.Background(), "r1", "etl", domain.TaskSpec{TaskID: "extract"})
+	if err != nil {
+		t.Fatalf("passthrough err = %v", err)
+	}
+	if got := inner.seen(); len(got) != 1 || got[0] != "extract" {
+		t.Errorf("inner saw %v, want [extract]", got)
+	}
+}
+
+// TestBuffered_Passthrough_PropagatesInnerError: in Lite mode an inner error
+// surfaces directly — same shape as the original sync dispatcher contract.
+func TestBuffered_Passthrough_PropagatesInnerError(t *testing.T) {
+	innerErr := errors.New("kube down")
+	inner := &recordingInner{err: innerErr}
+	d := dispatch.NewBuffered(inner, nil, discardLogger(), nil, dispatch.BufferConfig{BufferSize: 0, Workers: 0})
+	defer d.Close()
+	if err := d.Dispatch(context.Background(), "r1", "etl", domain.TaskSpec{TaskID: "t"}); !errors.Is(err, innerErr) {
+		t.Errorf("passthrough err = %v, want wrap of innerErr", err)
+	}
+}
+
+// TestBuffered_Async_AcceptsAndDrains: BufferSize>0 returns immediately
+// (the dispatcher's contract from the scheduler's POV: nil = "I have accepted
+// responsibility for this task") and workers drain the channel into the
+// inner dispatcher.
+func TestBuffered_Async_AcceptsAndDrains(t *testing.T) {
+	inner := &recordingInner{}
+	d := dispatch.NewBuffered(inner, &recordingSink{}, discardLogger(), nil, dispatch.BufferConfig{BufferSize: 4, Workers: 2})
+	defer d.Close()
+	for _, id := range []string{"a", "b", "c"} {
+		if err := d.Dispatch(context.Background(), "r1", "etl", domain.TaskSpec{TaskID: id}); err != nil {
+			t.Fatalf("Dispatch %s: %v", id, err)
+		}
+	}
+	// Wait for the inner dispatcher to see all three (workers run async).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && inner.callCount.Load() < 3 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if inner.callCount.Load() != 3 {
+		t.Errorf("inner saw %d calls, want 3", inner.callCount.Load())
+	}
+}
+
+// TestBuffered_Async_BackpressureWhenChannelFull is the load-bearing
+// backpressure contract: when the channel cannot accept a new request,
+// Dispatch returns ErrAtCapacity. The scheduler treats this exactly like a
+// transient inner-dispatcher error: log + metric + leave TI as scheduled so
+// the next tick re-tries. This is what bounds tick latency under load.
+func TestBuffered_Async_BackpressureWhenChannelFull(t *testing.T) {
+	// One slow worker, channel-of-one — the second Dispatch must fail fast
+	// because the first is blocking the only worker and the channel is full.
+	inner := &recordingInner{delay: 200 * time.Millisecond}
+	d := dispatch.NewBuffered(inner, &recordingSink{}, discardLogger(), nil, dispatch.BufferConfig{BufferSize: 1, Workers: 1})
+	defer d.Close()
+
+	if err := d.Dispatch(context.Background(), "r1", "etl", domain.TaskSpec{TaskID: "slow"}); err != nil {
+		t.Fatalf("first Dispatch: %v", err)
+	}
+	// At least one more must end up "at capacity": the worker is asleep on the
+	// first call, the channel has only one slot, and the test floods the queue.
+	hitCapacity := false
+	for i := 0; i < 10 && !hitCapacity; i++ {
+		err := d.Dispatch(context.Background(), "r1", "etl", domain.TaskSpec{TaskID: "flood"})
+		if errors.Is(err, dispatch.ErrAtCapacity) {
+			hitCapacity = true
+		}
+	}
+	if !hitCapacity {
+		t.Errorf("expected at least one Dispatch to return ErrAtCapacity under flood")
+	}
+}
+
+// TestBuffered_Async_WorkerFailureMarksTIFailed: when the inner dispatcher
+// errors, the worker calls back via the sink so the scheduler observes the
+// failure (and the TI is failed with reason 'dispatch_failed: ...' — the
+// retry budget governs retry, matching Airflow's KubernetesExecutor).
+// Without this callback the TI would sit `queued` forever (no reaper catches
+// a queued TI; ADR 0031 #128 only targets `running`).
+func TestBuffered_Async_WorkerFailureMarksTIFailed(t *testing.T) {
+	innerErr := errors.New("kube create pod refused")
+	inner := &recordingInner{err: innerErr}
+	sink := &recordingSink{}
+	d := dispatch.NewBuffered(inner, sink, discardLogger(), nil, dispatch.BufferConfig{BufferSize: 4, Workers: 1})
+	defer d.Close()
+
+	if err := d.Dispatch(context.Background(), "r1", "etl", domain.TaskSpec{TaskID: "doomed"}); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && len(sink.snapshot()) == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	got := sink.snapshot()
+	if len(got) != 1 || got[0].taskID != "doomed" || got[0].runID != "r1" {
+		t.Errorf("sink failed = %+v, want one failure for r1/doomed", got)
+	}
+}
+
+// TestBuffered_Async_PanicInInnerDoesNotCrash is the resilience pin: a panic
+// in the wrapped dispatcher (a bug, a malformed task, anything) must not
+// crash the worker goroutine. The worker recovers, the failure is reported
+// via the sink, and the pool keeps draining.
+func TestBuffered_Async_PanicInInnerDoesNotCrash(t *testing.T) {
+	panicker := &panicInner{}
+	sink := &recordingSink{}
+	d := dispatch.NewBuffered(panicker, sink, discardLogger(), nil, dispatch.BufferConfig{BufferSize: 2, Workers: 1})
+	defer d.Close()
+
+	if err := d.Dispatch(context.Background(), "r1", "etl", domain.TaskSpec{TaskID: "boom"}); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && len(sink.snapshot()) == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := sink.snapshot(); len(got) != 1 || got[0].taskID != "boom" {
+		t.Errorf("panic must be reported via sink, got %+v", got)
+	}
+}
+
+type panicInner struct{}
+
+func (panicInner) Dispatch(context.Context, string, string, domain.TaskSpec) error {
+	panic("boom: inner dispatcher")
+}
+
+// TestBuffered_Close_DrainsPendingWork: Close blocks until in-flight workers
+// finish, so a shutdown does not abandon a task that the scheduler already
+// recorded as `queued`. After Close returns, every accepted Dispatch is
+// either delivered to the inner dispatcher or reported failed via the sink.
+func TestBuffered_Close_DrainsPendingWork(t *testing.T) {
+	inner := &recordingInner{}
+	d := dispatch.NewBuffered(inner, &recordingSink{}, discardLogger(), nil, dispatch.BufferConfig{BufferSize: 8, Workers: 2})
+	for _, id := range []string{"a", "b", "c", "d"} {
+		if err := d.Dispatch(context.Background(), "r1", "etl", domain.TaskSpec{TaskID: id}); err != nil {
+			t.Fatalf("Dispatch %s: %v", id, err)
+		}
+	}
+	d.Close()
+	if inner.callCount.Load() != 4 {
+		t.Errorf("after Close, inner saw %d calls, want 4 (every accepted Dispatch must drain)", inner.callCount.Load())
+	}
+}

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -42,6 +42,13 @@ type Metrics struct {
 	PodsRunning        prometheus.Gauge
 	PodPendingDuration prometheus.Histogram
 	KubernetesAPICalls *prometheus.CounterVec
+
+	// Dispatch pool (#127, ADR 0031): depth gauge, capacity-saturation counter,
+	// per-dispatch latency, inner-dispatcher error counter.
+	DispatchQueueDepth  prometheus.Gauge
+	DispatchAtCapacity  prometheus.Counter
+	DispatchLatency     prometheus.Histogram
+	DispatchInnerErrors prometheus.Counter
 }
 
 // NewMetrics registers every ADR 0010 collector with reg and returns the set.
@@ -119,6 +126,19 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		KubernetesAPICalls: f.NewCounterVec(prometheus.CounterOpts{
 			Name: "leoflow_kubernetes_api_calls_total", Help: "Kubernetes API calls.",
 		}, []string{"operation", "result"}),
+
+		DispatchQueueDepth: f.NewGauge(prometheus.GaugeOpts{
+			Name: "leoflow_dispatch_queue_depth", Help: "Number of dispatch requests currently buffered.",
+		}),
+		DispatchAtCapacity: f.NewCounter(prometheus.CounterOpts{
+			Name: "leoflow_dispatch_at_capacity_total", Help: "Dispatch requests rejected because the buffer was full.",
+		}),
+		DispatchLatency: f.NewHistogram(prometheus.HistogramOpts{
+			Name: "leoflow_dispatch_latency_seconds", Help: "End-to-end latency of one buffered dispatch (enqueue to worker completion).",
+		}),
+		DispatchInnerErrors: f.NewCounter(prometheus.CounterOpts{
+			Name: "leoflow_dispatch_inner_errors_total", Help: "Errors returned by the inner dispatcher inside a worker.",
+		}),
 	}
 }
 
@@ -149,3 +169,25 @@ func (m *Metrics) RecordUndispatchable(reason string) {
 func (m *Metrics) RecordTaskDuration(dagID, taskID, taskType string, seconds float64) {
 	m.TaskDuration.WithLabelValues(dagID, taskID, taskType).Observe(seconds)
 }
+
+// RecordDispatchQueueDepth sets the current depth of the buffered dispatch
+// queue (#127). Sampled on every successful enqueue.
+func (m *Metrics) RecordDispatchQueueDepth(depth int) {
+	m.DispatchQueueDepth.Set(float64(depth))
+}
+
+// RecordDispatchAtCapacity counts one rejection because the buffered dispatch
+// queue was full. Each rejection means the scheduler will retry on the next
+// tick — a rising rate signals the pool needs more workers or a deeper queue.
+func (m *Metrics) RecordDispatchAtCapacity() { m.DispatchAtCapacity.Inc() }
+
+// RecordDispatchLatencySeconds observes one end-to-end dispatch latency, from
+// enqueue to the worker's inner-dispatcher return. Reserved for future use by
+// the BufferedDispatcher.
+func (m *Metrics) RecordDispatchLatencySeconds(seconds float64) {
+	m.DispatchLatency.Observe(seconds)
+}
+
+// RecordDispatchInnerError counts one error returned by the inner dispatcher
+// inside a worker — typically a Kubernetes API failure or pod-create rejection.
+func (m *Metrics) RecordDispatchInnerError() { m.DispatchInnerErrors.Inc() }

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -113,6 +113,12 @@ type Querier interface {
 	// delivered between our list and our write (defense in depth — a late
 	// report wins over the reaper). Idempotent on a second call.
 	MarkTaskAgentLost(ctx context.Context, id pgtype.UUID) (int64, error)
+	// Fails a TI whose asynchronous dispatch (BufferedDispatcher worker) errored
+	// inside the inner dispatcher. Targets the active row by (dag_run_id,
+	// task_id) and the active states (scheduled/queued) — a TI that already
+	// moved to running/terminal between the worker accepting the request and
+	// the dispatch failing is left alone (defense in depth).
+	MarkTaskDispatchFailed(ctx context.Context, arg MarkTaskDispatchFailedParams) error
 	RecordStagingVolume(ctx context.Context, arg RecordStagingVolumeParams) error
 	// Stamps last_heartbeat_at on the active TI of an attempt. Bounded by the
 	// (dag_run_id, task_id, try_number) tuple to match the agent's identity. The

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -277,6 +277,20 @@ WHERE ti.state = 'running'
 ORDER BY ti.last_heartbeat_at
 LIMIT 100;
 
+-- name: MarkTaskDispatchFailed :exec
+-- Fails a TI whose asynchronous dispatch (BufferedDispatcher worker) errored
+-- inside the inner dispatcher. Targets the active row by (dag_run_id,
+-- task_id) and the active states (scheduled/queued) — a TI that already
+-- moved to running/terminal between the worker accepting the request and
+-- the dispatch failing is left alone (defense in depth).
+UPDATE task_instances
+SET state = 'failed',
+    ended_at = now(),
+    error_message = $3
+WHERE dag_run_id = $1
+  AND task_id = $2
+  AND state IN ('scheduled', 'queued');
+
 -- name: MarkTaskAgentLost :execrows
 -- Fails a TI whose agent went silent. The WHERE state='running' guard
 -- prevents overwriting a TI the agent's last terminal report finally

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -796,6 +796,32 @@ func (q *Queries) MarkTaskAgentLost(ctx context.Context, id pgtype.UUID) (int64,
 	return result.RowsAffected(), nil
 }
 
+const markTaskDispatchFailed = `-- name: MarkTaskDispatchFailed :exec
+UPDATE task_instances
+SET state = 'failed',
+    ended_at = now(),
+    error_message = $3
+WHERE dag_run_id = $1
+  AND task_id = $2
+  AND state IN ('scheduled', 'queued')
+`
+
+type MarkTaskDispatchFailedParams struct {
+	DagRunID     pgtype.UUID `json:"dag_run_id"`
+	TaskID       string      `json:"task_id"`
+	ErrorMessage *string     `json:"error_message"`
+}
+
+// Fails a TI whose asynchronous dispatch (BufferedDispatcher worker) errored
+// inside the inner dispatcher. Targets the active row by (dag_run_id,
+// task_id) and the active states (scheduled/queued) — a TI that already
+// moved to running/terminal between the worker accepting the request and
+// the dispatch failing is left alone (defense in depth).
+func (q *Queries) MarkTaskDispatchFailed(ctx context.Context, arg MarkTaskDispatchFailedParams) error {
+	_, err := q.db.Exec(ctx, markTaskDispatchFailed, arg.DagRunID, arg.TaskID, arg.ErrorMessage)
+	return err
+}
+
 const recordTaskHeartbeat = `-- name: RecordTaskHeartbeat :exec
 UPDATE task_instances
 SET last_heartbeat_at = now()

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -320,6 +320,24 @@ func (s *SchedulerStore) ListAgentLostCandidates(ctx context.Context) ([]schedul
 	return out, nil
 }
 
+// MarkTaskDispatchFailed transitions a TI to `failed` after its asynchronous
+// dispatch failed inside the BufferedDispatcher worker (#127). The SQL guard
+// only targets scheduled/queued rows, so a TI that already moved to running
+// or terminal between the worker accepting the request and the dispatch
+// failing is left alone (defense in depth — the agent's late progress report
+// wins over the dispatcher's "I failed" claim).
+func (s *SchedulerStore) MarkTaskDispatchFailed(ctx context.Context, runID, taskID, reason string) error {
+	rid, err := parseUUID(runID)
+	if err != nil {
+		return err
+	}
+	return s.q.MarkTaskDispatchFailed(ctx, queries.MarkTaskDispatchFailedParams{
+		DagRunID:     rid,
+		TaskID:       taskID,
+		ErrorMessage: &reason,
+	})
+}
+
 // MarkTaskAgentLost transitions one TI to `failed` with the agent_lost
 // reason. The WHERE state='running' guard makes this idempotent and prevents
 // a late terminal report being overwritten — if the row already moved, we


### PR DESCRIPTION
## Summary
Wraps the existing \`Dispatcher\` in a \`BufferedDispatcher\` so the scheduler tick is decoupled from the inner dispatcher's latency (typically a Kubernetes API call). Closes #127. This is the third leg of the ADR 0031 architecture, following #120 (run reaper) and #128 (TI heartbeat reaper).

## Why this matters
The user's review on the reaper PRs raised the second axis of scheduler resilience: **"it must trigger close to the scheduled time"**. Today \`scheduler.launchQueued\` calls \`dispatcher.Dispatch\` synchronously inside the tick. For N tasks transitioning to queued in the same tick, the tick stretches by N × dispatch latency. With a 1 s tick and 50 queued tasks behind a 200 ms kube-apiserver, every tick is silently 10× behind real-time.

## Design
- **BufferSize=0 (Lite default)**: passthrough sync — no goroutines, no channel, no overhead. Zero behaviour change for subprocess-based installs.
- **BufferSize>0 (Pro opt-in)**: bounded channel + worker pool. The tick enqueues and returns in microseconds; the inner dispatch happens in the worker.

### Backpressure
When the channel is full, \`Dispatch\` returns \`ErrAtCapacity\`. The scheduler treats this like a transient inner error today — log, metric, leave the TI scheduled, retry next tick. **This bounds tick latency under load**: even with a saturated pool, the tick keeps cycling at its configured interval.

### Worker failure
If the inner dispatcher errors (or panics — the worker recovers), the worker reports the failure via a small \`FailureSink\` callback so the scheduler marks the TI failed with reason \`dispatch_failed: <inner error>\`. Without this callback a \`queued\` TI would sit forever (no reaper targets \`queued\`; #128 only targets \`running\`). The retry budget governs whether the task is retried — same shape as Airflow's KubernetesExecutor.

### Defaults
- \`scheduler.dispatch.buffer_size: 0\` (sync passthrough, zero regression risk)
- \`scheduler.dispatch.workers: 0\`

Pro deployments opt in via \`values.yaml\`:
\`\`\`yaml
scheduler:
  dispatch:
    buffer_size: 256
    workers: 16
\`\`\`

## Tests
- \`internal/dispatch/buffered_test.go\` — passthrough preserves inner errors, async accepts + drains, backpressure returns ErrAtCapacity under flood, worker failures report via sink, panic in inner is recovered + reported, Close drains pending work.
- \`internal/config/server_test.go\` — defaults pinned.

## New observability
- \`leoflow_dispatch_queue_depth\` (gauge)
- \`leoflow_dispatch_at_capacity_total\` (counter — a rising rate signals the pool needs more workers or a deeper queue)
- \`leoflow_dispatch_latency_seconds\` (histogram, reserved for future use)
- \`leoflow_dispatch_inner_errors_total\` (counter)

## Test plan
- [x] \`go test ./...\` — green
- [x] \`golangci-lint run ./...\` v2.12.2 — 0 issues
- [x] Pre-commit gate (test + coverage 78.5%) passes
- [ ] Manual Pro test: set buffer_size=256, workers=16, observe tick stays fast under burst of 100 queued tasks.

## Related
- ADR 0031 — Scheduler architecture (two-phase work: planning sync, dispatch async).
- #120 / PR #126 — Run reaper (merged).
- #128 / PR #131 — TI heartbeat reaper (merged).
- #129 — Catchup correctness (open, scheduled next).
- #130 — Leader-overlap test coverage (open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)