### PR TITLE
docs(examples): Dockerfile in every example + index README + CI drift gate (#318)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -287,6 +287,23 @@ jobs:
         run: redocly lint docs/api/openapi.yaml
 
   # ─────────────────────────────────────────────────────────────────────
+  # Examples Dockerfile drift check (#318). The Dockerfile in each
+  # examples/<name>/ is generated from leoflow.yaml by
+  # scripts/sync-example-dockerfiles.sh. If a contributor changes the
+  # YAML (python_version or dependencies) and forgets to regenerate, the
+  # checked-in Dockerfile lies about what the image will run. Catch
+  # that drift here so a Pro operator copying the Dockerfile out as a
+  # template gets the same image Lite would have produced.
+  # ─────────────────────────────────────────────────────────────────────
+  examples-dockerfile-drift:
+    name: Examples Dockerfile drift (#318)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Check Dockerfiles are in sync with leoflow.yaml
+        run: bash scripts/sync-example-dockerfiles.sh --check
+
+  # ─────────────────────────────────────────────────────────────────────
   # Python parser tests — matrix across every Python the host detector
   # claims to support (`internal/setup/detect.go` pythonCandidates). If a
   # new minor is added to that list, add it here too — otherwise the

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,85 @@
+# Example DAGs
+
+Twenty reference projects covering every supported task type, operator pattern,
+and connector. Each directory ships:
+
+- `dag.py` — the DAG, written against the Airflow SDK 3.2.x
+- `leoflow.yaml` — Leoflow's deploy config (python version, dependencies,
+  per-task overrides)
+- `Dockerfile` — the DAG image (#318); kept in sync with `leoflow.yaml` by
+  `scripts/sync-example-dockerfiles.sh`
+
+A handful also ship `README.md` files (the connector cookbook entries plus
+`lifecycle` and `http_load` — those are the canonical templates for adding
+prose to the others).
+
+## Lite — the dev loop
+
+```sh
+leoflow lite examples/<name>/      # hot-reload at http://localhost:8088
+```
+
+`leoflow lite` watches the workspace, synthesizes the Dockerfile if one is
+missing (the script-generated ones in this tree mirror what `lite` would
+produce — checking them in lets a Pro operator copy the same file verbatim
+without running Lite), builds the image into the local k3d cluster (or runs
+the DAG in-process under `--executor=subprocess`), and re-registers the DAG
+on every save.
+
+## Pro — the deploy loop
+
+```sh
+# 1. Compile + build the DAG image. The image tag must be a registry your
+#    cluster can pull from.
+leoflow compile examples/<name>/ \
+  --image my-registry.example.com/<name>:<tag> --build --push -o dag.json
+
+# 2. Register the compiled artifact with the control plane.
+leoflow push dag.json --server $LEOFLOW_SERVER --token $LEOFLOW_TOKEN
+
+# 3. Trigger from the UI, or:
+curl -X POST -H "Authorization: Bearer $LEOFLOW_TOKEN" -H 'Content-Type: application/json' \
+  -d '{}' "$LEOFLOW_SERVER/api/v2/dags/<name>/dagRuns"
+```
+
+The Pro walkthrough — building locally vs Cloud Build, image pull secrets,
+registry permissions — is in [`docs/deploy.md`](../docs/deploy.md). The
+managed-Connection examples (`*_load`, `gcp_gcs_load`, `http_load`) each ship
+a `README.md` walking through their specific Connection wiring.
+
+## Index
+
+| Example | Description |
+|---|---|
+| [api_chain](api_chain/) | Chain two public API calls — list users, then fetch one user's details. |
+| [bash_pipeline](bash_pipeline/) | `BashOperator` tasks (the `bash` task type). |
+| [csv_report](csv_report/) | Generate a CSV, compute a report from it, all in-task (no deps). |
+| [duckdb_http_csv](duckdb_http_csv/) | DuckDB reads a remote CSV over HTTP and aggregates it (out-of-core). |
+| [fan_out_aggregate](fan_out_aggregate/) | Fan-out to parallel workers then fan-in to an aggregate (map-reduce). |
+| [gcp_gcs_load](gcp_gcs_load/) | Write + read a GCS object via a managed `google_cloud_platform` Connection (key or keyless/ADC). |
+| [http_jsonplaceholder](http_jsonplaceholder/) | Fetch posts from a public JSON API (jsonplaceholder) and summarize. |
+| [http_load](http_load/) | POST a payload to an external HTTP endpoint via a managed Connection, assert the echo round-trips. |
+| [http_operator](http_operator/) | `HttpOperator` hitting a public API inline (the `http_api` task type). |
+| [lifecycle](lifecycle/) | Three-task pipeline (extract → transform → load) passing data via XCom — the canonical pod-per-task smoke. |
+| [ml_hparam_search](ml_hparam_search/) | Parallel hyperparameter search with map-reduce aggregation (toy ML). |
+| [montecarlo_pi](montecarlo_pi/) | Estimate pi with parallel Monte-Carlo workers, then combine. |
+| [mssql_load](mssql_load/) | Compute rows and load them into an external Microsoft SQL Server via a managed Connection. |
+| [mysql_load](mysql_load/) | Compute rows and load them into an external MySQL/MariaDB via a managed Connection. |
+| [postgres_load](postgres_load/) | Compute rows and load them into an external Postgres via a managed Connection. |
+| [redis_load](redis_load/) | Compute a key-value payload and write it into a Redis hash via a managed Connection. |
+| [sqlite_load](sqlite_load/) | Compute rows and load them into a sqlite file via a managed Connection. |
+| [taskflow_sales](taskflow_sales/) | Pure TaskFlow ETL passing data via XCom (no external deps). |
+| [weather_open_meteo](weather_open_meteo/) | Fetch current weather from the public Open-Meteo API (no key) per city. |
+| [xcom_typed](xcom_typed/) | Pass typed dict payloads across tasks via XCom with validation. |
+
+## Adding a new example
+
+1. Create `examples/<name>/dag.py` + `leoflow.yaml` (use any existing example
+   as a template; `leoflow init examples/<name>` scaffolds the pair).
+2. Run `bash scripts/sync-example-dockerfiles.sh` to generate the Dockerfile.
+3. (Optional) Add a `README.md` describing what the example exercises.
+4. Add a row to the index table above.
+
+CI runs `scripts/sync-example-dockerfiles.sh --check` so a Dockerfile out of
+sync with `leoflow.yaml` fails the build — change the YAML, re-run the script,
+commit the regenerated Dockerfile in the same change.

--- a/examples/api_chain/Dockerfile
+++ b/examples/api_chain/Dockerfile
@@ -1,8 +1,9 @@
 # Standard DAG image (#318). Built by 'leoflow compile --build' or by hand:
-#   docker build -t my-registry/lifecycle:<tag> .
+#   docker build -t my-registry/api_chain:<tag> .
 # Synthesized by scripts/sync-example-dockerfiles.sh from leoflow.yaml; do
 # not hand-edit — re-run the script after changing python_version or
 # dependencies, or CI's drift check fails.
 FROM leoflow-base:py3.11
+RUN pip install --no-cache-dir "requests==2.32.3"
 COPY dag.py /home/leoflow/dag.py
 ENV PYTHONPATH=/home/leoflow

--- a/examples/bash_pipeline/Dockerfile
+++ b/examples/bash_pipeline/Dockerfile
@@ -1,5 +1,5 @@
 # Standard DAG image (#318). Built by 'leoflow compile --build' or by hand:
-#   docker build -t my-registry/lifecycle:<tag> .
+#   docker build -t my-registry/bash_pipeline:<tag> .
 # Synthesized by scripts/sync-example-dockerfiles.sh from leoflow.yaml; do
 # not hand-edit — re-run the script after changing python_version or
 # dependencies, or CI's drift check fails.

--- a/examples/csv_report/Dockerfile
+++ b/examples/csv_report/Dockerfile
@@ -1,5 +1,5 @@
 # Standard DAG image (#318). Built by 'leoflow compile --build' or by hand:
-#   docker build -t my-registry/lifecycle:<tag> .
+#   docker build -t my-registry/csv_report:<tag> .
 # Synthesized by scripts/sync-example-dockerfiles.sh from leoflow.yaml; do
 # not hand-edit — re-run the script after changing python_version or
 # dependencies, or CI's drift check fails.

--- a/examples/duckdb_http_csv/Dockerfile
+++ b/examples/duckdb_http_csv/Dockerfile
@@ -1,8 +1,9 @@
 # Standard DAG image (#318). Built by 'leoflow compile --build' or by hand:
-#   docker build -t my-registry/lifecycle:<tag> .
+#   docker build -t my-registry/duckdb_http_csv:<tag> .
 # Synthesized by scripts/sync-example-dockerfiles.sh from leoflow.yaml; do
 # not hand-edit — re-run the script after changing python_version or
 # dependencies, or CI's drift check fails.
 FROM leoflow-base:py3.11
+RUN pip install --no-cache-dir "duckdb==1.4.4"
 COPY dag.py /home/leoflow/dag.py
 ENV PYTHONPATH=/home/leoflow

--- a/examples/fan_out_aggregate/Dockerfile
+++ b/examples/fan_out_aggregate/Dockerfile
@@ -1,5 +1,5 @@
 # Standard DAG image (#318). Built by 'leoflow compile --build' or by hand:
-#   docker build -t my-registry/lifecycle:<tag> .
+#   docker build -t my-registry/fan_out_aggregate:<tag> .
 # Synthesized by scripts/sync-example-dockerfiles.sh from leoflow.yaml; do
 # not hand-edit — re-run the script after changing python_version or
 # dependencies, or CI's drift check fails.

--- a/examples/gcp_gcs_load/Dockerfile
+++ b/examples/gcp_gcs_load/Dockerfile
@@ -1,8 +1,9 @@
 # Standard DAG image (#318). Built by 'leoflow compile --build' or by hand:
-#   docker build -t my-registry/lifecycle:<tag> .
+#   docker build -t my-registry/gcp_gcs_load:<tag> .
 # Synthesized by scripts/sync-example-dockerfiles.sh from leoflow.yaml; do
 # not hand-edit — re-run the script after changing python_version or
 # dependencies, or CI's drift check fails.
 FROM leoflow-base:py3.11
+RUN pip install --no-cache-dir "google-auth==2.35.0" "google-cloud-storage==2.18.2"
 COPY dag.py /home/leoflow/dag.py
 ENV PYTHONPATH=/home/leoflow

--- a/examples/http_jsonplaceholder/Dockerfile
+++ b/examples/http_jsonplaceholder/Dockerfile
@@ -1,8 +1,9 @@
 # Standard DAG image (#318). Built by 'leoflow compile --build' or by hand:
-#   docker build -t my-registry/lifecycle:<tag> .
+#   docker build -t my-registry/http_jsonplaceholder:<tag> .
 # Synthesized by scripts/sync-example-dockerfiles.sh from leoflow.yaml; do
 # not hand-edit — re-run the script after changing python_version or
 # dependencies, or CI's drift check fails.
 FROM leoflow-base:py3.11
+RUN pip install --no-cache-dir "requests==2.32.3"
 COPY dag.py /home/leoflow/dag.py
 ENV PYTHONPATH=/home/leoflow

--- a/examples/http_load/Dockerfile
+++ b/examples/http_load/Dockerfile
@@ -1,5 +1,5 @@
 # Standard DAG image (#318). Built by 'leoflow compile --build' or by hand:
-#   docker build -t my-registry/lifecycle:<tag> .
+#   docker build -t my-registry/http_load:<tag> .
 # Synthesized by scripts/sync-example-dockerfiles.sh from leoflow.yaml; do
 # not hand-edit — re-run the script after changing python_version or
 # dependencies, or CI's drift check fails.

--- a/examples/http_operator/Dockerfile
+++ b/examples/http_operator/Dockerfile
@@ -1,5 +1,5 @@
 # Standard DAG image (#318). Built by 'leoflow compile --build' or by hand:
-#   docker build -t my-registry/lifecycle:<tag> .
+#   docker build -t my-registry/http_operator:<tag> .
 # Synthesized by scripts/sync-example-dockerfiles.sh from leoflow.yaml; do
 # not hand-edit — re-run the script after changing python_version or
 # dependencies, or CI's drift check fails.

--- a/examples/ml_hparam_search/Dockerfile
+++ b/examples/ml_hparam_search/Dockerfile
@@ -1,5 +1,5 @@
 # Standard DAG image (#318). Built by 'leoflow compile --build' or by hand:
-#   docker build -t my-registry/lifecycle:<tag> .
+#   docker build -t my-registry/ml_hparam_search:<tag> .
 # Synthesized by scripts/sync-example-dockerfiles.sh from leoflow.yaml; do
 # not hand-edit — re-run the script after changing python_version or
 # dependencies, or CI's drift check fails.

--- a/examples/montecarlo_pi/Dockerfile
+++ b/examples/montecarlo_pi/Dockerfile
@@ -1,5 +1,5 @@
 # Standard DAG image (#318). Built by 'leoflow compile --build' or by hand:
-#   docker build -t my-registry/lifecycle:<tag> .
+#   docker build -t my-registry/montecarlo_pi:<tag> .
 # Synthesized by scripts/sync-example-dockerfiles.sh from leoflow.yaml; do
 # not hand-edit — re-run the script after changing python_version or
 # dependencies, or CI's drift check fails.

--- a/examples/mssql_load/Dockerfile
+++ b/examples/mssql_load/Dockerfile
@@ -1,8 +1,9 @@
 # Standard DAG image (#318). Built by 'leoflow compile --build' or by hand:
-#   docker build -t my-registry/lifecycle:<tag> .
+#   docker build -t my-registry/mssql_load:<tag> .
 # Synthesized by scripts/sync-example-dockerfiles.sh from leoflow.yaml; do
 # not hand-edit — re-run the script after changing python_version or
 # dependencies, or CI's drift check fails.
 FROM leoflow-base:py3.11
+RUN pip install --no-cache-dir "pymssql==2.3.2"
 COPY dag.py /home/leoflow/dag.py
 ENV PYTHONPATH=/home/leoflow

--- a/examples/mysql_load/Dockerfile
+++ b/examples/mysql_load/Dockerfile
@@ -1,8 +1,9 @@
 # Standard DAG image (#318). Built by 'leoflow compile --build' or by hand:
-#   docker build -t my-registry/lifecycle:<tag> .
+#   docker build -t my-registry/mysql_load:<tag> .
 # Synthesized by scripts/sync-example-dockerfiles.sh from leoflow.yaml; do
 # not hand-edit — re-run the script after changing python_version or
 # dependencies, or CI's drift check fails.
 FROM leoflow-base:py3.11
+RUN pip install --no-cache-dir "PyMySQL==1.1.1"
 COPY dag.py /home/leoflow/dag.py
 ENV PYTHONPATH=/home/leoflow

--- a/examples/postgres_load/Dockerfile
+++ b/examples/postgres_load/Dockerfile
@@ -1,8 +1,9 @@
 # Standard DAG image (#318). Built by 'leoflow compile --build' or by hand:
-#   docker build -t my-registry/lifecycle:<tag> .
+#   docker build -t my-registry/postgres_load:<tag> .
 # Synthesized by scripts/sync-example-dockerfiles.sh from leoflow.yaml; do
 # not hand-edit — re-run the script after changing python_version or
 # dependencies, or CI's drift check fails.
 FROM leoflow-base:py3.11
+RUN pip install --no-cache-dir "psycopg2-binary==2.9.10"
 COPY dag.py /home/leoflow/dag.py
 ENV PYTHONPATH=/home/leoflow

--- a/examples/redis_load/Dockerfile
+++ b/examples/redis_load/Dockerfile
@@ -1,8 +1,9 @@
 # Standard DAG image (#318). Built by 'leoflow compile --build' or by hand:
-#   docker build -t my-registry/lifecycle:<tag> .
+#   docker build -t my-registry/redis_load:<tag> .
 # Synthesized by scripts/sync-example-dockerfiles.sh from leoflow.yaml; do
 # not hand-edit — re-run the script after changing python_version or
 # dependencies, or CI's drift check fails.
 FROM leoflow-base:py3.11
+RUN pip install --no-cache-dir "redis==5.2.1"
 COPY dag.py /home/leoflow/dag.py
 ENV PYTHONPATH=/home/leoflow

--- a/examples/sqlite_load/Dockerfile
+++ b/examples/sqlite_load/Dockerfile
@@ -1,5 +1,5 @@
 # Standard DAG image (#318). Built by 'leoflow compile --build' or by hand:
-#   docker build -t my-registry/lifecycle:<tag> .
+#   docker build -t my-registry/sqlite_load:<tag> .
 # Synthesized by scripts/sync-example-dockerfiles.sh from leoflow.yaml; do
 # not hand-edit — re-run the script after changing python_version or
 # dependencies, or CI's drift check fails.

--- a/examples/taskflow_sales/Dockerfile
+++ b/examples/taskflow_sales/Dockerfile
@@ -1,5 +1,5 @@
 # Standard DAG image (#318). Built by 'leoflow compile --build' or by hand:
-#   docker build -t my-registry/lifecycle:<tag> .
+#   docker build -t my-registry/taskflow_sales:<tag> .
 # Synthesized by scripts/sync-example-dockerfiles.sh from leoflow.yaml; do
 # not hand-edit — re-run the script after changing python_version or
 # dependencies, or CI's drift check fails.

--- a/examples/weather_open_meteo/Dockerfile
+++ b/examples/weather_open_meteo/Dockerfile
@@ -1,8 +1,9 @@
 # Standard DAG image (#318). Built by 'leoflow compile --build' or by hand:
-#   docker build -t my-registry/lifecycle:<tag> .
+#   docker build -t my-registry/weather_open_meteo:<tag> .
 # Synthesized by scripts/sync-example-dockerfiles.sh from leoflow.yaml; do
 # not hand-edit — re-run the script after changing python_version or
 # dependencies, or CI's drift check fails.
 FROM leoflow-base:py3.11
+RUN pip install --no-cache-dir "requests==2.32.3"
 COPY dag.py /home/leoflow/dag.py
 ENV PYTHONPATH=/home/leoflow

--- a/examples/xcom_typed/Dockerfile
+++ b/examples/xcom_typed/Dockerfile
@@ -1,5 +1,5 @@
 # Standard DAG image (#318). Built by 'leoflow compile --build' or by hand:
-#   docker build -t my-registry/lifecycle:<tag> .
+#   docker build -t my-registry/xcom_typed:<tag> .
 # Synthesized by scripts/sync-example-dockerfiles.sh from leoflow.yaml; do
 # not hand-edit — re-run the script after changing python_version or
 # dependencies, or CI's drift check fails.

--- a/scripts/sync-example-dockerfiles.sh
+++ b/scripts/sync-example-dockerfiles.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# sync-example-dockerfiles.sh — keep each examples/<dag>/Dockerfile aligned with
+# its leoflow.yaml (#318). Idempotent: re-running on an in-sync tree is a no-op.
+#
+# The generated Dockerfile follows the same template `leoflow lite` uses
+# in-process (internal/cli/dev.go devDockerfile): FROM the matching task base,
+# pip install declared dependencies, COPY the DAG source, set PYTHONPATH.
+# Operators copying these into a Pro deploy walkthrough get the same shape
+# regardless of which executor they came from.
+#
+# Usage:
+#   scripts/sync-example-dockerfiles.sh                # write/overwrite all
+#   scripts/sync-example-dockerfiles.sh --check        # CI mode: exit non-zero on drift
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+mode="${1:-write}"
+[ "$mode" = "--check" ] && mode="check"
+
+gen_dockerfile() {
+  local yaml="$1"
+  local py
+  py="$(awk -F'[ "]+' '/^python_version:/ {print $2; exit}' "$yaml")"
+  py="${py:-3.11}"
+
+  # Collect declared pip deps. Each line under `dependencies:` looks like
+  # `  - package==version`; we take everything after the leading `- `.
+  local deps_args=""
+  if awk '/^dependencies:/ {found=1; next} found && /^[^ ]/ {exit} found && /- / {sub(/^[ ]*-[ ]*/, "", $0); print}' "$yaml" \
+       | grep -q .; then
+    while IFS= read -r dep; do
+      deps_args+=" \"$dep\""
+    done < <(awk '/^dependencies:/ {found=1; next} found && /^[^ ]/ {exit} found && /- / {sub(/^[ ]*-[ ]*/, "", $0); print}' "$yaml")
+  fi
+
+  cat <<EOF
+# Standard DAG image (#318). Built by 'leoflow compile --build' or by hand:
+#   docker build -t my-registry/$(basename "$(dirname "$yaml")"):<tag> .
+# Synthesized by scripts/sync-example-dockerfiles.sh from leoflow.yaml; do
+# not hand-edit — re-run the script after changing python_version or
+# dependencies, or CI's drift check fails.
+FROM leoflow-base:py${py}
+EOF
+  if [ -n "$deps_args" ]; then
+    printf 'RUN pip install --no-cache-dir%s\n' "$deps_args"
+  fi
+  cat <<EOF
+COPY dag.py /home/leoflow/dag.py
+ENV PYTHONPATH=/home/leoflow
+EOF
+}
+
+drift=0
+for yaml in examples/*/leoflow.yaml; do
+  dir="$(dirname "$yaml")"
+  dockerfile="$dir/Dockerfile"
+  expected="$(gen_dockerfile "$yaml")"
+  if [ "$mode" = "check" ]; then
+    actual="$(cat "$dockerfile" 2>/dev/null || true)"
+    if [ "$actual" != "$expected" ]; then
+      echo "::error::$(realpath --relative-to=. "$dockerfile") is out of sync with leoflow.yaml" >&2
+      drift=1
+    fi
+  else
+    printf '%s\n' "$expected" > "$dockerfile"
+  fi
+done
+
+if [ "$mode" = "check" ] && [ "$drift" -ne 0 ]; then
+  echo "" >&2
+  echo "Fix: run scripts/sync-example-dockerfiles.sh and commit the result." >&2
+  exit 1
+fi


### PR DESCRIPTION
Partial fix for #318 (items 2 + 3, scoped per the user's direction: \"sem publicar, só ter os Dockerfiles\"). Items 1 (publishing to GHCR) and 4 (Cloud Build walkthrough) deferred to follow-ups if/when the operator surface needs them.

## What lands

| File | What |
|---|---|
| \`scripts/sync-example-dockerfiles.sh\` | Generates each \`examples/<dag>/Dockerfile\` from its \`leoflow.yaml\` — same template Lite uses in-process. Idempotent; \`--check\` is the CI drift gate. |
| \`examples/<dag>/Dockerfile\` × 19 | Net-new (lifecycle had one already, re-wrote through the same template for the comment header). |
| \`examples/README.md\` | Index page listing every example, Lite + Pro run flows, \"how to add\" instructions. |
| \`.github/workflows/ci.yaml\` | New \`examples-dockerfile-drift\` job runs the sync script in \`--check\` mode. A YAML change without a Dockerfile regen now fails the build. |

## Why now
The Pro deploy story for any example was implicit before today: only \`lifecycle\` shipped a Dockerfile. Operators trying to bring \`fan_out_aggregate\` or \`postgres_load\` up on Pro had to either copy from \`lifecycle\`, hand-translate the leoflow.yaml deps, or run \`leoflow lite\` first and copy the synthesized Dockerfile from \`~/.leoflow/...\`. Each path is a rough edge the operator dogfooded on GKE reports as a productivity tax.

## Sample generated Dockerfiles

**With a dep** (\`examples/duckdb_http_csv\`):
\`\`\`dockerfile
FROM leoflow-base:py3.11
RUN pip install --no-cache-dir \"duckdb==1.4.4\"
COPY dag.py /home/leoflow/dag.py
ENV PYTHONPATH=/home/leoflow
\`\`\`

**No deps** (\`examples/bash_pipeline\`):
\`\`\`dockerfile
FROM leoflow-base:py3.11
COPY dag.py /home/leoflow/dag.py
ENV PYTHONPATH=/home/leoflow
\`\`\`

## Test plan
- [x] All 20 examples compile cleanly via \`leoflow compile examples/<name>/\` (20 OK / 0 FAIL)
- [x] Sync script is idempotent (re-running on in-sync tree exits clean)
- [x] \`scripts/sync-example-dockerfiles.sh --check\` is the new CI gate
- [x] \`go test ./...\` clean
- [x] \`golangci-lint\` clean

## Follow-ups (filed separately if/when warranted)
- 13 examples still want full prose READMEs (the index in \`examples/README.md\` covers the \"what is this?\" gap for now)
- #318 item 1 (publish runtime base to GHCR) — only worth it once we have a reason operators won't \`make runtime-images\` locally
- #318 item 4 (Cloud Build walkthrough) — pure docs, low priority