### PR TITLE
test(connections): mysql/mariadb cookbook entry + table-driven chain-of-custody (#142)

### DIFF
--- a/docs/connections/index.md
+++ b/docs/connections/index.md
@@ -17,7 +17,7 @@ URI shape, an example DAG, and how to test it.
 | Type | Doc | Example DAG | Status |
 |---|---|---|---|
 | `postgres` | [postgres.md](postgres.md) | [examples/postgres_load](https://github.com/neochaotic/leoflow/tree/main/examples/postgres_load) | ✅ documented + automated test (#138) |
-| `mysql` | TBD (#69) | TBD | 📋 planned |
+| `mysql` / `mariadb` | [mysql.md](mysql.md) | [examples/mysql_load](https://github.com/neochaotic/leoflow/tree/main/examples/mysql_load) | ✅ documented + automated test (#69, table-driven via #138) |
 | `mssql` | TBD (#71) | TBD | 📋 planned |
 | `sqlite` | TBD (#70) | TBD | 📋 planned |
 | `redis` | TBD (#73) | TBD | 📋 planned |

--- a/docs/connections/mysql.md
+++ b/docs/connections/mysql.md
@@ -1,0 +1,108 @@
+# MySQL / MariaDB connection
+
+Connect a task to an external MySQL or MariaDB over a managed Leoflow
+Connection. MariaDB uses the same `mysql` protocol, so the URI shape
+and the Python driver are identical; only the `conn_type` differs
+(`mysql` vs `mariadb`).
+
+## URI shape
+
+```
+mysql://<login>:<password>@<host>:<port>/<schema>
+```
+
+The control plane builds this URI from the Connection's fields. The
+percent-escaping is identical to the Postgres path — special characters
+in the password become `%XX` sequences. The Python side must
+un-escape: see "The PyMySQL gotcha" below.
+
+## Fields the UI asks for
+
+| Field | Required | Notes |
+|---|---|---|
+| Conn Id | yes | e.g. `my_db`. Exported as `AIRFLOW_CONN_MY_DB`. |
+| Conn Type | yes | `mysql` or `mariadb`. Both produce a `mysql://` (or `mariadb://`) URI. |
+| Host | yes | DNS name or IP. From inside a k3d cluster use `host.k3d.internal` for a host-bound port. |
+| Schema | yes | The database name. |
+| Login | yes | The MySQL user (`root`, `app_user`, …). |
+| Password | yes | Stored encrypted at rest (ADR 0019). |
+| Port | optional | Defaults to `3306`. |
+| Extra | optional | JSON object, e.g. `{"ssl":{"ca":"/etc/ssl/certs/ca.pem"}}` for TLS. |
+
+## The PyMySQL gotcha
+
+PyMySQL's `pymysql.connect()` accepts **kwargs**, not a URI string. The
+user task must parse the URI itself:
+
+```python
+import os
+from urllib.parse import unquote, urlparse
+import pymysql
+
+url = urlparse(os.environ["AIRFLOW_CONN_MY_DB"])
+conn = pymysql.connect(
+    host=url.hostname,
+    port=url.port or 3306,
+    user=url.username or "",
+    password=unquote(url.password or ""),  # important: un-escape the percent encoding
+    database=(url.path or "").lstrip("/"),
+)
+```
+
+The `unquote` is the critical step: the URI builder percent-escapes
+reserved characters (`@` → `%40`, `:` → `%3A`, etc.) so the URI parses
+correctly; without `unquote`, PyMySQL would see `%40` instead of `@` in
+the password and authentication would fail with a confusing error.
+
+Alternative drivers:
+
+- **SQLAlchemy** accepts the URL directly:
+  `create_engine("mysql+pymysql://...")`. SQLAlchemy handles the
+  un-escape automatically.
+- **mysqlclient** (the C driver): same kwarg shape as PyMySQL; un-escape
+  the password.
+- **mysql-connector-python**: accepts kwargs OR a URI; un-escape recommended.
+
+## Example DAG
+
+[`examples/mysql_load`](https://github.com/neochaotic/leoflow/tree/main/examples/mysql_load) reads `AIRFLOW_CONN_MY_DB`, parses it, opens
+a `pymysql` connection, and writes 20 rows. The example's
+[README](https://github.com/neochaotic/leoflow/tree/main/examples/mysql_load/README.md)
+walks through Docker spin-up, Connection setup, and verification.
+
+## Lite vs Pro caveats
+
+- **Lite (subprocess)** runs the task on the host. The Connection URI's
+  `host` resolves against the host's name lookup — `localhost` works
+  for a host-bound Docker container.
+- **Lite (k3d)** runs the task in a pod. Use `host.k3d.internal` to
+  reach a host-bound port.
+- **Pro (Kubernetes)** runs the task in a pod. The target MySQL must be
+  reachable via cluster DNS (a `Service`) or external DNS the pod's
+  network policy permits.
+
+## Security notes
+
+- **TLS in transit**: pass an SSL config in **Extra**, e.g.
+  `{"ssl":{"ca":"/etc/ssl/certs/ca.pem"}}`. PyMySQL accepts this via
+  the `ssl=` kwarg. Re-pass it to `pymysql.connect()` in your task.
+- **MariaDB**: identical wire protocol; choose `conn_type=mariadb` so
+  the URI scheme reflects the database. The driver does not care.
+- **MySQL 8 auth plugin**: `caching_sha2_password` is the default for
+  MySQL 8 users; PyMySQL ≥1.1 supports it. Older drivers may need
+  `mysql_native_password`.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Access denied for user 'root'@'host' (using password: YES)` with the right password | The password contains percent-escaped chars and you did NOT call `unquote` | Wrap with `urllib.parse.unquote(url.password)` — see the gotcha above. |
+| `Authentication plugin 'caching_sha2_password' cannot be loaded` | Old driver, MySQL 8 default | Upgrade PyMySQL to ≥1.1 or use `mysql_native_password` in the MySQL user. |
+| `Can't connect to MySQL server on 'host' (111)` | Network/DNS issue | From the task's pod / host, `mysql 'mysql://...'` to isolate. |
+
+## Related
+
+- ADR 0019 — secret encryption at rest.
+- ADR 0021 — agent secret delivery.
+- #69 — MySQL connector umbrella.
+- #138 — chain-of-custody contract test (covers `mysql` + `mariadb`).

--- a/examples/mysql_load/README.md
+++ b/examples/mysql_load/README.md
@@ -1,0 +1,89 @@
+# mysql_load — write rows into an external MySQL/MariaDB via a managed Connection
+
+This example is a **test DAG** for the MySQL/MariaDB connector. The same
+shape as
+[`postgres_load`](../postgres_load/README.md) — it just exercises the
+`mysql://` URI path instead of `postgres://`.
+
+## What it tests
+
+1. Admin creates a `mysql` (or `mariadb`) Connection in the UI.
+2. The control plane encrypts and stores it (ADR 0019).
+3. The agent fetches the URI via gRPC and exports it as
+   `AIRFLOW_CONN_MY_DB`.
+4. The user task `load()` parses the URI with `urllib.parse`, opens a
+   real `pymysql` connection, and writes 20 rows.
+5. You can verify the rows exist in the target MySQL/MariaDB.
+
+## Why parse the URI (the PyMySQL gotcha)
+
+`pymysql.connect()` accepts kwargs (`host=`, `port=`, `user=`,
+`password=`, `database=`), **not** a URI string. The DAG therefore
+parses `AIRFLOW_CONN_MY_DB` with `urllib.parse.urlparse` and un-quotes
+the password (the URI builder percent-escapes reserved characters so
+`p@ss` becomes `p%40ss`; the un-quote brings it back).
+
+This pattern applies to most non-postgres SQL connectors; the cookbook
+page at `docs/connections/mysql.md` covers it.
+
+## How to run it (Lima / subprocess executor)
+
+### 1. Spin up a target MySQL
+
+```sh
+docker run --rm -d --name leoflow-warehouse-mysql \
+  -e MYSQL_ROOT_PASSWORD=etl \
+  -e MYSQL_DATABASE=warehouse \
+  -p 53306:3306 \
+  mysql:8
+```
+
+Wait ~10 s for the server to initialise (first run is slow).
+
+### 2. Create the Connection in the UI
+
+Open `http://localhost:8088` → **Admin → Connections → +**.
+
+| Field | Value |
+|---|---|
+| Conn Id | `my_db` |
+| Conn Type | `mysql` |
+| Host | `localhost` (host) or `host.k3d.internal` (k3d) |
+| Schema | `warehouse` |
+| Login | `root` |
+| Password | `etl` |
+| Port | `53306` |
+
+Save.
+
+### 3. Trigger the DAG
+
+```sh
+leoflow lite path/to/this/example
+```
+
+In the UI: open `mysql_load` → **Trigger DAG**.
+
+### 4. Verify
+
+```sh
+docker exec leoflow-warehouse-mysql \
+  mysql -uroot -petl -D warehouse \
+  -e "SELECT COUNT(*), MIN(name), MAX(score) FROM example_load;"
+```
+
+Expected: 20 rows. `MIN(name)` is `cat_0`, scores range 0–99.
+
+## MariaDB
+
+Identical, but use `conn_type=mariadb` and `mariadb:11` for the Docker
+image. The URI scheme becomes `mariadb://` and `pymysql` connects to
+either equally.
+
+## Related
+
+- `docs/connections/mysql.md` — cookbook entry for MySQL/MariaDB.
+- `examples/postgres_load/` — the sibling Postgres example.
+- ADR 0021 — agent secret delivery.
+- Issue #138 — chain-of-custody contract test (covers mysql + mariadb).
+- Issue #69 — MySQL connector umbrella.

--- a/examples/mysql_load/dag.py
+++ b/examples/mysql_load/dag.py
@@ -1,0 +1,63 @@
+"""mysql_load — compute rows and load them into an external MySQL/MariaDB.
+
+The target DSN comes from a managed Leoflow Connection injected as
+AIRFLOW_CONN_MY_DB (create it in Admin → Connections); falls back to a local
+DSN for a quick demo.
+
+Note: PyMySQL does not accept the Airflow URI string directly — we parse it
+with urllib.parse and pass the fields as kwargs. The cookbook page at
+docs/connections/mysql.md documents this gotcha.
+"""
+from __future__ import annotations
+
+import os
+from urllib.parse import unquote, urlparse
+
+from airflow.sdk import DAG, task
+
+
+@task
+def compute() -> list[tuple]:
+    rows = [(f"cat_{i}", (i * 7) % 100) for i in range(20)]
+    print(f"compute: {len(rows)} rows")
+    return rows
+
+
+@task
+def load(rows: list[tuple]) -> None:
+    import pymysql
+
+    raw = os.environ.get("AIRFLOW_CONN_MY_DB") or os.environ.get(
+        "MY_DB_URL", "mysql://root:etl@127.0.0.1:53306/warehouse"
+    )
+    src = "managed Connection my_db" if os.environ.get("AIRFLOW_CONN_MY_DB") else "fallback DSN"
+    print(f"load: connecting via {src}")
+
+    # PyMySQL takes kwargs, not a URI. Parse the AIRFLOW_CONN URI into the
+    # fields it needs; un-quote the password so percent-escaped reserved
+    # characters (@, :, /, ...) come through verbatim.
+    url = urlparse(raw)
+    conn = pymysql.connect(
+        host=url.hostname or "127.0.0.1",
+        port=url.port or 3306,
+        user=url.username or "",
+        password=unquote(url.password or ""),
+        database=(url.path or "/warehouse").lstrip("/"),
+    )
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "CREATE TABLE IF NOT EXISTS example_load (name VARCHAR(64) PRIMARY KEY, score INT)"
+            )
+            cur.execute("TRUNCATE example_load")
+            cur.executemany("INSERT INTO example_load VALUES (%s, %s)", rows)
+            conn.commit()
+            cur.execute("SELECT COUNT(*) FROM example_load")
+            (count,) = cur.fetchone()
+            print(f"load: {count} rows in example_load")
+    finally:
+        conn.close()
+
+
+with DAG("mysql_load", schedule=None, catchup=False, tags=["example"]):
+    load(compute())

--- a/examples/mysql_load/leoflow.yaml
+++ b/examples/mysql_load/leoflow.yaml
@@ -1,0 +1,9 @@
+schema_version: "1.0"
+dag_id: mysql_load
+description: Compute rows and load them into an external MySQL/MariaDB via a managed Connection.
+owner: examples
+tags:
+  - example
+python_version: "3.11"
+dependencies:
+  - PyMySQL==1.1.1

--- a/internal/storage/connection_delivery_e2e_test.go
+++ b/internal/storage/connection_delivery_e2e_test.go
@@ -15,9 +15,10 @@ import (
 
 // TestConnectionDeliveryChainOfCustodyIntegration is the rigorous companion to
 // the per-layer tests. Each layer (Repository CRUD, SecretConnectionURIs,
-// agentrpc.GetConnections, agent.buildEnv) has its own unit/integration test;
-// this one walks the **whole chain** for one Connection and proves the env
-// var the user-side Python sees matches what the Admin user posted.
+// agentrpc.GetConnections, agent.buildEnv) has its own unit/integration
+// test; this one walks the **whole chain** for one Connection per
+// supported conn_type and proves the env var the user-side Python sees
+// matches what the Admin user posted.
 //
 // Specifically: a refactor that breaks the wiring between layers without
 // changing any individual layer's behaviour (e.g. tenant_id encoding
@@ -28,86 +29,102 @@ import (
 // Edge case the per-layer tests miss: a password with URI-reserved
 // characters (`@`, `:`, `/`, `?`, `#`, `%`, `+`). The URI builder must
 // percent-escape them so the final URI is parseable; the user-side Python
-// (psycopg2.connect, etc.) then sees the original password. A regression
-// here would surface only at the connector boundary — too late.
+// (psycopg2.connect, pymysql, etc.) then sees the original password. A
+// regression here would surface only at the connector boundary — too late.
+//
+// Table-driven across the locally-testable SQL connectors so adding the
+// next (mssql, sqlite) is a 1-line change.
 func TestConnectionDeliveryChainOfCustodyIntegration(t *testing.T) {
-	repo, _, ctx := openRepo(t)
-	key := make([]byte, 32)
-	for i := range key {
-		key[i] = byte(i + 7)
-	}
-	cipher, err := secrets.NewAESGCM(key)
-	if err != nil {
-		t.Fatal(err)
-	}
-	repo.SetCipher(cipher)
-
-	// The Connection the Admin posts. Password has URI-reserved characters
-	// on purpose — they must percent-escape through the URI and decode back
-	// when the connector parses the env var.
-	connID := fmt.Sprintf("e2e_pg_%d", time.Now().UnixNano())
 	const rawPassword = "p@ss/w0rd:!#$" //nolint:gosec // hardcoded test fixture, not a credential
-	port := 5432
-	if cerr := repo.SetConnection(ctx, "default", domain.Connection{
-		ConnID: connID, ConnType: "postgres",
-		Host: "warehouse.example.com", Login: "etl_user",
-		Password: rawPassword, Port: &port, Schema: "analytics",
-	}); cerr != nil {
-		t.Fatalf("SetConnection: %v", cerr)
+	cases := []struct {
+		connType    string
+		defaultPort int
+		host        string
+		schema      string
+	}{
+		{connType: "postgres", defaultPort: 5432, host: "warehouse.example.com", schema: "analytics"},
+		{connType: "mysql", defaultPort: 3306, host: "warehouse.example.com", schema: "analytics"},
+		{connType: "mariadb", defaultPort: 3306, host: "warehouse.example.com", schema: "analytics"},
 	}
-	t.Cleanup(func() { _ = repo.DeleteConnection(ctx, "default", connID) })
+	for _, tc := range cases {
+		t.Run(tc.connType, func(t *testing.T) {
+			repo, _, ctx := openRepo(t)
+			key := make([]byte, 32)
+			for i := range key {
+				key[i] = byte(i + 7)
+			}
+			cipher, err := secrets.NewAESGCM(key)
+			if err != nil {
+				t.Fatal(err)
+			}
+			repo.SetCipher(cipher)
 
-	tenantUUID, err := repo.TenantUUID(ctx, "default")
-	if err != nil {
-		t.Fatalf("TenantUUID: %v", err)
-	}
+			connID := fmt.Sprintf("e2e_%s_%d", tc.connType, time.Now().UnixNano())
+			port := tc.defaultPort
+			if cerr := repo.SetConnection(ctx, "default", domain.Connection{
+				ConnID: connID, ConnType: tc.connType,
+				Host: tc.host, Login: "etl_user",
+				Password: rawPassword, Port: &port, Schema: tc.schema,
+			}); cerr != nil {
+				t.Fatalf("SetConnection: %v", cerr)
+			}
+			t.Cleanup(func() { _ = repo.DeleteConnection(ctx, "default", connID) })
 
-	// Layer hop: agent calls GetConnections → server.SecretConnectionURIs
-	// → returns the URI map. We call SecretConnectionURIs directly because
-	// the agentrpc handler is a thin pass-through over it (see
-	// internal/agentrpc/secrets.go::GetConnections); the per-layer tests
-	// already cover the gRPC handler. The wiring this test validates is
-	// what the Repository returns vs what the env-renderer outputs.
-	uris, err := repo.SecretConnectionURIs(ctx, tenantUUID)
-	if err != nil {
-		t.Fatalf("SecretConnectionURIs: %v", err)
-	}
-	uri, present := uris[connID]
-	if !present {
-		t.Fatalf("URI for %q missing from delivery map; got keys = %v",
-			connID, mapKeys(uris))
-	}
+			tenantUUID, err := repo.TenantUUID(ctx, "default")
+			if err != nil {
+				t.Fatalf("TenantUUID: %v", err)
+			}
 
-	// The agent renders this as the env entry; mirror the exact format the
-	// agent uses (internal/agent/runner.go::secretsEnv) so a divergence is
-	// caught here.
-	envEntry := "AIRFLOW_CONN_" + strings.ToUpper(connID) + "=" + uri
-	if !strings.HasPrefix(envEntry, "AIRFLOW_CONN_") {
-		t.Errorf("env entry missing required prefix: %q", envEntry)
-	}
+			// Layer hop: agent calls GetConnections → server.SecretConnectionURIs
+			// → returns the URI map. The agentrpc handler is a thin pass-through
+			// (see internal/agentrpc/secrets.go::GetConnections); the per-layer
+			// tests already cover the gRPC handler. The wiring this test
+			// validates is what the Repository returns vs what the env-renderer
+			// outputs.
+			uris, err := repo.SecretConnectionURIs(ctx, tenantUUID)
+			if err != nil {
+				t.Fatalf("SecretConnectionURIs: %v", err)
+			}
+			uri, present := uris[connID]
+			if !present {
+				t.Fatalf("URI for %q missing from delivery map; got keys = %v",
+					connID, mapKeys(uris))
+			}
 
-	// The end-user contract: psycopg2.connect(<URI>) must accept it, which
-	// requires url.Parse to succeed and round-trip the password unencoded.
-	parsed, perr := url.Parse(uri)
-	if perr != nil {
-		t.Fatalf("URI is not parseable (the Python connector would fail): %q err=%v", uri, perr)
-	}
-	if parsed.Scheme != "postgres" {
-		t.Errorf("scheme = %q, want postgres", parsed.Scheme)
-	}
-	if parsed.Host != "warehouse.example.com:5432" {
-		t.Errorf("host = %q, want warehouse.example.com:5432", parsed.Host)
-	}
-	if parsed.User.Username() != "etl_user" {
-		t.Errorf("username = %q, want etl_user", parsed.User.Username())
-	}
-	gotPassword, _ := parsed.User.Password()
-	if gotPassword != rawPassword {
-		t.Errorf("password round-trip failed: got %q, want %q (the URI builder must percent-escape; net/url must un-escape on parse)",
-			gotPassword, rawPassword)
-	}
-	if !strings.HasPrefix(parsed.Path, "/analytics") {
-		t.Errorf("path = %q, want /analytics", parsed.Path)
+			// The agent renders this as the env entry; mirror the exact format
+			// the agent uses (internal/agent/runner.go::secretsEnv) so a
+			// divergence is caught here.
+			envEntry := "AIRFLOW_CONN_" + strings.ToUpper(connID) + "=" + uri
+			if !strings.HasPrefix(envEntry, "AIRFLOW_CONN_") {
+				t.Errorf("env entry missing required prefix: %q", envEntry)
+			}
+
+			// The end-user contract: the Python connector must accept the URI,
+			// which requires url.Parse to succeed and round-trip the password
+			// unencoded.
+			parsed, perr := url.Parse(uri)
+			if perr != nil {
+				t.Fatalf("URI is not parseable (the Python connector would fail): %q err=%v", uri, perr)
+			}
+			if parsed.Scheme != tc.connType {
+				t.Errorf("scheme = %q, want %q", parsed.Scheme, tc.connType)
+			}
+			wantHost := fmt.Sprintf("%s:%d", tc.host, tc.defaultPort)
+			if parsed.Host != wantHost {
+				t.Errorf("host = %q, want %q", parsed.Host, wantHost)
+			}
+			if parsed.User.Username() != "etl_user" {
+				t.Errorf("username = %q, want etl_user", parsed.User.Username())
+			}
+			gotPassword, _ := parsed.User.Password()
+			if gotPassword != rawPassword {
+				t.Errorf("password round-trip failed: got %q, want %q (the URI builder must percent-escape; net/url must un-escape on parse)",
+					gotPassword, rawPassword)
+			}
+			if !strings.HasPrefix(parsed.Path, "/"+tc.schema) {
+				t.Errorf("path = %q, want /%s prefix", parsed.Path, tc.schema)
+			}
+		})
 	}
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -140,6 +140,7 @@ nav:
       - Connections cookbook:
           - Overview: connections/index.md
           - Postgres: connections/postgres.md
+          - MySQL / MariaDB: connections/mysql.md
       - Troubleshooting & observability: troubleshooting.md
       - UI compatibility: ui-compatibility.md
       - Staging volume: staging-volume.md


### PR DESCRIPTION
## Summary
Closes #69 (MySQL connector slice of #142). Second entry of the connector cookbook.

The deliverables match the three-part contract every cookbook entry honours: doc page + example DAG + automated test.

## Test refactor
\`TestConnectionDeliveryChainOfCustodyIntegration\` is now table-driven across **postgres + mysql + mariadb**. The URI builder is type-agnostic (uses \`Connection.ConnType\` as the URI scheme), so extending coverage is real validation that the generic path produces the right URI shape for each — including the percent-escape + round-trip the user-side Python depends on.

Adding the next connector (mssql, sqlite, redis, http) is a 1-line addition to the cases table.

## Example DAG
\`examples/mysql_load/\` mirrors \`examples/postgres_load/\` but uses \`pymysql\`. Documents an important gotcha visible at user code: **PyMySQL's \`pymysql.connect()\` takes kwargs, NOT a URI string.** The DAG parses \`AIRFLOW_CONN_MY_DB\` with \`urllib.parse.urlparse\` and un-quotes the password (the URI builder percent-escapes reserved characters; without \`unquote\` the password would arrive as \`%40\` instead of \`@\` and authentication would fail).

## Cookbook page
\`docs/connections/mysql.md\` covers:
- URI shape (\`mysql://user:pass@host:port/db\` — same for MariaDB)
- The PyMySQL gotcha with copy-pasteable code
- Alternative drivers (SQLAlchemy accepts the URL directly; mysqlclient + mysql-connector-python both need the un-escape)
- Lite vs Pro caveats
- Security (TLS via Extra, MySQL 8 auth plugin)
- Troubleshooting (the \"Access denied\" diagnosis that points at missing \`unquote\`)

\`docs/connections/index.md\` table updated; mkdocs nav extended.

## Test plan
- [x] \`go test -tags integration ./internal/storage/...\` — green (DATABASE_URL set)
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`scripts/gen-adr-index.sh --check\` — up to date
- [x] Pre-commit gate passes
- [ ] Manual: \`leoflow lite examples/mysql_load\` against a Docker mysql:8 — verify rows + log line

## Related
- #142 — connector cookbook umbrella.
- #138 — chain-of-custody contract test (now covers mysql + mariadb).
- #69 — MySQL connector umbrella (closed by this PR).
- ADR 0019, ADR 0021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)