### PR TITLE
ci(docs): trigger build on PRs so ADR-index / mkdocs drift fails pre-merge (#155)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,16 @@ name: Docs
 
 # Build the MkDocs site and publish it to GitHub Pages.
 # Enable once: Settings → Pages → Build and deployment → Source: GitHub Actions.
+#
+# Build runs on PRs too (#155) so an ADR added without regenerating
+# docs/adrs.md, or a broken mkdocs link, fails the PR before merge instead
+# of breaking the published site post-merge. The deploy job only runs on
+# pushes to main — PR runs build + check, never publish.
 on:
   push:
+    branches: [main]
+    paths: ["docs/**", "mkdocs.yml", ".github/workflows/docs.yml", "internal/cli/**", "parser/**", "runtime/python/**"]
+  pull_request:
     branches: [main]
     paths: ["docs/**", "mkdocs.yml", ".github/workflows/docs.yml", "internal/cli/**", "parser/**", "runtime/python/**"]
   workflow_dispatch:
@@ -63,6 +71,9 @@ jobs:
         with: { path: site }
   deploy:
     needs: build
+    # Only publish on a real push to main, never on a PR run (#155). PR runs
+    # exist to gate the build; the published site is updated by main.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary
Closes #155. Add \`pull_request\` trigger to the Docs workflow so the same checks (\`gen-adr-index.sh --check\`, \`mkdocs build --strict\`) run on PRs and fail the PR before merge — fixes the process gap we hit with #126's ADR 0031.

## Why
PR #126 added \`docs/adr/0031-scheduler-architecture.md\` but did not regenerate \`docs/adrs.md\`. The Docs workflow caught it on push-to-main, after the merge. Main was red until PR #153 fixed it post-hoc.

Same kind of mistake on the next ADR would repeat the same dance. Gating PRs closes the loop.

## How
- \`pull_request\` trigger with the same \`paths:\` filter as the push trigger (only relevant changes trigger the build).
- The \`deploy\` job is gated to \`github.event_name == 'push'\` so PR runs only build + check; the published Pages site is still updated only on pushes to main.

## Test plan
- [x] gofmt / vet / lint / unit + coverage gate all pass locally.
- [ ] When this PR is opened, the Docs workflow runs on it; the build job appears in the checks list and gates merge.
- [ ] When this PR merges, the deploy job runs against main as before.

## Related
- #126 — introduced the original gap (ADR 0031 sans index regen).
- PR #153 — post-hoc fix for the resulting main breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)