### PR TITLE
fix(scheduler): enforce per-DAG max_active_runs (closes #200 partial)

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -46,6 +46,12 @@ type ScheduledDAG struct {
 	LastLogical *time.Time
 	StartDate   *time.Time
 	Catchup     bool
+	// MaxActiveRuns caps how many runs of this DAG may be active (queued or
+	// running) at once. Zero means "unlimited" (Airflow-faithful: a missing
+	// limit is unbounded). The scheduler enforces the cap in createDueRuns:
+	// once the active-run count reaches this value, additional due slots are
+	// skipped on this tick (issue #200).
+	MaxActiveRuns int
 }
 
 // Store is the scheduler's view of persistent state. The concrete
@@ -265,10 +271,12 @@ func (s *Scheduler) Step(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("listing active runs: %w", err)
 	}
+	activeByDAG := make(map[string]int, len(runs))
 	for _, run := range runs {
+		activeByDAG[run.DagID]++
 		s.advanceSafely(ctx, run)
 	}
-	createErr := s.createDueRuns(ctx)
+	createErr := s.createDueRuns(ctx, activeByDAG)
 	s.reapOrphansIfLeader(ctx)
 	return createErr
 }
@@ -315,19 +323,26 @@ func (s *Scheduler) advanceSafely(ctx context.Context, run RunState) {
 }
 
 // createDueRuns creates a new run for each scheduled DAG whose next cron slot
-// after its latest run has arrived.
-func (s *Scheduler) createDueRuns(ctx context.Context) error {
+// after its latest run has arrived. activeByDAG carries the count of already-
+// active runs per DAG so the per-DAG max_active_runs cap is honored (#200): a
+// DAG that has reached its cap is skipped this tick, and a backfill that would
+// exceed the cap is truncated to the remaining headroom. The local
+// `createdThisTick` map folds creations made in this same tick into the cap
+// so a single tick cannot itself breach the limit.
+func (s *Scheduler) createDueRuns(ctx context.Context, activeByDAG map[string]int) error {
 	dags, err := s.store.ScheduledDAGs(ctx)
 	if err != nil {
 		return fmt.Errorf("listing scheduled dags: %w", err)
 	}
 	now := time.Now().UTC()
+	createdThisTick := make(map[string]int, len(dags))
 	for _, d := range dags {
 		if domain.IsOnceSchedule(d.Schedule) {
 			// @once: fire exactly one run on first sight, then never again. Once the
 			// run exists, the DAG's LastLogical is non-nil and this is skipped.
-			if d.LastLogical == nil {
+			if d.LastLogical == nil && s.hasHeadroom(d, activeByDAG, createdThisTick) {
 				s.createScheduledRun(ctx, d.DagID, now)
+				createdThisTick[d.DagID]++
 			}
 			continue
 		}
@@ -358,15 +373,44 @@ func (s *Scheduler) createDueRuns(ctx context.Context) error {
 			if !due {
 				continue
 			}
+			if !s.hasHeadroom(d, activeByDAG, createdThisTick) {
+				s.recordCapSkip(d.DagID)
+				continue
+			}
 			s.createScheduledRun(ctx, d.DagID, logical)
+			createdThisTick[d.DagID]++
 			continue
 		}
 		slots := dueScheduledSlots(d.Schedule, d.LastLogical, d.StartDate, now, d.Catchup, maxCatchupSlotsPerTick)
 		for _, logical := range slots {
+			if !s.hasHeadroom(d, activeByDAG, createdThisTick) {
+				s.recordCapSkip(d.DagID)
+				break
+			}
 			s.createScheduledRun(ctx, d.DagID, logical)
+			createdThisTick[d.DagID]++
 		}
 	}
 	return nil
+}
+
+// hasHeadroom reports whether the DAG may take another active run without
+// exceeding its max_active_runs cap. A cap of zero means "unlimited"
+// (Airflow-faithful default for an unset limit).
+func (s *Scheduler) hasHeadroom(d ScheduledDAG, active map[string]int, justCreated map[string]int) bool {
+	if d.MaxActiveRuns <= 0 {
+		return true
+	}
+	return active[d.DagID]+justCreated[d.DagID] < d.MaxActiveRuns
+}
+
+// recordCapSkip logs (once per DAG between successful creations) and meters
+// that a due slot was skipped because the DAG is at its max_active_runs cap.
+// We use a single metric label so dashboards can see "is concurrency the
+// bottleneck right now?" without per-DAG cardinality.
+func (s *Scheduler) recordCapSkip(dagID string) {
+	s.logger.Debug("skipping due run; DAG is at max_active_runs cap", "dag", dagID)
+	s.record("max_active_runs_cap")
 }
 
 // createScheduledRun creates one scheduled run for a DAG, isolating per-DAG

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -338,9 +338,11 @@ func (s *Scheduler) createDueRuns(ctx context.Context, activeByDAG map[string]in
 	createdThisTick := make(map[string]int, len(dags))
 	for _, d := range dags {
 		if domain.IsOnceSchedule(d.Schedule) {
-			// @once: fire exactly one run on first sight, then never again. Once the
-			// run exists, the DAG's LastLogical is non-nil and this is skipped.
-			if d.LastLogical == nil && s.hasHeadroom(d, activeByDAG, createdThisTick) {
+			// @once: fire exactly one run on first sight, then never again. Once
+			// the run exists, the DAG's LastLogical is non-nil and this is
+			// skipped — that single-shot semantic already prevents any cap
+			// breach, so no headroom check is needed here.
+			if d.LastLogical == nil {
 				s.createScheduledRun(ctx, d.DagID, now)
 				createdThisTick[d.DagID]++
 			}
@@ -395,8 +397,14 @@ func (s *Scheduler) createDueRuns(ctx context.Context, activeByDAG map[string]in
 }
 
 // hasHeadroom reports whether the DAG may take another active run without
-// exceeding its max_active_runs cap. A cap of zero means "unlimited"
-// (Airflow-faithful default for an unset limit).
+// exceeding its max_active_runs cap. A non-positive cap is treated as
+// "unlimited" — a defensive guard for hand-edited rows: the column is
+// `NOT NULL DEFAULT 16` (migration 002) and the repository upsert defaults
+// missing values to 16 (`repository.go:509`), so a zero only appears via a
+// direct DB write. Diverging from Airflow's "missing == default 16" makes
+// the scheduler fail open rather than locking the DAG out forever when a
+// bad row is encountered. Callers pass `justCreated` so a single tick
+// folds in its own creations and cannot itself breach the cap.
 func (s *Scheduler) hasHeadroom(d ScheduledDAG, active map[string]int, justCreated map[string]int) bool {
 	if d.MaxActiveRuns <= 0 {
 		return true

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -334,6 +334,65 @@ func TestStepOnceScheduleFiresExactlyOnce(t *testing.T) {
 	}
 }
 
+// TestStepRespectsMaxActiveRunsWhenAtCap: with max_active_runs=1 and one
+// already-active run for that DAG, even a backfill that would otherwise
+// produce many catchup slots must produce zero new runs — the cap is a
+// hard ceiling on concurrent active runs per DAG (Airflow #200).
+func TestStepRespectsMaxActiveRunsWhenAtCap(t *testing.T) {
+	last := time.Now().UTC().Add(-6 * time.Hour).Truncate(time.Hour)
+	store := newFakeStore(RunState{
+		RunID: "r-existing", DagID: "etl", State: domain.DagRunStateRunning,
+	})
+	store.scheduled = []ScheduledDAG{{
+		DagID: "etl", Schedule: "@hourly", LastLogical: &last,
+		Catchup: true, MaxActiveRuns: 1,
+	}}
+	if err := newScheduler(store).Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.createdRuns) != 0 {
+		t.Errorf("DAG already at max_active_runs cap must create no new run, got %v", store.createdRuns)
+	}
+}
+
+// TestStepRespectsMaxActiveRunsCapsBackfill: same backfill window but no
+// existing active runs and max_active_runs=1 — at most ONE new run should be
+// created this tick (the remaining slots are skipped, not queued).
+func TestStepRespectsMaxActiveRunsCapsBackfill(t *testing.T) {
+	last := time.Now().UTC().Add(-6 * time.Hour).Truncate(time.Hour)
+	store := newFakeStore()
+	store.scheduled = []ScheduledDAG{{
+		DagID: "etl", Schedule: "@hourly", LastLogical: &last,
+		Catchup: true, MaxActiveRuns: 1,
+	}}
+	if err := newScheduler(store).Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.createdRuns) != 1 {
+		t.Errorf("max_active_runs=1 should cap backfill at one new run, got %d (%v)",
+			len(store.createdRuns), store.createdRuns)
+	}
+}
+
+// TestStepMaxActiveRunsZeroMeansUnlimited: cap=0 preserves the legacy
+// behavior (Airflow-faithful: a missing limit is unlimited). Backfill
+// proceeds as if there were no cap.
+func TestStepMaxActiveRunsZeroMeansUnlimited(t *testing.T) {
+	last := time.Now().UTC().Add(-6 * time.Hour).Truncate(time.Hour)
+	store := newFakeStore()
+	store.scheduled = []ScheduledDAG{{
+		DagID: "etl", Schedule: "@hourly", LastLogical: &last,
+		Catchup: true, MaxActiveRuns: 0,
+	}}
+	if err := newScheduler(store).Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.createdRuns) < 2 {
+		t.Errorf("max_active_runs=0 (unlimited) should backfill the whole gap, got %d (%v)",
+			len(store.createdRuns), store.createdRuns)
+	}
+}
+
 func TestStepWarnsOnUnparseableScheduleAndCreatesNoRun(t *testing.T) {
 	store := newFakeStore()
 	// A 4-field cron (the real bug): the scheduler must not silently ignore it.

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -338,10 +338,16 @@ func TestStepOnceScheduleFiresExactlyOnce(t *testing.T) {
 // already-active run for that DAG, even a backfill that would otherwise
 // produce many catchup slots must produce zero new runs — the cap is a
 // hard ceiling on concurrent active runs per DAG (Airflow #200).
+//
+// The fake run carries Tasks so PlanRun/FinalizeRun see a non-terminal
+// topology and do not auto-finalize it during this tick (which would change
+// the snapshot the cap is checked against).
 func TestStepRespectsMaxActiveRunsWhenAtCap(t *testing.T) {
 	last := time.Now().UTC().Add(-6 * time.Hour).Truncate(time.Hour)
 	store := newFakeStore(RunState{
 		RunID: "r-existing", DagID: "etl", State: domain.DagRunStateRunning,
+		Tasks:  linearTasks(),
+		States: map[string]domain.TaskState{"a": domain.TaskStateRunning, "b": domain.TaskStateNone},
 	})
 	store.scheduled = []ScheduledDAG{{
 		DagID: "etl", Schedule: "@hourly", LastLogical: &last,
@@ -352,6 +358,24 @@ func TestStepRespectsMaxActiveRunsWhenAtCap(t *testing.T) {
 	}
 	if len(store.createdRuns) != 0 {
 		t.Errorf("DAG already at max_active_runs cap must create no new run, got %v", store.createdRuns)
+	}
+}
+
+// TestStepOnceScheduleIgnoresMaxActiveRuns covers the documented
+// invariant after dropping the dead headroom check on the @once branch:
+// @once is single-shot regardless of cap. LastLogical=nil means "never
+// fired"; the cap is irrelevant because @once will never compete with
+// itself.
+func TestStepOnceScheduleIgnoresMaxActiveRuns(t *testing.T) {
+	store := newFakeStore()
+	store.scheduled = []ScheduledDAG{{
+		DagID: "once_dag", Schedule: "@once", MaxActiveRuns: 1,
+	}}
+	if err := newScheduler(store).Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.createdRuns) != 1 || store.createdRuns[0] != "once_dag" {
+		t.Errorf("@once must fire its single run regardless of cap, got %v", store.createdRuns)
 	}
 }
 

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -14,6 +14,9 @@ type Querier interface {
 	AddFavorite(ctx context.Context, arg AddFavoriteParams) error
 	AssignUserRole(ctx context.Context, arg AssignUserRoleParams) error
 	ClearDagRuns(ctx context.Context, dagID pgtype.UUID) (int64, error)
+	// Counts queued+running runs for a single DAG; used by the manual-trigger
+	// path to enforce max_active_runs (#200) before insert.
+	CountActiveDagRunsByDagID(ctx context.Context, dagID pgtype.UUID) (int64, error)
 	CountAuditLogs(ctx context.Context, arg CountAuditLogsParams) (int64, error)
 	CountConnections(ctx context.Context, tenantID pgtype.UUID) (int64, error)
 	CountDagRunStatesInWindow(ctx context.Context, arg CountDagRunStatesInWindowParams) ([]CountDagRunStatesInWindowRow, error)

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -94,8 +94,9 @@ type Querier interface {
 	// on the next tick (the reaper is a backstop, not a sprint).
 	ListOrphanCandidates(ctx context.Context) ([]ListOrphanCandidatesRow, error)
 	// Returns each cron-scheduled DAG with the bits the scheduler needs to decide
-	// both "is there a slot due?" (schedule + last_logical) and "how many slots
-	// should I backfill on this tick?" (catchup + start_date, see #129).
+	// both "is there a slot due?" (schedule + last_logical), "how many slots
+	// should I backfill on this tick?" (catchup + start_date, see #129), and
+	// "may this DAG take another active run?" (max_active_runs, see #200).
 	ListScheduledDags(ctx context.Context) ([]ListScheduledDagsRow, error)
 	ListTaskInstancesByRun(ctx context.Context, dagRunID pgtype.UUID) ([]TaskInstance, error)
 	ListVariables(ctx context.Context, arg ListVariablesParams) ([]ListVariablesRow, error)

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -19,6 +19,12 @@ LIMIT $2 OFFSET $3;
 -- name: CountDagRunsByDag :one
 SELECT count(*) FROM dag_runs WHERE dag_id = $1;
 
+-- name: CountActiveDagRunsByDagID :one
+-- Counts queued+running runs for a single DAG; used by the manual-trigger
+-- path to enforce max_active_runs (#200) before insert.
+SELECT count(*) FROM dag_runs
+WHERE dag_id = $1 AND state IN ('queued', 'running');
+
 -- name: ListActiveDagRuns :many
 SELECT * FROM dag_runs
 WHERE state IN ('queued', 'running')

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -70,9 +70,10 @@ RETURNING *;
 
 -- name: ListScheduledDags :many
 -- Returns each cron-scheduled DAG with the bits the scheduler needs to decide
--- both "is there a slot due?" (schedule + last_logical) and "how many slots
--- should I backfill on this tick?" (catchup + start_date, see #129).
-SELECT d.dag_id, d.schedule, d.catchup, d.start_date,
+-- both "is there a slot due?" (schedule + last_logical), "how many slots
+-- should I backfill on this tick?" (catchup + start_date, see #129), and
+-- "may this DAG take another active run?" (max_active_runs, see #200).
+SELECT d.dag_id, d.schedule, d.catchup, d.start_date, d.max_active_runs,
   (SELECT max(dr.logical_date) FROM dag_runs dr WHERE dr.dag_id = d.id) AS last_logical
 FROM dags d
 WHERE d.is_active = true AND d.is_paused = false

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -655,7 +655,7 @@ func (q *Queries) ListOrphanCandidates(ctx context.Context) ([]ListOrphanCandida
 }
 
 const listScheduledDags = `-- name: ListScheduledDags :many
-SELECT d.dag_id, d.schedule, d.catchup, d.start_date,
+SELECT d.dag_id, d.schedule, d.catchup, d.start_date, d.max_active_runs,
   (SELECT max(dr.logical_date) FROM dag_runs dr WHERE dr.dag_id = d.id) AS last_logical
 FROM dags d
 WHERE d.is_active = true AND d.is_paused = false
@@ -663,16 +663,18 @@ WHERE d.is_active = true AND d.is_paused = false
 `
 
 type ListScheduledDagsRow struct {
-	DagID       string             `json:"dag_id"`
-	Schedule    *string            `json:"schedule"`
-	Catchup     bool               `json:"catchup"`
-	StartDate   pgtype.Timestamptz `json:"start_date"`
-	LastLogical interface{}        `json:"last_logical"`
+	DagID         string             `json:"dag_id"`
+	Schedule      *string            `json:"schedule"`
+	Catchup       bool               `json:"catchup"`
+	StartDate     pgtype.Timestamptz `json:"start_date"`
+	MaxActiveRuns int32              `json:"max_active_runs"`
+	LastLogical   interface{}        `json:"last_logical"`
 }
 
 // Returns each cron-scheduled DAG with the bits the scheduler needs to decide
-// both "is there a slot due?" (schedule + last_logical) and "how many slots
-// should I backfill on this tick?" (catchup + start_date, see #129).
+// both "is there a slot due?" (schedule + last_logical), "how many slots
+// should I backfill on this tick?" (catchup + start_date, see #129), and
+// "may this DAG take another active run?" (max_active_runs, see #200).
 func (q *Queries) ListScheduledDags(ctx context.Context) ([]ListScheduledDagsRow, error) {
 	rows, err := q.db.Query(ctx, listScheduledDags)
 	if err != nil {
@@ -687,6 +689,7 @@ func (q *Queries) ListScheduledDags(ctx context.Context) ([]ListScheduledDagsRow
 			&i.Schedule,
 			&i.Catchup,
 			&i.StartDate,
+			&i.MaxActiveRuns,
 			&i.LastLogical,
 		); err != nil {
 			return nil, err

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -11,6 +11,20 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const countActiveDagRunsByDagID = `-- name: CountActiveDagRunsByDagID :one
+SELECT count(*) FROM dag_runs
+WHERE dag_id = $1 AND state IN ('queued', 'running')
+`
+
+// Counts queued+running runs for a single DAG; used by the manual-trigger
+// path to enforce max_active_runs (#200) before insert.
+func (q *Queries) CountActiveDagRunsByDagID(ctx context.Context, dagID pgtype.UUID) (int64, error) {
+	row := q.db.QueryRow(ctx, countActiveDagRunsByDagID, dagID)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const countDagRunStatesInWindow = `-- name: CountDagRunStatesInWindow :many
 SELECT r.state AS state, count(*) AS n
 FROM dag_runs r

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -212,11 +212,28 @@ func (r *Repository) DeleteDagRun(ctx context.Context, tenant, dagID, runID stri
 	return nil
 }
 
-// CreateDagRun inserts a new run for a DAG at its current version.
+// CreateDagRun inserts a new run for a DAG at its current version. The
+// per-DAG max_active_runs cap (#200) is enforced here for any caller that
+// goes through the repository — manual triggers via the API, scripted
+// backfills, and any future programmatic trigger path — so the contract
+// is honored in one place. A cap of zero is treated as "unlimited" to
+// match the scheduler path (see `Scheduler.hasHeadroom`). The check
+// races with concurrent inserts, but the small overshoot window is
+// bounded by the number of concurrent writers and lets us avoid an
+// advisory lock on the hot path.
 func (r *Repository) CreateDagRun(ctx context.Context, tenant, dagID string, run domain.DagRun) (domain.DagRun, error) {
 	dag, err := r.resolveDag(ctx, tenant, dagID)
 	if err != nil {
 		return domain.DagRun{}, err
+	}
+	if maxActive := int(dag.MaxActiveRuns); maxActive > 0 {
+		active, countErr := r.q.CountActiveDagRunsByDagID(ctx, dag.ID)
+		if countErr != nil {
+			return domain.DagRun{}, fmt.Errorf("counting active runs: %w", countErr)
+		}
+		if int(active) >= maxActive {
+			return domain.DagRun{}, fmt.Errorf("dag %q is at max_active_runs cap of %d: %w", dagID, maxActive, domain.ErrConflict)
+		}
 	}
 	created, err := r.q.CreateDagRun(ctx, queries.CreateDagRunParams{
 		TenantID:     dag.TenantID,

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -182,11 +182,12 @@ func (s *SchedulerStore) ScheduledDAGs(ctx context.Context) ([]scheduler.Schedul
 	out := make([]scheduler.ScheduledDAG, 0, len(rows))
 	for _, r := range rows {
 		out = append(out, scheduler.ScheduledDAG{
-			DagID:       r.DagID,
-			Schedule:    strOrEmpty(r.Schedule),
-			LastLogical: timeFromAny(r.LastLogical),
-			StartDate:   timePtr(r.StartDate),
-			Catchup:     r.Catchup,
+			DagID:         r.DagID,
+			Schedule:      strOrEmpty(r.Schedule),
+			LastLogical:   timeFromAny(r.LastLogical),
+			StartDate:     timePtr(r.StartDate),
+			Catchup:       r.Catchup,
+			MaxActiveRuns: int(r.MaxActiveRuns),
 		})
 	}
 	return out, nil

--- a/internal/storage/ui_queries_integration_test.go
+++ b/internal/storage/ui_queries_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -1083,5 +1084,69 @@ func TestClearRebindsRunToCurrentVersion(t *testing.T) {
 	}
 	if !hasLoad {
 		t.Errorf("after clear the run should re-bind to v2 (tasks include 'load'), got %v", tasks)
+	}
+}
+
+// TestCreateDagRunRespectsMaxActiveRunsIntegration: manual triggers must
+// honor the per-DAG `max_active_runs` cap (#200). Two active runs are
+// created against a DAG configured for at most 2; a third trigger must
+// fail with a conflict error (mapped to 409 at the API layer). The cap
+// counts queued+running; terminal runs do not count, so after one run is
+// marked success the next trigger succeeds again.
+func TestCreateDagRunRespectsMaxActiveRunsIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+
+	dagID := fmt.Sprintf("max_active_runs_cap_%d", time.Now().UnixNano())
+	spec := domain.DAGSpec{
+		SchemaVersion: "1.0", DagID: dagID, DagVersion: "v1", Image: "img:v1",
+		MaxActiveRuns: 2,
+		Tasks:         []domain.TaskSpec{{TaskID: "t", Type: domain.TaskTypePython}},
+	}
+	hash, err := spec.CanonicalHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created, rerr := repo.RegisterDagVersion(ctx, "default", spec, hash); rerr != nil || !created {
+		t.Fatalf("register: created=%v err=%v", created, rerr)
+	}
+
+	for i := 0; i < 2; i++ {
+		if _, err := repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+			RunID:       fmt.Sprintf("manual__%d", i),
+			State:       domain.DagRunStateRunning,
+			RunType:     "manual",
+			LogicalDate: time.Now().UTC().Add(time.Duration(i) * time.Second),
+		}); err != nil {
+			t.Fatalf("create run %d: %v", i, err)
+		}
+	}
+
+	_, err = repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+		RunID:       "manual__overflow",
+		State:       domain.DagRunStateRunning,
+		RunType:     "manual",
+		LogicalDate: time.Now().UTC().Add(3 * time.Second),
+	})
+	if err == nil {
+		t.Fatal("third trigger past max_active_runs=2 should have failed")
+	}
+	if !errors.Is(err, domain.ErrConflict) {
+		t.Errorf("third trigger should return domain.ErrConflict (mapped to 409), got %v", err)
+	}
+	if !strings.Contains(err.Error(), "max_active_runs") {
+		t.Errorf("error should mention max_active_runs so users see why, got %q", err.Error())
+	}
+
+	// Terminal runs free a slot — mark one success and the next trigger succeeds.
+	if err := repo.SetDagRunState(ctx, "default", dagID, "manual__0", string(domain.DagRunStateSuccess)); err != nil {
+		t.Fatalf("setting first run success: %v", err)
+	}
+	if _, err := repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+		RunID:       "manual__after_free",
+		State:       domain.DagRunStateRunning,
+		RunType:     "manual",
+		LogicalDate: time.Now().UTC().Add(4 * time.Second),
+	}); err != nil {
+		t.Fatalf("after freeing a slot the trigger should succeed: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Wires the existing `dags.max_active_runs` column (default 16, present since migration 002) into both the scheduler **and** the manual-trigger API. Before this PR the cap was visible in the UI but never enforced — a catchup window or a backfill script could create unbounded concurrent runs and exhaust executor capacity for a single DAG.

Surfaced by the resilience audit (#200) as a contract bug: Airflow's `max_active_runs` is documented as a hard cap, and we expose the field in the DAG details DTO but neither the scheduler nor the API honored it.

## What changed

**Scheduler side** (`internal/scheduler/scheduler.go`):
- `ListScheduledDags` returns `max_active_runs` alongside the catchup bits (#129).
- `Step` counts active runs per DAG from the already-loaded `ActiveRuns()` result — no extra query.
- `createDueRuns` receives the per-DAG active count and folds in the creations it makes within the same tick, so a single tick cannot itself breach the cap.
- Cap-hit slots are skipped (not queued). A `max_active_runs_cap` metric label surfaces the bottleneck without per-DAG cardinality.

**API side** (`internal/storage/repository.go`):
- `CreateDagRun` (the manual-trigger path) now counts active runs and returns `domain.ErrConflict` (mapped to HTTP 409) when at the cap. The error message names the cap value so users see why.

## Semantics

- A cap of `0` is treated as "unlimited" — defensive guard for hand-edited rows; the DB column is `NOT NULL DEFAULT 16` and the repository upsert defaults missing values to 16, so this only matters if someone writes the table directly.
- `@once` schedules ignore the cap by design — they fire exactly once via the `LastLogical` invariant.
- Manual triggers race on count-then-insert; the overshoot window is bounded by concurrent writers, which lets us skip an advisory lock on the hot path.

## Behavior change to be aware of

DAGs with `catchup=true` and a stale `LastLogical` previously created up to `maxCatchupSlotsPerTick=100` runs per tick. Now they create at most `max_active_runs` (16 by default) per tick, and the rest follow on subsequent ticks as runs complete. **This is the intended Airflow contract**, but is observable.

Backfill scripts that fire >16 manual triggers in a tight loop will now receive 409 on the overflow. Pre-alpha is the right time to surface this.

## Scope split

`max_active_tasks` is a separate concern — filed as #207. It needs a new DB column, parser/compile plumbing, and a different enforcement point (`PlanRun`'s `scheduled → queued` promotion with cross-run aggregation).

## Review findings filed as follow-ups

- #208: scheduler followers also run `createDueRuns` (only the leader should)
- #209: scheduler aggregation is tenant-blind (single-tenant correct today; future trap)

## Test plan

- [x] Scheduler unit tests: at-cap → 0 new runs; cap=1 + 6h backfill → exactly 1; cap=0 → unlimited (defensive); @once respects single-shot regardless of cap
- [x] Repository integration test (real PG): 2 runs at cap=2 → 3rd returns ErrConflict with "max_active_runs" in the message; freeing a slot allows the next trigger
- [x] `go test ./...` clean
- [x] `golangci-lint run ./...` → 0 issues
- [x] Full storage integration suite green locally (real PG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)