### PR TITLE
docs: clear 3 stale claims + reconcile Editions/Operating modes + Docker contradiction (#91 partial)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@
 
 | | |
 |---|---|
-| [Operating modes](docs/operating-modes.md) | Demo · Dev · Production (coming soon) |
+| [Operating modes](docs/operating-modes.md) · [Editions](docs/editions.md) | Demo · Dev · Production · the Lite/Pro split |
 | [DAG authoring](docs/dag-authoring.md) | write a DAG; the dev → deploy lifecycle |
 | [CI/CD & deploy examples](docs/deploy.md) | GitHub Actions · GitLab · Cloud Build/Run · generic |
+| [Helm chart](helm/leoflow/README.md) | Production install: values reference, hardening, PoC recipe |
 | [HTTP API (Scalar)](docs/api-reference.md) · [Go packages](docs/go-api.md) | API references |
 | [Concepts & glossary](docs/concepts.md) · [Architecture](docs/architecture.md) | the model & the *why* |
 
@@ -176,7 +177,7 @@ control plane (capped); everything else runs pod-per-task. Read
 - **Execution** — real pod-per-task execution via the `leoflow-agent` over gRPC (Kubernetes, ADR 0015), plus inline `http_api` goroutines for short calls; orphaned-pod reconciliation and completed-pod garbage collection.
 - **Data flow** — XCom on Redis (256 KB limit, TTL, optional schema validation) passed between tasks; log shipping to disk with a read API and live tailing over Redis pub/sub.
 
-**Not yet implemented:** the Airflow 3.2.x UI integration (Phase 5); the Helm chart, load tests, and S3/GCS log sinks (Phase 6). Tracked refinements live in the [issue tracker](https://github.com/neochaotic/leoflow/issues).
+**Not yet implemented:** load tests (Phase 6) and S3/GCS log sinks. Tracked refinements live in the [issue tracker](https://github.com/neochaotic/leoflow/issues).
 
 ## Features in the MVP
 
@@ -248,9 +249,9 @@ TOKEN=$(./bin/leoflow auth create-token --username admin@leoflow.local --passwor
 ./bin/leoflow push my-dag/dag.json --token "$TOKEN"
 ```
 
-> **Two dev environments.** `make dev-up` runs Postgres + Redis as plain Docker containers on the host for a fast inner loop (control plane on the host). Full in-cluster execution — control plane and dependencies on a local Kubernetes cluster (k3d/kind) via the Helm chart, mirroring production and exercising real task pods — arrives with the e2e work in a later phase. Task execution is on Kubernetes only (ADR 0015); the host containers are dev dependencies, not the execution path.
+> **Two dev environments.** `make dev-up` runs Postgres + Redis as plain Docker containers on the host for a fast inner loop (control plane on the host). For full in-cluster execution (control plane and dependencies on a local Kubernetes cluster, mirroring production and exercising real task pods), the [Helm chart](helm/leoflow/README.md) is installable on any K8s cluster — chart-test CI gates every change with `helm lint` + `helm-unittest` (41 tests) + kind install/upgrade smoke. Task execution is on Kubernetes only (ADR 0015); the host containers are dev dependencies, not the execution path.
 
-> The Airflow 3.2.1 UI ships embedded in the server and is served at `/` (Phase 5; see the one-command demo above and `docs/ui-compatibility.md`). The Scalar API reference is at `/docs`. The Helm chart and load tests are the remaining Phase 6 work.
+> The Airflow 3.2.1 UI ships embedded in the server and is served at `/` (see the one-command demo above and `docs/ui-compatibility.md`). The Scalar API reference is at `/docs`. Load tests are the remaining Phase 6 work.
 
 ## Honest Comparison
 

--- a/docs/editions.md
+++ b/docs/editions.md
@@ -1,9 +1,13 @@
 # Editions
 
 !!! warning "Pre-alpha"
-    Leoflow is **pre-alpha**. Only the **Lite** edition exists today, and it is for
-    local iteration on a trusted network — not durable or production use. The
-    Production (enterprise) edition is not released yet.
+    Leoflow is **pre-alpha**. Only the **Lite** edition is officially supported
+    today (local iteration on a trusted network — not durable or production
+    use). The **Production** chart is installable + chart-test gated, but not
+    cleared for official use until the v0.1.0-alpha cut.
+
+> See also [Operating modes](operating-modes.md) for the Demo/Dev/Production
+> runtime view (this page is the per-edition distribution + posture view).
 
 Leoflow is planned in two editions that share the same engine, the same
 Airflow-3.2.x UI, and the same DAG format (`dag.py` + `leoflow.yaml`). You author a
@@ -11,14 +15,14 @@ DAG once and it runs on either.
 
 | | **Lite** | **Production** |
 |---|---|---|
-| Status | **Available now** (pre-alpha) | Enterprise — *coming* |
-| Install | one command (`curl … \| sh`) on one machine | Helm chart on your cluster |
+| Status | **Available now** (pre-alpha) | **Chart installable** (gated); officially supported after v0.1.0-alpha |
+| Install | one command (`curl … \| sh`) on one machine | [Helm chart](helm-chart.md) on your cluster |
 | Command | `leoflow lite` | the deployed control plane |
 | Auth | a single local **admin** login (password shown once at setup) | enterprise: SSO/OIDC, full RBAC, multi-tenant |
 | Executors | a local **k3d** mini-cluster (real pods, **requires Docker** to host the cluster) or **subprocess** (dev-only, unsandboxed, no Docker) | **Kubernetes only**, at scale |
 | Deploy | edit + hot-reload | GitOps: `leoflow compile` in CI → immutable image + `dag.json` |
 | Intended use | local, small, or **light production** projects on a **trusted/internal network** | teams and production workloads at scale |
-| Datastores | **Postgres, auto-selected**: the Docker `postgres:16` when Docker is present, else an **embedded managed** Postgres (downloaded under `~/.leoflow`, no Docker); **no Redis** | **external** managed Postgres + Redis |
+| Datastores | **Postgres, auto-selected**: the Docker `postgres:16` when Docker is present, else an **embedded managed** Postgres (downloaded under `~/.leoflow`, no Docker); **no Redis** | **external** managed Postgres + Redis (see [chart docs](helm-chart.md#datastore-compatibility) for versions) |
 
 ## Leoflow Lite
 

--- a/docs/operating-modes.md
+++ b/docs/operating-modes.md
@@ -1,7 +1,11 @@
 # Operating modes: Demo · Dev · Production
 
 Leoflow runs in three modes. **The product proves itself in Dev first**;
-Production is a near-term goal, not yet for testing.
+Production is a near-term goal, not yet officially for testing (the chart
+is installable + gated, but not blessed until the v0.1.0-alpha cut).
+
+> See also [Editions](editions.md) for the Lite/Production distribution split
+> (this page is the runtime mode view; Editions is the packaging + posture view).
 
 | | **Demo** | **Dev** (`leoflow lite`) | **Production** *(coming soon)* |
 |---|---|---|---|
@@ -37,7 +41,16 @@ Dev runs user code unsandboxed (subprocess) or in throwaway pods (k3d); it is fo
 local development only.
 
 ## Production *(coming soon)*
-Helm chart + published images (#48), real cluster, TLS on the agent channel
-(#58), keyless cloud auth via workload identity (#56), least-privilege secret
-scoping (#59). Not yet supported for testing — see the roadmap. We harden Dev
-until the product earns its way to Production.
+Real cluster install via the **[Helm chart](helm-chart.md)** (chart-test
+gated, multi-arch images published per release, signed with cosign).
+Hardening templates ship as opt-in toggles: HPA + PDB + NetworkPolicy +
+ServiceMonitor. Still **not officially supported for testing** until the
+v0.1.0-alpha cut clears the user's hands-on validation — but the chart is
+installable today against any K8s cluster with external Postgres + Redis.
+
+Pending Production work (tracked separately): TLS on the agent channel
+(#58), keyless cloud auth via workload identity (#56), least-privilege
+secret scoping (#59).
+
+> See [Editions](editions.md) for the Lite/Production split (same engine,
+> different distribution + posture).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,8 +6,11 @@ trusted internal network — see [Editions](editions.md).
 
 ## Prerequisites
 
-- **Docker** running — Lite brings up its own Postgres + Redis with it. (No
-  Docker? Point Lite at your own datastores with `--no-up`.)
+- **One of the following** for the datastores:
+    - **Docker** running (preferred — Lite spins up `postgres:16` automatically), OR
+    - **Nothing** — Lite falls back to an embedded managed Postgres downloaded
+      under `~/.leoflow` (no Docker, no system Postgres needed). See
+      [Editions § Datastores](editions.md) for the auto-selection logic.
 - Linux or macOS (incl. WSL2). No system Python needed — Lite installs a managed
   one. See [Installation](installation.md) for details.
 


### PR DESCRIPTION
## Summary
Bundle of 5 doc fixes from this session's doc review. All bite on a fresh read of the project.

## Changes

### 1. README.md — 3 stale "not yet implemented" claims removed
The README asserted (for weeks):
- L179: *"Not yet implemented: the Airflow 3.2.x UI integration (Phase 5); the Helm chart, load tests, and S3/GCS log sinks (Phase 6)"*
- L251: *"Full in-cluster execution arrives with the e2e work in a later phase"*
- L253: *"The Helm chart and load tests are the remaining Phase 6 work"*

All three are now wrong:
- UI shipped (embedded Airflow 3.2.1 SPA at \`/\`)
- Helm chart shipped + hardened + chart-test gated (10+ PRs this session: #143, #96, #48, #185, #183, #186, #187, #170, etc.)
- kind-e2e is in CI

Rewritten to mention only what's actually pending (load tests + S3/GCS log sinks).

### 2. README docs table — Helm chart row added
Was unlinked. Now points to \`helm/leoflow/README.md\` (also mirrored at \`/helm-chart\` on the public docs site via #192). Also added \`[Editions]\` next to Operating modes — they were parallel docs with no cross-link.

### 3. operating-modes.md Production section — stale "(#48 coming soon)"
#48 (leoflow-migrate image) closed earlier this session (landed as #170). Rewrote to reflect reality (chart installable, gated, not officially blessed until v0.1.0-alpha) + linked to the chart docs.

### 4. Editions ↔ Operating modes cross-link
Two parallel docs covering the edition split with different framings (Lite/Pro vs Demo/Dev/Production). Added a \`> See also\` callout at the top of each.

### 5. Quickstart vs Editions — Docker contradiction
Quickstart Prerequisites: *"Docker running"* (required). But editions.md + installation.md: *Docker is OPTIONAL* (managed embedded Postgres path). User on a no-Docker machine bounces.

Rewrote Prerequisites to document both paths + link to the auto-selection logic.

## Test plan
- [x] All referenced links exist (helm-chart.md mirrored from chart README via #192)
- [x] Pre-commit gate green (coverage 78.4%)
- [ ] Docs workflow CI on this PR (mkdocs \`--strict\` validates internal links)

## Out of scope (deferred)
- Broader product-narrative rewrite of README (the "Power Lab / MCP" angle the user later said to ignore)
- Annotating remaining ~25 leaf values fields with \`# --\` (already 80% coverage from #192)
- AAA UX/product review (this PR is \`#91 partial\`; full UX review is bigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)