### PR TITLE
fix(server): refuse Pro boot without agent-gRPC TLS (#281)

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -115,6 +115,11 @@ func run() error {
 	if err := guardInsecureSecretsForEdition(cfg.UI.Edition, allowInsecureSecrets); err != nil {
 		return err
 	}
+	// A Pro deployment without agent-gRPC TLS boots but can't deliver secrets —
+	// refuse it loudly rather than fail every secrets RPC cryptically (#281).
+	if err := guardTLSForEdition(cfg.UI.Edition, cfg.Server.GRPCTLSCert, cfg.Server.GRPCTLSKey); err != nil {
+		return err
+	}
 	grpcSrv, gerr := startAgentGRPC(ctx, cfg.Server.GRPCAddr, authn, execStore, repo, xcomSvc, logSink, logTailer, allowInsecureSecrets, cfg.Server.GRPCTLSCert, cfg.Server.GRPCTLSKey, tel.Logger)
 	if gerr != nil {
 		return gerr

--- a/cmd/leoflow-server/tls_guard.go
+++ b/cmd/leoflow-server/tls_guard.go
@@ -23,3 +23,24 @@ func guardInsecureSecretsForEdition(edition string, allowInsecure bool) error {
 		"either set agentTLS.enabled=true in the Helm values (with cert-manager) or unset the env var " +
 		"(see ADR 0014 and issue #58)")
 }
+
+// guardTLSForEdition refuses boot when a Pro deployment has no TLS on the agent
+// gRPC channel (#281). Without it the control plane boots and looks healthy, but
+// guardSecretChannel then rejects every secrets RPC to a task pod
+// ("refusing to send secrets over an insecure channel") — tasks queue/fail with
+// no obvious cause. An operator who overrides agentTLS.enabled=false hits exactly
+// this. Fail loudly at boot instead. Lite (edition=lite) and the unmarked default
+// keep the plaintext dev loop.
+func guardTLSForEdition(edition, grpcTLSCert, grpcTLSKey string) error {
+	if edition != "pro" {
+		return nil
+	}
+	if grpcTLSCert != "" && grpcTLSKey != "" {
+		return nil
+	}
+	return errors.New("the Pro edition requires TLS on the agent gRPC channel, but it is off: " +
+		"set both LEOFLOW_SERVER_GRPC_TLS_CERT and LEOFLOW_SERVER_GRPC_TLS_KEY (the Helm chart " +
+		"sets them from agentTLS.enabled=true + cert-manager). Booting without them would look " +
+		"healthy but every secrets RPC to a task pod would fail (PermissionDenied: refusing to " +
+		"send secrets over an insecure channel), leaving tasks stuck. See ADR 0014, #58, #281")
+}

--- a/cmd/leoflow-server/tls_guard_test.go
+++ b/cmd/leoflow-server/tls_guard_test.go
@@ -44,3 +44,43 @@ func TestRefuseInsecureSecretsInProd(t *testing.T) {
 		})
 	}
 }
+
+// TestRefuseProWithoutTLS: the Pro edition requires TLS on the agent gRPC channel.
+// An operator who overrides agentTLS.enabled=false boots a control plane that looks
+// healthy, then every secrets RPC to a task pod fails cryptically. Refuse it loudly
+// at boot instead (#281). Lite + the unmarked default keep the plaintext dev loop.
+func TestRefuseProWithoutTLS(t *testing.T) {
+	cases := []struct {
+		name             string
+		edition          string
+		cert, key        string
+		wantErrSubstring string // empty = expect no error
+	}{
+		{name: "pro + cert+key: OK", edition: "pro", cert: "/c.pem", key: "/k.pem"},
+		{name: "pro + no cert: REFUSED", edition: "pro", cert: "", key: "/k.pem",
+			wantErrSubstring: "LEOFLOW_SERVER_GRPC_TLS_CERT"},
+		{name: "pro + no key: REFUSED", edition: "pro", cert: "/c.pem", key: "",
+			wantErrSubstring: "LEOFLOW_SERVER_GRPC_TLS_KEY"},
+		{name: "pro + neither: names the chart value", edition: "pro", cert: "", key: "",
+			wantErrSubstring: "agentTLS.enabled"},
+		{name: "lite + no TLS: allowed (dev)", edition: "lite", cert: "", key: ""},
+		{name: "empty edition + no TLS: allowed (dev fallback)", edition: "", cert: "", key: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := guardTLSForEdition(tc.edition, tc.cert, tc.key)
+			if tc.wantErrSubstring == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErrSubstring)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSubstring) {
+				t.Errorf("error %q missing %q", err.Error(), tc.wantErrSubstring)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The silent failure

An operator who overrides `agentTLS.enabled=false` on a **Pro** deployment booted a control plane that looked healthy — then `guardSecretChannel` rejected **every secrets RPC** to a task pod (`refusing to send secrets over an insecure channel`), leaving tasks stuck with no obvious cause.

The existing guard only caught `edition=pro` **+** `LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS=true`. It did **not** catch `edition=pro` + TLS off with the flag *unset* — exactly the operator-override state (#281).

## Fix

`guardTLSForEdition`: `edition=pro` requires **both** `LEOFLOW_SERVER_GRPC_TLS_CERT` and `LEOFLOW_SERVER_GRPC_TLS_KEY`; boot fails loudly with a message naming both env keys and the `agentTLS.enabled` chart value. Lite + the unmarked default keep the plaintext dev loop.

**Composes with the existing insecure-flag guard:** the flag is refused first (its own message); TLS-off is refused here.

## Tests

Table-driven: pro needs both cert+key (missing either → refused, naming the missing key); lite / empty edition allowed without TLS. Existing insecure-flag guard test unchanged and still green. `golangci-lint` clean.

Closes #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)