### PR TITLE
ci(security): run Trivy fs scan on PRs, not just push/schedule (#437)

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -62,12 +62,13 @@ jobs:
 
   # ─────────────────────────────────────────────────────────────────────
   # Trivy: container image scanning (ADR 0014)
-  # Runs only on tags or main; not on every PR to avoid noise.
+  # Runs on PRs too (#437): a fixable dependency CVE must fail its own PR check,
+  # not slip through and redden main on the post-merge run (as it did in #436 and
+  # #439). ignore-unfixed keeps the gate to actionable, fixable findings only.
   # ─────────────────────────────────────────────────────────────────────
   trivy:
     name: Trivy (image scan)
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -85,9 +86,13 @@ jobs:
           format: sarif
           output: trivy-fs.sarif
 
+      # Upload the SARIF baseline to the Security tab only on push/schedule. On a
+      # PR the scan still gates the check (exit-code 1 above), but we do not upload
+      # so a PR run cannot collide with or overwrite the main branch baseline under
+      # the shared trivy-fs category (#437).
       - name: Upload Trivy SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4.35.5
-        if: always()
+        if: always() && github.event_name != 'pull_request'
         with:
           sarif_file: trivy-fs.sarif
           category: trivy-fs


### PR DESCRIPTION
## What

Removes the `push`/`schedule`-only gate on the Trivy filesystem job so it runs on **`pull_request`** too. Closes #437.

```diff
   trivy:
     name: Trivy (image scan)
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'schedule'
```

## Why

`govulncheck` runs on PRs but reports only vulns reachable by our call paths. Trivy flags the **dependency version** regardless of reachability — a stronger signal for a dep bump — and it was push-only. Result: a fixable CVE passed a green PR and then reddened main on the post-merge Security run. That happened **twice in one session**:

- `x/net` + `x/text` → #436
- `google.golang.org/grpc` → #439

Both were textbook "PR-green ≠ main-green". This moves the signal left so the CVE fails its **own** PR.

## SARIF-collision guard

The scan still gates via `exit-code: 1` (unchanged). The **upload** step is now `if: always() && github.event_name != 'pull_request'` — SARIF publishes to the Security tab only on push/schedule, so a PR run can't collide with or overwrite the `main` baseline under the shared `trivy-fs` category. PRs **scan-and-gate**; they don't publish.

(Inline PR alerts would need a separate category or a distinct PR-scoped upload — deliberately out of scope here to keep the baseline clean; can revisit if wanted.)

## Self-validation

Because `pull_request` workflow changes take effect for the PR's own run, **this PR is the first to run Trivy on a PR**. main is currently clean (post-#439), so its Trivy check should pass — proving the gate runs green when there's nothing to fix.

actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)