### PR TITLE
docs(examples): fix http_load default + document paused semantics

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -14,6 +14,42 @@ Leoflow keeps Airflow's vocabulary so the UI and mental model are familiar.
 | **Executor** | Runs a task physically: Kubernetes (pod-per-task), subprocess (dev), or inline. |
 | **Agent** | Small Go binary (PID 1) inside the task container that talks gRPC to the control plane. |
 
+## What "paused" means (and what it does **not** mean)
+
+A **paused** DAG is one whose `is_paused` flag is `true` in the metadata database
+— typically toggled with the on/off switch next to the DAG name in the UI.
+
+| Action | Paused DAG | Unpaused DAG |
+|---|---|---|
+| **Scheduler-created runs** (cron, `@daily`, `@hourly`, …) | ❌ Suspended — no new scheduled runs are created | ✅ Created at each interval |
+| **Catchup backfills** | ❌ Suspended — backlog accrues silently until you unpause | ✅ Created on each tick (subject to `catchup`/`max_active_runs`) |
+| **Manual triggers** (UI **Trigger DAG** button, `POST /api/v2/dags/{id}/dagRuns`) | ✅ **Always run** — pause does not gate manual triggers | ✅ Run |
+| **In-flight runs** (already created when the pause flipped) | ✅ Continue to completion — pause is not a kill switch | ✅ Continue |
+
+This is **intentional** and mirrors Apache Airflow's contract: *paused* gates the
+scheduler, not the operator. An operator who triggers a DAG manually has already
+acknowledged the side effects — pause is for *quieting the cron*, not for
+*disabling the pipeline*.
+
+If you want a real "no runs at all" switch, the supported pattern is the same as
+in Airflow: pause the DAG **and** instruct operators not to trigger it. There is
+no separate "disable" flag.
+
+### Why not block manual triggers too?
+
+Three reasons we kept Airflow's behavior:
+
+1. **Operations parity.** Sites migrating from Airflow have runbooks ("trigger
+   `etl_recover` manually if scheduler is paused") that depend on this.
+2. **Debugging.** Pausing a flapping DAG and then manually triggering one good
+   run to capture a clean trace is a common pattern.
+3. **Escape hatch.** During an incident, the on-call may need to force a single
+   run without unblocking the entire schedule.
+
+If you triggered a paused DAG by accident, **delete the run** from the run list
+— that's the supported undo. Pausing again afterward will not retroactively
+suspend it.
+
 ## Why "DAG = image"
 Airflow's pod-per-task model is right; its Python control plane is the bottleneck.
 Leoflow keeps the model, rewrites the control plane in Go, and makes **each DAG its

--- a/examples/http_load/README.md
+++ b/examples/http_load/README.md
@@ -33,8 +33,10 @@ docker run --rm -d --name leoflow-httpbin \
   mccutchen/go-httpbin
 ```
 
-The DAG defaults to `http://host.k3d.internal:58080` (works inside k3d).
-From the host or via subprocess, use `localhost:58080`.
+The DAG's built-in fallback is `http://localhost:58080`, so the quick demo
+on Lite/subprocess works out-of-the-box with the command above. Inside k3d,
+either port-forward into the cluster or create the `http_target` Connection
+(below) — the in-cluster hostname is no longer the default.
 
 ### 2. Create the Connection in the UI
 

--- a/examples/http_load/dag.py
+++ b/examples/http_load/dag.py
@@ -25,8 +25,14 @@ def _resolve_target() -> tuple[str, dict[str, str], tuple[str, str] | None]:
     Strip __extra__ (it is delivery metadata, not part of the request URL),
     pull headers out of it, and surface basic auth separately.
     """
+    # The fallback targets `localhost:58080` because that's where the README
+    # tells operators to run go-httpbin on Lite/subprocess (the quick-demo
+    # path). On k3d, port-forward into the cluster or — preferred — create the
+    # AIRFLOW_CONN_HTTP_TARGET Connection. The previous default
+    # (`host.k3d.internal:58080`) only resolved *inside* k3d networking and
+    # surfaced as `gaierror Errno 8` on Lite/macOS — see #348.
     raw = os.environ.get("AIRFLOW_CONN_HTTP_TARGET") or os.environ.get(
-        "HTTP_TARGET_URI", "http://host.k3d.internal:58080"
+        "HTTP_TARGET_URI", "http://localhost:58080"
     )
     parsed = urlparse(raw)
     qs = parse_qs(parsed.query)
@@ -73,7 +79,16 @@ def call() -> dict[str, str]:
         with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310 - example DAG
             body = json.loads(resp.read().decode("utf-8"))
     except urllib.error.URLError as err:
-        raise RuntimeError(f"http call failed: {err}") from err
+        # Most common cause in a quick demo: nothing is listening on
+        # localhost:58080. Point operators at the README's setup steps
+        # (docker run mccutchen/go-httpbin) and at the optional Connection.
+        hint = (
+            "is anything listening on the target? "
+            "Start the echo server (`docker run --rm -d --name leoflow-httpbin "
+            "-p 58080:8080 mccutchen/go-httpbin`) or configure the "
+            "`http_target` Connection — see examples/http_load/README.md"
+        )
+        raise RuntimeError(f"http call failed ({base}/anything): {err} — {hint}") from err
     echoed = body.get("json")
     if echoed != payload:
         raise AssertionError(f"echo mismatch: sent={payload}, echoed={echoed}")


### PR DESCRIPTION
## Summary
- Switch `examples/http_load/dag.py` fallback from `host.k3d.internal:58080` → `localhost:58080` so the quick-demo path works on Lite/subprocess out of the box (matches what the README tells operators to run).
- Improve the `URLError` message to point at the README setup and at the optional `AIRFLOW_CONN_HTTP_TARGET` Connection — failure is now actionable instead of a bare `gaierror Errno 8`.
- Update `examples/http_load/README.md` to reflect the new default.
- Add **"What 'paused' means (and what it does not mean)"** to `docs/concepts.md`. Documents the Airflow-faithful contract (pause gates the scheduler, never the manual trigger), the rationale we kept it (ops parity, debugging, escape hatch), and the supported undo (delete the run).

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('examples/http_load/dag.py').read())"` — syntax OK
- [x] `make ci-local` — green (gofmt, build, lint, test, govulncheck, helm-unittest, parser pytest, ADR index, mkdocs --strict)
- [x] Coverage stays at 80.1% (pre-commit gate passed)
- [ ] Operator-level: `leoflow lite examples/http_load/` with no `AIRFLOW_CONN_HTTP_TARGET`, no httpbin running → expect actionable error pointing at the README
- [ ] Same, after `docker run --rm -d -p 58080:8080 mccutchen/go-httpbin` → expect green run

Closes #348.