### PR TITLE
docs(articles): in-browser IDE = simple/quick edits; favorite IDE supported

### DIFF
--- a/articles/2026-06-leoflow-lite-airflow-dev-env-devto.md
+++ b/articles/2026-06-leoflow-lite-airflow-dev-env-devto.md
@@ -55,10 +55,10 @@ with DAG("hello", schedule="@daily"):
 
 Save the file and the DAG reloads in the UI in a couple of seconds.
 
-Prefer to stay in the browser? Lite ships an **in-browser IDE** — hit the **IDE**
-button in the UI (bottom-right in the screenshot above) to edit `dag.py` and
-`leoflow.yaml` right there. Or use your own editor; either way, every save
-hot-reloads.
+Lite ships a **simple in-browser editor for quick edits** — hit the **IDE** button in
+the UI (bottom-right in the screenshot above) to tweak `dag.py` / `leoflow.yaml`
+without leaving the page. For real work, use **your favorite IDE** (VS Code, PyCharm,
+Vim — whatever) on the files locally; either way, every save hot-reloads.
 
 ## What's supported
 


### PR DESCRIPTION
Refines C's IDE line per feedback: the in-browser editor is simple (quick edits); your favorite IDE (VS Code/PyCharm/Vim) is fully supported for real work — save hot-reloads either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)