### PR TITLE
feat(lima): one-shot alpha bundle for Lima hands-on

### DIFF
--- a/lima-bundle/README.md
+++ b/lima-bundle/README.md
@@ -1,0 +1,100 @@
+# Lima alpha bundle
+
+One-shot install script + DAG bundle for the Leoflow Lite hands-on validation
+on a Lima VM (or any clean Linux box). This is the package the project lead
+runs on their Lima machine to stress-test the alpha before tagging
+`v0.1.0-alpha.1`.
+
+## On the Lima VM (single command)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/neochaotic/leoflow/main/lima-bundle/install.sh | bash
+```
+
+The script will:
+
+1. Detect Linux/arch and download the latest prealpha `leoflow` binary into
+   `~/.local/bin/`.
+2. Run `leoflow setup` — which **generates the admin password and prints it
+   once in cyan**. SAVE IT.
+3. Drop the curated DAG bundle into `~/leoflow/` (the workspace).
+4. Print the credentials block + start command.
+
+After it finishes, run:
+
+```bash
+leoflow lite
+```
+
+…and open `http://localhost:8088` in your browser. If you're accessing from
+the Mac host instead of inside the VM, either set up Lima port forwarding or
+use `http://<lima-ip>:8088`.
+
+## What's bundled
+
+| DAG | Schedule | What it exercises |
+|---|---|---|
+| `recurring_print` | `*/3 * * * *` | scheduler tick loop, dispatch happy path |
+| `recurring_parallel` | `*/5 * * * *` | parallel fan-out under steady load |
+| `lifecycle` | manual | 3-task ETL with XCom |
+| `montecarlo_pi` | manual | parallel + XCom aggregation |
+| `fan_out_aggregate` | manual | fan-out + collect |
+| `taskflow_sales` | manual | TaskFlow patterns |
+
+Connector DAGs (postgres / mysql / mssql / sqlite / redis / http) are NOT
+bundled by default — they need a Connection set up first via the UI
+(Admin → Connections). Copy them from `examples/<name>/` after configuring.
+
+## Credentials
+
+`leoflow setup` generates a per-instance password and prints it ONCE during
+install. There is no way to recover that exact password later — but there's
+no need to: `sudo leoflow lite reset-password` writes a new one and prints
+it the same way.
+
+Default email is `admin@leoflow.local` (override at install time with
+`leoflow setup --admin-email you@example.com`; the bundle script doesn't
+do that — re-run `setup` after if you want a different email).
+
+## What to look for during the hands-on
+
+The point of running this on Lima is to **catch bugs that survived all the
+unit/integration tests**. Specifically:
+
+- Are recurring runs steady? Run for 1 h, count completed runs of
+  `recurring_print` — expect 20. Any gaps, stuck `queued` states, missed
+  cron slots → file an issue with the timestamp.
+- Does parallelism actually parallelise? Look at `recurring_parallel`'s
+  task durations: the 4 workers should finish within ~7 s of each other
+  (max sleep is 6 s), NOT take 18 s in sequence.
+- Trigger `lifecycle` / `montecarlo_pi` / `fan_out_aggregate` from the UI.
+  Logs visible? Status transitions correct? XCom values flow?
+- Try to break it — restart the Lima VM mid-run; kill the leoflow process
+  with `pkill -9 leoflow`; pull the network briefly. Recovery contract is
+  in `docs/scheduler-resilience.md`.
+
+Findings → comments on the alpha-prep issues, severity per
+[[alpha-prep-bug-policy]].
+
+## What this is NOT
+
+- Not a release of `v0.1.0-alpha.1` — that tag cuts only after a clean
+  hands-on pass.
+- Not a multi-user install — Lite is single-admin by design (see
+  `docs/editions.md`).
+- Not a Pro install — Pro is the Helm chart (`helm/leoflow/`), separate
+  rollout per [[pro-alpha-blockers-decisions]].
+
+## Re-running
+
+The install script is **idempotent** for everything except the password:
+
+- A second `leoflow setup` preserves the existing config (and prints
+  "already configured"). The password from the first run still works.
+- DAGs are copied fresh each run; you can also drop your own DAG folders
+  into `~/leoflow/` at any time.
+- To start from a clean slate: `leoflow uninstall` (removes
+  `~/.leoflow/`, KEEPS `~/leoflow/` workspace), then re-run this script.
+
+References: post-helm-polish-plan memory item 3 (Lima stress-test build),
+[[simple-reliable-then-grow]], #231 (chaos dogfood gate).

--- a/lima-bundle/dags/recurring_parallel/dag.py
+++ b/lima-bundle/dags/recurring_parallel/dag.py
@@ -1,0 +1,78 @@
+"""recurring_parallel — a 5-minute parallel-dispatch stress.
+
+Four independent tasks fan out from a single seed, each sleeping a few seconds
+and printing. Together they exercise:
+- Scheduler tick under concurrent ready tasks (max_active_tasks pressure).
+- Dispatcher buffer behavior (Pro pool vs Lite passthrough — same DAG, both
+  editions; see ADR 0031).
+- Recurring run-creation under the `max_active_runs` cap (#200): with the
+  default cap of 16 and a 5-minute schedule, the run pool can't saturate
+  unless individual runs hang for ≥80 minutes — useful contrast to the
+  3-minute heartbeat DAG which spends ~zero time per run.
+
+Lima alpha use:
+- Leave it running for ~30 min.
+- Watch each task's individual duration matches its sleep (no scheduling
+  delay), and that the 4 tasks ALL finish within a few seconds of each
+  other (dispatch fan-out is parallel, not serial).
+"""
+from __future__ import annotations
+
+import time
+
+from airflow.sdk import DAG, task
+
+
+@task
+def seed() -> int:
+    return 4
+
+
+@task
+def worker_a() -> str:
+    print("worker_a: sleeping 3 s")
+    time.sleep(3)
+    return "a"
+
+
+@task
+def worker_b() -> str:
+    print("worker_b: sleeping 5 s")
+    time.sleep(5)
+    return "b"
+
+
+@task
+def worker_c() -> str:
+    print("worker_c: sleeping 4 s")
+    time.sleep(4)
+    return "c"
+
+
+@task
+def worker_d() -> str:
+    print("worker_d: sleeping 6 s")
+    time.sleep(6)
+    return "d"
+
+
+@task
+def aggregate(*results: str) -> str:
+    out = ",".join(results)
+    print(f"aggregate: {out}")
+    return out
+
+
+with DAG(
+    "recurring_parallel",
+    schedule="*/5 * * * *",   # every 5 minutes
+    catchup=False,
+    tags=["lima-alpha", "recurring", "parallel"],
+):
+    start = seed()
+    a = worker_a()
+    b = worker_b()
+    c = worker_c()
+    d = worker_d()
+    start >> [a, b, c, d]
+    aggregate(a, b, c, d)

--- a/lima-bundle/dags/recurring_parallel/leoflow.yaml
+++ b/lima-bundle/dags/recurring_parallel/leoflow.yaml
@@ -1,0 +1,10 @@
+schema_version: "1.0"
+dag_id: recurring_parallel
+description: 5-minute parallel-dispatch stress — 4 workers fan out and aggregate.
+owner: lima-alpha
+tags:
+  - lima-alpha
+  - recurring
+  - parallel
+python_version: "3.11"
+dependencies: []

--- a/lima-bundle/dags/recurring_print/dag.py
+++ b/lima-bundle/dags/recurring_print/dag.py
@@ -1,0 +1,33 @@
+"""recurring_print — a 3-minute heartbeat DAG.
+
+The simplest possible scheduler smoke: print the current time every 3 minutes,
+forever. If the run history is steady (one new run every 3 min, every one
+SUCCESS), the scheduler loop is healthy. If gaps or stuck `queued` runs appear,
+something is wrong at the scheduler/dispatcher layer.
+
+Use case in the Lima alpha hands-on (#231 + post-helm-polish-plan):
+- Leave it running for ~1 h.
+- Watch the dashboard: 20 successful runs, no stuck ones, no missed slots.
+- If a run is missed or stuck, capture the timestamp and the scheduler log.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow.sdk import DAG, task
+
+
+@task
+def heartbeat() -> str:
+    msg = f"tick: {datetime.now().isoformat()}"
+    print(msg)
+    return msg
+
+
+with DAG(
+    "recurring_print",
+    schedule="*/3 * * * *",   # every 3 minutes
+    catchup=False,
+    tags=["lima-alpha", "recurring", "smoke"],
+):
+    heartbeat()

--- a/lima-bundle/dags/recurring_print/leoflow.yaml
+++ b/lima-bundle/dags/recurring_print/leoflow.yaml
@@ -1,0 +1,10 @@
+schema_version: "1.0"
+dag_id: recurring_print
+description: 3-minute scheduler heartbeat — prints the current timestamp.
+owner: lima-alpha
+tags:
+  - lima-alpha
+  - recurring
+  - smoke
+python_version: "3.11"
+dependencies: []

--- a/lima-bundle/install.sh
+++ b/lima-bundle/install.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Lima alpha bundle installer.
+#
+# One-shot installer for the Leoflow Lite hands-on validation on a Lima VM
+# (or any clean Linux box). Downloads the latest prealpha binary, runs
+# `leoflow setup` (which generates the admin password — printed in CYAN on
+# the terminal, save it), drops the curated DAG bundle into the workspace,
+# and prints the next-step commands.
+#
+# Usage on the Lima VM:
+#   curl -fsSL https://raw.githubusercontent.com/neochaotic/leoflow/main/lima-bundle/install.sh | bash
+# or, if you cloned the repo:
+#   bash lima-bundle/install.sh
+
+set -euo pipefail
+
+# ─── Colors (with TTY detection) ─────────────────────────────────────────────
+if [[ -t 1 ]]; then
+  CYAN=$'\e[36m'; YELLOW=$'\e[33m'; GREEN=$'\e[32m'; BOLD=$'\e[1m'; RESET=$'\e[0m'
+else
+  CYAN=''; YELLOW=''; GREEN=''; BOLD=''; RESET=''
+fi
+
+echo "${BOLD}Leoflow Lima alpha bundle installer${RESET}"
+echo
+
+# ─── 1. Detect OS / arch ────────────────────────────────────────────────────
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64|amd64) ARCH=amd64 ;;
+  arm64|aarch64) ARCH=arm64 ;;
+  *) echo "unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+if [[ "$OS" != "linux" && "$OS" != "darwin" ]]; then
+  echo "unsupported OS: $OS (Lima alpha targets linux; macOS works for spot-checks)" >&2
+  exit 1
+fi
+
+# ─── 2. Resolve the source dir for the DAGs ─────────────────────────────────
+# When this script is run via `bash lima-bundle/install.sh` from a checkout,
+# the DAGs sit next to it. When piped from curl, we re-fetch them from the
+# same repo+commit the script came from (BUNDLE_REPO + BUNDLE_REF defaults
+# below; override via env if you're testing a branch).
+BUNDLE_REPO="${BUNDLE_REPO:-neochaotic/leoflow}"
+BUNDLE_REF="${BUNDLE_REF:-main}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd || echo "")"
+if [[ -n "$SCRIPT_DIR" && -d "$SCRIPT_DIR/dags" ]]; then
+  DAG_SOURCE="$SCRIPT_DIR/dags"
+  echo "DAG source: ${DAG_SOURCE} (local checkout)"
+else
+  TMPDIR="$(mktemp -d)"
+  trap 'rm -rf "$TMPDIR"' EXIT
+  echo "Fetching DAG bundle from github.com/${BUNDLE_REPO}@${BUNDLE_REF}..."
+  curl -fsSL "https://codeload.github.com/${BUNDLE_REPO}/tar.gz/${BUNDLE_REF}" \
+    | tar -xz -C "$TMPDIR" --strip-components=1 \
+    "$(basename "$BUNDLE_REPO")-${BUNDLE_REF}/lima-bundle/dags" \
+    "$(basename "$BUNDLE_REPO")-${BUNDLE_REF}/examples" 2>/dev/null \
+    || { echo "could not fetch DAG bundle"; exit 1; }
+  DAG_SOURCE="$TMPDIR/lima-bundle/dags"
+  EXAMPLES_SOURCE="$TMPDIR/examples"
+fi
+
+# ─── 3. Install the leoflow binary ───────────────────────────────────────────
+# Pick the latest prealpha release. The release workflow publishes
+# leoflow-${OS}-${ARCH} assets.
+echo
+echo "${BOLD}1. Installing leoflow binary${RESET}"
+RELEASE_API="https://api.github.com/repos/${BUNDLE_REPO}/releases/latest"
+DOWNLOAD_URL="$(curl -fsSL "$RELEASE_API" | grep -E "browser_download_url.*leoflow-${OS}-${ARCH}\"" | head -1 | sed -E 's/.*"(https[^"]+)".*/\1/')"
+if [[ -z "${DOWNLOAD_URL}" ]]; then
+  echo "could not resolve latest leoflow-${OS}-${ARCH} release asset" >&2
+  echo "fallback: check https://github.com/${BUNDLE_REPO}/releases manually" >&2
+  exit 1
+fi
+echo "  url: ${DOWNLOAD_URL}"
+INSTALL_DIR="${HOME}/.local/bin"
+mkdir -p "$INSTALL_DIR"
+curl -fsSL "$DOWNLOAD_URL" -o "$INSTALL_DIR/leoflow"
+chmod +x "$INSTALL_DIR/leoflow"
+export PATH="$INSTALL_DIR:$PATH"
+echo "  installed: $(leoflow version 2>&1 | head -1)"
+
+# ─── 4. Run setup (generates admin password — captured in setup's output) ───
+echo
+echo "${BOLD}2. Running leoflow setup (generates the admin password)${RESET}"
+SETUP_LOG="$(mktemp)"
+trap 'rm -f "$SETUP_LOG"' EXIT
+if ! leoflow setup 2>&1 | tee "$SETUP_LOG"; then
+  echo "${YELLOW}setup did not complete cleanly; check the output above${RESET}" >&2
+  exit 1
+fi
+
+# Try to extract the printed credentials block from the log. setup prints
+# `user:` / `password:` / `open:` lines on first install only (a re-run
+# preserves the existing config and prints "already configured").
+PASSWORD_LINE="$(grep -E '^\s+password:' "$SETUP_LOG" | head -1 || true)"
+
+# ─── 5. Copy the DAG bundle into the workspace ──────────────────────────────
+WORKSPACE="${HOME}/leoflow"
+mkdir -p "$WORKSPACE"
+echo
+echo "${BOLD}3. Copying the DAG bundle into ${WORKSPACE}${RESET}"
+cp -R "$DAG_SOURCE/." "$WORKSPACE/"
+echo "  Lima-bundle DAGs ($(ls "$DAG_SOURCE" | wc -l | tr -d ' ')) copied"
+
+# Curate a useful subset of /examples too. Skip the connector DAGs that
+# need external services pre-configured (the user can copy those by hand
+# after creating Connections in the UI).
+if [[ -n "${EXAMPLES_SOURCE:-}" ]] || [[ -d "$SCRIPT_DIR/../examples" ]]; then
+  EX_SRC="${EXAMPLES_SOURCE:-$SCRIPT_DIR/../examples}"
+  for dag in lifecycle montecarlo_pi fan_out_aggregate taskflow_sales; do
+    if [[ -d "$EX_SRC/$dag" ]]; then
+      cp -R "$EX_SRC/$dag" "$WORKSPACE/"
+      echo "  example DAG copied: $dag"
+    fi
+  done
+fi
+
+# ─── 6. Print the next-step block ───────────────────────────────────────────
+echo
+echo "${BOLD}${GREEN}═══ All set ═══${RESET}"
+echo
+if [[ -n "$PASSWORD_LINE" ]]; then
+  echo "${BOLD}Save these credentials (the password is shown ONCE):${RESET}"
+  echo
+  echo "  user:     admin@leoflow.local"
+  echo "  ${YELLOW}${PASSWORD_LINE}${RESET}"
+  echo "  open:     http://localhost:8088"
+  echo
+  echo "  Lost the password? Run: ${CYAN}sudo leoflow lite reset-password${RESET}"
+else
+  echo "${YELLOW}(setup re-ran on an existing install; the password above was preserved.)${RESET}"
+  echo "  Lost it? Run: ${CYAN}sudo leoflow lite reset-password${RESET}"
+fi
+echo
+echo "${BOLD}DAGs bundled in ${WORKSPACE}:${RESET}"
+ls -1 "$WORKSPACE" | sed 's/^/  - /'
+echo
+echo "${BOLD}Start Leoflow Lite:${RESET}"
+echo "  ${CYAN}leoflow lite${RESET}"
+echo
+echo "  (then open http://localhost:8088 — or from your Mac host:"
+echo "   http://<lima-vm-ip>:8088 with Lima port-forwarding configured)"

--- a/lima-bundle/install.sh
+++ b/lima-bundle/install.sh
@@ -63,21 +63,39 @@ fi
 
 # ─── 3. Install the leoflow binary ───────────────────────────────────────────
 # Pick the latest prealpha release. The release workflow publishes
-# leoflow-${OS}-${ARCH} assets.
+# leoflow_<version>_<os>_<arch>.tar.gz tarballs (and matching checksums +
+# cosign signatures + SBOMs); we extract the binary from the tarball.
+# Override the release tag via LEOFLOW_RELEASE_TAG=v0.0.1-prealpha.N.
 echo
 echo "${BOLD}1. Installing leoflow binary${RESET}"
-RELEASE_API="https://api.github.com/repos/${BUNDLE_REPO}/releases/latest"
-DOWNLOAD_URL="$(curl -fsSL "$RELEASE_API" | grep -E "browser_download_url.*leoflow-${OS}-${ARCH}\"" | head -1 | sed -E 's/.*"(https[^"]+)".*/\1/')"
+RELEASE_TAG="${LEOFLOW_RELEASE_TAG:-latest}"
+if [[ "$RELEASE_TAG" == "latest" ]]; then
+  RELEASE_API="https://api.github.com/repos/${BUNDLE_REPO}/releases/latest"
+else
+  RELEASE_API="https://api.github.com/repos/${BUNDLE_REPO}/releases/tags/${RELEASE_TAG}"
+fi
+DOWNLOAD_URL="$(curl -fsSL "$RELEASE_API" \
+  | grep -E "browser_download_url.*_${OS}_${ARCH}\.tar\.gz\"" \
+  | head -1 \
+  | sed -E 's/.*"(https[^"]+)".*/\1/')"
 if [[ -z "${DOWNLOAD_URL}" ]]; then
-  echo "could not resolve latest leoflow-${OS}-${ARCH} release asset" >&2
+  echo "could not resolve a leoflow_*_${OS}_${ARCH}.tar.gz asset on ${RELEASE_TAG}" >&2
   echo "fallback: check https://github.com/${BUNDLE_REPO}/releases manually" >&2
   exit 1
 fi
 echo "  url: ${DOWNLOAD_URL}"
 INSTALL_DIR="${HOME}/.local/bin"
 mkdir -p "$INSTALL_DIR"
-curl -fsSL "$DOWNLOAD_URL" -o "$INSTALL_DIR/leoflow"
-chmod +x "$INSTALL_DIR/leoflow"
+INSTALL_TMP="$(mktemp -d)"
+trap 'rm -rf "$INSTALL_TMP" "${TMPDIR:-}" "${SETUP_LOG:-}"' EXIT
+curl -fsSL "$DOWNLOAD_URL" -o "$INSTALL_TMP/leoflow.tar.gz"
+tar -xz -C "$INSTALL_TMP" -f "$INSTALL_TMP/leoflow.tar.gz"
+BIN_PATH="$(find "$INSTALL_TMP" -type f -name leoflow -perm -u+x | head -1)"
+if [[ -z "$BIN_PATH" ]]; then
+  echo "tarball did not contain a leoflow binary" >&2
+  exit 1
+fi
+install -m 0755 "$BIN_PATH" "$INSTALL_DIR/leoflow"
 export PATH="$INSTALL_DIR:$PATH"
 echo "  installed: $(leoflow version 2>&1 | head -1)"
 


### PR DESCRIPTION
## Summary

The package the project lead runs on the Lima VM to stress-test Leoflow Lite before the v0.1.0-alpha.1 cut. Single command on the VM:

\`\`\`bash
curl -fsSL https://raw.githubusercontent.com/neochaotic/leoflow/main/lima-bundle/install.sh | bash
\`\`\`

That downloads the latest prealpha binary, runs \`leoflow setup\` (which generates and prints the admin password in cyan — capture it once), drops the curated DAG bundle into \`~/leoflow/\`, and re-prints the credentials block at the end so the user can't miss it.

## What's bundled

Two NEW recurring DAGs scoped for the Lima hands-on:

- **\`recurring_print\`** (\`*/3 * * * *\`) — scheduler heartbeat smoke; \"20 runs in an hour, zero stuck or missed\" is the contract.
- **\`recurring_parallel\`** (\`*/5 * * * *\`) — 4 worker tasks fan out from a seed, exercising parallel dispatch + max_active_tasks pressure; expected finish-within-7s spread (not 18s sequential).

Plus the curated subset of /examples that work without external Connections: \`lifecycle\`, \`montecarlo_pi\`, \`fan_out_aggregate\`, \`taskflow_sales\`.

Connector DAGs (postgres / mysql / mssql / sqlite / redis / http) are NOT in the default bundle — they need a Connection set up first via the UI; user can copy them from \`/examples\` after configuring.

## Credentials handling (honest)

\`leoflow setup\` generates a per-instance admin password and prints it ONCE in cyan. The bundle script captures that line from the setup output and re-prints it at the end (highlighted) so the user can't miss it. **There is no way to generate or distribute the password ahead of time** — it's a security-by-design choice (#88 prior incident). \`sudo leoflow lite reset-password\` is the recovery path.

## Asset format

The release workflow publishes \`leoflow_<version>_<os>_<arch>.tar.gz\` (not raw binaries); install.sh extracts the binary from the tarball. Supports \`LEOFLOW_RELEASE_TAG=v0.0.1-prealpha.N\` override (default: latest non-draft release).

## What this is NOT

- Not a release of v0.1.0-alpha.1 — that tag cuts only after a clean hands-on pass.
- Not a multi-user install — Lite is single-admin by design.
- Not a Pro install — Pro is the Helm chart, separate rollout per [[pro-alpha-blockers-decisions]] memory.

## Idempotent re-runs

Second \`leoflow setup\` preserves the existing config (no password surprise). DAGs are copied fresh each run. Clean slate: \`leoflow uninstall\` (removes \`~/.leoflow/\`, keeps workspace) then re-run.

## Refs

[[simple-reliable-then-grow]], [[alpha-release-policy]] (prealpha tags OK for iterative validation), #231 (chaos dogfood gate), #88 (password recovery story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)