### PR TITLE
feat: GCP connector secret paths — key_path (K8s Secret) + key_secret_name (Secret Manager)

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -782,6 +782,7 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 	podExec.SetStagingStore(store) // record per-run staging volumes in the metadatabase (ADR 0022)
 	dispatcher := dispatch.NewDispatcher(podExec, execStore, authn, controlAddr, agentTokenTTL)
 	dispatcher.SetAgentTLSCAConfigMap(cfg.Executor.AgentTLSCAConfigMap)
+	dispatcher.SetTaskSecret(cfg.Executor.TaskSecretName, cfg.Executor.TaskSecretMountPath)
 	dispatcher.SetPlatformDefaults(platformDefaults(cfg.Executor.Defaults))
 	sched.SetDispatcher(wrapBuffered(dispatcher, store, logger, metrics, cfg.Scheduler.Dispatch)) //nolint:contextcheck // buffered worker deliberately detaches from caller ctx
 	startReconciler(ctx, cs, execStore, logger)

--- a/docs/adr/0035-cloud-connector-auth-keyless-first.md
+++ b/docs/adr/0035-cloud-connector-auth-keyless-first.md
@@ -60,19 +60,21 @@ cloud key.
    keep it as a documented escape hatch (dev / low-criticality), never the
    recommended path — and org policy often forbids creating such keys anyway.
 
-4. **Resolution order in the task:** `keyfile_dict` → `key_path` → ADC. Field
-   names are clean short names (`keyfile_dict`, `key_path`, `project`, `scopes`,
-   `num_retries`); the legacy `extra__google_cloud_platform__<name>` names are
-   accepted as a migration fallback only. `scopes` takes a list **or** a comma
-   string (Airflow takes only the string).
+4. **Resolution order in the task:** `keyfile_dict` → `key_path` →
+   `key_secret_name` → ADC. Field names are clean short names (`keyfile_dict`,
+   `key_path`, `key_secret_name`, `project`, `scopes`, `num_retries`); the legacy
+   `extra__google_cloud_platform__<name>` names are accepted as a migration
+   fallback only. `scopes` takes a list **or** a comma string (Airflow takes only
+   the string).
 
 5. **No cloud SDK in the Go control plane.** Connection validation is
    **structural only** (check the key shape, or report keyless); the token
    exchange happens in the task. Keeps core connector-agnostic and avoids a Go
    cloud-SDK supply-chain surface (consistent with ADR 0014).
 
-6. **v1 scope.** Handle `keyfile_dict`, `key_path`, `project`/`project_id`,
-   `scopes`/`scope`, `num_retries`. Defer `key_secret_name`,
+6. **v1 scope.** Handle `keyfile_dict`, `key_path` (mounted K8s Secret via the
+   chart's `taskSecret`), `key_secret_name` (GCP Secret Manager, fetched in the
+   task via ADC), `project`/`project_id`, `scopes`/`scope`, `num_retries`. Defer
    `key_secret_project_id`, `credential_config_file`, `impersonation_chain`,
    `quota_project_id`.
 

--- a/docs/connections/google_cloud_platform.md
+++ b/docs/connections/google_cloud_platform.md
@@ -24,17 +24,18 @@ form is also accepted.
 
 | Field | Meaning |
 |---|---|
-| `keyfile_dict` | Service-account JSON, inline (key mode). **Encrypted at rest** (ADR 0019). |
-| `key_path` | Path to a service-account JSON file mounted in the task (key mode). |
+| `keyfile_dict` | Service-account JSON, inline (key in the connection). **Encrypted at rest** (ADR 0019). Discouraged. |
+| `key_path` | Path to a service-account JSON **file mounted from a Kubernetes Secret** (the chart's `taskSecret`). |
+| `key_secret_name` | Name (or full resource path) of a **GCP Secret Manager** secret holding the JSON key; fetched in the task via ADC. |
 | `project` / `project_id` | GCP project (optional). |
 | `scopes` / `scope` | OAuth scopes — a list **or** a comma-separated string. |
 | `num_retries` | Pass-through to your GCP client (optional). |
 
 **Resolution order (first match wins):** `keyfile_dict` → `key_path` →
-**ADC (keyless)**. Leave all key fields empty for keyless.
+`key_secret_name` → **ADC (keyless)**. Leave all key fields empty for keyless.
 
-Not handled in v1: `key_secret_name`, `key_secret_project_id`,
-`credential_config_file`, `impersonation_chain`, `quota_project_id`.
+Not handled in v1: `key_secret_project_id`, `credential_config_file`,
+`impersonation_chain`, `quota_project_id`.
 
 ## Auth modes
 
@@ -48,16 +49,36 @@ No key in the Connection. Credentials come from Application Default Credentials:
   or `GOOGLE_APPLICATION_CREDENTIALS`).
 - **Lite (k3d):** no metadata server → keyless unavailable; use key mode.
 
-### Key (service-account JSON)
-Paste the SA JSON into Extra as `keyfile_dict` (encrypted at rest), or point
-`key_path` at a file mounted in the task. Works on every executor.
+### Key from a Kubernetes Secret (`key_path`) — preferred when not keyless
+The key lives in a **Kubernetes Secret**, mounted read-only into every task pod;
+the connection only references the file by `key_path`. The key never enters
+Leoflow's DB/API/UI. Wire it via the chart:
+
+```bash
+kubectl -n leoflow create secret generic gcp-sa-key --from-file=key.json=/path/to/key.json
+helm upgrade leoflow ./helm/leoflow -n leoflow --reuse-values \
+  --set taskSecret.name=gcp-sa-key --set taskSecret.mountPath=/etc/leoflow/secrets
+```
+Then set the connection's `key_path` to `/etc/leoflow/secrets/key.json`.
+
+### Key from GCP Secret Manager (`key_secret_name`)
+The connection references a Secret Manager secret name; the task fetches it at
+runtime via ADC (so the task still needs an ambient identity — typically
+Workload Identity — to *read* the secret). Grant the task's GSA
+`roles/secretmanager.secretAccessor`.
+
+### Key inline (`keyfile_dict`) — discouraged
+The SA JSON in the connection's Extra (encrypted at rest). Convenient for
+dev/low-criticality; **not** recommended (see Security below).
 
 ## Lite vs Pro
 
 | | Lite (subprocess) | Lite (k3d) | Pro (GKE) |
 |---|---|---|---|
 | Keyless (ADC) | ✅ host ADC | ❌ (no metadata server) | ✅ Workload Identity |
-| Key (`keyfile_dict` / `key_path`) | ✅ | ✅ | ✅ |
+| `key_path` (K8s Secret) | ✅ (mount a file) | ✅ (k3d Secret) | ✅ (chart `taskSecret`) |
+| `key_secret_name` (Secret Manager) | ✅ (needs ADC) | ⚠️ needs ADC | ✅ (WI + secretAccessor) |
+| `keyfile_dict` (inline) | ✅ | ✅ | ✅ |
 
 ## Security — Leoflow is not a key manager
 
@@ -67,9 +88,11 @@ does not aspire to store cloud keys (see [ADR 0035](../adr/0035-cloud-connector-
 In order of preference:
 
 1. **Keyless (Workload Identity / ADC)** — recommended. No key anywhere.
-2. **`key_path` + a mounted Kubernetes Secret** — the key lives in the cluster's
-   secret store; the connection holds only the path. The key never enters
-   Leoflow's DB/API/UI.
+2. **Reference a platform-managed secret** — the key lives in the cluster's or
+   cloud's secret store; the connection holds only a reference. The key never
+   enters Leoflow's DB/API/UI:
+   - **`key_path` + a mounted Kubernetes Secret** (chart `taskSecret`);
+   - **`key_secret_name` + GCP Secret Manager** (task fetches via ADC).
 3. **`keyfile_dict`** — **discouraged.** It stores the key inside the connection
    (encrypted at rest with `LEOFLOW_SECRET_KEY`, ADR 0019; delivered only over
    the TLS agent channel, ADR 0021). It is the cloud-key analog of how

--- a/examples/gcp_gcs_load/README.md
+++ b/examples/gcp_gcs_load/README.md
@@ -40,15 +40,17 @@ No key in the Connection — credentials come from the ambient identity.
 ### Pro (GKE — Workload Identity)
 1. Create a GCP service account (GSA) with the needed roles (e.g.
    `roles/storage.objectAdmin` on the bucket).
-2. Bind the task pod's Kubernetes SA (KSA) to the GSA:
+2. Let the chart create + annotate the task KSA (cloud-agnostic knob):
    ```bash
+   helm upgrade leoflow ./helm/leoflow -n leoflow --reuse-values \
+     --set taskServiceAccount.create=true --set taskServiceAccount.name=leoflow-gcs \
+     --set 'taskServiceAccount.annotations.iam\.gke\.io/gcp-service-account=GSA@PROJECT.iam.gserviceaccount.com'
    gcloud iam service-accounts add-iam-policy-binding GSA@PROJECT.iam.gserviceaccount.com \
      --role roles/iam.workloadIdentityUser \
-     --member "serviceAccount:PROJECT.svc.id.goog[leoflow/KSA]"
-   kubectl -n leoflow annotate serviceaccount KSA \
-     iam.gke.io/gcp-service-account=GSA@PROJECT.iam.gserviceaccount.com
+     --member "serviceAccount:PROJECT.svc.id.goog[leoflow/leoflow-gcs]"
    ```
-   (The chart's task-ServiceAccount knob automates this — see the Helm values.)
+   Then set `execution.service_account: leoflow-gcs` in the DAG's `leoflow.yaml`
+   (already done in this example).
 3. Create the Connection `google_cloud_default` with **empty key fields** (just
    `project`/`scopes` if you want). Run the DAG — no key touches the cluster.
 

--- a/examples/gcp_gcs_load/README.md
+++ b/examples/gcp_gcs_load/README.md
@@ -76,6 +76,27 @@ server, so keyless isn't available there — use key mode under k3d.)
    (The JSON is encrypted at rest — ADR 0019.)
 3. Run the DAG. Works on Lite (subprocess or k3d) and Pro alike.
 
+## Key from a Kubernetes Secret (`key_path`) — preferred when not keyless
+
+The key stays in the cluster's secret store; Leoflow only mounts it.
+
+```bash
+kubectl -n leoflow create secret generic gcp-sa-key --from-file=key.json=/path/to/key.json
+helm upgrade leoflow ./helm/leoflow -n leoflow --reuse-values \
+  --set taskSecret.name=gcp-sa-key --set taskSecret.mountPath=/etc/leoflow/secrets
+```
+Then the Connection's Extra: `{ "key_path": "/etc/leoflow/secrets/key.json", "project": "my-project" }`.
+
+## Key from GCP Secret Manager (`key_secret_name`)
+
+Store the JSON key in Secret Manager; the task fetches it via ADC (so the task's
+identity — typically Workload Identity — needs `roles/secretmanager.secretAccessor`).
+
+```bash
+gcloud secrets create leoflow-gcp-key --data-file=/path/to/key.json
+```
+Then the Connection's Extra: `{ "key_secret_name": "leoflow-gcp-key", "project": "my-project" }`.
+
 ## Run + verify
 
 ```bash

--- a/examples/gcp_gcs_load/dag.py
+++ b/examples/gcp_gcs_load/dag.py
@@ -47,7 +47,8 @@ def _field(extra: dict, name: str):
 def gcp_credentials(conn_id: str = GCP_CONN):
     """Resolve GCP credentials from a Leoflow Connection. Returns (creds, project, mode).
 
-    Resolution (first match wins): keyfile_dict -> key_path -> ADC (keyless).
+    Resolution (first match wins): keyfile_dict -> key_path (K8s Secret) ->
+    key_secret_name (GCP Secret Manager) -> ADC (keyless / Workload Identity).
     """
     import google.auth
     from google.oauth2 import service_account
@@ -67,7 +68,23 @@ def gcp_credentials(conn_id: str = GCP_CONN):
         return creds, project or info.get("project_id"), "key (keyfile_dict)"
     if key_path:
         creds = service_account.Credentials.from_service_account_file(key_path, scopes=scopes)
-        return creds, project, "key (key_path)"
+        return creds, project, "key (key_path / K8s Secret)"
+
+    key_secret_name = _field(extra, "key_secret_name")
+    if key_secret_name:
+        # Fetch the key from GCP Secret Manager using ADC (so the task still needs
+        # an ambient identity to *read* the secret — typically Workload Identity).
+        from google.cloud import secretmanager
+
+        sm = secretmanager.SecretManagerServiceClient()
+        name = key_secret_name
+        if not name.startswith("projects/"):
+            name = f"projects/{project}/secrets/{name}/versions/latest"
+        payload = sm.access_secret_version(name=name).payload.data.decode("utf-8")
+        info = json.loads(payload)
+        creds = service_account.Credentials.from_service_account_info(info, scopes=scopes)
+        return creds, project or info.get("project_id"), "key (Secret Manager)"
+
     creds, adc_project = google.auth.default(scopes=scopes)
     return creds, project or adc_project, "keyless (ADC / Workload Identity)"
 

--- a/examples/gcp_gcs_load/leoflow.yaml
+++ b/examples/gcp_gcs_load/leoflow.yaml
@@ -8,6 +8,7 @@ python_version: "3.11"
 dependencies:
   - google-auth==2.35.0
   - google-cloud-storage==2.18.2
+  - google-cloud-secret-manager==2.20.2
 
 # Keyless on Pro/GKE: run the task pod as a Kubernetes ServiceAccount bound to a
 # GCP service account via Workload Identity, so credentials come from the

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -216,4 +216,9 @@ differ from what's committed.
 | serviceAccount.create | bool | `true` | Create a dedicated ServiceAccount for the leoflow-server. Set `false` only if you bring your own via `name`. |
 | serviceAccount.name | string | `""` | Override the ServiceAccount name. Defaults to the chart fullname when empty. |
 | taskNamespace | string | `"leoflow"` | Namespace where the control plane creates task pods. MUST match the namespace the server expects (server code currently targets `leoflow`). The chart grants the control plane RBAC to manage pods here; if you override this, the RBAC follows but the server still looks at `leoflow`. |
+| taskSecret.mountPath | string | `"/etc/leoflow/secrets"` | Read-only mount path in the task pod. A connection references files here, e.g. `/etc/leoflow/secrets/key.json`. |
+| taskSecret.name | string | `""` | Name of an existing Kubernetes Secret to mount into task pods. Empty = none. |
+| taskServiceAccount.annotations | object | `{}` | Annotations. GKE Workload Identity: `iam.gke.io/gcp-service-account: GSA@PROJECT.iam.gserviceaccount.com`. EKS IRSA: `eks.amazonaws.com/role-arn: ...`. |
+| taskServiceAccount.create | bool | `false` | Create a ServiceAccount in taskNamespace for task pods to run as. |
+| taskServiceAccount.name | string | `"leoflow-task"` | Name of the task ServiceAccount (use this as `execution.service_account`). |
 | tolerations | list | `[]` | Pod tolerations (standard K8s — allow scheduling on tainted nodes). |

--- a/helm/leoflow/templates/deployment.yaml
+++ b/helm/leoflow/templates/deployment.yaml
@@ -118,6 +118,16 @@ spec:
             - name: LEOFLOW_EXECUTOR_AGENT_TLS_CA_CONFIGMAP
               value: {{ .Values.agentTLS.caConfigMap | quote }}
             {{- end }}
+            {{- if .Values.taskSecret.name }}
+            # Mount a Kubernetes Secret read-only into every task pod so a task can
+            # read a credential (e.g. a GCP service-account key referenced by a
+            # connection's key_path) from the cluster's secret store — Leoflow
+            # never stores the key itself (ADR 0035).
+            - name: LEOFLOW_EXECUTOR_TASK_SECRET_NAME
+              value: {{ .Values.taskSecret.name | quote }}
+            - name: LEOFLOW_EXECUTOR_TASK_SECRET_MOUNT_PATH
+              value: {{ .Values.taskSecret.mountPath | quote }}
+            {{- end }}
             - name: LEOFLOW_DATABASE_URL
               valueFrom:
                 secretKeyRef:

--- a/helm/leoflow/templates/task-serviceaccount.yaml
+++ b/helm/leoflow/templates/task-serviceaccount.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.taskServiceAccount.create -}}
+{{/*
+ServiceAccount that task pods run as (set per-task via execution.service_account).
+Created in taskNamespace, separate from the control-plane ServiceAccount. On GKE,
+annotate it for Workload Identity (iam.gke.io/gcp-service-account) so tasks reach
+GCP keylessly — the recommended auth for the google_cloud_platform connector
+(ADR 0035). Leoflow does not store cloud keys.
+*/}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.taskServiceAccount.name }}
+  namespace: {{ .Values.taskNamespace }}
+  labels:
+    {{- include "leoflow.labels" . | nindent 4 }}
+  {{- with .Values.taskServiceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/helm/leoflow/values.yaml
+++ b/helm/leoflow/values.yaml
@@ -172,6 +172,18 @@ agentTLS:
   # -- Name of a ConfigMap with key `ca.crt`. Mounted into task pods so the agent verifies the server cert. Typically a cert-manager trust-bundle.
   caConfigMap: ""
 
+# Mount a Kubernetes Secret read-only into every task pod, so a task can read a
+# credential that lives in the cluster's secret store — e.g. a GCP service-account
+# key a `google_cloud_platform` connection references by `key_path` — instead of
+# storing the key in Leoflow (ADR 0035; Leoflow is not a key manager). You create
+# the Secret (`kubectl create secret generic ...`); the chart only mounts it.
+# Prefer keyless (Workload Identity) over this; use it when keyless is unavailable.
+taskSecret:
+  # -- Name of an existing Kubernetes Secret to mount into task pods. Empty = none.
+  name: ""
+  # -- Read-only mount path in the task pod. A connection's `key_path` points here, e.g. `/etc/leoflow/secrets/key.json`.
+  mountPath: /etc/leoflow/secrets
+
 observability:
   otel:
     # -- Export OpenTelemetry traces. When false, internal spans are no-ops.

--- a/helm/leoflow/values.yaml
+++ b/helm/leoflow/values.yaml
@@ -17,6 +17,19 @@ replicaCount: 1
 # override this, the RBAC follows but the server still looks at `leoflow`.
 taskNamespace: leoflow
 
+# ServiceAccount that TASK pods run as (distinct from the control-plane
+# serviceAccount above). On GKE, annotate it for Workload Identity so tasks reach
+# GCP keylessly — the google_cloud_platform connector's recommended auth (ADR
+# 0035). Reference it per-task via `execution.service_account: <name>` in
+# leoflow.yaml. Created in `taskNamespace`.
+taskServiceAccount:
+  # -- Create a ServiceAccount in taskNamespace for task pods to run as.
+  create: false
+  # -- Name of the task ServiceAccount (use this as `execution.service_account`).
+  name: leoflow-task
+  # -- Annotations. GKE Workload Identity: `iam.gke.io/gcp-service-account: GSA@PROJECT.iam.gserviceaccount.com`. EKS IRSA: `eks.amazonaws.com/role-arn: ...`.
+  annotations: {}
+
 serviceAccount:
   # -- Create a dedicated ServiceAccount for the leoflow-server. Set `false` only if you bring your own via `name`.
   create: true
@@ -172,16 +185,17 @@ agentTLS:
   # -- Name of a ConfigMap with key `ca.crt`. Mounted into task pods so the agent verifies the server cert. Typically a cert-manager trust-bundle.
   caConfigMap: ""
 
-# Mount a Kubernetes Secret read-only into every task pod, so a task can read a
-# credential that lives in the cluster's secret store — e.g. a GCP service-account
-# key a `google_cloud_platform` connection references by `key_path` — instead of
-# storing the key in Leoflow (ADR 0035; Leoflow is not a key manager). You create
+# Mount a Kubernetes Secret read-only into every task pod (cloud-agnostic), so a
+# task can read ANY credential that lives in the cluster's secret store — a GCP
+# service-account key, an AWS credentials file, an Azure cert, a private CA, etc.
+# — referenced by a connection (e.g. the google_cloud_platform `key_path`) instead
+# of being stored in Leoflow (ADR 0035; Leoflow is not a key manager). You create
 # the Secret (`kubectl create secret generic ...`); the chart only mounts it.
 # Prefer keyless (Workload Identity) over this; use it when keyless is unavailable.
 taskSecret:
   # -- Name of an existing Kubernetes Secret to mount into task pods. Empty = none.
   name: ""
-  # -- Read-only mount path in the task pod. A connection's `key_path` points here, e.g. `/etc/leoflow/secrets/key.json`.
+  # -- Read-only mount path in the task pod. A connection references files here, e.g. `/etc/leoflow/secrets/key.json`.
   mountPath: /etc/leoflow/secrets
 
 observability:

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -55,6 +55,14 @@ type ExecutorSection struct {
 	// the agent verifies the control plane's gRPC TLS cert (issue #58). Empty =
 	// agents use the insecure channel (dev).
 	AgentTLSCAConfigMap string `mapstructure:"agent_tls_ca_configmap"`
+	// TaskSecretName names a Kubernetes Secret mounted (read-only) into every task
+	// pod at TaskSecretMountPath. It lets a task read a credential that lives in
+	// the cluster's secret store (e.g. a GCP service-account key) referenced by a
+	// connection's key_path — so Leoflow never stores the key itself (ADR 0035).
+	// Empty = no secret mounted.
+	TaskSecretName string `mapstructure:"task_secret_name"`
+	// TaskSecretMountPath is where TaskSecretName is mounted in the task pod.
+	TaskSecretMountPath string `mapstructure:"task_secret_mount_path"`
 	// Defaults holds per-cluster task defaults applied at dispatch to fill gaps the
 	// DAG artifact left empty (ADR 0023, layer L0). They never override a value
 	// baked into dag.json, keeping the artifact portable across clusters.
@@ -235,6 +243,8 @@ var serverDefaults = map[string]any{
 	"executor.subprocess_workdir":               "",
 	"executor.agent_control_plane_addr":         "",
 	"executor.agent_tls_ca_configmap":           "",
+	"executor.task_secret_name":                 "",
+	"executor.task_secret_mount_path":           "/etc/leoflow/secrets",
 	"executor.defaults.staging_access_mode":     "ReadWriteMany",
 	"logs.dir":                                  "/var/log/leoflow",
 	"observability.otel.enabled":                true,

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -65,6 +65,8 @@ type Dispatcher struct {
 	controlAddr    string
 	tokenTTL       time.Duration
 	tlsCAConfigMap string
+	taskSecret     string
+	taskSecretPath string
 	defaults       PlatformDefaults
 }
 
@@ -79,6 +81,14 @@ func NewDispatcher(exec executor.Executor, resolver Resolver, issuer TokenIssuer
 // agents verify the control plane's gRPC TLS cert (issue #58). Empty = the agent
 // stays on the insecure channel (dev).
 func (d *Dispatcher) SetAgentTLSCAConfigMap(name string) { d.tlsCAConfigMap = name }
+
+// SetTaskSecret configures a Kubernetes Secret mounted read-only into every task
+// pod at mountPath, so tasks can read a credential (e.g. a GCP service-account
+// key referenced by a connection's key_path) from the cluster's secret store
+// rather than from Leoflow (ADR 0035). Empty name = nothing mounted.
+func (d *Dispatcher) SetTaskSecret(name, mountPath string) {
+	d.taskSecret, d.taskSecretPath = name, mountPath
+}
 
 // SetPlatformDefaults configures the per-cluster task defaults applied at
 // dispatch to fill gaps the DAG artifact left empty (ADR 0023, layer L0).
@@ -143,6 +153,8 @@ func (d *Dispatcher) Dispatch(ctx context.Context, runID, dagID string, task dom
 		req.StagingAccessMode = d.defaults.StagingAccessMode
 	}
 	req.AgentTLSCAConfigMap = d.tlsCAConfigMap
+	req.TaskSecretName = d.taskSecret
+	req.TaskSecretMountPath = d.taskSecretPath
 	return d.exec.Execute(ctx, req)
 }
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -56,6 +56,13 @@ type Request struct {
 	// (key ca.crt) the agent uses to verify the control plane's gRPC TLS cert
 	// (issue #58). It is mounted into the task pod and selects TLS for the agent.
 	AgentTLSCAConfigMap string
+
+	// TaskSecretName, when set, is a Kubernetes Secret mounted read-only into the
+	// task pod at TaskSecretMountPath. It carries a credential a task references by
+	// path (e.g. a GCP service-account key via the connection's key_path), keeping
+	// the key in the cluster's secret store rather than in Leoflow (ADR 0035).
+	TaskSecretName      string
+	TaskSecretMountPath string
 }
 
 // Executor runs or dispatches a task. For synchronous executors (inline HTTP)

--- a/internal/executor/kubernetes.go
+++ b/internal/executor/kubernetes.go
@@ -95,7 +95,33 @@ func BuildPod(req Request) *corev1.Pod {
 	}
 	mountStagingVolume(pod, req)
 	mountAgentTLSCA(pod, req)
+	mountTaskSecret(pod, req)
 	return pod
+}
+
+// taskSecretVolumeName is the pod volume name for the operator-supplied task
+// credential Secret.
+const taskSecretVolumeName = "leoflow-task-secret"
+
+// mountTaskSecret mounts an operator-configured Kubernetes Secret (when set)
+// read-only into the task pod at req.TaskSecretMountPath. This is how a task
+// reads a credential that lives in the cluster's secret store — e.g. a GCP
+// service-account key a connection references by key_path — so Leoflow never
+// stores the key itself (ADR 0035).
+func mountTaskSecret(pod *corev1.Pod, req Request) {
+	if req.TaskSecretName == "" || req.TaskSecretMountPath == "" {
+		return
+	}
+	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+		Name: taskSecretVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{SecretName: req.TaskSecretName},
+		},
+	})
+	c := &pod.Spec.Containers[0]
+	c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{
+		Name: taskSecretVolumeName, MountPath: req.TaskSecretMountPath, ReadOnly: true,
+	})
 }
 
 // agentCAVolumeName / agentCADir / agentCAFile place the CA the agent uses to

--- a/internal/executor/kubernetes_test.go
+++ b/internal/executor/kubernetes_test.go
@@ -138,6 +138,55 @@ func TestBuildPodMountsAgentTLSCA(t *testing.T) {
 	}
 }
 
+func TestBuildPodMountsTaskSecret(t *testing.T) {
+	// No task secret -> no extra volume/mount.
+	base := BuildPod(sampleReq())
+	for _, v := range base.Spec.Volumes {
+		if v.Name == taskSecretVolumeName {
+			t.Fatalf("no task secret configured should not mount a volume: %+v", base.Spec.Volumes)
+		}
+	}
+	// With a task secret, mount it read-only at the configured path so a task can
+	// read a credential by key_path (ADR 0035 — Leoflow does not store the key).
+	req := sampleReq()
+	req.TaskSecretName = "gcp-sa-key"
+	req.TaskSecretMountPath = "/var/secrets/gcp"
+	pod := BuildPod(req)
+	var vol *corev1.Volume
+	for i := range pod.Spec.Volumes {
+		if pod.Spec.Volumes[i].Secret != nil && pod.Spec.Volumes[i].Secret.SecretName == "gcp-sa-key" {
+			vol = &pod.Spec.Volumes[i]
+		}
+	}
+	if vol == nil {
+		t.Fatalf("task secret not mounted as a volume: %+v", pod.Spec.Volumes)
+	}
+	c := pod.Spec.Containers[0]
+	mounted := false
+	for _, m := range c.VolumeMounts {
+		if m.Name == vol.Name {
+			if m.MountPath != "/var/secrets/gcp" {
+				t.Errorf("mount path = %q, want /var/secrets/gcp", m.MountPath)
+			}
+			if !m.ReadOnly {
+				t.Error("task secret must be mounted read-only")
+			}
+			mounted = true
+		}
+	}
+	if !mounted {
+		t.Errorf("task secret volume not mounted: %+v", c.VolumeMounts)
+	}
+	// A name without a mount path mounts nothing (both are required).
+	req2 := sampleReq()
+	req2.TaskSecretName = "gcp-sa-key"
+	for _, v := range BuildPod(req2).Spec.Volumes {
+		if v.Name == taskSecretVolumeName {
+			t.Error("a task secret without a mount path should not mount")
+		}
+	}
+}
+
 func TestBuildPodSanitizesName(t *testing.T) {
 	req := sampleReq()
 	req.DagID = "ETL Vendas"


### PR DESCRIPTION
## What

Completes the `google_cloud_platform` credential ladder (ADR 0035) beyond keyless/`keyfile_dict`, keeping the stance that **Leoflow does not store the key** — it references a platform-managed secret.

- **`key_path` + Kubernetes Secret (new server code):** `executor.task_secret_name` / `task_secret_mount_path` config → dispatcher → `BuildPod` mounts the named K8s Secret read-only into every task pod. Chart knob `taskSecret.{name,mountPath}`. The connection's `key_path` points at the mounted file; the key never enters Leoflow's DB/API/UI. Unit-tested in `kubernetes_test.go`.
- **`key_secret_name` + GCP Secret Manager:** the example helper fetches the key from Secret Manager via ADC (task needs Workload Identity + `secretmanager.secretAccessor`).
- Resolution: `keyfile_dict` → `key_path` → `key_secret_name` → ADC (keyless).

## Docs
- Cookbook + example README document all four paths and Lite-vs-Pro support.
- ADR 0035 v1 scope updated to include `key_path` + `key_secret_name`.

## Testing
- Go: `BuildPod` mounts the secret read-only when configured; not when unset/partial. Lint A+ clean.
- Live: keyless is fully validated (real GCS write, prior PR). key_path/Secret Manager deliver the credential; a real GCS write on key-modes needs a service-account key, which this org blocks creating (`iam.disableServiceAccountKeyCreation`) — exactly why keyless is the default.

Relates to #77, #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)