### PR TITLE
ci(release): bump actions to Node 24 (checkout@v5, setup-go@v6) — closes #172

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,11 +18,11 @@ jobs:
     name: Build, sign, publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -85,7 +85,7 @@ jobs:
       packages: write
       id-token: write       # keyless cosign signing
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:


### PR DESCRIPTION
## Summary
Closes #172. Parallel to #168 (which bumped helm-ci.yaml). GitHub Actions deprecates Node 20 on **June 2, 2026** (forced Node 24 default) and removes Node 20 entirely on September 16, 2026. \`release.yaml\` was still on the Node-20 pins.

## Bumps
| Action | Before | After |
|---|---|---|
| \`actions/checkout\` | \`34e114876b0b...\` (v4, Node 20) | \`93cb6efe1820...\` (v5, Node 24) |
| \`actions/setup-go\` | \`40f1582b2485...\` (v5, Node 20) | \`4a3601121dd0...\` (v6.4.0, Node 24) |

Other release-job actions (cosign, sbom-action, docker/*, goreleaser) were not flagged in the deprecation warnings — already Node 24 or shell-only. Left untouched.

## Breaking change audit: setup-go@v6
v6 introduces one breaking change beyond the runtime bump: [actions/setup-go#460](https://github.com/actions/setup-go/pull/460) "Improve toolchain handling" — setup-go now honours \`go.mod\`'s \`toolchain\` directive by default.

Our \`go.mod\`:
\`\`\`
go 1.26.0
toolchain go1.26.3
\`\`\`

\`release.yaml\` passes \`go-version: 1.26.3\` via \`env.GO_VERSION\` — **matches the toolchain directive**, so no functional change. If we ever bump the toolchain ahead of \`GO_VERSION\`, v6 would auto-download the newer Go (which is the desired behaviour).

## Test plan
- [x] \`python3 -c 'yaml.safe_load(...)'\` — YAML valid
- [x] SHAs verified against \`gh api .../git/ref/tags/...\` (both resolve to commits)
- [x] Pre-commit gate green (coverage 78.4%)
- [ ] Workflow only triggers on \`tags: ["v*"]\` — cannot smoke this PR's CI. Verification happens on the next pre-alpha tag push.

## Helm alpha-prep sequence — now 7/8 ✅
1. ✅ #166 — wire \`LEOFLOW_SECRET_KEY\`
2. ✅ #167 — chart-test gate + 2 chart fixes
3. ✅ #168 — helm-ci.yaml Node 24
4. ✅ #169 — PoC Bitnami recipe
5. ✅ #170 — migrate image publish
6. ✅ #171 — PoC secretKey fixture fix
7. **This PR (#172)** — release.yaml Node 24
8. ⏳ Next — #96 chart hardening (HPA/PDB/NetworkPolicy/ServiceMonitor)

Plus 3 hardening follow-ups still open: #173 (path filter), #174 (migrate Job runAsNonRoot), #175 (Bitnami version pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)