### PR TITLE
feat(release): publish leoflow-runtime base image + Pro deploy docs (v0.0.2)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -142,6 +142,84 @@ jobs:
             cosign sign --yes "${tag}@${DIGEST}"
           done
 
+  # ── Build + push the Leoflow task base image (runtime/Dockerfile)
+  # A DAG image is `FROM ghcr.io/neochaotic/leoflow-runtime:py<ver>` (ADR 0003):
+  # the base ships the leoflow-agent (PID 1) and the leoflow_runtime helper, so a
+  # `leoflow compile --build` needs nothing but a registry. Before this job the
+  # base only existed locally (built from a source checkout), which blocked
+  # testing Pro without the repo (#318). One leg per supported Python so an author
+  # picks the interpreter via `python_version`. Multi-arch + keyless cosign mirror
+  # leoflow-server/leoflow-migrate.
+  runtime-image:
+    name: Build + push leoflow-runtime base (py${{ matrix.python }})
+    needs: release
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.10", "3.11", "3.12"]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write       # keyless cosign signing
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v2.4.3
+
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/leoflow-runtime
+          # Two tags per Python line: an immutable per-release pin
+          # (py3.11-v0.0.2-rc.1) and a moving line tag (py3.11) the docs and the
+          # generated DAG Dockerfile default to. No bare `:latest` — the tag must
+          # always name a Python version.
+          tags: |
+            type=raw,value=py${{ matrix.python }}-${{ github.ref_name }}
+            type=raw,value=py${{ matrix.python }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.ref_name }}
+
+      - name: Build + push (multi-arch)
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: runtime/Dockerfile
+          build-args: |
+            PYTHON_VERSION=${{ matrix.python }}
+            GO_VERSION=${{ env.GO_VERSION }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Sign image with cosign (keyless)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          for tag in $TAGS; do
+            cosign sign --yes "${tag}@${DIGEST}"
+          done
+
   # ── Faithful install smoke: run the REAL `curl | sh` of the just-published
   # release in a clean container per distro and verify the binary plus the managed
   # CPython actually run. This catches install-path bugs (PATH, checksum, tar, the
@@ -285,22 +363,22 @@ jobs:
   # it can act on any failure; on success it leaves the published pre-release
   # untouched.
   gate:
-    name: Gate release on install + lite-cold-start + upgrade + migrate image
-    needs: [release, install-smoke, lite-cold-start-smoke, upgrade-smoke, migrate-image]
+    name: Gate release on install + lite-cold-start + upgrade + migrate + runtime image
+    needs: [release, install-smoke, lite-cold-start-smoke, upgrade-smoke, migrate-image, runtime-image]
     if: always() && needs.release.result == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write   # Edit the published release back to a draft on failure.
     steps:
-      - name: Retract release to draft on smoke or migrate-image failure
-        if: needs.install-smoke.result != 'success' || needs.lite-cold-start-smoke.result != 'success' || needs.upgrade-smoke.result != 'success' || needs.migrate-image.result != 'success'
+      - name: Retract release to draft on smoke or image failure
+        if: needs.install-smoke.result != 'success' || needs.lite-cold-start-smoke.result != 'success' || needs.upgrade-smoke.result != 'success' || needs.migrate-image.result != 'success' || needs.runtime-image.result != 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eu
-          echo "::error::release blocked: install-smoke=${{ needs.install-smoke.result }} lite-cold-start-smoke=${{ needs.lite-cold-start-smoke.result }} upgrade-smoke=${{ needs.upgrade-smoke.result }} migrate-image=${{ needs.migrate-image.result }}; retracting ${GITHUB_REF_NAME} to a draft."
+          echo "::error::release blocked: install-smoke=${{ needs.install-smoke.result }} lite-cold-start-smoke=${{ needs.lite-cold-start-smoke.result }} upgrade-smoke=${{ needs.upgrade-smoke.result }} migrate-image=${{ needs.migrate-image.result }} runtime-image=${{ needs.runtime-image.result }}; retracting ${GITHUB_REF_NAME} to a draft."
           gh release edit "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" --draft
           exit 1
       - name: Confirm release passed all gates
-        if: needs.install-smoke.result == 'success' && needs.lite-cold-start-smoke.result == 'success' && needs.upgrade-smoke.result == 'success' && needs.migrate-image.result == 'success'
-        run: echo "install smoke + lite cold-start + upgrade smoke + migrate-image passed; ${GITHUB_REF_NAME} stays published."
+        if: needs.install-smoke.result == 'success' && needs.lite-cold-start-smoke.result == 'success' && needs.upgrade-smoke.result == 'success' && needs.migrate-image.result == 'success' && needs.runtime-image.result == 'success'
+        run: echo "install smoke + lite cold-start + upgrade smoke + migrate-image + runtime-image passed; ${GITHUB_REF_NAME} stays published."

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ leoflow compile .              # generates Dockerfile, builds image, produces da
 leoflow push ./dag.json        # registers with the control plane
 ```
 
-That is the entire developer surface. The CLI builds the image against an official base (`leoflow/python-runtime:3.11`), pushes to your registry, and registers a versioned DAG. The Airflow UI shows it at the next refresh.
+That is the entire developer surface. The CLI builds the image on the published Leoflow task base (`ghcr.io/neochaotic/leoflow-runtime:py3.11`, selected by `python_version`), pushes to your registry, and registers a versioned DAG. The Airflow UI shows it at the next refresh.
 
 ## Native map-reduce for ML/AI
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -26,6 +26,49 @@ flowchart LR
     The same checks that warn you locally in `leoflow lite` fail the CI build, so a
     bad `dag_id`/`task_id` binding or an unsupported operator never reaches prod.
 
+!!! note "First time? Do it by hand once"
+    The [**first Pro DAG walkthrough**](first-pro-dag.md) runs these three steps
+    manually so you can watch the DAG cross each boundary. Come back here to wire
+    the same steps into CI.
+
+## Your repo of DAGs
+
+In Pro you keep your DAGs in a Git repository — one directory per DAG — and CI
+turns each into an artifact when it changes. Nothing here is Leoflow-specific
+magic: it's a normal repo plus three CLI calls.
+
+```text
+my-dags/                      # your Git repo
+├── .github/workflows/
+│   └── deploy-dag.yml        # the CI below
+└── dags/
+    ├── my_pipeline/
+    │   ├── dag.py            # the DAG (TaskFlow / operators)
+    │   ├── leoflow.yaml      # id, python_version, dependencies
+    │   └── Dockerfile        # FROM ghcr.io/neochaotic/leoflow-runtime:py3.11
+    └── another_pipeline/
+        ├── dag.py
+        ├── leoflow.yaml
+        └── Dockerfile
+```
+
+Each DAG directory is a self-contained project — its own dependencies, its own
+image. A typical `Dockerfile` is four lines of boilerplate (the
+[walkthrough](first-pro-dag.md) shows it); it layers your code onto the
+**published task base**, so CI pulls a signed image instead of building one.
+
+**The mental model:** a push that touches `dags/my_pipeline/**` triggers CI for
+*that* DAG only (the `paths:` filter), which compiles → builds → pushes the image
+→ registers `dag.json`. The control plane runs the new version on the next
+trigger. One DAG per pipeline keeps blast radius small: a broken
+`another_pipeline` never blocks `my_pipeline`.
+
+!!! tip "Tag images immutably"
+    The recipes tag by git SHA (`my_pipeline:$GIT_SHA`), never `:latest`. The
+    image a `dag.json` points at is then frozen — re-running an old DAG version
+    pulls exactly the bytes it shipped with, and a rollback is a re-`push` of the
+    older `dag.json`.
+
 ## Prerequisites
 - The `leoflow` CLI on the runner (download the release binary, or `go install`).
 - **Python 3.11+ on the runner** (`leoflow compile` invokes the stdlib-only

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,5 +1,10 @@
 # CI/CD & deploy examples
 
+!!! tip "New to Pro? Start with the walkthrough"
+    [**Your first Pro DAG (≈20 min)**](first-pro-dag.md) takes one DAG from source
+    to a running pod by hand, so you see each artifact boundary before you automate
+    it. This page is the CI recipes for the same pipeline.
+
 Deploying a Leoflow DAG is the same everywhere because a DAG is an **immutable
 artifact** — a `dag.json` + a container image, versioned together (ADR 0003).
 The pipeline is always:

--- a/docs/first-pro-dag.md
+++ b/docs/first-pro-dag.md
@@ -1,0 +1,124 @@
+# Your first Pro DAG (≈20 min)
+
+This is the end-to-end Pro path: take one DAG from source to a running task on a
+control plane. Where the 2-minute [Lite loop](local-deploy.md) hides the artifact
+boundary so you can iterate, Pro makes it explicit — because that boundary is what
+your CI pipeline automates later.
+
+A DAG is an **immutable artifact** — a `dag.json` + a container image, versioned
+together ([ADR 0003](adr/0003-dag-as-image.md)). Every step below moves the DAG
+across one boundary:
+
+```mermaid
+flowchart LR
+  A[dag.py + leoflow.yaml] --> B[compile → dag.json]
+  B --> C[build DAG image<br/>FROM leoflow-runtime]
+  C --> D[push image → registry]
+  D --> E[register dag.json → control plane]
+  E --> F[trigger → runs in a pod]
+```
+
+The DAG image is built `FROM` the **published Leoflow task base**
+(`ghcr.io/neochaotic/leoflow-runtime:py3.11`), which bundles the `leoflow-agent`
+(PID 1, talks gRPC to the control plane) and the `leoflow_runtime` Python helper.
+You never build the base yourself — pull it from GHCR, multi-arch, signed.
+
+## Prerequisites
+
+- `docker` (or `podman`/`nerdctl` — pass `--builder`).
+- The `leoflow` CLI and Python 3.11+ on your machine
+  (see [Python on the runner](deploy.md#python-on-the-runner)).
+- A reachable Leoflow **control plane** (`LEOFLOW_SERVER`) and a push token
+  (`LEOFLOW_TOKEN`). For a throwaway target, the Helm chart's
+  [Pro deployment](helm-chart.md) brings one up; a local registry
+  (`docker run -d -p 5000:5000 registry:2`) is enough to push DAG images to.
+
+## Step 1 — a project (`dag.py` + `leoflow.yaml` + `Dockerfile`)
+
+```python title="dag.py"
+from airflow.sdk import DAG, task
+
+@task
+def extract() -> dict:
+    return {"rows": 42}
+
+@task
+def load(data: dict) -> None:
+    print(f"loaded {data['rows']} rows")
+
+with DAG("first_pro_dag", schedule=None) as dag:
+    load(extract())
+```
+
+```yaml title="leoflow.yaml"
+dag_id: first_pro_dag
+python_version: "3.11"
+dependencies:
+  - requests==2.32.3
+```
+
+```dockerfile title="Dockerfile"
+FROM ghcr.io/neochaotic/leoflow-runtime:py3.11
+RUN pip install --no-cache-dir requests==2.32.3
+COPY dag.py /home/leoflow/dag.py
+ENV PYTHONPATH=/home/leoflow
+```
+
+!!! tip "The Dockerfile is boilerplate"
+    It always layers the same way: `FROM` the base, install your deps, `COPY` the
+    DAG, set `PYTHONPATH`. The [Lite loop](local-deploy.md) generates this for you;
+    in Pro you keep it in the repo so the image is fully reproducible in CI.
+
+## Step 2 — compile, build, and push
+
+```bash
+leoflow setup                 # once per machine: extracts the parser
+leoflow compile . --build --push \
+  --image localhost:5000/first-pro-dag:v1.0.0 \
+  --dag-version v1.0.0
+```
+
+This single command crosses three boundaries:
+
+1. **compile** — parses `dag.py`, overlays `leoflow.yaml`, runs the guardrails
+   (unknown `task_id`, unsupported operator, duplicate keys), and writes `dag.json`
+   with `--image` recorded inside it.
+2. **build** — builds the image from your `Dockerfile`.
+3. **push** — pushes it to your registry.
+
+Because the `--image` you pass is written into `dag.json`, the registered artifact
+and the pushed image can never drift.
+
+!!! tip "The guardrails are your CI gate"
+    The same checks fail the build here that warn you in `leoflow lite`, so a bad
+    binding or an unsupported operator never reaches the control plane.
+
+## Step 3 — register the artifact
+
+```bash
+leoflow push dag.json --url "$LEOFLOW_SERVER" --token "$LEOFLOW_TOKEN"
+```
+
+The control plane now knows the DAG, its version, and which image to pull.
+
+## Step 4 — trigger and watch it run
+
+Trigger from the Airflow UI (Trigger DAG) or the API:
+
+```bash
+curl -X POST "$LEOFLOW_SERVER/api/v2/dags/first_pro_dag/dagRuns" \
+  -H "Authorization: Bearer $LEOFLOW_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"logical_date": "2026-01-01T00:00:00Z"}'
+```
+
+The scheduler pulls your image, runs each task in its own pod, and the UI shows
+state and logs at the next refresh. That is the whole Pro lifecycle.
+
+## From here
+
+- **Automate it in CI.** Steps 2–3 are exactly what a pipeline runs on every push —
+  see [CI/CD & deploy examples](deploy.md) for GitHub Actions / GitLab / Cloud Build
+  recipes (and the Python-on-the-runner notes).
+- **Add credentials.** Declare a connection in the UI; it is delivered to the pod as
+  `AIRFLOW_CONN_*` — see [Variables & Connections](variables-connections.md).

--- a/docs/first-pro-dag.md
+++ b/docs/first-pro-dag.md
@@ -96,7 +96,7 @@ and the pushed image can never drift.
 ## Step 3 — register the artifact
 
 ```bash
-leoflow push dag.json --url "$LEOFLOW_SERVER" --token "$LEOFLOW_TOKEN"
+leoflow push dag.json --server "$LEOFLOW_SERVER" --token "$LEOFLOW_TOKEN"
 ```
 
 The control plane now knows the DAG, its version, and which image to pull.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
       - Architecture: architecture.md
   - Authoring & deploy:
       - DAG authoring: dag-authoring.md
+      - First Pro DAG (walkthrough): first-pro-dag.md
       - CI/CD & deploy examples: deploy.md
   - Reference:
       - reference.md


### PR DESCRIPTION
## Why

Pro DAG-deploy was untestable without a Leoflow source checkout, and the docs
pointed at a base image name that was never published. This unblocks the Pro
happy path for everyone (closes the core of #318) **without** waiting for the
long-running connectors/operators epic (`feat/connectors` → v0.1.0).

Targets a small **v0.0.2** (patch per ADR 0037): polish + docs + a release-side
feature that does not change the public API.

## What

- **Publish the task base image.** A new `runtime-image` job in `release.yaml`
  builds + pushes `ghcr.io/neochaotic/leoflow-runtime:py{3.10,3.11,3.12}{,-<tag>}`
  multi-arch, keyless-signed, gated like `leoflow-server`/`leoflow-migrate`. A DAG
  image now `FROM`s a published, signed base — no checkout required.
- **First Pro DAG walkthrough** (`docs/first-pro-dag.md`): the artifact-boundary
  path (compile → build → push → register → trigger) done by hand, wired into the
  nav and surfaced from `deploy.md`.
- **Human-first CI doc** (`deploy.md`): a "Your repo of DAGs" section — the
  one-dir-per-DAG monorepo layout and the path-filtered "a push to `dags/X` builds
  X" mental model.
- **README**: point the task base at the published `leoflow-runtime:py3.11`
  (was `leoflow/python-runtime:3.11`, which never existed — the inconsistency
  flagged on #318).
- **Bug fix**: the walkthrough used `leoflow push --url`; the real flag is
  `--server` (verified against `internal/cli/push.go`).

## Validation

- Built `runtime/Dockerfile` locally (py3.11, `GO_VERSION=1.26.4`) — base builds,
  airflow 3.2.1 installs, the `golang:1.26.4` tag resolves.
- `go test ./...` green; pre-commit coverage gate 80%.
- `mkdocs build --strict` clean (no broken links/nav).

## Not in scope

The yaml-driven `compile --build` (generate the Dockerfile from `leoflow.yaml`,
derive the image from `registry:`) depends on the connectors catalog and ships
with the connectors/operators bundle in **v0.1.0**.

Refs #318
