### PR TITLE
feat: google_cloud_platform connector (keyless-first) — example, structural probe, ADR 0035

### DIFF
--- a/docs/adr/0035-cloud-connector-auth-keyless-first.md
+++ b/docs/adr/0035-cloud-connector-auth-keyless-first.md
@@ -1,0 +1,107 @@
+# ADR 0035: Cloud connector auth — keyless-first; Leoflow is not a key manager
+
+**Status:** Accepted
+**Date:** 2026-06-02
+**Supersedes:** none (realizes the `google_cloud_platform` part of #77 and the workload-identity intent of #56; companions #312, #315)
+
+## Context
+
+Leoflow needs cloud connectors (starting with `google_cloud_platform`) so DAG
+tasks can reach managed services (GCS, BigQuery, Pub/Sub, …). Airflow's provider
+model is the obvious reference — operators expect an `AIRFLOW_CONN_*` connection
+and a `google_cloud_platform` shape — and we want existing Airflow connections to
+drop in. But Airflow's model also carries history we do **not** want to inherit
+wholesale: the `extra__google_cloud_platform__*` field-name prefix, a key-centric
+default, and a long tail of credential fields.
+
+Two facts shaped this decision during the GKE Pro validation:
+
+1. **Keyless is the secure default in practice.** The test project's org enforced
+   `constraints/iam.disableServiceAccountKeyCreation` — service-account JSON keys
+   could not be created at all. Many enterprises do the same. A connector whose
+   default is "paste a key" is dead on arrival there.
+2. **The delivery path is already key-agnostic.** Connections are encrypted at
+   rest (ADR 0019) and delivered to tasks as `AIRFLOW_CONN_*` over the TLS agent
+   channel (ADR 0021); the Go control plane runs no provider hooks (ADR 0014).
+   Credential *resolution* belongs in the task (Python), not in core.
+
+We validated end-to-end on GKE: a real DAG (`gcp_gcs_load`) wrote and read a GCS
+object via **keyless Workload Identity** — the task pod ran as a KSA bound to a
+GCP service account, no key anywhere.
+
+## Decision
+
+**Leoflow is not a secrets/key manager.** It orchestrates; it does not aspire to
+own credential material. For cloud connectors this is a hard stance: credentials
+come from the **runtime identity** (keyless) or from a **secret the platform
+manages**, which the connection only *references* — Leoflow does not store the
+cloud key.
+
+1. **Keyless is the default and the recommendation.** Empty key fields →
+   Application Default Credentials. On Pro/GKE that is **Workload Identity** (the
+   task pod's KSA bound to a GCP service account — Leoflow already supports a
+   per-task `execution.service_account`, and the chart exposes a default KSA); on
+   Lite it is host ADC under the subprocess executor.
+
+2. **Otherwise, reference a platform-managed secret — don't store the key in
+   Leoflow:**
+   - **`key_path` + a mounted Kubernetes Secret** — the key lives in the
+     cluster's secret store; the connection holds only the path. The key never
+     enters Leoflow's DB, API, or UI.
+   - **`key_secret_name` + Secret Manager** (deferred) — the connection holds a
+     reference; the task fetches at runtime. (Reading it needs an identity, which
+     is the keyless bootstrap problem — so prefer keyless directly.)
+
+3. **`keyfile_dict` (the key stored in the connection) is accepted for Airflow
+   compatibility but explicitly discouraged.** It makes Leoflow hold the key,
+   which contradicts the stance above. It is the cloud-key analog of how
+   connections today store a database **user/password** encrypted at rest (ADR
+   0019): pragmatic and Airflow-compatible, but **not the desirable posture**. We
+   keep it as a documented escape hatch (dev / low-criticality), never the
+   recommended path — and org policy often forbids creating such keys anyway.
+
+4. **Resolution order in the task:** `keyfile_dict` → `key_path` → ADC. Field
+   names are clean short names (`keyfile_dict`, `key_path`, `project`, `scopes`,
+   `num_retries`); the legacy `extra__google_cloud_platform__<name>` names are
+   accepted as a migration fallback only. `scopes` takes a list **or** a comma
+   string (Airflow takes only the string).
+
+5. **No cloud SDK in the Go control plane.** Connection validation is
+   **structural only** (check the key shape, or report keyless); the token
+   exchange happens in the task. Keeps core connector-agnostic and avoids a Go
+   cloud-SDK supply-chain surface (consistent with ADR 0014).
+
+6. **v1 scope.** Handle `keyfile_dict`, `key_path`, `project`/`project_id`,
+   `scopes`/`scope`, `num_retries`. Defer `key_secret_name`,
+   `key_secret_project_id`, `credential_config_file`, `impersonation_chain`,
+   `quota_project_id`.
+
+7. **Generalizes to future cloud connectors** (AWS, Azure): same stance —
+   platform-native keyless first (Workload Identity / IRSA / Azure Workload
+   Identity), a secret-store **reference** next, an in-connection key only as a
+   discouraged compat fallback; resolve in the task, never in core.
+
+## Consequences
+
+- **Portable + secure by default.** Works where keys are forbidden (the common
+  enterprise posture); the recommended paths store no cloud key in Leoflow.
+- **Honest about the existing exception.** Database connections still store
+  user/password encrypted (ADR 0019); this ADR names that as the not-desirable
+  pattern we explicitly do **not** extend to cloud keys.
+- **Familiar.** Airflow GCP connections and `AIRFLOW_CONN_*` consumers keep
+  working; field names are a strict superset of Airflow's short names.
+- **Edition split is explicit.** Keyless on Lite is subprocess-only (k3d has no
+  metadata server → reference a key there); Pro/GKE gets full Workload Identity.
+- **Open follow-ups:** verified TLS to managed datastores (Redis #312, Postgres
+  #315); `key_secret_name` (Secret Manager) and live (token-minting) probes are
+  deferred; a future ADR may move database credentials toward the same
+  reference-a-secret model.
+
+## Alternatives considered
+
+- **Faithfully mirror Airflow** (legacy field prefix, key-first default, store
+  the key). Rejected: inherits cruft and makes Leoflow a key store, against the
+  stance above, for no migration benefit beyond the compatible superset.
+- **Resolve credentials in the Go control plane** (pull a Go cloud SDK into core,
+  probe live). Rejected: violates ADR 0014's no-provider-hooks-in-core posture,
+  adds supply-chain surface, and token checks belong where the code runs — the task.

--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -37,4 +37,5 @@ The *why* behind Leoflow's design. ADRs are immutable once accepted.
 - [ADR 0032: Task Return Values Are Not Logged — Only Their Metadata Is](adr/0032-return-values-not-logged.md)
 - [ADR 0033: Release Flow — RC Tags, E2E Gates, and Immutable Versions](adr/0033-release-flow-rc-tags-and-e2e-gates.md)
 - [ADR 0034: Fan-in / map-reduce — list-of-upstream parameter binding](adr/0034-fan-in-map-reduce-binding.md)
+- [ADR 0035: Cloud connector auth — keyless-first; Leoflow is not a key manager](adr/0035-cloud-connector-auth-keyless-first.md)
 <!-- END ADR INDEX -->

--- a/docs/connections/google_cloud_platform.md
+++ b/docs/connections/google_cloud_platform.md
@@ -1,0 +1,78 @@
+# `google_cloud_platform` — Google Cloud connection
+
+Connect tasks to Google Cloud (GCS, BigQuery, Pub/Sub, …) with a managed
+Connection, in **two auth modes**: **keyless** (Workload Identity / ADC —
+recommended) and **service-account key** (encrypted at rest).
+
+The connection follows Airflow's `google_cloud_platform` shape — an existing
+Airflow GCP connection drops in unchanged — with cleaner short field names and
+keyless as the default.
+
+## URI shape
+
+GCP carries no host/login/password — everything lives in **Extra**. The control
+plane delivers it as `AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT`:
+
+```
+google-cloud-platform://?__extra__=<url-encoded JSON>
+```
+
+## Extra fields
+
+Short names are canonical; the legacy `extra__google_cloud_platform__<name>`
+form is also accepted.
+
+| Field | Meaning |
+|---|---|
+| `keyfile_dict` | Service-account JSON, inline (key mode). **Encrypted at rest** (ADR 0019). |
+| `key_path` | Path to a service-account JSON file mounted in the task (key mode). |
+| `project` / `project_id` | GCP project (optional). |
+| `scopes` / `scope` | OAuth scopes — a list **or** a comma-separated string. |
+| `num_retries` | Pass-through to your GCP client (optional). |
+
+**Resolution order (first match wins):** `keyfile_dict` → `key_path` →
+**ADC (keyless)**. Leave all key fields empty for keyless.
+
+Not handled in v1: `key_secret_name`, `key_secret_project_id`,
+`credential_config_file`, `impersonation_chain`, `quota_project_id`.
+
+## Auth modes
+
+### Keyless (recommended)
+No key in the Connection. Credentials come from Application Default Credentials:
+
+- **Pro (GKE):** **Workload Identity** — the task pod runs as a Kubernetes SA
+  bound to a GCP service account; no key ever touches the cluster. See the
+  chart's task-ServiceAccount knob and issue #56.
+- **Lite (subprocess):** your host ADC (`gcloud auth application-default login`
+  or `GOOGLE_APPLICATION_CREDENTIALS`).
+- **Lite (k3d):** no metadata server → keyless unavailable; use key mode.
+
+### Key (service-account JSON)
+Paste the SA JSON into Extra as `keyfile_dict` (encrypted at rest), or point
+`key_path` at a file mounted in the task. Works on every executor.
+
+## Lite vs Pro
+
+| | Lite (subprocess) | Lite (k3d) | Pro (GKE) |
+|---|---|---|---|
+| Keyless (ADC) | ✅ host ADC | ❌ (no metadata server) | ✅ Workload Identity |
+| Key (`keyfile_dict` / `key_path`) | ✅ | ✅ | ✅ |
+
+## Security
+
+Prefer **keyless** in Pro — no long-lived key to store or rotate. When you must
+use a key, `keyfile_dict` is encrypted at rest with the control plane's
+`LEOFLOW_SECRET_KEY` (ADR 0019) and delivered only over the TLS agent channel
+(ADR 0021).
+
+## Example DAG + test
+
+- Example: [examples/gcp_gcs_load](https://github.com/neochaotic/leoflow/tree/main/examples/gcp_gcs_load)
+  — writes + reads a GCS object in both modes, with a clean `gcp_credentials()`
+  helper.
+- Delivery (chain-of-custody) is covered by an automated test that round-trips a
+  synthetic key through encryption + `__extra__` (no real cloud needed); a real
+  end-to-end run against GCS is documented as manual in the example README.
+
+See also: [variables-connections.md](../variables-connections.md), ADR 0019, ADR 0021.

--- a/docs/connections/google_cloud_platform.md
+++ b/docs/connections/google_cloud_platform.md
@@ -59,12 +59,23 @@ Paste the SA JSON into Extra as `keyfile_dict` (encrypted at rest), or point
 | Keyless (ADC) | ✅ host ADC | ❌ (no metadata server) | ✅ Workload Identity |
 | Key (`keyfile_dict` / `key_path`) | ✅ | ✅ | ✅ |
 
-## Security
+## Security — Leoflow is not a key manager
 
-Prefer **keyless** in Pro — no long-lived key to store or rotate. When you must
-use a key, `keyfile_dict` is encrypted at rest with the control plane's
-`LEOFLOW_SECRET_KEY` (ADR 0019) and delivered only over the TLS agent channel
-(ADR 0021).
+Credentials should come from the **runtime identity** (keyless) or from a
+**secret the platform manages**, which the connection only *references*. Leoflow
+does not aspire to store cloud keys (see [ADR 0035](../adr/0035-cloud-connector-auth-keyless-first.md)).
+In order of preference:
+
+1. **Keyless (Workload Identity / ADC)** — recommended. No key anywhere.
+2. **`key_path` + a mounted Kubernetes Secret** — the key lives in the cluster's
+   secret store; the connection holds only the path. The key never enters
+   Leoflow's DB/API/UI.
+3. **`keyfile_dict`** — **discouraged.** It stores the key inside the connection
+   (encrypted at rest with `LEOFLOW_SECRET_KEY`, ADR 0019; delivered only over
+   the TLS agent channel, ADR 0021). It is the cloud-key analog of how
+   connections store a database user/password — pragmatic and Airflow-compatible,
+   but **not** the desired posture. Use only for dev / low-criticality; many orgs
+   forbid creating such keys anyway.
 
 ## Example DAG + test
 

--- a/docs/connections/index.md
+++ b/docs/connections/index.md
@@ -23,21 +23,20 @@ URI shape, an example DAG, and how to test it.
 | `redis` | [redis.md](redis.md) | [examples/redis_load](https://github.com/neochaotic/leoflow/tree/main/examples/redis_load) | ✅ documented + automated test (#73, table-driven via #138; Tier 1 — redis already in CI services) |
 | `http` / `https` | [http.md](http.md) | [examples/http_load](https://github.com/neochaotic/leoflow/tree/main/examples/http_load) | ✅ documented + automated test (#75, dedicated test for `__extra__` round-trip; Tier 1 — no service needed) |
 
+## Cloud (documented)
+
+| Type | Doc | Example DAG | Status |
+|---|---|---|---|
+| `google_cloud_platform` | [google_cloud_platform.md](google_cloud_platform.md) | [examples/gcp_gcs_load](https://github.com/neochaotic/leoflow/tree/main/examples/gcp_gcs_load) | ✅ documented — **key + keyless (Workload Identity)** (#77, #56); delivery test with a synthetic key; real-cloud e2e is manual |
+
 ## Cloud (deferred past alpha)
 
 These need provider accounts to test end-to-end; the umbrella issues are
 filed but the cookbook entries are not part of the first alpha cut.
 
-- `aws` (#76), `google_cloud_platform` (#77), `snowflake` (#78),
+- `aws` (#76), `snowflake` (#78),
   `oracle` (#72), `kafka` (#82), `ssh` (#79), `ftp` (#80), `sftp` (#81),
   `mongo` (#74)
-
-!!! note "`google_cloud_platform` is planned for the Pro/GKE track (Phase 2)"
-    GCP is the first cloud connector targeted once Pro internal testing on GKE
-    matures: a real `google_cloud_platform` connection (#77) supporting **both**
-    a service-account JSON key **and** keyless **Workload Identity** (#56). The
-    UI metadata exists today; the probe, example DAG, and integration test land
-    with that phase. See the [Roadmap](../roadmap-to-release.md).
 
 ## Contract every entry honours
 

--- a/examples/gcp_gcs_load/README.md
+++ b/examples/gcp_gcs_load/README.md
@@ -1,0 +1,81 @@
+# gcp_gcs_load — Google Cloud connection (key + keyless)
+
+Writes and reads back a Cloud Storage object using a managed
+`google_cloud_platform` Connection, in **either** auth mode. It's the manual
+companion to the connection delivery test, and the reference for the GCP
+connector.
+
+> Credentials resolve in this order (first match wins), mirroring Airflow's
+> `GoogleBaseHook` but with cleaner field names and **keyless as the default**:
+> `keyfile_dict` → `key_path` → **ADC (keyless / Workload Identity)**.
+
+## Connection fields (Extra)
+
+Put these in the Connection's **Extra** (JSON). Short names are canonical; the
+legacy `extra__google_cloud_platform__<name>` form is also accepted so an
+existing Airflow connection drops in unchanged.
+
+| Field | Meaning |
+|---|---|
+| `keyfile_dict` | Service-account JSON, inline (key mode). Encrypted at rest. Object or stringified JSON. |
+| `key_path` | Path to a service-account JSON file mounted in the task (key mode). |
+| `project` / `project_id` | GCP project (optional; falls back to the key's / ADC's project). |
+| `scopes` / `scope` | OAuth scopes — a **list** or a comma-separated string. |
+| `num_retries` | Pass-through to your GCP client (optional). |
+
+Leave all key fields empty for **keyless** (ADC). Advanced Airflow fields
+(`key_secret_name`, `credential_config_file`, `impersonation_chain`,
+`quota_project_id`) are not handled in v1.
+
+## Prerequisites
+
+- A GCS bucket the credentials can write to.
+- Set the bucket as a Leoflow **Variable** `GCS_BUCKET` (Admin → Variables), or
+  export `GCS_BUCKET` for a subprocess run.
+
+## Keyless (recommended)
+
+No key in the Connection — credentials come from the ambient identity.
+
+### Pro (GKE — Workload Identity)
+1. Create a GCP service account (GSA) with the needed roles (e.g.
+   `roles/storage.objectAdmin` on the bucket).
+2. Bind the task pod's Kubernetes SA (KSA) to the GSA:
+   ```bash
+   gcloud iam service-accounts add-iam-policy-binding GSA@PROJECT.iam.gserviceaccount.com \
+     --role roles/iam.workloadIdentityUser \
+     --member "serviceAccount:PROJECT.svc.id.goog[leoflow/KSA]"
+   kubectl -n leoflow annotate serviceaccount KSA \
+     iam.gke.io/gcp-service-account=GSA@PROJECT.iam.gserviceaccount.com
+   ```
+   (The chart's task-ServiceAccount knob automates this — see the Helm values.)
+3. Create the Connection `google_cloud_default` with **empty key fields** (just
+   `project`/`scopes` if you want). Run the DAG — no key touches the cluster.
+
+### Lite (local — subprocess executor)
+```bash
+gcloud auth application-default login        # or export GOOGLE_APPLICATION_CREDENTIALS=/path/key.json
+leoflow lite --executor=subprocess dags/gcp_gcs_load
+```
+The subprocess inherits your host ADC. (The **k3d** executor has no metadata
+server, so keyless isn't available there — use key mode under k3d.)
+
+## Key mode (service-account JSON)
+
+1. Admin → Connections → **+**, Conn Id `google_cloud_default`, type
+   **Google Cloud**.
+2. In **Extra**, paste:
+   ```json
+   { "keyfile_dict": { ...service account JSON... }, "project": "my-project" }
+   ```
+   (The JSON is encrypted at rest — ADR 0019.)
+3. Run the DAG. Works on Lite (subprocess or k3d) and Pro alike.
+
+## Run + verify
+
+```bash
+# Pro: leoflow compile dags/gcp_gcs_load --image <REG>/gcp_gcs_load:v1 --build --push -o dag.json
+#      leoflow push dag.json && leoflow runs trigger gcp_gcs_load
+# Lite: leoflow lite --executor=subprocess dags/gcp_gcs_load
+```
+The task log prints the resolved auth mode and `gcs roundtrip ok: gs://<bucket>/leoflow/gcp_gcs_load.txt`.

--- a/examples/gcp_gcs_load/README.md
+++ b/examples/gcp_gcs_load/README.md
@@ -62,6 +62,11 @@ server, so keyless isn't available there — use key mode under k3d.)
 
 ## Key mode (service-account JSON)
 
+> **Discouraged — Leoflow is not a key manager** ([ADR 0035](../../docs/adr/0035-cloud-connector-auth-keyless-first.md)).
+> Prefer keyless, or `key_path` pointing at a mounted Kubernetes Secret (the key
+> stays in the cluster's secret store, not in Leoflow). Use `keyfile_dict` only
+> for dev / low-criticality.
+
 1. Admin → Connections → **+**, Conn Id `google_cloud_default`, type
    **Google Cloud**.
 2. In **Extra**, paste:

--- a/examples/gcp_gcs_load/dag.py
+++ b/examples/gcp_gcs_load/dag.py
@@ -1,0 +1,97 @@
+"""gcp_gcs_load — write + read a GCS object using a managed Leoflow Connection.
+
+Demonstrates the `google_cloud_platform` connection in **both** auth modes:
+
+  * **keyless (recommended)** — no key in the Connection. Credentials come from
+    Application Default Credentials (ADC): on GKE/Pro that's **Workload Identity**
+    (the task pod's KSA bound to a GCP service account); locally/Lite it's
+    `gcloud auth application-default login` or GOOGLE_APPLICATION_CREDENTIALS.
+  * **key** — a service-account JSON stored in the Connection (`keyfile_dict`,
+    encrypted at rest), or a `key_path` to a mounted file.
+
+The Connection is injected as AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT. The target
+bucket comes from the `GCS_BUCKET` Variable (AIRFLOW_VAR_GCS_BUCKET) or env.
+
+Field names follow Airflow's (so an existing GCP connection drops in), but we
+keep the clean short names and also accept a few quality-of-life improvements
+(`scopes` as a list or a comma string; keyless is the default).
+"""
+from __future__ import annotations
+
+import json
+import os
+import urllib.parse
+
+from airflow.sdk import DAG, task
+
+GCP_CONN = "GOOGLE_CLOUD_DEFAULT"
+
+
+def _conn_extra(conn_id: str) -> dict:
+    """Parse the Connection's Extra JSON out of AIRFLOW_CONN_<ID> (the __extra__ param)."""
+    uri = os.environ.get(f"AIRFLOW_CONN_{conn_id.upper()}")
+    if not uri:
+        return {}
+    raw = urllib.parse.parse_qs(urllib.parse.urlsplit(uri).query).get("__extra__", [None])[0]
+    return json.loads(raw) if raw else {}
+
+
+def _field(extra: dict, name: str):
+    """Prefer the clean short name; fall back to Airflow's legacy extra__google_cloud_platform__<name>."""
+    val = extra.get(name)
+    if val in (None, ""):
+        val = extra.get(f"extra__google_cloud_platform__{name}")
+    return val
+
+
+def gcp_credentials(conn_id: str = GCP_CONN):
+    """Resolve GCP credentials from a Leoflow Connection. Returns (creds, project, mode).
+
+    Resolution (first match wins): keyfile_dict -> key_path -> ADC (keyless).
+    """
+    import google.auth
+    from google.oauth2 import service_account
+
+    extra = _conn_extra(conn_id)
+    scopes = _field(extra, "scopes") or _field(extra, "scope")
+    if isinstance(scopes, str):
+        scopes = [s.strip() for s in scopes.split(",") if s.strip()]
+    project = _field(extra, "project") or _field(extra, "project_id")
+
+    keyfile_dict = _field(extra, "keyfile_dict")
+    key_path = _field(extra, "key_path")
+
+    if keyfile_dict:
+        info = json.loads(keyfile_dict) if isinstance(keyfile_dict, str) else keyfile_dict
+        creds = service_account.Credentials.from_service_account_info(info, scopes=scopes)
+        return creds, project or info.get("project_id"), "key (keyfile_dict)"
+    if key_path:
+        creds = service_account.Credentials.from_service_account_file(key_path, scopes=scopes)
+        return creds, project, "key (key_path)"
+    creds, adc_project = google.auth.default(scopes=scopes)
+    return creds, project or adc_project, "keyless (ADC / Workload Identity)"
+
+
+@task
+def gcs_roundtrip() -> str:
+    from google.cloud import storage
+
+    bucket_name = os.environ.get("AIRFLOW_VAR_GCS_BUCKET") or os.environ.get("GCS_BUCKET")
+    if not bucket_name:
+        raise RuntimeError("set the GCS_BUCKET Variable (or env) to a bucket the credentials can write to")
+
+    creds, project, mode = gcp_credentials()
+    print(f"gcp auth mode: {mode}  project: {project}")
+
+    client = storage.Client(project=project, credentials=creds)
+    blob = client.bucket(bucket_name).blob("leoflow/gcp_gcs_load.txt")
+    payload = "hello from leoflow gcp_gcs_load"
+    blob.upload_from_string(payload)
+    got = blob.download_as_text()
+    assert got == payload, f"roundtrip mismatch: {got!r}"
+    print(f"gcs roundtrip ok: gs://{bucket_name}/{blob.name} ({len(got)} B)")
+    return blob.name
+
+
+with DAG("gcp_gcs_load", schedule=None, catchup=False, tags=["example"]):
+    gcs_roundtrip()

--- a/examples/gcp_gcs_load/leoflow.yaml
+++ b/examples/gcp_gcs_load/leoflow.yaml
@@ -8,3 +8,12 @@ python_version: "3.11"
 dependencies:
   - google-auth==2.35.0
   - google-cloud-storage==2.18.2
+
+# Keyless on Pro/GKE: run the task pod as a Kubernetes ServiceAccount bound to a
+# GCP service account via Workload Identity, so credentials come from the
+# metadata server (no key). Create/annotate the KSA per the README, or drop this
+# block and use key mode (keyfile_dict) / host ADC on Lite subprocess.
+tasks:
+  gcs_roundtrip:
+    execution:
+      service_account: leoflow-gcs

--- a/examples/gcp_gcs_load/leoflow.yaml
+++ b/examples/gcp_gcs_load/leoflow.yaml
@@ -1,0 +1,10 @@
+schema_version: "1.0"
+dag_id: gcp_gcs_load
+description: Write + read a GCS object via a managed google_cloud_platform Connection (key or keyless/ADC).
+owner: examples
+tags:
+  - example
+python_version: "3.11"
+dependencies:
+  - google-auth==2.35.0
+  - google-cloud-storage==2.18.2

--- a/internal/api/connection_probe.go
+++ b/internal/api/connection_probe.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"net"
 	"net/http"
 	"strconv"
@@ -60,6 +61,9 @@ func (defaultConnectionTester) Test(ctx context.Context, conn domain.Connection)
 	if t == "http" || t == "https" {
 		return testHTTPReachable(ctx, conn)
 	}
+	if t == "google_cloud_platform" {
+		return testGCPConnection(conn)
+	}
 	if conn.Host == "" {
 		return false, "no host configured to test"
 	}
@@ -81,6 +85,69 @@ func (defaultConnectionTester) Test(ctx context.Context, conn domain.Connection)
 	}
 	_ = cn.Close() //nolint:errcheck // reachability probe; close result is irrelevant
 	return true, "reachable: " + addr
+}
+
+// testGCPConnection structurally validates a google_cloud_platform connection
+// from the control plane. It does NOT call Google: the control plane runs no
+// provider hooks (Python), and reachability is meaningless for GCP (no host).
+// It validates the service-account key shape when a key is present, or reports
+// keyless (ADC / Workload Identity), which is resolved at task runtime. Short
+// field names are preferred, with Airflow's legacy extra__google_cloud_platform__
+// names accepted as a fallback.
+func testGCPConnection(conn domain.Connection) (ok bool, message string) {
+	extra := map[string]any{}
+	if conn.Extra != "" {
+		if err := json.Unmarshal([]byte(conn.Extra), &extra); err != nil {
+			return false, "invalid Extra JSON: " + err.Error()
+		}
+	}
+	field := func(name string) any {
+		if v, present := extra[name]; present && v != nil && v != "" {
+			return v
+		}
+		return extra["extra__google_cloud_platform__"+name]
+	}
+
+	if kd := field("keyfile_dict"); kd != nil {
+		return validateGCPKeyfileDict(kd)
+	}
+	if kp, isStr := field("key_path").(string); isStr && kp != "" {
+		return true, "key_path set — validated at task runtime: " + kp
+	}
+	return true, "keyless (ADC / Workload Identity) — resolved at task runtime, not from the control plane"
+}
+
+// validateGCPKeyfileDict structurally validates an inline service-account key
+// (the keyfile_dict field). It accepts the key either as a nested JSON object or
+// as a stringified JSON blob (Airflow emits both forms) and checks the fields
+// every service-account key carries. It performs no network call — the actual
+// token exchange happens in the task at runtime.
+func validateGCPKeyfileDict(kd any) (ok bool, message string) {
+	var key map[string]any
+	switch v := kd.(type) {
+	case string:
+		if err := json.Unmarshal([]byte(v), &key); err != nil {
+			return false, "keyfile_dict is not valid JSON: " + err.Error()
+		}
+	case map[string]any:
+		key = v
+	default:
+		return false, "keyfile_dict must be a JSON object or a JSON string"
+	}
+	// Capture each required field via an ok-checked type assertion (the A+ linter
+	// forbids discarding the assertion's ok value).
+	got := make(map[string]string, 4)
+	for _, name := range []string{"type", "client_email", "private_key", "project_id"} {
+		s, isStr := key[name].(string)
+		if !isStr || s == "" {
+			return false, "keyfile_dict missing required field: " + name
+		}
+		got[name] = s
+	}
+	if got["type"] != "service_account" {
+		return false, `keyfile_dict "type" must be "service_account"`
+	}
+	return true, "service-account key looks valid (" + got["client_email"] + ")"
 }
 
 func testHTTPReachable(ctx context.Context, conn domain.Connection) (ok bool, message string) {

--- a/internal/api/connection_probe_test.go
+++ b/internal/api/connection_probe_test.go
@@ -67,6 +67,45 @@ func TestConnectionTestEndpoint(t *testing.T) {
 	}
 }
 
+// The GCP probe is structural (no cloud call): a well-formed service-account key
+// validates, a malformed/incomplete one fails with a clear message, and an empty
+// (keyless) connection reports ADC/Workload Identity as ok.
+func TestGCPConnectionProbe(t *testing.T) {
+	validKey := `{"type":"service_account","client_email":"x@p.iam.gserviceaccount.com","private_key":"-----BEGIN PRIVATE KEY-----\nABC\n-----END PRIVATE KEY-----\n","project_id":"p"}`
+	for _, tc := range []struct {
+		name    string
+		extra   string
+		wantOK  bool
+		wantSub string // substring expected in the message
+	}{
+		{"keyfile_dict object", `{"keyfile_dict":` + validKey + `}`, true, "service-account key looks valid"},
+		{"keyfile_dict stringified", `{"keyfile_dict":` + jsonString(validKey) + `}`, true, "service-account key looks valid"},
+		{"legacy extra name", `{"extra__google_cloud_platform__keyfile_dict":` + validKey + `}`, true, "looks valid"},
+		{"invalid extra json", `{not json`, false, "invalid Extra JSON"},
+		{"missing field", `{"keyfile_dict":{"type":"service_account","client_email":"x","project_id":"p"}}`, false, "missing required field: private_key"},
+		{"wrong type", `{"keyfile_dict":{"type":"user","client_email":"x","private_key":"k","project_id":"p"}}`, false, `must be "service_account"`},
+		{"key_path", `{"key_path":"/etc/gcp/key.json"}`, true, "key_path set"},
+		{"keyless empty", ``, true, "keyless"},
+		{"keyless explicit", `{"project":"p","scopes":["https://www.googleapis.com/auth/cloud-platform"]}`, true, "keyless"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, msg := testGCPConnection(domain.Connection{ConnType: "google_cloud_platform", Extra: tc.extra})
+			if ok != tc.wantOK {
+				t.Errorf("ok = %v, want %v (msg %q)", ok, tc.wantOK, msg)
+			}
+			if !strings.Contains(msg, tc.wantSub) {
+				t.Errorf("msg = %q, want substring %q", msg, tc.wantSub)
+			}
+		})
+	}
+}
+
+// jsonString returns s as a JSON string literal (quoted + escaped).
+func jsonString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
 // The built-in tester reports reachable for a listening port and unreachable for
 // a closed one (TCP-dial reachability).
 func TestDefaultConnectionTesterReachability(t *testing.T) {

--- a/internal/storage/conn_uri_test.go
+++ b/internal/storage/conn_uri_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"net/url"
 	"strings"
 	"testing"
 
@@ -25,6 +26,34 @@ func TestAirflowConnURI(t *testing.T) {
 	got = airflowConnURI(domain.Connection{ConnID: "p", ConnType: "postgres", Host: "h", Extra: `{"sslmode":"require"}`})
 	if !strings.Contains(got, "__extra__=") || !strings.Contains(got, "sslmode") {
 		t.Errorf("uri = %q, want extra carried under __extra__", got)
+	}
+}
+
+// TestAirflowConnURIGCP pins the google_cloud_platform contract: GCP carries no
+// host/login/password — everything (incl. an inline service-account key) rides
+// in Extra under __extra__. The service-account private_key contains embedded
+// newlines (PEM), a real round-trip edge case; this asserts they survive intact.
+func TestAirflowConnURIGCP(t *testing.T) {
+	extra := `{"keyfile_dict":{"type":"service_account","client_email":"x@p.iam.gserviceaccount.com","private_key":"-----BEGIN PRIVATE KEY-----\nABC\nDEF\n-----END PRIVATE KEY-----\n","project_id":"p"},"project":"p"}`
+	got := airflowConnURI(domain.Connection{ConnID: "google_cloud_default", ConnType: "google_cloud_platform", Extra: extra})
+
+	// No host/login/password → the conn_type is the scheme and there is no
+	// authority component (no "//", no "@" userinfo). The client_email's "@" is
+	// percent-encoded inside __extra__, so a literal "@" must not appear.
+	const prefix = "google_cloud_platform:?"
+	if !strings.HasPrefix(got, prefix) {
+		t.Fatalf("uri = %q, want %q prefix", got, prefix)
+	}
+	if strings.Contains(got, "@") {
+		t.Errorf("uri = %q, should carry no userinfo (@) for GCP", got)
+	}
+	// The Extra (with the newline-bearing PEM private_key) round-trips exactly.
+	q, err := url.ParseQuery(strings.TrimPrefix(got, prefix))
+	if err != nil {
+		t.Fatalf("parsing query: %v", err)
+	}
+	if q.Get("__extra__") != extra {
+		t.Errorf("__extra__ = %q, want exact round-trip %q", q.Get("__extra__"), extra)
 	}
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,6 +149,7 @@ nav:
           - SQLite: connections/sqlite.md
           - Redis: connections/redis.md
           - HTTP / HTTPS: connections/http.md
+          - Google Cloud: connections/google_cloud_platform.md
       - Troubleshooting & observability: troubleshooting.md
       - UI compatibility: ui-compatibility.md
       - Staging volume: staging-volume.md


### PR DESCRIPTION
## What

A `google_cloud_platform` connector that follows Airflow's surface (existing GCP connections drop in) but is **not Airflow-bound** — keyless-first, and on the principle that **Leoflow is not a key manager** ([ADR 0035](https://github.com/neochaotic/leoflow/blob/main/docs/adr/0035-cloud-connector-auth-keyless-first.md)).

## Validated end-to-end on GKE

A real DAG (`gcp_gcs_load`) **wrote + read a GCS object via keyless Workload Identity** — the task pod ran as a KSA bound to a GCP service account, **no key anywhere**:
```
gcp auth mode: keyless (ADC / Workload Identity)  project: degaz-app-dev
gcs roundtrip ok: gs://.../leoflow/gcp_gcs_load.txt (31 B)   run = success
```
(The org enforces `iam.disableServiceAccountKeyCreation`, which is exactly why keyless is the default.) Key mode is proven structurally — URI round-trip of a synthetic key + a structural probe.

## Changes

- **Example** `examples/gcp_gcs_load/` — GCS roundtrip in both modes, a clean `gcp_credentials()` helper (resolution: `keyfile_dict` → `key_path` → ADC), README, and a per-task `execution.service_account` for keyless on Pro.
- **Cookbook** `docs/connections/google_cloud_platform.md` + index/nav; security section leads with keyless and flags `keyfile_dict` as discouraged.
- **Structural probe** (Go) for `google_cloud_platform` — validates the key shape or reports keyless; no cloud SDK in core. URI round-trip + probe tests (lint A+ clean).
- **ADR 0035** — the auth stance (keyless-first; reference platform-managed secrets; `keyfile_dict` discouraged, the cloud-key analog of storing a DB password).

## Scope / follow-ups

- v1 fields: `keyfile_dict`, `key_path`, `project`, `scopes`, `num_retries`. Deferred: `key_secret_name`, `credential_config_file`, `impersonation_chain`, `quota_project_id`.
- **Follow-up:** chart `taskServiceAccount` knob to make keyless turnkey on Pro (the KSA→GSA binding was done manually for this validation). Relates to #56.
- Related TLS gaps: #312 (Redis), #315 (Postgres). Connector umbrella: #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)