### PR TITLE
fix(api): Cache-Control: no-store on /api/v2/* + /ui/* (Cluster B, #211/#271)

### DIFF
--- a/internal/api/no_store.go
+++ b/internal/api/no_store.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// NoStoreOnVolatileRoutes stamps every response served from the SPA-facing
+// JSON surface (`/api/v2/*` and `/ui/*`) with `Cache-Control: no-store,
+// must-revalidate` so the browser HTTP cache does not return a pre-mutation
+// payload after a PATCH/POST/DELETE.
+//
+// Why this exists (#211, #271): mark-state PATCH succeeds in single-digit
+// ms; TanStack Query then invalidates its in-memory cache and re-fetches.
+// Without this header, the browser's HTTP cache layer can serve the OLD
+// response to that re-fetch (the original GET response had no explicit
+// caching directive, so the browser falls back to heuristic caching). The
+// SPA renders stale state until the next "natural" refresh — the
+// observable symptom is "marcar como falha demora uma eternidade".
+//
+// Static assets (`/ide/vs/*` for the Monaco bundle) are content-hashed
+// and SHOULD cache, so they are explicitly excluded.
+//
+// We deliberately use "no-store" rather than "no-cache": no-store forbids
+// the browser from writing the response anywhere, which is the strongest
+// guarantee we can give a TanStack-backed SPA. "must-revalidate" is added
+// for older intermediaries (proxies / SW) that may not honor no-store
+// alone. This is ADR-0017-compatible: no SPA changes.
+func NoStoreOnVolatileRoutes() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		p := c.Request.URL.Path
+		if strings.HasPrefix(p, "/api/v2/") || strings.HasPrefix(p, "/ui/") {
+			c.Header("Cache-Control", "no-store, must-revalidate")
+		}
+		c.Next()
+	}
+}

--- a/internal/api/no_store_test.go
+++ b/internal/api/no_store_test.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TestNoStoreOnVolatileRoutes pins the rule that the SPA-facing JSON surface
+// (every `/api/v2/*` and `/ui/*` response) must declare itself uncacheable.
+// Without this header the browser HTTP cache returns the pre-mutation
+// response after a mark-state PATCH, so the user sees stale state even
+// though TanStack Query already invalidated its in-memory cache (#211, #271).
+//
+// Static assets the SPA loads from /ide/vs/... (Monaco bundle) are
+// content-hashed and SHOULD be cached, so the middleware skips them.
+func TestNoStoreOnVolatileRoutes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(NoStoreOnVolatileRoutes())
+	r.GET("/api/v2/dags", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{}) })
+	r.GET("/ui/dags", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{}) })
+	r.PATCH("/api/v2/dags/:id/dagRuns/:r/taskInstances/:t", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{})
+	})
+	r.GET("/ide/vs/loader.js", func(c *gin.Context) { c.String(http.StatusOK, "// monaco") })
+	r.GET("/healthz", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	get := func(method, path string) *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), method, path, http.NoBody))
+		return rec
+	}
+
+	cases := []struct {
+		name          string
+		method        string
+		path          string
+		wantNoStore   bool
+		wantStatus    int
+		wantSetHeader string
+	}{
+		{"v2 dags list", http.MethodGet, "/api/v2/dags", true, http.StatusOK, "no-store, must-revalidate"},
+		{"ui dags helper", http.MethodGet, "/ui/dags", true, http.StatusOK, "no-store, must-revalidate"},
+		{"v2 mark-state PATCH", http.MethodPatch, "/api/v2/dags/d/dagRuns/r/taskInstances/t", true, http.StatusOK, "no-store, must-revalidate"},
+		{"monaco asset", http.MethodGet, "/ide/vs/loader.js", false, http.StatusOK, ""},
+		{"healthz", http.MethodGet, "/healthz", false, http.StatusOK, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := get(tc.method, tc.path)
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+			got := rec.Header().Get("Cache-Control")
+			if tc.wantNoStore {
+				if got != tc.wantSetHeader {
+					t.Errorf("Cache-Control = %q, want %q", got, tc.wantSetHeader)
+				}
+			} else {
+				if got != "" {
+					t.Errorf("Cache-Control = %q on non-volatile route; want unset", got)
+				}
+			}
+		})
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -97,6 +97,7 @@ func NewServer(deps Dependencies) *gin.Engine {
 	r.Use(Observe(deps.Metrics, deps.Tracer))
 	r.Use(StructuredLogger(deps.Logger))
 	r.Use(CORS(deps.CORSOrigins))
+	r.Use(NoStoreOnVolatileRoutes())
 	if deps.DevNoAuth {
 		r.Use(DevBypassAuth())
 	} else {


### PR DESCRIPTION
## Summary
First Phase 1 fix from `docs/frontend-assessment.md` — Cluster B (mark-state instant feedback).

Server-side latency is 228–518 μs (Phase 0 baseline ruled it out), so the staleness the user feels has to live in the cache layer. The mark-state PATCH succeeds in single-digit ms; TanStack Query invalidates its in-memory cache and re-fetches; **without an explicit `Cache-Control` directive on our GETs, the browser HTTP cache can return the pre-mutation payload** to that re-fetch under heuristic caching. The user sees the old state until the heuristic window expires — observed as "marcar como falha demora uma eternidade".

## Fix
New `NoStoreOnVolatileRoutes()` middleware stamps `Cache-Control: no-store, must-revalidate` on every `/api/v2/*` and `/ui/*` response. Static assets (Monaco bundle under `/ide/vs/*`) and `/ide`, `/healthz`, `/readyz`, `/metrics` are excluded — those should cache or are operator endpoints.

Wired into the global middleware chain in `internal/api/server.go` so every handler benefits automatically.

## Test
`TestNoStoreOnVolatileRoutes` pins five route patterns. RED → GREEN.

## Live verification
Local Mac, prealpha.27 build + this PR:
- `GET /api/v2/dags` → `Cache-Control: no-store, must-revalidate` ✓
- `GET /ui/dags` → `Cache-Control: no-store, must-revalidate` ✓
- `GET /healthz` → no header ✓
- `GET /ide` → no header ✓

## Compatibility
ADR-0017 safe — no SPA changes. Stamps headers the SPA does not need to know about.

## Tracks
Closes part of #211, #271. Cluster A (#213/#216), C (#214), D (#215), E (#217), F (#209/#210/#212) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)