### PR TITLE
fix(agent): enforce execution_timeout_seconds on pod-path tasks (closes #194)

### DIFF
--- a/docs/scheduler-resilience.md
+++ b/docs/scheduler-resilience.md
@@ -15,6 +15,7 @@ across the fleet.
 
 | Failure mode | Detected by | Default SLA | What happens |
 |---|---|---|---|
+| **Task code wedged past its declared `execution_timeout_seconds`** | **Agent itself** ([#194](https://github.com/neochaotic/leoflow/issues/194)) | **`execution_timeout_seconds`** (per-task) | **TI failed with `execution_timeout: task exceeded N`. Retries kick in if budget remains.** |
 | Agent process crashed mid-task (TI in `running`, no heartbeat) | TI heartbeat reaper ([#128](https://github.com/neochaotic/leoflow/issues/128)) | **90 s** | TI failed with `agent_lost`. Retries kick in if budget remains. |
 | Scheduler crashed before dispatching (TI stuck in `queued`) | Dispatch-lost reaper ([#202](https://github.com/neochaotic/leoflow/issues/202)) | **3 min** | TI failed with `dispatch_lost`. Frees the run for the orphan reaper on the next tick. |
 | Run stuck `running` with no active TIs (post-crash limbo) | Orphan-run reaper ([#120](https://github.com/neochaotic/leoflow/issues/120)) | **5 min** | Run failed with `orphaned`; any remaining active TIs flipped to `failed`. |

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -77,7 +77,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return r.execute(ctx, argv, env)
+	return r.execute(ctx, argv, env, time.Duration(spec.GetExecutionTimeoutSeconds())*time.Second)
 }
 
 func (r *Runner) register(ctx context.Context) error {
@@ -149,7 +149,7 @@ func (r *Runner) secretsEnv(ctx context.Context) []string {
 	return out
 }
 
-func (r *Runner) execute(ctx context.Context, argv, env []string) error {
+func (r *Runner) execute(ctx context.Context, argv, env []string, timeout time.Duration) error {
 	if err := r.report(ctx, agentv1.TaskState_TASK_STATE_RUNNING, 0, ""); err != nil {
 		return err
 	}
@@ -162,11 +162,24 @@ func (r *Runner) execute(ctx context.Context, argv, env []string) error {
 		go r.heartbeat(runCtx, cancel)
 	}
 
+	// `execution_timeout_seconds` enforcement (#194): wrap the runCtx in a
+	// deadline so a wedged user process is interrupted at the boundary the user
+	// declared, not at the 90 s heartbeat reaper. Zero (unset) preserves the
+	// previous "no time bound" behavior. The deadline-fired vs heartbeat-canceled
+	// vs parent-canceled cases are disambiguated below by inspecting
+	// timeoutCtx.Err() after Cmd.Run returns.
+	timeoutCtx := runCtx
+	if timeout > 0 {
+		var timeoutCancel context.CancelFunc
+		timeoutCtx, timeoutCancel = context.WithTimeout(runCtx, timeout)
+		defer timeoutCancel()
+	}
+
 	// Frame the run so a task with no print() still has visible logs in the UI —
 	// matching real Airflow, which always emits start/end framing (#119).
 	start := time.Now()
 	emitTaskStarted(r.Sink)
-	exitCode, runErr := r.Cmd.Run(runCtx, argv, env, stdout, stderr)
+	exitCode, runErr := r.Cmd.Run(timeoutCtx, argv, env, stdout, stderr)
 	stdout.flush()
 	stderr.flush()
 	emitTaskEnded(r.Sink, exitCode, runErr, time.Since(start))
@@ -174,6 +187,13 @@ func (r *Runner) execute(ctx context.Context, argv, env []string) error {
 		slog.Warn("closing log stream", "error", cerr)
 	}
 
+	// Override the failure reason when the timeout fired. The check is on
+	// timeoutCtx (not runCtx or ctx) so a heartbeat-driven cancel or a
+	// parent SIGTERM still flows through the generic fail path.
+	if timeout > 0 && errors.Is(timeoutCtx.Err(), context.DeadlineExceeded) {
+		msg := fmt.Sprintf("execution_timeout: task exceeded %s limit", timeout)
+		return r.failWithReason(ctx, exitCode, msg)
+	}
 	if runErr != nil || exitCode != 0 {
 		return r.fail(ctx, exitCode, runErr)
 	}
@@ -181,6 +201,16 @@ func (r *Runner) execute(ctx context.Context, argv, env []string) error {
 		return r.fail(ctx, 0, err)
 	}
 	return r.report(ctx, agentv1.TaskState_TASK_STATE_SUCCESS, 0, "")
+}
+
+// failWithReason is fail() but with a pre-built error message — used by the
+// execution_timeout path so the operator sees "timeout" rather than the
+// generic "task exited non-zero" or the raw context.DeadlineExceeded.
+func (r *Runner) failWithReason(ctx context.Context, exitCode int, msg string) error {
+	if rerr := r.report(ctx, agentv1.TaskState_TASK_STATE_FAILED, clampExit(exitCode), msg); rerr != nil {
+		slog.Warn("reporting failed state", "error", rerr)
+	}
+	return errors.New(msg)
 }
 
 func (r *Runner) fail(ctx context.Context, exitCode int, cause error) error {

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -21,6 +21,7 @@ type fakeClient struct {
 	spec               *agentv1.TaskSpec
 	xcom               map[string]*agentv1.FetchXComResponse
 	states             []agentv1.TaskState
+	reports            []*agentv1.ReportStateRequest
 	pushed             []*agentv1.PushXComRequest
 	registered         bool
 	terminateAt        agentv1.TaskState // state for which ReportState returns should_terminate
@@ -72,6 +73,7 @@ func (f *fakeClient) StreamLogs(context.Context, ...grpc.CallOption) (grpc.BidiS
 
 func (f *fakeClient) ReportState(_ context.Context, in *agentv1.ReportStateRequest, _ ...grpc.CallOption) (*agentv1.ReportStateResponse, error) {
 	f.states = append(f.states, in.GetState())
+	f.reports = append(f.reports, in)
 	return &agentv1.ReportStateResponse{Acknowledged: true, ShouldTerminate: in.GetState() == f.terminateAt}, nil
 }
 
@@ -277,6 +279,61 @@ func TestRunnerHeartbeatCancelsOnTerminate(t *testing.T) {
 	}
 	if last := client.states[len(client.states)-1]; last != agentv1.TaskState_TASK_STATE_FAILED {
 		t.Errorf("final state = %v, want failed after termination", last)
+	}
+}
+
+// TestRunnerEnforcesExecutionTimeout covers issue #194: the pod-path agent must
+// stop a task that exceeds its declared execution_timeout_seconds, not rely on
+// the scheduler's 90 s heartbeat reaper (which leaves the wedged user code
+// running until the agent itself notices). When the timeout fires, the failure
+// is reported with a clear "execution_timeout" message so the operator can
+// distinguish it from a crash or an exit-code failure.
+func TestRunnerEnforcesExecutionTimeout(t *testing.T) {
+	client := &fakeClient{
+		spec: &agentv1.TaskSpec{
+			Operator:                "bash",
+			Entrypoint:              "sleep 1000",
+			ExecutionTimeoutSeconds: 1, // proto carries seconds; the implementation uses time.Duration
+		},
+	}
+	cmd := &fakeCmd{blockUntilCancel: true}
+	r := newRunner(client, cmd, &recordingSink{})
+
+	if err := r.Run(context.Background()); err == nil {
+		t.Fatal("a task that exceeds its execution_timeout_seconds must fail")
+	}
+	if last := client.states[len(client.states)-1]; last != agentv1.TaskState_TASK_STATE_FAILED {
+		t.Errorf("final state = %v, want failed after timeout", last)
+	}
+	// The terminal report must name the failure as a timeout (not "task exited
+	// non-zero"), so the user can tell a hang from a crash.
+	if n := len(client.reports); n > 0 {
+		got := client.reports[n-1].GetErrorMessage()
+		if !strings.Contains(got, "execution_timeout") {
+			t.Errorf("error message should name execution_timeout, got %q", got)
+		}
+	}
+}
+
+// TestRunnerHonorsZeroTimeout keeps the existing semantics for tasks with no
+// declared timeout (0): no time bound, the task runs until it finishes or the
+// agent process itself is canceled.
+func TestRunnerHonorsZeroTimeout(t *testing.T) {
+	client := &fakeClient{
+		spec: &agentv1.TaskSpec{
+			Operator:                "python",
+			Entrypoint:              "dag:fast",
+			ExecutionTimeoutSeconds: 0, // unset → no timeout applies
+		},
+	}
+	cmd := &fakeCmd{exitCode: 0}
+	r := newRunner(client, cmd, &recordingSink{})
+
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("zero execution_timeout_seconds must not interfere with a fast task: %v", err)
+	}
+	if last := client.states[len(client.states)-1]; last != agentv1.TaskState_TASK_STATE_SUCCESS {
+		t.Errorf("final state = %v, want success", last)
 	}
 }
 


### PR DESCRIPTION
## Summary

The **last severe contract bug** from the resilience audit. The agent fetched the TaskSpec but ignored \`ExecutionTimeoutSeconds\` — a wedged user process kept running until the scheduler's 90 s heartbeat reaper kicked in. That mitigation works when the agent itself crashes, but a healthy agent with wedged user code under a declared timeout was the gap: the user set "30 s max" and got "90 s + retry" silently.

The agent now wraps the user-process context in \`context.WithTimeout\` when \`ExecutionTimeoutSeconds &gt; 0\`. On deadline expiry it reports the failure as \`execution_timeout: task exceeded Ns limit\` (distinguishable from a generic exit-code failure or an agent-lost report), and the normal retry budget applies as for any other failure.

## What changed

- \`internal/agent/runner.go::execute\` accepts a \`timeout time.Duration\` and wraps \`runCtx\` in \`context.WithTimeout\` when nonzero.
- After \`Cmd.Run\` returns, \`timeoutCtx.Err() == context.DeadlineExceeded\` triggers a new \`failWithReason\` path that reports the failure as \`execution_timeout\` instead of "task exited non-zero".
- The check is on the timeout-bound context, not the heartbeat-canceled \`runCtx\` or the parent \`ctx\` — so control-plane \`should_terminate\` and parent SIGTERM still flow through the generic \`fail()\` path.

## Tests

- \`TestRunnerEnforcesExecutionTimeout\` — blocking task + \`ExecutionTimeoutSeconds=1\` → fails inside the budget with \`execution_timeout\` in the report.
- \`TestRunnerHonorsZeroTimeout\` — \`ExecutionTimeoutSeconds=0\` preserves the no-time-bound behavior (legacy spec safe).
- \`fakeClient\` extended to capture \`reports []*ReportStateRequest\` so error_message can be asserted.

## Docs

\`docs/scheduler-resilience.md\` SLA table updated: agent-side timeout enforcement is now the **first** defense, above the 90 s heartbeat reaper (now correctly framed as a backstop for crashed agents).

## Recovery model after this PR

| Failure | Defense | SLA |
|---|---|---|
| Task wedged past declared timeout (healthy agent) | **Agent (#194)** | **\`execution_timeout_seconds\`** (per-task) |
| Agent crashed mid-task | TI heartbeat reaper (#128) | 90 s |
| Scheduler crashed mid-dispatch | Dispatch-lost reaper (#202) | 3 min |
| Run stuck after all TIs settled | Orphan-run reaper (#120) | 5 min |

## Closes the alpha-prep contract-bug list

All 3 severes from the resilience audit are now closed: #201 retry_delay, #200 max_active_runs (+#206 manual trigger 409), #194 execution_timeout. The remaining open backlog (#207 max_active_tasks, #197 fairness, #208 followers, #209 tenant-blind) is post-alpha by triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)