### PR TITLE
fix(api): include state hash in ti_summaries ETag (closes #289)

### DIFF
--- a/internal/api/ui_summaries.go
+++ b/internal/api/ui_summaries.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -146,7 +148,20 @@ func tiSummariesHandler(reader TaskSummaryReader) gin.HandlerFunc {
 		}
 		byRun, latest, count := aggregateSummaries(tis)
 
-		etag := fmt.Sprintf(`W/"%d-%d"`, count, latest.UnixNano())
+		// #289: mark-state PATCH changes a TI's state without moving its
+		// started/ended timestamps, so the original `count + latest` ETag
+		// was identical before and after the mutation and the SPA's
+		// TanStack Query kept serving the cached body. Fold a fingerprint
+		// of every (run, task, state) into the ETag so any state change
+		// invalidates it. Sort for stability (map iteration is random).
+		fingerprints := make([]string, 0, len(tis))
+		for _, ti := range tis {
+			fingerprints = append(fingerprints, ti.RunID+":"+ti.TaskID+":"+string(ti.State))
+		}
+		sort.Strings(fingerprints)
+		h := fnv.New64a()
+		_, _ = h.Write([]byte(strings.Join(fingerprints, "|")))
+		etag := fmt.Sprintf(`W/"%d-%d-%x"`, count, latest.UnixNano(), h.Sum64())
 		c.Header("ETag", etag)
 		c.Header("Content-Type", "application/x-ndjson")
 		if match := c.GetHeader("If-None-Match"); match == etag {

--- a/internal/api/ui_summaries_test.go
+++ b/internal/api/ui_summaries_test.go
@@ -123,3 +123,31 @@ func TestTISummariesConditionalGET(t *testing.T) {
 		t.Errorf("matching If-None-Match = %d, want 304", rec.Code)
 	}
 }
+
+// TestTISummariesETagInvalidatesOnStateChange pins #289: the mark-state PATCH
+// flips a finished task's state but leaves its StartedAt/EndedAt timestamps
+// untouched. The original ETag formula (count + max(started, ended)) was
+// therefore identical before and after the mutation, so the grid view kept
+// receiving 304 with no body and the SPA showed the OLD state until a manual
+// reload. The ETag must include a fingerprint of the per-task states so any
+// state change invalidates it.
+func TestTISummariesETagInvalidatesOnStateChange(t *testing.T) {
+	// Same TI fixture but with a different state — only the state field
+	// changes between the two reads.
+	started := time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)
+	ended := time.Date(2026, 6, 1, 10, 0, 5, 0, time.UTC)
+	before := &fakeTaskSummary{tis: []domain.TaskInstance{
+		{RunID: "r1", TaskID: "x", State: domain.TaskStateSuccess, StartedAt: &started, EndedAt: &ended, TryNumber: 1},
+	}}
+	after := &fakeTaskSummary{tis: []domain.TaskInstance{
+		{RunID: "r1", TaskID: "x", State: domain.TaskStateFailed, StartedAt: &started, EndedAt: &ended, TryNumber: 1},
+	}}
+	etagBefore := authGet(summariesServer(before), http.MethodGet, "/ui/grid/ti_summaries/etl?run_ids=r1", "").Header().Get("ETag")
+	etagAfter := authGet(summariesServer(after), http.MethodGet, "/ui/grid/ti_summaries/etl?run_ids=r1", "").Header().Get("ETag")
+	if etagBefore == "" || etagAfter == "" {
+		t.Fatalf("missing ETag (before=%q after=%q)", etagBefore, etagAfter)
+	}
+	if etagBefore == etagAfter {
+		t.Errorf("ETag must differ when a TI's state changes (timestamps unchanged); both = %q — grid keeps stale data (#289)", etagBefore)
+	}
+}


### PR DESCRIPTION
## Summary
The grid view never refreshed after mark-state because the \`ti_summaries\` ETag formula didn't include state — only counts and timestamps. Mark-state changes state in DB but leaves \`start_date\`/\`end_date\` untouched, so the ETag was identical before and after the mutation. The server returned 304, TanStack Query kept the cached body, and the user saw the old state until manual reload.

PR #287 (no-store) didn't catch this: it forbids the **browser HTTP cache**, but TanStack's **in-memory JS cache** still honored the ETag via \`If-None-Match\`.

## Fix
Fold a sorted FNV64 hash of every \`(run_id, task_id, state)\` triple into the ETag:

```
W/"<count>-<latest>-<fnv64_of_states>"
```

Any state change → different hash → ETag invalidates → 200 with new body.

## Live verification (local Mac)
- ETag before mark-as-failed: \`W/\"1-...-ccb7b29317fa574a\"\`
- ETag after mark-as-failed:  \`W/\"1-...-816a29f257c61122\"\` ✓

Grid view now reflects state changes within the 1s auto-refresh poll.

## Test
\`TestTISummariesETagInvalidatesOnStateChange\` pins the bug shape (same timestamps, different state → different ETag). RED → GREEN.

## Why this matters now
This was masked before PR #287. With #287 closing the browser-cache hole, the ETag-trust path became the visible cache. Closing both gives the user the snappy mark-state experience reported in #211.

Closes #289. Combined with #287 + #288, the user's "marcar como falha demora uma eternidade" should be resolved end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)