### PR TITLE
fix(cli): polish init next-step + compile no-image output (closes #D6, #D10)

### DIFF
--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -104,8 +104,19 @@ func runCompile(cmd *cobra.Command, dir string, o compileOptions) error {
 			return perr
 		}
 	}
-	_, werr := fmt.Fprintf(cmd.OutOrStdout(), "Compiled %s -> %s (image %s, version %s)\n", dagSourcePath(dir, cfg), o.output, o.image, o.dagVersion)
+	_, werr := fmt.Fprint(cmd.OutOrStdout(), compileSummary(dagSourcePath(dir, cfg), o.output, o.image, o.dagVersion))
 	return werr
+}
+
+// compileSummary formats the success line for `leoflow compile`. When image is
+// empty it renders `no image` instead of `image ` to avoid the dangling-comma
+// artifact reported as #D10 in the dogfood audit (#212).
+func compileSummary(src, out, image, version string) string {
+	imageField := "image " + image
+	if image == "" {
+		imageField = "no image"
+	}
+	return fmt.Sprintf("Compiled %s -> %s (%s, version %s)\n", src, out, imageField, version)
 }
 
 // checkImageFlags enforces the --build/--image relationship and notes when an

--- a/internal/cli/compile_summary_test.go
+++ b/internal/cli/compile_summary_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import "testing"
+
+// TestCompileSummaryNoImage covers #D10 from the Lite dogfood audit (#212):
+// when `--image` is not set, the success line previously printed a dangling
+// comma — `(image , version dev)` — making the output look broken. The empty
+// case must render a clean substitute like `no image`.
+func TestCompileSummaryNoImage(t *testing.T) {
+	got := compileSummary("dag.py", "dag.json", "", "dev")
+	want := "Compiled dag.py -> dag.json (no image, version dev)\n"
+	if got != want {
+		t.Errorf("empty image summary mismatch\n got: %q\nwant: %q", got, want)
+	}
+}
+
+// TestCompileSummaryWithImage pins the happy-path format so the no-image fix
+// does not silently rewrite the populated case.
+func TestCompileSummaryWithImage(t *testing.T) {
+	got := compileSummary("dag.py", "dag.json", "registry/etl:v1", "dev")
+	want := "Compiled dag.py -> dag.json (image registry/etl:v1, version dev)\n"
+	if got != want {
+		t.Errorf("populated image summary mismatch\n got: %q\nwant: %q", got, want)
+	}
+}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -40,7 +40,12 @@ func newInitCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Initialized Leoflow project %q in %s\n", dagID, args[0])
+			_, err = fmt.Fprintf(cmd.OutOrStdout(),
+				"Initialized Leoflow project %q in %s\n"+
+					"\nNext steps:\n"+
+					"  leoflow validate %s    # quick syntax check\n"+
+					"  leoflow lite %s        # run it locally with the embedded scheduler\n",
+				dagID, args[0], args[0], args[0])
 			return err
 		},
 	}

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestInitCommandPrintsNextStep covers #D6 from the Lite dogfood audit (#212):
+// after scaffolding a project, the user has no idea what command to run next.
+// The success message must surface at least one concrete next-step hint
+// (typically `leoflow lite <path>` or `leoflow validate <path>`) so the
+// onboarding loop terminates at a useful instruction rather than dead air.
+func TestInitCommandPrintsNextStep(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "myproj")
+	cmd := newInitCommand()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetArgs([]string{target})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	got := stdout.String()
+	if !strings.Contains(got, "Initialized Leoflow project") {
+		t.Errorf("missing success line; got: %q", got)
+	}
+	if !strings.Contains(got, "leoflow lite") && !strings.Contains(got, "leoflow validate") {
+		t.Errorf("D6: expected a next-step suggestion (leoflow lite / leoflow validate); got: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Two cheap dogfood-audit (#212) corrections visible in the first five minutes of a new-user session.

- **#D6** — `leoflow init` now prints a "Next steps" block with `leoflow validate <path>` and `leoflow lite <path>`, so the onboarding loop ends on an actionable instruction instead of a dead-air "Initialized" message.
- **#D10** — `leoflow compile` without `--image` previously printed `Compiled ... (image , version dev)` (dangling comma → looked broken). Extracted `compileSummary()` so the empty case renders `no image`; populated case is unchanged.

## Tests

- `TestInitCommandPrintsNextStep` — asserts the success block contains a `leoflow lite|validate` suggestion.
- `TestCompileSummaryNoImage` — pins the empty-image format.
- `TestCompileSummaryWithImage` — pins the populated-image format so the no-image fix can't silently rewrite the happy path.

All three pass. Pre-commit gate green (`gofmt`, `go vet`, `golangci-lint` 0 issues, `ruff`, coverage 78.8% > 78%).

## Test plan

- [ ] `leoflow init /tmp/x` prints the new next-step block
- [ ] `leoflow compile <project>` without --image prints `no image` (not `image ,`)
- [ ] `leoflow compile <project> --image foo:v1` still prints `image foo:v1`