### PR TITLE
ci(release): opensuse install-smoke resilient to expired repo GPG keys

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -247,7 +247,7 @@ jobs:
           - { image: "ubuntu:24.04", prep: "apt-get update -qq && apt-get install -y -qq curl ca-certificates tar" }
           - { image: "fedora:41", prep: "dnf install -y -q tar curl --allowerasing" }
           - { image: "quay.io/rockylinux/rockylinux:9", prep: "dnf install -y -q tar curl --allowerasing" }
-          - { image: "opensuse/leap:15", prep: "zypper -n in -y curl tar gzip" }
+          - { image: "opensuse/leap:15", prep: "zypper --no-gpg-checks -n in -y curl tar gzip" }
           - { image: "archlinux:latest", prep: "pacman -Sy --noconfirm curl tar" }
           - { image: "alpine:3.20", prep: "apk add --no-cache curl tar" }
     steps:


### PR DESCRIPTION
The v0.1.0-rc.3 release gate failed only on `opensuse/leap:15`, at the **prereq** step `zypper -n in -y curl tar gzip` — the openSUSE Non-OSS repo's signing key had **expired** (distro infra, before `install.sh` runs). The other four distros pass and `install.sh` is unchanged.

Add `--no-gpg-checks` to the opensuse base-package prep so a recurring upstream key expiry doesn't false-positive the release gate.

Unblocks re-cutting `v0.1.0-rc.3` (option 1: fix + re-cut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)