### PR TITLE
fix(dispatch): bound the shutdown drain; the timeout it relied on never existed (#463)

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -391,12 +391,22 @@ func buildK8sClient() (kubernetes.Interface, error) {
 			return nil, fmt.Errorf("no in-cluster config or kubeconfig: %w", err)
 		}
 	}
+	// Bound every API call. Workers dispatch with a detached context (they
+	// already accepted responsibility for the task), so without a client-side
+	// deadline an apiserver that accepts the connection and never answers hangs
+	// a worker for good — and with it the shutdown drain (#463).
+	cfg.Timeout = k8sClientTimeout
 	cs, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("building kubernetes client: %w", err)
 	}
 	return cs, nil
 }
+
+// k8sClientTimeout caps a single Kubernetes API call. Generous enough for a pod
+// create against a loaded apiserver, short enough that a hung call is cut well
+// inside the dispatch drain timeout.
+const k8sClientTimeout = 10 * time.Second
 
 // reconcileInterval is how often the pod reconciler sweeps for failed pods.
 const reconcileInterval = 30 * time.Second

--- a/internal/dispatch/buffered.go
+++ b/internal/dispatch/buffered.go
@@ -3,9 +3,11 @@ package dispatch
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"runtime/debug"
 	"sync"
+	"time"
 
 	"github.com/neochaotic/leoflow/internal/domain"
 )
@@ -16,6 +18,11 @@ import (
 // the next tick re-tries. It is the backpressure signal that bounds tick
 // latency under load (ADR 0031: tick rate decoupled from executor latency).
 var ErrAtCapacity = errors.New("dispatch buffer at capacity; will retry next tick")
+
+// ErrDrainTimeout is returned by Close when workers did not finish within the
+// drain timeout. Shutdown continues: blocking forever is worse, because the
+// runtime then kills the process and no drain happens at all (#463).
+var ErrDrainTimeout = errors.New("drain timed out")
 
 // Inner is the underlying synchronous dispatcher BufferedDispatcher wraps —
 // matches scheduler.Dispatcher exactly so production wires through one type.
@@ -48,7 +55,17 @@ type MetricsRecorder interface {
 type BufferConfig struct {
 	BufferSize int
 	Workers    int
+	// DrainTimeout bounds how long Close waits for workers to finish. Zero
+	// selects defaultDrainTimeout. Without a bound, one worker stuck in a
+	// remote call that never answers blocks shutdown until the runtime kills
+	// the process, which loses the drain entirely (#463).
+	DrainTimeout time.Duration
 }
+
+// defaultDrainTimeout leaves room for an in-flight dispatch to finish while
+// staying well inside a typical Kubernetes terminationGracePeriodSeconds (30s),
+// so an abandoned drain is still reported before the pod is SIGKILLed.
+const defaultDrainTimeout = 15 * time.Second
 
 // dispatchRequest carries one queued dispatch from the scheduler to a worker.
 // runID, dagID, task are the same arguments the synchronous interface takes;
@@ -142,8 +159,15 @@ func (b *BufferedDispatcher) Dispatch(ctx context.Context, runID, dagID string, 
 // Close stops accepting new dispatches, drains the in-flight queue (each buffered
 // request is still processed by the inner dispatcher — or failed via the sink —
 // so no TI is left stuck `queued`), and waits for every worker to finish. Under
-// mu so a concurrent Dispatch never sends on the closed channel. Idempotent;
-// returns error to satisfy io.Closer (it never errors). #133.
+// mu so a concurrent Dispatch never sends on the closed channel. Idempotent.
+//
+// The wait is bounded by cfg.DrainTimeout (#463). A worker sits in the inner
+// dispatcher with a detached context, so a remote API that accepts the
+// connection and never answers would otherwise block shutdown forever — the
+// process then dies by SIGKILL and loses the drain #133 added. On expiry Close
+// returns an error naming how many workers were abandoned; the caller logs it
+// and proceeds with shutdown rather than hanging. The abandoned goroutines die
+// with the process.
 func (b *BufferedDispatcher) Close() error {
 	b.once.Do(func() {
 		b.mu.Lock()
@@ -153,8 +177,23 @@ func (b *BufferedDispatcher) Close() error {
 		}
 		b.mu.Unlock()
 	})
-	b.wg.Wait()
-	return nil
+	timeout := b.cfg.DrainTimeout
+	if timeout <= 0 {
+		timeout = defaultDrainTimeout
+	}
+	drained := make(chan struct{})
+	go func() {
+		b.wg.Wait()
+		close(drained)
+	}()
+	select {
+	case <-drained:
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("draining dispatch pool: %w after %s; in-flight dispatches were abandoned "+
+			"(their task instances stay queued until the stale-queued reaper picks them up)",
+			ErrDrainTimeout, timeout)
+	}
 }
 
 // worker drains the queue, calling the inner dispatcher and reporting failures
@@ -183,8 +222,9 @@ func (b *BufferedDispatcher) dispatchOne(req dispatchRequest) {
 	// Use a background context: the caller's ctx may already be canceled by
 	// the time the worker picks the request up (a long tick has rolled over),
 	// but we already accepted responsibility for this dispatch — abandoning it
-	// would leave a `queued` TI without a runner. The inner dispatcher's own
-	// timeout protects against hanging.
+	// would leave a `queued` TI without a runner. Hanging is bounded from two
+	// sides instead: the Kubernetes client carries a per-call timeout, and
+	// Close stops waiting after cfg.DrainTimeout (#463).
 	if err := b.inner.Dispatch(context.Background(), req.runID, req.dagID, req.task); err != nil { //nolint:contextcheck // worker intentionally detaches from the caller's ctx
 		b.logger.Error("dispatch failed in worker",
 			"run", req.runID, "dag", req.dagID, "task", req.task.TaskID, "error", err)

--- a/internal/dispatch/buffered_test.go
+++ b/internal/dispatch/buffered_test.go
@@ -343,3 +343,45 @@ func TestBuffered_Close_DrainsAllBufferedRequests(t *testing.T) {
 		t.Fatalf("after Close the inner saw %d of %d requests — Close dropped buffered work (would strand TIs `queued`, #133)", got, n)
 	}
 }
+
+// blockingInner hangs in Dispatch until released. It stands in for the real
+// failure this guards: a kube-apiserver that accepts the connection and never
+// answers, with no client-side deadline to cut it short.
+type blockingInner struct {
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingInner) Dispatch(context.Context, string, string, domain.TaskSpec) error {
+	b.once.Do(func() { close(b.entered) })
+	<-b.release
+	return nil
+}
+
+// TestBuffered_Close_ReturnsWhenWorkerHangs: Close must not wait forever on a
+// worker stuck in the inner dispatcher. Wiring Close() into shutdown (#133)
+// turned a leaked worker into a blocked shutdown: the pod then rides out its
+// termination grace period and is SIGKILLed, losing the very drain #133 added.
+// Close bounds the wait and reports what it abandoned (#463).
+func TestBuffered_Close_ReturnsWhenWorkerHangs(t *testing.T) {
+	inner := &blockingInner{entered: make(chan struct{}), release: make(chan struct{})}
+	defer close(inner.release)
+	d := dispatch.NewBuffered(inner, &recordingSink{}, discardLogger(), nil,
+		dispatch.BufferConfig{BufferSize: 4, Workers: 1, DrainTimeout: 100 * time.Millisecond})
+	if err := d.Dispatch(context.Background(), "r1", "etl", domain.TaskSpec{TaskID: "stuck"}); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	<-inner.entered // the worker is now inside the hanging inner dispatcher
+
+	done := make(chan error, 1)
+	go func() { done <- d.Close() }()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Close returned nil; want an error naming the abandoned dispatches")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Close did not return within 3s while a worker was hung — shutdown would block until SIGKILL")
+	}
+}


### PR DESCRIPTION
Closes #463. **Do not merge until `v0.1.2-rc.1` is promoted** — see below.

## The defect

`Close()` waited unbounded on `wg.Wait()`, justified by this comment:

> The inner dispatcher's own timeout protects against hanging.

That timeout does not exist. `Dispatch` sets no deadline, the worker detaches into `context.Background()`, and `buildK8sClient` never set `rest.Config.Timeout`.

Wiring `Close()` into shutdown in #133 was the right call, but it converted a leaked worker into a blocked shutdown: an apiserver that accepts the connection and never answers pins a worker → pins `Close` → pins `drainDispatch`, until the runtime SIGKILLs the pod and the drain #133 added is lost entirely. The failure mode is worse than the leak it replaced.

## Fix — bounded from both sides

- **`BufferConfig.DrainTimeout`** (default 15s, comfortably inside a typical 30s `terminationGracePeriodSeconds`) stops the wait and returns `ErrDrainTimeout` naming what was abandoned. `drainDispatch` already logs a `Close` error, so shutdown now proceeds instead of hanging.
- **`rest.Config.Timeout = 10s`** on the Kubernetes client, so a single hung call is cut well before the drain deadline. This one matters independently of shutdown — a pinned worker is a lost dispatch slot at any time, not just during termination.

Abandoned dispatches leave their task instances `queued`, which the stale-queued reaper already covers. The error message says so explicitly, because that is the next thing an operator reading it needs to know.

The comment now describes the protection that actually exists.

## Test

Written failing first: `TestBuffered_Close_ReturnsWhenWorkerHangs` pins the only worker inside a blocking inner dispatcher and requires `Close` to return an error within 3s. Before the fix it hangs; the harness fails it at the deadline rather than letting the suite stall.

## Verification

| Gate | Result |
|---|---|
| `go test -race ./internal/dispatch/... ./cmd/leoflow-server/...` | pass ✓ |
| `golangci-lint run` on both packages | 0 issues ✓ |
| `gofmt -l .` | clean ✓ |
| `go build ./...` | clean ✓ |

Note on the full-suite run: `internal/cli`'s `TestDevSubprocessSetupMissingAgent` fails on this machine, and **fails identically on `main` with no changes applied** — it asserts an error when the agent binary is missing, but finds `bin/leoflow-agent` present after a local `make build`. Environment-dependent, pre-existing, unrelated to this change. Filed separately rather than folded in here.

## Merge timing

`v0.1.2-rc.1` is tagged at `55ce554` and awaiting hands-on validation. Promotion tags a **new** commit on `main` (verified: both `v0.1.0` and `v0.1.1` sit one commit after their RC), so anything merged before that commit ships in `v0.1.2` stable untested by the RC. Holding this until promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)