### PR TITLE
fix(scheduler): enforce retry_delay_seconds cooldown on up_for_retry → none (closes #201)

### DIFF
--- a/internal/scheduler/plan.go
+++ b/internal/scheduler/plan.go
@@ -1,6 +1,10 @@
 package scheduler
 
-import "github.com/neochaotic/leoflow/internal/domain"
+import (
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
 
 // PlannedTransition is a decided state change for a task instance within a run.
 type PlannedTransition struct {
@@ -39,6 +43,14 @@ func PlanRun(run RunState) []PlannedTransition {
 				decided[t.TaskID] = true
 			}
 		case domain.TaskStateUpForRetry:
+			if !readyToRetry(run, t.TaskID) {
+				// Cooldown still active — keep the task in up_for_retry. Mark
+				// decided so the second loop also leaves it alone (otherwise
+				// decideStart would re-evaluate based on effective state and
+				// re-emit a transition).
+				decided[t.TaskID] = true
+				continue
+			}
 			out = append(out, PlannedTransition{TaskID: t.TaskID, To: domain.TaskStateNone})
 			effective[t.TaskID] = domain.TaskStateNone
 			decided[t.TaskID] = true
@@ -70,6 +82,31 @@ func PlanRun(run RunState) []PlannedTransition {
 // terminally by default.
 func retriable(run RunState, taskID string) bool {
 	return run.Tries[taskID] < run.MaxTries[taskID]
+}
+
+// readyToRetry reports whether the cooldown window from the user's declared
+// retry_delay_seconds has elapsed since the task ended. The check honors the
+// "absent data falls back to immediate retry" convention so legacy callers
+// (tests, in-flight DAGs predating issue #201) keep working unchanged.
+//
+// Returns true when:
+//   - delay is 0 (no cooldown declared), OR
+//   - the task's EndedAt is not recorded (can't compute, retry immediately), OR
+//   - run.Now is zero (no clock provided — test seam preserves old behavior), OR
+//   - run.Now >= EndedAt + delay (cooldown has elapsed)
+func readyToRetry(run RunState, taskID string) bool {
+	delay := run.RetryDelaySeconds[taskID]
+	if delay <= 0 {
+		return true
+	}
+	ended := run.EndedAt[taskID]
+	if ended == nil {
+		return true
+	}
+	if run.Now.IsZero() {
+		return true
+	}
+	return !run.Now.Before(ended.Add(time.Duration(delay) * time.Second))
 }
 
 func decideStart(t domain.TaskSpec, deps []string, states map[string]domain.TaskState) (domain.TaskState, bool) {

--- a/internal/scheduler/plan_test.go
+++ b/internal/scheduler/plan_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"testing"
+	"time"
 
 	"github.com/neochaotic/leoflow/internal/domain"
 )
@@ -121,6 +122,67 @@ func TestFinalizeRun(t *testing.T) {
 	}
 	if state, done := FinalizeRun(st(tasks, map[string]domain.TaskState{"a": domain.TaskStateSuccess, "b": domain.TaskStateFailed})); !done || state != domain.DagRunStateFailed {
 		t.Errorf("one failed => (%q,%v), want (failed,true)", state, done)
+	}
+}
+
+// TestPlanRunHoldsUpForRetryDuringDelay pins issue #201: a task in up_for_retry
+// must NOT be released back to `none` until `retry_delay_seconds` have elapsed
+// since `ended_at`. Without this gate, retries fire on the next tick (~1s),
+// defeating the user-declared backoff that exists precisely to give transient
+// failure causes (rate limits, upstream blips) time to recover.
+func TestPlanRunHoldsUpForRetryDuringDelay(t *testing.T) {
+	endedAt := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	run := RunState{
+		Tasks:             linear(),
+		States:            map[string]domain.TaskState{"a": domain.TaskStateUpForRetry, "b": domain.TaskStateNone},
+		Tries:             map[string]int{"a": 2},
+		MaxTries:          map[string]int{"a": 3},
+		EndedAt:           map[string]*time.Time{"a": &endedAt},
+		RetryDelaySeconds: map[string]int{"a": 60}, // 1 minute cooldown
+		Now:               endedAt.Add(10 * time.Second),
+	}
+	got := planMap(run)
+	if _, ok := got["a"]; ok {
+		t.Errorf("a planned %q at 10s after failure; should remain up_for_retry until +60s", got["a"])
+	}
+}
+
+// TestPlanRunReleasesUpForRetryAfterDelay completes the contract: the same
+// task IS released to `none` (and then to `scheduled` via decideStart in the
+// same plan pass) once the cooldown has elapsed.
+func TestPlanRunReleasesUpForRetryAfterDelay(t *testing.T) {
+	endedAt := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	run := RunState{
+		Tasks:             linear(),
+		States:            map[string]domain.TaskState{"a": domain.TaskStateUpForRetry, "b": domain.TaskStateNone},
+		Tries:             map[string]int{"a": 2},
+		MaxTries:          map[string]int{"a": 3},
+		EndedAt:           map[string]*time.Time{"a": &endedAt},
+		RetryDelaySeconds: map[string]int{"a": 60},
+		Now:               endedAt.Add(61 * time.Second),
+	}
+	got := planMap(run)
+	// up_for_retry → none in this tick; subsequent tick handles none → scheduled
+	// (the existing TestPlanRunResetsUpForRetry pins the same single-step shape).
+	if got["a"] != domain.TaskStateNone {
+		t.Errorf("a = %q at 61s after failure; want none (cooldown elapsed, ready to reset)", got["a"])
+	}
+}
+
+// TestPlanRunBackwardsCompatNoRetryDelay confirms that when retry_delay_seconds
+// is 0 or absent (legacy behavior), the task transitions immediately — no
+// regression for DAGs that opted out of backoff.
+func TestPlanRunBackwardsCompatNoRetryDelay(t *testing.T) {
+	run := RunState{
+		Tasks:             linear(),
+		States:            map[string]domain.TaskState{"a": domain.TaskStateUpForRetry, "b": domain.TaskStateNone},
+		Tries:             map[string]int{"a": 2},
+		MaxTries:          map[string]int{"a": 3},
+		RetryDelaySeconds: map[string]int{"a": 0}, // no delay
+		// EndedAt absent, Now zero — neither matters when delay == 0
+	}
+	if got := planMap(run); got["a"] != domain.TaskStateNone {
+		t.Errorf("a = %q with no retry_delay; want none (immediate reset, same as existing behavior)", got["a"])
 	}
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -24,6 +24,16 @@ type RunState struct {
 	// driving retry decisions. Absent entries mean no retry budget.
 	Tries    map[string]int
 	MaxTries map[string]int
+	// EndedAt holds the failure timestamp per task (only meaningful for tasks
+	// currently in `up_for_retry`). Combined with RetryDelaySeconds + Now, it
+	// gates the `up_for_retry → none` transition so retries honor user-
+	// declared backoff (issue #201). Absent entries mean no cooldown applies.
+	EndedAt           map[string]*time.Time
+	RetryDelaySeconds map[string]int
+	// Now is the wall-clock value the planner compares against EndedAt. Zero
+	// means "skip the cooldown gate" so legacy callers + tests that don't set
+	// retry_delay get the previous (immediate-retry) behavior.
+	Now time.Time
 }
 
 // ScheduledDAG is a cron-scheduled DAG and the logical date of its latest run.

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -56,20 +56,37 @@ func (s *SchedulerStore) ActiveRuns(ctx context.Context) ([]scheduler.RunState, 
 		states := make(map[string]domain.TaskState, len(tis))
 		tries := make(map[string]int, len(tis))
 		maxTries := make(map[string]int, len(tis))
+		endedAt := make(map[string]*time.Time, len(tis))
 		for _, ti := range tis {
 			states[ti.TaskID] = domain.TaskState(ti.State)
 			tries[ti.TaskID] = int(ti.TryNumber)
 			maxTries[ti.TaskID] = int(ti.MaxTries)
+			if ti.EndedAt.Valid {
+				ts := ti.EndedAt.Time
+				endedAt[ti.TaskID] = &ts
+			}
+		}
+		// Build per-task retry_delay_seconds from the DAG spec so the planner
+		// can gate `up_for_retry → none` on the user-declared cooldown (#201).
+		// TaskSpec.RetryDelaySeconds is *int (omitempty); nil = no cooldown.
+		retryDelay := make(map[string]int, len(spec.Tasks))
+		for _, t := range spec.Tasks {
+			if t.RetryDelaySeconds != nil {
+				retryDelay[t.TaskID] = *t.RetryDelaySeconds
+			}
 		}
 		out = append(out, scheduler.RunState{
-			RunID:    uuidToString(run.ID),
-			DagID:    spec.DagID,
-			TenantID: uuidToString(run.TenantID),
-			State:    domain.DagRunState(run.State),
-			Tasks:    spec.Tasks,
-			States:   states,
-			Tries:    tries,
-			MaxTries: maxTries,
+			RunID:             uuidToString(run.ID),
+			DagID:             spec.DagID,
+			TenantID:          uuidToString(run.TenantID),
+			State:             domain.DagRunState(run.State),
+			Tasks:             spec.Tasks,
+			States:            states,
+			Tries:             tries,
+			MaxTries:          maxTries,
+			EndedAt:           endedAt,
+			RetryDelaySeconds: retryDelay,
+			Now:               time.Now(),
 		})
 	}
 	return out, nil


### PR DESCRIPTION
## Summary
Closes #201. Found in [resilience audit (2026-05-31)](#).

\`plan.go:41-44\` transitioned a task from \`up_for_retry\` straight to \`none\` on every tick, never checking the user's declared \`retry_delay_seconds\`. Effective backoff was **~1 second** (one scheduler tick) regardless of the value the user set in the DAG spec.

## Impact for users
A task with \`retry_delay_seconds: 60\` retried in ~1s. If the failure cause was transient (upstream rate limit, transient DB error, slow flaky API), the immediate retry hammered the upstream → more failures, no recovery window. The cooldown was advertised in the spec but defeated by the planner.

## Change
- **\`RunState\` gains 3 fields**: \`EndedAt\`, \`RetryDelaySeconds\`, \`Now\`. All optional / absent-data-safe → legacy callers (existing tests, in-flight DAGs predating this fix) get the previous immediate-retry behavior with no migration.
- **\`plan.go\` calls a new \`readyToRetry\` helper** before the \`up_for_retry → none\` transition. When the cooldown hasn't elapsed, the task stays in \`up_for_retry\` (no transition emitted); next tick re-checks.
- **\`storage/scheduler_store.go\` populates the new fields** from the DB (\`TaskInstance.EndedAt\`) and the DAG spec (\`TaskSpec.RetryDelaySeconds\`, *int pointer dereferenced — absent = no cooldown). \`Now\` is wall clock.

## TDD
Three new tests in \`plan_test.go\`:

| Test | What it pins |
|---|---|
| \`TestPlanRunHoldsUpForRetryDuringDelay\` | endedAt + 10s with 60s delay → **no transition** (regression guard) |
| \`TestPlanRunReleasesUpForRetryAfterDelay\` | endedAt + 61s with 60s delay → transitions to \`none\` (cooldown elapsed path) |
| \`TestPlanRunBackwardsCompatNoRetryDelay\` | no delay / no timestamps → transitions to \`none\` immediately (legacy preserved) |

Ran red on all three before implementation; green after. Existing 7 plan tests still pass — cooldown gate is purely additive when the new fields are absent.

## Out of scope
- **Exponential backoff** (\`retry_exponential_backoff: true\` in Airflow): separate option, separate PR. Immediate fix here is honoring the **linear delay** that's already declared in the spec.
- The other 9 resilience findings (#194-#200, #202-#203, #204) — most filed as separate issues; the parallel one (#200 max_active enforcement) is next in this branch's sister PR.

## Local gates
\`\`\`
go test ./...                         → all green
golangci-lint run ./internal/scheduler ./internal/storage  → 0 issues
Coverage gate (pre-commit)            → 78.4% (floor 78%)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)