### PR TITLE
feat(ide): toolkit — download examples, new folder, rename, drag-drop

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	leoflow "github.com/neochaotic/leoflow"
 	"github.com/neochaotic/leoflow/internal/agentrpc"
 	"github.com/neochaotic/leoflow/internal/api"
 	"github.com/neochaotic/leoflow/internal/auth"
@@ -194,6 +195,7 @@ func run() error {
 		UI:                           uiSrv,
 		Workspace:                    editorFS,
 		MonacoDir:                    cfg.UI.MonacoDir,
+		ExamplesFS:                   leoflow.ExampleDAGs(),
 	})
 
 	apiSrv := &http.Server{Addr: cfg.Server.HTTPAddr, Handler: handler, ReadHeaderTimeout: 10 * time.Second}

--- a/embed.go
+++ b/embed.go
@@ -29,3 +29,13 @@ var devCompose []byte
 // datastores up with `leoflow lite` alone — it is materialized under ~/.leoflow
 // on first run.
 func DevCompose() []byte { return devCompose }
+
+//go:embed all:examples
+var exampleDAGs embed.FS
+
+// ExampleDAGs returns the embedded DAG examples (one subdirectory per DAG,
+// each with dag.py + leoflow.yaml). The Lite IDE's "Download examples"
+// button materializes them into the user's workspace under examples/, so a
+// fresh install can try every operator without a separate git checkout.
+// Root is "examples/" — the same layout as the source tree.
+func ExampleDAGs() embed.FS { return exampleDAGs }

--- a/internal/api/ide.go
+++ b/internal/api/ide.go
@@ -3,8 +3,10 @@ package api
 import (
 	_ "embed"
 	"errors"
+	"fmt"
 	"io/fs"
 	"net/http"
+	"path"
 	"path/filepath"
 
 	"github.com/gin-gonic/gin"
@@ -26,6 +28,7 @@ type WorkspaceFS interface {
 	Read(rel string) ([]byte, error)
 	Write(rel string, data []byte) error
 	Create(rel string, dir bool) error
+	Move(from, to string) error
 	Delete(rel string) error
 }
 
@@ -52,13 +55,34 @@ type ideCreateBody struct {
 	Dir  bool   `json:"dir"`
 }
 
+// ideMoveBody is the POST payload for /ide/move, the rename / drag-drop op.
+type ideMoveBody struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// ideInstallExamplesBody picks the target subdir under the workspace where the
+// embedded example DAGs get materialized. Empty means "examples".
+type ideInstallExamplesBody struct {
+	Dir string `json:"dir"`
+}
+
+// ideInstallExamplesResp reports what was written so the IDE can refresh its
+// tree and the user can see what they got.
+type ideInstallExamplesResp struct {
+	Installed []string `json:"installed"`
+	Skipped   []string `json:"skipped"`
+}
+
 // registerIDE mounts the Lite web editor: the workspace filesystem API, the
 // editor page, and the Monaco assets. When fs is nil — Production, or Lite
 // without a workspace configured — nothing is registered, so the editor is
 // unavailable (404). Reads require read:dag and mutations write:dag, since the
 // workspace holds DAG source. monacoDir is where `leoflow setup` placed the
 // pinned Monaco bundle; when empty or absent the page shows a setup hint.
-func registerIDE(r gin.IRouter, store WorkspaceFS, monacoDir string) {
+// examples, when non-nil, backs the "Download examples" button — typically the
+// embedded examples.FS shipped by package leoflow.
+func registerIDE(r gin.IRouter, store WorkspaceFS, monacoDir string, examples fs.FS) {
 	if store == nil {
 		return
 	}
@@ -66,7 +90,11 @@ func registerIDE(r gin.IRouter, store WorkspaceFS, monacoDir string) {
 	r.GET("/api/v2/ide/file", RequirePermission("read", "dag"), ideReadHandler(store))
 	r.PUT("/api/v2/ide/file", RequirePermission("write", "dag"), ideWriteHandler(store))
 	r.POST("/api/v2/ide/file", RequirePermission("write", "dag"), ideCreateHandler(store))
+	r.POST("/api/v2/ide/move", RequirePermission("write", "dag"), ideMoveHandler(store))
 	r.DELETE("/api/v2/ide/file", RequirePermission("write", "dag"), ideDeleteHandler(store))
+	if examples != nil {
+		r.POST("/api/v2/ide/examples/install", RequirePermission("write", "dag"), ideInstallExamplesHandler(store, examples))
+	}
 
 	r.GET("/ide", idePageHandler())
 	r.HEAD("/ide/vs/*filepath", monacoHandler(monacoDir))
@@ -114,17 +142,17 @@ func ideTreeHandler(store WorkspaceFS) gin.HandlerFunc {
 
 func ideReadHandler(store WorkspaceFS) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		path := c.Query("path")
-		if path == "" {
+		rel := c.Query("path")
+		if rel == "" {
 			AbortProblem(c, http.StatusBadRequest, "invalid_request", "query parameter 'path' is required")
 			return
 		}
-		data, err := store.Read(path)
+		data, err := store.Read(rel)
 		if err != nil {
 			abortIDEError(c, err)
 			return
 		}
-		c.JSON(http.StatusOK, ideFileDTO{Path: path, Content: string(data)})
+		c.JSON(http.StatusOK, ideFileDTO{Path: rel, Content: string(data)})
 	}
 }
 
@@ -158,14 +186,76 @@ func ideCreateHandler(store WorkspaceFS) gin.HandlerFunc {
 	}
 }
 
+func ideMoveHandler(store WorkspaceFS) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var body ideMoveBody
+		if err := c.ShouldBindJSON(&body); err != nil || body.From == "" || body.To == "" {
+			AbortProblem(c, http.StatusBadRequest, "invalid_request", "a JSON body with non-empty 'from' and 'to' is required")
+			return
+		}
+		if err := store.Move(body.From, body.To); err != nil {
+			abortIDEError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, body)
+	}
+}
+
+// ideInstallExamplesHandler materializes the embedded example DAGs (one
+// subdir per DAG) under `<dir>/<dag>/` inside the workspace. Files that
+// already exist on disk are skipped so a re-install doesn't clobber edits.
+func ideInstallExamplesHandler(store WorkspaceFS, examples fs.FS) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var body ideInstallExamplesBody
+		// Body is optional; default target is "examples".
+		_ = c.ShouldBindJSON(&body) //nolint:errcheck // body is optional
+		target := body.Dir
+		if target == "" {
+			target = "examples"
+		}
+		resp := ideInstallExamplesResp{Installed: []string{}, Skipped: []string{}}
+		// Walk the embedded examples FS. Embedded root is "examples" (matches
+		// the source tree), so we strip that prefix and re-anchor under target.
+		walkErr := fs.WalkDir(examples, "examples", func(p string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if p == "examples" || d.IsDir() {
+				return nil
+			}
+			rel := path.Join(target, p[len("examples/"):])
+			data, rerr := fs.ReadFile(examples, p)
+			if rerr != nil {
+				return fmt.Errorf("reading embedded %q: %w", p, rerr)
+			}
+			// Skip if the file already exists on disk — Read returns nil error
+			// when the file is found.
+			if _, sterr := store.Read(rel); sterr == nil {
+				resp.Skipped = append(resp.Skipped, rel)
+				return nil
+			}
+			if werr := store.Write(rel, data); werr != nil {
+				return fmt.Errorf("writing %q: %w", rel, werr)
+			}
+			resp.Installed = append(resp.Installed, rel)
+			return nil
+		})
+		if walkErr != nil {
+			AbortProblem(c, http.StatusInternalServerError, "ide_error", walkErr.Error())
+			return
+		}
+		c.JSON(http.StatusOK, resp)
+	}
+}
+
 func ideDeleteHandler(store WorkspaceFS) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		path := c.Query("path")
-		if path == "" {
+		rel := c.Query("path")
+		if rel == "" {
 			AbortProblem(c, http.StatusBadRequest, "invalid_request", "query parameter 'path' is required")
 			return
 		}
-		if err := store.Delete(path); err != nil {
+		if err := store.Delete(rel); err != nil {
 			abortIDEError(c, err)
 			return
 		}

--- a/internal/api/ide_page.html
+++ b/internal/api/ide_page.html
@@ -56,7 +56,10 @@
   <strong>Leoflow</strong> Editor
   <span class="path" id="current-path"></span>
   <span class="spacer"></span>
+  <button id="btn-examples" title="Materialize the bundled DAG examples under /examples">Download examples</button>
+  <button id="btn-newdir" title="Create a new folder at the workspace root or under the current selection">New folder</button>
   <button id="btn-new">New file</button>
+  <button id="btn-rename" title="Rename or move the selected file/folder">Rename</button>
   <button id="btn-delete">Delete</button>
   <button id="btn-save">Save (⌘S)</button>
 </header>
@@ -79,8 +82,18 @@ const api = {
   create: (p, dir) => fetch("/api/v2/ide/file", { method: "POST",
             headers: { "content-type": "application/json" },
             body: JSON.stringify({ path: p, dir: !!dir }) }),
+  move:   (from, to) => fetch("/api/v2/ide/move", { method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ from, to }) }),
+  installExamples: (dir) => fetch("/api/v2/ide/examples/install", { method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ dir: dir || "examples" }) }).then(r => r.json()),
   remove: (p) => fetch("/api/v2/ide/file?path=" + encodeURIComponent(p), { method: "DELETE" }),
 };
+
+// Currently selected tree node — used as the parent for "New folder/file" and
+// as the source for drag operations. May be a file or a directory.
+let selected = null;
 
 const statusEl = document.getElementById("status");
 const pathEl = document.getElementById("current-path");
@@ -106,12 +119,66 @@ async function refreshTree() {
       div.style.paddingLeft = (10 + e.path.split("/").length * 12) + "px";
       div.textContent = (e.is_dir ? "▸ " : "") + e.name;
       div.dataset.path = e.path;
-      if (!e.is_dir) div.onclick = () => openFile(e.path);
+      div.dataset.isDir = e.is_dir ? "1" : "";
+      div.draggable = true;
+      div.onclick = (ev) => {
+        ev.stopPropagation();
+        selected = { path: e.path, isDir: e.is_dir };
+        document.querySelectorAll("#tree .node").forEach((n) =>
+          n.classList.toggle("active", n.dataset.path === e.path));
+        if (!e.is_dir) openFile(e.path);
+      };
+      // Drag source: stash the source path on the dataTransfer object.
+      div.ondragstart = (ev) => {
+        ev.dataTransfer.setData("text/plain", e.path);
+        ev.dataTransfer.effectAllowed = "move";
+      };
+      // Drop target: dirs only. Drop a file/dir into the target dir.
+      if (e.is_dir) {
+        div.ondragover = (ev) => { ev.preventDefault(); ev.dataTransfer.dropEffect = "move"; };
+        div.ondrop = async (ev) => {
+          ev.preventDefault();
+          const from = ev.dataTransfer.getData("text/plain");
+          if (!from || from === e.path) return;
+          // Block drop into self/descendant — Move would fail at the server but
+          // the early check keeps the UX snappy.
+          if (e.path.startsWith(from + "/")) {
+            setStatus("cannot move a folder into itself");
+            return;
+          }
+          const name = from.split("/").pop();
+          await doMove(from, e.path + "/" + name);
+        };
+      }
       if (e.path === current) div.classList.add("active");
       treeEl.appendChild(div);
     });
     if (!entries || entries.length === 0) treeEl.textContent = "empty workspace";
+    // Root-level drop target: drop onto the empty area moves to workspace root.
+    treeEl.ondragover = (ev) => { ev.preventDefault(); ev.dataTransfer.dropEffect = "move"; };
+    treeEl.ondrop = async (ev) => {
+      if (ev.target !== treeEl) return; // only when dropped on the bg, not on a node
+      ev.preventDefault();
+      const from = ev.dataTransfer.getData("text/plain");
+      if (!from) return;
+      const name = from.split("/").pop();
+      if (name === from) return; // already at root
+      await doMove(from, name);
+    };
   } catch (err) { setStatus("tree error: " + err); }
+}
+
+async function doMove(from, to) {
+  const res = await api.move(from, to);
+  if (res.ok) {
+    if (current === from) { current = to; pathEl.textContent = to; }
+    setStatus("moved " + from + " → " + to);
+    await refreshTree();
+  } else {
+    let detail = "";
+    try { detail = (await res.json()).detail || ""; } catch { /* ignore */ }
+    setStatus("move failed (" + res.status + ")" + (detail ? ": " + detail : ""));
+  }
 }
 
 async function openFile(path) {
@@ -140,12 +207,52 @@ async function save() {
   setStatus(res.ok ? "saved " + current : "save failed (" + res.status + ")");
 }
 
+// parentPath returns the directory the new file/folder should live in, based on
+// the current selection: a selected directory is used as-is, a selected file's
+// parent directory is used, and no selection means the workspace root.
+function parentPath() {
+  if (!selected) return "";
+  if (selected.isDir) return selected.path;
+  const slash = selected.path.lastIndexOf("/");
+  return slash < 0 ? "" : selected.path.slice(0, slash);
+}
+
 async function newFile() {
-  const p = prompt("New file path (relative to workspace):");
-  if (!p) return;
+  const base = parentPath();
+  const prompted = prompt("New file name" + (base ? ` (inside ${base}/)` : " (at workspace root)") + ":");
+  if (!prompted) return;
+  const p = base ? base + "/" + prompted : prompted;
   const res = await api.create(p, false);
   if (res.ok) { await refreshTree(); openFile(p); }
   else setStatus("create failed (" + res.status + ")");
+}
+
+async function newDir() {
+  const base = parentPath();
+  const prompted = prompt("New folder name" + (base ? ` (inside ${base}/)` : " (at workspace root)") + ":");
+  if (!prompted) return;
+  const p = base ? base + "/" + prompted : prompted;
+  const res = await api.create(p, true);
+  if (res.ok) { await refreshTree(); setStatus("created folder " + p); }
+  else setStatus("create folder failed (" + res.status + ")");
+}
+
+async function renameSelected() {
+  if (!selected) { setStatus("select a file or folder to rename"); return; }
+  const proposed = prompt("Rename " + selected.path + " to:", selected.path);
+  if (!proposed || proposed === selected.path) return;
+  await doMove(selected.path, proposed);
+}
+
+async function downloadExamples() {
+  setStatus("installing examples…");
+  try {
+    const r = await api.installExamples("examples");
+    const installed = (r.installed || []).length;
+    const skipped = (r.skipped || []).length;
+    setStatus(`examples: ${installed} installed, ${skipped} skipped (existed)`);
+    await refreshTree();
+  } catch (err) { setStatus("install error: " + err); }
 }
 
 async function deleteCurrent() {
@@ -168,7 +275,10 @@ function bootEditor() {
     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, save);
     document.getElementById("btn-save").onclick = save;
     document.getElementById("btn-new").onclick = newFile;
+    document.getElementById("btn-newdir").onclick = newDir;
+    document.getElementById("btn-rename").onclick = renameSelected;
     document.getElementById("btn-delete").onclick = deleteCurrent;
+    document.getElementById("btn-examples").onclick = downloadExamples;
     refreshTree();
     // Deep-link: /ide?open=<path> opens a file directly (shareable links).
     const open = new URLSearchParams(location.search).get("open");

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"io/fs"
 	"log/slog"
 	"net/http"
 
@@ -79,6 +80,10 @@ type Dependencies struct {
 	// missing makes the page show a setup hint instead of a broken editor.
 	MonacoDir string
 
+	// ExamplesFS backs the IDE's "Download examples" button — typically the
+	// `embed.FS` shipped from the leoflow root package. Nil disables the button.
+	ExamplesFS fs.FS
+
 	// SchedulerHealth reports the scheduler's heartbeat for /monitor/health.
 	// When nil the component reports healthy (single-process role assumption).
 	SchedulerHealth Heartbeater
@@ -135,7 +140,7 @@ func NewServer(deps Dependencies) *gin.Engine {
 	registerUIConnections(r, deps.Connections, deps.ConnectionTest)
 	registerUIFavorites(r, deps.Favorites)
 	registerImportErrors(r, deps.ImportErrors)
-	registerIDE(r, deps.Workspace, deps.MonacoDir)
+	registerIDE(r, deps.Workspace, deps.MonacoDir, deps.ExamplesFS)
 	registerUIStubs(r)
 	registerAPIStubs(r)
 	if deps.UI != nil {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -145,6 +145,31 @@ func (f *FS) Create(rel string, dir bool) error {
 	return file.Close()
 }
 
+// Move renames or relocates a file or directory inside the workspace. It
+// auto-creates any missing parent directories on the destination side, and
+// refuses to clobber an existing destination — the IDE surface (drag-drop /
+// rename) asks the user to pick a fresh name on a collision.
+func (f *FS) Move(from, to string) error {
+	src, err := f.resolve(from)
+	if err != nil {
+		return err
+	}
+	dst, err := f.resolve(to)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Lstat(dst); err == nil {
+		return fmt.Errorf("destination %q already exists", to)
+	}
+	if mkErr := os.MkdirAll(filepath.Dir(dst), 0o750); mkErr != nil {
+		return fmt.Errorf("creating parent of %q: %w", to, mkErr)
+	}
+	if rnErr := os.Rename(src, dst); rnErr != nil {
+		return fmt.Errorf("moving %q to %q: %w", from, to, rnErr)
+	}
+	return nil
+}
+
 // Delete removes the file or directory (recursively) at rel.
 func (f *FS) Delete(rel string) error {
 	abs, err := f.resolve(rel)

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -74,20 +74,26 @@ func (f *FS) Root() string { return f.root }
 
 // resolve maps a slash-separated relative path to an absolute path inside the
 // root, refusing absolute inputs and any path that escapes the root via "..".
+//
+// The first gate is the stdlib's filepath.IsLocal — it rejects absolute paths,
+// empty inputs, paths that climb out via "..", and (on Windows) reserved
+// device names. Using IsLocal here also lets static analyzers (CodeQL's
+// go/path-injection rule, gosec's G304) recognize this function as the
+// sanitizer for caller paths, so downstream os.* calls do not need
+// per-call suppressions.
 func (f *FS) resolve(rel string) (string, error) {
-	if filepath.IsAbs(rel) || strings.HasPrefix(rel, "/") {
-		return "", fmt.Errorf("%w: %q must be relative to the workspace", ErrUnsafePath, rel)
+	slashed := filepath.ToSlash(rel)
+	if !filepath.IsLocal(slashed) {
+		return "", fmt.Errorf("%w: %q is not a local workspace path", ErrUnsafePath, rel)
 	}
-	clean := path.Clean(filepath.ToSlash(rel))
+	clean := path.Clean(slashed)
 	if clean == "." {
 		return "", fmt.Errorf("%w: %q resolves to the workspace root", ErrUnsafePath, rel)
 	}
-	// A normalized path that climbs out (".." or "../…") is an escape: reject it
-	// rather than silently clamping it back inside the root.
-	if clean == ".." || strings.HasPrefix(clean, "../") {
-		return "", fmt.Errorf("%w: %q escapes the workspace", ErrUnsafePath, rel)
-	}
 	abs := filepath.Join(f.root, filepath.FromSlash(clean))
+	// Defense in depth: even after IsLocal, re-check that the joined absolute
+	// path stays under the root. Cheap and catches future Go releases or OS
+	// edge cases where the lexical guarantees of IsLocal might drift.
 	if abs != f.root && !strings.HasPrefix(abs, f.root+string(os.PathSeparator)) {
 		return "", fmt.Errorf("%w: %q escapes the workspace", ErrUnsafePath, rel)
 	}

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -186,3 +186,94 @@ func TestReadMissingFile(t *testing.T) {
 		t.Fatal("Read of a missing file should error")
 	}
 }
+
+// TestMoveRenamesFiles pins the contract for the IDE's "rename / drag-drop"
+// surface: moving a file or directory updates the path, the source disappears,
+// the destination matches what was there before, and the operation is confined
+// to the workspace root just like Read/Write/Create.
+func TestMoveRenamesFiles(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "old.py"), []byte("print('hi')"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "sub"), 0o750); err != nil {
+		t.Fatalf("seed dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "sub", "inner.txt"), []byte("inner"), 0o600); err != nil {
+		t.Fatalf("seed inner: %v", err)
+	}
+	fs, ferr := New(root)
+	if ferr != nil {
+		t.Fatalf("New: %v", ferr)
+	}
+
+	// Rename a file in-place.
+	if mErr := fs.Move("old.py", "new.py"); mErr != nil {
+		t.Fatalf("rename file: %v", mErr)
+	}
+	if _, sErr := os.Stat(filepath.Join(root, "old.py")); !os.IsNotExist(sErr) {
+		t.Errorf("old.py should be gone, got err=%v", sErr)
+	}
+	got, err := os.ReadFile(filepath.Join(root, "new.py"))
+	if err != nil || string(got) != "print('hi')" {
+		t.Errorf("new.py = (%q, %v), want (\"print('hi')\", nil)", got, err)
+	}
+
+	// Move a file into a different folder (auto-create parents).
+	if err := fs.Move("new.py", "scripts/new.py"); err != nil {
+		t.Fatalf("move into dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "scripts", "new.py")); err != nil {
+		t.Errorf("scripts/new.py missing: %v", err)
+	}
+
+	// Move a whole directory (file inside follows).
+	if err := fs.Move("sub", "moved_sub"); err != nil {
+		t.Fatalf("move dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "moved_sub", "inner.txt")); err != nil {
+		t.Errorf("moved_sub/inner.txt missing: %v", err)
+	}
+}
+
+// TestMoveRefusesUnsafePaths confines Move to the workspace, mirroring
+// Read/Write/Create. Without this, a drag-drop bug in the UI could overwrite
+// arbitrary files on the host.
+func TestMoveRefusesUnsafePaths(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("a"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	fs, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	for _, p := range []string{"../escape.txt", "/etc/passwd", "../../host.txt"} {
+		if err := fs.Move("a.txt", p); err == nil {
+			t.Errorf("Move to %q must be rejected", p)
+		}
+		if err := fs.Move(p, "ok.txt"); err == nil {
+			t.Errorf("Move from %q must be rejected", p)
+		}
+	}
+}
+
+// TestMoveRefusesOverwriteExisting prevents silent data loss: a drag-drop
+// that lands on an existing file/folder must fail loudly rather than
+// clobber. The IDE surface should ask the user to confirm/rename instead.
+func TestMoveRefusesOverwriteExisting(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("a"), 0o600); err != nil {
+		t.Fatalf("seed a: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "b.txt"), []byte("b"), 0o600); err != nil {
+		t.Fatalf("seed b: %v", err)
+	}
+	fs, err := New(root)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := fs.Move("a.txt", "b.txt"); err == nil {
+		t.Errorf("Move onto existing path must fail")
+	}
+}


### PR DESCRIPTION
## Summary
User-requested second priority: basic IDE moves the Lite editor was missing — download bundled DAG examples, create folders, rename/move files, drag-and-drop in the tree.

## What's in this PR

### Backend
- \`workspace.FS.Move(from, to)\` — safe rename, auto-parent-create, refuses to clobber existing destinations.
- \`POST /api/v2/ide/move {from, to}\` — wire for rename and drag-drop.
- \`POST /api/v2/ide/examples/install {dir?}\` — materialize the embedded DAG examples (one per subdir) under \`<dir>/<dag>/\`. Files already on disk are skipped so a re-install never clobbers user edits.
- \`embed.go\` gains an \`exampleDAGs\` FS so the binary ships the examples; no separate git checkout required.

### Frontend (\`internal/api/ide_page.html\`)
- New buttons: **Download examples**, **New folder**, **Rename**.
- New-folder / new-file prompts honour the selected node as the parent.
- Tree nodes are draggable; dirs and the root area accept drops. A drop computes the destination as \`<target>/<basename>\` and POSTs to \`/ide/move\`. Self / descendant drops are blocked client-side.

## Tests
\`TestMoveRenamesFiles\`, \`TestMoveRefusesUnsafePaths\`, \`TestMoveRefusesOverwriteExisting\`. Existing workspace + IDE suites stay green.

## Live verification (Mac, local Lite)
- Install: **46 files across 19 DAG subdirs** under \`~/leoflow/examples/\` ✓
- Move: \`api_chain\` → \`api_chain_renamed\` ✓
- Create-folder: dropped a new dir at workspace root ✓
- Re-install idempotent: 2 installed, 44 skipped ✓

## Notes
The HTML uses inline JS (existing style) — keeps the editor self-contained, no build step. Larger UI work (multi-file tabs, search, etc.) is intentionally deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)