### PR TITLE
release: cut v0.1.1 stable (rc.1 promotion + Go 1.26.5 security bump)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
   PYTHON_VERSION: "3.11"
   GOLANGCI_LINT_VERSION: "v2.12.2"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
   REGISTRY: ghcr.io
 
 jobs:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -13,7 +13,7 @@ permissions:
   security-events: write    # Required for SARIF upload to GitHub Security tab
 
 env:
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.5"
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,15 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 > **dbt-native orchestration.** A dbt project becomes a Leoflow DAG — one pod per
 > model, no Cosmos at runtime, no Airflow in the parser — and develops **locally with
-> zero config** against an embedded duckdb. This promotes `v0.1.1-rc.1` verbatim: the
-> same artifacts, soaked on Lite (arm64) end-to-end.
+> zero config** against an embedded duckdb. This promotes `v0.1.1-rc.1` after a clean
+> Lite (arm64) end-to-end soak, plus a Go 1.26.5 toolchain bump for a newly-disclosed
+> standard-library advisory (below) — no functional change from the rc.
+
+### Security
+
+- **Go toolchain 1.26.4 → 1.26.5**, closing `GO-2026-4970` (root escape via symlink +
+  trailing slash in the standard-library `os` package), disclosed after the rc was cut
+  and reachable from the installer's download path.
 
 ### The 0.1.1 line, in brief
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-07-10
+
+> **dbt-native orchestration.** A dbt project becomes a Leoflow DAG — one pod per
+> model, no Cosmos at runtime, no Airflow in the parser — and develops **locally with
+> zero config** against an embedded duckdb. This promotes `v0.1.1-rc.1` verbatim: the
+> same artifacts, soaked on Lite (arm64) end-to-end.
+
+### The 0.1.1 line, in brief
+
+- **dbt projects as Leoflow DAGs (ADR 0042).** A dbt project compiles straight to
+  Leoflow tasks from its `manifest.json`, in Go — one task per model/seed/snapshot/test,
+  wired by dbt's own dependency graph.
+- **Mix dbt with operators (ADR 0043)** via `dbt_group("name")`, and **multiple dbt
+  projects, one per business domain (ADR 0044)** via a namespaced `dbt_groups` map.
+- **Adapters:** Postgres, Snowflake, BigQuery, Databricks, and **duckdb** — mapped from a
+  managed connection at runtime, so no warehouse credential is baked into the image.
+- **Zero-config local dbt (Lite):** a dbt project with no connection and no
+  `profiles.yml` just runs against an embedded duckdb, never touching your global
+  `~/.dbt`; model edits hot-reload.
+
+Per-rc detail is in the `0.1.1-rc.1` section below.
+
 ## [0.1.1-rc.1] - 2026-07-05
 
 > First release candidate of the **0.1.1** line — **dbt-native orchestration**. A dbt
@@ -204,7 +226,8 @@ Per-rc detail is in the `0.1.0-rc.1` … `0.1.0-rc.4` sections below.
 - Browser end-to-end verification (rendering, write-flow paths, screenshots) is
   the remaining Phase 5 acceptance step; see `docs/ui-compatibility.md`.
 
-[Unreleased]: https://github.com/neochaotic/leoflow/compare/v0.1.1-rc.1...HEAD
+[Unreleased]: https://github.com/neochaotic/leoflow/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/neochaotic/leoflow/compare/v0.1.1-rc.1...v0.1.1
 [0.1.1-rc.1]: https://github.com/neochaotic/leoflow/compare/v0.1.0...v0.1.1-rc.1
 [0.1.0]: https://github.com/neochaotic/leoflow/compare/v0.1.0-rc.4...v0.1.0
 [0.1.0-rc.4]: https://github.com/neochaotic/leoflow/compare/v0.1.0-rc.3...v0.1.0-rc.4

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/neochaotic/leoflow
 
 go 1.26.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/gin-gonic/gin v1.12.0


### PR DESCRIPTION
Cuts **v0.1.1 stable** — the dbt-native orchestration line — promoting `v0.1.1-rc.1` after a clean end-to-end soak, **plus a Go toolchain security bump** required to ship safely.

## Contents
1. **CHANGELOG:** `[0.1.1]` stable section + link refs (matches the v0.1.0 promotion, #414).
2. **Security:** Go toolchain **1.26.4 → 1.26.5** closing **GO-2026-4970** (root escape via symlink + trailing slash in the stdlib `os` package) — disclosed *after* the rc was cut and reachable from the installer's download path. `govulncheck` is clean on 1.26.5 (0 called vulnerabilities, verified locally). Bumps `go.mod` toolchain + the ci/security/release `GO_VERSION` pins (also drives `runtime/Dockerfile`'s build arg).

Not byte-verbatim vs the rc, but **no functional change** — only the toolchain patch.

## Why now (rc.1 soak — Lite arm64, Lima)
- **dbt zero-config** DAG green: `pre → shop__raw → shop__stg → shop__mart` all success; embedded **duckdb auto-created** and materialized (raw/stg/mart = 2 rows each); global `~/.dbt/profiles.yml` untouched.
- **Regression** DAG green (BashOperator + `@task`).
- Log clean — zero ERROR/panic/exit-127; only the expected subprocess-unsandboxed WARNs. pysrc self-heal (#239) fired.
- Cloud adapters (Snowflake/BigQuery/Databricks) validated by hand earlier.

## After merge
Tag `v0.1.1` on the merge commit → `release.yaml` (goreleaser + cosign + SBOMs + GHCR + install-smoke ×7 + e2e gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)