### PR TITLE
fix(ui): inject clipboard fallback so copy buttons work on plain http origins (closes #242)

### DIFF
--- a/internal/ui/handler.go
+++ b/internal/ui/handler.go
@@ -18,6 +18,28 @@ import (
 // request time, mirroring Airflow's TemplateResponse.
 const baseHrefPlaceholder = "{{ backend_server_base_url }}"
 
+// clipboardFallbackHTML defines navigator.clipboard.writeText when the native
+// Clipboard API is unavailable. The API is gated behind a secure context, so
+// users hitting Lite over a plain http://<lan-ip>:8080 origin (a real Lima /
+// dogfood scenario) see the SPA's copy buttons silently fail (#242). The
+// fallback uses the legacy document.execCommand('copy') + offscreen textarea
+// trick. On https / localhost the native API is present and the polyfill is
+// a no-op, so it is always injected.
+const clipboardFallbackHTML = `<script>` +
+	`(function(){` +
+	`if(window.isSecureContext&&navigator.clipboard&&navigator.clipboard.writeText)return;` +
+	`var w=function(t){return new Promise(function(r,e){` +
+	`var ta=document.createElement('textarea');ta.value=t;` +
+	`ta.setAttribute('readonly','');ta.style.position='fixed';ta.style.top='-1000px';` +
+	`document.body.appendChild(ta);ta.select();` +
+	`try{document.execCommand('copy');r()}catch(x){e(x)}` +
+	`finally{document.body.removeChild(ta)}` +
+	`})};` +
+	`if(!navigator.clipboard)navigator.clipboard={writeText:w};` +
+	`else if(!navigator.clipboard.writeText)navigator.clipboard.writeText=w;` +
+	`})();` +
+	`</script>`
+
 // liteBannerHTML is a discreet, neutral-gray "LITE" pill fixed at top-center,
 // injected into the served shell in the Lite edition so the local environment is
 // never mistaken for production. The slate gray (with white text) reads well on
@@ -216,6 +238,9 @@ func (s *Server) Index(w http.ResponseWriter, basePath string) {
 		title = "Leoflow"
 	}
 	body = strings.ReplaceAll(body, "<title>Airflow</title>", "<title>"+title+"</title>")
+	// Always inject the clipboard polyfill — no-op on https / localhost, the
+	// only place it matters is plain http://<lan-ip>:port (#242).
+	body = injectBeforeBodyEnd(body, clipboardFallbackHTML)
 	if s.liteBanner {
 		body = injectBeforeBodyEnd(body, liteBannerHTML)
 	}

--- a/internal/ui/handler_test.go
+++ b/internal/ui/handler_test.go
@@ -76,6 +76,25 @@ func TestIndexRewritesTitleToInstanceName(t *testing.T) {
 	}
 }
 
+// TestIndexInjectsClipboardFallback covers #242: the Airflow SPA's copy
+// buttons (logs, run IDs, etc.) call navigator.clipboard.writeText, which
+// throws on plain http:// LAN origins because the Clipboard API requires a
+// secure context. The Leoflow shell injects a tiny polyfill so the copy
+// button still works when users access Lite over `http://<host-lan-ip>:8080`.
+// The polyfill is a no-op when the native API is available, so it is always
+// injected.
+func TestIndexInjectsClipboardFallback(t *testing.T) {
+	rec := httptest.NewRecorder()
+	fixture().Index(rec, "/")
+	body := rec.Body.String()
+	if !strings.Contains(body, "navigator.clipboard") {
+		t.Errorf("polyfill missing — body should reference navigator.clipboard; got %q", body)
+	}
+	if !strings.Contains(body, "execCommand('copy')") {
+		t.Errorf("polyfill missing — body should fall back to document.execCommand('copy'); got %q", body)
+	}
+}
+
 func TestStaticServesHashedAssetImmutable(t *testing.T) {
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/assets/app-abc123.js", http.NoBody)


### PR DESCRIPTION
## Summary

Closes #242. Lite users hitting the server over a plain http://<lan-ip>:8080 origin (e.g., from another machine on the LAN) saw the SPA's copy buttons fail silently — the Clipboard API requires a secure context, so navigator.clipboard is undefined off http://localhost.

This injects a small polyfill into the served shell that defines navigator.clipboard.writeText via document.execCommand('copy') + offscreen textarea, but only when the native API is missing. On https / localhost it is a no-op.

## Why always inject

We cannot tell at request time whether the browser will load the page via https, localhost, or a LAN IP. The check is purely client-side and the polyfill is ~25 lines, so the safe default is to always include it.

## Tests

- `TestIndexInjectsClipboardFallback` asserts the polyfill is in every served index.html (references both `navigator.clipboard` and `execCommand('copy')`).

All existing UI tests still pass; pre-commit gate green (gofmt, vet, golangci-lint, ruff, coverage 78.9% > 78%).

## Test plan

- [ ] Lite over `http://localhost:8080` — copy still works (native API path)
- [ ] Lite over `http://<lan-ip>:8080` from another device — copy works (polyfill path)
- [ ] Pro over `https://…` — copy still works (native API path, polyfill skipped)