### PR TITLE
fix(scheduler): #311 ctx-canceled log noise + leader-churn observability (Tier A+B)

### DIFF
--- a/cmd/leoflow-server/leader_watch_test.go
+++ b/cmd/leoflow-server/leader_watch_test.go
@@ -40,7 +40,7 @@ func TestWatchLeadershipStepsDownOnLostLock(t *testing.T) {
 	defer cancel()
 	chk := &fakeChecker{held: false}
 	done := make(chan struct{})
-	go func() { watchLeadership(ctx, chk, time.Millisecond, cancel, discardLog()); close(done) }()
+	go func() { watchLeadership(ctx, chk, time.Millisecond, cancel, discardLog(), nil); close(done) }()
 
 	select {
 	case <-ctx.Done(): // stepped down
@@ -58,7 +58,7 @@ func TestWatchLeadershipToleratesTransientErrors(t *testing.T) {
 	chk := &fakeChecker{err: errors.New("connection blip")}
 	start := time.Now()
 	done := make(chan struct{})
-	go func() { watchLeadership(ctx, chk, 10*time.Millisecond, cancel, discardLog()); close(done) }()
+	go func() { watchLeadership(ctx, chk, 10*time.Millisecond, cancel, discardLog(), nil); close(done) }()
 
 	select {
 	case <-ctx.Done():
@@ -74,13 +74,69 @@ func TestWatchLeadershipToleratesTransientErrors(t *testing.T) {
 	}
 }
 
+// TestWatchLeadershipFiresOnStepDownWithReason: when leadership is lost the
+// callback fires EXACTLY ONCE with the structured reason, BEFORE cancel().
+// Operators alert on the per-reason counter, so a miscount here would mask
+// leader-churn alerts (#311).
+func TestWatchLeadershipFiresOnStepDownWithReason(t *testing.T) {
+	cases := []struct {
+		name       string
+		chk        *fakeChecker
+		wantReason string
+		interval   time.Duration
+	}{
+		{name: "lock_released", chk: &fakeChecker{held: false}, wantReason: "lock_released", interval: time.Millisecond},
+		{name: "check_timeout", chk: &fakeChecker{err: errors.New("blip")}, wantReason: "check_timeout", interval: 5 * time.Millisecond},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			var (
+				mu              sync.Mutex
+				reasons         []string
+				cancelledBefore bool
+			)
+			tracker := func(reason string) {
+				mu.Lock()
+				reasons = append(reasons, reason)
+				// Contract: onStepDown fires BEFORE cancel() — the scheduler
+				// must have time to flip its steppingDown flag before the
+				// reapers see ctx-canceled. Capture ctx.Err() inside the
+				// callback to assert that ordering.
+				cancelledBefore = ctx.Err() != nil
+				mu.Unlock()
+			}
+			done := make(chan struct{})
+			go func() {
+				watchLeadership(ctx, tc.chk, tc.interval, cancel, discardLog(), tracker)
+				close(done)
+			}()
+			select {
+			case <-ctx.Done():
+			case <-time.After(2 * time.Second):
+				t.Fatal("did not step down")
+			}
+			<-done
+			mu.Lock()
+			defer mu.Unlock()
+			if len(reasons) != 1 || reasons[0] != tc.wantReason {
+				t.Errorf("reasons = %v, want exactly [%q]", reasons, tc.wantReason)
+			}
+			if cancelledBefore {
+				t.Error("onStepDown fired AFTER cancel(); must fire before so the scheduler tags the cancel-fanout as expected (#311)")
+			}
+		})
+	}
+}
+
 // TestWatchLeadershipStaysWhileHolding: while the lock is held, the watchdog
 // never cancels the run.
 func TestWatchLeadershipStaysWhileHolding(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	chk := &fakeChecker{held: true}
 	done := make(chan struct{})
-	go func() { watchLeadership(ctx, chk, time.Millisecond, cancel, discardLog()); close(done) }()
+	go func() { watchLeadership(ctx, chk, time.Millisecond, cancel, discardLog(), nil); close(done) }()
 
 	time.Sleep(40 * time.Millisecond)
 	select {

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -638,16 +638,27 @@ type leadershipChecker interface {
 func campaignAndRun(ctx context.Context, leader *scheduler.Leader, sched *scheduler.Scheduler, logger *slog.Logger) {
 	ticker := time.NewTicker(leaderCheckInterval)
 	defer ticker.Stop()
+	// stepDownAt is the wall-clock the previous runAsLeader returned at (i.e.
+	// when we transitioned out of leadership). Zero means "no prior step-down
+	// in this process" — the first acquisition at boot doesn't record a
+	// re-acquire latency (no churn happened yet).
+	var stepDownAt time.Time
 	for {
 		acquired, err := leader.TryAcquire(ctx)
 		switch {
 		case err != nil:
 			logger.Error("acquiring leadership", "error", err)
 		case acquired:
+			// Record the time we spent stepped down (#311 observability). A
+			// growing P99 here surfaces leader churn that affects scheduling
+			// latency — operators alert on the histogram, not log content.
+			sched.RecordReacquireSince(stepDownAt)
+			sched.ClearSteppingDown()
 			runAsLeader(ctx, leader, sched, logger)
 			if ctx.Err() != nil {
 				return // shutting down, not a leadership loss
 			}
+			stepDownAt = time.Now()
 			logger.Warn("stepped down as scheduler leader; re-campaigning")
 		default:
 			logger.Info("scheduler follower; retrying for leadership")
@@ -676,7 +687,12 @@ func runAsLeader(ctx context.Context, leader *scheduler.Leader, sched *scheduler
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		watchLeadership(runCtx, leader, leaderCheckInterval, cancel, logger)
+		// The watch passes the step-down reason to the scheduler BEFORE
+		// canceling the run-context, so the reapers/Step that are about to
+		// return ctx-canceled log at WARN ("expected during step-down") not
+		// ERROR (#311). A nil scheduler is tolerated by tests.
+		watchLeadership(runCtx, leader, leaderCheckInterval, cancel, logger,
+			func(reason string) { sched.MarkSteppingDown(reason) })
 	}()
 
 	if runErr := sched.Run(runCtx); runErr != nil && !errors.Is(runErr, context.Canceled) {
@@ -690,11 +706,19 @@ func runAsLeader(ctx context.Context, leader *scheduler.Leader, sched *scheduler
 // watchLeadership cancels the run when leadership is lost: a definitive "not
 // held" steps down immediately, while transient check errors are tolerated up to
 // maxLeaderCheckFailures (a connection blip should not churn leadership). It
-// returns when the run context is canceled.
-func watchLeadership(ctx context.Context, chk leadershipChecker, interval time.Duration, cancel context.CancelFunc, logger *slog.Logger) {
+// returns when the run context is canceled. The onStepDown callback fires
+// once, BEFORE cancel(), with the step-down reason so the scheduler can
+// classify the cancel fanout (#311) and increment the per-reason counter.
+func watchLeadership(ctx context.Context, chk leadershipChecker, interval time.Duration, cancel context.CancelFunc, logger *slog.Logger, onStepDown func(reason string)) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	failures := 0
+	stepDown := func(reason string) {
+		if onStepDown != nil {
+			onStepDown(reason)
+		}
+		cancel()
+	}
 	for {
 		select {
 		case <-ctx.Done():
@@ -709,13 +733,15 @@ func watchLeadership(ctx context.Context, chk leadershipChecker, interval time.D
 				failures++
 				logger.Warn("leadership check failed", "error", err, "consecutive", failures)
 				if failures >= maxLeaderCheckFailures {
-					logger.Warn("too many failed leadership checks; stepping down")
-					cancel()
+					logger.Warn("too many failed leadership checks; stepping down",
+						"reason", "check_timeout", "consecutive_failures", failures)
+					stepDown("check_timeout")
 					return
 				}
 			case !held:
-				logger.Warn("lost scheduler advisory lock; stepping down")
-				cancel()
+				logger.Warn("lost scheduler advisory lock; stepping down",
+					"reason", "lock_released")
+				stepDown("lock_released")
 				return
 			default:
 				failures = 0

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -18,6 +18,8 @@ type Metrics struct {
 	ActiveDAGRuns         *prometheus.GaugeVec
 	QueuedTasks           *prometheus.GaugeVec
 	TasksUndispatchable   *prometheus.CounterVec
+	SchedulerStepDowns    *prometheus.CounterVec // #311 leader churn observability
+	SchedulerReacquire    prometheus.Histogram   // #311 step-down → re-acquire latency
 
 	// Task lifecycle
 	TaskStateTransitions    *prometheus.CounterVec
@@ -68,6 +70,20 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		SchedulerLeader: f.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "leoflow_scheduler_leader", Help: "1 when this replica is the scheduler leader.",
 		}, []string{"replica_id"}),
+		SchedulerStepDowns: f.NewCounterVec(prometheus.CounterOpts{
+			Name: "leoflow_scheduler_step_downs_total",
+			Help: "Scheduler leadership step-downs by reason (lock_released, check_timeout, shutdown). " +
+				"Operators alert on rate(...[5m]); a sudden uptick usually indicates a Postgres connection-stability issue (#311).",
+		}, []string{"reason"}),
+		SchedulerReacquire: f.NewHistogram(prometheus.HistogramOpts{
+			Name: "leoflow_scheduler_reacquire_seconds",
+			Help: "Wall-clock seconds between a leader step-down and the same replica reacquiring leadership. " +
+				"A growing P99 signals leader churn that affects scheduling latency (#311).",
+			// Buckets span ~10ms (transient blip) to ~5min (extended outage); the
+			// issue body reports observed re-acquire ~10ms, so the low end is the
+			// reportable distribution.
+			Buckets: []float64{0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30, 60, 300},
+		}),
 		ActiveDAGRuns: f.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "leoflow_active_dag_runs", Help: "Active dag runs by dag and state.",
 		}, []string{"dag_id", "state"}),
@@ -151,6 +167,22 @@ func (m *Metrics) RecordHTTPRequest(method, path string, status int, dur time.Du
 // RecordSchedulerDecision records one scheduler decision by type.
 func (m *Metrics) RecordSchedulerDecision(decisionType string) {
 	m.SchedulerDecisions.WithLabelValues(decisionType).Inc()
+}
+
+// RecordSchedulerStepDown increments the leader step-down counter (#311). The
+// reason label lets operators distinguish a transient lock_released (pgx blip)
+// from a check_timeout (the lock-check failed repeatedly) or a clean shutdown,
+// so they can alert on the rate of the noisy reasons without paging on
+// expected shutdowns.
+func (m *Metrics) RecordSchedulerStepDown(reason string) {
+	m.SchedulerStepDowns.WithLabelValues(reason).Inc()
+}
+
+// ObserveSchedulerReacquire records the wall-clock duration of a step-down →
+// re-acquire cycle (#311). Use the histogram's P99 in alerts: a P99 growing
+// past a second indicates churn that is starting to delay scheduling.
+func (m *Metrics) ObserveSchedulerReacquire(d time.Duration) {
+	m.SchedulerReacquire.Observe(d.Seconds())
 }
 
 // RecordTaskTransition records a task instance state transition.

--- a/internal/scheduler/log_canceled_test.go
+++ b/internal/scheduler/log_canceled_test.go
@@ -1,0 +1,77 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// recordingHandler captures every slog Record so a test can assert level +
+// message + key attributes. It is package-local because slog/slogtest doesn't
+// give us a per-record list; we only need the bare minimum.
+type recordingHandler struct {
+	records []slog.Record
+}
+
+func (h *recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.records = append(h.records, r)
+	return nil
+}
+func (h *recordingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *recordingHandler) WithGroup(_ string) slog.Handler      { return h }
+
+// TestLogSchedulerErrorDowngradesCanceled pins the contract: a context.Canceled
+// error (or any error wrapping it) is logged at WARN, not ERROR. The trigger
+// is a leader step-down — the scheduler cancels its run-context as part of the
+// graceful loss-of-lock path, and the reapers / scheduler-step that were
+// mid-flight return `context canceled`. That is **expected**, not a failure;
+// surfacing it as ERROR fires false alerts (#311 was filed by an operator
+// seeing exactly this on GKE Pro). A genuine failure (any other error) still
+// reaches ERROR so real problems are not muted.
+func TestLogSchedulerErrorDowngradesCanceled(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		wantLvl slog.Level
+	}{
+		{
+			name:    "context.Canceled itself → WARN",
+			err:     context.Canceled,
+			wantLvl: slog.LevelWarn,
+		},
+		{
+			name:    "fmt.Errorf wrap of context.Canceled → WARN (errors.Is unwraps)",
+			err:     fmt.Errorf("listing orphan candidates: %w", context.Canceled),
+			wantLvl: slog.LevelWarn,
+		},
+		{
+			name:    "DeadlineExceeded → ERROR (a real stall, not a step-down)",
+			err:     context.DeadlineExceeded,
+			wantLvl: slog.LevelError,
+		},
+		{
+			name:    "generic infra error → ERROR",
+			err:     errors.New("postgres connection refused"),
+			wantLvl: slog.LevelError,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &recordingHandler{}
+			logSchedulerError(slog.New(h), "orphan reaper", tc.err)
+			if len(h.records) != 1 {
+				t.Fatalf("expected 1 record, got %d", len(h.records))
+			}
+			if got := h.records[0].Level; got != tc.wantLvl {
+				t.Errorf("level = %v, want %v (err=%v)", got, tc.wantLvl, tc.err)
+			}
+			if !strings.Contains(h.records[0].Message, "orphan reaper") {
+				t.Errorf("message %q lost the caller's prefix", h.records[0].Message)
+			}
+		})
+	}
+}

--- a/internal/scheduler/log_canceled_test.go
+++ b/internal/scheduler/log_canceled_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 )
 
 // recordingHandler captures every slog Record so a test can assert level +
@@ -34,44 +35,141 @@ func (h *recordingHandler) WithGroup(_ string) slog.Handler      { return h }
 // reaches ERROR so real problems are not muted.
 func TestLogSchedulerErrorDowngradesCanceled(t *testing.T) {
 	tests := []struct {
-		name    string
-		err     error
-		wantLvl slog.Level
+		name       string
+		err        error
+		inStepDown bool
+		wantLvl    slog.Level
 	}{
 		{
-			name:    "context.Canceled itself → WARN",
-			err:     context.Canceled,
-			wantLvl: slog.LevelWarn,
+			name:       "ctx-canceled INSIDE step-down → WARN (expected fan-out)",
+			err:        context.Canceled,
+			inStepDown: true,
+			wantLvl:    slog.LevelWarn,
 		},
 		{
-			name:    "fmt.Errorf wrap of context.Canceled → WARN (errors.Is unwraps)",
-			err:     fmt.Errorf("listing orphan candidates: %w", context.Canceled),
-			wantLvl: slog.LevelWarn,
+			name:       "fmt.Errorf wrap of ctx-canceled INSIDE step-down → WARN",
+			err:        fmt.Errorf("listing orphan candidates: %w", context.Canceled),
+			inStepDown: true,
+			wantLvl:    slog.LevelWarn,
 		},
 		{
-			name:    "DeadlineExceeded → ERROR (a real stall, not a step-down)",
-			err:     context.DeadlineExceeded,
-			wantLvl: slog.LevelError,
+			name:       "ctx-canceled OUTSIDE step-down → ERROR (tripwire — unexpected cancel)",
+			err:        context.Canceled,
+			inStepDown: false,
+			wantLvl:    slog.LevelError,
 		},
 		{
-			name:    "generic infra error → ERROR",
-			err:     errors.New("postgres connection refused"),
-			wantLvl: slog.LevelError,
+			name:       "wrapped ctx-canceled OUTSIDE step-down → ERROR (tripwire holds for wraps too)",
+			err:        fmt.Errorf("listing orphan candidates: %w", context.Canceled),
+			inStepDown: false,
+			wantLvl:    slog.LevelError,
+		},
+		{
+			name:       "DeadlineExceeded INSIDE step-down → ERROR (a real stall, not a deliberate cancel)",
+			err:        context.DeadlineExceeded,
+			inStepDown: true,
+			wantLvl:    slog.LevelError,
+		},
+		{
+			name:       "generic infra error → ERROR (regardless of step-down state)",
+			err:        errors.New("postgres connection refused"),
+			inStepDown: true,
+			wantLvl:    slog.LevelError,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			h := &recordingHandler{}
-			logSchedulerError(slog.New(h), "orphan reaper", tc.err)
+			logSchedulerError(slog.New(h), "orphan reaper", tc.err, tc.inStepDown)
 			if len(h.records) != 1 {
 				t.Fatalf("expected 1 record, got %d", len(h.records))
 			}
 			if got := h.records[0].Level; got != tc.wantLvl {
-				t.Errorf("level = %v, want %v (err=%v)", got, tc.wantLvl, tc.err)
+				t.Errorf("level = %v, want %v (err=%v inStepDown=%v)", got, tc.wantLvl, tc.err, tc.inStepDown)
 			}
 			if !strings.Contains(h.records[0].Message, "orphan reaper") {
 				t.Errorf("message %q lost the caller's prefix", h.records[0].Message)
 			}
 		})
 	}
+}
+
+// TestMarkSteppingDownIncrementsCounter pins the step-down counter contract.
+// Operators alert on `rate(leoflow_scheduler_step_downs_total[5m])`, so this
+// test guards that MarkSteppingDown actually emits exactly one count per
+// step-down (no double-count under repeated calls — the counter is the rate of
+// step-down EVENTS, not of state-flag-flips) and that the reason label is
+// preserved verbatim.
+func TestMarkSteppingDownIncrementsCounter(t *testing.T) {
+	rec := &fakeRecorder{}
+	s := NewScheduler(nil, slog.New(&recordingHandler{}), time.Second)
+	s.SetRecorder(rec)
+
+	s.MarkSteppingDown("lock_released")
+	if !s.SteppingDown() {
+		t.Error("after MarkSteppingDown, SteppingDown() must be true")
+	}
+	if got := rec.stepDowns["lock_released"]; got != 1 {
+		t.Errorf("counter[lock_released] = %d, want 1", got)
+	}
+
+	// ClearSteppingDown closes the window without touching the counter (a
+	// step-down is one event, not a Mark/Clear pair).
+	s.ClearSteppingDown()
+	if s.SteppingDown() {
+		t.Error("after ClearSteppingDown, SteppingDown() must be false")
+	}
+	if got := rec.stepDowns["lock_released"]; got != 1 {
+		t.Errorf("counter[lock_released] = %d after Clear, want still 1 (Clear is not an event)", got)
+	}
+
+	// A second step-down with a different reason is a distinct labeled count.
+	s.MarkSteppingDown("check_timeout")
+	if got := rec.stepDowns["check_timeout"]; got != 1 {
+		t.Errorf("counter[check_timeout] = %d, want 1", got)
+	}
+	if got := rec.stepDowns["lock_released"]; got != 1 {
+		t.Errorf("counter[lock_released] = %d after second step-down, want still 1", got)
+	}
+}
+
+// (fakeRecorder is declared in scheduler_test.go and tracks stepDowns by
+// reason; this file reuses it.)
+
+// TestRecordReacquireSinceObserves pins the re-acquire latency contract: a
+// non-zero stepDownAt against a non-nil Recorder records EXACTLY ONE histogram
+// sample (operators alert on this as the leader-churn SLI); a zero stepDownAt
+// (first boot, no prior step-down) records nothing; a nil Recorder is a no-op
+// (the scheduler must tolerate being constructed without one).
+func TestRecordReacquireSinceObserves(t *testing.T) {
+	t.Run("non-zero stepDownAt + Recorder → one sample", func(t *testing.T) {
+		rec := &fakeRecorder{}
+		s := NewScheduler(nil, slog.New(&recordingHandler{}), time.Second)
+		s.SetRecorder(rec)
+		stepDownAt := time.Now().Add(-50 * time.Millisecond)
+		s.RecordReacquireSince(stepDownAt)
+		if got := len(rec.reacquireSamples); got != 1 {
+			t.Fatalf("expected 1 sample, got %d", got)
+		}
+		// The recorded duration is wall-clock since stepDownAt — at least the
+		// time we waited above (no upper bound — test sched can stall).
+		if s := rec.reacquireSamples[0]; s < 40*time.Millisecond {
+			t.Errorf("sample = %v, expected >= 40ms (we slept 50ms before recording)", s)
+		}
+	})
+	t.Run("zero stepDownAt → no sample (no churn happened)", func(t *testing.T) {
+		rec := &fakeRecorder{}
+		s := NewScheduler(nil, slog.New(&recordingHandler{}), time.Second)
+		s.SetRecorder(rec)
+		s.RecordReacquireSince(time.Time{}) // zero value = first boot
+		if got := len(rec.reacquireSamples); got != 0 {
+			t.Errorf("zero stepDownAt should record nothing, got %d sample(s)", got)
+		}
+	})
+	t.Run("nil Recorder → no-op (no panic)", func(t *testing.T) {
+		s := NewScheduler(nil, slog.New(&recordingHandler{}), time.Second)
+		// No SetRecorder; the scheduler is constructed with recorder=nil.
+		s.RecordReacquireSince(time.Now().Add(-1 * time.Second))
+		// If we get here without a panic, the nil-guard works.
+	})
 }

--- a/internal/scheduler/resilience_test.go
+++ b/internal/scheduler/resilience_test.go
@@ -123,8 +123,10 @@ func (r *capturingRecorder) RecordSchedulerDecision(d string) {
 	defer r.mu.Unlock()
 	r.decisions = append(r.decisions, d)
 }
-func (r *capturingRecorder) RecordTaskTransition(_, _, _ string) {}
-func (r *capturingRecorder) RecordUndispatchable(string)         {}
+func (r *capturingRecorder) RecordTaskTransition(_, _, _ string)       {}
+func (r *capturingRecorder) RecordUndispatchable(string)               {}
+func (r *capturingRecorder) RecordSchedulerStepDown(string)            {}
+func (r *capturingRecorder) ObserveSchedulerReacquire(_ time.Duration) {}
 
 func (r *capturingRecorder) count(decision string) int {
 	r.mu.Lock()

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"runtime/debug"
@@ -10,6 +11,21 @@ import (
 
 	"github.com/neochaotic/leoflow/internal/domain"
 )
+
+// logSchedulerError logs an error from the scheduler loop or one of its
+// reapers, downgrading to WARN when the error wraps context.Canceled. That
+// cancellation is the expected fan-out of a graceful leader step-down (the
+// scheduler cancels its run-context when it loses the Postgres advisory lock,
+// and every in-flight loop returns "context canceled" milliseconds later).
+// Surfacing those as ERROR pages on a non-event (#311). DeadlineExceeded is
+// kept at ERROR — a deadline IS a real stall worth seeing.
+func logSchedulerError(logger *slog.Logger, msg string, err error) {
+	if errors.Is(err, context.Canceled) {
+		logger.Warn(msg+" canceled (likely leader step-down)", "error", err)
+		return
+	}
+	logger.Error(msg, "error", err)
+}
 
 // RunState is the scheduler's snapshot of a dag run: its topology and the
 // current state of each task.
@@ -250,7 +266,7 @@ func (s *Scheduler) tick(ctx context.Context) {
 	stepCtx, cancel := context.WithTimeout(ctx, s.stepTimeout)
 	defer cancel()
 	if err := s.Step(stepCtx); err != nil {
-		s.logger.Error("scheduler step", "error", err)
+		logSchedulerError(s.logger, "scheduler step", err)
 	}
 }
 
@@ -326,12 +342,12 @@ func (s *Scheduler) reapOrphansIfLeader(ctx context.Context) {
 	}
 	runReaper := newOrphanReaper(s.store, s.logger, s.orphanThreshold, s.recorder)
 	if err := runReaper.run(ctx); err != nil {
-		s.logger.Error("orphan reaper", "error", err)
+		logSchedulerError(s.logger, "orphan reaper", err)
 		s.record("orphan_list_error")
 	}
 	tiReaper := newAgentLostReaper(s.store, s.logger, s.agentLostThreshold, s.recorder)
 	if err := tiReaper.run(ctx); err != nil {
-		s.logger.Error("agent-lost reaper", "error", err)
+		logSchedulerError(s.logger, "agent-lost reaper", err)
 		s.record("agent_lost_list_error")
 	}
 	// The dispatch-lost reaper (#202) catches TIs left in `queued` after a
@@ -342,7 +358,7 @@ func (s *Scheduler) reapOrphansIfLeader(ctx context.Context) {
 	// chain once the threshold elapses.
 	dispatchReaper := newDispatchLostReaper(s.store, s.logger, s.dispatchLostThreshold, s.recorder)
 	if err := dispatchReaper.run(ctx); err != nil {
-		s.logger.Error("dispatch-lost reaper", "error", err)
+		logSchedulerError(s.logger, "dispatch-lost reaper", err)
 		s.record("dispatch_lost_list_error")
 	}
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -13,15 +13,22 @@ import (
 )
 
 // logSchedulerError logs an error from the scheduler loop or one of its
-// reapers, downgrading to WARN when the error wraps context.Canceled. That
-// cancellation is the expected fan-out of a graceful leader step-down (the
-// scheduler cancels its run-context when it loses the Postgres advisory lock,
-// and every in-flight loop returns "context canceled" milliseconds later).
-// Surfacing those as ERROR pages on a non-event (#311). DeadlineExceeded is
-// kept at ERROR — a deadline IS a real stall worth seeing.
-func logSchedulerError(logger *slog.Logger, msg string, err error) {
-	if errors.Is(err, context.Canceled) {
-		logger.Warn(msg+" canceled (likely leader step-down)", "error", err)
+// reapers, downgrading to WARN ONLY when (a) the error wraps context.Canceled
+// AND (b) the caller is currently in the step-down window. Both conditions
+// together identify the expected cancel-fanout of a graceful leader step-down
+// (the scheduler cancels its run-context when it loses the Postgres advisory
+// lock, and every in-flight loop returns "context canceled" milliseconds
+// later). Surfacing those as ERROR pages on a non-event (#311).
+//
+// When context.Canceled appears OUTSIDE a known step-down (someone else
+// canceled the loop — a bug, a misconfig, a shutdown race), we KEEP it at
+// ERROR. The tripwire is what catches an unexpected cancel that the downgrade
+// would otherwise have silently swallowed. DeadlineExceeded is also kept at
+// ERROR — a deadline IS a real stall worth seeing, not a deliberate cancel.
+func logSchedulerError(logger *slog.Logger, msg string, err error, inStepDown bool) {
+	if inStepDown && errors.Is(err, context.Canceled) {
+		logger.Warn(msg+" canceled (leader step-down in progress)",
+			"error", err, "expected", true)
 		return
 	}
 	logger.Error(msg, "error", err)
@@ -107,6 +114,14 @@ type Recorder interface {
 	RecordTaskTransition(from, to, dagID string)
 	// RecordUndispatchable counts tasks queued with no executor to launch them.
 	RecordUndispatchable(reason string)
+	// RecordSchedulerStepDown counts a leader step-down by reason — the rate
+	// of this counter is the operator-facing SLI for leader-churn (#311). A
+	// nil Recorder is tolerated by the scheduler so tests need not stub it.
+	RecordSchedulerStepDown(reason string)
+	// ObserveSchedulerReacquire records the wall-clock duration of a step-down
+	// → re-acquire cycle (#311). Operators alert on P99 to spot churn that
+	// starts to delay scheduling latency.
+	ObserveSchedulerReacquire(d time.Duration)
 }
 
 // Dispatcher launches a task instance for execution. The scheduler dispatches a
@@ -166,6 +181,7 @@ type Scheduler struct {
 	dispatchLostThreshold time.Duration
 	lastTick              atomic.Int64 // unix-nano of the last loop iteration; 0 = not yet ticked
 	leading               atomic.Bool  // true only while this instance holds leadership and ticks
+	steppingDown          atomic.Bool  // true only during a leader step-down — the campaign loop sets it before canceling the run-context so the expected cancel-fanout logs at WARN, not ERROR (#311 tripwire preserved when it's false)
 	// warnedSchedules dedupes the "unparseable schedule" warning per DAG (keyed by
 	// the offending expression) so a bad cron logs once, not every tick. Accessed
 	// only from the single-threaded tick (createDueRuns), so it needs no lock.
@@ -226,6 +242,41 @@ func (s *Scheduler) SetLeading(on bool) {
 	s.leading.Store(on)
 }
 
+// MarkSteppingDown records that a graceful step-down has begun. The campaign
+// loop calls this BEFORE canceling the scheduler's run-context, so any
+// in-flight reaper/Step that returns "context canceled" inside the window logs
+// at WARN (expected) instead of ERROR. It also increments the step-down
+// counter labeled by reason, so operators can alert on the *rate* of churn
+// (rate(...[5m])) instead of grep'ing log content. ClearSteppingDown closes
+// the window; outside it, context.Canceled stays ERROR — the tripwire that
+// catches an unexpected cancel a flat downgrade would silently swallow.
+func (s *Scheduler) MarkSteppingDown(reason string) {
+	s.steppingDown.Store(true)
+	if s.recorder != nil {
+		s.recorder.RecordSchedulerStepDown(reason)
+	}
+}
+
+// ClearSteppingDown ends the step-down window opened by MarkSteppingDown.
+// Idempotent — calling it when no step-down is active is a no-op.
+func (s *Scheduler) ClearSteppingDown() { s.steppingDown.Store(false) }
+
+// RecordReacquireSince records the time spent stepped down (#311). It is
+// called by the campaign loop immediately after a successful re-acquire, with
+// the timestamp captured at the moment of step-down. A zero stepDownAt (no
+// prior step-down — first acquisition at boot) is ignored.
+func (s *Scheduler) RecordReacquireSince(stepDownAt time.Time) {
+	if stepDownAt.IsZero() || s.recorder == nil {
+		return
+	}
+	s.recorder.ObserveSchedulerReacquire(time.Since(stepDownAt))
+}
+
+// SteppingDown exposes the current step-down state for tests and callers that
+// want to classify an error themselves (the four scheduler.go log sites call
+// logSchedulerError with this value).
+func (s *Scheduler) SteppingDown() bool { return s.steppingDown.Load() }
+
 // SetRecorder attaches a metrics recorder (optional).
 func (s *Scheduler) SetRecorder(r Recorder) { s.recorder = r }
 
@@ -266,7 +317,7 @@ func (s *Scheduler) tick(ctx context.Context) {
 	stepCtx, cancel := context.WithTimeout(ctx, s.stepTimeout)
 	defer cancel()
 	if err := s.Step(stepCtx); err != nil {
-		logSchedulerError(s.logger, "scheduler step", err)
+		logSchedulerError(s.logger, "scheduler step", err, s.steppingDown.Load())
 	}
 }
 
@@ -342,12 +393,12 @@ func (s *Scheduler) reapOrphansIfLeader(ctx context.Context) {
 	}
 	runReaper := newOrphanReaper(s.store, s.logger, s.orphanThreshold, s.recorder)
 	if err := runReaper.run(ctx); err != nil {
-		logSchedulerError(s.logger, "orphan reaper", err)
+		logSchedulerError(s.logger, "orphan reaper", err, s.steppingDown.Load())
 		s.record("orphan_list_error")
 	}
 	tiReaper := newAgentLostReaper(s.store, s.logger, s.agentLostThreshold, s.recorder)
 	if err := tiReaper.run(ctx); err != nil {
-		logSchedulerError(s.logger, "agent-lost reaper", err)
+		logSchedulerError(s.logger, "agent-lost reaper", err, s.steppingDown.Load())
 		s.record("agent_lost_list_error")
 	}
 	// The dispatch-lost reaper (#202) catches TIs left in `queued` after a
@@ -358,7 +409,7 @@ func (s *Scheduler) reapOrphansIfLeader(ctx context.Context) {
 	// chain once the threshold elapses.
 	dispatchReaper := newDispatchLostReaper(s.store, s.logger, s.dispatchLostThreshold, s.recorder)
 	if err := dispatchReaper.run(ctx); err != nil {
-		logSchedulerError(s.logger, "dispatch-lost reaper", err)
+		logSchedulerError(s.logger, "dispatch-lost reaper", err, s.steppingDown.Load())
 		s.record("dispatch_lost_list_error")
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -569,12 +569,25 @@ func TestHeartbeatIsLeadershipAware(t *testing.T) {
 	}
 }
 
-type fakeRecorder struct{ undispatchable []string }
+type fakeRecorder struct {
+	undispatchable   []string
+	stepDowns        map[string]int
+	reacquireSamples []time.Duration
+}
 
 func (r *fakeRecorder) RecordSchedulerDecision(string)      {}
 func (r *fakeRecorder) RecordTaskTransition(_, _, _ string) {}
 func (r *fakeRecorder) RecordUndispatchable(reason string) {
 	r.undispatchable = append(r.undispatchable, reason)
+}
+func (r *fakeRecorder) RecordSchedulerStepDown(reason string) {
+	if r.stepDowns == nil {
+		r.stepDowns = map[string]int{}
+	}
+	r.stepDowns[reason]++
+}
+func (r *fakeRecorder) ObserveSchedulerReacquire(d time.Duration) {
+	r.reacquireSamples = append(r.reacquireSamples, d)
 }
 
 func freshRun() *fakeStore {


### PR DESCRIPTION
Closes #311.

## TL;DR
The original incident: a single transient pgx blip → 4×ERROR logs (false alarm). After this PR:
- 1×WARN with **structured reason** (\`reason=lock_released\` or \`check_timeout\`)
- 4×WARN from the reapers/Step, tagged \`expected=true\` (only downgraded because the watchdog flagged \`steppingDown=true\` BEFORE cancel)
- 1×counter sample on \`leoflow_scheduler_step_downs_total\` (per-reason)
- 1×histogram sample on \`leoflow_scheduler_reacquire_seconds\`

A future incident is observable as **rate spikes on the counter** and **P99 spikes on the histogram** — no log content parsing needed. An *unexpected* cancel outside a known step-down still ERRORs (tripwire preserved).

## Two commits, two tiers
1. \`42615da\` **Tier A — log hygiene.** Downgrade ctx-canceled returned from reapers/Step during step-down to WARN.
2. \`95ded4c\` **Tier B — observability + tripwire.** The substantive bit. Adds:
   - \`steppingDown\` atomic flag on the Scheduler; WARN now requires BOTH \`errors.Is(canceled)\` AND being in the window. Outside the window, ctx-canceled is back at ERROR.
   - \`leoflow_scheduler_step_downs_total{reason}\` counter (operators alert on \`rate(...[5m])\`)
   - \`leoflow_scheduler_reacquire_seconds\` histogram (10ms–5min buckets covering the #311-observed value to extended outages)
   - \`watchLeadership\` now takes an \`onStepDown(reason)\` callback fired BEFORE \`cancel()\` so the scheduler has time to flip its flag before the reapers see ctx-canceled
   - Structured log fields: \`reason=lock_released\` / \`reason=check_timeout, consecutive_failures=N\`

## Why this matters
The scheduler is critical-path. The original Tier A alone would have been pure cosmetics: by downgrading every ctx-canceled to WARN, it would have **silenced a real signal** if the lock started flapping (which is the failure mode the issue body asks us to investigate). Tier B keeps Tier A's hygiene win but adds the metrics that make leader-churn alertable, plus the tripwire that catches unexpected cancels the downgrade would otherwise have swallowed.

## Tier C deferred
Issue #311 also asks for *"a dedicated, long-lived connection for the advisory lock with keepalive"*. That is a substantive change to \`internal/scheduler/leader.go\` + pgxpool config and deserves its own PR with a Cloud SQL maintenance-window integration test. **Filing as a follow-up issue.**

## Test plan
- [x] \`go test ./...\` passes
- [x] \`golangci-lint\` clean
- [x] Coverage 80.0% (gate passes)
- [x] New tests for the 4 contracts (callback ordering, counter rate-of-events, histogram observation, tripwire)
- [ ] Live re-test on GKE Pro — the next step-down should produce one WARN + one counter sample + one histogram sample (no ERROR storm)