### PR TITLE
test(connections): mssql cookbook entry — same shape as mysql (#142)

### DIFF
--- a/docs/connections/index.md
+++ b/docs/connections/index.md
@@ -18,7 +18,7 @@ URI shape, an example DAG, and how to test it.
 |---|---|---|---|
 | `postgres` | [postgres.md](postgres.md) | [examples/postgres_load](https://github.com/neochaotic/leoflow/tree/main/examples/postgres_load) | ✅ documented + automated test (#138) |
 | `mysql` / `mariadb` | [mysql.md](mysql.md) | [examples/mysql_load](https://github.com/neochaotic/leoflow/tree/main/examples/mysql_load) | ✅ documented + automated test (#69, table-driven via #138) |
-| `mssql` | TBD (#71) | TBD | 📋 planned |
+| `mssql` | [mssql.md](mssql.md) | [examples/mssql_load](https://github.com/neochaotic/leoflow/tree/main/examples/mssql_load) | ✅ documented + automated test (#71, table-driven via #138) |
 | `sqlite` | TBD (#70) | TBD | 📋 planned |
 | `redis` | TBD (#73) | TBD | 📋 planned |
 | `http` | TBD (#75) | TBD | 📋 planned |

--- a/docs/connections/mssql.md
+++ b/docs/connections/mssql.md
@@ -1,0 +1,126 @@
+# Microsoft SQL Server connection
+
+Connect a task to an external Microsoft SQL Server (Azure SQL, on-prem
+instance, or a Docker `mcr.microsoft.com/mssql/server` container) over a
+managed Leoflow Connection.
+
+## URI shape
+
+```
+mssql://<login>:<password>@<host>:<port>/<database>
+```
+
+The control plane builds this URI from the Connection's fields. Reserved
+characters in the password are percent-escaped (the `@` in a strong SQL
+Server password becomes `%40`); the user-side Python must un-escape on
+the way out. See the gotcha below.
+
+## Fields the UI asks for
+
+| Field | Required | Notes |
+|---|---|---|
+| Conn Id | yes | e.g. `mssql_target`. Exported as `AIRFLOW_CONN_MSSQL_TARGET`. |
+| Conn Type | yes | `mssql`. |
+| Host | yes | DNS name or IP. For Azure SQL: `<server>.database.windows.net`. |
+| Schema | yes | The database name (yes, Airflow calls it "schema"; SQL Server calls it "database"). |
+| Login | yes | The SQL user (`sa`, `app_user`, …). Azure AD logins look like `user@tenant`. |
+| Password | yes | Stored encrypted at rest (ADR 0019). SQL Server's strong-password policy means special chars are typical. |
+| Port | optional | Defaults to `1433`. |
+| Extra | optional | JSON: `{"encrypt":"true","TrustServerCertificate":"false"}` for TLS with cert verification. |
+
+## The pymssql gotcha
+
+`pymssql.connect()` accepts kwargs (`server=`, `port=`, `user=`,
+`password=`, `database=`), **not** a URI string. The user task must
+parse the URI itself:
+
+```python
+import os
+from urllib.parse import unquote, urlparse
+import pymssql
+
+url = urlparse(os.environ["AIRFLOW_CONN_MSSQL_TARGET"])
+conn = pymssql.connect(
+    server=url.hostname,
+    port=url.port or 1433,
+    user=url.username or "",
+    password=unquote(url.password or ""),
+    database=(url.path or "").lstrip("/"),
+)
+```
+
+The `unquote` is the critical step: the URI builder percent-escapes
+reserved characters (`@` → `%40`); without `unquote`, pymssql would see
+`Etl%401234` instead of `Etl@1234` and authentication would fail.
+
+## Alternative drivers
+
+- **pyodbc**: the most common production driver. Build a connection
+  string from the parsed URL:
+  ```python
+  cnxn_str = (
+      f"DRIVER={{ODBC Driver 18 for SQL Server}};"
+      f"SERVER={url.hostname},{url.port or 1433};"
+      f"DATABASE={(url.path or '').lstrip('/')};"
+      f"UID={url.username};PWD={unquote(url.password)};"
+      "Encrypt=yes;TrustServerCertificate=no"
+  )
+  cnxn = pyodbc.connect(cnxn_str)
+  ```
+  Requires the ODBC driver installed in the image
+  (`apt install msodbcsql18`).
+- **SQLAlchemy** accepts the URL with the right dialect:
+  `create_engine("mssql+pyodbc://...")` for pyodbc, or
+  `create_engine("mssql+pymssql://...")` for pymssql. SQLAlchemy
+  handles the un-escape automatically.
+
+## Example DAG
+
+[`examples/mssql_load`](https://github.com/neochaotic/leoflow/tree/main/examples/mssql_load) reads `AIRFLOW_CONN_MSSQL_TARGET`, opens a
+`pymssql` connection, and writes 20 rows. The example's
+[README](https://github.com/neochaotic/leoflow/tree/main/examples/mssql_load/README.md)
+walks through Docker spin-up, Connection setup (with a password
+containing `@`), and verification.
+
+## Lite vs Pro caveats
+
+- **Lite (subprocess)** runs the task on the host. The Connection's
+  `host` resolves against the host's name lookup.
+- **Lite (k3d)** runs the task in a pod. Use `host.k3d.internal` to
+  reach a host-bound port.
+- **Pro (Kubernetes)** runs the task in a pod. The target SQL Server
+  must be reachable via cluster DNS, an Azure-managed PrivateLink, or
+  external DNS the pod's network policy permits.
+- **Azure SQL specifics**: the host is `<server>.database.windows.net`,
+  port is always `1433`, and `Extra` should set
+  `{"encrypt":"true","TrustServerCertificate":"false"}` to force TLS
+  with certificate verification. Azure AD logins look like
+  `user@tenant`; that single `@` is enough to exercise the percent-escape
+  path.
+
+## Security notes
+
+- **TLS in transit**: SQL Server 2017+ requires TLS by default. Set
+  `Encrypt=yes;TrustServerCertificate=no` in pyodbc / pymssql kwargs.
+- **MSSQL_SA_PASSWORD strength**: SQL Server's strong-password policy
+  requires 8+ characters, at least 3 of: uppercase, lowercase, digits,
+  special. Trivially-weak passwords (`password`, `etl`) are refused at
+  container start.
+- **SSPI / Kerberos**: not supported by `pymssql` cleanly; use pyodbc
+  with the appropriate driver if you need it.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `Login failed for user 'sa'` with the right password | The password contains `@` (or other reserved chars) and you did NOT call `unquote` | Wrap with `urllib.parse.unquote(url.password)`. |
+| `Adaptive Server connection failed` | Network/DNS issue or wrong port | From the task's pod / host, try `sqlcmd -S host,port` with the same coords. |
+| `Cannot open database "warehouse" requested by the login` | The database does not exist | Create it: `sqlcmd -Q "CREATE DATABASE warehouse"`. |
+| `SSL provider: The certificate chain was issued by an authority that is not trusted` | TLS with a self-signed cert + verify-on | For local dev only, set `TrustServerCertificate=yes`. Production: trust the CA. |
+
+## Related
+
+- ADR 0019 — secret encryption at rest.
+- ADR 0021 — agent secret delivery.
+- #71 — MSSQL connector umbrella.
+- #138 — chain-of-custody contract test (covers `mssql`).

--- a/examples/mssql_load/README.md
+++ b/examples/mssql_load/README.md
@@ -1,0 +1,87 @@
+# mssql_load — write rows into an external SQL Server via a managed Connection
+
+This example is a **test DAG** for the Microsoft SQL Server connector. Same
+shape as [`postgres_load`](../postgres_load/README.md) and
+[`mysql_load`](../mysql_load/README.md) — it just exercises the `mssql://`
+URI path.
+
+## What it tests
+
+1. Admin creates an `mssql` Connection in the UI.
+2. The control plane encrypts and stores it (ADR 0019).
+3. The agent fetches the URI via gRPC and exports it as
+   `AIRFLOW_CONN_MSSQL_TARGET`.
+4. The user task `load()` parses the URI with `urllib.parse`, opens a real
+   `pymssql` connection, and writes 20 rows.
+5. You can verify the rows exist in the target SQL Server.
+
+Like PyMySQL, `pymssql.connect()` takes kwargs (not a URI), so the DAG
+parses the URI itself. See `docs/connections/mssql.md` for the gotcha and
+the alternative drivers (pyodbc, SQLAlchemy).
+
+## How to run it (Lima / subprocess executor)
+
+### 1. Spin up a target SQL Server
+
+```sh
+docker run --rm -d --name leoflow-warehouse-mssql \
+  -e ACCEPT_EULA=Y \
+  -e MSSQL_SA_PASSWORD='Etl@1234' \
+  -p 51433:1433 \
+  mcr.microsoft.com/mssql/server:2022-latest
+```
+
+SQL Server takes ~30 s to initialise the system DBs on first run. Then
+create the `warehouse` database:
+
+```sh
+docker exec leoflow-warehouse-mssql \
+  /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P 'Etl@1234' \
+  -Q "CREATE DATABASE warehouse"
+```
+
+(`-No` skips the TLS prompt the 2022 image asks for.)
+
+### 2. Create the Connection in the UI
+
+Open `http://localhost:8088` → **Admin → Connections → +**.
+
+| Field | Value |
+|---|---|
+| Conn Id | `mssql_target` |
+| Conn Type | `mssql` |
+| Host | `localhost` (host) or `host.k3d.internal` (k3d) |
+| Schema | `warehouse` |
+| Login | `sa` |
+| Password | `Etl@1234` (notice the `@`) |
+| Port | `51433` |
+
+The `@` in the password is the point — it must percent-escape through the
+URI builder (`%40`) and come back via `unquote` to `@` when the task runs.
+A regression would surface as an authentication failure here.
+
+### 3. Trigger the DAG
+
+```sh
+leoflow lite path/to/this/example
+```
+
+In the UI: open `mssql_load` → **Trigger DAG**.
+
+### 4. Verify
+
+```sh
+docker exec leoflow-warehouse-mssql \
+  /opt/mssql-tools18/bin/sqlcmd -No -S localhost -U sa -P 'Etl@1234' \
+  -d warehouse -Q "SELECT COUNT(*) FROM example_load;"
+```
+
+Expected: 20.
+
+## Related
+
+- `docs/connections/mssql.md` — cookbook entry for SQL Server.
+- `examples/postgres_load/`, `examples/mysql_load/` — sibling examples.
+- ADR 0021 — agent secret delivery.
+- Issue #138 — chain-of-custody contract test (now covers mssql).
+- Issue #71 — MSSQL connector umbrella.

--- a/examples/mssql_load/dag.py
+++ b/examples/mssql_load/dag.py
@@ -1,0 +1,68 @@
+"""mssql_load — compute rows and load them into an external SQL Server.
+
+The target DSN comes from a managed Leoflow Connection injected as
+AIRFLOW_CONN_MSSQL_TARGET (create it in Admin → Connections); falls back to
+a local DSN for a quick demo.
+
+Note: pymssql does not accept the Airflow URI string directly — we parse it
+with urllib.parse and pass the fields as kwargs. The cookbook page at
+docs/connections/mssql.md documents this gotcha (and the alternative
+pyodbc/SQLAlchemy paths).
+"""
+from __future__ import annotations
+
+import os
+from urllib.parse import unquote, urlparse
+
+from airflow.sdk import DAG, task
+
+
+@task
+def compute() -> list[tuple]:
+    rows = [(f"cat_{i}", (i * 7) % 100) for i in range(20)]
+    print(f"compute: {len(rows)} rows")
+    return rows
+
+
+@task
+def load(rows: list[tuple]) -> None:
+    import pymssql
+
+    raw = os.environ.get("AIRFLOW_CONN_MSSQL_TARGET") or os.environ.get(
+        "MSSQL_TARGET_DSN", "mssql://sa:Etl%401234@127.0.0.1:51433/warehouse"
+    )
+    src = (
+        "managed Connection mssql_target"
+        if os.environ.get("AIRFLOW_CONN_MSSQL_TARGET")
+        else "fallback DSN"
+    )
+    print(f"load: connecting via {src}")
+
+    # pymssql takes kwargs, not a URI. Parse and un-quote the password so
+    # percent-escaped reserved characters (@, :, /, ...) come through verbatim.
+    url = urlparse(raw)
+    conn = pymssql.connect(
+        server=url.hostname or "127.0.0.1",
+        port=url.port or 1433,
+        user=url.username or "",
+        password=unquote(url.password or ""),
+        database=(url.path or "/warehouse").lstrip("/"),
+    )
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "IF OBJECT_ID('example_load', 'U') IS NULL "
+            "CREATE TABLE example_load (name NVARCHAR(64) PRIMARY KEY, score INT)"
+        )
+        cur.execute("TRUNCATE TABLE example_load")
+        cur.executemany("INSERT INTO example_load VALUES (%s, %s)", rows)
+        conn.commit()
+        cur.execute("SELECT COUNT(*) FROM example_load")
+        (count,) = cur.fetchone()
+        print(f"load: {count} rows in example_load")
+    finally:
+        conn.close()
+
+
+with DAG("mssql_load", schedule=None, catchup=False, tags=["example"]):
+    load(compute())

--- a/examples/mssql_load/leoflow.yaml
+++ b/examples/mssql_load/leoflow.yaml
@@ -1,0 +1,9 @@
+schema_version: "1.0"
+dag_id: mssql_load
+description: Compute rows and load them into an external Microsoft SQL Server via a managed Connection.
+owner: examples
+tags:
+  - example
+python_version: "3.11"
+dependencies:
+  - pymssql==2.3.2

--- a/internal/storage/connection_delivery_e2e_test.go
+++ b/internal/storage/connection_delivery_e2e_test.go
@@ -45,6 +45,7 @@ func TestConnectionDeliveryChainOfCustodyIntegration(t *testing.T) {
 		{connType: "postgres", defaultPort: 5432, host: "warehouse.example.com", schema: "analytics"},
 		{connType: "mysql", defaultPort: 3306, host: "warehouse.example.com", schema: "analytics"},
 		{connType: "mariadb", defaultPort: 3306, host: "warehouse.example.com", schema: "analytics"},
+		{connType: "mssql", defaultPort: 1433, host: "warehouse.example.com", schema: "analytics"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.connType, func(t *testing.T) {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,6 +141,7 @@ nav:
           - Overview: connections/index.md
           - Postgres: connections/postgres.md
           - MySQL / MariaDB: connections/mysql.md
+          - Microsoft SQL Server: connections/mssql.md
       - Troubleshooting & observability: troubleshooting.md
       - UI compatibility: ui-compatibility.md
       - Staging volume: staging-volume.md


### PR DESCRIPTION
## Summary
Closes #71. Third entry of the connector cookbook.

Same three-part contract as #157 (postgres) and #158 (mysql): doc page + example DAG + automated test. The mssql shape is closest to mysql — `pymssql.connect()` takes kwargs, not a URI, so the DAG parses + unquotes the URI just like \`pymysql\`.

## What ships
- **Test (1 line)**: \`TestConnectionDeliveryChainOfCustodyIntegration\` adds the \`mssql\` case (port 1433). The same URI-builder + percent-escape + round-trip contract is now validated for 4 conn types.
- **examples/mssql_load/**: pymssql + parse + unquote pattern. The example password is \`Etl@1234\` — the \`@\` deliberately exercises the percent-escape path that protects user pipelines.
- **docs/connections/mssql.md**: URI shape, the pymssql gotcha (with code), pyodbc + SQLAlchemy alternatives, Azure SQL specifics, MSSQL_SA password policy, troubleshooting.

## Cookbook progress (#142)

| Type | Status |
|---|---|
| \`postgres\` | ✅ #157 (merged) |
| \`mysql\` / \`mariadb\` | ✅ #158 (merged) |
| **\`mssql\`** | **this PR** |
| \`sqlite\` | next (no host/port — file-based) |
| \`redis\` | next |
| \`http\` | next |

## Test plan
- [x] \`go test ./...\` — green
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`scripts/gen-adr-index.sh --check\` — up to date
- [x] Pre-commit gate passes
- [x] Docs workflow on PR (#156) gates this PR
- [ ] Manual on Lima: \`leoflow lite examples/mssql_load\` against \`mcr.microsoft.com/mssql/server:2022-latest\` — verify rows

## Related
- #142 — connector cookbook umbrella.
- #138 — chain-of-custody contract test (now covers postgres + mysql + mariadb + mssql).
- #71 — MSSQL connector umbrella (closed).
- ADR 0019, ADR 0021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)