### PR TITLE
docs(articles): mention the in-browser IDE in C

### DIFF
--- a/articles/2026-06-leoflow-lite-airflow-dev-env-devto.md
+++ b/articles/2026-06-leoflow-lite-airflow-dev-env-devto.md
@@ -55,6 +55,11 @@ with DAG("hello", schedule="@daily"):
 
 Save the file and the DAG reloads in the UI in a couple of seconds.
 
+Prefer to stay in the browser? Lite ships an **in-browser IDE** — hit the **IDE**
+button in the UI (bottom-right in the screenshot above) to edit `dag.py` and
+`leoflow.yaml` right there. Or use your own editor; either way, every save
+hot-reloads.
+
 ## What's supported
 
 Lite runs the same Airflow-compatible engine as Leoflow's production mode:


### PR DESCRIPTION
Adds a line to article C calling out the in-browser IDE (visible in the hero screenshot but not in the text). After merge I'll re-dispatch the publish so C updates in place (id preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)