### PR TITLE
ci(helm): byte-length guard on PoC fixture secretKey (#171 regression class)

### DIFF
--- a/scripts/helm-template-checks.sh
+++ b/scripts/helm-template-checks.sh
@@ -73,6 +73,28 @@ expect_in_job() {
 expect_in_job 'runAsNonRoot: true' "runAsNonRoot:true (restricted PSA gate)"
 expect_in_job 'runAsUser: 65532'   "runAsUser:65532 (distroless nonroot UID)"
 
+# Regression guard for PR #171: the PoC values fixture (the recipe in
+# helm/leoflow/examples/) shipped with a 34-byte secretKey, which
+# silently broke ParseKey (AES-256 requires exactly 32 bytes) and made
+# Connection management 503 for anyone following the recipe verbatim.
+# Validate every YAML fixture under helm/leoflow/examples/ that sets
+# `secretKey:` so a future fixture edit can't repeat the same class of
+# bug. The check is plain bash — no python / yq dependency.
+for fixture in helm/leoflow/examples/*.yaml; do
+  [ -f "$fixture" ] || continue
+  fixture_key=$(grep -E '^secretKey: ' "$fixture" 2>/dev/null \
+    | head -1 \
+    | sed -E 's/^secretKey: *//; s/^["'\'']?//; s/["'\'']?$//; s/ *#.*$//')
+  if [ -n "$fixture_key" ]; then
+    if [ "${#fixture_key}" -eq 32 ]; then
+      echo "OK:   $(basename "$fixture") secretKey is exactly 32 bytes (AES-256)"
+    else
+      echo "FAIL: $(basename "$fixture") secretKey is ${#fixture_key} bytes, want 32 — ParseKey would reject this and the recipe would break Connection management" >&2
+      fail=1
+    fi
+  fi
+done
+
 if [ "$fail" -ne 0 ]; then
   echo
   echo "helm-template-checks: one or more contracts unmet (see FAIL lines above)" >&2


### PR DESCRIPTION
## Summary
PR #171 fixed a 34-byte secretKey in \`helm/leoflow/examples/poc-with-bitnami.yaml\` that silently broke Connection management for anyone following the recipe. The fix landed quickly, but **nothing in CI catches the same class of mistake on a future fixture edit**. This is the second pass from my self-review on the last 5 tasks ("the fix corrigiu apenas o secretKey; não adicionei assertion validando byte length de fixtures futuras").

## What this adds
A guard in \`scripts/helm-template-checks.sh\` that iterates every \`*.yaml\` under \`helm/leoflow/examples/\`, extracts the literal \`secretKey:\` value (plain bash — no python/yq dep), and asserts it is exactly 32 bytes. Inline comments are stripped from the extracted value so \`secretKey: foo  # comment\` works.

## TDD verification (proves the guard actually catches the class)
\`\`\`
$ sed -i 's/^secretKey: .*/secretKey: leoflow-poc-this-is-now-34-bytes-broken/' helm/leoflow/examples/poc-with-bitnami.yaml
$ bash scripts/helm-template-checks.sh
...
FAIL: poc-with-bitnami.yaml secretKey is 39 bytes, want 32 —
      ParseKey would reject this and the recipe would break Connection management

$ git checkout helm/leoflow/examples/poc-with-bitnami.yaml
$ bash scripts/helm-template-checks.sh
...
OK:   poc-with-bitnami.yaml secretKey is exactly 32 bytes (AES-256)
helm-template-checks: all contracts met
\`\`\`

The broken fixture was reverted; only the guard is in the diff.

## Why bash (not python/yq)
\`helm-template-checks.sh\` runs in the lint job of helm-ci.yaml. Adding a python/yq dependency for parsing one line is overkill. \`grep + sed + \${#var}\` is enough and keeps the script's "any-shell-anywhere" promise.

## Forward compatibility
The loop is over \`helm/leoflow/examples/*.yaml\`, so adding a future fixture (e.g. \`poc-with-cnpg.yaml\` if #175 evolves to support CloudNativePG) gets the same protection for free.

## Helm alpha-prep status
Plus this regression guard (closes a gap, doesn't close a follow-up issue):

- ✅ #166, ✅ #167, ✅ #168, ✅ #169, ✅ #170, ✅ #171
- ✅ #172 (release.yaml Node 24) — PR #176 ready to merge
- ✅ #173 (path filter widen) — PR #177 ready to merge
- ✅ #174 (migrate Job non-root) — PR #178 in CI
- **This PR** — #171 regression guard
- ⏳ #175 (Bitnami version pin)
- ⏳ #96 (chart hardening)

## Test plan
- [x] Local: guard catches the broken-fixture case (verified by TDD above)
- [x] Local: guard passes on the current correct fixture
- [x] Pre-commit gate green
- [ ] Helm CI on this PR (triggers since \`scripts/helm-template-checks.sh\` is in the path filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)