### PR TITLE
docs(planning): Airflow 3.X connector compatibility — complexity study

### DIFF
--- a/docs/adr/0036-airflow-runtime-compat-shim.md
+++ b/docs/adr/0036-airflow-runtime-compat-shim.md
@@ -1,0 +1,205 @@
+# ADR 0036: Airflow 3.X runtime compatibility shim — one model, one policy seam
+
+**Status:** Accepted
+**Date:** 2026-06-03
+**Companions:** ADR 0014 (no provider hooks in core), ADR 0019 (encryption at rest), ADR 0021 (`AIRFLOW_CONN_*` wire format), ADR 0024 (parser structural shim), ADR 0035 (cloud connector auth — keyless-first)
+
+## Context
+
+Existing Airflow 3.X DAGs commonly use provider hooks — `from airflow.providers.postgres.hooks.postgres import PostgresHook`, `from airflow.providers.google.cloud.hooks.gcs import GCSHook`. Leoflow today injects `AIRFLOW_CONN_*` env vars (ADR 0021) but offers no `BaseHook.get_connection()` surface, so user code has to parse the URI manually. This forces an unnecessary rewrite of every migrating DAG.
+
+Two compatibility paths were evaluated (`docs/planning/airflow-connector-compatibility.md`):
+
+- Re-implement hooks natively in Leoflow (~4,000 LOC; breaks every `from airflow.providers...` import).
+- Pull `apache-airflow` itself into task images (adds 200-300 MB, 600 transitive deps, 4-7 s Lite cold start, imports a DB stack into pods that have no DB).
+
+Neither serves both goals — Airflow-compat for adoption *and* long-term independence.
+
+A **minimal runtime shim** of the Airflow 3.X SDK surface (`airflow.sdk.definitions.{hooks.base, connection, variable}` + `airflow.providers.common.compat.*` re-exports + a vendored `DbApiHook` under Apache 2.0) is ~1,200 LOC of pure Python. Leoflow's `Connection` model already has 100% field-level parity with Airflow 3.X's. Strategy A in the planning doc.
+
+Separately, ADR 0035 (GCP keyless-first) introduced a security invariant: cloud keys should not enter Leoflow's DB. Naive Strategy A would let an upstream `GCSHook` accept `keyfile_dict` from the Connection without warning and would silently drop `key_secret_name` (a Leoflow-only field), contradicting ADR 0035.
+
+The two intents meet at the `BaseHook.get_connection` seam.
+
+## The two halves never live together
+
+Connection **metadata** and connector **code** are owned by different sides of the
+system. They meet only at runtime, via an env var. The full picture:
+
+```text
+┌─────────────────────────────────────────┐    ┌──────────────────────────────────┐
+│  Admin UI / API  (Leoflow control plane,│    │  leoflow.yaml  (user, per-DAG)   │
+│                   Go — ADR 0014)        │    │                                  │
+│                                         │    │  dependencies:                   │
+│  POST /api/v2/connections               │    │    - apache-airflow-providers-   │
+│  {conn_id: "my_pg", type: "postgres",   │    │      postgres==6.0               │
+│   host: "...", login: "...",            │    │    - psycopg2-binary==2.9        │
+│   password: "...", extra: "{...}"}      │    │                                  │
+└────────────────────┬────────────────────┘    └─────────────────┬────────────────┘
+                     │                                            │
+                     ▼                                            ▼
+┌─────────────────────────────────────────┐    ┌──────────────────────────────────┐
+│  Leoflow DB (encrypted, ADR 0019)       │    │  DAG image (built once per push) │
+│  connections:                           │    │  ─────────────                   │
+│    id="my_pg" type="postgres"           │    │  leoflow-base:py3.11             │
+│    password = AES-256-GCM(...)          │    │  + apache-airflow-providers-     │
+│    extra    = AES-256-GCM(...)          │    │      postgres   (PostgresHook)   │
+└────────────────────┬────────────────────┘    │  + leoflow-runtime-compat-shim   │
+                     │                          │      (airflow.sdk.* shim,        │
+                     │ on dispatch              │       ADR 0036)                  │
+                     ▼                          └─────────────────┬────────────────┘
+┌─────────────────────────────────────────┐                      │
+│  Leoflow agent (Go, in the pod or       │                      │
+│  subprocess host)                       │                      │
+│  - decrypts password + extra            │                      │
+│  - renders the URI:                     │                      │
+│    AIRFLOW_CONN_MY_PG=                  │                      │
+│      postgres://login:pw@host:5432/db   │                      │
+│      ?__extra__={"sslmode": ...}        │                      │
+│    (ADR 0021 wire format)               │                      │
+│  - injects env var into the task        │                      │
+└────────────────────┬────────────────────┘                      │
+                     │                                            │
+                     └────────────────► task process ◄────────────┘
+                                              │
+                                              ▼
+                ┌──────────────────────────────────────────────┐
+                │  User DAG (Python)                           │
+                │                                              │
+                │  from airflow.providers.postgres.hooks       │
+                │       .postgres import PostgresHook          │
+                │  hook = PostgresHook(postgres_conn_id=        │
+                │                      "my_pg")                │
+                │  hook.get_records("SELECT 1")                │
+                └─────────────────────┬────────────────────────┘
+                                      │
+                                      ▼ provider calls
+                                      │ BaseHook.get_connection("my_pg")
+                ┌──────────────────────────────────────────────┐
+                │  Leoflow runtime compat shim  (ADR 0036)     │
+                │  ──────────────────────────                  │
+                │  1. Read AIRFLOW_CONN_MY_PG env var          │
+                │  2. Parse URI → host/login/password/port/    │
+                │      schema/extra                            │
+                │  3. Pre-processor (per-type policy seam)     │
+                │     • cloud type → cloud resolver            │
+                │       (ADR 0035 chain: keyfile_dict →        │
+                │        key_path → key_secret_name → ADC)     │
+                │       fetches Secret Manager NOW if          │
+                │       key_secret_name is set; emits the      │
+                │       fetched key as a transient keyfile_    │
+                │       dict so the upstream hook understands. │
+                │     • non-cloud type → pass through.         │
+                │  4. Return a canonical                       │
+                │      airflow.sdk.definitions.Connection      │
+                └─────────────────────┬────────────────────────┘
+                                      │
+                                      ▼
+                ┌──────────────────────────────────────────────┐
+                │  Upstream PostgresHook                       │
+                │  (apache-airflow-providers-postgres)         │
+                │  - receives the canonical Connection         │
+                │  - psycopg2.connect(...) → real query        │
+                └──────────────────────────────────────────────┘
+```
+
+Two consequences fall out of the picture and matter for this ADR:
+
+- Leoflow's image **never** carries provider code. `apache-airflow-providers-*` is opt-in per DAG via `leoflow.yaml.dependencies`. Multiple DAG images can declare different providers and still share the same admin-managed Connection — connections are BYO-hook.
+- The pre-processor is the **only** seam where ADR 0035 lives. There is no parallel "native" connector hierarchy; the security policy is policy-as-code at one point.
+
+## Decision
+
+1. **Build one runtime shim, on by default.** A new `leoflow_python_compat/airflow/...` package mirrors Airflow 3.X's `airflow.sdk.*` surface (`BaseHook`, `Connection`, `Variable`, exceptions, `execution_time.context`, the `providers.common.compat.*` re-exports). The shim ships in every Leoflow runtime image (~50 KB, dormant until a provider import triggers it). Upstream provider packages (`apache-airflow-providers-<X>`) are **opt-in** — declared in `leoflow.yaml.dependencies` and pip-installed during DAG image build. The Leoflow control plane image **never** carries provider code.
+
+2. **Vendor `apache-airflow-providers-common-sql.DbApiHook` verbatim** under Apache 2.0 attribution. That single 1,250-LOC file lights up postgres, mysql, sqlite, mssql, snowflake, oracle, trino, db2, vertica, exasol without re-implementation. Pin the vendored version per Leoflow release.
+
+3. **No `apache-airflow` install at runtime.** The shim satisfies every `from airflow.sdk...` and `from airflow.providers.common.compat...` import the providers actually use. Upstream provider wheels the user pip-installs resolve their `airflow` imports against the shim.
+
+4. **One pre-processor enforces ADR 0035 at the seam.** `BaseHook.get_connection(conn_id)` reads `AIRFLOW_CONN_<ID>` (the agent already emits this — `internal/agent/runner.go:170`), then runs `extra` through a **policy pipeline before returning** the Connection to any upstream hook:
+   - **Cloud-typed connections** route through a per-cloud resolver (`gcp_resolver.py`, future `aws_resolver.py`, `azure_resolver.py`). Each follows the ADR 0035 chain: `keyfile_dict` → emit + log a one-time warning ("ADR 0035: cloud key stored in Leoflow DB; prefer `key_path` or Workload Identity"); `key_path` → pass through (upstream hooks already understand it); `key_secret_name` → **fetch the secret now**, emit it as a transient `keyfile_dict` for the upstream hook's call site only — the secret never lands in our DB; empty → leave minimal, upstream falls through to ADC / Workload Identity.
+   - **Non-cloud connections** (postgres, mysql, http, redis, etc.) pass through unchanged — the user/password model in ADR 0019 already governs them.
+
+5. **Skip the Airflow SecretsBackend chain.** The shim's `_get_connection` reads `AIRFLOW_CONN_*` directly. Leoflow's connection delivery is single-source; mirroring Airflow's backend-chain plumbing would be code without behavior we don't already have.
+
+6. **CI matrix is the regression gate.** Every Leoflow minor release pip-installs upstream `apache-airflow-providers-{postgres,sqlite,redis,http,mysql}` against the shim and runs the providers' own smoke tests. Each new Airflow minor gets a budgeted shim-alignment pass (~1-2 engineer-days per minor).
+
+7. **Officially-supported hooks for Leoflow `v0.x`:** `postgres`, `http`, `sqlite`, `redis`, `mysql`. Each ships with a cookbook page, a connection-test DAG, and CI gating. Cloud hooks (`gcp_*`, future `aws_*`, `azure_*`) add an entry per phase, gated by the per-cloud resolver from clause 4.
+
+8. **`leoflow_runtime` native API is an additive overlay, not a replacement.** For each officially-supported hook we may later ship a Leoflow-flavored surface (e.g. `from leoflow_runtime.cloud.gcp import gcs_client`) that delegates through the **same** pre-processor. No second hook hierarchy; ergonomic surface only. Deferred until the shim is in production for two releases.
+
+9. **Where connector code lives — the BYO-hook contract (the dependency is mandatory).**
+   - **Connection metadata** (host, login, password, extra JSON) is owned by the Leoflow control plane: created in the admin UI, encrypted at rest (ADR 0019), delivered to the task as `AIRFLOW_CONN_<ID>` (ADR 0021).
+   - **Hook code** (e.g. `PostgresHook.get_records()`, `GCSHook.upload()`) is owned by the user's DAG image: pip-installed from `apache-airflow-providers-<X>` per `leoflow.yaml.dependencies`. **Leoflow ships no provider code.** The shim provides only the `airflow.sdk.*` import surface; without the matching provider wheel installed, `from airflow.providers.postgres.hooks.postgres import PostgresHook` raises `ModuleNotFoundError` — a clear, fast, import-time failure.
+   - They meet exclusively at the env var. Different DAG images can declare different providers and still share the same admin-managed connection.
+   - **Doc contract (mandatory).** Every cookbook page for an Airflow-compat hook lists the required `dependencies:` entry in a fixed format at the top of the page:
+     ```yaml
+     # leoflow.yaml — required for PostgresHook
+     dependencies:
+       - apache-airflow-providers-postgres>=6.0
+       - psycopg2-binary>=2.9
+     ```
+     The cookbook page also names the exact `ModuleNotFoundError` the user will see if the dep is missing, so search engines route them back. The shim emits a one-time helpful note at runtime if `from airflow.providers...` fails for a `conn_type` whose metadata is registered in the admin UI but whose pip package is not installed — pointing at the corresponding cookbook page.
+   - **No default provider bundling.** Leoflow's `leoflow init` scaffold leaves `dependencies: []`. We do not auto-add providers ("opinionated defaults" would carry image size + CVE surface the user didn't ask for). The first time the user adds a Connection in the admin UI, the UI shows a one-line note: "Don't forget to add `apache-airflow-providers-<type>` to your DAG's `leoflow.yaml.dependencies`."
+
+10. **Admin panel implementation stays Go-only.** Connection CRUD, type catalog, form-field schema, structural validation, and UI rendering live in the Go control plane (no Python, no Airflow SDK call — ADR 0014). Two intentional divergences from Airflow's admin-side pattern:
+    - **Form widgets** — `internal/api/connection_hook_meta.go` holds a curated static registry for the ~10 most-used types (postgres, mysql, sqlite, mssql, redis, http, gcp, future aws/azure, plus a generic fallback). Non-curated types render with a generic form (standard fields + raw "Extra JSON" textarea). Hook functionality at runtime is identical either way; the divergence is only in form polish. Tradeoff named: when an upstream provider adds a new field, we update the Go registry on the next release rather than introspecting Python at request time.
+    - **`test_connection()`** — defaults to structural validation only (`internal/api/connection_probe.go`). A real "probe in an ephemeral pod" path is reserved as an opt-in Pro feature in a follow-up ADR (would spin up a one-shot pod with the user's image, invoke `Hook.test_connection()`, return the result, tear down).
+
+11. **Operators we already ship are unchanged — separate parser shim, separate path, no provider deps required.** The existing parser-side Airflow shim (ADR 0024 — `parser/leoflow_parser/_shim/airflow/` with `DAG`, `BaseOperator`, `XComArg`, `PythonOperator`, `EmptyOperator`, `BashOperator` (stub), `HttpOperator` (stub), and the `@task` decorator) is **structural only and lives at compile time**. The parser converts those into Leoflow task types (`bash`, `python`, `http_api`) in `dag.json`, and `runtime/python/leoflow_runtime/runner.py` executes them directly — never importing `airflow.providers.*`, never touching `BaseHook`.
+
+    Two tiers of "Airflow imports that work on Leoflow" — they have very different dependency contracts and must be documented as such:
+
+    | Tier | Import | Needs `apache-airflow-providers-*` in `leoflow.yaml.dependencies`? | Runtime path |
+    |---|---|---|---|
+    | **A. Native (already shipped)** | `from airflow.sdk import DAG, task` | **No** | Parser maps to `python` / `bash` / `http_api` task types; runtime executes directly. |
+    | A. | `from airflow.providers.standard.operators.python import PythonOperator` | **No** | Same as above. |
+    | A. | `from airflow.providers.standard.operators.bash import BashOperator` | **No** | Same. |
+    | A. | `from airflow.providers.standard.operators.empty import EmptyOperator` | **No** | Same. |
+    | A. | `from airflow.providers.http.operators.http import HttpOperator` | **No** | Task type `http_api` — Leoflow agent executes the HTTP call. |
+    | **B. Compat (this ADR)** | `from airflow.providers.postgres.hooks.postgres import PostgresHook` | **Yes** — `apache-airflow-providers-postgres` + `psycopg2-binary` | Through the runtime compat shim (clauses 1-9). |
+    | B. | `from airflow.providers.google.cloud.hooks.gcs import GCSHook` | **Yes** — `apache-airflow-providers-google` | Through the shim + the GCP resolver (clause 4 + ADR 0035). |
+    | B. | `from airflow.providers.http.hooks.http import HttpHook` | **Yes** — `apache-airflow-providers-http` | Through the shim. (Distinct from `HttpOperator` in tier A.) |
+    | B. | any other `from airflow.providers.<X>.hooks.<Y>...` | **Yes** — the matching `apache-airflow-providers-<X>` | Through the shim. |
+
+    **Out of scope (still rejected at compile time per the closed-set policy):** sensors, dynamic task mapping (`.expand`/`.partial`), `TaskGroup`, branching operators, untyped operators outside the standard / http providers. Parser fails fast with "not supported by Leoflow" — no behavior change in this ADR.
+    - **The runtime compat shim of this ADR (0036) is a parallel new module, not a rewrite of the parser shim.** The two coexist:
+      - **Compile time (ADR 0024):** parser shim resolves `from airflow.sdk import DAG, task`, `from airflow.providers.standard.operators.bash import BashOperator`, etc. so the parser can introspect `dag.py`. Result: `dag.json` with task entries of type `bash`/`python`/`http_api`.
+      - **Runtime (ADR 0036):** compat shim resolves `from airflow.providers.<X>.hooks.<Y> import <Z>Hook` so user code can fetch a `Connection` and call provider methods. Triggered only when the DAG actually imports a hook.
+    - **Existing DAGs that use only `@task`, `BashOperator`, `PythonOperator`, `HttpOperator`, `EmptyOperator` are completely unaffected.** They never touch the runtime compat shim and require no `apache-airflow-providers-*` in `leoflow.yaml.dependencies`.
+    - **A DAG that mixes both** (e.g. uses `@task` for the work AND `PostgresHook` inside the callable to talk to a DB) gets the existing operator behavior **plus** the runtime compat shim — both apply, no conflict. The DAG declares the provider for the hook and otherwise looks the same.
+
+12. **Supported Airflow line — pin to a minor, not a patch.** Leoflow already targets Airflow 3.2.x for the HTTP API and UI compatibility (CLAUDE.md non-negotiable #8). The runtime compat shim mirrors that:
+
+    - **Compat target for Leoflow `v0.x`:** the Airflow **3.2** minor line (currently `3.2.1` at the time of this ADR; whatever the latest stable patch is when each Leoflow release ships). Providers tested in CI are the ones declaring compatibility with `apache-airflow~=3.2` (i.e. `>=3.2.0,<3.3.0` in pip semantics).
+    - **Why a minor, not a patch.** Patch bumps inside 3.2.x are bug-fix-only by Airflow's policy; the SDK surface is stable across patches. Pinning to `3.2.1` would force a Leoflow rebump on every Airflow patch with no behavior change in our shim. Pinning to the minor line lets us track Airflow's own stable contract.
+    - **Concrete pins per layer:**
+      - `leoflow_python_compat/airflow/__version__` reports `"3.2"` (the minor we mirror), not a specific patch.
+      - The CI matrix's reference Airflow install is the latest 3.2.x patch at job run time, refreshed on each Leoflow release cut.
+      - Cookbook pages for hooks pin provider lines using the upstream's compatibility matrix (e.g. "Postgres: `apache-airflow-providers-postgres>=6.0,<7` — built against Airflow 3.2.x"). We do not pin to a specific provider patch; that's the user's choice via their `leoflow.yaml.dependencies`.
+    - **When Airflow 3.3 ships,** a follow-up Leoflow release bumps the target to 3.3.x in a single coordinated change: shim alignment pass (budgeted 1-2 engineer-days per clause 6), CI matrix rebuild, release notes name the supported Airflow line explicitly. Older Leoflow versions stay pinned to 3.2.x and receive security patches but not new-Airflow compat.
+    - **Documented support matrix.** A table in the chart / install docs maps each Leoflow release to the Airflow minor line it targets, e.g.:
+      ```text
+      Leoflow 0.1.x  →  Airflow 3.2.x  (current)
+      Leoflow 0.2.x  →  Airflow 3.2.x  (continues)
+      Leoflow 0.3.x  →  Airflow 3.3.x  (when upstream cuts 3.3)
+      ```
+      Mismatches (a DAG image with a provider that requires Airflow 3.3 running on Leoflow 0.2) fail at task import with the upstream's own version-check error — we do not add a second version check.
+
+## Consequences
+
+- **Drop-in compatibility today.** Existing Airflow 3.X DAGs using `from airflow.providers.<X>.hooks.<Y> import <Z>Hook` run unchanged on Leoflow once their `leoflow.yaml.dependencies` lists the corresponding provider. No DAG-side rewrite.
+- **ADR 0035 honored.** Cloud keys never reach upstream hooks via Leoflow's DB unless the operator explicitly chose `keyfile_dict`. `key_secret_name` (Secret Manager) becomes a first-class path that flows through the pre-processor without polluting the DB.
+- **Independence preserved.** No `apache-airflow` install. Lite cold start unchanged. Task pod image bumps by ~50 KB on the shim itself (versus +200-300 MB if we let `apache-airflow` get pulled in).
+- **Bounded maintenance.** ~1,200 LOC of shim + ~30 LOC per cloud resolver. Airflow minor drift budgeted at 1-2 engineer-days per release, gated by the CI matrix.
+- **One model, two faces.** Compat surface = `from airflow.providers...` (the present); native overlay = `from leoflow_runtime...` (the future). Same wire identity, same security stance, no parallel registry.
+- **Admin UI stays Go.** No Python in the control plane; no Airflow SDK calls. Curated registry for the form polish; structural validation today, opt-in real probe later.
+- **Lite vs Pro is unchanged.** Pre-processor logic is pure Python; runs identically under subprocess (Lite) and pod (Pro). The cloud resolvers' "what counts as keyless" differs per edition (Lite uses host ADC; Pro uses Workload Identity) — already true and respected via `google.auth.default()` semantics.
+
+## Alternatives considered
+
+- **Re-implement hooks natively in `leoflow_runtime.hooks.*` (~4,000 LOC).** Rejected as the primary path: breaks every Airflow DAG's `from airflow.providers...` imports unless we also ship an import rewriter, and matching upstream method signatures eats most of the LOC savings. Viable later as a targeted ergonomic overlay (clause 8); not viable as the only surface.
+- **Allow user-installed `apache-airflow` runtime.** Rejected: +200-300 MB image bloat + 600 transitive Python deps + 4-7 s cold start + a DB stack imported into pods that have no DB + CVEs we don't audit. Conflicts with the "Python minimal, Go max" principle. Acceptable only as a user-managed escape hatch for connectors the shim doesn't support.
+- **Two parallel connector tiers (Leoflow-native vs Airflow-compat).** Rejected: forces the user to pick a tier up-front, breaks the drop-in promise, and doubles the catalog / UI / probe code. The pre-processor seam achieves the same security stance with one model.
+- **Move ADR 0035 enforcement into the Go control plane.** Rejected: would re-introduce cloud SDKs in core (violates ADR 0014). Resolution at the task is where the token exchange already happens correctly per ADR 0035 clause 5.
+- **Python in the admin panel (introspect provider form widgets at request time).** Rejected: pulls Airflow + every installed provider into the control plane image; conflicts with ADR 0014. Curated Go registry + generic fallback is the right tradeoff for form polish; runtime behavior is identical.

--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -38,4 +38,5 @@ The *why* behind Leoflow's design. ADRs are immutable once accepted.
 - [ADR 0033: Release Flow — RC Tags, E2E Gates, and Immutable Versions](adr/0033-release-flow-rc-tags-and-e2e-gates.md)
 - [ADR 0034: Fan-in / map-reduce — list-of-upstream parameter binding](adr/0034-fan-in-map-reduce-binding.md)
 - [ADR 0035: Cloud connector auth — keyless-first; Leoflow is not a key manager](adr/0035-cloud-connector-auth-keyless-first.md)
+- [ADR 0036: Airflow 3.X runtime compatibility shim — one model, one policy seam](adr/0036-airflow-runtime-compat-shim.md)
 <!-- END ADR INDEX -->

--- a/docs/planning/airflow-connector-compatibility.md
+++ b/docs/planning/airflow-connector-compatibility.md
@@ -1,7 +1,7 @@
 # Airflow 3.X connector compatibility — complexity study
 
-> **Status:** planning document, not yet an ADR. The recommendation here is a
-> proposal to feed an ADR before any code lands. **Scope is exclusively Airflow
+> **Status:** planning document, not yet ADR 0036. The recommendation here is a
+> proposal to feed ADR 0036 before any code lands. **Scope is exclusively Airflow
 > 3.X (3.2.x line, `main` as of 2026-06-02). Airflow 2.x is out of scope.**
 >
 > **Goal:**
@@ -14,6 +14,126 @@
 >
 > Both goals are reachable simultaneously with a small Python shim. This
 > document measures how small.
+
+## The model in one picture — connection metadata and connector code never live together
+
+Connection **metadata** (host, login, password, extra JSON) is owned by the
+Leoflow control plane: created in the admin UI, encrypted at rest (ADR 0019).
+Connector **code** (`PostgresHook.get_records()`, `GCSHook.upload()`, …) is
+owned by the user's DAG image: pip-installed from `apache-airflow-providers-<X>`
+declared in `leoflow.yaml.dependencies`. Leoflow ships **no** provider code.
+
+The two meet only at runtime, through the `AIRFLOW_CONN_<ID>` environment
+variable (ADR 0021 wire format) that the Leoflow agent stamps into the task
+process. The Leoflow runtime compat shim (ADR 0036) intercepts
+`BaseHook.get_connection()` and returns the canonical Connection. The upstream
+hook does the real work.
+
+```text
+┌─────────────────────────────────────────┐    ┌──────────────────────────────────┐
+│  Admin UI / API  (Leoflow control plane,│    │  leoflow.yaml  (user, per-DAG)   │
+│                   Go — ADR 0014)        │    │                                  │
+│                                         │    │  dependencies:                   │
+│  POST /api/v2/connections               │    │    - apache-airflow-providers-   │
+│  {conn_id: "my_pg", type: "postgres",   │    │      postgres==6.0               │
+│   host: "...", login: "...",            │    │    - psycopg2-binary==2.9        │
+│   password: "...", extra: "{...}"}      │    │                                  │
+└────────────────────┬────────────────────┘    └─────────────────┬────────────────┘
+                     │                                            │
+                     ▼                                            ▼
+┌─────────────────────────────────────────┐    ┌──────────────────────────────────┐
+│  Leoflow DB (encrypted, ADR 0019)       │    │  DAG image (built once per push) │
+│  connections:                           │    │  ─────────────                   │
+│    id="my_pg" type="postgres"           │    │  leoflow-base:py3.11             │
+│    password = AES-256-GCM(...)          │    │  + apache-airflow-providers-     │
+│    extra    = AES-256-GCM(...)          │    │      postgres   (PostgresHook)   │
+└────────────────────┬────────────────────┘    │  + leoflow-runtime-compat-shim   │
+                     │                          │      (airflow.sdk.* shim,        │
+                     │ on dispatch              │       ADR 0036)                  │
+                     ▼                          └─────────────────┬────────────────┘
+┌─────────────────────────────────────────┐                      │
+│  Leoflow agent (Go, in the pod or       │                      │
+│  subprocess host)                       │                      │
+│  - decrypts password + extra            │                      │
+│  - renders the URI:                     │                      │
+│    AIRFLOW_CONN_MY_PG=                  │                      │
+│      postgres://login:pw@host:5432/db   │                      │
+│      ?__extra__={"sslmode": ...}        │                      │
+│    (ADR 0021 wire format)               │                      │
+│  - injects env var into the task        │                      │
+└────────────────────┬────────────────────┘                      │
+                     │                                            │
+                     └────────────────► task process ◄────────────┘
+                                              │
+                                              ▼
+                ┌──────────────────────────────────────────────┐
+                │  User DAG (Python)                           │
+                │                                              │
+                │  from airflow.providers.postgres.hooks       │
+                │       .postgres import PostgresHook          │
+                │  hook = PostgresHook(postgres_conn_id=        │
+                │                      "my_pg")                │
+                │  hook.get_records("SELECT 1")                │
+                └─────────────────────┬────────────────────────┘
+                                      │
+                                      ▼ provider calls
+                                      │ BaseHook.get_connection("my_pg")
+                ┌──────────────────────────────────────────────┐
+                │  Leoflow runtime compat shim  (ADR 0036)     │
+                │  ──────────────────────────                  │
+                │  1. Read AIRFLOW_CONN_MY_PG env var          │
+                │  2. Parse URI → host/login/password/port/    │
+                │      schema/extra                            │
+                │  3. Pre-processor (per-type policy seam)     │
+                │     • cloud type → cloud resolver            │
+                │       (ADR 0035 chain: keyfile_dict →        │
+                │        key_path → key_secret_name → ADC)     │
+                │       fetches Secret Manager NOW if          │
+                │       key_secret_name is set; emits the      │
+                │       fetched key as a transient keyfile_    │
+                │       dict so the upstream hook understands. │
+                │     • non-cloud type → pass through.         │
+                │  4. Return a canonical                       │
+                │      airflow.sdk.definitions.Connection      │
+                └─────────────────────┬────────────────────────┘
+                                      │
+                                      ▼
+                ┌──────────────────────────────────────────────┐
+                │  Upstream PostgresHook                       │
+                │  (apache-airflow-providers-postgres)         │
+                │  - receives the canonical Connection         │
+                │  - psycopg2.connect(...) → real query        │
+                └──────────────────────────────────────────────┘
+```
+
+### What works out of the box vs what needs a provider declared
+
+Two tiers of "Airflow imports that work on Leoflow" — they have very
+different dependency contracts, and the cookbook pages must state this in
+the very first line.
+
+| Tier | Import | Needs a provider in `leoflow.yaml.dependencies`? | Runtime path |
+|---|---|---|---|
+| **A. Native (already shipped)** | `from airflow.sdk import DAG, task` | **No** | Parser maps to `python` / `bash` / `http_api` task types; Leoflow runtime executes directly. |
+| A. | `from airflow.providers.standard.operators.python import PythonOperator` | **No** | Same as above. |
+| A. | `from airflow.providers.standard.operators.bash import BashOperator` | **No** | Same. |
+| A. | `from airflow.providers.standard.operators.empty import EmptyOperator` | **No** | Same. |
+| A. | `from airflow.providers.http.operators.http import HttpOperator` | **No** | Task type `http_api` — Leoflow agent executes the HTTP call. |
+| **B. Compat (ADR 0036)** | `from airflow.providers.postgres.hooks.postgres import PostgresHook` | **Yes — `apache-airflow-providers-postgres` + `psycopg2-binary`** | Through the runtime compat shim. |
+| B. | `from airflow.providers.google.cloud.hooks.gcs import GCSHook` | **Yes — `apache-airflow-providers-google`** | Shim + GCP resolver (ADR 0035). |
+| B. | `from airflow.providers.http.hooks.http import HttpHook` | **Yes — `apache-airflow-providers-http`** | Shim. (Distinct from `HttpOperator` in tier A.) |
+| B. | any other `from airflow.providers.<X>.hooks.<Y>...` | **Yes — the matching `apache-airflow-providers-<X>`** | Shim. |
+
+Forgetting the dependency for a tier-B import is a fast, loud failure:
+`ModuleNotFoundError: No module named 'airflow.providers.postgres'` at
+import time, before any task work runs. The cookbook page for the hook
+names the exact error so search engines route the user back to the right
+recipe.
+
+Out of scope (still rejected at compile time per the closed-set policy):
+sensors, dynamic task mapping (`.expand` / `.partial`), `TaskGroup`,
+branching operators, untyped operators outside the standard / http
+providers. Parser fails fast with "not supported by Leoflow".
 
 ## 0. TL;DR
 
@@ -436,7 +556,7 @@ upside the shim doesn't already provide.
 
 ## 6. Open questions for the ADR
 
-These are the decisions that an ADR would need to lock before code lands.
+These are the decisions that ADR 0036 would need to lock before code lands.
 Not blockers for this study, but listed so they're explicit:
 
 1. **Module namespace.** Do we expose the shim at `airflow.*` (so user

--- a/docs/planning/airflow-connector-compatibility.md
+++ b/docs/planning/airflow-connector-compatibility.md
@@ -1,0 +1,467 @@
+# Airflow 3.X connector compatibility — complexity study
+
+> **Status:** planning document, not yet an ADR. The recommendation here is a
+> proposal to feed an ADR before any code lands. **Scope is exclusively Airflow
+> 3.X (3.2.x line, `main` as of 2026-06-02). Airflow 2.x is out of scope.**
+>
+> **Goal:**
+> - **Long-term:** Leoflow stays architecturally independent of Apache Airflow
+>   (no Airflow at runtime, no Flask/SQLAlchemy/Pendulum stack in our pods).
+> - **Short-term:** existing Airflow 3.X DAGs that use connectors
+>   (`from airflow.providers.postgres.hooks.postgres import PostgresHook`) run
+>   on Leoflow **unchanged**, so adoption costs nothing for current Airflow
+>   users.
+>
+> Both goals are reachable simultaneously with a small Python shim. This
+> document measures how small.
+
+## 0. TL;DR
+
+| | Strategy A — **Shim Airflow core minimally**, use upstream providers | Strategy B — Re-implement hooks natively in Leoflow | Strategy C — Allow user-installed `apache-airflow-providers-*` |
+|---|---|---|---|
+| **New code in Leoflow** | ~1,200 LOC Python | ~4,000 LOC Python (top-15 hooks + base) | 0 |
+| **Runtime image footprint** | +~50 MB (shim + per-provider SDK only) | +~10 MB (per-provider SDK only) | **+200-300 MB** (apache-airflow pulls Flask, SQLAlchemy, FAB, Pendulum, Alembic, Connexion, ~600 transitive deps) |
+| **User DAG `import airflow.providers.*` works?** | YES (default) | NO without an import rewriter — every DAG would have to change `from airflow.providers.postgres.hooks.postgres import PostgresHook` → `from leoflow_runtime.hooks.postgres import PostgresHook` | YES |
+| **Maintenance** | 1-2 engineer-days per Airflow minor (CI matrix re-runs upstream provider tests against the shim) | Ongoing per-hook drift with the underlying SDKs (boto3, google-cloud-storage, etc.) | None on Leoflow's side; full surface drift cost lands on the user |
+| **Conflict with ADR 0024** | No — natural extension of the same "shim, don't install" principle | No | YES — pulls the full Airflow control plane into a task pod that has no DB |
+| **Cold-start of Lite subprocess executor** | Negligible (shim is ~0.05 s import) | Negligible | **Catastrophic** — Airflow imports Flask + SQLAlchemy + Pendulum = 4-7 s on a laptop |
+
+**Recommendation: Strategy A.** ~1,200 LOC of pure Python unlocks ~80 upstream providers without touching ADR 0024's spirit. The Connection model in Leoflow already has **100% field-level parity** with Airflow 3.X's, so the gap is only "give user code a `BaseHook.get_connection()`-shaped door into the env vars the agent already injects."
+
+## 1. Architecture in Airflow 3.X
+
+A reminder of the 3.X layout, because it differs from 2.x in ways that
+materially simplify embedding.
+
+### 1.1 The canonical import paths moved into a task SDK
+
+In Airflow 3.x the runtime hook surface lives at `airflow.sdk.*`, not at the
+2.x paths (`airflow.hooks.base`, `airflow.models.Connection`). Provider code
+no longer imports those 2.x paths directly — they import from a stable
+**compatibility re-export package**:
+
+```python
+# How a 3.x provider opens — this is the import surface to mimic.
+from airflow.providers.common.compat.sdk import (
+    BaseHook,
+    Connection,
+    AirflowException,
+    AirflowOptionalProviderFeatureException,
+    conf,
+)
+```
+
+That `airflow.providers.common.compat.sdk` is a thin re-export of:
+
+| Re-export | Resolves to | LOC | Notes |
+|---|---|---:|---|
+| `BaseHook` | `airflow.sdk.definitions.hooks.base.BaseHook` | 107 | The 3.x base hook. |
+| `Connection` | `airflow.sdk.definitions.connection.Connection` | 571 | URI parser, `__extra__` round-trip, attrs-backed dataclass. **No Fernet here** — encryption is the metastore's job in 3.x. |
+| `AirflowException` | `airflow.sdk.exceptions.AirflowException` | (in a 40-LOC exceptions file) | |
+| `conf` | `airflow.configuration.conf` | (large; we stub) | |
+| `AirflowOptionalProviderFeatureException` | same exceptions file | | |
+
+The **provider-to-provider contract is the compat layer**, not the SDK. That
+means a shim only has to mock `compat.*` precisely; the SDK itself we can
+implement with looser fidelity.
+
+### 1.2 `BaseHook` (107 LOC) — what providers actually call
+
+The full public surface a Hook subclass uses from `BaseHook`:
+
+- `__init__(self, logger_name=None)`
+- `get_connection(cls, conn_id) -> Connection`  *(the workhorse)*
+- `aget_connection(cls, conn_id) -> Connection`  *(async siblings call this)*
+- `get_hook(cls, conn_id, hook_params=None)`  *(used by sensors)*
+- `get_conn(self)`  *(abstract — each provider implements)*
+- `get_connection_form_widgets(cls)` + `get_ui_field_behaviour(cls)`  *(form metadata for the Airflow UI; Leoflow can return `{}`)*
+- `log` property (from `LoggingMixin`)
+
+That's the entire seven-method surface to fake.
+
+### 1.3 `Connection` (571 LOC) — what providers actually use
+
+Despite the file's size, providers use a narrow subset:
+
+- `conn_id`, `conn_type`, `host`, `login`, `password`, `port`, `schema`, `extra`
+- `extra_dejson` property (returns `json.loads(extra)` or `{}`)
+- `get_uri()` (SQLAlchemy-friendly URI; the inverse of `from_uri`)
+- `from_uri(uri)` class method (constructs from `AIRFLOW_CONN_<ID>` value)
+- `EXTRA_KEY = "__extra__"` class constant
+
+The other ~450 LOC handle Fernet roundtripping (not relevant — Leoflow encrypts
+elsewhere) and the metastore ORM (not relevant — Leoflow's metastore is Go).
+
+### 1.4 Connection resolution chain
+
+`_get_connection(conn_id)` in `airflow.sdk.execution_time.context`:
+
+```text
+1. SecretCache.get_connection_uri(conn_id) → if hit, build Connection.from_uri(...)
+2. For each backend in ensure_secrets_backend_loaded():
+     conn = backend.get_connection(conn_id) → if non-None, return
+3. raise AirflowNotFoundException(...)
+```
+
+The default backend chain in 3.x starts with the
+`EnvironmentVariablesBackend`, which reads exactly the `AIRFLOW_CONN_<ID>`
+env var Leoflow's agent already produces (`internal/agent/runner.go:170`).
+
+**Implication:** Leoflow's shim can skip the entire backend chain and read
+the env var directly. Strictly less code, strictly more deterministic.
+
+### 1.5 Provider package layout in 3.x
+
+Each provider is a separate PyPI package (Apache 2.0) at
+`providers/<name>/src/airflow/providers/<name>/{hooks,operators,sensors,
+transfers,triggers}/`. Distributed independently
+(`apache-airflow-providers-<name>` on PyPI).
+
+The runtime requirement of each provider package on `apache-airflow>=3.0` is
+the **compat re-export**, not core Airflow itself. Mock `compat.*` and the
+hard dep on `apache-airflow` is satisfied (the package metadata cares about
+the import surface, not the wheel).
+
+## 2. Provider catalog (top-15, measured against upstream 3.x main)
+
+For each provider: file path of the main hook(s), LOC, what they import from
+`airflow.*`, what underlying SDK they wrap, how thick the wrapper is.
+
+| Provider | PyPI package | Hook LOC | `airflow.*` imports | Underlying SDK | Depth |
+|---|---|---:|---|---|---|
+| **postgres** | `apache-airflow-providers-postgres` | ~900 (`hooks/postgres.py`) | 8 lines: `common.compat.sdk` (BaseHook/Connection/conf), `common.sql.hooks.sql.DbApiHook`, `common.sql.hooks.lineage`, `postgres.dialects`, `openlineage.sqlparser`, cross-deps for IAM | psycopg2, psycopg3, sqlalchemy, pandas, polars, more_itertools | THICK (~30 methods, IAM, dialects, lineage) |
+| **mysql** | `apache-airflow-providers-mysql` | 658 | 6 lines, same DbApiHook + amazon cross-dep | mysqlclient, mysql-connector | THICK (13 methods, dual driver, IAM) |
+| **sqlite** | `apache-airflow-providers-sqlite` | **51** | 1 line: `DbApiHook` | stdlib `sqlite3` | THIN |
+| **mssql** | `apache-airflow-providers-microsoft-mssql` | 175 | 4 lines | pymssql | MEDIUM (12 methods) |
+| **snowflake** | `apache-airflow-providers-snowflake` | 1,040 | 7 lines | snowflake-connector-python, snowflake-sqlalchemy, snowpark | THICK (35 methods, OAuth, private key) |
+| **http** | `apache-airflow-providers-http` | ~750 | 5 lines (BaseHook, Connection, async helper) | requests, aiohttp, tenacity, pydantic | THICK (sync+async, retry) |
+| **redis** | `apache-airflow-providers-redis` | **162** | 1 line: `BaseHook` | redis | THIN (4 methods, pure connection factory) |
+| **amazon** (S3 alone) | `apache-airflow-providers-amazon` | **1,543** (`hooks/s3.py`); 52 hook files total | 8 lines | boto3, botocore, aiobotocore | THICK (60+ methods on S3 alone) |
+| **google** (GCS alone) | `apache-airflow-providers-google` | **1,850** (`hooks/gcs.py`); 47 hook files total | 7 lines | google-cloud-storage, gcloud-aio-storage | THICK (~40 methods) |
+| **microsoft.azure** (WASB) | `apache-airflow-providers-microsoft-azure` | 1,047 (`hooks/wasb.py`) | 5 lines | azure-storage-blob, azure-identity | THICK (sync+async, multi-auth) |
+| **slack** | `apache-airflow-providers-slack` | 427 | 4 lines | slack-sdk | THIN-MEDIUM |
+| **ftp** | `apache-airflow-providers-ftp` | 358 | 1 line: `BaseHook` | stdlib `ftplib` | MEDIUM |
+| **ssh** | `apache-airflow-providers-ssh` | 672 | 6 lines (incl. `airflow.sdk.definitions._internal.types.NOTSET`) | paramiko, asyncssh | THICK (sync+async) |
+| **databricks** | `apache-airflow-providers-databricks` | ~1,050 | 3 lines | requests, databricks-sdk | THICK (40 methods, sync+async) |
+| **dbt-cloud** | `apache-airflow-providers-dbt-cloud` | ~1,050 | 3 lines (extends `HttpHook`, not `BaseHook` directly) | aiohttp, requests, tenacity, asgiref | THICK |
+
+### 2.1 The hidden lynchpin: `apache-airflow-providers-common-sql`
+
+Every DB provider (postgres, mysql, sqlite, mssql, snowflake, plus oracle,
+db2, trino, vertica, exasol, etc.) extends `DbApiHook` defined in
+`providers/common/sql/src/airflow/providers/common/sql/hooks/sql.py` —
+**~1,250 LOC** that depends on `airflow.exceptions`,
+`airflow.providers.common.compat.module_loading`,
+`airflow.providers.common.compat.sdk` (`BaseHook` + `conf`), and
+`airflow.providers.common.sql.dialects`.
+
+This file is the single biggest lever in the whole study: **vendor it
+verbatim** (Apache 2.0 permits with attribution) and ~10 DB providers light
+up at zero re-implementation cost.
+
+### 2.2 The other lynchpin: `airflow.providers.common.compat`
+
+`compat.sdk`, `compat.connection`, `compat.lineage` and `compat.module_loading`
+are universally imported. They're each ~10-30 LOC of pure re-exports. **Any
+embedding strategy must mock this package.**
+
+## 3. Three embedding strategies — concrete cost
+
+### Strategy A — Stub Airflow core minimally, use upstream providers
+
+We extend the existing parser shim (`parser/leoflow_parser/_shim/airflow/`)
+into a **runtime shim** that provides:
+
+| Module | LOC estimate | Notes |
+|---|---:|---|
+| `airflow.sdk.definitions.hooks.base.BaseHook` | ~120 | Mirror the 107-line upstream file; replace `Connection.get` to read `AIRFLOW_CONN_*` directly. |
+| `airflow.sdk.definitions.connection.Connection` | ~400 | Re-implement `from_uri` / `get_uri` / `__extra__` handling. Cannot shortcut: every DB hook calls `conn.get_uri()` for SQLAlchemy. |
+| `airflow.sdk.definitions.variable.Variable` | ~80 | `get/set` against `AIRFLOW_VAR_*` env. |
+| `airflow.sdk.exceptions` | ~40 | `AirflowException`, `AirflowNotFoundException`, `AirflowRuntimeError`, `ErrorType` enum, `AirflowOptionalProviderFeatureException`. |
+| `airflow.sdk.log` | ~30 | `mask_secret` (Leoflow already masks in the UI; can be a no-op for the agent's purposes). |
+| `airflow.sdk.execution_time.context` | ~150 | `_get_connection`, `_async_get_connection`, `_get_variable` reading from env + a worker-local cache. |
+| `airflow.sdk._shared.module_loading` | ~20 | `import_string` (wraps stdlib `importlib`). |
+| `airflow.sdk.definitions._internal.logging_mixin.LoggingMixin` | ~25 | Wraps `logging.getLogger(self.__class__.__name__)`. |
+| `airflow.sdk.definitions._internal.types` | ~15 | `NOTSET`, `ArgNotSet`, `is_arg_set` (SSH hook needs these). |
+| `airflow.sdk.providers_manager_runtime` | ~50 | Stub `ProvidersManagerTaskRuntime` (`Connection` imports it). |
+| `airflow.providers.common.compat.sdk` | ~30 | Re-export aliases — pure forwarding. |
+| `airflow.providers.common.compat.connection` | ~30 | `get_async_connection`. |
+| `airflow.providers.common.compat.lineage.hook` | ~15 | `get_hook_lineage_collector` returning a no-op. |
+| `airflow.providers.common.compat.module_loading` | ~10 | Re-export `import_string`. |
+| `airflow.exceptions` | ~25 | `AirflowProviderDeprecationWarning` alias. |
+| `airflow.utils.log.logging_mixin` (legacy alias) | ~10 | Some hooks still use this path. |
+| `airflow.utils.helpers` | ~30 | `chunks`, `exactly_one` (S3 + Slack need them). |
+| `airflow.models.Connection` (legacy alias used by HttpHook) | ~5 | Re-export. |
+| `airflow.configuration.conf` | ~40 | Stub returning `None`/defaults; providers call `conf.getint("...")`. |
+| `airflow.utils.strings.to_boolean` | ~10 | Snowflake needs it. |
+| `airflow.utils.timezone` | ~20 | datetime helpers (Snowflake, GCS). |
+
+**Total shim:** ~1,100-1,300 LOC of pure Python that covers ~95% of the
+surface DB + HTTP + S3 + GCS + Redis + Slack hooks actually touch.
+
+**Critical decision: vendor `providers.common.sql.hooks.sql.DbApiHook`
+verbatim.** Re-distribute the file under Apache 2.0 attribution. That single
+1,250-LOC file lights up postgres / mysql / sqlite / mssql / snowflake / oracle
+/ trino / db2 / vertica / exasol at **zero re-implementation cost**. Same
+treatment for `providers.common.sql.dialects.dialect` (~200 LOC).
+
+**Image size impact:** ~1,500 LOC of pure Python + the user-installed
+provider wheels. **No `apache-airflow` install.** A typical postgres-only
+image goes from ~80 MB (Python slim) to ~140 MB (slim + psycopg2-binary +
+sqlalchemy + shim). Versus ~600 MB if Strategy C lets apache-airflow get
+pulled in.
+
+**Risk surface:** every Airflow 3.x minor release can rename or add an
+internal helper. Empirical pattern from 2.x→3.x: ~3-5 breaking internal
+moves per minor. **Maintenance: budget 1-2 engineer-days per Airflow minor**
+to keep the shim aligned, gated by a CI matrix that pip-installs each
+upstream provider against the shim and runs its smoke tests.
+
+**ADR 0024 alignment:** the existing shim is parser-only. Extending it to a
+runtime shim is a deliberate, principled scope expansion of the same idea
+("we never install Airflow"), not a contradiction. Worth a new ADR
+("Runtime hook compatibility shim").
+
+### Strategy B — Re-implement hooks natively in `leoflow_runtime.hooks.*`
+
+Estimated LOC for native re-implementations of the top-15 (Leoflow-flavored,
+no Airflow surface):
+
+| Hook | Native LOC estimate | Saved vs. Airflow |
+|---|---:|---|
+| Postgres | 200 | 4.5× shrinkage (drop IAM, dialects, lineage, pandas/polars helpers) |
+| MySQL | 180 | 3.6× |
+| SQLite | 40 | parity |
+| MSSQL | 120 | similar |
+| Snowflake | 350 | 3× (still need OAuth + key auth) |
+| HTTP | 200 | 3.7× (drop sync+async dichotomy) |
+| Redis | 80 | parity |
+| S3 | 400 | 4× (cover the 15 ops people actually use) |
+| GCS | 400 | 4.5× |
+| WASB | 350 | 3× |
+| Slack | 100 | 4× |
+| FTP | 200 | 1.8× |
+| SSH | 350 | 2× |
+| Databricks | 400 | 2.6× |
+| dbt Cloud | 350 | 3× |
+| **Total** | **~3,720 LOC** | |
+
+Plus a shared `leoflow_runtime.connections.Connection` (~150 LOC) and
+`BaseHook` (~80 LOC): **~4,000 LOC total**.
+
+**Pros:** owns the surface; ADR-clean; no Airflow version drift; full
+control over error messages, logging, and observability.
+
+**Cons:** the upgrade story is brutal. Every Airflow DAG that does
+`from airflow.providers.postgres.hooks.postgres import PostgresHook`
+breaks. We'd need an import-rewriter
+(`airflow.providers.postgres.hooks.postgres` →
+`leoflow_runtime.hooks.postgres`) and the public surface would need to
+match Airflow's method signatures *anyway* — most of the LOC savings vanish.
+
+### Strategy C — Allow user-installed `apache-airflow-providers-*`
+
+User declares `apache-airflow-providers-postgres` in `leoflow.yaml.deps`;
+runtime pip-installs at venv build / image build time. The providers import
+`from airflow.providers.common.compat.sdk import BaseHook, Connection` which
+forces `apache-airflow>=3.0` as a runtime dep.
+
+- **Image size impact:** apache-airflow 3.2.x is **~150-180 MB installed**
+  (Flask, SQLAlchemy, Alembic, Pendulum, FAB, Connexion, …). On top of slim
+  Python: image grows from ~80 MB → **~280-350 MB** before the provider's
+  own deps. With postgres + psycopg2-binary + sqlalchemy, expect ~450 MB. A
+  real-world DAG image with 3 providers: **600-800 MB**.
+- **Conflict with ADR 0024:** the ADR forbids importing real Airflow during
+  *parsing*. It does not formally forbid importing it at *runtime*.
+  However: (a) it makes the Lite edition's `subprocess` executor terrible
+  (cold start dominated by Airflow's import of Flask + SQLAlchemy +
+  Pendulum, easily 4-7 s on a laptop); (b) it pulls in CVEs we can't audit;
+  (c) it imports a database stack into a *task pod* that has no DB.
+- **Conflict with "Python minimal, Go max" principle:** very large negative
+  impact. apache-airflow brings ~600 transitive Python deps.
+
+**Verdict:** acceptable only as an escape hatch for connectors we don't
+support; never the default path.
+
+## 4. Connection model gap (field-by-field)
+
+Already 100% parity. The Leoflow Connection model
+(`internal/domain/connection.go`) and the AIRFLOW_CONN URI renderer
+(`internal/storage/conn_uri.go:40`) cover every field a 3.x `Connection`
+exposes:
+
+| Field | Airflow 3.X `Connection` | Leoflow `domain.Connection` | Status |
+|---|---|---|---|
+| `conn_id` | `str` | `ConnID string` | PARITY |
+| `conn_type` | `str \| None` | `ConnType string` | PARITY |
+| `description` | `str \| None` | `Description string` | PARITY |
+| `host` | `str \| None` | `Host string` | PARITY |
+| `schema` | `str \| None` | `Schema string` | PARITY |
+| `login` | `str \| None` | `Login string` | PARITY |
+| `password` | `str \| None` | `Password string` (AES-256-GCM at rest, ADR 0019) | PARITY + better — Airflow 3.x SDK doesn't encrypt; the metastore does. |
+| `port` | `int \| None` | `Port *int` | PARITY |
+| `extra` | `str \| None` (JSON-as-string) | `Extra string` (AES-256-GCM at rest) | PARITY |
+| `EXTRA_KEY = "__extra__"` | URI carries extra in `?__extra__=` | `internal/storage/conn_uri.go:40` emits exactly this | PARITY |
+
+**URI form** `<conn_type>://<login>:<password>@<host>:<port>/<schema>?__extra__=<json>`
+— Leoflow already renders this byte-for-byte. The only edge case handled:
+`sqlite:///` triple-slash idempotency (`conn_uri.go:31-35`).
+
+**Gap on the model side: zero.** The Connection is feature-complete for
+Airflow 3.X parity. The gap is entirely in how that connection is
+*consumed*: today user code reads the env var and parses the URI manually.
+Once a `BaseHook.get_connection()` exists, every Airflow-style hook works.
+
+## 5. Recommendation
+
+### Pick Strategy A as the default. Use Strategy B as a targeted overlay for the 5 hooks where Leoflow-native ergonomics matter.
+
+**Why:**
+
+1. The shim already exists in spirit (the parser shim at
+   `parser/leoflow_parser/_shim/airflow/`) and ADR 0024 already documented
+   the "shim, don't install" principle. This is an extension, not a
+   reversal.
+2. Field-level parity on `Connection` is already 100%. The only missing
+   piece is a `BaseHook` class wired to the existing `AIRFLOW_CONN_*` env-var
+   delivery — which Leoflow's agent (`internal/agent/runner.go:170`) already
+   produces.
+3. ~1,200-1,500 LOC of Python shim unlocks the long tail (~80 providers).
+   Re-implementing all 80 natively would be 15k+ LOC and nobody on
+   Leoflow's roadmap wants to maintain that.
+4. The 3.x design — secrets backends, no Fernet in the SDK, attrs-based
+   dataclasses — is dramatically more shimmable than 2.x's `airflow.models`
+   jungle. **The window to do this cheaply is now**; only 3.x as the cut
+   matters.
+
+### Phasing
+
+**Phase A.0 — Foundations (~1 sprint, ~1-2 weeks of focused work).**
+
+- Write a failing integration test:
+  ```python
+  from airflow.providers.postgres.hooks.postgres import PostgresHook
+  rows = PostgresHook(postgres_conn_id="my_db").get_records("SELECT 1")
+  ```
+  inside a real Lite-executed task. This is the regression contract.
+- Move the parser shim into a shared package:
+  `leoflow_python_compat/airflow/...` with two entry points (parser-mode =
+  lazy stubs; runtime-mode = real shim). Runtime install gated by
+  `leoflow.yaml.airflow_compat: true`.
+- Implement `BaseHook`, `Connection`, `Variable`, `exceptions`,
+  `log.mask_secret`, `execution_time.context._get_connection` (reads
+  `AIRFLOW_CONN_*` env directly — skip the SecretsBackend chain entirely;
+  it's overkill for our model).
+- Vendor `providers.common.sql.hooks.sql.DbApiHook` +
+  `providers.common.sql.dialects.dialect` verbatim (Apache 2.0
+  attribution).
+- CI matrix: pip-install upstream
+  `apache-airflow-providers-{postgres,sqlite,redis,http}` against the shim
+  and run their unit tests. **This is the regression gate.**
+
+**Phase A.1 — The 80/20 cut.** Ship official Leoflow support
+(CI matrix + cookbook page + connection-test DAG, matching the precedent set
+by the prior connector-rigor work) for these **five hooks**:
+
+1. **postgres** — Lite's own datastore tier; the most-used connector
+   full-stop.
+2. **http** — REST APIs, webhooks; the lingua franca of integration.
+3. **sqlite** — 51 LOC upstream, almost free; great for tutorials.
+4. **redis** — 162 LOC, ~zero risk; already a Leoflow infra primitive.
+5. **mysql** — Postgres' counterpart; very common.
+
+These five cover the majority of "I want to migrate my Airflow DAG" cases
+per Airflow's own provider download stats (postgres + http + mysql
+consistently top-3 downloads).
+
+**Phase A.2 — Cloud expansion.** Add S3, GCS, WASB. These three account for
+almost all object-storage traffic. Each is heavy upstream (1k+ LOC) but our
+cost is *zero* if Strategy A holds — we just need the shim to satisfy
+their imports.
+
+**Phase A.3 — Long tail.** Slack, FTP, SSH, Snowflake, Databricks, dbt:
+documented as "should work via the shim, not formally tested." Users opt-in
+via `airflow_compat: true`.
+
+**Phase B (later, optional overlay).** For the 5 hooks in A.1 *only*, ship
+a native `leoflow_runtime.hooks.postgres.PostgresHook` that subclasses the
+upstream PostgresHook by composition. This gives Leoflow-native ergonomics
+(better error messages, structured logging into our lifecycle stream)
+while still satisfying `isinstance(h, PostgresHook)` for DAG code.
+**Total new LOC for B: ~500.** Skip this until A is in production for 2
+releases.
+
+### Risks
+
+1. **Airflow provider drift.** A minor release renames
+   `providers.common.compat.sdk`. *Mitigation:* CI matrix on every Airflow
+   minor; pin the supported Airflow line per Leoflow release (e.g. Leoflow
+   0.2 supports Airflow providers compatible with `apache-airflow~=3.2`,
+   0.3 bumps to 3.3). Document the support matrix.
+2. **License.** All providers are Apache 2.0 — re-distributing `DbApiHook`
+   is explicitly permitted with attribution. No GPL anywhere in the
+   top-15.
+3. **Provider-to-provider deps.** PostgresHook imports `AwsBaseHook` and
+   `AzureBaseHook` for IAM. *The cleanest workaround:* monkey-patch those
+   imports to `None`-yielding stubs and lazily fail only when the user
+   actually invokes IAM auth. **Cost: ~30 LOC of import hooks.** Same
+   trick handles OpenLineage cross-imports.
+4. **Async surface.** Async hooks (`aget_connection`, `HttpAsyncHook`) use
+   `sync_to_async` from `asgiref` and `asyncio`. The shim must stub
+   `_async_get_connection`. Trivial — already shown in 3.x source.
+5. **Connection encryption mismatch.** Leoflow encrypts `password` at rest;
+   Airflow 3.x SDK does not. **Zero conflict** — encryption is metastore-
+   side. We decrypt before stamping `AIRFLOW_CONN_*` (already the case at
+   `internal/agent/runner.go:170`).
+6. **Variable scope.** Leoflow Variables are plaintext today. The shim's
+   `Variable.get()` will read `AIRFLOW_VAR_<KEY>` which the agent already
+   emits (`internal/agent/runner.go:163`) — no behavior change required.
+
+### Bottom line
+
+Build a ~1,200 LOC Python "runtime compatibility shim" that fakes
+`airflow.sdk.definitions.{hooks.base, connection, variable}`,
+`airflow.sdk.exceptions/log/execution_time.context`, the
+`airflow.providers.common.compat.*` re-export layer, and vendors the
+1,250-line `DbApiHook` verbatim. Gate it behind an opt-in
+`airflow_compat: true` in `leoflow.yaml` so the default Lite footprint stays
+slim. Officially support 5 hooks via CI (postgres / http / sqlite / redis /
+mysql), document the rest as best-effort. The Connection model has zero
+gap. Avoid Strategy C (pulling apache-airflow into the image) at all costs
+— it adds 200+ MB and 600 transitive Python deps for no architectural gain.
+Strategy B (native re-implementation) is a tempting overlay later but the
+wrong primary path: it would force re-litigating every Airflow method
+signature for ~4,000 LOC of ongoing maintenance, with no compatibility
+upside the shim doesn't already provide.
+
+## 6. Open questions for the ADR
+
+These are the decisions that an ADR would need to lock before code lands.
+Not blockers for this study, but listed so they're explicit:
+
+1. **Module namespace.** Do we expose the shim at `airflow.*` (so user
+   imports work unchanged) or at `leoflow_compat.airflow.*` (so it's
+   explicit)? Strong lean: `airflow.*` for compatibility, but only on
+   `sys.path` when `airflow_compat: true`. This avoids polluting non-
+   compat builds.
+2. **Versioned support matrix.** Leoflow 0.2 supports providers from
+   Airflow 3.2; 0.3 from 3.3. Or do we pick a single "supported Airflow
+   range" per Leoflow release and document it?
+3. **Test isolation.** Should the CI matrix run *upstream* provider test
+   suites (slow, large, real network) or only a curated subset of "smoke"
+   tests we write ourselves?
+4. **Error surface.** When an unsupported provider's hook raises an
+   internal-looking error (e.g. `AirflowOptionalProviderFeatureException`),
+   do we re-raise as a Leoflow-branded error or let it bubble?
+
+## 7. Files this study referenced (Leoflow side)
+
+- Parser shim: `parser/leoflow_parser/_shim/airflow/_core.py`,
+  `parser/leoflow_parser/_shim/airflow/sdk/__init__.py`
+- Runtime: `runtime/python/leoflow_runtime/runner.py`,
+  `runtime/python/leoflow_runtime/xcom.py`
+- Connection model: `internal/domain/connection.go`
+- AIRFLOW_CONN URI rendering: `internal/storage/conn_uri.go`
+- Agent env injection: `internal/agent/runner.go` (lines 153-170)
+- Encryption ADR: `docs/adr/0019-secret-encryption-at-rest.md`
+- Parser shim ADR: `docs/adr/0024-dag-parsing-structural-shim.md`

--- a/docs/planning/connectors-two-tier-model.md
+++ b/docs/planning/connectors-two-tier-model.md
@@ -1,0 +1,221 @@
+# Connectors — does ADR 0035 (GCP keyless-first) coexist with the Airflow-compat shim?
+
+> **Companion to** [`airflow-connector-compatibility.md`](airflow-connector-compatibility.md).
+> Reviews the `google_cloud_platform` connector already shipped (ADR 0035 + `examples/gcp_gcs_load/`) against Strategy A of the compatibility study, and answers: **do we need two classes of connectors going forward (a "Leoflow-native" tier and an "Airflow-compat" tier), or can one model serve both?**
+>
+> **Verdict: a two-tier model is real, but it's a policy split, not a code-split.** One shim is enough; the security policy from ADR 0035 lives in a pre-processor that runs *before* the connection is handed to any Airflow-style hook.
+
+## 1. What we ship today on GCP (recap)
+
+### 1.1 ADR 0035 — the position
+
+`docs/adr/0035-cloud-connector-auth-keyless-first.md` declares, accepted, on 2026-06-02:
+
+> **Leoflow is not a secrets/key manager.** It orchestrates; it does not aspire to own credential material.
+
+Concretely for cloud connectors:
+
+- **Default:** keyless. Runtime identity (Workload Identity on GKE, ADC on Lite/subprocess).
+- **Else:** a *reference* to a platform-managed secret — `key_path` (mounted K8s Secret) or `key_secret_name` (GCP Secret Manager). **The key never enters Leoflow's DB.**
+- **`keyfile_dict`** (the cloud key stored inline in the Connection) is **accepted for Airflow compatibility but explicitly discouraged**. It's the cloud-key analog of how `postgres_conn` stores a user/password encrypted at rest (ADR 0019): pragmatic, Airflow-compatible, but not the desirable posture.
+- **Resolution order in the task:** `keyfile_dict` → `key_path` → `key_secret_name` → ADC.
+- **Field names** are short (`keyfile_dict`, `key_path`, `key_secret_name`, `project`, `scopes`); legacy `extra__google_cloud_platform__<name>` accepted as migration fallback only.
+- **No cloud SDK in the Go control plane** — validation is *structural* (`internal/api/connection_probe.go:64`); the token exchange happens in the task.
+- **Generalizes to future AWS/Azure** — same stance: keyless first, secret-reference next, key-in-DB only as a discouraged fallback.
+
+### 1.2 The implementation shape — `examples/gcp_gcs_load/dag.py`
+
+Today the GCP connector resolves credentials inside the **DAG itself**, via an inline helper:
+
+```python
+# examples/gcp_gcs_load/dag.py — actual shape
+def gcp_credentials(conn_id: str = GCP_CONN):
+    extra = _conn_extra(conn_id)  # parses __extra__ from AIRFLOW_CONN_<ID>
+    # short name preferred; extra__google_cloud_platform__<name> accepted as fallback.
+    if keyfile_dict := _field(extra, "keyfile_dict"):
+        return service_account.Credentials.from_service_account_info(...)
+    if key_path := _field(extra, "key_path"):
+        return service_account.Credentials.from_service_account_file(key_path, ...)
+    if key_secret_name := _field(extra, "key_secret_name"):
+        # Fetch from GCP Secret Manager using ADC — bootstrap still needs an ambient identity.
+        ...
+    return google.auth.default(...)   # keyless / Workload Identity
+
+@task
+def gcs_roundtrip():
+    creds, project, mode = gcp_credentials()
+    client = storage.Client(project=project, credentials=creds)
+    # ... real GCS work ...
+```
+
+**Key observations:**
+
+1. **The user's DAG owns the resolver.** There is no `LeoflowGCPHook` class today; the resolver is a helper function the user copies into their DAG (or imports from a snippet library we publish).
+2. **`AIRFLOW_CONN_<ID>` is the on-the-wire format.** The Go agent already emits it (`internal/agent/runner.go:170`); the helper parses it via `urllib.parse`. This is *the same wire format* Strategy A's shim would feed to upstream provider hooks.
+3. **The Go side carries a structural probe**, not a real auth probe. `connection_probe.go:90` validates the `keyfile_dict` JSON shape and lights up green for keyless paths; it never mints a token.
+
+## 2. Does this coexist with Strategy A (the Airflow-compat shim)?
+
+### 2.1 The points of friction — there are three
+
+| # | Friction | Severity |
+|---|---|---|
+| 1 | Airflow's `apache-airflow-providers-google.GCSHook` accepts `keyfile_dict` in the Connection's `extra` and **does not warn** the user that the key is now sitting in our DB. ADR 0035 calls this pattern "explicitly discouraged." | Medium — same DB-at-rest stance ADR 0019 already lives with. Not a blocker; needs a UX nudge. |
+| 2 | `key_secret_name` (GCP Secret Manager reference) is a **Leoflow extension** — the upstream GCSHook doesn't recognize the field. If a user creates a connection with `key_secret_name` set and then writes `from airflow.providers.google.cloud.hooks.gcs import GCSHook`, the hook ignores the field and tries to fall through to ADC (which may not exist), and the task fails silently. | High — silent fallback to wrong path. |
+| 3 | `key_path` (mounted K8s Secret) **is** recognized by upstream GCSHook (as `extra__google_cloud_platform__key_path`). So that path "just works" through the shim. | Low — already compatible. |
+
+### 2.2 Strategy A's promise was "drop-in Airflow hook imports"
+
+The promise was:
+
+```python
+# user writes this — works because our shim defines BaseHook + Connection
+from airflow.providers.google.cloud.hooks.gcs import GCSHook
+hook = GCSHook(gcp_conn_id="google_cloud_default")
+hook.upload(bucket_name=..., object_name=..., data=...)
+```
+
+If we ship Strategy A naively for `google_cloud_platform`, friction #2 (silent `key_secret_name` drop) breaks ADR 0035's invariant: a connection that the operator set up *expecting* a Secret-Manager-fetched key actually runs with a different identity. That is a **security regression**, not a compatibility regression — exactly the class the user worried about.
+
+## 3. The two-tier model — what it is and isn't
+
+### 3.1 What it is — a *policy split*, not a code-split
+
+The right model is **one shim** (the Strategy-A `BaseHook` + `Connection`) **with a connection-time pre-processor** that enforces ADR 0035's resolution order *before* the Airflow hook ever sees the `extra` JSON. We do not maintain two parallel hook hierarchies.
+
+```text
+            ┌─────────────────────────────────────────────────┐
+            │  User DAG:                                       │
+            │    from airflow.providers.google...gcs import   │
+            │           GCSHook                                │
+            │    hook = GCSHook(gcp_conn_id="x")               │
+            └────────────────────────┬─────────────────────────┘
+                                     ▼
+            ┌─────────────────────────────────────────────────┐
+            │  Leoflow shim — airflow.sdk.* BaseHook           │
+            │    Connection.get(conn_id)                       │
+            └────────────────────────┬─────────────────────────┘
+                                     ▼
+            ┌─────────────────────────────────────────────────┐
+            │  resolveCredentials(extra) — Leoflow native      │
+            │    1. keyfile_dict → emit as `extra__...keyfile_dict`
+            │       AND log "key in DB — see ADR 0035; consider  │
+            │       key_path or Workload Identity"               │
+            │    2. key_path → emit as `extra__...key_path`      │
+            │       (upstream hook reads the file natively)      │
+            │    3. key_secret_name → FETCH from Secret Manager  │
+            │       NOW; emit the fetched key as a              │
+            │       transient `extra__...keyfile_dict` for       │
+            │       the upstream hook to consume.                │
+            │    4. Otherwise: leave `extra` minimal → upstream  │
+            │       falls through to ADC (Workload Identity).    │
+            └────────────────────────┬─────────────────────────┘
+                                     ▼
+            ┌─────────────────────────────────────────────────┐
+            │  Upstream GCSHook (pip-installed provider)       │
+            │  Reads the standard extra__google_cloud_platform │
+            │  __* field names that it already supports —       │
+            │  never sees Leoflow-only fields.                  │
+            └─────────────────────────────────────────────────┘
+```
+
+### 3.2 What it isn't — *not* two parallel hook hierarchies
+
+We are **not** doing:
+
+- A `leoflow_runtime.hooks.gcp.LeoflowGCPHook` for the "native" tier and a `from airflow.providers.google... GCSHook` for the "compat" tier.
+- A `LeoflowConnection` class and an `AirflowConnection` class.
+- A connection-type registry with two parallel entries (`google_cloud_platform_native` vs `google_cloud_platform_compat`).
+
+All of those would force the user to pick a tier up-front, breaking the "drop-in Airflow DAG" promise.
+
+### 3.3 The split is in policy, applied at the `BaseHook.get_connection` seam
+
+The pre-processor (~80 LOC of Python in the shim) is the single seam where ADR 0035 lives. By the time the Connection object hits the upstream hook, its `extra` JSON is canonicalized to what the upstream provider already understands. **There is no second hierarchy to maintain.**
+
+The cost in the planning doc was ~1,200 LOC for the shim. Add ~80 LOC for the pre-processor + ~30 LOC per cloud provider for its specific resolver (`gcp_resolver.py`, future `aws_resolver.py`, future `azure_resolver.py`). For three clouds: ~1,400 LOC total. Negligible delta from the original estimate.
+
+## 4. Does the existing GCP code need to change?
+
+Mostly **no**, but a few small adjustments make the seam cleaner once Strategy A lands.
+
+### 4.1 Today's GCP example DAG — should it stop using its inline helper?
+
+The inline helper in `examples/gcp_gcs_load/dag.py` is **the right shape for today**, before the shim exists. It works on Lite and Pro identically and is the only way for a user to consume our `key_secret_name` extension without the shim.
+
+**After Strategy A.0 lands** (the shim with the GCP resolver), the example should be **rewritten in two halves**:
+
+```python
+# Half 1 — the "compat" path: a real Airflow DAG works unchanged on Leoflow
+from airflow.providers.google.cloud.hooks.gcs import GCSHook
+hook = GCSHook(gcp_conn_id="google_cloud_default")
+hook.upload(bucket_name="x", object_name="y", data="...")
+```
+
+```python
+# Half 2 — the "native" path: ergonomic, Leoflow-flavored, same wire identity
+from leoflow_runtime.cloud.gcp import gcs_client
+client = gcs_client(conn_id="google_cloud_default")   # resolves per ADR 0035
+client.bucket("x").blob("y").upload_from_string("...")
+```
+
+Both halves resolve credentials through the **same** ADR 0035 chain (the pre-processor). Half 1 proves Airflow compat; Half 2 demonstrates the Leoflow ergonomic surface. The user picks one — the security guarantee is identical.
+
+### 4.2 Go side — is `connection_probe.go` aligned?
+
+Yes, with one caveat. Today `testGCPConnection` (`connection_probe.go:90`) returns:
+
+- "keyfile_dict structurally valid" → green
+- "key_path set — validated at task runtime" → green (yellow would be more honest)
+- "keyless (ADC / Workload Identity) — resolved at task runtime" → green
+
+After the shim, **add a fourth case for `key_secret_name`**: green with the note "Secret Manager reference — resolved at task runtime". One conditional, ~5 LOC.
+
+The probe stays structural — no cloud SDK in Go (ADR 0014 stance preserved).
+
+### 4.3 ADR 0035 — does it need a revision?
+
+**No.** ADR 0035 is correct as written. The shim does not change the security stance; it adds a compat surface that *honors* the stance via the pre-processor. The follow-up ADR (the one Strategy A asks for — "Runtime hook compatibility shim") will *reference* ADR 0035 and say: "Cloud-flavored connections resolve `extra` through the ADR 0035 chain before reaching any upstream hook."
+
+## 5. Generalizing to AWS / Azure
+
+The same pattern works:
+
+| Cloud | Keyless equivalent | Reference-a-secret equivalent | Key-in-DB (discouraged) |
+|---|---|---|---|
+| GCP | Workload Identity (GKE) / ADC | `key_path` (K8s Secret), `key_secret_name` (Secret Manager) | `keyfile_dict` |
+| AWS | IRSA (EKS) / instance role | `role_arn` (assume role) / Secrets Manager reference | `aws_access_key_id` + `aws_secret_access_key` |
+| Azure | Workload Identity (AKS) | Key Vault reference | `client_secret` (service principal password) |
+
+Each gets its own ~30-LOC resolver in the pre-processor. The shim itself is unchanged.
+
+The ADR 0035 generalization clause already anticipates this:
+
+> 7. Generalizes to future cloud connectors (AWS, Azure): same stance — platform-native keyless first … resolve in the task, never in core.
+
+## 6. Bottom line — answer to the user's question
+
+> "as vezes nao é seguro ficar armazenando chaves no nosso database — mas pensando em abrir uma exception para caso de integracao nao nativa — consegue avaliar a ADR e o connector GCP que foi implantado se esse connector casa com isso ou se teriamos que fazer 2 classes de connectores: os nossos nativos que seriam o futuro e os do Airflow que seria o presente"
+
+**The GCP connector and ADR 0035 do casa with Strategy A — but only with a small policy seam in the shim.** Specifically:
+
+1. **One connection model** (the one Leoflow already has — 100% field-level parity with Airflow 3.X per §4 of the compatibility study).
+2. **One shim** (Strategy A — ~1,200 LOC).
+3. **One ADR 0035 pre-processor** at the `BaseHook.get_connection` seam (~80 LOC + ~30 LOC per cloud) that canonicalizes `extra` to upstream-hook field names *and* fetches secret-store references *before* the upstream hook sees the Connection.
+
+This gives both:
+
+- **Present (Airflow compat):** Existing Airflow DAGs that import `from airflow.providers.google.cloud.hooks.gcs import GCSHook` run unchanged. The user's drop-in promise holds.
+- **Future (Leoflow native):** A `leoflow_runtime.cloud.gcp.gcs_client(conn_id)` surface that delegates to the same pre-processor + chooses an ergonomic API surface. The user gets Leoflow-flavored errors, logging, observability hooks. No second hook hierarchy to maintain.
+
+The **exception** the user mentioned ("abrir uma exception para caso de integracao nao nativa") fits naturally: when an Airflow provider would otherwise force a `keyfile_dict`-style key into our DB (e.g. an obscure cloud whose only provider auth path is "store the key"), the pre-processor logs a one-time warning ("ADR 0035: this connector stores a cloud key in Leoflow's DB; see `key_path` for the recommended pattern") and proceeds. Compat preserved, security stance honored, no parallel hierarchy.
+
+## 7. Concrete next steps (before any code)
+
+1. **Open an ADR** ("Runtime hook compatibility shim") that locks the model in §3 and references both ADR 0019 (encryption at rest) and ADR 0035 (cloud auth posture).
+2. **Add to the ADR's "Decision":** the pre-processor pipeline; the cloud-resolver plug-in point; the warning emitted when `keyfile_dict` is in use.
+3. **Phase A.1 of the compatibility study** stays as-is (postgres / http / sqlite / redis / mysql first — none of these has the cloud-key issue).
+4. **Phase A.2** adds the GCP resolver as the *first* cloud — same scope as today's GCP connector but with the pre-processor seam in place.
+5. **Phase A.2+** adds AWS and Azure resolvers (same ~30 LOC pattern each).
+
+No urgent rework of today's GCP code is required; the migration of `examples/gcp_gcs_load/dag.py` to the dual-path example shape (§4.1) ships alongside the shim.

--- a/docs/planning/connectors-two-tier-model.md
+++ b/docs/planning/connectors-two-tier-model.md
@@ -175,7 +175,7 @@ The probe stays structural — no cloud SDK in Go (ADR 0014 stance preserved).
 
 ### 4.3 ADR 0035 — does it need a revision?
 
-**No.** ADR 0035 is correct as written. The shim does not change the security stance; it adds a compat surface that *honors* the stance via the pre-processor. The follow-up ADR (the one Strategy A asks for — "Runtime hook compatibility shim") will *reference* ADR 0035 and say: "Cloud-flavored connections resolve `extra` through the ADR 0035 chain before reaching any upstream hook."
+**No.** ADR 0035 is correct as written. The shim does not change the security stance; it adds a compat surface that *honors* the stance via the pre-processor. The follow-up ADR (the one Strategy A asks for — ADR 0036 (Runtime hook compatibility shim)) will *reference* ADR 0035 and say: "Cloud-flavored connections resolve `extra` through the ADR 0035 chain before reaching any upstream hook."
 
 ## 5. Generalizing to AWS / Azure
 
@@ -212,7 +212,7 @@ The **exception** the user mentioned ("abrir uma exception para caso de integrac
 
 ## 7. Concrete next steps (before any code)
 
-1. **Open an ADR** ("Runtime hook compatibility shim") that locks the model in §3 and references both ADR 0019 (encryption at rest) and ADR 0035 (cloud auth posture).
+1. **Open an ADR** (ADR 0036 (Runtime hook compatibility shim)) that locks the model in §3 and references both ADR 0019 (encryption at rest) and ADR 0035 (cloud auth posture).
 2. **Add to the ADR's "Decision":** the pre-processor pipeline; the cloud-resolver plug-in point; the warning emitted when `keyfile_dict` is in use.
 3. **Phase A.1 of the compatibility study** stays as-is (postgres / http / sqlite / redis / mysql first — none of these has the cloud-key issue).
 4. **Phase A.2** adds the GCP resolver as the *first* cloud — same scope as today's GCP connector but with the pre-processor seam in place.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,6 +157,8 @@ nav:
       - Roadmap: roadmap-to-release.md
       - Contributing: contributing.md
       - Architecture decisions (ADRs): adrs.md
+      - Planning:
+          - "Airflow 3.X connector compatibility": planning/airflow-connector-compatibility.md
       - Background:
           - MVP reverse analysis: reverse-analysis-mvp.md
           - UI walk report: ui-walk-report.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,6 +159,7 @@ nav:
       - Architecture decisions (ADRs): adrs.md
       - Planning:
           - "Airflow 3.X connector compatibility": planning/airflow-connector-compatibility.md
+          - "Connectors — two-tier model (ADR 0035 + shim)": planning/connectors-two-tier-model.md
       - Background:
           - MVP reverse analysis: reverse-analysis-mvp.md
           - UI walk report: ui-walk-report.md


### PR DESCRIPTION
## Summary

Planning doc that answers: **can we run most Airflow 3.X connector functionality in Leoflow reliably, without taking on Airflow as a runtime dependency?**

Scope: **Airflow 3.X only.** 2.x is out of scope per user direction.

## What's in the study

- **Architecture** of Airflow 3.X's connector layer (BaseHook = 107 LOC; Connection = 571 LOC; both moved to \`airflow.sdk.*\`; no Fernet in the SDK).
- **Provider catalog** measured against upstream 3.x main for the top-15 providers — LOC, \`airflow.*\` imports, underlying SDKs, wrapper depth.
- **Three embedding strategies** with concrete costs:
  - **A.** Shim core minimally + use upstream providers (~1,200 LOC, +50 MB)
  - **B.** Re-implement hooks natively (~4,000 LOC, breaks \`from airflow.providers.*\` unless we ship an import rewriter)
  - **C.** Allow user-installed \`apache-airflow-providers-*\` (forces apache-airflow itself + 600 transitive deps, +200-300 MB image, 4-7 s Lite cold start)
- **Connection model gap**: zero. Leoflow already has 100% field-level parity with Airflow 3.X's Connection, including the \`__extra__\` URI key.
- **Recommendation: Strategy A**, with a 4-phase rollout (foundations → 5-hook 80/20 → cloud → long tail).
- **Open questions** for the ADR that would actually authorize code.

## What this PR is and is NOT

- IS: planning document under \`docs/planning/\` + a new "Planning" section in the mkdocs nav.
- IS NOT: code, ADR, or implementation. The ADR is the next step if you agree with the recommendation.

## Test plan

- [x] \`make ci-local\` clean (mkdocs --strict accepts the new page + nav)
- [ ] CI green
- [ ] Doc reviewed end-to-end before opening an ADR PR

## Long-term framing (from your direction)

> "a ideia e ser independente do airflow a longo prazo mas se conseguirmos rodar a maioria das funcionalidades do airflow de forma confiavel poderia ajudar na popularizacao"

The recommended Strategy A gives you both at the same time:
- **Long-term independence** — we never install apache-airflow; the shim is 1.2k LOC of pure Python we own.
- **Short-term compatibility** — existing Airflow DAGs do \`from airflow.providers.postgres.hooks.postgres import PostgresHook\` and it just works.