### PR TITLE
diag(ui): observability for Lima Bugs #3 (Dags Falhados) + #11 (/static 404)

### DIFF
--- a/internal/api/ui_dashboard.go
+++ b/internal/api/ui_dashboard.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -42,14 +43,25 @@ var tiStateOrder = []string{
 	"upstream_failed", "skipped", "deferred",
 }
 
-// dagStatsHandler implements GET /ui/dashboard/dag_stats.
+// dagStatsHandler implements GET /ui/dashboard/dag_stats. The result is logged
+// at INFO level (with tenant + the four counts) so Lima debugging — "the
+// dashboard shows 0 failed but I see 2 failed DAGs" — has a server-side trail
+// to compare against the DB. Lima Bug #3 / 2026-06-01.
 func dagStatsHandler(reader DashboardStatsReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		s, err := reader.DagStats(c.Request.Context(), tenantOf(c))
+		tenant := tenantOf(c)
+		s, err := reader.DagStats(c.Request.Context(), tenant)
 		if err != nil {
 			handleRepoError(c, err)
 			return
 		}
+		slog.Info("/ui/dashboard/dag_stats",
+			"tenant", tenant,
+			"active_dag_count", s.Active,
+			"failed_dag_count", s.Failed,
+			"running_dag_count", s.Running,
+			"queued_dag_count", s.Queued,
+		)
 		c.JSON(http.StatusOK, gin.H{
 			"active_dag_count":  s.Active,
 			"failed_dag_count":  s.Failed,

--- a/internal/ui/handler.go
+++ b/internal/ui/handler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io/fs"
+	"log/slog"
 	"mime"
 	"net/http"
 	"path"
@@ -102,6 +103,16 @@ func (s *Server) StaticHandler() http.Handler {
 		}
 		data, err := fs.ReadFile(s.fsys, name)
 		if err != nil {
+			// Lima Bug #11 / 2026-06-01: occasional 404 on /static/* paths whose
+			// exact name we never captured. Logging the resolved name + the SPA
+			// referrer + user-agent surfaces it on the next reproduction so we
+			// either add the missing asset or fix the rewrite that produced it.
+			slog.Info("ui static 404",
+				"resolved_name", name,
+				"raw_path", r.URL.Path,
+				"referer", r.Referer(),
+				"user_agent", r.UserAgent(),
+			)
 			http.NotFound(w, r)
 			return
 		}


### PR DESCRIPTION
## Summary

Two diagnostic-only log lines so the next Lima test gives us the data needed to fix Lima Bugs #3 and #11 — both of which I cannot reproduce without your environment.

**No behavior change.** Pure logging additions.

## Changes

### `internal/api/ui_dashboard.go` — Bug #3 (Dags Falhados counter wrong)

`dagStatsHandler` now logs at INFO on every `/ui/dashboard/dag_stats`:
```
ts=… level=INFO msg="/ui/dashboard/dag_stats" tenant=default active_dag_count=N failed_dag_count=N running_dag_count=N queued_dag_count=N
```

Hypothesis on what's happening (waiting for data):
- tenant mismatch — admin user's tenant ≠ where DAGs/runs live
- `ResetTaskInstanceToNone` (clear task) updates TI but NOT DagRun.state — could leave DagRun in stale state
- finalize-rollup race — TI failed but FinalizeRun hasn't run yet, DagRun still `running`

The log + a direct PSQL query (`SELECT state, count(*) FROM dag_runs GROUP BY state`) will disambiguate.

### `internal/ui/handler.go` — Bug #11 (/static/*filepath single 404)

`StaticHandler` logs every 404 with: resolved name, raw URL, Referer, User-Agent. The original capture said "one 404 in entire session" without naming the file. Next reproduction surfaces it.

## What's needed from the next Lima test

For **#3**: open the dashboard, copy the `/ui/dashboard/dag_stats` log line, send it. Also run on Lima: `psql … -c "SELECT state, count(*) FROM dag_runs GROUP BY state;"` and send the result.

For **#11**: if another `/static` 404 happens, the log line names the file and the referring page — paste that.

## Tests

- Existing `TestDagStatsHandler` keeps passing (handler shape unchanged).
- Existing `internal/ui` tests pass (static-handler 404 path was already covered, this just adds a log).
- Full suite green; lint 0 issues; coverage 78.9% ≥ 78%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)