### PR TITLE
ci(helm): bump actions to Node 24 (checkout@v5, setup-helm@v5)

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -35,8 +35,8 @@ jobs:
     name: helm lint + template-checks + kubeconform
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: v3.16.2
 
@@ -67,9 +67,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a # v4
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: v3.16.2
 


### PR DESCRIPTION
## Summary
GH Actions deprecates Node.js 20 on **June 2, 2026** (forced Node 24 default) and removes it entirely on **September 16, 2026**. Recent runs of `helm-ci.yaml` (merged in #167) emit the deprecation warning on `actions/checkout@v4` and `azure/setup-helm@v4`.

Bump both to Node 24 series, keeping the SHA-pinned + version-comment pattern per ADR 0014:

- `actions/checkout@93cb6efe...` (v5)
- `azure/setup-helm@dda3372f...` (v5.0.0)

`helm/kind-action@ef37e7f...` (v1.14.0) stays — shell-only, not affected by Node runtime changes.

## Why `azure/setup-helm`?
Despite the `Azure/` prefix it is the de-facto official Helm setup action — the Helm core team references it; the prefix is historical from when the AKS team built it. Audited manual `curl` and `engineerd/setup-helm`, kept azure/ for parity with the wider Helm CI ecosystem.

## Test plan
- [x] SHAs verified as commits (not annotated tag objects) via `gh api repos/.../commits/<sha>`
- [x] `helm-template-checks.sh` still green locally
- [ ] Helm CI gate runs on this PR (verify it triggers + both jobs pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)