### PR TITLE
fix(ci): release smoke jobs (libicu + version capture)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -212,7 +212,13 @@ jobs:
       - name: Install prerequisites
         run: |
           apt-get update -qq
-          apt-get install -y -qq curl ca-certificates tar procps
+          # libicu74 + krb5-libs are linked by the relocatable Postgres binary;
+          # a stock ubuntu:24.04 image ships without them so `leoflow lite
+          # --postgres managed` errors out at boot ("system libraries missing").
+          # Real Ubuntu desktops typically have these via libreoffice/curl,
+          # but a slim CI container does not — install them explicitly so the
+          # smoke job actually exercises the managed-PG path (#96).
+          apt-get install -y -qq curl ca-certificates tar procps libicu74 libgssapi-krb5-2
       - name: Install Leoflow via the published install.sh
         env:
           LEOFLOW_VERSION: ${{ github.ref_name }}

--- a/test/release/upgrade-smoke.sh
+++ b/test/release/upgrade-smoke.sh
@@ -52,8 +52,15 @@ LEOFLOW_VERSION="${PREVIOUS}" \
 # rc files but we cannot rely on those in a sh-only smoke runner.
 export PATH="${HOME}/.local/bin:${HOME}/.leoflow/bin:${PATH}"
 
-INSTALLED="$(leoflow version --output json 2>/dev/null | grep -oE 'v[0-9][^"]*' | head -1 || leoflow version 2>/dev/null | head -1)"
+# `leoflow version` prints a free-form line like:
+#   leoflow v0.0.1-prealpha.23 (commit abc, built ..., go1.26.3)
+# Earlier pipelines using `--output json | grep | head` silently returned
+# empty because `head -1` exits 0 even on empty input, so the `||` fallback
+# never fired (gate falsely failed against valid binaries). Capture the
+# whole line and let the case-match below assert the tag.
+INSTALLED="$(command -v leoflow >/dev/null 2>&1 && leoflow version 2>&1 | head -1 || true)"
 if [ -z "${INSTALLED}" ]; then
+  echo "==> debug: PATH=${PATH}; which leoflow=$(command -v leoflow || echo missing)" >&2
   fail "leoflow version reported nothing after installing ${PREVIOUS}"
 fi
 case "${INSTALLED}" in
@@ -65,7 +72,7 @@ echo "==> installing current version (${LEOFLOW_VERSION}) ON TOP of ${PREVIOUS}"
 LEOFLOW_VERSION="${LEOFLOW_VERSION}" \
   curl -fsSL "https://raw.githubusercontent.com/${LEOFLOW_REPO}/${LEOFLOW_VERSION}/install.sh" | sh
 
-UPGRADED="$(leoflow version --output json 2>/dev/null | grep -oE 'v[0-9][^"]*' | head -1 || leoflow version 2>/dev/null | head -1)"
+UPGRADED="$(command -v leoflow >/dev/null 2>&1 && leoflow version 2>&1 | head -1 || true)"
 case "${UPGRADED}" in
   *${LEOFLOW_VERSION}*) pass "upgrade landed (${UPGRADED})" ;;
   *) fail "after upgrading, expected ${LEOFLOW_VERSION}, got '${UPGRADED}'" ;;


### PR DESCRIPTION
## Summary
- **Lite cold-start**: install `libicu74` and `libgssapi-krb5-2` in the prep step. Stock `ubuntu:24.04` ships without them, so the relocatable Postgres fails to launch on boot.
- **Upgrade smoke**: replace the silent-empty `--output json | grep | head` pipeline with `command -v leoflow + leoflow version | head -1`. Old form returned `""` (head exits 0 on empty input) → gate falsely failed against valid binaries.

Both bugs surfaced on `v0.0.1-prealpha.24` — gate retracted a perfectly good release to draft despite all 7 install-smoke distros passing.

## Test plan
- [ ] Cut next prealpha tag; release workflow runs the new smoke jobs and the gate publishes the release.
- [ ] Cold-start ubuntu container actually boots `leoflow lite --postgres managed` and `/readyz` responds.
- [ ] Upgrade smoke prints the captured version line and the case-match passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)