### PR TITLE
fix(scheduler): UTC-normalise cron inputs to prevent post-clear double-fire

### DIFF
--- a/internal/scheduler/catchup.go
+++ b/internal/scheduler/catchup.go
@@ -33,6 +33,23 @@ func dueScheduledSlots(expr string, lastLogical, startDate *time.Time, now time.
 	if err != nil {
 		return nil
 	}
+	// Normalise all time inputs to UTC. SpecSchedule.Next evaluates the cron
+	// fields in the argument's Location, so a seed in -0300 would treat
+	// "@daily = 0 0 * * *" as "local midnight" (03:00 UTC) instead of UTC
+	// midnight. pgx returns timestamptz values in the session TZ, which on
+	// many Lite deployments is not UTC — that produced the post-delete
+	// double-fire (one run at 00:00Z, another at 03:00Z for -0300 hosts).
+	// All cron logic in this package speaks UTC; do the coercion at the
+	// boundary so the inner loop never has to think about it.
+	now = now.UTC()
+	if lastLogical != nil {
+		u := lastLogical.UTC()
+		lastLogical = &u
+	}
+	if startDate != nil {
+		u := startDate.UTC()
+		startDate = &u
+	}
 	// Seed the iteration. For a first-ever sight (lastLogical == nil) we seed
 	// from one period before the start_date so the start_date slot itself can
 	// be emitted (cron.Next returns the strict next slot after the argument).

--- a/internal/scheduler/catchup_test.go
+++ b/internal/scheduler/catchup_test.go
@@ -123,3 +123,32 @@ func TestDueScheduledSlots(t *testing.T) {
 		})
 	}
 }
+
+// TestDueScheduledSlotsRespectsUTCWhenSeedHasOffset reproduces the double-fire
+// observed on local Mac (-0300): a freshly registered @daily DAG creates ONE
+// run for the most recent UTC midnight, then the NEXT scheduler tick reads
+// back last_logical from Postgres in the connection's session TZ and the
+// cron's Next is called on that offset-bearing time. SpecSchedule.Next
+// evaluates "@daily = 0 0 * * *" in the argument's Location, so "next
+// midnight" becomes local midnight (03:00 UTC for -0300) instead of UTC
+// midnight — at-or-before `now`, so a SECOND run is created within the same
+// calendar day. With the fix, dueScheduledSlots normalises the seed to UTC
+// and emits nothing on the second tick (the real next slot is tomorrow
+// 00:00 UTC).
+func TestDueScheduledSlotsRespectsUTCWhenSeedHasOffset(t *testing.T) {
+	// "Now" is later the same UTC day as both candidate slots; without the
+	// fix, the local-midnight slot (03:00 UTC) is before `now` and gets
+	// emitted as a (wrong) second run.
+	now := time.Date(2026, 6, 1, 22, 55, 0, 0, time.UTC)
+	saoPaulo, err := time.LoadLocation("America/Sao_Paulo")
+	if err != nil {
+		t.Skipf("tz data unavailable: %v", err)
+	}
+	// Same instant as 2026-06-01T00:00:00Z but stamped in -0300, mirroring
+	// what pgx returns from a Postgres column read.
+	lastLogical := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC).In(saoPaulo)
+	got := dueScheduledSlots("@daily", &lastLogical, nil, now, false, 100)
+	if len(got) != 0 {
+		t.Fatalf("expected 0 slots (last run already covers today's UTC midnight), got %d: %v", len(got), got)
+	}
+}

--- a/internal/scheduler/cron.go
+++ b/internal/scheduler/cron.go
@@ -30,6 +30,14 @@ func nextScheduledRun(expr string, last *time.Time, now time.Time) (logical time
 	if err != nil {
 		return time.Time{}, false
 	}
+	// SpecSchedule.Next evaluates cron fields in the argument's Location;
+	// any non-UTC time.Time would skew "@daily = 0 0 * * *" by the offset.
+	// Coerce both inputs to UTC at the boundary (mirrors dueScheduledSlots).
+	now = now.UTC()
+	if last != nil {
+		u := last.UTC()
+		last = &u
+	}
 	if last == nil {
 		return mostRecentSlot(schedule, now)
 	}


### PR DESCRIPTION
## Summary
@daily (and any time-of-day cron) double-fires after the run history is cleared on a host whose Postgres session TZ is not UTC. You reported this on local Mac (`-0300`) with the scaffolded `hello` DAG: two scheduled runs queued one second apart — one at `2026-06-01T00:00:00Z` and one at `2026-06-01T03:00:00Z`.

## Root cause
`SpecSchedule.Next(t)` evaluates cron fields in `t.Location`. `pgx` returns `timestamptz` columns in the session TZ, so `last_logical` read back as `2026-05-31T21:00:00-0300` (same instant as `2026-06-01T00:00:00Z`) made the next-slot calculation pick local midnight (`2026-06-01T00:00:00-0300` = `2026-06-01T03:00:00Z`) instead of UTC midnight. That second slot is already at-or-before `now`, so a duplicate run gets created on the very next tick.

## Fix
Coerce `now`, `lastLogical`, and `startDate` to UTC at the boundary of `dueScheduledSlots` and `nextScheduledRun`. All cron arithmetic in the scheduler package speaks UTC; doing the conversion at the entry point keeps the inner loops TZ-agnostic.

## Test
Added `TestDueScheduledSlotsRespectsUTCWhenSeedHasOffset` — pins the exact bug shape (lastLogical stamped in `-0300`, same instant as UTC midnight) and asserts zero slots emitted under `catchup=false`. RED → GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)