### PR TITLE
ci: pull postgres/redis services from the ECR public mirror, not Docker Hub

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16
+        image: public.ecr.aws/docker/library/postgres:16
         env:
           POSTGRES_USER: leoflow
           POSTGRES_PASSWORD: leoflow
@@ -104,7 +104,7 @@ jobs:
         options: >-
           --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
       redis:
-        image: redis:7
+        image: public.ecr.aws/docker/library/redis:7
         ports: [6379:6379]
         options: --health-cmd "redis-cli ping" --health-interval 5s --health-timeout 3s --health-retries 10
 
@@ -155,7 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16
+        image: public.ecr.aws/docker/library/postgres:16
         env:
           POSTGRES_USER: leoflow
           POSTGRES_PASSWORD: leoflow
@@ -164,7 +164,7 @@ jobs:
         options: >-
           --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
       redis:
-        image: redis:7
+        image: public.ecr.aws/docker/library/redis:7
         ports: [6379:6379]
         options: --health-cmd "redis-cli ping" --health-interval 5s --health-timeout 3s --health-retries 10
     env:
@@ -195,7 +195,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16
+        image: public.ecr.aws/docker/library/postgres:16
         env:
           POSTGRES_USER: leoflow
           POSTGRES_PASSWORD: leoflow
@@ -204,7 +204,7 @@ jobs:
         options: >-
           --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
       redis:
-        image: redis:7
+        image: public.ecr.aws/docker/library/redis:7
         ports: [6379:6379]
         options: --health-cmd "redis-cli ping" --health-interval 5s --health-timeout 3s --health-retries 10
     steps:
@@ -255,7 +255,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16
+        image: public.ecr.aws/docker/library/postgres:16
         env:
           POSTGRES_USER: leoflow
           POSTGRES_PASSWORD: leoflow
@@ -289,7 +289,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16
+        image: public.ecr.aws/docker/library/postgres:16
         env:
           POSTGRES_USER: leoflow
           POSTGRES_PASSWORD: leoflow
@@ -323,7 +323,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16
+        image: public.ecr.aws/docker/library/postgres:16
         env:
           POSTGRES_USER: leoflow
           POSTGRES_PASSWORD: leoflow
@@ -410,7 +410,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16
+        image: public.ecr.aws/docker/library/postgres:16
         env:
           POSTGRES_USER: leoflow
           POSTGRES_PASSWORD: leoflow
@@ -419,7 +419,7 @@ jobs:
         options: >-
           --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
       redis:
-        image: redis:7
+        image: public.ecr.aws/docker/library/redis:7
         ports: [6379:6379]
         options: --health-cmd "redis-cli ping" --health-interval 5s --health-timeout 3s --health-retries 10
     env:
@@ -464,7 +464,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16
+        image: public.ecr.aws/docker/library/postgres:16
         env:
           POSTGRES_USER: leoflow
           POSTGRES_PASSWORD: leoflow
@@ -473,7 +473,7 @@ jobs:
         options: >-
           --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
       redis:
-        image: redis:7
+        image: public.ecr.aws/docker/library/redis:7
         ports: [6379:6379]
         options: --health-cmd "redis-cli ping" --health-interval 5s --health-timeout 3s --health-retries 10
     env:
@@ -516,7 +516,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16
+        image: public.ecr.aws/docker/library/postgres:16
         env:
           POSTGRES_USER: leoflow
           POSTGRES_PASSWORD: leoflow
@@ -525,7 +525,7 @@ jobs:
         options: >-
           --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
       redis:
-        image: redis:7
+        image: public.ecr.aws/docker/library/redis:7
         ports: [6379:6379]
         options: --health-cmd "redis-cli ping" --health-interval 5s --health-timeout 3s --health-retries 10
     env:


### PR DESCRIPTION
## Problem

The `Integration tests` job — and every other job with a `postgres`/`redis` **service container** — intermittently failed at **"Initialize containers"** with the runner's `docker pull postgres:16` timing out against Docker Hub:

```
Error response from daemon: Get "https://registry-1.docker.io/v2/": context deadline exceeded
```

It reddened **both a PR run and the post-merge main run** in a single session. Service containers are pulled by the runner **before any step runs**, so the binary-download retry pattern from #392 (gitleaks) isn't reachable for a `services:` image.

## Fix

Point every `services:` image at the **AWS ECR Public mirror of the Docker Official Images** — `public.ecr.aws/docker/library/postgres:16` and `.../redis:7`. Same images, no Docker Hub rate limits / transient registry timeouts, no auth required. This is the same philosophy as #392: get off Docker Hub for CI infra.

15 occurrences in `ci.yaml` (9× postgres, 6× redis), one-line each, `services:` blocks otherwise unchanged.

## Verification

- Both tags pull cleanly with **no auth** and resolve to the real official images (verified digests locally).
- `actionlint` clean.

Local `docker-compose.dev.yaml` is left on Docker Hub — the flake is a fresh-runner problem; local dev has a warm cache and this avoids changing every developer's `make dev-up`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)