### PR TITLE
fix(parser): capture operator retries/retry_delay/execution_timeout (#434)

### DIFF
--- a/parser/leoflow_parser/_shim/airflow/_core.py
+++ b/parser/leoflow_parser/_shim/airflow/_core.py
@@ -84,6 +84,10 @@ class DAG:
         self.schedule = schedule
         self.tags = list(tags or [])
         self.task_dict: dict = {}
+        # Airflow applies default_args to every operator in the DAG; the compiler
+        # reads it as the fallback for a task's retries/retry_delay/execution_timeout
+        # (#434). Kept as a plain dict; empty when not given.
+        self.default_args: dict = dict(kwargs.get("default_args") or {})
         # Collect on construction too, so DAGs defined without `with` (e.g.
         # module-level `dag = DAG(...)` with operators attached via dag=) are seen.
         COLLECTED[dag_id] = self

--- a/parser/leoflow_parser/compiler.py
+++ b/parser/leoflow_parser/compiler.py
@@ -274,6 +274,14 @@ def _map_task(task, source: str, dag=None) -> dict[str, Any]:
 # others stay a loud reject until wired.
 _ON_FAILURE_CALLBACK = "on_failure_callback"
 
+# Airflow scheduling attributes captured by the compiler outside a generic
+# operator's constructor kwargs (#434): trigger_rule via _trigger_rule, the rest
+# via _apply_scheduling_attrs. _split_operator_args skips them so they are not
+# mistaken for the operator's own args (and a timedelta does not trip its reject).
+_SCHEDULING_ATTR_NAMES = frozenset(
+    {"trigger_rule", "retries", "retry_delay", "execution_timeout"}
+)
+
 # Task types whose runtime path is Python with a real try/except, so an
 # on_failure_callback can run in-process on the task's final failure (#424). A
 # bash task execs bash in place (os.execvp), leaving no Python to run it.
@@ -336,6 +344,14 @@ def _split_operator_args(task) -> tuple[dict[str, list[str]], dict[str, Any]]:
     xcom: dict[str, list[str]] = {}
     operator_args: dict[str, Any] = {}
     for name, value in raw.items():
+        # Airflow scheduling attributes (trigger_rule + retries/retry_delay/
+        # execution_timeout) are captured separately — _trigger_rule and
+        # _apply_scheduling_attrs (#434) — NOT as operator constructor args. Skip
+        # them here: they are not the operator's own kwargs, and a timedelta
+        # (retry_delay/execution_timeout) would otherwise trip the non-serialisable
+        # reject below and fail an otherwise-valid provider operator at compile.
+        if name in _SCHEDULING_ATTR_NAMES:
+            continue
         # on_failure_callback is a callable that cannot be serialised into
         # dag.json, but it is SUPPORTED (#424 inc 4): the runtime re-imports dag.py
         # and calls it in the task process on failure. Accept it here as a marker

--- a/parser/leoflow_parser/compiler.py
+++ b/parser/leoflow_parser/compiler.py
@@ -45,7 +45,7 @@ def compile_dag(
         "dag_id": dag.dag_id,
         "dag_version": dag_version,
         "image": image,
-        "tasks": [_map_task(task, source) for task in _ordered_tasks(dag)],
+        "tasks": [_map_task(task, source, dag) for task in _ordered_tasks(dag)],
     }
 
     schedule = _schedule(dag)
@@ -234,7 +234,7 @@ def _ordered_tasks(dag) -> list[Any]:
     return [dag.task_dict[task_id] for task_id in sorted(dag.task_dict)]
 
 
-def _map_task(task, source: str) -> dict[str, Any]:
+def _map_task(task, source: str, dag=None) -> dict[str, Any]:
     task_type = _operator_type(task)
     entry: dict[str, Any] = {"task_id": task.task_id, "type": task_type}
 
@@ -245,6 +245,8 @@ def _map_task(task, source: str) -> dict[str, Any]:
     rule = _trigger_rule(task)
     if rule != "all_success":
         entry["trigger_rule"] = rule
+
+    _apply_scheduling_attrs(task, dag, entry)
 
     if task_type == "python":
         entry["entrypoint"] = _python_entrypoint(task, source)
@@ -417,6 +419,41 @@ def _trigger_rule(task) -> str:
     if value not in _SUPPORTED_TRIGGER_RULES:
         raise ValueError(f"unsupported trigger rule {value!r} on task {task.task_id}")
     return value
+
+
+def _sched_attr(task, dag, name: str):
+    """Resolve an Airflow scheduling attribute (retries/retry_delay/execution_timeout)
+    the way Airflow does: the value set on the operator wins; otherwise the DAG's
+    default_args supplies it (#434). Returns None when neither sets it, so the task
+    emits no key and the Go side's leoflow.yaml defaults still apply."""
+    value = getattr(task, name, None)
+    if value is None and dag is not None:
+        value = (getattr(dag, "default_args", None) or {}).get(name)
+    return value
+
+
+def _seconds(value) -> int | None:
+    """Coerce an Airflow duration (a timedelta, or a bare int/float of seconds) to a
+    whole number of seconds. None stays None."""
+    if value is None:
+        return None
+    total = value.total_seconds() if hasattr(value, "total_seconds") else value
+    return int(total)
+
+
+def _apply_scheduling_attrs(task, dag, entry: dict[str, Any]) -> None:
+    """Capture retries / retry_delay / execution_timeout (operator or default_args)
+    onto the task entry, converting durations to seconds. Silently dropping these —
+    the pre-#434 behavior — made a migrated DAG's retries=3 run once with no retry."""
+    retries = _sched_attr(task, dag, "retries")
+    if retries is not None:
+        entry["retries"] = int(retries)
+    retry_delay = _seconds(_sched_attr(task, dag, "retry_delay"))
+    if retry_delay is not None:
+        entry["retry_delay_seconds"] = retry_delay
+    execution_timeout = _seconds(_sched_attr(task, dag, "execution_timeout"))
+    if execution_timeout is not None:
+        entry["execution_timeout_seconds"] = execution_timeout
 
 
 def _python_entrypoint(task, source: str) -> str:

--- a/parser/tests/test_shim_edges.py
+++ b/parser/tests/test_shim_edges.py
@@ -316,3 +316,65 @@ def test_generic_operator_with_native_substring_name_is_captured(
     t = _task(spec, "t")
     assert t["type"] == "airflow_operator"
     assert t["operator_class"] == f"airflow.providers.acme.operators.run.{class_name}"
+
+
+# --- Airflow scheduling attrs on the operator / default_args (#434) --------------
+# retries / retry_delay / execution_timeout set the Airflow way must be captured, not
+# silently dropped (a DAG migrated with retries=3 must not run once with no retry).
+
+def test_operator_retries_and_timeouts_are_captured(monkeypatch, tmp_path):
+    """retries / retry_delay / execution_timeout set ON the operator reach dag.json
+    (converted to seconds), instead of being silently dropped (#434)."""
+    spec = _compile(monkeypatch, tmp_path, """
+        from datetime import timedelta
+        from airflow.providers.standard.operators.bash import BashOperator
+        from airflow.sdk import DAG
+        with DAG("g"):
+            BashOperator(task_id="b", bash_command="false",
+                         retries=3, retry_delay=timedelta(seconds=30),
+                         execution_timeout=timedelta(minutes=5))
+    """)
+    b = _task(spec, "b")
+    assert b["retries"] == 3
+    assert b["retry_delay_seconds"] == 30
+    assert b["execution_timeout_seconds"] == 300
+
+
+def test_dag_default_args_retries_are_captured(monkeypatch, tmp_path):
+    """default_args on the DAG apply to a task that does not set its own (#434)."""
+    spec = _compile(monkeypatch, tmp_path, """
+        from datetime import timedelta
+        from airflow.providers.standard.operators.bash import BashOperator
+        from airflow.sdk import DAG
+        with DAG("g", default_args={"retries": 2, "retry_delay": timedelta(seconds=15)}):
+            BashOperator(task_id="b", bash_command="false")
+    """)
+    b = _task(spec, "b")
+    assert b["retries"] == 2
+    assert b["retry_delay_seconds"] == 15
+
+
+def test_operator_retries_win_over_default_args(monkeypatch, tmp_path):
+    """A per-operator value is more specific than default_args and wins (#434)."""
+    spec = _compile(monkeypatch, tmp_path, """
+        from airflow.providers.standard.operators.bash import BashOperator
+        from airflow.sdk import DAG
+        with DAG("g", default_args={"retries": 2}):
+            BashOperator(task_id="b", bash_command="false", retries=5)
+    """)
+    assert _task(spec, "b")["retries"] == 5
+
+
+def test_no_scheduling_attrs_emits_no_keys(monkeypatch, tmp_path):
+    """A task with no retries/timeout emits none — so the Go side's default_args /
+    leoflow.yaml defaults still apply (nil, not a forced 0)."""
+    spec = _compile(monkeypatch, tmp_path, """
+        from airflow.providers.standard.operators.bash import BashOperator
+        from airflow.sdk import DAG
+        with DAG("g"):
+            BashOperator(task_id="b", bash_command="false")
+    """)
+    b = _task(spec, "b")
+    assert "retries" not in b
+    assert "retry_delay_seconds" not in b
+    assert "execution_timeout_seconds" not in b

--- a/parser/tests/test_shim_edges.py
+++ b/parser/tests/test_shim_edges.py
@@ -378,3 +378,37 @@ def test_no_scheduling_attrs_emits_no_keys(monkeypatch, tmp_path):
     assert "retries" not in b
     assert "retry_delay_seconds" not in b
     assert "execution_timeout_seconds" not in b
+
+
+def test_task_decorator_retries_are_captured(monkeypatch, tmp_path):
+    """@task(retries=…, retry_delay=…) — the common TaskFlow style — is captured too
+    (the decorator kwargs flow to the underlying python operator, #434)."""
+    spec = _compile(monkeypatch, tmp_path, """
+        from datetime import timedelta
+        from airflow.sdk import DAG, task
+        @task(retries=2, retry_delay=timedelta(seconds=10))
+        def a() -> None: ...
+        with DAG("g"):
+            a()
+    """)
+    a = _task(spec, "a")
+    assert a["type"] == "python"
+    assert a["retries"] == 2
+    assert a["retry_delay_seconds"] == 10
+
+
+def test_provider_operator_retries_are_captured(monkeypatch, tmp_path):
+    """A generic provider operator (type=airflow_operator) also carries its retries
+    /timeout, so a captured operator is not exempt from the #434 fix."""
+    spec = _compile(monkeypatch, tmp_path, """
+        from datetime import timedelta
+        from airflow.providers.snowflake.operators.snowflake import SQLExecuteQueryOperator
+        from airflow.sdk import DAG
+        with DAG("g"):
+            SQLExecuteQueryOperator(task_id="q", conn_id="sf", sql="SELECT 1",
+                                    retries=4, execution_timeout=timedelta(minutes=2))
+    """)
+    q = _task(spec, "q")
+    assert q["type"] == "airflow_operator"
+    assert q["retries"] == 4
+    assert q["execution_timeout_seconds"] == 120


### PR DESCRIPTION
## The footgun

A task's Airflow scheduling attributes set **on the operator** (or the DAG's `default_args`) were **silently dropped** at compile — only `trigger_rule` was captured. A DAG migrated from Airflow with `retries=3` compiled to `max_tries=1` and ran **once, no retry** — the opposite of what the author wrote, and a silent data-loss-class footgun that violates the project's loud-reject > silent-drop principle.

```python
BashOperator(task_id="b", bash_command="false",
             retries=3, retry_delay=timedelta(seconds=30),
             execution_timeout=timedelta(minutes=5))
```
compiled to `{ "task_id": "b", "type": "bash", "entrypoint": "false" }` — retries/timeout gone.

## Fix (option A: capture; leoflow.yaml overrides)

The parser now reads `retries` / `retry_delay` / `execution_timeout` off the operator, **falling back to the DAG's `default_args`** (the shim now stores it), converts durations to whole seconds, and emits `retries` / `retry_delay_seconds` / `execution_timeout_seconds`. A task that sets none emits **no keys** (nil preserved).

Precedence is handled by the existing Go overlay — **most-specific wins**:

| Source | Mechanism | Priority |
|---|---|---|
| `leoflow.yaml tasks.<id>` | `applyTaskOverride` overwrites | highest |
| operator kwarg | **this change** | |
| DAG `default_args` | **this change** (fallback) | |
| `leoflow.yaml defaults` | `applyDefaultRetries` fills only nil | lowest |

So `leoflow.yaml` still overrides, and an operator value wins over a DAG-wide default.

## Tests (parser)

Operator capture (+ `timedelta`→seconds), `default_args` fallback, operator-wins-over-`default_args`, and no-attrs-emits-no-keys. Full parser suite green; ruff clean. The `retries`/`retry_delay_seconds`/`execution_timeout_seconds` task fields already exist in `dag-schema.json` and `domain.TaskSpec`.

Closes #434.

🤖 Generated with [Claude Code](https://claude.com/claude-code)