### PR TITLE
fix(cli): lead compile failure with the Python error summary (closes #D9)

### DIFF
--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -218,7 +219,18 @@ func runParser(cmd *cobra.Command, command string, a parserArgs) error {
 	var stderr bytes.Buffer
 	pc.Stderr = io.MultiWriter(cmd.ErrOrStderr(), &stderr)
 	if err := pc.Run(); err != nil {
-		if detail := lastLines(strings.TrimSpace(stderr.String()), 20); detail != "" {
+		raw := strings.TrimSpace(stderr.String())
+		detail := lastLines(raw, 20)
+		// Lead with the user-actionable summary line (e.g. `SyntaxError: ...`)
+		// when present, so the cause is visible above the bounded traceback
+		// instead of buried under our internal parser file paths (#D9).
+		if summary := parserErrorSummary(raw); summary != "" {
+			if detail != "" {
+				return fmt.Errorf("%s\n\n%s", summary, detail)
+			}
+			return errors.New(summary)
+		}
+		if detail != "" {
 			return fmt.Errorf("running parser %q: %w\n%s", command, err, detail)
 		}
 		return fmt.Errorf("running parser %q: %w", command, err)
@@ -237,6 +249,29 @@ func lastLines(s string, n int) string {
 		lines = lines[len(lines)-n:]
 	}
 	return strings.Join(lines, "\n")
+}
+
+// pythonErrorRe matches a single Python exception-summary line of the form
+// `<CamelCaseName>Error: <message>` — the canonical last line of a traceback.
+// The leading-uppercase + ending-in-Error shape filters out the noisy
+// `File "..."` and code-snippet lines that surround it.
+var pythonErrorRe = regexp.MustCompile(`^[A-Z][A-Za-z0-9_]*Error: .+$`)
+
+// parserErrorSummary extracts the deepest Python exception summary
+// (`*Error: message`) from a parser traceback. The deepest line is the
+// actual cause; intermediate "During handling of the above exception ..."
+// wrappers are skipped. Returns "" when no error line is present so callers
+// can fall back to the raw traceback. Closes #D9 from the dogfood audit
+// (#212): users see a one-line cause instead of an internal-paths dump.
+func parserErrorSummary(stderr string) string {
+	var last string
+	for _, raw := range strings.Split(stderr, "\n") {
+		ln := strings.TrimSpace(raw)
+		if pythonErrorRe.MatchString(ln) {
+			last = ln
+		}
+	}
+	return last
 }
 
 // overlayProject writes the leoflow.yaml Leoflow-specific config (staging and

--- a/internal/cli/compile_error_test.go
+++ b/internal/cli/compile_error_test.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParserErrorSummary covers #D9 from the Lite dogfood audit (#212): when
+// the parser fails on a broken dag.py the user previously got only the raw
+// Python traceback (with our internal parser paths in it) dumped to the
+// terminal. parserErrorSummary lifts the meaningful `*Error: message` line
+// out of the traceback so the compile/validate caller can lead with a clean,
+// one-line summary before the bounded traceback tail.
+func TestParserErrorSummary(t *testing.T) {
+	cases := []struct {
+		name   string
+		stderr string
+		want   string
+	}{
+		{
+			name: "syntax error",
+			stderr: `  File "/tmp/dag.py", line 1
+    this_is_not_python
+                     ^
+SyntaxError: invalid syntax`,
+			want: "SyntaxError: invalid syntax",
+		},
+		{
+			name: "name error wraps deep traceback",
+			stderr: `Traceback (most recent call last):
+  File "parser/leoflow_parser/compiler.py", line 73, in compile
+    user_module = importlib.import_module(...)
+  File "/tmp/dag.py", line 8, in <module>
+    do_stuff(undefined)
+NameError: name 'undefined' is not defined`,
+			want: "NameError: name 'undefined' is not defined",
+		},
+		{
+			name: "import error",
+			stderr: `Traceback (most recent call last):
+  File "/tmp/dag.py", line 1, in <module>
+    from nonexistent import thing
+ImportError: No module named 'nonexistent'`,
+			want: "ImportError: No module named 'nonexistent'",
+		},
+		{
+			name:   "no python error pattern → empty",
+			stderr: "some non-python output\nrandom line",
+			want:   "",
+		},
+		{
+			name:   "empty input",
+			stderr: "",
+			want:   "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parserErrorSummary(tc.stderr)
+			if got != tc.want {
+				t.Errorf("parserErrorSummary mismatch\n got: %q\nwant: %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParserErrorSummaryPrefersUserError pins the precedence: when both the
+// user's dag.py file and an internal parser file appear in the traceback, the
+// summary should reflect the *last* error line — that is the actual cause,
+// not an intermediate wrapper.
+func TestParserErrorSummaryPrefersUserError(t *testing.T) {
+	stderr := `Traceback (most recent call last):
+  File "parser/wrapper.py", line 12, in run
+    raise WrapError("inner") from None
+WrapError: inner
+During handling of the above exception, another exception occurred:
+  File "/tmp/dag.py", line 3, in <module>
+    1/0
+ZeroDivisionError: division by zero`
+	got := parserErrorSummary(stderr)
+	if !strings.Contains(got, "ZeroDivisionError") {
+		t.Errorf("expected ZeroDivisionError (the deepest cause); got: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #D9 (dogfood audit #212). A failing `leoflow compile` used to dump the raw parser traceback — with our internal `parser/leoflow_parser/compiler.py:...` paths at the top — and bury the actual user-facing error at the bottom. New users could not tell whether the breakage was their `dag.py` or our infrastructure.

`runParser` now extracts the deepest `*Error: <message>` line via `parserErrorSummary()` and uses it as the lead of the returned error. The bounded traceback tail still follows for users who need the full context.

## Behavior

- **SyntaxError in dag.py** → leads with `SyntaxError: invalid syntax`, traceback below.
- **NameError / ImportError / etc.** → same shape.
- **Nested traceback** (during-handling-of-the-above) → leads with the *deepest* cause line.
- **No Python-error shape** → falls back to the previous `running parser %q: %w` format.

## Tests

- `TestParserErrorSummary` (5 sub-cases): SyntaxError / NameError / ImportError / no-match / empty.
- `TestParserErrorSummaryPrefersUserError` pins the precedence on the deepest line.

Pre-commit gate green (`gofmt`, `vet`, `golangci-lint` 0 issues, `ruff`, coverage 78.9% > 78%).

## Test plan

- [ ] `leoflow compile` over a broken `dag.py` shows `SyntaxError: …` on the first line of stderr
- [ ] Existing happy-path compile still succeeds