### PR TITLE
diag(#217 UI freeze on broken DAG) + chore(make ci-local pre-push gate)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,26 @@ reportcard: ## Verify Go Report Card grade is A+ (ADR 0012)
 vuln: ## Run govulncheck (ADR 0014)
 	govulncheck ./...
 
+.PHONY: ci-local
+ci-local: ## Run every CI gate locally — pre-push tripwire so a PR does not arrive red
+	@echo "▸ gofmt"
+	@test -z "$$(gofmt -l . | tee /dev/stderr)" || (echo "FAIL: gofmt"; exit 1)
+	@echo "▸ go build"
+	@go build ./...
+	@echo "▸ golangci-lint"
+	@golangci-lint run ./...
+	@echo "▸ go test"
+	@go test ./...
+	@echo "▸ python parser tests"
+	@command -v python3 >/dev/null && (cd parser && python3 -m pytest -q) || echo "skip pytest (no python3)"
+	@echo "▸ ADR index check"
+	@bash scripts/gen-adr-index.sh --check
+	@echo "▸ mkdocs build --strict"
+	@(command -v mkdocs >/dev/null && mkdocs build --strict --quiet) \
+		|| (command -v python3 >/dev/null && python3 -c "import mkdocs" 2>/dev/null && python3 -m mkdocs build --strict --quiet) \
+		|| echo "skip mkdocs (not installed: pip install mkdocs-material mkdocs-mermaid2-plugin)"
+	@echo "✅ ci-local clean — push when ready"
+
 .PHONY: dev-up
 dev-up: ## Start local Postgres + Redis (wait healthy) and apply migrations
 	docker compose up -d --wait

--- a/internal/api/import_errors.go
+++ b/internal/api/import_errors.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"hash/crc32"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -56,11 +57,19 @@ type importErrorBody struct {
 
 func listImportErrorsHandler(store ImportErrorStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// Trace timing: a save in the workspace lights up the SPA's
+		// import-error banner; if this read becomes slow when DAGs break,
+		// it shows up in the log next to /ui/dashboard/dag_stats so the
+		// freeze pattern (#217) is greppable: "slow handler + concurrent
+		// watcher reload" is the signature we are looking for.
+		start := time.Now()
 		errs, err := store.ListImportErrors(c.Request.Context(), tenantOf(c))
 		if err != nil {
 			handleRepoError(c, err)
 			return
 		}
+		slog.Info("/api/v2/importErrors GET",
+			"tenant", tenantOf(c), "count", len(errs), "duration_ms", time.Since(start).Milliseconds())
 		out := importErrorCollectionDTO{ImportErrors: make([]importErrorDTO, 0, len(errs)), TotalEntries: len(errs)}
 		for _, e := range errs {
 			out.ImportErrors = append(out.ImportErrors, toImportErrorDTO(e))

--- a/internal/api/ui_dags.go
+++ b/internal/api/ui_dags.go
@@ -3,8 +3,10 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -148,6 +150,12 @@ func strPtrOrNil(s string) *string {
 // runs query), never per-DAG.
 func uiDagsHandler(dags DagRepository, latest DagLatestRunsReader, favorites FavoriteStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// #217 diagnostic: the SPA polls this every 1s on Lite and reportedly
+		// freezes when a DAG breaks. If a single slow ListDagsFiltered or
+		// LatestRunsForDags lights up here while the watcher is reloading the
+		// workspace, that's the contention point. Two timings: per-query +
+		// total. Grep the log for "duration_ms" outliers.
+		t0 := time.Now()
 		limit, offset := pagination(c)
 		tenant := tenantOf(c)
 		ds, total, err := dags.ListDagsFiltered(c.Request.Context(), tenant,
@@ -156,6 +164,7 @@ func uiDagsHandler(dags DagRepository, latest DagLatestRunsReader, favorites Fav
 			handleRepoError(c, err)
 			return
 		}
+		listMs := time.Since(t0).Milliseconds()
 		runsLimit := defaultDagRunsLimit
 		if n, perr := strconv.Atoi(c.Query("dag_runs_limit")); perr == nil && n > 0 {
 			runsLimit = n
@@ -164,11 +173,16 @@ func uiDagsHandler(dags DagRepository, latest DagLatestRunsReader, favorites Fav
 		for i, d := range ds {
 			ids[i] = d.DagID
 		}
+		t1 := time.Now()
 		runsByDag, err := latest.LatestRunsForDags(c.Request.Context(), tenant, ids, runsLimit)
 		if err != nil {
 			handleRepoError(c, err)
 			return
 		}
+		runsMs := time.Since(t1).Milliseconds()
+		slog.Info("/ui/dags",
+			"tenant", tenant, "total", total, "list_ms", listMs, "runs_ms", runsMs,
+			"total_ms", time.Since(t0).Milliseconds())
 		// Resolve the user's favorites once so each DAG can report is_favorite (the
 		// star). Best-effort: a lookup failure just leaves every star unset.
 		var favs map[string]bool

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -1538,7 +1538,15 @@ func devWatchLoop(ctx context.Context, cmd *cobra.Command, ws *WorkspaceSpec, re
 			}
 			snap = cur
 			devPrintf(cmd.OutOrStdout(), "[%s] change detected → reloading …\n", time.Now().Format("15:04:05"))
-			if rerr := reload(); rerr != nil {
+			// Time the reload — a broken DAG's reload should still finish in
+			// ~1s. Anything multi-second is a red flag (parser hang, lock
+			// contention with the running control plane, slow registration
+			// retry). Log it so the user can grep for slow reloads when they
+			// notice the UI freezing on save (#217 diagnostic).
+			reloadStart := time.Now()
+			rerr := reload()
+			devPrintf(cmd.OutOrStdout(), "[%s] reload finished in %s\n", time.Now().Format("15:04:05"), time.Since(reloadStart).Truncate(time.Millisecond))
+			if rerr != nil {
 				devPrintf(cmd.ErrOrStderr(), "✗ %v\n", rerr)
 			}
 		}


### PR DESCRIPTION
## Summary

Two threads in one PR:

1. **#217 diagnostic instrumentation** — the SEVERE Lima report where a syntax error in one DAG freezes the whole UI. Cannot repro locally without matching filesystem state; this PR ships the timing logs that will pinpoint the contention point on the next reproduction. No functional fix yet — instrumentation only.

2. **`make ci-local` pre-push gate** — bundles every CI gate so a contributor catches drift before pushing. PRs #258 and #259 hit a parade of CI failures (mkdocs strict, ADR index, env-dependent test) that local pre-commit hooks did NOT cover. From now on: `make ci-local` before push.

## Diagnostic timing (#217)

- `internal/cli/dev.go` (watcher reload): `[hh:mm:ss] reload finished in <duration>`
- `internal/api/import_errors.go` (GET /api/v2/importErrors): `tenant=… count=… duration_ms=…`
- `internal/api/ui_dags.go` (GET /ui/dags): `tenant=… total=… list_ms=… runs_ms=… total_ms=…`

Cross-correlation: grep `reload finished` alongside `/ui/dags` timings during a freeze surfaces the contending side (watcher reload vs API handler latency).

## `make ci-local` targets

- gofmt
- go build ./...
- golangci-lint
- go test ./...
- python parser pytest
- scripts/gen-adr-index.sh --check
- mkdocs build --strict

The last two are the ones that bit #258 and #259 because the pre-commit hook doesn't cover them.

## Test plan

- [x] `make ci-local` clean locally (all 7 gates pass)
- [ ] Next Lima reproduction of UI freeze captures the timing logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)