### PR TITLE
docs(deploy): document BYO Python on the runner for Pro CI builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -260,11 +260,19 @@ jobs:
         run: redocly lint docs/api/openapi.yaml
 
   # ─────────────────────────────────────────────────────────────────────
-  # Python parser tests
-  # ─────────────────────────────────────────────────────────────────────
+  # Python parser tests — matrix across every Python the host detector
+  # claims to support (`internal/setup/detect.go` pythonCandidates). If a
+  # new minor is added to that list, add it here too — otherwise the
+  # detector promises compatibility we never verified, which is exactly
+  # the silent-regression risk #220 (F2) flagged. Only 3.11/3.12/3.13 are
+  # generally available today; bump as 3.14+ ship and stabilise.
   python-parser:
-    name: Python parser tests
+    name: Python parser tests (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
     defaults:
       run:
         working-directory: parser
@@ -272,7 +280,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.python-version }}
 
       - name: Install
         run: |

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -23,8 +23,34 @@ flowchart LR
 
 ## Prerequisites
 - The `leoflow` CLI on the runner (download the release binary, or `go install`).
+- **Python 3.11+ on the runner** (`leoflow compile` invokes the stdlib-only
+  parser shim — [ADR 0024](adr/0024-dag-parsing-structural-shim.md) — to turn `dag.py`
+  into `dag.json`). See [Python on the runner](#python-on-the-runner) below.
 - A container registry your cluster can pull from.
 - `LEOFLOW_SERVER` (control plane URL) and `LEOFLOW_TOKEN` (a push token) as CI secrets.
+
+## Python on the runner
+
+The `leoflow compile` step needs Python 3.11, 3.12, or 3.13 to parse `dag.py`.
+**Bring your own Python** on the runner — do not rely on `leoflow setup` to
+download a managed CPython in CI (that path is designed for first-touch on a
+developer laptop, not for build pipelines, where it adds ~50 MB to every run
+and bypasses your runner's pin/caching).
+
+The recommended path on each runner type:
+
+| Runner | Recipe |
+|---|---|
+| **GitHub Actions** | Add `actions/setup-python@v5` with `python-version: '3.12'` before installing leoflow. Cached automatically. |
+| **GitLab CI** | Use a `python:3.12-slim` (or `python:3.12-bookworm`) base image instead of a bare `alpine`/`ubuntu`. |
+| **Cloud Build / CodeBuild** | Use a `python:3.x-slim` build step, or one of the cloud-provider's "python3.12" images. |
+| **Self-hosted runners** | Pin Python via your image baseline (`apt install python3.12` or `pyenv`) and version-lock in your runner provisioning. |
+| **Generic Docker-in-Docker** | Base your build container on `python:3.12-slim` (gives you Python + a Debian userland for the `docker build` shell). |
+
+Older Python (≤3.10) fails the compile cleanly — `leoflow compile` errors out
+with the version requirement, not a confusing traceback. Newer Python (3.14+)
+is accepted by the upper end of the detection range; the range is bumped per
+release once the parser shim is re-verified against it.
 
 ## Examples
 
@@ -42,6 +68,8 @@ flowchart LR
         permissions: { contents: read, packages: write }
         steps:
           - uses: actions/checkout@v4
+          - uses: actions/setup-python@v5     # BYO Python — see #python-on-the-runner
+            with: { python-version: '3.12' }
           - uses: docker/login-action@v3
             with:
               registry: ghcr.io
@@ -62,8 +90,13 @@ flowchart LR
 
     ```yaml title=".gitlab-ci.yml"
     deploy_dag:
+      # Default docker:27 is Alpine-based; install python3 before leoflow compile.
+      # Alternative: a custom base image that bakes Python+Docker together.
+      # See #python-on-the-runner for the rationale.
       image: docker:27
       services: [docker:27-dind]
+      before_script:
+        - apk add --no-cache python3   # 3.12 on Alpine 3.20+; see #python-on-the-runner
       rules:
         - if: $CI_COMMIT_BRANCH == "main"
           changes: ["dags/my_pipeline/**/*"]
@@ -88,6 +121,9 @@ flowchart LR
         args:
           - -c
           - |
+            # BYO Python — Cloud Builders' docker image is Debian; install python3.
+            # See #python-on-the-runner for the rationale.
+            apt-get update -qq && apt-get install -y --no-install-recommends python3
             curl -fsSL https://github.com/neochaotic/leoflow/releases/latest/download/leoflow-linux-amd64 -o /usr/bin/leoflow && chmod +x /usr/bin/leoflow
             IMAGE="$_REGION-docker.pkg.dev/$PROJECT_ID/dags/my_pipeline:$SHORT_SHA"
             leoflow compile dags/my_pipeline --image "$$IMAGE" --build --push -o dag.json
@@ -100,7 +136,8 @@ flowchart LR
 
 === "Generic / Makefile"
 
-    Any runner with Docker + the `leoflow` CLI:
+    Any runner with Docker, **Python 3.11+**, and the `leoflow` CLI
+    (see [Python on the runner](#python-on-the-runner)):
 
     ```bash
     IMAGE="$REGISTRY/my_pipeline:$(git rev-parse --short HEAD)"

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -52,6 +52,23 @@ with the version requirement, not a confusing traceback. Newer Python (3.14+)
 is accepted by the upper end of the detection range; the range is bumped per
 release once the parser shim is re-verified against it.
 
+### One more step: `leoflow setup` extracts the parser
+
+After the `leoflow` binary lands on the runner and Python is in scope, run
+`leoflow setup` ONCE per runner. The CLI ships the parser source embedded;
+`setup` extracts it under `~/.leoflow/pysrc/parser/` and writes a config
+file pointing the `compile` command at the chosen interpreter. Without this
+step `leoflow compile` fails with `No module named leoflow_parser` (the
+runner's Python has no idea where the parser lives).
+
+The snippets below all show `leoflow setup` as the step after the install,
+before `leoflow compile`. The follow-up to make this implicit (auto-bootstrap
+on first compile, or embed the parser execution inside the Go binary) is
+tracked separately; for the alpha cut, calling it explicitly is the
+recommended path because it's the operation that decides whether managed
+CPython is downloaded, and that's a step CI operators should consciously opt
+into.
+
 ## Examples
 
 === "GitHub Actions"
@@ -77,6 +94,8 @@ release once the parser shim is re-verified against it.
               password: ${{ secrets.GITHUB_TOKEN }}
           - name: Install leoflow
             run: curl -fsSL https://github.com/neochaotic/leoflow/releases/latest/download/leoflow-linux-amd64 -o /usr/local/bin/leoflow && chmod +x /usr/local/bin/leoflow
+          - name: Bootstrap the parser (uses the BYO Python from above)
+            run: leoflow setup
           - name: Compile + build + push image
             run: |
               IMAGE=ghcr.io/${{ github.repository }}/my_pipeline:${{ github.sha }}
@@ -105,6 +124,7 @@ release once the parser shim is re-verified against it.
       script:
         - echo "$CI_REGISTRY_PASSWORD" | docker login -u "$CI_REGISTRY_USER" --password-stdin "$CI_REGISTRY"
         - wget -qO /usr/local/bin/leoflow https://github.com/neochaotic/leoflow/releases/latest/download/leoflow-linux-amd64 && chmod +x /usr/local/bin/leoflow
+        - leoflow setup        # extracts the parser into ~/.leoflow/ using the python3 from before_script
         - leoflow compile dags/my_pipeline --image "$IMAGE" --build --push -o dag.json
         - leoflow push dag.json --server "$LEOFLOW_SERVER"   # LEOFLOW_TOKEN from CI vars
     ```
@@ -125,6 +145,7 @@ release once the parser shim is re-verified against it.
             # See #python-on-the-runner for the rationale.
             apt-get update -qq && apt-get install -y --no-install-recommends python3
             curl -fsSL https://github.com/neochaotic/leoflow/releases/latest/download/leoflow-linux-amd64 -o /usr/bin/leoflow && chmod +x /usr/bin/leoflow
+            leoflow setup    # extracts the parser into ~/.leoflow/ using the python3 just installed
             IMAGE="$_REGION-docker.pkg.dev/$PROJECT_ID/dags/my_pipeline:$SHORT_SHA"
             leoflow compile dags/my_pipeline --image "$$IMAGE" --build --push -o dag.json
             leoflow push dag.json --server "$_LEOFLOW_SERVER"
@@ -140,6 +161,7 @@ release once the parser shim is re-verified against it.
     (see [Python on the runner](#python-on-the-runner)):
 
     ```bash
+    leoflow setup    # one-shot per runner: extracts the parser into ~/.leoflow/
     IMAGE="$REGISTRY/my_pipeline:$(git rev-parse --short HEAD)"
     leoflow compile dags/my_pipeline --image "$IMAGE" --build --push -o dag.json
     leoflow push dag.json --server "$LEOFLOW_SERVER" --token "$LEOFLOW_TOKEN"

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -150,6 +150,65 @@ func TestValidateGracefulWithoutPython(t *testing.T) {
 	}
 }
 
+// TestCompileFailThenRecoverIsClean covers the out-of-order scenario surfaced
+// during the BYO-Python deploy-docs review: a CI user who runs
+// `leoflow compile` before `leoflow setup` (or before a working parser_cmd
+// is in scope) sees a clean failure, and a subsequent run with the parser
+// correctly wired succeeds — no partial dag.json, no stale state from the
+// failed attempt that would poison the recovery.
+//
+// The contract here is "fail early, leave nothing behind". We do not test
+// `leoflow setup` end-to-end (that path provisions a managed Python on disk,
+// which a unit test cannot afford); we simulate "fixed parser_cmd" by
+// swapping the failing parser command for a working fake on the second run.
+func TestCompileFailThenRecoverIsClean(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "proj")
+	if _, _, err := run(t, "init", dir); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(dir, "dag.json")
+
+	// Step 1 — broken parser command. compile must fail.
+	brokenParser := filepath.Join(t.TempDir(), "broken-parser.sh")
+	brokenScript := "#!/usr/bin/env bash\necho 'No module named leoflow_parser' >&2\nexit 1\n"
+	if err := os.WriteFile(brokenParser, []byte(brokenScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := run(t, "compile", dir, "--output", out, "--image", "test:v1", "--parser-cmd", brokenParser); err == nil {
+		t.Fatal("compile with a broken parser-cmd should fail, but it succeeded")
+	}
+	if _, err := os.Stat(out); err == nil {
+		t.Fatalf("compile fail must NOT have written %s — found stale output that would mask the next run", out)
+	}
+
+	// Step 2 — supply a working parser_cmd (the recovery the user would do by
+	// running `leoflow setup` in real life). compile must succeed cleanly.
+	goodParser := filepath.Join(t.TempDir(), "good-parser.sh")
+	goodScript := "#!/usr/bin/env bash\n" +
+		"out=\"\"\n" +
+		"while [ $# -gt 0 ]; do case \"$1\" in --output) out=\"$2\"; shift 2;; *) shift;; esac; done\n" +
+		"cat > \"$out\" <<'JSON'\n" +
+		"{\"schema_version\":\"1.0\",\"dag_id\":\"proj\",\"dag_version\":\"dev\",\"image\":\"test:v1\",\"tasks\":[{\"task_id\":\"hello\",\"type\":\"python\",\"entrypoint\":\"dag:hello\"}]}\n" +
+		"JSON\n"
+	if err := os.WriteFile(goodParser, []byte(goodScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := run(t, "compile", dir, "--output", out, "--image", "test:v1", "--parser-cmd", goodParser); err != nil {
+		t.Fatalf("compile with a working parser-cmd should recover after a prior failure, got %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("dag.json missing after recovery: %v", err)
+	}
+	var spec domain.DAGSpec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("dag.json from recovery is invalid: %v", err)
+	}
+	if err := spec.Validate(); err != nil {
+		t.Errorf("recovered dag.json does not pass schema validation: %v", err)
+	}
+}
+
 func TestCompileProducesValidDAGJSON(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "proj")
 	if _, _, err := run(t, "init", dir); err != nil {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -150,6 +150,78 @@ func TestValidateGracefulWithoutPython(t *testing.T) {
 	}
 }
 
+// TestCompileRecoversAfterConfigUpdate covers the EXACT user scenario from
+// the BYO-Python docs review: run `leoflow compile` before `leoflow setup`
+// (so the default parser_cmd has no module to load), then "fix the state"
+// by writing a working parser_cmd into ~/.leoflow/config.yaml (which is
+// what `leoflow setup` does in real life), then re-run compile WITHOUT any
+// flag override and confirm it picks up the new config and succeeds.
+//
+// This is the file-state version of TestCompileFailThenRecoverIsClean
+// below — that one swaps the --parser-cmd flag between runs, which proves
+// flag overrides recover cleanly but does NOT prove that the config-file
+// read path picks up a fresh value after a previous failed invocation.
+func TestCompileRecoversAfterConfigUpdate(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	leoflowDir := filepath.Join(home, ".leoflow")
+	if err := os.MkdirAll(leoflowDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(leoflowDir, "config.yaml")
+
+	dir := filepath.Join(t.TempDir(), "proj")
+	if _, _, err := run(t, "init", dir); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(dir, "dag.json")
+
+	brokenParser := filepath.Join(t.TempDir(), "broken-parser.sh")
+	if err := os.WriteFile(brokenParser, []byte("#!/usr/bin/env bash\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte("parser_cmd: \""+brokenParser+"\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := run(t, "compile", dir, "--output", out, "--image", "test:v1"); err == nil {
+		t.Fatal("compile should fail when config's parser_cmd is broken")
+	}
+	if _, err := os.Stat(out); err == nil {
+		t.Fatalf("compile fail left a stale %s — recovery via config update would be poisoned", out)
+	}
+
+	// Simulate `leoflow setup` having just landed: overwrite the config with
+	// a working parser_cmd. The next compile must pick up the new value
+	// (no in-process caching of the file content from the previous run).
+	goodParser := filepath.Join(t.TempDir(), "good-parser.sh")
+	goodScript := "#!/usr/bin/env bash\n" +
+		"out=\"\"\n" +
+		"while [ $# -gt 0 ]; do case \"$1\" in --output) out=\"$2\"; shift 2;; *) shift;; esac; done\n" +
+		"cat > \"$out\" <<'JSON'\n" +
+		"{\"schema_version\":\"1.0\",\"dag_id\":\"proj\",\"dag_version\":\"dev\",\"image\":\"test:v1\",\"tasks\":[{\"task_id\":\"hello\",\"type\":\"python\",\"entrypoint\":\"dag:hello\"}]}\n" +
+		"JSON\n"
+	if err := os.WriteFile(goodParser, []byte(goodScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte("parser_cmd: \""+goodParser+"\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := run(t, "compile", dir, "--output", out, "--image", "test:v1"); err != nil {
+		t.Fatalf("compile must recover after the config's parser_cmd is fixed, got %v", err)
+	}
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("dag.json missing after config-update recovery: %v", err)
+	}
+	var spec domain.DAGSpec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("recovered dag.json is invalid JSON: %v", err)
+	}
+	if err := spec.Validate(); err != nil {
+		t.Errorf("recovered dag.json does not pass schema validation: %v", err)
+	}
+}
+
 // TestCompileFailThenRecoverIsClean covers the out-of-order scenario surfaced
 // during the BYO-Python deploy-docs review: a CI user who runs
 // `leoflow compile` before `leoflow setup` (or before a working parser_cmd


### PR DESCRIPTION
## Summary

Documents the BYO Python pattern for Pro CI builds and adds two regression-prevention pieces surfaced by a critical self-review of the original docs change:

| Change | Why |
|---|---|
| `docs/deploy.md` Prerequisites + new "Python on the runner" section | Python was an undocumented prerequisite; the section names recipes for GHA, GitLab, Cloud Build, generic/self-hosted |
| `docs/deploy.md` snippets: add `leoflow setup` step | Discovery during review: BYO Python alone is insufficient — `leoflow compile` also needs the parser source extracted under `~/.leoflow/pysrc/` (which `setup` does using the BYO Python; no managed download when one is already in scope) |
| `docs/deploy.md` new subsection "One more step: `leoflow setup`" | Explains why setup is a separate explicit step (CI operators consciously decide whether to opt into the managed CPython download path) |
| **F2** `.github/workflows/ci.yaml` parser job → matrix on 3.11/3.12/3.13 | `detect.go` promises compatibility across the range; the parser CI was pinned to 3.11. A 3.12/3.13 regression would land silently |
| **F3** `TestCompileFailThenRecoverIsClean` (flag-override recovery) | Proves no state pollution when `--parser-cmd` swaps between a failing and a working command |
| **F3 extended** `TestCompileRecoversAfterConfigUpdate` (file-state recovery) | Same recovery contract via `~/.leoflow/config.yaml` mutation (matches the real `leoflow setup` flow); proves the file content isn't cached in-process |

## Tracked follow-ups

- **#222** — architectural: auto-bootstrap on compile, or fully embed the parser in the Go binary (eliminates this category of "out-of-order" friction entirely).
- **#220** — Lima + CI Python detection test plan, updated to reflect the `leoflow setup` requirement and to add rows 8/9 for the "wrong order then right order" scenario.
- Self-review remaining findings (F1 `python3` symlink probing, F4 docs caching guidance, F5 contributor-dogfood leak) — noted in the review punch list, not in this PR.

## Test plan

- [x] `go test ./...` clean
- [x] golangci-lint v2.12.2 clean
- [x] Both new CLI tests pass locally (`TestCompileFailThenRecoverIsClean` and `TestCompileRecoversAfterConfigUpdate`)
- [x] CI matrix expansion validated by running the same parser pytest against 3.11/3.12/3.13 locally (matrix lands on GHA)
- [x] ADR 0024 link target verified (`docs/adr/0024-dag-parsing-structural-shim.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)