### PR TITLE
sec(ci): scorecard quick wins — least-privilege tokens + pinned actions + BP token

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,10 +16,11 @@ on:
     paths: ["docs/**", "mkdocs.yml", ".github/workflows/docs.yml", "internal/cli/**", "parser/**", "runtime/python/**", "helm/leoflow/README.md", "helm/leoflow/values.yaml", "helm/leoflow/README.md.gotmpl"]
   workflow_dispatch:
 
+# Least-privilege default: read-only at the top level. Only the deploy job
+# (push-to-main) needs to write to Pages; the build job (which runs on PRs too)
+# stays read-only so a PR cannot accidentally publish.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -29,8 +30,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with: { go-version: stable }
       # Auto-generate the CLI reference (git-ignored) from Cobra.
       - run: go run ./cmd/leoflow gen-docs --dir docs/cli
@@ -43,7 +44,7 @@ jobs:
             ./internal/domain ./internal/scheduler ./internal/executor ./internal/dispatch \
             ./internal/agent ./internal/agentrpc ./internal/storage ./internal/auth \
             ./internal/config ./internal/cli ./internal/api
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with: { python-version: "3.12" }
       # Imaging libs for the Material social-cards plugin.
       - run: sudo apt-get update && sudo apt-get install -y libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
@@ -73,7 +74,7 @@ jobs:
           </head><body>The Go reference moved. Redirecting to
           <a href="../go-api.html">Go packages</a>…</body></html>
           HTML
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with: { path: site }
   deploy:
     needs: build
@@ -81,9 +82,12 @@ jobs:
     # exist to gate the build; the published site is updated by main.
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      pages: write      # Publish the built site to GitHub Pages.
+      id-token: write   # OIDC token for the Pages deployment.
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/prune-prealpha.yaml
+++ b/.github/workflows/prune-prealpha.yaml
@@ -28,13 +28,18 @@ on:
         type: string
         default: "90"
 
+# Least-privilege default: the workflow itself reads only; the prune job below
+# elevates to contents:write to delete releases + tags. Scoping the write per
+# job keeps OpenSSF Scorecard's Token-Permissions check happy.
 permissions:
-  contents: write # delete releases and tags
+  contents: read
 
 jobs:
   prune:
     name: Prune stale pre-alpha releases
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # Delete pre-alpha releases and their tags.
     steps:
       - name: Prune
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,10 +4,12 @@ on:
   push:
     tags: ["v*"]
 
+# Least-privilege default: read-only at the top level. Each job that needs to
+# write (the release publish, the migrate image push, the gate's draft-edit)
+# opts in explicitly. OpenSSF Scorecard Token-Permissions check penalises any
+# write that lives at the workflow scope.
 permissions:
-  contents: write       # For creating releases
-  packages: write       # For pushing images to GHCR
-  id-token: write       # For cosign keyless signing
+  contents: read
 
 env:
   GO_VERSION: "1.26.3"
@@ -17,6 +19,10 @@ jobs:
   release:
     name: Build, sign, publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # GoReleaser creates the GitHub release.
+      packages: write   # Push the leoflow-server image to GHCR.
+      id-token: write   # Cosign keyless signing via Sigstore OIDC.
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -197,6 +203,8 @@ jobs:
     needs: [release, install-smoke, migrate-image]
     if: always() && needs.release.result == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write   # Edit the published release back to a draft on failure.
     steps:
       - name: Retract release to draft on smoke or migrate-image failure
         if: needs.install-smoke.result != 'success' || needs.migrate-image.result != 'success'

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -28,6 +28,13 @@ jobs:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
+          # PAT (fine-grained, read-only on Administration + Contents +
+          # Metadata) so Branch-Protection check can read classic protection
+          # rules. The default GITHUB_TOKEN cannot read them and the check
+          # returns -1 (internal error) without one. The secret is named
+          # SCORECARD_READ_TOKEN; absent = check still errors as before.
+          # See: https://github.com/ossf/scorecard-action/blob/main/docs/authentication/fine-grained-auth-token.md
+          repo_token: ${{ secrets.SCORECARD_READ_TOKEN || secrets.GITHUB_TOKEN }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
## Summary

OpenSSF Scorecard quick wins to lift the badge score from **6.1/10** toward ~7.5-7.8/10. Three issues addressed:

### 1. Token-Permissions (0/10 → ~10/10)

Three workflows had `contents: write`, `packages: write`, `pages: write`, or `id-token: write` declared at the **workflow** scope. Scorecard penalises any write that lives outside a specific job. Moved to per-job least-privilege:

- **`release.yaml`** — top `contents: read`; `release` job gets the three writes (contents/packages/id-token), `gate` job gets `contents: write` for `gh release edit`. `install-smoke` and `migrate-image` inherit read-only (migrate-image already had its own scoped writes).
- **`prune-prealpha.yaml`** — top `contents: read`; `prune` job gets `contents: write`.
- **`docs.yml`** — top `contents: read`; `deploy` job gets `pages: write` + `id-token: write`. The `build` job (which runs on PRs too) is now read-only — a PR cannot accidentally publish.

### 2. Pinned-Dependencies (5/10 → ~10/10)

`docs.yml` referenced GitHub Actions by major tag (`@v4`, `@v5`). Pinned all five to 40-char commit SHAs with the major-version comment (the same convention `release.yaml` + `scorecard.yaml` already follow):

- `actions/checkout` `@v4` → `@34e114876b0b... # v4`
- `actions/setup-go` `@v5` → `@40f1582b2485... # v5`
- `actions/setup-python` `@v5` → `@a26af69be951... # v5`
- `actions/upload-pages-artifact` `@v3` → `@56afc609e742... # v3`
- `actions/deploy-pages` `@v4` → `@d6db90164ac5... # v4`

Dependabot will keep the SHAs fresh.

### 3. Branch-Protection (-1 / internal error → ~8-10)

The check returned `-1` with `github tokens can't read classic branch protection rules`. The fix is a fine-grained PAT. Wired `scorecard-action` to use it via the secret `SCORECARD_READ_TOKEN`, falling back to `GITHUB_TOKEN` when the secret isn't set — no regression if the user hasn't added it yet.

**Action required for full effect of (3)**: add a fine-grained PAT with read access to **Administration + Contents + Metadata** as the repository secret `SCORECARD_READ_TOKEN`. Instructions: https://github.com/ossf/scorecard-action/blob/main/docs/authentication/fine-grained-auth-token.md

## What this does NOT change

The remaining sub-10 checks are not movable by code alone:
- `Code-Review` 0/10 — needs PR review approvals (solo dev)
- `Maintained` 0/10 — self-resolves at repo age 90d
- `Contributors` 0/10 — needs external committers
- `CII-Best-Practices` 0/10 — manual application at https://bestpractices.coreinfrastructure.org
- `Fuzzing` 0/10 — would need Go fuzz targets

## Tests

- YAML syntax validated (`python -c "import yaml; yaml.safe_load(...)"`) for all touched files.
- Pre-commit hook: gofmt + vet + lint (0 issues) + ruff + test coverage 79.6% ≥ 78%.
- No code changes — workflow-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)