### PR TITLE
feat(alerts): native on-failure alerting — config + dag.json + Go notifier (#424)

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -604,6 +604,7 @@ func startScheduler(ctx context.Context, cfg *config.ServerConfig, pg *storage.P
 	sched.SetAlerter(failurealert.New(
 		alerts.NewNotifier(&http.Client{Timeout: alertHTTPTimeout}),
 		connEndpointResolver{repo},
+		metrics,
 		logger,
 	))
 	podDispatch := setupDispatch(ctx, cfg, sched, execStore, authn, store, logger, metrics)

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -624,10 +624,15 @@ const alertHTTPTimeout = 10 * time.Second
 // an alert channel's endpoint URL is the connection's decrypted secret (#424).
 type connEndpointResolver struct{ repo *storage.Repository }
 
-// ResolveAlertEndpoint returns the connection's secret (the full channel webhook
-// URL) for the tenant, or an error when it is missing/undecryptable.
-func (c connEndpointResolver) ResolveAlertEndpoint(ctx context.Context, tenantID, connID string) (string, error) {
-	return c.repo.ConnectionSecret(ctx, tenantID, connID)
+// ResolveAlertEndpoint returns the connection's endpoint — its secret URL and any
+// headers from the connection extra — for the tenant, or an error when it is
+// missing/undecryptable.
+func (c connEndpointResolver) ResolveAlertEndpoint(ctx context.Context, tenantID, connID string) (failurealert.Endpoint, error) {
+	url, headers, err := c.repo.AlertEndpoint(ctx, tenantID, connID)
+	if err != nil {
+		return failurealert.Endpoint{}, err
+	}
+	return failurealert.Endpoint{URL: url, Headers: headers}, nil
 }
 
 // leaderCheckInterval is how often we both poll for leadership (as a follower)

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -24,12 +24,14 @@ import (
 
 	leoflow "github.com/neochaotic/leoflow"
 	"github.com/neochaotic/leoflow/internal/agentrpc"
+	"github.com/neochaotic/leoflow/internal/alerts"
 	"github.com/neochaotic/leoflow/internal/api"
 	"github.com/neochaotic/leoflow/internal/auth"
 	"github.com/neochaotic/leoflow/internal/config"
 	"github.com/neochaotic/leoflow/internal/dispatch"
 	"github.com/neochaotic/leoflow/internal/domain"
 	"github.com/neochaotic/leoflow/internal/executor"
+	"github.com/neochaotic/leoflow/internal/failurealert"
 	"github.com/neochaotic/leoflow/internal/logs"
 	"github.com/neochaotic/leoflow/internal/observability"
 	"github.com/neochaotic/leoflow/internal/scheduler"
@@ -124,7 +126,7 @@ func run() error {
 	var schedulerHealth api.Heartbeater
 	podDispatch := false
 	if cfg.Scheduler.Enabled {
-		sched, dispatchOn, serr := startScheduler(ctx, cfg, pg, execStore, authn, xcomSvc, logSink, tel.Logger, tel.Metrics)
+		sched, dispatchOn, serr := startScheduler(ctx, cfg, pg, repo, execStore, authn, xcomSvc, logSink, tel.Logger, tel.Metrics)
 		if serr != nil {
 			return serr
 		}
@@ -578,7 +580,7 @@ func startStagingGC(ctx context.Context, cs kubernetes.Interface, store executor
 	}()
 }
 
-func startScheduler(ctx context.Context, cfg *config.ServerConfig, pg *storage.Postgres, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, xcomSvc executor.XComPusher, logSink logs.Sink, logger *slog.Logger, metrics *observability.Metrics) (*scheduler.Scheduler, bool, error) {
+func startScheduler(ctx context.Context, cfg *config.ServerConfig, pg *storage.Postgres, repo *storage.Repository, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, xcomSvc executor.XComPusher, logSink logs.Sink, logger *slog.Logger, metrics *observability.Metrics) (*scheduler.Scheduler, bool, error) {
 	leaderPool, err := storage.NewLeaderPool(ctx, cfg.Database)
 	if err != nil {
 		return nil, false, fmt.Errorf("leader pool: %w", err)
@@ -596,6 +598,14 @@ func startScheduler(ctx context.Context, cfg *config.ServerConfig, pg *storage.P
 		MaxSeconds:  cfg.Executor.HTTP.InlineMaxDurationSeconds,
 		UserAgent:   cfg.Executor.HTTP.UserAgent,
 	}))
+	// Native on-failure alerting (#424): the scheduler fires Slack/webhook rules
+	// declared in leoflow.yaml when a run finalizes failed, resolving each rule's
+	// managed connection to its endpoint URL. Best-effort, off the tick path.
+	sched.SetAlerter(failurealert.New(
+		alerts.NewNotifier(&http.Client{Timeout: alertHTTPTimeout}),
+		connEndpointResolver{repo},
+		logger,
+	))
 	podDispatch := setupDispatch(ctx, cfg, sched, execStore, authn, store, logger, metrics)
 	leader := scheduler.NewLeader(leaderPool)
 	go func() {
@@ -603,6 +613,20 @@ func startScheduler(ctx context.Context, cfg *config.ServerConfig, pg *storage.P
 		campaignAndRun(ctx, leader, sched, logger)
 	}()
 	return sched, podDispatch, nil
+}
+
+// alertHTTPTimeout bounds each on-failure alert POST so a slow or hung channel
+// endpoint cannot pile up detached alert goroutines (#424).
+const alertHTTPTimeout = 10 * time.Second
+
+// connEndpointResolver adapts the connection store to failurealert.EndpointResolver:
+// an alert channel's endpoint URL is the connection's decrypted secret (#424).
+type connEndpointResolver struct{ repo *storage.Repository }
+
+// ResolveAlertEndpoint returns the connection's secret (the full channel webhook
+// URL) for the tenant, or an error when it is missing/undecryptable.
+func (c connEndpointResolver) ResolveAlertEndpoint(ctx context.Context, tenantID, connID string) (string, error) {
+	return c.repo.ConnectionSecret(ctx, tenantID, connID)
 }
 
 // leaderCheckInterval is how often we both poll for leadership (as a follower)

--- a/docs/alerting.md
+++ b/docs/alerting.md
@@ -1,0 +1,143 @@
+# On-failure alerting
+
+Leoflow can **notify you when a run fails** — Slack or a generic webhook — with no
+extra task and no Python. You declare the rules in `leoflow.yaml`; the **scheduler
+fires them in Go** the moment a DagRun reaches the terminal `failed` state.
+
+```yaml
+# leoflow.yaml
+alerts:
+  on_failure:
+    - type: slack
+      conn: slack_prod
+      message: "🚨 {{dag}} run {{run_id}} failed on {{task}}"
+    - type: webhook
+      conn: pagerduty
+```
+
+That's it. Compile and deploy as usual — when a run of this DAG fails, both the
+Slack message and the PagerDuty webhook fire.
+
+> **Native, not a task.** This runs in the control plane on the terminal failure —
+> no task pod, no Python in the hot path, and it can't be skipped by an upstream
+> failure the way a notify *task* can. For the task-based pattern (and its
+> trade-offs) see [When to use a task instead](#when-to-use-a-task-instead).
+
+## How it works
+
+```
+leoflow.yaml ──► compile ──► dag.json ──► scheduler sees the run fail
+   alerts:      (validate    (Alerts        │
+               + overlay)    baked in)      ▼
+                                     fire off the tick, in a goroutine
+                                            │
+                                            ▼
+                         for each rule: resolve the connection → endpoint URL,
+                         render the message, POST it
+                                            │
+                                            ▼
+                                 Slack / PagerDuty / Opsgenie / Teams …
+```
+
+Three guarantees hold by design:
+
+- 🔒 **The secret stays in the connection.** The webhook URL (which *is* a secret)
+  lives encrypted in a managed connection — never in `leoflow.yaml` and never in
+  the compiled `dag.json`.
+- 🛟 **Best-effort.** A delivery that fails (a 500, a bad URL, a missing
+  connection) is logged and dropped — it can **never** fail the run, and one bad
+  rule never stops the others.
+- ⚡ **Off the tick path.** Alerts dispatch in a detached goroutine, so a slow
+  endpoint can't stall the scheduler.
+
+## Setting up the connection
+
+The endpoint URL is stored as the connection's **secret** (so it's encrypted at
+rest). Create the connection once, then reference it by id from any DAG.
+
+=== "Slack"
+
+    Create a [Slack incoming webhook](https://api.slack.com/messaging/webhooks)
+    and store its full URL:
+
+    ```console
+    $ curl -X POST .../api/v2/connections -d '{
+        "connection_id":"slack_prod","conn_type":"slack",
+        "password":"https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXX"}'
+    ```
+
+=== "Generic webhook"
+
+    Any endpoint that accepts a JSON `POST` (PagerDuty Events v2, Opsgenie, a
+    Microsoft Teams incoming webhook, your own service):
+
+    ```console
+    $ curl -X POST .../api/v2/connections -d '{
+        "connection_id":"pagerduty","conn_type":"http",
+        "password":"https://events.pagerduty.com/v2/enqueue"}'
+    ```
+
+> The webhook URL goes in `password` on purpose: Leoflow encrypts it at rest and
+> hands it straight to the sender at failure time. `host`/`login`/`schema` are
+> ignored for alert connections.
+
+## The message
+
+`message` is optional. When set, these placeholders are substituted at failure
+time; when omitted, Leoflow sends a default one-line summary.
+
+| Placeholder        | Becomes                                             |
+| ------------------ | --------------------------------------------------- |
+| `{{dag}}`          | the DAG id                                          |
+| `{{run_id}}`       | the failed run id                                   |
+| `{{logical_date}}` | the run's logical date (empty for unscheduled runs) |
+| `{{task}}`         | the first task that failed                          |
+| `{{tasks}}`        | every failed task, comma-separated                  |
+
+**What each channel receives:**
+
+- **`slack`** → Slack's incoming-webhook shape: `{"text": "<your message>"}`.
+- **`webhook`** → a structured JSON body, so your service can route on it:
+
+  ```json
+  {
+    "dag_id": "sales",
+    "run_id": "manual__2026-07-17T09:00:00Z",
+    "logical_date": "2026-07-17T09:00:00Z",
+    "failed_tasks": ["transform"],
+    "message": "🚨 sales run … failed on transform"
+  }
+  ```
+
+## When to use a task instead
+
+The `alerts:` block is the right default. But if you need the notification to run
+your **own code** (enrich the payload, hit an internal API, page via a provider
+operator), add a notify **task** guarded by a failure trigger rule — it runs in a
+pod with full operator fidelity:
+
+```python
+alert = SlackWebhookOperator(
+    task_id="alert", slack_webhook_conn_id="slack",
+    message="pipeline failed 🚨", trigger_rule="one_failed",
+)
+[extract, transform] >> alert
+```
+
+Trade-off: a task runs a pod and is itself a task in the graph (it can be skipped
+if the whole run is torn down), whereas the native `alerts:` block always fires on
+the terminal failure, in the control plane, for free.
+
+## Reference
+
+| Field                      | Required | Notes                                              |
+| -------------------------- | -------- | -------------------------------------------------- |
+| `alerts.on_failure[].type` | yes      | `slack` or `webhook`                               |
+| `alerts.on_failure[].conn` | yes      | managed connection id; its secret = the endpoint URL |
+| `alerts.on_failure[].message` | no    | templated (see above); empty → default summary     |
+
+!!! note "Scope today"
+    Only `on_failure` is wired, firing on the terminal **DagRun** failure.
+    `on_success` / `on_retry` / SLA-miss alerts and a genuine Airflow
+    `on_failure_callback` (run in a dedicated pod) are planned — tracked in
+    [#424](https://github.com/neochaotic/leoflow/issues/424).

--- a/docs/api/dag-schema.json
+++ b/docs/api/dag-schema.json
@@ -106,6 +106,26 @@
       },
       "additionalProperties": false
     },
+    "alerts": {
+      "type": "object",
+      "description": "Native on-failure alerting (#424), overlaid from leoflow.yaml; the scheduler fires it when the DagRun reaches failed.",
+      "properties": {
+        "on_failure": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": { "type": "string", "enum": ["slack", "webhook"] },
+              "conn": { "type": "string", "minLength": 1 },
+              "message": { "type": "string" }
+            },
+            "required": ["type", "conn"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "tasks": {
       "type": "array",
       "minItems": 1,

--- a/docs/api/leoflow-yaml-schema.json
+++ b/docs/api/leoflow-yaml-schema.json
@@ -164,6 +164,28 @@
       }
     },
 
+    "alerts": {
+      "type": "object",
+      "description": "Native on-failure alerting (#424). The scheduler fires these rules when a DagRun reaches the terminal failed state — in Go, with no task pod.",
+      "properties": {
+        "on_failure": {
+          "type": "array",
+          "description": "Rules dispatched when the DagRun fails.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": { "type": "string", "enum": ["slack", "webhook"], "description": "Channel: slack (incoming webhook) or webhook (generic HTTP POST)." },
+              "conn": { "type": "string", "minLength": 1, "description": "Managed Leoflow connection id holding the endpoint and its secret. Required — no literal URLs/tokens in leoflow.yaml." },
+              "message": { "type": "string", "description": "Optional notification body, templated with run context ({{dag}}, {{run_id}}, {{task}})." }
+            },
+            "required": ["type", "conn"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+
     "tasks": {
       "type": "object",
       "description": "Per-task overrides bound by task_id (ADR 0023). Each key MUST match a task_id in the compiled DAG; an unknown id fails the compile. A set field overrides the value compiled from the DAG (task override > DAG defaults).",

--- a/internal/alerts/alerts.go
+++ b/internal/alerts/alerts.go
@@ -67,10 +67,11 @@ func NewNotifier(client *http.Client) *Notifier {
 
 // Send posts message to url for the given channel type: "slack" sends Slack's
 // {"text": …} incoming-webhook shape; "webhook" sends a structured JSON payload
-// carrying the run context. A non-2xx response or an unknown channel type is an
-// error; the caller decides whether that is fatal (it should not be — an alert
-// failure must not fail the run).
-func (n *Notifier) Send(ctx context.Context, channelType, url, message string, ev Event) error {
+// carrying the run context. Any headers are applied to the request (e.g. an
+// Authorization header for an endpoint whose token is not in the URL). A non-2xx
+// response or an unknown channel type is an error; the caller decides whether
+// that is fatal (it should not be — an alert failure must not fail the run).
+func (n *Notifier) Send(ctx context.Context, channelType, url string, headers map[string]string, message string, ev Event) error {
 	var payload any
 	switch channelType {
 	case "slack":
@@ -95,6 +96,9 @@ func (n *Notifier) Send(ctx context.Context, channelType, url, message string, e
 		return fmt.Errorf("building %s alert request: %w", channelType, err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
 	resp, err := n.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("sending %s alert: %w", channelType, err)

--- a/internal/alerts/alerts.go
+++ b/internal/alerts/alerts.go
@@ -1,0 +1,109 @@
+// Package alerts sends native on-failure notifications (#424). The scheduler
+// resolves each leoflow.yaml alert rule's connection to an endpoint URL and calls
+// a Notifier — Slack incoming webhooks and generic HTTP webhooks — entirely in
+// Go, with no task pod and no Python in the hot path. Connection lookup lives in
+// the caller; this package only renders the message and performs the HTTP POST,
+// so it stays trivially testable and free of storage dependencies.
+package alerts
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Event carries the DagRun context exposed to an alert message template and to
+// the structured webhook payload.
+type Event struct {
+	// DagID is the failed run's DAG id.
+	DagID string
+	// RunID is the failed DagRun id.
+	RunID string
+	// LogicalDate is the run's logical date (may be empty for unscheduled runs).
+	LogicalDate string
+	// FailedTasks lists the task_ids that reached the failed state.
+	FailedTasks []string
+}
+
+// Render substitutes the run context into a message template, replacing
+// {{dag}}, {{run_id}}, {{logical_date}}, {{task}} (the first failed task) and
+// {{tasks}} (all failed tasks, comma-separated). An empty template yields a
+// default one-line summary so an operator never receives a blank alert.
+func Render(tmpl string, ev Event) string {
+	if strings.TrimSpace(tmpl) == "" {
+		tmpl = "DAG {{dag}} run {{run_id}} failed"
+		if len(ev.FailedTasks) > 0 {
+			tmpl += ": {{tasks}}"
+		}
+	}
+	firstTask := ""
+	if len(ev.FailedTasks) > 0 {
+		firstTask = ev.FailedTasks[0]
+	}
+	r := strings.NewReplacer(
+		"{{dag}}", ev.DagID,
+		"{{run_id}}", ev.RunID,
+		"{{logical_date}}", ev.LogicalDate,
+		"{{task}}", firstTask,
+		"{{tasks}}", strings.Join(ev.FailedTasks, ", "),
+	)
+	return r.Replace(tmpl)
+}
+
+// Notifier posts resolved alerts over HTTP. It is safe for concurrent use.
+type Notifier struct {
+	client *http.Client
+}
+
+// NewNotifier returns a Notifier that sends with the given HTTP client. The
+// client SHOULD carry a timeout so a slow endpoint cannot wedge the caller.
+func NewNotifier(client *http.Client) *Notifier {
+	return &Notifier{client: client}
+}
+
+// Send posts message to url for the given channel type: "slack" sends Slack's
+// {"text": …} incoming-webhook shape; "webhook" sends a structured JSON payload
+// carrying the run context. A non-2xx response or an unknown channel type is an
+// error; the caller decides whether that is fatal (it should not be — an alert
+// failure must not fail the run).
+func (n *Notifier) Send(ctx context.Context, channelType, url, message string, ev Event) error {
+	var payload any
+	switch channelType {
+	case "slack":
+		payload = map[string]string{"text": message}
+	case "webhook":
+		payload = map[string]any{
+			"dag_id":       ev.DagID,
+			"run_id":       ev.RunID,
+			"logical_date": ev.LogicalDate,
+			"failed_tasks": ev.FailedTasks,
+			"message":      message,
+		}
+	default:
+		return fmt.Errorf("unknown alert channel type %q", channelType)
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("encoding %s alert payload: %w", channelType, err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("building %s alert request: %w", channelType, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("sending %s alert: %w", channelType, err)
+	}
+	defer func() { _ = resp.Body.Close() }() //nolint:errcheck // best-effort close of the alert response body
+	//nolint:errcheck // draining the (capped) body for connection reuse; count/err are irrelevant
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("%s alert endpoint returned %s", channelType, resp.Status)
+	}
+	return nil
+}

--- a/internal/alerts/alerts_test.go
+++ b/internal/alerts/alerts_test.go
@@ -41,7 +41,7 @@ func TestSendSlackPostsText(t *testing.T) {
 	defer srv.Close()
 
 	n := NewNotifier(&http.Client{Timeout: 2 * time.Second})
-	if err := n.Send(context.Background(), "slack", srv.URL, "boom", Event{DagID: "d", RunID: "r"}); err != nil {
+	if err := n.Send(context.Background(), "slack", srv.URL, nil, "boom", Event{DagID: "d", RunID: "r"}); err != nil {
 		t.Fatalf("Send slack: %v", err)
 	}
 	if body["text"] != "boom" {
@@ -60,11 +60,29 @@ func TestSendWebhookPostsStructuredPayload(t *testing.T) {
 
 	n := NewNotifier(&http.Client{Timeout: 2 * time.Second})
 	ev := Event{DagID: "sales", RunID: "run-1", FailedTasks: []string{"load"}}
-	if err := n.Send(context.Background(), "webhook", srv.URL, "sales failed", ev); err != nil {
+	if err := n.Send(context.Background(), "webhook", srv.URL, nil, "sales failed", ev); err != nil {
 		t.Fatalf("Send webhook: %v", err)
 	}
 	if body["dag_id"] != "sales" || body["run_id"] != "run-1" || body["message"] != "sales failed" {
 		t.Fatalf("webhook payload = %v, want dag_id/run_id/message set", body)
+	}
+}
+
+func TestSendAppliesAuthHeader(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := NewNotifier(&http.Client{Timeout: 2 * time.Second})
+	headers := map[string]string{"Authorization": "GenieKey abc123"}
+	if err := n.Send(context.Background(), "webhook", srv.URL, headers, "ping", Event{}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if gotAuth != "GenieKey abc123" {
+		t.Fatalf("Authorization header = %q, want it applied", gotAuth)
 	}
 }
 
@@ -75,14 +93,14 @@ func TestSendNon2xxIsError(t *testing.T) {
 	defer srv.Close()
 
 	n := NewNotifier(&http.Client{Timeout: 2 * time.Second})
-	if err := n.Send(context.Background(), "slack", srv.URL, "x", Event{}); err == nil {
+	if err := n.Send(context.Background(), "slack", srv.URL, nil, "x", Event{}); err == nil {
 		t.Fatal("expected error on non-2xx response")
 	}
 }
 
 func TestSendUnknownChannelIsError(t *testing.T) {
 	n := NewNotifier(&http.Client{Timeout: 2 * time.Second})
-	if err := n.Send(context.Background(), "carrier-pigeon", "http://x", "m", Event{}); err == nil {
+	if err := n.Send(context.Background(), "carrier-pigeon", "http://x", nil, "m", Event{}); err == nil {
 		t.Fatal("expected error on unknown channel type")
 	}
 }

--- a/internal/alerts/alerts_test.go
+++ b/internal/alerts/alerts_test.go
@@ -1,0 +1,97 @@
+package alerts
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRenderSubstitutesRunContext(t *testing.T) {
+	ev := Event{DagID: "sales", RunID: "run-1", LogicalDate: "2026-07-17", FailedTasks: []string{"extract", "load"}}
+	got := Render("{{dag}} {{run_id}} @ {{logical_date}} failed: {{tasks}}", ev)
+	want := "sales run-1 @ 2026-07-17 failed: extract, load"
+	if got != want {
+		t.Fatalf("Render = %q, want %q", got, want)
+	}
+}
+
+// An empty template yields a sensible default summary rather than a blank message.
+func TestRenderEmptyTemplateDefaults(t *testing.T) {
+	ev := Event{DagID: "sales", RunID: "run-1", FailedTasks: []string{"load"}}
+	got := Render("", ev)
+	if got == "" {
+		t.Fatal("empty template must produce a default summary")
+	}
+	if !contains(got, "sales") || !contains(got, "run-1") {
+		t.Fatalf("default summary %q missing dag/run", got)
+	}
+}
+
+func TestSendSlackPostsText(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := NewNotifier(&http.Client{Timeout: 2 * time.Second})
+	if err := n.Send(context.Background(), "slack", srv.URL, "boom", Event{DagID: "d", RunID: "r"}); err != nil {
+		t.Fatalf("Send slack: %v", err)
+	}
+	if body["text"] != "boom" {
+		t.Fatalf("slack payload = %v, want text=boom", body)
+	}
+}
+
+func TestSendWebhookPostsStructuredPayload(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	n := NewNotifier(&http.Client{Timeout: 2 * time.Second})
+	ev := Event{DagID: "sales", RunID: "run-1", FailedTasks: []string{"load"}}
+	if err := n.Send(context.Background(), "webhook", srv.URL, "sales failed", ev); err != nil {
+		t.Fatalf("Send webhook: %v", err)
+	}
+	if body["dag_id"] != "sales" || body["run_id"] != "run-1" || body["message"] != "sales failed" {
+		t.Fatalf("webhook payload = %v, want dag_id/run_id/message set", body)
+	}
+}
+
+func TestSendNon2xxIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	n := NewNotifier(&http.Client{Timeout: 2 * time.Second})
+	if err := n.Send(context.Background(), "slack", srv.URL, "x", Event{}); err == nil {
+		t.Fatal("expected error on non-2xx response")
+	}
+}
+
+func TestSendUnknownChannelIsError(t *testing.T) {
+	n := NewNotifier(&http.Client{Timeout: 2 * time.Second})
+	if err := n.Send(context.Background(), "carrier-pigeon", "http://x", "m", Event{}); err == nil {
+		t.Fatal("expected error on unknown channel type")
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -608,13 +608,14 @@ func parserErrorSummary(stderr string) string {
 	return last
 }
 
-// overlayProject writes the leoflow.yaml Leoflow-specific config (staging and
-// per-task overrides) onto the produced dag.json. These are deployment concerns,
-// not Airflow DAG attributes, so the parser does not emit them (ADR 0022, 0023).
+// overlayProject writes the leoflow.yaml Leoflow-specific config (staging,
+// on-failure alerts, and per-task overrides) onto the produced dag.json. These
+// are deployment concerns, not Airflow DAG attributes, so the parser does not
+// emit them (ADR 0022, 0023; #424).
 // Per-task overrides are bound by task_id; an entry naming a task absent from the
 // DAG is a hard error (no silent drop). No-op when nothing is configured.
 func overlayProject(dagJSONPath string, cfg *domain.LeoflowConfig) error {
-	if cfg.Staging == nil && len(cfg.Tasks) == 0 {
+	if cfg.Staging == nil && cfg.Alerts == nil && len(cfg.Tasks) == 0 {
 		return nil
 	}
 	data, err := os.ReadFile(dagJSONPath) //nolint:gosec // G304: output path is operator-supplied on the CLI.
@@ -627,6 +628,9 @@ func overlayProject(dagJSONPath string, cfg *domain.LeoflowConfig) error {
 	}
 	if cfg.Staging != nil {
 		spec.Staging = cfg.Staging
+	}
+	if cfg.Alerts != nil {
+		spec.Alerts = cfg.Alerts
 	}
 	if verr := validateTaskBindings(cfg.Tasks, spec.Tasks); verr != nil {
 		return verr

--- a/internal/cli/compile_overlay_test.go
+++ b/internal/cli/compile_overlay_test.go
@@ -126,3 +126,26 @@ func TestOverlayProjectPreservesStaging(t *testing.T) {
 		t.Errorf("staging = %+v, want enabled 5Gi", got.Staging)
 	}
 }
+
+// The overlay carries the leoflow.yaml alerts: block onto the compiled dag.json
+// (#424), so the scheduler can fire it without re-reading leoflow.yaml.
+func TestOverlayProjectCarriesAlerts(t *testing.T) {
+	path := writeDagJSON(t)
+	cfg := &domain.LeoflowConfig{
+		DagID: "proj",
+		Alerts: &domain.AlertsConfig{OnFailure: []domain.AlertRule{
+			{Type: "slack", Conn: "slack_prod", Message: "{{dag}} failed"},
+			{Type: "webhook", Conn: "pagerduty"},
+		}},
+	}
+	if err := overlayProject(path, cfg); err != nil {
+		t.Fatalf("overlayProject: %v", err)
+	}
+	got := readSpec(t, path)
+	if got.Alerts == nil || len(got.Alerts.OnFailure) != 2 {
+		t.Fatalf("alerts not carried: %+v", got.Alerts)
+	}
+	if got.Alerts.OnFailure[0].Type != "slack" || got.Alerts.OnFailure[0].Conn != "slack_prod" {
+		t.Errorf("first rule = %+v", got.Alerts.OnFailure[0])
+	}
+}

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -42,6 +42,35 @@ type LeoflowConfig struct {
 	// key must match a task_id in the compiled DAG; the compiler errors on an
 	// unknown id rather than silently dropping it.
 	Tasks map[string]*TaskConfig `json:"tasks,omitempty" yaml:"tasks,omitempty"`
+	// Alerts declares native on-failure alerting (#424): the scheduler fires the
+	// listed rules when a DagRun reaches the terminal failed state, in Go, with no
+	// task pod and no Python in the hot path. A Leoflow deployment concern (not an
+	// Airflow DAG attribute), so it lives in leoflow.yaml and the compiler overlays
+	// it onto the produced dag.json.
+	Alerts *AlertsConfig `json:"alerts,omitempty" yaml:"alerts,omitempty"`
+}
+
+// AlertsConfig groups alert rules by the lifecycle event that fires them. Only
+// on_failure is wired today (#424); on_success/on_retry are reserved for a later
+// increment so the surface can grow without a breaking change.
+type AlertsConfig struct {
+	// OnFailure lists the rules dispatched when a DagRun reaches failed.
+	OnFailure []AlertRule `json:"on_failure,omitempty" yaml:"on_failure,omitempty"`
+}
+
+// AlertRule is one channel to notify on an alert event. The endpoint and its
+// secret always come from a managed connection (Conn), never a literal URL or
+// token in leoflow.yaml — that keeps credentials out of the compiled dag.json and
+// mirrors the env-ref secret discipline.
+type AlertRule struct {
+	// Type is the channel: "slack" (Slack incoming webhook) or "webhook" (a generic
+	// HTTP POST, e.g. PagerDuty/Opsgenie/Teams). Validated by the schema enum.
+	Type string `json:"type" yaml:"type"`
+	// Conn is the managed Leoflow connection id holding the endpoint (and secret).
+	Conn string `json:"conn" yaml:"conn"`
+	// Message is the optional notification body; it is templated at fire time with
+	// run context ({{dag}}, {{run_id}}, {{task}}, …). Empty uses a default summary.
+	Message string `json:"message,omitempty" yaml:"message,omitempty"`
 }
 
 // DbtConfig declares a dbt project as the DAG source (ADR 0042). The compiler

--- a/internal/domain/config_alerts_test.go
+++ b/internal/domain/config_alerts_test.go
@@ -1,0 +1,64 @@
+package domain
+
+import (
+	"testing"
+
+	yaml "go.yaml.in/yaml/v3"
+)
+
+// A leoflow.yaml alerts: block (native on-failure alerting, #424) unmarshals into
+// the typed config and validates against the canonical schema.
+func TestAlertsConfigUnmarshalsAndValidates(t *testing.T) {
+	const y = `
+dag_id: sales
+alerts:
+  on_failure:
+    - type: slack
+      conn: slack_prod
+      message: "{{dag}} failed"
+    - type: webhook
+      conn: pagerduty
+`
+	var c LeoflowConfig
+	if err := yaml.Unmarshal([]byte(y), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.Alerts == nil || len(c.Alerts.OnFailure) != 2 {
+		t.Fatalf("alerts.on_failure not parsed: %+v", c.Alerts)
+	}
+	first := c.Alerts.OnFailure[0]
+	if first.Type != "slack" || first.Conn != "slack_prod" || first.Message != "{{dag}} failed" {
+		t.Fatalf("first rule mismatch: %+v", first)
+	}
+	if c.Alerts.OnFailure[1].Type != "webhook" || c.Alerts.OnFailure[1].Conn != "pagerduty" {
+		t.Fatalf("second rule mismatch: %+v", c.Alerts.OnFailure[1])
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("valid alerts config rejected: %v", err)
+	}
+}
+
+// An unknown alert type is rejected by the schema enum, not silently accepted —
+// consistent with how dbt granularity and connector names fail loud.
+func TestAlertsConfigRejectsUnknownType(t *testing.T) {
+	c := &LeoflowConfig{
+		DagID:  "sales",
+		Alerts: &AlertsConfig{OnFailure: []AlertRule{{Type: "carrier-pigeon", Conn: "x"}}},
+	}
+	if err := c.Validate(); err == nil {
+		t.Fatal("expected unknown alert type to be rejected")
+	}
+}
+
+// An alert rule without a connection is rejected: the endpoint and its secret must
+// come from a managed connection, never a literal URL/token in leoflow.yaml (which
+// would then be rendered into dag.json). Aligns with the env-ref secret discipline.
+func TestAlertsConfigRequiresConn(t *testing.T) {
+	c := &LeoflowConfig{
+		DagID:  "sales",
+		Alerts: &AlertsConfig{OnFailure: []AlertRule{{Type: "slack"}}},
+	}
+	if err := c.Validate(); err == nil {
+		t.Fatal("expected alert rule without conn to be rejected")
+	}
+}

--- a/internal/domain/dag.go
+++ b/internal/domain/dag.go
@@ -80,7 +80,11 @@ type DAGSpec struct {
 	// Staging, when enabled, requests an ephemeral RWX volume shared by the run's
 	// tasks at /staging (ADR 0022). nil/disabled means no staging volume.
 	Staging *StagingConfig `json:"staging,omitempty"`
-	Tasks   []TaskSpec     `json:"tasks"`
+	// Alerts declares native on-failure alerting (#424), overlaid from leoflow.yaml
+	// at compile time so the scheduler fires it from the artifact without re-reading
+	// the project config. nil means no alerting.
+	Alerts *AlertsConfig `json:"alerts,omitempty"`
+	Tasks  []TaskSpec    `json:"tasks"`
 	// Source is the original dag.py text, captured at compile time so the UI's
 	// Code tab can show the Python a human wrote (not the compiled spec). It is
 	// part of the artifact: changing it produces a new version.

--- a/internal/domain/schemas/dag-schema.json
+++ b/internal/domain/schemas/dag-schema.json
@@ -106,6 +106,26 @@
       },
       "additionalProperties": false
     },
+    "alerts": {
+      "type": "object",
+      "description": "Native on-failure alerting (#424), overlaid from leoflow.yaml; the scheduler fires it when the DagRun reaches failed.",
+      "properties": {
+        "on_failure": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": { "type": "string", "enum": ["slack", "webhook"] },
+              "conn": { "type": "string", "minLength": 1 },
+              "message": { "type": "string" }
+            },
+            "required": ["type", "conn"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "tasks": {
       "type": "array",
       "minItems": 1,

--- a/internal/domain/schemas/leoflow-yaml-schema.json
+++ b/internal/domain/schemas/leoflow-yaml-schema.json
@@ -164,6 +164,28 @@
       }
     },
 
+    "alerts": {
+      "type": "object",
+      "description": "Native on-failure alerting (#424). The scheduler fires these rules when a DagRun reaches the terminal failed state — in Go, with no task pod.",
+      "properties": {
+        "on_failure": {
+          "type": "array",
+          "description": "Rules dispatched when the DagRun fails.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": { "type": "string", "enum": ["slack", "webhook"], "description": "Channel: slack (incoming webhook) or webhook (generic HTTP POST)." },
+              "conn": { "type": "string", "minLength": 1, "description": "Managed Leoflow connection id holding the endpoint and its secret. Required — no literal URLs/tokens in leoflow.yaml." },
+              "message": { "type": "string", "description": "Optional notification body, templated with run context ({{dag}}, {{run_id}}, {{task}})." }
+            },
+            "required": ["type", "conn"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+
     "tasks": {
       "type": "object",
       "description": "Per-task overrides bound by task_id (ADR 0023). Each key MUST match a task_id in the compiled DAG; an unknown id fails the compile. A set field overrides the value compiled from the DAG (task override > DAG defaults).",

--- a/internal/failurealert/dispatcher.go
+++ b/internal/failurealert/dispatcher.go
@@ -1,0 +1,82 @@
+// Package failurealert adapts a DAG's on-failure alert rules (#424) to the
+// scheduler's Alerter seam: it resolves each rule's managed connection to an
+// endpoint URL, renders the message, and sends it via the alerts notifier —
+// best-effort, so a delivery failure is logged and never fails the run. It is
+// the piece that wires the pure notifier (internal/alerts) and the connection
+// store together, kept out of the scheduler so that package stays storage-free.
+package failurealert
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/neochaotic/leoflow/internal/alerts"
+	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/scheduler"
+)
+
+// EndpointResolver maps a managed connection id to the channel endpoint URL to
+// POST to (including any secret carried by the connection). tenantID scopes the
+// lookup. The connection→URL contract lives in the implementation so this
+// package needs no storage dependency.
+type EndpointResolver interface {
+	ResolveAlertEndpoint(ctx context.Context, tenantID, connID string) (string, error)
+}
+
+// sender is the subset of *alerts.Notifier this package needs, named locally so
+// it can be faked in tests.
+type sender interface {
+	Send(ctx context.Context, channelType, url, message string, ev alerts.Event) error
+}
+
+// Dispatcher implements scheduler.Alerter by resolving and sending a run's
+// on-failure alert rules.
+type Dispatcher struct {
+	notifier sender
+	resolver EndpointResolver
+	logger   *slog.Logger
+}
+
+// New builds a Dispatcher over the given notifier, connection resolver, and
+// logger.
+func New(notifier sender, resolver EndpointResolver, logger *slog.Logger) *Dispatcher {
+	return &Dispatcher{notifier: notifier, resolver: resolver, logger: logger}
+}
+
+// AlertRunFailed dispatches every on_failure rule of a failed run. Each rule is
+// resolved, rendered, and sent independently: a resolver or send error on one
+// rule is logged and skipped so the remaining rules still fire (best-effort).
+func (d *Dispatcher) AlertRunFailed(ctx context.Context, run scheduler.RunState) {
+	if run.Alerts == nil {
+		return
+	}
+	ev := alerts.Event{DagID: run.DagID, RunID: run.RunID, FailedTasks: failedTasks(run)}
+	for _, rule := range run.Alerts.OnFailure {
+		url, err := d.resolver.ResolveAlertEndpoint(ctx, run.TenantID, rule.Conn)
+		if err != nil {
+			d.logger.Error("resolving alert connection",
+				"dag", run.DagID, "run", run.RunID, "conn", rule.Conn, "error", err)
+			continue
+		}
+		message := alerts.Render(rule.Message, ev)
+		if serr := d.notifier.Send(ctx, rule.Type, url, message, ev); serr != nil {
+			d.logger.Error("sending on-failure alert",
+				"dag", run.DagID, "run", run.RunID, "type", rule.Type, "conn", rule.Conn, "error", serr)
+			continue
+		}
+		d.logger.Info("on-failure alert sent",
+			"dag", run.DagID, "run", run.RunID, "type", rule.Type, "conn", rule.Conn)
+	}
+}
+
+// failedTasks returns the task_ids that actually failed (not merely upstream-
+// failed), in DAG order, so the message template names a real culprit.
+func failedTasks(run scheduler.RunState) []string {
+	var out []string
+	for _, t := range run.Tasks {
+		if run.States[t.TaskID] == domain.TaskStateFailed {
+			out = append(out, t.TaskID)
+		}
+	}
+	return out
+}

--- a/internal/failurealert/dispatcher.go
+++ b/internal/failurealert/dispatcher.go
@@ -29,18 +29,39 @@ type sender interface {
 	Send(ctx context.Context, channelType, url, message string, ev alerts.Event) error
 }
 
+// Recorder counts alert dispatches for observability (principle 10). result is
+// "sent" on a successful POST or "failed" when the connection can't be resolved
+// or the send errors. A nil Recorder disables metrics.
+type Recorder interface {
+	RecordAlert(dagID, channelType, result string)
+}
+
+// alert dispatch outcomes reported to the Recorder.
+const (
+	resultSent   = "sent"
+	resultFailed = "failed"
+)
+
 // Dispatcher implements scheduler.Alerter by resolving and sending a run's
 // on-failure alert rules.
 type Dispatcher struct {
 	notifier sender
 	resolver EndpointResolver
+	recorder Recorder
 	logger   *slog.Logger
 }
 
-// New builds a Dispatcher over the given notifier, connection resolver, and
-// logger.
-func New(notifier sender, resolver EndpointResolver, logger *slog.Logger) *Dispatcher {
-	return &Dispatcher{notifier: notifier, resolver: resolver, logger: logger}
+// New builds a Dispatcher over the given notifier, connection resolver, metrics
+// recorder (nil disables metrics), and logger.
+func New(notifier sender, resolver EndpointResolver, recorder Recorder, logger *slog.Logger) *Dispatcher {
+	return &Dispatcher{notifier: notifier, resolver: resolver, recorder: recorder, logger: logger}
+}
+
+// record reports an alert outcome to the Recorder when one is configured.
+func (d *Dispatcher) record(dagID, channelType, result string) {
+	if d.recorder != nil {
+		d.recorder.RecordAlert(dagID, channelType, result)
+	}
 }
 
 // AlertRunFailed dispatches every on_failure rule of a failed run. Each rule is
@@ -56,16 +77,19 @@ func (d *Dispatcher) AlertRunFailed(ctx context.Context, run scheduler.RunState)
 		if err != nil {
 			d.logger.Error("resolving alert connection",
 				"dag", run.DagID, "run", run.RunID, "conn", rule.Conn, "error", err)
+			d.record(run.DagID, rule.Type, resultFailed)
 			continue
 		}
 		message := alerts.Render(rule.Message, ev)
 		if serr := d.notifier.Send(ctx, rule.Type, url, message, ev); serr != nil {
 			d.logger.Error("sending on-failure alert",
 				"dag", run.DagID, "run", run.RunID, "type", rule.Type, "conn", rule.Conn, "error", serr)
+			d.record(run.DagID, rule.Type, resultFailed)
 			continue
 		}
 		d.logger.Info("on-failure alert sent",
 			"dag", run.DagID, "run", run.RunID, "type", rule.Type, "conn", rule.Conn)
+		d.record(run.DagID, rule.Type, resultSent)
 	}
 }
 

--- a/internal/failurealert/dispatcher.go
+++ b/internal/failurealert/dispatcher.go
@@ -15,18 +15,26 @@ import (
 	"github.com/neochaotic/leoflow/internal/scheduler"
 )
 
-// EndpointResolver maps a managed connection id to the channel endpoint URL to
-// POST to (including any secret carried by the connection). tenantID scopes the
-// lookup. The connection→URL contract lives in the implementation so this
-// package needs no storage dependency.
+// Endpoint is a resolved alert channel: the URL to POST to and any headers the
+// endpoint requires (e.g. an Authorization header when the token is not carried
+// in the URL, as with Opsgenie).
+type Endpoint struct {
+	URL     string
+	Headers map[string]string
+}
+
+// EndpointResolver maps a managed connection id to its channel Endpoint
+// (including any secret the connection carries). tenantID scopes the lookup. The
+// connection→endpoint contract lives in the implementation so this package needs
+// no storage dependency.
 type EndpointResolver interface {
-	ResolveAlertEndpoint(ctx context.Context, tenantID, connID string) (string, error)
+	ResolveAlertEndpoint(ctx context.Context, tenantID, connID string) (Endpoint, error)
 }
 
 // sender is the subset of *alerts.Notifier this package needs, named locally so
 // it can be faked in tests.
 type sender interface {
-	Send(ctx context.Context, channelType, url, message string, ev alerts.Event) error
+	Send(ctx context.Context, channelType, url string, headers map[string]string, message string, ev alerts.Event) error
 }
 
 // Recorder counts alert dispatches for observability (principle 10). result is
@@ -73,7 +81,7 @@ func (d *Dispatcher) AlertRunFailed(ctx context.Context, run scheduler.RunState)
 	}
 	ev := alerts.Event{DagID: run.DagID, RunID: run.RunID, FailedTasks: failedTasks(run)}
 	for _, rule := range run.Alerts.OnFailure {
-		url, err := d.resolver.ResolveAlertEndpoint(ctx, run.TenantID, rule.Conn)
+		endpoint, err := d.resolver.ResolveAlertEndpoint(ctx, run.TenantID, rule.Conn)
 		if err != nil {
 			d.logger.Error("resolving alert connection",
 				"dag", run.DagID, "run", run.RunID, "conn", rule.Conn, "error", err)
@@ -81,7 +89,7 @@ func (d *Dispatcher) AlertRunFailed(ctx context.Context, run scheduler.RunState)
 			continue
 		}
 		message := alerts.Render(rule.Message, ev)
-		if serr := d.notifier.Send(ctx, rule.Type, url, message, ev); serr != nil {
+		if serr := d.notifier.Send(ctx, rule.Type, endpoint.URL, endpoint.Headers, message, ev); serr != nil {
 			d.logger.Error("sending on-failure alert",
 				"dag", run.DagID, "run", run.RunID, "type", rule.Type, "conn", rule.Conn, "error", serr)
 			d.record(run.DagID, rule.Type, resultFailed)

--- a/internal/failurealert/dispatcher_test.go
+++ b/internal/failurealert/dispatcher_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 
@@ -12,6 +13,17 @@ import (
 	"github.com/neochaotic/leoflow/internal/domain"
 	"github.com/neochaotic/leoflow/internal/scheduler"
 )
+
+type fakeRecorder struct {
+	mu    sync.Mutex
+	calls []string // "dag:type:result"
+}
+
+func (f *fakeRecorder) RecordAlert(dagID, channelType, result string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, dagID+":"+channelType+":"+result)
+}
 
 type fakeResolver struct {
 	urls map[string]string
@@ -70,7 +82,7 @@ func TestAlertRunFailedSendsEveryRule(t *testing.T) {
 		"pagerduty":  "https://events.pagerduty.com/enqueue",
 	}}
 	snd := &fakeSender{}
-	d := New(snd, res, quietLogger())
+	d := New(snd, res, nil, quietLogger())
 
 	d.AlertRunFailed(context.Background(), failedRun())
 
@@ -93,7 +105,7 @@ func TestAlertRunFailedIsBestEffort(t *testing.T) {
 		err:  map[string]error{"slack_prod": errors.New("no such connection")},
 	}
 	snd := &fakeSender{}
-	d := New(snd, res, quietLogger())
+	d := New(snd, res, nil, quietLogger())
 
 	d.AlertRunFailed(context.Background(), failedRun())
 
@@ -112,7 +124,7 @@ func TestAlertRunFailedSwallowsSendError(t *testing.T) {
 	snd := &fakeSender{fail: map[string]error{
 		"https://hooks.slack.com/services/xxx": errors.New("slack 500"),
 	}}
-	d := New(snd, res, quietLogger())
+	d := New(snd, res, nil, quietLogger())
 
 	d.AlertRunFailed(context.Background(), failedRun())
 
@@ -121,7 +133,47 @@ func TestAlertRunFailedSwallowsSendError(t *testing.T) {
 	}
 }
 
+// Each rule records a metric: "sent" on success, "failed" when the send errors —
+// so operators can alert on the alerter itself (observability, principle 10).
+func TestAlertRunFailedRecordsMetrics(t *testing.T) {
+	res := &fakeResolver{urls: map[string]string{
+		"slack_prod": "https://hooks.slack.com/services/xxx",
+		"pagerduty":  "https://events.pagerduty.com/enqueue",
+	}}
+	snd := &fakeSender{fail: map[string]error{
+		"https://events.pagerduty.com/enqueue": errors.New("pd 500"),
+	}}
+	rec := &fakeRecorder{}
+	d := New(snd, res, rec, quietLogger())
+
+	d.AlertRunFailed(context.Background(), failedRun())
+
+	got := strings.Join(rec.calls, ",")
+	if !strings.Contains(got, "etl:slack:sent") {
+		t.Errorf("missing slack sent metric: %v", rec.calls)
+	}
+	if !strings.Contains(got, "etl:webhook:failed") {
+		t.Errorf("missing webhook failed metric: %v", rec.calls)
+	}
+}
+
+// A resolver failure also records a "failed" metric (not a silent drop).
+func TestAlertRunFailedRecordsResolveFailure(t *testing.T) {
+	res := &fakeResolver{
+		urls: map[string]string{"pagerduty": "https://events.pagerduty.com/enqueue"},
+		err:  map[string]error{"slack_prod": errors.New("no such connection")},
+	}
+	rec := &fakeRecorder{}
+	d := New(&fakeSender{}, res, rec, quietLogger())
+
+	d.AlertRunFailed(context.Background(), failedRun())
+
+	if !strings.Contains(strings.Join(rec.calls, ","), "etl:slack:failed") {
+		t.Errorf("a resolve failure must record failed: %v", rec.calls)
+	}
+}
+
 // The Dispatcher satisfies the scheduler's Alerter seam.
 func TestDispatcherImplementsAlerter(t *testing.T) {
-	var _ scheduler.Alerter = New(&fakeSender{}, &fakeResolver{}, quietLogger())
+	var _ scheduler.Alerter = New(&fakeSender{}, &fakeResolver{}, nil, quietLogger())
 }

--- a/internal/failurealert/dispatcher_test.go
+++ b/internal/failurealert/dispatcher_test.go
@@ -102,6 +102,25 @@ func TestAlertRunFailedIsBestEffort(t *testing.T) {
 	}
 }
 
+// A send failure on one rule is logged and swallowed; the run is never affected
+// and the remaining rule still sends (best-effort at the send layer too).
+func TestAlertRunFailedSwallowsSendError(t *testing.T) {
+	res := &fakeResolver{urls: map[string]string{
+		"slack_prod": "https://hooks.slack.com/services/xxx",
+		"pagerduty":  "https://events.pagerduty.com/enqueue",
+	}}
+	snd := &fakeSender{fail: map[string]error{
+		"https://hooks.slack.com/services/xxx": errors.New("slack 500"),
+	}}
+	d := New(snd, res, quietLogger())
+
+	d.AlertRunFailed(context.Background(), failedRun())
+
+	if len(snd.sent) != 1 || snd.sent[0].channelType != "webhook" {
+		t.Fatalf("a failed send must not drop the other rule; got %+v", snd.sent)
+	}
+}
+
 // The Dispatcher satisfies the scheduler's Alerter seam.
 func TestDispatcherImplementsAlerter(t *testing.T) {
 	var _ scheduler.Alerter = New(&fakeSender{}, &fakeResolver{}, quietLogger())

--- a/internal/failurealert/dispatcher_test.go
+++ b/internal/failurealert/dispatcher_test.go
@@ -1,0 +1,108 @@
+package failurealert
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/alerts"
+	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/scheduler"
+)
+
+type fakeResolver struct {
+	urls map[string]string
+	err  map[string]error
+}
+
+func (f *fakeResolver) ResolveAlertEndpoint(_ context.Context, _, connID string) (string, error) {
+	if e := f.err[connID]; e != nil {
+		return "", e
+	}
+	return f.urls[connID], nil
+}
+
+type capturedSend struct {
+	channelType, url, message string
+	ev                        alerts.Event
+}
+
+type fakeSender struct {
+	mu   sync.Mutex
+	sent []capturedSend
+	fail map[string]error // keyed by url
+}
+
+func (f *fakeSender) Send(_ context.Context, channelType, url, message string, ev alerts.Event) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if e := f.fail[url]; e != nil {
+		return e
+	}
+	f.sent = append(f.sent, capturedSend{channelType, url, message, ev})
+	return nil
+}
+
+func quietLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+func failedRun() scheduler.RunState {
+	return scheduler.RunState{
+		RunID: "r1", DagID: "etl", TenantID: "t1",
+		Tasks: []domain.TaskSpec{{TaskID: "extract"}, {TaskID: "load"}},
+		States: map[string]domain.TaskState{
+			"extract": domain.TaskStateFailed,
+			"load":    domain.TaskStateUpstreamFailed,
+		},
+		Alerts: &domain.AlertsConfig{OnFailure: []domain.AlertRule{
+			{Type: "slack", Conn: "slack_prod", Message: "{{dag}} failed on {{task}}"},
+			{Type: "webhook", Conn: "pagerduty"},
+		}},
+	}
+}
+
+// Every rule is resolved, rendered, and sent; the failed task drives the template.
+func TestAlertRunFailedSendsEveryRule(t *testing.T) {
+	res := &fakeResolver{urls: map[string]string{
+		"slack_prod": "https://hooks.slack.com/services/xxx",
+		"pagerduty":  "https://events.pagerduty.com/enqueue",
+	}}
+	snd := &fakeSender{}
+	d := New(snd, res, quietLogger())
+
+	d.AlertRunFailed(context.Background(), failedRun())
+
+	if len(snd.sent) != 2 {
+		t.Fatalf("sent %d alerts, want 2", len(snd.sent))
+	}
+	got := snd.sent[0]
+	if got.channelType != "slack" || got.url != "https://hooks.slack.com/services/xxx" {
+		t.Errorf("slack rule mis-sent: %+v", got)
+	}
+	if got.message != "etl failed on extract" {
+		t.Errorf("message = %q, want rendered with the failed task", got.message)
+	}
+}
+
+// A resolver failure on one rule is logged and skipped; the other rule still sends.
+func TestAlertRunFailedIsBestEffort(t *testing.T) {
+	res := &fakeResolver{
+		urls: map[string]string{"pagerduty": "https://events.pagerduty.com/enqueue"},
+		err:  map[string]error{"slack_prod": errors.New("no such connection")},
+	}
+	snd := &fakeSender{}
+	d := New(snd, res, quietLogger())
+
+	d.AlertRunFailed(context.Background(), failedRun())
+
+	if len(snd.sent) != 1 || snd.sent[0].channelType != "webhook" {
+		t.Fatalf("expected only the webhook to send, got %+v", snd.sent)
+	}
+}
+
+// The Dispatcher satisfies the scheduler's Alerter seam.
+func TestDispatcherImplementsAlerter(t *testing.T) {
+	var _ scheduler.Alerter = New(&fakeSender{}, &fakeResolver{}, quietLogger())
+}

--- a/internal/failurealert/dispatcher_test.go
+++ b/internal/failurealert/dispatcher_test.go
@@ -26,19 +26,21 @@ func (f *fakeRecorder) RecordAlert(dagID, channelType, result string) {
 }
 
 type fakeResolver struct {
-	urls map[string]string
-	err  map[string]error
+	urls    map[string]string
+	headers map[string]map[string]string
+	err     map[string]error
 }
 
-func (f *fakeResolver) ResolveAlertEndpoint(_ context.Context, _, connID string) (string, error) {
+func (f *fakeResolver) ResolveAlertEndpoint(_ context.Context, _, connID string) (Endpoint, error) {
 	if e := f.err[connID]; e != nil {
-		return "", e
+		return Endpoint{}, e
 	}
-	return f.urls[connID], nil
+	return Endpoint{URL: f.urls[connID], Headers: f.headers[connID]}, nil
 }
 
 type capturedSend struct {
 	channelType, url, message string
+	headers                   map[string]string
 	ev                        alerts.Event
 }
 
@@ -48,13 +50,13 @@ type fakeSender struct {
 	fail map[string]error // keyed by url
 }
 
-func (f *fakeSender) Send(_ context.Context, channelType, url, message string, ev alerts.Event) error {
+func (f *fakeSender) Send(_ context.Context, channelType, url string, headers map[string]string, message string, ev alerts.Event) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if e := f.fail[url]; e != nil {
 		return e
 	}
-	f.sent = append(f.sent, capturedSend{channelType, url, message, ev})
+	f.sent = append(f.sent, capturedSend{channelType, url, message, headers, ev})
 	return nil
 }
 
@@ -170,6 +172,25 @@ func TestAlertRunFailedRecordsResolveFailure(t *testing.T) {
 
 	if !strings.Contains(strings.Join(rec.calls, ","), "etl:slack:failed") {
 		t.Errorf("a resolve failure must record failed: %v", rec.calls)
+	}
+}
+
+// The resolver's headers reach the sender, so an endpoint that needs an auth
+// header (e.g. Opsgenie) gets one.
+func TestAlertRunFailedForwardsHeaders(t *testing.T) {
+	res := &fakeResolver{
+		urls:    map[string]string{"slack_prod": "u1", "pagerduty": "u2"},
+		headers: map[string]map[string]string{"pagerduty": {"Authorization": "GenieKey k"}},
+	}
+	snd := &fakeSender{}
+	d := New(snd, res, nil, quietLogger())
+
+	d.AlertRunFailed(context.Background(), failedRun())
+
+	for _, s := range snd.sent {
+		if s.channelType == "webhook" && s.headers["Authorization"] != "GenieKey k" {
+			t.Fatalf("webhook send missing auth header: %+v", s)
+		}
 	}
 }
 

--- a/internal/observability/metrics.go
+++ b/internal/observability/metrics.go
@@ -20,6 +20,7 @@ type Metrics struct {
 	TasksUndispatchable   *prometheus.CounterVec
 	SchedulerStepDowns    *prometheus.CounterVec // #311 leader churn observability
 	SchedulerReacquire    prometheus.Histogram   // #311 step-down → re-acquire latency
+	AlertsDispatched      *prometheus.CounterVec // #424 on-failure alerts, by outcome
 
 	// Task lifecycle
 	TaskStateTransitions    *prometheus.CounterVec
@@ -105,6 +106,11 @@ func NewMetrics(reg prometheus.Registerer) *Metrics {
 		QueuedTasks: f.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "leoflow_queued_tasks", Help: "Queued task instances by dag.",
 		}, []string{"dag_id"}),
+		AlertsDispatched: f.NewCounterVec(prometheus.CounterOpts{
+			Name: "leoflow_alerts_dispatched_total",
+			Help: "Native on-failure alerts dispatched, by channel type and outcome (sent, failed). " +
+				"Operators alert on rate of result=\"failed\" to catch a broken alert path (#424).",
+		}, []string{"dag_id", "type", "result"}),
 
 		TaskStateTransitions: f.NewCounterVec(prometheus.CounterOpts{
 			Name: "leoflow_task_state_transitions_total", Help: "Task state transitions.",
@@ -244,6 +250,12 @@ func (m *Metrics) RecordHTTPRequest(method, path string, status int, dur time.Du
 // RecordSchedulerDecision records one scheduler decision by type.
 func (m *Metrics) RecordSchedulerDecision(decisionType string) {
 	m.SchedulerDecisions.WithLabelValues(decisionType).Inc()
+}
+
+// RecordAlert counts one on-failure alert dispatch (#424) by dag, channel type,
+// and outcome ("sent" or "failed"). Satisfies failurealert.Recorder.
+func (m *Metrics) RecordAlert(dagID, channelType, result string) {
+	m.AlertsDispatched.WithLabelValues(dagID, channelType, result).Inc()
 }
 
 // RecordSchedulerStepDown increments the leader step-down counter (#311). The

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -165,6 +165,12 @@ const maxCatchupSlotsPerTick = 100
 // that a real orphan is reaped before the operator looks at the dashboard.
 const defaultOrphanThreshold = 5 * time.Minute
 
+// defaultAlertConcurrency caps concurrent on-failure alert dispatches (#424) so a
+// mass failure can't spawn an unbounded burst of alert goroutines/POSTs. Each
+// dispatch is short (bounded by the notifier's HTTP timeout), so a small pool
+// absorbs normal bursts; beyond it, extra alerts are dropped best-effort.
+const defaultAlertConcurrency = 8
+
 // defaultAgentLostThreshold is how long a running TI may go without an agent
 // heartbeat before the TI reaper declares the agent lost. 90 s is 6x the
 // default agent heartbeat interval (15 s, see cmd/leoflow-agent/main.go),
@@ -181,14 +187,19 @@ const defaultDispatchLostThreshold = 3 * time.Minute
 
 // Scheduler advances dag runs by applying the planning rules each tick.
 type Scheduler struct {
-	store                 Store
-	logger                *slog.Logger
-	interval              time.Duration
-	stepTimeout           time.Duration
-	recorder              Recorder
-	dispatcher            Dispatcher
-	inline                InlineRunner
-	alerter               Alerter
+	store       Store
+	logger      *slog.Logger
+	interval    time.Duration
+	stepTimeout time.Duration
+	recorder    Recorder
+	dispatcher  Dispatcher
+	inline      InlineRunner
+	alerter     Alerter
+	// alertSem bounds concurrent on-failure alert dispatches (#424): a mass
+	// failure must not spawn an unbounded burst of alert goroutines/POSTs. A
+	// buffered channel used as a counting semaphore; a saturated slot drops the
+	// alert (best-effort) rather than blocking the tick.
+	alertSem              chan struct{}
 	orphanThreshold       time.Duration
 	agentLostThreshold    time.Duration
 	dispatchLostThreshold time.Duration
@@ -212,6 +223,7 @@ func NewScheduler(store Store, logger *slog.Logger, interval time.Duration) *Sch
 		agentLostThreshold:    defaultAgentLostThreshold,
 		dispatchLostThreshold: defaultDispatchLostThreshold,
 		warnedSchedules:       map[string]string{},
+		alertSem:              make(chan struct{}, defaultAlertConcurrency),
 	}
 }
 
@@ -304,6 +316,16 @@ func (s *Scheduler) SetInlineRunner(r InlineRunner) { s.inline = r }
 // SetAlerter attaches the on-failure alerter (optional; #424). Without it, or
 // for a DAG with no alert rules, the scheduler finalizes failures silently.
 func (s *Scheduler) SetAlerter(a Alerter) { s.alerter = a }
+
+// SetAlertConcurrency caps how many on-failure alert dispatches may run at once
+// (#424). n < 1 is treated as 1. Mainly a config/test seam; the default is
+// defaultAlertConcurrency.
+func (s *Scheduler) SetAlertConcurrency(n int) {
+	if n < 1 {
+		n = 1
+	}
+	s.alertSem = make(chan struct{}, n)
+}
 
 // Alerter dispatches a DAG's on-failure alert rules for a run that finalized in
 // the failed state. Implementations resolve each rule's managed connection to an
@@ -608,7 +630,19 @@ func (s *Scheduler) maybeAlertFailure(ctx context.Context, state domain.DagRunSt
 	if run.Alerts == nil || len(run.Alerts.OnFailure) == 0 {
 		return
 	}
-	go s.alerter.AlertRunFailed(context.WithoutCancel(ctx), run)
+	// Acquire a dispatch slot without blocking the tick. A saturated semaphore
+	// means a burst of failures is already sending; dropping this one (with a
+	// warning) is the best-effort trade-off that protects the scheduler.
+	select {
+	case s.alertSem <- struct{}{}:
+		go func() {
+			defer func() { <-s.alertSem }()
+			s.alerter.AlertRunFailed(context.WithoutCancel(ctx), run)
+		}()
+	default:
+		s.logger.Warn("dropping on-failure alert: dispatch saturated",
+			"dag", run.DagID, "run", run.RunID, "limit", cap(s.alertSem))
+	}
 }
 
 // applyPlanned launches a task as it becomes queued and records the resulting

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -62,6 +62,10 @@ type RunState struct {
 	// means "skip the cooldown gate" so legacy callers + tests that don't set
 	// retry_delay get the previous (immediate-retry) behavior.
 	Now time.Time
+	// Alerts carries the DAG's native on-failure alerting config (#424), loaded
+	// from the dag.json alongside Tasks. nil means no alerting; the scheduler
+	// dispatches these rules once the run finalizes as failed.
+	Alerts *domain.AlertsConfig
 }
 
 // ScheduledDAG is a cron-scheduled DAG and the logical date of its latest run.
@@ -184,6 +188,7 @@ type Scheduler struct {
 	recorder              Recorder
 	dispatcher            Dispatcher
 	inline                InlineRunner
+	alerter               Alerter
 	orphanThreshold       time.Duration
 	agentLostThreshold    time.Duration
 	dispatchLostThreshold time.Duration
@@ -295,6 +300,20 @@ func (s *Scheduler) SetDispatcher(d Dispatcher) { s.dispatcher = d }
 // SetInlineRunner attaches the inline http_api runner (optional; without it
 // inline http_api tasks fall back to the standard queued dispatch path).
 func (s *Scheduler) SetInlineRunner(r InlineRunner) { s.inline = r }
+
+// SetAlerter attaches the on-failure alerter (optional; #424). Without it, or
+// for a DAG with no alert rules, the scheduler finalizes failures silently.
+func (s *Scheduler) SetAlerter(a Alerter) { s.alerter = a }
+
+// Alerter dispatches a DAG's on-failure alert rules for a run that finalized in
+// the failed state. Implementations resolve each rule's managed connection to an
+// endpoint and send (Slack/webhook). The scheduler calls it from a detached
+// goroutine, so an implementation may block on network I/O without stalling the
+// tick; it MUST treat every send as best-effort — a delivery failure is logged,
+// never propagated, so alerting can never fail a run.
+type Alerter interface {
+	AlertRunFailed(ctx context.Context, run RunState)
+}
 
 // Run drives the scheduling loop until ctx is canceled. The loop is crash-proof:
 // a panic or error in a tick is recovered and logged, so the scheduler keeps
@@ -572,8 +591,24 @@ func (s *Scheduler) advance(ctx context.Context, run RunState) error {
 		if err := s.store.SetRunState(ctx, run.RunID, state); err != nil {
 			return fmt.Errorf("finalizing run: %w", err)
 		}
+		s.maybeAlertFailure(ctx, state, run)
 	}
 	return nil
+}
+
+// maybeAlertFailure fires the DAG's on-failure alert rules when a run finalizes
+// failed. It runs in a detached goroutine (WithoutCancel) so a slow endpoint
+// never stalls the tick, and the alerter's own best-effort contract means a
+// delivery failure cannot fail the run. A nil alerter or a DAG without rules is
+// a no-op.
+func (s *Scheduler) maybeAlertFailure(ctx context.Context, state domain.DagRunState, run RunState) {
+	if state != domain.DagRunStateFailed || s.alerter == nil {
+		return
+	}
+	if run.Alerts == nil || len(run.Alerts.OnFailure) == 0 {
+		return
+	}
+	go s.alerter.AlertRunFailed(context.WithoutCancel(ctx), run)
 }
 
 // applyPlanned launches a task as it becomes queued and records the resulting

--- a/internal/scheduler/scheduler_alerts_test.go
+++ b/internal/scheduler/scheduler_alerts_test.go
@@ -14,6 +14,52 @@ type recordingAlerter struct{ ch chan RunState }
 
 func (r *recordingAlerter) AlertRunFailed(_ context.Context, run RunState) { r.ch <- run }
 
+// blockingAlerter signals when a dispatch starts and then holds the concurrency
+// slot until released, so a test can prove the scheduler bounds concurrency.
+type blockingAlerter struct {
+	started chan RunState
+	release chan struct{}
+}
+
+func (b *blockingAlerter) AlertRunFailed(_ context.Context, run RunState) {
+	b.started <- run
+	<-b.release
+}
+
+func exhaustedFailedRun(id string) RunState {
+	return RunState{
+		RunID: id, DagID: "etl", State: domain.DagRunStateRunning, Tasks: linearTasks(),
+		States:   map[string]domain.TaskState{"a": domain.TaskStateFailed, "b": domain.TaskStateUpstreamFailed},
+		Tries:    map[string]int{"a": 3, "b": 1},
+		MaxTries: map[string]int{"a": 3, "b": 3},
+		Alerts:   &domain.AlertsConfig{OnFailure: []domain.AlertRule{{Type: "slack", Conn: "slack"}}},
+	}
+}
+
+// With the concurrency bound at 1, a second simultaneously-failing run is dropped
+// (best-effort) rather than spawning an unbounded second dispatch goroutine.
+func TestStepBoundsAlertConcurrency(t *testing.T) {
+	al := &blockingAlerter{started: make(chan RunState, 4), release: make(chan struct{})}
+	defer close(al.release)
+	store := newFakeStore(exhaustedFailedRun("r1"), exhaustedFailedRun("r2"))
+	s := newScheduler(store)
+	s.SetAlerter(al)
+	s.SetAlertConcurrency(1)
+	if err := s.Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-al.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected one alert to start")
+	}
+	select {
+	case <-al.started:
+		t.Fatal("the second alert must be dropped while the slot is held, not spawned")
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
 // A run that finalizes failed with on_failure rules fires the alerter exactly once.
 func TestStepAlertsOnFailedFinalize(t *testing.T) {
 	store := newFakeStore(RunState{

--- a/internal/scheduler/scheduler_alerts_test.go
+++ b/internal/scheduler/scheduler_alerts_test.go
@@ -1,0 +1,81 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// recordingAlerter signals each AlertRunFailed call over a buffered channel so a
+// test can observe the scheduler's fire-and-forget dispatch deterministically.
+type recordingAlerter struct{ ch chan RunState }
+
+func (r *recordingAlerter) AlertRunFailed(_ context.Context, run RunState) { r.ch <- run }
+
+// A run that finalizes failed with on_failure rules fires the alerter exactly once.
+func TestStepAlertsOnFailedFinalize(t *testing.T) {
+	store := newFakeStore(RunState{
+		RunID: "r1", DagID: "etl", State: domain.DagRunStateRunning, Tasks: linearTasks(),
+		States:   map[string]domain.TaskState{"a": domain.TaskStateFailed, "b": domain.TaskStateUpstreamFailed},
+		Tries:    map[string]int{"a": 3, "b": 1},
+		MaxTries: map[string]int{"a": 3, "b": 3},
+		Alerts:   &domain.AlertsConfig{OnFailure: []domain.AlertRule{{Type: "slack", Conn: "slack"}}},
+	})
+	al := &recordingAlerter{ch: make(chan RunState, 1)}
+	s := newScheduler(store)
+	s.SetAlerter(al)
+	if err := s.Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case got := <-al.ch:
+		if got.RunID != "r1" {
+			t.Errorf("alerted run = %q, want r1", got.RunID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected an on-failure alert to fire")
+	}
+}
+
+// A successful run never alerts, even with on_failure rules configured.
+func TestStepNoAlertOnSuccess(t *testing.T) {
+	store := newFakeStore(RunState{
+		RunID: "r1", State: domain.DagRunStateRunning, Tasks: linearTasks(),
+		States: map[string]domain.TaskState{"a": domain.TaskStateSuccess, "b": domain.TaskStateSuccess},
+		Alerts: &domain.AlertsConfig{OnFailure: []domain.AlertRule{{Type: "slack", Conn: "slack"}}},
+	})
+	al := &recordingAlerter{ch: make(chan RunState, 1)}
+	s := newScheduler(store)
+	s.SetAlerter(al)
+	if err := s.Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-al.ch:
+		t.Fatal("no alert expected on a successful run")
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+// A failed run with no alert rules does not fire the alerter (nothing to send).
+func TestStepNoAlertWhenNoRules(t *testing.T) {
+	store := newFakeStore(RunState{
+		RunID: "r1", State: domain.DagRunStateRunning, Tasks: linearTasks(),
+		States:   map[string]domain.TaskState{"a": domain.TaskStateFailed, "b": domain.TaskStateUpstreamFailed},
+		Tries:    map[string]int{"a": 3, "b": 1},
+		MaxTries: map[string]int{"a": 3, "b": 3},
+	})
+	al := &recordingAlerter{ch: make(chan RunState, 1)}
+	s := newScheduler(store)
+	s.SetAlerter(al)
+	if err := s.Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-al.ch:
+		t.Fatal("no alert expected without on_failure rules")
+	case <-time.After(150 * time.Millisecond):
+	}
+}

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -860,6 +860,33 @@ func (r *Repository) SecretConnectionURIs(ctx context.Context, tenantID string) 
 	return out, nil
 }
 
+// ConnectionSecret returns a connection's decrypted password for a tenant UUID.
+// On-failure alerting (#424) stores the full channel webhook URL there (secret,
+// so it stays encrypted), and the resolver hands it straight to the notifier. An
+// absent or empty secret is an error — a misconfigured alert connection must fail
+// loud (best-effort at the send layer, not here). Never expose this in UI/API.
+func (r *Repository) ConnectionSecret(ctx context.Context, tenantID, connID string) (string, error) {
+	tid, err := parseUUID(tenantID)
+	if err != nil {
+		return "", err
+	}
+	row, err := r.q.GetConnection(ctx, queries.GetConnectionParams{TenantID: tid, ConnID: connID})
+	if err != nil {
+		return "", mapNotFound(err)
+	}
+	if row.Password == nil {
+		return "", fmt.Errorf("connection %q has no secret to resolve", connID)
+	}
+	pass, err := r.decryptExtra(row.Password)
+	if err != nil {
+		return "", fmt.Errorf("decrypting connection %q secret: %w", connID, err)
+	}
+	if pass == "" {
+		return "", fmt.Errorf("connection %q secret is empty", connID)
+	}
+	return pass, nil
+}
+
 // AddFavorite marks a DAG as a favorite for the user (idempotent).
 func (r *Repository) AddFavorite(ctx context.Context, tenant, userID, dagID string) error {
 	if err := r.q.AddFavorite(ctx, queries.AddFavoriteParams{Tenant: tenant, UserID: userID, DagID: dagID}); err != nil {

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -860,31 +860,61 @@ func (r *Repository) SecretConnectionURIs(ctx context.Context, tenantID string) 
 	return out, nil
 }
 
-// ConnectionSecret returns a connection's decrypted password for a tenant UUID.
-// On-failure alerting (#424) stores the full channel webhook URL there (secret,
-// so it stays encrypted), and the resolver hands it straight to the notifier. An
-// absent or empty secret is an error — a misconfigured alert connection must fail
-// loud (best-effort at the send layer, not here). Never expose this in UI/API.
-func (r *Repository) ConnectionSecret(ctx context.Context, tenantID, connID string) (string, error) {
+// AlertEndpoint resolves an alert channel connection (#424) to its endpoint for a
+// tenant UUID: the decrypted password is the channel URL (the full webhook URL,
+// kept encrypted at rest), and an optional `headers` object in the connection's
+// extra becomes request headers (e.g. an Authorization header for an endpoint
+// whose token is not in the URL). An absent/empty URL is an error — a
+// misconfigured alert connection must fail loud. Never expose these in UI/API.
+func (r *Repository) AlertEndpoint(ctx context.Context, tenantID, connID string) (endpointURL string, headers map[string]string, err error) {
 	tid, err := parseUUID(tenantID)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	row, err := r.q.GetConnection(ctx, queries.GetConnectionParams{TenantID: tid, ConnID: connID})
 	if err != nil {
-		return "", mapNotFound(err)
+		return "", nil, mapNotFound(err)
 	}
 	if row.Password == nil {
-		return "", fmt.Errorf("connection %q has no secret to resolve", connID)
+		return "", nil, fmt.Errorf("connection %q has no secret to resolve", connID)
 	}
-	pass, err := r.decryptExtra(row.Password)
+	endpointURL, err = r.decryptExtra(row.Password)
 	if err != nil {
-		return "", fmt.Errorf("decrypting connection %q secret: %w", connID, err)
+		return "", nil, fmt.Errorf("decrypting connection %q secret: %w", connID, err)
 	}
-	if pass == "" {
-		return "", fmt.Errorf("connection %q secret is empty", connID)
+	if endpointURL == "" {
+		return "", nil, fmt.Errorf("connection %q secret is empty", connID)
 	}
-	return pass, nil
+	headers, err = r.alertHeaders(connID, row.Extra)
+	if err != nil {
+		return "", nil, err
+	}
+	return endpointURL, headers, nil
+}
+
+// alertHeaders decrypts a connection's extra and extracts its optional `headers`
+// object (a string→string map), the conventional Airflow HTTP-connection shape.
+// A nil/empty or headerless extra yields an empty map (not an error), so the
+// caller can range over it unconditionally.
+func (r *Repository) alertHeaders(connID string, enc *string) (map[string]string, error) {
+	headers := map[string]string{}
+	extra, err := r.decryptExtra(enc)
+	if err != nil {
+		return nil, fmt.Errorf("decrypting connection %q extra: %w", connID, err)
+	}
+	if extra == "" {
+		return headers, nil
+	}
+	var parsed struct {
+		Headers map[string]string `json:"headers"`
+	}
+	if uerr := json.Unmarshal([]byte(extra), &parsed); uerr != nil {
+		return nil, fmt.Errorf("parsing connection %q extra: %w", connID, uerr)
+	}
+	for k, v := range parsed.Headers {
+		headers[k] = v
+	}
+	return headers, nil
 }
 
 // AddFavorite marks a DAG as a favorite for the user (idempotent).

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -95,6 +95,7 @@ func (s *SchedulerStore) ActiveRuns(ctx context.Context) ([]scheduler.RunState, 
 			RetryDelaySeconds: retryDelay,
 			RescheduleAt:      rescheduleAt,
 			Now:               time.Now(),
+			Alerts:            spec.Alerts,
 		})
 	}
 	return out, nil

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,6 +115,7 @@ nav:
       - First Pro DAG (walkthrough): first-pro-dag.md
       - Airflow operators & sensors: airflow-operators.md
       - dbt projects as DAGs: dbt.md
+      - On-failure alerting: alerting.md
       - CI/CD & deploy examples: deploy.md
   - Reference:
       - reference.md


### PR DESCRIPTION
Native on-failure alerting (#424), built in TDD increments — now **functional end-to-end**. Only the callback-via-pod surface (inc 4) is deferred.

A Leoflow-native `alerts:` block in leoflow.yaml, fired by the **scheduler in Go** on terminal DagRun failure — no task pod, no Python in the hot path. Endpoint + secret come from a **managed connection** (the full webhook URL is stored in the connection's encrypted secret; nothing sensitive lands in dag.json).

```yaml
alerts:
  on_failure:
    - type: slack        # slack | webhook
      conn: slack_prod    # managed connection id (its secret = the webhook URL)
      message: "{{dag}} run {{run_id}} failed: {{tasks}}"
    - type: webhook
      conn: pagerduty
```

## Flow
`leoflow.yaml` → **compile** (validate + overlay) → `dag.json` → **scheduler** finalizes a run failed → detached goroutine → **dispatcher** resolves each rule's connection → **notifier** POSTs (Slack `{"text":…}` / structured webhook). Best-effort (an alert failure never fails the run), async (never stalls the tick).

## Increments
- [x] **1 — config layer.** `AlertsConfig`/`AlertRule` on `LeoflowConfig`; schema validates `type` enum + required non-empty `conn`.
- [x] **2 — dag.json overlay.** `Alerts` on `DAGSpec`; `overlayProject` carries it; `dag-schema.json` synced.
- [x] **3a — Go notifier.** `internal/alerts`: `Render()` templating + `Notifier.Send()` (Slack / structured webhook; non-2xx & unknown channel = error). httptest, no storage deps.
- [x] **3b-i — scheduler seam.** `RunState.Alerts` + `Alerter` interface + `SetAlerter`; fires from a detached goroutine only on failed-finalize.
- [x] **3b-ii — dispatcher.** `internal/failurealert`: resolves each rule (behind `EndpointResolver`), renders, sends; every rule independent (best-effort). 94.7% covered.
- [x] **3b-iii — wiring.** `RunState.Alerts` loaded from dag.json; `Repository.ConnectionSecret` returns the decrypted URL; server boot builds the notifier + resolver and `SetAlerter`s them.
- [ ] **4 — `on_failure_callback` via pod** (second surface of "os dois"; user Python in a dedicated pod, never the scheduler). Deferred.

Every increment is test-first (red→green) and holds the golangci-lint A+ floor; filtered coverage 80.5% total. `on_success`/`on_retry`/SLA are intentionally reserved (simple-reliable first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)