### PR TITLE
test(connections): sqlite cookbook entry — file-path shape, Tier 1 (#142, #70)

### DIFF
--- a/docs/connections/index.md
+++ b/docs/connections/index.md
@@ -19,7 +19,7 @@ URI shape, an example DAG, and how to test it.
 | `postgres` | [postgres.md](postgres.md) | [examples/postgres_load](https://github.com/neochaotic/leoflow/tree/main/examples/postgres_load) | ✅ documented + automated test (#138) |
 | `mysql` / `mariadb` | [mysql.md](mysql.md) | [examples/mysql_load](https://github.com/neochaotic/leoflow/tree/main/examples/mysql_load) | ✅ documented + automated test (#69, table-driven via #138) |
 | `mssql` | [mssql.md](mssql.md) | [examples/mssql_load](https://github.com/neochaotic/leoflow/tree/main/examples/mssql_load) | ✅ documented + automated test (#71, table-driven via #138) |
-| `sqlite` | TBD (#70) | TBD | 📋 planned |
+| `sqlite` | [sqlite.md](sqlite.md) | [examples/sqlite_load](https://github.com/neochaotic/leoflow/tree/main/examples/sqlite_load) | ✅ documented + automated test (#70, dedicated test for file-path shape; Tier 1 — no service needed) |
 | `redis` | TBD (#73) | TBD | 📋 planned |
 | `http` | TBD (#75) | TBD | 📋 planned |
 

--- a/docs/connections/sqlite.md
+++ b/docs/connections/sqlite.md
@@ -102,7 +102,7 @@ sqlite is a library, not a service, so the Tier 1 cost is zero (see
 |---|---|---|
 | `OperationalError: unable to open database file` | Path missing or unwritable | Use an absolute path; ensure the pod / process can write to it. |
 | `urlparse(...).path` is empty | The Schema field was left blank, or the URI uses the 2-slash form | Use an absolute path in Schema (starts with `/`). |
-| `database is locked` | Multiple concurrent writers | Pick a different DB; sqlite serialises writes by design. |
+| `database is locked` | Multiple concurrent writers | Pick a different DB; sqlite serializes writes by design. |
 
 ## Related
 

--- a/docs/connections/sqlite.md
+++ b/docs/connections/sqlite.md
@@ -1,0 +1,113 @@
+# SQLite connection
+
+Connect a task to a sqlite database file. Unlike the SQL-family entries
+(postgres, mysql, mssql), sqlite has no server — the database is a single
+file on disk. This page documents what makes the connector different.
+
+## URI shape
+
+```
+sqlite:///<absolute file path>
+```
+
+Three slashes total: two for the `scheme://` separator and one for the
+leading `/` of an absolute path. Examples:
+
+| File path | URI |
+|---|---|
+| `/var/lib/leoflow/warehouse.db` | `sqlite:///var/lib/leoflow/warehouse.db` |
+| `/tmp/demo.db` | `sqlite:///tmp/demo.db` |
+| (relative path — avoid) | `sqlite://warehouse.db` ← parses, but `urlparse(...).path` returns `""` for the host-less 2-slash form. Use an absolute path. |
+
+The control plane builds this URI from the Connection's **Schema** field
+(which is, by sqlite convention, the file path). There is no host, port,
+login, or password.
+
+## Fields the UI asks for
+
+| Field | Required | Notes |
+|---|---|---|
+| Conn Id | yes | e.g. `sqlite_target`. Exported as `AIRFLOW_CONN_SQLITE_TARGET`. |
+| Conn Type | yes | `sqlite`. |
+| Schema | yes | The **absolute path** to the database file. |
+| Host | no | Leave blank. |
+| Login | no | Leave blank. |
+| Password | no | Leave blank. There is nothing to encrypt; the cipher gate still applies (#142). |
+| Port | no | Leave blank. |
+| Extra | optional | JSON for connect-time pragmas, e.g. `{"timeout":5,"detect_types":"PARSE_DECLTYPES"}`. The DAG passes these to `sqlite3.connect`. |
+
+## The path-extraction pattern
+
+`sqlite3.connect()` takes a path string, NOT a URI. The user task must
+parse the URI itself and pull `parsed.path`:
+
+```python
+import os, sqlite3
+from urllib.parse import urlparse
+
+raw = os.environ["AIRFLOW_CONN_SQLITE_TARGET"]
+path = urlparse(raw).path
+if not path:
+    raise ValueError(f"sqlite URI has no path: {raw!r}")
+conn = sqlite3.connect(path)
+```
+
+Unlike the SQL family there is no `unquote` step — paths are not
+percent-escaped.
+
+## Example DAG
+
+[`examples/sqlite_load`](https://github.com/neochaotic/leoflow/tree/main/examples/sqlite_load) uses only Python's standard-library
+`sqlite3`. The example's
+[README](https://github.com/neochaotic/leoflow/tree/main/examples/sqlite_load/README.md)
+walks through Connection setup and verification.
+
+## Lite vs Pro caveats
+
+- **Lite (subprocess)** runs the task on the host. The path resolves
+  against the host filesystem — a writable temp dir is fine for demos.
+- **Lite (k3d)** runs the task in a pod. The path resolves inside the
+  pod; the file disappears when the pod exits unless you mount a
+  hostPath or a PVC.
+- **Pro (Kubernetes)** same as k3d: persistence requires a volume. For
+  shared state across pods, sqlite is the wrong tool — use a real
+  service (postgres / mysql) instead.
+
+## Why no encryption / no password
+
+sqlite's file-system permissions are the access control. If the task can
+read the file, it can read the data; if the file mode says `0600` and
+the file is owned by the running user, only that user can open it. The
+URI carries no secret, so the Repository's cipher does not actually
+encrypt anything for a sqlite Connection — but it must still be
+configured (the SetConnection gate refuses writes without a cipher; the
+gate's purpose is "never store a credential in plaintext", and for
+sqlite there is no credential to store).
+
+For at-rest encryption of the sqlite **file itself**, use SQLCipher
+(`pip install sqlcipher3-binary`) and pass the key via Extra. That is
+out of scope for the cookbook entry but a documented pattern in the
+SQLCipher project.
+
+## Tier 1 integration test
+
+`TestSQLiteConnectionURIShapeIntegration` (in `internal/storage/`)
+covers this entry. It runs on every PR with no service container —
+sqlite is a library, not a service, so the Tier 1 cost is zero (see
+[#162](https://github.com/neochaotic/leoflow/issues/162)).
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `OperationalError: unable to open database file` | Path missing or unwritable | Use an absolute path; ensure the pod / process can write to it. |
+| `urlparse(...).path` is empty | The Schema field was left blank, or the URI uses the 2-slash form | Use an absolute path in Schema (starts with `/`). |
+| `database is locked` | Multiple concurrent writers | Pick a different DB; sqlite serialises writes by design. |
+
+## Related
+
+- ADR 0019 — secret encryption at rest (mostly a no-op for sqlite).
+- ADR 0021 — agent secret delivery.
+- #70 — sqlite connector umbrella.
+- #138 — chain-of-custody contract test (sqlite gets a dedicated test).
+- #162 — tiered integration-test pipeline (sqlite is Tier 1).

--- a/examples/sqlite_load/README.md
+++ b/examples/sqlite_load/README.md
@@ -1,0 +1,94 @@
+# sqlite_load — write rows into a sqlite file via a managed Connection
+
+This example is a **test DAG** for the sqlite connector. Unlike the other
+SQL-family cookbook entries (postgres, mysql, mssql), sqlite has no
+server, no port, no login, and no password — the database is a single
+file on disk. This entry validates that the Connection delivery path
+handles a "no-credentials, file-path-only" shape correctly.
+
+## What it tests
+
+1. Admin creates a `sqlite` Connection in the UI; the **Schema** field
+   carries the absolute file path.
+2. The control plane stores it (no encryption needed since there is no
+   password, but the cipher gate still applies).
+3. The agent fetches the URI via gRPC and exports it as
+   `AIRFLOW_CONN_SQLITE_TARGET=sqlite:///path/to/db`.
+4. The user task `load()` parses the URI with `urllib.parse.urlparse`,
+   takes `.path`, and opens it with `sqlite3.connect`.
+5. You can verify the rows exist in the resulting sqlite file.
+
+This example uses **only the Python standard library** (`sqlite3`) —
+no third-party driver to install.
+
+## How to run it (Lima / subprocess executor)
+
+### 1. Pick a path for the sqlite file
+
+The file does not need to exist; `sqlite3.connect` creates it on first
+write. Pick something writable by the task:
+
+- Subprocess executor: `/tmp/leoflow_warehouse.db` (the OS temp dir).
+- k3d executor: the file lives inside the pod and disappears when it
+  exits. Use a hostPath mount or a PVC if you need persistence.
+
+### 2. Create the Connection in the UI
+
+Open `http://localhost:8088` → **Admin → Connections → +**.
+
+| Field | Value |
+|---|---|
+| Conn Id | `sqlite_target` |
+| Conn Type | `sqlite` |
+| Schema | `/tmp/leoflow_warehouse.db` (the absolute path) |
+| Host | *(leave blank)* |
+| Login | *(leave blank)* |
+| Password | *(leave blank)* |
+| Port | *(leave blank)* |
+
+Save. The resulting `AIRFLOW_CONN_SQLITE_TARGET` env var will be
+`sqlite:///tmp/leoflow_warehouse.db`.
+
+### 3. Trigger the DAG
+
+```sh
+leoflow lite path/to/this/example
+```
+
+In the UI: open `sqlite_load` → **Trigger DAG**.
+
+### 4. Verify
+
+```sh
+sqlite3 /tmp/leoflow_warehouse.db "SELECT COUNT(*), MIN(name), MAX(score) FROM example_load;"
+```
+
+Expected: 20 rows. `MIN(name)` is `cat_0`, scores range 0–99.
+
+## What can go wrong
+
+- **The Schema field is empty** → the URI builder emits `sqlite://` with
+  no path, and `urlparse(...).path` is `""`. The DAG raises ValueError
+  with a clear message.
+- **The path is relative** (e.g. `warehouse.db`) → sqlite resolves it
+  relative to the task's CWD, which is the agent's working directory.
+  Use an absolute path for predictable behavior.
+- **The pod cannot write to the path** (k3d, read-only filesystem,
+  PV permission) → sqlite raises `OperationalError: unable to open
+  database file`. Mount a writable volume.
+
+## Why this entry has no service container
+
+sqlite is a **library**, not a service. The integration test
+(`TestSQLiteConnectionURIShapeIntegration` in `internal/storage/`) runs
+on every PR without needing a Docker container — this entry is **Tier 1**
+in the [tiered pipeline](https://github.com/neochaotic/leoflow/issues/162).
+
+## Related
+
+- `docs/connections/sqlite.md` — cookbook entry.
+- ADR 0021 — agent secret delivery.
+- Issue #138 — chain-of-custody contract test (covers sqlite via a
+  separate test, not the table-driven SQL-family one).
+- Issue #70 — sqlite connector umbrella.
+- Issue #162 — tiered integration-test pipeline.

--- a/examples/sqlite_load/dag.py
+++ b/examples/sqlite_load/dag.py
@@ -1,0 +1,58 @@
+"""sqlite_load — compute rows and load them into a sqlite file.
+
+The target DB path comes from a managed Leoflow Connection injected as
+AIRFLOW_CONN_SQLITE_TARGET (create it in Admin → Connections). The Schema
+field carries the absolute file path; the URI looks like
+`sqlite:///var/lib/leoflow/warehouse.db`.
+
+No third-party driver needed — `sqlite3` is in the Python standard library.
+Falls back to a local DB file under /tmp for a quick demo.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+from urllib.parse import urlparse
+
+from airflow.sdk import DAG, task
+
+
+@task
+def compute() -> list[tuple]:
+    rows = [(f"cat_{i}", (i * 7) % 100) for i in range(20)]
+    print(f"compute: {len(rows)} rows")
+    return rows
+
+
+@task
+def load(rows: list[tuple]) -> None:
+    raw = os.environ.get("AIRFLOW_CONN_SQLITE_TARGET") or os.environ.get(
+        "SQLITE_TARGET_PATH", "sqlite:///tmp/leoflow_warehouse.db"
+    )
+    src = "managed Connection sqlite_target" if os.environ.get("AIRFLOW_CONN_SQLITE_TARGET") else "fallback DSN"
+    print(f"load: connecting via {src}")
+
+    # sqlite3.connect takes a file path, not a URI. Parse the URI and use
+    # parsed.path verbatim. Unlike the SQL family there is no password,
+    # host, or port — just the path.
+    path = urlparse(raw).path
+    if not path:
+        raise ValueError(f"sqlite URI has no path: {raw!r}")
+
+    conn = sqlite3.connect(path)
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS example_load (name TEXT PRIMARY KEY, score INTEGER)"
+        )
+        cur.execute("DELETE FROM example_load")
+        cur.executemany("INSERT INTO example_load VALUES (?, ?)", rows)
+        conn.commit()
+        (count,) = cur.execute("SELECT COUNT(*) FROM example_load").fetchone()
+        print(f"load: {count} rows in example_load at {path}")
+    finally:
+        conn.close()
+
+
+with DAG("sqlite_load", schedule=None, catchup=False, tags=["example"]):
+    load(compute())

--- a/examples/sqlite_load/leoflow.yaml
+++ b/examples/sqlite_load/leoflow.yaml
@@ -1,0 +1,9 @@
+schema_version: "1.0"
+dag_id: sqlite_load
+description: Compute rows and load them into a sqlite file via a managed Connection.
+owner: examples
+tags:
+  - example
+python_version: "3.11"
+# sqlite3 is part of the Python stdlib — no third-party dependency needed.
+dependencies: []

--- a/internal/storage/conn_uri.go
+++ b/internal/storage/conn_uri.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/neochaotic/leoflow/internal/domain"
 )
@@ -21,7 +22,17 @@ func airflowConnURI(c domain.Connection) string {
 	}
 	u.Host = host
 	if c.Schema != "" {
-		u.Path = "/" + c.Schema
+		// sqlite's canonical URI is `sqlite:///<absolute path>` (3 slashes).
+		// The operator may type the path with or without a leading slash; if
+		// we always prepend `/` we double up and emit `sqlite:////...` which
+		// SQLAlchemy and `urlparse(uri).path` parse incorrectly. Idempotent
+		// handling is a no-op for postgres/mysql/etc. (their schema names
+		// never start with `/`).
+		if strings.HasPrefix(c.Schema, "/") {
+			u.Path = c.Schema
+		} else {
+			u.Path = "/" + c.Schema
+		}
 	}
 	// Airflow carries the connection's extra (a JSON blob) in the URI under the
 	// __extra__ query param; without this, extra params (sslmode, etc.) are lost.

--- a/internal/storage/conn_uri_test.go
+++ b/internal/storage/conn_uri_test.go
@@ -27,3 +27,37 @@ func TestAirflowConnURI(t *testing.T) {
 		t.Errorf("uri = %q, want extra carried under __extra__", got)
 	}
 }
+
+// TestAirflowConnURISQLitePath pins the sqlite contract: the Schema field
+// carries the database file path, and the builder must render the canonical
+// 3-slash form `sqlite:///<absolute path>` whether the operator typed the path
+// with or without a leading slash. A double-prepend bug here produces 4
+// slashes and breaks SQLAlchemy / `urlparse(...).path` parsing in user DAGs.
+func TestAirflowConnURISQLitePath(t *testing.T) {
+	cases := []struct {
+		name   string
+		schema string
+		want   string
+	}{
+		{
+			name:   "absolute path with leading slash",
+			schema: "/var/lib/leoflow/warehouse.db",
+			want:   "sqlite:///var/lib/leoflow/warehouse.db",
+		},
+		{
+			name:   "relative path without leading slash",
+			schema: "var/lib/leoflow/warehouse.db",
+			want:   "sqlite:///var/lib/leoflow/warehouse.db",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := airflowConnURI(domain.Connection{
+				ConnID: "sqlite_target", ConnType: "sqlite", Schema: tc.schema,
+			})
+			if got != tc.want {
+				t.Errorf("uri = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/storage/connection_delivery_e2e_test.go
+++ b/internal/storage/connection_delivery_e2e_test.go
@@ -138,3 +138,76 @@ func mapKeys(m map[string]string) []string {
 	}
 	return out
 }
+
+// TestSQLiteConnectionURIShapeIntegration is the sqlite counterpart to the
+// SQL-family chain-of-custody test. sqlite has no host, no port, no login,
+// and no password — the **schema field carries the file path** and the
+// URI is `sqlite:///<absolute path>`. None of the percent-escape edge
+// cases apply, but the path round-trip and the no-host/no-user invariants
+// are real and broken by plausible refactors.
+//
+// A regression that would surface only here: the URI builder accidentally
+// emits `sqlite://<path>` (two slashes — wrong), drops the path, or
+// percent-escapes the path's `/` separators.
+func TestSQLiteConnectionURIShapeIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 11)
+	}
+	cipher, err := secrets.NewAESGCM(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo.SetCipher(cipher)
+
+	connID := fmt.Sprintf("e2e_sqlite_%d", time.Now().UnixNano())
+	const dbPath = "/var/lib/leoflow/warehouse.db"
+	if cerr := repo.SetConnection(ctx, "default", domain.Connection{
+		ConnID: connID, ConnType: "sqlite",
+		Schema: dbPath, // sqlite convention: the "schema" field is the file path
+	}); cerr != nil {
+		t.Fatalf("SetConnection: %v", cerr)
+	}
+	t.Cleanup(func() { _ = repo.DeleteConnection(ctx, "default", connID) })
+
+	tenantUUID, err := repo.TenantUUID(ctx, "default")
+	if err != nil {
+		t.Fatalf("TenantUUID: %v", err)
+	}
+	uris, err := repo.SecretConnectionURIs(ctx, tenantUUID)
+	if err != nil {
+		t.Fatalf("SecretConnectionURIs: %v", err)
+	}
+	uri, present := uris[connID]
+	if !present {
+		t.Fatalf("URI for %q missing from delivery map; got keys = %v",
+			connID, mapKeys(uris))
+	}
+
+	// The canonical sqlite URI is `sqlite:///<absolute path>` — three
+	// slashes (two for the scheme separator, one for the absolute path).
+	parsed, perr := url.Parse(uri)
+	if perr != nil {
+		t.Fatalf("URI is not parseable (the Python connector would fail): %q err=%v", uri, perr)
+	}
+	if parsed.Scheme != "sqlite" {
+		t.Errorf("scheme = %q, want sqlite", parsed.Scheme)
+	}
+	if parsed.Host != "" {
+		t.Errorf("host = %q, want empty (sqlite has no host)", parsed.Host)
+	}
+	if parsed.User != nil {
+		t.Errorf("user = %v, want nil (sqlite has no login/password)", parsed.User)
+	}
+	if parsed.Path != dbPath {
+		t.Errorf("path round-trip failed: got %q, want %q", parsed.Path, dbPath)
+	}
+	// The DAG's user code does `urlparse(uri).path` to extract the file
+	// path, then sqlite3.connect(path). Mirror that here so the contract
+	// the cookbook documents is exactly what the test asserts.
+	wantStringForm := "sqlite://" + dbPath
+	if uri != wantStringForm {
+		t.Errorf("uri = %q, want %q (the canonical 3-slash form)", uri, wantStringForm)
+	}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -142,6 +142,7 @@ nav:
           - Postgres: connections/postgres.md
           - MySQL / MariaDB: connections/mysql.md
           - Microsoft SQL Server: connections/mssql.md
+          - SQLite: connections/sqlite.md
       - Troubleshooting & observability: troubleshooting.md
       - UI compatibility: ui-compatibility.md
       - Staging volume: staging-volume.md


### PR DESCRIPTION
## Summary
Closes #70. Fourth connector cookbook entry. **First entry that doesn't fit the SQL-family table** — sqlite has no host, no port, no login, no password. The Schema field carries the file path; the URI is \`sqlite:///<absolute path>\` (three slashes).

## What's different from postgres/mysql/mssql
- **No password to percent-escape** → no round-trip test needed.
- **No host or port** → the existing table-driven test struct doesn't fit.
- **No third-party driver** → uses stdlib \`sqlite3\` only.
- **Library, not a service** → integration test runs on every PR with **no Docker container** → lands as **Tier 1** in the tiered pipeline (#162).

## Deliverables (3-part contract per [[connector-test-docs-rigor]])

### 1. Test (\`TestSQLiteConnectionURIShapeIntegration\`)
Separate from the SQL-family table because the shape is fundamentally different. Validates:
- \`scheme=sqlite\`, \`host=\"\"\`, \`user=nil\` (sqlite has no auth)
- Path round-trip: the Schema value comes back verbatim from \`urlparse(uri).path\`
- The canonical \`sqlite://\` + path string form (3-slash for absolute paths)

### 2. Example DAG (\`examples/sqlite_load/\`)
Uses only stdlib \`sqlite3\`. Parses \`AIRFLOW_CONN_SQLITE_TARGET\` with \`urllib.parse\`, raises \`ValueError\` with a clear message if the path is empty (vs silently writing to \`\":memory:\"\`), opens the file, writes 20 rows. The example's README walks through Connection setup (most fields blank) and verification (\`sqlite3 path.db \"SELECT COUNT(*)\"\`).

### 3. Cookbook page (\`docs/connections/sqlite.md\`)
- URI shape with the 3-slash gotcha (and why the 2-slash variant fails).
- The path-extraction pattern (with code).
- Lite vs Pro caveats (k3d/Pro need a volume for persistence).
- The "no encryption / no password" explanation (file-system permissions are the access control; SQLCipher noted as out-of-scope).
- Explicit **Tier 1** designation per #162.

## Test plan
- [x] \`go test ./...\` — green
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`scripts/gen-adr-index.sh --check\` — up to date
- [x] Pre-commit gate passes
- [x] Docs workflow on PR (#156) gates this PR

## Cookbook progress (#142)

| Type | Status | Tier |
|---|---|---|
| postgres | ✅ #157 | Tier 1 ✅ |
| mysql / mariadb | ✅ #158 | Tier 2 (planned) |
| mssql | ✅ #159 | Tier 2 (planned) |
| **sqlite** | **this PR** | **Tier 1 ✅** |
| redis | next | Tier 1 (already in CI) |
| http | next | Tier 1 (httptest) |

## Related
- #142 — connector cookbook umbrella.
- #138 — chain-of-custody test (sqlite gets a dedicated test alongside the table-driven SQL family).
- #70 — sqlite connector umbrella (closed).
- #162 — tiered integration-test pipeline (sqlite is the first Tier 1 entry that needed deliberate design).
- ADR 0019, ADR 0021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)