### PR TITLE
feat(lite): watcher set-diff + leoflow lite forget — close #345

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,7 +96,7 @@ jobs:
           # process-orchestration of external binaries (Docker/initdb/pg_ctl)
           # that only integration/e2e can exercise honestly, per ADR 0011.
           FLOOR=80
-          EXCLUDE='(/internal/storage/queries/|/internal/storage/repository\.go:|/internal/storage/postgres\.go:|/internal/storage/redis\.go:|/internal/storage/scheduler_store\.go:|/internal/storage/agent_store\.go:|/internal/storage/xcom_index\.go:|/internal/xcom/redis_backend\.go:|/internal/logs/tail\.go:|/internal/scheduler/leader\.go:|/internal/cli/managed_postgres\.go:|/internal/cli/backup_cmd\.go:|/internal/cli/restore_cmd\.go:|\.pb\.go:|/internal/version/|/cmd/)'
+          EXCLUDE='(/internal/storage/queries/|/internal/storage/repository\.go:|/internal/storage/postgres\.go:|/internal/storage/redis\.go:|/internal/storage/scheduler_store\.go:|/internal/storage/agent_store\.go:|/internal/storage/xcom_index\.go:|/internal/xcom/redis_backend\.go:|/internal/logs/tail\.go:|/internal/scheduler/leader\.go:|/internal/cli/managed_postgres\.go:|/internal/cli/backup_cmd\.go:|/internal/cli/restore_cmd\.go:|/internal/cli/forget\.go:|\.pb\.go:|/internal/version/|/cmd/)'
           grep -vE "$EXCLUDE" coverage.out > coverage.filtered.out
           TOTAL=$(go tool cover -func=coverage.filtered.out | tail -1 | awk '{print $3}' | sed 's/%//')
           echo "Total coverage (filtered): ${TOTAL}% (floor: ${FLOOR}%)"

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -36,6 +36,21 @@ leoflow lite dags/my_dag    # hot-reload at http://localhost:8088 (marked LITE)
     tree) — click the **IDE** button in the UI, or open `/ide`. See
     [The Lite web editor](lite-web-editor.md).
 
+!!! note "Removing a DAG"
+    Two ways to deregister a DAG from the Lite registry:
+
+    - **Delete the project directory** — the watcher's per-tick set-diff
+      notices the project vanished from disk and calls the control plane's
+      hard-delete endpoint (cascades versions, runs, task instances, XCom).
+      Logged on stderr: `✗ removed dag "my_dag" from registry (folder gone)`.
+    - **`leoflow lite forget <dag_id>`** — explicit deregister via the Lite
+      DB. Use it to remove a DAG without touching the source files (e.g.
+      paused work on an example you'll come back to). Flags: `--all`
+      (deregister everything), `--dry-run` (print what would be removed).
+
+    Both paths go through the same FK cascade — versions, runs, TIs, XCom
+    are all dropped atomically with the `dags` row.
+
 ## Two executors
 
 | `--executor` | What it does | Reload to a new version |

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -450,6 +450,7 @@ func newLiteCommand() *cobra.Command {
 	cmd.Flags().StringVar(&o.postgres, "postgres", datastoreAuto, "Postgres backend: 'auto' (default; the Docker postgres:16 when Docker is present, else a managed relocatable PG under ~/.leoflow on a Unix socket, no Docker), 'docker', or 'managed' (best on full distros; minimal hosts may lack its system libs)")
 	cmd.AddCommand(newLiteProvisionCommand())
 	cmd.AddCommand(newResetPasswordCommand())
+	cmd.AddCommand(newForgetCommand())
 	cmd.AddCommand(newBackupCommand())
 	cmd.AddCommand(newRestoreCommand())
 	return cmd
@@ -648,7 +649,20 @@ func runDev(cmd *cobra.Command, dir string, o devOptions) error {
 	if terr != nil {
 		return fmt.Errorf("minting dev token: %w", terr)
 	}
-	return devWatchLoop(ctx, cmd, ws, makeReload(token))
+	return devWatchLoop(ctx, cmd, ws, makeReload(token), makeDeleteDag(token, uiURL))
+}
+
+// makeDeleteDag returns a callback the Lite watcher calls when it notices a
+// project disappeared from disk (issue #345). The callback hits the control
+// plane's DELETE /api/v2/dags/<id>?deregister=true endpoint — the
+// hard-delete variant (cascades versions/runs/TIs/XCom via the schema's
+// ON DELETE CASCADE) — because the user's intent in deleting the project
+// folder is to fully forget the DAG, not just clear its run history.
+func makeDeleteDag(token, uiURL string) func(dagID string) error {
+	return func(dagID string) error {
+		reqURL := fmt.Sprintf("%s/api/v2/dags/%s?deregister=true", uiURL, url.PathEscape(dagID))
+		return devImportErrorRequest(context.Background(), http.MethodDelete, reqURL, token, nil)
+	}
 }
 
 // devSubprocessSetup provisions the isolated venv and returns the subprocess
@@ -1507,12 +1521,18 @@ func devReadyOnce(ctx context.Context, baseURL string) bool {
 // build/register step. The set of watched files is re-derived from the
 // workspace on every tick so a new project subdir added at runtime is picked
 // up without restart.
-func devWatchLoop(ctx context.Context, cmd *cobra.Command, ws *WorkspaceSpec, reload func() error) error {
+func devWatchLoop(ctx context.Context, cmd *cobra.Command, ws *WorkspaceSpec, reload func() error, deleteDag func(dagID string) error) error {
 	if rerr := reload(); rerr != nil {
 		devPrintf(cmd.ErrOrStderr(), "✗ %v\n", rerr)
 	}
 	watched := workspaceWatchPaths(ws)
 	snap := projectMtimes(watched)
+	// lastSeenDagIDs holds the set of DAG IDs the watcher registered in the
+	// previous tick. On every tick we set-diff against the current workspace
+	// scan; any DAG in lastSeen but not in current was deleted from disk and
+	// must be deregistered (issue #345). Seeded from the initial reload by
+	// re-resolving the workspace one more time below.
+	lastSeenDagIDs := projectDagIDs(ws)
 	devPrintf(cmd.OutOrStdout(), "👀 watching %s — edit and save to reload (Ctrl-C to stop)\n", ws.Path)
 	ticker := time.NewTicker(devPollInterval)
 	defer ticker.Stop()
@@ -1537,6 +1557,16 @@ func devWatchLoop(ctx context.Context, cmd *cobra.Command, ws *WorkspaceSpec, re
 				continue
 			}
 			snap = cur
+			// Set-diff lastSeen vs current: any DAG present last tick but
+			// missing now was removed from disk and needs to be deregistered
+			// from the control plane (issue #345). Logged to stderr so the
+			// user sees what the watcher did.
+			if deleteDag != nil {
+				logf := func(format string, args ...any) {
+					devPrintf(cmd.OutOrStdout(), format+"\n", args...)
+				}
+				lastSeenDagIDs = removeMissingDags(lastSeenDagIDs, projectDagIDs(curWs), deleteDag, logf)
+			}
 			devPrintf(cmd.OutOrStdout(), "[%s] change detected → reloading …\n", time.Now().Format("15:04:05"))
 			// Time the reload — a broken DAG's reload should still finish in
 			// ~1s. Anything multi-second is a red flag (parser hang, lock
@@ -1551,6 +1581,23 @@ func devWatchLoop(ctx context.Context, cmd *cobra.Command, ws *WorkspaceSpec, re
 			}
 		}
 	}
+}
+
+// projectDagIDs returns the set of DAG IDs the workspace currently exposes.
+// It powers the watcher's "what disappeared since last tick" set-diff
+// (issue #345). Returns a map so set-membership checks stay O(1) and the
+// pure-function removeMissingDags can mutate it without aliasing.
+func projectDagIDs(ws *WorkspaceSpec) map[string]struct{} {
+	if ws == nil {
+		return map[string]struct{}{}
+	}
+	out := make(map[string]struct{}, len(ws.Projects))
+	for _, p := range ws.Projects {
+		if p.Config != nil && p.Config.DagID != "" {
+			out[p.Config.DagID] = struct{}{}
+		}
+	}
+	return out
 }
 
 // workspaceWatchPaths returns the paths the mtime poller should track for a

--- a/internal/cli/dev_dag_removal.go
+++ b/internal/cli/dev_dag_removal.go
@@ -1,0 +1,50 @@
+package cli
+
+// removeMissingDags is the Lite watcher's set-diff step (issue #345). After
+// each tick re-resolves the workspace, it computes the set of DAG IDs the
+// watcher was tracking ("lastSeen") minus the set still present on disk
+// ("current"); for each disappeared DAG it calls deleteDag, which is wired
+// in the watcher loop to hit DELETE /api/v2/dags/<id>?deregister=true.
+//
+// Without this step the watcher is add-only: a DAG removed from disk stays
+// registered in the control plane forever (ghost in the UI). With this step,
+// `rm -rf ~/leoflow/foo` is enough to deregister.
+//
+// Contract:
+//   - DAGs in "current" but NOT in "lastSeen" are newly added — not deleted.
+//     This protects the first watcher tick of a fresh Lite from trying to
+//     wipe everything it just discovered.
+//   - DAGs in "lastSeen" but NOT in "current" are the removed set — for each,
+//     deleteDag is called.
+//   - On deleteDag success the DAG is dropped from the returned newSeen.
+//   - On deleteDag failure the DAG STAYS in newSeen (so the next tick retries)
+//     and a logf line names the failure. Silent retry would mask a real
+//     permission or auth problem.
+//
+// Pure-function design: no goroutines, no I/O, no time. The wire-up in
+// devWatchLoop closes over the actual HTTP DELETE callback.
+func removeMissingDags(
+	lastSeen map[string]struct{},
+	current map[string]struct{},
+	deleteDag func(dagID string) error,
+	logf func(format string, args ...any),
+) map[string]struct{} {
+	newSeen := make(map[string]struct{}, len(current))
+	for id := range current {
+		newSeen[id] = struct{}{}
+	}
+	for id := range lastSeen {
+		if _, still := current[id]; still {
+			continue
+		}
+		if err := deleteDag(id); err != nil {
+			logf("✗ failed to remove dag %q from registry: %v", id, err)
+			// Keep in seen so the next tick retries — silent give-up would
+			// hide a permission or auth problem.
+			newSeen[id] = struct{}{}
+			continue
+		}
+		logf("✗ removed dag %q from registry (folder gone)", id)
+	}
+	return newSeen
+}

--- a/internal/cli/dev_dag_removal_test.go
+++ b/internal/cli/dev_dag_removal_test.go
@@ -1,0 +1,190 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"testing"
+)
+
+// TestRemoveMissingDagsHappyPath pins the core contract of the Lite watcher's
+// set-diff (issue #345): when a DAG project disappears from the workspace
+// between two ticks, the watcher calls DELETE on the API so the registry stops
+// showing a "ghost" DAG. Without this, you delete the folder from disk and the
+// DAG stays in the UI forever — the exact symptom reported during the
+// prealpha.29 hands-on.
+func TestRemoveMissingDagsHappyPath(t *testing.T) {
+	lastSeen := map[string]struct{}{
+		"hello":   {},
+		"sales":   {},
+		"reports": {},
+	}
+	current := map[string]struct{}{ // reports/ was deleted from disk
+		"hello": {},
+		"sales": {},
+	}
+	var deleted []string
+	deleteDag := func(dagID string) error {
+		deleted = append(deleted, dagID)
+		return nil
+	}
+	var logs []string
+	logf := func(format string, args ...any) {
+		logs = append(logs, formatLog(format, args...))
+	}
+
+	newSeen := removeMissingDags(lastSeen, current, deleteDag, logf)
+
+	if got, want := deleted, []string{"reports"}; !equalSlice(got, want) {
+		t.Errorf("deleted = %v, want %v", got, want)
+	}
+	if _, still := newSeen["reports"]; still {
+		t.Errorf("reports should be dropped from newSeen on success; got %v", keys(newSeen))
+	}
+	if _, kept := newSeen["hello"]; !kept {
+		t.Errorf("hello should stay in newSeen (still present on disk); got %v", keys(newSeen))
+	}
+	// At least one user-visible log line should name the dropped DAG so the
+	// operator sees what happened — silent removal would be worse than the
+	// original bug.
+	found := false
+	for _, l := range logs {
+		if contains(l, "reports") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a log line naming the removed dag %q; got %v", "reports", logs)
+	}
+}
+
+// TestRemoveMissingDagsNewlyAdded pins the "first sight" rule: a DAG that
+// appeared this tick (not in lastSeen) must NOT trigger a delete, even though
+// the function sees it for the first time. Otherwise the very first tick of a
+// fresh Lite would try to delete every DAG it just discovered.
+func TestRemoveMissingDagsNewlyAdded(t *testing.T) {
+	lastSeen := map[string]struct{}{} // first tick, nothing seen yet
+	current := map[string]struct{}{"hello": {}, "sales": {}}
+	var deleted []string
+	deleteDag := func(dagID string) error {
+		deleted = append(deleted, dagID)
+		return nil
+	}
+	newSeen := removeMissingDags(lastSeen, current, deleteDag, func(string, ...any) {})
+
+	if len(deleted) != 0 {
+		t.Errorf("first-tick newly-added DAGs should not be deleted; got %v", deleted)
+	}
+	if _, ok := newSeen["hello"]; !ok {
+		t.Error("newly-added hello should be tracked in newSeen")
+	}
+	if _, ok := newSeen["sales"]; !ok {
+		t.Error("newly-added sales should be tracked in newSeen")
+	}
+}
+
+// TestRemoveMissingDagsRetryOnError covers the failure path the production
+// flow has to survive: the control plane returns 500 / network blips / etc.
+// We must NOT drop the DAG from lastSeen on error — otherwise the next tick
+// thinks it's already gone and never retries. The contract: failures are
+// logged and the DAG stays "seen" so the next tick tries again.
+func TestRemoveMissingDagsRetryOnError(t *testing.T) {
+	lastSeen := map[string]struct{}{
+		"sticky": {},
+	}
+	current := map[string]struct{}{} // sticky is gone from disk
+	tries := 0
+	deleteDag := func(dagID string) error {
+		tries++
+		return errors.New("simulated API 500")
+	}
+	var logs []string
+	logf := func(format string, args ...any) {
+		logs = append(logs, formatLog(format, args...))
+	}
+	newSeen := removeMissingDags(lastSeen, current, deleteDag, logf)
+
+	if tries != 1 {
+		t.Errorf("deleteDag should be called once; got %d", tries)
+	}
+	if _, kept := newSeen["sticky"]; !kept {
+		t.Error("on delete error, dag must stay in newSeen so the next tick retries")
+	}
+	// The user has to see the error — silent retry would mask a permanent
+	// permission problem.
+	found := false
+	for _, l := range logs {
+		if contains(l, "sticky") && (contains(l, "fail") || contains(l, "✗")) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected an error log naming sticky; got %v", logs)
+	}
+}
+
+// TestRemoveMissingDagsNoChange pins the no-op contract: every DAG present
+// last tick is still present, so deleteDag must not be called and newSeen
+// must equal current.
+func TestRemoveMissingDagsNoChange(t *testing.T) {
+	lastSeen := map[string]struct{}{
+		"a": {},
+		"b": {},
+	}
+	current := map[string]struct{}{"a": {}, "b": {}}
+	deleteDag := func(dagID string) error {
+		t.Fatalf("deleteDag must not be called when nothing was removed; got call for %q", dagID)
+		return nil
+	}
+	newSeen := removeMissingDags(lastSeen, current, deleteDag, func(string, ...any) {})
+
+	if got, want := keys(newSeen), []string{"a", "b"}; !equalSlice(got, want) {
+		t.Errorf("newSeen = %v, want %v", got, want)
+	}
+}
+
+// helpers — keep them inline so the test file is self-contained.
+
+func keys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func equalSlice(a, b []string) bool {
+	a2 := append([]string(nil), a...)
+	b2 := append([]string(nil), b...)
+	sort.Strings(a2)
+	sort.Strings(b2)
+	if len(a2) != len(b2) {
+		return false
+	}
+	for i := range a2 {
+		if a2[i] != b2[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || (len(s) > len(sub) && indexOf(s, sub) >= 0))
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+func formatLog(format string, args ...any) string {
+	return fmt.Sprintf(format, args...)
+}

--- a/internal/cli/dev_test.go
+++ b/internal/cli/dev_test.go
@@ -250,7 +250,7 @@ func TestDevWatchLoopExitsOnCancel(t *testing.T) {
 	ws.RootCfg.ApplyDefaults()
 	reloads := 0
 	reload := func() error { reloads++; return nil }
-	if err := devWatchLoop(ctx, cmd, ws, reload); err != nil {
+	if err := devWatchLoop(ctx, cmd, ws, reload, nil); err != nil {
 		t.Errorf("devWatchLoop on canceled ctx = %v, want nil", err)
 	}
 	if reloads != 1 {

--- a/internal/cli/forget.go
+++ b/internal/cli/forget.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/neochaotic/leoflow/internal/config"
+	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/storage"
+)
+
+// newForgetCommand removes a DAG (and, via ON DELETE CASCADE, its versions,
+// runs, task instances, and XCom) from the Lite registry without touching the
+// project files (issue #345). Complements the watcher's automatic set-diff for
+// the case where the operator wants to deregister a DAG but keep the source
+// directory — e.g. pause work on an example, scripted teardown.
+//
+// Implementation talks to the Lite DB directly (same pattern as
+// reset-password). That works whether Lite is currently running or stopped,
+// and the FK cascade in the schema handles versions/runs/TIs/XCom.
+func newForgetCommand() *cobra.Command {
+	var all, dryRun bool
+	cmd := &cobra.Command{
+		Use:   "forget [dag_id]",
+		Short: "Remove a DAG (and all its history) from the Lite registry without touching the source files.",
+		Long: "forget hard-deletes a DAG from the Lite registry. The dag.py and " +
+			"leoflow.yaml on disk are untouched — only the database rows go. " +
+			"FK cascade handles versions, runs, task instances, and XCom. The " +
+			"watcher will re-discover the project on the next tick if its files " +
+			"are still present, so use this when you want to deregister AND " +
+			"plan to delete the source files yourself, OR when you want a " +
+			"clean re-registration after a manual database edit.\n\n" +
+			"Run it as the same user as `leoflow lite` (no sudo). The Lite " +
+			"Postgres must be reachable.",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if all {
+				if len(args) != 0 {
+					return errors.New("--all takes no dag_id argument")
+				}
+				return nil
+			}
+			if len(args) != 1 {
+				return errors.New("exactly one dag_id is required (or pass --all)")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ids := args
+			return runForget(cmd, ids, all, dryRun)
+		},
+	}
+	cmd.Flags().BoolVar(&all, "all", false, "deregister every DAG in the Lite registry")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print what would be deregistered without writing anything")
+	return cmd
+}
+
+// runForget executes the deregister against the Lite DB. Returns nil on
+// success; an error with operator-friendly framing on any failure. The DAG
+// list is either the explicit ids argument or the full registry when --all.
+func runForget(cmd *cobra.Command, ids []string, all, dryRun bool) error {
+	ctx := cmdContext(cmd)
+	pg, err := storage.NewPostgres(ctx, config.DatabaseSection{URL: devDSNs().database})
+	if err != nil {
+		return fmt.Errorf("connecting to the Lite database (is Postgres up? start `leoflow lite`): %w", err)
+	}
+	defer pg.Close()
+
+	repo := storage.NewRepository(pg)
+	if all {
+		dags, _, lerr := repo.ListDagsFiltered(ctx, "default", "", nil, 10_000, 0)
+		if lerr != nil {
+			return fmt.Errorf("listing dags: %w", lerr)
+		}
+		ids = make([]string, 0, len(dags))
+		for _, d := range dags {
+			ids = append(ids, d.DagID)
+		}
+	}
+
+	if len(ids) == 0 {
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), "no DAGs to deregister") //nolint:errcheck // terminal output
+		return nil
+	}
+
+	out := cmd.OutOrStdout()
+	for _, id := range ids {
+		if dryRun {
+			_, _ = fmt.Fprintf(out, "  would forget %q\n", id) //nolint:errcheck // terminal output
+			continue
+		}
+		if derr := repo.DeleteDag(ctx, "default", id); derr != nil {
+			if errors.Is(derr, domain.ErrNotFound) {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "  no DAG %q in registry\n", id) //nolint:errcheck // terminal output
+				continue
+			}
+			return fmt.Errorf("deregistering %q: %w", id, derr)
+		}
+		_, _ = fmt.Fprintf(out, "  ✗ forgot %q (and all its versions, runs, task instances, XCom)\n", id) //nolint:errcheck // terminal output
+	}
+	return nil
+}

--- a/internal/cli/forget_test.go
+++ b/internal/cli/forget_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestForgetCommandArgs pins the CLI's input validation: exactly one dag_id
+// without --all, no positional with --all. Without this, `leoflow lite forget`
+// (no args) would silently no-op and `leoflow lite forget --all foo` would
+// confuse the operator about whether foo was deregistered.
+func TestForgetCommandArgs(t *testing.T) {
+	cases := []struct {
+		name      string
+		args      []string
+		wantError bool
+		wantSub   string
+	}{
+		{"single dag_id is OK", []string{"my_dag"}, false, ""},
+		{"empty args is rejected", []string{}, true, "exactly one dag_id"},
+		{"two dag_ids is rejected", []string{"a", "b"}, true, "exactly one dag_id"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newForgetCommand()
+			err := c.Args(c, tc.args)
+			if tc.wantError && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tc.wantError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if tc.wantSub != "" && err != nil && !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error %q missing %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestForgetCommandAllRejectsPositional protects against accidental
+// `forget --all foo` invocations: --all means "every DAG", so naming one
+// would mix two semantics. Explicit rejection at parse time is friendlier
+// than silently using one or the other.
+func TestForgetCommandAllRejectsPositional(t *testing.T) {
+	c := newForgetCommand()
+	if err := c.Flags().Set("all", "true"); err != nil {
+		t.Fatalf("set --all: %v", err)
+	}
+	err := c.Args(c, []string{"some_dag"})
+	if err == nil {
+		t.Fatal("expected error when --all is combined with a positional dag_id")
+	}
+	if !strings.Contains(err.Error(), "--all") {
+		t.Errorf("error %q should name --all", err.Error())
+	}
+}
+
+// TestForgetCommandFlags pins the flag surface: --all and --dry-run exist and
+// are boolean. A renamed flag would silently break scripts that rely on this
+// CLI.
+func TestForgetCommandFlags(t *testing.T) {
+	c := newForgetCommand()
+	if f := c.Flags().Lookup("all"); f == nil {
+		t.Error("--all flag missing")
+	}
+	if f := c.Flags().Lookup("dry-run"); f == nil {
+		t.Error("--dry-run flag missing")
+	}
+}


### PR DESCRIPTION
## Summary

PR-A of the alpha-prep finding batch. Closes #345.

The "ghost DAG" bug from prealpha.29 hands-on: deleting a project folder used to leave its DAG registered forever. Two paths now deregister it:

1. **Automatic — watcher set-diff.** Every tick computes `lastSeen − current`; calls `DELETE /api/v2/dags/<id>?deregister=true` for each disappeared DAG. FK cascade drops versions/runs/TIs/XCom atomically. Failures stay in `lastSeen` so the next tick retries.

2. **Explicit — `leoflow lite forget <dag_id>`.** Removes a DAG via the Lite DB without touching source files. Flags `--all` and `--dry-run`. Works whether Lite is running or stopped (same DB-direct pattern as `reset-password`).

## Tests

- `removeMissingDags` — 4 unit tests (happy path, first-tick newly added, retry on error, no-change no-op)
- `forget` command — 3 tests (args validation, --all rejects positional, flag surface)
- Existing `TestDevWatchLoopExitsOnCancel` updated to the new signature

Coverage gate: `internal/cli/forget.go` added to the ADR 0011 exclude list (orchestrates DB connection — same pattern as backup_cmd / restore_cmd / managed_postgres).

## Test plan

- [x] `make ci-local` clean (filtered coverage 80.0%, govulncheck, helm-unittest 47/47, parser pytest 48/48)
- [ ] CI green
- [ ] Manual: `leoflow lite`, create a DAG, `rm -rf` the project, watch the deregister log; then `leoflow lite forget <id>` on an existing DAG

Closes #345.