### PR TITLE
fix(server, helm): #58 — Pro edition refuses plaintext-secrets env at boot

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -100,6 +100,7 @@ jobs:
             --set redis.url='redis://x/0' \
             --set auth.jwtSecret=x \
             --set 'secretKey=leoflow-helm-ci-secret-key-32by!' \
+            --set agentTLS.serverCertSecret=leoflow-agent-tls-ci \
             | kubeconform -strict -summary -ignore-missing-schemas \
                 -schema-location default
 
@@ -150,6 +151,7 @@ jobs:
             --set redis.url='redis://redis:6379/0' \
             --set auth.jwtSecret=ci-jwt-secret \
             --set 'secretKey=leoflow-helm-ci-secret-key-32by!' \
+            --set agentTLS.enabled=false \
             --set bootstrap.password=ci-admin \
             --wait --timeout 240s
           kubectl -n leoflow rollout status deploy/leoflow --timeout=120s

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -108,6 +108,14 @@ func run() error {
 	// insecure (dev) until gRPC TLS lands (issue #58); otherwise the handlers
 	// fail closed on a plaintext channel.
 	allowInsecureSecrets := os.Getenv("LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS") == "true"
+	// Pro alpha blocker (#58): a production-edition deployment MUST NOT ship
+	// secrets over a plaintext channel. The chart's deployment template stamps
+	// LEOFLOW_UI_EDITION=production; refuse to boot if the insecure escape
+	// hatch is set alongside it. Lite (edition=lite) and the unmarked default
+	// (edition="") still tolerate the flag for the dev inner loop.
+	if err := guardInsecureSecretsForEdition(cfg.UI.Edition, allowInsecureSecrets); err != nil {
+		return err
+	}
 	grpcSrv, gerr := startAgentGRPC(ctx, cfg.Server.GRPCAddr, authn, execStore, repo, xcomSvc, logSink, logTailer, allowInsecureSecrets, cfg.Server.GRPCTLSCert, cfg.Server.GRPCTLSKey, tel.Logger)
 	if gerr != nil {
 		return gerr

--- a/cmd/leoflow-server/tls_guard.go
+++ b/cmd/leoflow-server/tls_guard.go
@@ -1,0 +1,26 @@
+package main
+
+import "errors"
+
+// guardInsecureSecretsForEdition refuses the dev-only insecure-secrets escape
+// hatch when the chart marks the deployment as production edition (#58, Pro
+// alpha blocker). The flag is a deliberate dev convenience for Lite that lets
+// the control plane ship secrets over a plaintext gRPC channel — fine on
+// localhost, never inside a real cluster.
+//
+// Memory: pro-alpha-blockers-decisions documents the design choice
+// (server-TLS + per-task JWT; refuse plaintext under the Pro chart marker).
+// Lite (edition=lite) and the unmarked default (edition="") still allow the
+// flag so the inner dev loop keeps working without TLS.
+func guardInsecureSecretsForEdition(edition string, allowInsecure bool) error {
+	if !allowInsecure {
+		return nil
+	}
+	if edition != "production" {
+		return nil
+	}
+	return errors.New("LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS=true is not allowed in the production edition: " +
+		"a Pro deployment ships secrets only over the TLS-enabled gRPC channel — " +
+		"either set agentTLS.enabled=true in the Helm values (with cert-manager) or unset the env var " +
+		"(see ADR 0014 and issue #58)")
+}

--- a/cmd/leoflow-server/tls_guard_test.go
+++ b/cmd/leoflow-server/tls_guard_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRefuseInsecureSecretsInProd: a Pro chart deployment (edition=production)
+// MUST NOT boot with LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS=true. The dev-only
+// escape hatch is fine on Lite, but inside a real cluster shipping secrets over
+// a plaintext gRPC channel is the kind of mistake that should be loud (#58).
+//
+// Lite (edition=lite) and the default (edition="") still tolerate the flag so
+// the local dev loop keeps working.
+func TestRefuseInsecureSecretsInProd(t *testing.T) {
+	cases := []struct {
+		name             string
+		edition          string
+		allowInsecure    bool
+		wantErrSubstring string // empty = expect no error
+	}{
+		{name: "lite + insecure: allowed (dev/inner loop)", edition: "lite", allowInsecure: true},
+		{name: "empty edition + insecure: allowed (dev fallback)", edition: "", allowInsecure: true},
+		{name: "production + insecure: REFUSED", edition: "production", allowInsecure: true,
+			wantErrSubstring: "LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS"},
+		{name: "production + NO insecure: allowed (default secure)", edition: "production", allowInsecure: false},
+		{name: "lite + NO insecure: allowed", edition: "lite", allowInsecure: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := guardInsecureSecretsForEdition(tc.edition, tc.allowInsecure)
+			if tc.wantErrSubstring == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErrSubstring)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSubstring) {
+				t.Errorf("error %q does not mention %q", err.Error(), tc.wantErrSubstring)
+			}
+		})
+	}
+}

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -126,7 +126,7 @@ differ from what's committed.
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Pod affinity rules (standard K8s — co-locate or anti-affinity). |
 | agentTLS.caConfigMap | string | `""` | Name of a ConfigMap with key `ca.crt`. Mounted into task pods so the agent verifies the server cert. Typically a cert-manager trust-bundle. |
-| agentTLS.enabled | bool | `false` | Enable TLS on the agent ↔ control plane gRPC channel (#58). When false, the per-task JWT still authenticates each call but the channel is plaintext (acceptable in-cluster). |
+| agentTLS.enabled | bool | `true` | Enable TLS on the agent ↔ control plane gRPC channel (#58). Default ON for the Pro alpha: the chart marks this deployment as the production edition, and the server refuses to boot with `LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS=true` so secrets cannot accidentally travel a plaintext channel. Disable only for an isolated, in-cluster test where the threat model accepts plaintext. |
 | agentTLS.serverCertSecret | string | `""` | Name of a `kubernetes.io/tls` Secret (with `tls.crt`/`tls.key`) for the gRPC server. Typically produced by a cert-manager `Certificate`. Required when `enabled: true`. |
 | auth.existingSecret | string | `""` | Name of a Secret with key `jwtSecret` (takes precedence over `jwtSecret`). |
 | auth.jwtSecret | string | `""` | HMAC secret signing API + agent JWTs. Set inline OR reference an existing Secret via `existingSecret`. Generate with `openssl rand -base64 64`. |

--- a/helm/leoflow/templates/deployment.yaml
+++ b/helm/leoflow/templates/deployment.yaml
@@ -69,6 +69,12 @@ spec:
             - name: grpc
               containerPort: {{ .Values.ports.grpc }}
           env:
+            # Mark this deployment as the Pro edition. The control plane uses
+            # this signal to refuse the LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS=true
+            # dev escape hatch at boot (#58 / ADR 0014), so a Pro install cannot
+            # accidentally ship secrets over a plaintext gRPC channel.
+            - name: LEOFLOW_UI_EDITION
+              value: "production"
             - name: LEOFLOW_SERVER_HTTP_ADDR
               value: ":{{ .Values.ports.http }}"
             - name: LEOFLOW_SERVER_METRICS_ADDR

--- a/helm/leoflow/tests/deployment_test.yaml
+++ b/helm/leoflow/tests/deployment_test.yaml
@@ -8,6 +8,7 @@ tests:
     set:
       redis.url: redis://host/0
       auth.jwtSecret: jwt
+      agentTLS.enabled: false
     asserts:
       - failedTemplate:
           errorMessage: "database.url or database.existingSecret is required: the Production edition needs an external Postgres (the embedded datastore is Lite-only)."
@@ -16,6 +17,7 @@ tests:
     set:
       database.url: postgres://h/d
       auth.jwtSecret: jwt
+      agentTLS.enabled: false
     asserts:
       - failedTemplate:
           errorMessage: "redis.url or redis.existingSecret is required: the Production edition needs an external Redis (the embedded XCom + log tailer is Lite-only)."
@@ -25,6 +27,7 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
+      agentTLS.enabled: false
       # NOT setting secretKey / secretKeyExistingSecret
     asserts:
       - hasDocuments:
@@ -39,6 +42,7 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
+      agentTLS.enabled: false
       secretKey: leoflow-unittest-secretkey-32by!
     asserts:
       - contains:
@@ -55,6 +59,7 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
+      agentTLS.enabled: false
       secretKeyExistingSecret: my-external-key
     asserts:
       - contains:
@@ -71,6 +76,7 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
+      agentTLS.enabled: false
       secretKey: too-short-12345
     asserts:
       - failedTemplate:
@@ -81,6 +87,7 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
+      agentTLS.enabled: false
       secretKey: leoflow-unittest-secretkey-32by!
     asserts:
       - hasDocuments:
@@ -91,6 +98,7 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
+      agentTLS.enabled: false
       secretKey: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef  # gitleaks:allow — fixture, all-hex zeros pattern, not a credential
     asserts:
       - hasDocuments:
@@ -101,6 +109,7 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
+      agentTLS.enabled: false
       secretKey: too-short-12345          # would normally fail
       secretKeyExistingSecret: my-key     # but the existingSecret takes precedence; chart can't validate it
     asserts:
@@ -112,6 +121,7 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
+      agentTLS.enabled: false
     asserts:
       - equal:
           path: spec.template.spec.securityContext.runAsNonRoot

--- a/helm/leoflow/tests/hardening_test.yaml
+++ b/helm/leoflow/tests/hardening_test.yaml
@@ -9,6 +9,7 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
+      agentTLS.enabled: false
     asserts:
       - hasDocuments:
           count: 0
@@ -19,6 +20,7 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
+      agentTLS.enabled: false
       autoscaling.enabled: true
       autoscaling.minReplicas: 3
       autoscaling.maxReplicas: 9
@@ -45,6 +47,7 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
+      agentTLS.enabled: false
     asserts:
       - hasDocuments:
           count: 0
@@ -55,6 +58,7 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
+      agentTLS.enabled: false
       podDisruptionBudget.enabled: true
       podDisruptionBudget.minAvailable: 2
     asserts:
@@ -73,6 +77,7 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
+      agentTLS.enabled: false
     asserts:
       - hasDocuments:
           count: 0
@@ -83,6 +88,7 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
+      agentTLS.enabled: false
       networkPolicy.enabled: true
     asserts:
       - hasDocuments:
@@ -113,6 +119,7 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
+      agentTLS.enabled: false
     asserts:
       - hasDocuments:
           count: 0
@@ -123,6 +130,7 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
+      agentTLS.enabled: false
       metrics.serviceMonitor.enabled: true
     asserts:
       - hasDocuments:

--- a/helm/leoflow/values.yaml
+++ b/helm/leoflow/values.yaml
@@ -147,8 +147,8 @@ migrations:
 # so the agent verifies the server cert. Typically both are produced by
 # cert-manager (a Certificate Secret + a trust-bundle/CA ConfigMap).
 agentTLS:
-  # -- Enable TLS on the agent ↔ control plane gRPC channel (#58). When false, the per-task JWT still authenticates each call but the channel is plaintext (acceptable in-cluster).
-  enabled: false
+  # -- Enable TLS on the agent ↔ control plane gRPC channel (#58). Default ON for the Pro alpha: the chart marks this deployment as the production edition, and the server refuses to boot with `LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS=true` so secrets cannot accidentally travel a plaintext channel. Disable only for an isolated, in-cluster test where the threat model accepts plaintext.
+  enabled: true
   # -- Name of a `kubernetes.io/tls` Secret (with `tls.crt`/`tls.key`) for the gRPC server. Typically produced by a cert-manager `Certificate`. Required when `enabled: true`.
   serverCertSecret: ""
   # -- Name of a ConfigMap with key `ca.crt`. Mounted into task pods so the agent verifies the server cert. Typically a cert-manager trust-bundle.

--- a/scripts/helm-template-checks.sh
+++ b/scripts/helm-template-checks.sh
@@ -24,7 +24,8 @@ RENDERED=$(helm template leoflow-test "$CHART" \
   --set database.url='postgres://leoflow:p@db:5432/leoflow?sslmode=disable' \
   --set redis.url='redis://r:6379/0' \
   --set auth.jwtSecret='helm-template-check-jwt-fixture' \
-  --set secretKey='leoflow-tmpl-check-secret-key-32')
+  --set secretKey='leoflow-tmpl-check-secret-key-32' \
+  --set agentTLS.serverCertSecret='leoflow-agent-tls-fixture')
 
 fail=0
 expect_substring() {
@@ -58,6 +59,7 @@ JOB_RENDERED=$(helm template leoflow-test "$CHART" \
   --set redis.url='redis://r:6379/0' \
   --set auth.jwtSecret='helm-template-check-jwt-fixture' \
   --set secretKey='leoflow-tmpl-check-secret-key-32' \
+  --set agentTLS.serverCertSecret='leoflow-agent-tls-fixture' \
   --show-only templates/migration-job.yaml)
 
 expect_in_job() {


### PR DESCRIPTION
## Summary

Third of 5 Pro-alpha hard blockers (memory \`pro-alpha-blockers-decisions\`). Implements the decision verbatim: server-TLS + per-task JWT; refuse the dev-only insecure-secrets escape hatch when the chart marks the deployment as production.

## What ships

- \`cmd/leoflow-server/tls_guard.go\` (+ test): pure helper that errors only when \`edition=="production" && allowInsecure==true\`.
- \`cmd/leoflow-server/main.go\`: calls the guard right after computing \`allowInsecureSecrets\`. Misconfigured Pro pod CrashLoops with a clear message instead of running.
- \`helm/leoflow/templates/deployment.yaml\`: stamps \`LEOFLOW_UI_EDITION=production\` so the guard has the signal it needs.
- \`helm/leoflow/values.yaml\`: \`agentTLS.enabled\` default flips to \`true\` — the doc comment explains the trade-off.

## Test plan

- [x] 5-case table-driven unit test covers (edition × allowInsecure) matrix incl. the new REFUSED case
- [x] \`make ci-local\` clean (gofmt, build, lint, tests, parser, ADR index, mkdocs strict)

## Memory tally

3 of 5 Pro-alpha blockers shipped this session: #208 (PR #261 merged), #150 (PR #262 open), #58 (this PR). #227 S3 logs remains; #228 deprioritized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)