### PR TITLE
docs(aaa-pass): sweep "Dev" edition references → "Lite"

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,7 +34,7 @@ Then open **<http://localhost:8080>** and log in as **`admin@leoflow.local`** /
 !!! tip "What you're looking at"
     One process serves the API (`/api/v2`), the internal UI API (`/ui/*`), and the
     React UI (ADR 0017). It auto-applies migrations and seeds the admin user on
-    first boot. The three operating modes (Demo · Dev · Pro-soon) are
+    first boot. The three operating modes (Lite · Pro-soon · Demo) are
     described in [Operating modes](operating-modes.md).
 
 ## 2. Set up for development
@@ -93,7 +93,7 @@ merge. They are not bureaucracy; they are why the codebase stays an A+.
 
     Open a [new issue](https://github.com/neochaotic/leoflow/issues/new/choose) and
     pick **Bug report**. The form asks for repro steps, how you're running Leoflow
-    (Demo / Dev / local server), and environment — fill it in fully so we can
+    (Lite / Pro / Demo), and environment — fill it in fully so we can
     reproduce.
 
 === "Propose a feature"

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -181,6 +181,6 @@ into.
 Deploying the control plane itself (Helm chart, published `leoflow-server`/
 `leoflow-migrate` images, TLS on the agent channel, keyless cloud auth) is the
 **Pro** track — see [Operating modes](operating-modes.md) and the
-[Roadmap](roadmap-to-release.md). The product proves itself in **Dev** first.
+[Roadmap](roadmap-to-release.md). The product proves itself in **Lite** first.
 
 See also: [DAG authoring](dag-authoring.md) · [Operating modes](operating-modes.md).

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -133,11 +133,11 @@ Open it to see the offending file, its bundle, and the full traceback:
 Fix the file and save — the watcher registers the next good version and the banner
 **clears automatically** (~2 s). No restart, no manual cleanup.
 
-!!! note "Dev vs production"
+!!! note "Lite vs Pro"
     This banner is driven by a control-plane feed (`GET /api/v2/importErrors`) and
-    works in any environment. In **production** you rarely see it: DAGs are
+    works in any environment. In **Pro** you rarely see it: DAGs are
     immutable artifacts and a broken DAG fails `leoflow compile` in **CI** before it
-    is ever deployed — CI is the safety net there. In **dev**, where you edit live,
+    is ever deployed — CI is the safety net there. In **Lite**, where you edit live,
     the `leoflow lite` watcher publishes the error so you catch it in the UI, not
     only the terminal.
 

--- a/docs/editions.md
+++ b/docs/editions.md
@@ -6,7 +6,7 @@
     use). The **Pro** chart is installable + chart-test gated, but not
     cleared for official use until the v0.1.0-alpha cut.
 
-> See also [Operating modes](operating-modes.md) for the Demo/Dev/Pro
+> See also [Operating modes](operating-modes.md) for the Lite/Pro/Demo
 > runtime view (this page is the per-edition distribution + posture view).
 
 Leoflow is planned in two editions that share the same engine, the same

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -50,7 +50,7 @@ distinct actions (ADR 0020).
 But deregister alone is **not permanent while the source exists** — it gets
 re-registered:
 
-- **Dev (`leoflow lite`):** the watcher re-registers the DAG on the next reload.
+- **Lite (`leoflow lite`):** the watcher re-registers the DAG on the next reload.
   To remove it for good, **delete the DAG's file** (or stop/point `leoflow lite`
   elsewhere).
 - **Pro (CI deploy):** the next deploy that still includes the DAG

--- a/docs/roadmap-to-release.md
+++ b/docs/roadmap-to-release.md
@@ -9,17 +9,17 @@ This consolidates the open work after the audit + reverse analysis
 
 ## Release phases — Alpha · Beta · GA
 
-The product **proves itself in Dev first**; Pro matures behind it.
+The product **proves itself in Lite first**; Pro matures behind it.
 
 ```mermaid
 flowchart LR
-  A["Alpha — Dev<br/>(now)"] --> B["Beta — Pro track"] --> G["GA — hardened"]
+  A["Alpha — Lite<br/>(now)"] --> B["Beta — Pro track"] --> G["GA — hardened"]
 ```
 
 ### 🟡 Alpha — Developer experience (current focus)
 A data engineer can author, run, and iterate on DAGs locally with confidence.
 
-- `leoflow lite` (isolated k3d/subprocess), `leoflow lite provision`, `leoflow db`, hot reload, DEV marker.
+- `leoflow lite` (isolated k3d/subprocess), `leoflow lite provision`, `leoflow db`, hot reload, LITE marker.
 - DAG authoring + binding/overrides (ADR 0023), guardrails, embedded migrations.
 - Documentation site, examples, the `dags/` convention.
 - **Exit:** the dev loop is reliable end-to-end; the authoring model is documented and tested.

--- a/docs/ui-compatibility.md
+++ b/docs/ui-compatibility.md
@@ -5,7 +5,7 @@
     (unmodified Airflow UI on `/api/v2` alone) was not viable. **That realistic path
     was taken and it works:** Leoflow serves the unmodified Apache Airflow 3.2.1
     React SPA **and** implements the internal `/ui/*` API (ADR 0017 / ADR 0018). The
-    grid, graph, dashboard, and run views run against Leoflow today (Demo + Dev,
+    grid, graph, dashboard, and run views run against Leoflow today (Demo + Lite,
     browser-verified). The standing risk below is real and accepted: `/ui/*` is
     internal/unstable (AIP-84), so a new Airflow UI version can break a screen — we
     pin to 3.2.1 and guard with a browser contract sweep.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,8 +134,8 @@ nav:
       - HTTP API (Scalar): api-reference.html
       - Configuration: configuration.md
   - Guides:
-      - The leoflow dev workflow: dev-workflow.md
-      - Local deploy (the dev loop): local-deploy.md
+      - The leoflow lite workflow: dev-workflow.md
+      - Local deploy (the Lite loop): local-deploy.md
       - The Lite web editor: lite-web-editor.md
       - Examples: examples.md
       - "Map-reduce for ML": cookbook/map-reduce.md


### PR DESCRIPTION
## Summary
- Renames the user-facing edition name across docs that still showed the old **Dev** framing — Lite is the edition; "Dev" was the pre-rename label
- Touched: `deploy.md`, `dev-workflow.md`, `examples.md`, `roadmap-to-release.md`, `editions.md`, `contributing.md`, `ui-compatibility.md`, plus the mkdocs nav title
- Generic lowercase "dev" (subprocess as "dev-only", "dev dependencies") **kept** — that means *development*, not the edition
- The file name `dev-workflow.md` is preserved so existing cross-links (8+ references) keep working; only the nav label changes to "The leoflow lite workflow"

## Test plan
- [ ] mkdocs builds; nav reads "The leoflow lite workflow"
- [ ] No new broken cross-links (existing `dev-workflow.md` paths intact)