### PR TITLE
fix(config): UI auto_refresh_interval env var was silently dropped (closes #210)

### DIFF
--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -243,8 +243,15 @@ var serverDefaults = map[string]any{
 	"ui.edition":                                "",
 	"ui.workspace":                              "",
 	"ui.monaco_dir":                             "",
-	"auth.dev_no_auth":                          false,
-	"secret_key":                                "",
+	// Must appear here even though the zero value is meaningful (the handler
+	// falls back to api.DefaultUIAutoRefreshIntervalSeconds when ≤ 0): viper's
+	// AutomaticEnv only binds env vars for keys it has seen via SetDefault or
+	// SetConfigFile. Without this line LEOFLOW_UI_AUTO_REFRESH_INTERVAL_SECONDS
+	// was silently dropped, so `leoflow lite` (which exports the env var to
+	// poll every 1s) was actually running at the 30s production default.
+	"ui.auto_refresh_interval_seconds": 0,
+	"auth.dev_no_auth":                 false,
+	"secret_key":                       "",
 }
 
 // LoadServer assembles the server configuration from defaults, the given file,

--- a/internal/config/server_test.go
+++ b/internal/config/server_test.go
@@ -184,3 +184,21 @@ func TestValidateRejectsDevNoAuthOnNonLoopback(t *testing.T) {
 		t.Errorf("non-dev config should validate, got %v", err)
 	}
 }
+
+// TestLoadServerReadsUIAutoRefreshIntervalFromEnv pins the bug that broke #247:
+// `leoflow lite` exports LEOFLOW_UI_AUTO_REFRESH_INTERVAL_SECONDS=1 so the SPA
+// polls fast in the dev loop, but the server returned 30 (the handler fallback)
+// because `ui.auto_refresh_interval_seconds` was missing from serverDefaults —
+// without an entry there, viper's AutomaticEnv never bound the env key, so the
+// value silently fell back to the zero default. Users had to reload the page
+// to see state changes (observed locally 2026-06-01).
+func TestLoadServerReadsUIAutoRefreshIntervalFromEnv(t *testing.T) {
+	t.Setenv("LEOFLOW_UI_AUTO_REFRESH_INTERVAL_SECONDS", "1")
+	c, err := LoadServer("", nil)
+	if err != nil {
+		t.Fatalf("LoadServer: %v", err)
+	}
+	if c.UI.AutoRefreshIntervalSeconds != 1 {
+		t.Errorf("UI.AutoRefreshIntervalSeconds = %d, want 1 (env var must override default)", c.UI.AutoRefreshIntervalSeconds)
+	}
+}


### PR DESCRIPTION
## Summary
\`leoflow lite\` has been exporting \`LEOFLOW_UI_AUTO_REFRESH_INTERVAL_SECONDS=1\` since #247 so the SPA polls fast in the dev loop. The server was **silently** returning 30 (the handler fallback) because \`ui.auto_refresh_interval_seconds\` was missing from \`serverDefaults\`.

viper's \`AutomaticEnv\` only binds env vars for keys it has previously seen via \`SetDefault\` or \`SetConfigFile\`. Without that entry, the env var was dropped, the value fell back to the production 30s default, and users had to reload the page to see state changes.

## Fix
One line in \`internal/config/server.go\`: register the key in \`serverDefaults\` with a zero default (the handler's existing \`<= 0\` fallback to \`DefaultUIAutoRefreshIntervalSeconds\` still covers it for Pro).

## Test
\`TestLoadServerReadsUIAutoRefreshIntervalFromEnv\` pins the bug — RED → GREEN.

## Live verification
Local Mac (prealpha.27 build), \`leoflow lite\` running:

| | Before | After |
|---|---|---|
| \`GET /ui/config\` → \`auto_refresh_interval\` | **30** ❌ | **1** ✓ |

## Why this matters now
User reported: \"agora ativa na hora mas só se eu atualizar a pagina para ver\". The mark-state PATCH is instant (PR #287 killed the browser-cache staleness), but the other views (grid, dashboard, DAG list) still polled at 30s. With this fix they poll at 1s.

Combined with #287, the perceived UI latency for mark-state should drop from \"forever\" to \"≤ 1 second\".

## Tracks
Closes #210. Cluster F (#209/#212/#271 remaining lag) still needs the DagRun-state aggregation work + the SSE push channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)