### PR TITLE
feat(cli): leoflow deploy — pipeline-less Lite→Pro promotion (ADR 0041)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -210,6 +210,61 @@ jobs:
         run: bash test/e2e/lite-multidag.sh
 
   # ─────────────────────────────────────────────────────────────────────
+  # The real `leoflow deploy` path on k3d with a registry the cluster pulls
+  # from (test/e2e/deploy-e2e.sh, ADR 0041): one `leoflow deploy` builds for
+  # the cluster arch, PUSHES to a k3d-managed registry, captures the digest,
+  # re-pins dag.json, registers — then the cluster pulls the digest-pinned image
+  # and runs it. Gates the build→push→digest→register glue unit tests leave to
+  # e2e. Runs clean on Linux (no Docker Desktop proxy). ~10 min.
+  # ─────────────────────────────────────────────────────────────────────
+  deploy-e2e:
+    name: E2E deploy (k3d + registry)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: leoflow
+          POSTGRES_PASSWORD: leoflow
+          POSTGRES_DB: leoflow
+        ports: [5432:5432]
+        options: >-
+          --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
+      redis:
+        image: redis:7
+        ports: [6379:6379]
+        options: --health-cmd "redis-cli ping" --health-interval 5s --health-timeout 3s --health-retries 10
+    env:
+      # k3d pods dial the runner control plane via host.k3d.internal (Linux only).
+      LEOFLOW_E2E_HOST_ADDR: host.k3d.internal
+      # leoflow compile spawns `python3 -m leoflow_parser`; the parser ships under
+      # parser/ and needs no install — just PYTHONPATH (the airflow-free shim).
+      PYTHONPATH: parser
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install k3d + kubectl + jq + migrate
+        run: |
+          set -euo pipefail
+          curl -fsSL https://raw.githubusercontent.com/k3d-io/k3d/v5.7.4/install.sh | TAG=v5.7.4 bash
+          curl -fsSLO "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          sudo install -m 0755 kubectl /usr/local/bin/kubectl
+          sudo apt-get update -qq && sudo apt-get install -y -qq jq
+          go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+      - name: Apply migrations
+        run: ~/go/bin/migrate -path migrations -database "postgres://leoflow:leoflow@localhost:5432/leoflow?sslmode=disable" up
+      - name: Build binaries
+        run: make build
+      - name: Run the k3d deploy e2e
+        run: bash test/e2e/deploy-e2e.sh
+
+  # ─────────────────────────────────────────────────────────────────────
   # TDD discipline check: every new exported function in production code
   # must have a corresponding test added or modified in the same PR.
   # This is a best-effort heuristic; reviewers verify the spirit of ADR 0011.

--- a/docs/adr/0041-leoflow-deploy-pipelineless.md
+++ b/docs/adr/0041-leoflow-deploy-pipelineless.md
@@ -1,6 +1,6 @@
 # ADR 0041: `leoflow deploy` — pipeline-less promotion from Lite to Pro
 
-**Status:** Accepted (design; implementation post-v0.1.0)
+**Status:** Accepted — implementation in progress (branch `feat/deploy`, PR #367); target **v0.0.2-rc.2**, independent of the held v0.1.0 connectors epic
 **Date:** 2026-06-04
 **Companions:** ADR 0003 (DAG as immutable artifact), ADR 0019 (secret encryption), ADR 0021 (AIRFLOW_CONN delivery), the editions split (Lite/Pro)
 
@@ -53,7 +53,7 @@ itself). It aligns with the standing loud-reject-over-silent principle.
 - **NOT in the yaml** (environment, not per-DAG): the target control plane
   `--server` and the auth token. The same DAG deploys to staging and prod by
   changing only `--server`. Provided via flag, `LEOFLOW_TOKEN` env, or a persisted
-  session (`leoflow login`).
+  session (`leoflow auth login`).
 
 ### Two auths, kept separate
 1. **Registry auth** (image push) — the **builder's** credential (`docker login`,
@@ -62,12 +62,15 @@ itself). It aligns with the standing loud-reject-over-silent principle.
    `docker push`. Leoflow is registry-agnostic.
 2. **Control-plane auth** (register `dag.json`) — a JWT bearer token. Precedence:
    `--token` (default from `LEOFLOW_TOKEN`) → `--username`/`--password` (deploy
-   fetches a token via `/auth/login`) → a persisted session from `leoflow login`.
+   fetches a token via `/auth/login`) → a persisted session from `leoflow auth login`.
 
-### `leoflow login` ships alongside `deploy`
-`leoflow login --server <pro>` stores the token in `~/.leoflow/config`, so
+### `leoflow auth login` ships alongside `deploy`
+`leoflow auth login --server <pro>` stores the token in `~/.leoflow/config`, so
 `leoflow deploy` then needs **no auth flags**. This is what makes the pipeline-less
-loop fluid (login once, deploy many).
+loop fluid (login once, deploy many). It is nested under `auth` (sibling of
+`auth create-token`) to disambiguate from `docker login` (registry auth, which
+Leoflow never handles); it prompts for the password interactively (hidden) when
+not given, so the secret never lands in shell history.
 
 ### The CLI is runtime-independent (Lite and CI share it)
 
@@ -81,7 +84,7 @@ two settings with no special-casing:
 - **From Lite** — a developer who has `leoflow lite` up still invokes `deploy`/
   `login` as plain client calls against the Pro `--server`.
 - **From a CI pipeline, without Lite** — a runner that only has the `leoflow`
-  binary runs `leoflow login` + `leoflow deploy` (journey 3); it never starts a
+  binary runs `leoflow auth login` + `leoflow deploy` (journey 3); it never starts a
   local runtime.
 
 **Packaging note (deferred optimization).** The single `leoflow` binary already
@@ -181,6 +184,35 @@ only show one by-hand sequence:
 When `deploy` ships, `first-pro-dag.md` is restructured around journeys (1) and
 (2) — replacing the current by-hand `compile --build --push` + `push` sequence —
 and `deploy.md` keeps (3) as the automated variant.
+
+### Two-tier happy path (rc.2 reality vs. the complete vision)
+
+The fully-ergonomic Pro path is **Dockerfile-free** — `compile --build`
+synthesizes the image from `leoflow.yaml` (`FROM` the published base, install
+`connectors:`/`dependencies:`, copy the DAG). But that **yaml-driven build is part
+of the v0.1.0 connectors epic** (it calls `EffectiveDependencies()`), which is
+**held**. `feat/deploy` (rc.2) ships `deploy` itself but **not** the yaml-driven
+build. To document a happy path that is *true on the branch it ships on* without
+waiting for v0.1.0, the walkthrough is written in **two tiers**:
+
+- **Tier 1 — the simple happy path (true in rc.2).** Deploy a **shipped example**
+  whose `Dockerfile` builds `FROM` the CI-published base
+  (`ghcr.io/neochaotic/leoflow-runtime`). The user authors nothing and writes no
+  Dockerfile — it belongs to the example. `leoflow auth login` → `leoflow deploy
+  examples/<dag>`. This runs today on `feat/deploy`. "A Dockerfile is for examples
+  only" holds: the example carries it; the user never writes one.
+- **Tier 2 — the complete happy path (your first DAG, end-to-end).** Author your
+  own DAG, **yaml-driven, no Dockerfile**, with `connectors:`/`dependencies:`. The
+  prose/structure is borrowed now from the connectors-branch `first-pro-dag.md`,
+  marked clearly as the **complete path that becomes executable when v0.1.0 lands**
+  (the yaml-driven build). No connectors code is duplicated into `feat/deploy`.
+
+**Branch sync (deferred, not a rebase).** `feat/deploy` stays independent of the
+held v0.1.0: we borrow the connectors docs' *ideas*, not its code. When v0.1.0
+unfreezes, the branches are reconciled — Tier 2 loses its "lands with v0.1.0"
+caveat and the yaml-driven build is wired once (no duplicate `compile_build.go`).
+Rebasing `feat/deploy` onto `feat/connectors` was rejected: it would couple
+rc.2's Steve-unblock to the held epic.
 
 ## Open questions (decide during implementation)
 

--- a/docs/adr/0041-leoflow-deploy-pipelineless.md
+++ b/docs/adr/0041-leoflow-deploy-pipelineless.md
@@ -116,8 +116,11 @@ is what keeps that option open.
   artifact, which is how Pro learns it; subsequent deploys register new versions,
   and "latest" in Pro means the newest registered artifact, each pinning its own
   digest.
-- **Default tag strategy:** `git-sha` (immutable per commit); falls back to a
-  timestamp when the project is not in git.
+- **Tag strategy:** `tag_strategy: version` (the config default) tags by the DAG
+  version label (`git describe`); `tag_strategy: git_sha` tags by the immutable
+  short commit sha (`git rev-parse --short HEAD`), falling back to the version
+  label when the project is not in git. (Either way the artifact is then re-pinned
+  by digest, so the tag is a convenience, not the integrity boundary.)
 - **Output:** a clear per-phase summary —
   `built … @sha256 · pushed … · registered <dag> <version> → <server>/dags/<dag>`.
 

--- a/docs/adr/0041-leoflow-deploy-pipelineless.md
+++ b/docs/adr/0041-leoflow-deploy-pipelineless.md
@@ -217,26 +217,30 @@ caveat and the yaml-driven build is wired once (no duplicate `compile_build.go`)
 Rebasing `feat/deploy` onto `feat/connectors` was rejected: it would couple
 rc.2's Steve-unblock to the held epic.
 
-## Open questions (decide during implementation)
+## Open questions (decide during implementation — tracked as issues)
 
 - **Registry reachability asymmetry.** The dev pushes; the *cluster* pulls the same
   ref. A LAN/short-name `registry.url` that resolves differently inside the cluster
   (or needs different TLS trust) makes the dev's push succeed while the pod's pull
   fails. `imagePullSecrets` covers *auth*, not *name/reachability*. Decide whether
   deploy does a best-effort reachability hint.
-- **Paused/catchup on first register.** `versions.go` does not set `IsPaused`, so a
-  fresh deploy inherits the default; if that is active-with-catchup, a deploy could
-  immediately fire a backlog on Pro. Decide: register **paused** by default with an
-  `--activate`, or document the current behavior loudly.
-- **CLI ↔ Pro version skew.** A newer Lite writes a `dag.json` `schema_version` an
-  older Pro cannot parse (or vice versa). The register endpoint should reject with
-  an explicit "upgrade Pro" message, not a confusing validation error.
+- **Paused/catchup on first register** (issue #370). `versions.go` does not set
+  `IsPaused`, so a fresh deploy inherits the default; if that is active-with-catchup,
+  a deploy could immediately fire a backlog on Pro. Decide: register **paused** by
+  default with an `--activate`, or document the current behavior loudly.
+- **CLI ↔ Pro version skew** (issue #371). A newer Lite writes a `dag.json`
+  `schema_version` an older Pro cannot parse (or vice versa). The register endpoint
+  should reject with an explicit "upgrade Pro" message, not a confusing error.
+- **Re-register of the same version returns 500, not 409** (issue #368). The unique
+  violation on `dag_versions_unique` should map to a 409 with an actionable message.
+- **Default task SA for private-registry pulls** (issue #369). `imagePullSecrets`
+  on the task SA only apply when pods run as it; default the execution SA so they do.
 - **Tenant is implicit (works, document it).** `RegisterDagVersion` uses
   `tenantOf(token)` — deploy lands in the **token's tenant**. On a multi-tenant Pro
   the user selects the tenant by which token they `login` with; the docs must say so.
 
 ## Deferred (explicitly out of scope here)
-- **Rollback UX.** The model is already versioned server-side
+- **Rollback UX** (issue #372). The model is already versioned server-side
   (`POST /dags/{id}/versions`), so the data supports rollback, but there is no
   `leoflow deploy --rollback` / pin-previous command yet. Name now, build later.
 - **Secrets baked into the image during Lite dev** get pushed to the registry on

--- a/docs/adr/0041-leoflow-deploy-pipelineless.md
+++ b/docs/adr/0041-leoflow-deploy-pipelineless.md
@@ -259,17 +259,22 @@ K8s executor (`internal/executor/kubernetes.go::BuildPod`) sets **no**
 `ImagePullSecrets`, and the task ServiceAccount template carries none either. A
 private-registry deploy would therefore fail the task pod with `ErrImagePull`.
 
-**Fix (cheap, no executor code):** attach `imagePullSecrets` to the **task
-ServiceAccount** — Kubernetes auto-injects a SA's pull secrets into every pod that
-uses it. Two parts:
-- `values.yaml`: `taskServiceAccount.imagePullSecrets: []`; emit the block in
-  `templates/task-serviceaccount.yaml`.
-- **Ensure task pods default to that SA.** Today the pod only runs as
-  `taskServiceAccount` when `Execution.ServiceAccount` is set
-  (`kubernetes.go:93`); otherwise it falls back to the namespace `default` SA,
-  which has no pull secrets. The deploy path requires task pods to default to the
-  task SA (or, as a heavier alternative, a per-pod `ImagePullSecrets` fed from
-  server config into `BuildPod`).
+**Done (rc.2):** `taskServiceAccount.imagePullSecrets` (values + the block in
+`templates/task-serviceaccount.yaml`, helm-unittested) — Kubernetes auto-injects a
+SA's pull secrets into every pod that uses it.
+
+**The remaining half — task pods must *run as* that SA — is by contract, not by
+default (rc.2 decision).** Today a pod runs as `taskServiceAccount` only when
+`Execution.ServiceAccount` is set (`kubernetes.go:93`); otherwise it uses the
+namespace `default` SA, which has no pull secrets. We **do not** change the
+executor default for rc.2: the GKE/Workload-Identity pattern *already* requires
+`execution.service_account: <taskServiceAccount.name>` in the DAG's `leoflow.yaml`
+(Workload Identity binds to the same SA), so those users already run as it and the
+pull secrets apply. The requirement is surfaced in `NOTES.txt` (printed when
+`imagePullSecrets` is set) and the values comment. **Deferred (own,
+cluster-tested change):** a server-config default execution SA applied in
+`BuildPod` when a task names none — nice ergonomics, but a behavior change on a
+path already validated on GKE, so not slipped into rc.2.
 
 This chart change is a **prerequisite** for journeys (1) and (2) against a private
 registry; public images (e.g. the shipped examples on a public GHCR) work without

--- a/docs/adr/0041-leoflow-deploy-pipelineless.md
+++ b/docs/adr/0041-leoflow-deploy-pipelineless.md
@@ -1,0 +1,250 @@
+# ADR 0041: `leoflow deploy` — pipeline-less promotion from Lite to Pro
+
+**Status:** Accepted (design; implementation post-v0.1.0)
+**Date:** 2026-06-04
+**Companions:** ADR 0003 (DAG as immutable artifact), ADR 0019 (secret encryption), ADR 0021 (AIRFLOW_CONN delivery), the editions split (Lite/Pro)
+
+## Context
+
+Today, promoting a DAG to a Pro control plane is **three CLI calls** —
+`leoflow compile --build --push --image …` then `leoflow push dag.json --server …`
+(after a `leoflow auth create-token`). CI automates them; by hand it is awkward.
+A user who built and tested a DAG in **Lite** (the local loop) and wants it in
+**Pro** but has **no CI pipeline yet** has no single, ergonomic command.
+
+This ADR defines **`leoflow deploy`**: one command that promotes a DAG (or a whole
+workspace) from a developer's machine to a Pro control plane, **without a
+pipeline**, reusing the existing primitives (`compile`, `--build`, `--push`,
+`push`). It is the manual happy path the `first-pro-dag` walkthrough already
+describes, collapsed into one verb.
+
+## Decision
+
+### Split by edition, not by cluster topology
+- **Lite** (`leoflow lite`) runs locally and needs **no registry** — unchanged.
+- **`leoflow deploy` targets Pro and REQUIRES a registry.** We do **not** add a
+  single-node image-import path for Pro (it complicates our side — per-node
+  containerd trust). Kubernetes pulls images from a registry; a Pro deploy needs
+  one, full stop.
+
+### Registry is mandatory for deploy — fail loudly when missing
+`leoflow deploy` without a configured `registry:` is a **loud, actionable error**,
+never a silent attempt:
+
+```
+error: deploy requires a container registry, but none is configured.
+  A Pro deploy pushes the DAG image to a registry your cluster can pull from
+  (Lite runs locally and needs none). Add to leoflow.yaml:
+
+      registry:
+        url: ghcr.io/<your-org>     # or ECR / Artifact Registry / ACR / private
+        image_name: <name>
+
+  Then authenticate your builder once:  docker login ghcr.io
+```
+
+This is **documented as a hard requirement** of the command (docs + the error
+itself). It aligns with the standing loud-reject-over-silent principle.
+
+### What lives where
+- **`leoflow.yaml`** (per-DAG, part of the artifact): `registry:` (`url`,
+  `image_name`, `tag_strategy`). Optional for Lite (ignored locally), required for
+  deploy.
+- **NOT in the yaml** (environment, not per-DAG): the target control plane
+  `--server` and the auth token. The same DAG deploys to staging and prod by
+  changing only `--server`. Provided via flag, `LEOFLOW_TOKEN` env, or a persisted
+  session (`leoflow login`).
+
+### Two auths, kept separate
+1. **Registry auth** (image push) — the **builder's** credential (`docker login`,
+   or cloud helpers: `aws ecr get-login`, `gcloud auth configure-docker`,
+   `az acr login`). Leoflow never stores registry credentials; it shells out to
+   `docker push`. Leoflow is registry-agnostic.
+2. **Control-plane auth** (register `dag.json`) — a JWT bearer token. Precedence:
+   `--token` (default from `LEOFLOW_TOKEN`) → `--username`/`--password` (deploy
+   fetches a token via `/auth/login`) → a persisted session from `leoflow login`.
+
+### `leoflow login` ships alongside `deploy`
+`leoflow login --server <pro>` stores the token in `~/.leoflow/config`, so
+`leoflow deploy` then needs **no auth flags**. This is what makes the pipeline-less
+loop fluid (login once, deploy many).
+
+### The CLI is runtime-independent (Lite and CI share it)
+
+`deploy`, `login`, `compile`, and `push` are **client-side by contract**: they talk
+to a remote control plane via `--server` + a token and require **no local runtime**
+— no `leoflow lite`, no embedded server, no datastore. They already live in the
+root command's *authoring* group (`internal/cli/root.go`), distinct from the
+*runtime* group (`lite`/`server`). This is what lets the exact same commands run in
+two settings with no special-casing:
+
+- **From Lite** — a developer who has `leoflow lite` up still invokes `deploy`/
+  `login` as plain client calls against the Pro `--server`.
+- **From a CI pipeline, without Lite** — a runner that only has the `leoflow`
+  binary runs `leoflow login` + `leoflow deploy` (journey 3); it never starts a
+  local runtime.
+
+**Packaging note (deferred optimization).** The single `leoflow` binary already
+serves both — CI simply calls the authoring subcommands. A **slim, client-only
+build** (build-tag-gated to exclude `lite`/`server`/the SPA, shrinking the CI
+image) is a *packaging* optimization, not a requirement, and is deferred until
+binary size is a real pain. The contract above (commands are runtime-independent)
+is what keeps that option open.
+
+### Deploy scope — single, by id, or all
+- `leoflow deploy [path]` (default `.`) — the DAG project in that directory.
+- `leoflow deploy <dag_id>` — resolve the id to its subdir in a multi-DAG
+  workspace and deploy that one.
+- `leoflow deploy --all` — every DAG in the workspace (reuses `DiscoverProjects`).
+  **Best-effort**: build+push+register each, print a per-DAG summary, and exit
+  non-zero if **any** failed (so CI catches it) — partial pushes are not rolled
+  back (images are content-addressed; a re-deploy is idempotent).
+
+### Behavior + UX
+- **Registers only** by default (the artifact is published; scheduled DAGs run on
+  their schedule). `--trigger` opts into kicking a run immediately.
+- **Confirmation** when interactive and the server is non-loopback (a real Pro):
+  `Deploy <dag> → <server>? [y/N]`. `--yes` skips it (CI/automation).
+- **Rebuilds** the image by default (simple, deterministic); `--skip-build`
+  re-uses an already-built image (promote without rebuild).
+- **Pins by digest:** the push captures the image digest and writes
+  `registry/img@sha256:…` into `dag.json` — Pro pulls **exactly** the bytes that
+  were built; there is no `:latest` lookup. The first deploy *registers* the
+  artifact, which is how Pro learns it; subsequent deploys register new versions,
+  and "latest" in Pro means the newest registered artifact, each pinning its own
+  digest.
+- **Default tag strategy:** `git-sha` (immutable per commit); falls back to a
+  timestamp when the project is not in git.
+- **Output:** a clear per-phase summary —
+  `built … @sha256 · pushed … · registered <dag> <version> → <server>/dags/<dag>`.
+
+### Target architecture — cross-build by default (Mac-safe)
+
+The common dev setup is **macOS/arm64**; the common Pro cluster is **Linux/amd64**.
+A local `docker build` inherits the host arch (`internal/cli/compile.go:182` passes
+no `--platform`), so a Mac-built image would crash the task pod with
+`exec format error`. Decision:
+
+- **`leoflow deploy` defaults to `--platform linux/amd64`** — it builds for the
+  cluster, not the laptop. On Docker Desktop this "just works" (bundled QEMU/binfmt
+  cross-builds with no setup); the runtime base is already published multi-arch
+  (`release.yaml` → `linux/amd64,linux/arm64`), so the cross-build resolves.
+- **`--platform` is overridable:** `linux/arm64` (Graviton) or a comma list
+  (`linux/amd64,linux/arm64`). A multi-arch value routes through
+  `<builder> buildx build --platform … --push` (a manifest list cannot be `--load`ed
+  locally, so multi-arch is inherently a push).
+- **Builder-agnostic, no new library surface.** The platform fix is just a CLI arg
+  to the operator-chosen `--builder` (`docker`/`podman`/`nerdctl`); Leoflow shells
+  out and never links the Docker Go SDK (ADR 0015). (`docker/docker` in `go.sum` is
+  a test-only transitive of golang-migrate's `dktest` — `go mod why` reports it
+  unneeded by any package; govulncheck finds it unreachable.)
+- **Loud first-time note:** cross-building under emulation is slow (pip/wheels); the
+  command prints a one-line heads-up so a long build is not mistaken for a hang.
+  Non-Docker-Desktop runtimes (Colima/Lima/podman) may need a one-time
+  `docker run --privileged tonistiigi/binfmt --install all`.
+
+### What the artifact does NOT carry — connections & variables
+
+The DAG **image + `dag.json`** travel; **connections and variables do not** — they
+live encrypted in the Pro control-plane DB (ADR 0019), not in the artifact. So a
+deploy can succeed and the DAG still fail at runtime because its `conn_id` does not
+exist on Pro. This bites journey (2) hardest (an example DAG that needs a
+connection). The deploy flow must therefore:
+
+- **Surface the dependency, not hide it.** A deploy of a DAG that references a
+  `conn_id` prints the connections it expects and reminds the user to create them
+  on Pro (UI or API), the same way the registry-missing error teaches.
+- A future `leoflow connections push` (seed selected connections to Pro) is a
+  natural follow-up but is **out of scope** here — secrets crossing machines is a
+  deliberate, separately-designed step, never an implicit side effect of deploy.
+
+## Happy paths (documentation restructures on ship)
+
+`deploy` reshapes the Pro happy path into **three journeys**, which the docs
+(`docs/first-pro-dag.md`, `docs/deploy.md`) must present distinctly — today they
+only show one by-hand sequence:
+
+1. **Your own DAG — develop in Lite, then deploy.** Iterate locally with
+   `leoflow lite` (fast, no registry, hot-reload); when it is ready,
+   `leoflow deploy --server <pro>` promotes it. Lite is the dev loop; deploy is
+   the promotion. This is the path for DAGs you are writing.
+
+2. **An example DAG — deploy directly, no Lite.** The shipped examples are
+   known-good, so you skip the local loop entirely: configure `registry:` (and any
+   connection the example needs), then `leoflow deploy --server <pro>`. Good for a
+   first taste of Pro without authoring anything.
+
+3. **Automated — a CI pipeline (esteira).** The same `compile → build → push →
+   register` (or one `leoflow deploy`) on every push (the `deploy.md` recipes),
+   for teams that already have a pipeline.
+
+When `deploy` ships, `first-pro-dag.md` is restructured around journeys (1) and
+(2) — replacing the current by-hand `compile --build --push` + `push` sequence —
+and `deploy.md` keeps (3) as the automated variant.
+
+## Open questions (decide during implementation)
+
+- **Registry reachability asymmetry.** The dev pushes; the *cluster* pulls the same
+  ref. A LAN/short-name `registry.url` that resolves differently inside the cluster
+  (or needs different TLS trust) makes the dev's push succeed while the pod's pull
+  fails. `imagePullSecrets` covers *auth*, not *name/reachability*. Decide whether
+  deploy does a best-effort reachability hint.
+- **Paused/catchup on first register.** `versions.go` does not set `IsPaused`, so a
+  fresh deploy inherits the default; if that is active-with-catchup, a deploy could
+  immediately fire a backlog on Pro. Decide: register **paused** by default with an
+  `--activate`, or document the current behavior loudly.
+- **CLI ↔ Pro version skew.** A newer Lite writes a `dag.json` `schema_version` an
+  older Pro cannot parse (or vice versa). The register endpoint should reject with
+  an explicit "upgrade Pro" message, not a confusing validation error.
+- **Tenant is implicit (works, document it).** `RegisterDagVersion` uses
+  `tenantOf(token)` — deploy lands in the **token's tenant**. On a multi-tenant Pro
+  the user selects the tenant by which token they `login` with; the docs must say so.
+
+## Deferred (explicitly out of scope here)
+- **Rollback UX.** The model is already versioned server-side
+  (`POST /dags/{id}/versions`), so the data supports rollback, but there is no
+  `leoflow deploy --rollback` / pin-previous command yet. Name now, build later.
+- **Secrets baked into the image during Lite dev** get pushed to the registry on
+  deploy. A lint/warn for obvious secret material in the build context is a later
+  hardening, not part of this command.
+- **Bundled in-cluster registry** (Pro shipping its own `registry:2`) — it is the
+  part that complicates *our* side (per-node containerd trust, TLS, image GC).
+  Reconsider only on real demand for multi-node-without-external-registry.
+- **Named environments / contexts** (`--env prod`, kubectl-style) — start with
+  `--server` + `login`; add named targets if demand appears.
+- **A "Deploy" button in the Lite web editor** — viable Lite-first (it has Docker),
+  but a UI concern that reuses this same `deploy` command; not part of the CLI work.
+
+## Cluster wiring (Helm) — required for the deploy path to actually pull
+
+The deploy story is only complete if the **task pod** can pull the DAG image from
+a **private** registry. Today the chart's `imagePullSecrets` is applied **only to
+the control-plane Deployment** (`deployment.yaml`); the per-task pod built by the
+K8s executor (`internal/executor/kubernetes.go::BuildPod`) sets **no**
+`ImagePullSecrets`, and the task ServiceAccount template carries none either. A
+private-registry deploy would therefore fail the task pod with `ErrImagePull`.
+
+**Fix (cheap, no executor code):** attach `imagePullSecrets` to the **task
+ServiceAccount** — Kubernetes auto-injects a SA's pull secrets into every pod that
+uses it. Two parts:
+- `values.yaml`: `taskServiceAccount.imagePullSecrets: []`; emit the block in
+  `templates/task-serviceaccount.yaml`.
+- **Ensure task pods default to that SA.** Today the pod only runs as
+  `taskServiceAccount` when `Execution.ServiceAccount` is set
+  (`kubernetes.go:93`); otherwise it falls back to the namespace `default` SA,
+  which has no pull secrets. The deploy path requires task pods to default to the
+  task SA (or, as a heavier alternative, a per-pod `ImagePullSecrets` fed from
+  server config into `BuildPod`).
+
+This chart change is a **prerequisite** for journeys (1) and (2) against a private
+registry; public images (e.g. the shipped examples on a public GHCR) work without
+it, which is why journey (2) is the gentlest first taste of Pro.
+
+## Consequences
+- The pipeline-less promotion becomes one command, reusing tested primitives —
+  little new code on our side (orchestration + a registry-presence check + the
+  digest capture + `login`).
+- A registry is a hard, documented prerequisite for Pro deploy; the failure path
+  teaches the user instead of guessing.
+- The artifact stays immutable and environment-agnostic: `leoflow.yaml` describes
+  the DAG + where its image lives; `--server`/`login` chooses where it runs.

--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -40,4 +40,5 @@ The *why* behind Leoflow's design. ADRs are immutable once accepted.
 - [ADR 0035: Cloud connector auth — keyless-first; Leoflow is not a key manager](adr/0035-cloud-connector-auth-keyless-first.md)
 - [ADR 0036: Airflow 3.X runtime compatibility shim — one model, one policy seam](adr/0036-airflow-runtime-compat-shim.md)
 - [ADR 0037: Release version scheme — skip alpha/beta, RC discipline from `v0.0.1`](adr/0037-release-version-scheme.md)
+- [ADR 0041: `leoflow deploy` — pipeline-less promotion from Lite to Pro](adr/0041-leoflow-deploy-pipelineless.md)
 <!-- END ADR INDEX -->

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,13 +1,27 @@
 # CI/CD & deploy examples
 
 !!! tip "New to Pro? Start with the walkthrough"
-    [**Your first Pro DAG (≈20 min)**](first-pro-dag.md) takes one DAG from source
-    to a running pod by hand, so you see each artifact boundary before you automate
-    it. This page is the CI recipes for the same pipeline.
+    [**Your first Pro DAG (≈10 min)**](first-pro-dag.md) takes one DAG from source
+    to a running pod with **one command** (`leoflow deploy`), so you see each
+    artifact boundary before you automate it. This page is the CI recipes for the
+    same pipeline.
 
 Deploying a Leoflow DAG is the same everywhere because a DAG is an **immutable
 artifact** — a `dag.json` + a container image, versioned together (ADR 0003).
-The pipeline is always:
+
+**By hand or for a team without a pipeline,** one command does it all:
+
+```bash
+leoflow auth login --server "$LEOFLOW_SERVER"   # once; stores the token
+leoflow deploy --yes                            # compile → build → push → register
+```
+
+`leoflow deploy` is the [pipeline-less promotion](adr/0041-leoflow-deploy-pipelineless.md)
+— it cross-builds for the cluster, pins the image by digest, and registers the
+artifact. `--yes` skips the confirmation prompt (use it in automation).
+
+**In a pipeline,** the same three boundaries are explicit so each can be cached,
+gated, and audited independently:
 
 ```mermaid
 flowchart LR
@@ -21,6 +35,11 @@ flowchart LR
    build the DAG image.
 2. **push the image** to your registry, tagged by git SHA (immutable).
 3. **`leoflow push dag.json`** — register the artifact with the control plane.
+
+!!! note "`deploy` vs. the three explicit steps"
+    They do the same thing. A pipeline can run the one-liner (`leoflow deploy
+    --yes`) just as well; the explicit steps are shown because most CI systems want
+    the build and the register as separate, individually-cacheable stages.
 
 !!! tip "The guardrails are your CI gate"
     The same checks that warn you locally in `leoflow lite` fail the CI build, so a

--- a/docs/first-pro-dag.md
+++ b/docs/first-pro-dag.md
@@ -1,37 +1,56 @@
-# Your first Pro DAG (≈20 min)
+# Your first Pro DAG (≈10 min)
 
 This is the end-to-end Pro path: take one DAG from source to a running task on a
-control plane. Where the 2-minute [Lite loop](local-deploy.md) hides the artifact
-boundary so you can iterate, Pro makes it explicit — because that boundary is what
-your CI pipeline automates later.
+control plane — in **one command**. Where the 2-minute [Lite loop](local-deploy.md)
+hides the artifact boundary so you can iterate, Pro makes it explicit, because that
+boundary is what `leoflow deploy` automates for you.
 
 A DAG is an **immutable artifact** — a `dag.json` + a container image, versioned
-together ([ADR 0003](adr/0003-dag-as-image.md)). Every step below moves the DAG
-across one boundary:
+together ([ADR 0003](adr/0003-dag-as-image.md)). `leoflow deploy` moves it across
+every boundary in one shot:
 
 ```mermaid
 flowchart LR
   A[dag.py + leoflow.yaml] --> B[compile → dag.json]
   B --> C[build DAG image<br/>FROM leoflow-runtime]
-  C --> D[push image → registry]
-  D --> E[register dag.json → control plane]
-  E --> F[trigger → runs in a pod]
+  C --> D[push image → your registry]
+  D --> E[re-pin by digest<br/>+ register → control plane]
+  E --> F[runs in a pod]
 ```
 
-The DAG image is built `FROM` the **published Leoflow task base**
-(`ghcr.io/neochaotic/leoflow-runtime:py3.11`), which bundles the `leoflow-agent`
-(PID 1, talks gRPC to the control plane) and the `leoflow_runtime` Python helper.
-You never build the base yourself — pull it from GHCR, multi-arch, signed.
+!!! info "Two versions of this walkthrough"
+    - **The simple path (below)** — a minimal DAG with a `Dockerfile`, deployed
+      today with `leoflow deploy`. Everything here runs as-is.
+    - **[The complete path](#the-complete-path-your-own-dag-yaml-driven)** — author
+      your own DAG with **no Dockerfile** (the build is synthesized from
+      `leoflow.yaml`) and real `connectors:`. That richer flow lands with the
+      connectors release; it is shown at the end so you can see where this is going.
 
 ## Prerequisites
 
-- `docker` (or `podman`/`nerdctl` — pass `--builder`).
-- The `leoflow` CLI and Python 3.11+ on your machine
-  (see [Python on the runner](deploy.md#python-on-the-runner)).
-- A reachable Leoflow **control plane** (`LEOFLOW_SERVER`) and a push token
-  (`LEOFLOW_TOKEN`). For a throwaway target, the Helm chart's
-  [Pro deployment](helm-chart.md) brings one up; a local registry
-  (`docker run -d -p 5000:5000 registry:2`) is enough to push DAG images to.
+- **`docker`** (or `podman`/`nerdctl` — pass `--builder`). Used to build and push
+  the DAG image. On Docker Desktop, cross-building for the cluster "just works".
+- The **`leoflow` CLI** and Python 3.11+ on your machine (`leoflow setup` once).
+- **A container registry your cluster can pull from** — anywhere: Docker Hub, GHCR,
+  Amazon ECR, Google Artifact Registry, Azure ACR, or a private one. You push the
+  DAG image there; the control plane pulls it. (Lite needs none — this is a Pro
+  thing.)
+- **A reachable Pro control plane.** A throwaway one comes from the
+  [Helm chart](helm-chart.md).
+
+## Step 0 — log in once
+
+```console
+$ leoflow auth login --server https://pro.example.com
+Username: admin
+Password:
+Logged in to https://pro.example.com (token saved to ~/.leoflow/config.yaml)
+```
+
+The token is stored, so every later `leoflow deploy` needs **no auth flags**. The
+password is read hidden — it never lands in your shell history. (This is the
+control-plane login; it is unrelated to `docker login`, which authenticates your
+*builder* to the registry — do that once too: `docker login ghcr.io`.)
 
 ## Step 1 — a project (`dag.py` + `leoflow.yaml` + `Dockerfile`)
 
@@ -55,6 +74,12 @@ dag_id: first_pro_dag
 python_version: "3.11"
 dependencies:
   - requests==2.32.3
+registry:
+  # Wherever you want the artifact to live — this is just an example.
+  # Docker Hub: docker.io/your-user · ECR: <acct>.dkr.ecr.<region>.amazonaws.com
+  # Artifact Registry: <region>-docker.pkg.dev/<project>/<repo> · GHCR: ghcr.io/your-org
+  url: ghcr.io/your-org
+  image_name: first-pro-dag
 ```
 
 ```dockerfile title="Dockerfile"
@@ -64,61 +89,126 @@ COPY dag.py /home/leoflow/dag.py
 ENV PYTHONPATH=/home/leoflow
 ```
 
-!!! tip "The Dockerfile is boilerplate"
-    It always layers the same way: `FROM` the base, install your deps, `COPY` the
-    DAG, set `PYTHONPATH`. The [Lite loop](local-deploy.md) generates this for you;
-    in Pro you keep it in the repo so the image is fully reproducible in CI.
+!!! tip "The base image is ours; you never build it"
+    Your image layers `FROM` the **published Leoflow task base**
+    (`ghcr.io/neochaotic/leoflow-runtime:py3.11`) — it bundles the `leoflow-agent`
+    (PID 1, talks gRPC to the control plane) and the `leoflow_runtime` helper, is
+    multi-arch and signed, and is built by our CI. You only add your deps and copy
+    your DAG in. (In [the complete path](#the-complete-path-your-own-dag-yaml-driven)
+    even this Dockerfile goes away — it is synthesized from `leoflow.yaml`.)
 
-## Step 2 — compile, build, and push
+## Step 2 — deploy (one command)
 
-```bash
-leoflow setup                 # once per machine: extracts the parser
-leoflow compile . --build --push \
-  --image localhost:5000/first-pro-dag:v1.0.0 \
-  --dag-version v1.0.0
+```console
+$ leoflow deploy
+Deploy first_pro_dag -> https://pro.example.com? [y/N] y
+…  (compile → build for linux/amd64 → push → register)
+Deployed first_pro_dag -> https://pro.example.com
+  image ghcr.io/your-org/first-pro-dag@sha256:9f2c…
+  registered version 1a2b3c4
 ```
 
-This single command crosses three boundaries:
+That one command crossed every boundary:
 
-1. **compile** — parses `dag.py`, overlays `leoflow.yaml`, runs the guardrails
-   (unknown `task_id`, unsupported operator, duplicate keys), and writes `dag.json`
-   with `--image` recorded inside it.
-2. **build** — builds the image from your `Dockerfile`.
-3. **push** — pushes it to your registry.
+1. **compile** — parsed `dag.py`, overlaid `leoflow.yaml`, ran the guardrails
+   (unknown `task_id`, unsupported operator, duplicate keys), wrote `dag.json`.
+2. **build** — built the image from your `Dockerfile`, **for the cluster's
+   architecture** (`linux/amd64` by default, so a macOS/arm64 laptop produces an
+   image the cluster can actually run).
+3. **push** — pushed it to your `registry:`.
+4. **re-pin + register** — captured the image **digest** and wrote
+   `…@sha256:…` into `dag.json`, then registered that with the control plane. Pro
+   now pulls **exactly** the bytes you built — no `:latest` drift.
 
-Because the `--image` you pass is written into `dag.json`, the registered artifact
-and the pushed image can never drift.
+!!! note "It registers, it doesn't run — by default"
+    `deploy` publishes the artifact; a scheduled DAG then runs on its schedule.
+    Add `--trigger` to kick a run immediately, or trigger from the Airflow UI.
 
-!!! tip "The guardrails are your CI gate"
-    The same checks fail the build here that warn you in `leoflow lite`, so a bad
-    binding or an unsupported operator never reaches the control plane.
+## Step 3 — trigger and watch it run
 
-## Step 3 — register the artifact
-
-```bash
-leoflow push dag.json --server "$LEOFLOW_SERVER" --token "$LEOFLOW_TOKEN"
+```console
+$ leoflow deploy --trigger
+…
+Deployed first_pro_dag -> https://pro.example.com
+  image ghcr.io/your-org/first-pro-dag@sha256:9f2c…
+  registered version 1a2b3c4
+  triggered run manual__1717525200
 ```
 
-The control plane now knows the DAG, its version, and which image to pull.
+The scheduler pulls your image, runs each task in its own pod, and the Airflow UI
+shows state and logs. That is the whole Pro lifecycle, in one verb.
 
-## Step 4 — trigger and watch it run
+## When it doesn't work
 
-Trigger from the Airflow UI (Trigger DAG) or the API:
+`deploy` fails loudly and tells you the fix. The four you'll actually hit:
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `deploy requires a container registry…` | no `registry:` in `leoflow.yaml` | add the `registry:` block (Step 1) and `docker login <registry>` |
+| `denied` / `unauthorized` on push | builder not logged in to the registry | `docker login ghcr.io` (registry auth ≠ control-plane auth) |
+| Task pod: `exec format error` | image arch ≠ cluster arch | already handled — deploy builds `linux/amd64`; for a Graviton cluster pass `--platform linux/arm64` |
+| DAG runs but a task fails on a missing `conn_id` | connections live in the control plane, **not** in the image | deploy prints `note: this DAG expects connection(s): …` — create them on Pro (UI/API) first; see [Variables & Connections](variables-connections.md) |
+
+## Deploy more than one DAG
 
 ```bash
-curl -X POST "$LEOFLOW_SERVER/api/v2/dags/first_pro_dag/dagRuns" \
-  -H "Authorization: Bearer $LEOFLOW_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"logical_date": "2026-01-01T00:00:00Z"}'
+leoflow deploy <dag_id>     # a specific DAG in a multi-DAG workspace
+leoflow deploy --all        # every DAG in the workspace (best-effort; non-zero exit if any fail)
+leoflow deploy --skip-build # promote an already-built image without rebuilding
 ```
 
-The scheduler pulls your image, runs each task in its own pod, and the UI shows
-state and logs at the next refresh. That is the whole Pro lifecycle.
+## The complete path — your own DAG, yaml-driven
+
+!!! warning "Lands with the connectors release (v0.1.0)"
+    The flow below is the **complete, Dockerfile-free** authoring experience. The
+    yaml-driven build (synthesizing the image from `leoflow.yaml`) ships with the
+    connectors release. On the current release, keep the `Dockerfile` from Step 1.
+    This section shows where the happy path is going.
+
+When the yaml-driven build lands, the project is **two files** — no Dockerfile, no
+`requirements.txt`:
+
+```python title="dag.py"
+from airflow.sdk import DAG, task
+from airflow.providers.postgres.hooks.postgres import PostgresHook  # inside a @task
+
+@task
+def load() -> int:
+    rows = PostgresHook(postgres_conn_id="warehouse").get_first("SELECT count(*) FROM orders")[0]
+    print(f"orders: {rows}")
+    return rows
+
+with DAG("orders_report", schedule="@daily") as dag:
+    load()
+```
+
+```yaml title="leoflow.yaml"
+dag_id: orders_report
+python_version: "3.11"
+connectors:
+  - postgres            # installs the provider; the form renders in the UI
+registry:
+  url: ghcr.io/your-org
+  image_name: orders-report
+```
+
+```console
+$ leoflow auth login --server https://pro.example.com   # once
+$ leoflow deploy --trigger
+note: this DAG expects connection(s): warehouse
+      create them on the control plane (UI or API) before the run.
+Deployed orders_report -> https://pro.example.com
+  image ghcr.io/your-org/orders-report@sha256:… · triggered run manual__…
+```
+
+`leoflow compile --build` synthesizes the image from the yaml — `FROM` our base,
+your `connectors:`/`dependencies:` installed, your DAG copied in. The only
+Dockerfiles in the repo are the ones under `examples/`.
 
 ## From here
 
-- **Automate it in CI.** Steps 2–3 are exactly what a pipeline runs on every push —
+- **Automate it.** `leoflow deploy` is exactly what a pipeline runs on every push —
   see [CI/CD & deploy examples](deploy.md) for GitHub Actions / GitLab / Cloud Build
   recipes (and the Python-on-the-runner notes).
-- **Add credentials.** Declare a connection in the UI; it is delivered to the pod as
-  `AIRFLOW_CONN_*` — see [Variables & Connections](variables-connections.md).
+- **The design.** [ADR 0041](adr/0041-leoflow-deploy-pipelineless.md) records why
+  deploy works the way it does (registry mandatory, digest pinning, two-tier path).

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -306,5 +306,6 @@ differ from what's committed.
 | taskSecret.name | string | `""` | Name of an existing Kubernetes Secret to mount into task pods. Empty = none. |
 | taskServiceAccount.annotations | object | `{}` | Annotations. GKE Workload Identity: `iam.gke.io/gcp-service-account: GSA@PROJECT.iam.gserviceaccount.com`. EKS IRSA: `eks.amazonaws.com/role-arn: ...`. |
 | taskServiceAccount.create | bool | `false` | Create a ServiceAccount in taskNamespace for task pods to run as. |
+| taskServiceAccount.imagePullSecrets | list | `[]` | Pull secrets for private DAG images. Kubernetes auto-injects these into every task pod that runs as this SA, so a `leoflow deploy` to a private registry can be pulled (ADR 0041). Reference an existing docker-registry secret, e.g. `[{name: regcred}]`. |
 | taskServiceAccount.name | string | `"leoflow-task"` | Name of the task ServiceAccount (use this as `execution.service_account`). |
 | tolerations | list | `[]` | Pod tolerations (standard K8s — allow scheduling on tainted nodes). |

--- a/helm/leoflow/templates/NOTES.txt
+++ b/helm/leoflow/templates/NOTES.txt
@@ -22,6 +22,14 @@ WARNING: no database URL set. Provide .Values.database.url or .Values.database.e
 
 WARNING: no JWT secret set. Provide .Values.auth.jwtSecret or .Values.auth.existingSecret (key jwtSecret).
 {{- end }}
+{{- if .Values.taskServiceAccount.imagePullSecrets }}
+
+NOTE: taskServiceAccount.imagePullSecrets is set (for private DAG images), but
+Kubernetes only injects them into pods that RUN AS this ServiceAccount. Set
+`execution.service_account: {{ .Values.taskServiceAccount.name }}` in each DAG's
+leoflow.yaml (the same field Workload Identity uses), or task pods will fall back
+to the namespace default SA and the pull secrets will not apply.
+{{- end }}
 {{- if .Values.migrations.enabled }}
 
 Migrations run as a pre-install/pre-upgrade Job using image

--- a/helm/leoflow/templates/task-serviceaccount.yaml
+++ b/helm/leoflow/templates/task-serviceaccount.yaml
@@ -17,4 +17,14 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- with .Values.taskServiceAccount.imagePullSecrets }}
+{{/*
+Pull secrets for the DAG images the task pods pull from a private registry.
+Kubernetes auto-injects a ServiceAccount's imagePullSecrets into every pod that
+uses it, so task pods need no per-pod change — provided they run as this SA
+(set execution.service_account to taskServiceAccount.name). ADR 0041.
+*/}}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end -}}

--- a/helm/leoflow/tests/task_serviceaccount_test.yaml
+++ b/helm/leoflow/tests/task_serviceaccount_test.yaml
@@ -1,0 +1,37 @@
+suite: task ServiceAccount (imagePullSecrets for private-registry pulls)
+templates:
+  - task-serviceaccount.yaml
+release:
+  name: leoflow
+  namespace: leoflow
+tests:
+  - it: renders nothing when taskServiceAccount.create is false (the default)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the ServiceAccount when create is true
+    set:
+      taskServiceAccount.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+
+  - it: attaches imagePullSecrets so task pods can pull a private DAG image
+    set:
+      taskServiceAccount.create: true
+      taskServiceAccount.imagePullSecrets:
+        - name: regcred
+    asserts:
+      - equal:
+          path: imagePullSecrets[0].name
+          value: regcred
+
+  - it: omits imagePullSecrets when none are configured
+    set:
+      taskServiceAccount.create: true
+    asserts:
+      - notExists:
+          path: imagePullSecrets

--- a/helm/leoflow/values.yaml
+++ b/helm/leoflow/values.yaml
@@ -29,6 +29,11 @@ taskServiceAccount:
   name: leoflow-task
   # -- Annotations. GKE Workload Identity: `iam.gke.io/gcp-service-account: GSA@PROJECT.iam.gserviceaccount.com`. EKS IRSA: `eks.amazonaws.com/role-arn: ...`.
   annotations: {}
+  # -- Pull secrets for private DAG images. Kubernetes auto-injects these into
+  # every task pod that runs as this SA, so a `leoflow deploy` to a private
+  # registry can be pulled (ADR 0041). Reference an existing docker-registry
+  # secret, e.g. `[{name: regcred}]`.
+  imagePullSecrets: []
 
 serviceAccount:
   # -- Create a dedicated ServiceAccount for the leoflow-server. Set `false` only if you bring your own via `name`.

--- a/internal/cli/build_digest.go
+++ b/internal/cli/build_digest.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+)
+
+// inspectDigestArgs assembles the builder argv that prints a pushed image's
+// repo digest (repo@sha256:...). RepoDigests is populated only after a push, so
+// this must run post-push. Works across docker/podman/nerdctl, which all expose
+// RepoDigests via `inspect --format`.
+func inspectDigestArgs(image string) []string {
+	return []string{"inspect", "--format", "{{index .RepoDigests 0}}", image}
+}
+
+// parseDigestRef validates and trims the inspect output into a pinned image
+// reference. An empty result means the image was never pushed (no RepoDigests);
+// a result without an @sha256 digest is not a pin. Both are loud errors so a
+// deploy never registers an unpinned image.
+func parseDigestRef(out string) (string, error) {
+	ref := strings.TrimSpace(out)
+	if ref == "" || ref == "<no value>" {
+		return "", fmt.Errorf("image has no repo digest (was it pushed?)")
+	}
+	if !strings.Contains(ref, "@sha256:") {
+		return "", fmt.Errorf("inspect returned %q, which is not a digest-pinned reference", ref)
+	}
+	return ref, nil
+}

--- a/internal/cli/build_digest.go
+++ b/internal/cli/build_digest.go
@@ -1,8 +1,12 @@
 package cli
 
 import (
+	"bytes"
 	"fmt"
+	"os/exec"
 	"strings"
+
+	"github.com/spf13/cobra"
 )
 
 // inspectDigestArgs assembles the builder argv that prints a pushed image's
@@ -26,4 +30,19 @@ func parseDigestRef(out string) (string, error) {
 		return "", fmt.Errorf("inspect returned %q, which is not a digest-pinned reference", ref)
 	}
 	return ref, nil
+}
+
+// imageDigest shells out to the builder to resolve image's pinned repo digest
+// after a push (ADR 0015: no Docker SDK). The returned reference is what deploy
+// writes into dag.json so Pro pulls exactly the bytes that were built.
+func imageDigest(cmd *cobra.Command, builder, image string) (string, error) {
+	//nolint:gosec // G204: builder is operator-configured by design (ADR 0015).
+	ic := exec.CommandContext(cmdContext(cmd), builder, inspectDigestArgs(image)...)
+	var out bytes.Buffer
+	ic.Stdout = &out
+	ic.Stderr = cmd.ErrOrStderr()
+	if err := ic.Run(); err != nil {
+		return "", fmt.Errorf("inspecting image %q with %q: %w", image, builder, err)
+	}
+	return parseDigestRef(out.String())
 }

--- a/internal/cli/build_digest_test.go
+++ b/internal/cli/build_digest_test.go
@@ -1,0 +1,40 @@
+package cli
+
+import "testing"
+
+func TestInspectDigestArgs(t *testing.T) {
+	args := inspectDigestArgs("ghcr.io/org/etl:v1")
+	if args[0] != "inspect" {
+		t.Errorf("args[0] = %q, want inspect", args[0])
+	}
+	if argIndex(args, "ghcr.io/org/etl:v1") < 0 {
+		t.Errorf("image missing from args: %v", args)
+	}
+	// It must ask the builder for the repo digest, not the local image ID.
+	if argIndex(args, "--format") < 0 {
+		t.Errorf("want a --format flag selecting RepoDigests: %v", args)
+	}
+}
+
+func TestParseDigestRefExtractsPinnedRef(t *testing.T) {
+	got, err := parseDigestRef("ghcr.io/org/etl@sha256:deadbeefcafe\n")
+	if err != nil {
+		t.Fatalf("parseDigestRef: %v", err)
+	}
+	if got != "ghcr.io/org/etl@sha256:deadbeefcafe" {
+		t.Errorf("ref = %q, want the trimmed repo@sha256 ref", got)
+	}
+}
+
+func TestParseDigestRefRejectsEmpty(t *testing.T) {
+	// An image with no RepoDigests (never pushed) yields an empty inspect result.
+	if _, err := parseDigestRef("  \n"); err == nil {
+		t.Error("expected an error when the image has no repo digest (not pushed)")
+	}
+}
+
+func TestParseDigestRefRejectsUnpinned(t *testing.T) {
+	if _, err := parseDigestRef("ghcr.io/org/etl:v1\n"); err == nil {
+		t.Error("expected an error when the ref carries no @sha256 digest")
+	}
+}

--- a/internal/cli/build_imageref.go
+++ b/internal/cli/build_imageref.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+)
+
+// composeImageRef builds the pushed image reference `<url>/<image_name>:<tag>`
+// from the registry config, tolerating a trailing slash on the URL.
+func composeImageRef(url, imageName, tag string) string {
+	return fmt.Sprintf("%s/%s:%s", strings.TrimRight(url, "/"), imageName, tag)
+}
+
+// resolveImageTag picks the image tag from the registry's tag strategy. The
+// default (and "git-sha"/"git_sha") prefers the immutable git sha, so each
+// commit maps to a distinct artifact; it falls back to the DAG version when the
+// project is not in git. "version" tags by the DAG version explicitly.
+func resolveImageTag(strategy, version, gitSHA string) string {
+	switch strategy {
+	case "version":
+		return version
+	case "git_sha", "git-sha":
+		return gitSHA
+	default:
+		if gitSHA != "" {
+			return gitSHA
+		}
+		return version
+	}
+}

--- a/internal/cli/build_imageref_test.go
+++ b/internal/cli/build_imageref_test.go
@@ -1,0 +1,33 @@
+package cli
+
+import "testing"
+
+func TestComposeImageRef(t *testing.T) {
+	if got := composeImageRef("ghcr.io/org", "etl", "abc"); got != "ghcr.io/org/etl:abc" {
+		t.Errorf("ref = %q, want ghcr.io/org/etl:abc", got)
+	}
+	// A trailing slash on the URL must not double up.
+	if got := composeImageRef("ghcr.io/org/", "etl", "abc"); got != "ghcr.io/org/etl:abc" {
+		t.Errorf("ref = %q, want a single slash join", got)
+	}
+}
+
+func TestResolveImageTagByStrategy(t *testing.T) {
+	cases := []struct {
+		strategy, version, gitSHA, want string
+	}{
+		{"version", "v1", "sha9", "v1"},
+		{"git_sha", "v1", "sha9", "sha9"},
+		{"git-sha", "v1", "sha9", "sha9"},
+		// Default (unset) prefers the immutable git sha...
+		{"", "v1", "sha9", "sha9"},
+		// ...but falls back to the version when not in git.
+		{"", "v1", "", "v1"},
+	}
+	for _, c := range cases {
+		if got := resolveImageTag(c.strategy, c.version, c.gitSHA); got != c.want {
+			t.Errorf("resolveImageTag(%q,%q,%q) = %q, want %q",
+				c.strategy, c.version, c.gitSHA, got, c.want)
+		}
+	}
+}

--- a/internal/cli/build_platform_test.go
+++ b/internal/cli/build_platform_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func argIndex(args []string, want string) int {
+	for i, a := range args {
+		if a == want {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestBuildArgsIncludesPlatform(t *testing.T) {
+	// The Mac-safe default: a single linux/amd64 platform must reach the builder
+	// so a macOS/arm64 dev build runs on an amd64 cluster (ADR 0041).
+	args := buildArgs("ghcr.io/org/etl:v1", "Dockerfile", ".", []string{"linux/amd64"})
+
+	if args[0] != "build" {
+		t.Errorf("args[0] = %q, want build", args[0])
+	}
+	i := argIndex(args, "--platform")
+	if i < 0 || i+1 >= len(args) || args[i+1] != "linux/amd64" {
+		t.Fatalf("want --platform linux/amd64 in %v", args)
+	}
+	// The image, dockerfile and context must still be present.
+	if argIndex(args, "ghcr.io/org/etl:v1") < 0 || argIndex(args, "Dockerfile") < 0 {
+		t.Errorf("args missing image/dockerfile: %v", args)
+	}
+}
+
+func TestBuildArgsOmitsPlatformWhenEmpty(t *testing.T) {
+	args := buildArgs("img", "Dockerfile", ".", nil)
+	if argIndex(args, "--platform") != -1 {
+		t.Errorf("expected no --platform when platforms empty: %v", args)
+	}
+}
+
+func TestBuildArgsJoinsMultiplePlatforms(t *testing.T) {
+	args := buildArgs("img", "Dockerfile", ".", []string{"linux/amd64", "linux/arm64"})
+	i := argIndex(args, "--platform")
+	if i < 0 || args[i+1] != "linux/amd64,linux/arm64" {
+		t.Errorf("want joined platforms, got %v", args)
+	}
+	if !strings.HasPrefix(args[i+1], "linux/amd64") {
+		t.Errorf("platform list order changed: %v", args)
+	}
+}

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -97,7 +97,11 @@ func runCompile(cmd *cobra.Command, dir string, o compileOptions) error {
 		return eerr
 	}
 	if o.build {
-		if berr := buildImage(cmd, o.builder, o.image, filepath.Join(dir, o.dockerfile), dir); berr != nil {
+		var platforms []string
+		if cfg.Build != nil {
+			platforms = cfg.Build.Platforms
+		}
+		if berr := buildImage(cmd, o.builder, o.image, filepath.Join(dir, o.dockerfile), dir, platforms); berr != nil {
 			return berr
 		}
 	}
@@ -137,12 +141,25 @@ func checkImageFlags(cmd *cobra.Command, build, push bool, image string) error {
 	return nil
 }
 
+// buildArgs assembles the builder argv for a DAG image build. When platforms is
+// non-empty it injects `--platform a,b`, so a deploy can target the cluster's
+// architecture instead of the host's — the Mac-safe default linux/amd64 (ADR
+// 0041). A single platform works with a plain `docker build`; a multi-platform
+// list is the caller's signal to route through buildx (the deploy command does).
+func buildArgs(image, dockerfile, contextDir string, platforms []string) []string {
+	args := []string{"build"}
+	if len(platforms) > 0 {
+		args = append(args, "--platform", strings.Join(platforms, ","))
+	}
+	return append(args, "-t", image, "-f", dockerfile, contextDir)
+}
+
 // buildImage shells out to the configured builder to build the DAG image
 // out-of-process (ADR 0015: no Docker SDK in our binaries). The build context
-// is the DAG directory.
-func buildImage(cmd *cobra.Command, builder, image, dockerfile, contextDir string) error {
+// is the DAG directory; platforms selects the target architecture(s).
+func buildImage(cmd *cobra.Command, builder, image, dockerfile, contextDir string, platforms []string) error {
 	//nolint:gosec // G204: builder is operator-configured by design (ADR 0015).
-	bc := exec.CommandContext(cmdContext(cmd), builder, "build", "-t", image, "-f", dockerfile, contextDir)
+	bc := exec.CommandContext(cmdContext(cmd), builder, buildArgs(image, dockerfile, contextDir, platforms)...)
 	bc.Stdout = cmd.OutOrStdout()
 	bc.Stderr = cmd.ErrOrStderr()
 	if err := bc.Run(); err != nil {

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -212,6 +212,17 @@ func gitVersion(ctx context.Context) string {
 	return strings.TrimSpace(string(out))
 }
 
+// gitSHA returns the short commit hash, or "" when the project is not in git —
+// so a deploy with tag_strategy git_sha gets a genuine per-commit tag and falls
+// back to the version label otherwise.
+func gitSHA(ctx context.Context) string {
+	out, err := exec.CommandContext(ctx, "git", "rev-parse", "--short", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
 // resolveParserCommand returns the explicit --parser-cmd value when set,
 // otherwise the command resolved from configuration.
 func resolveParserCommand(cmd *cobra.Command, explicit string) (string, error) {

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// requireRegistry enforces ADR 0041's hard prerequisite: a Pro deploy pushes the
+// DAG image to a registry the cluster can pull from, so a configured registry is
+// mandatory. It returns a loud, actionable error (never a silent attempt) when
+// the registry URL or image name is missing — Lite runs locally and needs none,
+// but deploy does, full stop.
+func requireRegistry(cfg *domain.LeoflowConfig) error {
+	if cfg != nil && cfg.Registry != nil &&
+		strings.TrimSpace(cfg.Registry.URL) != "" && strings.TrimSpace(cfg.Registry.ImageName) != "" {
+		return nil
+	}
+	return fmt.Errorf(`deploy requires a container registry, but none is configured.
+  A Pro deploy pushes the DAG image to a registry your cluster can pull from
+  (Lite runs locally and needs none). Add to leoflow.yaml:
+
+      registry:
+        url: ghcr.io/<your-org>     # or ECR / Artifact Registry / ACR / private
+        image_name: <name>
+
+  Then authenticate your builder once:  docker login ghcr.io`)
+}

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -1,11 +1,55 @@
 package cli
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 
+	"github.com/spf13/cobra"
+
+	"github.com/neochaotic/leoflow/internal/config"
 	"github.com/neochaotic/leoflow/internal/domain"
 )
+
+// deployOptions holds the resolved flags for a deploy run.
+type deployOptions struct {
+	serverURL  string
+	token      string
+	builder    string
+	dockerfile string
+	dagVersion string
+}
+
+// newDeployCommand builds `leoflow deploy [path]`: the pipeline-less promotion of
+// a DAG to a Pro control plane (ADR 0041). It reuses the compile/build/push
+// primitives, then re-pins the image by digest and registers the dag.json — one
+// verb for what is otherwise compile --build --push + push by hand.
+func newDeployCommand() *cobra.Command {
+	var o deployOptions
+	cmd := &cobra.Command{
+		Use:   "deploy [path]",
+		Short: "Build, push, and register a DAG to a control plane (Pro).",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir := "."
+			if len(args) == 1 {
+				dir = args[0]
+			}
+			return runDeploy(cmd, dir, o)
+		},
+	}
+	cmd.Flags().StringVar(&o.serverURL, "server", "", "control plane base URL (default: config server_url)")
+	cmd.Flags().StringVar(&o.token, "token", os.Getenv("LEOFLOW_TOKEN"), "JWT bearer token (default: config token)")
+	cmd.Flags().StringVar(&o.builder, "builder", "docker", "image build tool to shell out to (e.g. docker, podman, nerdctl)")
+	cmd.Flags().StringVar(&o.dockerfile, "dockerfile", "Dockerfile", "Dockerfile path relative to the DAG directory")
+	cmd.Flags().StringVar(&o.dagVersion, "dag-version", "", "DAG version label (default: git describe, else dev)")
+	return cmd
+}
 
 // requireRegistry enforces ADR 0041's hard prerequisite: a Pro deploy pushes the
 // DAG image to a registry the cluster can pull from, so a configured registry is
@@ -26,4 +70,127 @@ func requireRegistry(cfg *domain.LeoflowConfig) error {
         image_name: <name>
 
   Then authenticate your builder once:  docker login ghcr.io`)
+}
+
+// repinImageInSpec rewrites the compiled dag.json's image field to the
+// digest-pinned reference, preserving every other field, so Pro pulls exactly
+// the bytes that were built (ADR 0003 + 0041). It round-trips through a generic
+// map so unknown/future fields survive untouched.
+func repinImageInSpec(data []byte, digestRef string) ([]byte, error) {
+	var spec map[string]any
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return nil, fmt.Errorf("parsing compiled dag.json: %w", err)
+	}
+	spec["image"] = digestRef
+	out, err := json.Marshal(spec)
+	if err != nil {
+		return nil, fmt.Errorf("encoding re-pinned dag.json: %w", err)
+	}
+	return out, nil
+}
+
+// deployImageRef composes the pushed image reference for a project from its
+// registry config and the resolved version, applying the tag strategy.
+func deployImageRef(cfg *domain.LeoflowConfig, version string) string {
+	tag := resolveImageTag(cfg.Registry.TagStrategy, version, version)
+	return composeImageRef(cfg.Registry.URL, cfg.Registry.ImageName, tag)
+}
+
+// resolveServerToken applies the deploy auth precedence: --server/--token, then
+// LEOFLOW_* env (via the token flag default), then the persisted config written
+// by `leoflow auth login`.
+func resolveServerToken(cmd *cobra.Command, serverFlag, tokenFlag string) (serverURL, token string, err error) {
+	serverURL, token = serverFlag, tokenFlag
+	if serverURL == "" || token == "" {
+		cfg, cerr := config.Load(configFilePath(cmd), cmd.Flags())
+		if cerr != nil {
+			return "", "", cerr
+		}
+		if serverURL == "" {
+			serverURL = cfg.ServerURL
+		}
+		if token == "" {
+			token = cfg.Token
+		}
+	}
+	return serverURL, token, nil
+}
+
+// runDeploy orchestrates the pipeline-less promotion: validate the project,
+// enforce the registry, build+push the image for the target platform, re-pin it
+// by digest into dag.json, and register that with the control plane.
+func runDeploy(cmd *cobra.Command, dir string, o deployOptions) error {
+	cfg, err := loadProjectConfig(dir)
+	if err != nil {
+		return err
+	}
+	if verr := cfg.Validate(); verr != nil {
+		return fmt.Errorf("invalid %s: %w", projectConfigPath(dir), verr)
+	}
+	if rerr := requireRegistry(cfg); rerr != nil {
+		return rerr
+	}
+
+	serverURL, token, serr := resolveServerToken(cmd, o.serverURL, o.token)
+	if serr != nil {
+		return serr
+	}
+
+	version := o.dagVersion
+	if version == "" {
+		version = gitVersion(cmdContext(cmd))
+	}
+	image := deployImageRef(cfg, version)
+
+	output := filepath.Join(dir, "dag.json")
+	co := compileOptions{
+		output:     output,
+		image:      image,
+		builder:    o.builder,
+		dockerfile: o.dockerfile,
+		dagVersion: version,
+		build:      true,
+		push:       true,
+	}
+	if cerr := runCompile(cmd, dir, co); cerr != nil {
+		return cerr
+	}
+
+	digestRef, derr := imageDigest(cmd, o.builder, image)
+	if derr != nil {
+		return derr
+	}
+	return registerDeployedDAG(cmdContext(cmd), cmd.OutOrStdout(), serverURL, token, output, digestRef, version)
+}
+
+// registerDeployedDAG re-pins the compiled dag.json to the pushed image's digest
+// and registers it with the control plane, then prints a per-phase summary. It
+// is split from runDeploy so the post-build flow (which needs no builder) is
+// unit-testable against a fake control plane.
+func registerDeployedDAG(ctx context.Context, out io.Writer, serverURL, token, output, digestRef, version string) error {
+	data, rerr := os.ReadFile(output) //nolint:gosec // output path is operator-controlled (the DAG dir).
+	if rerr != nil {
+		return fmt.Errorf("reading %s: %w", output, rerr)
+	}
+	repinned, perr := repinImageInSpec(data, digestRef)
+	if perr != nil {
+		return perr
+	}
+	if werr := os.WriteFile(output, repinned, 0o600); werr != nil {
+		return fmt.Errorf("writing %s: %w", output, werr)
+	}
+	var spec domain.DAGSpec
+	if jerr := json.Unmarshal(repinned, &spec); jerr != nil {
+		return fmt.Errorf("parsing compiled dag.json: %w", jerr)
+	}
+	status, body, uerr := pushVersion(ctx, serverURL, token, spec.DagID, repinned)
+	if uerr != nil {
+		return uerr
+	}
+	if status >= http.StatusMultipleChoices {
+		return fmt.Errorf("server returned %d: %s", status, body)
+	}
+	_, err := fmt.Fprintf(out,
+		"Deployed %s -> %s\n  image %s\n  registered version %s\n", spec.DagID, serverURL, digestRef, version)
+	return err
 }

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -28,6 +28,7 @@ type deployOptions struct {
 	all        bool
 	skipBuild  bool
 	trigger    bool
+	yes        bool
 }
 
 // newDeployCommand builds `leoflow deploy [path]`: the pipeline-less promotion of
@@ -47,6 +48,7 @@ func newDeployCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&o.all, "all", false, "deploy every DAG project in the workspace")
 	cmd.Flags().BoolVar(&o.skipBuild, "skip-build", false, "re-use the already-built image (promote without rebuilding)")
 	cmd.Flags().BoolVar(&o.trigger, "trigger", false, "trigger a run immediately after registering")
+	cmd.Flags().BoolVarP(&o.yes, "yes", "y", false, "skip the confirmation prompt (for automation)")
 	cmd.Flags().StringVar(&o.serverURL, "server", "", "control plane base URL (default: config server_url)")
 	cmd.Flags().StringVar(&o.token, "token", os.Getenv("LEOFLOW_TOKEN"), "JWT bearer token (default: config token)")
 	cmd.Flags().StringVar(&o.builder, "builder", "docker", "image build tool to shell out to (e.g. docker, podman, nerdctl)")
@@ -115,6 +117,14 @@ func deployAll(cmd *cobra.Command, o deployOptions) error {
 		return fmt.Errorf("no DAG projects found in workspace %s", wsDir)
 	}
 	out, errOut := cmd.OutOrStdout(), cmd.ErrOrStderr()
+	if serverURL, _, terr := resolveServerToken(cmd, o.serverURL, o.token); terr == nil &&
+		shouldConfirm(serverURL, o.yes, cmdInteractive(cmd)) {
+		target := fmt.Sprintf("%d DAG(s) from %s", len(ws.Projects), wsDir)
+		if !confirmDeploy(cmd.InOrStdin(), out, target, serverURL) {
+			return fmt.Errorf("deploy aborted")
+		}
+	}
+	o.yes = true // confirmed once for the whole workspace; no per-project prompts
 	var failed []string
 	for _, p := range ws.Projects {
 		devPrintf(out, "==> deploying %s (%s)\n", p.DagID, p.Path)
@@ -214,6 +224,10 @@ func runDeploy(cmd *cobra.Command, dir string, o deployOptions) error {
 	serverURL, token, serr := resolveServerToken(cmd, o.serverURL, o.token)
 	if serr != nil {
 		return serr
+	}
+	if shouldConfirm(serverURL, o.yes, cmdInteractive(cmd)) &&
+		!confirmDeploy(cmd.InOrStdin(), cmd.OutOrStdout(), dir, serverURL) {
+		return fmt.Errorf("deploy aborted")
 	}
 
 	version := o.dagVersion

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -24,6 +26,8 @@ type deployOptions struct {
 	dockerfile string
 	dagVersion string
 	all        bool
+	skipBuild  bool
+	trigger    bool
 }
 
 // newDeployCommand builds `leoflow deploy [path]`: the pipeline-less promotion of
@@ -41,6 +45,8 @@ func newDeployCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&o.all, "all", false, "deploy every DAG project in the workspace")
+	cmd.Flags().BoolVar(&o.skipBuild, "skip-build", false, "re-use the already-built image (promote without rebuilding)")
+	cmd.Flags().BoolVar(&o.trigger, "trigger", false, "trigger a run immediately after registering")
 	cmd.Flags().StringVar(&o.serverURL, "server", "", "control plane base URL (default: config server_url)")
 	cmd.Flags().StringVar(&o.token, "token", os.Getenv("LEOFLOW_TOKEN"), "JWT bearer token (default: config token)")
 	cmd.Flags().StringVar(&o.builder, "builder", "docker", "image build tool to shell out to (e.g. docker, podman, nerdctl)")
@@ -223,8 +229,8 @@ func runDeploy(cmd *cobra.Command, dir string, o deployOptions) error {
 		builder:    o.builder,
 		dockerfile: o.dockerfile,
 		dagVersion: version,
-		build:      true,
-		push:       true,
+		build:      !o.skipBuild,
+		push:       !o.skipBuild,
 	}
 	if cerr := runCompile(cmd, dir, co); cerr != nil {
 		return cerr
@@ -234,37 +240,81 @@ func runDeploy(cmd *cobra.Command, dir string, o deployOptions) error {
 	if derr != nil {
 		return derr
 	}
-	return registerDeployedDAG(cmdContext(cmd), cmd.OutOrStdout(), serverURL, token, output, digestRef, version)
+	ctx, out := cmdContext(cmd), cmd.OutOrStdout()
+	dagID, rerr := registerDeployedDAG(ctx, out, serverURL, token, output, digestRef, version)
+	if rerr != nil {
+		return rerr
+	}
+	if o.trigger {
+		return triggerDeployRun(ctx, out, serverURL, token, dagID)
+	}
+	return nil
 }
 
 // registerDeployedDAG re-pins the compiled dag.json to the pushed image's digest
 // and registers it with the control plane, then prints a per-phase summary. It
 // is split from runDeploy so the post-build flow (which needs no builder) is
 // unit-testable against a fake control plane.
-func registerDeployedDAG(ctx context.Context, out io.Writer, serverURL, token, output, digestRef, version string) error {
+func registerDeployedDAG(ctx context.Context, out io.Writer, serverURL, token, output, digestRef, version string) (dagID string, err error) {
 	data, rerr := os.ReadFile(output) //nolint:gosec // output path is operator-controlled (the DAG dir).
 	if rerr != nil {
-		return fmt.Errorf("reading %s: %w", output, rerr)
+		return "", fmt.Errorf("reading %s: %w", output, rerr)
 	}
 	repinned, perr := repinImageInSpec(data, digestRef)
 	if perr != nil {
-		return perr
+		return "", perr
 	}
 	if werr := os.WriteFile(output, repinned, 0o600); werr != nil {
-		return fmt.Errorf("writing %s: %w", output, werr)
+		return "", fmt.Errorf("writing %s: %w", output, werr)
 	}
 	var spec domain.DAGSpec
 	if jerr := json.Unmarshal(repinned, &spec); jerr != nil {
-		return fmt.Errorf("parsing compiled dag.json: %w", jerr)
+		return "", fmt.Errorf("parsing compiled dag.json: %w", jerr)
 	}
 	status, body, uerr := pushVersion(ctx, serverURL, token, spec.DagID, repinned)
 	if uerr != nil {
-		return uerr
+		return "", uerr
 	}
 	if status >= http.StatusMultipleChoices {
-		return fmt.Errorf("server returned %d: %s", status, body)
+		return "", fmt.Errorf("server returned %d: %s", status, body)
 	}
-	_, err := fmt.Fprintf(out,
-		"Deployed %s -> %s\n  image %s\n  registered version %s\n", spec.DagID, serverURL, digestRef, version)
+	if _, werr := fmt.Fprintf(out,
+		"Deployed %s -> %s\n  image %s\n  registered version %s\n", spec.DagID, serverURL, digestRef, version); werr != nil {
+		return "", werr
+	}
+	return spec.DagID, nil
+}
+
+// triggerDeployRun kicks a manual run of the just-registered DAG, the --trigger
+// opt-in (deploy registers only by default). It posts to the Airflow-compatible
+// trigger endpoint with a unique manual run id.
+func triggerDeployRun(ctx context.Context, out io.Writer, serverURL, token, dagID string) error {
+	runID := fmt.Sprintf("manual__%d", time.Now().UTC().Unix())
+	payload := []byte(fmt.Sprintf(`{"dag_run_id":%q}`, runID))
+	url := strings.TrimRight(serverURL, "/") + "/api/v2/dags/" + dagID + "/dagRuns"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("building trigger request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
+	if err != nil {
+		return fmt.Errorf("triggering run for %q: %w", dagID, err)
+	}
+	raw, readErr := io.ReadAll(resp.Body)
+	closeErr := resp.Body.Close()
+	if readErr != nil {
+		return fmt.Errorf("reading trigger response: %w", readErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("closing trigger response: %w", closeErr)
+	}
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("trigger returned %d: %s", resp.StatusCode, string(raw))
+	}
+	_, err = fmt.Fprintf(out, "  triggered run %s\n", runID)
 	return err
 }

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -23,6 +23,7 @@ type deployOptions struct {
 	builder    string
 	dockerfile string
 	dagVersion string
+	all        bool
 }
 
 // newDeployCommand builds `leoflow deploy [path]`: the pipeline-less promotion of
@@ -32,23 +33,96 @@ type deployOptions struct {
 func newDeployCommand() *cobra.Command {
 	var o deployOptions
 	cmd := &cobra.Command{
-		Use:   "deploy [path]",
+		Use:   "deploy [path | dag_id]",
 		Short: "Build, push, and register a DAG to a control plane (Pro).",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			dir := "."
-			if len(args) == 1 {
-				dir = args[0]
-			}
-			return runDeploy(cmd, dir, o)
+			return runDeployTarget(cmd, args, o)
 		},
 	}
+	cmd.Flags().BoolVar(&o.all, "all", false, "deploy every DAG project in the workspace")
 	cmd.Flags().StringVar(&o.serverURL, "server", "", "control plane base URL (default: config server_url)")
 	cmd.Flags().StringVar(&o.token, "token", os.Getenv("LEOFLOW_TOKEN"), "JWT bearer token (default: config token)")
 	cmd.Flags().StringVar(&o.builder, "builder", "docker", "image build tool to shell out to (e.g. docker, podman, nerdctl)")
 	cmd.Flags().StringVar(&o.dockerfile, "dockerfile", "Dockerfile", "Dockerfile path relative to the DAG directory")
 	cmd.Flags().StringVar(&o.dagVersion, "dag-version", "", "DAG version label (default: git describe, else dev)")
 	return cmd
+}
+
+// runDeployTarget resolves what to deploy from the args and flags: --all (every
+// project in the workspace), a directory path, or a dag_id (resolved to its
+// subdir in the multi-DAG workspace). A bare invocation deploys the current dir.
+func runDeployTarget(cmd *cobra.Command, args []string, o deployOptions) error {
+	if o.all {
+		if len(args) > 0 {
+			return fmt.Errorf("--all deploys the whole workspace; do not also pass a path or dag_id")
+		}
+		return deployAll(cmd, o)
+	}
+	target := "."
+	if len(args) == 1 {
+		target = args[0]
+	}
+	if info, err := os.Stat(target); err == nil && info.IsDir() {
+		return runDeploy(cmd, target, o)
+	}
+	if len(args) == 1 {
+		dir, rerr := resolveProjectDir(defaultWorkspace(cmd), target)
+		if rerr != nil {
+			return rerr
+		}
+		return runDeploy(cmd, dir, o)
+	}
+	return runDeploy(cmd, target, o)
+}
+
+// resolveProjectDir maps a dag_id to its project directory within the workspace,
+// erroring (with the available ids) when no project matches — so a typo is a
+// loud, helpful failure rather than a silent wrong-DAG deploy.
+func resolveProjectDir(workspaceDir, dagID string) (string, error) {
+	ws, err := ResolveWorkspace(workspaceDir)
+	if err != nil {
+		return "", err
+	}
+	available := make([]string, 0, len(ws.Projects))
+	for _, p := range ws.Projects {
+		if p.DagID == dagID {
+			return p.Path, nil
+		}
+		available = append(available, p.DagID)
+	}
+	return "", fmt.Errorf("no DAG %q in workspace %s; available: %s",
+		dagID, workspaceDir, strings.Join(available, ", "))
+}
+
+// deployAll deploys every project in the workspace, best-effort: it builds,
+// pushes, and registers each, prints a per-DAG summary, and returns a non-zero
+// error if any failed (so CI catches it) — partial pushes are not rolled back
+// (content-addressed images make a re-deploy idempotent). ADR 0041.
+func deployAll(cmd *cobra.Command, o deployOptions) error {
+	wsDir := defaultWorkspace(cmd)
+	ws, err := ResolveWorkspace(wsDir)
+	if err != nil {
+		return err
+	}
+	if len(ws.Projects) == 0 {
+		return fmt.Errorf("no DAG projects found in workspace %s", wsDir)
+	}
+	out, errOut := cmd.OutOrStdout(), cmd.ErrOrStderr()
+	var failed []string
+	for _, p := range ws.Projects {
+		devPrintf(out, "==> deploying %s (%s)\n", p.DagID, p.Path)
+		if derr := runDeploy(cmd, p.Path, o); derr != nil {
+			failed = append(failed, p.DagID)
+			devPrintf(errOut, "    FAILED %s: %v\n", p.DagID, derr)
+		}
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("%d of %d deploys failed: %s",
+			len(failed), len(ws.Projects), strings.Join(failed, ", "))
+	}
+	_, err = fmt.Fprintf(out, "Deployed %d DAG(s) from %s\n", len(ws.Projects), wsDir)
+	return err
 }
 
 // requireRegistry enforces ADR 0041's hard prerequisite: a Pro deploy pushes the

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -245,6 +245,7 @@ func runDeploy(cmd *cobra.Command, dir string, o deployOptions) error {
 	if rerr != nil {
 		return rerr
 	}
+	surfaceConnections(out, output)
 	if o.trigger {
 		return triggerDeployRun(ctx, out, serverURL, token, dagID)
 	}

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -180,9 +180,11 @@ func repinImageInSpec(data []byte, digestRef string) ([]byte, error) {
 }
 
 // deployImageRef composes the pushed image reference for a project from its
-// registry config and the resolved version, applying the tag strategy.
-func deployImageRef(cfg *domain.LeoflowConfig, version string) string {
-	tag := resolveImageTag(cfg.Registry.TagStrategy, version, version)
+// registry config, the resolved version, and the git sha, applying the tag
+// strategy (so tag_strategy: git_sha yields a genuine commit tag, not the
+// version label).
+func deployImageRef(cfg *domain.LeoflowConfig, version, sha string) string {
+	tag := resolveImageTag(cfg.Registry.TagStrategy, version, sha)
 	return composeImageRef(cfg.Registry.URL, cfg.Registry.ImageName, tag)
 }
 
@@ -234,7 +236,7 @@ func runDeploy(cmd *cobra.Command, dir string, o deployOptions) error {
 	if version == "" {
 		version = gitVersion(cmdContext(cmd))
 	}
-	image := deployImageRef(cfg, version)
+	image := deployImageRef(cfg, version, gitSHA(cmdContext(cmd)))
 
 	output := filepath.Join(dir, "dag.json")
 	co := compileOptions{

--- a/internal/cli/deploy_confirm.go
+++ b/internal/cli/deploy_confirm.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// isLoopback reports whether the control-plane URL points at the local machine
+// (a Lite/dev target). Deploys to a non-loopback server are the ones worth a
+// confirmation; loopback ones are not.
+func isLoopback(serverURL string) bool {
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		return false
+	}
+	host := u.Hostname()
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+// shouldConfirm decides whether to prompt before a deploy: only when not already
+// confirmed (--yes), the session is interactive, and the target is a real
+// (non-loopback) control plane. CI (non-interactive) and Lite (loopback) never
+// prompt.
+func shouldConfirm(serverURL string, yes, interactive bool) bool {
+	return !yes && interactive && !isLoopback(serverURL)
+}
+
+// cmdInteractive reports whether the command's stdin is a terminal, so an
+// automated/piped invocation is never blocked on a prompt. It reuses the
+// x/term-based isInteractive (which, unlike a ModeCharDevice check, tells a TTY
+// from a pipe).
+func cmdInteractive(cmd *cobra.Command) bool {
+	f, ok := cmd.InOrStdin().(*os.File)
+	return ok && isInteractive(f)
+}
+
+// confirmDeploy prints the prompt and reads a yes/no answer from in, returning
+// true only on an explicit y/yes.
+func confirmDeploy(in io.Reader, out io.Writer, target, serverURL string) bool {
+	devPrintf(out, "Deploy %s -> %s? [y/N] ", target, serverURL)
+	line, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && err != io.EOF { // EOF still yields the typed answer
+		return false
+	}
+	answer := strings.TrimSpace(strings.ToLower(line))
+	return answer == "y" || answer == "yes"
+}

--- a/internal/cli/deploy_confirm_test.go
+++ b/internal/cli/deploy_confirm_test.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsLoopback(t *testing.T) {
+	cases := map[string]bool{
+		"http://localhost:8080":   true,
+		"http://127.0.0.1":        true,
+		"http://[::1]:8080":       true,
+		"https://pro.example.com": false,
+		"http://10.0.0.5:8080":    false,
+	}
+	for url, want := range cases {
+		if got := isLoopback(url); got != want {
+			t.Errorf("isLoopback(%q) = %v, want %v", url, got, want)
+		}
+	}
+}
+
+func TestShouldConfirm(t *testing.T) {
+	// Prompt only when interactive, not --yes, and a real (non-loopback) server.
+	if !shouldConfirm("https://pro", false, true) {
+		t.Error("want confirm for an interactive deploy to a real server")
+	}
+	if shouldConfirm("https://pro", true, true) {
+		t.Error("--yes must skip the prompt")
+	}
+	if shouldConfirm("https://pro", false, false) {
+		t.Error("non-interactive (CI) must skip the prompt")
+	}
+	if shouldConfirm("http://localhost:8080", false, true) {
+		t.Error("loopback (Lite) must skip the prompt")
+	}
+}
+
+func TestConfirmDeploy(t *testing.T) {
+	for in, want := range map[string]bool{"y\n": true, "yes\n": true, "n\n": false, "\n": false, "nope\n": false} {
+		var out strings.Builder
+		if got := confirmDeploy(strings.NewReader(in), &out, "etl", "https://pro"); got != want {
+			t.Errorf("confirmDeploy(%q) = %v, want %v", in, got, want)
+		}
+		if !strings.Contains(out.String(), "Deploy etl") {
+			t.Errorf("prompt = %q, want it to name the target", out.String())
+		}
+	}
+}

--- a/internal/cli/deploy_confirm_test.go
+++ b/internal/cli/deploy_confirm_test.go
@@ -12,6 +12,7 @@ func TestIsLoopback(t *testing.T) {
 		"http://[::1]:8080":       true,
 		"https://pro.example.com": false,
 		"http://10.0.0.5:8080":    false,
+		"://malformed":            false, // unparseable URL is treated as non-loopback
 	}
 	for url, want := range cases {
 		if got := isLoopback(url); got != want {

--- a/internal/cli/deploy_connections.go
+++ b/internal/cli/deploy_connections.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"sort"
+	"strings"
+)
+
+// collectConnIDs extracts the connection ids a compiled DAG references, scanning
+// each task and its operator_args for any key whose name contains "conn_id". The
+// result is sorted and de-duplicated. This is how deploy surfaces the runtime
+// dependency the artifact does NOT carry: connections live in the control-plane
+// DB, not in the image+dag.json, so a deploy can succeed yet the DAG fail at
+// runtime if they are not created on Pro first (ADR 0041).
+func collectConnIDs(dagJSON []byte) []string {
+	var spec struct {
+		Tasks []map[string]any `json:"tasks"`
+	}
+	if err := json.Unmarshal(dagJSON, &spec); err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var ids []string
+	add := func(v any) {
+		if s, ok := v.(string); ok && s != "" && !seen[s] {
+			seen[s] = true
+			ids = append(ids, s)
+		}
+	}
+	scan := func(m map[string]any) {
+		for k, v := range m {
+			if strings.Contains(strings.ToLower(k), "conn_id") {
+				add(v)
+			}
+		}
+	}
+	for _, t := range spec.Tasks {
+		scan(t)
+		if args, ok := t["operator_args"].(map[string]any); ok {
+			scan(args)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// surfaceConnections reads the compiled dag.json and, when the DAG references any
+// connection, prints a reminder to create them on the control plane — never a
+// silent gap between "deploy succeeded" and "the DAG actually runs".
+func surfaceConnections(out io.Writer, dagJSONPath string) {
+	data, err := os.ReadFile(dagJSONPath) //nolint:gosec // path is the operator-controlled DAG dir.
+	if err != nil {
+		return
+	}
+	ids := collectConnIDs(data)
+	if len(ids) == 0 {
+		return
+	}
+	devPrintf(out, "  note: this DAG expects connection(s): %s\n", strings.Join(ids, ", "))
+	devPrintf(out, "        create them on the control plane (UI or API) before the run; "+
+		"they are not part of the image (ADR 0041).\n")
+}

--- a/internal/cli/deploy_connections_test.go
+++ b/internal/cli/deploy_connections_test.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestCollectConnIDs(t *testing.T) {
+	dagJSON := []byte(`{
+		"dag_id":"etl",
+		"tasks":[
+			{"task_id":"q","type":"airflow_operator",
+			 "operator_args":{"snowflake_conn_id":"sf","sql":"SELECT 1"}},
+			{"task_id":"load","type":"python","conn_id":"pg"},
+			{"task_id":"dup","type":"airflow_operator","operator_args":{"conn_id":"pg"}},
+			{"task_id":"none","type":"python"}
+		]
+	}`)
+	got := collectConnIDs(dagJSON)
+	want := []string{"pg", "sf"} // sorted, de-duped (pg appears twice)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("collectConnIDs = %v, want %v", got, want)
+	}
+}
+
+func TestCollectConnIDsNoneWhenAbsent(t *testing.T) {
+	if got := collectConnIDs([]byte(`{"dag_id":"x","tasks":[{"task_id":"a","type":"python"}]}`)); len(got) != 0 {
+		t.Errorf("expected no conn ids, got %v", got)
+	}
+}
+
+func TestSurfaceConnectionsPrintsReminder(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "dag.json")
+	if err := os.WriteFile(out, []byte(`{"dag_id":"etl","tasks":[{"task_id":"q","type":"airflow_operator","operator_args":{"conn_id":"sf"}}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var sb strings.Builder
+	surfaceConnections(&sb, out)
+	if !strings.Contains(sb.String(), "sf") || !strings.Contains(sb.String(), "connection") {
+		t.Errorf("reminder = %q, want it to name the connection", sb.String())
+	}
+}
+
+func TestSurfaceConnectionsSilentWhenNone(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "dag.json")
+	if err := os.WriteFile(out, []byte(`{"dag_id":"etl","tasks":[{"task_id":"a","type":"python"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var sb strings.Builder
+	surfaceConnections(&sb, out)
+	if sb.String() != "" {
+		t.Errorf("expected no output when the DAG has no connections, got %q", sb.String())
+	}
+}

--- a/internal/cli/deploy_test.go
+++ b/internal/cli/deploy_test.go
@@ -34,9 +34,12 @@ func TestRegisterDeployedDAGRepinsAndRegisters(t *testing.T) {
 	digest := "ghcr.io/org/etl@sha256:cafef00d"
 
 	var sb strings.Builder
-	err := registerDeployedDAG(context.Background(), &sb, srv.URL, "tok", out, digest, "v1")
+	dagID, err := registerDeployedDAG(context.Background(), &sb, srv.URL, "tok", out, digest, "v1")
 	if err != nil {
 		t.Fatalf("registerDeployedDAG: %v", err)
+	}
+	if dagID != "etl" {
+		t.Errorf("dagID = %q, want etl", dagID)
 	}
 	if gotPath != "/api/v2/dags/etl/versions" {
 		t.Errorf("path = %q", gotPath)
@@ -68,9 +71,48 @@ func TestRegisterDeployedDAGSurfacesServerError(t *testing.T) {
 	if err := os.WriteFile(out, []byte(pushSpec), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	err := registerDeployedDAG(context.Background(), io.Discard, srv.URL, "tok", out, "r@sha256:x", "v1")
+	_, err := registerDeployedDAG(context.Background(), io.Discard, srv.URL, "tok", out, "r@sha256:x", "v1")
 	if err == nil {
 		t.Error("expected an error when the control plane rejects the register")
+	}
+}
+
+func TestTriggerDeployRunPostsToDagRuns(t *testing.T) {
+	var gotPath, gotAuth, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	var sb strings.Builder
+	if err := triggerDeployRun(context.Background(), &sb, srv.URL, "tok", "etl"); err != nil {
+		t.Fatalf("triggerDeployRun: %v", err)
+	}
+	if gotPath != "/api/v2/dags/etl/dagRuns" {
+		t.Errorf("path = %q, want the dagRuns trigger endpoint", gotPath)
+	}
+	if gotAuth != "Bearer tok" {
+		t.Errorf("auth = %q", gotAuth)
+	}
+	if !strings.Contains(gotBody, "dag_run_id") {
+		t.Errorf("body = %q, want a dag_run_id", gotBody)
+	}
+	if !strings.Contains(sb.String(), "triggered run") {
+		t.Errorf("summary = %q, want a triggered-run line", sb.String())
+	}
+}
+
+func TestTriggerDeployRunSurfacesError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer srv.Close()
+	if err := triggerDeployRun(context.Background(), io.Discard, srv.URL, "tok", "etl"); err == nil {
+		t.Error("expected an error when the trigger is rejected")
 	}
 }
 

--- a/internal/cli/deploy_test.go
+++ b/internal/cli/deploy_test.go
@@ -1,11 +1,172 @@
 package cli
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/neochaotic/leoflow/internal/domain"
 )
+
+func TestRegisterDeployedDAGRepinsAndRegisters(t *testing.T) {
+	var gotPath, gotAuth, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	// A compiled dag.json carrying the tag ref; register must re-pin it to the
+	// digest before posting, and the file on disk must end up re-pinned too.
+	out := filepath.Join(t.TempDir(), "dag.json")
+	if err := os.WriteFile(out, []byte(pushSpec), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	digest := "ghcr.io/org/etl@sha256:cafef00d"
+
+	var sb strings.Builder
+	err := registerDeployedDAG(context.Background(), &sb, srv.URL, "tok", out, digest, "v1")
+	if err != nil {
+		t.Fatalf("registerDeployedDAG: %v", err)
+	}
+	if gotPath != "/api/v2/dags/etl/versions" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if gotAuth != "Bearer tok" {
+		t.Errorf("auth = %q, want Bearer tok", gotAuth)
+	}
+	if !strings.Contains(gotBody, digest) {
+		t.Errorf("posted spec was not re-pinned to the digest: %s", gotBody)
+	}
+	if !strings.Contains(sb.String(), "Deployed etl") {
+		t.Errorf("summary = %q, want a Deployed line", sb.String())
+	}
+	// The on-disk dag.json must also be re-pinned (the immutable artifact).
+	repinned, _ := os.ReadFile(out)
+	if !strings.Contains(string(repinned), digest) {
+		t.Errorf("dag.json on disk was not re-pinned: %s", repinned)
+	}
+}
+
+func TestRegisterDeployedDAGSurfacesServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, "forbidden")
+	}))
+	defer srv.Close()
+
+	out := filepath.Join(t.TempDir(), "dag.json")
+	if err := os.WriteFile(out, []byte(pushSpec), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := registerDeployedDAG(context.Background(), io.Discard, srv.URL, "tok", out, "r@sha256:x", "v1")
+	if err == nil {
+		t.Error("expected an error when the control plane rejects the register")
+	}
+}
+
+func TestDeployRunsPastGuardThenFailsAtCompile(t *testing.T) {
+	// A project WITH a registry passes the guard, so deploy proceeds to resolve
+	// the image ref and invoke compile. With the parser stubbed to a failing
+	// command, the run fails after the guard — exercising the orchestration
+	// middle without a real parser or builder.
+	dir := filepath.Join(t.TempDir(), "proj")
+	if _, _, err := run(t, "init", dir); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	f := filepath.Join(dir, "leoflow.yaml")
+	data, _ := os.ReadFile(f)
+	withRegistry := string(data) + "\nregistry:\n  url: ghcr.io/org\n  image_name: etl\n"
+	if err := os.WriteFile(f, []byte(withRegistry), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("LEOFLOW_PARSER_CMD", "false") // deterministic compile failure, no python
+	if _, _, err := run(t, "deploy", dir, "--server", "http://127.0.0.1:0"); err == nil {
+		t.Error("expected deploy to fail at compile when the parser fails")
+	}
+}
+
+func TestResolveServerTokenPrecedence(t *testing.T) {
+	cmd := newDeployCommand()
+	// Flags win outright — config is not even consulted.
+	srv, tok, err := resolveServerToken(cmd, "https://pro", "flag-tok")
+	if err != nil {
+		t.Fatalf("resolveServerToken: %v", err)
+	}
+	if srv != "https://pro" || tok != "flag-tok" {
+		t.Errorf("flags should win: got server=%q token=%q", srv, tok)
+	}
+}
+
+func TestResolveServerTokenFallsBackToEnv(t *testing.T) {
+	t.Setenv("LEOFLOW_SERVER_URL", "https://env-pro")
+	t.Setenv("LEOFLOW_TOKEN", "env-tok")
+	cmd := newDeployCommand()
+	srv, tok, err := resolveServerToken(cmd, "", "")
+	if err != nil {
+		t.Fatalf("resolveServerToken: %v", err)
+	}
+	if srv != "https://env-pro" || tok != "env-tok" {
+		t.Errorf("config/env fallback: got server=%q token=%q", srv, tok)
+	}
+}
+
+func TestDeployImageRef(t *testing.T) {
+	cfg := &domain.LeoflowConfig{Registry: &domain.RegistryConfig{
+		URL: "ghcr.io/org", ImageName: "etl", TagStrategy: "version",
+	}}
+	if got := deployImageRef(cfg, "v3"); got != "ghcr.io/org/etl:v3" {
+		t.Errorf("ref = %q, want ghcr.io/org/etl:v3", got)
+	}
+}
+
+func TestRepinImageInSpec(t *testing.T) {
+	in := []byte(`{"schema_version":"1.0","dag_id":"etl","dag_version":"v1","image":"ghcr.io/org/etl:v1","tasks":[{"task_id":"a","type":"python","entrypoint":"dag:a"}]}`)
+	out, err := repinImageInSpec(in, "ghcr.io/org/etl@sha256:deadbeef")
+	if err != nil {
+		t.Fatalf("repinImageInSpec: %v", err)
+	}
+	var m map[string]any
+	if uerr := json.Unmarshal(out, &m); uerr != nil {
+		t.Fatalf("output is not valid JSON: %v", uerr)
+	}
+	if m["image"] != "ghcr.io/org/etl@sha256:deadbeef" {
+		t.Errorf("image = %v, want the digest-pinned ref", m["image"])
+	}
+	// Every other field must survive the re-pin untouched.
+	if m["dag_id"] != "etl" || m["dag_version"] != "v1" {
+		t.Errorf("re-pin dropped fields: %v", m)
+	}
+	if tasks, ok := m["tasks"].([]any); !ok || len(tasks) != 1 {
+		t.Errorf("tasks not preserved: %v", m["tasks"])
+	}
+}
+
+func TestDeployCommandRejectsMissingRegistry(t *testing.T) {
+	// A scaffolded project has no registry: deploy must fail at the guard,
+	// before touching any builder or server.
+	dir := filepath.Join(t.TempDir(), "proj")
+	if _, _, err := run(t, "init", dir); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	_, stderr, err := run(t, "deploy", dir)
+	if err == nil {
+		t.Fatal("expected deploy to fail on a project with no registry")
+	}
+	if !strings.Contains(err.Error()+stderr, "registry") {
+		t.Errorf("error should name the missing registry; got err=%v stderr=%q", err, stderr)
+	}
+}
 
 func TestRequireRegistryRejectsUnconfigured(t *testing.T) {
 	// ApplyDefaults instantiates Registry but leaves URL empty — deploy must

--- a/internal/cli/deploy_test.go
+++ b/internal/cli/deploy_test.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+func TestRequireRegistryRejectsUnconfigured(t *testing.T) {
+	// ApplyDefaults instantiates Registry but leaves URL empty — deploy must
+	// still reject it, loudly and actionably (ADR 0041).
+	cfg := &domain.LeoflowConfig{}
+	cfg.ApplyDefaults()
+
+	err := requireRegistry(cfg)
+	if err == nil {
+		t.Fatal("expected requireRegistry to reject a config with no registry URL")
+	}
+	msg := err.Error()
+	for _, want := range []string{"registry", "leoflow.yaml", "docker login"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q; got:\n%s", want, msg)
+		}
+	}
+}
+
+func TestRequireRegistryRejectsMissingImageName(t *testing.T) {
+	cfg := &domain.LeoflowConfig{Registry: &domain.RegistryConfig{URL: "ghcr.io/org"}}
+	if err := requireRegistry(cfg); err == nil {
+		t.Error("expected requireRegistry to reject a registry URL with no image_name")
+	}
+}
+
+func TestRequireRegistryAcceptsConfigured(t *testing.T) {
+	cfg := &domain.LeoflowConfig{Registry: &domain.RegistryConfig{URL: "ghcr.io/org", ImageName: "etl"}}
+	if err := requireRegistry(cfg); err != nil {
+		t.Errorf("requireRegistry on a configured registry: %v", err)
+	}
+}

--- a/internal/cli/deploy_test.go
+++ b/internal/cli/deploy_test.go
@@ -256,11 +256,19 @@ func TestResolveServerTokenFallsBackToEnv(t *testing.T) {
 }
 
 func TestDeployImageRef(t *testing.T) {
-	cfg := &domain.LeoflowConfig{Registry: &domain.RegistryConfig{
-		URL: "ghcr.io/org", ImageName: "etl", TagStrategy: "version",
-	}}
-	if got := deployImageRef(cfg, "v3"); got != "ghcr.io/org/etl:v3" {
-		t.Errorf("ref = %q, want ghcr.io/org/etl:v3", got)
+	base := func(strategy string) *domain.LeoflowConfig {
+		return &domain.LeoflowConfig{Registry: &domain.RegistryConfig{
+			URL: "ghcr.io/org", ImageName: "etl", TagStrategy: strategy,
+		}}
+	}
+	// version strategy tags by the version label.
+	if got := deployImageRef(base("version"), "v3", "1a2b3c4"); got != "ghcr.io/org/etl:v3" {
+		t.Errorf("version: ref = %q, want ghcr.io/org/etl:v3", got)
+	}
+	// git_sha strategy tags by the actual commit sha (the #2 fix — it used to
+	// collapse to the version label).
+	if got := deployImageRef(base("git_sha"), "v3", "1a2b3c4"); got != "ghcr.io/org/etl:1a2b3c4" {
+		t.Errorf("git_sha: ref = %q, want ghcr.io/org/etl:1a2b3c4", got)
 	}
 }
 

--- a/internal/cli/deploy_test.go
+++ b/internal/cli/deploy_test.go
@@ -96,6 +96,98 @@ func TestDeployRunsPastGuardThenFailsAtCompile(t *testing.T) {
 	}
 }
 
+func TestResolveProjectDirFindsByDagID(t *testing.T) {
+	ws := t.TempDir()
+	for _, name := range []string{"alpha", "beta"} {
+		if _, _, err := run(t, "init", filepath.Join(ws, name)); err != nil {
+			t.Fatalf("init %s: %v", name, err)
+		}
+	}
+	spec, err := ResolveWorkspace(ws)
+	if err != nil {
+		t.Fatalf("ResolveWorkspace: %v", err)
+	}
+	if len(spec.Projects) == 0 {
+		t.Fatal("expected discovered projects")
+	}
+	want := spec.Projects[0]
+	got, gerr := resolveProjectDir(ws, want.DagID)
+	if gerr != nil {
+		t.Fatalf("resolveProjectDir(%q): %v", want.DagID, gerr)
+	}
+	if got != want.Path {
+		t.Errorf("dir = %q, want %q", got, want.Path)
+	}
+	if _, err := resolveProjectDir(ws, "definitely-not-a-dag"); err == nil {
+		t.Error("expected an error for an unknown dag_id")
+	}
+}
+
+func TestDeployUnknownDagIDFails(t *testing.T) {
+	ws := t.TempDir()
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("workspace: "+ws+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := run(t, "deploy", "ghost-dag", "--config", cfgPath); err == nil {
+		t.Error("expected deploy of an unknown dag_id to fail")
+	}
+}
+
+func TestDeployAllEmptyWorkspaceFails(t *testing.T) {
+	ws := t.TempDir() // empty: no DAG projects
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("workspace: "+ws+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := run(t, "deploy", "--all", "--config", cfgPath); err == nil {
+		t.Error("expected --all on an empty workspace to fail")
+	}
+}
+
+func TestDeployAllRejectsExtraArg(t *testing.T) {
+	if _, _, err := run(t, "deploy", "somedir", "--all"); err == nil {
+		t.Error("expected --all combined with a path/dag_id to be rejected")
+	}
+}
+
+func TestDeployAllReportsPerProjectFailure(t *testing.T) {
+	// A workspace with one scaffolded project that has no registry: --all must
+	// iterate to it, fail it at the registry guard, and report a non-zero result.
+	ws := t.TempDir()
+	if _, _, err := run(t, "init", filepath.Join(ws, "one")); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("workspace: "+ws+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := run(t, "deploy", "--all", "--config", cfgPath); err == nil {
+		t.Error("expected --all to report the registry-less project's failure")
+	}
+}
+
+func TestDeployByDagIDReachesProjectThenGuard(t *testing.T) {
+	ws := t.TempDir()
+	if _, _, err := run(t, "init", filepath.Join(ws, "solo")); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	spec, err := ResolveWorkspace(ws)
+	if err != nil || len(spec.Projects) == 0 {
+		t.Fatalf("resolve workspace: %v", err)
+	}
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	if werr := os.WriteFile(cfgPath, []byte("workspace: "+ws+"\n"), 0o600); werr != nil {
+		t.Fatal(werr)
+	}
+	// Deploying by the resolved dag_id reaches its project, which has no
+	// registry -> the guard fires. Proves the dag_id->dir resolution path.
+	_, _, derr := run(t, "deploy", spec.Projects[0].DagID, "--config", cfgPath)
+	if derr == nil || !strings.Contains(derr.Error(), "registry") {
+		t.Errorf("want a registry guard error via dag_id resolution, got %v", derr)
+	}
+}
+
 func TestResolveServerTokenPrecedence(t *testing.T) {
 	cmd := newDeployCommand()
 	// Flags win outright — config is not even consulted.

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/neochaotic/leoflow/internal/config"
+)
+
+// newLoginCommand builds `leoflow login`: it exchanges credentials for a JWT at
+// the control plane and persists the token (and server URL) to the config file,
+// so subsequent `push`/`deploy` calls need no auth flags. This is what makes the
+// pipeline-less Lite->Pro loop fluid (login once, deploy many) — ADR 0041.
+func newLoginCommand() *cobra.Command {
+	var serverURL, username, password string
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "Authenticate to a control plane and store the token.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if serverURL == "" {
+				cfg, cerr := config.Load(configFilePath(cmd), cmd.Flags())
+				if cerr != nil {
+					return cerr
+				}
+				serverURL = cfg.ServerURL
+			}
+			token, err := requestToken(cmdContext(cmd), serverURL, username, password)
+			if err != nil {
+				return err
+			}
+			path, perr := sessionConfigPath(cmd)
+			if perr != nil {
+				return perr
+			}
+			if serr := config.PersistSession(path, serverURL, token); serr != nil {
+				return serr
+			}
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Logged in to %s (token saved to %s)\n", serverURL, path)
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&serverURL, "server", "", "control plane base URL (default: config server_url)")
+	cmd.Flags().StringVar(&username, "username", os.Getenv("LEOFLOW_USERNAME"), "username")
+	cmd.Flags().StringVar(&password, "password", os.Getenv("LEOFLOW_PASSWORD"), "password")
+	return cmd
+}
+
+// sessionConfigPath resolves the config file `login` writes to: the --config
+// flag when set, otherwise the default ~/.leoflow/config.yaml. Unlike
+// configFilePath, it returns the default path even when the file does not yet
+// exist, because login is allowed to create it.
+func sessionConfigPath(cmd *cobra.Command) (string, error) {
+	if p, err := cmd.Flags().GetString("config"); err == nil && strings.TrimSpace(p) != "" {
+		return p, nil
+	}
+	return config.DefaultConfigFile()
+}

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -1,11 +1,14 @@
 package cli
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"github.com/neochaotic/leoflow/internal/config"
 )
@@ -30,6 +33,11 @@ func newLoginCommand() *cobra.Command {
 					return cerr
 				}
 				serverURL = cfg.ServerURL
+			}
+			var cerr error
+			username, password, cerr = resolveCredentials(cmd, username, password)
+			if cerr != nil {
+				return cerr
 			}
 			token, err := requestToken(cmdContext(cmd), serverURL, username, password)
 			if err != nil {
@@ -61,4 +69,56 @@ func sessionConfigPath(cmd *cobra.Command) (string, error) {
 		return p, nil
 	}
 	return config.DefaultConfigFile()
+}
+
+// resolveCredentials fills missing username/password by prompting when the
+// session is interactive — the password is read hidden so it never lands in
+// shell history. In a non-interactive session (CI) the values must come from
+// flags/env, so a missing one is a loud error rather than a hang on a prompt.
+func resolveCredentials(cmd *cobra.Command, username, password string) (user, pass string, err error) {
+	user, pass = username, password
+	interactive := cmdInteractive(cmd)
+	if user == "" {
+		if !interactive {
+			return "", "", fmt.Errorf("username required: pass --username or set LEOFLOW_USERNAME")
+		}
+		if user, err = promptValue(cmd.InOrStdin(), cmd.OutOrStdout(), "Username: "); err != nil {
+			return "", "", err
+		}
+	}
+	if pass == "" {
+		if !interactive {
+			return "", "", fmt.Errorf("password required: pass --password or set LEOFLOW_PASSWORD")
+		}
+		if pass, err = promptPassword(cmd.InOrStdin(), cmd.OutOrStdout()); err != nil {
+			return "", "", err
+		}
+	}
+	return user, pass, nil
+}
+
+// promptValue prints a label and reads a trimmed line of input.
+func promptValue(in io.Reader, out io.Writer, label string) (string, error) {
+	devPrintf(out, "%s", label)
+	line, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+	return strings.TrimSpace(line), nil
+}
+
+// promptPassword reads a password without echoing it when in is a terminal;
+// otherwise (a pipe, e.g. `echo pw | leoflow auth login`) it falls back to a
+// plain line read so the value can still be supplied non-interactively.
+func promptPassword(in io.Reader, out io.Writer) (string, error) {
+	if f, ok := in.(*os.File); ok && term.IsTerminal(int(f.Fd())) {
+		devPrintf(out, "Password: ")
+		secret, err := term.ReadPassword(int(f.Fd()))
+		devPrintf(out, "\n") // ReadPassword swallows the user's newline
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(string(secret)), nil
+	}
+	return promptValue(in, out, "Password: ")
 }

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -10,15 +10,18 @@ import (
 	"github.com/neochaotic/leoflow/internal/config"
 )
 
-// newLoginCommand builds `leoflow login`: it exchanges credentials for a JWT at
-// the control plane and persists the token (and server URL) to the config file,
-// so subsequent `push`/`deploy` calls need no auth flags. This is what makes the
-// pipeline-less Lite->Pro loop fluid (login once, deploy many) — ADR 0041.
+// newLoginCommand builds `leoflow auth login`: it exchanges credentials for a
+// JWT at a control plane (typically Pro) and persists the token (and server URL)
+// to the config file, so subsequent `push`/`deploy` calls need no auth flags.
+// This is what makes the pipeline-less Lite->Pro loop fluid (login once, deploy
+// many) — ADR 0041. It is distinct from `docker login` (registry auth), which
+// Leoflow never handles. It is a sibling of `auth create-token`, which prints a
+// token for CI rather than persisting an interactive session.
 func newLoginCommand() *cobra.Command {
 	var serverURL, username, password string
 	cmd := &cobra.Command{
 		Use:   "login",
-		Short: "Authenticate to a control plane and store the token.",
+		Short: "Authenticate to a control plane (Pro) and store the token.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if serverURL == "" {

--- a/internal/cli/login_test.go
+++ b/internal/cli/login_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/config"
+)
+
+func TestLoginPersistsTokenAndServer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/auth/token" {
+			t.Errorf("login posted to %q, want /auth/token", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"access_token":"jwt-login"}`)
+	}))
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	out, _, err := run(t, "login", "--server", srv.URL,
+		"--username", "admin", "--password", "pw", "--config", cfgPath)
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(out), "logged in") {
+		t.Errorf("output = %q, want a 'logged in' confirmation", out)
+	}
+
+	cfg, err := config.Load(cfgPath, nil)
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if cfg.Token != "jwt-login" {
+		t.Errorf("persisted Token = %q, want jwt-login", cfg.Token)
+	}
+	if cfg.ServerURL != srv.URL {
+		t.Errorf("persisted ServerURL = %q, want %q", cfg.ServerURL, srv.URL)
+	}
+}
+
+func TestLoginUsesConfigServerWhenFlagOmitted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"access_token":"jwt-from-config"}`)
+	}))
+	defer srv.Close()
+
+	// Seed a config file whose server_url points at the fake server; login must
+	// fall back to it when --server is not given.
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("server_url: "+srv.URL+"\n"), 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	if _, _, err := run(t, "login", "--username", "a", "--password", "b", "--config", cfgPath); err != nil {
+		t.Fatalf("login with server from config: %v", err)
+	}
+	cfg, err := config.Load(cfgPath, nil)
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if cfg.Token != "jwt-from-config" {
+		t.Errorf("Token = %q, want jwt-from-config", cfg.Token)
+	}
+}
+
+func TestLoginFailsLoudlyOnBadCredentials(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	if _, _, err := run(t, "login", "--server", srv.URL,
+		"--username", "admin", "--password", "wrong", "--config", cfgPath); err == nil {
+		t.Error("expected login to fail on 401, got nil error")
+	}
+}

--- a/internal/cli/login_test.go
+++ b/internal/cli/login_test.go
@@ -22,7 +22,7 @@ func TestLoginPersistsTokenAndServer(t *testing.T) {
 	defer srv.Close()
 
 	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
-	out, _, err := run(t, "login", "--server", srv.URL,
+	out, _, err := run(t, "auth", "login", "--server", srv.URL,
 		"--username", "admin", "--password", "pw", "--config", cfgPath)
 	if err != nil {
 		t.Fatalf("login: %v", err)
@@ -56,7 +56,7 @@ func TestLoginUsesConfigServerWhenFlagOmitted(t *testing.T) {
 		t.Fatalf("seed config: %v", err)
 	}
 
-	if _, _, err := run(t, "login", "--username", "a", "--password", "b", "--config", cfgPath); err != nil {
+	if _, _, err := run(t, "auth", "login", "--username", "a", "--password", "b", "--config", cfgPath); err != nil {
 		t.Fatalf("login with server from config: %v", err)
 	}
 	cfg, err := config.Load(cfgPath, nil)
@@ -75,7 +75,7 @@ func TestLoginFailsLoudlyOnBadCredentials(t *testing.T) {
 	defer srv.Close()
 
 	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
-	if _, _, err := run(t, "login", "--server", srv.URL,
+	if _, _, err := run(t, "auth", "login", "--server", srv.URL,
 		"--username", "admin", "--password", "wrong", "--config", cfgPath); err == nil {
 		t.Error("expected login to fail on 401, got nil error")
 	}

--- a/internal/cli/login_test.go
+++ b/internal/cli/login_test.go
@@ -68,6 +68,88 @@ func TestLoginUsesConfigServerWhenFlagOmitted(t *testing.T) {
 	}
 }
 
+func TestResolveCredentialsKeepsProvided(t *testing.T) {
+	// Both given as flags/env: no prompt, returned as-is (the CI path).
+	cmd := newAuthCommand()
+	u, p, err := resolveCredentials(cmd, "admin", "pw")
+	if err != nil || u != "admin" || p != "pw" {
+		t.Fatalf("resolveCredentials = (%q,%q,%v), want (admin,pw,nil)", u, p, err)
+	}
+}
+
+func TestResolveCredentialsNonInteractiveMissingErrors(t *testing.T) {
+	// Non-interactive (test stdin is a buffer, not a TTY): a missing value is a
+	// loud error, never a hang on a prompt.
+	cmd := newAuthCommand()
+	if _, _, err := resolveCredentials(cmd, "", "pw"); err == nil {
+		t.Error("expected an error for a missing username in a non-interactive session")
+	}
+	if _, _, err := resolveCredentials(cmd, "admin", ""); err == nil {
+		t.Error("expected an error for a missing password in a non-interactive session")
+	}
+}
+
+func TestPromptLineReadsTrimmedInput(t *testing.T) {
+	var out strings.Builder
+	got, err := promptValue(strings.NewReader("admin\n"), &out, "Username: ")
+	if err != nil {
+		t.Fatalf("promptValue: %v", err)
+	}
+	if got != "admin" {
+		t.Errorf("line = %q, want admin", got)
+	}
+	if !strings.Contains(out.String(), "Username:") {
+		t.Errorf("label = %q, want the prompt", out.String())
+	}
+}
+
+func TestSessionConfigPathFallsBackToDefault(t *testing.T) {
+	// A bare login command has no --config flag, so the write target is the
+	// default ~/.leoflow/config.yaml (resolved even when it does not yet exist).
+	p, err := sessionConfigPath(newLoginCommand())
+	if err != nil {
+		t.Fatalf("sessionConfigPath: %v", err)
+	}
+	if !strings.HasSuffix(p, "config.yaml") {
+		t.Errorf("path = %q, want the default config.yaml", p)
+	}
+}
+
+func TestPromptValueHandlesEOFWithoutNewline(t *testing.T) {
+	var out strings.Builder
+	got, err := promptValue(strings.NewReader("admin"), &out, "Username: ") // no trailing \n
+	if err != nil {
+		t.Fatalf("promptValue at EOF: %v", err)
+	}
+	if got != "admin" {
+		t.Errorf("line = %q, want admin (EOF is not an error)", got)
+	}
+}
+
+func TestPromptPasswordFallsBackToPlainReadOffTTY(t *testing.T) {
+	// A piped (non-terminal) reader falls back to a plain line read, so a
+	// password can be supplied non-interactively (echo pw | leoflow auth login).
+	var out strings.Builder
+	got, err := promptPassword(strings.NewReader("s3cret\n"), &out)
+	if err != nil {
+		t.Fatalf("promptPassword off a pipe: %v", err)
+	}
+	if got != "s3cret" {
+		t.Errorf("password = %q, want s3cret", got)
+	}
+}
+
+func TestLoginCommandErrorsWhenCredsMissingNonInteractive(t *testing.T) {
+	// No flags, no env, non-interactive (test stdin is a pipe): the command must
+	// fail loudly via resolveCredentials rather than hang on a prompt.
+	t.Setenv("LEOFLOW_USERNAME", "")
+	t.Setenv("LEOFLOW_PASSWORD", "")
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	if _, _, err := run(t, "auth", "login", "--server", "http://127.0.0.1:0", "--config", cfgPath); err == nil {
+		t.Error("expected login to fail when credentials are missing in a non-interactive session")
+	}
+}
+
 func TestLoginFailsLoudlyOnBadCredentials(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -35,12 +35,17 @@ func newPushCommand() *cobra.Command {
 			if verr := spec.Validate(); verr != nil {
 				return fmt.Errorf("invalid dag.json: %w", verr)
 			}
-			if serverURL == "" {
+			if serverURL == "" || token == "" {
 				cfg, cerr := config.Load(configFilePath(cmd), cmd.Flags())
 				if cerr != nil {
 					return cerr
 				}
-				serverURL = cfg.ServerURL
+				if serverURL == "" {
+					serverURL = cfg.ServerURL
+				}
+				if token == "" {
+					token = cfg.Token
+				}
 			}
 			status, body, err := pushVersion(cmdContext(cmd), serverURL, token, spec.DagID, data)
 			if err != nil {

--- a/internal/cli/push_test.go
+++ b/internal/cli/push_test.go
@@ -60,6 +60,32 @@ func TestPushCommandEndToEnd(t *testing.T) {
 	}
 }
 
+func TestPushCommandUsesConfigTokenWhenFlagAbsent(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	// A config produced by `leoflow login`: it carries both server_url and token.
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("server_url: "+srv.URL+"\ntoken: jwt-saved\n"), 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	f := filepath.Join(t.TempDir(), "dag.json")
+	if err := os.WriteFile(f, []byte(pushSpec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := run(t, "push", f, "--config", cfgPath); err != nil {
+		t.Fatalf("push using config token: %v", err)
+	}
+	if gotAuth != "Bearer jwt-saved" {
+		t.Errorf("auth = %q, want the token persisted by login (Bearer jwt-saved)", gotAuth)
+	}
+}
+
 func TestPushCommandUsesConfigServerURL(t *testing.T) {
 	var hit bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -31,7 +31,7 @@ func NewRootCommand() *cobra.Command {
 		&cobra.Group{ID: "lifecycle", Title: "Lifecycle (install, configure, repair, retire):"},
 	)
 
-	authoring := []*cobra.Command{newInitCommand(), newValidateCommand(), newCompileCommand(), newPushCommand()}
+	authoring := []*cobra.Command{newInitCommand(), newValidateCommand(), newCompileCommand(), newPushCommand(), newLoginCommand()}
 	runtime := []*cobra.Command{newLiteCommand(), newServerCommand()}
 	inspection := []*cobra.Command{newDagsCommand(), newRunsCommand(), newAuthCommand()}
 	lifecycle := []*cobra.Command{newSetupCommand(), newDoctorCommand(), newDBCommand(), newUninstallCommand(), newVersionCommand()}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -31,7 +31,7 @@ func NewRootCommand() *cobra.Command {
 		&cobra.Group{ID: "lifecycle", Title: "Lifecycle (install, configure, repair, retire):"},
 	)
 
-	authoring := []*cobra.Command{newInitCommand(), newValidateCommand(), newCompileCommand(), newPushCommand(), newLoginCommand()}
+	authoring := []*cobra.Command{newInitCommand(), newValidateCommand(), newCompileCommand(), newPushCommand()}
 	runtime := []*cobra.Command{newLiteCommand(), newServerCommand()}
 	inspection := []*cobra.Command{newDagsCommand(), newRunsCommand(), newAuthCommand()}
 	lifecycle := []*cobra.Command{newSetupCommand(), newDoctorCommand(), newDBCommand(), newUninstallCommand(), newVersionCommand()}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -31,7 +31,7 @@ func NewRootCommand() *cobra.Command {
 		&cobra.Group{ID: "lifecycle", Title: "Lifecycle (install, configure, repair, retire):"},
 	)
 
-	authoring := []*cobra.Command{newInitCommand(), newValidateCommand(), newCompileCommand(), newPushCommand()}
+	authoring := []*cobra.Command{newInitCommand(), newValidateCommand(), newCompileCommand(), newPushCommand(), newDeployCommand()}
 	runtime := []*cobra.Command{newLiteCommand(), newServerCommand()}
 	inspection := []*cobra.Command{newDagsCommand(), newRunsCommand(), newAuthCommand()}
 	lifecycle := []*cobra.Command{newSetupCommand(), newDoctorCommand(), newDBCommand(), newUninstallCommand(), newVersionCommand()}

--- a/internal/cli/token.go
+++ b/internal/cli/token.go
@@ -22,6 +22,7 @@ func newAuthCommand() *cobra.Command {
 		Short: "Manage authentication tokens.",
 	}
 	auth.AddCommand(newCreateTokenCommand())
+	auth.AddCommand(newLoginCommand())
 	return auth
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,9 @@ var flagToKey = map[string]string{
 type Config struct {
 	// ServerURL is the control plane base URL used by push and auth create-token.
 	ServerURL string `mapstructure:"server_url"`
+	// Token is the JWT bearer token persisted by `leoflow login` and used by
+	// push and deploy when no --token flag or LEOFLOW_TOKEN env is set.
+	Token string `mapstructure:"token"`
 	// LogLevel is reserved for CLI log verbosity (not yet wired).
 	LogLevel string `mapstructure:"log_level"`
 	// Registry is reserved for the image registry used by image build (ADR 0003).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,6 +83,10 @@ func Load(configFile string, flags *pflag.FlagSet) (*Config, error) {
 	v.SetDefault("log_level", defaultLogLevel)
 	v.SetDefault("parser_cmd", defaultParserCmd)
 	v.SetDefault("registry", "")
+	// Register token so viper's AutomaticEnv binds LEOFLOW_TOKEN (viper only
+	// resolves env vars for keys it knows). The file path works regardless, as
+	// ReadInConfig populates the key directly.
+	v.SetDefault("token", "")
 
 	v.SetEnvPrefix("LEOFLOW")
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))

--- a/internal/config/persist.go
+++ b/internal/config/persist.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// PersistSession writes the control-plane server URL and auth token into the
+// config file at path, preserving any other keys already there (e.g. the Lite
+// settings written by `leoflow setup`). It creates the file and its parent
+// directory when absent, and keeps the file at 0600 because the token is a
+// secret. An empty path is an error: the caller must resolve the target first.
+func PersistSession(path, serverURL, token string) error {
+	if path == "" {
+		return fmt.Errorf("persisting session: no config file path")
+	}
+
+	values := map[string]any{}
+	if data, err := os.ReadFile(path); err == nil {
+		if uerr := yaml.Unmarshal(data, &values); uerr != nil {
+			return fmt.Errorf("parsing existing config %q: %w", path, uerr)
+		}
+		if values == nil {
+			values = map[string]any{}
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("reading config %q: %w", path, err)
+	}
+
+	values["server_url"] = serverURL
+	values["token"] = token
+
+	out, err := yaml.Marshal(values)
+	if err != nil {
+		return fmt.Errorf("encoding config: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		return fmt.Errorf("writing config %q: %w", path, err)
+	}
+	return nil
+}

--- a/internal/config/persist_test.go
+++ b/internal/config/persist_test.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPersistSessionPreservesExistingKeys(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("admin_email: admin@leoflow.local\nlite_port: 8080\n"), 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	if err := PersistSession(path, "https://pro.example.com", "jwt-token-123"); err != nil {
+		t.Fatalf("PersistSession: %v", err)
+	}
+
+	cfg, err := Load(path, nil)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Token != "jwt-token-123" {
+		t.Errorf("Token = %q, want jwt-token-123", cfg.Token)
+	}
+	if cfg.ServerURL != "https://pro.example.com" {
+		t.Errorf("ServerURL = %q, want the persisted server", cfg.ServerURL)
+	}
+	// The pre-existing Lite settings must survive the merge.
+	if cfg.AdminEmail != "admin@leoflow.local" {
+		t.Errorf("AdminEmail = %q, want it preserved", cfg.AdminEmail)
+	}
+	if cfg.LitePort != 8080 {
+		t.Errorf("LitePort = %d, want it preserved (8080)", cfg.LitePort)
+	}
+}
+
+func TestPersistSessionEmptyPathErrors(t *testing.T) {
+	if err := PersistSession("", "http://x", "tok"); err == nil {
+		t.Error("expected an error for an empty config path")
+	}
+}
+
+func TestPersistSessionRejectsCorruptExistingConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	// A YAML scalar where a mapping is expected makes Unmarshal-into-map fail.
+	if err := os.WriteFile(path, []byte("just-a-string\n"), 0o600); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+	if err := PersistSession(path, "http://x", "tok"); err == nil {
+		t.Error("expected an error when the existing config is not a mapping")
+	}
+}
+
+func TestPersistSessionCreatesFileAndParentDir(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "dir", "config.yaml")
+
+	if err := PersistSession(path, "http://localhost:8080", "tok"); err != nil {
+		t.Fatalf("PersistSession into a missing dir: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("expected the config file to be created: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("config perm = %o, want 0600 (token is a secret)", perm)
+	}
+	cfg, err := Load(path, nil)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Token != "tok" {
+		t.Errorf("Token = %q, want tok", cfg.Token)
+	}
+}

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -15,9 +15,12 @@ gate-and-release policy these tests implement.
 | `lite-login.sh` | Lite happy path: `leoflow setup` → control plane → admin login → JWT → web editor | ~15 s | `ci.yaml` job `e2e-lite` on every PR + push |
 | `lite-multidag.sh` | The multi-DAG materialization contract: subdir DAG → `dag.json.source` carries `dag.py` verbatim (the property the subprocess executor depends on to materialize per-TI work dirs) | ~5 s | `ci.yaml` job `e2e-lite-multidag` on every PR + push |
 | `e2e.sh` | Pod-path E2E on k3d: build images, k3d import, agent-over-gRPC, real pod-per-task | minutes | Manual / separate workflow |
+| `deploy-e2e.sh` | The real `leoflow deploy` path (ADR 0041): `auth login` → one `leoflow deploy` that builds for the cluster arch, **pushes to a registry the cluster pulls from**, captures the digest, re-pins `dag.json`, registers — then the cluster pulls the digest-pinned image and runs it | minutes | Manual / separate workflow |
 
 The `lite-*` scripts gate Lite behavior; `e2e.sh` gates the pod-path that
-Lite cluster mode and Pro both rely on.
+Lite cluster mode and Pro both rely on; `deploy-e2e.sh` gates the pipeline-less
+`leoflow deploy` promotion (the build→push→digest→register glue that unit tests
+leave to e2e).
 
 ## Running locally
 
@@ -54,6 +57,29 @@ script sets through `LEOFLOW_EXECUTOR_AGENT_CONTROL_PLANE_ADDR` — the host
 listen address (`0.0.0.0:9091`) is not reachable from inside a pod. The DAG
 image is imported into the cluster with `k3d image import` so no registry
 is needed.
+
+### Deploy test (`deploy-e2e.sh`) — k3d + a registry the cluster pulls from
+
+```bash
+make dev-up      # Postgres + Redis on the host
+make build       # bin/leoflow, bin/leoflow-server
+bash test/e2e/deploy-e2e.sh
+```
+
+Unlike `e2e.sh` (which `k3d image import`s the image), this uses a **k3d-managed
+registry** so it exercises the real push→pull path: a single `leoflow deploy`
+builds for the cluster arch (auto-detected — `linux/arm64` on an arm64 Mac,
+`linux/amd64` on amd64 CI), pushes to `k3d-registry.localhost:5111`, captures the
+image digest, re-pins `dag.json`, and registers; the cluster then pulls the
+digest-pinned image and runs it. It binds the API on `:18080` by default
+(`LEOFLOW_E2E_HTTP_PORT`) to avoid clashing with a Lima/other forward on 8080.
+
+!!! note "Docker Desktop on macOS"
+    The host `docker push` to the k3d registry can be intermittently routed
+    through Docker Desktop's HTTP proxy. If a push times out
+    (`proxyconnect … i/o timeout`), add `k3d-registry.localhost:5111` to Docker
+    Desktop → Settings → Resources → Proxies bypass, or run this gate on Linux/CI
+    (no Docker Desktop proxy), where it is clean.
 
 ## Adding a new gate
 

--- a/test/e2e/deploy-e2e.sh
+++ b/test/e2e/deploy-e2e.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+#
+# End-to-end smoke test for `leoflow deploy` (ADR 0041) on a local k3d cluster.
+#
+# Unlike e2e.sh (which `k3d image import`s the DAG image), this exercises the
+# REAL deploy path: a k3d-managed registry the cluster pulls from, `leoflow auth
+# login` to persist a token, then a single `leoflow deploy` that compiles, builds
+# for the cluster arch, PUSHES to the registry, captures the image digest,
+# re-pins dag.json by digest, and registers it. It then triggers a run and
+# asserts the task reaches 'success' — i.e. the cluster pulled the digest-pinned
+# image from the registry and ran it. This is the slice unit tests left to e2e.
+#
+# Requirements: k3d, kubectl, docker, jq, curl, the leoflow binaries
+# (`make build`), and a running dev database (`make dev-up`). Developer/CI tool.
+#
+# The registry is named `k3d-registry.localhost`: `.localhost` resolves to the
+# loopback on the host, so `docker push` works over HTTP (loopback is insecure-OK)
+# and the SAME ref resolves inside the cluster via k3d's registry mirror — no
+# /etc/hosts edit, no insecure-registry config.
+#
+# Usage: test/e2e/deploy-e2e.sh [cluster-name]
+set -euo pipefail
+
+CLUSTER="${1:-leoflow-deploy-e2e}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKDIR="$(mktemp -d)"
+PY_VERSION="3.11"
+BASE_IMAGE="leoflow-base:py${PY_VERSION}"
+DAG_ID="deploydag"
+REG_NAME="registry.localhost"          # k3d prefixes 'k3d-' → k3d-registry.localhost
+REG_PORT="5111"
+REG_FULLNAME="k3d-${REG_NAME}"         # the registry node name (for k3d registry delete)
+REG_HOST="${REG_FULLNAME}:${REG_PORT}" # same ref on host (loopback) and in-cluster
+# Default off 8080: on the dev Mac that port is the Lima VM's forward (do not
+# fight it). Override with LEOFLOW_E2E_HTTP_PORT.
+HTTP_PORT="${LEOFLOW_E2E_HTTP_PORT:-18080}"
+API="http://localhost:${HTTP_PORT}"
+GRPC_PORT="9091"
+HOST_ADDR="${LEOFLOW_E2E_HOST_ADDR:-host.docker.internal}"
+CFG="${WORKDIR}/leoflow-config.yaml"   # login persists token+server here
+SERVER_PID=""
+
+# The parser runs in-process via `python3 -m leoflow_parser` (compile, inside
+# deploy). Make it resolvable without an install.
+export PYTHONPATH="${ROOT}/parser:${PYTHONPATH:-}"
+
+# Build for the cluster's architecture. k3d nodes run the host arch, so on an
+# arm64 Mac the image must be linux/arm64 (deploy's linux/amd64 default would
+# exec-format-error on an arm64 node); on amd64 CI it is linux/amd64.
+case "$(uname -m)" in
+  arm64|aarch64) PLATFORM="linux/arm64" ;;
+  *)             PLATFORM="linux/amd64" ;;
+esac
+
+log()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+dump_pods() {
+  printf '\033[1;33m--- task pods (namespace leoflow) ---\033[0m\n' >&2
+  kubectl get pods -n leoflow -o wide >&2 2>&1 || true
+  for p in $(kubectl get pods -n leoflow -o name 2>/dev/null); do
+    printf '\033[1;33m--- describe/logs %s ---\033[0m\n' "$p" >&2
+    kubectl describe -n leoflow "$p" >&2 2>&1 | tail -20 || true
+    kubectl logs -n leoflow "$p" --all-containers --tail=60 >&2 2>&1 || true
+  done
+}
+fail() { printf '\033[1;31mFAIL:\033[0m %s\n' "$*" >&2; dump_pods; exit 1; }
+
+cleanup() {
+  [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
+  k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
+  k3d registry delete "$REG_FULLNAME" >/dev/null 2>&1 || true
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+for tool in k3d kubectl docker jq curl; do
+  command -v "$tool" >/dev/null || fail "missing required tool: $tool"
+done
+
+log "Building the task base image ($BASE_IMAGE)"
+docker build -f "$ROOT/runtime/Dockerfile" --build-arg "PYTHON_VERSION=${PY_VERSION}" -t "$BASE_IMAGE" "$ROOT"
+
+log "Creating k3d registry ($REG_HOST) + cluster '$CLUSTER' (cluster pulls from the registry)"
+k3d registry create "$REG_NAME" --port "$REG_PORT" >/dev/null
+k3d cluster create "$CLUSTER" --registry-use "$REG_HOST" --wait
+kubectl create namespace leoflow
+
+log "Starting the control plane (agents dial ${HOST_ADDR}:${GRPC_PORT})"
+export LEOFLOW_AUTH_JWT_SECRET="e2e-secret"
+export LEOFLOW_BOOTSTRAP_PASSWORD="admin"
+export LEOFLOW_SERVER_HTTP_ADDR="0.0.0.0:${HTTP_PORT}"
+export LEOFLOW_EXECUTOR_AGENT_CONTROL_PLANE_ADDR="${HOST_ADDR}:${GRPC_PORT}"
+export LEOFLOW_LOGS_DIR="${WORKDIR}/logs"
+export LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS=true
+"$ROOT/bin/leoflow-server" &
+SERVER_PID=$!
+sleep 5
+
+log "Scaffolding a DAG project with a registry: block ($DAG_ID, platform $PLATFORM)"
+"$ROOT/bin/leoflow" init "$WORKDIR/$DAG_ID" >/dev/null
+cat > "$WORKDIR/$DAG_ID/dag.py" <<'PY'
+"""deploydag — leoflow deploy smoke DAG."""
+from __future__ import annotations
+
+from airflow.sdk import DAG, task
+
+
+@task
+def hello() -> None:
+    print("hello from leoflow deploy e2e")
+
+
+with DAG("deploydag", schedule="@daily", catchup=False, tags=["deploy-e2e"]):
+    hello()
+PY
+# The DAG image layers FROM the local base; deploy pushes the COMPLETE image
+# (all layers baked in) to the registry, so the cluster pulls it whole — no need
+# to seed the base into the registry.
+cat > "$WORKDIR/$DAG_ID/Dockerfile" <<DOCKER
+FROM ${BASE_IMAGE}
+COPY dag.py /home/leoflow/dag.py
+ENV PYTHONPATH=/home/leoflow
+DOCKER
+# leoflow.yaml: registry: makes deploy mandatory-registry happy; build.platforms
+# matches the cluster arch.
+cat > "$WORKDIR/$DAG_ID/leoflow.yaml" <<YAML
+dag_id: ${DAG_ID}
+python_version: "${PY_VERSION}"
+build:
+  platforms:
+    - ${PLATFORM}
+registry:
+  url: ${REG_HOST}
+  image_name: ${DAG_ID}
+YAML
+
+log "leoflow auth login (persists token to \$CFG)"
+"$ROOT/bin/leoflow" auth login --server "$API" \
+  --username admin@leoflow.local --password admin --config "$CFG"
+
+log "leoflow deploy — compile → build($PLATFORM) → push($REG_HOST) → digest re-pin → register"
+# Unique version per run so a re-run against the shared dev DB does not collide
+# with a prior run's registered version (dag_versions is unique per dag+version).
+"$ROOT/bin/leoflow" deploy "$WORKDIR/$DAG_ID" --yes --config "$CFG" \
+  --dag-version "e2e-$(date +%s)"
+
+log "Asserting dag.json was re-pinned by digest"
+IMG="$(jq -r '.image' "$WORKDIR/$DAG_ID/dag.json")"
+echo "$IMG" | grep -q "@sha256:" || fail "dag.json image not digest-pinned: $IMG"
+echo "$IMG" | grep -q "^${REG_HOST}/${DAG_ID}@sha256:" || fail "unexpected image ref: $IMG"
+log "registered image: $IMG"
+
+TOKEN="$("$ROOT/bin/leoflow" auth create-token --server "$API" --username admin@leoflow.local --password admin)"
+
+log "Triggering a run (the cluster must pull the digest-pinned image from the registry)"
+RUN_ID="$(curl -fsS -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{}' "$API/api/v2/dags/$DAG_ID/dagRuns" | jq -r '.dag_run_id')"
+[ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ] || fail "no dag_run_id returned"
+log "run = $RUN_ID"
+
+log "Waiting for the task to succeed (proves registry pull + pod-per-task run)"
+deadline=$(( $(date +%s) + 300 ))
+while :; do
+  states="$(curl -fsS -H "Authorization: Bearer $TOKEN" \
+    "$API/api/v2/dags/$DAG_ID/dagRuns/$RUN_ID/taskInstances" | jq -r '.task_instances[].state')"
+  log "task states: [$(echo "$states" | tr '\n' ' ')] pods: [$(kubectl get pods -n leoflow --no-headers 2>/dev/null | awk '{print $1"="$3}' | tr '\n' ' ')]"
+  echo "$states" | grep -qE 'failed|upstream_failed' && fail "a task failed: $states"
+  if [ -n "$states" ] && ! echo "$states" | grep -qvE 'success|skipped'; then
+    log "all tasks terminal-success: $states"
+    break
+  fi
+  [ "$(date +%s)" -gt "$deadline" ] && fail "timed out; last states: ${states:-<none>}"
+  sleep 3
+done
+
+log "Asserting the task logged from its pod"
+hlog=""
+for try in 0 1 2; do
+  body="$(curl -fsS -H "Authorization: Bearer $TOKEN" \
+    "$API/api/v2/dags/$DAG_ID/dagRuns/$RUN_ID/taskInstances/hello/logs/$try" 2>/dev/null || true)"
+  if echo "$body" | grep -q "hello from leoflow deploy e2e"; then hlog="$body"; break; fi
+done
+[ -n "$hlog" ] || fail "no 'hello' log shipped — the deployed image did not run"
+
+log "DEPLOY E2E passed — leoflow deploy built, pushed, pinned by digest, and the cluster ran it"


### PR DESCRIPTION
Implements `leoflow deploy` + `leoflow auth login` per **ADR 0041** (draft PR #366): one verb to promote a Lite-built DAG (or a whole workspace) to a Pro control plane **without a CI pipeline**, reusing the existing compile/build/push primitives. Target: **v0.0.2-rc.2** (unblocks Steve #318; independent of the held connectors epic).

## What's here (12 TDD commits, all gated)
- **`leoflow auth login`** — exchanges credentials for a JWT and persists it (+ server URL) to the config, preserving Lite settings. Nested under `auth` (sibling of `create-token`) to disambiguate from `docker login`. `push`/`deploy` then read the token from config.
- **Registry-mandatory guard** — deploy without a configured `registry:` fails loudly + actionably (the ADR headline).
- **Cross-build by default** — `buildImage` honors `Build.Platforms` (default `linux/amd64`), so a macOS/arm64 build runs on an amd64 cluster. Builder-agnostic; no Docker Go SDK linked.
- **Digest pinning** — captures the pushed image's repo digest and re-pins `dag.json` so Pro pulls exactly the bytes built (no `:latest`).
- **`leoflow deploy [path | dag_id]`** — load → Validate → guard → image ref/tag → build+push → digest → re-pin → register.
- **Scope** — `--all` (best-effort per-DAG, non-zero exit on any failure) and `<dag_id>` resolution via the multi-DAG workspace.
- **Flags** — `--skip-build` (promote without rebuild), `--trigger` (kick a run), `--yes`/confirmation prompt (interactive + non-loopback only).
- **Connection surfacing** — after register, prints the `conn_id`s the DAG expects (artifact does not carry connections), never a silent runtime gap.

## Testing
Pure helpers + command paths are unit-tested (registry guard, image ref, tag strategy, digest parse, re-pin, register-against-fake-server, trigger, scope resolution, confirmation logic). The build/push **shell-out** is intentionally left to the **deploy e2e** (next slice). Coverage ≥ 80%, lint clean (golangci-lint v2.12.2).

## Still to land before cutting v0.0.2-rc.2
- docs: `first-pro-dag.md` restructured into the 3 journeys + a `deploy`/`auth login` section; sync ADR 0041 wording (`auth login`).
- Helm: `imagePullSecrets` on the task ServiceAccount (private-registry pulls).
- deploy e2e on k3d (covers the real build→push→register→run).

Companion design: ADR 0041 (PR #366).