### PR TITLE
fix(scheduler): catchup correctness — leader downtime no longer drops scheduled runs (#129)

### DIFF
--- a/internal/scheduler/catchup.go
+++ b/internal/scheduler/catchup.go
@@ -1,0 +1,103 @@
+package scheduler
+
+import (
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+// dueScheduledSlots returns the logical dates for which the scheduler should
+// create runs on the current tick (#129). It is the pure planner-side
+// decision: given the cron expression, the latest run's logical date (nil
+// if the DAG has never run), the DAG's start_date floor (nil for "no floor"),
+// "now", a catchup flag, and a per-tick cap, return the chronological list
+// of due slots.
+//
+// Behavior mirrors Airflow:
+//   - catchup=true  → backfill every missed slot, capped at maxSlots.
+//   - catchup=false → fire exactly one run for the most recent missed slot.
+//
+// Two safety guards:
+//   - maxSlots bounds the per-tick work. A multi-hour outage that produced
+//     thousands of missed slots will not stall the tick; the remainder is
+//     picked up on the next interval (the scheduler is reconciliation-loop
+//     based, ADR 0031, so retry next tick is the correct shape).
+//   - The start_date floor prevents creating a run for a logical_date earlier
+//     than the DAG's official start (Airflow semantics).
+//
+// An unparseable cron expression yields nothing. nextScheduledRun + the
+// scheduleParseable backstop in createDueRuns already log the bad expression
+// once; this helper stays silent.
+func dueScheduledSlots(expr string, lastLogical, startDate *time.Time, now time.Time, catchup bool, maxSlots int) []time.Time {
+	schedule, err := cron.ParseStandard(expr)
+	if err != nil {
+		return nil
+	}
+	// Seed the iteration. For a first-ever sight (lastLogical == nil) we seed
+	// from one period before the start_date so the start_date slot itself can
+	// be emitted (cron.Next returns the strict next slot after the argument).
+	// If there is no start_date and no last_logical, fall back to the
+	// single-slot legacy semantics: emit the most recent slot at or before
+	// now (catchup=false equivalent), since backfilling all of history would
+	// be unsafe by default.
+	seed, ok := catchupSeed(schedule, lastLogical, startDate, now)
+	if !ok {
+		return nil
+	}
+
+	// Enumerate slots strictly after seed and at or before now. Skip any slot
+	// before start_date (the floor) — handles the case where lastLogical is
+	// older than start_date.
+	var slots []time.Time
+	cursor := seed
+	for {
+		cursor = schedule.Next(cursor)
+		if cursor.After(now) {
+			break
+		}
+		if startDate != nil && cursor.Before(*startDate) {
+			continue
+		}
+		slots = append(slots, cursor)
+		if len(slots) >= maxSlots {
+			break
+		}
+	}
+	if len(slots) == 0 {
+		return nil
+	}
+	if !catchup {
+		// Skip-ahead semantics: only fire the most recent missed slot.
+		return slots[len(slots)-1:]
+	}
+	return slots
+}
+
+// catchupSeed picks the time to feed schedule.Next from on the first
+// iteration. ok=false means "no slot can possibly be due" (no seed available).
+func catchupSeed(schedule cron.Schedule, lastLogical, startDate *time.Time, now time.Time) (time.Time, bool) {
+	if lastLogical != nil {
+		return *lastLogical, true
+	}
+	if startDate != nil {
+		// Step back one period so the start_date slot itself is emittable
+		// (Next is strict).
+		period := schedulePeriod(schedule, now)
+		if period <= 0 {
+			return time.Time{}, false
+		}
+		return startDate.Add(-period), true
+	}
+	// Fall back to "most recent slot at or before now" semantics: emit nothing
+	// from the catchup helper. createDueRuns will pick up the legacy
+	// nextScheduledRun path for this shape (see scheduler.go).
+	return time.Time{}, false
+}
+
+// schedulePeriod returns the period between two consecutive slots, estimated
+// from the next two slots after now. 0 means the schedule is degenerate.
+func schedulePeriod(schedule cron.Schedule, now time.Time) time.Duration {
+	a := schedule.Next(now)
+	b := schedule.Next(a)
+	return b.Sub(a)
+}

--- a/internal/scheduler/catchup_test.go
+++ b/internal/scheduler/catchup_test.go
@@ -1,0 +1,125 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+)
+
+// TestDueScheduledSlots covers the catchup decision (#129): given a schedule,
+// the latest run's logical date, "now", a catchup flag, and a start_date floor,
+// returns the list of logical dates the scheduler should create runs for in
+// the current tick — capped at maxSlots so a multi-hour outage cannot stall
+// the tick.
+//
+// The contract pins both Airflow-parity rules:
+//   - catchup=true backfills every missed slot.
+//   - catchup=false jumps straight to the latest slot ≤ now (single run).
+//
+// And two safety guards: the per-tick cap and the start_date floor.
+func TestDueScheduledSlots(t *testing.T) {
+	hourly := "@hourly"
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	hour := func(h int) *time.Time {
+		t := time.Date(2026, 5, 28, h, 0, 0, 0, time.UTC)
+		return &t
+	}
+
+	tests := []struct {
+		name      string
+		expr      string
+		last      *time.Time
+		startDate *time.Time
+		catchup   bool
+		maxSlots  int
+		want      []time.Time
+	}{
+		{
+			// 6 missed hourly slots → 6 runs created, in chronological order.
+			name: "catchup=true backfills every missed slot",
+			expr: hourly, last: hour(6), catchup: true, maxSlots: 100,
+			want: []time.Time{
+				time.Date(2026, 5, 28, 7, 0, 0, 0, time.UTC),
+				time.Date(2026, 5, 28, 8, 0, 0, 0, time.UTC),
+				time.Date(2026, 5, 28, 9, 0, 0, 0, time.UTC),
+				time.Date(2026, 5, 28, 10, 0, 0, 0, time.UTC),
+				time.Date(2026, 5, 28, 11, 0, 0, 0, time.UTC),
+				time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			// Same gap, catchup=false → only the most recent slot. The 5
+			// skipped runs are intentionally lost; the operator chose this.
+			name: "catchup=false jumps to the latest missed slot only",
+			expr: hourly, last: hour(6), catchup: false, maxSlots: 100,
+			want: []time.Time{time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)},
+		},
+		{
+			// Cap < gap → we create the cap and stop; the remaining slots are
+			// picked up on the next tick. Order is chronological so progress
+			// is monotonic.
+			name: "catchup=true respects maxSlots cap",
+			expr: hourly, last: hour(6), catchup: true, maxSlots: 3,
+			want: []time.Time{
+				time.Date(2026, 5, 28, 7, 0, 0, 0, time.UTC),
+				time.Date(2026, 5, 28, 8, 0, 0, 0, time.UTC),
+				time.Date(2026, 5, 28, 9, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			// No missed slot → empty (next slot is strictly after now).
+			name: "not due",
+			expr: hourly, last: hour(12), catchup: true, maxSlots: 100,
+			want: nil,
+		},
+		{
+			// First-ever sight for a DAG with catchup=true and a start_date 3 h ago:
+			// backfill from start_date forward (Airflow semantics).
+			name: "first-run catchup=true backfills from start_date",
+			expr: hourly, last: nil, startDate: hour(9), catchup: true, maxSlots: 100,
+			want: []time.Time{
+				time.Date(2026, 5, 28, 9, 0, 0, 0, time.UTC),
+				time.Date(2026, 5, 28, 10, 0, 0, 0, time.UTC),
+				time.Date(2026, 5, 28, 11, 0, 0, 0, time.UTC),
+				time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			// First-ever sight with catchup=false: only the most recent slot.
+			name: "first-run catchup=false fires only the latest slot",
+			expr: hourly, last: nil, startDate: hour(9), catchup: false, maxSlots: 100,
+			want: []time.Time{time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)},
+		},
+		{
+			// start_date floor: even with catchup=true, no run is created
+			// before the DAG's official start_date — protects against
+			// accidentally creating runs against unintended dates.
+			name: "start_date floor blocks pre-start slots",
+			expr: hourly, last: hour(6), startDate: hour(9), catchup: true, maxSlots: 100,
+			want: []time.Time{
+				time.Date(2026, 5, 28, 9, 0, 0, 0, time.UTC),
+				time.Date(2026, 5, 28, 10, 0, 0, 0, time.UTC),
+				time.Date(2026, 5, 28, 11, 0, 0, 0, time.UTC),
+				time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			// Unparseable schedule yields no slots (and never panics).
+			name: "unparseable schedule yields nothing",
+			expr: "* not a cron *", last: hour(6), catchup: true, maxSlots: 100,
+			want: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dueScheduledSlots(tc.expr, tc.last, tc.startDate, now, tc.catchup, tc.maxSlots)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len = %d, want %d (got=%v)", len(got), len(tc.want), got)
+			}
+			for i := range got {
+				if !got[i].Equal(tc.want[i]) {
+					t.Errorf("[%d] = %v, want %v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -27,10 +27,15 @@ type RunState struct {
 }
 
 // ScheduledDAG is a cron-scheduled DAG and the logical date of its latest run.
+// Catchup and StartDate drive the per-tick catchup decision (#129): when a
+// leader has been down across multiple slots, catchup=true backfills every
+// missed slot while catchup=false jumps straight to the most recent one.
 type ScheduledDAG struct {
 	DagID       string
 	Schedule    string
 	LastLogical *time.Time
+	StartDate   *time.Time
+	Catchup     bool
 }
 
 // Store is the scheduler's view of persistent state. The concrete
@@ -79,6 +84,14 @@ type Dispatcher interface {
 type InlineRunner interface {
 	Start(ctx context.Context, runID, dagID, tenantID string, tryNumber int, task domain.TaskSpec) (started bool, err error)
 }
+
+// maxCatchupSlotsPerTick caps how many missed cron slots are backfilled for
+// one DAG on a single scheduler tick (#129). After a leader has been down
+// across hundreds of slots, the catchup helper would produce that many runs;
+// the cap protects the tick from being stalled by a degenerate inputs and
+// the rest are picked up on the next interval (reconciliation-loop semantics,
+// ADR 0031).
+const maxCatchupSlotsPerTick = 100
 
 // defaultOrphanThreshold is how long a running dag run may stay quiet before
 // the reaper declares it orphaned. Five minutes is well above any healthy tick
@@ -326,11 +339,22 @@ func (s *Scheduler) createDueRuns(ctx context.Context) error {
 			}
 			continue
 		}
-		logical, due := nextScheduledRun(d.Schedule, d.LastLogical, now)
-		if !due {
+		// First-run with no start_date keeps the legacy single-slot semantics
+		// (most recent slot at or before now) — backfilling unbounded history
+		// for a fresh DAG would be unsafe by default. The catchup helper opts
+		// in only when there is either a last_logical or a start_date floor.
+		if d.LastLogical == nil && d.StartDate == nil {
+			logical, due := nextScheduledRun(d.Schedule, d.LastLogical, now)
+			if !due {
+				continue
+			}
+			s.createScheduledRun(ctx, d.DagID, logical)
 			continue
 		}
-		s.createScheduledRun(ctx, d.DagID, logical)
+		slots := dueScheduledSlots(d.Schedule, d.LastLogical, d.StartDate, now, d.Catchup, maxCatchupSlotsPerTick)
+		for _, logical := range slots {
+			s.createScheduledRun(ctx, d.DagID, logical)
+		}
 	}
 	return nil
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -244,6 +244,45 @@ func TestStepDoesNotReapOnFollower(t *testing.T) {
 	}
 }
 
+// TestStepCatchupBackfillsMissedSlots: a DAG with catchup=true whose leader
+// was down for 6 hours produces 6 hourly runs on the next tick (#129).
+// Without catchup wiring, the legacy single-run path silently dropped the 5
+// intermediate slots.
+func TestStepCatchupBackfillsMissedSlots(t *testing.T) {
+	last := time.Now().UTC().Add(-6 * time.Hour).Truncate(time.Hour)
+	store := newFakeStore()
+	store.scheduled = []ScheduledDAG{{
+		DagID: "etl", Schedule: "@hourly", LastLogical: &last, Catchup: true,
+	}}
+	if err := newScheduler(store).Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// The exact count varies by the wall clock fraction within the current
+	// hour; assert "more than 1" to pin the catchup behavior without
+	// flakiness — 1 means catchup did not trigger.
+	if len(store.createdRuns) < 2 {
+		t.Errorf("catchup=true with 6h gap should create multiple runs, got %d (%v)",
+			len(store.createdRuns), store.createdRuns)
+	}
+}
+
+// TestStepCatchupFalseCreatesOnlyLatest: same gap, catchup=false → exactly
+// one run is created (the most recent slot). This is the operator-opt-out
+// for "I don't want SLA misses backfilled."
+func TestStepCatchupFalseCreatesOnlyLatest(t *testing.T) {
+	last := time.Now().UTC().Add(-6 * time.Hour).Truncate(time.Hour)
+	store := newFakeStore()
+	store.scheduled = []ScheduledDAG{{
+		DagID: "etl", Schedule: "@hourly", LastLogical: &last, Catchup: false,
+	}}
+	if err := newScheduler(store).Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.createdRuns) != 1 || store.createdRuns[0] != "etl" {
+		t.Errorf("catchup=false should create exactly one run, got %v", store.createdRuns)
+	}
+}
+
 func TestStepCreatesDueScheduledRun(t *testing.T) {
 	last := time.Now().UTC().Add(-2 * time.Hour)
 	store := newFakeStore()

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -93,6 +93,9 @@ type Querier interface {
 	// tick's reap work even after a multi-hour outage; the rest are picked up
 	// on the next tick (the reaper is a backstop, not a sprint).
 	ListOrphanCandidates(ctx context.Context) ([]ListOrphanCandidatesRow, error)
+	// Returns each cron-scheduled DAG with the bits the scheduler needs to decide
+	// both "is there a slot due?" (schedule + last_logical) and "how many slots
+	// should I backfill on this tick?" (catchup + start_date, see #129).
 	ListScheduledDags(ctx context.Context) ([]ListScheduledDagsRow, error)
 	ListTaskInstancesByRun(ctx context.Context, dagRunID pgtype.UUID) ([]TaskInstance, error)
 	ListVariables(ctx context.Context, arg ListVariablesParams) ([]ListVariablesRow, error)

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -69,7 +69,10 @@ WHERE id = $1
 RETURNING *;
 
 -- name: ListScheduledDags :many
-SELECT d.dag_id, d.schedule,
+-- Returns each cron-scheduled DAG with the bits the scheduler needs to decide
+-- both "is there a slot due?" (schedule + last_logical) and "how many slots
+-- should I backfill on this tick?" (catchup + start_date, see #129).
+SELECT d.dag_id, d.schedule, d.catchup, d.start_date,
   (SELECT max(dr.logical_date) FROM dag_runs dr WHERE dr.dag_id = d.id) AS last_logical
 FROM dags d
 WHERE d.is_active = true AND d.is_paused = false

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -655,7 +655,7 @@ func (q *Queries) ListOrphanCandidates(ctx context.Context) ([]ListOrphanCandida
 }
 
 const listScheduledDags = `-- name: ListScheduledDags :many
-SELECT d.dag_id, d.schedule,
+SELECT d.dag_id, d.schedule, d.catchup, d.start_date,
   (SELECT max(dr.logical_date) FROM dag_runs dr WHERE dr.dag_id = d.id) AS last_logical
 FROM dags d
 WHERE d.is_active = true AND d.is_paused = false
@@ -663,11 +663,16 @@ WHERE d.is_active = true AND d.is_paused = false
 `
 
 type ListScheduledDagsRow struct {
-	DagID       string      `json:"dag_id"`
-	Schedule    *string     `json:"schedule"`
-	LastLogical interface{} `json:"last_logical"`
+	DagID       string             `json:"dag_id"`
+	Schedule    *string            `json:"schedule"`
+	Catchup     bool               `json:"catchup"`
+	StartDate   pgtype.Timestamptz `json:"start_date"`
+	LastLogical interface{}        `json:"last_logical"`
 }
 
+// Returns each cron-scheduled DAG with the bits the scheduler needs to decide
+// both "is there a slot due?" (schedule + last_logical) and "how many slots
+// should I backfill on this tick?" (catchup + start_date, see #129).
 func (q *Queries) ListScheduledDags(ctx context.Context) ([]ListScheduledDagsRow, error) {
 	rows, err := q.db.Query(ctx, listScheduledDags)
 	if err != nil {
@@ -677,7 +682,13 @@ func (q *Queries) ListScheduledDags(ctx context.Context) ([]ListScheduledDagsRow
 	items := []ListScheduledDagsRow{}
 	for rows.Next() {
 		var i ListScheduledDagsRow
-		if err := rows.Scan(&i.DagID, &i.Schedule, &i.LastLogical); err != nil {
+		if err := rows.Scan(
+			&i.DagID,
+			&i.Schedule,
+			&i.Catchup,
+			&i.StartDate,
+			&i.LastLogical,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -168,6 +168,8 @@ func (s *SchedulerStore) ScheduledDAGs(ctx context.Context) ([]scheduler.Schedul
 			DagID:       r.DagID,
 			Schedule:    strOrEmpty(r.Schedule),
 			LastLogical: timeFromAny(r.LastLogical),
+			StartDate:   timePtr(r.StartDate),
+			Catchup:     r.Catchup,
 		})
 	}
 	return out, nil


### PR DESCRIPTION
## Summary
Today \`createDueRuns\` calls \`nextScheduledRun\` which returns at most ONE due slot per tick. After a leader has been down across N missed cron slots, recovery creates a single run and the prior N-1 are silently lost — exactly the "scheduler must trigger close to the scheduled time" gap the user called out on the reaper review.

The DAG schema has had a \`catchup\` column since migration 002 (always read by the parser, written to the DB) but the scheduler ignored it. This PR honours it with Airflow-parity semantics:

- **\`catchup=true\`** → backfill every missed slot.
- **\`catchup=false\`** → fire only the most recent missed slot (operator opts out of SLA-miss backfill).

Closes #129. This is the 4th leg of the ADR 0031 scheduler-resilience arc.

## Safety guards
1. **Per-tick cap (100 slots/DAG)**: a multi-hour outage that produced thousands of missed slots cannot stall the tick — the rest are picked up on the next interval (reconciliation-loop semantics).
2. **\`start_date\` floor**: no run is ever created with a logical_date before the DAG's official start. Airflow semantics, also a defense against a misconfigured catchup creating runs against unintended historical dates.
3. **First-run fallback**: a fresh DAG with no \`last_logical\` AND no \`start_date\` keeps the legacy single-slot path. Unbounded backfill from epoch by default would be unsafe.

## How
- New pure helper \`dueScheduledSlots(expr, lastLogical, startDate, now, catchup, maxSlots) []time.Time\` — table-tested for 8 cases (catchup true/false, with/without missed gap, with/without start_date floor, cap, unparseable schedule).
- Extended \`scheduler.ScheduledDAG\` struct with \`StartDate\` and \`Catchup\`.
- Extended \`ListScheduledDags\` SQL + \`SchedulerStore.ScheduledDAGs\` mapping.
- \`createDueRuns\` now iterates over \`dueScheduledSlots\` and creates a run for each.

## Tests
- Unit (\`internal/scheduler/catchup_test.go\`): 8-case table covering the contract.
- Step-level (\`internal/scheduler/scheduler_test.go\`): \`TestStepCatchupBackfillsMissedSlots\` (catchup=true with 6h gap produces multiple runs), \`TestStepCatchupFalseCreatesOnlyLatest\` (same gap, one run).

## Test plan
- [x] \`go test ./...\` — green
- [x] \`golangci-lint run ./...\` v2.12.2 — 0 issues
- [x] Pre-commit gate (test + coverage 78.5%) passes
- [ ] CI integration tests against real Postgres

## Related
- ADR 0031 — Scheduler architecture (this is the "close to scheduled time" leg).
- #120 / PR #126 — Run reaper (merged).
- #128 / PR #131 — TI heartbeat reaper (merged).
- #127 / PR #132 — Async dispatch (merged).
- #130 — Leader-overlap test coverage (open).
- #133 — BufferedDispatcher graceful shutdown (follow-up from #127 critical review).
- #134 — Integration test for MarkTaskDispatchFailed (follow-up from #127 critical review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)