### PR TITLE
docs: XCom storage + concurrent-write semantics; Lite serial dispatch callout

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -10,7 +10,7 @@ Leoflow keeps Airflow's vocabulary so the UI and mental model are familiar.
 | **DagRun** | One execution of a DAG, identified by `dag_id` + `logical_date`. |
 | **Logical date** | The "business" date of a run (Airflow 3's rename of `execution_date`). |
 | **Trigger rule** | When a task runs based on upstream states (`all_success`, `one_failed`, …). |
-| **XCom** | Small (≤256 KB) typed value passed between tasks. Stored in Redis. |
+| **XCom** | Small (≤256 KB) typed value passed between tasks. Stored in **Postgres** on Lite (no Redis, see [ADR 0026](adr/0026-lite-datastore-no-redis.md)) and in **Redis** on Production. Writes are **last-write-wins** — two parallel tasks pushing the same key produce the later write with no conflict detection ([#198](https://github.com/neochaotic/leoflow/issues/198)). |
 | **Executor** | Runs a task physically: Kubernetes (pod-per-task), subprocess (dev), or inline. |
 | **Agent** | Small Go binary (PID 1) inside the task container that talks gRPC to the control plane. |
 

--- a/docs/editions.md
+++ b/docs/editions.md
@@ -60,6 +60,16 @@ restart), which suits light production, and a single datastore is simpler to
 operate; Redis is a Production-scale concern (multi-node locking, high XCom
 throughput). (See [ADR 0026](adr/0026-lite-datastore-no-redis.md).)
 
+!!! info "Task dispatch is serial on Lite (by design)"
+    Lite's [BufferedDispatcher](adr/0031-scheduler-architecture.md) uses
+    `BufferSize=0` — task dispatch runs synchronously on the scheduler tick, one
+    task at a time. A fan-out DAG with N parallel branches still **executes** in
+    parallel inside the cluster (real pods, or subprocesses), but the **launch**
+    of those tasks is serialized through one goroutine. This is what makes Lite
+    cheap to operate on a single machine. For higher launch throughput, Production
+    uses `BufferSize>0` + `Workers>1` (a bounded pool).
+    See [#203](https://github.com/neochaotic/leoflow/issues/203) for the rationale.
+
 For task execution, the **k3d** path runs real pods and therefore **requires Docker
 to host the cluster** — but Docker is only the *substrate* of k3d, never an executor:
 Lite talks to the Kubernetes API, and a Docker-socket executor was rejected because


### PR DESCRIPTION
## Summary

Two cheap pre-alpha doc fixes from the resilience-audit triage. Closes #198 and #203.

- **concepts.md**: the XCom glossary row claimed "Stored in Redis" — stale since Lite went no-Redis (ADR 0026, Postgres-backed XCom). Updated to name both backends and document the **last-write-wins** concurrent-write semantic so users don't assume transactional isolation across parallel `xcom_push` calls.
- **editions.md**: add a Lite-section info callout explaining that `BufferSize=0` serializes task **dispatch**, while task **execution** still runs in parallel inside the cluster — a frequent confusion when a fan-out DAG looks "slow to launch" on Lite. Links to ADR 0031 (scheduler architecture) and the rationale issue.

Both findings were filed during the resilience-audit pass on 2026-05-31 and are non-bug docs polish; shipping inline keeps the alpha bar tight.

## Test plan

- [x] Verified ADR 0026 and ADR 0031 file references resolve (`docs/adr/0026-lite-datastore-no-redis.md`, `docs/adr/0031-scheduler-architecture.md`).
- [x] Pre-commit gates clean.
- [ ] CI mkdocs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)