### PR TITLE
feat(lite): per-DAG venvs + auto uv installer

### DIFF
--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -51,6 +51,16 @@ leoflow lite dags/my_dag    # hot-reload at http://localhost:8088 (marked LITE)
     Both paths go through the same FK cascade — versions, runs, TIs, XCom
     are all dropped atomically with the `dags` row.
 
+!!! note "Per-DAG venvs (subprocess executor)"
+    Each DAG gets its own virtualenv under `~/.leoflow/dev/venvs/<dag_id>/`, so
+    editing one project's `dependencies:` only re-runs pip for **that** DAG —
+    other DAGs' venvs are untouched. Two DAGs can pin **conflicting** versions
+    of the same package without interfering. If
+    [`uv`](https://github.com/astral-sh/uv) is on `PATH`, Lite uses it for the
+    install (5–10× faster cold runs); otherwise it falls back to `pip` from
+    the venv. The k3d executor is unaffected — each DAG already ships in its
+    own image.
+
 ## Two executors
 
 | `--executor` | What it does | Reload to a new version |

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -676,11 +676,18 @@ func devSubprocessSetup(ctx context.Context, cmd *cobra.Command, ws *WorkspaceSp
 	if err != nil {
 		return nil, nil, err
 	}
-	venvPy, verr := ensureDevVenv(ctx, cmd, home, resolveRuntimeSrc(o.runtimeSrc, home), ws.RootCfg.Dependencies)
+	runtimeSrc := resolveRuntimeSrc(o.runtimeSrc, home)
+	// Per-DAG venvs: every project gets its own ~/.leoflow/dev/venvs/<dag_id>/.
+	// Editing one project's `dependencies:` only re-runs pip for THAT project,
+	// not the whole workspace (#346). The first project's venv is the boot
+	// fallback exposed via LEOFLOW_PYTHON so the agent always has a runnable
+	// interpreter even before per-DAG resolution kicks in on Execute().
+	bootPy, verr := ensureWorkspaceDagVenvs(ctx, cmd, ws, home, runtimeSrc)
 	if verr != nil {
 		return nil, nil, verr
 	}
-	env = subprocessServerEnv(o.host, o.port, agentBin, ws.Path, venvPy, o.adminHash, o.adminEmail, o.jwtSecret)
+	venvsRoot := filepath.Join(home, "venvs")
+	env = subprocessServerEnv(o.host, o.port, agentBin, ws.Path, bootPy, venvsRoot, o.adminHash, o.adminEmail, o.jwtSecret)
 	env = append(env, liteEditorEnv(ws.Path, filepath.Dir(home))...)
 	makeReload = func(token string) func() error {
 		return func() error {
@@ -691,10 +698,47 @@ func devSubprocessSetup(ctx context.Context, cmd *cobra.Command, ws *WorkspaceSp
 			if rerr != nil {
 				return rerr
 			}
+			// Refresh per-DAG venvs on every reload too — a new project, or a
+			// `dependencies:` edit, is picked up here (the gate inside
+			// ensureDagVenv makes the unchanged-project case a cheap no-op).
+			if _, perr := ensureWorkspaceDagVenvs(ctx, cmd, curWs, home, runtimeSrc); perr != nil {
+				return perr
+			}
 			return devCompileAndRegisterAll(ctx, cmd, curWs, compileOptions{image: o.image}, token, nil, devURL(o.port))
 		}
 	}
 	return env, makeReload, nil
+}
+
+// ensureWorkspaceDagVenvs creates / refreshes the per-DAG venv for every
+// project in the workspace and returns the first project's venv Python, which
+// the control plane exports as LEOFLOW_PYTHON for the boot fallback path.
+// Failure to provision any one project's venv stops the loop and surfaces
+// which project failed — there is no point pretending the workspace is up
+// when a DAG cannot import its runtime.
+func ensureWorkspaceDagVenvs(ctx context.Context, cmd *cobra.Command, ws *WorkspaceSpec, home, runtimeSrc string) (bootPy string, err error) {
+	for _, p := range ws.Projects {
+		dagID := p.DagID
+		deps := []string(nil)
+		if p.Config != nil {
+			deps = p.Config.Dependencies
+		}
+		py, verr := ensureDagVenv(ctx, cmd, home, dagID, runtimeSrc, deps)
+		if verr != nil {
+			return "", fmt.Errorf("provisioning venv for project %q: %w", p.Path, verr)
+		}
+		if bootPy == "" {
+			bootPy = py
+		}
+	}
+	if bootPy == "" {
+		// No projects discovered yet — fall back to the legacy single-venv
+		// location so the server can still boot with a usable LEOFLOW_PYTHON.
+		// A later watcher tick will create per-DAG venvs once the user adds a
+		// dag.py to the workspace.
+		bootPy = venvPython(home)
+	}
+	return bootPy, nil
 }
 
 // devClusterSetup ensures the task base image, the dedicated k3d cluster, its
@@ -954,19 +998,7 @@ func venvPython(home string) string {
 	return filepath.Join(home, "venv", "bin", "python")
 }
 
-// venvPipArgs builds the pip-install argv for the dev venv: the task runtime,
-// the Airflow Task SDK, and the project's declared dependencies.
-func venvPipArgs(runtimeSrc string, deps []string) []string {
-	args := make([]string, 0, 6+len(deps))
-	args = append(args, "-m", "pip", "install", "-q", runtimeSrc, taskSDKVersion)
-	return append(args, deps...)
-}
-
-// ensureDevVenv creates the isolated dev venv if absent and installs the task
-// runtime + Airflow SDK + project deps into it (skipping the install when the
-// runtime is already present, so reruns are fast). It returns the venv's python
-// path, which the agent uses to run user code — the host's Python is untouched.
-// devBasePython returns the interpreter used to CREATE the dev venv: the managed
+// devBasePython returns the interpreter used to CREATE a dev venv: the managed
 // relocatable CPython 3.11 (installed by `leoflow setup` under ~/.leoflow/python)
 // when present, since it bundles venv + ensurepip. It falls back to a python3.11
 // / python3 on PATH. Using the managed interpreter avoids needing the system
@@ -1000,76 +1032,6 @@ func resolveRuntimeSrc(flagValue, home string) string {
 	return filepath.Join(filepath.Dir(home), "pysrc", "runtime", "python")
 }
 
-func ensureDevVenv(ctx context.Context, cmd *cobra.Command, home, runtimeSrc string, deps []string) (string, error) {
-	py := venvPython(home)
-	if _, err := os.Stat(py); err != nil {
-		devPrintln(cmd.OutOrStdout(), "▸ creating isolated dev venv …")
-		base := devBasePython(home)
-		mk := exec.CommandContext(ctx, base, "-m", "venv", filepath.Join(home, "venv")) //nolint:gosec // base is the managed CPython or a resolved python3
-		mk.Stdout, mk.Stderr = cmd.OutOrStdout(), cmd.ErrOrStderr()
-		if e := mk.Run(); e != nil {
-			return "", fmt.Errorf("creating dev venv with %s (the managed CPython bundles venv; a system python3 may need its python3-venv package): %w", base, e)
-		}
-	}
-	// Runtime + Airflow SDK: install when either (a) the runtime is not importable
-	// (fresh venv) or (b) the installed runtime's checksum drifts from the bundled
-	// pysrc — which is the binary-upgrade case (#239). Gating only on (a) meant a
-	// binary upgrade kept the OLD runtime in the venv (the import succeeds, so the
-	// install branch never fires) and any runtime improvements (lifecycle log
-	// lines, drill-down markers, etc.) were invisible until the user manually
-	// deleted the venv.
-	check := exec.CommandContext(ctx, py, "-c", "import leoflow_runtime") //nolint:gosec // py is the managed venv interpreter
-	importOK := check.Run() == nil
-	need, want, cerr := needsRuntimeInstall(home, runtimeSrc, importOK)
-	if cerr != nil {
-		// Checksum failure is recoverable (e.g. pysrc not yet extracted): fall
-		// back to the old behavior — install only when the import fails.
-		need = !importOK
-	}
-	if need {
-		devPrintln(cmd.OutOrStdout(), "▸ installing task runtime + Airflow SDK into the dev venv …")
-		install := exec.CommandContext(ctx, py, venvPipArgs(runtimeSrc, nil)...) //nolint:gosec // py is the managed venv interpreter
-		install.Stdout, install.Stderr = cmd.OutOrStdout(), cmd.ErrOrStderr()
-		if e := install.Run(); e != nil {
-			return "", fmt.Errorf("installing dev venv runtime: %w", e)
-		}
-		// Record what we just installed so the next startup can skip when nothing
-		// changed. Best-effort: a write failure means the next startup reinstalls
-		// (slow, not broken) — better than leaving a stale marker.
-		if want != "" {
-			if e := writeRuntimeMarker(home, want); e != nil {
-				slog.Warn("recording dev venv runtime checksum", "error", e)
-			}
-		}
-	}
-	// Project deps: (re)install when the active project's declared dependencies
-	// change — gating only on the runtime above meant switching projects, or
-	// editing `dependencies:`, never refreshed the venv (#116). Additive: extra
-	// packages from a previous project are harmless.
-	if len(deps) > 0 && !devDepsUpToDate(home, deps) {
-		devPrintln(cmd.OutOrStdout(), "▸ installing project dependencies into the dev venv …")
-		install := exec.CommandContext(ctx, py, venvDepsArgs(deps)...) //nolint:gosec // py is the managed venv interpreter
-		install.Stdout, install.Stderr = cmd.OutOrStdout(), cmd.ErrOrStderr()
-		if e := install.Run(); e != nil {
-			return "", fmt.Errorf("installing project dependencies: %w", e)
-		}
-		if e := writeDevDepsMarker(home, deps); e != nil {
-			return "", fmt.Errorf("recording installed project deps: %w", e)
-		}
-	}
-	return py, nil
-}
-
-// venvDepsArgs is the pip invocation that installs just the project's declared
-// dependencies into the dev venv.
-func venvDepsArgs(deps []string) []string {
-	return append([]string{"-m", "pip", "install", "-q"}, deps...)
-}
-
-// devDepsMarkerPath is the file recording which project dependencies the dev venv
-// currently has installed.
-func devDepsMarkerPath(home string) string { return filepath.Join(home, "venv", ".leoflow-deps") }
-
 // devDepsSignature is an order-independent canonical form of a dependency list, so
 // reordering `dependencies:` does not force a needless reinstall.
 func devDepsSignature(deps []string) string {
@@ -1078,49 +1040,9 @@ func devDepsSignature(deps []string) string {
 	return strings.Join(s, "\n")
 }
 
-// devDepsUpToDate reports whether the dev venv already has exactly these project
-// deps installed (per the marker written by the last successful install).
-func devDepsUpToDate(home string, deps []string) bool {
-	b, err := os.ReadFile(devDepsMarkerPath(home)) //nolint:gosec // path derived from the per-user dev home
-	if err != nil {
-		return false
-	}
-	return string(b) == devDepsSignature(deps)
-}
-
-// writeDevDepsMarker records the project deps just installed into the dev venv.
-func writeDevDepsMarker(home string, deps []string) error {
-	return os.WriteFile(devDepsMarkerPath(home), []byte(devDepsSignature(deps)), 0o600)
-}
-
-// runtimeMarkerPath is the file recording the checksum of the leoflow_runtime
-// source last installed into the dev venv. Sits alongside devDepsMarkerPath so a
-// single "rm venv/.leoflow-*" wipes all of the venv's freshness state.
-func runtimeMarkerPath(home string) string {
-	return filepath.Join(home, "venv", ".leoflow-runtime-checksum")
-}
-
-// runtimeInstalledChecksum returns the checksum recorded by the most recent
-// runtime install into the dev venv, or "" if absent (fresh venv, or a venv
-// from a binary that pre-dates this gate).
-func runtimeInstalledChecksum(home string) string {
-	b, err := os.ReadFile(runtimeMarkerPath(home)) //nolint:gosec // path derived from the per-user dev home
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(b))
-}
-
-// writeRuntimeMarker stamps the dev venv with the checksum of the runtime
-// source just installed. Subsequent leoflow lite startups compare this against
-// the bundled pysrc to detect a binary upgrade (#239).
-func writeRuntimeMarker(home, checksum string) error {
-	return os.WriteFile(runtimeMarkerPath(home), []byte(checksum+"\n"), 0o600)
-}
-
 // runtimeSrcChecksum returns a stable SHA-256 hex digest covering every `.py`
 // file under runtimeSrc, walked in deterministic path order. Used by
-// ensureDevVenv to decide whether the venv's installed leoflow_runtime has
+// ensureDagVenv to decide whether the venv's installed leoflow_runtime has
 // drifted from the bundled pysrc after a binary upgrade (#239).
 //
 // Non-Python files (READMEs, __pycache__/*.pyc, etc.) are ignored: a stray
@@ -1164,33 +1086,6 @@ func runtimeSrcChecksum(runtimeSrc string) (string, error) {
 		h.Write([]byte{0})
 	}
 	return hex.EncodeToString(h.Sum(nil)), nil
-}
-
-// needsRuntimeInstall decides whether the dev venv requires (re)installing
-// leoflow_runtime. Three triggers, in order:
-//
-//  1. The runtime is not importable in the venv (fresh venv, broken install).
-//  2. The bundled pysrc checksum cannot be computed — defensive: better to
-//     reinstall than to skip and leave the user stuck with a stale runtime.
-//  3. The marker checksum does not match the bundled pysrc checksum (binary
-//     upgrade — #239).
-//
-// Returns (need, want, err): `want` is the bundled checksum to stamp into the
-// marker after a successful install. `err` is non-nil only when the source
-// walk truly fails (e.g. permission denied); the caller can choose to fall
-// back to the import-only gate.
-func needsRuntimeInstall(home, runtimeSrc string, importOK bool) (need bool, want string, err error) {
-	want, err = runtimeSrcChecksum(runtimeSrc)
-	if err != nil {
-		return true, "", err
-	}
-	if !importOK {
-		return true, want, nil
-	}
-	if runtimeInstalledChecksum(home) != want {
-		return true, want, nil
-	}
-	return false, want, nil
 }
 
 // devRun and devOutput run external dev tools (k3d/docker/kubectl). They are
@@ -1446,15 +1341,19 @@ func loadLiteAdmin(cmd *cobra.Command) (hash, email, jwtSecret string) {
 }
 
 // subprocessServerEnv adds the subprocess-executor settings: the agent binary,
-// the project workdir (so dag.py imports), the venv Python, and a dialable
-// control-plane address (the server binds 0.0.0.0, which is not a dial target).
-func subprocessServerEnv(host string, port int, agentBin, workDir, venvPython, adminHash, adminEmail, jwtSecret string) []string {
+// the project workdir (so dag.py imports), the venv Python (boot fallback when
+// the per-DAG venv lookup misses), the per-DAG venvs root (LEOFLOW_LITE_VENVS_ROOT
+// — the subprocess executor consults <root>/<dag_id>/bin/python to override the
+// fallback per task), and a dialable control-plane address (the server binds
+// 0.0.0.0, which is not a dial target).
+func subprocessServerEnv(host string, port int, agentBin, workDir, venvPython, venvsRoot, adminHash, adminEmail, jwtSecret string) []string {
 	return append(sharedServerEnv(host, port, adminHash, adminEmail, jwtSecret),
 		"LEOFLOW_EXECUTOR_TYPE=subprocess",
 		"LEOFLOW_EXECUTOR_AGENT_PATH="+agentBin,
 		"LEOFLOW_EXECUTOR_AGENT_CONTROL_PLANE_ADDR=127.0.0.1"+devGRPCBindAddr(port),
 		"LEOFLOW_EXECUTOR_SUBPROCESS_WORKDIR="+workDir,
 		"LEOFLOW_PYTHON="+venvPython,
+		"LEOFLOW_LITE_VENVS_ROOT="+venvsRoot,
 	)
 }
 

--- a/internal/cli/dev_dag_venv.go
+++ b/internal/cli/dev_dag_venv.go
@@ -1,0 +1,201 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// sanitizeDagIDForFs makes a dag_id safe to use as a single filesystem path
+// component. Letters, digits, '_' and '-' pass through; anything else becomes
+// '_'. An empty string maps to "_" so we never produce an empty component
+// (which would collapse into the parent dir). Used to derive the per-DAG venv
+// directory name from the user-controlled dag_id.
+func sanitizeDagIDForFs(id string) string {
+	if id == "" {
+		return "_"
+	}
+	var b strings.Builder
+	b.Grow(len(id))
+	for _, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
+// dagVenvDir returns the per-DAG venv directory under the Lite dev home —
+// ~/.leoflow/dev/venvs/<sanitized-dag-id>. The "venvs" suffix (plural) is
+// deliberate so it never collides with the legacy single-venv layout at
+// ~/.leoflow/dev/venv (#346).
+func dagVenvDir(home, dagID string) string {
+	return filepath.Join(home, "venvs", sanitizeDagIDForFs(dagID))
+}
+
+// dagVenvPython returns the Python interpreter inside the per-DAG venv,
+// honoring the platform layout (bin on Unix, Scripts on Windows).
+func dagVenvPython(home, dagID string) string {
+	dir := dagVenvDir(home, dagID)
+	if runtime.GOOS == "windows" {
+		return filepath.Join(dir, "Scripts", "python.exe")
+	}
+	return filepath.Join(dir, "bin", "python")
+}
+
+// dagVenvDepsMarkerPath records which project dependencies the per-DAG venv
+// currently has installed. Lives inside the venv directory so a single
+// `rm -rf` of that directory wipes the freshness signal alongside the venv.
+func dagVenvDepsMarkerPath(home, dagID string) string {
+	return filepath.Join(dagVenvDir(home, dagID), ".leoflow-deps")
+}
+
+// dagVenvRuntimeMarkerPath records the checksum of the leoflow_runtime source
+// last installed into the per-DAG venv, so a binary upgrade triggers a
+// reinstall instead of leaving stale runtime in place (#239 carried over to
+// the per-DAG layout).
+func dagVenvRuntimeMarkerPath(home, dagID string) string {
+	return filepath.Join(dagVenvDir(home, dagID), ".leoflow-runtime-checksum")
+}
+
+// installer is the Python package installer Lite uses to populate per-DAG
+// venvs. uv is preferred when available (5–10× faster cold installs, #87),
+// with pip as a portable fallback.
+type installer string
+
+const (
+	installerPip installer = "pip"
+	installerUv  installer = "uv"
+)
+
+// detectInstaller reports which installer Lite should use, preferring uv on
+// PATH and falling back to pip. lookPath is the seam that lets tests force
+// uv vs pip without touching the real PATH.
+func detectInstaller(lookPath func(string) (string, error)) installer {
+	if _, err := lookPath("uv"); err == nil {
+		return installerUv
+	}
+	return installerPip
+}
+
+// installerCmd returns the (cmd, args) to install `packages` into the venv
+// whose Python is `py`. For pip it shells the venv's own Python with
+// `-m pip install`, so the install lands in that venv regardless of $PATH.
+// For uv it invokes the global uv binary with `--python <py>` so uv resolves
+// and writes into the target venv directly (uv does the activation itself).
+//
+// The argv shapes are pinned by TestInstallerCmdShapes so the wire never
+// silently drifts (a missing `--python` on uv would install into a stray
+// global env; a missing `-m` on pip would shell out to a system pip with
+// the wrong site-packages).
+func installerCmd(inst installer, py string, packages []string) (cmd string, args []string) {
+	switch inst {
+	case installerUv:
+		args = append([]string{"pip", "install", "-q", "--python", py}, packages...)
+		return "uv", args
+	default:
+		args = append([]string{"-m", "pip", "install", "-q"}, packages...)
+		return py, args
+	}
+}
+
+// ensureDagVenv creates the per-DAG venv under home/venvs/<dag_id>/ if absent
+// and installs the task runtime + Airflow SDK + the project's declared
+// dependencies into it (skipping the install when the runtime is already
+// present AND its source checksum has not drifted, and skipping deps when the
+// dep marker matches). Returns the venv's Python path — what the subprocess
+// executor exports as LEOFLOW_PYTHON for tasks of that DAG.
+//
+// The freshness gates mirror the single-venv ensureDevVenv (deps signature +
+// runtime checksum) but are scoped to one DAG, so editing one project's
+// `dependencies:` never re-runs pip for every other project in the workspace.
+func ensureDagVenv(ctx context.Context, cmd *cobra.Command, home, dagID, runtimeSrc string, deps []string) (string, error) {
+	py := dagVenvPython(home, dagID)
+	dir := dagVenvDir(home, dagID)
+	inst := detectInstaller(exec.LookPath)
+
+	if _, err := os.Stat(py); err != nil {
+		devPrintf(cmd.OutOrStdout(), "▸ creating isolated dev venv for %q …\n", dagID)
+		base := devBasePython(home)
+		mk := exec.CommandContext(ctx, base, "-m", "venv", dir) //nolint:gosec // base is the managed CPython or a resolved python3
+		mk.Stdout, mk.Stderr = cmd.OutOrStdout(), cmd.ErrOrStderr()
+		if e := mk.Run(); e != nil {
+			return "", fmt.Errorf("creating dev venv for %q with %s (the managed CPython bundles venv; a system python3 may need its python3-venv package): %w", dagID, base, e)
+		}
+	}
+
+	// Runtime + Airflow SDK: install when either (a) the runtime is not
+	// importable (fresh venv) or (b) the installed runtime's checksum drifts
+	// from the bundled pysrc — the binary-upgrade case (#239). Empty checksum
+	// makes the import-gate the sole signal.
+	check := exec.CommandContext(ctx, py, "-c", "import leoflow_runtime") //nolint:gosec // py is a managed per-DAG venv interpreter
+	importOK := check.Run() == nil
+	want, cerr := runtimeSrcChecksum(runtimeSrc)
+	need := !importOK
+	if cerr == nil && want != "" && dagVenvRuntimeChecksum(home, dagID) != want {
+		need = true
+	}
+	if need {
+		devPrintf(cmd.OutOrStdout(), "▸ installing task runtime + Airflow SDK into the %q venv (using %s) …\n", dagID, inst)
+		runCmd, runArgs := installerCmd(inst, py, []string{runtimeSrc, taskSDKVersion})
+		install := exec.CommandContext(ctx, runCmd, runArgs...) //nolint:gosec // runCmd is the venv's py or "uv" — both vetted
+		install.Stdout, install.Stderr = cmd.OutOrStdout(), cmd.ErrOrStderr()
+		if e := install.Run(); e != nil {
+			return "", fmt.Errorf("installing runtime into venv %q: %w", dagID, e)
+		}
+		if want != "" {
+			if e := os.WriteFile(dagVenvRuntimeMarkerPath(home, dagID), []byte(want+"\n"), 0o600); e != nil {
+				// Best-effort marker write: a failure means the next startup
+				// reinstalls (slow, not broken) — better than leaving a stale
+				// marker that masks the upgrade.
+				devPrintf(cmd.OutOrStdout(), "  (warning) recording runtime checksum for %q: %v\n", dagID, e)
+			}
+		}
+	}
+
+	// Project deps: (re)install when the project's `dependencies:` change.
+	// Skipped entirely when the project declares none — most quick-demo DAGs
+	// only need runtime + SDK and pay no install cost after the first boot.
+	if len(deps) > 0 && !dagVenvDepsUpToDate(home, dagID, deps) {
+		devPrintf(cmd.OutOrStdout(), "▸ installing %d dep(s) into the %q venv (using %s) …\n", len(deps), dagID, inst)
+		runCmd, runArgs := installerCmd(inst, py, deps)
+		install := exec.CommandContext(ctx, runCmd, runArgs...) //nolint:gosec // runCmd is the venv's py or "uv" — both vetted
+		install.Stdout, install.Stderr = cmd.OutOrStdout(), cmd.ErrOrStderr()
+		if e := install.Run(); e != nil {
+			return "", fmt.Errorf("installing deps into venv %q: %w", dagID, e)
+		}
+		if e := os.WriteFile(dagVenvDepsMarkerPath(home, dagID), []byte(devDepsSignature(deps)), 0o600); e != nil {
+			return "", fmt.Errorf("recording deps marker for %q: %w", dagID, e)
+		}
+	}
+	return py, nil
+}
+
+// dagVenvRuntimeChecksum returns the checksum recorded by the most recent
+// runtime install into the per-DAG venv (empty when no marker yet).
+func dagVenvRuntimeChecksum(home, dagID string) string {
+	b, err := os.ReadFile(dagVenvRuntimeMarkerPath(home, dagID)) //nolint:gosec // path derived from the per-user dev home + sanitized dag_id
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
+}
+
+// dagVenvDepsUpToDate reports whether the per-DAG venv already has exactly
+// these deps installed, by signature comparison.
+func dagVenvDepsUpToDate(home, dagID string, deps []string) bool {
+	b, err := os.ReadFile(dagVenvDepsMarkerPath(home, dagID)) //nolint:gosec // path derived from the per-user dev home + sanitized dag_id
+	if err != nil {
+		return false
+	}
+	return string(b) == devDepsSignature(deps)
+}

--- a/internal/cli/dev_dag_venv_test.go
+++ b/internal/cli/dev_dag_venv_test.go
@@ -1,0 +1,196 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestSanitizeDagIDForFs(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"sales_etl", "sales_etl"},
+		{"my-dag", "my-dag"},
+		{"with.dots", "with_dots"},
+		{"weird/slash", "weird_slash"},
+		{"../escape", "___escape"},
+		{"name with spaces", "name_with_spaces"},
+		{"", "_"},
+		{"...", "___"},
+	}
+	for _, c := range cases {
+		if got := sanitizeDagIDForFs(c.in); got != c.want {
+			t.Errorf("sanitizeDagIDForFs(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDagVenvPathLayout(t *testing.T) {
+	home := filepath.FromSlash("/h/.leoflow/dev")
+	dir := dagVenvDir(home, "sales_etl")
+	wantDir := filepath.Join(home, "venvs", "sales_etl")
+	if dir != wantDir {
+		t.Errorf("dagVenvDir = %q, want %q", dir, wantDir)
+	}
+	py := dagVenvPython(home, "sales_etl")
+	wantPy := filepath.Join(wantDir, "bin", "python")
+	if runtime.GOOS == "windows" {
+		wantPy = filepath.Join(wantDir, "Scripts", "python.exe")
+	}
+	if py != wantPy {
+		t.Errorf("dagVenvPython = %q, want %q", py, wantPy)
+	}
+	// Markers live inside the per-DAG venv directory so a single rm -rf wipes
+	// every freshness/lock signal alongside the venv itself — the
+	// single-shared-venv layout had to manage them at the root.
+	if got := dagVenvDepsMarkerPath(home, "sales_etl"); !strings.HasPrefix(got, wantDir) {
+		t.Errorf("dagVenvDepsMarkerPath = %q, want a path under %q", got, wantDir)
+	}
+	if got := dagVenvRuntimeMarkerPath(home, "sales_etl"); !strings.HasPrefix(got, wantDir) {
+		t.Errorf("dagVenvRuntimeMarkerPath = %q, want a path under %q", got, wantDir)
+	}
+}
+
+func TestDetectInstallerPrefersUv(t *testing.T) {
+	uvFound := func(name string) (string, error) {
+		if name == "uv" {
+			return "/opt/homebrew/bin/uv", nil
+		}
+		return "", errors.New("not found")
+	}
+	if got := detectInstaller(uvFound); got != installerUv {
+		t.Errorf("detectInstaller(uv on PATH) = %q, want uv", got)
+	}
+	noUv := func(_ string) (string, error) { return "", errors.New("not found") }
+	if got := detectInstaller(noUv); got != installerPip {
+		t.Errorf("detectInstaller(no uv) = %q, want pip", got)
+	}
+}
+
+func TestInstallerCmdShapes(t *testing.T) {
+	// pip: run the venv's Python as the installer host. Tests rely on
+	// argv[0]==<py> so the venv-relative install path is preserved even when
+	// the operator's $PATH points elsewhere.
+	cmd, args := installerCmd(installerPip, "/v/py", []string{"pandas", "duckdb==1"})
+	if cmd != "/v/py" {
+		t.Errorf("pip cmd = %q, want /v/py", cmd)
+	}
+	joined := strings.Join(args, " ")
+	for _, must := range []string{"-m", "pip", "install", "pandas", "duckdb==1"} {
+		if !strings.Contains(joined, must) {
+			t.Errorf("pip args %q missing %q", joined, must)
+		}
+	}
+	// uv: invoke `uv pip install --python <py> ...` so uv resolves and
+	// installs into the target venv directly — no need to activate it.
+	cmd, args = installerCmd(installerUv, "/v/py", []string{"pandas"})
+	if cmd != "uv" {
+		t.Errorf("uv cmd = %q, want uv", cmd)
+	}
+	joined = strings.Join(args, " ")
+	for _, must := range []string{"pip", "install", "--python", "/v/py", "pandas"} {
+		if !strings.Contains(joined, must) {
+			t.Errorf("uv args %q missing %q", joined, must)
+		}
+	}
+	// Empty package list is a no-op shape — callers should not invoke it,
+	// but if they do, the argv must still be valid (no trailing space, no
+	// dangling separator).
+	cmd, args = installerCmd(installerUv, "/v/py", nil)
+	if cmd == "" || len(args) == 0 {
+		t.Errorf("installerCmd(uv, nil) returned empty cmd/args: %q %v", cmd, args)
+	}
+}
+
+// TestEnsureDagVenvSkipsAllGatesWhenAlreadyFresh exercises the happy
+// short-circuit: the venv exists with the runtime importable AND the marker
+// matches AND the deps marker matches → no install runs, no error returned.
+// Uses a sh stub for "python" so we never depend on a real interpreter or
+// network, but the function still walks every gate (venv-exists, import-OK,
+// checksum-match, deps-match) — the regression class being protected against
+// is a startup-time pip storm that hits every Lite reload when the gates
+// accidentally invert (#346's user pain).
+func TestEnsureDagVenvSkipsAllGatesWhenAlreadyFresh(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sh stub is POSIX-only; the per-DAG layout is exercised by TestDagVenvPathLayout on Windows")
+	}
+	home := t.TempDir()
+	dagID := "etl"
+	venvDir := dagVenvDir(home, dagID)
+	binDir := filepath.Join(venvDir, "bin")
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// A python stub that always succeeds — used for the `python -c "import
+	// leoflow_runtime"` gate. Any args are ignored.
+	pyStub := filepath.Join(binDir, "python")
+	if err := os.WriteFile(pyStub, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A pysrc fixture so runtimeSrcChecksum returns a stable value; then
+	// stamp the matching marker so the binary-upgrade gate skips.
+	runtimeRoot := writeRuntimeFixture(t, t.TempDir(), map[string]string{
+		"runner.py": "def run(): pass\n",
+	})
+	want, cerr := runtimeSrcChecksum(runtimeRoot)
+	if cerr != nil {
+		t.Fatalf("runtimeSrcChecksum: %v", cerr)
+	}
+	if err := os.WriteFile(dagVenvRuntimeMarkerPath(home, dagID), []byte(want), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	deps := []string{"requests==2.31.0"}
+	if err := os.WriteFile(dagVenvDepsMarkerPath(home, dagID), []byte(devDepsSignature(deps)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ensureDagVenv(context.Background(), devTestCmd(), home, dagID, runtimeRoot, deps)
+	if err != nil {
+		t.Fatalf("ensureDagVenv: %v", err)
+	}
+	if got != pyStub {
+		t.Errorf("ensureDagVenv returned %q, want %q (the stub)", got, pyStub)
+	}
+}
+
+// TestEnsureWorkspaceDagVenvsEmptyFallback pins the no-projects boot path:
+// when the workspace has no DAGs yet (the first user dropping a dag.py into
+// a fresh workspace), the boot venv falls back to the legacy single-venv
+// location so the server still has a usable LEOFLOW_PYTHON. A regression
+// here would be a control plane that won't start until at least one DAG is
+// registered — the exact onboarding hole this branch prevents.
+func TestEnsureWorkspaceDagVenvsEmptyFallback(t *testing.T) {
+	home := t.TempDir()
+	ws := &WorkspaceSpec{Path: "ws", Projects: nil}
+	got, err := ensureWorkspaceDagVenvs(context.Background(), devTestCmd(), ws, home, "runtime/python")
+	if err != nil {
+		t.Fatalf("ensureWorkspaceDagVenvs(empty): %v", err)
+	}
+	if want := venvPython(home); got != want {
+		t.Errorf("empty workspace must fall back to legacy venv %q, got %q", want, got)
+	}
+}
+
+func TestLiteVenvsRootEnvWiringFromSubprocessServerEnv(t *testing.T) {
+	// The subprocess executor reads LEOFLOW_LITE_VENVS_ROOT to look up the
+	// per-DAG interpreter for each task. Without this env, the per-DAG
+	// install on the watcher side would create venvs the executor never
+	// finds — a silent regression that would only surface as
+	// ModuleNotFoundError on the first task. Pin the wire so the
+	// regression is impossible.
+	env := strings.Join(subprocessServerEnv("127.0.0.1", 8088, "/bin/agent", "/proj", "/venv/py", "/h/venvs", "", "", ""), "\n")
+	for _, must := range []string{
+		"LEOFLOW_LITE_VENVS_ROOT=/h/venvs",
+		// And the legacy LEOFLOW_PYTHON remains as the boot/fallback.
+		"LEOFLOW_PYTHON=/venv/py",
+	} {
+		if !strings.Contains(env, must) {
+			t.Errorf("subprocessServerEnv missing %q\nfull env:\n%s", must, env)
+		}
+	}
+}

--- a/internal/cli/dev_test.go
+++ b/internal/cli/dev_test.go
@@ -227,7 +227,7 @@ func TestStartDevServerStartsAndErrors(t *testing.T) {
 	defer cancel()
 
 	// A real, harmless binary starts successfully and a *Cmd is returned.
-	srv, err := startDevServer(ctx, cmd, "/bin/sleep", subprocessServerEnv("127.0.0.1", 8088, "/bin/true", t.TempDir(), "python3", "", "", ""))
+	srv, err := startDevServer(ctx, cmd, "/bin/sleep", subprocessServerEnv("127.0.0.1", 8088, "/bin/true", t.TempDir(), "python3", t.TempDir(), "", "", ""))
 	if err != nil || srv == nil {
 		t.Fatalf("startDevServer(real bin) = (%v,%v), want a running cmd", srv, err)
 	}
@@ -267,16 +267,6 @@ func TestVenvPythonOSAware(t *testing.T) {
 	}
 	if got != want {
 		t.Errorf("venvPython = %q, want %q", got, want)
-	}
-}
-
-func TestVenvPipArgs(t *testing.T) {
-	args := venvPipArgs("runtime/python", []string{"pandas==2.1.0"})
-	joined := strings.Join(args, " ")
-	for _, must := range []string{"-m pip install", "runtime/python", taskSDKVersion, "pandas==2.1.0"} {
-		if !strings.Contains(joined, must) {
-			t.Errorf("pip args %q missing %q", joined, must)
-		}
 	}
 }
 
@@ -336,7 +326,7 @@ func TestMergeLiteDefaults(t *testing.T) {
 }
 
 func TestServerEnvBuilders(t *testing.T) {
-	sub := strings.Join(subprocessServerEnv("127.0.0.1", 8088, "/bin/agent", "/proj", "/venv/py", "", "", ""), "\n")
+	sub := strings.Join(subprocessServerEnv("127.0.0.1", 8088, "/bin/agent", "/proj", "/venv/py", "/h/venvs", "", "", ""), "\n")
 	// Lite binds its own HTTP/gRPC/metrics ports (distinct from the demo's 8080/9090/9091).
 	for _, must := range []string{"LEOFLOW_EXECUTOR_TYPE=subprocess", "LEOFLOW_EXECUTOR_AGENT_PATH=/bin/agent", "LEOFLOW_EXECUTOR_SUBPROCESS_WORKDIR=/proj", "LEOFLOW_PYTHON=/venv/py", "127.0.0.1:9099", "LEOFLOW_SERVER_HTTP_ADDR=127.0.0.1:8088", "LEOFLOW_SERVER_GRPC_ADDR=:9099", "LEOFLOW_SERVER_METRICS_ADDR=:9098"} {
 		if !strings.Contains(sub, must) {
@@ -354,7 +344,7 @@ func TestServerEnvBuilders(t *testing.T) {
 	if !strings.Contains(sub, "LEOFLOW_OBSERVABILITY_OTEL_ENABLED=false") {
 		t.Error("Lite env should disable the OTLP exporter (no local collector)")
 	}
-	alt := strings.Join(subprocessServerEnv("127.0.0.1", 8090, "/bin/agent", "/proj", "/venv/py", "", "", ""), "\n")
+	alt := strings.Join(subprocessServerEnv("127.0.0.1", 8090, "/bin/agent", "/proj", "/venv/py", "/h/venvs", "", "", ""), "\n")
 	for _, must := range []string{"LEOFLOW_SERVER_GRPC_ADDR=:9101", "LEOFLOW_SERVER_METRICS_ADDR=:9100", "127.0.0.1:9101"} {
 		if !strings.Contains(alt, must) {
 			t.Errorf("--port 8090 should offset gRPC/metrics, missing %q", must)

--- a/internal/cli/dev_venv_test.go
+++ b/internal/cli/dev_venv_test.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -91,119 +90,6 @@ func TestRuntimeSrcChecksum_IgnoresNonPyFiles(t *testing.T) {
 	}
 }
 
-// TestRuntimeMarkerRoundtrip: after writeRuntimeMarker, runtimeInstalledChecksum
-// returns the same value, and is empty when no marker exists yet.
-func TestRuntimeMarkerRoundtrip(t *testing.T) {
-	home := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(home, "venv"), 0o750); err != nil {
-		t.Fatal(err)
-	}
-	if got := runtimeInstalledChecksum(home); got != "" {
-		t.Errorf("absent marker must report empty, got %q", got)
-	}
-	want := "deadbeef" + "00000000000000000000000000000000000000000000000000000000"
-	if err := writeRuntimeMarker(home, want); err != nil {
-		t.Fatal(err)
-	}
-	if got := runtimeInstalledChecksum(home); got != want {
-		t.Errorf("roundtrip mismatch: got %q want %q", got, want)
-	}
-}
-
-// TestNeedsRuntimeInstall_BinaryUpgradeTriggersReinstall is the Lima bug #239
-// case end-to-end: the venv exists with leoflow_runtime importable, but the
-// installed checksum is from a previous binary. Must report needsInstall=true
-// even though the import would succeed.
-func TestNeedsRuntimeInstall_BinaryUpgradeTriggersReinstall(t *testing.T) {
-	home := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(home, "venv"), 0o750); err != nil {
-		t.Fatal(err)
-	}
-	// Marker says checksum X is installed (the old binary's runtime).
-	if err := writeRuntimeMarker(home, "deadbeef"+strings.Repeat("0", 56)); err != nil {
-		t.Fatal(err)
-	}
-	// pysrc has a different checksum (the upgraded binary's runtime).
-	src := writeRuntimeFixture(t, t.TempDir(), map[string]string{
-		"runner.py": "def run(): print('[leoflow] new')\n",
-	})
-
-	need, want, err := needsRuntimeInstall(home, src, true /*importOK*/)
-	if err != nil {
-		t.Fatalf("needsRuntimeInstall: %v", err)
-	}
-	if !need {
-		t.Errorf("bug #239: needsRuntimeInstall=false on a mismatched marker; install must fire on binary upgrade")
-	}
-	if want == "" {
-		t.Errorf("expected a non-empty want-checksum to write into the marker after install")
-	}
-}
-
-// TestNeedsRuntimeInstall_MarkerMatchesIsSkipped: when the installed checksum
-// matches the pysrc checksum, the install MUST be skipped — that's the whole
-// point of the gate (no needless `pip install` on every lite startup).
-func TestNeedsRuntimeInstall_MarkerMatchesIsSkipped(t *testing.T) {
-	home := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(home, "venv"), 0o750); err != nil {
-		t.Fatal(err)
-	}
-	src := writeRuntimeFixture(t, t.TempDir(), map[string]string{
-		"runner.py": "def run(): pass\n",
-	})
-	want, err := runtimeSrcChecksum(src)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if werr := writeRuntimeMarker(home, want); werr != nil {
-		t.Fatal(werr)
-	}
-
-	need, _, err := needsRuntimeInstall(home, src, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if need {
-		t.Errorf("matching marker must skip install (no needless pip on every startup)")
-	}
-}
-
-// TestNeedsRuntimeInstall_ImportFailedAlwaysInstalls: when the import check
-// failed (fresh venv), the marker is irrelevant — must install.
-func TestNeedsRuntimeInstall_ImportFailedAlwaysInstalls(t *testing.T) {
-	home := t.TempDir()
-	src := writeRuntimeFixture(t, t.TempDir(), map[string]string{
-		"runner.py": "def run(): pass\n",
-	})
-	need, _, err := needsRuntimeInstall(home, src, false /*importOK*/)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !need {
-		t.Errorf("import check failed must always require install (fresh venv path)")
-	}
-}
-
-// TestNeedsRuntimeInstall_MissingMarkerInstalls: an old venv that pre-dates the
-// marker (installed by a binary that didn't have this check) must reinstall on
-// next lite startup — otherwise we never reach a known-good state.
-func TestNeedsRuntimeInstall_MissingMarkerInstalls(t *testing.T) {
-	home := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(home, "venv"), 0o750); err != nil {
-		t.Fatal(err)
-	}
-	src := writeRuntimeFixture(t, t.TempDir(), map[string]string{
-		"runner.py": "def run(): pass\n",
-	})
-	need, _, err := needsRuntimeInstall(home, src, true /*importOK*/)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !need {
-		t.Errorf("missing marker on existing venv must trigger reinstall (defensive — recover to known-good)")
-	}
-}
-
 // TestDevDepsSignatureOrderIndependent: the canonical signature ignores ordering,
 // so a leoflow.yaml that just reorders `dependencies:` does not force a needless
 // reinstall.
@@ -219,24 +105,58 @@ func TestDevDepsSignatureOrderIndependent(t *testing.T) {
 	}
 }
 
-// TestDevDepsRoundtrip: after writeDevDepsMarker, devDepsUpToDate is true for the
-// same deps and false when the deps change — which is what gates the reinstall
-// when switching projects or editing dependencies (#116).
-func TestDevDepsRoundtrip(t *testing.T) {
+// TestDagVenvDepsRoundtrip: writing the per-DAG deps marker makes
+// dagVenvDepsUpToDate report true for the same deps (in any order) and false
+// when the deps change — gates the reinstall when one DAG's `dependencies:`
+// is edited, without re-running pip for every other DAG in the workspace
+// (#346 — the issue with the shared single-venv layout).
+func TestDagVenvDepsRoundtrip(t *testing.T) {
 	home := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(home, "venv"), 0o750); err != nil {
+	dagID := "etl"
+	venvDir := dagVenvDir(home, dagID)
+	if err := os.MkdirAll(venvDir, 0o750); err != nil {
 		t.Fatal(err)
 	}
-	if devDepsUpToDate(home, []string{"x"}) {
-		t.Errorf("an absent marker must report not up-to-date")
+	if dagVenvDepsUpToDate(home, dagID, []string{"x"}) {
+		t.Errorf("absent marker must report not up-to-date")
 	}
-	if err := writeDevDepsMarker(home, []string{"requests==2.31.0", "duckdb==1.4.4"}); err != nil {
+	deps := []string{"requests==2.31.0", "duckdb==1.4.4"}
+	if err := os.WriteFile(dagVenvDepsMarkerPath(home, dagID), []byte(devDepsSignature(deps)), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if !devDepsUpToDate(home, []string{"duckdb==1.4.4", "requests==2.31.0"}) {
+	if !dagVenvDepsUpToDate(home, dagID, []string{"duckdb==1.4.4", "requests==2.31.0"}) {
 		t.Errorf("same deps (any order) must report up-to-date after a successful install")
 	}
-	if devDepsUpToDate(home, []string{"requests==2.31.0"}) {
-		t.Errorf("a different dep set must report not up-to-date (forces reinstall on project switch)")
+	if dagVenvDepsUpToDate(home, dagID, []string{"requests==2.31.0"}) {
+		t.Errorf("a different dep set must report not up-to-date (forces reinstall on dep edit)")
+	}
+	// And the per-DAG marker is scoped: a *different* DAG with no marker yet
+	// is not up-to-date for the same deps — proves the gate is keyed.
+	if dagVenvDepsUpToDate(home, "other", deps) {
+		t.Errorf("the marker must be per-DAG; an unrelated DAG must not inherit it")
+	}
+}
+
+// TestDagVenvRuntimeChecksumRoundtrip pins the per-DAG runtime checksum
+// marker: empty when absent, returns the stamped value after a write. The
+// binary-upgrade reinstall (#239) carries over from the single-venv layout —
+// without this, a `leoflow lite` rerun after `make dev-install` would keep
+// the previous build's runtime in the venv.
+func TestDagVenvRuntimeChecksumRoundtrip(t *testing.T) {
+	home := t.TempDir()
+	dagID := "etl"
+	venvDir := dagVenvDir(home, dagID)
+	if err := os.MkdirAll(venvDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if got := dagVenvRuntimeChecksum(home, dagID); got != "" {
+		t.Errorf("absent marker must report empty, got %q", got)
+	}
+	want := "deadbeef" + "00000000000000000000000000000000000000000000000000000000"
+	if err := os.WriteFile(dagVenvRuntimeMarkerPath(home, dagID), []byte(want+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := dagVenvRuntimeChecksum(home, dagID); got != want {
+		t.Errorf("roundtrip mismatch: got %q want %q", got, want)
 	}
 }

--- a/internal/executor/subprocess.go
+++ b/internal/executor/subprocess.go
@@ -49,14 +49,43 @@ func materializeWorkDir(source, taskInstanceID string) (workDir string, cleanup 
 type SubprocessExecutor struct {
 	agentPath string
 	workDir   string
-	logger    *slog.Logger
+	// liteVenvsRoot, when set (Lite-only via LEOFLOW_LITE_VENVS_ROOT), is the
+	// directory where each DAG owns its own venv at
+	// <root>/<dag_id>/bin/python. Execute consults it per-task and overrides
+	// the agent's inherited LEOFLOW_PYTHON so the right venv runs the right
+	// DAG. Empty in Pro / k8s / cluster-mode Lite.
+	liteVenvsRoot string
+	logger        *slog.Logger
 }
 
 // NewSubprocessExecutor builds a SubprocessExecutor running the given agent
-// binary. It warns that user code runs unsandboxed.
+// binary. It warns that user code runs unsandboxed. The per-DAG venv root
+// is read from LEOFLOW_LITE_VENVS_ROOT at construction time so the executor
+// can pick the right Python for each task without a follow-up call.
 func NewSubprocessExecutor(agentPath string, logger *slog.Logger) *SubprocessExecutor {
 	logger.Warn("subprocess executor active; user code runs without isolation. Do NOT use in production")
-	return &SubprocessExecutor{agentPath: agentPath, logger: logger}
+	return &SubprocessExecutor{
+		agentPath:     agentPath,
+		liteVenvsRoot: os.Getenv("LEOFLOW_LITE_VENVS_ROOT"),
+		logger:        logger,
+	}
+}
+
+// resolveLitePythonForDag returns the per-DAG venv interpreter at
+// <venvsRoot>/<dagID>/bin/python when both fields are non-empty AND the file
+// exists, and "" otherwise (so the caller keeps the inherited LEOFLOW_PYTHON).
+// Pulled out so it can be unit-tested without spawning a subprocess (the bug
+// class is silent fallback to the wrong venv — exactly what an integration
+// test would mask).
+func resolveLitePythonForDag(venvsRoot, dagID string) string {
+	if venvsRoot == "" || dagID == "" {
+		return ""
+	}
+	candidate := filepath.Join(venvsRoot, dagID, "bin", "python")
+	if _, err := os.Stat(candidate); err != nil {
+		return ""
+	}
+	return candidate
 }
 
 // SetWorkDir sets the working directory the agent runs in. In a task pod the
@@ -113,6 +142,13 @@ func (e *SubprocessExecutor) Execute(ctx context.Context, req Request) error {
 	// as "signal: killed" and a falsely failed task), mirroring the inline runner.
 	cmd := exec.CommandContext(context.WithoutCancel(ctx), e.agentPath) //nolint:gosec // dev-only executor running the trusted agent binary
 	cmd.Env = append(os.Environ(), agentEnv(req)...)
+	// Lite-only: when a per-DAG venv exists, override the inherited
+	// LEOFLOW_PYTHON so the agent's `python -m leoflow_runtime` resolves the
+	// DAG's own dependencies. Last write wins in os/exec, so appending here
+	// is enough to beat any earlier server-inherited LEOFLOW_PYTHON.
+	if perDagPy := resolveLitePythonForDag(e.liteVenvsRoot, req.DagID); perDagPy != "" {
+		cmd.Env = append(cmd.Env, "LEOFLOW_PYTHON="+perDagPy)
+	}
 	cmd.Dir = workDir
 	// Surface the agent's own diagnostics (it logs to stderr); otherwise an agent
 	// that fails to start or connect fails silently. The task's stdout/stderr are

--- a/internal/executor/subprocess_lite_venv_test.go
+++ b/internal/executor/subprocess_lite_venv_test.go
@@ -1,0 +1,51 @@
+package executor
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestResolveLitePythonForDagPrefersPerDagVenv pins the Lite per-DAG Python
+// resolution contract: the subprocess executor consults
+// LEOFLOW_LITE_VENVS_ROOT/<dag_id>/bin/python for each Request and, when that
+// file exists, exports it as LEOFLOW_PYTHON so the agent runs the DAG's own
+// venv. Without an override, it returns "" so the boot-fallback
+// (server-inherited LEOFLOW_PYTHON) keeps applying.
+//
+// The bug class this protects against: a one-character mismatch between the
+// CLI's venv layout and the executor's lookup would have every task run
+// against the boot fallback (the WRONG venv), and the only symptom would be
+// ModuleNotFoundError on a dep that was successfully installed — exactly the
+// class of failure issue #346 traces to.
+func TestResolveLitePythonForDagPrefersPerDagVenv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Lite per-DAG venv path differs on Windows; tested via TestDagVenvPathLayout in internal/cli")
+	}
+	root := t.TempDir()
+	dagID := "sales_etl"
+	pyDir := filepath.Join(root, dagID, "bin")
+	if err := os.MkdirAll(pyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	py := filepath.Join(pyDir, "python")
+	if err := os.WriteFile(py, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := resolveLitePythonForDag(root, dagID); got != py {
+		t.Errorf("override for %q = %q, want %q", dagID, got, py)
+	}
+	if got := resolveLitePythonForDag(root, "unknown_dag"); got != "" {
+		t.Errorf("override for unknown dag = %q, want \"\" (fallback to inherited LEOFLOW_PYTHON)", got)
+	}
+	if got := resolveLitePythonForDag("", dagID); got != "" {
+		t.Errorf("empty venvs root must skip resolution, got %q", got)
+	}
+	// Empty DagID happens for old agents / tests where the executor is built
+	// without a routing target; it must NOT collapse to <root>/bin/python.
+	if got := resolveLitePythonForDag(root, ""); got != "" {
+		t.Errorf("empty dag_id must skip resolution, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- **Per-DAG venvs.** Each project gets its own `~/.leoflow/dev/venvs/<dag_id>/`. Editing one DAG's `dependencies:` only re-runs pip for **that** DAG; other DAGs' venvs are untouched. Two DAGs can pin conflicting versions of the same package without interfering.
- **Per-task LEOFLOW_PYTHON override.** The subprocess executor reads `LEOFLOW_LITE_VENVS_ROOT` at boot (Lite-only env), then on each `Execute()` looks up `<root>/<dag_id>/bin/python` and overrides the agent's inherited `LEOFLOW_PYTHON` so tasks run against the right venv.
- **uv when available.** `detectInstaller` prefers `uv` on `PATH` for 5–10× faster cold installs; falls back to `<venv-py> -m pip install` when uv is absent. Both argv shapes are pinned by `TestInstallerCmdShapes`.
- **Deletes the now-unused single-venv helpers** (`ensureDevVenv`, `venvPipArgs`, `venvDepsArgs`, `needsRuntimeInstall`, marker round-trip helpers) and their tests. The per-DAG layout has direct equivalents; surface area shrinks by ~110 lines.

Closes #346 and #87.

## Why

Today's shared venv at `~/.leoflow/dev/venv/` packs every workspace DAG's deps into one `site-packages`. Two failure modes:
1. Conflicting pins silently lose (last-write-wins on import order).
2. Editing one project's `dependencies:` forces pip across the whole workspace — cost grows with the number of DAGs and with each cold cache.

Per-DAG venvs make every DAG hermetic (matches the Pro/k3d image model, where each DAG is already its own container) and the install gate (deps signature + runtime checksum) keeps the unchanged-project tick a cheap no-op.

## Test plan
- [x] `make ci-local` — gofmt, build, lint, race tests, govulncheck, helm-unittest, parser pytest, ADR index, mkdocs --strict — all green
- [x] Coverage: 80.1% (floor 80) — added `TestEnsureDagVenvSkipsAllGatesWhenAlreadyFresh` (POSIX-only sh stub) and `TestEnsureWorkspaceDagVenvsEmptyFallback` to keep the new orchestration covered
- [x] New unit tests: `TestSanitizeDagIDForFs`, `TestDagVenvPathLayout`, `TestDetectInstallerPrefersUv`, `TestInstallerCmdShapes`, `TestLiteVenvsRootEnvWiringFromSubprocessServerEnv`, `TestResolveLitePythonForDagPrefersPerDagVenv` (executor)
- [ ] Operator validation: `leoflow lite ~/leoflow/` with two DAGs declaring conflicting pins (e.g. `requests==2.28` vs `requests==2.31`) → both DAGs run green, each importing its pinned version
- [ ] Operator validation: with `uv` installed (`pipx install uv`), first-run install prints `using uv` and is visibly faster than the prior shared-venv path

## Notes
- The legacy `~/.leoflow/dev/venv/` directory is left in place after upgrade — it becomes dead state that the user can remove. No migration is performed; the per-DAG layout starts empty and fills on first reload.
- k3d / cluster executor is unaffected — each DAG already ships in its own image.