### PR TITLE
chore(ci): raise unit-coverage floor 78% → 80% + sync local exclude list

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,12 +90,12 @@ jobs:
 
       - name: Enforce coverage floor
         run: |
-          # Coverage floor: 78% (raised from 75 to lock in the resilience /
-          # critical-path tests; filtered total ~79%). Exclude generated code,
-          # main packages, version, and process-orchestration of external
-          # binaries (Docker/initdb/pg_ctl) that only integration/e2e can
-          # exercise honestly, per ADR 0011.
-          FLOOR=78
+          # Coverage floor: 80% (raised from 78 after the alpha-prep batch
+          # — #295/#296/#297/#299 — pushed the filtered total above 80%).
+          # Exclude generated code, main packages, version, and the
+          # process-orchestration of external binaries (Docker/initdb/pg_ctl)
+          # that only integration/e2e can exercise honestly, per ADR 0011.
+          FLOOR=80
           EXCLUDE='(/internal/storage/queries/|/internal/storage/repository\.go:|/internal/storage/postgres\.go:|/internal/storage/redis\.go:|/internal/storage/scheduler_store\.go:|/internal/storage/agent_store\.go:|/internal/storage/xcom_index\.go:|/internal/xcom/redis_backend\.go:|/internal/logs/tail\.go:|/internal/scheduler/leader\.go:|/internal/cli/managed_postgres\.go:|/internal/cli/backup_cmd\.go:|/internal/cli/restore_cmd\.go:|\.pb\.go:|/internal/version/|/cmd/)'
           grep -vE "$EXCLUDE" coverage.out > coverage.filtered.out
           TOTAL=$(go tool cover -func=coverage.filtered.out | tail -1 | awk '{print $3}' | sed 's/%//')

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -7,9 +7,11 @@
 set -euo pipefail
 
 # Coverage floor (percent). Keep in sync with .github/workflows/ci.yaml.
-# Raised 75 -> 78 to lock in the resilience/critical-path test coverage; the
-# filtered total sits at ~79%, leaving a small margin for platform variance.
-COVERAGE_FLOOR=78
+# History: 75 -> 78 locked in resilience/critical-path tests; 78 -> 80 follows
+# the alpha-prep batch (#295/#296/#297/#299) that pushed the filtered total
+# above 80%. The thin margin is intentional: each new PR must come with
+# tests so we never ratchet down silently.
+COVERAGE_FLOOR=80
 
 echo "[pre-commit] gofmt"
 unformatted=$(gofmt -l $(git diff --cached --name-only --diff-filter=ACM | grep '\.go$' || true) 2>/dev/null || true)
@@ -44,7 +46,7 @@ go test -coverprofile="$profile" ./... >/dev/null
 # packages, version, and the thin process/lock-binding files (DB, locks, and
 # external-binary orchestration like Docker/initdb/pg_ctl) that are exercised
 # by integration/e2e tests rather than unit tests.
-exclude='(/internal/storage/queries/|/internal/storage/repository\.go:|/internal/storage/postgres\.go:|/internal/storage/redis\.go:|/internal/storage/scheduler_store\.go:|/internal/storage/agent_store\.go:|/internal/storage/xcom_index\.go:|/internal/xcom/redis_backend\.go:|/internal/logs/tail\.go:|/internal/scheduler/leader\.go:|/internal/cli/managed_postgres\.go:|\.pb\.go:|/internal/version/|/cmd/)'
+exclude='(/internal/storage/queries/|/internal/storage/repository\.go:|/internal/storage/postgres\.go:|/internal/storage/redis\.go:|/internal/storage/scheduler_store\.go:|/internal/storage/agent_store\.go:|/internal/storage/xcom_index\.go:|/internal/xcom/redis_backend\.go:|/internal/logs/tail\.go:|/internal/scheduler/leader\.go:|/internal/cli/managed_postgres\.go:|/internal/cli/backup_cmd\.go:|/internal/cli/restore_cmd\.go:|\.pb\.go:|/internal/version/|/cmd/)'
 grep -vE "$exclude" "$profile" >"$filtered"
 current=$(go tool cover -func="$filtered" | tail -1 | awk '{print $3}' | tr -d '%')
 rm -f "$profile" "$filtered"


### PR DESCRIPTION
## Summary

The alpha-prep batch (#295/#296/#297/#299) pushed the filtered unit-coverage total above 80% with comfortable margin. Lock in the gain so every future PR carries tests or the gate refuses the commit.

## Changes

- **`scripts/pre-commit`**: `COVERAGE_FLOOR=78 → 80`. Comment now records the full history (75 → 78 → 80).
- **`.github/workflows/ci.yaml`**: `FLOOR=78 → 80`. Same comment refresh.
- **Sync exclude regex**: the local hook was missing `internal/cli/backup_cmd.go` and `internal/cli/restore_cmd.go`, which CI already excluded as thin pg_dump/pg_restore orchestration (same rationale as `managed_postgres.go`). Without that fix, local would have surfaced a 78.8% false-fail at the new 80% floor; with it, local matches CI at 80.1%.

## Why ratchet up

ADR 0011: coverage is a floor, not a ceiling. The floor only does work if it tracks reality — when reality moves up, the floor follows so future regressions can't silently land. The 0.1% margin is intentionally thin: any PR that touches production code without tests will fail the gate immediately, even at +0.1%.

## Operator follow-up

After merge, re-install the local hook:

```sh
cp scripts/pre-commit .git/hooks/pre-commit
chmod +x .git/hooks/pre-commit
```

Otherwise the local pre-commit will keep using the old 78% threshold and you'll get a CI failure that the hook didn't catch.

## Test plan

- [ ] `pre-commit` locally on a no-test PR errors out with "below floor 80%"
- [ ] `pre-commit` locally on this PR passes at 80.1%