### PR TITLE
fix(storage, ci): retry Postgres ping at boot + #96 lite cold-start smoke

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -192,6 +192,68 @@ jobs:
           leoflow version
           "$HOME/.leoflow/python/bin/python3.11" --version
 
+  # ── Cold-start smoke (#96): the actual user flow we cannot reproduce in
+  # any other gate — install fresh, run `leoflow setup`, boot `leoflow lite`,
+  # wait for /readyz to respond. Catches the class of bug where the binary
+  # is installed correctly but boot fails (Postgres race, managed-runtime
+  # missing libs, agent port collision, etc.). Uses `--postgres managed` so
+  # the smoke does NOT need Docker-in-Docker; the relocatable Postgres
+  # `leoflow setup` extracted is exercised here for real. Pinned to ubuntu
+  # (the most representative dev environment); the 7-distro install-smoke
+  # above still gates `--version` works on each distro. Extending the cold
+  # start to more distros lands as managed-runtime portability work (#97)
+  # validates each base.
+  lite-cold-start-smoke:
+    name: Lite cold-start (boot + /readyz, managed PG)
+    needs: release
+    runs-on: ubuntu-latest
+    container: ubuntu:24.04
+    steps:
+      - name: Install prerequisites
+        run: |
+          apt-get update -qq
+          apt-get install -y -qq curl ca-certificates tar procps
+      - name: Install Leoflow via the published install.sh
+        env:
+          LEOFLOW_VERSION: ${{ github.ref_name }}
+        run: curl -fsSL "https://raw.githubusercontent.com/${{ github.repository }}/${{ github.ref_name }}/install.sh" | sh
+      - name: leoflow setup (non-interactive, defaults)
+        run: |
+          set -eu
+          export PATH="$HOME/.local/bin:$PATH"
+          mkdir -p /tmp/ws
+          leoflow setup --workspace /tmp/ws </dev/null
+      - name: Boot leoflow lite and wait for /readyz
+        run: |
+          set -eu
+          export PATH="$HOME/.local/bin:$PATH"
+          # Background lite; capture stdout+stderr so we can dump on failure.
+          leoflow lite --postgres managed --port 8088 --host 127.0.0.1 >/tmp/lite.log 2>&1 &
+          LITE_PID=$!
+          # Poll /readyz up to 60s. The Postgres-retry budget is 30s by
+          # itself; budget here is loose enough that a managed-PG cold extract
+          # is not penalized while still catching real hangs.
+          ready=0
+          for _ in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:8088/readyz >/dev/null 2>&1; then
+              ready=1
+              break
+            fi
+            sleep 1
+          done
+          if [ "$ready" -ne 1 ]; then
+            echo "::error::/readyz never responded after 60s"
+            echo "--- lite log (tail) ---"
+            tail -200 /tmp/lite.log || true
+            kill -TERM "$LITE_PID" 2>/dev/null || true
+            exit 1
+          fi
+          echo "✓ /readyz responded"
+          # Graceful shutdown; assert SIGTERM is honored (otherwise the
+          # process becomes a CI zombie and future runs leak).
+          kill -TERM "$LITE_PID"
+          wait "$LITE_PID" 2>/dev/null || true
+
   # ── Release gate: if the install smoke OR the migrate-image build failed,
   # retract the pre-release to a draft so `curl | sh` (which resolves the
   # newest public release) and the Helm chart (which references the migrate
@@ -199,22 +261,22 @@ jobs:
   # act on either failure; on success it leaves the published pre-release
   # untouched.
   gate:
-    name: Gate release on install smoke + migrate image
-    needs: [release, install-smoke, migrate-image]
+    name: Gate release on install + lite-cold-start + migrate image
+    needs: [release, install-smoke, lite-cold-start-smoke, migrate-image]
     if: always() && needs.release.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write   # Edit the published release back to a draft on failure.
     steps:
       - name: Retract release to draft on smoke or migrate-image failure
-        if: needs.install-smoke.result != 'success' || needs.migrate-image.result != 'success'
+        if: needs.install-smoke.result != 'success' || needs.lite-cold-start-smoke.result != 'success' || needs.migrate-image.result != 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eu
-          echo "::error::release blocked: install-smoke=${{ needs.install-smoke.result }} migrate-image=${{ needs.migrate-image.result }}; retracting ${GITHUB_REF_NAME} to a draft."
+          echo "::error::release blocked: install-smoke=${{ needs.install-smoke.result }} lite-cold-start-smoke=${{ needs.lite-cold-start-smoke.result }} migrate-image=${{ needs.migrate-image.result }}; retracting ${GITHUB_REF_NAME} to a draft."
           gh release edit "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" --draft
           exit 1
       - name: Confirm release passed all gates
-        if: needs.install-smoke.result == 'success' && needs.migrate-image.result == 'success'
-        run: echo "install smoke + migrate-image passed; ${GITHUB_REF_NAME} stays published."
+        if: needs.install-smoke.result == 'success' && needs.lite-cold-start-smoke.result == 'success' && needs.migrate-image.result == 'success'
+        run: echo "install smoke + lite cold-start + migrate-image passed; ${GITHUB_REF_NAME} stays published."

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -4,14 +4,30 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/neochaotic/leoflow/internal/config"
 	"github.com/neochaotic/leoflow/internal/storage/queries"
 )
+
+// pgStartupBudget caps how long NewPostgres waits for the first successful
+// ping. Lite hits this when docker compose marks Postgres Healthy (pg_isready)
+// before the server accepts client TCP — the first ping gets `connection reset
+// by peer`. Pro hits it during external-PG failover, network blips, or restart
+// of the upstream cluster. 30s is comfortably above docker cold-start on a
+// busy laptop but still surfaces a real misconfig (wrong DSN, blocked auth)
+// before the operator gives up.
+const pgStartupBudget = 30 * time.Second
+
+// pgStartupBackoff is the first delay between failed pings; the loop doubles
+// it up to a 3s cap. Small enough that a healthy Postgres still feels instant;
+// large enough that real misconfigs don't get hammered with reconnect storms.
+const pgStartupBackoff = 100 * time.Millisecond
 
 // Postgres holds a pgx connection pool and the generated query set.
 type Postgres struct {
@@ -34,7 +50,13 @@ func poolConfig(cfg config.DatabaseSection) (*pgxpool.Config, error) {
 	return pc, nil
 }
 
-// NewPostgres opens a connection pool and verifies connectivity.
+// NewPostgres opens a connection pool and verifies connectivity, retrying
+// transient failures during boot for up to pgStartupBudget. Pre-2026-06,
+// the first failed ping fatal-ed the server, so a docker compose race or
+// any Pro failover blip became a hard crash. The retry loop keeps Lite
+// boot ergonomic and Pro startup resilient under realistic upstream-PG
+// dynamics. A truly broken setup (wrong DSN, bad auth) still surfaces
+// quickly because the underlying error is wrapped into the final error.
 func NewPostgres(ctx context.Context, cfg config.DatabaseSection) (*Postgres, error) {
 	pc, err := poolConfig(cfg)
 	if err != nil {
@@ -44,11 +66,47 @@ func NewPostgres(ctx context.Context, cfg config.DatabaseSection) (*Postgres, er
 	if err != nil {
 		return nil, fmt.Errorf("creating connection pool: %w", err)
 	}
-	if err := pool.Ping(ctx); err != nil {
+	if err := connectWithRetry(ctx, pool.Ping, pgStartupBudget, pgStartupBackoff); err != nil {
 		pool.Close()
-		return nil, fmt.Errorf("pinging database: %w", err)
+		return nil, err
 	}
 	return &Postgres{Pool: pool, Queries: queries.New(pool)}, nil
+}
+
+// connectWithRetry calls pingFn until it returns nil, the budget elapses, or
+// the context is canceled. Backoff doubles each iteration up to 3s. The final
+// error wraps the LAST underlying error so the operator can distinguish
+// "connection reset" (transient race) from "auth failed" or "no such host"
+// (real misconfig that will never recover). Extracted as a top-level helper
+// so it is testable without a live Postgres — see postgres_retry_test.go.
+func connectWithRetry(ctx context.Context, pingFn func(context.Context) error, budget, initialBackoff time.Duration) error {
+	deadline := time.Now().Add(budget)
+	backoff := initialBackoff
+	const maxBackoff = 3 * time.Second
+	var lastErr error
+	for {
+		lastErr = pingFn(ctx)
+		if lastErr == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("postgres unreachable after %s: %w", budget, lastErr)
+		}
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return context.Canceled
+			}
+			return ctx.Err()
+		}
+		if backoff < maxBackoff {
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+		}
+	}
 }
 
 // NewLeaderPool opens a dedicated single-connection pool for the scheduler

--- a/internal/storage/postgres_retry_test.go
+++ b/internal/storage/postgres_retry_test.go
@@ -1,0 +1,75 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestConnectWithRetrySucceedsAfterTransientFailures: cold-start race —
+// `pg_isready` says OK before Postgres accepts client connections; the first N
+// pings hit "connection reset by peer", then the server is up. The control
+// plane must retry instead of dying. This is the test that would have caught
+// the Lima 2026-06-01 boot failure where docker compose reported the Postgres
+// container Healthy but the pgx ping immediately got reset.
+func TestConnectWithRetrySucceedsAfterTransientFailures(t *testing.T) {
+	calls := 0
+	transient := errors.New("read tcp 127.0.0.1->127.0.0.1: read: connection reset by peer")
+	ping := func(_ context.Context) error {
+		calls++
+		if calls < 3 {
+			return transient
+		}
+		return nil
+	}
+	if err := connectWithRetry(context.Background(), ping, 2*time.Second, 1*time.Millisecond); err != nil {
+		t.Fatalf("retry must recover from transient failures, got: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 ping attempts (2 fail + 1 success), got %d", calls)
+	}
+}
+
+// TestConnectWithRetryGivesUpAfterBudget: Postgres never comes back; the
+// caller MUST see the last underlying error wrapped, not a generic timeout,
+// so the operator can see e.g. "wrong DSN" vs "auth failed" vs "host
+// unreachable".
+func TestConnectWithRetryGivesUpAfterBudget(t *testing.T) {
+	underlying := errors.New("pg_hba.conf rejects connection: wrong password")
+	ping := func(_ context.Context) error { return underlying }
+	err := connectWithRetry(context.Background(), ping, 50*time.Millisecond, 1*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected an error after the budget elapsed, got nil")
+	}
+	if !errors.Is(err, underlying) {
+		t.Errorf("budget-exhausted error must wrap the last underlying error; got: %v", err)
+	}
+}
+
+// TestConnectWithRetryRespectsContextCancel: if the operator hits Ctrl-C
+// during startup, the retry loop must exit immediately, not run out the full
+// budget. Otherwise a stuck `leoflow lite` ignores SIGINT for 30s.
+func TestConnectWithRetryRespectsContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	ping := func(_ context.Context) error {
+		calls++
+		if calls == 1 {
+			cancel() // cancel after the first failed ping
+		}
+		return errors.New("never resolves")
+	}
+	start := time.Now()
+	err := connectWithRetry(ctx, ping, 10*time.Second, 200*time.Millisecond)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected error after context cancel")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected ctx.Canceled error, got %v", err)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("loop must exit on ctx cancel, but ran for %s", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary

Two complementary tools for the class of cold-start race the Lima user hit on 2026-06-01 with v0.0.1-prealpha.23:

\`\`\`
error: connecting to Postgres (is it up?): failed to connect to \`user=leoflow database=postgres\`:
127.0.0.1:5432 (localhost): failed to receive message: read tcp 127.0.0.1:40246->127.0.0.1:5432:
read: connection reset by peer
\`\`\`

Docker reported the container Healthy (\`pg_isready\`) BEFORE Postgres accepted client TCP. First \`pgx.Ping()\` got reset. \`leoflow lite\` exited.

**Not a regression** — the race has existed forever; it surfaces on fresh installs (first \`initdb\`). Earlier installs had pre-initialized PG volumes and skipped the race.

## Root-cause fix: retry at boot

\`storage.NewPostgres\` retries the initial Ping up to 30s with exponential backoff. Final error wraps the LAST underlying error so real misconfigs (wrong DSN, bad auth) surface clearly. The retry helps:

- **Lite + Docker Postgres** — the exact race above (one-time fix, every future install benefits)
- **Lite + Managed Postgres** — subprocess pg still initializing
- **Pro + external Postgres** — failover, network blip, restart upstream

Same code path, three failure modes resolved.

## Regression guard: #96 lite cold-start smoke

Why no existing test caught this: every Postgres-touching test runs against an ALREADY-READY Postgres (\`make dev-up\` ran minutes earlier). The release \`install-smoke\` checked \`leoflow version\` + CPython then stopped — never booted \`leoflow lite\`.

New \`lite-cold-start-smoke\` job in \`release.yaml\`:
- Install via install.sh
- \`leoflow setup\` non-interactively
- \`leoflow lite --postgres managed\` (no Docker-in-Docker; relocatable PG is exercised for real)
- Poll \`/readyz\` for 60s; fail with log tail on timeout
- Graceful SIGTERM

Pinned to ubuntu:24.04 for the first iteration. Wired into the \`gate\` job so a regression retracts the release to DRAFT.

## Test plan

- [x] 3 unit tests for \`connectWithRetry\` (success-after-N, budget-expiry, context-cancel)
- [x] \`make ci-local\` clean
- [x] actionlint passes
- [ ] First release tag after merge exercises the new cold-start gate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)