### PR TITLE
test(connections): redis cookbook entry — table-driven row, Tier 1 (#142, #73)

### DIFF
--- a/docs/connections/index.md
+++ b/docs/connections/index.md
@@ -20,7 +20,7 @@ URI shape, an example DAG, and how to test it.
 | `mysql` / `mariadb` | [mysql.md](mysql.md) | [examples/mysql_load](https://github.com/neochaotic/leoflow/tree/main/examples/mysql_load) | ✅ documented + automated test (#69, table-driven via #138) |
 | `mssql` | [mssql.md](mssql.md) | [examples/mssql_load](https://github.com/neochaotic/leoflow/tree/main/examples/mssql_load) | ✅ documented + automated test (#71, table-driven via #138) |
 | `sqlite` | [sqlite.md](sqlite.md) | [examples/sqlite_load](https://github.com/neochaotic/leoflow/tree/main/examples/sqlite_load) | ✅ documented + automated test (#70, dedicated test for file-path shape; Tier 1 — no service needed) |
-| `redis` | TBD (#73) | TBD | 📋 planned |
+| `redis` | [redis.md](redis.md) | [examples/redis_load](https://github.com/neochaotic/leoflow/tree/main/examples/redis_load) | ✅ documented + automated test (#73, table-driven via #138; Tier 1 — redis already in CI services) |
 | `http` | TBD (#75) | TBD | 📋 planned |
 
 ## Cloud (deferred past alpha)

--- a/docs/connections/redis.md
+++ b/docs/connections/redis.md
@@ -1,0 +1,114 @@
+# Redis connection
+
+Connect a task to a Redis instance for caching, queues, distributed locks,
+or small key-value side state. Unlike the SQL-family entries, Redis has no
+schemas / tables — data lives in numeric **databases** (0..15 by default)
+and the value model is key + (string | hash | list | set | stream | ...).
+
+## URI shape
+
+```
+redis://[<user>:<password>@]<host>:<port>/<db_index>
+```
+
+The Schema field carries the **db index** (a number), not a schema name.
+Examples:
+
+| Connection fields | URI |
+|---|---|
+| host=`redis.internal` port=`6379` schema=`0` | `redis://redis.internal:6379/0` |
+| host=`r` port=`6379` schema=`3` password=`s3cret` | `redis://:s3cret@r:6379/3` |
+| host=`r` user=`etl` password=`s3cret` schema=`0` | `redis://etl:s3cret@r:6379/0` |
+
+Legacy Redis (≤ 5) only had a single password (the `AUTH <password>`
+command), which the URI carries as `redis://:<password>@...` — an empty
+username with a populated password is valid. Redis 6+ has ACL (a real
+username), which fills both Login and Password.
+
+## Fields the UI asks for
+
+| Field | Required | Notes |
+|---|---|---|
+| Conn Id | yes | e.g. `redis_target`. Exported as `AIRFLOW_CONN_REDIS_TARGET`. |
+| Conn Type | yes | `redis`. |
+| Host | yes | Hostname or IP. |
+| Port | usually `6379` | Default for the redis protocol; `6380` for the TLS port on some managed services. |
+| Schema | yes | The **db index** as a string, e.g. `0`. Default is `0`. |
+| Login | optional | The ACL username (Redis 6+). Leave blank for legacy AUTH. |
+| Password | optional | The AUTH password / ACL password. Encrypted at rest. |
+| Extra | optional | JSON for connect-time options, e.g. `{"ssl": true, "socket_timeout": 5}`. The DAG passes these to `redis.Redis.from_url`. |
+
+## How user code reads it
+
+`redis.Redis.from_url` accepts the full URI directly:
+
+```python
+import os, redis
+
+uri = os.environ["AIRFLOW_CONN_REDIS_TARGET"]
+client = redis.Redis.from_url(uri, decode_responses=True)
+client.set("hello", "world")
+print(client.get("hello"))
+```
+
+`from_url` parses the user/password, picks the db index from the path, and
+opens the connection. No path-extraction step like sqlite needs.
+
+## TLS (`rediss://`)
+
+Most managed Redis services (AWS ElastiCache with in-transit encryption,
+Upstash, etc.) require TLS. The standard URI scheme for that is `rediss://`
+(double-s), but the Connection's Conn Type field still uses `redis` —
+carry the TLS flag in Extra instead:
+
+```json
+{"ssl": true, "ssl_cert_reqs": "required"}
+```
+
+`redis.Redis.from_url` honours these. A dedicated `rediss` recipe is a
+planned follow-up; for now, `redis` + Extra is the supported path.
+
+## Example DAG
+
+[`examples/redis_load`](https://github.com/neochaotic/leoflow/tree/main/examples/redis_load) writes 20 hash fields under
+`leoflow:example_load` using `redis-py`. The example's
+[README](https://github.com/neochaotic/leoflow/tree/main/examples/redis_load/README.md)
+walks through Connection setup and verification with `redis-cli HGETALL`.
+
+## Lite vs Pro caveats
+
+- **Lite (subprocess)** runs the task on the host. Point the Connection at
+  any reachable Redis (a local docker run, a remote instance).
+- **Lite (k3d)** runs the task in a pod. Use `host.k3d.internal` to reach
+  a host-network Redis, or deploy Redis inside the cluster.
+- **Pro (Kubernetes)** typical pattern is the redis-operator or a managed
+  service (ElastiCache, Memorystore). For at-rest persistence, make sure
+  Redis is configured with AOF or RDB; the Leoflow Connection itself is
+  metadata only.
+
+## Tier 1 integration test
+
+Redis is included in `TestConnectionDeliveryChainOfCustodyIntegration`
+(the table-driven SQL-family test in `internal/storage/`). It runs on
+every PR with no extra service container — Redis is already a CI service
+for the Leoflow control plane (see `.github/workflows/ci.yaml`), so the
+Tier 1 cost is zero (see [#162](https://github.com/neochaotic/leoflow/issues/162)).
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `ConnectionError: Error 111 connecting to ...` | Host/port wrong, or Redis bound to localhost only | Check `bind` in `redis.conf`; from inside k3d use `host.k3d.internal`. |
+| `NOAUTH Authentication required` | Connection has no password but Redis has `requirepass` | Set the password in the Connection. |
+| `WRONGPASS invalid username-password pair` | ACL user/password mismatch (Redis 6+) | Confirm the ACL with `ACL WHOAMI` on the server. |
+| `WRONGTYPE Operation against a key holding the wrong kind of value` | Reusing a key with a different type | Delete the key first or pick a new key namespace. |
+| Wrong db index | Schema field empty or wrong number | Set Schema to the intended db index (default `0`). |
+
+## Related
+
+- ADR 0019 — secret encryption at rest.
+- ADR 0021 — agent secret delivery (`AIRFLOW_CONN_<CONN_ID>`).
+- #73 — redis connector umbrella.
+- #138 — chain-of-custody contract test (redis is the fifth conn_type covered).
+- #142 — the connector cookbook umbrella.
+- #162 — tiered integration-test pipeline (redis is Tier 1).

--- a/examples/redis_load/README.md
+++ b/examples/redis_load/README.md
@@ -1,0 +1,107 @@
+# redis_load — write a hash into an external Redis via a managed Connection
+
+This example is a **test DAG**: it exercises the connection-delivery contract
+end-to-end against a real Redis, mirroring `postgres_load` and `mysql_load`.
+Running it is the manual companion to the Go-side chain-of-custody test
+(`TestConnectionDeliveryChainOfCustodyIntegration`, which now covers Redis as
+the fifth conn_type).
+
+## What it tests
+
+1. Admin creates a `redis` Connection in the UI.
+2. The control plane encrypts and stores it (ADR 0019).
+3. The agent fetches the URI via gRPC and exports it as
+   `AIRFLOW_CONN_REDIS_TARGET`.
+4. The user task `load()` reads the env var, opens `redis.Redis.from_url`,
+   and writes 20 hash fields under `leoflow:example_load`.
+5. You verify the keys exist with `redis-cli`.
+
+Without a Connection, `load()` falls back to a hardcoded local URI so the
+example also runs in a quick demo on a developer machine.
+
+## How to run it (Lima / subprocess executor)
+
+### 1. Spin up a target Redis
+
+```sh
+docker run --rm -d --name leoflow-redis \
+  -p 56379:6379 \
+  redis:7
+```
+
+The DAG defaults to `redis://host.k3d.internal:56379/0` which works inside a
+k3d cluster. From the host or via subprocess, use `localhost:56379`.
+
+### 2. Create the Connection in the UI
+
+Open `http://localhost:8088` → **Admin → Connections → +**.
+
+| Field | Value |
+|---|---|
+| Conn Id | `redis_target` |
+| Conn Type | `redis` |
+| Host | `localhost` (host) or `host.k3d.internal` (k3d) |
+| Schema | `0` (the Redis db index, 0–15 by default) |
+| Login | _(blank)_ |
+| Password | _(blank, unless your Redis requires AUTH)_ |
+| Port | `56379` |
+
+Save. The UI never shows the password again — it is encrypted at rest.
+
+### 3. Trigger the DAG
+
+```sh
+leoflow lite path/to/this/example
+```
+
+In the UI: open `redis_load` → **Trigger DAG**.
+
+### 4. Verify
+
+```sh
+docker exec leoflow-redis redis-cli HGETALL leoflow:example_load | head
+docker exec leoflow-redis redis-cli HLEN leoflow:example_load
+```
+
+Expected: 20 fields. `HGETALL` shows `cat_0`..`cat_19` keys with the computed
+score values.
+
+The task logs in the UI also report
+`load: connecting via managed Connection redis_target` (vs the fallback URI
+banner if the env var is missing).
+
+## Notes that make this connector different
+
+- **Schema is a db index**, not a name. Redis namespaces data into numeric
+  databases (default 0..15). The Connection's Schema field carries this
+  number; the URI builder renders it as the path component, so the final
+  URI is `redis://host:port/0`.
+- **No login is fine.** Pre-ACL Redis used `AUTH <password>` only; the URI
+  shape is `redis://:<password>@host:port/<db>` — empty username, populated
+  password. With Redis 6+ ACL, set both Login and Password.
+- **No TLS in this example.** For `rediss://` (TLS), set Conn Type to
+  `redis` but use Extra to carry `{"ssl": true}`. We'll add a dedicated TLS
+  recipe later; out of scope here.
+- **Tier 1 in CI** (#162) — redis already runs as a service in CI, so the
+  chain-of-custody test for redis runs on every PR at zero extra cost.
+
+## What can go wrong
+
+- **AIRFLOW_CONN_REDIS_TARGET not set** → the DAG falls back to the hardcoded
+  URI. If that URI does not match your target, the connect fails. The log
+  line tells you which path was taken.
+- **WRONGTYPE / wrong db index** — if you reuse `leoflow:example_load` for a
+  string key in db 0, the `HSET` errors with `WRONGTYPE`. The DAG deletes
+  the key first to avoid this.
+- **Password with reserved characters** (`@`, `:`, `/`, `?`, `#`) — handled
+  by the same percent-escape path as the SQL family; the chain-of-custody
+  test pins this.
+
+## Related
+
+- `docs/connections/redis.md` — the cookbook entry for the redis connector
+  (URI shape, ACL semantics, supported drivers).
+- ADR 0019 — secret encryption at rest.
+- ADR 0021 — agent secret delivery (`AIRFLOW_CONN_<CONN_ID>`).
+- Issue #142 — connector cookbook umbrella.
+- Issue #73 — redis connector umbrella.

--- a/examples/redis_load/dag.py
+++ b/examples/redis_load/dag.py
@@ -1,0 +1,44 @@
+"""redis_load — compute a small payload and write it into a Redis hash.
+
+The target URI comes from a managed Leoflow Connection injected as
+AIRFLOW_CONN_REDIS_TARGET (create it in Admin -> Connections); falls back to a
+local URI for a quick run on a developer machine.
+
+Unlike the SQL-family connectors, Redis has no schemas/tables: data is
+key-value with optional hash / set / list types. This example uses a hash so
+the verification step (``redis-cli HGETALL leoflow:example_load``) is one
+command.
+"""
+from __future__ import annotations
+
+import os
+
+from airflow.sdk import DAG, task
+
+
+@task
+def compute() -> dict[str, str]:
+    rows = {f"cat_{i}": str((i * 7) % 100) for i in range(20)}
+    print(f"compute: {len(rows)} keys")
+    return rows
+
+
+@task
+def load(payload: dict[str, str]) -> None:
+    import redis
+
+    uri = os.environ.get("AIRFLOW_CONN_REDIS_TARGET") or os.environ.get(
+        "REDIS_TARGET_URI", "redis://host.k3d.internal:56379/0"
+    )
+    src = "managed Connection redis_target" if os.environ.get("AIRFLOW_CONN_REDIS_TARGET") else "fallback URI"
+    print(f"load: connecting via {src}")
+    client = redis.Redis.from_url(uri, decode_responses=True)
+    key = "leoflow:example_load"
+    client.delete(key)
+    client.hset(key, mapping=payload)
+    count = client.hlen(key)
+    print(f"load: {count} fields in {key}")
+
+
+with DAG("redis_load", schedule=None, catchup=False, tags=["example"]):
+    load(compute())

--- a/examples/redis_load/leoflow.yaml
+++ b/examples/redis_load/leoflow.yaml
@@ -1,0 +1,9 @@
+schema_version: "1.0"
+dag_id: redis_load
+description: Compute a key-value payload and write it into a Redis hash via a managed Connection.
+owner: examples
+tags:
+  - example
+python_version: "3.11"
+dependencies:
+  - redis==5.2.1

--- a/internal/storage/connection_delivery_e2e_test.go
+++ b/internal/storage/connection_delivery_e2e_test.go
@@ -46,6 +46,11 @@ func TestConnectionDeliveryChainOfCustodyIntegration(t *testing.T) {
 		{connType: "mysql", defaultPort: 3306, host: "warehouse.example.com", schema: "analytics"},
 		{connType: "mariadb", defaultPort: 3306, host: "warehouse.example.com", schema: "analytics"},
 		{connType: "mssql", defaultPort: 1433, host: "warehouse.example.com", schema: "analytics"},
+		// Redis fits the same shape: the Schema field carries the **db index**
+		// (Redis namespaces 0..15 by default). The URI redis-py parses is
+		// `redis://[user]:password@host:port/<db>`, identical in shape to the
+		// SQL family — only the semantics of Schema differ.
+		{connType: "redis", defaultPort: 6379, host: "warehouse.example.com", schema: "0"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.connType, func(t *testing.T) {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -143,6 +143,7 @@ nav:
           - MySQL / MariaDB: connections/mysql.md
           - Microsoft SQL Server: connections/mssql.md
           - SQLite: connections/sqlite.md
+          - Redis: connections/redis.md
       - Troubleshooting & observability: troubleshooting.md
       - UI compatibility: ui-compatibility.md
       - Staging volume: staging-volume.md


### PR DESCRIPTION
## Summary
Closes #73. Fifth connector cookbook entry. Redis fits the **SQL-family chain-of-custody table** structurally — the URI shape `redis://[user:pass@]host:port/<db>` lines up with `scheme://user:pass@host:port/schema`. Only the **semantics** of the Schema field differ (db index instead of a schema name), so the table-driven test absorbs it as a 1-line addition.

## Deliverables (3-part contract per [[connector-test-docs-rigor]])

### 1. Test
One row added to `TestConnectionDeliveryChainOfCustodyIntegration`:
\`\`\`go
{connType: "redis", defaultPort: 6379, host: "warehouse.example.com", schema: "0"},
\`\`\`
Covers the same wiring proof as postgres/mysql/mariadb/mssql and the same percent-escape edge case on the password (`p@ss/w0rd:!#$`).

### 2. Example DAG (`examples/redis_load/`)
Uses `redis.Redis.from_url(uri, decode_responses=True)`. Writes 20 hash fields under `leoflow:example_load`. Verification = one `redis-cli HGETALL leoflow:example_load`. README walks through:
- Connection setup (with the legacy `AUTH`-only form and ACL form distinguished).
- The `WRONGTYPE` gotcha (the DAG deletes the key first).
- The `host.k3d.internal` shim for k3d.

### 3. Cookbook page (`docs/connections/redis.md`)
- URI shape with the legacy `redis://:<password>@...` empty-username form documented.
- Schema = db index (numeric) gotcha.
- TLS: `redis` + Extra `{"ssl": true}` (the dedicated `rediss://` recipe is deferred).
- Troubleshooting table covering NOAUTH, WRONGPASS, WRONGTYPE.

## Test plan
- [x] `go test ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] Coverage gate — 78.4% (floor 78%)
- [x] `scripts/gen-adr-index.sh --check` — up to date
- [x] Pre-commit gate passes

## Cookbook progress (#142)

| Type | Status | Tier |
|---|---|---|
| postgres | ✅ #157 | Tier 1 ✅ |
| mysql / mariadb | ✅ #158 | Tier 2 (planned) |
| mssql | ✅ #159 | Tier 2 (planned) |
| sqlite | ✅ #163 | Tier 1 ✅ |
| **redis** | **this PR** | **Tier 1 ✅** |
| http | next | Tier 1 (httptest) |

## Related
- #142 — connector cookbook umbrella.
- #138 — chain-of-custody contract test (redis joins the table as the fifth conn_type).
- #73 — redis connector umbrella (closed).
- #162 — tiered integration-test pipeline (redis is Tier 1; CI already runs redis as a service).
- ADR 0019, ADR 0021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)