### PR TITLE
feat(helm): database.caConfigMap mounts a CA bundle for verified TLS to managed Postgres (#315)

### DIFF
--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -58,6 +58,45 @@ its own.
 > the chart's visibility**: rotating them requires a manual
 > `kubectl rollout restart deployment/leoflow` for the change to take effect.
 
+## Verified TLS to managed Postgres (#315)
+
+Managed Postgres (Cloud SQL, RDS, Azure DB) presents a server cert signed by
+a provider / per-instance CA that is **not** in the container's system roots.
+Without the CA bundle mounted, the strongest TLS posture you can pin is
+`sslmode=require` — encrypted but the server cert is **not verified**
+(MITM-vulnerable). To upgrade to `sslmode=verify-full`:
+
+1. Create a ConfigMap holding the CA bundle as `ca.crt`:
+
+   ```bash
+   kubectl create configmap managed-pg-ca \
+     -n leoflow --from-file=ca.crt=server-ca.pem
+   ```
+
+2. Reference it from `database.caConfigMap` and point the DSN at the mounted
+   path:
+
+   ```bash
+   helm upgrade --install leoflow ./helm/leoflow -n leoflow \
+     --set database.caConfigMap=managed-pg-ca \
+     --set database.url='postgres://user:pass@cloudsql-private-ip:5432/leoflow?sslmode=verify-full&sslrootcert=/etc/leoflow/db-ca/ca.crt'
+   ```
+
+The chart mounts the ConfigMap readonly at `/etc/leoflow/db-ca/ca.crt`. pgx
+reads `sslrootcert` from the DSN natively, so no extra Go-side configuration
+is required.
+
+> **Rotation note.** Kubernetes auto-updates the mounted file when the
+> ConfigMap changes, but the pgx pool keeps its existing connections until
+> they cycle. Cert rotation that invalidates the old chain may break in-flight
+> connections; rolling the pod (`kubectl rollout restart deploy/leoflow`)
+> guarantees a clean cutover.
+
+> **Redis sibling — coming next** (#312). The same pattern lands for Redis in
+> a follow-up PR: a `redis.caConfigMap` knob mounts the bundle and the Go
+> client overrides its `TLSConfig.RootCAs` from the file (go-redis does not
+> read CA paths from the URL the way pgx does).
+
 ## Migrations
 
 The pre-install/pre-upgrade Job runs `migrate -path <path> -database <url> up`
@@ -152,6 +191,7 @@ differ from what's committed.
 | config.logsDir | string | `"/var/log/leoflow"` | Directory inside the pod where task logs are written. Mounted from `logs.persistence` (a PVC by default) so logs survive pod restarts. Set `logs.persistence.enabled: false` to fall back to an ephemeral emptyDir (dev only). |
 | config.scheduler.enabled | bool | `true` | Run the scheduler loop. Disable only for read-only API-only replicas (rare). |
 | config.scheduler.loopIntervalMs | int | `1000` | Scheduler loop interval in milliseconds. Lower = faster reactivity, higher CPU. 1000ms is the production-tested default. |
+| database.caConfigMap | string | `""` | Name of a ConfigMap with key `ca.crt` holding the managed-Postgres CA bundle (#315). When set, the chart mounts it at `/etc/leoflow/db-ca/ca.crt` so the operator can pin `sslmode=verify-full&sslrootcert=/etc/leoflow/db-ca/ca.crt` in the DSN. Empty (default) means TLS still works via `sslmode=require`, but the server cert is NOT verified — the connection is encrypted but MITM-vulnerable, the standard managed-DB posture before this knob. |
 | database.existingSecret | string | `""` | Name of a Secret with key `databaseUrl` (takes precedence over `url`). |
 | database.maxIdleConns | int | `5` | Max idle DB connections kept in the pool. Should be ≤ `maxOpenConns`. |
 | database.maxOpenConns | int | `20` | Max concurrent open DB connections (Postgres-side load gate). Increase for high-throughput Pro deployments. |

--- a/helm/leoflow/README.md.gotmpl
+++ b/helm/leoflow/README.md.gotmpl
@@ -58,6 +58,45 @@ its own.
 > the chart's visibility**: rotating them requires a manual
 > `kubectl rollout restart deployment/leoflow` for the change to take effect.
 
+## Verified TLS to managed Postgres (#315)
+
+Managed Postgres (Cloud SQL, RDS, Azure DB) presents a server cert signed by
+a provider / per-instance CA that is **not** in the container's system roots.
+Without the CA bundle mounted, the strongest TLS posture you can pin is
+`sslmode=require` — encrypted but the server cert is **not verified**
+(MITM-vulnerable). To upgrade to `sslmode=verify-full`:
+
+1. Create a ConfigMap holding the CA bundle as `ca.crt`:
+
+   ```bash
+   kubectl create configmap managed-pg-ca \
+     -n leoflow --from-file=ca.crt=server-ca.pem
+   ```
+
+2. Reference it from `database.caConfigMap` and point the DSN at the mounted
+   path:
+
+   ```bash
+   helm upgrade --install leoflow ./helm/leoflow -n leoflow \
+     --set database.caConfigMap=managed-pg-ca \
+     --set database.url='postgres://user:pass@cloudsql-private-ip:5432/leoflow?sslmode=verify-full&sslrootcert=/etc/leoflow/db-ca/ca.crt'
+   ```
+
+The chart mounts the ConfigMap readonly at `/etc/leoflow/db-ca/ca.crt`. pgx
+reads `sslrootcert` from the DSN natively, so no extra Go-side configuration
+is required.
+
+> **Rotation note.** Kubernetes auto-updates the mounted file when the
+> ConfigMap changes, but the pgx pool keeps its existing connections until
+> they cycle. Cert rotation that invalidates the old chain may break in-flight
+> connections; rolling the pod (`kubectl rollout restart deploy/leoflow`)
+> guarantees a clean cutover.
+
+> **Redis sibling — coming next** (#312). The same pattern lands for Redis in
+> a follow-up PR: a `redis.caConfigMap` knob mounts the bundle and the Go
+> client overrides its `TLSConfig.RootCAs` from the file (go-redis does not
+> read CA paths from the URL the way pgx does).
+
 ## Migrations
 
 The pre-install/pre-upgrade Job runs `migrate -path <path> -database <url> up`

--- a/helm/leoflow/templates/deployment.yaml
+++ b/helm/leoflow/templates/deployment.yaml
@@ -183,6 +183,14 @@ spec:
               mountPath: /etc/leoflow/grpc-tls
               readOnly: true
             {{- end }}
+            {{- if .Values.database.caConfigMap }}
+            # Managed-Postgres CA bundle (#315). The DSN references this path
+            # via `sslmode=verify-full&sslrootcert=/etc/leoflow/db-ca/ca.crt` —
+            # pgx reads sslrootcert natively, so no Go-side wiring is needed.
+            - name: db-ca
+              mountPath: /etc/leoflow/db-ca
+              readOnly: true
+            {{- end }}
       volumes:
         - name: logs
           {{- if .Values.logs.persistence.enabled }}
@@ -197,6 +205,14 @@ spec:
         - name: grpc-tls
           secret:
             secretName: {{ required "agentTLS.serverCertSecret is required when agentTLS.enabled" .Values.agentTLS.serverCertSecret }}
+        {{- end }}
+        {{- if .Values.database.caConfigMap }}
+        - name: db-ca
+          configMap:
+            name: {{ .Values.database.caConfigMap }}
+            items:
+              - key: ca.crt
+                path: ca.crt
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm/leoflow/tests/deployment_test.yaml
+++ b/helm/leoflow/tests/deployment_test.yaml
@@ -168,6 +168,52 @@ tests:
           # and `helm upgrade` would silently leave the old credentials live.
           pattern: "^[a-f0-9]{64}$"
 
+  # #315 — Postgres CA injection knob. When database.caConfigMap is set, the
+  # podTemplate gains a `db-ca` ConfigMap volume + a volumeMount at
+  # /etc/leoflow/db-ca. Operators then pin
+  # `sslmode=verify-full&sslrootcert=/etc/leoflow/db-ca/ca.crt` on the DSN —
+  # pgx reads sslrootcert natively, so no Go-side wiring is needed.
+  - it: "#315 — no db-ca volume rendered when database.caConfigMap is unset (regression guard)"
+    template: deployment.yaml
+    set:
+      database.url: postgres://h/d
+      redis.url: redis://h/0
+      auth.jwtSecret: jwt
+      agentTLS.enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.volumes[?(@.name == 'db-ca')]
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts[?(@.name == 'db-ca')]
+
+  - it: "#315 — database.caConfigMap mounts /etc/leoflow/db-ca/ca.crt readonly"
+    template: deployment.yaml
+    set:
+      database.url: "postgres://h/d?sslmode=verify-full&sslrootcert=/etc/leoflow/db-ca/ca.crt"
+      database.caConfigMap: managed-pg-ca
+      redis.url: redis://h/0
+      auth.jwtSecret: jwt
+      agentTLS.enabled: false
+    asserts:
+      # Volume: a ConfigMap named after the operator's ConfigMap, exposing
+      # just the ca.crt key.
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: db-ca
+            configMap:
+              name: managed-pg-ca
+              items:
+                - key: ca.crt
+                  path: ca.crt
+      # VolumeMount: mounted readonly at the well-known path the DSN expects.
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: db-ca
+            mountPath: /etc/leoflow/db-ca
+            readOnly: true
+
   - it: pod + container securityContext pin runAsNonRoot + UID 65532 (distroless nonroot)
     template: deployment.yaml
     set:

--- a/helm/leoflow/values.yaml
+++ b/helm/leoflow/values.yaml
@@ -82,6 +82,8 @@ database:
   url: ""
   # -- Name of a Secret with key `databaseUrl` (takes precedence over `url`).
   existingSecret: ""
+  # -- Name of a ConfigMap with key `ca.crt` holding the managed-Postgres CA bundle (#315). When set, the chart mounts it at `/etc/leoflow/db-ca/ca.crt` so the operator can pin `sslmode=verify-full&sslrootcert=/etc/leoflow/db-ca/ca.crt` in the DSN. Empty (default) means TLS still works via `sslmode=require`, but the server cert is NOT verified — the connection is encrypted but MITM-vulnerable, the standard managed-DB posture before this knob.
+  caConfigMap: ""
   # -- Max concurrent open DB connections (Postgres-side load gate). Increase for high-throughput Pro deployments.
   maxOpenConns: 20
   # -- Max idle DB connections kept in the pool. Should be ≤ `maxOpenConns`.


### PR DESCRIPTION
Closes #315 (PG sibling of #312). Pure chart change — pgx reads \`sslrootcert\` from the DSN natively, so this lands without any Go-side wiring. Redis (#312) is the follow-up PR.

## The bug
Without a CA bundle mounted, the strongest TLS posture a Pro operator could pin against managed Postgres (Cloud SQL, RDS, Azure DB) was \`sslmode=require\` — encrypted but the server cert is **not verified**. Bringing the chart to \`sslmode=verify-full\` needs the per-instance CA in the pod and a \`sslrootcert=\` pointing at it; the chart had no knob for that until now.

## Fix (mirrors the \`agentTLS.caConfigMap\` pattern that already exists)
- **\`values.yaml\`**: new \`database.caConfigMap\` (default empty). When set, must name a ConfigMap with a \`ca.crt\` key.
- **\`templates/deployment.yaml\`**: gated \`db-ca\` Volume + VolumeMount when the knob is set. ConfigMap projected with \`items: ca.crt -> ca.crt\` so the mount path is the deterministic **/etc/leoflow/db-ca/ca.crt** — the operator pins that exact path on the DSN as \`sslrootcert=\`.
- **helm-unittest** (2 new):
  - \`#315 — no db-ca volume rendered when database.caConfigMap is unset\` (regression guard)
  - \`#315 — database.caConfigMap mounts /etc/leoflow/db-ca/ca.crt readonly\` (asserts Volume and VolumeMount shape)
- **Chart README**: new section \"Verified TLS to managed Postgres\" walking the ConfigMap creation, \`helm upgrade --set\` invocation, and the rotation caveat (kubelet auto-updates the mounted file but the pgx pool keeps its open connections; rolling the pod is the clean cutover).

## Operator usage
\`\`\`bash
kubectl create configmap managed-pg-ca \\
  -n leoflow --from-file=ca.crt=server-ca.pem

helm upgrade --install leoflow ./helm/leoflow -n leoflow \\
  --set database.caConfigMap=managed-pg-ca \\
  --set database.url='postgres://user:pass@cloudsql-private-ip:5432/leoflow?sslmode=verify-full&sslrootcert=/etc/leoflow/db-ca/ca.crt'
\`\`\`

## Test plan
- [x] \`helm unittest\` 45/45 (43 prior + 2 new)
- [x] \`helm-docs\` regenerated
- [x] Pre-commit lint + tests clean
- [ ] Live: deploy on GKE Pro against Cloud SQL with \`verify-full\` + \`sslrootcert\` pointing at \`/etc/leoflow/db-ca/ca.crt\`; pod boots and the migration Job + server both connect cleanly

## Follow-up
**PR 2 (#312 Redis):** Redis needs the same chart knob + a Go-side \`TLSConfig.RootCAs\` override because go-redis doesn't read CA paths from the URL the way pgx does. Lands as a separate PR right after this one.