### PR TITLE
docs(deploy): cache ~/.leoflow/ between CI runs (F4 from #221 review)

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -69,6 +69,15 @@ recommended path because it's the operation that decides whether managed
 CPython is downloaded, and that's a step CI operators should consciously opt
 into.
 
+!!! tip "Cache `~/.leoflow/` between CI runs"
+    Ephemeral CI runners re-extract the parser on every build (~3-5 s).
+    Cache the directory keyed by the leoflow binary version (or the leoflow
+    release URL) to skip it on warm runs:
+    `actions/cache` on GitHub Actions, `cache:` keys on GitLab CI, the
+    workspace cache on Cloud Build. With Python on PATH, the cache hit makes
+    `leoflow setup` a near-no-op. Skip the cache if your runner image
+    already bakes `~/.leoflow/pysrc/` in (some self-hosted setups do).
+
 ## Examples
 
 === "GitHub Actions"


### PR DESCRIPTION
F4 from the PR #221 self-review punch-list. Single tip callout added under the existing "One more step: \`leoflow setup\`" subsection telling CI operators to cache \`~/.leoflow/\` between runs so the parser re-extraction (~3-5s on every build) becomes a near-no-op on warm runs.

Per-CI-system primitive named: \`actions/cache\` (GHA), \`cache:\` keys (GitLab), workspace cache (Cloud Build). Self-hosted exception called out (some image baselines bake the directory in already).

🤖 Generated with [Claude Code](https://claude.com/claude-code)