### PR TITLE
fix(ci): smoke jobs — ubuntu:22.04 + LEOFLOW_VERSION env propagation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -207,18 +207,21 @@ jobs:
     name: Lite cold-start (boot + /readyz, managed PG)
     needs: release
     runs-on: ubuntu-latest
-    container: ubuntu:24.04
+    # ubuntu:22.04 (libicu70) matches the libicu the bundled relocatable
+    # Postgres 16.13.0 was linked against. ubuntu:24.04 ships libicu74,
+    # which the bundled PG cannot dlopen → "system libraries missing" boot
+    # error (we saw this on prealpha.24/.25). The actual user environment
+    # this smoke is mimicking — a Lima-style Ubuntu LTS dev VM — is also
+    # 22.04, so this is the right base to pin.
+    container: ubuntu:22.04
     steps:
       - name: Install prerequisites
         run: |
           apt-get update -qq
-          # libicu74 + krb5-libs are linked by the relocatable Postgres binary;
-          # a stock ubuntu:24.04 image ships without them so `leoflow lite
-          # --postgres managed` errors out at boot ("system libraries missing").
-          # Real Ubuntu desktops typically have these via libreoffice/curl,
-          # but a slim CI container does not — install them explicitly so the
-          # smoke job actually exercises the managed-PG path (#96).
-          apt-get install -y -qq curl ca-certificates tar procps libicu74 libgssapi-krb5-2
+          # libicu70 + krb5-libs are linked by the relocatable Postgres
+          # binary; the slim ubuntu:22.04 CI image is missing them so the
+          # managed-PG path needs them installed up-front (#96).
+          apt-get install -y -qq curl ca-certificates tar procps libicu70 libgssapi-krb5-2
       - name: Install Leoflow via the published install.sh
         env:
           LEOFLOW_VERSION: ${{ github.ref_name }}

--- a/test/release/upgrade-smoke.sh
+++ b/test/release/upgrade-smoke.sh
@@ -45,8 +45,16 @@ fi
 echo "==> upgrading from ${PREVIOUS} → ${LEOFLOW_VERSION}"
 
 echo "==> installing previous version (${PREVIOUS})"
-LEOFLOW_VERSION="${PREVIOUS}" \
-  curl -fsSL "https://raw.githubusercontent.com/${LEOFLOW_REPO}/${LEOFLOW_VERSION}/install.sh" | sh
+# `VAR=value cmd1 | cmd2` only exports VAR to cmd1 — the piped sh runs
+# without LEOFLOW_VERSION and install.sh falls back to "latest", which is
+# the just-cut tag we are testing AGAINST, not the previous one. Export
+# explicitly so install.sh inside the `| sh` pipeline sees it. (Previous
+# silent breakage: prealpha.24 coincidentally matched because "latest"
+# resolved to the previous tag at that moment.)
+INSTALL_URL="https://raw.githubusercontent.com/${LEOFLOW_REPO}/${LEOFLOW_VERSION}/install.sh"
+export LEOFLOW_VERSION_FOR_INSTALL="${PREVIOUS}"
+LEOFLOW_VERSION="${LEOFLOW_VERSION_FOR_INSTALL}" \
+  sh -c "curl -fsSL \"${INSTALL_URL}\" | LEOFLOW_VERSION=\"${LEOFLOW_VERSION_FOR_INSTALL}\" sh"
 
 # Make the binary discoverable on this shell — install.sh writes a hint to
 # rc files but we cannot rely on those in a sh-only smoke runner.
@@ -69,8 +77,8 @@ case "${INSTALLED}" in
 esac
 
 echo "==> installing current version (${LEOFLOW_VERSION}) ON TOP of ${PREVIOUS}"
-LEOFLOW_VERSION="${LEOFLOW_VERSION}" \
-  curl -fsSL "https://raw.githubusercontent.com/${LEOFLOW_REPO}/${LEOFLOW_VERSION}/install.sh" | sh
+# Same env-propagation guard as the previous install (see above).
+sh -c "curl -fsSL \"${INSTALL_URL}\" | LEOFLOW_VERSION=\"${LEOFLOW_VERSION}\" sh"
 
 UPGRADED="$(command -v leoflow >/dev/null 2>&1 && leoflow version 2>&1 | head -1 || true)"
 case "${UPGRADED}" in


### PR DESCRIPTION
## Summary
Two deeper bugs surfaced on prealpha.25:

- **Lite cold-start**: ubuntu:24.04 ships libicu74 but the bundled relocatable Postgres 16.13.0 was built against libicu70 (Ubuntu 22 ABI) — the binary cannot dlopen its symbols regardless of libicu74 being installed. Switch container to `ubuntu:22.04` + `libicu70`. This is also closer to the Lima dev VM the smoke is mimicking.
- **Upgrade smoke**: `LEOFLOW_VERSION=$PREV curl … | sh` propagates the var to curl only — the piped `sh` (where install.sh runs) starts in a fresh process **without** LEOFLOW_VERSION, so install.sh falls back to "latest" and installs the just-cut tag instead of the previous one. prealpha.24 coincidentally passed because "latest" was the previous tag at that moment; prealpha.25 exposed it. Push the env var **inside** the pipeline (`sh -c "curl … | LEOFLOW_VERSION=… sh"`).

Verified the env-propagation fix locally with a fake install.sh.

## Known gap (follow-up)
- The cold-start smoke now covers Ubuntu 22 LTS only. Ubuntu 24 users can't use `--postgres managed` until the bundled PG is rebuilt against libicu74 or a dual-bundle approach lands. This is documented behavior with a graceful error message pointing to `--postgres docker`. Tracking issue follows.

## Test plan
- [ ] Cut next prealpha; both smoke jobs go green.
- [ ] Open follow-up issue for Ubuntu 24 managed-PG support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)