### PR TITLE
fix(lite): re-mint the watcher token so hot-reload survives past 1h (#407)

### DIFF
--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -620,7 +620,7 @@ func runDev(cmd *cobra.Command, dir string, o devOptions) error {
 	// build/register strategy. k8s runs real pods on a dedicated k3d cluster;
 	// subprocess runs unsandboxed on the host (fast loop).
 	var serverEnv []string
-	var makeReload func(token string) func() error
+	var makeReload func(mintToken func() string) func() error
 	if o.executor == "subprocess" {
 		serverEnv, makeReload, err = devSubprocessSetup(ctx, cmd, ws, o, home)
 	} else {
@@ -642,17 +642,26 @@ func runDev(cmd *cobra.Command, dir string, o devOptions) error {
 	announceReady(out, o.host, o.port, o.adminEmail, ws.Path)
 	// Mint an admin token in-process signed with the dev JWT secret; the control
 	// plane validates it by signature + claims, so no login or seeded user is
-	// needed (works against a fresh or pre-existing dev database).
-	token, terr := auth.MintUserToken(resolveLiteJWTSecret(o.jwtSecret), time.Hour, auth.User{
-		ID: "leoflow-dev", TenantID: "default", Email: devAdminUser, Roles: []string{"admin"},
-	})
-	if terr != nil {
-		return fmt.Errorf("minting dev token: %w", terr)
-	}
+	// needed. Re-minted per operation (signing is cheap) so a Lite left running
+	// for hours never hits the token's expiry — hot-reload registration keeps
+	// working instead of silently 401-ing after an hour (#407).
 	logf := func(format string, args ...any) { devPrintf(cmd.OutOrStdout(), format+"\n", args...) }
-	del := makeDeleteDag(token, uiURL, home, logf)
-	boot := makeBootReconcile(token, uiURL, ws.Path, projectDagIDs(ws), del, logf)
-	return devWatchLoop(ctx, cmd, ws, makeReload(token), del, boot)
+	mintToken := func() string {
+		tok, err := auth.MintUserToken(resolveLiteJWTSecret(o.jwtSecret), time.Hour, auth.User{
+			ID: "leoflow-dev", TenantID: "default", Email: devAdminUser, Roles: []string{"admin"},
+		})
+		if err != nil {
+			logf("✗ minting dev token: %v", err)
+			return ""
+		}
+		return tok
+	}
+	if mintToken() == "" {
+		return fmt.Errorf("minting the dev token failed — check the JWT secret")
+	}
+	del := makeDeleteDag(mintToken, uiURL, home, logf)
+	boot := makeBootReconcile(mintToken, uiURL, ws.Path, projectDagIDs(ws), del, logf)
+	return devWatchLoop(ctx, cmd, ws, makeReload(mintToken), del, boot)
 }
 
 // makeDeleteDag returns a callback the Lite watcher calls when it notices a
@@ -661,10 +670,10 @@ func runDev(cmd *cobra.Command, dir string, o devOptions) error {
 // hard-delete variant (cascades versions/runs/TIs/XCom via the schema's
 // ON DELETE CASCADE) — because the user's intent in deleting the project
 // folder is to fully forget the DAG, not just clear its run history.
-func makeDeleteDag(token, uiURL, home string, logf func(format string, args ...any)) func(dagID string) error {
+func makeDeleteDag(mintToken func() string, uiURL, home string, logf func(format string, args ...any)) func(dagID string) error {
 	return func(dagID string) error {
 		reqURL := fmt.Sprintf("%s/api/v2/dags/%s?deregister=true", uiURL, url.PathEscape(dagID))
-		if err := devImportErrorRequest(context.Background(), http.MethodDelete, reqURL, token, nil); err != nil {
+		if err := devImportErrorRequest(context.Background(), http.MethodDelete, reqURL, mintToken(), nil); err != nil {
 			return err
 		}
 		// Reclaim the per-DAG venv with the DAG (it carries the Airflow SDK). A
@@ -684,7 +693,7 @@ func makeDeleteDag(token, uiURL, home string, logf func(format string, args ...a
 // with user code running unsandboxed on the host. The venv is shared across
 // projects and uses the dependency-union from WorkspaceSpec.RootCfg so every
 // DAG's imports resolve from a single virtualenv.
-func devSubprocessSetup(ctx context.Context, cmd *cobra.Command, ws *WorkspaceSpec, o devOptions, home string) (env []string, makeReload func(string) func() error, err error) {
+func devSubprocessSetup(ctx context.Context, cmd *cobra.Command, ws *WorkspaceSpec, o devOptions, home string) (env []string, makeReload func(func() string) func() error, err error) {
 	agentBin, err := resolveBinary(o.agentBin, "leoflow-agent")
 	if err != nil {
 		return nil, nil, err
@@ -702,8 +711,9 @@ func devSubprocessSetup(ctx context.Context, cmd *cobra.Command, ws *WorkspaceSp
 	venvsRoot := filepath.Join(home, "venvs")
 	env = subprocessServerEnv(o.host, o.port, agentBin, ws.Path, bootPy, venvsRoot, o.adminHash, o.adminEmail, o.jwtSecret)
 	env = append(env, liteEditorEnv(ws.Path, filepath.Dir(home))...)
-	makeReload = func(token string) func() error {
+	makeReload = func(mintToken func() string) func() error {
 		return func() error {
+			token := mintToken()
 			// Re-resolve the workspace on every reload so DAGs added or removed
 			// since boot are picked up (no need to restart lite to register a new
 			// subdir).
@@ -768,7 +778,7 @@ func ensureWorkspaceDagVenvs(ctx context.Context, cmd *cobra.Command, ws *Worksp
 // BuildKit cache; far worse cold). The function fails loud with a hint to use
 // --executor=subprocess. Cluster-mode multi-DAG is tracked as a follow-up
 // (the "Stage" mode design conversation).
-func devClusterSetup(ctx context.Context, cmd *cobra.Command, ws *WorkspaceSpec, o devOptions, home string) (env []string, makeReload func(string) func() error, err error) {
+func devClusterSetup(ctx context.Context, cmd *cobra.Command, ws *WorkspaceSpec, o devOptions, home string) (env []string, makeReload func(func() string) func() error, err error) {
 	if len(ws.Projects) != 1 {
 		paths := make([]string, 0, len(ws.Projects))
 		for _, p := range ws.Projects {
@@ -799,14 +809,17 @@ func devClusterSetup(ctx context.Context, cmd *cobra.Command, ws *WorkspaceSpec,
 		return nil, nil, derr
 	}
 	image := devDagImageRef(cfg.DagID)
-	makeReload = func(token string) func() error {
-		base := func() error {
-			opts := compileOptions{image: image, build: true, builder: "docker", dockerfile: "Dockerfile"}
-			return devCompileAndRegister(ctx, cmd, dir, opts, token, func() error {
-				return k3dImport(ctx, cmd, image)
-			}, devURL(o.port))
+	makeReload = func(mintToken func() string) func() error {
+		return func() error {
+			token := mintToken()
+			base := func() error {
+				opts := compileOptions{image: image, build: true, builder: "docker", dockerfile: "Dockerfile"}
+				return devCompileAndRegister(ctx, cmd, dir, opts, token, func() error {
+					return k3dImport(ctx, cmd, image)
+				}, devURL(o.port))
+			}
+			return devReportingReload(ctx, base, devURL(o.port), token, dagSourcePath(dir, cfg))()
 		}
-		return devReportingReload(ctx, base, devURL(o.port), token, dagSourcePath(dir, cfg))
 	}
 	env = clusterServerEnv(o.host, o.port, kubeconfig, o.adminHash, o.adminEmail, o.jwtSecret)
 	if wd, aerr := filepath.Abs(dir); aerr == nil {

--- a/internal/cli/dev_reconcile.go
+++ b/internal/cli/dev_reconcile.go
@@ -157,12 +157,14 @@ func reconcileImportErrors(
 // It returns the DAG-ID set the watcher seeds its per-tick diff from. Each step is
 // independently fail-safe — a failed list fetch skips that step, never wiping.
 func makeBootReconcile(
-	token, uiURL, workspaceRoot string,
+	mintToken func() string,
+	uiURL, workspaceRoot string,
 	workspace map[string]struct{},
 	deleteDag func(dagID string) error,
 	logf func(format string, args ...any),
 ) func() map[string]struct{} {
 	return func() map[string]struct{} {
+		token := mintToken()
 		registered, ferr := fetchRegisteredDagIDs(uiURL, token)
 		seen := reconcileStartup(registered, ferr, workspace, deleteDag, logf)
 		files, ierr := fetchImportErrorFiles(uiURL, token)

--- a/internal/cli/dev_test.go
+++ b/internal/cli/dev_test.go
@@ -541,7 +541,7 @@ func TestDevClusterSetupStubbed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("devClusterSetup: %v", err)
 	}
-	if makeReload == nil || makeReload("tok") == nil {
+	if makeReload == nil || makeReload(func() string { return "tok" }) == nil {
 		t.Fatal("expected a reload factory")
 	}
 	joined := strings.Join(env, "\n")

--- a/internal/cli/dev_token_test.go
+++ b/internal/cli/dev_token_test.go
@@ -1,0 +1,18 @@
+package cli
+
+import "testing"
+
+// TestMakeDeleteDagRemintsToken: the deregister callback mints a FRESH token on
+// every call. A long-running Lite would otherwise reuse the one token it minted at
+// startup, which expires after an hour — silently breaking hot-reload registration
+// (#407). The HTTP call fails here (no server), but the mint must still happen per
+// call.
+func TestMakeDeleteDagRemintsToken(t *testing.T) {
+	var calls int
+	del := makeDeleteDag(func() string { calls++; return "" }, "http://127.0.0.1:0", t.TempDir(), func(string, ...any) {})
+	_ = del("a")
+	_ = del("b")
+	if calls != 2 {
+		t.Errorf("token minted %d times across 2 deregisters, want 2 (fresh per call, #407)", calls)
+	}
+}

--- a/internal/cli/dev_token_test.go
+++ b/internal/cli/dev_token_test.go
@@ -16,3 +16,21 @@ func TestMakeDeleteDagRemintsToken(t *testing.T) {
 		t.Errorf("token minted %d times across 2 deregisters, want 2 (fresh per call, #407)", calls)
 	}
 }
+
+// TestMakeBootReconcileMintsToken: the boot reconcile mints a fresh token when it
+// runs, rather than capturing one — same #407 guard, on the reconcile path. (The
+// control plane is unreachable here, so the fetches fail and reconcile no-ops, but
+// the token must still be minted at the top of the pass.)
+func TestMakeBootReconcileMintsToken(t *testing.T) {
+	var calls int
+	boot := makeBootReconcile(
+		func() string { calls++; return "" },
+		"http://127.0.0.1:0", t.TempDir(), set("a"),
+		func(string) error { return nil },
+		func(string, ...any) {},
+	)
+	_ = boot()
+	if calls != 1 {
+		t.Errorf("boot reconcile minted %d tokens, want 1 (fresh per boot, #407)", calls)
+	}
+}


### PR DESCRIPTION
A long-running `leoflow lite` minted one 1-hour token at startup and reused it; after an hour every hot-reload registration silently 401'd. Re-mint a fresh token per operation (local loopback in-process credential — cheap). Test-first; lint + build green.

Closes #407.

🤖 Generated with [Claude Code](https://claude.com/claude-code)