### PR TITLE
fix(helm): wire LEOFLOW_SECRET_KEY in chart (ADR 0019 — Pro Connection encryption)

### DIFF
--- a/helm/leoflow/templates/deployment.yaml
+++ b/helm/leoflow/templates/deployment.yaml
@@ -109,6 +109,17 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.auth.existingSecret | default (include "leoflow.secretName" .) }}
                   key: jwtSecret
+            {{- if or .Values.secretKeyExistingSecret .Values.secretKey }}
+            # LEOFLOW_SECRET_KEY (ADR 0019) — Connection password / Extra
+            # encryption-at-rest key. Without it, the API refuses Connection
+            # writes (Variables still work). Optional so users who only use
+            # Variables can omit it; recommended for any real Pro install.
+            - name: LEOFLOW_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secretKeyExistingSecret | default (include "leoflow.secretName" .) }}
+                  key: secretKey
+            {{- end }}
             {{- if or .Values.bootstrap.existingSecret .Values.bootstrap.password }}
             - name: LEOFLOW_BOOTSTRAP_PASSWORD
               valueFrom:

--- a/helm/leoflow/templates/secret.yaml
+++ b/helm/leoflow/templates/secret.yaml
@@ -6,7 +6,8 @@ via an existingSecret). Keys are only included when an inline value is set.
 {{- $needsRedis := and (not .Values.redis.existingSecret) .Values.redis.url -}}
 {{- $needsJWT := and (not .Values.auth.existingSecret) .Values.auth.jwtSecret -}}
 {{- $needsBootstrap := and (not .Values.bootstrap.existingSecret) .Values.bootstrap.password -}}
-{{- if or $needsDB $needsRedis $needsJWT $needsBootstrap -}}
+{{- $needsSecretKey := and (not .Values.secretKeyExistingSecret) .Values.secretKey -}}
+{{- if or $needsDB $needsRedis $needsJWT $needsBootstrap $needsSecretKey -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -27,5 +28,8 @@ stringData:
   {{- end }}
   {{- if $needsBootstrap }}
   bootstrapPassword: {{ .Values.bootstrap.password | quote }}
+  {{- end }}
+  {{- if $needsSecretKey }}
+  secretKey: {{ .Values.secretKey | quote }}
   {{- end }}
 {{- end -}}

--- a/helm/leoflow/values.yaml
+++ b/helm/leoflow/values.yaml
@@ -64,6 +64,15 @@ auth:
   existingSecret: ""   # name of a Secret with key jwtSecret (overrides jwtSecret)
   tokenTtlSeconds: 3600
 
+# secretKey (LEOFLOW_SECRET_KEY) is the 32-byte key the control plane uses to
+# encrypt connection passwords + Extra blobs at rest (ADR 0019). Without it,
+# Connection management is disabled and the API rejects writes with 503
+# (Variables still work). Set it, or reference an existing secret.
+#
+# Generate one with:  openssl rand -base64 32   (must decode to 32 bytes)
+secretKey: ""
+secretKeyExistingSecret: ""   # name of a Secret with key secretKey (overrides secretKey)
+
 # bootstrap creates the initial admin user on first start when set.
 bootstrap:
   password: ""         # leave empty to skip; or reference existingSecret/key bootstrapPassword

--- a/scripts/helm-template-checks.sh
+++ b/scripts/helm-template-checks.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# helm-template-checks.sh — render the chart with a minimal Pro-shaped values
+# set and assert the rendered output contains the env vars and Secret keys the
+# control plane needs at runtime.
+#
+# This is the seed of the eventual chart-test CI gate (issue #143). It is
+# intentionally small and shell-only so it can run in any CI runner with `helm`
+# installed (or locally with `brew install helm`).
+#
+# Run from the repo root:
+#   bash scripts/helm-template-checks.sh
+set -euo pipefail
+
+CHART="helm/leoflow"
+if [ ! -f "$CHART/Chart.yaml" ]; then
+  echo "helm-template-checks: $CHART not found; run from the repo root" >&2
+  exit 2
+fi
+
+# Minimal Pro-shaped values: external Postgres + external Redis + a jwtSecret
+# and a secretKey (the values the chart will encrypt at rest and inject as env).
+# Fixture keys are NOT real credentials — only used to render the chart.
+RENDERED=$(helm template leoflow-test "$CHART" \
+  --set database.url='postgres://leoflow:p@db:5432/leoflow?sslmode=disable' \
+  --set redis.url='redis://r:6379/0' \
+  --set auth.jwtSecret='helm-template-check-jwt-fixture' \
+  --set secretKey='helm-template-check-secret-fixture-32B!!!')
+
+fail=0
+expect_substring() {
+  local needle="$1"
+  local description="$2"
+  if ! grep -qF -- "$needle" <<<"$RENDERED"; then
+    echo "FAIL: missing $description ($needle)" >&2
+    fail=1
+  else
+    echo "OK:   $description"
+  fi
+}
+
+# Each line below is a contract the chart must honour. Add to this list as new
+# config keys land.
+expect_substring 'name: LEOFLOW_DATABASE_URL'  "DB URL env entry in deployment"
+expect_substring 'name: LEOFLOW_REDIS_URL'     "Redis URL env entry in deployment"
+expect_substring 'name: LEOFLOW_AUTH_JWT_SECRET' "JWT secret env entry in deployment"
+expect_substring 'name: LEOFLOW_SECRET_KEY'    "Connection encryption key env entry in deployment (ADR 0019)"
+expect_substring 'jwtSecret:'                  "jwtSecret key in chart-managed Secret"
+expect_substring 'secretKey:'                  "secretKey in chart-managed Secret (ADR 0019)"
+
+if [ "$fail" -ne 0 ]; then
+  echo
+  echo "helm-template-checks: one or more contracts unmet (see FAIL lines above)" >&2
+  exit 1
+fi
+echo
+echo "helm-template-checks: all contracts met"


### PR DESCRIPTION
## Summary
First of three Helm-chart alpha-prep PRs (sequence: this → #143 gate → #48 migrate image → #96 hardening).

The chart skeleton already fails install loudly when external Postgres / Redis are missing (`deployment.yaml:8-13`), but **silently omits `LEOFLOW_SECRET_KEY`**. A Pro install boots fine, the API works, Variables work, but the Connections endpoints return 503 ("no LEOFLOW_SECRET_KEY set; connection management disabled") at the first write. The chart documented the intent (ADR 0019) but didn't deliver it.

## Changes
- **`values.yaml`** — new `secretKey` (inline) + `secretKeyExistingSecret` (existing Secret reference). Documented as optional with the failure mode if omitted and a `openssl rand -base64 32` hint.
- **`templates/deployment.yaml`** — optional `LEOFLOW_SECRET_KEY` env entry, rendered only when either source is configured. Variables-only installs keep working unchanged; Connection-using installs get the key.
- **`templates/secret.yaml`** — chart-managed Secret gets a `secretKey` key when the inline value is set, parallel to `jwtSecret` / `bootstrapPassword`.
- **`scripts/helm-template-checks.sh`** (new) — minimal shell contract test that renders the chart with a Pro-shaped value set and asserts every required env entry + Secret key is present. Designed to be called from the future `helm-ci.yaml` gate (#143).

## TDD
The script was written first asserting `LEOFLOW_SECRET_KEY` + `secretKey:` in the rendered output. Ran red (both missing). Then the three template files were amended to make it green. The other four contracts (DB / Redis / JWT env + jwtSecret in Secret) stayed green throughout — proves the script catches real gaps, not just every line.

```
$ bash scripts/helm-template-checks.sh
OK:   DB URL env entry in deployment
OK:   Redis URL env entry in deployment
OK:   JWT secret env entry in deployment
OK:   Connection encryption key env entry in deployment (ADR 0019)
OK:   jwtSecret key in chart-managed Secret
OK:   secretKey in chart-managed Secret (ADR 0019)
helm-template-checks: all contracts met
```

## Regression / backwards compat
- **Variables-only installs**: unchanged. Without `secretKey`, the env var is omitted; the server logs the existing "connection management disabled" warning at startup; Variables work fine.
- **Existing Pro installs with their own Secret**: set `secretKeyExistingSecret: <name>` (parallel to the `auth.existingSecret` pattern).

## Test plan
- [x] `bash scripts/helm-template-checks.sh` — green
- [x] `helm lint helm/leoflow` — 0 chart failures
- [x] Regression: rendering without `secretKey` set produces 0 mentions of `LEOFLOW_SECRET_KEY` or `secretKey:` (confirmed with grep)
- [x] `go test ./...` — green
- [x] Pre-commit gate passes (coverage 78.4%)

## Sequence
1. **This PR** — wire the key.
2. **Next (#143)** — `helm-ci.yaml` workflow with `helm lint` + kind install + upgrade smoke, calling `scripts/helm-template-checks.sh` as one of the contract steps.
3. **Then (#48)** — finish `leoflow-migrate` image build + ghcr push so the migration Job actually runs.
4. **Finally (#96)** — merge the chart hardening draft (HPA, PDB, NetworkPolicy, ServiceMonitor) on top of a working gate.

## Related
- ADR 0019 — secret encryption at rest.
- #143 — chart-test CI gate (next).
- #48 — leoflow-migrate image build.
- #96 — chart hardening (draft).

🤖 Generated with [Claude Code](https://claude.com/claude-code)