### PR TITLE
fix(parser): reject oversized literal task args at compile (#149)

### DIFF
--- a/docs/dag-authoring.md
+++ b/docs/dag-authoring.md
@@ -146,6 +146,12 @@ How it works, and the Phase-A limits:
   (wired as XCom, like `sql=build_sql()` above). A non-serializable arg — a
   callable, a `datetime`, an arbitrary object — is a **loud compile error**; move
   that logic into a `@task`.
+- Literal args are for **small constants**. A task's literal args (`@task`
+  `call_args` and operator `operator_args`) ride as a **single environment
+  variable** at dispatch, which POSIX caps at ~128 KiB; `leoflow compile` rejects a
+  payload over **100 KiB** with a clear error naming the task. For large data, pass
+  a **Connection** or an **external-storage** reference (S3/GCS) and fetch it inside
+  the task — never a big dict/list literal.
 - The provider must be declared in `leoflow.yaml` (`connectors:` or
   `dependencies:`). If it isn't, `leoflow compile` fails and prints the exact line
   to add — no surprise `ModuleNotFoundError` in the pod.

--- a/parser/leoflow_parser/compiler.py
+++ b/parser/leoflow_parser/compiler.py
@@ -234,6 +234,31 @@ def _ordered_tasks(dag) -> list[Any]:
     return [dag.task_dict[task_id] for task_id in sorted(dag.task_dict)]
 
 
+# A task's literal args (call_args / operator_args) ride as a SINGLE environment
+# variable at dispatch (LEOFLOW_CALL_ARGS_JSON / LEOFLOW_OPERATOR_ARGS). POSIX caps
+# a single env var at ~128 KiB on Linux; 100 KiB leaves headroom for the rest of
+# the process environment. Over that, dispatch fails with a cryptic OS error — so
+# gate it at compile with a clear pointer to the right pattern (#149).
+_MAX_LITERAL_ARG_BYTES = 100 * 1024
+
+
+def _check_literal_payload_size(task_id: str, kind: str, payload: dict[str, Any]) -> None:
+    """Reject a literal-arg payload too large to ride in one env var at dispatch
+    (#149). ``kind`` is "call_args" or "operator_args"; the error names the task,
+    the size, and the fix (small constants only; large data via a Connection or
+    external storage fetched inside the task)."""
+    size = len(json.dumps(payload).encode("utf-8"))
+    if size > _MAX_LITERAL_ARG_BYTES:
+        raise ValueError(
+            f"{kind} on task {task_id!r} is {size} bytes, over the "
+            f"{_MAX_LITERAL_ARG_BYTES}-byte compile limit: it rides as a single "
+            f"environment variable at dispatch and would exceed the POSIX env-var "
+            f"limit, failing the task with a cryptic OS error. Pass small constants "
+            f"only — for large data use a Connection or external storage (e.g. S3/GCS) "
+            f"and fetch it inside the task."
+        )
+
+
 def _map_task(task, source: str, dag=None) -> dict[str, Any]:
     task_type = _operator_type(task)
     entry: dict[str, Any] = {"task_id": task.task_id, "type": task_type}
@@ -254,6 +279,7 @@ def _map_task(task, source: str, dag=None) -> dict[str, Any]:
         if xcom_input:
             entry["xcom_input"] = xcom_input
         if call_args:
+            _check_literal_payload_size(task.task_id, "call_args", call_args)
             entry["call_args"] = call_args
     elif task_type == "bash":
         entry["entrypoint"] = _bash_command(task)
@@ -265,6 +291,7 @@ def _map_task(task, source: str, dag=None) -> dict[str, Any]:
         if xcom_input:
             entry["xcom_input"] = xcom_input
         if operator_args:
+            _check_literal_payload_size(task.task_id, "operator_args", operator_args)
             entry["operator_args"] = operator_args
     _check_callbacks(task, task_type, entry)
     return entry

--- a/parser/tests/test_shim_edges.py
+++ b/parser/tests/test_shim_edges.py
@@ -412,3 +412,51 @@ def test_provider_operator_retries_are_captured(monkeypatch, tmp_path):
     assert q["type"] == "airflow_operator"
     assert q["retries"] == 4
     assert q["execution_timeout_seconds"] == 120
+
+
+# --- oversized literal args exceed the env-var limit at dispatch (#149) -----------
+
+def test_oversized_task_literal_arg_is_a_loud_compile_error(monkeypatch, tmp_path):
+    """A @task bound to a huge literal rides as a single LEOFLOW_CALL_ARGS_JSON env
+    var and would blow the POSIX per-var limit at dispatch — the compiler must
+    reject it with an actionable message (#149)."""
+    with pytest.raises(ValueError) as ei:
+        _compile(monkeypatch, tmp_path, """
+            from airflow.sdk import DAG, task
+            @task
+            def consume(rows) -> None: ...
+            with DAG("g"):
+                consume(["x" * 1024] * 200)   # ~200 KiB literal
+        """)
+    msg = str(ei.value)
+    assert "consume" in msg                                   # names the task
+    assert "call_args" in msg
+    assert "limit" in msg.lower() or "exceed" in msg.lower()  # says it's too big
+    assert "Connection" in msg or "external" in msg           # points at the fix
+
+
+def test_small_task_literal_arg_compiles(monkeypatch, tmp_path):
+    """A small literal is fine — the cap only rejects oversized payloads (#149)."""
+    spec = _compile(monkeypatch, tmp_path, """
+        from airflow.sdk import DAG, task
+        @task
+        def consume(rows) -> None: ...
+        with DAG("g"):
+            consume([1, 2, 3])
+    """)
+    assert _task(spec, "consume")["call_args"] == {"rows": [1, 2, 3]}
+
+
+def test_oversized_operator_arg_is_a_loud_compile_error(monkeypatch, tmp_path):
+    """The same env-var limit applies to a generic operator's literal kwargs
+    (LEOFLOW_OPERATOR_ARGS) — the cap covers operator_args too (#149)."""
+    with pytest.raises(ValueError) as ei:
+        _compile(monkeypatch, tmp_path, """
+            from airflow.providers.snowflake.operators.snowflake import SQLExecuteQueryOperator
+            from airflow.sdk import DAG
+            with DAG("g"):
+                SQLExecuteQueryOperator(task_id="q", conn_id="sf", sql="x" * (200 * 1024))
+        """)
+    msg = str(ei.value)
+    assert "q" in msg and "operator_args" in msg
+    assert "Connection" in msg or "external" in msg


### PR DESCRIPTION
## The footgun

A `@task` bound to a large literal (`task(rows=<huge_list>)`) — or a generic operator with a large literal kwarg — rides as a **single environment variable** at dispatch (`LEOFLOW_CALL_ARGS_JSON` / `LEOFLOW_OPERATOR_ARGS`). POSIX caps a single env var at ~128 KiB on Linux, so the task failed with a **cryptic OS error** at dispatch, with no pointer to the cause.

## Fix

Gate it at compile: sum `json.dumps` of a task's `call_args` / `operator_args` and, over **100 KiB** (headroom under the ~128 KiB limit), raise a clear error naming the task, the size, and the fix (small constants only; large data via a Connection or external storage fetched inside the task).

Covers **`operator_args` too** — it shares the exact same single-env-var delivery, so leaving it uncapped would be the identical footgun (critical-review call).

## Critical review

- **Boundary:** `> 100 KiB` rejects; exactly-100 KiB passes.
- **Size measure:** `json.dumps(...).encode("utf-8")` (real UTF-8 bytes). Python's `dumps` is marginally larger than the agent's Go `json.Marshal`, so the check is **conservative** (rejects slightly before the real limit); the 28 KiB headroom absorbs it — no false-negative overflow.
- **Out of scope (runtime, separate concern):** a DagRun's `params`/`conf` ride in their own env var (`LEOFLOW_PARAMS`) delivered at trigger time, not from the DAG — a compile-time cap can't catch it.

## Tests

Oversized `call_args` and oversized `operator_args` are loud compile errors; a small literal still compiles. Threshold documented in `dag-authoring.md`. Full parser suite + ruff clean.

Closes #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)