### PR TITLE
fix(dispatch): wire BufferedDispatcher.Close() into shutdown + fix the Close race (#133)

### DIFF
--- a/cmd/leoflow-server/dispatch_wiring_test.go
+++ b/cmd/leoflow-server/dispatch_wiring_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/config"
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+type noopInner struct{}
+
+func (noopInner) Dispatch(context.Context, string, string, domain.TaskSpec) error { return nil }
+
+// wrapBuffered must hand back a closeable pool ONLY in buffered mode, so run()
+// can drain it on shutdown (#133). Passthrough (Lite, BufferSize=0) has no pool
+// and returns a nil closer — deferring Close() on it would be a nil-pointer bug.
+func TestWrapBuffered_ReturnsCloserOnlyWhenBuffered(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	disp, closer := wrapBuffered(noopInner{}, nil, log, nil, config.DispatchSection{BufferSize: 0})
+	if disp == nil {
+		t.Fatal("passthrough dispatcher is nil")
+	}
+	if closer != nil {
+		t.Errorf("passthrough returned a non-nil closer (%T); Lite has no pool to close", closer)
+	}
+
+	disp2, closer2 := wrapBuffered(noopInner{}, nil, log, nil, config.DispatchSection{BufferSize: 4, Workers: 2})
+	if disp2 == nil {
+		t.Fatal("buffered dispatcher is nil")
+	}
+	if closer2 == nil {
+		t.Fatal("buffered returned a nil closer; run() can't drain the pool on shutdown (#133)")
+	}
+	if err := closer2.Close(); err != nil {
+		t.Errorf("closer.Close() = %v, want nil", err)
+	}
+}

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -131,10 +132,14 @@ func run() error {
 	var schedulerHealth api.Heartbeater
 	podDispatch := false
 	if cfg.Scheduler.Enabled {
-		sched, dispatchOn, serr := startScheduler(ctx, cfg, pg, repo, execStore, authn, xcomSvc, logSink, tel.Logger, tel.Metrics)
+		sched, dispatchOn, dispatchCloser, serr := startScheduler(ctx, cfg, pg, repo, execStore, authn, xcomSvc, logSink, tel.Logger, tel.Metrics)
 		if serr != nil {
 			return serr
 		}
+		// On shutdown, drain the buffered dispatch pool (if any) so in-flight
+		// dispatches settle (success or failed via the sink) instead of leaking
+		// workers and leaving TIs stuck `queued` (#133). nil in Lite/passthrough.
+		defer drainDispatch(dispatchCloser, tel.Logger)
 		schedulerHealth = sched
 		podDispatch = dispatchOn
 	}
@@ -585,10 +590,10 @@ func startStagingGC(ctx context.Context, cs kubernetes.Interface, store executor
 	}()
 }
 
-func startScheduler(ctx context.Context, cfg *config.ServerConfig, pg *storage.Postgres, repo *storage.Repository, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, xcomSvc executor.XComPusher, logSink logs.Sink, logger *slog.Logger, metrics *observability.Metrics) (*scheduler.Scheduler, bool, error) {
+func startScheduler(ctx context.Context, cfg *config.ServerConfig, pg *storage.Postgres, repo *storage.Repository, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, xcomSvc executor.XComPusher, logSink logs.Sink, logger *slog.Logger, metrics *observability.Metrics) (*scheduler.Scheduler, bool, io.Closer, error) {
 	leaderPool, err := storage.NewLeaderPool(ctx, cfg.Database)
 	if err != nil {
-		return nil, false, fmt.Errorf("leader pool: %w", err)
+		return nil, false, nil, fmt.Errorf("leader pool: %w", err)
 	}
 	store := storage.NewSchedulerStore(pg)
 	sched := scheduler.NewScheduler(store, logger,
@@ -612,13 +617,25 @@ func startScheduler(ctx context.Context, cfg *config.ServerConfig, pg *storage.P
 		metrics,
 		logger,
 	))
-	podDispatch := setupDispatch(ctx, cfg, sched, execStore, authn, store, logger, metrics)
+	podDispatch, dispatchCloser := setupDispatch(ctx, cfg, sched, execStore, authn, store, logger, metrics)
 	leader := scheduler.NewLeader(leaderPool)
 	go func() {
 		defer leaderPool.Close()
 		campaignAndRun(ctx, leader, sched, logger)
 	}()
-	return sched, podDispatch, nil
+	return sched, podDispatch, dispatchCloser, nil
+}
+
+// drainDispatch closes the buffered dispatch pool on shutdown so in-flight
+// dispatches drain instead of leaking workers / leaving TIs stuck `queued`
+// (#133). Nil closer (Lite/passthrough) is a no-op; a close error is logged.
+func drainDispatch(closer io.Closer, logger *slog.Logger) {
+	if closer == nil {
+		return
+	}
+	if err := closer.Close(); err != nil {
+		logger.Error("draining dispatch pool on shutdown", "error", err)
+	}
 }
 
 // alertHTTPTimeout bounds each on-failure alert POST so a slow or hung channel
@@ -791,7 +808,7 @@ func serve(s *http.Server, errCh chan<- error) {
 // setupDispatch wires the pod-path executor selected by executor.type onto the
 // scheduler and returns whether pod dispatch is active. "subprocess" runs the
 // agent on the host (dev only); "kubernetes" (default) launches task pods.
-func setupDispatch(ctx context.Context, cfg *config.ServerConfig, sched *scheduler.Scheduler, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, store *storage.SchedulerStore, logger *slog.Logger, metrics *observability.Metrics) bool {
+func setupDispatch(ctx context.Context, cfg *config.ServerConfig, sched *scheduler.Scheduler, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, store *storage.SchedulerStore, logger *slog.Logger, metrics *observability.Metrics) (bool, io.Closer) {
 	if cfg.Executor.Type == "subprocess" {
 		return setupSubprocessDispatch(cfg, sched, execStore, authn, logger, store, metrics) //nolint:contextcheck // buffered worker deliberately detaches from caller ctx
 	}
@@ -809,23 +826,24 @@ func resolveAgentControlAddr(cfg *config.ServerConfig) string {
 
 // setupSubprocessDispatch wires the dev-only subprocess executor (ADR 0023): it
 // runs the agent on the host with no isolation, so it is gated to dev use.
-func setupSubprocessDispatch(cfg *config.ServerConfig, sched *scheduler.Scheduler, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, logger *slog.Logger, sink dispatch.FailureSink, metrics *observability.Metrics) bool {
+func setupSubprocessDispatch(cfg *config.ServerConfig, sched *scheduler.Scheduler, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, logger *slog.Logger, sink dispatch.FailureSink, metrics *observability.Metrics) (bool, io.Closer) {
 	subExec := executor.NewSubprocessExecutor(cfg.Executor.AgentPath, logger)
 	subExec.SetWorkDir(cfg.Executor.SubprocessWorkDir)
 	dispatcher := dispatch.NewDispatcher(subExec, execStore, authn, resolveAgentControlAddr(cfg), agentTokenTTL)
 	dispatcher.SetPlatformDefaults(platformDefaults(cfg.Executor.Defaults))
-	sched.SetDispatcher(wrapBuffered(dispatcher, sink, logger, metrics, cfg.Scheduler.Dispatch))
+	disp, closer := wrapBuffered(dispatcher, sink, logger, metrics, cfg.Scheduler.Dispatch)
+	sched.SetDispatcher(disp)
 	logger.Warn("subprocess dispatch enabled (dev only; user code runs unsandboxed)")
-	return true
+	return true, closer
 }
 
 // setupK8sDispatch wires the production pod-per-task executor; it is a no-op
 // (only inline http_api tasks run) when no Kubernetes client is available.
-func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *scheduler.Scheduler, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, store *storage.SchedulerStore, logger *slog.Logger, metrics *observability.Metrics) bool {
+func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *scheduler.Scheduler, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, store *storage.SchedulerStore, logger *slog.Logger, metrics *observability.Metrics) (bool, io.Closer) {
 	cs, perr := buildK8sClient()
 	if perr != nil {
 		logger.Warn("pod dispatch disabled; only inline http_api tasks will run", "error", perr)
-		return false
+		return false, nil
 	}
 	controlAddr := resolveAgentControlAddr(cfg)
 	podExec := executor.NewKubernetesExecutor(cs, podNamespace)
@@ -834,11 +852,12 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 	dispatcher.SetAgentTLSCAConfigMap(cfg.Executor.AgentTLSCAConfigMap)
 	dispatcher.SetTaskSecret(cfg.Executor.TaskSecretName, cfg.Executor.TaskSecretMountPath)
 	dispatcher.SetPlatformDefaults(platformDefaults(cfg.Executor.Defaults))
-	sched.SetDispatcher(wrapBuffered(dispatcher, store, logger, metrics, cfg.Scheduler.Dispatch)) //nolint:contextcheck // buffered worker deliberately detaches from caller ctx
+	disp, closer := wrapBuffered(dispatcher, store, logger, metrics, cfg.Scheduler.Dispatch) //nolint:contextcheck // buffered worker deliberately detaches from caller ctx
+	sched.SetDispatcher(disp)
 	startReconciler(ctx, cs, execStore, logger)
 	startStagingGC(ctx, cs, store, logger)
 	logger.Info("pod dispatch enabled", "namespace", podNamespace, "agent_control_plane_addr", controlAddr)
-	return true
+	return true, closer
 }
 
 // wrapBuffered returns the dispatcher to plug into the scheduler. When
@@ -847,11 +866,14 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 // caller passes a FailureSink (typically the SchedulerStore) so worker-side
 // dispatch failures fail the TI with a clear reason instead of leaving it
 // stuck `queued`.
-func wrapBuffered(inner dispatch.Inner, sink dispatch.FailureSink, logger *slog.Logger, metrics *observability.Metrics, cfg config.DispatchSection) scheduler.Dispatcher {
+// The io.Closer is non-nil only in buffered mode; the caller defers Close() on
+// shutdown so in-flight dispatches drain (workers finish or fail via the sink)
+// instead of leaking goroutines and leaving TIs stuck `queued` (#133).
+func wrapBuffered(inner dispatch.Inner, sink dispatch.FailureSink, logger *slog.Logger, metrics *observability.Metrics, cfg config.DispatchSection) (scheduler.Dispatcher, io.Closer) {
 	if cfg.BufferSize <= 0 {
 		// Passthrough: keep the inner dispatcher exposed verbatim so the
-		// scheduler sees the same surface it always did in Lite.
-		return inner
+		// scheduler sees the same surface it always did in Lite. No pool to close.
+		return inner, nil
 	}
 	bd := dispatch.NewBuffered(inner, sink, logger, metrics, dispatch.BufferConfig{
 		BufferSize: cfg.BufferSize,
@@ -859,7 +881,7 @@ func wrapBuffered(inner dispatch.Inner, sink dispatch.FailureSink, logger *slog.
 	})
 	logger.Info("buffered dispatch enabled (async pool)",
 		"buffer_size", cfg.BufferSize, "workers", cfg.Workers)
-	return bd
+	return bd, bd
 }
 
 // platformDefaults maps the executor.defaults config (L0 task defaults, ADR

--- a/internal/dispatch/buffered.go
+++ b/internal/dispatch/buffered.go
@@ -71,8 +71,12 @@ type BufferedDispatcher struct {
 	cfg     BufferConfig
 	queue   chan dispatchRequest
 	wg      sync.WaitGroup
-	closed  chan struct{}
-	once    sync.Once
+	// mu guards closed and serializes Dispatch's send against Close's channel
+	// close, so a Dispatch racing Close returns ErrAtCapacity instead of
+	// panicking on send-to-closed-channel (#133).
+	mu     sync.RWMutex
+	closed bool
+	once   sync.Once
 }
 
 // NewBuffered constructs a BufferedDispatcher. BufferSize=0 returns a
@@ -85,7 +89,6 @@ func NewBuffered(inner Inner, sink FailureSink, logger *slog.Logger, metrics Met
 		logger:  logger,
 		metrics: metrics,
 		cfg:     cfg,
-		closed:  make(chan struct{}),
 	}
 	if cfg.BufferSize <= 0 {
 		return b
@@ -111,6 +114,17 @@ func (b *BufferedDispatcher) Dispatch(ctx context.Context, runID, dagID string, 
 	if b.queue == nil {
 		return b.inner.Dispatch(ctx, runID, dagID, task)
 	}
+	// RLock pairs with Close's Lock: while any Dispatch holds it, Close can't
+	// close the queue channel, so the non-blocking send below can never hit a
+	// closed channel. Once Close has run, closed is true and we refuse (#133).
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	if b.closed {
+		if b.metrics != nil {
+			b.metrics.RecordDispatchAtCapacity()
+		}
+		return ErrAtCapacity
+	}
 	select {
 	case b.queue <- dispatchRequest{runID: runID, dagID: dagID, task: task}:
 		if b.metrics != nil {
@@ -125,16 +139,22 @@ func (b *BufferedDispatcher) Dispatch(ctx context.Context, runID, dagID string, 
 	}
 }
 
-// Close stops accepting new dispatches, drains the in-flight queue, and waits
-// for every worker to finish. Calling Close more than once is safe.
-func (b *BufferedDispatcher) Close() {
+// Close stops accepting new dispatches, drains the in-flight queue (each buffered
+// request is still processed by the inner dispatcher — or failed via the sink —
+// so no TI is left stuck `queued`), and waits for every worker to finish. Under
+// mu so a concurrent Dispatch never sends on the closed channel. Idempotent;
+// returns error to satisfy io.Closer (it never errors). #133.
+func (b *BufferedDispatcher) Close() error {
 	b.once.Do(func() {
+		b.mu.Lock()
+		b.closed = true
 		if b.queue != nil {
 			close(b.queue)
 		}
-		close(b.closed)
+		b.mu.Unlock()
 	})
 	b.wg.Wait()
+	return nil
 }
 
 // worker drains the queue, calling the inner dispatcher and reporting failures

--- a/internal/dispatch/buffered_test.go
+++ b/internal/dispatch/buffered_test.go
@@ -319,3 +319,27 @@ func TestBuffered_ConcurrentDispatchAndClose_NoPanic(t *testing.T) {
 	_ = d.Close() // races with the in-flight Dispatch goroutines
 	wg.Wait()     // no panic reaching here = pass
 }
+
+// TestBuffered_Close_DrainsAllBufferedRequests (Level A, #133): a Close with
+// requests still sitting in the buffer must process every one (via the inner /
+// sink) before returning — never drop them, which is what left TIs stuck
+// `queued`. One slow worker guarantees the buffer is non-empty at Close time.
+func TestBuffered_Close_DrainsAllBufferedRequests(t *testing.T) {
+	inner := &recordingInner{delay: 15 * time.Millisecond}
+	d := dispatch.NewBuffered(inner, &recordingSink{}, discardLogger(), nil,
+		dispatch.BufferConfig{BufferSize: 8, Workers: 1})
+	const n = 8
+	for i := 0; i < n; i++ {
+		if err := d.Dispatch(context.Background(), "r", "etl", domain.TaskSpec{TaskID: "t"}); err != nil {
+			t.Fatalf("Dispatch %d: %v (all %d should fit the buffer)", i, err, n)
+		}
+	}
+	// Close must BLOCK until the single slow worker has drained every buffered
+	// request (~8 x 15ms), then return — nothing dropped.
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close err = %v", err)
+	}
+	if got := inner.callCount.Load(); got != n {
+		t.Fatalf("after Close the inner saw %d of %d requests — Close dropped buffered work (would strand TIs `queued`, #133)", got, n)
+	}
+}

--- a/internal/dispatch/buffered_test.go
+++ b/internal/dispatch/buffered_test.go
@@ -288,3 +288,34 @@ func TestBuffered_Close_DrainsPendingWork(t *testing.T) {
 		t.Errorf("after Close, inner saw %d calls, want 4 (every accepted Dispatch must drain)", inner.callCount.Load())
 	}
 }
+
+// TestBuffered_DispatchAfterClose_ReturnsAtCapacity: a Dispatch after Close must
+// return ErrAtCapacity, not panic on send-to-closed-channel (#133 race fix).
+func TestBuffered_DispatchAfterClose_ReturnsAtCapacity(t *testing.T) {
+	d := dispatch.NewBuffered(&recordingInner{}, &recordingSink{}, discardLogger(), nil,
+		dispatch.BufferConfig{BufferSize: 4, Workers: 1})
+	if err := d.Close(); err != nil {
+		t.Fatalf("Close err = %v", err)
+	}
+	err := d.Dispatch(context.Background(), "r", "d", domain.TaskSpec{TaskID: "t"})
+	if !errors.Is(err, dispatch.ErrAtCapacity) {
+		t.Fatalf("Dispatch after Close = %v, want ErrAtCapacity (must not panic)", err)
+	}
+}
+
+// TestBuffered_ConcurrentDispatchAndClose_NoPanic: Dispatch racing Close must never
+// panic (send-on-closed). Run with -race to also catch the data race (#133).
+func TestBuffered_ConcurrentDispatchAndClose_NoPanic(t *testing.T) {
+	d := dispatch.NewBuffered(&recordingInner{}, &recordingSink{}, discardLogger(), nil,
+		dispatch.BufferConfig{BufferSize: 8, Workers: 2})
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = d.Dispatch(context.Background(), "r", "d", domain.TaskSpec{TaskID: "t"})
+		}()
+	}
+	_ = d.Close() // races with the in-flight Dispatch goroutines
+	wg.Wait()     // no panic reaching here = pass
+}

--- a/internal/storage/buffered_drain_integration_test.go
+++ b/internal/storage/buffered_drain_integration_test.go
@@ -1,0 +1,77 @@
+//go:build integration
+
+// Package storage_test — Level B integration for #133 (and the intent of the
+// closed #134): the BufferedDispatcher's drain-on-Close must reach the REAL
+// storage.SchedulerStore sink and move a `queued` TI to `failed` in real
+// Postgres, never leaving it stranded `queued`. A fake-sink unit test can't
+// prove the SQL transition; this drives the production wiring end to end.
+//
+// Deterministic (no flake): Close blocks on wg.Wait until the worker's
+// dispatchOne — including the synchronous sink call — completes, so the DB is
+// settled by the time Close returns.
+//
+// See [[tests-must-be-reality-anchored]] memory. Skips without DATABASE_URL.
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/dispatch"
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// failingInner is a dispatch.Inner that always errors, so the drain path hits
+// the FailureSink (the real SchedulerStore) exactly as a genuine dispatch would.
+type failingInner struct{}
+
+func (failingInner) Dispatch(context.Context, string, string, domain.TaskSpec) error {
+	return errors.New("simulated inner dispatch failure during drain")
+}
+
+func TestBuffered_Close_DrainsToRealSink_NoStuckQueuedIntegration(t *testing.T) {
+	repo, sched, ctx := openRepo(t)
+
+	dagID := fmt.Sprintf("buffered_drain_%d", time.Now().UnixNano())
+	tasks := []domain.TaskSpec{{TaskID: "load", Type: domain.TaskTypePython}}
+	registerSpec(t, repo, ctx, dagID, tasks)
+	if _, err := repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+		RunID: "r1", State: domain.DagRunStateRunning, RunType: "manual",
+		LogicalDate: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateDagRun: %v", err)
+	}
+	runUUID := resolveRunUUID(t, sched, ctx, dagID)
+	if err := sched.MaterializeTasks(ctx, runUUID, tasks); err != nil {
+		t.Fatalf("MaterializeTasks: %v", err)
+	}
+	// The scheduler accepted the buffered dispatch and wrote the TI `queued` —
+	// the exact state a shutdown that dropped the buffer would strand.
+	if err := sched.ApplyTransition(ctx, runUUID, "load", domain.TaskStateQueued); err != nil {
+		t.Fatalf("ApplyTransition to queued: %v", err)
+	}
+
+	// Production wiring: a BufferedDispatcher fronting a failing inner, with the
+	// REAL SchedulerStore as the FailureSink (as setupK8sDispatch wires it).
+	bd := dispatch.NewBuffered(failingInner{}, sched,
+		slog.New(slog.NewTextHandler(io.Discard, nil)), nil,
+		dispatch.BufferConfig{BufferSize: 4, Workers: 1})
+	if err := bd.Dispatch(ctx, runUUID, dagID, tasks[0]); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+
+	// Shutdown drains: inner fails -> reportFailure -> real sink -> the TI must
+	// move queued -> failed in real Postgres, not sit stuck (#133).
+	if err := bd.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if st := taskInstanceState(t, sched, ctx, runUUID, "load"); st != domain.TaskStateFailed {
+		t.Fatalf("after drain, TI 'load' = %q, want failed — the drain must reach the real sink and never strand it `queued` (#133/#134)", st)
+	}
+}


### PR DESCRIPTION
## The bug (Pro only)

With `scheduler.dispatch.buffer_size > 0`, the `*BufferedDispatcher` was created inside `wrapBuffered` and only the `scheduler.Dispatcher` interface escaped — main had **no handle to `Close()`** it. Every SIGTERM:
- **leaked the worker goroutines**, and
- **dropped accepted-but-undrained dispatches** → those TIs sit `queued` forever after restart (no reaper targets `queued`).

Lite (`buffer_size=0` passthrough) is unaffected — which is why CI (Lite defaults) stayed green.

## Fix — wiring

`wrapBuffered` now returns an `io.Closer` too (nil in passthrough), threaded up through `setup*Dispatch → setupDispatch → startScheduler`; `run()` `defer`s `drainDispatch()`. On shutdown the pool drains — each buffered request is still processed by the inner dispatcher (or failed via the sink), then `wg.Wait()` holds the process until workers finish.

## Fix — the Close race (bonus in #133)

`Dispatch` did `queue <- req` with no guard, so a `Dispatch` racing `Close` **panicked on send-to-closed-channel** (the `closed` field was dead code). Replaced with a `sync.RWMutex` + `closed bool`: `Dispatch` takes `RLock` and refuses with `ErrAtCapacity` once closed; `Close` takes the exclusive `Lock` before closing the channel, so no send can race the close. `Close()` now returns `error` (`io.Closer`).

## Tests

- `Dispatch` after `Close` → `ErrAtCapacity`, **no panic**.
- 64-goroutine `Dispatch`/`Close` race — clean under **`-race`**.
- `wrapBuffered` hands back a closer **only** in buffered mode (nil in Lite).
- Existing drain/backpressure tests unchanged. `golangci-lint` clean.

## Acceptance (all met)

- ✅ graceful shutdown waits for in-flight dispatches to settle (`Close → wg.Wait`).
- ✅ no TI left stuck `queued` after restart (`Close` drains; a racing `Dispatch` gets `ErrAtCapacity` → TI stays `scheduled`, re-dispatched on restart — not `queued`).
- ✅ concurrent `Dispatch` during `Close` returns `ErrAtCapacity`, never panics.

Closes #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)