### PR TITLE
ci(helm): widen path filter to include internal/config — closes #173

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -26,6 +26,12 @@ on:
       - "deploy/Dockerfile.server"
       - "deploy/Dockerfile.migrate"
       - "migrations/**"
+      # internal/config defines the LEOFLOW_* env contract (Viper struct
+      # tags) the chart wires through. Renaming an env name there without
+      # touching the chart would slip past helm-template-checks.sh unless
+      # this gate also runs on config changes. Small dir (4 files); the
+      # false-positive cost from test-only edits is bounded.
+      - "internal/config/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Closes #173. \`scripts/helm-template-checks.sh\` (PR #166) asserts the chart wires every required \`LEOFLOW_*\` env var, but the workflow's path filter only triggered on chart / Dockerfile / migrations changes. A server-side rename — e.g. \`LEOFLOW_SECRET_KEY → LEOFLOW_CIPHER_KEY\` in \`internal/config/server.go\` — would **not** trigger the gate; the chart would still ship the old env name, the contract test would pass on the old chart, and the rename would only break at runtime.

## Fix
Add \`internal/config/**\` to the trigger paths.

## Scope rationale (narrower than the issue suggested)
The issue mentioned \`cmd/leoflow-server/**\` too — I deliberately left it out:

| Path | Included? | Why |
|---|---|---|
| \`internal/config/**\` | ✅ | The env contract lives here in Viper struct tags. Small dir (4 files), rarely touched outside config work. |
| \`cmd/leoflow-server/**\` | ❌ | Mostly tests; \`main.go\` only consumes Viper-mapped names. Removing a call site there wouldn't make the contract test fail (env still rendered) — different bug class. |

## Test plan
- [x] \`python3 -c 'yaml.safe_load(...)'\` — YAML valid
- [x] Pre-commit gate green
- [ ] Verification (rename triggers helm-ci) — can't smoke on this PR since it doesn't touch \`internal/config\`. But the workflow itself IS in the path filter, so this PR runs helm-ci, confirming the YAML parses + the gate still works.
- [ ] Future PR touching only \`internal/config/server.go\` will be the first real smoke. The next #172 / #174 / #175 / #96 PRs are all good candidates if any of them touches config.

## Helm alpha-prep follow-ups
- ✅ #172 (release.yaml Node 24) — PR #176 open
- **This PR (#173)** — path filter
- ⏳ #174 — migrate Job runAsNonRoot
- ⏳ #175 — Bitnami version pin
- ⏳ #96 — chart hardening (HPA/PDB/NetworkPolicy/ServiceMonitor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)