### PR TITLE
fix(observability): no-op tracer when OTel disabled; fail loud on empty endpoint (#319)

### DIFF
--- a/internal/observability/setup.go
+++ b/internal/observability/setup.go
@@ -2,12 +2,14 @@ package observability
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 // Config configures observability setup.
@@ -35,7 +37,18 @@ func Setup(ctx context.Context, cfg Config) (*Telemetry, func(), error) {
 	metrics := NewMetrics(reg)
 
 	shutdown := func() {}
-	if cfg.OTelEnabled {
+	switch {
+	case cfg.OTelEnabled && cfg.OTelEndpoint == "":
+		// Empty endpoint with enabled=true is a misconfig: the OTLP/gRPC
+		// exporter would silently fall back to localhost:4317 (the SDK
+		// default), producing the "dial tcp [::1]:4317" log spam #319
+		// reports. Fail loud at boot — operators must opt into a real
+		// endpoint when they opt into OTel.
+		return nil, nil, errors.New(
+			"observability.otel.enabled=true but observability.otel.endpoint is empty: " +
+				"set the OTLP/gRPC endpoint explicitly (e.g. otel-collector:4317) " +
+				"or set enabled=false to skip tracing (#319)")
+	case cfg.OTelEnabled:
 		tp, err := newTracerProvider(ctx, cfg.OTelEndpoint, cfg.ServiceName)
 		if err != nil {
 			return nil, nil, err
@@ -50,6 +63,17 @@ func Setup(ctx context.Context, cfg Config) (*Telemetry, func(), error) {
 				logger.Error("otel tracer shutdown", "error", err)
 			}
 		}
+	default:
+		// Disabled: install the noop provider explicitly so a polluted
+		// global (test bleed, a stray OTEL_EXPORTER_* env var that
+		// auto-instantiates a real exporter, or any future package that
+		// SetTracerProvider's at init) cannot leave a real exporter live
+		// behind our back. The downstream effect we are blocking: the api
+		// handler middleware (internal/api/observe.go) calls
+		// otel.Tracer("leoflow") which resolves through this global; with
+		// a real provider behind it, every request creates a recording
+		// span and the batcher tries to flush to localhost:4317 (#319).
+		otel.SetTracerProvider(noop.NewTracerProvider())
 	}
 
 	return &Telemetry{

--- a/internal/observability/setup_test.go
+++ b/internal/observability/setup_test.go
@@ -3,6 +3,9 @@ package observability
 import (
 	"context"
 	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 func TestSetupDisabledOTel(t *testing.T) {
@@ -26,6 +29,7 @@ func TestSetupDisabledOTel(t *testing.T) {
 }
 
 func TestSetupEnabledOTelDoesNotBlock(t *testing.T) {
+	t.Cleanup(resetGlobalTracerProvider)
 	tel, shutdown, err := Setup(context.Background(), Config{
 		ServiceName:  "leoflow-test",
 		LogLevel:     "info",
@@ -40,4 +44,63 @@ func TestSetupEnabledOTelDoesNotBlock(t *testing.T) {
 		t.Fatal("nil telemetry")
 	}
 	shutdown()
+}
+
+// TestSetupOTelDisabledInstallsNoopProvider pins the fix for #319: when
+// OTelEnabled=false the global tracer provider MUST be the no-op
+// implementation. Without explicitly installing it, the global stays at
+// whatever state the process happens to be in — e.g. a stray OTEL_EXPORTER_*
+// env var auto-instantiating a real exporter, or test pollution from an
+// earlier Setup(enabled=true) call. The downstream effect is that
+// `otel.Tracer("leoflow")` in handler middleware (internal/api/observe.go)
+// returns a real, recording tracer that tries to flush spans to
+// localhost:4317 — the spam #319 reports.
+func TestSetupOTelDisabledInstallsNoopProvider(t *testing.T) {
+	t.Cleanup(resetGlobalTracerProvider)
+	// Pollute the global with a real-ish provider first, simulating the
+	// scenario where some other init path installed one before Setup runs.
+	otel.SetTracerProvider(otel.GetTracerProvider())
+
+	_, shutdown, err := Setup(context.Background(), Config{
+		ServiceName: "leoflow-test",
+		OTelEnabled: false,
+	})
+	if err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	defer shutdown()
+
+	// The no-op tracer's span is non-recording. That is the documented
+	// invariant of the no-op SDK and the simplest contract to assert.
+	_, span := otel.GetTracerProvider().Tracer("test").Start(context.Background(), "probe")
+	defer span.End()
+	if span.IsRecording() {
+		t.Errorf("expected disabled OTel to yield a non-recording span; got recording=true (provider=%T)", otel.GetTracerProvider())
+	}
+}
+
+// TestSetupOTelEnabledWithEmptyEndpointRefuses pins the second leg of the
+// fix: an `enabled=true` with no endpoint must NOT silently fall back to the
+// otlptracegrpc default (`localhost:4317`), which is the exact behavior #319
+// reports as a connection-refused log storm. The operator must configure the
+// endpoint explicitly — empty endpoint with enabled=true is a misconfig and
+// should fail loud at boot, not silently spam.
+func TestSetupOTelEnabledWithEmptyEndpointRefuses(t *testing.T) {
+	t.Cleanup(resetGlobalTracerProvider)
+
+	_, _, err := Setup(context.Background(), Config{
+		ServiceName:  "leoflow-test",
+		OTelEnabled:  true,
+		OTelEndpoint: "",
+	})
+	if err == nil {
+		t.Fatal("expected an error when OTel is enabled without an endpoint, got nil")
+	}
+}
+
+// resetGlobalTracerProvider reinstalls the otel default noop provider so a
+// test that flips the global tracer provider doesn't leak state to the next
+// test in the same package.
+func resetGlobalTracerProvider() {
+	otel.SetTracerProvider(noop.NewTracerProvider())
 }


### PR DESCRIPTION
Closes #319.

## The bug
With \`observability.otel.enabled=false\` (the chart default) the server still logs:
\`\`\`
traces export: exporter export timeout: ... dial tcp [::1]:4317: connect: cannot assign requested address
\`\`\`
Operator reported it on GKE Pro, default values.

## Root cause
\`Setup()\` correctly skipped installing the batcher exporter on the disabled path, but it did NOT install a noop tracer provider. The global tracer provider was left at whatever state the process happened to be in. Any path that polluted the global (a stray \`OTEL_EXPORTER_OTLP_ENDPOINT\` env var auto-instantiating a real exporter, test bleed, a future package \`SetTracerProvider\`'ing at init) silently left a real exporter behind us. The api handler middleware (\`internal/api/observe.go:22\` \`otel.Tracer(\"leoflow\")\`) then created **recording** spans every request whose batcher flush dialed the unconfigured default \`localhost:4317\`.

## Two-leg fix

1. **Disabled → explicit noop provider.** \`Setup()\` now installs \`noop.NewTracerProvider()\` via \`otel.SetTracerProvider(...)\` on the disabled path. Guarantees no real provider can leak through — subsequent \`otel.Tracer(...)\` calls always resolve to no-op.

2. **Enabled + empty endpoint → loud boot failure.** Previously \`otlptracegrpc.New(\"\")\` fell back to \`localhost:4317\` (the SDK default), which is the exact misconfig shape #319 reports. Now it's a hard error at boot: *\"set the OTLP/gRPC endpoint explicitly or set enabled=false\"*. Operators opting into OTel must commit to where the traces go.

## Tests
- \`TestSetupOTelDisabledInstallsNoopProvider\` — pre-pollutes the global with a real-ish provider; asserts \`Setup()\` resets it. Spans probed afterwards are non-recording (the documented no-op SDK invariant).
- \`TestSetupOTelEnabledWithEmptyEndpointRefuses\` — \`Setup()\` returns an error instead of silently spamming localhost.
- Existing \`TestSetupDisabledOTel\` & \`TestSetupEnabledOTelDoesNotBlock\` kept as regression coverage.

## Test plan
- [x] \`go test ./internal/observability/\` — all 4 tests pass
- [x] \`golangci-lint\` clean
- [x] Coverage 80.0%
- [ ] Live: redeploy Pro with default values; tail logs for 10 min — should see zero OTLP-related error lines
- [ ] Live: set \`otel.enabled=true, otel.endpoint=\"\"\` in values; \`helm upgrade\` — pod should crashloop with the clear boot error, NOT silently flap on localhost:4317