### PR TITLE
docs(pro): cert-manager TLS setup for agentTLS default (#268)

### DIFF
--- a/docs/pro-tls.md
+++ b/docs/pro-tls.md
@@ -1,0 +1,91 @@
+# Pro TLS (agent gRPC) with cert-manager
+
+The Pro control plane delivers secrets (Connections, Variables) to task pods over
+gRPC. In Pro that channel **must be TLS** — the server refuses to boot without it
+(#281), and the chart refuses to install when `agentTLS.enabled` but the cert
+Secret or CA ConfigMap is missing (#280). The clean way to provision the cert is
+[cert-manager](https://cert-manager.io).
+
+An operator-ready values file is at
+[`helm/leoflow/examples/values-pro-tls.yaml`](https://github.com/neochaotic/leoflow/blob/main/helm/leoflow/examples/values-pro-tls.yaml)
+— `-f` it after the steps below. (The full chart value reference is the
+[Helm chart](helm-chart.md) page.)
+
+## 1. Install cert-manager
+
+```console
+$ helm repo add jetstack https://charts.jetstack.io --force-update
+$ helm install cert-manager jetstack/cert-manager \
+    --namespace cert-manager --create-namespace \
+    --version v1.16.2 --set crds.enabled=true
+```
+
+## 2. An Issuer
+
+**Self-signed** (in-cluster / internal — the common case, since the agent channel
+never leaves the cluster):
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: leoflow-selfsigned
+  namespace: leoflow
+spec:
+  selfSigned: {}
+```
+
+For a CA that agents across namespaces trust, use a **self-signed CA** issuer (a
+root Certificate + a `kind: Issuer` with `ca.secretName`); for externally-reachable
+endpoints use an **ACME/Let's Encrypt** `ClusterIssuer` instead.
+
+## 3. A Certificate
+
+The Certificate's `secretName` must match `agentTLS.serverCertSecret`:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: leoflow-agent-tls
+  namespace: leoflow
+spec:
+  secretName: leoflow-agent-tls          # == agentTLS.serverCertSecret
+  duration: 2160h                        # 90d
+  renewBefore: 360h                      # 15d
+  issuerRef:
+    name: leoflow-selfsigned
+    kind: Issuer
+  dnsNames:
+    - leoflow.leoflow.svc                 # the control-plane Service DNS
+    - leoflow.leoflow.svc.cluster.local
+```
+
+## 4. The CA trust bundle for task pods
+
+Task pods verify the server cert against `agentTLS.caConfigMap`. Publish the
+signing CA to a ConfigMap — cert-manager's
+[trust-manager](https://cert-manager.io/docs/trust/trust-manager/) `Bundle` is the
+standard way, or copy the issuer's `ca.crt` into a ConfigMap keyed `ca.crt`. Set
+`agentTLS.caConfigMap` to that ConfigMap's name.
+
+## 5. Install
+
+```console
+$ helm install leoflow leoflow/leoflow -n leoflow \
+    -f values-pro-tls.yaml
+```
+
+## Troubleshooting
+
+- **`the Pro edition requires TLS on the agent gRPC channel, but it is off`** — the
+  server refused to boot because `LEOFLOW_SERVER_GRPC_TLS_CERT`/`_KEY` are unset
+  (i.e. `agentTLS.enabled=false`, or the cert Secret didn't mount). Provide the
+  cert as above; **do not** work around it with `agentTLS.enabled=false` — that
+  ships secrets over plaintext (#281).
+- **`agentTLS.caConfigMap is required when agentTLS.enabled`** — helm refused the
+  install because the CA ConfigMap is missing. Without it task pods fail the cert
+  chain (`x509: certificate signed by unknown authority`) and hang (#280). Do step 4.
+- **Tasks stuck queued, agent logs `certificate signed by unknown authority`** —
+  `caConfigMap` points at a ConfigMap that doesn't hold the CA that signed
+  `serverCertSecret`. Re-check the trust bundle.

--- a/helm/leoflow/examples/values-pro-tls.yaml
+++ b/helm/leoflow/examples/values-pro-tls.yaml
@@ -1,0 +1,32 @@
+# values-pro-tls.yaml — a Pro install with agent-gRPC TLS via cert-manager.
+#
+# Use with:  helm install leoflow leoflow/leoflow -n leoflow -f values-pro-tls.yaml
+#
+# Prerequisites (see docs/helm-chart.md):
+#   1. cert-manager installed in the cluster.
+#   2. A (self-signed or ACME) Issuer/ClusterIssuer.
+#   3. A Certificate whose Secret name matches agentTLS.serverCertSecret below,
+#      and a ConfigMap holding the signing CA whose name matches agentTLS.caConfigMap.
+#
+# The Pro edition refuses to boot without TLS on the agent channel (#281), and the
+# chart refuses to install when agentTLS.enabled but the cert Secret / CA ConfigMap
+# are missing (#280) — so this file wires all three together.
+
+# External datastores are mandatory for Pro (the embedded ones are Lite-only).
+database:
+  url: "postgres://leoflow:CHANGEME@postgres:5432/leoflow?sslmode=require"
+redis:
+  url: "redis://redis:6379/0"
+
+auth:
+  jwtSecret: "CHANGEME-jwt-signing-secret"
+# 32 raw bytes or 64-char hex. Generate: openssl rand -hex 16
+secretKey: "CHANGEME-leoflow-secret-key-32by"
+
+agentTLS:
+  enabled: true
+  # kubernetes.io/tls Secret produced by the cert-manager Certificate below.
+  serverCertSecret: "leoflow-agent-tls"
+  # ConfigMap holding the CA that signed serverCertSecret, so task pods verify the
+  # server cert. With cert-manager, point this at the trust-bundle ConfigMap.
+  caConfigMap: "leoflow-agent-ca"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,7 @@ nav:
       - reference.md
       - CLI reference: cli/leoflow.md
       - Helm chart: helm-chart.md
+      - Pro TLS (cert-manager): pro-tls.md
       - Go packages (GoDocs):
           - Overview: go-api.md
           - internal/domain: go/internal/domain.md


### PR DESCRIPTION
After #263 flipped `agentTLS.enabled=true`, a fresh Pro install fails immediately without a TLS Secret — and the natural (wrong) reaction is `agentTLS.enabled=false`, shipping plaintext by accident. This documents the right path.

## What

- **`docs/pro-tls.md`** — walks an operator through cert-manager end-to-end: install → self-signed Issuer → Certificate (`secretName == agentTLS.serverCertSecret`) → CA trust-bundle ConfigMap (`agentTLS.caConfigMap`) → install. Plus a **troubleshooting** section keyed to the exact boot-refusal (#281) and chart-guard (#280) error messages.
- **`helm/leoflow/examples/values-pro-tls.yaml`** — a ready values file to `-f` directly.
- Wired into the mkdocs nav.

## Why not `docs/helm-chart.md`

`docs/helm-chart.md` is **auto-generated** (mirrored from `helm/leoflow/README.md` by `docs.yml`, #183) and gitignored — a hand-authored guide there would be clobbered. So it lives on its own page.

## Verified

- The example **renders the chart** (`helm template -f values-pro-tls.yaml`).
- The cert-manager YAML snippets **parse**.
- `pro-tls.md` is in the nav (not ignored).

Closes #268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)