### PR TITLE
fix(scheduler): #208 — gate Step() on leadership before any reads or writes

### DIFF
--- a/internal/scheduler/resilience_test.go
+++ b/internal/scheduler/resilience_test.go
@@ -154,7 +154,12 @@ func queuedEmptyRun(id string) RunState {
 }
 
 func newResilienceScheduler(store Store) *Scheduler {
-	return NewScheduler(store, slog.New(slog.NewTextHandler(io.Discard, nil)), time.Millisecond)
+	s := NewScheduler(store, slog.New(slog.NewTextHandler(io.Discard, nil)), time.Millisecond)
+	// Resilience suite exercises the writer path (panics inside the run loop,
+	// flaky stores, etc.). All Step() calls must execute past the leadership
+	// gate (#208) — default the helper to leader.
+	s.SetLeading(true)
+	return s
 }
 
 // TestStepIsolatesErroringRun asserts a per-run error does not block the other

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -289,6 +289,17 @@ func (s *Scheduler) Heartbeat() (bool, time.Time) {
 // by the caller); the later phases still execute.
 func (s *Scheduler) Step(ctx context.Context) error {
 	s.lastTick.Store(time.Now().UnixNano())
+	// Single-writer invariant (ADR 0031 / issue #208): a follower MUST NOT
+	// read or write scheduler state. The lastTick.Store above keeps the
+	// follower's heartbeat live so the orchestrator can prove the instance
+	// is alive without granting it the writer role. Lifting the gate here
+	// (instead of only inside reapOrphansIfLeader) removes the wasted reads,
+	// the duplicate ApplyTransition / CreateScheduledRun attempts that ON
+	// CONFLICT used to swallow, and the "what does a follower's count drift
+	// mean?" puzzle.
+	if !s.leading.Load() {
+		return nil
+	}
 	runs, err := s.store.ActiveRuns(ctx)
 	if err != nil {
 		return fmt.Errorf("listing active runs: %w", err)

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -34,13 +34,20 @@ type fakeStore struct {
 	agentLostMarked    []string
 	staleQueuedCands   []StaleQueuedCandidate
 	dispatchLostMarked []string
+	// activeRunsCalls counts ActiveRuns invocations so the follower-side gate
+	// can be asserted: a follower must NOT read run state (single-writer
+	// invariant, ADR 0031 / issue #208).
+	activeRunsCalls int
 }
 
 func newFakeStore(runs ...RunState) *fakeStore {
 	return &fakeStore{runs: runs, runStates: map[string]domain.DagRunState{}}
 }
 
-func (f *fakeStore) ActiveRuns(context.Context) ([]RunState, error) { return f.runs, nil }
+func (f *fakeStore) ActiveRuns(context.Context) ([]RunState, error) {
+	f.activeRunsCalls++
+	return f.runs, nil
+}
 func (f *fakeStore) ScheduledDAGs(context.Context) ([]ScheduledDAG, error) {
 	return f.scheduled, nil
 }
@@ -97,7 +104,13 @@ func (f *fakeStore) MarkTaskDispatchLost(_ context.Context, tiID string) error {
 }
 
 func newScheduler(store Store) *Scheduler {
-	return NewScheduler(store, slog.New(slog.NewTextHandler(io.Discard, nil)), time.Millisecond)
+	s := NewScheduler(store, slog.New(slog.NewTextHandler(io.Discard, nil)), time.Millisecond)
+	// Default tests to leader so the writer-path assertions (which is most of
+	// them) execute. Follower-mode tests opt out with `s.SetLeading(false)`.
+	// Without this default every Step() returns early at the leadership gate
+	// (#208) and the test asserts on a no-op tick.
+	s.SetLeading(true)
+	return s
 }
 
 func retriableRun(aState domain.TaskState, aTry int) *fakeStore {
@@ -244,12 +257,51 @@ func TestStepDoesNotReapOnFollower(t *testing.T) {
 	store := newFakeStore()
 	store.reapCands = []ReapCandidate{{RunID: "stuck", LastActivity: time.Now().UTC().Add(-1 * time.Hour)}}
 	s := newScheduler(store)
-	// SetLeading defaults to false; do not call it. A follower must not reap.
+	s.SetLeading(false) // newScheduler defaults to leader; this test wants follower.
 	if err := s.Step(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 	if len(store.reaped) != 0 {
 		t.Errorf("follower must not reap; got %v", store.reaped)
+	}
+}
+
+// TestStepFollowerSkipsAllWrites: a follower (no leadership lock) MUST NOT read
+// or write scheduler state. Today only the reaper is gated; ActiveRuns and
+// createDueRuns also run on every follower, violating the single-writer
+// invariant of ADR 0031. The fix lifts the leader gate to the top of Step()
+// after the heartbeat store (issue #208).
+func TestStepFollowerSkipsAllWrites(t *testing.T) {
+	store := newFakeStore(RunState{
+		RunID: "r1", DagID: "etl", State: domain.DagRunStateRunning, Tasks: linearTasks(),
+		States: map[string]domain.TaskState{"a": domain.TaskStateNone, "b": domain.TaskStateNone},
+		Tries:  map[string]int{"a": 1, "b": 1}, MaxTries: map[string]int{"a": 3, "b": 3},
+	})
+	store.scheduled = []ScheduledDAG{{DagID: "etl", Schedule: "@hourly"}}
+	store.reapCands = []ReapCandidate{{RunID: "stuck", LastActivity: time.Now().UTC().Add(-1 * time.Hour)}}
+	s := newScheduler(store)
+	s.SetLeading(false) // newScheduler defaults to leader; opt out for this follower-mode test.
+
+	if err := s.Step(context.Background()); err != nil {
+		t.Fatalf("Step on follower must not return infra-level error: %v", err)
+	}
+	if store.activeRunsCalls != 0 {
+		t.Errorf("follower must not read ActiveRuns; got %d calls", store.activeRunsCalls)
+	}
+	if len(store.transitions) != 0 {
+		t.Errorf("follower must not write transitions; got %d", len(store.transitions))
+	}
+	if len(store.createdRuns) != 0 {
+		t.Errorf("follower must not create scheduled runs; got %v", store.createdRuns)
+	}
+	if len(store.reaped) != 0 {
+		t.Errorf("follower must not reap; got %v", store.reaped)
+	}
+	// Heartbeat MUST still fire — the leadership check sits AFTER lastTick.Store
+	// so the orchestrator can prove the instance is alive without granting it
+	// the writer role.
+	if s.lastTick.Load() == 0 {
+		t.Errorf("follower must still update lastTick (heartbeat); got 0")
 	}
 }
 
@@ -432,6 +484,7 @@ func TestStepWarnsOnUnparseableScheduleAndCreatesNoRun(t *testing.T) {
 	store.scheduled = []ScheduledDAG{{DagID: "etl", Schedule: "*/3 * * *"}}
 	var buf bytes.Buffer
 	s := NewScheduler(store, slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})), time.Millisecond)
+	s.SetLeading(true) // direct NewScheduler call — needs explicit leader so createDueRuns runs (#208 gate).
 
 	if err := s.Step(context.Background()); err != nil {
 		t.Fatal(err)

--- a/internal/scheduler/stale_queued_reap_test.go
+++ b/internal/scheduler/stale_queued_reap_test.go
@@ -140,7 +140,7 @@ func TestStepSkipsDispatchLostReaperOnFollower(t *testing.T) {
 		{TaskInstanceID: "stuck-ti", QueuedAt: time.Now().UTC().Add(-10 * time.Minute)},
 	}
 	s := newScheduler(store)
-	// Default leading=false; explicitly assert that no reap happens.
+	s.SetLeading(false) // newScheduler defaults to leader; opt out for follower-mode test.
 	if err := s.Step(context.Background()); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/storage/e2e_integration_test.go
+++ b/internal/storage/e2e_integration_test.go
@@ -43,6 +43,7 @@ func TestEndToEndPushTriggerSchedule(t *testing.T) {
 	sched := scheduler.NewScheduler(storage.NewSchedulerStore(pg),
 		slog.New(slog.NewTextHandler(io.Discard, nil)), time.Millisecond)
 	sched.SetDispatcher(noopDispatcher{})
+	sched.SetLeading(true) // #208: Step() now gates on leader; e2e exercises the writer path.
 
 	dagID := fmt.Sprintf("e2e_%d", time.Now().UnixNano())
 	spec := domain.DAGSpec{


### PR DESCRIPTION
## Summary

First of 5 Pro-alpha hard blockers (per memory \`pro-alpha-blockers-decisions\`). Implements the design exactly as pre-decided:

> Decision: follower does NOT read anything (gate at top of Step(), return early after lastTick.Store).

Single-writer invariant of ADR 0031: today the gate exists only inside \`reapOrphansIfLeader\` — \`ActiveRuns\`, \`advanceSafely\`, and \`createDueRuns\` still run on every follower. ON CONFLICT silently swallows the duplicates, but the wasted reads, the contention, and the "what does a follower's drift count mean?" puzzle stay. This PR lifts the gate to the top of Step() so followers early-return after the heartbeat store.

## Test changes

- New \`TestStepFollowerSkipsAllWrites\`: asserts no ActiveRuns calls, no transitions, no createdRuns, no reaped, AND lastTick > 0 — the contract pinned in all directions.
- \`newScheduler\` helper now defaults to leader (most tests are writer-path); follower tests opt out with \`SetLeading(false)\`.
- Storage e2e integration test sets leader explicitly.

## Test plan

- [x] \`make ci-local\` clean
- [x] Integration tests against real Postgres pass
- [x] New follower test catches missing gate (mutation: removed gate → test fails)

## Followup

4 Pro-alpha blockers remain: #58 (TLS), #228 (per-tenant auth), #227 (S3 logs), #150 (upgrade smoke gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)