### PR TITLE
fix(release): release-notes install command pins the exact tag

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -135,10 +135,12 @@ release:
   prerelease: auto
   name_template: "{{ .Tag }}"
   header: |
-    ## Leoflow {{ .Tag }} (pre-alpha)
+    ## Leoflow {{ .Tag }}
 
-    Pre-alpha build — APIs and on-disk shape may still change before the
-    `v0.1.0` cut. Install **this exact release** with:
+    A `0.x` (pre-1.0) build — SemVer carries the maturity, there is no separate
+    alpha/beta, and the pre-alpha series ended at `v0.0.1` (ADR 0037). APIs and
+    on-disk shape may still evolve between minor versions; `-rc.N` tags are release
+    candidates gated by the E2E suite. Install **this exact release** with:
 
     ```bash
     LEOFLOW_VERSION={{ .Tag }} curl -fsSL https://raw.githubusercontent.com/neochaotic/leoflow/{{ .Tag }}/install.sh | sh

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -138,11 +138,15 @@ release:
     ## Leoflow {{ .Tag }} (pre-alpha)
 
     Pre-alpha build — APIs and on-disk shape may still change before the
-    `v0.1.0` cut. Install with:
+    `v0.1.0` cut. Install **this exact release** with:
 
     ```bash
-    curl -fsSL https://raw.githubusercontent.com/neochaotic/leoflow/main/install.sh | sh
+    LEOFLOW_VERSION={{ .Tag }} curl -fsSL https://raw.githubusercontent.com/neochaotic/leoflow/{{ .Tag }}/install.sh | sh
     ```
+
+    > A bare `curl … | sh` installs the latest **stable** release (`/releases/latest`
+    > excludes pre-releases), so on a pre-release page it would NOT give you `{{ .Tag }}`.
+    > Pinning `LEOFLOW_VERSION` (and fetching `install.sh` from the tag) installs this build.
   footer: |
     ---
     Artifacts are checksummed (SHA-256) and the checksums file is cosign-signed


### PR DESCRIPTION
**Bug** (spotted on the live `v0.1.0-rc.1` page): the release notes show the same
generic `curl …/main/install.sh | sh` on every release. On a **pre-release** page
that is misleading — a bare curl resolves `/releases/latest`, which **excludes
pre-releases**, so it installs the latest **stable** (today `v0.0.2`), NOT the
pre-release the page is for. It also fetched `install.sh` from `main` (not the tag),
so it was non-reproducible and diverged from the install-smoke (which uses the tag's
`install.sh`).

**Fix:** pin both — `LEOFLOW_VERSION={{ .Tag }}` and fetch `install.sh` from
`{{ .Tag }}` — so every release page installs exactly that build, plus a note
explaining the bare-curl/stable behavior. (The live `v0.1.0-rc.1` notes were also
edited directly to unblock the current hands-on.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)