### PR TITLE
feat(alerts): saturation-drop metric (#435 part 1)

### DIFF
--- a/internal/scheduler/resilience_test.go
+++ b/internal/scheduler/resilience_test.go
@@ -117,6 +117,7 @@ func (f *flakyStore) snapshotMaterialized() []string {
 type capturingRecorder struct {
 	mu        sync.Mutex
 	decisions []string
+	alerts    []string // "<dag>/<type>/<result>" per RecordAlert call
 }
 
 func (r *capturingRecorder) RecordSchedulerDecision(d string) {
@@ -128,6 +129,23 @@ func (r *capturingRecorder) RecordTaskTransition(_, _, _ string)       {}
 func (r *capturingRecorder) RecordUndispatchable(string)               {}
 func (r *capturingRecorder) RecordSchedulerStepDown(string)            {}
 func (r *capturingRecorder) ObserveSchedulerReacquire(_ time.Duration) {}
+func (r *capturingRecorder) RecordAlert(dagID, channelType, result string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.alerts = append(r.alerts, dagID+"/"+channelType+"/"+result)
+}
+
+func (r *capturingRecorder) alertCount(entry string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n := 0
+	for _, a := range r.alerts {
+		if a == entry {
+			n++
+		}
+	}
+	return n
+}
 
 func (r *capturingRecorder) count(decision string) int {
 	r.mu.Lock()

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -134,6 +134,10 @@ type Recorder interface {
 	// → re-acquire cycle (#311). Operators alert on P99 to spot churn that
 	// starts to delay scheduling latency.
 	ObserveSchedulerReacquire(d time.Duration)
+	// RecordAlert counts one on-failure alert outcome by dag, channel type, and
+	// result. The scheduler records result="dropped" when its dispatch semaphore
+	// is saturated (#435); the dispatcher records "sent"/"failed" for deliveries.
+	RecordAlert(dagID, channelType, result string)
 }
 
 // Dispatcher launches a task instance for execution. The scheduler dispatches a
@@ -642,8 +646,21 @@ func (s *Scheduler) maybeAlertFailure(ctx context.Context, state domain.DagRunSt
 	default:
 		s.logger.Warn("dropping on-failure alert: dispatch saturated",
 			"dag", run.DagID, "run", run.RunID, "limit", cap(s.alertSem))
+		// Record the drop per rule (mirrors the dispatcher's per-rule sent/failed),
+		// so a burst of saturation-drops is a metric operators can alert on, not
+		// just a log line (#435). Best-effort: a nil recorder is a no-op.
+		if s.recorder != nil {
+			for _, rule := range run.Alerts.OnFailure {
+				s.recorder.RecordAlert(run.DagID, rule.Type, alertResultDropped)
+			}
+		}
 	}
 }
+
+// alertResultDropped is the RecordAlert result for an on-failure alert the
+// scheduler drops because its dispatch semaphore is saturated (#435). It sits
+// alongside the dispatcher's "sent"/"failed" on the same metric.
+const alertResultDropped = "dropped"
 
 // applyPlanned launches a task as it becomes queued and records the resulting
 // transition. Non-queued transitions are recorded directly.

--- a/internal/scheduler/scheduler_alerts_test.go
+++ b/internal/scheduler/scheduler_alerts_test.go
@@ -60,6 +60,32 @@ func TestStepBoundsAlertConcurrency(t *testing.T) {
 	}
 }
 
+// When the dispatch semaphore is saturated the dropped alert is not just logged —
+// it is recorded as result="dropped" so operators can alert on a burst (#435).
+func TestStepRecordsDroppedAlertWhenSaturated(t *testing.T) {
+	al := &blockingAlerter{started: make(chan RunState, 4), release: make(chan struct{})}
+	defer close(al.release)
+	rec := &capturingRecorder{}
+	store := newFakeStore(exhaustedFailedRun("r1"), exhaustedFailedRun("r2"))
+	s := newScheduler(store)
+	s.SetAlerter(al)
+	s.SetRecorder(rec)
+	s.SetAlertConcurrency(1)
+	if err := s.Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// One dispatch acquired the slot and blocks; the other run's alert is dropped.
+	select {
+	case <-al.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected one alert to start")
+	}
+	// The drop is recorded synchronously in the finalize path (etl DAG, slack rule).
+	if got := rec.alertCount("etl/slack/dropped"); got != 1 {
+		t.Fatalf("dropped-alert records = %d, want 1 (%v)", got, rec.alerts)
+	}
+}
+
 // A run that finalizes failed with on_failure rules fires the alerter exactly once.
 func TestStepAlertsOnFailedFinalize(t *testing.T) {
 	store := newFakeStore(RunState{

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -617,6 +617,7 @@ func (r *fakeRecorder) RecordSchedulerStepDown(reason string) {
 func (r *fakeRecorder) ObserveSchedulerReacquire(d time.Duration) {
 	r.reacquireSamples = append(r.reacquireSamples, d)
 }
+func (r *fakeRecorder) RecordAlert(_, _, _ string) {}
 
 func freshRun() *fakeStore {
 	// 'a' starts scheduled so a single Step plans it none->queued via launchQueued


### PR DESCRIPTION
## What

When the scheduler's on-failure alert-dispatch semaphore is saturated it drops the alert best-effort with a `WARN` log — but there was **no metric**, so a burst of dropped alerts was invisible to alerting (only greppable in logs).

Adds `RecordAlert` to the `scheduler.Recorder` interface and records **`result="dropped"`** — per rule, mirroring the dispatcher's per-rule `sent`/`failed` — on the same `leoflow_alerts_dispatched_total{dag_id,type,result}` metric.

## Critical review (done before shipping, per the standing rule)

- **No double-count:** the scheduler records `dropped` only in the saturation path, where the alert is *not* dispatched; the dispatcher records `sent`/`failed` only when it *is*. Mutually exclusive.
- **Per-rule consistency:** the drop loops over `OnFailure` so the metric's `type` label stays meaningful (matches sent/failed granularity).
- **Nil recorder:** guarded — stays a no-op.
- **No import cycle:** the `"dropped"` const is local to the scheduler (failurealert imports scheduler, not vice-versa); `observability.Metrics` already implements `RecordAlert`.
- **Complexity:** `golangci-lint` clean (gocyclo ≤ 15).

## Test

With concurrency bound at 1 and one dispatch holding the slot, a second simultaneously-failing run's alert is recorded as `<dag>/<type>/dropped`. Reality-anchored (drives the real saturation path).

## Scope

Part 1 of #435. **Part 2** (a callback-run signal from the pod) stays **deferred** as the issue notes — it needs a runtime→control-plane channel and is disproportionate now. Leaving #435 open for part 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)