### PR TITLE
docs(install): split installation.md into Lite + Pro tracks (#91)

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,31 +1,49 @@
 # Installation
 
-One command installs Leoflow and bootstraps everything it needs — **no sudo, no
-system Python, no package manager**:
+Leoflow ships in **two editions** — pick the install path that matches the one
+you want:
+
+| Edition | Where it runs | Who it's for | Install path |
+|---|---|---|---|
+| **Lite** | Your laptop or a single VM (no Kubernetes, no Docker required) | Local development, small teams, evaluation | [Install Lite](#install-lite) |
+| **Pro** | A Kubernetes cluster (pod-per-task executor) | Team-scale and production workloads | [Install Pro](#install-pro) |
+
+See [Editions](editions.md) for the full feature-by-feature breakdown. The two
+editions share the same Go control plane and the same Airflow-compatible
+HTTP API — Pro adds the K8s executor, HA scheduler, and external-datastore
+expectations; Lite bundles everything in one host process.
+
+!!! warning "Pre-alpha builds expire"
+    Pre-alpha binaries and images carry a baked-in expiry (~90 days) and
+    refuse to run past it — `leoflow version` shows `[expires …]`. When one
+    expires, re-install (Lite) or `helm upgrade` to a newer tag (Pro).
+    `LEOFLOW_IGNORE_EXPIRY=1` overrides in a pinch.
+
+---
+
+## Install Lite
+
+One command installs Leoflow Lite and bootstraps everything it needs — **no
+sudo, no system Python, no package manager**:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/neochaotic/leoflow/main/install.sh | sh
 ```
 
-That script downloads the release archive for your OS/architecture, verifies its
-SHA-256 against the signed checksums, installs the binaries to `~/.leoflow/bin`,
-and then runs [`leoflow setup`](#what-leoflow-setup-does).
+That script downloads the release archive for your OS/architecture, verifies
+its SHA-256 against the signed checksums, installs the binaries to
+`~/.leoflow/bin`, and then runs [`leoflow setup`](#what-leoflow-setup-does).
 
-!!! warning "Pre-alpha builds expire"
-    Pre-alpha binaries carry a baked-in expiry (~90 days) and refuse to run past
-    it — `leoflow version` shows `[expires …]`. This is intentional: pre-alpha
-    builds are not durable. When one expires, re-run the install command for a
-    fresh build. (`LEOFLOW_IGNORE_EXPIRY=1` overrides in a pinch.)
+### What you need
 
-## What you need
-
-Almost nothing. The control plane, CLI, and agent are **static Go binaries**, and
-`leoflow setup` provisions a Python 3.11 itself if you don't have one.
+Almost nothing. The control plane, CLI, and agent are **static Go binaries**,
+and `leoflow setup` provisions a Python 3.11 itself if you don't have one.
 
 There are **two execution paths** — and **no Docker executor**, on purpose
 ([ADR 0015](https://github.com/neochaotic/leoflow/blob/main/docs/adr/0015-kubernetes-only-execution.md)):
-the Docker Go SDK carries an unfixable advisory (Moby AuthZ bypass, GO-2026-4887)
-that would reach the control-plane binary and fail the security gate. So:
+the Docker Go SDK carries an unfixable advisory (Moby AuthZ bypass,
+GO-2026-4887) that would reach the control-plane binary and fail the security
+gate. So:
 
 | Executor | Needs | Isolation | For |
 |---|---|---|---|
@@ -38,7 +56,7 @@ picks the highest path available**; without Docker it uses subprocess. Run
 [`leoflow doctor`](#leoflow-doctor) anytime to see where you stand, and see
 [Choosing an executor](dev-workflow.md#choosing-an-executor) for the trade-offs.
 
-## What `leoflow setup` does
+### What `leoflow setup` does
 
 `setup` is idempotent — re-running is safe. It:
 
@@ -61,12 +79,12 @@ picks the highest path available**; without Docker it uses subprocess. Run
    Recover it with `leoflow lite reset-password`.
 
 !!! warning "Lite is for trusted networks"
-    The admin password is short by design and there is no SSO/RBAC — run Lite on
-    **localhost, an internal network, or a VPN**, never exposed publicly. See
-    [Editions](editions.md).
+    The admin password is short by design and there is no SSO/RBAC — run Lite
+    on **localhost, an internal network, or a VPN**, never exposed publicly.
+    Production-grade deploys are Pro's job. See [Editions](editions.md).
 
-Everything Leoflow manages lives under `~/.leoflow`; your DAG source lives in the
-workspace — the two are kept separate.
+Everything Leoflow manages lives under `~/.leoflow`; your DAG source lives in
+the workspace — the two are kept separate.
 
 ```bash
 leoflow setup                      # interactive on a terminal; defaults otherwise (safe to re-run)
@@ -75,25 +93,25 @@ leoflow setup --workspace ~/work   # choose where your DAG projects live
 ```
 
 !!! note "There is no scanned `dags/` folder"
-    Unlike Airflow, Leoflow has no monolithic DAGs directory. Each DAG is its own
-    project (`dag.py` + `leoflow.yaml`); you point `leoflow lite <path>` at it. The
-    workspace is just a convenient home for those projects.
+    Unlike Airflow, Leoflow has no monolithic DAGs directory. Each DAG is its
+    own project (`dag.py` + `leoflow.yaml`); you point `leoflow lite <path>` at
+    it. The workspace is just a convenient home for those projects.
 
-## Platforms
+### Platforms
 
-Leoflow ships **Linux and macOS** binaries for **amd64 and arm64**. Because the
-install never touches your system package manager, the Linux **distribution does
-not matter** — only the C library and CPU architecture do:
+Leoflow ships **Linux and macOS** binaries for **amd64 and arm64**. Because
+the install never touches your system package manager, the Linux
+**distribution does not matter** — only the C library and CPU architecture do:
 
-- **glibc distros** (Ubuntu, Debian, Fedora, RHEL/Rocky/Alma, Arch, openSUSE) and
-  **musl** (Alpine) are both supported; `setup` detects musl and fetches the
-  matching CPython build.
+- **glibc distros** (Ubuntu, Debian, Fedora, RHEL/Rocky/Alma, Arch, openSUSE)
+  and **musl** (Alpine) are both supported; `setup` detects musl and fetches
+  the matching CPython build.
 - **Windows:** use **WSL2** (it's a glibc Linux). Keep your project in the WSL
-  **native filesystem** (`~/...`), not under `/mnt/c` — `leoflow lite`'s hot-reload
-  uses inotify, which is unreliable on the Windows 9p mount. `leoflow doctor`
-  warns when your project is under `/mnt`.
+  **native filesystem** (`~/...`), not under `/mnt/c` — `leoflow lite`'s
+  hot-reload uses inotify, which is unreliable on the Windows 9p mount.
+  `leoflow doctor` warns when your project is under `/mnt`.
 
-## Verifying the download
+### Verifying the download
 
 The release publishes `checksums.txt` (SHA-256), and the checksums file is
 **cosign-signed** (keyless). `install.sh` verifies the archive checksum
@@ -108,7 +126,7 @@ cosign verify-blob \
   checksums.txt
 ```
 
-## `leoflow doctor`
+### `leoflow doctor`
 
 A read-only diagnostic — it changes nothing:
 
@@ -129,7 +147,7 @@ leoflow doctor
   next: run `leoflow setup` to bootstrap the managed runtime.
 ```
 
-## Installer options
+### Installer options
 
 | Variable | Effect |
 |---|---|
@@ -137,7 +155,7 @@ leoflow doctor
 | `LEOFLOW_NO_SETUP=1` | install binaries only; run `leoflow setup` yourself later |
 | `LEOFLOW_INSTALL_DIR=~/.leoflow/bin` | where to put the binaries |
 
-## Building from source
+### Building Lite from source
 
 If you have a Go toolchain and prefer to build it yourself:
 
@@ -150,29 +168,164 @@ leoflow setup
 ```
 
 The subsequent `leoflow setup` provisions the same managed runtime the
-install-script path uses (managed CPython under `~/.leoflow/`). A source build
-is **not stamped with an expiry**, so unlike a pre-alpha release binary it never
-refuses to run after 90 days.
+install-script path uses (managed CPython under `~/.leoflow/`). A source
+build is **not stamped with an expiry**, so unlike a pre-alpha release binary
+it never refuses to run after 90 days.
 
-## Uninstalling
+### Uninstalling Lite
 
-Use the built-in command — it removes the install directory and (with `--purge`)
-your workspace too:
+Use the built-in command — it removes the install directory and (with
+`--purge`) your workspace too:
 
 ```bash
 leoflow uninstall              # removes ~/.leoflow (binaries, managed Python, parser, config)
 leoflow uninstall --purge      # also removes ~/leoflow (your DAGs!)
 ```
 
-If the `leoflow` binary is gone or broken, fall back to the same paths by hand:
+If the `leoflow` binary is gone or broken, fall back to the same paths by
+hand:
 
 ```bash
 rm -rf ~/.leoflow              # what `leoflow uninstall` would have removed
 rm -rf ~/leoflow               # what `--purge` adds (your workspace)
 ```
 
+---
+
+## Install Pro
+
+Pro installs the **control plane into Kubernetes** via the Leoflow Helm
+chart. Task pods are scheduled into the cluster by the same control plane —
+no host-side process supervisor, no managed Python sidecar. DAGs ship as
+**container images** built in CI ([CI/CD & deploy examples](deploy.md)).
+
+### What you need
+
+| Requirement | Why |
+|---|---|
+| A **Kubernetes cluster** (1.27+ recommended) | runs the control plane and task pods |
+| `kubectl` configured against that cluster | applies the chart and lets the chart's pre-install Job run migrations |
+| **Helm 3.12+** | installs the chart |
+| An **external Postgres** (PostgreSQL **13+**) | Pro datastore — the chart refuses to install without `database.url` (the embedded datastore is Lite-only) |
+| An **external Redis** (Redis **6.0+**) | XCom + advisory locks — the chart refuses to install without `redis.url` |
+
+Managed services are first-class — RDS / Cloud SQL / Azure Database for
+Postgres on the SQL side; ElastiCache / Memorystore / Azure Cache for Redis.
+See the chart's [Datastore compatibility](helm-chart.md#datastore-compatibility)
+table for tested versions; managed providers that present a per-instance or
+provider-specific CA expose a `caConfigMap` knob (Postgres and Redis sides
+respectively) for verified TLS.
+
+!!! note "No managed datastore yet? There's a PoC path."
+    For a one-cluster evaluation (kind, minikube, k3d, scratch namespace), the
+    chart deliberately won't fall back to embedded datastores — that's Lite's
+    job. The supported PoC path is to install plain Postgres + Redis
+    manifests alongside the chart, then point Leoflow at the in-cluster
+    Services. Recipe: [`helm/leoflow/examples/README.md`](https://github.com/neochaotic/leoflow/tree/main/helm/leoflow/examples/README.md).
+    **Not for production.**
+
+### Install with Helm
+
+The chart is published per release (and built from `helm/leoflow` in the
+repo). For pre-alpha cadence, the simplest path is to install directly from
+the cloned repo at a checked-out tag:
+
+```bash
+git clone --depth 1 --branch v0.0.1-prealpha.27 https://github.com/neochaotic/leoflow
+cd leoflow
+
+kubectl create namespace leoflow
+
+helm install lf ./helm/leoflow -n leoflow \
+  --set image.tag=v0.0.1-prealpha.27 \
+  --set migrations.image.tag=v0.0.1-prealpha.27 \
+  --set database.url='postgres://USER:PASS@HOST:5432/leoflow?sslmode=verify-full' \
+  --set redis.url='rediss://HOST:6380/0' \
+  --set auth.jwtSecret="$(openssl rand -base64 64)" \
+  --set secretKey="$(openssl rand -hex 16)" \
+  --set bootstrap.password='change-me'
+```
+
+What this installs (one Deployment, one Service, RBAC for the pod-per-task
+executor, a pre-install/upgrade migrations Job; optional Ingress, PDB, HPA,
+ServiceMonitor, NetworkPolicy):
+
+- **`leoflow-server`** Deployment listening on HTTP `8080`, metrics `9090`,
+  and agent gRPC `9091`.
+- A pre-install/pre-upgrade **Job** running `golang-migrate` against
+  `database.url` before the server starts.
+- A **ServiceAccount + Role/RoleBinding** letting the control plane create,
+  watch, and delete **task pods** (and read their logs) in `taskNamespace`.
+- A chart-managed **Secret** holding the inline DB / Redis / JWT / bootstrap
+  credentials. Skipped when you bring your own via `*.existingSecret`.
+
+Open the UI by port-forwarding the Service, or enable `ingress.enabled=true`
+with a controller of your choice — see the chart's
+[ingress values](helm-chart.md) for the field shape. Log in as the bootstrap
+admin (`admin@leoflow.local` / the password you set above) and rotate it.
+
+### Bring-your-own Secrets
+
+Inline `--set` values bake credentials into the chart-managed Secret.
+Production deploys typically pre-create Secrets (sealed-secrets,
+External Secrets, etc.) and point the chart at them:
+
+```bash
+--set database.existingSecret=my-db     # key: databaseUrl
+--set redis.existingSecret=my-redis     # key: redisUrl
+--set auth.existingSecret=my-jwt        # key: jwtSecret
+--set secretKeyExistingSecret=my-key    # key: secretKey
+--set bootstrap.existingSecret=my-boot  # key: bootstrapPassword
+```
+
+When **every** credential comes from an existing Secret, the chart creates
+no Secret of its own. The `checksum/secret` annotation on the pod template
+only sees the chart-managed Secret, so rotation of an
+`existingSecret` requires a manual `kubectl rollout restart deploy/lf-leoflow`.
+
+### Upgrades
+
+`helm upgrade` runs the migrations Job, rolls the Deployment, and respects
+PDB/replica settings. The full upgrade contract — version skew, downtime
+expectations, rollback — lives in [Upgrades](upgrades.md).
+
+### Verifying the chart and images
+
+Both the **chart** and the **images** (`leoflow-server`, `leoflow-migrate`,
+plus `leoflow` and `leoflow-agent` binaries) are published by
+`.github/workflows/release.yaml` and **cosign-signed** (keyless):
+
+```bash
+# Verify the server image at a release tag.
+cosign verify ghcr.io/neochaotic/leoflow-server:v0.0.1-prealpha.27 \
+  --certificate-identity-regexp 'https://github.com/neochaotic/leoflow' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+### Full values reference
+
+The chart [README on this site](helm-chart.md) is auto-generated from
+`values.yaml` by `helm-docs` and documents every knob — TLS, observability,
+networking, autoscaling, secret wiring. Treat it as the source of truth.
+
+### Uninstalling Pro
+
+```bash
+helm uninstall lf -n leoflow
+kubectl delete namespace leoflow
+```
+
+This removes the chart-managed resources. PVCs (e.g. for control-plane logs
+when `logs.persistence.enabled=true`) and any **external** Postgres / Redis
+data outlive the chart — drop them out of band when you're done.
+
+---
+
 ## Next
 
 - [Quickstart](quickstart.md) — run your first DAG.
-- [The `leoflow lite` workflow](dev-workflow.md) — the hot-reload inner loop.
-- [Editions](editions.md) — Lite (now) vs Pro (chart-installable).
+- [The `leoflow lite` workflow](dev-workflow.md) — the hot-reload inner loop
+  (Lite).
+- [Helm chart](helm-chart.md) — full Pro values reference.
+- [CI/CD & deploy examples](deploy.md) — packaging DAGs as images for Pro.
+- [Editions](editions.md) — Lite vs Pro, feature by feature.


### PR DESCRIPTION
## Summary

User flagged: the install page only documented Lite ("a seção de install so tem falando sobre o lite nao tem nada do pro"). A reader looking for "how do I install Leoflow Pro?" hit dead air — Pro was buried behind \`helm-chart.md\` and the Editions overview.

This PR reorganizes \`docs/installation.md\` into a hub:

- Opens with a Lite-vs-Pro decision (one table) and links to Editions for the deep comparison.
- **Install Lite** — existing content reorganized under one heading (binary install, what setup does, platforms, doctor, installer options, source build, uninstall). No behavior change.
- **Install Pro** — new track: prereqs (K8s 1.27+, kubectl, Helm 3.12+, external Postgres 13+, external Redis 6.0+), \`helm install\` with the credential set every Pro install needs, \`*.existingSecret\` BYO variant, upgrade pointer, cosign verify command, full-values link to \`helm-chart.md\`, uninstall.

Scope discipline:
- \`helm-chart.md\` remains the single source of truth for chart values (auto-generated). \`installation.md\` links to it instead of duplicating.
- No mkdocs nav changes.
- The pre-alpha warning moves to the top so it applies to both tracks.

## Test plan
- [x] pre-commit gate (lint + ruff + 80.1% coverage) clean
- [ ] CI Docs job builds clean (mkdocs --strict)
- [ ] Visual: open the rendered page, confirm the two tracks read as a clean Lite vs Pro split