### PR TITLE
ci(security): run pinned gitleaks binary, drop the flaky Docker Hub pull

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -102,9 +102,24 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-      # Run the gitleaks binary directly: the v2 action makes GitHub API calls
-      # that crash under the default token, and the container needs no token.
+      # Run the pinned gitleaks binary directly (no Docker / Docker Hub). The v2
+      # action makes GitHub API calls that crash under the default token; and a
+      # `docker run zricethezav/gitleaks:latest` pull from Docker Hub is rate-limited
+      # and flaked on a transient registry timeout ("context deadline exceeded",
+      # exit 125) on a main push. The release tarball from GitHub is reliable in
+      # Actions, version-pinned (reproducible rules), and the download is retried.
+      # `dir .` auto-loads the repo's .gitleaks.toml allowlist.
       - name: gitleaks
+        env:
+          GITLEAKS_VERSION: "8.30.1"
         run: |
-          docker run --rm -v "${{ github.workspace }}:/repo" \
-            zricethezav/gitleaks:latest dir /repo --no-banner --redact --exit-code 1
+          set -euo pipefail
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          ok=0
+          for i in 1 2 3; do
+            if curl -fsSL "$url" -o /tmp/gitleaks.tgz; then ok=1; break; fi
+            echo "::warning::gitleaks download attempt ${i} failed; retrying in 5s"; sleep 5
+          done
+          [ "$ok" = 1 ] || { echo "::error::could not download gitleaks v${GITLEAKS_VERSION} after 3 attempts"; exit 1; }
+          tar -xzf /tmp/gitleaks.tgz -C /tmp gitleaks
+          /tmp/gitleaks dir . --no-banner --redact --exit-code 1


### PR DESCRIPTION
**What broke:** the Security workflow's `gitleaks` job failed on a `main` push with

```
Unable to find image 'zricethezav/gitleaks:latest' locally
docker: ... Get "https://registry-1.docker.io/v2/": context deadline exceeded
Error: Process completed with exit code 125.
```

It was **not a leak** — gitleaks never ran; the **Docker Hub image pull timed out**.
The repo is clean (verified locally: the only hits are in the gitignored, never
committed `.claude/settings.local.json`, which CI doesn't see; a re-run of the job
went green). Docker Hub pulls of an unpinned `:latest` with no retry are rate-limited
and intermittently slow in Actions — it can flake on any branch.

**Fix:** download the **pinned** gitleaks release tarball from GitHub (reliable in
Actions, no Docker Hub, reproducible rules via a fixed version `8.30.1`) with a 3×
download retry, and run the binary directly. `dir .` still auto-loads the repo's
`.gitleaks.toml` allowlist — no behavior change to what is scanned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)