### PR TITLE
fix(release): publish both v-prefixed and no-v image tags so any chart pin works

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,11 +112,13 @@ jobs:
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/leoflow-migrate
-          # ref,event=tag stamps the tag verbatim (v0.0.1-prealpha.18); the
+          # ref,event=tag stamps the tag verbatim (v0.0.1-prealpha.N); the
           # semver pattern strips the leading `v` so users pinning by version
-          # (0.0.1-prealpha.18) work too. No `:latest` for pre-alpha tags —
-          # GoReleaser doesn't push `:latest` for leoflow-server either, so
-          # the two images stay in sync.
+          # (0.0.1-prealpha.N) work too. Server publishes BOTH forms from
+          # GoReleaser (one docker build, two manifest names), so any operator
+          # pin against either convention resolves to the same digest. No
+          # `:latest` for pre-alpha tags — GoReleaser doesn't push `:latest`
+          # for leoflow-server either, so the two images stay in sync.
           tags: |
             type=ref,event=tag
             type=semver,pattern={{version}}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -88,12 +88,19 @@ signs:
 # Control-plane container image (the binary embeds the UI). Built per arch and
 # joined into a multi-arch manifest.
 dockers:
+  # Each per-arch image gets BOTH tag forms — `{{ .Version }}` (no `v`, the
+  # GoReleaser default) AND `v{{ .Version }}` (the raw git tag). The migrate
+  # workflow already publishes both forms via docker/metadata-action; keeping
+  # server symmetric means a chart `--set image.tag=<X>` pin works no matter
+  # which convention the operator follows. Both shapes are signed by cosign
+  # below (cosign sign by digest, so duplicate tags share signatures).
   - id: server-amd64
     ids: [leoflow-server]
     goarch: amd64
     dockerfile: deploy/Dockerfile.server.release
     image_templates:
       - "ghcr.io/neochaotic/leoflow-server:{{ .Version }}-amd64"
+      - "ghcr.io/neochaotic/leoflow-server:v{{ .Version }}-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.version={{ .Version }}"
@@ -105,6 +112,7 @@ dockers:
     dockerfile: deploy/Dockerfile.server.release
     image_templates:
       - "ghcr.io/neochaotic/leoflow-server:{{ .Version }}-arm64"
+      - "ghcr.io/neochaotic/leoflow-server:v{{ .Version }}-arm64"
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.version={{ .Version }}"
@@ -116,6 +124,12 @@ docker_manifests:
     image_templates:
       - "ghcr.io/neochaotic/leoflow-server:{{ .Version }}-amd64"
       - "ghcr.io/neochaotic/leoflow-server:{{ .Version }}-arm64"
+  # `v`-prefixed manifest pointing at the same per-arch images. Pulls of
+  # `:v0.0.1-prealpha.N` and `:0.0.1-prealpha.N` resolve to identical digests.
+  - name_template: "ghcr.io/neochaotic/leoflow-server:v{{ .Version }}"
+    image_templates:
+      - "ghcr.io/neochaotic/leoflow-server:v{{ .Version }}-amd64"
+      - "ghcr.io/neochaotic/leoflow-server:v{{ .Version }}-arm64"
 
 release:
   github:

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -149,8 +149,8 @@ differ from what's committed.
 | database.maxOpenConns | int | `20` | Max concurrent open DB connections (Postgres-side load gate). Increase for high-throughput Pro deployments. |
 | database.url | string | `""` | External Postgres DSN. Required for Pro (the embedded datastore is Lite-only); the chart `fail`s the install if neither this nor `existingSecret` is set. Example: `postgres://user:pass@host:5432/leoflow?sslmode=disable`. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/neochaotic/leoflow-server"` | Control-plane image. Published by `release.yaml` on every tag, signed with cosign. |
-| image.tag | string | `""` | Image tag. Defaults to `.Chart.appVersion` when empty; pre-alpha installs should pin `--set image.tag=v0.0.1-prealpha.N`. |
+| image.repository | string | `"ghcr.io/neochaotic/leoflow-server"` | Control-plane image. Published by GoReleaser on every tag, signed with cosign. |
+| image.tag | string | `""` | Image tag. Defaults to `.Chart.appVersion` when empty; pre-alpha installs should pin `--set image.tag=v0.0.1-prealpha.N` (the `v`-prefix and no-`v` forms are both published and resolve to the same digest, so either works). |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` | Ingress annotations (controller-specific: rewrites, TLS, auth, etc.). |
 | ingress.className | string | `""` | Ingress class name (e.g. `nginx`). Leave empty to use the cluster default. |
@@ -169,7 +169,7 @@ differ from what's committed.
 | migrations.enabled | bool | `true` |  |
 | migrations.image.pullPolicy | string | `"IfNotPresent"` |  |
 | migrations.image.repository | string | `"ghcr.io/neochaotic/leoflow-migrate"` | leoflow-migrate image bundling Leoflow SQL migrations on top of `migrate/migrate`. Published per release by `release.yaml`, signed with cosign, multi-arch (amd64 + arm64). |
-| migrations.image.tag | string | `""` | Migration image tag. Defaults to `.Chart.appVersion` when empty — currently lags the published prealpha cadence, so PIN EXPLICITLY: `--set migrations.image.tag=v0.0.1-prealpha.18` (or whatever tag matches your server image). |
+| migrations.image.tag | string | `""` | Migration image tag. Defaults to `.Chart.appVersion` when empty. Pin to the same tag as `image.tag` (both server and migrate publish both `v`-prefix and no-`v` forms — use whichever convention you prefer, they resolve to the same digest): `--set migrations.image.tag=v0.0.1-prealpha.N`. |
 | migrations.path | string | `"/migrations"` | Path inside the migrate image where the SQL files live. Must match the COPY destination in `deploy/Dockerfile.migrate`. |
 | migrations.podSecurityContext.fsGroup | int | `65532` |  |
 | migrations.podSecurityContext.runAsGroup | int | `65532` |  |

--- a/helm/leoflow/values.yaml
+++ b/helm/leoflow/values.yaml
@@ -1,9 +1,9 @@
 # Default values for the Leoflow control plane chart.
 
 image:
-  # -- Control-plane image. Published by `release.yaml` on every tag, signed with cosign.
+  # -- Control-plane image. Published by GoReleaser on every tag, signed with cosign.
   repository: ghcr.io/neochaotic/leoflow-server
-  # -- Image tag. Defaults to `.Chart.appVersion` when empty; pre-alpha installs should pin `--set image.tag=v0.0.1-prealpha.N`.
+  # -- Image tag. Defaults to `.Chart.appVersion` when empty; pre-alpha installs should pin `--set image.tag=v0.0.1-prealpha.N` (the `v`-prefix and no-`v` forms are both published and resolve to the same digest, so either works).
   tag: ""
   pullPolicy: IfNotPresent
 imagePullSecrets: []
@@ -127,7 +127,7 @@ migrations:
   image:
     # -- leoflow-migrate image bundling Leoflow SQL migrations on top of `migrate/migrate`. Published per release by `release.yaml`, signed with cosign, multi-arch (amd64 + arm64).
     repository: ghcr.io/neochaotic/leoflow-migrate
-    # -- Migration image tag. Defaults to `.Chart.appVersion` when empty — currently lags the published prealpha cadence, so PIN EXPLICITLY: `--set migrations.image.tag=v0.0.1-prealpha.18` (or whatever tag matches your server image).
+    # -- Migration image tag. Defaults to `.Chart.appVersion` when empty. Pin to the same tag as `image.tag` (both server and migrate publish both `v`-prefix and no-`v` forms — use whichever convention you prefer, they resolve to the same digest): `--set migrations.image.tag=v0.0.1-prealpha.N`.
     tag: ""
     pullPolicy: IfNotPresent
   # -- Path inside the migrate image where the SQL files live. Must match the COPY destination in `deploy/Dockerfile.migrate`.


### PR DESCRIPTION
Closes #1 (release-tag inconsistency surfaced during GKE Pro testing).

## The bug
Server images publish only \`0.0.1-prealpha.N\` (no \`v\`), but migrate publishes BOTH \`v0.0.1-prealpha.N\` and \`0.0.1-prealpha.N\`. A Helm install pinning \`--set image.tag=v0.0.1-prealpha.N\` 404s on the server image but loads migrate fine — silent failure mode reported in the GKE Pro backlog. The chart's \`values.yaml\` comment further misleads by recommending the \`v\`-form (\"currently lags … PIN EXPLICITLY: \`--set migrations.image.tag=v0.0.1-prealpha.18\`\"), which has never resolved for server.

## Fix
- **\`.goreleaser.yaml\`**: each per-arch docker build now produces BOTH tag forms (\`:0.0.1-prealpha.N-<arch>\` AND \`:v0.0.1-prealpha.N-<arch>\`); a second \`docker_manifests\` block points the \`v\`-prefixed manifest at the same per-arch images. Same digest, two names. Cosign signs by digest, so duplicates cost nothing extra.
- **\`release.yaml\`**: updates the migrate-image comment to describe both forms instead of treating them as a server/migrate skew.
- **\`helm/leoflow/values.yaml\`**: replaces the stale \"currently lags\" caveat with the new contract — both forms publish to the same digest, pin whichever convention you prefer. Migration image inherits the same shape. \`helm-docs\` README regenerated.

## Validation
Locally ran \`goreleaser release --snapshot --clean\` — both \`leoflow-server:0.0.1-prealpha.28-SNAPSHOT-…\` and \`leoflow-server:v0.0.1-prealpha.28-SNAPSHOT-…\` were built with identical image IDs (\`b98a497\`, \`3e514dd\`):
\`\`\`
ghcr.io/neochaotic/leoflow-server:0.0.1-prealpha.28-SNAPSHOT-2059176-amd64   b98a4975319a
ghcr.io/neochaotic/leoflow-server:v0.0.1-prealpha.28-SNAPSHOT-2059176-amd64  b98a4975319a   ← same digest
\`\`\`

## Backwards compatibility
Purely additive — existing no-\`v\` pins keep working unchanged. New v-prefix pins now work too. The \`deploy/gke/02-install-leoflow.sh\` script can keep its current \`IMAGE_TAG="0.0.1-prealpha.28"\` pin, no edit needed.

## Test plan
- [x] \`goreleaser check\` clean
- [x] \`goreleaser release --snapshot\` produces both forms with same digest (verified above)
- [x] \`helm unittest helm/leoflow\` — 41/41 pass
- [x] \`helm-docs\` regenerated; chart README in sync with values.yaml
- [ ] First post-merge release tag will confirm both \`v0.0.1-prealpha.N\` and \`0.0.1-prealpha.N\` resolve in GHCR