### PR TITLE
docs+build: retire goreportcard (dead service) — badge + working A+ validator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,14 @@ SHELL := /usr/bin/env bash
 
 # ─── Tool versions (pinned; see ADR 0012 / 0014) ───
 GOLANGCI_LINT_VERSION ?= v2.12.2
-GOREPORTCARD_VERSION  ?= latest
 GOVULNCHECK_VERSION   ?= latest
 MIGRATE_VERSION       ?= latest
 SQLC_VERSION          ?= latest
+# Go Report Card checkers (the site + its CLI were retired in 2026; we run the
+# same checks with maintained tools via scripts/reportcard.sh — see ADR 0012).
+GOCYCLO_VERSION       ?= latest
+INEFFASSIGN_VERSION   ?= latest
+MISSPELL_VERSION      ?= latest
 
 # ─── Pinned Airflow UI (see ADR 0017 / docs/ui-compatibility.md) ───
 AIRFLOW_UI_VERSION ?= 3.2.1
@@ -46,8 +50,10 @@ help: ## Show this help
 setup: ## Install Go tools, Python parser, and the pre-commit hook
 	go mod download
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
-	go install github.com/gojp/goreportcard/cmd/goreportcard-cli@$(GOREPORTCARD_VERSION)
 	go install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
+	go install github.com/fzipp/gocyclo/cmd/gocyclo@$(GOCYCLO_VERSION)
+	go install github.com/gordonklaus/ineffassign@$(INEFFASSIGN_VERSION)
+	go install github.com/client9/misspell/cmd/misspell@$(MISSPELL_VERSION)
 	go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@$(MIGRATE_VERSION)
 	go install github.com/sqlc-dev/sqlc/cmd/sqlc@$(SQLC_VERSION)
 	command -v python3 >/dev/null && pip install -e "./parser[dev]" && pip install -e ./runtime/python || echo "skip parser/runtime install (python3 not found)"
@@ -188,8 +194,8 @@ fmt: ## Format Go code
 	gofmt -w .
 
 .PHONY: reportcard
-reportcard: ## Verify Go Report Card grade is A+ (ADR 0012)
-	goreportcard-cli -v
+reportcard: ## Verify the Go Report Card A+ floor (ADR 0012) with maintained tools
+	bash scripts/reportcard.sh
 
 .PHONY: vuln
 vuln: ## Run govulncheck (ADR 0014)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </p>
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Go Report Card](https://goreportcard.com/badge/github.com/neochaotic/leoflow?v=2)](https://goreportcard.com/report/github.com/neochaotic/leoflow)
+[![Code quality: golangci-lint A+](https://img.shields.io/badge/golangci--lint-A%2B-00ADD8?logo=go&logoColor=white)](docs/adr/0012-code-quality-standards.md)
 [![CI](https://github.com/neochaotic/leoflow/actions/workflows/ci.yaml/badge.svg)](https://github.com/neochaotic/leoflow/actions/workflows/ci.yaml)
 [![Security](https://github.com/neochaotic/leoflow/actions/workflows/security.yaml/badge.svg)](https://github.com/neochaotic/leoflow/actions/workflows/security.yaml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/neochaotic/leoflow/badge)](https://securityscorecards.dev/viewer/?uri=github.com/neochaotic/leoflow)
@@ -128,7 +128,7 @@ Leoflow is a **GitOps-first, container-native workflow orchestrator** written in
 - **GitOps-first.** Your DAG is a versioned artifact (`dag.json` + container image), not live source code. CI builds it. The registry stores it. Rollback is a tag change.
 - **Container-native.** Each DAG is its own container image, with its own dependencies, its own Python version, its own everything. Built automatically from a one-page `leoflow.yaml` — you never touch Docker unless you want to.
 - **Airflow-UI compatible.** The MVP runs the unmodified Apache Airflow 3.2.x UI. Your team's muscle memory survives the migration. No new tool to learn.
-- **Go performance, Go discipline.** Static binary. No GIL. Goroutines for concurrency. Test-driven from the first commit. Go Report Card A+ enforced in CI.
+- **Go performance, Go discipline.** Static binary. No GIL. Goroutines for concurrency. Test-driven from the first commit. The full `golangci-lint` A+ stack enforced in CI.
 
 ## What It Looks Like to Use
 
@@ -381,7 +381,7 @@ We borrow from Argo Workflows (container-native), from Prefect (modern developer
 Leoflow holds itself to a higher bar than most open source projects, because workflow orchestrators must be boring and reliable to be useful:
 
 - **Strict TDD** — every line of production code is preceded by a failing test ([ADR 0011](docs/adr/0011-tdd-strict.md))
-- **Go Report Card A+** — enforced in CI from the first commit ([ADR 0012](docs/adr/0012-code-quality-standards.md))
+- **golangci-lint A+ stack** — the goreportcard checks (gofmt, govet, gocyclo ≤ 15, golint, ineffassign, misspell) enforced in CI from the first commit ([ADR 0012](docs/adr/0012-code-quality-standards.md))
 - **GoDocs on every exported identifier** — no exceptions
 - **Supply chain security from day one** — govulncheck, gosec, Trivy, CodeQL, Scorecard, signed releases ([ADR 0014](docs/adr/0014-supply-chain-security.md))
 - **Per-phase coverage floors** — rising from 70% to 85% across the MVP phases

--- a/scripts/reportcard.sh
+++ b/scripts/reportcard.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Local Go Report Card A+ validation (ADR 0012).
+#
+# goreportcard.com was retired ("sunset") in 2026 and its badge now renders
+# "retired" for every project. Its CLI (goreportcard-cli) also bit-rotted: it
+# shells out to the long-archived `gometalinter`, so go_vet/gocyclo/gofmt error
+# out and it reports a bogus "Grade F". This script runs the SAME seven checks
+# with maintained tooling, so the A+ floor stays verifiable locally and in CI
+# without the dead service. golangci-lint (revive) is the maintained, stricter
+# successor to the retired `golint` and subsumes several of the checks; we still
+# run the standalone tools so each Go Report Card criterion is visible on its own.
+set -euo pipefail
+
+# Generated code is excluded exactly as CI's coverage/lint config does. The file
+# lists are word-split into command args on purpose — every path is git-tracked
+# and space-free — so SC2046 is disabled at those call sites. (Portable to macOS
+# bash 3.2: no arrays/mapfile.)
+GEN='\.pb\.go|/queries/|_string\.go'
+go_files() { git ls-files '*.go' | grep -vE "$GEN"; }
+prod_go() { go_files | grep -vE '_test\.go'; }
+
+fail=0
+ok() { printf '  \033[32m✓\033[0m %-14s %s\n' "$1" "$2"; }
+bad() {
+	printf '  \033[31m✗\033[0m %-14s %s\n' "$1" "$2"
+	[ -n "${3:-}" ] && echo "$3"
+	fail=1
+}
+need() { command -v "$1" >/dev/null || { echo "missing tool: $1 (run: make setup)"; exit 2; }; }
+
+for t in gocyclo ineffassign misspell golangci-lint; do need "$t"; done
+
+# 1. gofmt — every file is formatted.
+# shellcheck disable=SC2046
+if out=$(gofmt -l $(go_files)) && [ -z "$out" ]; then
+	ok gofmt "clean"
+else
+	bad gofmt "not formatted:" "$out"
+fi
+
+# 2. go vet — no suspicious constructs.
+if out=$(go vet ./... 2>&1); then ok "go vet" "clean"; else bad "go vet" "issues:" "$out"; fi
+
+# 3. gocyclo — no production function over 15 (table-driven tests are exempt,
+#    matching the golangci-lint config that gates CI).
+# shellcheck disable=SC2046
+out=$(gocyclo -over 15 $(prod_go) 2>/dev/null || true)
+if [ -z "$out" ]; then ok gocyclo "clean (≤15)"; else bad gocyclo "functions over 15:" "$out"; fi
+
+# 4. ineffassign — no ineffectual assignments.
+if out=$(ineffassign ./... 2>&1); then ok ineffassign "clean"; else bad ineffassign "issues:" "$out"; fi
+
+# 5. misspell — Go sources only. (The embedded Airflow UI ships localized,
+#    non-English docs, and the authoring guide intentionally shows a mistyped
+#    task_id in an error example — both are .md, so scanning .go keeps this signal
+#    honest, and golangci-lint already spell-checks .go too.)
+# shellcheck disable=SC2046
+out=$(misspell $(go_files))
+if [ -z "$out" ]; then ok misspell "clean"; else bad misspell "misspellings:" "$out"; fi
+
+# 6. license — the repository ships a license (Apache 2.0).
+if [ -f LICENSE ]; then ok license "present"; else bad license "no LICENSE file"; fi
+
+# 7. golint (retired) → the golangci-lint stack, its maintained superset, must be
+#    clean: GoDocs on every export (revive), plus the extended linters in .golangci.yaml.
+if out=$(golangci-lint run ./... 2>&1); then ok golangci-lint "0 issues"; else bad golangci-lint "issues:" "$out"; fi
+
+echo
+if [ "$fail" -ne 0 ]; then
+	echo -e "\033[31mreportcard: NOT A+\033[0m — fix the above (ADR 0012)"
+	exit 1
+fi
+echo -e "\033[32mreportcard: A+\033[0m — all seven Go Report Card checks clean"


### PR DESCRIPTION
**goreportcard.com was sunset.** Its badges render `go report: retired` for every project (confirmed against `gin-gonic/gin`), and its CLI bit-rotted — `goreportcard-cli` shells out to the archived `gometalinter`, so it now prints a bogus **"Grade F"**. The grade didn't drop; the *service* is gone.

Our A+ discipline is unaffected — the same checks run in CI via the `golangci-lint` stack (ADR 0012), verified green.

## Changes
1. **README badge** → static **golangci-lint A+** badge linking [ADR 0012](docs/adr/0012-code-quality-standards.md) (was the dead `retired` chip); two prose mentions reworded off the retired brand.
2. **`make reportcard`** → new **`scripts/reportcard.sh`** that runs the seven Go Report Card checks with maintained tools (gofmt, go vet, gocyclo ≤ 15, ineffassign, misspell, license, golangci-lint) and prints a per-criterion report. `make setup` installs the checkers instead of the dead CLI.

## Validation (tested + validated, per request)
`scripts/reportcard.sh` on the current tree — **A+, all seven clean**:
```
✓ gofmt          clean
✓ go vet         clean
✓ gocyclo        clean (≤15)
✓ ineffassign    clean
✓ misspell       clean
✓ license        present
✓ golangci-lint  0 issues
```
Also: production code has **0 functions over gocyclo 15**; the golint/misspell "hits" seen during the sweep were all false positives (`_ "embed"` idiom; German vendored UI locales; an intentionally mistyped `task_id` in a docs error example). Script is portable to macOS bash 3.2 and shellcheck-clean. Left ADR-title-derived references (`docs/adrs.md`, ADR 0012) as-is — the ADR is immutable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)