### PR TITLE
fix(parser): reject branching / short-circuit / virtualenv / sensors at compile (closes #225)

### DIFF
--- a/docs/dag-authoring.md
+++ b/docs/dag-authoring.md
@@ -44,17 +44,19 @@ with DAG("my_pipeline", schedule="@daily", catchup=False, tags=["etl"]):
 
 ### Not (yet) supported — limitations
 
-- **Branching** (`BranchPythonOperator`, `@task.branch`): currently treated as a
-  plain `python` task, **losing the branch semantics** — avoid for now (a future
-  release will make this a hard compile error rather than a silent mistranslation).
-- **Dynamic task mapping** (`.expand` / `.partial`), **sensors**,
+- **Branching** (`BranchPythonOperator`, `@task.branch`), **short-circuit**
+  (`@task.short_circuit`, `ShortCircuitOperator`), **virtualenv operators**
+  (`PythonVirtualenvOperator`), **sensors** — `leoflow compile` **rejects** any
+  of these with a clear error naming the construct ([#225](https://github.com/neochaotic/leoflow/issues/225)).
+  Refusing silent mistranslation is the contract: every "skipped" branch
+  would otherwise actually execute at runtime.
+- **Dynamic task mapping** (`.expand` / `.partial`),
   **KubernetesPodOperator**, **datasets/assets** triggers, **Jinja templating**.
 - **Provider operators** (S3, Postgres, …): do the work inside a `@task` instead
   (your image already has the libraries).
 - **Per-task `default_args` in `dag.py`** are ignored; use `leoflow.yaml`.
 
-> Anything not translated is a **hard compile error** (no silent drop) — except
-> branching, noted above.
+> Anything not translated is a **hard compile error** (no silent drop).
 
 ## leoflow.yaml — deploy config
 

--- a/parser/leoflow_parser/compiler.py
+++ b/parser/leoflow_parser/compiler.py
@@ -185,6 +185,25 @@ def _map_task(task, source: str) -> dict[str, Any]:
 
 def _operator_type(task) -> str:
     name = type(task).__name__
+    # Reject silent-wrong-execution shapes BEFORE the substring catch-alls below
+    # (issue #225). BranchPythonOperator / ShortCircuitOperator / @task.branch
+    # all carry "Python" in their class name, so the legacy substring match used
+    # to translate them to a plain `python` task — and every "skipped" branch
+    # would then actually execute. Refusing them at compile is the loud failure
+    # the parser owes; remove the gate when real translation lands.
+    for marker, feature in (
+        ("Branch", "branching (@task.branch / BranchPythonOperator)"),
+        ("ShortCircuit", "short-circuit (@task.short_circuit / ShortCircuitOperator)"),
+        ("Virtualenv", "virtualenv operators (PythonVirtualenvOperator)"),
+        ("Sensor", "sensors (BaseSensorOperator and subclasses)"),
+    ):
+        if marker in name:
+            raise ValueError(
+                f"unsupported operator {name!r} on task {task.task_id!r}: "
+                f"{feature} is not supported by Leoflow yet — refusing to "
+                "silently mistranslate. See docs/dag-authoring.md for the "
+                "current supported operator list."
+            )
     if "Bash" in name:
         return "bash"
     if "Http" in name:

--- a/parser/tests/fixtures/branching_python_operator.py
+++ b/parser/tests/fixtures/branching_python_operator.py
@@ -1,0 +1,37 @@
+"""Branching DAG using BranchPythonOperator — the silently-mistranslated case.
+
+This fixture proves the parser REJECTS the construct rather than letting it
+through as a plain python task (which would silently run every downstream
+branch — issue #225). It uses a locally-defined operator subclass so the test
+runs regardless of which shim classes are exported.
+"""
+from __future__ import annotations
+
+from airflow.sdk import DAG, PythonOperator
+
+
+class BranchPythonOperator(PythonOperator):
+    """Stand-in for airflow.providers.standard.operators.python.BranchPythonOperator.
+
+    The parser's substring match on 'Python' used to translate this to a plain
+    python task — silently dropping the branch semantics.
+    """
+
+
+def _pick():
+    return "left"
+
+
+def _left():
+    pass
+
+
+def _right():
+    pass
+
+
+with DAG("branching_python_operator", schedule=None, catchup=False):
+    pick = BranchPythonOperator(task_id="pick", python_callable=_pick)
+    left = PythonOperator(task_id="left", python_callable=_left)
+    right = PythonOperator(task_id="right", python_callable=_right)
+    pick >> [left, right]

--- a/parser/tests/test_compiler.py
+++ b/parser/tests/test_compiler.py
@@ -99,6 +99,23 @@ def test_mixed_operators(tmp_path, dag_schema):
     assert tasks["notify"]["depends_on"] == ["transform"]
 
 
+# Issue #225: BranchPythonOperator (and friends) were silently translated to a
+# plain `python` task by the legacy substring-match in _operator_type — the
+# parser would compile a branching DAG and every "skipped" branch would
+# execute at runtime. The fix refuses these at compile time with a clear
+# error; this test locks the contract.
+def test_branching_python_operator_is_rejected(tmp_path):
+    with pytest.raises(ValueError) as excinfo:
+        _compile(tmp_path, "branching_python_operator", "branching_python_operator")
+    msg = str(excinfo.value).lower()
+    assert "branchpythonoperator" in msg or "branching" in msg, (
+        f"the compile error must name branching so the user understands; got: {excinfo.value}"
+    )
+    assert "not supported" in msg or "supported" in msg, (
+        f"the compile error should point at the supported list; got: {excinfo.value}"
+    )
+
+
 def test_missing_dag_raises(tmp_path):
     empty = tmp_path / "empty.py"
     empty.write_text("x = 1\n")


### PR DESCRIPTION
## Summary

Critical silent-correctness bug surfaced by the Leoflow-vs-Airflow 3.2.x readiness analysis. \`_operator_type\` used substring matching, so a class literally named \`BranchPythonOperator\` (or \`ShortCircuitOperator\`, etc.) hit the \"Python\" branch and was silently translated to a plain \`python\` task — losing the branch semantics entirely. **Every \"skipped\" branch would actually execute at runtime, with the UI showing green ticks.**

This is the worst class of bug: the DAG compiles, the user sees green, and the results are wrong.

## Reproduction

```python
>>> from leoflow_parser.compiler import _operator_type
>>> class BranchPythonOperator:
...     task_id = 'pick'
>>> _operator_type(BranchPythonOperator())
'python'  # ← silently lost the branch semantics
```

## Fix

In \`_operator_type\`, reject any class name containing \`Branch\`, \`ShortCircuit\`, \`Virtualenv\`, or \`Sensor\` **before** the substring catch-all, with a named error that points at the supported list. The gate is **loud** (compile, not runtime), and the message explains both the construct and the doc.

## Tests

- New \`tests/fixtures/branching_python_operator.py\` uses a class literally named \`BranchPythonOperator\` (reproducing the silent bug).
- New \`test_branching_python_operator_is_rejected\` asserts \`compile\` raises \`ValueError\` naming \"branching\" and \"supported\".
- Existing 38 parser tests still pass — the rejection only catches the named markers; plain \`PythonOperator\` and \`@task\` are untouched.

## Docs

\`docs/dag-authoring.md\` moves branching from the \"avoid for now\" caveat to the \"hard compile error\" list, alongside short-circuit / virtualenv / sensors. The rejection list lives in \`_operator_type\`; when real translation lands (separate epic), the gate is removed.

## Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)