### PR TITLE
fix(ui): inject the gold PRO badge on the Pro edition (Lima dogfood feedback)

### DIFF
--- a/cmd/leoflow-server/edition_badge_test.go
+++ b/cmd/leoflow-server/edition_badge_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/config"
+)
+
+// TestEditionBadgeSelection exercises the two edition-badge guards used at
+// boot. The silver LITE pill is the Lite edition or the legacy dev auth bypass;
+// the gold PRO pill is the Pro edition only. Demo and the unmarked default
+// render no pill. Both badges share a switch on cfg.UI.Edition so a single
+// regression in either selector would silently leave the SPA shell unbranded.
+func TestEditionBadgeSelection(t *testing.T) {
+	tests := []struct {
+		name      string
+		edition   string
+		devNoAuth bool
+		wantLite  bool
+		wantPro   bool
+	}{
+		{name: "lite shows silver", edition: "lite", wantLite: true},
+		{name: "pro shows gold", edition: "pro", wantPro: true},
+		{name: "demo shows neither", edition: "demo"},
+		{name: "empty edition shows neither", edition: ""},
+		{name: "dev-no-auth bypass forces silver", edition: "", devNoAuth: true, wantLite: true},
+		{name: "pro edition is exclusive with the lite path", edition: "pro", devNoAuth: false, wantPro: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config.ServerConfig{
+				UI:   config.UISection{Edition: tc.edition},
+				Auth: config.AuthSection{DevNoAuth: tc.devNoAuth},
+			}
+			if got := showLiteBadge(cfg); got != tc.wantLite {
+				t.Errorf("showLiteBadge(edition=%q, devNoAuth=%v) = %v, want %v",
+					tc.edition, tc.devNoAuth, got, tc.wantLite)
+			}
+			if got := showProBadge(cfg); got != tc.wantPro {
+				t.Errorf("showProBadge(edition=%q) = %v, want %v",
+					tc.edition, got, tc.wantPro)
+			}
+		})
+	}
+}

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -153,6 +153,7 @@ func run() error {
 	// also when the legacy dev auth bypass is on. The demo/production show neither.
 	uiSrv := ui.New()
 	uiSrv.SetLiteBanner(showLiteBadge(cfg))
+	uiSrv.SetProBanner(showProBadge(cfg))
 	uiSrv.SetInstanceName(cfg.UI.InstanceName)
 
 	editorFS := liteEditorFS(cfg, tel.Logger)
@@ -229,10 +230,17 @@ func awaitShutdown(ctx context.Context, errCh <-chan error, logger *slog.Logger,
 	}
 }
 
-// showLiteBadge reports whether the served UI shows the LITE badge: the Lite
-// edition, or the legacy dev auth bypass.
+// showLiteBadge reports whether the served UI shows the silver LITE badge: the
+// Lite edition, or the legacy dev auth bypass.
 func showLiteBadge(cfg *config.ServerConfig) bool {
 	return cfg.UI.Edition == "lite" || cfg.Auth.DevNoAuth
+}
+
+// showProBadge reports whether the served UI shows the gold PRO badge — the
+// Pro edition, set explicitly by the Helm chart (values.yaml: ui.edition=pro).
+// Demo and empty editions show no badge.
+func showProBadge(cfg *config.ServerConfig) bool {
+	return cfg.UI.Edition == "pro"
 }
 
 // liteEditorFS builds the workspace filesystem backing the Lite web editor when

--- a/cmd/leoflow-server/tls_guard.go
+++ b/cmd/leoflow-server/tls_guard.go
@@ -3,23 +3,22 @@ package main
 import "errors"
 
 // guardInsecureSecretsForEdition refuses the dev-only insecure-secrets escape
-// hatch when the chart marks the deployment as production edition (#58, Pro
-// alpha blocker). The flag is a deliberate dev convenience for Lite that lets
-// the control plane ship secrets over a plaintext gRPC channel — fine on
+// hatch when the chart marks the deployment as the Pro edition (#58, Pro alpha
+// blocker). The flag is a deliberate dev convenience for Lite that lets the
+// control plane ship secrets over a plaintext gRPC channel — fine on
 // localhost, never inside a real cluster.
 //
-// Memory: pro-alpha-blockers-decisions documents the design choice
-// (server-TLS + per-task JWT; refuse plaintext under the Pro chart marker).
-// Lite (edition=lite) and the unmarked default (edition="") still allow the
-// flag so the inner dev loop keeps working without TLS.
+// The Helm chart sets LEOFLOW_UI_EDITION=pro on every Pro install; Lite
+// (edition=lite) and the unmarked default (edition="") still allow the flag so
+// the inner dev loop keeps working without TLS.
 func guardInsecureSecretsForEdition(edition string, allowInsecure bool) error {
 	if !allowInsecure {
 		return nil
 	}
-	if edition != "production" {
+	if edition != "pro" {
 		return nil
 	}
-	return errors.New("LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS=true is not allowed in the production edition: " +
+	return errors.New("LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS=true is not allowed in the Pro edition: " +
 		"a Pro deployment ships secrets only over the TLS-enabled gRPC channel — " +
 		"either set agentTLS.enabled=true in the Helm values (with cert-manager) or unset the env var " +
 		"(see ADR 0014 and issue #58)")

--- a/cmd/leoflow-server/tls_guard_test.go
+++ b/cmd/leoflow-server/tls_guard_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// TestRefuseInsecureSecretsInProd: a Pro chart deployment (edition=production)
+// TestRefuseInsecureSecretsInProd: a Pro chart deployment (edition=pro)
 // MUST NOT boot with LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS=true. The dev-only
 // escape hatch is fine on Lite, but inside a real cluster shipping secrets over
 // a plaintext gRPC channel is the kind of mistake that should be loud (#58).
@@ -21,9 +21,9 @@ func TestRefuseInsecureSecretsInProd(t *testing.T) {
 	}{
 		{name: "lite + insecure: allowed (dev/inner loop)", edition: "lite", allowInsecure: true},
 		{name: "empty edition + insecure: allowed (dev fallback)", edition: "", allowInsecure: true},
-		{name: "production + insecure: REFUSED", edition: "production", allowInsecure: true,
+		{name: "pro + insecure: REFUSED", edition: "pro", allowInsecure: true,
 			wantErrSubstring: "LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS"},
-		{name: "production + NO insecure: allowed (default secure)", edition: "production", allowInsecure: false},
+		{name: "pro + NO insecure: allowed (default secure)", edition: "pro", allowInsecure: false},
 		{name: "lite + NO insecure: allowed", edition: "lite", allowInsecure: false},
 	}
 	for _, tc := range cases {

--- a/embed_test.go
+++ b/embed_test.go
@@ -1,0 +1,49 @@
+package leoflow
+
+import (
+	"io/fs"
+	"testing"
+)
+
+// TestEmbeddedAssetsPresent asserts the three embed accessors return populated
+// trees / payloads. A regression here means a binary-only install (no source
+// checkout) cannot bootstrap the parser, the Lite Docker compose, or the
+// example DAGs — silent failures that surface only at first-run.
+func TestEmbeddedAssetsPresent(t *testing.T) {
+	t.Run("PythonSources contains the parser package", func(t *testing.T) {
+		entries, err := fs.ReadDir(PythonSources(), "parser/leoflow_parser")
+		if err != nil {
+			t.Fatalf("read parser dir: %v", err)
+		}
+		if len(entries) == 0 {
+			t.Fatal("parser/leoflow_parser is empty — go:embed pattern stale")
+		}
+	})
+
+	t.Run("PythonSources contains the runtime package", func(t *testing.T) {
+		entries, err := fs.ReadDir(PythonSources(), "runtime/python/leoflow_runtime")
+		if err != nil {
+			t.Fatalf("read runtime dir: %v", err)
+		}
+		if len(entries) == 0 {
+			t.Fatal("runtime/python/leoflow_runtime is empty — go:embed pattern stale")
+		}
+	})
+
+	t.Run("DevCompose is a non-empty YAML", func(t *testing.T) {
+		data := DevCompose()
+		if len(data) == 0 {
+			t.Fatal("docker-compose.dev.yaml is not embedded")
+		}
+	})
+
+	t.Run("ExampleDAGs ships at least one DAG project", func(t *testing.T) {
+		entries, err := fs.ReadDir(ExampleDAGs(), "examples")
+		if err != nil {
+			t.Fatalf("read examples dir: %v", err)
+		}
+		if len(entries) == 0 {
+			t.Fatal("examples/ is empty — DAG sample bundle missing")
+		}
+	})
+}

--- a/helm/leoflow/templates/deployment.yaml
+++ b/helm/leoflow/templates/deployment.yaml
@@ -1,15 +1,15 @@
 {{- /*
-The Production edition (this chart) must use EXTERNAL managed datastores and must
+The Pro edition (this chart) must use EXTERNAL managed datastores and must
 never fall back to Lite's embedded backends (embedded Postgres / in-process XCom
 + tailer — ADR 0026/0027). The server selects embedded backends when no Redis URL
 is set, so fail the install loudly with a clear message if Postgres or Redis is
 not configured, rather than letting a misconfigured Pro deploy run embedded.
 */}}
 {{- if and (not .Values.database.existingSecret) (not .Values.database.url) -}}
-{{- fail "database.url or database.existingSecret is required: the Production edition needs an external Postgres (the embedded datastore is Lite-only)." -}}
+{{- fail "database.url or database.existingSecret is required: the Pro edition needs an external Postgres (the embedded datastore is Lite-only)." -}}
 {{- end -}}
 {{- if and (not .Values.redis.existingSecret) (not .Values.redis.url) -}}
-{{- fail "redis.url or redis.existingSecret is required: the Production edition needs an external Redis (the embedded XCom + log tailer is Lite-only)." -}}
+{{- fail "redis.url or redis.existingSecret is required: the Pro edition needs an external Redis (the embedded XCom + log tailer is Lite-only)." -}}
 {{- end -}}
 {{- /*
 Validate `secretKey` length up-front so a wrong key fails the install
@@ -70,11 +70,13 @@ spec:
               containerPort: {{ .Values.ports.grpc }}
           env:
             # Mark this deployment as the Pro edition. The control plane uses
-            # this signal to refuse the LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS=true
-            # dev escape hatch at boot (#58 / ADR 0014), so a Pro install cannot
-            # accidentally ship secrets over a plaintext gRPC channel.
+            # this signal for two things: (a) refuse the
+            # LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS=true dev escape hatch at boot
+            # (#58 / ADR 0014) so a Pro install cannot accidentally ship secrets
+            # over a plaintext gRPC channel; (b) inject the gold PRO badge into
+            # the served SPA shell, mirroring Lite's silver LITE pill.
             - name: LEOFLOW_UI_EDITION
-              value: "production"
+              value: "pro"
             - name: LEOFLOW_SERVER_HTTP_ADDR
               value: ":{{ .Values.ports.http }}"
             - name: LEOFLOW_SERVER_METRICS_ADDR

--- a/helm/leoflow/tests/deployment_test.yaml
+++ b/helm/leoflow/tests/deployment_test.yaml
@@ -11,7 +11,7 @@ tests:
       agentTLS.enabled: false
     asserts:
       - failedTemplate:
-          errorMessage: "database.url or database.existingSecret is required: the Production edition needs an external Postgres (the embedded datastore is Lite-only)."
+          errorMessage: "database.url or database.existingSecret is required: the Pro edition needs an external Postgres (the embedded datastore is Lite-only)."
 
   - it: fails the install if redis.url AND redis.existingSecret are both empty
     set:
@@ -20,7 +20,7 @@ tests:
       agentTLS.enabled: false
     asserts:
       - failedTemplate:
-          errorMessage: "redis.url or redis.existingSecret is required: the Production edition needs an external Redis (the embedded XCom + log tailer is Lite-only)."
+          errorMessage: "redis.url or redis.existingSecret is required: the Pro edition needs an external Redis (the embedded XCom + log tailer is Lite-only)."
 
   - it: omits LEOFLOW_SECRET_KEY env entry when neither secretKey nor secretKeyExistingSecret is set
     set:

--- a/internal/agent/framing_test.go
+++ b/internal/agent/framing_test.go
@@ -10,11 +10,39 @@ import (
 )
 
 // linesSink captures whole LogLine values so a framing test can assert message,
-// level, and stream (capSink only records the message + line number).
-type linesSink struct{ ls []*agentv1.LogLine }
+// level, and stream (capSink only records the message + line number). When err
+// is non-nil Send returns it (so the framing helpers' "log-and-continue" error
+// path is exercised).
+type linesSink struct {
+	ls  []*agentv1.LogLine
+	err error
+}
 
-func (s *linesSink) Send(l *agentv1.LogLine) error { s.ls = append(s.ls, l); return nil }
-func (s *linesSink) Close() error                  { return nil }
+func (s *linesSink) Send(l *agentv1.LogLine) error {
+	s.ls = append(s.ls, l)
+	return s.err
+}
+func (s *linesSink) Close() error { return nil }
+
+// TestFramingSurvivesSinkErrors exercises the log-and-continue branch on the
+// three framing helpers. A sink returning an error must NOT propagate — the
+// framing is purely cosmetic, and propagating would mean a flaky log shipper
+// could make a task that succeeded look as if it failed. This locks that
+// behavior; the runtime can keep going on a degraded sink (the comment on
+// each helper spells it out).
+func TestFramingSurvivesSinkErrors(t *testing.T) {
+	want := errors.New("sink briefly unreachable")
+	s := &linesSink{err: want}
+	// All three helpers swallow the error.
+	emitTaskStarted(s)
+	emitTaskEnded(s, 0, nil, time.Second)
+	emitTaskBoot(s, []string{"python3", "-u", "task.py"}, []string{"AIRFLOW_VAR_GREETING=hi"})
+	// Each helper appended its line via the recorder BEFORE Send returned the
+	// error; the count proves no helper short-circuited on its own.
+	if got := len(s.ls); got < 3 {
+		t.Errorf("framing helpers did not all attempt a Send (got %d, want >= 3)", got)
+	}
+}
 
 // TestEmitTaskStarted writes a synthetic "▸ task started" line at INFO with
 // stream "agent" — so the UI's Logs panel is never empty even for a task that

--- a/internal/agentrpc/map_state_test.go
+++ b/internal/agentrpc/map_state_test.go
@@ -1,0 +1,60 @@
+package agentrpc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// TestMapStateCoversEveryReportedTransition pins the agent → domain state
+// translation. The agent's gRPC contract carries a proto enum; the control
+// plane consumes a domain string. A missing case here makes a real task
+// transition (e.g. SUCCESS reported by the agent) drop on the floor with no
+// state update — visible only as a "stuck running" task in the UI. The unit
+// test makes every known mapping explicit, and the default catches an
+// unsupported state with InvalidArgument (so a forwards-compatible agent
+// reporting a new state hits a loud error instead of silently mapping to
+// "running" or empty).
+func TestMapStateCoversEveryReportedTransition(t *testing.T) {
+	cases := []struct {
+		in   agentv1.TaskState
+		want domain.TaskState
+	}{
+		{agentv1.TaskState_TASK_STATE_RUNNING, domain.TaskStateRunning},
+		{agentv1.TaskState_TASK_STATE_SUCCESS, domain.TaskStateSuccess},
+		{agentv1.TaskState_TASK_STATE_FAILED, domain.TaskStateFailed},
+		{agentv1.TaskState_TASK_STATE_SKIPPED, domain.TaskStateSkipped},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in.String(), func(t *testing.T) {
+			got, err := mapState(tc.in)
+			if err != nil {
+				t.Fatalf("mapState(%v) error: %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("mapState(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("unsupported state returns InvalidArgument", func(t *testing.T) {
+		got, err := mapState(agentv1.TaskState_TASK_STATE_UNSPECIFIED)
+		if err == nil {
+			t.Fatalf("expected error, got state %q", got)
+		}
+		st, ok := status.FromError(err)
+		if !ok {
+			t.Fatalf("expected gRPC status error, got %v (type %T)", err, err)
+		}
+		if st.Code() != codes.InvalidArgument {
+			t.Errorf("code = %v, want InvalidArgument", st.Code())
+		}
+		if !strings.Contains(st.Message(), "unsupported task state") {
+			t.Errorf("message %q does not name 'unsupported task state'", st.Message())
+		}
+	})
+}

--- a/internal/api/audit_writer_test.go
+++ b/internal/api/audit_writer_test.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+)
+
+// fakeAuditWriter records every audit entry attempt and can be told to return
+// an error so the recordTaskAudit "log-and-continue" branch is exercised.
+type fakeAuditWriter struct {
+	calls []recordedAudit
+	err   error
+}
+
+type recordedAudit struct {
+	tenant, userID, action, dagID, runID, taskID string
+	tryNumber                                    int
+}
+
+func (f *fakeAuditWriter) RecordTaskActionAudit(_ context.Context, tenant, userID, action, dagID, runID, taskID string, tryNumber int) error {
+	f.calls = append(f.calls, recordedAudit{tenant, userID, action, dagID, runID, taskID, tryNumber})
+	return f.err
+}
+
+// TestRecordTaskAuditNonFatal pins the contract on the audit side-channel:
+// audit failure NEVER fails the user action. The function is best-effort by
+// design — a flaky audit DB must not be allowed to flip "clear task instance"
+// from 200 to 5xx in the UI. The branches here are: nil writer (no-op);
+// no-user in context (action recorded with empty userID); writer error
+// (logged and dropped). Each is a real production shape during an outage.
+func TestRecordTaskAuditNonFatal(t *testing.T) {
+	mkCtx := func(user *auth.User) *gin.Context {
+		c, _ := gin.CreateTestContext(httptest.NewRecorder())
+		c.Request = httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/", http.NoBody)
+		c.Params = gin.Params{{Key: "dag_id", Value: "etl"}}
+		if user != nil {
+			c.Set(contextKeyUser, user)
+		}
+		return c
+	}
+
+	t.Run("nil writer → no-op (no panic)", func(t *testing.T) {
+		// If this returns, the early-return branch worked.
+		recordTaskAudit(mkCtx(&auth.User{ID: "u1"}), nil, "clear", "r1", "extract", 1)
+	})
+
+	t.Run("happy path: writer records the action with the user id", func(t *testing.T) {
+		w := &fakeAuditWriter{}
+		recordTaskAudit(mkCtx(&auth.User{ID: "u1"}), w, "clear", "r1", "extract", 2)
+		if len(w.calls) != 1 {
+			t.Fatalf("calls = %d, want 1", len(w.calls))
+		}
+		got := w.calls[0]
+		if got.userID != "u1" || got.action != "clear" || got.taskID != "extract" || got.tryNumber != 2 {
+			t.Errorf("recorded audit = %+v, want u1/clear/extract/try=2", got)
+		}
+	})
+
+	t.Run("no user in context: action still recorded with empty user id", func(t *testing.T) {
+		w := &fakeAuditWriter{}
+		recordTaskAudit(mkCtx(nil), w, "clear", "r1", "extract", 1)
+		if len(w.calls) != 1 || w.calls[0].userID != "" {
+			t.Errorf("expected one call with empty userID, got %+v", w.calls)
+		}
+	})
+
+	t.Run("writer error is logged, not propagated", func(t *testing.T) {
+		w := &fakeAuditWriter{err: errors.New("audit table briefly unreachable")}
+		// No way for the caller to observe the error; if the helper grew a
+		// return value the user-facing action would start failing here. The
+		// test passes by simply returning.
+		recordTaskAudit(mkCtx(&auth.User{ID: "u1"}), w, "mark_failed", "r1", "extract", 1)
+		if len(w.calls) != 1 {
+			t.Errorf("writer should still be called once on error, got %d", len(w.calls))
+		}
+	})
+}

--- a/internal/api/docs_test.go
+++ b/internal/api/docs_test.go
@@ -2,9 +2,16 @@ package api
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/gin-gonic/gin"
 )
 
 // TestEmbeddedOpenAPIMatchesDocs guards against drift between the spec embedded
@@ -17,4 +24,57 @@ func TestEmbeddedOpenAPIMatchesDocs(t *testing.T) {
 	if !bytes.Equal(openAPISpec, canonical) {
 		t.Error("embedded openapi.yaml differs from docs/api/openapi.yaml; re-copy it")
 	}
+}
+
+// TestDocsHandlersServeKnownContent locks the three /docs surfaces — Scalar
+// HTML, raw YAML, JSON-coerced — so a regression in the embedded spec or the
+// YAML→JSON pipe is caught at unit time (it would otherwise only surface to a
+// browser hitting /docs).
+func TestDocsHandlersServeKnownContent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	registerDocs(r)
+
+	t.Run("/docs serves Scalar HTML", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/docs", http.NoBody)
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d", rec.Code)
+		}
+		if !strings.Contains(rec.Header().Get("Content-Type"), "text/html") {
+			t.Errorf("content-type = %q", rec.Header().Get("Content-Type"))
+		}
+		if !strings.Contains(rec.Body.String(), "api-reference") {
+			t.Error("response missing the Scalar reference script tag")
+		}
+	})
+
+	t.Run("/openapi.yaml serves the embedded spec verbatim", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/openapi.yaml", http.NoBody)
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d", rec.Code)
+		}
+		if !bytes.Equal(rec.Body.Bytes(), openAPISpec) {
+			t.Error("/openapi.yaml body differs from the embedded spec")
+		}
+	})
+
+	t.Run("/openapi.json transcodes the YAML spec", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/openapi.json", http.NoBody)
+		r.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d", rec.Code)
+		}
+		var doc map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &doc); err != nil {
+			t.Fatalf("response is not valid JSON: %v", err)
+		}
+		if _, ok := doc["openapi"]; !ok {
+			t.Error("decoded JSON is missing the top-level 'openapi' key")
+		}
+	})
 }

--- a/internal/api/health_test.go
+++ b/internal/api/health_test.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// fakeHealthCheck implements HealthChecker with a configurable Ping error so
+// the readiness handler can be exercised in both happy and degraded states.
+type fakeHealthCheck struct{ err error }
+
+func (f *fakeHealthCheck) Ping(context.Context) error { return f.err }
+
+// TestReadinessHandlerSurfacesDependencyHealth pins the K8s readiness contract:
+// every registered dependency is Ping'd in turn; the first failure aborts with
+// 503 and includes both the dependency name and the underlying error so an
+// operator can see which dep is degraded in `kubectl describe` events. All
+// happy → 200 "ready". This guards the chart's readinessProbe wiring against a
+// regression where a flaky dep silently passes traffic through.
+func TestReadinessHandlerSurfacesDependencyHealth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("all checks pass → 200 ready", func(t *testing.T) {
+		r := gin.New()
+		r.GET("/readyz", readinessHandler(map[string]HealthChecker{
+			"postgres": &fakeHealthCheck{},
+			"redis":    &fakeHealthCheck{},
+		}))
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", http.NoBody))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "ready") {
+			t.Errorf("body = %q, want 'ready'", rec.Body.String())
+		}
+	})
+
+	t.Run("one check fails → 503 with the dep name + error", func(t *testing.T) {
+		r := gin.New()
+		r.GET("/readyz", readinessHandler(map[string]HealthChecker{
+			"postgres": &fakeHealthCheck{err: errors.New("connection refused")},
+		}))
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", http.NoBody))
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want 503", rec.Code)
+		}
+		body := rec.Body.String()
+		if !strings.Contains(body, "postgres") {
+			t.Errorf("body missing the failed dep name 'postgres': %q", body)
+		}
+		if !strings.Contains(body, "connection refused") {
+			t.Errorf("body missing the underlying error message: %q", body)
+		}
+	})
+
+	t.Run("no checks configured → 200 ready (trivially)", func(t *testing.T) {
+		r := gin.New()
+		r.GET("/readyz", readinessHandler(nil))
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", http.NoBody))
+		if rec.Code != http.StatusOK {
+			t.Errorf("empty checks should pass, got %d", rec.Code)
+		}
+	})
+}
+
+// TestLivenessHandlerAlwaysOK: the liveness probe is intentionally trivial —
+// only an "am I alive" signal that K8s uses to decide whether to restart the
+// pod. It never reaches dependencies (a stuck postgres should NOT restart the
+// pod). This locks that behavior in.
+func TestLivenessHandlerAlwaysOK(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/livez", livenessHandler)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/livez", http.NoBody))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+}

--- a/internal/api/resources_test.go
+++ b/internal/api/resources_test.go
@@ -195,6 +195,75 @@ func TestClearIncludePastFutureFansAcrossRuns(t *testing.T) {
 	}
 }
 
+// TestExpandClearTasksDispatch covers the wrapper that decides whether to
+// expand seed task_ids along the DAG topology when the UI's Clear dialog has
+// "include upstream/downstream" ticked. It is the gate between the public
+// clear handler and expandTaskIDs; a regression here silently drops the flags
+// or fails open into expanding when the spec lookup hiccups, both of which
+// surface to the user as confusing partial clears.
+func TestExpandClearTasksDispatch(t *testing.T) {
+	tasks := []domain.TaskSpec{
+		{TaskID: "a"},
+		{TaskID: "b", DependsOn: []string{"a"}},
+		{TaskID: "c", DependsOn: []string{"b"}},
+	}
+	specs := &fakeSpecReader{spec: domain.DAGSpec{Tasks: tasks}}
+	mkCtx := func() *gin.Context {
+		c := &gin.Context{}
+		c.Request = httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/dags/etl/clearTaskInstances", http.NoBody)
+		c.Params = gin.Params{{Key: "dag_id", Value: "etl"}}
+		return c
+	}
+
+	t.Run("specs nil → seeds untouched", func(t *testing.T) {
+		got := expandClearTasks(mkCtx(), nil, clearRequest{
+			TaskIDs: clearTaskIDs{"b"}, IncludeUpstream: true, IncludeDownstream: true,
+		})
+		if len(got) != 1 || got[0] != "b" {
+			t.Errorf("specs=nil: got %v, want [b]", got)
+		}
+	})
+
+	t.Run("empty seeds → empty seeds (clear-whole-run)", func(t *testing.T) {
+		got := expandClearTasks(mkCtx(), specs, clearRequest{IncludeUpstream: true, IncludeDownstream: true})
+		if len(got) != 0 {
+			t.Errorf("empty seeds: got %v, want []", got)
+		}
+	})
+
+	t.Run("no flags → seeds returned unchanged (no DAG lookup)", func(t *testing.T) {
+		got := expandClearTasks(mkCtx(), specs, clearRequest{TaskIDs: []string{"b"}})
+		if len(got) != 1 || got[0] != "b" {
+			t.Errorf("no flags: got %v, want [b]", got)
+		}
+	})
+
+	t.Run("spec lookup error → seeds untouched (fail safe)", func(t *testing.T) {
+		broken := &fakeSpecReader{err: errors.New("postgres briefly unreachable")}
+		got := expandClearTasks(mkCtx(), broken, clearRequest{
+			TaskIDs: []string{"b"}, IncludeDownstream: true,
+		})
+		if len(got) != 1 || got[0] != "b" {
+			t.Errorf("spec error: got %v, want [b] (fail-safe seed-only)", got)
+		}
+	})
+
+	t.Run("happy path → fans out downstream of seed", func(t *testing.T) {
+		got := expandClearTasks(mkCtx(), specs, clearRequest{
+			TaskIDs: []string{"a"}, IncludeDownstream: true,
+		})
+		set := map[string]bool{}
+		for _, id := range got {
+			set[id] = true
+		}
+		for _, id := range []string{"a", "b", "c"} {
+			if !set[id] {
+				t.Errorf("downstream(a) missing %s: %v", id, got)
+			}
+		}
+	})
+}
+
 func TestExpandTaskIDs(t *testing.T) {
 	// a -> b -> c (c depends on b, b depends on a), plus a sibling d off a.
 	tasks := []domain.TaskSpec{

--- a/internal/api/ui_stubs_test.go
+++ b/internal/api/ui_stubs_test.go
@@ -84,6 +84,40 @@ func TestUIStubsReturnSchemaValidEmpties(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &graph); err != nil {
 		t.Fatalf("dependencies: %v (%s)", err, rec.Body.String())
 	}
+
+	// next_run_assets is the emptyObject() endpoint — pinning the bare `{}`
+	// shape the SPA expects for the "asset triggers" widget (returning an
+	// empty array instead would break the SPA's typed parser).
+	rec = authGet(srv, http.MethodGet, "/ui/next_run_assets/etl", "")
+	if rec.Code != http.StatusOK {
+		t.Errorf("next_run_assets = %d, want 200", rec.Code)
+	}
+	if rec.Body.String() != "{}" {
+		t.Errorf("next_run_assets body = %q, want '{}' (bare object, not collection)", rec.Body.String())
+	}
+}
+
+// TestZeroTaskInstanceStateCount asserts the helper returns every Airflow
+// 3.2.1 state name at zero. The dashboard's "states by count" widget breaks
+// silently if a state name is renamed or dropped (the front end iterates
+// known keys).
+func TestZeroTaskInstanceStateCount(t *testing.T) {
+	got := zeroTaskInstanceStateCount()
+	required := []string{
+		"no_status", "removed", "scheduled", "queued", "running", "success",
+		"restarting", "failed", "up_for_retry", "up_for_reschedule",
+		"upstream_failed", "skipped", "deferred",
+	}
+	for _, k := range required {
+		v, ok := got[k]
+		if !ok {
+			t.Errorf("missing state counter %q", k)
+			continue
+		}
+		if v != 0 {
+			t.Errorf("counter %q = %v, want 0", k, v)
+		}
+	}
 }
 
 func TestUIStubWritesStill501(t *testing.T) {

--- a/internal/cli/datastore_test.go
+++ b/internal/cli/datastore_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"encoding/hex"
 	"net"
 	"os"
 	"path/filepath"
@@ -59,6 +60,69 @@ func TestResolveDevDBPortPersistsAndReuses(t *testing.T) {
 func TestDevDBPortDefault(t *testing.T) {
 	if p := devDBPort(t.TempDir()); p != defaultDevDBPort {
 		t.Errorf("devDBPort with no db-port = %d, want %d", p, defaultDevDBPort)
+	}
+}
+
+// TestLeoflowHomeUnderUserHome anchors leoflowHome() to $HOME/.leoflow. A
+// regression would break the docker compose project name (datastore
+// reconnection) and the uninstall target on every machine.
+func TestLeoflowHomeUnderUserHome(t *testing.T) {
+	got, err := leoflowHome()
+	if err != nil {
+		t.Fatalf("leoflowHome: %v", err)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("UserHomeDir unavailable: %v", err)
+	}
+	want := filepath.Join(home, ".leoflow")
+	if got != want {
+		t.Errorf("leoflowHome() = %q, want %q", got, want)
+	}
+}
+
+// TestDevProjectNameStableAndShaped asserts devProjectName() returns the
+// `leoflow-<12hex>` shape projectName() produces for the leoflowHome() output.
+// The string is the docker-compose project name; drift here would orphan the
+// Postgres volume of every existing install.
+func TestDevProjectNameStableAndShaped(t *testing.T) {
+	got := devProjectName()
+	if !strings.HasPrefix(got, "leoflow-") {
+		t.Errorf("devProjectName() = %q, must start with 'leoflow-'", got)
+	}
+	rest := strings.TrimPrefix(got, "leoflow-")
+	if len(rest) != 12 {
+		t.Errorf("devProjectName() suffix = %q, want 12 hex chars", rest)
+	}
+	if _, err := hex.DecodeString(rest); err != nil {
+		t.Errorf("devProjectName() suffix %q is not hex: %v", rest, err)
+	}
+	// Stability: calling again returns the same string.
+	if again := devProjectName(); again != got {
+		t.Errorf("devProjectName() is not stable across calls: %q != %q", again, got)
+	}
+}
+
+// TestComposeEnvCarriesProjectAndPort: composeEnv() must publish both the
+// per-install COMPOSE_PROJECT_NAME (so docker compose targets this install's
+// resources) and the LEOFLOW_DB_PORT the compose file interpolates. A missing
+// either silently re-binds to the default port or clobbers another install.
+func TestComposeEnvCarriesProjectAndPort(t *testing.T) {
+	env := composeEnv()
+	var sawProject, sawPort bool
+	for _, kv := range env {
+		switch {
+		case strings.HasPrefix(kv, "COMPOSE_PROJECT_NAME=leoflow-"):
+			sawProject = true
+		case strings.HasPrefix(kv, "LEOFLOW_DB_PORT="):
+			sawPort = true
+		}
+	}
+	if !sawProject {
+		t.Error("composeEnv() missing COMPOSE_PROJECT_NAME=leoflow-*")
+	}
+	if !sawPort {
+		t.Error("composeEnv() missing LEOFLOW_DB_PORT=<n>")
 	}
 }
 

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -89,8 +89,10 @@ type UISection struct {
 	// (30s, production-safe). `leoflow lite` sets it to 1s for a snappy inner
 	// loop so the SPA reflects state changes almost immediately during dev.
 	AutoRefreshIntervalSeconds int `mapstructure:"auto_refresh_interval_seconds"`
-	// Edition marks the running edition; "lite" shows the LITE badge in the UI
-	// shell (independent of the auth mode). Empty/"production" shows no badge.
+	// Edition marks the running edition; "lite" shows the silver LITE badge and
+	// "pro" shows the gold PRO badge in the UI shell (independent of the auth
+	// mode). Empty/any other value shows no badge — Demo intentionally renders
+	// without an edition pill.
 	Edition string `mapstructure:"edition"`
 	// Workspace is the DAG project directory the Lite web editor edits (ADR 0025).
 	// Empty disables the editor (Production, or Lite without one).

--- a/internal/dispatch/buffered_test.go
+++ b/internal/dispatch/buffered_test.go
@@ -177,6 +177,72 @@ func TestBuffered_Async_WorkerFailureMarksTIFailed(t *testing.T) {
 	}
 }
 
+// TestBuffered_Async_FailureReportToSinkSurvivesSinkError covers the
+// reportFailure error path (the comment on it spells the contract out: "A sink
+// error is logged but cannot itself be propagated — the worker has already
+// done all it can"). The combination — inner dispatch fails AND the failure
+// report itself fails — is a realistic outage shape (the K8s API hiccups on
+// the dispatch, then the metadata DB is briefly unreachable when marking the
+// TI failed). The worker must keep draining instead of getting stuck or
+// crashing. Without this test the path was only exercised at 50%.
+func TestBuffered_Async_FailureReportToSinkSurvivesSinkError(t *testing.T) {
+	innerErr := errors.New("kube apiserver timeout")
+	sinkErr := errors.New("postgres briefly unreachable")
+	inner := &recordingInner{err: innerErr}
+	sink := &recordingSink{failErr: sinkErr}
+	d := dispatch.NewBuffered(inner, sink, discardLogger(), nil, dispatch.BufferConfig{BufferSize: 4, Workers: 1})
+	defer d.Close()
+
+	// Two tasks: both will fail to dispatch, both will fail to report. The
+	// second task only drains if the worker stayed alive after the first
+	// double-failure — that is the regression this guards against.
+	for _, taskID := range []string{"first", "second"} {
+		if err := d.Dispatch(context.Background(), "r1", "etl", domain.TaskSpec{TaskID: taskID}); err != nil {
+			t.Fatalf("Dispatch(%s): %v", taskID, err)
+		}
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && len(sink.snapshot()) < 2 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	got := sink.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("worker stalled after sink error: failures = %+v (want 2)", got)
+	}
+	if got[0].taskID != "first" || got[1].taskID != "second" {
+		t.Errorf("unexpected failure order: %+v", got)
+	}
+}
+
+// TestBuffered_Async_FailureSilentlyDroppedWithoutSink: if there is no sink at
+// all (NewBuffered called with nil), an inner dispatch error must NOT crash
+// the worker; the failure is simply lost — the scheduler's reaper picks the TI
+// up later. This pins the nil-sink early-return half of reportFailure.
+func TestBuffered_Async_FailureSilentlyDroppedWithoutSink(t *testing.T) {
+	innerErr := errors.New("kube apiserver timeout")
+	inner := &recordingInner{err: innerErr}
+	d := dispatch.NewBuffered(inner, nil, discardLogger(), nil, dispatch.BufferConfig{BufferSize: 2, Workers: 1})
+	defer d.Close()
+
+	if err := d.Dispatch(context.Background(), "r1", "etl", domain.TaskSpec{TaskID: "lost"}); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	// The inner dispatcher records every call (success or error), so we use
+	// that as the drain signal — sink is nil so we cannot observe via it.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && len(inner.seen()) == 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := inner.seen(); len(got) != 1 || got[0] != "lost" {
+		t.Errorf("worker did not invoke inner; calls = %+v", got)
+	}
+	// If we get here without panic the early-return path is exercised. The
+	// next Dispatch keeps draining, confirming the worker survived.
+	if err := d.Dispatch(context.Background(), "r1", "etl", domain.TaskSpec{TaskID: "alive"}); err != nil {
+		t.Fatalf("second Dispatch: %v", err)
+	}
+}
+
 // TestBuffered_Async_PanicInInnerDoesNotCrash is the resilience pin: a panic
 // in the wrapped dispatcher (a bug, a malformed task, anything) must not
 // crash the worker goroutine. The worker recovers, the failure is reported

--- a/internal/ui/handler.go
+++ b/internal/ui/handler.go
@@ -50,6 +50,18 @@ const liteBannerHTML = `<div id="leoflow-lite-banner">LITE</div>` +
 	`font:600 11px/1.7 system-ui,-apple-system,sans-serif;padding:1px 16px;` +
 	`border-radius:0 0 6px 6px;letter-spacing:3px;pointer-events:none}</style>`
 
+// proBannerHTML is the gold counterpart to liteBannerHTML, injected when the
+// running edition is "pro". Same shape and placement as the Lite pill so
+// operators get a consistent visual anchor across editions; only the color
+// shifts (gold #FFD700 with dark text), matching the gold edition badge in
+// docs/editions.md and the README's edition shield. pointer-events:none keeps
+// it click-through.
+const proBannerHTML = `<div id="leoflow-pro-banner">PRO</div>` +
+	`<style>#leoflow-pro-banner{position:fixed;top:0;left:50%;transform:translateX(-50%);` +
+	`z-index:2147483647;background:#FFD700;color:#1a1a1a;` +
+	`font:600 11px/1.7 system-ui,-apple-system,sans-serif;padding:1px 16px;` +
+	`border-radius:0 0 6px 6px;letter-spacing:3px;pointer-events:none}</style>`
+
 // ideButtonHTML is a discreet floating "IDE" button (bottom-right) injected into
 // the served shell when the Lite web editor is enabled (ADR 0025). It opens the
 // editor at /ide in a new tab, so the SPA is untouched.
@@ -81,6 +93,7 @@ type Server struct {
 	fsys         fs.FS
 	version      string
 	liteBanner   bool
+	proBanner    bool
 	editorButton bool
 	instanceName string
 }
@@ -89,6 +102,12 @@ type Server struct {
 // is enabled by the Lite edition (`leoflow lite`); the demo and production never
 // set it.
 func (s *Server) SetLiteBanner(on bool) { s.liteBanner = on }
+
+// SetProBanner toggles injection of the gold PRO overlay into the served shell.
+// It is enabled by the Pro edition (Helm install); Lite and Demo never set it.
+// The two edition pills are mutually exclusive in practice, but the server does
+// not enforce that — it trusts the edition resolved upstream.
+func (s *Server) SetProBanner(on bool) { s.proBanner = on }
 
 // SetEditorButton toggles injection of the "IDE" button that opens the Lite web
 // editor (/ide). It is enabled only when a workspace is configured (Lite).
@@ -243,6 +262,9 @@ func (s *Server) Index(w http.ResponseWriter, basePath string) {
 	body = injectBeforeBodyEnd(body, clipboardFallbackHTML)
 	if s.liteBanner {
 		body = injectBeforeBodyEnd(body, liteBannerHTML)
+	}
+	if s.proBanner {
+		body = injectBeforeBodyEnd(body, proBannerHTML)
 	}
 	if s.editorButton {
 		body = injectBeforeBodyEnd(body, ideButtonHTML)

--- a/internal/ui/handler_test.go
+++ b/internal/ui/handler_test.go
@@ -201,6 +201,40 @@ func TestIndexInjectsDevBannerOnlyInDevMode(t *testing.T) {
 	}
 }
 
+func TestIndexInjectsProBannerOnlyInProMode(t *testing.T) {
+	fsys := fstest.MapFS{"index.html": {Data: []byte(`<body><div id="root"></div></body>`)}}
+
+	pro := NewFromFS(fsys, "v")
+	pro.SetProBanner(true)
+	rec := httptest.NewRecorder()
+	pro.Index(rec, "/")
+	body := rec.Body.String()
+	if !strings.Contains(body, "leoflow-pro-banner") || !strings.Contains(body, ">PRO<") {
+		t.Errorf("pro mode must inject the PRO overlay, got:\n%s", body)
+	}
+	if strings.Index(body, "leoflow-pro-banner") > strings.Index(body, "</body>") {
+		t.Error("PRO overlay should be injected before </body>")
+	}
+
+	off := NewFromFS(fsys, "v") // pro banner not set → demo/lite
+	rec2 := httptest.NewRecorder()
+	off.Index(rec2, "/")
+	if strings.Contains(rec2.Body.String(), "leoflow-pro-banner") {
+		t.Error("non-pro mode must NOT inject the PRO overlay")
+	}
+
+	// Defensive: the two badges are mutually exclusive; the server should never
+	// flip both on at the same time, but if it did, neither should silently win.
+	both := NewFromFS(fsys, "v")
+	both.SetLiteBanner(true)
+	both.SetProBanner(true)
+	rec3 := httptest.NewRecorder()
+	both.Index(rec3, "/")
+	if !strings.Contains(rec3.Body.String(), ">LITE<") || !strings.Contains(rec3.Body.String(), ">PRO<") {
+		t.Error("both banners enabled: both pills should be in the body (server is the source of truth)")
+	}
+}
+
 func TestIndexInjectsEditorButtonOnlyWhenEnabled(t *testing.T) {
 	fsys := fstest.MapFS{"index.html": {Data: []byte(`<body><div id="root"></div></body>`)}}
 


### PR DESCRIPTION
## The bug
While testing Pro on GKE, the gold **PRO** edition badge was nowhere in the SPA shell — only Lite's silver pill was actually wired. Root cause: `cmd/leoflow-server/main.go:235` ramified only on \`Edition=="lite"\`, and \`internal/config/server.go:93\` literally said *"Empty/'production' shows no badge"*. The memo \`silver-gold-edition-badges\` (#175) had been wired half-way.

Compounding: \`helm/leoflow/templates/deployment.yaml\` was setting \`LEOFLOW_UI_EDITION=production\` while \`tls_guard.go\` branched on the same \`"production"\` literal — both stale relative to the \`lite-pro-naming\` branding ("Pro" is the edition name; lowercase "production" stays generic for deployment-environment use).

## Fix
- \`proBannerHTML\` (#FFD700 / dark text) + \`SetProBanner\` + inject hook in \`Index()\`, mirroring the Lite path exactly
- \`showProBadge(cfg)\` wired into server boot next to \`showLiteBadge\`; table-driven test covering both selectors
- Chart now sets \`LEOFLOW_UI_EDITION=pro\` (signals the Pro edition for both the gold badge and the existing insecure-secrets guard)
- \`tls_guard.go\` (and its test) branch on \`edition=="pro"\` — clearer naming, same posture
- Sweeps the deployment template's user-facing error messages and the helm-unittest fixtures from "Production edition" → "Pro edition"
- Refreshes the \`Edition\` config comment to document both pills

## Reality-anchored coverage tests bundled
Each one covers a real production-path branch that was silently uncovered. Surfaced by the coverage profile (the floor was at 79.3% on main; this PR's badge fix nudged it to 79.4% and these tests land it at 80.0%). Per the \`tests-must-be-reality-anchored\` memory these are real contracts, not padding:

- \`TestEmbeddedAssetsPresent\` — every \`embed.FS\` accessor returns a populated tree
- \`TestDocsHandlersServeKnownContent\` — \`/docs\` Scalar HTML, \`/openapi.{yaml,json}\`
- \`TestLeoflowHomeUnderUserHome\` / \`TestDevProjectNameStableAndShaped\` / \`TestComposeEnvCarriesProjectAndPort\` — docker-compose project naming (Lite Postgres volume reconnection)
- \`TestBuffered_Async_FailureReportToSinkSurvivesSinkError\` / \`...SilentlyDroppedWithoutSink\` — dispatcher keeps draining when the failure-report sink itself errors or is nil
- \`TestExpandClearTasksDispatch\` — UI Clear-with-upstream/downstream wiring + fail-safe seed-only return on spec error
- \`TestReadinessHandlerSurfacesDependencyHealth\` / \`TestLivenessHandlerAlwaysOK\` — K8s probe contract
- \`TestFramingSurvivesSinkErrors\` — agent's framing emitters log-and-continue on sink errors
- \`TestMapStateCoversEveryReportedTransition\` — every agent→domain task state mapping is explicit; unsupported state hits InvalidArgument
- \`TestRecordTaskAuditNonFatal\` — audit failure NEVER fails the user action (best-effort by design)
- \`TestUIStubsReturnSchemaValidEmpties\` (extended) + \`TestZeroTaskInstanceStateCount\` — SPA "no data" payload shapes locked

## Test plan
- [x] \`go test ./...\` passes, lint 0 issues, coverage 80.0% (just over floor)
- [x] \`helm unittest helm/leoflow\` — 41/41 pass
- [x] Live: \`make lite-redeploy\` → Lite still shows the silver pill, no Pro on Lite
- [ ] Live: redeploy GKE Pro → confirm the gold pill appears (depends on the cluster being on the new chart)