### PR TITLE
ci(helm): bump CI Helm 3.21.0 → 4.2.0 (closes #187)

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
-          version: v3.21.0
+          version: v4.2.0
 
       - name: helm lint
         run: helm lint helm/leoflow
@@ -77,11 +77,11 @@ jobs:
       - name: helm-unittest (template logic)
         run: |
           set -euo pipefail
-          # Helm 3 doesn't have a `--verify` flag on `helm plugin install` (it's
-          # only on `helm install` for charts), so don't pass it. On Helm 4.x the
-          # default flips to strict and a `--verify=false` flag DOES exist —
-          # tracked in #187 for the Helm 3 → 4 bump, NOT this PR's scope.
-          helm plugin install --version v1.1.0 https://github.com/helm-unittest/helm-unittest
+          # Helm 4 added `--verify` to `helm plugin install` with a default
+          # of strict verification. The helm-unittest plugin source isn't
+          # signed, so we explicitly opt out. (On Helm 3.x this flag didn't
+          # exist — see #187 history.)
+          helm plugin install --version v1.1.0 --verify=false https://github.com/helm-unittest/helm-unittest
           helm unittest helm/leoflow
 
       # Contract test: every required env entry + Secret key must be present
@@ -112,7 +112,7 @@ jobs:
 
       - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
-          version: v3.21.0
+          version: v4.2.0
 
       - uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:


### PR DESCRIPTION
## Summary
Closes **#187**. The Helm CI pinned to v3.21.0 since #184 was reactive — no deliberate decision to stay on the Helm 3 line.

## Why bump now
Three downsides of staying on 3.21:

1. **Dev/CI drift**: my local Mac is on \`v4.2.0+g0646808\`; CI on \`v3.21.0\`. Bugs that pass local can break CI. Happened twice this session:
   - The \`--verify=false\` flag (intended for Helm 4) broke Helm 3 with "unknown flag"
   - PR #169's PoC fixture passed my Helm 4 but had nuanced behavior on Helm 3
2. **#187 stayed open indefinitely** as latent debt — every CI run was fine, but the day someone bumped, the helm-unittest plugin install would fail.
3. **No technical blocker on Helm 4.x.** Audited the diff: chart syntax compatible (4.x dropped only Helm-2-era legacy), \`helm install --wait\` semantics unchanged, plugin install gained a \`--verify\` flag with strict default (we add \`--verify=false\` explicitly).

## Changes
- \`version: v3.21.0\` → \`version: v4.2.0\` (both lint + kind-e2e jobs)
- \`helm plugin install\` now passes \`--verify=false\` (required on Helm 4 since helm-unittest source isn't signed)

## Local validation on Helm 4.2.0
\`\`\`
helm lint helm/leoflow  → 0 failures
helm unittest .         → 41/41 passed
helm-template-checks.sh → 9/9 contracts met
helm template (Pro)     → 9 K8s resources rendered
```

## Out of scope
- **\`release.yaml\`** doesn't have \`setup-helm\` (no direct helm commands; goreleaser-action handles its own helm internally). Not affected.
- **\`helm/kind-action\`** installs kind, not helm. Helm version is separate.

## What CI validates that local can't
The kind-e2e job runs real \`helm install --wait\` + upgrade + smoke on Helm 4 against the kind cluster. That's the only unverified surface — local already covers helm template / lint / unittest / template-checks.

## Helm chart stack as of this PR

| Component | Version | Notes |
|---|---|---|
| Helm CLI | **v4.2.0** | This PR |
| helm-unittest | v1.1.0 | --verify=false required on Helm 4 |
| helm-docs | v1.14.2 | binary independent |
| kubeconform | v0.6.7 | independent |
| kind-action | v1.14.0 | unaffected |
| setup-helm | v5.0.0 | supports both Helm 3 + 4 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)