### PR TITLE
fix(cli): group --help into 4 navigable sections + refresh db wording (closes #D1, #D2)

### DIFF
--- a/internal/cli/db.go
+++ b/internal/cli/db.go
@@ -9,24 +9,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// newDBCommand groups dev-database management commands, mirroring Airflow's
-// `airflow db ...`. They operate ONLY on the isolated local dev database
-// (leoflow_dev); the demo/production database is managed via migrations + Helm.
+// newDBCommand groups Lite-database management commands, mirroring Airflow's
+// `airflow db ...`. They operate ONLY on the isolated local Lite database (the
+// schema name is still `leoflow_dev` for upgrade-in-place safety with installs
+// from before the Dev→Lite product rename); the production database is managed
+// via migrations + Helm.
 func newDBCommand() *cobra.Command {
 	db := &cobra.Command{
 		Use:   "db",
-		Short: "Manage the local dev database (leoflow_dev).",
+		Short: "Manage the local Lite database (schema name leoflow_dev for upgrade safety).",
 	}
 	db.AddCommand(newDBMigrateCommand(), newDBResetCommand())
 	return db
 }
 
-// newDBMigrateCommand creates the dev database if needed and applies the embedded
-// migrations (like `airflow db migrate`).
+// newDBMigrateCommand creates the Lite database if needed and applies the
+// embedded migrations (like `airflow db migrate`).
 func newDBMigrateCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "migrate",
-		Short: "Create (if needed) and migrate the dev database to the latest schema.",
+		Short: "Create (if needed) and migrate the Lite database to the latest schema.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := ensureDevDatabase(cmdContext(cmd), cmd); err != nil {
@@ -37,13 +39,13 @@ func newDBMigrateCommand() *cobra.Command {
 	}
 }
 
-// newDBResetCommand drops, recreates, and migrates the dev database (like
+// newDBResetCommand drops, recreates, and migrates the Lite database (like
 // `airflow db reset`). Destructive, so it requires --yes.
 func newDBResetCommand() *cobra.Command {
 	var yes bool
 	cmd := &cobra.Command{
 		Use:   "reset",
-		Short: "Drop, recreate, and migrate the dev database (DESTRUCTIVE).",
+		Short: "Drop, recreate, and migrate the Lite database (DESTRUCTIVE).",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if !yes {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -25,23 +25,42 @@ func NewRootCommand() *cobra.Command {
 	root.PersistentFlags().String("log-level", "", "log level: debug, info, warn, error")
 	root.PersistentFlags().String("server-url", "", "control plane API base URL")
 
-	root.AddCommand(
-		newVersionCommand(),
-		newDoctorCommand(),
-		newSetupCommand(),
-		newUninstallCommand(),
-		newInitCommand(),
-		newValidateCommand(),
-		newCompileCommand(),
-		newLiteCommand(),
-		newDBCommand(),
-		newPushCommand(),
-		newDagsCommand(),
-		newRunsCommand(),
-		newAuthCommand(),
-		newServerCommand(),
-		newGenDocsCommand(),
+	// Cobra command groups (issue #D1, dogfood audit #212): split the 17
+	// commands into four navigable sections so new users see "init → run"
+	// as one block, not as one long alphabetised list.
+	root.AddGroup(
+		&cobra.Group{ID: "authoring", Title: "Authoring loop (write → check → package → push):"},
+		&cobra.Group{ID: "runtime", Title: "Runtime (start the control plane):"},
+		&cobra.Group{ID: "inspection", Title: "Inspection (query DAGs / runs / auth):"},
+		&cobra.Group{ID: "lifecycle", Title: "Lifecycle (install, configure, repair, retire):"},
 	)
+
+	authoring := []*cobra.Command{newInitCommand(), newValidateCommand(), newCompileCommand(), newPushCommand()}
+	runtime := []*cobra.Command{newLiteCommand(), newServerCommand()}
+	inspection := []*cobra.Command{newDagsCommand(), newRunsCommand(), newAuthCommand()}
+	lifecycle := []*cobra.Command{newSetupCommand(), newDoctorCommand(), newDBCommand(), newUninstallCommand(), newVersionCommand()}
+
+	for _, c := range authoring {
+		c.GroupID = "authoring"
+		root.AddCommand(c)
+	}
+	for _, c := range runtime {
+		c.GroupID = "runtime"
+		root.AddCommand(c)
+	}
+	for _, c := range inspection {
+		c.GroupID = "inspection"
+		root.AddCommand(c)
+	}
+	for _, c := range lifecycle {
+		c.GroupID = "lifecycle"
+		root.AddCommand(c)
+	}
+
+	// gen-docs is a maintenance helper — leave ungrouped so it does not
+	// clutter the user-facing sections.
+	root.AddCommand(newGenDocsCommand())
+
 	return root
 }
 

--- a/internal/cli/root_groups_test.go
+++ b/internal/cli/root_groups_test.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRootCommandsHaveGroups covers #D1 from the Lite dogfood audit (#212):
+// `leoflow --help` listed every command in one long unordered block of 17
+// entries. New users could not tell authoring commands from runtime, runtime
+// from inspection, or admin from anything. Cobra command groups break the
+// list into navigable sections.
+func TestRootCommandsHaveGroups(t *testing.T) {
+	want := map[string]string{
+		// Authoring loop — write, check, package, push a DAG.
+		"init":     "authoring",
+		"validate": "authoring",
+		"compile":  "authoring",
+		"push":     "authoring",
+		// Runtime — start the control plane(s).
+		"lite":   "runtime",
+		"server": "runtime",
+		// Inspection — query state of registered DAGs / runs / auth tokens.
+		"dags": "inspection",
+		"runs": "inspection",
+		"auth": "inspection",
+		// Lifecycle — install, configure, repair, version, retire the host.
+		"setup":     "lifecycle",
+		"doctor":    "lifecycle",
+		"db":        "lifecycle",
+		"uninstall": "lifecycle",
+		"version":   "lifecycle",
+	}
+
+	root := NewRootCommand()
+	for _, cmd := range root.Commands() {
+		expected, ok := want[cmd.Name()]
+		if !ok {
+			continue // help/completion/gen-docs — leave ungrouped on purpose.
+		}
+		if cmd.GroupID != expected {
+			t.Errorf("%s GroupID = %q, want %q", cmd.Name(), cmd.GroupID, expected)
+		}
+	}
+}
+
+// TestRootDefinesFourGroups pins the group set itself so a typo in a GroupID
+// fails the GROUP definition, not the assignment.
+func TestRootDefinesFourGroups(t *testing.T) {
+	root := NewRootCommand()
+	want := map[string]bool{"authoring": false, "runtime": false, "inspection": false, "lifecycle": false}
+	for _, g := range root.Groups() {
+		if _, ok := want[g.ID]; ok {
+			want[g.ID] = true
+		}
+	}
+	for id, ok := range want {
+		if !ok {
+			t.Errorf("root command is missing group %q", id)
+		}
+	}
+}
+
+// TestDBHelpReferencesLite covers #D2: the `db` command's Short used to read
+// "Manage the local dev database (leoflow_dev)" — stale after the Dev→Lite
+// product rename. The underlying database name `leoflow_dev` is preserved
+// for backward compatibility, but the help should brand it as the Lite
+// database so new users do not look for a non-existent "dev" edition.
+func TestDBHelpReferencesLite(t *testing.T) {
+	db := newDBCommand()
+	if !strings.Contains(db.Short, "Lite") {
+		t.Errorf("db Short should mention Lite (post-rename); got %q", db.Short)
+	}
+}


### PR DESCRIPTION
## Summary

Two dogfood-audit (#212) corrections to the first-impression CLI surface.

**#D1** — \`leoflow --help\` listed 17 commands in one alphabetised block. Cobra command groups split them into four sections:

\`\`\`
Authoring loop (write → check → package → push):
  compile, init, push, validate

Runtime (start the control plane):
  lite, server

Inspection (query DAGs / runs / auth):
  auth, dags, runs

Lifecycle (install, configure, repair, retire):
  db, doctor, setup, uninstall, version
\`\`\`

\`completion\`, \`help\`, and \`gen-docs\` stay ungrouped — built-ins or maintainer helpers, not user-facing.

**#D2** — \`leoflow db\` Short used to read "Manage the local dev database (leoflow_dev)". Updated to "Manage the local Lite database (schema name leoflow_dev for upgrade safety)" so the post-Dev→Lite rename is consistent in the CLI surface, while still surfacing the legacy schema name (preserved for upgrade-in-place).

## Tests

- \`TestRootCommandsHaveGroups\` pins each command's expected GroupID.
- \`TestRootDefinesFourGroups\` pins the four group definitions exist.
- \`TestDBHelpReferencesLite\` asserts the db Short mentions Lite.

All pass; pre-commit gate green (gofmt, vet, golangci-lint, ruff, coverage 80.1% > 78%).

## Test plan

- [ ] \`leoflow --help\` shows four titled sections in the new order
- [ ] \`leoflow db --help\` reads "Lite database (schema name leoflow_dev …)"