### PR TITLE
fix(examples): fan_out_aggregate + montecarlo_pi reducers return value (was None)

### DIFF
--- a/examples/fan_out_aggregate/dag.py
+++ b/examples/fan_out_aggregate/dag.py
@@ -18,9 +18,13 @@ def shard(n: int) -> dict:
 
 
 @task
-def aggregate(parts: list[dict]) -> None:
+def aggregate(parts: list[dict]) -> dict:
     grand = sum(p["total"] for p in parts)
     print(f"aggregate: combined {len(parts)} shards -> {grand}")
+    # Return the aggregated value so it lands in XCom — the whole point of a
+    # fan-in DAG is the reducer's result, and the UI's XCom tab is where the
+    # user expects to see it. Returning None would erase the demo's payoff.
+    return {"shards": len(parts), "grand_total": grand}
 
 
 with DAG("fan_out_aggregate", schedule=None, catchup=False, tags=["example"]):

--- a/examples/montecarlo_pi/dag.py
+++ b/examples/montecarlo_pi/dag.py
@@ -18,11 +18,14 @@ def estimate(seed: int) -> dict:
 
 
 @task
-def combine(parts: list[dict]) -> None:
+def combine(parts: list[dict]) -> dict:
     inside = sum(p["inside"] for p in parts)
     total = sum(p["total"] for p in parts)
     pi = 4 * inside / total
     print(f"combine: {len(parts)} workers, {total:,} samples -> pi ≈ {pi:.5f}")
+    # Return the estimate so it lands in XCom (the UI's XCom tab is where the
+    # user expects to see the headline number; returning None hides it).
+    return {"workers": len(parts), "samples": total, "pi": pi}
 
 
 with DAG("montecarlo_pi", schedule=None, catchup=False, tags=["example"]):


### PR DESCRIPTION
## Summary

User flagged on Lima test of prealpha.23: triggered \`fan_out_aggregate\`, expected to see the computed total in the UI XCom tab. Saw \`returned None (no XCom pushed)\` in the logs and empty XCom.

**Not a bug in the runtime** — \`aggregate()\` is declared \`-> None\` and only \`print()\`s. Runtime correctly emits metadata-only line per ADR 0032; nothing to push.

**Bug in the example** — the whole point of fan-in / map-reduce is the chain compute → return → XCom → consumer. Reducers that print without returning teach the wrong pattern.

## Fix

Both \`aggregate\` (fan_out_aggregate) and \`combine\` (montecarlo_pi) now return a small dict with the headline number. \`ml_hparam_search\` already did this correctly.

Goldens unchanged — function bodies don't affect dag.json shape.

## Test plan

- [x] \`make ci-local\` clean (parser goldens still match)
- [ ] Next prealpha install: trigger fan_out_aggregate, XCom tab shows \`{"shards": 4, "grand_total": 7998000}\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)