### PR TITLE
docs(changelog): cut v0.1.0-rc.2 (reschedule sensors + release/CI fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.0-rc.2] - 2026-06-24
+
+> Second release candidate of the **0.1.0** line. On top of rc.1 it ships
+> **reschedule-mode sensors** — the first ADR 0040 Phase B capability, which rc.1
+> still rejected at compile — plus release- and CI-hardening fixes. E2E-gated on a
+> real k3d cluster.
+
+### Added
+
+- **Reschedule-mode sensors (ADR 0040, Phase B).** A sensor declared
+  `mode='reschedule'` now releases its pod between pokes instead of holding it:
+  on a not-ready poke the task transitions to `up_for_reschedule` and the
+  scheduler re-dispatches it once `reschedule_at` arrives — no retry budget
+  consumed (mirrors the `up_for_retry` rail). The agent reports
+  `up_for_reschedule` only when the task exits 75 **and** writes a parseable
+  reschedule file, so a bare exit 75 stays an ordinary failure. Validated on a
+  real k3d cluster via a `DateTimeSensor(mode='reschedule')` e2e guard that
+  visibly passes through `up_for_reschedule` and is re-dispatched to success
+  (#380, #389).
+
+### Fixed
+
+- Deterministic reschedule-sensor e2e guard: the wait loop asserts the sensor
+  passed through `up_for_reschedule` without timing flakiness (#390).
+- Release notes now install the exact release tag (`LEOFLOW_VERSION` + the
+  tag's `install.sh`) instead of resolving latest-stable, and drop the stale
+  `(pre-alpha)` wording (ADR 0037) (#391).
+
+### Changed
+
+- CI secret-scan runs a pinned `gitleaks` binary and drops the flaky Docker Hub
+  pull (#392).
+
 ## [0.1.0-rc.1] - 2026-06-16
 
 > First release candidate of the **0.1.0** line — a Go control plane that runs
@@ -71,5 +104,6 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Browser end-to-end verification (rendering, write-flow paths, screenshots) is
   the remaining Phase 5 acceptance step; see `docs/ui-compatibility.md`.
 
-[Unreleased]: https://github.com/neochaotic/leoflow/compare/v0.1.0-rc.1...HEAD
+[Unreleased]: https://github.com/neochaotic/leoflow/compare/v0.1.0-rc.2...HEAD
+[0.1.0-rc.2]: https://github.com/neochaotic/leoflow/compare/v0.1.0-rc.1...v0.1.0-rc.2
 [0.1.0-rc.1]: https://github.com/neochaotic/leoflow/releases/tag/v0.1.0-rc.1


### PR DESCRIPTION
## What

Cuts the `v0.1.0-rc.2` CHANGELOG section ahead of tagging. rc.2 ships on top of rc.1:

- **Reschedule-mode sensors (ADR 0040 Phase B)** — `mode='reschedule'` releases the pod between pokes (`up_for_reschedule` → re-dispatch on `reschedule_at`, no retry budget consumed). rc.1 still rejected this at compile (#380, #389).
- **Fixes:** deterministic reschedule-sensor e2e guard (#390); install command pinned to the release tag + stale pre-alpha wording dropped (#391).
- **CI:** pinned `gitleaks` binary, dropped the flaky Docker Hub pull (#392).

Docs-only change (CHANGELOG); the code under test is already on `main`.

## E2E validation

Ran the full k3d pod-per-task e2e (`test/e2e/e2e.sh`) on a real **x86_64** host before this PR. Green, including the rc.2 headline:

> `reschedule OK: waiter released its pod (up_for_reschedule), was re-dispatched, and succeeded after the flip`

Plus all existing guards: 8 tasks terminal-success, log shipping, TaskFlow value passing, Admin Variable + cloud connection (gcp/aws/azure) delivery, @task run-context, multi-key XCom, native bash Jinja → **"E2E passed"**.

## Next

On green CI, tag `v0.1.0-rc.2` (goreleaser: multi-arch, cosign, SBOMs, install/upgrade smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)