### PR TITLE
docs(aaa-pass): front-page map-reduce for ML/AI on README + landing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 <p align="center">
   <em>The workflow orchestrator that ate Apache Airflow's lunch.<br>
-  Same UI. Same vocabulary. Ten times the speed. Zero of the pain.</em>
+  Same UI. Same vocabulary. Ten times the speed. Zero of the pain.<br>
+  <strong>Native map-reduce for ML/AI</strong> — fan-out + reduce as a Python list comprehension, no XCom plumbing, no broker, no special operator.</em>
 </p>
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
@@ -17,7 +18,7 @@
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13068/badge)](https://www.bestpractices.dev/projects/13068)
 
 [![Edition: Lite](https://img.shields.io/badge/edition-Lite-C0C0C0?labelColor=4a4a4a)](docs/editions.md#leoflow-lite)
-[![Edition: Pro](https://img.shields.io/badge/edition-Pro-FFD700?labelColor=4a4a4a)](docs/editions.md#leoflow-production)
+[![Edition: Pro](https://img.shields.io/badge/edition-Pro-FFD700?labelColor=4a4a4a)](docs/editions.md#leoflow-pro-coming)
 
 ---
 
@@ -27,10 +28,11 @@
 
 | | |
 |---|---|
-| [Operating modes](docs/operating-modes.md) · [Editions](docs/editions.md) | Demo · Dev · Production · the Lite/Pro split |
-| [DAG authoring](docs/dag-authoring.md) | write a DAG; the dev → deploy lifecycle |
+| [Operating modes](docs/operating-modes.md) · [Editions](docs/editions.md) | Lite · Pro · Demo — the runtime split and the packaging split |
+| [DAG authoring](docs/dag-authoring.md) | write a DAG; the Lite → deploy lifecycle |
+| [**Map-reduce for ML**](docs/cookbook/map-reduce.md) | fan-out + reduce as a Python list comprehension |
 | [CI/CD & deploy examples](docs/deploy.md) | GitHub Actions · GitLab · Cloud Build/Run · generic |
-| [Helm chart](helm/leoflow/README.md) | Production install: values reference, hardening, PoC recipe |
+| [Helm chart](helm/leoflow/README.md) | Pro install: values reference, hardening, PoC recipe |
 | [HTTP API (Scalar)](docs/api-reference.md) · [Go packages](docs/go-api.md) | API references |
 | [Concepts & glossary](docs/concepts.md) · [Architecture](docs/architecture.md) | the model & the *why* |
 
@@ -127,6 +129,50 @@ leoflow push ./dag.json        # registers with the control plane
 ```
 
 That is the entire developer surface. The CLI builds the image against an official base (`leoflow/python-runtime:3.11`), pushes to your registry, and registers a versioned DAG. The Airflow UI shows it at the next refresh.
+
+## Native map-reduce for ML/AI
+
+Hyperparameter search, k-fold cross-validation, ensemble training, batch
+inference, sharded preprocessing, Monte Carlo — **every parallel ML workload
+is map-reduce**. Most orchestrators make you build it: an operator per fan-out,
+a broker for the intermediate values, shared storage for the artifacts, and a
+custom reducer that knows how to find them all. Leoflow expresses the whole
+pattern in **two lines of Python**:
+
+```python
+from airflow.sdk import DAG, task
+
+@task
+def trial(lr: float) -> dict:
+    return train_one(lr)                            # map
+
+@task
+def select_best(trials: list[dict]) -> dict:
+    return max(trials, key=lambda r: r["score"])    # reduce
+
+with DAG("hparam_search", schedule=None):
+    select_best([trial(lr) for lr in [0.001, 0.01, 0.05, 0.1, 0.5]])
+```
+
+That `[trial(lr) for lr in …]` is the whole map. `trials: list[dict]` is the
+whole reduce. **No XCom plumbing, no broker setup, no shared filesystem, no
+special operator** — the parser captures the list shape at compile time; the
+runtime assembles the upstream XComs in declaration order and delivers them
+as a real Python list. Per-trial isolation (own pod / own process), per-trial
+retry, deterministic ordering, and a 256 KB cap per upstream — and a
+`null` slot for any upstream that legitimately produced no result.
+
+| ML pattern | Map | Reduce |
+|---|---|---|
+| Hyperparameter search | one task per `(lr, batch, seed)` triple | pick the best metric |
+| K-fold cross-validation | one task per fold | average the metrics |
+| Ensemble training | one task per base model | combine predictions / stack |
+| Batch inference | one task per partition | collect predictions to a sink |
+| Monte Carlo | one task per worker | average / sum results |
+
+Runnable example: `examples/ml_hparam_search/`. Full reference:
+**[Map-reduce for ML](docs/cookbook/map-reduce.md)** — guarantees, limits, what
+activates fan-in vs what does not, and the on-disk `dag.json` shape.
 
 ## Architecture
 
@@ -275,10 +321,11 @@ We borrow from Argo Workflows (container-native), from Prefect (modern developer
 ## Documentation
 
 - [Architecture overview](docs/architecture.md)
-- [Architecture Decision Records (14 ADRs)](docs/adr/) — every major decision, with its reasoning
-- [API reference](docs/api/) — OpenAPI spec, also rendered as interactive docs at `/docs` in the running server
-- [Developer guide](docs/developer-guide.md) — writing your first DAG, migration from Airflow
-- [Operator guide](docs/operator-guide.md) — production deployment, monitoring, backup
+- [Architecture Decision Records](docs/adr/) — every major decision, with its reasoning
+- [HTTP API reference (Scalar)](docs/api-reference.md) — also rendered interactively at `/docs` in the running server
+- [DAG authoring](docs/dag-authoring.md) — writing your first DAG, the Lite → deploy lifecycle
+- [Quickstart](docs/quickstart.md) and [Installation](docs/installation.md) — getting Leoflow running locally
+- [Map-reduce for ML](docs/cookbook/map-reduce.md) · [Variables & Connections](docs/variables-connections.md) · [Troubleshooting](docs/troubleshooting.md)
 - [Security policy](SECURITY.md) — how to report vulnerabilities
 
 ## Engineering Discipline

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,8 @@ hide:
 
 <p class="home-hero__lead">
 The workflow orchestrator that ate Apache Airflow's lunch.<br>
-<strong>Same UI. Same vocabulary. A Go control plane instead of Python's. Zero of the pain.</strong>
+<strong>Same UI. Same vocabulary. A Go control plane instead of Python's. Zero of the pain.</strong><br>
+<em>Native map-reduce for ML/AI — fan-out + reduce as a Python list comprehension.</em>
 </p>
 
 [Get started](quickstart.md){ .md-button .md-button--primary }
@@ -91,7 +92,39 @@ SDK). They compile to one immutable artifact — `dag.json` + a container image.
 
     `/api/v2/*` and `/ui/*`, pinned to Airflow 3.2.x. [HTTP API →](api-reference.html)
 
+- :material-graph-outline: **Native map-reduce for ML/AI**
+
+    Fan-out + reduce as a Python list comprehension. No XCom plumbing, no
+    broker, no special operator. [Map-reduce for ML →](cookbook/map-reduce.md)
+
 </div>
+
+## Map-reduce in two lines of Python
+
+Every parallel ML workload — hyperparameter search, k-fold CV, ensemble
+training, batch inference, Monte Carlo — is the same pattern. Leoflow expresses
+it as a list comprehension:
+
+```python
+from airflow.sdk import DAG, task
+
+@task
+def trial(lr: float) -> dict:
+    return train_one(lr)                            # map
+
+@task
+def select_best(trials: list[dict]) -> dict:
+    return max(trials, key=lambda r: r["score"])    # reduce
+
+with DAG("hparam_search", schedule=None):
+    select_best([trial(lr) for lr in [0.001, 0.01, 0.05, 0.1, 0.5]])
+```
+
+The parser captures the list shape at compile time; the runtime assembles the
+upstream XComs in declaration order and delivers them as a real Python list —
+with per-trial isolation, per-trial retry, and a `null` slot for any upstream
+that legitimately produced no result. See **[Map-reduce for ML →](cookbook/map-reduce.md)**
+for the guarantees, limits, and the `dag.json` shape.
 
 ## The dev loop
 


### PR DESCRIPTION
Closes #218.

## Summary
Promotes Leoflow's map-reduce / fan-in pattern to the front door — it is the most differentiated feature for the ML/AI crowd, but it was buried in the cookbook with no front-page hook.

- **README.md**: hero tagline gets the map-reduce line; the docs table gets a row linking the cookbook; a new dedicated "Native map-reduce for ML/AI" section sits between "What It Looks Like to Use" and "Architecture" with the 2-line example and the ML pattern table
- **docs/index.md** (GitHub Pages landing): hero lead gets the same map-reduce line; the grid gets a fourth card; a top-level "Map-reduce in two lines of Python" section drops the example into the front door

## Also fixed on the README while there
- editions.md anchor: `#leoflow-production` → `#leoflow-pro-coming` (real anchor)
- "Demo · Dev · Production · the Lite/Pro split" → "Lite · Pro · Demo — the runtime split and the packaging split"
- "Production install" → "Pro install"
- Documentation section: removed broken links (`docs/api/`, `developer-guide.md`, `operator-guide.md`) and routed to the real pages (quickstart, installation, dag-authoring, api-reference, variables-connections, troubleshooting)

## Test plan
- [ ] mkdocs builds; landing renders the new card + section
- [ ] README renders on github.com (grid + new section + sweep)