### PR TITLE
fix(ide): skip example install when workspace root has a same-named project (closes #298 dup-detect)

### DIFF
--- a/internal/api/ide.go
+++ b/internal/api/ide.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -72,6 +73,15 @@ type ideInstallExamplesBody struct {
 type ideInstallExamplesResp struct {
 	Installed []string `json:"installed"`
 	Skipped   []string `json:"skipped"`
+	// SkippedExamples lists example project names that were not materialized
+	// because a workspace root project of the same name already exists.
+	// Lite's multi-DAG discovery refuses duplicate dag_ids at boot, so
+	// installing the colliding example would silently produce a workspace
+	// that the next `leoflow lite` boot rejects. Reporting this lets the
+	// IDE surface a "Skipped: bash_pipeline (already exists)" hint
+	// instead of leaving the user to discover the collision at startup.
+	// See alpha-prep issue #298 (sub-item: IDE dup-detect).
+	SkippedExamples []string `json:"skipped_examples"`
 }
 
 // registerIDE mounts the Lite web editor: the workspace filesystem API, the
@@ -213,17 +223,53 @@ func ideInstallExamplesHandler(store WorkspaceFS, examples fs.FS) gin.HandlerFun
 		if target == "" {
 			target = "examples"
 		}
-		resp := ideInstallExamplesResp{Installed: []string{}, Skipped: []string{}}
+		resp := ideInstallExamplesResp{
+			Installed:       []string{},
+			Skipped:         []string{},
+			SkippedExamples: []string{},
+		}
+
+		// Gather workspace top-level directories so the install can skip any
+		// example whose dir-name collides with an existing project — Lite's
+		// multi-DAG discovery (internal/cli/discover) treats every top-level
+		// directory as a candidate project and refuses duplicate dag_ids on
+		// boot, so installing the collision would silently break the next
+		// startup (alpha-prep #298, observed during prealpha.28 smoke).
+		rootProjects := make(map[string]bool)
+		if entries, terr := store.Tree(); terr == nil {
+			for _, e := range entries {
+				if e.IsDir && !strings.Contains(e.Path, "/") {
+					rootProjects[e.Name] = true
+				}
+			}
+		}
+
 		// Walk the embedded examples FS. Embedded root is "examples" (matches
 		// the source tree), so we strip that prefix and re-anchor under target.
 		walkErr := fs.WalkDir(examples, "examples", func(p string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
-			if p == "examples" || d.IsDir() {
+			if p == "examples" {
 				return nil
 			}
-			rel := path.Join(target, p[len("examples/"):])
+			// First path segment under "examples/" is the example's project
+			// name (e.g. "bash_pipeline"). When the user already has a
+			// top-level project with that name, skip the whole subtree.
+			relUnder := p[len("examples/"):]
+			projectName := relUnder
+			if i := strings.Index(relUnder, "/"); i > 0 {
+				projectName = relUnder[:i]
+			}
+			if d.IsDir() {
+				if rootProjects[projectName] {
+					resp.SkippedExamples = append(resp.SkippedExamples, projectName)
+					return fs.SkipDir
+				}
+				return nil
+			}
+
+			rel := path.Join(target, relUnder)
 			data, rerr := fs.ReadFile(examples, p)
 			if rerr != nil {
 				return fmt.Errorf("reading embedded %q: %w", p, rerr)

--- a/internal/api/ide_install_test.go
+++ b/internal/api/ide_install_test.go
@@ -1,0 +1,135 @@
+package api
+
+import (
+	"encoding/json"
+	"io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/workspace"
+)
+
+// mockExamplesFS produces a small embedded-FS replacement with two example
+// DAGs (`bash_pipeline`, `csv_report`) under the same `examples/` root the
+// real embed.FS uses. Enough for the install handler to walk and decide.
+func mockExamplesFS() fs.FS {
+	return fstest.MapFS{
+		"examples/bash_pipeline/dag.py":       &fstest.MapFile{Data: []byte("print('bash')\n")},
+		"examples/bash_pipeline/leoflow.yaml": &fstest.MapFile{Data: []byte("schema_version: \"1.0\"\ndag_id: bash_pipeline\n")},
+		"examples/csv_report/dag.py":          &fstest.MapFile{Data: []byte("print('csv')\n")},
+		"examples/csv_report/leoflow.yaml":    &fstest.MapFile{Data: []byte("schema_version: \"1.0\"\ndag_id: csv_report\n")},
+	}
+}
+
+// ideServerWithExamples wires the IDE routes including the install endpoint,
+// so the test can POST to /api/v2/ide/examples/install.
+func ideServerWithExamples(store WorkspaceFS, examples fs.FS) *gin.Engine {
+	return NewServer(Dependencies{
+		Logger:        discardLogger(),
+		Authenticator: &fakeAuthn{user: &auth.User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}},
+		RateLimiter:   auth.NewRateLimiter(100, time.Minute),
+		CORSOrigins:   []string{"*"},
+		Workspace:     store,
+		ExamplesFS:    examples,
+	})
+}
+
+func newWorkspaceWithProject(t *testing.T, name string) WorkspaceFS {
+	t.Helper()
+	dir := t.TempDir()
+	projectDir := filepath.Join(dir, name)
+	if err := os.MkdirAll(projectDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "leoflow.yaml"),
+		[]byte("schema_version: \"1.0\"\ndag_id: "+name+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "dag.py"), []byte("print('hi')\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := workspace.New(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+// TestInstallExamplesSkipsRootCollision covers #298b (alpha-prep): when the
+// workspace already has a top-level project with the same name as an
+// embedded example, the install must skip that example wholesale — otherwise
+// the next `leoflow lite` boot refuses to start (multi-DAG discovery rejects
+// duplicate dag_ids). The handler reports skipped examples in a dedicated
+// response field so the IDE can surface "skipped: bash_pipeline (already
+// exists)" to the user instead of silently producing a broken workspace.
+func TestInstallExamplesSkipsRootCollision(t *testing.T) {
+	srv := ideServerWithExamples(newWorkspaceWithProject(t, "bash_pipeline"), mockExamplesFS())
+
+	rec := authGet(srv, http.MethodPost, "/api/v2/ide/examples/install", "{}")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("install = %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	var got struct {
+		Installed       []string `json:"installed"`
+		Skipped         []string `json:"skipped"`
+		SkippedExamples []string `json:"skipped_examples"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+
+	if !slices.Contains(got.SkippedExamples, "bash_pipeline") {
+		t.Errorf("bash_pipeline should be in SkippedExamples (collides with workspace root); got %+v", got)
+	}
+	for _, p := range got.Installed {
+		if filepath.Base(filepath.Dir(p)) == "bash_pipeline" {
+			t.Errorf("bash_pipeline files should not have been installed; saw %q in Installed", p)
+		}
+	}
+	// csv_report does not collide and should be installed normally.
+	foundCSV := false
+	for _, p := range got.Installed {
+		if filepath.Base(filepath.Dir(p)) == "csv_report" {
+			foundCSV = true
+			break
+		}
+	}
+	if !foundCSV {
+		t.Errorf("csv_report should still install when only bash_pipeline collides; Installed=%+v", got.Installed)
+	}
+}
+
+// TestInstallExamplesCleanWorkspace pins the happy path: with no collisions,
+// every example materializes and nothing is reported as skipped.
+func TestInstallExamplesCleanWorkspace(t *testing.T) {
+	srv := ideServerWithExamples(newWorkspaceWithProject(t, "unrelated_project"), mockExamplesFS())
+
+	rec := authGet(srv, http.MethodPost, "/api/v2/ide/examples/install", "{}")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("install = %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	var got struct {
+		Installed       []string `json:"installed"`
+		Skipped         []string `json:"skipped"`
+		SkippedExamples []string `json:"skipped_examples"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.SkippedExamples) != 0 {
+		t.Errorf("clean workspace should not skip any example; got %+v", got.SkippedExamples)
+	}
+	if len(got.Installed) == 0 {
+		t.Errorf("clean workspace should install both examples; got nothing")
+	}
+}


### PR DESCRIPTION
## Summary

Closes the IDE-dup-detect sub-item of #298. Surfaced during prealpha.28 smoke: clicking "Download examples" while you already had a top-level project of the same name (\`~/leoflow/bash_pipeline\` from a prior \`leoflow init\`) silently produced two trees declaring the same \`dag_id\`. Next \`leoflow lite\` boot refused to start with "duplicate dag_id in workspace".

The install handler now:

- collects workspace top-level directory names (matching the scope multi-DAG discovery uses)
- skips embedded examples whose project dir-name collides
- reports the skipped examples in a dedicated \`skipped_examples\` response field so the IDE can surface a "Skipped: bash_pipeline (already exists)" hint instead of leaving the user to discover the collision at startup

## Behavior

- Workspace has \`bash_pipeline/\`, examples include \`bash_pipeline\` + \`csv_report\` → \`bash_pipeline\` listed in \`skipped_examples\`, \`csv_report\` installed.
- Empty / unrelated workspace → every example installed, \`skipped_examples\` empty.
- File-level collision (the existing per-file skip) is unchanged.

## Tests

- \`TestInstallExamplesSkipsRootCollision\` — collision case
- \`TestInstallExamplesCleanWorkspace\` — happy path

Pre-commit gate green (gofmt, vet, golangci-lint 0 issues, ruff, coverage 80.5% > 80%).

## Test plan

- [ ] Lite with existing \`~/leoflow/bash_pipeline/\` + click Download → response shows \`bash_pipeline\` in \`skipped_examples\`, other examples installed, \`leoflow lite\` boots after.
- [ ] Lite with empty workspace + click Download → every example installed.