### PR TITLE
fix(security): bump grpc to v1.82.1 — clear GHSA-hrxh-6v49-42gf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.53.0
 	golang.org/x/term v0.44.0
-	google.golang.org/grpc v1.81.1
+	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.1

--- a/go.sum
+++ b/go.sum
@@ -283,8 +283,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af h1:+5/Sw3GsDNlEmu7TfklWKPdQ0Ykja5VEmq2i817+jbI=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## What

Bumps a direct dep flagged by Trivy's filesystem scan on the **post-merge main** Security run:

| Package | From | To | Advisory |
|---|---|---|---|
| `google.golang.org/grpc` | v1.81.1 | v1.82.1 | GHSA-hrxh-6v49-42gf |

## Why it slipped past PR CI

Same pattern as #436: Trivy runs **on push to main only** (skipped on PRs). The advisory was disclosed after #438's CI ran, so it first surfaced on main. `govulncheck` stayed green (not on a reachable path); Trivy flags the dependency version regardless of reachability. This is exactly what **#437** proposes to fix (run Trivy fs on PRs).

## Verification

- `go build ./...` clean
- `internal/agentrpc`, `internal/executor` tests green (the gRPC-touching packages)
- Local `trivy fs --ignore-unfixed` (CI's flags) → **0 vulnerabilities**
- Installed version now sits **at** the fixed version — deterministic, not DB-timing dependent

🤖 Generated with [Claude Code](https://claude.com/claude-code)