### PR TITLE
fix(helm): #227 — Pro log directory backed by a PVC (durable across pod restarts)

### DIFF
--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -141,7 +141,7 @@ differ from what's committed.
 | bootstrap.password | string | `""` | Initial admin password (first install only). Leave empty to skip the bootstrap; the operator then creates the first admin out-of-band. |
 | config.agentControlPlaneAddr | string | `""` | gRPC address task pods dial back to reach the control plane. Defaults to the in-cluster Service DNS on `ports.grpc` when empty. Override for cross-cluster or external task pods. |
 | config.cors.allowedOrigins | list | `["*"]` | CORS allowed origins for the API. `["*"]` is fine for Pro behind an authenticated ingress; tighten for public-facing deploys. |
-| config.logsDir | string | `"/var/log/leoflow"` | Directory inside the pod where task logs are written. Mounted as emptyDir. |
+| config.logsDir | string | `"/var/log/leoflow"` | Directory inside the pod where task logs are written. Mounted from `logs.persistence` (a PVC by default) so logs survive pod restarts. Set `logs.persistence.enabled: false` to fall back to an ephemeral emptyDir (dev only). |
 | config.scheduler.enabled | bool | `true` | Run the scheduler loop. Disable only for read-only API-only replicas (rare). |
 | config.scheduler.loopIntervalMs | int | `1000` | Scheduler loop interval in milliseconds. Lower = faster reactivity, higher CPU. 1000ms is the production-tested default. |
 | database.existingSecret | string | `""` | Name of a Secret with key `databaseUrl` (takes precedence over `url`). |
@@ -157,6 +157,10 @@ differ from what's committed.
 | ingress.enabled | bool | `false` | Enable an Ingress resource exposing the control plane via HTTP/HTTPS. Requires an Ingress controller (nginx/traefik/etc.) in the cluster. |
 | ingress.hosts | list | `[{"host":"leoflow.local","paths":[{"path":"/","pathType":"Prefix"}]}]` | Host + path rules. Each host maps to one or more path entries routed to the leoflow-server's `http` port. |
 | ingress.tls | list | `[]` | TLS configuration. Each entry maps hosts to a TLS Secret (typically a cert-manager Certificate Secret). |
+| logs.persistence.accessMode | string | `"ReadWriteOnce"` | PVC access mode. `ReadWriteOnce` (default) is fine for single-replica deployments; `ReadWriteMany` is required when `replicaCount > 1`. |
+| logs.persistence.enabled | bool | `true` | Persist control-plane logs in a PVC (default ON). Disable for ephemeral emptyDir (dev only — logs lost on pod restart). |
+| logs.persistence.size | string | `"50Gi"` | PVC size for control-plane logs. ~1 GB/day per ~1000 active task runs is a sane starting point. |
+| logs.persistence.storageClass | string | `""` | StorageClass for the PVC. Empty uses the cluster default. Specify an RWX class when `accessMode: ReadWriteMany`. |
 | metrics.serviceMonitor.additionalLabels | object | `{}` | Extra labels on the ServiceMonitor. Required when the Prometheus instance has a `serviceMonitorSelector` filter (e.g. `{release: kube-prometheus-stack}`). |
 | metrics.serviceMonitor.enabled | bool | `false` | Enable ServiceMonitor for Prometheus scraping. Requires kube-prometheus-stack CRDs. |
 | metrics.serviceMonitor.interval | string | `"30s"` | Prometheus scrape interval. |

--- a/helm/leoflow/templates/deployment.yaml
+++ b/helm/leoflow/templates/deployment.yaml
@@ -173,7 +173,14 @@ spec:
             {{- end }}
       volumes:
         - name: logs
+          {{- if .Values.logs.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "leoflow.fullname" . }}-logs
+          {{- else }}
+          # Dev-only fallback: logs vanish on pod restart. Enable
+          # `logs.persistence.enabled` for durable storage (#227).
           emptyDir: {}
+          {{- end }}
         {{- if .Values.agentTLS.enabled }}
         - name: grpc-tls
           secret:

--- a/helm/leoflow/templates/pvc-logs.yaml
+++ b/helm/leoflow/templates/pvc-logs.yaml
@@ -1,0 +1,30 @@
+{{- /*
+PersistentVolumeClaim backing the control plane's log directory (#227).
+The pod-per-task executor streams task logs over gRPC into the control plane,
+which writes them under `config.logsDir`. Without a PVC those logs sit in an
+emptyDir and vanish on pod restart — operators replaying an incident or just
+clicking into an older run would lose the trail.
+
+Skipped when `logs.persistence.enabled: false` (deployment falls back to
+emptyDir, dev-only). When the chart's `replicaCount > 1`, the access mode
+must be `ReadWriteMany` (NFS, Longhorn-rwx, CephFS, EFS, Azure Files, GCP
+Filestore) so every replica can read+write the same volume.
+*/}}
+{{- if .Values.logs.persistence.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "leoflow.fullname" . }}-logs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "leoflow.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.logs.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.logs.persistence.size | quote }}
+  {{- with .Values.logs.persistence.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/helm/leoflow/values.yaml
+++ b/helm/leoflow/values.yaml
@@ -44,7 +44,7 @@ service:
 
 # config maps to LEOFLOW_* env. Non-secret settings live here; secrets below.
 config:
-  # -- Directory inside the pod where task logs are written. Mounted as emptyDir.
+  # -- Directory inside the pod where task logs are written. Mounted from `logs.persistence` (a PVC by default) so logs survive pod restarts. Set `logs.persistence.enabled: false` to fall back to an ephemeral emptyDir (dev only).
   logsDir: /var/log/leoflow
   scheduler:
     # -- Run the scheduler loop. Disable only for read-only API-only replicas (rare).
@@ -57,6 +57,24 @@ config:
       - "*"
   # -- gRPC address task pods dial back to reach the control plane. Defaults to the in-cluster Service DNS on `ports.grpc` when empty. Override for cross-cluster or external task pods.
   agentControlPlaneAddr: ""
+
+# Persistent log storage for the control plane (#227 — Pro alpha).
+# Task pods stream logs over gRPC to the control plane, which writes them under
+# `config.logsDir`. By default this directory lives on a PVC so logs survive
+# pod restarts. For multi-replica HA, set `accessMode: ReadWriteMany` and a
+# storage class that supports it (NFS, Longhorn-rwx, CephFS, EFS, Azure Files,
+# GCP Filestore). When you do not need durable logs (dev / throwaway clusters),
+# set `enabled: false` to use an emptyDir instead — logs vanish on pod restart.
+logs:
+  persistence:
+    # -- Persist control-plane logs in a PVC (default ON). Disable for ephemeral emptyDir (dev only — logs lost on pod restart).
+    enabled: true
+    # -- PVC size for control-plane logs. ~1 GB/day per ~1000 active task runs is a sane starting point.
+    size: 50Gi
+    # -- StorageClass for the PVC. Empty uses the cluster default. Specify an RWX class when `accessMode: ReadWriteMany`.
+    storageClass: ""
+    # -- PVC access mode. `ReadWriteOnce` (default) is fine for single-replica deployments; `ReadWriteMany` is required when `replicaCount > 1`.
+    accessMode: ReadWriteOnce
 
 # Database (Postgres). Provide an external URL, or a pre-existing secret.
 database:


### PR DESCRIPTION
## Summary

Fourth of 5 Pro-alpha hard blockers (memory \`pro-alpha-blockers-decisions\`). Per discussion this session, simplified design — a PVC is enough for the alpha, S3 is post-alpha if log archival demands appear:

- Wire format unchanged: control plane already streams logs from agents and writes them via \`DiskSink\` to \`LEOFLOW_LOGS_DIR\`.
- The new bit is just **what's mounted in front of that directory**: a PVC by default (logs survive pod restarts) with an emptyDir fallback for dev (\`logs.persistence.enabled: false\`).

Self-hosted-friendly by construction: zero dependency on object storage, no MinIO (discontinued), no AWS SDK in the binary.

## What ships

- \`helm/leoflow/values.yaml\` — new \`logs.persistence\` block (enabled by default, 50Gi RWO, optional storage class).
- \`helm/leoflow/templates/pvc-logs.yaml\` — new PVC, claimed only when enabled.
- \`helm/leoflow/templates/deployment.yaml\` — \`logs\` volume switches between PVC and emptyDir based on the toggle.

## Multi-replica HA

For \`replicaCount > 1\` operators set \`accessMode: ReadWriteMany\` + an RWX storage class (NFS, Longhorn-rwx, CephFS, EFS, Azure Files, GCP Filestore). The value comments call this out.

## Test plan

- [x] \`helm template\` with defaults: PVC rendered, deployment mounts it by claim name
- [x] \`helm template --set logs.persistence.enabled=false\`: PVC skipped, deployment falls back to emptyDir with the dev-only comment
- [x] \`make ci-local\` clean (mkdocs strict, lint, tests, parser)

## Memory tally

4 of 5 Pro-alpha blockers shipped this session: #208 (merged), #150 (PR #262 open), #58 (PR #263 open), #227 (this PR). #228 deprioritized by user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)