### PR TITLE
fix(executor): materialize dag.py per task instance so multi-DAG subdirs work

### DIFF
--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -23,6 +23,11 @@ type Resolved struct {
 	// Staging carries the DAG's opt-in staging-volume config (ADR 0022); nil or
 	// disabled means no per-run volume.
 	Staging *domain.StagingConfig
+	// Source is the dag.py text captured at compile time, threaded to the
+	// SubprocessExecutor so Lite tasks can importlib their DAG without relying
+	// on a globally-correct workdir. Empty for Pro (the container image carries
+	// the source) and ignored by the KubernetesExecutor.
+	Source string
 }
 
 // Resolver loads a task instance's execution context from storage.
@@ -106,6 +111,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, runID, dagID string, task dom
 		TryNumber:        r.TryNumber,
 		Image:            r.Image,
 		ImagePullPolicy:  r.ImagePullPolicy,
+		Source:           r.Source,
 		Operator:         string(task.Type),
 		Entrypoint:       task.Entrypoint,
 		Env:              task.Env,

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -26,6 +26,14 @@ type Request struct {
 	Execution       domain.Execution
 	TimeoutSeconds  int
 
+	// Source is the dag.py text captured at compile time. The SubprocessExecutor
+	// materializes it to a per-TI temp dir so `python -m leoflow_runtime
+	// dag:<task>` can importlib it from there — this is how multi-DAG Lite setups
+	// avoid the ModuleNotFoundError that hit Lima 2026-06-01 when the agent's
+	// global workdir didn't carry the user's dag.py. Empty for Pro (the
+	// container image already carries the source); ignored by the K8s executor.
+	Source string
+
 	// HTTPRequest is set for http_api tasks (run by InlineHTTPExecutor).
 	HTTPRequest *domain.HTTPRequest
 

--- a/internal/executor/subprocess.go
+++ b/internal/executor/subprocess.go
@@ -6,7 +6,43 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 )
+
+// materializeWorkDir stages req.Source into a per-task-instance temp dir as a
+// `dag.py` file, so the spawned agent's `python -m leoflow_runtime dag:<task>`
+// can importlib it without depending on a globally-correct CWD. Used by the
+// SubprocessExecutor (Lite). An empty source returns ("", no-op cleanup, nil)
+// so the executor falls back to its configured global workdir — preserving the
+// Pro/K8s path where the source lives inside the container image.
+//
+// The dir name embeds the task_instance_id so concurrent dispatches do not
+// collide and an operator inspecting /tmp can map a leftover dir back to its
+// run. Caller MUST defer cleanup() so dirs don't pile up across tasks.
+func materializeWorkDir(source, taskInstanceID string) (workDir string, cleanup func(), err error) {
+	noop := func() {}
+	if source == "" {
+		return "", noop, nil
+	}
+	prefix := fmt.Sprintf("leoflow-%s-", taskInstanceID)
+	dir, mkErr := os.MkdirTemp("", prefix)
+	if mkErr != nil {
+		return "", noop, fmt.Errorf("staging task workdir: %w", mkErr)
+	}
+	dagPath := filepath.Join(dir, "dag.py")
+	if werr := os.WriteFile(dagPath, []byte(source), 0o600); werr != nil {
+		if rmErr := os.RemoveAll(dir); rmErr != nil {
+			slog.Warn("cleaning up partial workdir after write error", "dir", dir, "error", rmErr)
+		}
+		return "", noop, fmt.Errorf("writing materialized dag.py: %w", werr)
+	}
+	cleanup = func() {
+		if rmErr := os.RemoveAll(dir); rmErr != nil {
+			slog.Warn("removing task workdir", "dir", dir, "error", rmErr)
+		}
+	}
+	return dir, cleanup, nil
+}
 
 // SubprocessExecutor runs the agent as a host subprocess with no isolation. It
 // is for dev mode only and logs a prominent warning on construction.
@@ -51,23 +87,39 @@ func agentEnv(req Request) []string {
 // A non-zero exit is therefore NOT a synchronous error; only a failure to start
 // is. The process is reaped in the background.
 func (e *SubprocessExecutor) Execute(ctx context.Context, req Request) error {
+	// Materialize the DAG's source into a per-TI temp dir so `python -m
+	// leoflow_runtime dag:<task>` can importlib it. Mirrors the Pro container's
+	// "source is staged at the worker's CWD" contract — but without Docker.
+	// Empty source falls back to the configured global workdir for backwards
+	// compatibility with the scaffolded single-DAG Lite layout.
+	workDir, cleanupWorkDir, err := materializeWorkDir(req.Source, req.TaskInstanceID)
+	if err != nil {
+		e.logger.Error("staging task workdir failed",
+			"task", req.TaskID, "task_instance_id", req.TaskInstanceID, "error", err)
+		return err
+	}
+	if workDir == "" {
+		workDir = e.workDir
+	}
 	// Entry log (Lima Bug 2 diagnostic, 2026-05-31): if a manual trigger sits
 	// in queued forever and this line is absent, the scheduler never reached
 	// Execute(); if present and the next line is absent, cmd.Start() failed.
 	e.logger.Info("spawning agent subprocess",
-		"task", req.TaskID, "run", req.RunID, "agent_path", e.agentPath, "work_dir", e.workDir)
+		"task", req.TaskID, "run", req.RunID, "agent_path", e.agentPath, "work_dir", workDir,
+		"materialized_source", req.Source != "")
 	// WithoutCancel detaches the agent from the dispatch context: like a pod, it
 	// must run to completion and report its own terminal state over gRPC. Binding
 	// it to ctx would SIGKILL the agent when the dispatch ctx is canceled (surfacing
 	// as "signal: killed" and a falsely failed task), mirroring the inline runner.
 	cmd := exec.CommandContext(context.WithoutCancel(ctx), e.agentPath) //nolint:gosec // dev-only executor running the trusted agent binary
 	cmd.Env = append(os.Environ(), agentEnv(req)...)
-	cmd.Dir = e.workDir
+	cmd.Dir = workDir
 	// Surface the agent's own diagnostics (it logs to stderr); otherwise an agent
 	// that fails to start or connect fails silently. The task's stdout/stderr are
 	// shipped separately over gRPC.
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	if err := cmd.Start(); err != nil {
+		cleanupWorkDir()
 		e.logger.Error("agent subprocess failed to start",
 			"task", req.TaskID, "agent_path", e.agentPath, "error", err)
 		return fmt.Errorf("starting agent subprocess for task %s: %w", req.TaskID, err)
@@ -75,6 +127,7 @@ func (e *SubprocessExecutor) Execute(ctx context.Context, req Request) error {
 	e.logger.Info("agent subprocess started",
 		"task", req.TaskID, "run", req.RunID, "pid", cmd.Process.Pid)
 	go func() {
+		defer cleanupWorkDir()
 		werr := cmd.Wait()
 		if werr != nil {
 			e.logger.Warn("agent subprocess exited non-zero (the agent reports task state over gRPC)",

--- a/internal/executor/subprocess_materialize_test.go
+++ b/internal/executor/subprocess_materialize_test.go
@@ -1,0 +1,73 @@
+package executor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestMaterializeWorkDir_WritesSourceToTempDir is the load-bearing test for the
+// Lima subdir-DAG fix: the SubprocessExecutor must place the dag.json's source
+// string into a dag.py file inside a per-TI temp dir, so the spawned agent's
+// `python -m leoflow_runtime dag:<task>` can importlib it.
+//
+// Without this, multi-DAG Lite setups (the user pasted source as a string but
+// has no on-disk dag.py at the workspace root) fail with ModuleNotFoundError —
+// confirmed on Lima 2026-06-01.
+func TestMaterializeWorkDir_WritesSourceToTempDir(t *testing.T) {
+	source := "from airflow.sdk import DAG, task\n@task\ndef hello():\n    return 1\n"
+
+	dir, cleanup, err := materializeWorkDir(source, "ti-abc-123")
+	if err != nil {
+		t.Fatalf("materializeWorkDir: %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	if dir == "" {
+		t.Fatal("expected a non-empty workdir for non-empty source")
+	}
+	if !strings.Contains(filepath.Base(dir), "ti-abc-123") {
+		t.Errorf("temp dir name %q should embed the task_instance_id", dir)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, "dag.py"))
+	if err != nil {
+		t.Fatalf("reading materialized dag.py: %v", err)
+	}
+	if string(got) != source {
+		t.Errorf("materialized dag.py content mismatch:\n got: %q\nwant: %q", got, source)
+	}
+}
+
+// TestMaterializeWorkDir_EmptySourceIsNoop is the Pro-path compatibility test:
+// in Kubernetes mode the source lives inside the container image, not in the
+// dag.json, so req.Source is empty. materializeWorkDir MUST then return a
+// nil-effect cleanup and an empty dir so the executor falls back to its
+// configured global workdir (unchanged for Pro).
+func TestMaterializeWorkDir_EmptySourceIsNoop(t *testing.T) {
+	dir, cleanup, err := materializeWorkDir("", "ti-xyz")
+	if err != nil {
+		t.Fatalf("empty source must not error: %v", err)
+	}
+	if dir != "" {
+		t.Errorf("empty source must return empty workdir, got %q", dir)
+	}
+	cleanup()
+}
+
+// TestMaterializeWorkDir_CleanupRemovesDir guarantees the per-TI temp dir does
+// not leak across tasks. The executor stages a `defer cleanup()` after Wait()
+// completes; this test confirms the cleanup actually does what it says.
+func TestMaterializeWorkDir_CleanupRemovesDir(t *testing.T) {
+	dir, cleanup, err := materializeWorkDir("x = 1\n", "ti-leak")
+	if err != nil {
+		t.Fatalf("materializeWorkDir: %v", err)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("dir should exist before cleanup: %v", err)
+	}
+	cleanup()
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Errorf("dir should be removed after cleanup, stat err = %v", err)
+	}
+}

--- a/internal/storage/agent_store.go
+++ b/internal/storage/agent_store.go
@@ -142,6 +142,8 @@ func (s *ExecutionStore) ResolveTask(ctx context.Context, runID, taskID string) 
 		ImagePullPolicy: pullPolicy,
 		TryNumber:       int(ti.TryNumber),
 		Staging:         spec.Staging,
+		// Materialize source on the executor side (Lite only); Pro ignores it.
+		Source: spec.Source,
 	}, nil
 }
 


### PR DESCRIPTION
## CRITICAL: this fix existed on a branch and was never merged

Without this in main, the multi-DAG workspace shipped in PR #246 fails every task with:

```text
ModuleNotFoundError: No module named 'dag'
  File ".../leoflow_runtime/runner.py", line 123, in run
    module = importlib.import_module(module_name)
```

Confirmed on Lima today against v0.0.1-prealpha.21 (which merged #246 but NOT this).

## Root cause

Multi-DAG workspaces (PR #246) lay DAGs in subdirs (`~/leoflow/<dag_id>/dag.py`). The agent's working directory is the workspace root, so `python -m leoflow_runtime dag:<task>` runs from a path where `import dag` finds nothing.

## Fix

The compiler captures dag.py contents into `dag.json`'s `Source` field. Dispatch threads it into `executor.Request.Source`. The subprocess executor's `materializeWorkDir` writes the source to a per-task-instance temp dir at `/tmp/leoflow-<TI-id>-<rand>/dag.py` and sets `cmd.Dir` to that dir, so importlib finds the module.

Empty `Source` (Pro/K8s where the source lives in the image) falls back to the configured global workdir.

## What's in

- `internal/domain/dag.go` — `DAGSpec.Source` (`source` in JSON).
- `parser/leoflow_parser/compiler.py` — captures dag.py contents into the spec.
- `internal/dispatch/dispatch.go` — `Resolved.Source` + threads through to executor `Request.Source`.
- `internal/executor/executor.go` — `Request.Source`.
- `internal/executor/subprocess.go` — `materializeWorkDir` + cleanup; logs `materialized_source` so the path is debuggable.
- `internal/storage/agent_store.go` — `ResolveTask` returns `Source: spec.Source`.
- `internal/executor/subprocess_materialize_test.go` — 3 unit tests pinning the contract (writes source, empty=noop, cleanup removes dir).

This commit was on `fix/lite-subdir-dag-materialization` since 2026-05-31 with a green local verification on Lima at the time. It got orphaned during the multi-DAG PR cascade — re-opening it now (rebased on current main, no conflicts).

## Tests

- 3 unit tests on `materializeWorkDir`.
- Full suite green; lint 0 issues; coverage gate passing.

## Manual verification needed (on Lima)

- [ ] Re-cut prealpha.22 with this merged
- [ ] `leoflow lite` + trigger any DAG → task succeeds (no ModuleNotFoundError)
- [ ] Spawn log shows `materialized_source: true` and `work_dir: /tmp/leoflow-<UUID>-N`

🤖 Generated with [Claude Code](https://claude.com/claude-code)