### PR TITLE
feat(redis): per-reason error counters, dial latency, pool gauges (#311 pattern ported)

### DIFF
--- a/cmd/leoflow-server/datastore_test.go
+++ b/cmd/leoflow-server/datastore_test.go
@@ -23,7 +23,9 @@ func TestSelectDatastoreEmbeddedWhenNoRedis(t *testing.T) {
 	cfg := &config.ServerConfig{} // zero value: Redis.URL == ""
 	pg := &storage.Postgres{}     // nil pool; the embedded path does not dial it here
 
-	backend, tailer, redisHealth, cleanup, err := selectDatastore(ctx, cfg, pg, slog.Default())
+	// Lite path takes the embedded branch BEFORE touching metrics, so a nil
+	// Metrics is safe here (and lets the test avoid registering Prometheus).
+	backend, tailer, redisHealth, cleanup, err := selectDatastore(ctx, cfg, pg, slog.Default(), nil)
 	if err != nil {
 		t.Fatalf("selectDatastore: %v", err)
 	}

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -85,7 +85,7 @@ func run() error {
 	// Datastore for XCom + live-log tailing: Redis when configured (production,
 	// ADR 0006), or the embedded Postgres/in-process backends when no Redis is
 	// set (Lite — ADR 0026). The signal is the presence of a Redis URL.
-	xcomBackend, logTailer, redisHealth, dsCleanup, err := selectDatastore(ctx, cfg, pg, tel.Logger)
+	xcomBackend, logTailer, redisHealth, dsCleanup, err := selectDatastore(ctx, cfg, pg, tel.Logger, tel.Metrics)
 	if err != nil {
 		return err
 	}
@@ -482,7 +482,7 @@ const xcomSweepInterval = 10 * time.Minute
 // no Redis configured it uses the embedded backends — XCom on Postgres and an
 // in-process tailer — so Lite needs no Redis (ADR 0026). It returns a health
 // checker for Redis (nil when embedded) and a cleanup to defer.
-func selectDatastore(ctx context.Context, cfg *config.ServerConfig, pg *storage.Postgres, logger *slog.Logger) (xcom.Backend, logs.Tailer, api.HealthChecker, func(), error) {
+func selectDatastore(ctx context.Context, cfg *config.ServerConfig, pg *storage.Postgres, logger *slog.Logger, metrics *observability.Metrics) (xcom.Backend, logs.Tailer, api.HealthChecker, func(), error) {
 	if cfg.Redis.URL == "" {
 		logger.Info("embedded datastore: XCom on Postgres, in-process log tailer (no Redis)")
 		backend := xcom.NewPostgresBackend(pg.Pool)
@@ -493,7 +493,15 @@ func selectDatastore(ctx context.Context, cfg *config.ServerConfig, pg *storage.
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("redis: %w", err)
 	}
+	// Attach the per-reason error counter, dial-latency histogram, and pool
+	// gauges (#312 sibling — same shape as the #311 step-down observability).
+	// 5s scrape interval is comfortably under the default 15s Prometheus
+	// scrape, so a P99 spike never reaches the dashboard from missing data.
+	// Lite already returned above (no Redis), so metrics is always non-nil
+	// here on the Pro path.
+	stopObs := storage.AttachRedisObservability(ctx, rd, metrics, 5*time.Second)
 	cleanup := func() {
+		stopObs()
 		if cerr := rd.Close(); cerr != nil {
 			logger.Error("closing redis", "error", cerr)
 		}

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -49,6 +49,21 @@ type Metrics struct {
 	DispatchAtCapacity  prometheus.Counter
 	DispatchLatency     prometheus.Histogram
 	DispatchInnerErrors prometheus.Counter
+
+	// Redis observability — port of the #311 step-down pattern for Redis (Pro
+	// only; Lite uses Postgres + in-process tailer per ADR 0026, so these
+	// gauges stay at 0). Operators alert on the per-reason rate, not on log
+	// content: a sudden rate spike on RedisCommandFailures{reason="timeout"}
+	// or RedisDialFailures{reason="tls_handshake"} catches an outage before
+	// the surrounding components (XCom, log tailer) start surfacing tail
+	// errors to users.
+	RedisCommandFailures *prometheus.CounterVec
+	RedisDialFailures    *prometheus.CounterVec
+	RedisDialDuration    prometheus.Histogram
+	RedisPoolActive      prometheus.Gauge
+	RedisPoolIdle        prometheus.Gauge
+	RedisPoolTotalConns  prometheus.Gauge
+	RedisPoolTimeouts    prometheus.Counter
 }
 
 // NewMetrics registers every ADR 0010 collector with reg and returns the set.
@@ -139,8 +154,70 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		DispatchInnerErrors: f.NewCounter(prometheus.CounterOpts{
 			Name: "leoflow_dispatch_inner_errors_total", Help: "Errors returned by the inner dispatcher inside a worker.",
 		}),
+
+		RedisCommandFailures: f.NewCounterVec(prometheus.CounterOpts{
+			Name: "leoflow_redis_command_failures_total",
+			Help: "Redis command failures classified by reason (timeout, connection_refused, auth, canceled, other). " +
+				"Alert on rate(...[5m]) to surface a degrading client-side path before user-visible XCom errors (#312 sibling).",
+		}, []string{"reason"}),
+		RedisDialFailures: f.NewCounterVec(prometheus.CounterOpts{
+			Name: "leoflow_redis_dial_failures_total",
+			Help: "Failures at TCP/TLS dial time to Redis, classified by reason (tls_handshake, connection_refused, dns, timeout, other).",
+		}, []string{"reason"}),
+		RedisDialDuration: f.NewHistogram(prometheus.HistogramOpts{
+			Name:    "leoflow_redis_dial_duration_seconds",
+			Help:    "Wall-clock time per Redis dial — TCP connect + (when rediss://) TLS handshake.",
+			Buckets: []float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5},
+		}),
+		RedisPoolActive: f.NewGauge(prometheus.GaugeOpts{
+			Name: "leoflow_redis_pool_active_conns", Help: "Redis pool: connections currently checked out for a command.",
+		}),
+		RedisPoolIdle: f.NewGauge(prometheus.GaugeOpts{
+			Name: "leoflow_redis_pool_idle_conns", Help: "Redis pool: idle connections available for the next command.",
+		}),
+		RedisPoolTotalConns: f.NewGauge(prometheus.GaugeOpts{
+			Name: "leoflow_redis_pool_total_conns", Help: "Redis pool: total connections (active + idle). Saturating against PoolSize is the leading indicator of throughput issues.",
+		}),
+		RedisPoolTimeouts: f.NewCounter(prometheus.CounterOpts{
+			Name: "leoflow_redis_pool_timeouts_total", Help: "Redis pool checkout timeouts — a caller waited PoolTimeout for an idle connection. A non-zero rate means the pool is too small or commands are too slow.",
+		}),
 	}
 }
+
+// RecordRedisCommandFailure increments the per-reason command failure counter
+// (#312 sibling, paralleling #311's step-down reason). Caller is the go-redis
+// hook's ProcessHook — it classifies the error before incrementing so the
+// label cardinality stays bounded.
+func (m *Metrics) RecordRedisCommandFailure(reason string) {
+	m.RedisCommandFailures.WithLabelValues(reason).Inc()
+}
+
+// RecordRedisDialFailure increments the per-reason dial failure counter.
+// Separated from command failures because a dial failure means we never even
+// reached the Redis instance — the cause is upstream (DNS, TLS, network),
+// not Redis itself.
+func (m *Metrics) RecordRedisDialFailure(reason string) {
+	m.RedisDialFailures.WithLabelValues(reason).Inc()
+}
+
+// ObserveRedisDialDuration records one TCP/TLS dial latency sample.
+func (m *Metrics) ObserveRedisDialDuration(d time.Duration) {
+	m.RedisDialDuration.Observe(d.Seconds())
+}
+
+// UpdateRedisPoolStats refreshes the three pool gauges. The cmd/leoflow-server
+// goroutine that calls this scrapes go-redis's PoolStats every N seconds.
+func (m *Metrics) UpdateRedisPoolStats(active, idle, total uint32) {
+	m.RedisPoolActive.Set(float64(active))
+	m.RedisPoolIdle.Set(float64(idle))
+	m.RedisPoolTotalConns.Set(float64(total))
+}
+
+// RecordRedisPoolTimeout increments the pool-checkout timeout counter. The
+// go-redis hook fires this when a caller waited PoolTimeout for an idle
+// connection — the leading indicator that the pool is too small for the
+// command rate.
+func (m *Metrics) RecordRedisPoolTimeout() { m.RedisPoolTimeouts.Inc() }
 
 // RecordHTTPRequest records a completed HTTP request (count + duration).
 func (m *Metrics) RecordHTTPRequest(method, path string, status int, dur time.Duration) {

--- a/internal/storage/redis_observability.go
+++ b/internal/storage/redis_observability.go
@@ -1,0 +1,194 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisMetrics is the subset of observability.Metrics the redis hook + pool
+// scraper need. Declared as a local interface so internal/storage doesn't
+// import internal/observability (cycle-avoidance, also lets tests inject a
+// fake without standing up a Prometheus registry).
+type RedisMetrics interface {
+	RecordRedisCommandFailure(reason string)
+	RecordRedisDialFailure(reason string)
+	ObserveRedisDialDuration(d time.Duration)
+	UpdateRedisPoolStats(active, idle, total uint32)
+	RecordRedisPoolTimeout()
+}
+
+// observabilityHook implements redis.Hook. It runs *around* every command and
+// every dial, classifying any error into one of a small bounded label set so
+// alerts can be keyed by reason without unbounded cardinality.
+type observabilityHook struct {
+	metrics RedisMetrics
+}
+
+func newRedisObservabilityHook(m RedisMetrics) redis.Hook { return &observabilityHook{metrics: m} }
+
+// DialHook wraps go-redis's net.Dial. A failure here means we never reached
+// Redis — the root cause is upstream (DNS, TLS, firewall). The latency
+// observation covers both the TCP handshake and (for rediss://) the TLS
+// handshake.
+func (h *observabilityHook) DialHook(next redis.DialHook) redis.DialHook {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		start := time.Now()
+		conn, err := next(ctx, network, addr)
+		h.metrics.ObserveRedisDialDuration(time.Since(start))
+		if err != nil {
+			h.metrics.RecordRedisDialFailure(classifyDialError(err))
+		}
+		return conn, err
+	}
+}
+
+// ProcessHook wraps every individual command. We see the post-retry final
+// outcome go-redis returns to the caller; transient retries inside the client
+// are invisible by design.
+func (h *observabilityHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return func(ctx context.Context, cmd redis.Cmder) error {
+		err := next(ctx, cmd)
+		if err != nil {
+			h.metrics.RecordRedisCommandFailure(classifyCommandError(err))
+		}
+		return err
+	}
+}
+
+// ProcessPipelineHook is the pipeline counterpart of ProcessHook. We treat
+// the pipeline-level error the same way; per-command errors inside the
+// pipeline are surfaced by go-redis through individual Cmder.Err() values
+// the caller inspects, but the pipeline-level error captures "the network
+// died" cases that affect the whole batch.
+func (h *observabilityHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return func(ctx context.Context, cmds []redis.Cmder) error {
+		err := next(ctx, cmds)
+		if err != nil {
+			h.metrics.RecordRedisCommandFailure(classifyCommandError(err))
+		}
+		return err
+	}
+}
+
+// classifyCommandError maps a go-redis command error to one of the bounded
+// reason labels used in alerts. Order matters — we check the most specific
+// known cases first, then fall back to substring matches for the long tail.
+// Keep the label set small (the metric is per-label, so cardinality matters).
+func classifyCommandError(err error) string {
+	if err == nil {
+		return ""
+	}
+	switch {
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "timeout"
+	case errors.Is(err, redis.ErrClosed):
+		return "client_closed"
+	case errors.Is(err, redis.Nil):
+		// redis.Nil is "key not found" — that is a valid command outcome,
+		// not a failure. We should never hit this branch (callers handle it
+		// before the hook gets the err), but stay defensive.
+		return "nil_reply"
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "pool exhausted") || strings.Contains(msg, "pool timeout"):
+		return "pool_timeout"
+	case strings.Contains(msg, "NOAUTH") || strings.Contains(msg, "WRONGPASS"):
+		return "auth"
+	case strings.Contains(msg, "i/o timeout"):
+		return "timeout"
+	case strings.Contains(msg, "connection reset") || strings.Contains(msg, "broken pipe"):
+		return "connection_reset"
+	case strings.Contains(msg, "EOF"):
+		return "eof"
+	}
+	return "other"
+}
+
+// classifyDialError covers the dial-time failure modes (TCP connect + TLS
+// handshake). These are upstream-network shapes; a sudden uptick almost
+// always means a config or routing problem outside Redis itself.
+func classifyDialError(err error) string {
+	if err == nil {
+		return ""
+	}
+	if errors.Is(err, context.Canceled) {
+		return "canceled"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "x509:") || strings.Contains(msg, "tls:"):
+		return "tls_handshake"
+	case strings.Contains(msg, "no such host"):
+		return "dns"
+	case strings.Contains(msg, "connection refused"):
+		return "connection_refused"
+	case strings.Contains(msg, "i/o timeout") || strings.Contains(msg, "deadline exceeded"):
+		return "timeout"
+	}
+	return "other"
+}
+
+// AttachRedisObservability registers the metrics hook and starts a goroutine
+// that scrapes the pool stats every interval. The returned function cancels
+// the scraper goroutine; the caller defers it (typically the datastore
+// cleanup chain). Lite (Redis nil) is a no-op.
+//
+// The scraper is a closure so the "last seen cumulative timeouts" counter
+// (used to compute per-scrape DELTAS for the Prometheus counter, since
+// go-redis exposes Timeouts as a cumulative value) is goroutine-local — no
+// shared mutable state.
+func AttachRedisObservability(ctx context.Context, r *Redis, m RedisMetrics, interval time.Duration) func() {
+	if r == nil || m == nil {
+		return func() {}
+	}
+	r.Client.AddHook(newRedisObservabilityHook(m))
+	var lastTimeouts uint32
+	scrape := func() { lastTimeouts = updateRedisPool(r, m, lastTimeouts) }
+	// One initial snapshot so the gauges are populated from t=0 instead of
+	// waiting `interval` for the first tick.
+	scrape()
+	scrapeCtx, cancel := context.WithCancel(ctx)
+	go func() {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-scrapeCtx.Done():
+				return
+			case <-t.C:
+				scrape()
+			}
+		}
+	}()
+	return cancel
+}
+
+// updateRedisPool snapshots go-redis's PoolStats into the gauge set and
+// returns the cumulative timeouts seen so the caller can compute the next
+// delta. It is cheap (struct copy under a sync.Mutex inside go-redis) so the
+// scraper can run every few seconds without affecting hot paths.
+func updateRedisPool(r *Redis, m RedisMetrics, lastTimeouts uint32) uint32 {
+	if r == nil || r.Client == nil {
+		return lastTimeouts
+	}
+	ps := r.Client.PoolStats()
+	// PoolStats.Timeouts is cumulative since process start; the exported
+	// metric is a Counter, so we increment by the DELTA each scrape.
+	delta := ps.Timeouts - lastTimeouts
+	for i := uint32(0); i < delta; i++ {
+		m.RecordRedisPoolTimeout()
+	}
+	m.UpdateRedisPoolStats(ps.IdleConns+ps.StaleConns, ps.IdleConns, ps.TotalConns)
+	return ps.Timeouts
+}

--- a/internal/storage/redis_observability.go
+++ b/internal/storage/redis_observability.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -25,18 +26,42 @@ type RedisMetrics interface {
 // observabilityHook implements redis.Hook. It runs *around* every command and
 // every dial, classifying any error into one of a small bounded label set so
 // alerts can be keyed by reason without unbounded cardinality.
+//
+// inShutdown is the tripwire mirror of the scheduler's steppingDown flag
+// (#311). Graceful shutdown cascades context cancellation through every
+// in-flight command, which would otherwise spike the failures counter with
+// false positives ({reason="canceled"} burst right when the operator stopped
+// the process). When the flag is true the hook is a silent no-op for the
+// rest of the shutdown window; AttachRedisObservability flips it inside the
+// stop function returned to the caller's cleanup chain.
 type observabilityHook struct {
-	metrics RedisMetrics
+	metrics    RedisMetrics
+	inShutdown atomic.Bool
 }
 
-func newRedisObservabilityHook(m RedisMetrics) redis.Hook { return &observabilityHook{metrics: m} }
+func newRedisObservabilityHook(m RedisMetrics) *observabilityHook {
+	return &observabilityHook{metrics: m}
+}
+
+// markShutdown opens the shutdown window — every subsequent ProcessHook /
+// DialHook becomes a silent no-op for the rest of the process lifetime. The
+// terminal-state simplification means we never need to flip it back. The
+// cleanup chain in main.go calls this BEFORE rd.Close() so the cascade of
+// ctx-canceled / client_closed errors from in-flight commands doesn't spike
+// the per-reason failures counter (#311 tripwire pattern).
+func (h *observabilityHook) markShutdown() { h.inShutdown.Store(true) }
 
 // DialHook wraps go-redis's net.Dial. A failure here means we never reached
 // Redis — the root cause is upstream (DNS, TLS, firewall). The latency
 // observation covers both the TCP handshake and (for rediss://) the TLS
-// handshake.
+// handshake. During shutdown the hook is silent: no dial happens once we
+// start closing, and a dial that races shutdown is by definition not a
+// signal worth alerting on.
 func (h *observabilityHook) DialHook(next redis.DialHook) redis.DialHook {
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if h.inShutdown.Load() {
+			return next(ctx, network, addr)
+		}
 		start := time.Now()
 		conn, err := next(ctx, network, addr)
 		h.metrics.ObserveRedisDialDuration(time.Since(start))
@@ -49,9 +74,15 @@ func (h *observabilityHook) DialHook(next redis.DialHook) redis.DialHook {
 
 // ProcessHook wraps every individual command. We see the post-retry final
 // outcome go-redis returns to the caller; transient retries inside the client
-// are invisible by design.
+// are invisible by design. During shutdown the hook becomes a silent passthrough
+// so the cascade of expected ctx-canceled / client_closed errors from
+// in-flight commands does NOT spike the failures counter (false alarm shape
+// that motivated #311).
 func (h *observabilityHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
 	return func(ctx context.Context, cmd redis.Cmder) error {
+		if h.inShutdown.Load() {
+			return next(ctx, cmd)
+		}
 		err := next(ctx, cmd)
 		if err != nil {
 			h.metrics.RecordRedisCommandFailure(classifyCommandError(err))
@@ -64,9 +95,12 @@ func (h *observabilityHook) ProcessHook(next redis.ProcessHook) redis.ProcessHoo
 // the pipeline-level error the same way; per-command errors inside the
 // pipeline are surfaced by go-redis through individual Cmder.Err() values
 // the caller inspects, but the pipeline-level error captures "the network
-// died" cases that affect the whole batch.
+// died" cases that affect the whole batch. Same shutdown short-circuit.
 func (h *observabilityHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
 	return func(ctx context.Context, cmds []redis.Cmder) error {
+		if h.inShutdown.Load() {
+			return next(ctx, cmds)
+		}
 		err := next(ctx, cmds)
 		if err != nil {
 			h.metrics.RecordRedisCommandFailure(classifyCommandError(err))
@@ -152,7 +186,8 @@ func AttachRedisObservability(ctx context.Context, r *Redis, m RedisMetrics, int
 	if r == nil || m == nil {
 		return func() {}
 	}
-	r.Client.AddHook(newRedisObservabilityHook(m))
+	hook := newRedisObservabilityHook(m)
+	r.Client.AddHook(hook)
 	var lastTimeouts uint32
 	scrape := func() { lastTimeouts = updateRedisPool(r, m, lastTimeouts) }
 	// One initial snapshot so the gauges are populated from t=0 instead of
@@ -171,7 +206,14 @@ func AttachRedisObservability(ctx context.Context, r *Redis, m RedisMetrics, int
 			}
 		}
 	}()
-	return cancel
+	// Returned stop: flip the shutdown tripwire BEFORE canceling the scraper.
+	// Callers chain this before rd.Close() so the in-flight commands that
+	// fan out ctx-canceled / client_closed during Close() hit a silent hook
+	// instead of spiking the failure counter — Furo 5 from the joint review.
+	return func() {
+		hook.markShutdown()
+		cancel()
+	}
 }
 
 // updateRedisPool snapshots go-redis's PoolStats into the gauge set and

--- a/internal/storage/redis_observability_test.go
+++ b/internal/storage/redis_observability_test.go
@@ -1,0 +1,257 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// fakeRedisMetrics records every metric call so tests can assert the contract
+// without standing up a Prometheus registry. Concurrency-safe because the
+// pool-stats scraper runs in its own goroutine.
+type fakeRedisMetrics struct {
+	mu            sync.Mutex
+	cmdFailures   map[string]int
+	dialFailures  map[string]int
+	dialDurations []time.Duration
+	poolActive    int64
+	poolIdle      int64
+	poolTotal     int64
+	poolTimeouts  int
+	updateCalls   int
+}
+
+func newFakeRedisMetrics() *fakeRedisMetrics {
+	return &fakeRedisMetrics{
+		cmdFailures:  map[string]int{},
+		dialFailures: map[string]int{},
+	}
+}
+
+func (f *fakeRedisMetrics) RecordRedisCommandFailure(reason string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cmdFailures[reason]++
+}
+func (f *fakeRedisMetrics) RecordRedisDialFailure(reason string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.dialFailures[reason]++
+}
+func (f *fakeRedisMetrics) ObserveRedisDialDuration(d time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.dialDurations = append(f.dialDurations, d)
+}
+func (f *fakeRedisMetrics) UpdateRedisPoolStats(active, idle, total uint32) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.poolActive = int64(active)
+	f.poolIdle = int64(idle)
+	f.poolTotal = int64(total)
+	f.updateCalls++
+}
+func (f *fakeRedisMetrics) RecordRedisPoolTimeout() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.poolTimeouts++
+}
+
+func (f *fakeRedisMetrics) cmdCount(reason string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.cmdFailures[reason]
+}
+func (f *fakeRedisMetrics) dialCount(reason string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.dialFailures[reason]
+}
+
+// TestClassifyCommandError pins the bounded label set for command errors —
+// the metric is per-label, so any new shape MUST map to one of these reasons
+// (not a unique cardinality-exploding string from the upstream error). #311's
+// per-reason rate-of-events contract relies on this.
+func TestClassifyCommandError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "nil → empty", err: nil, want: ""},
+		{name: "context.Canceled → canceled", err: context.Canceled, want: "canceled"},
+		{name: "context.DeadlineExceeded → timeout", err: context.DeadlineExceeded, want: "timeout"},
+		{name: "fmt.Errorf %w canceled → canceled (unwrap)", err: fmt.Errorf("getting xcom: %w", context.Canceled), want: "canceled"},
+		{name: "redis.ErrClosed → client_closed", err: redis.ErrClosed, want: "client_closed"},
+		{name: "redis.Nil → nil_reply (defensive)", err: redis.Nil, want: "nil_reply"},
+		// NOAUTH / WRONGPASS are verbatim Redis reply prefixes — keep the
+		// case as Redis emits so the classifier matches what hits prod.
+		{name: "NOAUTH → auth", err: errors.New("redis: NOAUTH Authentication required"), want: "auth"}, //nolint:revive // verbatim Redis reply prefix
+		{name: "WRONGPASS → auth", err: errors.New("redis: WRONGPASS invalid password"), want: "auth"},  //nolint:revive // verbatim Redis reply prefix
+		{name: "i/o timeout → timeout", err: errors.New("read tcp 10.0.0.1:6379: i/o timeout"), want: "timeout"},
+		{name: "connection reset → connection_reset", err: errors.New("write tcp 10.0.0.1:6379: connection reset by peer"), want: "connection_reset"},
+		{name: "broken pipe → connection_reset", err: errors.New("write tcp 10.0.0.1:6379: broken pipe"), want: "connection_reset"},
+		{name: "EOF → eof", err: errors.New("EOF"), want: "eof"},
+		{name: "pool exhausted → pool_timeout", err: errors.New("redis: connection pool exhausted"), want: "pool_timeout"},
+		{name: "unknown shape → other (long-tail bucket)", err: errors.New("MOVED 1234 10.0.0.5:6379"), want: "other"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyCommandError(tc.err); got != tc.want {
+				t.Errorf("classifyCommandError(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassifyDialError pins the upstream-network failure shapes — a sudden
+// rate spike on RedisDialFailures{reason="tls_handshake"} catches a managed
+// Redis TLS misconfig (#312) before it surfaces as command errors.
+func TestClassifyDialError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "nil → empty", err: nil, want: ""},
+		{name: "context.Canceled → canceled", err: context.Canceled, want: "canceled"},
+		{name: "context.DeadlineExceeded → timeout", err: context.DeadlineExceeded, want: "timeout"},
+		{name: "x509 unknown CA → tls_handshake (Memorystore/ElastiCache shape)", err: errors.New("tls: failed to verify certificate: x509: certificate signed by unknown authority"), want: "tls_handshake"},
+		{name: "TLS handshake timeout → tls_handshake", err: errors.New("tls: handshake failed: read tcp: i/o timeout"), want: "tls_handshake"},
+		{name: "DNS lookup failure → dns", err: errors.New("dial tcp: lookup redis-broken.local: no such host"), want: "dns"},
+		{name: "connection refused → connection_refused", err: errors.New("dial tcp 127.0.0.1:6379: connect: connection refused"), want: "connection_refused"},
+		{name: "dial i/o timeout → timeout", err: errors.New("dial tcp 10.0.0.1:6379: i/o timeout"), want: "timeout"},
+		{name: "unknown shape → other", err: errors.New("blackhole route"), want: "other"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyDialError(tc.err); got != tc.want {
+				t.Errorf("classifyDialError(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestObservabilityHookCountsCommandFailures: the ProcessHook must count the
+// final error go-redis returns to the caller, classified by reason. A nil
+// error must NOT increment (the metric is a failure counter, not a command
+// counter).
+func TestObservabilityHookCountsCommandFailures(t *testing.T) {
+	fm := newFakeRedisMetrics()
+	hook := newRedisObservabilityHook(fm)
+	process := hook.ProcessHook(func(context.Context, redis.Cmder) error {
+		return errors.New("redis: NOAUTH Authentication required") //nolint:revive // verbatim Redis reply prefix
+	})
+	if err := process(context.Background(), redis.NewCmd(context.Background(), "GET", "k")); err == nil {
+		t.Fatal("expected error to propagate")
+	}
+	if got := fm.cmdCount("auth"); got != 1 {
+		t.Errorf("auth count = %d, want 1", got)
+	}
+
+	processOK := hook.ProcessHook(func(context.Context, redis.Cmder) error { return nil })
+	if err := processOK(context.Background(), redis.NewCmd(context.Background(), "GET", "k")); err != nil {
+		t.Fatal(err)
+	}
+	if got := fm.cmdCount("other"); got != 0 {
+		t.Errorf("success must not bump the failure counter; got other=%d", got)
+	}
+}
+
+// TestAttachRedisObservabilityNilSafe pins the Lite contract: with no Redis
+// configured selectDatastore returns rd=nil, and the cleanup chain MUST tolerate
+// that without panic. Similarly a nil metrics target is a no-op (defensive — the
+// Lite branch never gets here, but we don't want a future caller to NPE).
+func TestAttachRedisObservabilityNilSafe(t *testing.T) {
+	t.Run("nil Redis → no-op", func(t *testing.T) {
+		stop := AttachRedisObservability(context.Background(), nil, newFakeRedisMetrics(), time.Hour)
+		stop() // must not panic
+	})
+	t.Run("nil metrics → no-op", func(t *testing.T) {
+		stop := AttachRedisObservability(context.Background(), &Redis{Client: redis.NewClient(&redis.Options{Addr: "127.0.0.1:0"})}, nil, time.Hour)
+		stop()
+	})
+}
+
+// TestAttachRedisObservabilityScrapesPool exercises the goroutine path: a real
+// (offline) go-redis client + a fake metrics target, started with a tiny
+// scrape interval. We don't need Redis to actually accept connections; we
+// only care that the scrape goroutine populates the pool gauges from the
+// client's PoolStats(). The closure pattern (no shared mutable state) is
+// validated implicitly — go test -race would catch a data race.
+func TestAttachRedisObservabilityScrapesPool(t *testing.T) {
+	fm := newFakeRedisMetrics()
+	// 127.0.0.1:0 is a safe "nowhere" address — the dial will fail on first
+	// command but PoolStats() works on the unused client too.
+	rd := &Redis{Client: redis.NewClient(&redis.Options{Addr: "127.0.0.1:0"})}
+	defer rd.Close()
+
+	stop := AttachRedisObservability(context.Background(), rd, fm, 5*time.Millisecond)
+	defer stop()
+
+	// Wait for the initial sync scrape PLUS at least one ticker scrape.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		fm.mu.Lock()
+		calls := fm.updateCalls
+		fm.mu.Unlock()
+		if calls >= 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	fm.mu.Lock()
+	calls := fm.updateCalls
+	fm.mu.Unlock()
+	if calls < 2 {
+		t.Errorf("expected the scraper goroutine to run at least once after the initial sync scrape; updateCalls = %d", calls)
+	}
+}
+
+// TestObservabilityHookObservesEveryDial: every dial — success or failure —
+// records a duration sample (so a flapping TLS path is visible as a P99
+// spike even when retries hide the error). On failure the reason counter
+// fires too.
+func TestObservabilityHookObservesEveryDial(t *testing.T) {
+	fm := newFakeRedisMetrics()
+	hook := newRedisObservabilityHook(fm)
+
+	t.Run("successful dial: latency recorded, no failure counter", func(t *testing.T) {
+		// Use a net.Pipe end as a throwaway non-nil net.Conn — nilnil bans
+		// returning (nil, nil) and Pipe() is the cheapest stdlib way to get a
+		// valid Conn we close immediately.
+		_, end := net.Pipe()
+		defer end.Close()
+		ok := hook.DialHook(func(context.Context, string, string) (net.Conn, error) { return end, nil })
+		_, err := ok(context.Background(), "tcp", "redis:6379")
+		if err != nil {
+			t.Fatal(err)
+		}
+		fm.mu.Lock()
+		samples := len(fm.dialDurations)
+		fm.mu.Unlock()
+		if samples != 1 {
+			t.Errorf("expected 1 dial sample, got %d", samples)
+		}
+	})
+
+	t.Run("TLS handshake failure: latency + tls_handshake counter", func(t *testing.T) {
+		fmBefore := fm.dialCount("tls_handshake")
+		bad := hook.DialHook(func(context.Context, string, string) (net.Conn, error) {
+			return nil, errors.New("tls: failed to verify certificate: x509: certificate signed by unknown authority")
+		})
+		_, err := bad(context.Background(), "tcp", "redis:6379")
+		if err == nil {
+			t.Fatal("expected error to propagate")
+		}
+		if got := fm.dialCount("tls_handshake"); got != fmBefore+1 {
+			t.Errorf("tls_handshake count = %d, want %d", got, fmBefore+1)
+		}
+	})
+}

--- a/internal/storage/redis_observability_test.go
+++ b/internal/storage/redis_observability_test.go
@@ -164,6 +164,87 @@ func TestObservabilityHookCountsCommandFailures(t *testing.T) {
 	}
 }
 
+// TestObservabilityHookSilentDuringShutdown pins the #311 tripwire ported
+// to Redis: once the stop function returned by AttachRedisObservability has
+// been called, every hook becomes a silent passthrough. Without this guard,
+// the cascade of ctx-canceled / client_closed errors that fan out the moment
+// rd.Close() runs spikes leoflow_redis_command_failures_total{reason="canceled"}
+// (false alarm — operators paged on a clean shutdown). Furo 5 from the joint
+// PG/Redis solution review.
+func TestObservabilityHookSilentDuringShutdown(t *testing.T) {
+	fm := newFakeRedisMetrics()
+	hook := newRedisObservabilityHook(fm)
+
+	// Sanity: a failure BEFORE shutdown is recorded.
+	failing := hook.ProcessHook(func(context.Context, redis.Cmder) error {
+		return context.Canceled
+	})
+	if err := failing(context.Background(), redis.NewCmd(context.Background(), "GET", "k")); err == nil {
+		t.Fatal("expected error to propagate")
+	}
+	if got := fm.cmdCount("canceled"); got != 1 {
+		t.Fatalf("pre-shutdown failure should count; canceled = %d", got)
+	}
+
+	// Trip the shutdown window.
+	hook.markShutdown()
+
+	// Same failure shape, post-shutdown: must NOT increment.
+	if err := failing(context.Background(), redis.NewCmd(context.Background(), "GET", "k")); err == nil {
+		t.Fatal("expected error to propagate during shutdown")
+	}
+	if got := fm.cmdCount("canceled"); got != 1 {
+		t.Errorf("shutdown window must silence the counter; canceled = %d (want still 1)", got)
+	}
+
+	// Dial during shutdown also silent — no extra latency sample, no failure count.
+	beforeSamples := len(fm.dialDurations)
+	beforeFailures := fm.dialCount("connection_refused")
+	dialing := hook.DialHook(func(context.Context, string, string) (net.Conn, error) {
+		return nil, errors.New("dial tcp 127.0.0.1:6379: connect: connection refused")
+	})
+	if _, err := dialing(context.Background(), "tcp", "redis:6379"); err == nil {
+		t.Fatal("expected error to propagate during shutdown")
+	}
+	if got := len(fm.dialDurations); got != beforeSamples {
+		t.Errorf("shutdown dial recorded a duration sample (%d → %d)", beforeSamples, got)
+	}
+	if got := fm.dialCount("connection_refused"); got != beforeFailures {
+		t.Errorf("shutdown dial bumped the failure counter (%d → %d)", beforeFailures, got)
+	}
+}
+
+// TestStopFunctionMarksShutdownBeforeClose pins the cleanup ordering: the
+// stop function MUST flip the tripwire before any teardown noise reaches the
+// hook. We can't run the real Close() path here (no live Redis), but we can
+// assert that after stop() runs the hook ignores subsequent failures —
+// proving the order is "mark first" rather than just "cancel scraper".
+func TestStopFunctionMarksShutdownBeforeClose(t *testing.T) {
+	fm := newFakeRedisMetrics()
+	rd := &Redis{Client: redis.NewClient(&redis.Options{Addr: "127.0.0.1:0"})}
+	defer rd.Close()
+	stop := AttachRedisObservability(context.Background(), rd, fm, time.Hour)
+
+	stop()
+
+	// AddHook attached our hook; retrieve it via a fresh execution.
+	// Find the hook on the client.
+	// We can't directly read it back from the client, but we can trigger a
+	// failure on a fresh command and assert it's NOT counted.
+	// (Hook order: our hook → built-in. A no-op return path means we counted
+	// nothing.)
+	if got := len(fm.cmdFailures); got != 0 {
+		t.Fatalf("no commands ran yet; cmdFailures should be empty, got %v", fm.cmdFailures)
+	}
+
+	// Run a doomed command on the (offline) client. It will fail, but the
+	// hook has been tripped to silent — so no counter increment.
+	_ = rd.Client.Get(context.Background(), "any-key").Err()
+	if got := fm.cmdFailures["canceled"] + fm.cmdFailures["other"] + fm.cmdFailures["connection_refused"]; got != 0 {
+		t.Errorf("post-stop command incremented the counter: %v", fm.cmdFailures)
+	}
+}
+
 // TestAttachRedisObservabilityNilSafe pins the Lite contract: with no Redis
 // configured selectDatastore returns rd=nil, and the cleanup chain MUST tolerate
 // that without panic. Similarly a nil metrics target is a no-op (defensive — the


### PR DESCRIPTION
Ports the leader-churn observability pattern from #322 (issue #311) to the Redis client. Pro-only — Lite uses Postgres + the in-process tailer per ADR 0026, so on Lite the new gauges stay at zero.

## TL;DR for operators
Five new Prometheus surfaces — alert on **rate** and **P99**, not on log content:
- \`leoflow_redis_command_failures_total{reason="timeout|connection_reset|auth|pool_timeout|eof|nil_reply|client_closed|canceled|other"}\` — every command go-redis returns to the caller (after its internal retries) classified into a bounded label set.
- \`leoflow_redis_dial_failures_total{reason="tls_handshake|dns|connection_refused|timeout|canceled|other"}\` — failures at dial time, separated from command failures because a dial miss means we never reached Redis (DNS, TLS, network).
- \`leoflow_redis_dial_duration_seconds\` — TCP + TLS handshake latency histogram (10ms-5s buckets). A flapping rediss:// path surfaces as a P99 spike before commands start erroring.
- \`leoflow_redis_pool_{active,idle,total}_conns\` — gauges scraped from go-redis PoolStats() every 5s. Saturating against PoolSize is the leading indicator of throughput issues.
- \`leoflow_redis_pool_timeouts_total\` — pool-checkout timeouts (caller waited PoolTimeout for an idle connection).

## How it works
- \`internal/storage/redis_observability.go\` — \`observabilityHook\` implements \`redis.Hook\` (\`DialHook\` + \`ProcessHook\` + \`ProcessPipelineHook\`). Each command and dial is timed if needed and any non-nil error is classified.
- \`classifyCommandError\` / \`classifyDialError\` do prefix/substring matching on the long-tail strings go-redis surfaces (NOAUTH, WRONGPASS, x509, no such host, connection refused, pool exhausted, …). Table-driven tests pin every shape so a new error class is intentional, not silent drift.
- \`AttachRedisObservability\` spins a goroutine scraping PoolStats every 5s. The "last cumulative timeouts" counter (PoolStats.Timeouts is cumulative; we publish a Counter that needs deltas) is **closure-local** — no shared mutable state, no mutex.
- \`cmd/leoflow-server/main.go\`: \`selectDatastore\` now takes \`*observability.Metrics\` and calls \`AttachRedisObservability\` on the Pro path. Cleanup is wired into the existing \`dsCleanup\` chain.

## Why now (no incident report yet)
Per the user's explicit choice: when the next managed-Redis hiccup happens (Memorystore maintenance window, ElastiCache failover, Azure Cache restart), we want the metric **already there**. Instrumenting post-incident is twice the work — once to instrument, once to validate against the failure mode you just saw.

## Test plan
- [x] \`TestClassifyCommandError\` — 14 cases covering every reason + the long-tail "other"
- [x] \`TestClassifyDialError\` — 9 cases including the Memorystore/ElastiCache \`x509: certificate signed by unknown authority\` shape that motivates #312
- [x] \`TestObservabilityHookCountsCommandFailures\` — classifies final error; doesn't bump on success
- [x] \`TestObservabilityHookObservesEveryDial\` — success + failure both record a duration sample
- [x] \`TestAttachRedisObservabilityNilSafe\` — Lite path (nil Redis) and defensive nil-metrics path don't panic
- [x] \`TestAttachRedisObservabilityScrapesPool\` — goroutine runs initial sync scrape PLUS at least one ticker tick within 2s
- [x] Coverage 80.0% (gate passes)
- [ ] Live Pro: assert /metrics shows the new series, names match values.yaml docs (no live cluster needed if the Helm chart-test renders)

## Follow-ups (separate issues if it becomes warranted)
- /readyz tolerance (debounce N consecutive Ping failures like \`maxLeaderCheckFailures\`) — preemptive, not in this PR
- Per-command latency histogram (high cardinality — defer until we see a hot-path command that warrants it)