### PR TITLE
test(connections): http/https cookbook entry — dedicated __extra__ round-trip, Tier 1 (#142, #75)

### DIFF
--- a/docs/connections/http.md
+++ b/docs/connections/http.md
@@ -1,0 +1,137 @@
+# HTTP connection
+
+Connect a task to an external HTTP / REST API: the base URL, optional basic
+auth, and any custom headers (including `Authorization: Bearer ...`) live in
+a managed Connection. The DAG reads the URI and constructs requests against
+it.
+
+## URI shape
+
+```
+http://[<user>:<password>@]<host>[:<port>][/]?__extra__=<json>
+```
+
+| Connection fields | URI |
+|---|---|
+| host=`api.example.com` port=`443` | `http://api.example.com:443` |
+| host=`api` login=`etl` password=`s3cret` | `http://etl:s3cret@api` |
+| host=`api` extra=`{"X-Tenant":"acme"}` | `http://api?__extra__=%7B%22X-Tenant%22%3A%22acme%22%7D` |
+
+Two non-obvious things:
+
+1. **The `__extra__` query parameter is delivery metadata**, not part of
+   the request URL. User code must strip it before building the actual
+   request. The example DAG (`examples/http_load`) demonstrates the
+   correct strip+parse pattern with `urllib.parse`.
+2. **HTTP has no schema/db namespace.** Leave the Schema field blank.
+   Path prefixes like `/v2/...` are typically the operator's concern,
+   appended at request time — not stored on the Connection.
+
+## Fields the UI asks for
+
+| Field | Required | Notes |
+|---|---|---|
+| Conn Id | yes | e.g. `http_target`. Exported as `AIRFLOW_CONN_HTTP_TARGET`. |
+| Conn Type | yes | `http` for plain HTTP, `https` for TLS. |
+| Host | yes | Hostname (no scheme, no port). |
+| Port | optional | Default depends on Conn Type (80 / 443). |
+| Schema | no | Leave blank. |
+| Login | optional | Basic-auth username. Encrypted at rest with the password. |
+| Password | optional | Basic-auth password. Percent-escaped in the URI; user code recovers it with `urllib.parse`. |
+| Extra | optional | JSON for custom headers, e.g. `{"Authorization":"Bearer <token>","X-Tenant":"acme"}`. Encrypted at rest. |
+
+## How user code reads it
+
+Two-step pattern: parse the URI, strip `__extra__`, build the request URL.
+
+```python
+import json, urllib.request
+from urllib.parse import parse_qs, urlparse
+
+raw = os.environ["AIRFLOW_CONN_HTTP_TARGET"]
+parsed = urlparse(raw)
+headers = {}
+qs = parse_qs(parsed.query)
+if "__extra__" in qs:
+    headers = json.loads(qs["__extra__"][0])
+
+base = f"{parsed.scheme}://{parsed.hostname}"
+if parsed.port:
+    base += f":{parsed.port}"
+
+req = urllib.request.Request(f"{base}/v2/foo", headers=headers)
+if parsed.username:
+    import base64
+    token = base64.b64encode(f"{parsed.username}:{parsed.password}".encode()).decode()
+    req.add_header("Authorization", f"Basic {token}")
+
+with urllib.request.urlopen(req) as resp:
+    body = resp.read()
+```
+
+## Authentication patterns
+
+- **Bearer token** — set `Extra = {"Authorization":"Bearer <token>"}`.
+  The Extra blob is encrypted at rest (ADR 0019).
+- **Basic auth** — populate Login + Password. The URI carries them in the
+  `user:password@host` form, percent-escaped.
+- **API key in a custom header** — set `Extra =
+  {"X-API-Key":"<value>"}`.
+- **OAuth2** — out of scope for the Connection itself; the DAG performs
+  the token exchange and caches the token (in XCom or Variables). The
+  Connection carries the client secret in Extra.
+
+## TLS / `https://`
+
+For HTTPS, set Conn Type to `https`. The URI builder renders the scheme
+accordingly; `urllib.request.urlopen` handles TLS via the system trust
+store. For self-signed certs, pass an explicit `ssl.SSLContext` — the
+example DAG doesn't cover this, see the Python `ssl` docs.
+
+## Example DAG
+
+[`examples/http_load`](https://github.com/neochaotic/leoflow/tree/main/examples/http_load) calls a local `go-httpbin`
+echo server and asserts the JSON round-trips. Stdlib only — no `requests`
+dep. The example's
+[README](https://github.com/neochaotic/leoflow/tree/main/examples/http_load/README.md)
+walks through Connection setup and verification.
+
+## Lite vs Pro caveats
+
+- **Lite (subprocess)** runs the task on the host. Outbound HTTP follows
+  the host's network. CORS, proxy, and DNS are the host's problem.
+- **Lite (k3d)** runs the task in a pod. Outbound calls go through the
+  k3d cluster network; for host-side services use `host.k3d.internal`.
+- **Pro (Kubernetes)** typical pattern is a NetworkPolicy gating outbound
+  traffic and a sidecar proxy (Envoy / Istio) for retries and mTLS. The
+  Leoflow Connection itself is unchanged.
+
+## Tier 1 integration test
+
+`TestHTTPConnectionURIShapeIntegration` (in `internal/storage/`) covers
+this entry. It validates the full delivery chain — Repository ->
+SecretConnectionURIs -> URI shape -> basic auth round-trip -> `__extra__`
+round-trip — without standing up a real HTTP server. The example DAG is
+the operator's manual verification step.
+
+Tier 1 cost is zero — no service container needed (see
+[#162](https://github.com/neochaotic/leoflow/issues/162)).
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `urllib.error.HTTPError: 401` | Auth header missing or stale | Confirm the Connection has Login+Password or the right Extra header. Re-fetch the token if Bearer. |
+| Server logs `?__extra__=...` in the URL | DAG didn't strip the delivery metadata | Add the `parse_qs / strip __extra__` step shown above. |
+| `ssl.SSLCertVerificationError` | Self-signed cert | Use a real cert (Let's Encrypt) or pass an `ssl.SSLContext` with the CA loaded. |
+| `urllib.error.URLError: <unreachable>` | k3d pod can't reach the host | Use `host.k3d.internal` instead of `localhost`. |
+| Bearer token leaks into logs | DAG prints the env var | Don't log `AIRFLOW_CONN_HTTP_TARGET`; log a hash or "via managed Connection" instead. |
+
+## Related
+
+- ADR 0019 — secret encryption at rest.
+- ADR 0021 — agent secret delivery (`AIRFLOW_CONN_<CONN_ID>`).
+- #75 — http connector umbrella.
+- #138 — chain-of-custody contract test (http has its own dedicated test).
+- #142 — connector cookbook umbrella.
+- #162 — tiered integration-test pipeline (http is Tier 1).

--- a/docs/connections/index.md
+++ b/docs/connections/index.md
@@ -21,7 +21,7 @@ URI shape, an example DAG, and how to test it.
 | `mssql` | [mssql.md](mssql.md) | [examples/mssql_load](https://github.com/neochaotic/leoflow/tree/main/examples/mssql_load) | ✅ documented + automated test (#71, table-driven via #138) |
 | `sqlite` | [sqlite.md](sqlite.md) | [examples/sqlite_load](https://github.com/neochaotic/leoflow/tree/main/examples/sqlite_load) | ✅ documented + automated test (#70, dedicated test for file-path shape; Tier 1 — no service needed) |
 | `redis` | [redis.md](redis.md) | [examples/redis_load](https://github.com/neochaotic/leoflow/tree/main/examples/redis_load) | ✅ documented + automated test (#73, table-driven via #138; Tier 1 — redis already in CI services) |
-| `http` | TBD (#75) | TBD | 📋 planned |
+| `http` / `https` | [http.md](http.md) | [examples/http_load](https://github.com/neochaotic/leoflow/tree/main/examples/http_load) | ✅ documented + automated test (#75, dedicated test for `__extra__` round-trip; Tier 1 — no service needed) |
 
 ## Cloud (deferred past alpha)
 

--- a/examples/http_load/README.md
+++ b/examples/http_load/README.md
@@ -1,0 +1,112 @@
+# http_load — call an HTTP endpoint via a managed Connection
+
+This example is a **test DAG**: it exercises the connection-delivery contract
+end-to-end against a real HTTP endpoint, mirroring `postgres_load` and
+`redis_load`. Running it is the manual companion to the Go-side
+chain-of-custody test
+(`TestHTTPConnectionURIShapeIntegration`).
+
+Uses only Python's stdlib (`urllib.request`) — no third-party HTTP client.
+
+## What it tests
+
+1. Admin creates an `http` Connection in the UI (host, optional basic auth,
+   custom headers in Extra).
+2. The control plane encrypts and stores it (ADR 0019).
+3. The agent fetches the URI via gRPC and exports it as
+   `AIRFLOW_CONN_HTTP_TARGET`.
+4. The user task `call()` reads the env var, **strips the `__extra__` query
+   param**, parses headers from it, and POSTs a JSON payload to
+   `/anything` (go-httpbin's echo endpoint).
+5. The task asserts the server echoed the exact payload back.
+
+Without a Connection, `call()` falls back to a hardcoded local URI so the
+example also runs in a quick demo on a developer machine.
+
+## How to run it (Lima / subprocess executor)
+
+### 1. Spin up an echo server
+
+```sh
+docker run --rm -d --name leoflow-httpbin \
+  -p 58080:8080 \
+  mccutchen/go-httpbin
+```
+
+The DAG defaults to `http://host.k3d.internal:58080` (works inside k3d).
+From the host or via subprocess, use `localhost:58080`.
+
+### 2. Create the Connection in the UI
+
+Open `http://localhost:8088` → **Admin → Connections → +**.
+
+| Field | Value |
+|---|---|
+| Conn Id | `http_target` |
+| Conn Type | `http` |
+| Host | `localhost` (host) or `host.k3d.internal` (k3d) |
+| Port | `58080` |
+| Schema | _(blank — HTTP has no schema)_ |
+| Login | _(blank, or your basic-auth username)_ |
+| Password | _(blank, or your basic-auth password)_ |
+| Extra | `{"X-Tenant":"acme"}` _(any custom headers go here)_ |
+
+Save. The password and the Extra blob are encrypted at rest.
+
+### 3. Trigger the DAG
+
+```sh
+leoflow lite path/to/this/example
+```
+
+In the UI: open `http_load` → **Trigger DAG**.
+
+### 4. Verify
+
+The DAG asserts the echo itself; a green run is the verification. The task
+log prints `call: echo OK (N fields)`.
+
+To inspect raw traffic:
+
+```sh
+docker logs leoflow-httpbin | tail
+```
+
+## Notes that make this connector different
+
+- **The Schema field is normally blank.** HTTP has no schema/db namespace.
+  Path prefixes (e.g. `/v2/...`) are typically appended by the operator
+  / DAG, not stored in the Connection.
+- **Headers go in Extra**, NOT in the URI itself. The URI builder packs
+  Extra under a `__extra__` query parameter; the example DAG strips it
+  before constructing the actual request URL (otherwise every request
+  would carry `?__extra__=...` and your server logs would be noisy).
+- **Basic auth lives in the URI**. The URI builder percent-escapes
+  reserved characters in the password; the example decodes via
+  `urllib.parse.urlparse(...).username` / `.password`.
+- **HTTPS is a different Conn Type.** `https` uses the same Connection
+  shape, just with TLS. See the cookbook page.
+- **Tier 1 in CI** (#162) — the chain-of-custody assertion is the Go
+  integration test alone; the example DAG is for operators to validate
+  their own deployment. Adding a Python httpbin-driven test to CI is a
+  future possibility but not gated here.
+
+## What can go wrong
+
+- **AIRFLOW_CONN_HTTP_TARGET not set** → the DAG falls back to the
+  hardcoded URI. The log line tells you which path was taken.
+- **The `__extra__` query param leaks into the real request URL**
+  (regression) → server logs will show it; the strip-Extra logic in
+  `_resolve_target()` exists to prevent this.
+- **Self-signed TLS cert (https://)** → `urllib.request.urlopen` will
+  reject it without an explicit context. The example doesn't cover this;
+  use a real cert or pass `ssl.SSLContext(...)`.
+
+## Related
+
+- `docs/connections/http.md` — the cookbook entry for the http connector
+  (URI shape, Bearer auth via Extra, http-vs-https).
+- ADR 0019 — secret encryption at rest.
+- ADR 0021 — agent secret delivery (`AIRFLOW_CONN_<CONN_ID>`).
+- Issue #142 — connector cookbook umbrella.
+- Issue #75 — http connector umbrella.

--- a/examples/http_load/dag.py
+++ b/examples/http_load/dag.py
@@ -1,0 +1,81 @@
+"""http_load — call an external HTTP endpoint via a managed Connection.
+
+The base URL and auth come from a managed Leoflow Connection injected as
+AIRFLOW_CONN_HTTP_TARGET (create it in Admin -> Connections). The DAG echoes a
+small payload via go-httpbin's /anything endpoint and asserts the round-trip,
+which is the simplest verification step for an HTTP connector.
+
+Falls back to a local URI for a quick run on a developer machine.
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+from urllib.parse import parse_qs, urlparse
+
+from airflow.sdk import DAG, task
+
+
+def _resolve_target() -> tuple[str, dict[str, str], tuple[str, str] | None]:
+    """Return (base_url, extra_headers, basic_auth) from the Connection URI.
+
+    The URI shape is `http://user:password@host:port/?__extra__=<json>`.
+    Strip __extra__ (it is delivery metadata, not part of the request URL),
+    pull headers out of it, and surface basic auth separately.
+    """
+    raw = os.environ.get("AIRFLOW_CONN_HTTP_TARGET") or os.environ.get(
+        "HTTP_TARGET_URI", "http://host.k3d.internal:58080"
+    )
+    parsed = urlparse(raw)
+    qs = parse_qs(parsed.query)
+    headers: dict[str, str] = {}
+    if "__extra__" in qs:
+        try:
+            blob = json.loads(qs["__extra__"][0])
+        except json.JSONDecodeError:
+            blob = {}
+        if isinstance(blob, dict):
+            headers = {str(k): str(v) for k, v in blob.items()}
+    auth = None
+    if parsed.username:
+        auth = (parsed.username, parsed.password or "")
+    netloc = parsed.hostname or ""
+    if parsed.port:
+        netloc = f"{netloc}:{parsed.port}"
+    base = f"{parsed.scheme}://{netloc}"
+    return base, headers, auth
+
+
+@task
+def call() -> dict[str, str]:
+    base, headers, auth = _resolve_target()
+    src = "managed Connection http_target" if os.environ.get("AIRFLOW_CONN_HTTP_TARGET") else "fallback URI"
+    print(f"call: base={base} via {src}")
+    payload = {"name": "leoflow", "value": "42"}
+    req = urllib.request.Request(
+        f"{base}/anything",
+        method="POST",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json", **headers},
+    )
+    if auth is not None:
+        import base64
+
+        token = base64.b64encode(f"{auth[0]}:{auth[1]}".encode()).decode()
+        req.add_header("Authorization", f"Basic {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310 - example DAG
+            body = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.URLError as err:
+        raise RuntimeError(f"http call failed: {err}") from err
+    echoed = body.get("json")
+    if echoed != payload:
+        raise AssertionError(f"echo mismatch: sent={payload}, echoed={echoed}")
+    print(f"call: echo OK ({len(echoed)} fields)")
+    return echoed
+
+
+with DAG("http_load", schedule=None, catchup=False, tags=["example"]):
+    call()

--- a/examples/http_load/dag.py
+++ b/examples/http_load/dag.py
@@ -51,8 +51,12 @@ def _resolve_target() -> tuple[str, dict[str, str], tuple[str, str] | None]:
 @task
 def call() -> dict[str, str]:
     base, headers, auth = _resolve_target()
+    # The diagnostic prints only which delivery path was taken (Connection vs
+    # fallback) — never the URL itself, since the env var may carry basic-auth
+    # in `user:password@host` form. Operators can see the configured host in
+    # the Admin -> Connections UI.
     src = "managed Connection http_target" if os.environ.get("AIRFLOW_CONN_HTTP_TARGET") else "fallback URI"
-    print(f"call: base={base} via {src}")
+    print(f"call: via {src}")
     payload = {"name": "leoflow", "value": "42"}
     req = urllib.request.Request(
         f"{base}/anything",

--- a/examples/http_load/leoflow.yaml
+++ b/examples/http_load/leoflow.yaml
@@ -1,0 +1,8 @@
+schema_version: "1.0"
+dag_id: http_load
+description: POST a payload to an external HTTP endpoint via a managed Connection, assert the echo round-trips.
+owner: examples
+tags:
+  - example
+python_version: "3.11"
+dependencies: []

--- a/internal/storage/connection_delivery_e2e_test.go
+++ b/internal/storage/connection_delivery_e2e_test.go
@@ -216,3 +216,89 @@ func TestSQLiteConnectionURIShapeIntegration(t *testing.T) {
 		t.Errorf("uri = %q, want %q (the canonical 3-slash form)", uri, wantStringForm)
 	}
 }
+
+// TestHTTPConnectionURIShapeIntegration is the http counterpart to the
+// SQL-family chain-of-custody test. The http conn type doesn't fit the
+// table because:
+//
+//   - There is no "schema" / db / namespace in HTTP — the Schema field is
+//     normally blank and the URI ends at the host (or host:port).
+//   - The high-value payload is in `Extra` (custom headers, including
+//     `Authorization: Bearer ...`) which the URI carries under `__extra__`.
+//
+// The contract this pins: a Connection POSTed in the UI with a password
+// containing URI-reserved characters AND an Extra JSON blob round-trips
+// end-to-end via `AIRFLOW_CONN_<ID>` — `url.Parse` recovers the password
+// unencoded and the Extra blob is recoverable from the `__extra__` query
+// parameter.
+func TestHTTPConnectionURIShapeIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 13)
+	}
+	cipher, err := secrets.NewAESGCM(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo.SetCipher(cipher)
+
+	const (
+		rawPassword = "p@ss/w0rd:!#$" //nolint:gosec // hardcoded test fixture, not a credential
+		rawExtra    = `{"Authorization":"Bearer abc.def","X-Tenant":"acme"}`
+	)
+	connID := fmt.Sprintf("e2e_http_%d", time.Now().UnixNano())
+	port := 443
+	if cerr := repo.SetConnection(ctx, "default", domain.Connection{
+		ConnID: connID, ConnType: "http",
+		Host:     "api.example.com",
+		Login:    "etl_user",
+		Password: rawPassword,
+		Port:     &port,
+		Extra:    rawExtra,
+	}); cerr != nil {
+		t.Fatalf("SetConnection: %v", cerr)
+	}
+	t.Cleanup(func() { _ = repo.DeleteConnection(ctx, "default", connID) })
+
+	tenantUUID, err := repo.TenantUUID(ctx, "default")
+	if err != nil {
+		t.Fatalf("TenantUUID: %v", err)
+	}
+	uris, err := repo.SecretConnectionURIs(ctx, tenantUUID)
+	if err != nil {
+		t.Fatalf("SecretConnectionURIs: %v", err)
+	}
+	uri, present := uris[connID]
+	if !present {
+		t.Fatalf("URI for %q missing from delivery map; got keys = %v",
+			connID, mapKeys(uris))
+	}
+
+	parsed, perr := url.Parse(uri)
+	if perr != nil {
+		t.Fatalf("URI is not parseable (Python requests would fail): %q err=%v", uri, perr)
+	}
+	if parsed.Scheme != "http" {
+		t.Errorf("scheme = %q, want http", parsed.Scheme)
+	}
+	if want := "api.example.com:443"; parsed.Host != want {
+		t.Errorf("host = %q, want %q", parsed.Host, want)
+	}
+	if parsed.User.Username() != "etl_user" {
+		t.Errorf("username = %q, want etl_user", parsed.User.Username())
+	}
+	gotPassword, _ := parsed.User.Password()
+	if gotPassword != rawPassword {
+		t.Errorf("password round-trip failed: got %q, want %q (the URI builder must percent-escape; net/url must un-escape on parse)",
+			gotPassword, rawPassword)
+	}
+	// The HTTP-specific edge: Extra (headers, including Bearer tokens) must
+	// survive the Repository -> SecretConnectionURIs -> agent env hop and
+	// be recoverable from `__extra__`. A regression here would silently drop
+	// the Authorization header — the request would 401 only at runtime.
+	gotExtra := parsed.Query().Get("__extra__")
+	if gotExtra != rawExtra {
+		t.Errorf("__extra__ round-trip failed: got %q, want %q", gotExtra, rawExtra)
+	}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,6 +144,7 @@ nav:
           - Microsoft SQL Server: connections/mssql.md
           - SQLite: connections/sqlite.md
           - Redis: connections/redis.md
+          - HTTP / HTTPS: connections/http.md
       - Troubleshooting & observability: troubleshooting.md
       - UI compatibility: ui-compatibility.md
       - Staging volume: staging-volume.md


### PR DESCRIPTION
## Summary
Closes #75. Sixth connector cookbook entry. The http conn type doesn't fit the SQL-family table — it has **no SQL schema concept** and the high-value payload (headers, including Bearer tokens) lives in **Extra**, carried under the `__extra__` query parameter. So http gets a dedicated chain-of-custody test, like sqlite did.

## What's different from postgres/mysql/mssql/redis

- **Schema field is blank.** No db/namespace.
- **Headers live in Extra.** `Authorization: Bearer ...`, `X-Tenant`, API keys — all JSON-encoded in Extra and delivered via `__extra__`.
- **User code must strip `__extra__`** before building the actual request URL (otherwise every request carries `?__extra__=...` and server logs are noisy).
- **`http` and `https` are both supported.** Same Connection shape, scheme differs.

## Deliverables (3-part contract per [[connector-test-docs-rigor]])

### 1. Test — `TestHTTPConnectionURIShapeIntegration`
Dedicated test (not table-driven, like sqlite). Validates the **full delivery chain** with the http-specific edges:
- URI parses, scheme=http, host=`api.example.com:443`.
- Basic-auth round-trip with a password containing URI-reserved chars (`p@ss/w0rd:!#\$`).
- **`__extra__` JSON blob round-trips exactly** — a regression here would silently drop the Authorization header and only 401 at runtime.

### 2. Example DAG — `examples/http_load/`
- Stdlib only (`urllib.request`, `urllib.parse`, `json`, `base64`). No `requests` dependency.
- POSTs JSON to go-httpbin's `/anything` echo endpoint and asserts the round-trip.
- Demonstrates the **strip `__extra__` before building the real URL** pattern.
- README walks through Connection setup (with Bearer-via-Extra and basic-auth-via-Connection both shown), `host.k3d.internal` for k3d, and the noisy-server-log gotcha.

### 3. Cookbook page — `docs/connections/http.md`
- URI shape with `__extra__` explained as delivery metadata, not part of the request.
- Four auth patterns (basic / Bearer / API key header / OAuth2 deferred).
- http-vs-https Conn Type distinction.
- TLS notes (system trust store; self-signed via explicit `ssl.SSLContext`).
- Troubleshooting table covering the Bearer-leaks-into-logs and `__extra__`-leaks-into-URL footguns.

## Test plan
- [x] `go test ./...` — green
- [x] `golangci-lint run ./...` — 0 issues
- [x] Coverage gate — 78.4% (floor 78%)
- [x] `scripts/gen-adr-index.sh --check` — up to date
- [x] Pre-commit gate passes

## Cookbook progress (#142)

| Type | Status | Tier |
|---|---|---|
| postgres | ✅ #157 | Tier 1 ✅ |
| mysql / mariadb | ✅ #158 | Tier 2 (planned) |
| mssql | ✅ #159 | Tier 2 (planned) |
| sqlite | ✅ #163 | Tier 1 ✅ |
| redis | ✅ #164 | Tier 1 ✅ |
| **http / https** | **this PR** | **Tier 1 ✅** |

**This completes the Tier 1 set** (postgres + redis + sqlite + http). Cloud connectors (#76 aws, #77 gcp, ...) are deferred past alpha per the cookbook plan.

## Related
- #142 — connector cookbook umbrella.
- #138 — chain-of-custody contract test (http gets its own dedicated test).
- #75 — http connector umbrella (closed).
- #162 — tiered integration-test pipeline (http is Tier 1).
- ADR 0019, ADR 0021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)