### PR TITLE
ci(security): harden publish-devto for OpenSSF Scorecard (token perms + pinned deps)

### DIFF
--- a/.github/workflows/publish-devto.yml
+++ b/.github/workflows/publish-devto.yml
@@ -27,17 +27,19 @@ on:
         default: true
 
 permissions:
-  contents: write # the action commits the returned article id back to the repo
+  contents: read
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # the publish step commits the returned article id back to the repo
     # Skip entirely if the token secret is not configured, so forks/CI stay green.
     if: ${{ github.repository == 'neochaotic/leoflow' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Publish articles on dev.to
-        uses: sinedied/publish-devto@v2
+        uses: sinedied/publish-devto@c713cc0934b35cb3df9fca759b98e36e6a540a85 # v2
         env:
           GIT_COMMITTER_NAME: neochaotic
           GIT_COMMITTER_EMAIL: alisson.david.rosa@gmail.com


### PR DESCRIPTION
Closes the two fixable OpenSSF Scorecard gaps that don't need a second maintainer, both in the dev.to publish workflow:

- **Token-Permissions** (was 0/10): top-level → `contents: read`; the publish job escalates to `contents: write` (it commits the article id back).
- **Pinned-Dependencies** (was 3/10): pin `actions/checkout@v4` and `sinedied/publish-devto@v2` to commit SHAs.

Every other workflow already had minimal perms + SHA pins. Score was 6.2/10 (fresh scan).

**Follow-up (needs a repo secret you create):** Branch-Protection (-1) needs the Scorecard action to run with a `repo`-scoped PAT to read protection settings. Code-Review (0) and Contributors (0) are structurally capped for a solo project — realistic solo ceiling ~8/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)