### PR TITLE
fix(helm): refuse to render when agentTLS is off, don't crash-loop (#459)

### DIFF
--- a/docs/pro-tls.md
+++ b/docs/pro-tls.md
@@ -79,10 +79,14 @@ $ helm install leoflow leoflow/leoflow -n leoflow \
 ## Troubleshooting
 
 - **`the Pro edition requires TLS on the agent gRPC channel, but it is off`** — the
-  server refused to boot because `LEOFLOW_SERVER_GRPC_TLS_CERT`/`_KEY` are unset
-  (i.e. `agentTLS.enabled=false`, or the cert Secret didn't mount). Provide the
-  cert as above; **do not** work around it with `agentTLS.enabled=false` — that
-  ships secrets over plaintext (#281).
+  server refused to boot because `LEOFLOW_SERVER_GRPC_TLS_CERT`/`_KEY` are unset:
+  the cert Secret didn't mount, or the server was started outside this chart.
+  Provide the cert as above (#281).
+- **`agentTLS.enabled=false is not a supported configuration`** — helm refused the
+  install. This chart only deploys the Pro edition, and that edition cannot boot
+  without a cert, so turning TLS off buys a `CrashLoopBackOff`, not a plaintext
+  deployment. Provision the cert as above; for a plaintext local loop use the Lite
+  dev server (`leoflow dev lite`), not this chart (#459).
 - **`agentTLS.caConfigMap is required when agentTLS.enabled`** — helm refused the
   install because the CA ConfigMap is missing. Without it task pods fail the cert
   chain (`x509: certificate signed by unknown authority`) and hang (#280). Do step 4.

--- a/helm/leoflow/templates/deployment.yaml
+++ b/helm/leoflow/templates/deployment.yaml
@@ -28,6 +28,19 @@ out-of-band Secret to validate its contents (operator's responsibility).
 {{- end -}}
 {{- end -}}
 {{- /*
+LEOFLOW_UI_EDITION below is the literal "pro" — this chart has no Lite mode — and
+guardTLSForEdition refuses boot when a Pro control plane has no gRPC cert/key. So
+agentTLS.enabled=false does not deploy a plaintext control plane, it deploys a
+crash-looping one, and the operator only learns why from container logs. Refuse at
+render instead. Keep the edition literal: it is the sole marker both boot guards
+key on, so turning it into a value would hand operators a free one-flag bypass of
+the TLS requirement AND of the insecure-secrets rejection. See #459, ADR 0014.
+*/ -}}
+{{- $agentTLS := .Values.agentTLS | default dict -}}
+{{- if not $agentTLS.enabled -}}
+{{- fail "agentTLS.enabled=false is not a supported configuration: this chart always deploys the Pro edition (LEOFLOW_UI_EDITION=pro) and the Pro control plane refuses to boot without a gRPC cert/key, so disabling TLS yields a CrashLoopBackOff (\"the Pro edition requires TLS on the agent gRPC channel\"), not a plaintext deployment. Provision a cert (cert-manager) and set agentTLS.serverCertSecret + agentTLS.caConfigMap. For a plaintext local loop use the Lite dev server (`leoflow dev lite`), not this chart." -}}
+{{- end -}}
+{{- /*
 agentTLS pairs a server cert with a CA the task pods trust. serverCertSecret is
 required inline where it mounts; validate caConfigMap here too, so an install with
 TLS "on" but no CA fails loudly instead of shipping a control plane whose task

--- a/helm/leoflow/tests/deployment_test.yaml
+++ b/helm/leoflow/tests/deployment_test.yaml
@@ -8,13 +8,19 @@ templates:
   - secret.yaml
 release:
   name: leoflow
+# The chart always deploys the Pro edition and now refuses to render without agent
+# TLS (#459), so every case needs a cert pair. Set it once here; the cases that
+# exercise the TLS wiring itself override these per-test.
+set:
+  agentTLS.enabled: true
+  agentTLS.serverCertSecret: leoflow-tls
+  agentTLS.caConfigMap: leoflow-ca
 tests:
   - it: fails the install if database.url AND database.existingSecret are both empty
     template: deployment.yaml
     set:
       redis.url: redis://host/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
     asserts:
       - failedTemplate:
           errorMessage: "database.url or database.existingSecret is required: the Pro edition needs an external Postgres (the embedded datastore is Lite-only)."
@@ -24,7 +30,6 @@ tests:
     set:
       database.url: postgres://h/d
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
     asserts:
       - failedTemplate:
           errorMessage: "redis.url or redis.existingSecret is required: the Pro edition needs an external Redis (the embedded XCom + log tailer is Lite-only)."
@@ -35,7 +40,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
       # NOT setting secretKey / secretKeyExistingSecret
     asserts:
       - hasDocuments:
@@ -51,7 +55,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
       secretKey: leoflow-unittest-secretkey-32by!
     asserts:
       - contains:
@@ -69,7 +72,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
       secretKeyExistingSecret: my-external-key
     asserts:
       - contains:
@@ -87,7 +89,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
       secretKey: too-short-12345
     asserts:
       - failedTemplate:
@@ -99,7 +100,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
       secretKey: leoflow-unittest-secretkey-32by!
     asserts:
       - hasDocuments:
@@ -111,7 +111,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
       secretKey: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef  # gitleaks:allow — fixture, all-hex zeros pattern, not a credential
     asserts:
       - hasDocuments:
@@ -123,7 +122,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
       secretKey: too-short-12345          # would normally fail
       secretKeyExistingSecret: my-key     # but the existingSecret takes precedence; chart can't validate it
     asserts:
@@ -142,7 +140,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
     asserts:
       - exists:
           path: spec.template.metadata.annotations["checksum/secret"]
@@ -158,7 +155,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt-original-value
-      agentTLS.enabled: false
     asserts:
       - matchRegex:
           path: spec.template.metadata.annotations["checksum/secret"]
@@ -179,7 +175,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
     asserts:
       - notExists:
           path: spec.template.spec.volumes[?(@.name == 'db-ca')]
@@ -193,7 +188,6 @@ tests:
       database.caConfigMap: managed-pg-ca
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
     asserts:
       # Volume: a ConfigMap named after the operator's ConfigMap, exposing
       # just the ca.crt key.
@@ -225,7 +219,6 @@ tests:
       database.url: postgres://h/d
       redis.url: rediss://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
     asserts:
       - notContains:
           path: spec.template.spec.containers[0].env
@@ -248,7 +241,6 @@ tests:
       database.url: postgres://h/d
       redis.url: rediss://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
       redis.caConfigMap: redis-ca-bundle
     asserts:
       - contains:
@@ -275,7 +267,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
     asserts:
       - equal:
           path: spec.template.spec.securityContext.runAsNonRoot
@@ -292,6 +283,34 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
           value: false
+
+  # The chart hardcodes LEOFLOW_UI_EDITION=pro, and the Pro server refuses to
+  # boot without a gRPC cert/key. So agentTLS.enabled=false cannot produce a
+  # plaintext deployment — only a crash-looping one. Fail at render instead.
+  - it: fails when agentTLS.enabled is false (chart is always Pro)
+    template: deployment.yaml
+    set:
+      database.url: postgres://h/d
+      redis.url: redis://h/0
+      auth.jwtSecret: jwt
+      agentTLS.enabled: false
+    asserts:
+      - failedTemplate:
+          errorMessage: "agentTLS.enabled=false is not a supported configuration: this chart always deploys the Pro edition (LEOFLOW_UI_EDITION=pro) and the Pro control plane refuses to boot without a gRPC cert/key, so disabling TLS yields a CrashLoopBackOff (\"the Pro edition requires TLS on the agent gRPC channel\"), not a plaintext deployment. Provision a cert (cert-manager) and set agentTLS.serverCertSecret + agentTLS.caConfigMap. For a plaintext local loop use the Lite dev server (`leoflow dev lite`), not this chart."
+
+  # Nulling the whole map (`--set agentTLS=null`) used to render a raw
+  # "nil pointer evaluating interface {}.enabled" instead of the guard message.
+  # It must land on the same actionable error as enabled=false.
+  - it: fails with the guard message when agentTLS is nulled entirely
+    template: deployment.yaml
+    set:
+      database.url: postgres://h/d
+      redis.url: redis://h/0
+      auth.jwtSecret: jwt
+      agentTLS: null
+    asserts:
+      - failedTemplate:
+          errorMessage: "agentTLS.enabled=false is not a supported configuration: this chart always deploys the Pro edition (LEOFLOW_UI_EDITION=pro) and the Pro control plane refuses to boot without a gRPC cert/key, so disabling TLS yields a CrashLoopBackOff (\"the Pro edition requires TLS on the agent gRPC channel\"), not a plaintext deployment. Provision a cert (cert-manager) and set agentTLS.serverCertSecret + agentTLS.caConfigMap. For a plaintext local loop use the Lite dev server (`leoflow dev lite`), not this chart."
 
   # #280: agentTLS.enabled with an empty caConfigMap silently ships a control
   # plane whose task pods can't verify the server cert → x509 unknown-authority.
@@ -329,7 +348,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
       replicaCount: 2
       logs.persistence.enabled: true
       logs.persistence.accessMode: ReadWriteOnce
@@ -346,7 +364,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
       replicaCount: 1                 # ignored when autoscaling is on
       autoscaling.enabled: true
       autoscaling.maxReplicas: 3
@@ -362,7 +379,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
       autoscaling.enabled: true
       autoscaling.maxReplicas: 3
       logs.persistence.enabled: true
@@ -377,7 +393,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
       replicaCount: 2
       logs.persistence.enabled: true
       logs.persistence.accessMode: ReadWriteMany

--- a/helm/leoflow/tests/hardening_test.yaml
+++ b/helm/leoflow/tests/hardening_test.yaml
@@ -1,6 +1,13 @@
 suite: production hardening toggles (HPA / PDB / NetworkPolicy / ServiceMonitor)
 release:
   name: leoflow
+# The chart always deploys the Pro edition and now refuses to render without agent
+# TLS (#459). These cases assert HPA / PDB / NetworkPolicy / ServiceMonitor shape,
+# not TLS wiring, so satisfy the guard once here.
+set:
+  agentTLS.enabled: true
+  agentTLS.serverCertSecret: leoflow-tls
+  agentTLS.caConfigMap: leoflow-ca
 tests:
   # ─── HPA ────────────────────────────────────────────────────────────────
   - it: HPA not rendered when autoscaling.enabled is false (default)
@@ -9,7 +16,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
     asserts:
       - hasDocuments:
           count: 0
@@ -20,7 +26,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
       autoscaling.enabled: true
       autoscaling.minReplicas: 3
       autoscaling.maxReplicas: 9
@@ -50,7 +55,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
     asserts:
       - hasDocuments:
           count: 0
@@ -61,7 +65,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
       podDisruptionBudget.enabled: true
       podDisruptionBudget.minAvailable: 2
     asserts:
@@ -80,7 +83,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
     asserts:
       - hasDocuments:
           count: 0
@@ -91,7 +93,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
       networkPolicy.enabled: true
     asserts:
       - hasDocuments:
@@ -122,7 +123,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
     asserts:
       - hasDocuments:
           count: 0
@@ -133,7 +133,6 @@ tests:
       database.url: postgres://h/d
       redis.url: redis://h/0
       auth.jwtSecret: jwt
-      agentTLS.enabled: false
       metrics.serviceMonitor.enabled: true
     asserts:
       - hasDocuments:


### PR DESCRIPTION
Closes #459.

## Why

`deployment.yaml` hardcodes `LEOFLOW_UI_EDITION: "pro"` and `guardTLSForEdition` (#281) refuses boot when a Pro control plane has no gRPC cert/key. So `agentTLS.enabled=false` never produced a plaintext deployment — it produced a `CrashLoopBackOff` whose cause is only visible in container logs.

#458 fixed the docs that advertised it as a supported knob. This fixes the chart itself, mirroring the #280 `caConfigMap` guard: fail at render, in ~1s, with an actionable message.

Also closes a smaller hole: `--set agentTLS=null` used to render a raw `nil pointer evaluating interface {}.enabled`. Reading through `.Values.agentTLS | default dict` lands it on the same guard.

## The alternative, and why it was rejected

#459 offered a second path: make the edition a value (`.Values.edition`, default `pro`), which would make `enabled: false` coherent for a Lite install and leave the existing tests untouched.

Rejected on security grounds. `edition` gates **nothing** but the two boot guards — the only reads are `tls_guard.go:18` and `tls_guard.go:35`; there are none in `ui/src`, `internal/api` or `internal/server`. So `--set edition=lite` would be a free, single-flag bypass of *both* the TLS requirement and the `LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS` rejection, costing the operator nothing but a UI badge — and the person most likely to find that flag is the one staring at a CrashLoopBackOff looking for a way to make it boot. Hard-fail instead narrows the reachable state space: the chart becomes structurally incapable of emitting a non-TLS Pro deployment.

Full analysis in [this comment](https://github.com/neochaotic/leoflow/issues/459#issuecomment-5136212383).

## Test migration — no assertion weakened

The ~28 cases that set `agentTLS.enabled: false` (to keep the rendered output minimal) now satisfy the guard from a **suite-level `set:`** block in `deployment_test.yaml` and `hardening_test.yaml`. No per-case assertion changed: every `equal:` in those suites targets a scalar path, and the three `notContains` target `LEOFLOW_SECRET_KEY` / `redis-ca`, not TLS. The #280 cases still override `caConfigMap: ""` per-test and still pass.

Two new cases cover the guard itself (`enabled: false`, and the nulled map), written failing-first.

## Verification

| Gate | Result |
|---|---|
| `helm unittest helm/leoflow` | **59/59** pass (was 57) ✓ |
| `helm lint helm/leoflow` | 0 failed ✓ |
| `./scripts/helm-template-checks.sh` | all contracts met ✓ |
| helm-docs README sync | in sync ✓ |

**Blast-radius check** (the failure mode #281 hit): no other site in the repo installs with `agentTLS.enabled=false`. `helm-ci.yaml` sets it `true` explicitly (lines 178-180), `helm-template-checks.sh` and the GKE scripts pass certs. Verified by grepping every `agentTLS` reference outside `tests/`.

`docs/pro-tls.md` troubleshooting updated: the boot-error bullet no longer lists `agentTLS.enabled=false` as a cause reachable through the chart, and the new render error gets its own entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)