### PR TITLE
fix(helm): migration Job runs non-root (65532) — closes #174

### DIFF
--- a/helm/leoflow/templates/migration-job.yaml
+++ b/helm/leoflow/templates/migration-job.yaml
@@ -26,10 +26,14 @@ spec:
         {{- include "leoflow.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: Never
+      securityContext:
+        {{- toYaml .Values.migrations.podSecurityContext | nindent 8 }}
       containers:
         - name: migrate
           image: "{{ .Values.migrations.image.repository }}:{{ $migrateTag }}"
           imagePullPolicy: {{ .Values.migrations.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.migrations.securityContext | nindent 12 }}
           args:
             - "-path={{ .Values.migrations.path }}"
             - "-database=$(LEOFLOW_DATABASE_URL)"

--- a/helm/leoflow/values.yaml
+++ b/helm/leoflow/values.yaml
@@ -97,6 +97,28 @@ migrations:
     pullPolicy: IfNotPresent
   # path of the migrations dir inside the image.
   path: /migrations
+  # Pod security for the pre-install/pre-upgrade Job. K8s' restricted Pod
+  # Security Admission requires runAsNonRoot + a numeric runAsUser on
+  # every pod, including hook Jobs. The Deployment is hardened identically
+  # (top-level podSecurityContext); these defaults mirror that posture so
+  # restricted-PSA clusters accept the migration Job too.
+  #
+  # The migrate/migrate base image runs as root by default, but the binary
+  # is a static Go binary that works fine under any UID — verified locally
+  # via `docker run --rm -u 65532:65532 migrate/migrate -version` and
+  # `ls /migrations` (migrations are world-readable, mode 644).
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    fsGroup: 65532
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    runAsNonRoot: true
+    runAsUser: 65532
+    capabilities:
+      drop: ["ALL"]
 
 # TLS for the agent <-> control plane gRPC channel (issue #58). Off by default
 # (the per-task token still authenticates each call). When enabled, the control

--- a/scripts/helm-template-checks.sh
+++ b/scripts/helm-template-checks.sh
@@ -47,6 +47,32 @@ expect_substring 'name: LEOFLOW_SECRET_KEY'    "Connection encryption key env en
 expect_substring 'jwtSecret:'                  "jwtSecret key in chart-managed Secret"
 expect_substring 'secretKey:'                  "secretKey in chart-managed Secret (ADR 0019)"
 
+# Migration Job must be hardened the same way as the Deployment (#174):
+# restricted-PSA clusters require runAsNonRoot+numeric runAsUser on EVERY
+# pod, including pre-install hooks. Scope the rendering to just the Job
+# template so we don't accidentally validate the Deployment's hardening
+# here (that lives in the same rendered output but is asserted above by
+# proxy of the env contract).
+JOB_RENDERED=$(helm template leoflow-test "$CHART" \
+  --set database.url='postgres://leoflow:p@db:5432/leoflow?sslmode=disable' \
+  --set redis.url='redis://r:6379/0' \
+  --set auth.jwtSecret='helm-template-check-jwt-fixture' \
+  --set secretKey='leoflow-tmpl-check-secret-key-32' \
+  --show-only templates/migration-job.yaml)
+
+expect_in_job() {
+  local needle="$1"
+  local description="$2"
+  if ! grep -qF -- "$needle" <<<"$JOB_RENDERED"; then
+    echo "FAIL: migrate Job missing $description ($needle)" >&2
+    fail=1
+  else
+    echo "OK:   migrate Job has $description"
+  fi
+}
+expect_in_job 'runAsNonRoot: true' "runAsNonRoot:true (restricted PSA gate)"
+expect_in_job 'runAsUser: 65532'   "runAsUser:65532 (distroless nonroot UID)"
+
 if [ "$fail" -ne 0 ]; then
   echo
   echo "helm-template-checks: one or more contracts unmet (see FAIL lines above)" >&2


### PR DESCRIPTION
## Summary
Closes #174. Third Helm follow-up after the audit. The \`leoflow-server\` Deployment is hardened with \`runAsNonRoot:true + runAsUser:65532\` since PR #167. The migration Job had **no securityContext at all** — ran as the container's default user (root, since \`migrate/migrate:v4.18.1\` has no \`USER\` directive). Restricted Pod Security Admission clusters reject this pod even though the rest of the chart works.

## Fix
Mirror the Deployment's posture in the Job's pod + container securityContext, exposed via two new chart values:

\`\`\`yaml
migrations:
  podSecurityContext:
    runAsNonRoot: true
    runAsUser: 65532
    runAsGroup: 65532
    fsGroup: 65532
  securityContext:
    allowPrivilegeEscalation: false
    runAsNonRoot: true
    runAsUser: 65532
    capabilities:
      drop: ["ALL"]
\`\`\`

## Why no Dockerfile change
The \`migrate/migrate\` base image's \`USER\` is root, but the binary is a static Go binary that runs fine as any UID. K8s' \`runAsUser\` overrides the image's USER. Verified locally:

\`\`\`bash
docker run --rm -u 65532:65532 migrate/migrate:v4.18.1 -version
# → 4.18.1

docker run --rm -u 65532:65532 -t leoflow-migrate sh -c 'ls /migrations'
# → 001_init_tenants_and_rbac.up.sql ... OK
\`\`\`

golang-migrate uses DB-level advisory locking, so no local filesystem writes needed → \`readOnlyRootFilesystem\`-compatible too if a future tightening wants it.

## TDD
Extended \`scripts/helm-template-checks.sh\` with a second \`helm template --show-only templates/migration-job.yaml\` pass and two new assertions:

\`\`\`
OK:   migrate Job has runAsNonRoot:true (restricted PSA gate)
OK:   migrate Job has runAsUser:65532 (distroless nonroot UID)
\`\`\`

Ran red first (both missing on the unchanged Job template), then made green by threading the two new value blocks through. The existing 6 assertions stayed green throughout — proves the new assertions catch the gap specifically.

## Test plan
- [x] \`bash scripts/helm-template-checks.sh\` — all 8 contracts met
- [x] Local smoke: \`migrate -version\` + \`ls /migrations\` both work as UID 65532
- [x] Pre-commit gate green
- [ ] Helm CI kind-e2e: install the chart against kind PG/Redis; the migration Job pod should start clean as UID 65532 and complete the migrate up.

## Helm alpha-prep follow-ups status
- ✅ #172 (release.yaml Node 24) — PR #176 green + mergeable
- ✅ #173 (helm-ci path filter) — PR #177 green + mergeable
- **This PR (#174)** — migrate Job non-root
- ⏳ #175 — Bitnami version pin
- ⏳ #96 — chart hardening (HPA/PDB/NetworkPolicy/ServiceMonitor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)