### PR TITLE
diag(api): timing log on PATCH /taskInstances (mark-state) for #271

### DIFF
--- a/internal/api/resources.go
+++ b/internal/api/resources.go
@@ -610,6 +610,13 @@ type markStateRequest struct {
 // changing state. It returns the (would-be) updated task instance.
 func patchTaskInstanceHandler(repo TaskInstanceRepository, runs DagRunRepository, versions DagVersionLister, audit AuditWriter) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// #271 diagnostic: timing the mark-state mutation so we can prove the
+		// backend write is instant when the user reports "marking a task as
+		// failed takes forever". The wall-clock here is the server's share
+		// of the latency; anything slower than ~50ms here is a real server
+		// regression, while anything beyond that on the UX side belongs to
+		// the SPA's cache invalidation (see #271 update).
+		t0 := time.Now()
 		action := strings.Trim(c.Param("action"), "/")
 		dryRun := action == "dry_run" || strings.HasSuffix(action, "/dry_run")
 		var body markStateRequest
@@ -628,6 +635,7 @@ func patchTaskInstanceHandler(repo TaskInstanceRepository, runs DagRunRepository
 				return
 			}
 		}
+		writeMs := time.Since(t0).Milliseconds()
 		dto, ok := findTaskInstanceDTO(c, repo, runs, versions, runID, taskID)
 		if !ok {
 			AbortProblem(c, http.StatusNotFound, "not found", "task instance not found")
@@ -639,6 +647,10 @@ func patchTaskInstanceHandler(repo TaskInstanceRepository, runs DagRunRepository
 		} else {
 			recordTaskAudit(c, audit, "taskinstance.mark."+body.NewState, runID, taskID, dto.TryNumber)
 		}
+		slog.Info("PATCH /taskInstances mark-state",
+			"tenant", tenantOf(c), "dag", dagID, "run", runID, "task", taskID,
+			"new_state", body.NewState, "dry_run", dryRun,
+			"write_ms", writeMs, "total_ms", time.Since(t0).Milliseconds())
 		c.JSON(http.StatusOK, dto)
 	}
 }


### PR DESCRIPTION
## Summary

User reports "marking a task as failed takes forever to reflect" on the Lima prealpha.23 test. Investigation in #271 narrowed it to the SPA: the upstream Airflow bundle invalidates TanStack Query keys for canonical \`/api/v2/*\` endpoints, but our \`/ui/*\` endpoints (grid, dashboard stats) are not in the invalidation set.

This PR adds server-side timing on the mark-state mutation so we can prove the gap is the SPA cache, not the backend.

## What ships

Single log line per mark-state call, with \`write_ms\` (DB write only) and \`total_ms\` (full handler). Aligned with the tracing pattern from PR #260 (\`/ui/dags\`, \`/importErrors\`).

## Test plan

- [x] \`make ci-local\` clean
- [ ] Next prealpha install: trigger any mark-failed action and confirm the log shows \`write_ms\` < 50ms — if YES the lag is 100% SPA, no further backend tuning to do

## Strategy for the UI cache lag

Documented in #271. Three paths to minimize Airflow-upgrade pain:
- **Mirror endpoint shapes** so SPA invalidation keys match
- **Shim script** that hooks queryClient and adds our /ui/* keys (small, upgrade-safe)
- **SSE / WebSocket** for live state (eliminates polling/cache entirely)

🤖 Generated with [Claude Code](https://claude.com/claude-code)