### PR TITLE
fix(helm): PoC secretKey fixture was 34 bytes, breaking Connection eval (#169)

### DIFF
--- a/helm/leoflow/examples/poc-with-bitnami.yaml
+++ b/helm/leoflow/examples/poc-with-bitnami.yaml
@@ -19,10 +19,17 @@ redis:
   url: redis://redis-master:6379/0
 
 # Fixture credentials. Replace before any real use, even for a temporary
-# demo on a shared cluster. The secretKey must be exactly 32 bytes (AES-256).
+# demo on a shared cluster.
+#
+# secretKey: MUST be exactly 32 raw bytes (or 64-char hex / base64-encoded
+# 32 bytes). The string below is verified at exactly 32 bytes so the AES-
+# 256-GCM init in the server succeeds out-of-the-box; without that, the
+# server logs a warning and the Connections API returns 503 — the recipe's
+# Connection-management evaluation fails silently. Generate a real key
+# with `openssl rand -hex 16` (64 hex chars = 32 bytes).
 auth:
   jwtSecret: leoflow-poc-jwt-please-replace-32B
-secretKey: leoflow-poc-32B-secret-key-replace
+secretKey: leoflow-poc-replace-with-32B-key
 bootstrap:
   password: leoflow-poc-admin
 


### PR DESCRIPTION
## Summary
Self-review on #169 caught a regression in my own fixture:

\`\`\`yaml
# helm/leoflow/examples/poc-with-bitnami.yaml (before)
secretKey: leoflow-poc-32B-secret-key-replace   # 34 bytes ❌
\`\`\`

\`secrets.ParseKey\` rejects anything that isn't exactly 32 raw bytes, 64-char hex, or valid base64. With this fixture the server logs:

\`\`\`
WARN no LEOFLOW_SECRET_KEY set; connection management disabled (Variables still work)
\`\`\`

…and every \`POST /api/v2/connections\` returns **503**. A user following the recipe verbatim gets a working server, can log in and manage Variables, but **silently hits 503 on Connection writes** — which breaks the headline product evaluation the recipe exists to enable.

## Fix
\`\`\`yaml
secretKey: leoflow-poc-replace-with-32B-key      # 32 bytes ✅
\`\`\`

Name doubles as a hint to the operator. Comment refreshed to explain why length matters and how to generate a real key (\`openssl rand -hex 16\` → 64 hex chars = 32 bytes).

## Ironic background
I spent extra cycles in #167 verifying the helm-ci.yaml fixtures (\`leoflow-helm-ci-secret-key-32by!\` and \`leoflow-tmpl-check-secret-key-32\`) are exactly 32 bytes — both correct — but forgot to re-check the PoC fixture when I wrote #169. Belt without suspenders. The audit prompt today caught it.

## Test plan
- [x] \`python3 -c 'len(...)' == 32\` — verified
- [x] \`helm template ... -f poc-with-bitnami.yaml\` → 9 K8s resources, no errors
- [x] Pre-commit gate green
- [ ] Helm CI on this PR (only triggers on \`helm/**\` paths, so it should — \`helm/leoflow/examples/poc-with-bitnami.yaml\` is in \`helm/**\`)

## Audit findings filed as follow-ups (out of scope here)
The full review surfaced 5 other items, none blocking, but worth tracking:

1. **release.yaml still Node 20** (\`actions/checkout@v4\`) — parallel to #168 (which fixed helm-ci.yaml). One-line bump in a separate PR.
2. **helm-ci path filter** doesn't include \`internal/config/server.go\` — a rename of \`LEOFLOW_SECRET_KEY\` server-side wouldn't trigger the contract test.
3. **Migrate Job has no securityContext** — runs as root in container. Pro Deployment is hardened (#167), but the Job is not. Restricted PSA clusters would reject it.
4. **Bitnami chart version drift** — recipe references \`oci://...bitnamicharts/postgresql\` without pinning major; service names could change in a future major bump (already happened with redis v18).
5. **Chart \`appVersion: 0.1.0\`** vs published \`v0.0.1-prealpha.N\` — default tag resolution doesn't match published images. Already flagged in #170 description.

I'll file these as separate issues after this lands. Item 1 is the most time-sensitive (June 2nd Node 24 forcing).

## Related
- #169 (the recipe that shipped the broken fixture), #143 (chart-test gate), ADR 0019.

🤖 Generated with [Claude Code](https://claude.com/claude-code)