### PR TITLE
fix(release): #150 — upgrade-in-place smoke gates every release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -254,29 +254,61 @@ jobs:
           kill -TERM "$LITE_PID"
           wait "$LITE_PID" 2>/dev/null || true
 
-  # ── Release gate: if the install smoke OR the migrate-image build failed,
-  # retract the pre-release to a draft so `curl | sh` (which resolves the
-  # newest public release) and the Helm chart (which references the migrate
-  # image by tag) stop handing users a broken build. Runs always() so it can
-  # act on either failure; on success it leaves the published pre-release
+  # ── Upgrade-in-place smoke (#150): install the previous non-draft prerelease,
+  # then install THIS tag on top, asserting the new version is in place. Catches
+  # the install.sh bug class where a fresh box succeeds but layering over an
+  # existing ~/.leoflow/ breaks. The gate retracts the release to a draft on
+  # failure, same as install-smoke. Skipped automatically when there is no
+  # previous non-draft release to upgrade from (the first published tag).
+  upgrade-smoke:
+    name: Upgrade smoke (previous → ${{ github.ref_name }})
+    needs: release
+    runs-on: ubuntu-latest
+    container: ubuntu:24.04
+    steps:
+      - name: Install prerequisites
+        run: |
+          apt-get update -qq
+          apt-get install -y -qq curl ca-certificates tar git
+          # gh CLI for release listing
+          mkdir -p /etc/apt/keyrings
+          chmod 755 /etc/apt/keyrings
+          out=$(mktemp) && curl -sL https://cli.github.com/packages/githubcli-archive-keyring.gpg > "$out" && cat "$out" > /etc/apt/keyrings/githubcli-archive-keyring.gpg
+          chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
+          apt-get update -qq
+          apt-get install -y -qq gh
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Run upgrade smoke
+        env:
+          LEOFLOW_REPO: ${{ github.repository }}
+          LEOFLOW_VERSION: ${{ github.ref_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: sh test/release/upgrade-smoke.sh
+
+  # ── Release gate: if any of the smoke jobs OR the migrate-image build
+  # failed, retract the pre-release to a draft so `curl | sh` (which resolves
+  # the newest public release) and the Helm chart (which references the
+  # migrate image by tag) stop handing users a broken build. Runs always() so
+  # it can act on any failure; on success it leaves the published pre-release
   # untouched.
   gate:
-    name: Gate release on install + lite-cold-start + migrate image
-    needs: [release, install-smoke, lite-cold-start-smoke, migrate-image]
+    name: Gate release on install + lite-cold-start + upgrade + migrate image
+    needs: [release, install-smoke, lite-cold-start-smoke, upgrade-smoke, migrate-image]
     if: always() && needs.release.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write   # Edit the published release back to a draft on failure.
     steps:
       - name: Retract release to draft on smoke or migrate-image failure
-        if: needs.install-smoke.result != 'success' || needs.lite-cold-start-smoke.result != 'success' || needs.migrate-image.result != 'success'
+        if: needs.install-smoke.result != 'success' || needs.lite-cold-start-smoke.result != 'success' || needs.upgrade-smoke.result != 'success' || needs.migrate-image.result != 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eu
-          echo "::error::release blocked: install-smoke=${{ needs.install-smoke.result }} lite-cold-start-smoke=${{ needs.lite-cold-start-smoke.result }} migrate-image=${{ needs.migrate-image.result }}; retracting ${GITHUB_REF_NAME} to a draft."
+          echo "::error::release blocked: install-smoke=${{ needs.install-smoke.result }} lite-cold-start-smoke=${{ needs.lite-cold-start-smoke.result }} upgrade-smoke=${{ needs.upgrade-smoke.result }} migrate-image=${{ needs.migrate-image.result }}; retracting ${GITHUB_REF_NAME} to a draft."
           gh release edit "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" --draft
           exit 1
       - name: Confirm release passed all gates
-        if: needs.install-smoke.result == 'success' && needs.lite-cold-start-smoke.result == 'success' && needs.migrate-image.result == 'success'
-        run: echo "install smoke + lite cold-start + migrate-image passed; ${GITHUB_REF_NAME} stays published."
+        if: needs.install-smoke.result == 'success' && needs.lite-cold-start-smoke.result == 'success' && needs.upgrade-smoke.result == 'success' && needs.migrate-image.result == 'success'
+        run: echo "install smoke + lite cold-start + upgrade smoke + migrate-image passed; ${GITHUB_REF_NAME} stays published."

--- a/test/release/upgrade-smoke.sh
+++ b/test/release/upgrade-smoke.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env sh
+# Upgrade-in-place smoke for the release gate (#150 / ADR 0033).
+#
+# Installs the PREVIOUS non-draft prerelease, runs `leoflow version` to prove
+# the old binary is healthy, then installs the CURRENT tag and asserts the new
+# version is in place + the binary still runs. Catches the class of bug where
+# install.sh handles a fresh box but breaks on top of an existing ~/.leoflow/
+# (stale config, stale pysrc, leftover PATH entries, etc.) — the failure mode
+# the user would otherwise hit on `leoflow upgrade`.
+#
+# Required env:
+#   LEOFLOW_REPO     — "owner/name"     (typically ${GITHUB_REPOSITORY})
+#   LEOFLOW_VERSION  — the just-pushed tag we are gating
+#   GH_TOKEN         — used by `gh release list` (auto in GitHub Actions)
+#
+# Run in a clean container (the release workflow does this; locally use
+# `docker run --rm -it -e LEOFLOW_REPO=... ubuntu:24.04 bash`).
+set -eu
+
+: "${LEOFLOW_REPO:?LEOFLOW_REPO must be set (e.g. neochaotic/leoflow)}"
+: "${LEOFLOW_VERSION:?LEOFLOW_VERSION must be set to the just-pushed tag}"
+
+fail() {
+  printf '  \033[31mFAIL\033[0m %s\n' "$1" >&2
+  exit 1
+}
+pass() { printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+
+echo "==> resolving previous non-draft prerelease (excluding ${LEOFLOW_VERSION})"
+# Page through enough releases to skip the just-published one and any drafts.
+# `gh release list` orders newest-first, so the first non-draft, non-self entry
+# is the previous prealpha.
+PREVIOUS="$(gh release list \
+  --repo "${LEOFLOW_REPO}" \
+  --limit 20 \
+  --json tagName,isDraft \
+  --jq 'map(select(.isDraft == false and .tagName != "'"${LEOFLOW_VERSION}"'")) | .[0].tagName')"
+
+if [ -z "${PREVIOUS}" ] || [ "${PREVIOUS}" = "null" ]; then
+  echo "==> no previous non-draft prerelease available — skipping upgrade smoke"
+  echo "    (first release on a fresh project; the next tag will exercise this gate)"
+  pass "skipped (nothing to upgrade from)"
+  exit 0
+fi
+echo "==> upgrading from ${PREVIOUS} → ${LEOFLOW_VERSION}"
+
+echo "==> installing previous version (${PREVIOUS})"
+LEOFLOW_VERSION="${PREVIOUS}" \
+  curl -fsSL "https://raw.githubusercontent.com/${LEOFLOW_REPO}/${LEOFLOW_VERSION}/install.sh" | sh
+
+# Make the binary discoverable on this shell — install.sh writes a hint to
+# rc files but we cannot rely on those in a sh-only smoke runner.
+export PATH="${HOME}/.local/bin:${HOME}/.leoflow/bin:${PATH}"
+
+INSTALLED="$(leoflow version --output json 2>/dev/null | grep -oE 'v[0-9][^"]*' | head -1 || leoflow version 2>/dev/null | head -1)"
+if [ -z "${INSTALLED}" ]; then
+  fail "leoflow version reported nothing after installing ${PREVIOUS}"
+fi
+case "${INSTALLED}" in
+  *${PREVIOUS}*) pass "previous version installed (${INSTALLED})" ;;
+  *) fail "expected ${PREVIOUS} after first install, got '${INSTALLED}'" ;;
+esac
+
+echo "==> installing current version (${LEOFLOW_VERSION}) ON TOP of ${PREVIOUS}"
+LEOFLOW_VERSION="${LEOFLOW_VERSION}" \
+  curl -fsSL "https://raw.githubusercontent.com/${LEOFLOW_REPO}/${LEOFLOW_VERSION}/install.sh" | sh
+
+UPGRADED="$(leoflow version --output json 2>/dev/null | grep -oE 'v[0-9][^"]*' | head -1 || leoflow version 2>/dev/null | head -1)"
+case "${UPGRADED}" in
+  *${LEOFLOW_VERSION}*) pass "upgrade landed (${UPGRADED})" ;;
+  *) fail "after upgrading, expected ${LEOFLOW_VERSION}, got '${UPGRADED}'" ;;
+esac
+
+echo "==> verifying the managed CPython still launches after the upgrade"
+if [ -x "${HOME}/.leoflow/python/bin/python3.11" ]; then
+  "${HOME}/.leoflow/python/bin/python3.11" --version >/dev/null
+  pass "managed CPython runs after upgrade"
+else
+  echo "    (managed CPython not extracted on this distro — skip)"
+fi
+
+echo
+echo "  \033[32m✅ upgrade-in-place ${PREVIOUS} → ${LEOFLOW_VERSION} verified.\033[0m"


### PR DESCRIPTION
## Summary

Second of 5 Pro-alpha hard blockers (memory \`pro-alpha-blockers-decisions\`). Gates every prealpha release on an upgrade-in-place smoke — \"a regression that ships to a user is a worse failure mode than a 10-minute slowdown per release.\"

## What ships

- \`test/release/upgrade-smoke.sh\` — clean POSIX-sh smoke; resolves previous non-draft prerelease, installs it, then installs current tag on top, asserts new version is in place + managed CPython still launches.
- \`.github/workflows/release.yaml\` — new \`upgrade-smoke\` job after \`release\` publish; \`gate\` job depends on it and retracts to DRAFT on failure.

## What this catches

The class of install.sh bug where a fresh box succeeds but layering over an existing \`~/.leoflow/\` breaks (stale config, stale pysrc, PATH issues, password file collisions). That is exactly the bug a user hits the SECOND time they install — \`install-smoke\` only covers the first.

## Test plan

- [x] \`make ci-local\` clean
- [x] Shell syntax check (\`sh -n\`) passes
- [ ] First release tag after this PR merges will exercise the gate end-to-end against v0.0.1-prealpha.23

## Followups

- Memory: 2 of 5 Pro-alpha blockers shipped (#208 + #150). #58 TLS, #228 tenant auth, #227 S3 logs remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)