### PR TITLE
feat(helm): production hardening templates — HPA, PDB, NetworkPolicy, ServiceMonitor (closes #96)

### DIFF
--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -111,6 +111,12 @@ differ from what's committed.
 | auth.existingSecret | string | `""` | Name of a Secret with key `jwtSecret` (takes precedence over `jwtSecret`). |
 | auth.jwtSecret | string | `""` | HMAC secret signing API + agent JWTs. Set inline OR reference an existing Secret via `existingSecret`. Generate with `openssl rand -base64 64`. |
 | auth.tokenTtlSeconds | int | `3600` |  |
+| autoscaling.behavior | object | `{}` |  |
+| autoscaling.enabled | bool | `false` | Enable HPA for the leoflow-server Deployment. Requires metrics-server. |
+| autoscaling.maxReplicas | int | `6` |  |
+| autoscaling.minReplicas | int | `2` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `70` |  |
+| autoscaling.targetMemoryUtilizationPercentage | string | `""` |  |
 | bootstrap.existingSecret | string | `""` | Name of a Secret with key `bootstrapPassword` (takes precedence over `password`). |
 | bootstrap.password | string | `""` | Initial admin password (first install only). Leave empty to skip the bootstrap; the operator then creates the first admin out-of-band. |
 | config.agentControlPlaneAddr | string | `""` |  |
@@ -133,6 +139,11 @@ differ from what's committed.
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
 | ingress.tls | list | `[]` |  |
+| metrics.serviceMonitor.additionalLabels | object | `{}` |  |
+| metrics.serviceMonitor.enabled | bool | `false` | Enable ServiceMonitor for Prometheus scraping. Requires kube-prometheus-stack CRDs. |
+| metrics.serviceMonitor.interval | string | `"30s"` |  |
+| metrics.serviceMonitor.namespace | string | `""` |  |
+| metrics.serviceMonitor.scrapeTimeout | string | `"10s"` |  |
 | migrations.enabled | bool | `true` |  |
 | migrations.image.pullPolicy | string | `"IfNotPresent"` |  |
 | migrations.image.repository | string | `"ghcr.io/neochaotic/leoflow-migrate"` |  |
@@ -147,12 +158,19 @@ differ from what's committed.
 | migrations.securityContext.readOnlyRootFilesystem | bool | `true` |  |
 | migrations.securityContext.runAsNonRoot | bool | `true` |  |
 | migrations.securityContext.runAsUser | int | `65532` |  |
+| networkPolicy.egress | list | `[]` |  |
+| networkPolicy.enabled | bool | `false` | Enable NetworkPolicy gating ingress + egress on the control-plane pods. Requires a CNI that enforces policies (Calico/Cilium/etc.). |
+| networkPolicy.ingressFrom | list | `[]` |  |
+| networkPolicy.metricsFrom | list | `[]` |  |
 | nodeSelector | object | `{}` |  |
 | observability.logFormat | string | `"json"` |  |
 | observability.logLevel | string | `"info"` |  |
 | observability.otel.enabled | bool | `false` |  |
 | observability.otel.endpoint | string | `""` |  |
 | podAnnotations | object | `{}` |  |
+| podDisruptionBudget.enabled | bool | `false` | Enable PDB for the leoflow-server Deployment. Pair with replicaCount > 1. |
+| podDisruptionBudget.maxUnavailable | string | `""` |  |
+| podDisruptionBudget.minAvailable | int | `1` |  |
 | podSecurityContext.fsGroup | int | `65532` |  |
 | podSecurityContext.runAsGroup | int | `65532` |  |
 | podSecurityContext.runAsNonRoot | bool | `true` |  |

--- a/helm/leoflow/templates/hpa.yaml
+++ b/helm/leoflow/templates/hpa.yaml
@@ -1,0 +1,42 @@
+{{- /*
+DRAFT (Production track) — HorizontalPodAutoscaler for the control plane.
+Safe because the scheduler leader-elects (ADR 0009): scaling the Deployment adds
+API/UI replicas while exactly one scheduler stays active. Disabled by default.
+*/ -}}
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "leoflow.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "leoflow.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "leoflow.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- with .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+    {{- with .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/leoflow/templates/networkpolicy.yaml
+++ b/helm/leoflow/templates/networkpolicy.yaml
@@ -1,0 +1,60 @@
+{{- /*
+DRAFT (Production track) — NetworkPolicy for the control plane. In our scenario
+the trust boundary is: clients/ingress hit HTTP; Prometheus scrapes metrics; and
+TASK PODS dial the gRPC port back (the pod-per-task agent, ADR 0002/0004). Egress
+must reach Postgres, Redis, the Kubernetes API (to create task pods), and DNS.
+
+This is a STARTING POINT — NetworkPolicy is environment-specific (CNI must
+enforce it). Defaults are permissive on egress (DNS + all) so enabling it does not
+silently break the control plane; tighten `egress` per your cluster. Disabled by
+default.
+*/ -}}
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "leoflow.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "leoflow.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "leoflow.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # HTTP/UI + gRPC (task pods dial back). Restrict sources via networkPolicy.ingressFrom.
+    - ports:
+        - port: {{ .Values.ports.http }}
+          protocol: TCP
+        - port: {{ .Values.ports.grpc }}
+          protocol: TCP
+      {{- with .Values.networkPolicy.ingressFrom }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.networkPolicy.metricsFrom }}
+    # Metrics scrape (e.g. the Prometheus pods' namespace/labels).
+    - ports:
+        - port: {{ $.Values.ports.metrics }}
+          protocol: TCP
+      from:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+  egress:
+    # DNS is always required for service discovery.
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    {{- with .Values.networkPolicy.egress }}
+    {{- toYaml . | nindent 4 }}
+    {{- else }}
+    # Default: allow all other egress (Postgres, Redis, kube-apiserver). Tighten
+    # by setting networkPolicy.egress to explicit rules for your data stores + API.
+    - {}
+    {{- end }}
+{{- end }}

--- a/helm/leoflow/templates/pdb.yaml
+++ b/helm/leoflow/templates/pdb.yaml
@@ -1,0 +1,24 @@
+{{- /*
+DRAFT (Production track) — PodDisruptionBudget so voluntary disruptions (node
+drains, upgrades) keep enough control-plane replicas serving the API. Disabled by
+default; set replicaCount > 1 (HA, leader-elected) before enabling.
+*/ -}}
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "leoflow.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "leoflow.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "leoflow.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/leoflow/templates/servicemonitor.yaml
+++ b/helm/leoflow/templates/servicemonitor.yaml
@@ -1,0 +1,29 @@
+{{- /*
+DRAFT (Production track) — Prometheus Operator ServiceMonitor so the control
+plane's /metrics (ADR 0010) is scraped automatically. Requires the
+monitoring.coreos.com CRDs (kube-prometheus-stack). Disabled by default.
+*/ -}}
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "leoflow.fullname" . }}
+  namespace: {{ .Values.metrics.serviceMonitor.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "leoflow.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "leoflow.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval | default "30s" }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout | default "10s" }}
+{{- end }}

--- a/helm/leoflow/tests/hardening_test.yaml
+++ b/helm/leoflow/tests/hardening_test.yaml
@@ -1,0 +1,140 @@
+suite: production hardening toggles (HPA / PDB / NetworkPolicy / ServiceMonitor)
+release:
+  name: leoflow
+tests:
+  # ─── HPA ────────────────────────────────────────────────────────────────
+  - it: HPA not rendered when autoscaling.enabled is false (default)
+    templates: [hpa.yaml]
+    set:
+      database.url: postgres://h/d
+      redis.url: redis://h/0
+      auth.jwtSecret: jwt
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: HPA rendered with min/max replicas + CPU target when autoscaling.enabled
+    templates: [hpa.yaml]
+    set:
+      database.url: postgres://h/d
+      redis.url: redis://h/0
+      auth.jwtSecret: jwt
+      autoscaling.enabled: true
+      autoscaling.minReplicas: 3
+      autoscaling.maxReplicas: 9
+      autoscaling.targetCPUUtilizationPercentage: 80
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: spec.minReplicas
+          value: 3
+      - equal:
+          path: spec.maxReplicas
+          value: 9
+      - equal:
+          path: spec.metrics[0].resource.target.averageUtilization
+          value: 80
+
+  # ─── PDB ────────────────────────────────────────────────────────────────
+  - it: PDB not rendered when podDisruptionBudget.enabled is false (default)
+    templates: [pdb.yaml]
+    set:
+      database.url: postgres://h/d
+      redis.url: redis://h/0
+      auth.jwtSecret: jwt
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: PDB rendered with minAvailable when enabled
+    templates: [pdb.yaml]
+    set:
+      database.url: postgres://h/d
+      redis.url: redis://h/0
+      auth.jwtSecret: jwt
+      podDisruptionBudget.enabled: true
+      podDisruptionBudget.minAvailable: 2
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 2
+
+  # ─── NetworkPolicy ──────────────────────────────────────────────────────
+  - it: NetworkPolicy not rendered when networkPolicy.enabled is false (default)
+    templates: [networkpolicy.yaml]
+    set:
+      database.url: postgres://h/d
+      redis.url: redis://h/0
+      auth.jwtSecret: jwt
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: NetworkPolicy renders both Ingress and Egress + DNS egress when enabled
+    templates: [networkpolicy.yaml]
+    set:
+      database.url: postgres://h/d
+      redis.url: redis://h/0
+      auth.jwtSecret: jwt
+      networkPolicy.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: NetworkPolicy
+      - contains:
+          path: spec.policyTypes
+          content: Ingress
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      # DNS egress always allowed — the template's default that protects users
+      # from silently breaking service discovery on first enable.
+      - contains:
+          path: spec.egress
+          content:
+            ports:
+              - port: 53
+                protocol: UDP
+              - port: 53
+                protocol: TCP
+
+  # ─── ServiceMonitor ─────────────────────────────────────────────────────
+  - it: ServiceMonitor not rendered when metrics.serviceMonitor.enabled is false (default)
+    templates: [servicemonitor.yaml]
+    set:
+      database.url: postgres://h/d
+      redis.url: redis://h/0
+      auth.jwtSecret: jwt
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: ServiceMonitor renders with metrics endpoint when enabled
+    templates: [servicemonitor.yaml]
+    set:
+      database.url: postgres://h/d
+      redis.url: redis://h/0
+      auth.jwtSecret: jwt
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceMonitor
+      - equal:
+          path: spec.endpoints[0].port
+          value: metrics
+      - equal:
+          path: spec.endpoints[0].path
+          value: /metrics
+      - equal:
+          path: spec.endpoints[0].interval
+          value: 30s

--- a/helm/leoflow/values.yaml
+++ b/helm/leoflow/values.yaml
@@ -164,6 +164,49 @@ resources:
     cpu: "1"
     memory: 512Mi
 
+# HorizontalPodAutoscaler for the control plane. Safe because the scheduler
+# leader-elects (ADR 0009) — scaling the Deployment adds API/UI replicas while
+# exactly one scheduler stays active. Disabled by default; flip `enabled: true`
+# in production after sizing replicas.
+autoscaling:
+  # -- Enable HPA for the leoflow-server Deployment. Requires metrics-server.
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 6
+  targetCPUUtilizationPercentage: 70
+  targetMemoryUtilizationPercentage: ""
+  behavior: {}
+
+# PodDisruptionBudget so voluntary disruptions (node drains, upgrades) keep
+# enough control-plane replicas serving the API. Disabled by default; set
+# `replicaCount > 1` (HA, leader-elected) before enabling.
+podDisruptionBudget:
+  # -- Enable PDB for the leoflow-server Deployment. Pair with replicaCount > 1.
+  enabled: false
+  minAvailable: 1
+  maxUnavailable: ""
+
+# NetworkPolicy for the control plane (requires a CNI that enforces it). The
+# template defaults to permissive egress so enabling it doesn't silently break
+# DB/Redis/kube-apiserver access — tighten per environment after install.
+networkPolicy:
+  # -- Enable NetworkPolicy gating ingress + egress on the control-plane pods. Requires a CNI that enforces policies (Calico/Cilium/etc.).
+  enabled: false
+  ingressFrom: []   # e.g. [{namespaceSelector: {}}] to allow same-namespace clients + task pods
+  metricsFrom: []   # e.g. [{namespaceSelector: {matchLabels: {kubernetes.io/metadata.name: monitoring}}}]
+  egress: []        # explicit egress rules; empty = allow-all besides DNS (always allowed)
+
+# Prometheus Operator ServiceMonitor for /metrics (ADR 0010). Requires the
+# monitoring.coreos.com CRDs (kube-prometheus-stack).
+metrics:
+  serviceMonitor:
+    # -- Enable ServiceMonitor for Prometheus scraping. Requires kube-prometheus-stack CRDs.
+    enabled: false
+    namespace: ""           # defaults to the release namespace
+    interval: 30s
+    scrapeTimeout: 10s
+    additionalLabels: {}    # e.g. {release: kube-prometheus-stack} to match the Prometheus selector
+
 ingress:
   enabled: false
   className: ""


### PR DESCRIPTION
## Summary
Closes **#96** — the last big Helm alpha-prep blocker. The draft branch \`draft/production-helm-ci\` had these 4 templates sitting open for weeks, gated behind "let the chart-test CI exist first". Now that:

- chart-test gate exists (#143 / #167)
- helm-docs gate exists (#182)
- helm-unittest gate exists (#184)
- template contract checks exist (#179)

…we can land the hardening on top.

## What this PR does
Cherry-picks the 4 template files + corresponding values.yaml entries from the draft — **ignoring everything else on that branch** (which was an old, divergent snapshot of the whole repo, reverting ADRs / removing files / etc.). All toggles default to \`enabled: false\` so existing Pro installs are unaffected.

## 4 new templates

| Template | What it enables | Default | When to enable |
|---|---|---|---|
| \`hpa.yaml\` | HorizontalPodAutoscaler on the leoflow-server Deployment | off | After sizing replicas; safe because scheduler leader-elects (ADR 0009) |
| \`pdb.yaml\` | PodDisruptionBudget keeping replicas during node drains | off | After \`replicaCount > 1\` |
| \`networkpolicy.yaml\` | Ingress (HTTP+gRPC) + Egress (DNS always, rest configurable) | off | When the CNI enforces (Calico/Cilium); permissive egress so it doesn't silently break datastore access |
| \`servicemonitor.yaml\` | Prometheus Operator scrape config for /metrics | off | When kube-prometheus-stack is installed |

## 4 new values blocks
\`autoscaling\`, \`podDisruptionBudget\`, \`networkPolicy\`, \`metrics.serviceMonitor\`. Each top-level toggle annotated with \`# --\` for the helm-docs table. Other knobs (replicas, intervals, etc.) intentionally **not** annotated to keep scope contained.

## 8 new helm-unittest tests
\`helm/leoflow/tests/hardening_test.yaml\` — 2 tests per template:
- "not rendered when \`<feature>.enabled\` is false" (default behaviour)
- "rendered with expected fields when enabled" (HPA min/max, PDB minAvailable, NetworkPolicy DNS egress, ServiceMonitor /metrics endpoint)

**Total chart unit test count: 22 across 4 suites** (was 14 across 3).

## Local gates (all green)
\`\`\`
helm unittest .          → 22/22 passed
helm-docs --dry-run diff → empty
helm lint                → 0 failures
helm-template-checks.sh  → 9/9 contracts met
helm template (toggles off) → 9 K8s resources (unchanged from main)
helm template (toggles on)  → 14 K8s resources (+ 4 hardening)
\`\`\`

## Out of scope
- **kind-e2e exercising toggles ON**: the existing gate validates toggle-OFF (the chart's default state on any first install). Validating toggle-ON behaviour against a real cluster (HPA needs metrics-server, ServiceMonitor needs Prometheus Operator CRDs, NetworkPolicy needs an enforcing CNI) would significantly expand the gate. Filing as follow-up issue if needed.
- **Annotating sub-keys** (e.g. \`autoscaling.minReplicas\`, \`networkPolicy.egress\`): top-level toggles only this round; sub-keys are part of #185 (values.yaml annotation pass).

## Helm alpha-prep status after this PR

**100% of the original alpha-prep arc closed.** Remaining open issues are quality-of-life / iteration:

- #183 chart README → GH Pages mirror
- #185 annotate remaining values.yaml fields  
- #186 helm-unittest suites for ingress/rbac/service
- #187 \`helm plugin install --verify=false\` for Helm 4 compat
- #180 verify path filter trigger (organic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)