### PR TITLE
docs: 6 medium AAA-pass fixes (refs #91, #217)

### DIFF
--- a/docs/connections/postgres.md
+++ b/docs/connections/postgres.md
@@ -24,7 +24,7 @@ covered by `TestConnectionDeliveryChainOfCustodyIntegration` — see #138.
 | Host | yes | DNS name or IP. From inside a k3d cluster use `host.k3d.internal` for a host-bound port. |
 | Schema | optional | The database name (Postgres calls it a "database"; Airflow calls it "schema" for historical reasons). Defaults vary by driver. |
 | Login | yes | The Postgres role. |
-| Password | yes | Stored encrypted at rest (ADR 0019). The UI never shows it again after save; use `leoflow lite reset-password` analogue is N/A — delete + recreate the Connection. |
+| Password | yes | Stored encrypted at rest (ADR 0019). The UI never shows the password again after save — to rotate it, edit the Connection and re-enter the password (or delete + recreate). |
 | Port | optional | Defaults to `5432`. |
 | Extra | optional | A JSON object — e.g. `{"sslmode":"require"}`. Stored encrypted at rest alongside the password. |
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -149,6 +149,8 @@ go install github.com/neochaotic/leoflow/cmd/leoflow-agent@latest
 leoflow setup
 ```
 
+The subsequent `leoflow setup` will download a managed Python under `~/.leoflow/` — the same managed runtime the install-script path uses, with no expiry.
+
 A source build is not stamped with an expiry, so it never expires.
 
 ## Uninstalling

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,12 +5,11 @@
 | Symptom | Cause / fix |
 |---|---|
 | `command not found: leoflow` | Not on PATH — `go install …/cmd/leoflow@latest` and add `$(go env GOPATH)/bin` to PATH. |
-| `docker compose up … no such file` | Run `leoflow lite` from the leoflow source tree, or use `--no-up` with deps already running. |
 | Task pod `ErrImagePull` | The DAG's image isn't in the cluster — rebuild + import (cluster-mode rebuilds on save; for a manual push, `leoflow compile --build --push`). |
 | Run stuck at `queued` (subprocess) | The agent must reach the control plane — dev uses `127.0.0.1:<grpc>`; the executor launches async and the agent reports state over gRPC. |
 | `Invalid credentials` in the UI | Type the password manually (autofill may add a trailing space; usernames are trimmed, passwords are not). |
-| No `DEV` marker on `localhost:8080` | That's the **Demo** (production-like) — the DEV marker is on `leoflow lite` (`:8088`). See [operating modes](operating-modes.md). |
-| `provision incomplete: dev database` | Postgres isn't up — start deps (`leoflow lite provision`) or `--no-up` against a running Postgres. |
+| No **Lite** badge on `http://localhost:8088` | That's the **Demo** (production-like) — the **Lite** badge is on `leoflow lite` (`:8088`). See [operating modes](operating-modes.md). |
+| `provision incomplete: dev database` | Postgres isn't up — end-users run `leoflow setup` to bootstrap. (`leoflow lite provision` is the contributor variant for a source checkout.) |
 
 ## Logs
 Task logs stream from the agent over gRPC to the control plane's log sink and are

--- a/docs/variables-connections.md
+++ b/docs/variables-connections.md
@@ -5,6 +5,11 @@ secrets encrypted at rest, AES-256-GCM — ADR 0019) and delivers them to task p
 at runtime as environment variables, so your task reads them with the **native
 Airflow APIs** *and* as plain env (ADR 0021).
 
+!!! note "Tenancy"
+    Tenancy is single-tenant on Lite; Pro adds multi-tenant isolation. The agent
+    injects the current tenant's Variables/Connections per
+    [ADR 0019](adr/0019-secret-encryption-at-rest.md).
+
 ## Manage them
 Via the Airflow-compatible UI (Admin → Variables / Connections) or the API:
 


### PR DESCRIPTION
## Summary

6 medium-severity docs polish from #217 (the AAA-pass backlog). All small, surgical rewordings — no structural changes — to resolve user-visible papercuts before the alpha cut.

| # | File | What |
|---|---|---|
| #DR-6 | `troubleshooting.md` | Drop the "leoflow source tree" row (end-users installed via `install.sh` don't have one) |
| #DR-7 | `troubleshooting.md` | "No Lite badge on `http://localhost:8088`" — badge name + port both corrected |
| #DR-8 | `troubleshooting.md` | Point end-users at `leoflow setup`; note `leoflow lite provision` is the contributor variant |
| #DR-11 | `variables-connections.md` | Add a top-of-page admonition documenting single-tenant Lite vs multi-tenant Pro (links to ADR 0019) |
| #DR-13 | `connections/postgres.md` | Rewrite the password row to explain rotation (edit + re-enter or delete + recreate) |
| #DR-14 | `installation.md` | One-sentence note that `leoflow setup` downloads the managed Python under `~/.leoflow/` with no expiry |

10 lines added, 4 removed across 4 files. Refs the umbrella #217.

## Test plan

- [x] Pre-commit gates clean (golangci-lint v2.12.2, ruff, full test suite, coverage 78.5% ≥ 78% floor).
- [ ] CI mkdocs build (link anchors validated locally).

Authored by a sub-agent in parallel with the inline #D15/#D4 work; the orchestrator committed it after sorting the working-tree state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)