### PR TITLE
feat(alerts): dedup on-failure alerts per failure episode (#431)

### DIFF
--- a/internal/scheduler/resilience_test.go
+++ b/internal/scheduler/resilience_test.go
@@ -91,6 +91,7 @@ func (f *flakyStore) SetRunState(_ context.Context, runID string, state domain.D
 	f.runStates[runID] = state
 	return nil
 }
+func (f *flakyStore) MarkRunAlerted(context.Context, string) (bool, error) { return true, nil }
 
 func (f *flakyStore) SetTaskNote(context.Context, string, string, string) error { return nil }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -99,6 +99,11 @@ type Store interface {
 	// re-dispatch, PRESERVING try_number (reschedule is not a retry; #380).
 	RedispatchReschedule(ctx context.Context, runID, taskID string) error
 	SetRunState(ctx context.Context, runID string, state domain.DagRunState) error
+	// MarkRunAlerted atomically claims a run's on-failure alert (#431): it reports
+	// true iff this call is the one that set alerted_at (it was NULL), and false
+	// when the run was already alerted for this failure episode. A clear resets
+	// the marker, so a genuine re-failure re-claims. Dedups duplicate pages.
+	MarkRunAlerted(ctx context.Context, runID string) (bool, error)
 	ScheduledDAGs(ctx context.Context) ([]ScheduledDAG, error)
 	CreateScheduledRun(ctx context.Context, dagID string, logical time.Time) error
 	// SetTaskNote attaches operational context to a task instance (shown in the
@@ -632,6 +637,16 @@ func (s *Scheduler) maybeAlertFailure(ctx context.Context, state domain.DagRunSt
 		return
 	}
 	if run.Alerts == nil || len(run.Alerts.OnFailure) == 0 {
+		return
+	}
+	// Dedup per failure episode (#431): atomically claim the alert. Skip if this
+	// episode was already alerted (a re-tick of the same failed state); a clear
+	// resets the marker so a genuine re-failure re-claims. Fail OPEN on a store
+	// error — a missed page is worse than a rare duplicate — but log it.
+	if won, err := s.store.MarkRunAlerted(ctx, run.RunID); err != nil {
+		s.logger.Error("claiming on-failure alert (alerting anyway)",
+			"dag", run.DagID, "run", run.RunID, "error", err)
+	} else if !won {
 		return
 	}
 	// Acquire a dispatch slot without blocking the tick. A saturated semaphore

--- a/internal/scheduler/scheduler_alerts_test.go
+++ b/internal/scheduler/scheduler_alerts_test.go
@@ -86,6 +86,52 @@ func TestStepRecordsDroppedAlertWhenSaturated(t *testing.T) {
 	}
 }
 
+// Dedup per failure episode (#431): a run whose failed state is re-ticked without
+// a clear alerts only once — the second MarkRunAlerted loses the CAS.
+func TestStepDedupsAlertPerEpisode(t *testing.T) {
+	store := newFakeStore(exhaustedFailedRun("r1"))
+	al := &recordingAlerter{ch: make(chan RunState, 2)}
+	s := newScheduler(store)
+	s.SetAlerter(al)
+	// First tick: the run finalizes failed and claims the alert (fires once).
+	if err := s.Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-al.ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected the first failure to alert")
+	}
+	// Second tick: the fake still returns the run as active (re-tick of the same
+	// failed episode, no clear). The claim is already held, so no second page.
+	if err := s.Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-al.ch:
+		t.Fatal("a re-tick of the same failed episode must not re-alert (#431)")
+	case <-time.After(150 * time.Millisecond):
+	}
+}
+
+// Fail-open (#431): if the dedup CAS errors, the alert still fires — a missed page
+// is worse than a rare duplicate.
+func TestStepAlertsWhenDedupErrors(t *testing.T) {
+	store := newFakeStore(exhaustedFailedRun("r1"))
+	store.markAlertedErr = true
+	al := &recordingAlerter{ch: make(chan RunState, 1)}
+	s := newScheduler(store)
+	s.SetAlerter(al)
+	if err := s.Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-al.ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a dedup error must fail open and still alert")
+	}
+}
+
 // A run that finalizes failed with on_failure rules fires the alerter exactly once.
 func TestStepAlertsOnFailedFinalize(t *testing.T) {
 	store := newFakeStore(RunState{

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -35,6 +35,10 @@ type fakeStore struct {
 	agentLostMarked    []string
 	staleQueuedCands   []StaleQueuedCandidate
 	dispatchLostMarked []string
+	// alertedRuns mirrors the real once-per-episode CAS (#431): the first
+	// MarkRunAlerted per runID wins (true), a repeat loses (false).
+	alertedRuns    map[string]bool
+	markAlertedErr bool
 	// activeRunsCalls counts ActiveRuns invocations so the follower-side gate
 	// can be asserted: a follower must NOT read run state (single-writer
 	// invariant, ADR 0031 / issue #208).
@@ -78,6 +82,19 @@ func (f *fakeStore) RedispatchReschedule(_ context.Context, runID, taskID string
 func (f *fakeStore) SetRunState(_ context.Context, runID string, state domain.DagRunState) error {
 	f.runStates[runID] = state
 	return nil
+}
+func (f *fakeStore) MarkRunAlerted(_ context.Context, runID string) (bool, error) {
+	if f.markAlertedErr {
+		return false, errors.New("mark alerted failed")
+	}
+	if f.alertedRuns == nil {
+		f.alertedRuns = map[string]bool{}
+	}
+	if f.alertedRuns[runID] {
+		return false, nil // already claimed this failure episode
+	}
+	f.alertedRuns[runID] = true
+	return true, nil
 }
 func (f *fakeStore) SetTaskNote(_ context.Context, _, taskID, note string) error {
 	if f.notes == nil {

--- a/internal/storage/lima_bugs_integration_test.go
+++ b/internal/storage/lima_bugs_integration_test.go
@@ -253,3 +253,48 @@ func taskInstanceID(t *testing.T, sched *storage.SchedulerStore, ctx context.Con
 	t.Fatalf("task instance id not found for %s/%s", runUUID, taskID)
 	return ""
 }
+
+// TestOnFailureAlertDedupResetsOnClearIntegration pins the #431 "once per failure
+// episode" contract at the SQL layer: MarkRunAlerted is an atomic claim (wins once
+// while alerted_at is NULL, loses on a re-tick of the same episode), and a Clear
+// (ResetDagRunToVersion) NULLs alerted_at so a genuine re-failure re-claims. A unit
+// test on a fake store can't prove the CAS or the reset — they live in the SQL.
+func TestOnFailureAlertDedupResetsOnClearIntegration(t *testing.T) {
+	repo, sched, ctx := openRepo(t)
+
+	dagID := fmt.Sprintf("alert_dedup_%d", time.Now().UnixNano())
+	tasks := []domain.TaskSpec{{TaskID: "hello", Type: domain.TaskTypePython}}
+	registerSpec(t, repo, ctx, dagID, tasks)
+	if _, err := repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+		RunID: "r1", State: domain.DagRunStateRunning, RunType: "manual",
+		LogicalDate: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateDagRun: %v", err)
+	}
+	runUUID := resolveRunUUID(t, sched, ctx, dagID)
+	if err := sched.MaterializeTasks(ctx, runUUID, tasks); err != nil {
+		t.Fatalf("MaterializeTasks: %v", err)
+	}
+	if err := sched.ApplyTransition(ctx, runUUID, "hello", domain.TaskStateFailed); err != nil {
+		t.Fatalf("ApplyTransition to failed: %v", err)
+	}
+
+	// First claim wins; the immediate re-tick (same failed episode, no clear) loses.
+	if won, err := sched.MarkRunAlerted(ctx, runUUID); err != nil || !won {
+		t.Fatalf("first MarkRunAlerted = (%v, %v), want (true, nil)", won, err)
+	}
+	if won, err := sched.MarkRunAlerted(ctx, runUUID); err != nil || won {
+		t.Fatalf("re-tick MarkRunAlerted = (%v, %v), want (false, nil) — no duplicate page", won, err)
+	}
+
+	// A Clear (resetDagRun=true) opens a new failure episode by NULLing alerted_at.
+	if _, err := repo.ClearTaskInstances(ctx, "default", dagID, "r1",
+		[]string{"hello"}, true /*onlyFailed*/, true /*resetDagRun*/); err != nil {
+		t.Fatalf("ClearTaskInstances: %v", err)
+	}
+
+	// The genuine re-failure after the clear re-claims and re-alerts.
+	if won, err := sched.MarkRunAlerted(ctx, runUUID); err != nil || !won {
+		t.Fatalf("post-clear MarkRunAlerted = (%v, %v), want (true, nil) — a clear must re-open the episode (#431)", won, err)
+	}
+}

--- a/internal/storage/queries/models.go
+++ b/internal/storage/queries/models.go
@@ -225,6 +225,7 @@ type DagRun struct {
 	StartedAt         pgtype.Timestamptz `json:"started_at"`
 	EndedAt           pgtype.Timestamptz `json:"ended_at"`
 	Note              *string            `json:"note"`
+	AlertedAt         pgtype.Timestamptz `json:"alerted_at"`
 }
 
 type DagVersion struct {

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -117,6 +117,12 @@ type Querier interface {
 	ListTaskInstancesByRun(ctx context.Context, dagRunID pgtype.UUID) ([]TaskInstance, error)
 	ListVariables(ctx context.Context, arg ListVariablesParams) ([]ListVariablesRow, error)
 	ListXComEntries(ctx context.Context, arg ListXComEntriesParams) ([]ListXComEntriesRow, error)
+	// Atomically claim the on-failure alert for a run (#431): set alerted_at once,
+	// only while it is NULL, and return the row iff this call won the claim. A second
+	// call (same failed episode, no clear) matches no row and reports "already
+	// alerted", so the scheduler skips the duplicate page. A clear nulls alerted_at,
+	// letting the next genuine failure re-claim.
+	MarkRunAlerted(ctx context.Context, id pgtype.UUID) (pgtype.UUID, error)
 	// Fails an orphaned dag run. The `state = 'running'` guard makes the reap a
 	// safety net, never a takeover: a competing finalizer (the normal scheduler
 	// path) cannot be overwritten. Idempotent: a second call on a run already
@@ -177,7 +183,9 @@ type Querier interface {
 	// Clear re-binds the run to the DAG's current registered version (ADR 0020): a
 	// re-run after a code/yaml fix picks up the newest image and config — in dev that
 	// is the last hot-reload, in prod the last deploy — while everything within a
-	// version stays reproducible.
+	// version stays reproducible. Clearing alerted_at (#431) makes the clear a new
+	// failure episode, so a genuine re-failure re-pages while a re-tick of the same
+	// failed state does not.
 	ResetDagRunToVersion(ctx context.Context, arg ResetDagRunToVersionParams) error
 	// Archives the current attempt into task_instance_history then resets the
 	// live row. See ResetTaskInstanceToNone for the per-attempt rationale.

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -69,10 +69,24 @@ RETURNING *;
 -- Clear re-binds the run to the DAG's current registered version (ADR 0020): a
 -- re-run after a code/yaml fix picks up the newest image and config — in dev that
 -- is the last hot-reload, in prod the last deploy — while everything within a
--- version stays reproducible.
+-- version stays reproducible. Clearing alerted_at (#431) makes the clear a new
+-- failure episode, so a genuine re-failure re-pages while a re-tick of the same
+-- failed state does not.
 UPDATE dag_runs
-SET state = 'queued', started_at = NULL, ended_at = NULL, dag_version_id = $2
+SET state = 'queued', started_at = NULL, ended_at = NULL, alerted_at = NULL,
+    dag_version_id = $2
 WHERE id = $1;
+
+-- name: MarkRunAlerted :one
+-- Atomically claim the on-failure alert for a run (#431): set alerted_at once,
+-- only while it is NULL, and return the row iff this call won the claim. A second
+-- call (same failed episode, no clear) matches no row and reports "already
+-- alerted", so the scheduler skips the duplicate page. A clear nulls alerted_at,
+-- letting the next genuine failure re-claim.
+UPDATE dag_runs
+SET alerted_at = now()
+WHERE id = $1 AND alerted_at IS NULL
+RETURNING id;
 
 -- name: StampDagRunState :exec
 -- Transitions a run's state and stamps the run's own timestamps so the UI can

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -155,7 +155,7 @@ func (q *Queries) CountTaskInstanceStatesInWindow(ctx context.Context, arg Count
 const createDagRun = `-- name: CreateDagRun :one
 INSERT INTO dag_runs (tenant_id, dag_id, dag_version_id, run_id, logical_date, state, trigger, note)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-RETURNING id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note
+RETURNING id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note, alerted_at
 `
 
 type CreateDagRunParams struct {
@@ -198,6 +198,7 @@ func (q *Queries) CreateDagRun(ctx context.Context, arg CreateDagRunParams) (Dag
 		&i.StartedAt,
 		&i.EndedAt,
 		&i.Note,
+		&i.AlertedAt,
 	)
 	return i, err
 }
@@ -321,7 +322,7 @@ func (q *Queries) FailTaskInstanceIfActive(ctx context.Context, arg FailTaskInst
 }
 
 const getDagRun = `-- name: GetDagRun :one
-SELECT id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note FROM dag_runs WHERE dag_id = $1 AND run_id = $2
+SELECT id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note, alerted_at FROM dag_runs WHERE dag_id = $1 AND run_id = $2
 `
 
 type GetDagRunParams struct {
@@ -349,12 +350,13 @@ func (q *Queries) GetDagRun(ctx context.Context, arg GetDagRunParams) (DagRun, e
 		&i.StartedAt,
 		&i.EndedAt,
 		&i.Note,
+		&i.AlertedAt,
 	)
 	return i, err
 }
 
 const getDagRunByID = `-- name: GetDagRunByID :one
-SELECT id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note FROM dag_runs WHERE id = $1
+SELECT id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note, alerted_at FROM dag_runs WHERE id = $1
 `
 
 func (q *Queries) GetDagRunByID(ctx context.Context, id pgtype.UUID) (DagRun, error) {
@@ -377,6 +379,7 @@ func (q *Queries) GetDagRunByID(ctx context.Context, id pgtype.UUID) (DagRun, er
 		&i.StartedAt,
 		&i.EndedAt,
 		&i.Note,
+		&i.AlertedAt,
 	)
 	return i, err
 }
@@ -463,7 +466,7 @@ func (q *Queries) LatestRunsForDags(ctx context.Context, arg LatestRunsForDagsPa
 }
 
 const listActiveDagRuns = `-- name: ListActiveDagRuns :many
-SELECT id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note FROM dag_runs
+SELECT id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note, alerted_at FROM dag_runs
 WHERE state IN ('queued', 'running')
 ORDER BY queued_at
 `
@@ -494,6 +497,7 @@ func (q *Queries) ListActiveDagRuns(ctx context.Context) ([]DagRun, error) {
 			&i.StartedAt,
 			&i.EndedAt,
 			&i.Note,
+			&i.AlertedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -561,7 +565,7 @@ func (q *Queries) ListAgentLostCandidates(ctx context.Context) ([]ListAgentLostC
 }
 
 const listDagRunsByDag = `-- name: ListDagRunsByDag :many
-SELECT id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note FROM dag_runs
+SELECT id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note, alerted_at FROM dag_runs
 WHERE dag_id = $1
 ORDER BY logical_date DESC
 LIMIT $2 OFFSET $3
@@ -599,6 +603,7 @@ func (q *Queries) ListDagRunsByDag(ctx context.Context, arg ListDagRunsByDagPara
 			&i.StartedAt,
 			&i.EndedAt,
 			&i.Note,
+			&i.AlertedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -938,6 +943,25 @@ func (q *Queries) ListTaskInstancesByRun(ctx context.Context, dagRunID pgtype.UU
 	return items, nil
 }
 
+const markRunAlerted = `-- name: MarkRunAlerted :one
+UPDATE dag_runs
+SET alerted_at = now()
+WHERE id = $1 AND alerted_at IS NULL
+RETURNING id
+`
+
+// Atomically claim the on-failure alert for a run (#431): set alerted_at once,
+// only while it is NULL, and return the row iff this call won the claim. A second
+// call (same failed episode, no clear) matches no row and reports "already
+// alerted", so the scheduler skips the duplicate page. A clear nulls alerted_at,
+// letting the next genuine failure re-claim.
+func (q *Queries) MarkRunAlerted(ctx context.Context, id pgtype.UUID) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, markRunAlerted, id)
+	var id_2 pgtype.UUID
+	err := row.Scan(&id_2)
+	return id_2, err
+}
+
 const markRunOrphanedRun = `-- name: MarkRunOrphanedRun :execrows
 UPDATE dag_runs
 SET state = 'failed',
@@ -1193,7 +1217,8 @@ func (q *Queries) ResetAllFailedTaskInstances(ctx context.Context, dagRunID pgty
 
 const resetDagRunToVersion = `-- name: ResetDagRunToVersion :exec
 UPDATE dag_runs
-SET state = 'queued', started_at = NULL, ended_at = NULL, dag_version_id = $2
+SET state = 'queued', started_at = NULL, ended_at = NULL, alerted_at = NULL,
+    dag_version_id = $2
 WHERE id = $1
 `
 
@@ -1205,7 +1230,9 @@ type ResetDagRunToVersionParams struct {
 // Clear re-binds the run to the DAG's current registered version (ADR 0020): a
 // re-run after a code/yaml fix picks up the newest image and config — in dev that
 // is the last hot-reload, in prod the last deploy — while everything within a
-// version stays reproducible.
+// version stays reproducible. Clearing alerted_at (#431) makes the clear a new
+// failure episode, so a genuine re-failure re-pages while a re-tick of the same
+// failed state does not.
 func (q *Queries) ResetDagRunToVersion(ctx context.Context, arg ResetDagRunToVersionParams) error {
 	_, err := q.db.Exec(ctx, resetDagRunToVersion, arg.ID, arg.DagVersionID)
 	return err
@@ -1439,7 +1466,7 @@ const updateDagRunState = `-- name: UpdateDagRunState :one
 UPDATE dag_runs
 SET state = $2, started_at = $3, ended_at = $4
 WHERE id = $1
-RETURNING id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note
+RETURNING id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note, alerted_at
 `
 
 type UpdateDagRunStateParams struct {
@@ -1474,6 +1501,7 @@ func (q *Queries) UpdateDagRunState(ctx context.Context, arg UpdateDagRunStatePa
 		&i.StartedAt,
 		&i.EndedAt,
 		&i.Note,
+		&i.AlertedAt,
 	)
 	return i, err
 }

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -193,6 +194,24 @@ func (s *SchedulerStore) SetRunState(ctx context.Context, runID string, state do
 		ID:    rid,
 		State: queries.DagRunState(state),
 	})
+}
+
+// MarkRunAlerted atomically claims a run's on-failure alert (#431): the UPDATE
+// sets alerted_at only while it is NULL and returns the row iff this call won.
+// pgx.ErrNoRows means the row already had alerted_at (already alerted this
+// episode) — not an error, just a lost claim, so report won=false.
+func (s *SchedulerStore) MarkRunAlerted(ctx context.Context, runID string) (bool, error) {
+	rid, err := parseUUID(runID)
+	if err != nil {
+		return false, err
+	}
+	if _, err := s.q.MarkRunAlerted(ctx, rid); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 // ScheduledDAGs returns active, unpaused, cron-scheduled DAGs with the logical

--- a/migrations/019_dag_run_alerted_at.down.sql
+++ b/migrations/019_dag_run_alerted_at.down.sql
@@ -1,0 +1,8 @@
+-- 019_dag_run_alerted_at.down.sql
+-- Drop the alerted_at column (additive, unreferenced by other objects).
+
+BEGIN;
+
+ALTER TABLE dag_runs DROP COLUMN IF EXISTS alerted_at;
+
+COMMIT;

--- a/migrations/019_dag_run_alerted_at.up.sql
+++ b/migrations/019_dag_run_alerted_at.up.sql
@@ -1,0 +1,12 @@
+-- 019_dag_run_alerted_at.up.sql
+-- On-failure alert dedup per failure episode (#431). alerted_at is claimed with an
+-- atomic compare-and-set (set once, only when NULL) the first time a failed run
+-- dispatches its on_failure alerts, so a re-tick of the same failed episode does
+-- not re-page. A clear resets it to NULL (see ResetDagRunToVersion), so a genuine
+-- re-failure after an operator clear re-claims and re-alerts — "once per episode".
+
+BEGIN;
+
+ALTER TABLE dag_runs ADD COLUMN IF NOT EXISTS alerted_at timestamptz;
+
+COMMIT;


### PR DESCRIPTION
## What

The scheduler fired `on_failure` alerts **every time** a run reached terminal `failed`. An operator clearing a failed task re-runs it → it re-finalizes failed → it alerts again; clear 5× → 5 pages.

**Option C (once per failure episode)** — chosen after investigating that terminal runs aren't re-processed, so the only re-alert path is a deliberate clear (a re-tick of the same episode from leader churn / a retried finalize could also double-page):

- **Claim** the alert with an **atomic CAS** on a new `dag_runs.alerted_at` column (set once while `NULL`).
- A **re-tick** of the same failed episode loses the claim → **skips** the duplicate page.
- A **clear** NULLs `alerted_at` (via `ResetDagRunToVersion`), re-opening the episode → a **genuine re-failure re-pages**.

## Changes

- Migration **019** adds nullable `dag_runs.alerted_at`; `MarkRunAlerted` is the CAS query.
- `scheduler.Store` grows `MarkRunAlerted`; `maybeAlertFailure` **claims before dispatch** and **fails open** on a store error (a missed page is worse than a rare duplicate).
- The clear path (`ClearTaskInstances → ResetDagRunToVersion`) resets the marker.

## Critical review (per the standing rule)

- **Ordering vs the #435 semaphore:** CAS wins → then dispatch/drop. A drop-after-claim = alert lost to saturation (recorded `dropped`) + marker set; no re-tick (terminal), and a clear resets the marker anyway. Coherent.
- **Reset tied to `resetDagRun`:** only reset when the run actually goes back to active (can re-finalize). A task-level clear that doesn't reset the run doesn't reset the marker — correct.
- **Fail-open** on DB error — right call for alerting.
- **Migration** additive/nullable/`IF NOT EXISTS`; pre-migration terminal runs never re-alert (not re-processed).

## Tests

- Scheduler unit: a re-tick does **not** re-alert; a dedup error **fails open** and still alerts.
- **Reality-anchored integration test** (real Postgres): CAS + reset-on-clear — win → lose on re-tick → clear → win again. The SQL a fake store can't cover.
- `golangci-lint` clean.

Closes #431.

🤖 Generated with [Claude Code](https://claude.com/claude-code)