### PR TITLE
fix(examples): regen gcp_gcs_load Dockerfile after secret-manager dep

### DIFF
--- a/examples/gcp_gcs_load/Dockerfile
+++ b/examples/gcp_gcs_load/Dockerfile
@@ -4,6 +4,6 @@
 # not hand-edit — re-run the script after changing python_version or
 # dependencies, or CI's drift check fails.
 FROM leoflow-base:py3.11
-RUN pip install --no-cache-dir "google-auth==2.35.0" "google-cloud-storage==2.18.2"
+RUN pip install --no-cache-dir "google-auth==2.35.0" "google-cloud-storage==2.18.2" "google-cloud-secret-manager==2.20.2"
 COPY dag.py /home/leoflow/dag.py
 ENV PYTHONPATH=/home/leoflow


### PR DESCRIPTION
## Summary
- PR #327 added \`google-cloud-secret-manager==2.20.2\` to \`examples/gcp_gcs_load/leoflow.yaml\` but did not regenerate the Dockerfile, so the #318 drift gate (added in #329) started failing on main right after the squash.
- Re-running \`scripts/sync-example-dockerfiles.sh\` brings the Dockerfile in sync — one-line addition to the \`pip install\` layer.

## Test plan
- [x] \`bash scripts/sync-example-dockerfiles.sh --check\` — clean
- [x] pre-commit gates pass (lint, ruff, coverage 80.1%)
- [ ] CI green on main after merge