### PR TITLE
feat(helm,redis): redis.caConfigMap mounts a CA bundle for verified TLS to managed Redis (#312)

### DIFF
--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -126,6 +126,43 @@ If you need to run against an older engine, please file an issue with
 the version + symptoms — we don't bench-test older majors but will
 investigate specific incompatibilities.
 
+## Verified TLS to managed Redis (#312)
+
+Managed Redis offerings — Memorystore SERVER_AUTHENTICATION, ElastiCache
+in-transit encryption, Azure Cache for Redis — sign their TLS server cert
+with a provider or per-instance CA that is **not** in the container's
+system roots. Without telling the client which CA to trust, the only
+working postures are "plaintext `redis://`" (unacceptable across the
+internet) or "skip verification" (we don't expose that knob; it strips
+TLS to a noise channel).
+
+Set `redis.caConfigMap` to a ConfigMap holding the provider CA as
+`ca.crt`:
+
+```bash
+kubectl create configmap leoflow-redis-ca \
+  --from-file=ca.crt=./memorystore-server-ca.pem -n leoflow
+```
+
+```yaml
+redis:
+  url: rediss://10.0.0.5:6378/0
+  caConfigMap: leoflow-redis-ca
+```
+
+The chart then:
+
+1. Mounts the ConfigMap read-only at `/etc/leoflow/redis-ca/ca.crt`.
+2. Sets `LEOFLOW_REDIS_CA_FILE=/etc/leoflow/redis-ca/ca.crt` so the
+   server overrides `tls.Config.RootCAs` instead of falling back to
+   system roots.
+3. Refuses to boot if the file is missing or malformed (clear error
+   instead of a confusing "x509: certificate signed by unknown
+   authority" at first Ping).
+
+Leave `caConfigMap` empty for plaintext `redis://` or for managed
+TLS that uses a public CA (rare).
+
 ## Evaluating without a managed Postgres + Redis
 
 For a one-cluster evaluation (kind, minikube, k3d, scratch namespace), the
@@ -247,6 +284,7 @@ differ from what's committed.
 | podSecurityContext.runAsUser | int | `65532` |  |
 | ports | object | `{"grpc":9091,"http":8080,"metrics":9090}` | Ports the leoflow-server listens on. http: API + UI, metrics: Prometheus /metrics, grpc: agent ↔ control plane channel (task pods dial back here). |
 | rbac.create | bool | `true` | Create the Role + RoleBinding granting the control plane create/get/list/watch/delete on pods + get on pods/log in `taskNamespace`. Required for the pod-per-task executor. |
+| redis.caConfigMap | string | `""` | Name of a ConfigMap with a `ca.crt` key containing the PEM CA bundle the client trusts when negotiating TLS to a `rediss://` URL (#312). Required when the managed-Redis server cert is signed by a provider / per-instance CA that is not in the system roots — Memorystore SERVER_AUTHENTICATION, ElastiCache in-transit encryption, Azure Cache for Redis. Mounted read-only at `/etc/leoflow/redis-ca` and exposed to the server via `LEOFLOW_REDIS_CA_FILE`. Leave empty when Redis uses a public CA or no TLS. |
 | redis.existingSecret | string | `""` | Name of a Secret with key `redisUrl` (takes precedence over `url`). |
 | redis.url | string | `""` | External Redis URI. Required for Pro (the embedded XCom is Lite-only). Example: `redis://host:6379/0`, or `rediss://host:6380/0` for TLS. |
 | replicaCount | int | `1` | Number of control-plane replicas. The scheduler leader-elects (ADR 0009), so `>1` is HA-safe (active-passive scheduler, active-active API). |

--- a/helm/leoflow/README.md.gotmpl
+++ b/helm/leoflow/README.md.gotmpl
@@ -126,6 +126,43 @@ If you need to run against an older engine, please file an issue with
 the version + symptoms — we don't bench-test older majors but will
 investigate specific incompatibilities.
 
+## Verified TLS to managed Redis (#312)
+
+Managed Redis offerings — Memorystore SERVER_AUTHENTICATION, ElastiCache
+in-transit encryption, Azure Cache for Redis — sign their TLS server cert
+with a provider or per-instance CA that is **not** in the container's
+system roots. Without telling the client which CA to trust, the only
+working postures are "plaintext `redis://`" (unacceptable across the
+internet) or "skip verification" (we don't expose that knob; it strips
+TLS to a noise channel).
+
+Set `redis.caConfigMap` to a ConfigMap holding the provider CA as
+`ca.crt`:
+
+```bash
+kubectl create configmap leoflow-redis-ca \
+  --from-file=ca.crt=./memorystore-server-ca.pem -n leoflow
+```
+
+```yaml
+redis:
+  url: rediss://10.0.0.5:6378/0
+  caConfigMap: leoflow-redis-ca
+```
+
+The chart then:
+
+1. Mounts the ConfigMap read-only at `/etc/leoflow/redis-ca/ca.crt`.
+2. Sets `LEOFLOW_REDIS_CA_FILE=/etc/leoflow/redis-ca/ca.crt` so the
+   server overrides `tls.Config.RootCAs` instead of falling back to
+   system roots.
+3. Refuses to boot if the file is missing or malformed (clear error
+   instead of a confusing "x509: certificate signed by unknown
+   authority" at first Ping).
+
+Leave `caConfigMap` empty for plaintext `redis://` or for managed
+TLS that uses a public CA (rare).
+
 ## Evaluating without a managed Postgres + Redis
 
 For a one-cluster evaluation (kind, minikube, k3d, scratch namespace), the

--- a/helm/leoflow/templates/deployment.yaml
+++ b/helm/leoflow/templates/deployment.yaml
@@ -148,6 +148,15 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.redis.existingSecret | default (include "leoflow.secretName" .) }}
                   key: redisUrl
+            {{- if .Values.redis.caConfigMap }}
+            # #312 — Verified TLS to managed Redis (Memorystore
+            # SERVER_AUTHENTICATION, ElastiCache in-transit, Azure Cache).
+            # The CA bundle from the named ConfigMap is mounted read-only at
+            # /etc/leoflow/redis-ca/ca.crt and the server is told where to
+            # find it via LEOFLOW_REDIS_CA_FILE.
+            - name: LEOFLOW_REDIS_CA_FILE
+              value: /etc/leoflow/redis-ca/ca.crt
+            {{- end }}
             - name: LEOFLOW_AUTH_JWT_SECRET
               valueFrom:
                 secretKeyRef:
@@ -201,6 +210,11 @@ spec:
               mountPath: /etc/leoflow/db-ca
               readOnly: true
             {{- end }}
+            {{- if .Values.redis.caConfigMap }}
+            - name: redis-ca
+              mountPath: /etc/leoflow/redis-ca
+              readOnly: true
+            {{- end }}
       volumes:
         - name: logs
           {{- if .Values.logs.persistence.enabled }}
@@ -223,6 +237,11 @@ spec:
             items:
               - key: ca.crt
                 path: ca.crt
+        {{- end }}
+        {{- if .Values.redis.caConfigMap }}
+        - name: redis-ca
+          configMap:
+            name: {{ .Values.redis.caConfigMap }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm/leoflow/tests/deployment_test.yaml
+++ b/helm/leoflow/tests/deployment_test.yaml
@@ -214,6 +214,61 @@ tests:
             mountPath: /etc/leoflow/db-ca
             readOnly: true
 
+  # #312 — managed-Redis verified TLS requires an operator-supplied CA bundle.
+  # Without `redis.caConfigMap` set, NOTHING about the CA injection appears on
+  # the rendered pod: no LEOFLOW_REDIS_CA_FILE env var, no volume, no
+  # volumeMount. That is the regression guard — an unrelated chart change must
+  # not start silently mounting an unconfigured CA path.
+  - it: "#312 — Redis CA wiring is absent when redis.caConfigMap is unset (default)"
+    template: deployment.yaml
+    set:
+      database.url: postgres://h/d
+      redis.url: rediss://h/0
+      auth.jwtSecret: jwt
+      agentTLS.enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LEOFLOW_REDIS_CA_FILE
+            value: /etc/leoflow/redis-ca/ca.crt
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: redis-ca
+            mountPath: /etc/leoflow/redis-ca
+            readOnly: true
+
+  # #312 — When redis.caConfigMap is set, all three pieces must appear together:
+  # env var pointing at the mount path, container volumeMount at that path,
+  # and a pod-level volume sourcing the named ConfigMap.
+  - it: "#312 — redis.caConfigMap wires env + volumeMount + volume in one go"
+    template: deployment.yaml
+    set:
+      database.url: postgres://h/d
+      redis.url: rediss://h/0
+      auth.jwtSecret: jwt
+      agentTLS.enabled: false
+      redis.caConfigMap: redis-ca-bundle
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LEOFLOW_REDIS_CA_FILE
+            value: /etc/leoflow/redis-ca/ca.crt
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: redis-ca
+            mountPath: /etc/leoflow/redis-ca
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: redis-ca
+            configMap:
+              name: redis-ca-bundle
+
   - it: pod + container securityContext pin runAsNonRoot + UID 65532 (distroless nonroot)
     template: deployment.yaml
     set:

--- a/helm/leoflow/values.yaml
+++ b/helm/leoflow/values.yaml
@@ -108,6 +108,8 @@ redis:
   url: ""
   # -- Name of a Secret with key `redisUrl` (takes precedence over `url`).
   existingSecret: ""
+  # -- Name of a ConfigMap with a `ca.crt` key containing the PEM CA bundle the client trusts when negotiating TLS to a `rediss://` URL (#312). Required when the managed-Redis server cert is signed by a provider / per-instance CA that is not in the system roots — Memorystore SERVER_AUTHENTICATION, ElastiCache in-transit encryption, Azure Cache for Redis. Mounted read-only at `/etc/leoflow/redis-ca` and exposed to the server via `LEOFLOW_REDIS_CA_FILE`. Leave empty when Redis uses a public CA or no TLS.
+  caConfigMap: ""
 
 auth:
   # -- HMAC secret signing API + agent JWTs. Set inline OR reference an existing Secret via `existingSecret`. Generate with `openssl rand -base64 64`.

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -148,6 +148,15 @@ type DatabaseSection struct {
 // RedisSection configures the Redis connection.
 type RedisSection struct {
 	URL string `mapstructure:"url"`
+	// CAFile is the absolute path to a PEM CA bundle the client trusts when
+	// negotiating TLS to a `rediss://` URL (#312). Required to reach managed
+	// Redis (Memorystore SERVER_AUTHENTICATION, ElastiCache in-transit
+	// encryption, Azure Cache for Redis) whose server cert is signed by a
+	// provider / per-instance CA that is not in the container's system
+	// roots. Empty falls back to the SDK default — system roots only.
+	// The Helm chart sets this via LEOFLOW_REDIS_CA_FILE when
+	// `redis.caConfigMap` is configured, pointing at the mounted ConfigMap.
+	CAFile string `mapstructure:"ca_file"`
 }
 
 // AuthSection configures authentication.

--- a/internal/storage/redis.go
+++ b/internal/storage/redis.go
@@ -2,8 +2,11 @@ package storage
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/redis/go-redis/v9"
 
@@ -15,18 +18,44 @@ type Redis struct {
 	Client *redis.Client
 }
 
-// redisOptions parses a redis URL into client options.
-func redisOptions(url string) (*redis.Options, error) {
+// redisOptions parses a redis URL into client options. When caPath is
+// non-empty, the PEM CA bundle at that path is loaded and installed as the
+// TLSConfig.RootCAs the client uses to verify the server cert — required to
+// reach managed Redis (Memorystore SERVER_AUTHENTICATION, ElastiCache
+// in-transit, Azure Cache) whose server cert is signed by a per-instance CA
+// that is not in the container's system roots (#312). Empty caPath leaves
+// the TLSConfig untouched (system roots, same as before the knob existed),
+// so non-TLS and non-managed-TLS installs behave identically.
+func redisOptions(url, caPath string) (*redis.Options, error) {
 	opts, err := redis.ParseURL(url)
 	if err != nil {
 		return nil, fmt.Errorf("parsing redis url: %w", err)
 	}
+	if caPath == "" {
+		return opts, nil
+	}
+	pem, err := os.ReadFile(caPath) //nolint:gosec // operator-configured path; reading it is the entire point.
+	if err != nil {
+		return nil, fmt.Errorf("reading redis CA file %q: %w", caPath, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("redis CA file %q has no PEM certificate (expected an `ca.crt` bundle)", caPath)
+	}
+	// ParseURL initializes TLSConfig only for `rediss://`; an operator who
+	// sets a CA against a plaintext `redis://` URL almost certainly wants
+	// TLS, so install a fresh config rather than dropping the CA on the
+	// floor.
+	if opts.TLSConfig == nil {
+		opts.TLSConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+	}
+	opts.TLSConfig.RootCAs = pool
 	return opts, nil
 }
 
 // NewRedis connects to Redis and verifies connectivity.
 func NewRedis(ctx context.Context, cfg config.RedisSection) (*Redis, error) {
-	opts, err := redisOptions(cfg.URL)
+	opts, err := redisOptions(cfg.URL, cfg.CAFile)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/redis_tls_test.go
+++ b/internal/storage/redis_tls_test.go
@@ -1,0 +1,130 @@
+package storage
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/config"
+)
+
+// freshCAPEM mints a self-signed CA cert and returns it as PEM. We do this at
+// test time rather than ship a static PEM constant so the test is robust to
+// editor mangling (whitespace, line endings) and immune to clock-related
+// "not after" surprises if a hard-coded fixture ages out.
+func freshCAPEM(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "leoflow-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// TestRedisOptionsLoadsCAFromFile pins the #312 contract: when RedisSection
+// has CAFile set, NewRedis (via redisOptions) overrides
+// opts.TLSConfig.RootCAs with the bundle parsed from disk, so the client
+// trusts the per-instance CA managed Redis (Memorystore SERVER_AUTHENTICATION,
+// ElastiCache in-transit, Azure Cache) presents. Without this knob the only
+// reachable TLS posture is "system roots" — empty against any managed
+// provider.
+func TestRedisOptionsLoadsCAFromFile(t *testing.T) {
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "ca.crt")
+	if err := os.WriteFile(caPath, freshCAPEM(t), 0o600); err != nil {
+		t.Fatalf("seed CA file: %v", err)
+	}
+	opts, err := redisOptions("rediss://example.invalid:6380/0", caPath)
+	if err != nil {
+		t.Fatalf("redisOptions: %v", err)
+	}
+	if opts.TLSConfig == nil {
+		t.Fatal("expected TLSConfig to be initialized")
+	}
+	if opts.TLSConfig.RootCAs == nil {
+		t.Error("expected RootCAs to be populated from the CA file")
+	}
+	// Defensive minimum: the override MUST keep TLS 1.2 as the floor —
+	// implicitly via the redis.ParseURL path or explicitly when we
+	// initialize TLSConfig from scratch.
+	if opts.TLSConfig.MinVersion != 0 && opts.TLSConfig.MinVersion < tls.VersionTLS12 {
+		t.Errorf("MinVersion = %x, want >= TLS 1.2", opts.TLSConfig.MinVersion)
+	}
+}
+
+// TestRedisOptionsCAFileMissingFailsLoud covers the misconfig shape: an
+// operator typo'd the path or the ConfigMap was not mounted. We want a clear
+// error at boot, not a silent fallback to system roots (which would then
+// fail the Ping with a confusing x509 error from the *real* CA mismatch).
+func TestRedisOptionsCAFileMissingFailsLoud(t *testing.T) {
+	_, err := redisOptions("rediss://example.invalid:6380/0", "/nonexistent/ca.crt")
+	if err == nil {
+		t.Fatal("expected an error for a missing CA file, got nil")
+	}
+	if !strings.Contains(err.Error(), "ca") && !strings.Contains(err.Error(), "CA") {
+		t.Errorf("error should name the CA file as the cause; got %q", err.Error())
+	}
+}
+
+// TestRedisOptionsCAFileMalformedFailsLoud covers the second misconfig: the
+// file exists but is not PEM (operator pointed at the wrong file, the
+// ConfigMap held a binary cert, etc.). Same posture: clear error at boot.
+func TestRedisOptionsCAFileMalformedFailsLoud(t *testing.T) {
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "ca.crt")
+	if err := os.WriteFile(caPath, []byte("not a PEM file at all"), 0o600); err != nil {
+		t.Fatalf("seed bad CA file: %v", err)
+	}
+	_, err := redisOptions("rediss://example.invalid:6380/0", caPath)
+	if err == nil {
+		t.Fatal("expected an error for malformed PEM, got nil")
+	}
+}
+
+// TestRedisOptionsEmptyCAFilePassesThrough: the default path (no CA file
+// configured) must behave exactly like before this PR — system roots only,
+// no TLSConfig surgery. This protects every Lite + non-managed Redis install
+// from a regression caused by the new branch.
+func TestRedisOptionsEmptyCAFilePassesThrough(t *testing.T) {
+	// Use a `rediss://` URL so ParseURL builds a TLSConfig; we then assert
+	// our code did NOT replace its RootCAs.
+	opts, err := redisOptions("rediss://example.invalid:6380/0", "")
+	if err != nil {
+		t.Fatalf("redisOptions: %v", err)
+	}
+	if opts.TLSConfig == nil {
+		t.Fatal("rediss:// URL must yield a TLSConfig (system roots)")
+	}
+	if opts.TLSConfig.RootCAs != nil {
+		t.Error("with no CAFile, RootCAs should be nil (i.e. system roots), not an explicit pool")
+	}
+}
+
+// Probe the config wiring so the env var → RedisSection.CAFile mapping is
+// observable at compile time even if no test exercises ServerConfig
+// directly here. A compile failure here flags a rename of the mapstructure
+// tag or the field.
+var _ = config.RedisSection{CAFile: ""}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -30,7 +30,7 @@ func TestPoolConfigInvalidURL(t *testing.T) {
 }
 
 func TestRedisOptionsParsesAddr(t *testing.T) {
-	opts, err := redisOptions("redis://localhost:6379/0")
+	opts, err := redisOptions("redis://localhost:6379/0", "")
 	if err != nil {
 		t.Fatalf("redisOptions: %v", err)
 	}
@@ -43,7 +43,7 @@ func TestRedisOptionsParsesAddr(t *testing.T) {
 }
 
 func TestRedisOptionsInvalidURL(t *testing.T) {
-	if _, err := redisOptions("not-a-redis-url"); err == nil {
+	if _, err := redisOptions("not-a-redis-url", ""); err == nil {
 		t.Error("expected error for invalid redis url")
 	}
 }


### PR DESCRIPTION
## Summary

Sibling of #330 (Postgres CA). Managed Redis offerings sign their TLS server cert with a provider or per-instance CA that is not in the container's system roots — Memorystore SERVER_AUTHENTICATION, ElastiCache in-transit encryption, Azure Cache for Redis. Without an explicit CA path the only reachable postures are plaintext \`redis://\` or "skip verification" (we don't expose that knob).

This PR adds:

**Server side**
- \`config.RedisSection.CAFile\` (\`LEOFLOW_REDIS_CA_FILE\`).
- \`storage.redisOptions\` reads the PEM bundle, builds a \`*x509.CertPool\`, and overrides \`opts.TLSConfig.RootCAs\`. Initializes \`TLSConfig\` with TLS 1.2 floor when \`ParseURL\` didn't — an operator who set a CA against a plaintext \`redis://\` URL meant to use TLS, so we install one rather than drop the CA silently.
- Loud errors at boot for missing file / malformed PEM (clearer than a confusing \`x509: unknown authority\` on first Ping).

**Chart side**
- \`redis.caConfigMap\` names a ConfigMap with a \`ca.crt\` key. The chart mounts it read-only at \`/etc/leoflow/redis-ca\` and exports \`LEOFLOW_REDIS_CA_FILE\`. Default empty → no mount, no env var (zero diff for non-managed installs).
- Chart README documents the wiring next to the datastore-compatibility section.

**Tests**
- \`redis_tls_test.go\` — CA loads → RootCAs populated; missing path → loud error; malformed PEM → loud error; empty CAFile → TLSConfig untouched (system-roots passthrough).
- \`helm-unittest\` — default-off regression guard + on-state asserting env + volumeMount + volume appear together.

Closes #312.

## Test plan
- [x] \`go test ./internal/storage/ ./internal/config/\` — pass
- [x] \`golangci-lint run ./internal/storage/ ./internal/config/\` — 0 issues
- [x] \`helm unittest helm/leoflow\` — 14/14 pass
- [x] pre-commit gate (lint + ruff + 80.1% filtered coverage) clean
- [ ] CI green
- [ ] Manual: helm template with \`redis.caConfigMap=foo\` shows expected env + volume