### PR TITLE
ci(e2e): multi-DAG materialization gate + ADR 0033 (release flow)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -183,6 +183,27 @@ jobs:
         run: bash test/e2e/lite-login.sh
 
   # ─────────────────────────────────────────────────────────────────────
+  # Multi-DAG materialization gate (ADR 0033).
+  # Asserts the contract `dag.json.source` carries dag.py byte-for-byte for
+  # subdir projects, the parser→spec property the subprocess executor depends
+  # on to materialize per-task-instance work dirs. Catches the regression that
+  # shipped in v0.0.1-prealpha.21 where multi-DAG workspaces failed every task
+  # with `ModuleNotFoundError: No module named 'dag'`. No Postgres needed —
+  # the contract is in the compiled artifact, not in any runtime state. ~5 s.
+  # ─────────────────────────────────────────────────────────────────────
+  e2e-lite-multidag:
+    name: E2E Lite (multi-DAG materialization gate)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - name: Multi-DAG materialization contract
+        run: bash test/e2e/lite-multidag.sh
+
+  # ─────────────────────────────────────────────────────────────────────
   # TDD discipline check: every new exported function in production code
   # must have a corresponding test added or modified in the same PR.
   # This is a best-effort heuristic; reviewers verify the spirit of ADR 0011.

--- a/docs/adr/0033-release-flow-rc-tags-and-e2e-gates.md
+++ b/docs/adr/0033-release-flow-rc-tags-and-e2e-gates.md
@@ -1,0 +1,170 @@
+# ADR 0033: Release Flow — RC Tags, E2E Gates, and Immutable Versions
+
+**Status:** Accepted
+**Date:** 2026-06-01
+**Effective from:** `v0.1.0-alpha.1` (first alpha tag); pre-alpha tags keep the
+simpler direct-tag flow described in [Pre-alpha exception](#pre-alpha-exception)
+below.
+
+## Context
+
+Today (pre-alpha) the release flow is `git tag vX.Y.Z` → `release.yaml` builds
++ publishes + runs `install-smoke` on 7 distros → if smoke fails, `gate` job
+retracts the release to a DRAFT. The smoke job only runs `leoflow version` +
+`python --version`, which let the v0.0.1-prealpha.21 regression slip through:
+multi-DAG workspaces shipped without the materialization fix, and every task
+on user-installed instances failed with `ModuleNotFoundError: No module named
+'dag'`.
+
+Two gaps to close before alpha:
+
+1. **The gate's E2E surface is too thin.** Smoke runs `--version` only; it
+   does not exercise the path the user actually runs (boot lite, register a
+   subdir DAG, trigger a task). PR #251 wired the multi-DAG materialization
+   contract; PR #C wires the matching gate (`test/e2e/lite-multidag.sh`) that
+   would have caught the prealpha.21 break.
+2. **There is no opt-in pre-release channel.** A user wanting to validate
+   a build BEFORE it becomes "latest" has no way to do so other than
+   installing the latest pre-release and discovering bugs in production.
+   For alpha, where each tag is a public commitment, this is unacceptable.
+
+## Decision
+
+### 1. Versions are immutable.
+
+A tag, once published (even as a draft), MUST NOT be moved to a different
+commit. Re-tagging breaks Sigstore signatures (tied to commit SHA), poisons
+mirrors/caches, and violates the universal semver convention. A bad release
+becomes a drafted release; the next good release gets the next version.
+
+This mirrors Go modules' approach: `go.mod retract vX.Y.Z` keeps the version
+visible-but-discouraged, and the next semver-greater tag becomes the install
+default.
+
+### 2. Two-channel release flow, from alpha onwards.
+
+Two tag conventions, distinguished by suffix:
+
+| Suffix | Channel | Visibility | Resolved by `install.sh` "latest"? |
+|---|---|---|---|
+| `vX.Y.Z-rc.N` | Release Candidate | DRAFT | No (drafts are skipped) |
+| `vX.Y.Z` | Final (or `-alpha.N`, `-beta.N`, etc.) | PRE-RELEASE or RELEASE | Yes |
+
+**Cutting a release:**
+
+```text
+git tag vX.Y.Z-rc.1
+git push origin vX.Y.Z-rc.1
+  → release.yaml builds + signs artifacts
+  → publishes the release as DRAFT (goreleaser draft=true for -rc.N tags)
+  → install-smoke runs against the drafted artifacts
+  → if any smoke fails: gate keeps the draft; report posted on the tag
+
+Human verifies the rc.N (Lima hands-on, dogfood, whatever the release needs):
+  LEOFLOW_VERSION=vX.Y.Z-rc.1 curl -fsSL https://...install.sh | sh
+  → Install the explicit tag (drafts are reachable by direct tag URL).
+  → Exercise whatever the rc is meant to validate.
+
+If rc.N is green:                  If rc.N is red (Lima found a bug):
+  git tag vX.Y.Z                     fix the bug
+  git push origin vX.Y.Z             git tag vX.Y.Z-rc.2 (skip rc.1 forever)
+  → release.yaml builds + signs      → repeat verification
+  → publishes as pre-release/release
+  → install-smoke runs (auto gate)
+  → if green, becomes "latest"
+```
+
+The `rc.N` drafts are never deleted manually — `prune-prealpha.yaml` already
+sweeps drafts older than its keep window.
+
+### 3. E2E gates that block both PRs and releases.
+
+Two complementary CI layers, both running `test/e2e/*.sh`:
+
+- **PR-time** (`ci.yaml`): every PR runs the full E2E suite. A failed E2E
+  blocks merge. Catches regressions before they reach main.
+- **Post-tag** (`release.yaml` install-smoke + an E2E step): the published
+  artifacts are exercised end-to-end in a clean container. A failed
+  post-tag E2E retracts the release to draft, even if the PR-time E2E was
+  green (the artifact in CI ran against `go build`, not the release tarball
+  — install paths, packaging, and managed runtime layers are tested only
+  here).
+
+**Test suite, as of this ADR:**
+
+| Script | What it gates |
+|---|---|
+| `test/e2e/lite-login.sh` | The Lite happy path: setup → control plane → admin login → JWT → workspace editor. |
+| `test/e2e/lite-multidag.sh` | The multi-DAG materialization contract: subdir DAG → `dag.json.source` carries dag.py verbatim (the property the subprocess executor depends on to materialize per-TI work dirs). |
+| `test/e2e/e2e.sh` | The pod-path E2E on k3d (build images, k3d import, agent-over-gRPC, real pod-per-task). Heavy; runs in a separate workflow today, may merge into `release.yaml` install-smoke later. |
+
+The suite grows as new release-blockers are identified. Each test SHOULD be:
+fast enough to run on every PR (target <60s), reality-anchored (no mocks at
+the boundary it gates), and named to match what it gates (the bug it would
+have caught — not how the test happens to be implemented).
+
+## Consequences
+
+### Positive
+
+- **A regression cannot reach `latest` undetected.** The prealpha.21 break
+  could not happen under this flow: PR-time E2E would have failed; even if
+  it had merged, install-smoke would have caught it post-tag and drafted the
+  release.
+- **Users opt in to release candidates.** `LEOFLOW_VERSION=vX.Y.Z-rc.1` is
+  explicit; nobody touches `-rc` tags by accident.
+- **Versions remain immutable, signatures remain valid.** A retracted draft
+  is still verifiable (the artifact, the SHA, the cosign signature) so
+  forensics on what failed are preserved.
+
+### Negative
+
+- **One extra step in the release ritual** when cutting a stable: tag `-rc.1`,
+  verify, then tag final. This is the cost of explicit gating; the
+  alternative is shipping bugs first and apologizing.
+- **Drafted versions accumulate.** `prune-prealpha.yaml` already covers this
+  (it sweeps drafts > 90 days old, keeping the newest N). No action required;
+  documented here for context.
+- **The "skip" appearance in stable history**: a bad `v1.2.4` drafted +
+  a good `v1.2.5` published is visible from the outside as "v1.2.4 missing
+  from latest." This is correct (semver allows non-contiguous sequences) and
+  matches what Kubernetes, Node.js, and Postgres ship — but the user
+  experience requires release notes on `v1.2.5` that name the drafted
+  predecessor when one exists.
+
+### Pre-alpha exception
+
+For pre-alpha tags (`v0.0.1-prealpha.N`), the simpler direct-tag flow stays
+in place: tag → build → publish as pre-release → install-smoke → gate
+retracts to draft on failure. The two-channel `-rc.N` flow becomes
+mandatory **starting at `v0.1.0-alpha.1`**, where the first public alpha
+commits to a more careful release ritual.
+
+This exception exists because pre-alpha tags are explicitly experimental and
+their churn (several per day during active development) would make a -rc
+step per tag a meaningful overhead with little additional value — the E2E
+gates run on the direct tag and catch regressions either way.
+
+## Implementation status
+
+- [x] Pre-alpha direct-tag + install-smoke gate (already shipped pre-ADR)
+- [x] `test/e2e/lite-login.sh` E2E in PR-time CI (existed before this ADR)
+- [x] `test/e2e/lite-multidag.sh` E2E in PR-time CI (this PR)
+- [ ] `goreleaser.yml` recognises `-rc.N` tags and publishes as DRAFT
+      (deferred to PR D, lands before `v0.1.0-alpha.1`)
+- [ ] `release.yaml` install-smoke runs `test/e2e/lite-multidag.sh` against
+      the installed artifact (deferred — needs a `--against-installed` flag
+      in the script first)
+- [ ] Release-notes template that mentions the drafted predecessor when one
+      exists (deferred to documentation pass)
+
+## Related
+
+- [ADR 0014 — Supply-chain security](0014-supply-chain-security.md): the
+  Cosign + SBOM + Trivy + govulncheck gates that already protect the
+  artifact. This ADR adds the *functional* gates on top.
+- [Memory — alpha-release-policy](../../README.md): "first `v0.1.0-alpha.1`
+  cut only after user hands-on testing." This ADR formalises that ritual
+  via the `-rc.N` convention.
+- [PR #251](https://github.com/neochaotic/leoflow/pull/251) — the
+  materialization fix this test guards.

--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -34,4 +34,5 @@ The *why* behind Leoflow's design. ADRs are immutable once accepted.
 - [ADR 0029: Lite Datastore Default — Docker Postgres (Managed PG is the Opt-In)](adr/0029-lite-datastore-default-docker.md)
 - [ADR 0030: Lite Datastore Auto-Selects — Docker Postgres, or a Managed PG When Docker Is Absent](adr/0030-lite-datastore-auto-select.md)
 - [ADR 0031: Scheduler Architecture — Reconciliation Loop, Two-Phase Dispatch, Two-Layer Reaping](adr/0031-scheduler-architecture.md)
+- [ADR 0033: Release Flow — RC Tags, E2E Gates, and Immutable Versions](adr/0033-release-flow-rc-tags-and-e2e-gates.md)
 <!-- END ADR INDEX -->

--- a/test/e2e/lite-multidag.sh
+++ b/test/e2e/lite-multidag.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# E2E for the multi-DAG materialization contract.
+#
+# Lima 2026-06-01 shipped v0.0.1-prealpha.21 with multi-DAG workspaces wired
+# (PR #246) but the parser branch that captured dag.py contents into the
+# spec's `source` field (PR #251) was orphaned and didn't merge with it.
+# Every task on Lima failed with `ModuleNotFoundError: No module named 'dag'`
+# because the subprocess executor's materialize step saw an empty Source.
+#
+# This script is the regression guard: it builds the CLI, scaffolds a subdir
+# DAG project, runs `leoflow compile`, and asserts the resulting dag.json
+# carries the source verbatim. No Postgres, no Redis, no agent — just the
+# parser→spec contract that multi-DAG depends on. Fast (~3-5 s in CI), so it
+# runs on every PR.
+#
+# Run from the repo root:  bash test/e2e/lite-multidag.sh
+set -euo pipefail
+
+HOME_DIR="$(mktemp -d)"
+WS="$HOME_DIR/ws"
+
+pass() { printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+fail() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; exit 1; }
+cleanup() { rm -rf "$HOME_DIR"; }
+trap cleanup EXIT
+
+echo "==> building leoflow"
+go build -o "$HOME_DIR/leoflow" ./cmd/leoflow
+
+echo "==> scaffolding a multi-DAG workspace (one DAG in a subdir)"
+mkdir -p "$WS/hello"
+cat > "$WS/hello/leoflow.yaml" <<'EOF'
+dag_id: hello
+python_version: "3.11"
+EOF
+# Distinguishable content the source-roundtrip assertion will match exactly.
+cat > "$WS/hello/dag.py" <<'EOF'
+from airflow.sdk import DAG, task
+
+
+@task
+def t() -> str:
+    return "ok-from-multidag-e2e"
+
+
+with DAG("hello", schedule=None):
+    t()
+EOF
+
+echo "==> compiling the subdir DAG"
+OUT="$HOME_DIR/hello.json"
+"$HOME_DIR/leoflow" compile "$WS/hello" --output "$OUT" >"$HOME_DIR/compile.log" 2>&1 \
+  || fail "leoflow compile failed:\n$(cat "$HOME_DIR/compile.log")"
+[ -s "$OUT" ] || fail "compile produced an empty dag.json"
+pass "compile produced a non-empty dag.json"
+
+# ─── Load-bearing assertion ──────────────────────────────────────────────
+# The materialization contract: dag.json MUST embed dag.py contents in the
+# `source` field. The subprocess executor reads `Source` from the resolved
+# task spec and writes it to a per-TI temp dir, so the spawned agent's
+# `python -m leoflow_runtime dag:<task>` finds the module. An empty Source
+# means materialize is a no-op and the agent's CWD is the workspace root,
+# where `import dag` resolves to nothing — the Lima failure mode.
+# ──────────────────────────────────────────────────────────────────────────
+echo "==> contract: dag.json.source carries the DAG source"
+SOURCE_LEN=$(python3 -c "import json; print(len(json.load(open('$OUT')).get('source', '')))")
+if [ "$SOURCE_LEN" -lt 50 ]; then
+  fail "dag.json.source is empty/missing (len=$SOURCE_LEN). The subprocess executor cannot materialize → 'ModuleNotFoundError: No module named dag' for any subdir DAG. This is the Lima v0.0.1-prealpha.21 regression."
+fi
+pass "dag.json.source is non-trivial ($SOURCE_LEN bytes)"
+
+echo "==> the source matches dag.py byte-for-byte"
+DAG_PY="$(cat "$WS/hello/dag.py")"
+JSON_SRC="$(python3 -c "import json; print(json.load(open('$OUT'))['source'], end='')")"
+[ "$DAG_PY" = "$JSON_SRC" ] || fail "dag.json.source does not match dag.py contents"
+pass "dag.json.source is byte-for-byte dag.py"
+
+echo "==> sanity: a second subdir DAG compiles independently (multi-DAG layout)"
+mkdir -p "$WS/second"
+cat > "$WS/second/leoflow.yaml" <<'EOF'
+dag_id: second
+python_version: "3.11"
+EOF
+cat > "$WS/second/dag.py" <<'EOF'
+from airflow.sdk import DAG, task
+@task
+def s2() -> str:
+    return "second"
+with DAG("second", schedule=None):
+    s2()
+EOF
+"$HOME_DIR/leoflow" compile "$WS/second" --output "$HOME_DIR/second.json" >"$HOME_DIR/compile-2.log" 2>&1 \
+  || fail "second subdir compile failed:\n$(cat "$HOME_DIR/compile-2.log")"
+SECOND_LEN=$(python3 -c "import json; print(len(json.load(open('$HOME_DIR/second.json')).get('source', '')))")
+[ "$SECOND_LEN" -gt 50 ] || fail "second dag.json.source is empty"
+pass "second subdir DAG also carries source (multi-DAG project independence)"
+
+echo
+echo "  ✅ Multi-DAG materialization contract verified."


### PR DESCRIPTION
## Summary

PR **C** of the bundle/test reorganization. Adds the regression guard for the class of bug that shipped `v0.0.1-prealpha.21` (multi-DAG workspaces wired but the parser branch that captured `dag.py` contents into `dag.json.source` was orphaned — every task on Lima failed with `ModuleNotFoundError: No module named 'dag'`).

## What's in

### `test/e2e/lite-multidag.sh`

Asserts the **parser → spec contract**: for a subdir DAG project, `leoflow compile` MUST emit a `dag.json` whose `source` field carries `dag.py` verbatim. That is the property the subprocess executor depends on to materialize a per-TI work dir; without it, every agent's `import dag` fails.

The test builds the CLI, scaffolds a subdir project, compiles, pins source length + byte-equality, then compiles a sibling DAG to catch independence regressions. **~5 s, no Postgres needed.**

### `.github/workflows/ci.yaml`

New `e2e-lite-multidag` job runs the script on every PR (and every push to main). Sits next to `e2e-lite` (the login happy-path). A red gate blocks merge.

### `docs/adr/0033-release-flow-rc-tags-and-e2e-gates.md`

Records the release flow the team agreed today:
- Tags are **immutable** (Sigstore + semver convention)
- **From `v0.1.0-alpha.1` onwards**, releases go through `-rc.N` drafts before the final tag. Pre-alpha keeps the simpler direct-tag flow
- **PR-time E2E** gates regressions BEFORE merge; **install-smoke E2E** gates regressions AFTER tag, retracting bad artefacts to draft
- `test/e2e/lite-multidag.sh` is the first gate added under this ADR

ADR index (`docs/adrs.md`) regenerated via `scripts/gen-adr-index.sh`.

## Test plan

- [ ] CI green: the new `e2e-lite-multidag` job passes against the multi-DAG fixture
- [ ] Manual: `bash test/e2e/lite-multidag.sh` exits 0 locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)