### PR TITLE
feat(callback): Airflow on_failure_callback, in-process on final failure (#424)

### DIFF
--- a/docs/api/dag-schema.json
+++ b/docs/api/dag-schema.json
@@ -168,6 +168,10 @@
           "type": "object",
           "description": "For type=airflow_operator: the operator's constructor kwargs captured at compile time."
         },
+        "on_failure_callback": {
+          "type": "boolean",
+          "description": "Marks that the task declares an Airflow on_failure_callback (#424); the runtime runs it in the task process on failure. The callable itself is not carried."
+        },
         "depends_on": {
           "type": "array",
           "items": {

--- a/internal/agent/returnvalue_test.go
+++ b/internal/agent/returnvalue_test.go
@@ -35,6 +35,35 @@ func TestNewReturnValuePathUnique(t *testing.T) {
 	}
 }
 
+// TestBuildEnvSignalsOnFailureCallback: when the task declares an
+// on_failure_callback, the agent stamps LEOFLOW_MAX_TRIES + LEOFLOW_ON_FAILURE_
+// CALLBACK so the runtime can fire it on the terminal attempt only (#424). A task
+// without the marker stamps neither signal.
+func TestBuildEnvSignalsOnFailureCallback(t *testing.T) {
+	r := newRunner(&fakeClient{}, &fakeCmd{}, &recordingSink{})
+	env, err := r.buildEnv(context.Background(),
+		&agentv1.TaskSpec{TryNumber: 3, MaxTries: 3, OnFailureCallback: true})
+	if err != nil {
+		t.Fatalf("buildEnv: %v", err)
+	}
+	if !contains(env, "LEOFLOW_MAX_TRIES=3") {
+		t.Errorf("buildEnv must stamp LEOFLOW_MAX_TRIES, got %v", env)
+	}
+	if !contains(env, "LEOFLOW_ON_FAILURE_CALLBACK=1") {
+		t.Errorf("buildEnv must signal on_failure_callback, got %v", env)
+	}
+
+	plain, err := r.buildEnv(context.Background(), &agentv1.TaskSpec{TryNumber: 1, MaxTries: 1})
+	if err != nil {
+		t.Fatalf("buildEnv: %v", err)
+	}
+	for _, kv := range plain {
+		if strings.HasPrefix(kv, "LEOFLOW_ON_FAILURE_CALLBACK=") {
+			t.Errorf("must not signal the callback without the marker, got %q", kv)
+		}
+	}
+}
+
 // TestBuildEnvInjectsReturnValuePath: the runner tells the runtime where to write
 // the return value (the agent's per-task path), and injects nothing when there is
 // no return path.

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -249,6 +249,14 @@ func runContextEnv(spec *agentv1.TaskSpec) []string {
 	if n := spec.GetTryNumber(); n > 0 {
 		env = append(env, fmt.Sprintf("LEOFLOW_TRY_NUMBER=%d", n))
 	}
+	if n := spec.GetMaxTries(); n > 0 {
+		env = append(env, fmt.Sprintf("LEOFLOW_MAX_TRIES=%d", n))
+	}
+	// Signal the runtime to run the task's on_failure_callback on its final failure
+	// (#424); the runtime re-imports dag.py for the callable only when this is set.
+	if spec.GetOnFailureCallback() {
+		env = append(env, "LEOFLOW_ON_FAILURE_CALLBACK=1")
+	}
 	if ld := spec.GetLogicalDate(); ld != "" {
 		env = append(env, "LEOFLOW_TS="+ld)
 		if t, perr := time.Parse(time.RFC3339, ld); perr == nil {

--- a/internal/agentrpc/server.go
+++ b/internal/agentrpc/server.go
@@ -63,6 +63,14 @@ type TaskSpec struct {
 	// get_first_reschedule_date returns it and cumulative timeout works. Empty on
 	// the first attempt (not yet rescheduled).
 	FirstRescheduleAt string
+	// MaxTries is the task's total attempt budget (retries + 1). The agent stamps
+	// LEOFLOW_MAX_TRIES so the runtime fires on_failure_callback only on the
+	// terminal attempt (#424). Zero is treated as 1 (no retries).
+	MaxTries int
+	// OnFailureCallback marks that the task declares an Airflow on_failure_callback
+	// (#424). The agent stamps LEOFLOW_ON_FAILURE_CALLBACK=1 so the runtime runs it
+	// in-process on the task's final failure.
+	OnFailureCallback bool
 }
 
 // Authenticator verifies an agent bearer token into a task instance identity.
@@ -171,6 +179,8 @@ func (s *Server) GetTaskSpec(ctx context.Context, _ *agentv1.GetTaskSpecRequest)
 		DataIntervalEnd:         spec.DataIntervalEnd,
 		ParamsJson:              spec.ParamsJSON,
 		FirstRescheduleAt:       spec.FirstRescheduleAt,
+		MaxTries:                clampInt32(spec.MaxTries),
+		OnFailureCallback:       spec.OnFailureCallback,
 	}, nil
 }
 

--- a/internal/domain/dag.go
+++ b/internal/domain/dag.go
@@ -141,6 +141,11 @@ type TaskSpec struct {
 	// The agent serializes them as the env var LEOFLOW_OPERATOR_ARGS; the runtime
 	// instantiates the operator with them.
 	OperatorArgs map[string]any `json:"operator_args,omitempty"`
+	// OnFailureCallback marks that the task declares an Airflow on_failure_callback
+	// (#424). The callable itself is not carried (it can't be serialized); the
+	// runtime re-imports dag.py and runs it in the task process on failure. The
+	// flag lets the agent/UI know a callback will run without importing user code.
+	OnFailureCallback bool `json:"on_failure_callback,omitempty"`
 }
 
 // HTTPRequest is the request executed directly by the control plane for

--- a/internal/domain/domain_test.go
+++ b/internal/domain/domain_test.go
@@ -43,6 +43,16 @@ func TestDAGSpecValidateAcceptsValidSpec(t *testing.T) {
 	}
 }
 
+// A task marked with on_failure_callback (#424) validates: the compiler emits
+// the boolean flag (the callable stays in dag.py), and the schema accepts it.
+func TestDAGSpecValidateAcceptsOnFailureCallback(t *testing.T) {
+	spec := validDAGSpec()
+	spec.Tasks[0].OnFailureCallback = true
+	if err := spec.Validate(); err != nil {
+		t.Fatalf("Validate() with on_failure_callback = %v, want nil", err)
+	}
+}
+
 func TestDAGSpecValidateRejectsInvalidSpecs(t *testing.T) {
 	cases := map[string]func(*DAGSpec){
 		"missing dag_id":       func(d *DAGSpec) { d.DagID = "" },

--- a/internal/domain/schemas/dag-schema.json
+++ b/internal/domain/schemas/dag-schema.json
@@ -168,6 +168,10 @@
           "type": "object",
           "description": "For type=airflow_operator: the operator's constructor kwargs captured at compile time."
         },
+        "on_failure_callback": {
+          "type": "boolean",
+          "description": "Marks that the task declares an Airflow on_failure_callback (#424); the runtime runs it in the task process on failure. The callable itself is not carried."
+        },
         "depends_on": {
           "type": "array",
           "items": {

--- a/internal/storage/agent_store.go
+++ b/internal/storage/agent_store.go
@@ -108,7 +108,18 @@ func (s *ExecutionStore) TaskSpec(ctx context.Context, id auth.AgentIdentity) (a
 		DataIntervalEnd:   dataIntervalEnd,
 		ParamsJSON:        paramsJSON,
 		FirstRescheduleAt: firstRescheduleAt,
+		MaxTries:          maxTries(task),
+		OnFailureCallback: task.OnFailureCallback,
 	}, nil
+}
+
+// maxTries is a task's total attempt budget: retries + 1 (a task with no retries
+// runs once). It gates on_failure_callback to the terminal attempt (#424).
+func maxTries(task domain.TaskSpec) int {
+	if task.Retries != nil {
+		return *task.Retries + 1
+	}
+	return 1
 }
 
 // ReportState records a state transition reported by the agent, persisting the

--- a/parser/leoflow_parser/compiler.py
+++ b/parser/leoflow_parser/compiler.py
@@ -264,22 +264,51 @@ def _map_task(task, source: str) -> dict[str, Any]:
             entry["xcom_input"] = xcom_input
         if operator_args:
             entry["operator_args"] = operator_args
-    if _has_on_failure_callback(task):
-        entry["on_failure_callback"] = True
+    _check_callbacks(task, task_type, entry)
     return entry
 
 
-# _ON_FAILURE_CALLBACK is the one Airflow callback kwarg Leoflow runs (#424 inc
-# 4); the others (on_success/on_retry) stay a loud reject until wired.
+# _ON_FAILURE_CALLBACK is the one Airflow callback kwarg Leoflow runs (#424); the
+# others stay a loud reject until wired.
 _ON_FAILURE_CALLBACK = "on_failure_callback"
 
+# Task types whose runtime path is Python with a real try/except, so an
+# on_failure_callback can run in-process on the task's final failure (#424). A
+# bash task execs bash in place (os.execvp), leaving no Python to run it.
+_CALLBACK_CAPABLE_TYPES = ("airflow_operator", "python")
 
-def _has_on_failure_callback(task) -> bool:
-    """Report whether the task declares a callable on_failure_callback. It is not
-    serialised into dag.json (a callable can't be); the runtime re-imports dag.py
-    and calls it in the task process on failure."""
-    cb = (getattr(task, "__leoflow_args__", {}) or {}).get(_ON_FAILURE_CALLBACK)
-    return callable(cb)
+
+def _has_callback(task, name: str) -> bool:
+    """Report whether the task declares a callable ``name``. Native tasks store it
+    as an attribute (the shim setattrs every kwarg); a generically-captured operator
+    carries it in ``__leoflow_args__``. Check both."""
+    if callable(getattr(task, name, None)):
+        return True
+    return callable((getattr(task, "__leoflow_args__", {}) or {}).get(name))
+
+
+def _check_callbacks(task, task_type: str, entry: dict) -> None:
+    """Resolve Airflow lifecycle callbacks (#424). ``on_failure_callback`` is marked
+    on a Python-path task (operator or @task) so the runtime runs it; on a bash task
+    it is a loud reject (no Python is left to run it). ``on_success_callback`` /
+    ``on_retry_callback`` are unsupported everywhere and always a loud reject —
+    never a silent drop, which would leave the author thinking their callback runs."""
+    for name in ("on_success_callback", "on_retry_callback"):
+        if _has_callback(task, name):
+            raise ValueError(
+                f"{name} on task {task.task_id!r} is not supported by Leoflow yet — "
+                "refusing to silently drop it. Use an alerts: block in leoflow.yaml, "
+                "or a downstream @task with a trigger_rule.")
+    if not _has_callback(task, _ON_FAILURE_CALLBACK):
+        return
+    if task_type in _CALLBACK_CAPABLE_TYPES:
+        entry[_ON_FAILURE_CALLBACK] = True
+        return
+    raise ValueError(
+        f"on_failure_callback on task {task.task_id!r} (type {task_type}) cannot run: "
+        "a bash task replaces its process with bash, so no Python is left to call it. "
+        "Use an alerts: block in leoflow.yaml, or a downstream @task with "
+        "trigger_rule='one_failed'.")
 
 
 def _split_operator_args(task) -> tuple[dict[str, list[str]], dict[str, Any]]:

--- a/parser/leoflow_parser/compiler.py
+++ b/parser/leoflow_parser/compiler.py
@@ -264,7 +264,22 @@ def _map_task(task, source: str) -> dict[str, Any]:
             entry["xcom_input"] = xcom_input
         if operator_args:
             entry["operator_args"] = operator_args
+    if _has_on_failure_callback(task):
+        entry["on_failure_callback"] = True
     return entry
+
+
+# _ON_FAILURE_CALLBACK is the one Airflow callback kwarg Leoflow runs (#424 inc
+# 4); the others (on_success/on_retry) stay a loud reject until wired.
+_ON_FAILURE_CALLBACK = "on_failure_callback"
+
+
+def _has_on_failure_callback(task) -> bool:
+    """Report whether the task declares a callable on_failure_callback. It is not
+    serialised into dag.json (a callable can't be); the runtime re-imports dag.py
+    and calls it in the task process on failure."""
+    cb = (getattr(task, "__leoflow_args__", {}) or {}).get(_ON_FAILURE_CALLBACK)
+    return callable(cb)
 
 
 def _split_operator_args(task) -> tuple[dict[str, list[str]], dict[str, Any]]:
@@ -287,6 +302,12 @@ def _split_operator_args(task) -> tuple[dict[str, list[str]], dict[str, Any]]:
     xcom: dict[str, list[str]] = {}
     operator_args: dict[str, Any] = {}
     for name, value in raw.items():
+        # on_failure_callback is a callable that cannot be serialised into
+        # dag.json, but it is SUPPORTED (#424 inc 4): the runtime re-imports dag.py
+        # and calls it in the task process on failure. Accept it here as a marker
+        # (see _has_on_failure_callback) instead of the non-serialisable reject.
+        if name == _ON_FAILURE_CALLBACK and callable(value):
+            continue
         single_upstream = getattr(getattr(value, "operator", None), "task_id", None)
         if single_upstream:
             xcom[name] = [single_upstream]

--- a/parser/leoflow_parser/compiler.py
+++ b/parser/leoflow_parser/compiler.py
@@ -304,10 +304,13 @@ def _check_callbacks(task, task_type: str, entry: dict) -> None:
     if task_type in _CALLBACK_CAPABLE_TYPES:
         entry[_ON_FAILURE_CALLBACK] = True
         return
+    # bash execs bash in place (no Python left); http_api runs inline in the Go
+    # control plane (no Python at all). Neither can run a Python callback.
     raise ValueError(
         f"on_failure_callback on task {task.task_id!r} (type {task_type}) cannot run: "
-        "a bash task replaces its process with bash, so no Python is left to call it. "
-        "Use an alerts: block in leoflow.yaml, or a downstream @task with "
+        "only a Python-executed task runs it in-process (a provider operator or a "
+        "@task). For HTTP use HttpOperator (a provider operator, which runs it); "
+        "otherwise use an alerts: block in leoflow.yaml, or a downstream @task with "
         "trigger_rule='one_failed'.")
 
 

--- a/parser/tests/test_shim_edges.py
+++ b/parser/tests/test_shim_edges.py
@@ -213,6 +213,48 @@ def test_operator_on_failure_callback_is_marked_not_rejected(monkeypatch, tmp_pa
     assert "on_failure_callback" not in q.get("operator_args", {})
 
 
+def test_python_task_on_failure_callback_is_marked(monkeypatch, tmp_path):
+    """A native @task runs in Python (run() has an except), so on_failure_callback
+    is supported and marked — same as a provider operator (#424)."""
+    spec = _compile(monkeypatch, tmp_path, """
+        from airflow.sdk import DAG, task
+        def notify(ctx): pass
+        @task(on_failure_callback=notify)
+        def a() -> None: ...
+        with DAG("g"):
+            a()
+    """)
+    a = _task(spec, "a")
+    assert a["type"] == "python"
+    assert a.get("on_failure_callback") is True
+
+
+def test_bash_task_on_failure_callback_is_loud_reject(monkeypatch, tmp_path):
+    """A bash task replaces its process with bash (os.execvp), so no Python is left
+    to run a callback — refuse loud rather than silently drop it (#424)."""
+    with pytest.raises(ValueError):
+        _compile(monkeypatch, tmp_path, """
+            from airflow.sdk import DAG
+            from airflow.providers.standard.operators.bash import BashOperator
+            def notify(ctx): pass
+            with DAG("g"):
+                BashOperator(task_id="b", bash_command="false", on_failure_callback=notify)
+        """)
+
+
+def test_native_task_on_success_callback_is_loud_reject(monkeypatch, tmp_path):
+    """on_success/on_retry callbacks are unsupported everywhere; on a native task
+    they must fail loud too (not be silently dropped)."""
+    with pytest.raises(ValueError):
+        _compile(monkeypatch, tmp_path, """
+            from airflow.sdk import DAG
+            from airflow.providers.standard.operators.bash import BashOperator
+            def notify(ctx): pass
+            with DAG("g"):
+                BashOperator(task_id="b", bash_command="true", on_success_callback=notify)
+        """)
+
+
 def test_operator_on_success_callback_still_rejected(monkeypatch, tmp_path):
     """Only on_failure_callback is wired (#424 inc 4); other callback kwargs stay a
     loud reject so we never silently drop them."""

--- a/parser/tests/test_shim_edges.py
+++ b/parser/tests/test_shim_edges.py
@@ -192,6 +192,40 @@ def test_operator_non_serialisable_arg_is_loud_reject(monkeypatch, tmp_path):
         """)
 
 
+def test_operator_on_failure_callback_is_marked_not_rejected(monkeypatch, tmp_path):
+    """on_failure_callback is a callable Leoflow cannot serialise into dag.json,
+    but instead of the general non-serialisable reject (ADR 0040 A1.1) it is
+    ACCEPTED and marked on the task (#424 inc 4): the runtime re-imports dag.py and
+    runs it in the task process on failure. The callable itself is not carried."""
+    spec = _compile(monkeypatch, tmp_path, """
+        from airflow.sdk import DAG
+        from airflow.providers.snowflake.operators.snowflake import SQLExecuteQueryOperator
+        def notify(context):
+            pass
+        with DAG("g"):
+            SQLExecuteQueryOperator(task_id="q", conn_id="sf", sql="SELECT 1",
+                                    on_failure_callback=notify)
+    """)
+    q = _task(spec, "q")
+    assert q["type"] == "airflow_operator"
+    assert q.get("on_failure_callback") is True
+    # the callable must NOT leak into the serialised operator args
+    assert "on_failure_callback" not in q.get("operator_args", {})
+
+
+def test_operator_on_success_callback_still_rejected(monkeypatch, tmp_path):
+    """Only on_failure_callback is wired (#424 inc 4); other callback kwargs stay a
+    loud reject so we never silently drop them."""
+    with pytest.raises(ValueError):
+        _compile(monkeypatch, tmp_path, """
+            from airflow.sdk import DAG
+            from airflow.providers.snowflake.operators.snowflake import SQLExecuteQueryOperator
+            with DAG("g"):
+                SQLExecuteQueryOperator(task_id="q", conn_id="sf", sql="SELECT 1",
+                                        on_success_callback=lambda ctx: None)
+        """)
+
+
 def test_http_sensor_is_generic_operator_not_native_http(monkeypatch, tmp_path):
     """A SENSOR whose name contains 'Http' (HttpSensor) must be captured as a
     generic airflow_operator (poke in a pod), NOT mistranslated to the native

--- a/proto/agent.proto
+++ b/proto/agent.proto
@@ -106,6 +106,8 @@ message TaskSpec {
     string data_interval_end = 19;                 // The DagRun's data interval end, RFC3339. Stamped as LEOFLOW_DATA_INTERVAL_END -> context data_interval_end. Empty leaves it unset.
     string params_json = 20;                        // The DagRun's params/conf, JSON-encoded (#148). Stamped as LEOFLOW_PARAMS so the standalone operator context exposes context['params'] / {{ params.X }}. Empty leaves params={}.
     string first_reschedule_at = 21;                 // For a reschedule-mode sensor re-dispatched after poking not-ready (#380): the time it FIRST entered reschedule, RFC3339. Stamped as LEOFLOW_FIRST_RESCHEDULE_AT so get_first_reschedule_date returns the real value and the sensor honors its cumulative timeout. Empty on the first attempt.
+    int32 max_tries = 22;                            // The task's total attempt budget (retries + 1). The agent stamps LEOFLOW_MAX_TRIES so the runtime fires on_failure_callback only on the terminal attempt (try_number == max_tries), never on an intermediate retry (#424).
+    bool on_failure_callback = 23;                   // The task declares an Airflow on_failure_callback (#424). The agent stamps LEOFLOW_ON_FAILURE_CALLBACK=1 so the runtime re-imports dag.py and runs it in-process on the task's final failure. The callable itself is not carried.
 }
 
 // XComUpstreams is the list of upstream task_ids whose return_values feed one

--- a/proto/agent/v1/agent.pb.go
+++ b/proto/agent/v1/agent.pb.go
@@ -470,16 +470,18 @@ type TaskSpec struct {
 	Environment             map[string]string         `protobuf:"bytes,9,rep,name=environment,proto3" json:"environment,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	XcomInputMapping        map[string]*XComUpstreams `protobuf:"bytes,10,rep,name=xcom_input_mapping,json=xcomInputMapping,proto3" json:"xcom_input_mapping,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // param_name -> ordered list of upstream task_ids (1 = single, N = fan-in)
 	ExecutionTimeoutSeconds int32                     `protobuf:"varint,11,opt,name=execution_timeout_seconds,json=executionTimeoutSeconds,proto3" json:"execution_timeout_seconds,omitempty"`
-	Extra                   *structpb.Struct          `protobuf:"bytes,12,opt,name=extra,proto3" json:"extra,omitempty"`                                                    // operator-specific fields
-	CallArgsJson            string                    `protobuf:"bytes,13,opt,name=call_args_json,json=callArgsJson,proto3" json:"call_args_json,omitempty"`                // TaskFlow literal call args, JSON-encoded (#115). Named call_args to leave 'params' free for Airflow's DAG-run params (#148).
-	OperatorClass           string                    `protobuf:"bytes,14,opt,name=operator_class,json=operatorClass,proto3" json:"operator_class,omitempty"`               // For operator='airflow_operator': the dotted provider operator/sensor class the runtime imports and executes (ADR 0040).
-	OperatorArgsJson        string                    `protobuf:"bytes,15,opt,name=operator_args_json,json=operatorArgsJson,proto3" json:"operator_args_json,omitempty"`    // For operator='airflow_operator': the operator's constructor kwargs, JSON-encoded. Delivered to the runtime as LEOFLOW_OPERATOR_ARGS.
-	LogicalDate             string                    `protobuf:"bytes,16,opt,name=logical_date,json=logicalDate,proto3" json:"logical_date,omitempty"`                     // The DagRun's logical date, RFC3339. The agent derives the runtime's LEOFLOW_TS (this value) and LEOFLOW_DS (the date) so the standalone operator context has a real ds/ts (ADR 0040). Empty leaves them unset.
-	DependsOn               []string                  `protobuf:"bytes,17,rep,name=depends_on,json=dependsOn,proto3" json:"depends_on,omitempty"`                           // The task's upstream task_ids. The agent fetches each one's return_value and delivers them as the LEOFLOW_XCOM_BY_TASK map so a captured operator's ti.xcom_pull(<id>) resolves it (chained operators, ADR 0040).
-	DataIntervalStart       string                    `protobuf:"bytes,18,opt,name=data_interval_start,json=dataIntervalStart,proto3" json:"data_interval_start,omitempty"` // The DagRun's data interval start, RFC3339. The agent stamps LEOFLOW_DATA_INTERVAL_START so the standalone operator context exposes data_interval_start (ADR 0040). Empty leaves it unset.
-	DataIntervalEnd         string                    `protobuf:"bytes,19,opt,name=data_interval_end,json=dataIntervalEnd,proto3" json:"data_interval_end,omitempty"`       // The DagRun's data interval end, RFC3339. Stamped as LEOFLOW_DATA_INTERVAL_END -> context data_interval_end. Empty leaves it unset.
-	ParamsJson              string                    `protobuf:"bytes,20,opt,name=params_json,json=paramsJson,proto3" json:"params_json,omitempty"`                        // The DagRun's params/conf, JSON-encoded (#148). Stamped as LEOFLOW_PARAMS so the standalone operator context exposes context['params'] / {{ params.X }}. Empty leaves params={}.
-	FirstRescheduleAt       string                    `protobuf:"bytes,21,opt,name=first_reschedule_at,json=firstRescheduleAt,proto3" json:"first_reschedule_at,omitempty"` // For a reschedule-mode sensor re-dispatched after poking not-ready (#380): the time it FIRST entered reschedule, RFC3339. Stamped as LEOFLOW_FIRST_RESCHEDULE_AT so get_first_reschedule_date returns the real value and the sensor honors its cumulative timeout. Empty on the first attempt.
+	Extra                   *structpb.Struct          `protobuf:"bytes,12,opt,name=extra,proto3" json:"extra,omitempty"`                                                     // operator-specific fields
+	CallArgsJson            string                    `protobuf:"bytes,13,opt,name=call_args_json,json=callArgsJson,proto3" json:"call_args_json,omitempty"`                 // TaskFlow literal call args, JSON-encoded (#115). Named call_args to leave 'params' free for Airflow's DAG-run params (#148).
+	OperatorClass           string                    `protobuf:"bytes,14,opt,name=operator_class,json=operatorClass,proto3" json:"operator_class,omitempty"`                // For operator='airflow_operator': the dotted provider operator/sensor class the runtime imports and executes (ADR 0040).
+	OperatorArgsJson        string                    `protobuf:"bytes,15,opt,name=operator_args_json,json=operatorArgsJson,proto3" json:"operator_args_json,omitempty"`     // For operator='airflow_operator': the operator's constructor kwargs, JSON-encoded. Delivered to the runtime as LEOFLOW_OPERATOR_ARGS.
+	LogicalDate             string                    `protobuf:"bytes,16,opt,name=logical_date,json=logicalDate,proto3" json:"logical_date,omitempty"`                      // The DagRun's logical date, RFC3339. The agent derives the runtime's LEOFLOW_TS (this value) and LEOFLOW_DS (the date) so the standalone operator context has a real ds/ts (ADR 0040). Empty leaves them unset.
+	DependsOn               []string                  `protobuf:"bytes,17,rep,name=depends_on,json=dependsOn,proto3" json:"depends_on,omitempty"`                            // The task's upstream task_ids. The agent fetches each one's return_value and delivers them as the LEOFLOW_XCOM_BY_TASK map so a captured operator's ti.xcom_pull(<id>) resolves it (chained operators, ADR 0040).
+	DataIntervalStart       string                    `protobuf:"bytes,18,opt,name=data_interval_start,json=dataIntervalStart,proto3" json:"data_interval_start,omitempty"`  // The DagRun's data interval start, RFC3339. The agent stamps LEOFLOW_DATA_INTERVAL_START so the standalone operator context exposes data_interval_start (ADR 0040). Empty leaves it unset.
+	DataIntervalEnd         string                    `protobuf:"bytes,19,opt,name=data_interval_end,json=dataIntervalEnd,proto3" json:"data_interval_end,omitempty"`        // The DagRun's data interval end, RFC3339. Stamped as LEOFLOW_DATA_INTERVAL_END -> context data_interval_end. Empty leaves it unset.
+	ParamsJson              string                    `protobuf:"bytes,20,opt,name=params_json,json=paramsJson,proto3" json:"params_json,omitempty"`                         // The DagRun's params/conf, JSON-encoded (#148). Stamped as LEOFLOW_PARAMS so the standalone operator context exposes context['params'] / {{ params.X }}. Empty leaves params={}.
+	FirstRescheduleAt       string                    `protobuf:"bytes,21,opt,name=first_reschedule_at,json=firstRescheduleAt,proto3" json:"first_reschedule_at,omitempty"`  // For a reschedule-mode sensor re-dispatched after poking not-ready (#380): the time it FIRST entered reschedule, RFC3339. Stamped as LEOFLOW_FIRST_RESCHEDULE_AT so get_first_reschedule_date returns the real value and the sensor honors its cumulative timeout. Empty on the first attempt.
+	MaxTries                int32                     `protobuf:"varint,22,opt,name=max_tries,json=maxTries,proto3" json:"max_tries,omitempty"`                              // The task's total attempt budget (retries + 1). The agent stamps LEOFLOW_MAX_TRIES so the runtime fires on_failure_callback only on the terminal attempt (try_number == max_tries), never on an intermediate retry (#424).
+	OnFailureCallback       bool                      `protobuf:"varint,23,opt,name=on_failure_callback,json=onFailureCallback,proto3" json:"on_failure_callback,omitempty"` // The task declares an Airflow on_failure_callback (#424). The agent stamps LEOFLOW_ON_FAILURE_CALLBACK=1 so the runtime re-imports dag.py and runs it in-process on the task's final failure. The callable itself is not carried.
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
 }
@@ -659,6 +661,20 @@ func (x *TaskSpec) GetFirstRescheduleAt() string {
 		return x.FirstRescheduleAt
 	}
 	return ""
+}
+
+func (x *TaskSpec) GetMaxTries() int32 {
+	if x != nil {
+		return x.MaxTries
+	}
+	return 0
+}
+
+func (x *TaskSpec) GetOnFailureCallback() bool {
+	if x != nil {
+		return x.OnFailureCallback
+	}
+	return false
 }
 
 // XComUpstreams is the list of upstream task_ids whose return_values feed one
@@ -1334,7 +1350,7 @@ const file_agent_proto_rawDesc = "" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12;\n" +
 	"\vserver_time\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"serverTime\"\x14\n" +
-	"\x12GetTaskSpecRequest\"\x94\b\n" +
+	"\x12GetTaskSpecRequest\"\xe1\b\n" +
 	"\bTaskSpec\x12\x1b\n" +
 	"\ttenant_id\x18\x01 \x01(\tR\btenantId\x12\x15\n" +
 	"\x06dag_id\x18\x02 \x01(\tR\x05dagId\x12\x1f\n" +
@@ -1363,7 +1379,9 @@ const file_agent_proto_rawDesc = "" +
 	"\x11data_interval_end\x18\x13 \x01(\tR\x0fdataIntervalEnd\x12\x1f\n" +
 	"\vparams_json\x18\x14 \x01(\tR\n" +
 	"paramsJson\x12.\n" +
-	"\x13first_reschedule_at\x18\x15 \x01(\tR\x11firstRescheduleAt\x1a>\n" +
+	"\x13first_reschedule_at\x18\x15 \x01(\tR\x11firstRescheduleAt\x12\x1b\n" +
+	"\tmax_tries\x18\x16 \x01(\x05R\bmaxTries\x12.\n" +
+	"\x13on_failure_callback\x18\x17 \x01(\bR\x11onFailureCallback\x1a>\n" +
 	"\x10EnvironmentEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1ad\n" +

--- a/runtime/python/leoflow_runtime/runner.py
+++ b/runtime/python/leoflow_runtime/runner.py
@@ -397,6 +397,72 @@ def _merge_operator_xcom(args: dict) -> dict:
     return args
 
 
+def _run_on_failure_callback(get_callback, context, try_number, max_tries) -> None:
+    """Run a task's Airflow ``on_failure_callback`` on its FINAL failed attempt
+    (#424 inc 4b).
+
+    Airflow calls the callback only when the task instance reaches terminal
+    ``failed`` (retries exhausted), never on an intermediate ``up_for_retry``
+    attempt. The runtime runs per attempt, so gate on ``try_number >= max_tries``:
+    for ``retries: 3``, a fail→fail→success run fires it zero times, and a
+    fail×3 run fires it once (on the last).
+
+    ``get_callback`` is a zero-arg resolver (it imports dag.py and finds the
+    task's callback) called lazily, only when this attempt is terminal. It is
+    best-effort + anti-loop: a callback that raises is logged and swallowed so it
+    can never re-trigger itself or change the task's own failed outcome.
+    """
+    if try_number < max_tries:
+        return
+    callback = get_callback()
+    if callback is None:
+        return
+    _lifecycle("running on_failure_callback")
+    try:
+        callback(context)
+    except Exception as exc:  # noqa: BLE001 — best-effort; never fail the task on its callback
+        _lifecycle(f"on_failure_callback raised {type(exc).__name__}: {exc} (ignored)")
+
+
+def _resolve_on_failure_callback():
+    """Import the DAG module and return the current task's ``on_failure_callback``
+    (or None). The callable can't be serialised into dag.json, so the compiler only
+    marks its presence (#424 inc 4a); here we re-import dag.py — real Airflow is
+    present at runtime, so the operator carries the real attribute — and read it off
+    the task. Any import/lookup problem yields None (best-effort: a resolution miss
+    must never turn into a task failure)."""
+    task_id = os.environ.get("LEOFLOW_TASK_ID", "")
+    module_name = os.environ.get("LEOFLOW_DAG_MODULE", "dag")
+    try:
+        module = importlib.import_module(module_name)
+    except Exception as exc:  # noqa: BLE001 — dag.py must not break failure handling
+        _lifecycle(f"on_failure_callback: cannot import {module_name!r} ({exc}); skipping")
+        return None
+    for obj in vars(module).values():
+        task_dict = getattr(obj, "task_dict", None)  # an Airflow DAG object
+        if isinstance(task_dict, dict) and task_id in task_dict:
+            return getattr(task_dict[task_id], "on_failure_callback", None)
+    return None
+
+
+def _maybe_fire_on_failure_callback(context) -> None:
+    """Fire the task's on_failure_callback if the compiler marked one
+    (LEOFLOW_ON_FAILURE_CALLBACK, set by the agent) and this attempt is terminal.
+    Reads try_number/max_tries from the env; a missing max_tries defaults to
+    try_number (treat as final). Fully guarded — never raises."""
+    if os.environ.get("LEOFLOW_ON_FAILURE_CALLBACK") != "1":
+        return
+    try:
+        try_number = int(os.environ.get("LEOFLOW_TRY_NUMBER", "1"))
+    except ValueError:
+        try_number = 1
+    try:
+        max_tries = int(os.environ.get("LEOFLOW_MAX_TRIES", str(try_number)))
+    except ValueError:
+        max_tries = try_number
+    _run_on_failure_callback(_resolve_on_failure_callback, context, try_number, max_tries)
+
+
 def run_operator(operator_class: str, args: dict) -> None:
     """Instantiate and execute a captured Airflow operator/sensor (ADR 0040 Phase
     A): ``import_string(class)(task_id, **args) → render_template_fields → execute``.
@@ -428,6 +494,10 @@ def run_operator(operator_class: str, args: dict) -> None:
                 f"{class_name} asked to defer (deferrable=True), which Leoflow does not "
                 f"support yet (ADR 0040 Phase C — no triggerer). Pass deferrable=False — "
                 f"the operator runs synchronously in the pod (poke-style).") from exc
+        # A genuine failure (not a reschedule/deferral): run the on_failure_callback
+        # on the terminal attempt before re-raising, so the task's failed state is
+        # unchanged (#424 inc 4b).
+        _maybe_fire_on_failure_callback(context)
         raise
     _write_return(result)
     _write_extra_links(op, context["ti"].pushed)

--- a/runtime/python/leoflow_runtime/runner.py
+++ b/runtime/python/leoflow_runtime/runner.py
@@ -156,6 +156,9 @@ def run(entrypoint: str) -> None:
         # ordering in the log panel matches the wall-clock order.
         sys.stdout.flush()
         sys.stderr.flush()
+        # Run the @task's on_failure_callback on its terminal attempt, before the
+        # re-raise, so the task's own failed outcome is unchanged (#424 inc 4b).
+        _maybe_fire_on_failure_callback(context)
         # Re-raise so Python's default handler emits the traceback to stderr —
         # the agent captures it.
         raise

--- a/runtime/python/tests/test_runner.py
+++ b/runtime/python/tests/test_runner.py
@@ -404,3 +404,86 @@ def test_standalone_ti_get_first_reschedule_date(monkeypatch):
     monkeypatch.setenv("LEOFLOW_FIRST_RESCHEDULE_AT", "2099-01-02T03:04:05+00:00")
     got = runner._StandaloneTaskInstance().get_first_reschedule_date({})
     assert got == datetime(2099, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+
+
+# --- on_failure_callback core (#424 inc 4b) -------------------------------------
+
+def test_on_failure_callback_fires_on_final_attempt():
+    calls = []
+    runner._run_on_failure_callback(
+        lambda: (lambda ctx: calls.append(ctx)), {"dag_id": "d"}, try_number=3, max_tries=3)
+    assert calls == [{"dag_id": "d"}]
+
+
+def test_on_failure_callback_skipped_when_retries_remain():
+    calls = []
+    runner._run_on_failure_callback(
+        lambda: (lambda ctx: calls.append(ctx)), {}, try_number=1, max_tries=3)
+    assert calls == []  # a retry will follow — not a terminal failure
+
+
+def test_on_failure_callback_swallows_error():
+    def boom(_ctx):
+        raise RuntimeError("nope")
+    # best-effort: must NOT raise, so the task's own failure is unaffected
+    runner._run_on_failure_callback(lambda: boom, {}, try_number=1, max_tries=1)
+
+
+def test_on_failure_callback_noop_when_absent():
+    # get_callback returns None (no callback declared) → no-op, no error
+    runner._run_on_failure_callback(lambda: None, {}, try_number=1, max_tries=1)
+
+
+def _fake_dag_module(monkeypatch, name, task_id, cb):
+    import sys
+    import types
+
+    class _Op:
+        def __init__(self, c):
+            self.on_failure_callback = c
+
+    class _Dag:
+        def __init__(self, td):
+            self.task_dict = td
+
+    mod = types.ModuleType(name)
+    mod.d = _Dag({task_id: _Op(cb)})
+    monkeypatch.setitem(sys.modules, name, mod)
+
+
+def test_resolve_on_failure_callback_reads_the_task_attr(monkeypatch):
+    def notify(_ctx):
+        pass
+    _fake_dag_module(monkeypatch, "fakedag_res", "t", notify)
+    monkeypatch.setenv("LEOFLOW_DAG_MODULE", "fakedag_res")
+    monkeypatch.setenv("LEOFLOW_TASK_ID", "t")
+    assert runner._resolve_on_failure_callback() is notify
+
+
+def test_maybe_fire_noop_without_marker(monkeypatch):
+    monkeypatch.delenv("LEOFLOW_ON_FAILURE_CALLBACK", raising=False)
+    runner._maybe_fire_on_failure_callback({})  # must not raise, must not import
+
+
+def test_maybe_fire_runs_on_final_attempt(monkeypatch):
+    calls = []
+    _fake_dag_module(monkeypatch, "fakedag_fire", "t", lambda ctx: calls.append(ctx))
+    monkeypatch.setenv("LEOFLOW_ON_FAILURE_CALLBACK", "1")
+    monkeypatch.setenv("LEOFLOW_DAG_MODULE", "fakedag_fire")
+    monkeypatch.setenv("LEOFLOW_TASK_ID", "t")
+    monkeypatch.setenv("LEOFLOW_TRY_NUMBER", "2")
+    monkeypatch.setenv("LEOFLOW_MAX_TRIES", "2")
+    runner._maybe_fire_on_failure_callback({"dag_id": "d"})
+    assert calls == [{"dag_id": "d"}]
+
+
+def test_maybe_fire_skips_when_retries_remain(monkeypatch):
+    calls = []
+    _fake_dag_module(monkeypatch, "fakedag_skip", "t", lambda ctx: calls.append(ctx))
+    monkeypatch.setenv("LEOFLOW_ON_FAILURE_CALLBACK", "1")
+    monkeypatch.setenv("LEOFLOW_DAG_MODULE", "fakedag_skip")
+    monkeypatch.setenv("LEOFLOW_TASK_ID", "t")
+    monkeypatch.setenv("LEOFLOW_TRY_NUMBER", "1")
+    monkeypatch.setenv("LEOFLOW_MAX_TRIES", "3")
+    runner._maybe_fire_on_failure_callback({})
+    assert calls == []


### PR DESCRIPTION
The second surface of "os dois" in #424: run a real Airflow `on_failure_callback` (your Python) when a task fails — complementing the native `alerts:` block (#430). **Functional end-to-end.**

Runs **in the task process** (no extra pod): the runtime catches the operator failure and, on the **terminal attempt only**, re-imports dag.py, reads the real callback, and calls it — best-effort. It coexists with the native `alerts:` block (that fires on the DagRun terminal failure in the Go scheduler; this fires per-task in the pod).

## Increments
- [x] **4a — compile-side.** Shim accepts `on_failure_callback` and marks the task (was a non-serialisable reject); `TaskSpec.OnFailureCallback` + dag-schema carry the flag. Only `on_failure_callback` is wired; on_success/on_retry stay a loud reject.
- [x] **4b — runtime execution.** `_run_on_failure_callback` gates on `try_number >= max_tries` (terminal attempt only), best-effort + anti-loop; `_resolve_on_failure_callback` re-imports dag.py and reads the real callable; wired into `run_operator`'s except.
- [x] **4c — signal delivery.** `max_tries` (retries + 1) + the marker added to agent.proto (regenerated), the agentrpc spec, and the agent_store mapping; the agent stamps `LEOFLOW_MAX_TRIES` + `LEOFLOW_ON_FAILURE_CALLBACK=1`.
- [ ] **docs.** A user-facing section in `docs/alerting.md` (lands once #430 merges, to avoid a duplicate on this off-main branch).

## Retry semantics (the key correctness point)
Fires **only on the final failure**, mirroring Airflow and the native `alerts:` block. For `retries: 3`:
- fail, fail, **succeed** → **0 callbacks**.
- fail ×3 (exhausted) → **1 callback**, on the last attempt.

## Guarantees
Best-effort + anti-loop (a callback that raises is logged, never re-dispatched, never changes the task's failed outcome). Known limit: a hard pod crash (OOM/kill) leaves no process to run it (documented; dedicated-pod fallback is future hardening).

Every increment is test-first (parser, domain, runtime airflow-free via a fake dag module, agent env); A+ held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)