### PR TITLE
fix(storage): guard the agent's task-state write on source state and attempt

### DIFF
--- a/internal/agentrpc/server.go
+++ b/internal/agentrpc/server.go
@@ -78,6 +78,14 @@ type Authenticator interface {
 	AuthenticateAgent(token string) (*auth.AgentIdentity, error)
 }
 
+// ErrStaleReport is returned by Store.ReportState when the report did not apply
+// because the task instance had already moved on — a reaper settled it, or a
+// retry advanced past the attempt the reporting agent was dispatched for. It is
+// not a failure of the RPC: the agent did nothing wrong and must not retry, so
+// the handler acknowledges and logs. Declared here rather than in the storage
+// package because storage implements this interface, not the reverse.
+var ErrStaleReport = errors.New("task state report did not apply: the task instance already moved on")
+
 // Store is the server's view of persistent task state.
 type Store interface {
 	// TaskSpec returns the execution spec for the identified task instance.
@@ -204,6 +212,17 @@ func (s *Server) ReportState(ctx context.Context, req *agentv1.ReportStateReques
 		return nil, err
 	}
 	if rerr := s.store.ReportState(ctx, *id, state, int(req.GetExitCode()), req.GetErrorMessage()); rerr != nil {
+		// A stale report is the guard working, not a fault: the row was already
+		// settled or already on a later attempt. Acknowledge so the agent stops
+		// (retrying would never apply either), but log it — a late report is
+		// evidence of a partition or a slow pod, and dropping it silently is the
+		// failure mode the guard exists to end.
+		if errors.Is(rerr, ErrStaleReport) {
+			slog.Warn("ignoring stale task state report",
+				"ti", id.TaskInstanceID, "run", id.RunID, "task", id.TaskID,
+				"try", id.TryNumber, "reported_state", state)
+			return &agentv1.ReportStateResponse{Acknowledged: true}, nil
+		}
 		return nil, status.Errorf(codes.Internal, "recording state: %v", rerr)
 	}
 	return &agentv1.ReportStateResponse{Acknowledged: true}, nil

--- a/internal/storage/agent_store.go
+++ b/internal/storage/agent_store.go
@@ -131,15 +131,27 @@ func (s *ExecutionStore) ReportState(ctx context.Context, id auth.AgentIdentity,
 	}
 	code := toInt32(exitCode)
 	params := queries.ReportTaskResultParams{
-		DagRunID: rid,
-		TaskID:   id.TaskID,
-		Column3:  queries.TaskState(state), // sqlc names the $3::task_state cast param Column3.
-		ExitCode: &code,
+		DagRunID:  rid,
+		TaskID:    id.TaskID,
+		Column3:   queries.TaskState(state), // sqlc names the $3::task_state cast param Column3.
+		ExitCode:  &code,
+		TryNumber: toInt32(id.TryNumber),
 	}
 	if errMsg != "" {
 		params.ErrorMessage = &errMsg
 	}
-	return s.q.ReportTaskResult(ctx, params)
+	rows, err := s.q.ReportTaskResult(ctx, params)
+	if err != nil {
+		return err
+	}
+	// The UPDATE is guarded on the source state and the attempt, so zero rows
+	// means the report arrived after the row moved on — not that anything
+	// failed. Surface it as a distinct condition so the caller can acknowledge
+	// the agent without pretending the write happened.
+	if rows == 0 {
+		return agentrpc.ErrStaleReport
+	}
+	return nil
 }
 
 // Reschedule parks an active task instance in up_for_reschedule with its next-poke

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -170,7 +170,32 @@ type Querier interface {
 	// enum type from `state = $3` but text from the literal comparisons below and
 	// rejects the parameter as having inconsistent types (SQLSTATE 42P08). The pod
 	// agent path is the first to exercise this query end-to-end.
-	ReportTaskResult(ctx context.Context, arg ReportTaskResultParams) error
+	//
+	// Guarded on both the source state and the attempt, matching the other three
+	// writes to this table (FailTaskInstanceIfActive, RescheduleTaskInstance,
+	// RecordHeartbeat). Two writers touch task_instances — the scheduler tick and
+	// this report — so an unguarded UPDATE lets a report that arrives late land
+	// wherever the row happens to be:
+	//   * after a reaper settled the row, it resurrects a terminal state (a run
+	//     reports success on work the system already abandoned, and downstream
+	//     tasks fire on it);
+	//   * after a retry, it lands on the next attempt, because ResetTaskInstanceToNone
+	//     bumps try_number in place rather than inserting a new row.
+	// The agent token already carries the try_number it was dispatched with, so the
+	// value that tells the attempts apart is present at the call site.
+	// Returns the affected row count so the caller can tell a real write from a
+	// rejected late report instead of dropping it silently.
+	//
+	// The state set is deliberately wider than the siblings' ('scheduled','queued',
+	// 'running'): it also admits 'none'. Those writes are driven by the scheduler,
+	// which only touches rows it has already advanced; this one is driven by the
+	// agent, which starts reporting earlier. launchQueued dispatches the pod BEFORE
+	// recording `queued`, so between those two statements a fast-starting task —
+	// routine under the Lite subprocess executor — legitimately reports `running`
+	// while the row is still `none`. Excluding it would reject a correct report,
+	// trading a rare silent corruption for a frequent one. The settled states
+	// (success/failed/skipped/upstream_failed) are what this guard is for.
+	ReportTaskResult(ctx context.Context, arg ReportTaskResultParams) (int64, error)
 	// A reschedule-mode sensor (mode='reschedule') poked not-ready: park the active TI
 	// in up_for_reschedule with its next-poke time ($3) so the scheduler re-dispatches
 	// it once reschedule_at passes (#380), without consuming retry budget. Guarded to

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -267,11 +267,36 @@ UPDATE task_instances
 SET state = 'failed', ended_at = now(), error_message = $2
 WHERE id = $1 AND state IN ('scheduled', 'queued', 'running');
 
--- name: ReportTaskResult :exec
+-- name: ReportTaskResult :execrows
 -- $3 is cast to task_state in every usage: without the cast Postgres deduces an
 -- enum type from `state = $3` but text from the literal comparisons below and
 -- rejects the parameter as having inconsistent types (SQLSTATE 42P08). The pod
 -- agent path is the first to exercise this query end-to-end.
+--
+-- Guarded on both the source state and the attempt, matching the other three
+-- writes to this table (FailTaskInstanceIfActive, RescheduleTaskInstance,
+-- RecordHeartbeat). Two writers touch task_instances — the scheduler tick and
+-- this report — so an unguarded UPDATE lets a report that arrives late land
+-- wherever the row happens to be:
+--   * after a reaper settled the row, it resurrects a terminal state (a run
+--     reports success on work the system already abandoned, and downstream
+--     tasks fire on it);
+--   * after a retry, it lands on the next attempt, because ResetTaskInstanceToNone
+--     bumps try_number in place rather than inserting a new row.
+-- The agent token already carries the try_number it was dispatched with, so the
+-- value that tells the attempts apart is present at the call site.
+-- Returns the affected row count so the caller can tell a real write from a
+-- rejected late report instead of dropping it silently.
+--
+-- The state set is deliberately wider than the siblings' ('scheduled','queued',
+-- 'running'): it also admits 'none'. Those writes are driven by the scheduler,
+-- which only touches rows it has already advanced; this one is driven by the
+-- agent, which starts reporting earlier. launchQueued dispatches the pod BEFORE
+-- recording `queued`, so between those two statements a fast-starting task —
+-- routine under the Lite subprocess executor — legitimately reports `running`
+-- while the row is still `none`. Excluding it would reject a correct report,
+-- trading a rare silent corruption for a frequent one. The settled states
+-- (success/failed/skipped/upstream_failed) are what this guard is for.
 UPDATE task_instances
 SET state = $3::task_state,
     exit_code = $4,
@@ -280,7 +305,9 @@ SET state = $3::task_state,
     ended_at = CASE WHEN $3::task_state IN ('success', 'failed', 'skipped', 'upstream_failed') THEN now() ELSE ended_at END,
     duration_seconds = CASE WHEN $3::task_state IN ('success', 'failed') AND started_at IS NOT NULL
         THEN EXTRACT(EPOCH FROM (now() - started_at)) ELSE duration_seconds END
-WHERE dag_run_id = $1 AND task_id = $2;
+WHERE dag_run_id = $1 AND task_id = $2
+  AND try_number = sqlc.arg(try_number)
+  AND state IN ('none', 'scheduled', 'queued', 'running');
 
 -- name: RescheduleTaskInstance :exec
 -- A reschedule-mode sensor (mode='reschedule') poked not-ready: park the active TI

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -1115,7 +1115,7 @@ func (q *Queries) RedispatchRescheduledTaskInstance(ctx context.Context, arg Red
 	return err
 }
 
-const reportTaskResult = `-- name: ReportTaskResult :exec
+const reportTaskResult = `-- name: ReportTaskResult :execrows
 UPDATE task_instances
 SET state = $3::task_state,
     exit_code = $4,
@@ -1125,6 +1125,8 @@ SET state = $3::task_state,
     duration_seconds = CASE WHEN $3::task_state IN ('success', 'failed') AND started_at IS NOT NULL
         THEN EXTRACT(EPOCH FROM (now() - started_at)) ELSE duration_seconds END
 WHERE dag_run_id = $1 AND task_id = $2
+  AND try_number = $6
+  AND state IN ('none', 'scheduled', 'queued', 'running')
 `
 
 type ReportTaskResultParams struct {
@@ -1133,21 +1135,52 @@ type ReportTaskResultParams struct {
 	Column3      TaskState   `json:"column_3"`
 	ExitCode     *int32      `json:"exit_code"`
 	ErrorMessage *string     `json:"error_message"`
+	TryNumber    int32       `json:"try_number"`
 }
 
 // $3 is cast to task_state in every usage: without the cast Postgres deduces an
 // enum type from `state = $3` but text from the literal comparisons below and
 // rejects the parameter as having inconsistent types (SQLSTATE 42P08). The pod
 // agent path is the first to exercise this query end-to-end.
-func (q *Queries) ReportTaskResult(ctx context.Context, arg ReportTaskResultParams) error {
-	_, err := q.db.Exec(ctx, reportTaskResult,
+//
+// Guarded on both the source state and the attempt, matching the other three
+// writes to this table (FailTaskInstanceIfActive, RescheduleTaskInstance,
+// RecordHeartbeat). Two writers touch task_instances — the scheduler tick and
+// this report — so an unguarded UPDATE lets a report that arrives late land
+// wherever the row happens to be:
+//   - after a reaper settled the row, it resurrects a terminal state (a run
+//     reports success on work the system already abandoned, and downstream
+//     tasks fire on it);
+//   - after a retry, it lands on the next attempt, because ResetTaskInstanceToNone
+//     bumps try_number in place rather than inserting a new row.
+//
+// The agent token already carries the try_number it was dispatched with, so the
+// value that tells the attempts apart is present at the call site.
+// Returns the affected row count so the caller can tell a real write from a
+// rejected late report instead of dropping it silently.
+//
+// The state set is deliberately wider than the siblings' ('scheduled','queued',
+// 'running'): it also admits 'none'. Those writes are driven by the scheduler,
+// which only touches rows it has already advanced; this one is driven by the
+// agent, which starts reporting earlier. launchQueued dispatches the pod BEFORE
+// recording `queued`, so between those two statements a fast-starting task —
+// routine under the Lite subprocess executor — legitimately reports `running`
+// while the row is still `none`. Excluding it would reject a correct report,
+// trading a rare silent corruption for a frequent one. The settled states
+// (success/failed/skipped/upstream_failed) are what this guard is for.
+func (q *Queries) ReportTaskResult(ctx context.Context, arg ReportTaskResultParams) (int64, error) {
+	result, err := q.db.Exec(ctx, reportTaskResult,
 		arg.DagRunID,
 		arg.TaskID,
 		arg.Column3,
 		arg.ExitCode,
 		arg.ErrorMessage,
+		arg.TryNumber,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const rescheduleTaskInstance = `-- name: RescheduleTaskInstance :exec

--- a/internal/storage/report_state_guard_integration_test.go
+++ b/internal/storage/report_state_guard_integration_test.go
@@ -1,0 +1,120 @@
+//go:build integration
+
+// Package storage_test — the write-side guard on agent-reported task state.
+//
+// Two writers touch task_instances: the scheduler tick and the agent's gRPC
+// report. ReportTaskResult carried neither a source-state predicate nor a
+// try_number predicate, so a report that arrives late — after a reaper already
+// settled the row, or after a retry already moved on to the next attempt —
+// overwrote whatever was there.
+//
+// A fake-store unit test cannot prove this: the guard lives in the UPDATE's
+// WHERE clause, so only real Postgres can show that the row did not move.
+// Both sibling writes on this table (FailTaskInstanceIfActive and
+// RescheduleTaskInstance) already carry the state predicate; these tests pin
+// the same invariant for the third.
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/agentrpc"
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/storage"
+)
+
+// seedRunningTask brings a fresh DAG up to a single materialized task instance
+// in `running`, the state an agent reports from, and returns the run UUID.
+func seedRunningTask(t *testing.T, repo *storage.Repository, sched *storage.SchedulerStore, ctx context.Context, dagID, taskID string) string {
+	t.Helper()
+	tasks := []domain.TaskSpec{{TaskID: taskID, Type: domain.TaskTypePython}}
+	registerSpec(t, repo, ctx, dagID, tasks)
+	if _, err := repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+		RunID: "r1", State: domain.DagRunStateRunning, RunType: "manual",
+		LogicalDate: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateDagRun: %v", err)
+	}
+	runUUID := resolveRunUUID(t, sched, ctx, dagID)
+	if err := sched.MaterializeTasks(ctx, runUUID, tasks); err != nil {
+		t.Fatalf("MaterializeTasks: %v", err)
+	}
+	for _, st := range []domain.TaskState{domain.TaskStateQueued, domain.TaskStateRunning} {
+		if err := sched.ApplyTransition(ctx, runUUID, taskID, st); err != nil {
+			t.Fatalf("ApplyTransition to %s: %v", st, err)
+		}
+	}
+	return runUUID
+}
+
+// TestReportStateDoesNotClobberTerminalIntegration: once a reaper has settled a
+// task instance as failed, a late report from the agent it gave up on must not
+// resurrect it as success.
+//
+// The sequence is ordinary in a cluster: the agent stops heartbeating during a
+// network partition, the heartbeat reaper fails the TI, the partition heals,
+// and the agent — which finished its work — reports success. Without the guard
+// the run reports green on work the system already abandoned, and downstream
+// tasks fire on it. Nothing errors and nothing alerts, which is what makes this
+// the worst failure shape an orchestrator has.
+func TestReportStateDoesNotClobberTerminalIntegration(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("guard_terminal_%d", time.Now().UnixNano())
+	runUUID := seedRunningTask(t, repo, sched, ctx, dagID, "load")
+
+	// The reaper gives up on the agent and settles the row.
+	if err := sched.ApplyTransition(ctx, runUUID, "load", domain.TaskStateFailed); err != nil {
+		t.Fatalf("ApplyTransition to failed: %v", err)
+	}
+
+	// The partition heals and the abandoned agent reports success.
+	id := auth.AgentIdentity{TenantID: "default", DagID: dagID, RunID: runUUID, TaskID: "load", TryNumber: 1}
+	err := exec.ReportState(ctx, id, domain.TaskStateSuccess, 0, "")
+	if !errors.Is(err, agentrpc.ErrStaleReport) {
+		t.Fatalf("ReportState = %v, want ErrStaleReport — the caller must be able to tell a rejected late report from a successful write", err)
+	}
+
+	if st := taskInstanceState(t, sched, ctx, runUUID, "load"); st != domain.TaskStateFailed {
+		t.Fatalf("TI 'load' = %q, want failed — a late report must never resurrect a row a reaper already settled", st)
+	}
+}
+
+// TestReportStateIgnoresStaleTryNumberIntegration: a report from an attempt the
+// scheduler has already retried past must not land on the current attempt.
+//
+// ResetTaskInstanceToNone bumps try_number in place rather than inserting a new
+// row, so without a try_number predicate the UPDATE matches the live row no
+// matter which attempt is reporting. The agent token already carries TryNumber,
+// so the value needed to tell them apart is present at the call site.
+func TestReportStateIgnoresStaleTryNumberIntegration(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("guard_stale_try_%d", time.Now().UnixNano())
+	runUUID := seedRunningTask(t, repo, sched, ctx, dagID, "load")
+
+	// Attempt 1 fails and the scheduler retries: try_number becomes 2, and the
+	// row goes back to none for re-dispatch.
+	if err := sched.ApplyTransition(ctx, runUUID, "load", domain.TaskStateFailed); err != nil {
+		t.Fatalf("ApplyTransition to failed: %v", err)
+	}
+	if err := sched.ResetForRetry(ctx, runUUID, "load"); err != nil {
+		t.Fatalf("ResetForRetry: %v", err)
+	}
+	if err := sched.ApplyTransition(ctx, runUUID, "load", domain.TaskStateQueued); err != nil {
+		t.Fatalf("ApplyTransition to queued: %v", err)
+	}
+
+	// The straggler from attempt 1 finally reports success.
+	stale := auth.AgentIdentity{TenantID: "default", DagID: dagID, RunID: runUUID, TaskID: "load", TryNumber: 1}
+	if err := exec.ReportState(ctx, stale, domain.TaskStateSuccess, 0, ""); !errors.Is(err, agentrpc.ErrStaleReport) {
+		t.Fatalf("ReportState (stale attempt) = %v, want ErrStaleReport", err)
+	}
+
+	if st := taskInstanceState(t, sched, ctx, runUUID, "load"); st != domain.TaskStateQueued {
+		t.Fatalf("TI 'load' = %q, want queued — attempt 1's report must not land on attempt 2", st)
+	}
+}

--- a/internal/storage/ui_queries_integration_test.go
+++ b/internal/storage/ui_queries_integration_test.go
@@ -849,7 +849,7 @@ func TestReportStateRecordsResultIntegration(t *testing.T) {
 		t.Fatalf("MaterializeTasks: %v", err)
 	}
 
-	id := auth.AgentIdentity{RunID: runUUID, TaskID: "t"}
+	id := auth.AgentIdentity{RunID: runUUID, TaskID: "t", TryNumber: 1} // production always stamps the dispatched attempt
 	// running then success — exactly the transitions the agent reports; both
 	// must record without a type-deduction error.
 	if err := exec.ReportState(ctx, id, domain.TaskStateRunning, 0, ""); err != nil {


### PR DESCRIPTION
Wave 1 item 2 of #465. **Do not merge until `v0.1.2-rc.1` is promoted.**

## The gap

`ReportTaskResult` was the only one of **four** writes to `task_instances` with no predicate on what it overwrites:

| Query | State guard |
|---|---|
| `FailTaskInstanceIfActive` | ✅ |
| `RescheduleTaskInstance` | ✅ — comment: *"so a late report never clobbers a terminal row"* |
| `RecordHeartbeat` | ✅ — *"skips already-terminal rows"* |
| **`ReportTaskResult`** | ❌ none, and no `try_number` either |

Three siblings carry it and one spells out the exact risk. This was an oversight, not a design choice.

## Proven, not inferred

Both integration tests in this PR **fail on the parent commit** against real Postgres:

```
TI 'load' = "success", want failed — a late report must never resurrect a row a reaper already settled
TI 'load' = "success", want queued — attempt 1's report must not land on attempt 2
```

- **Terminal clobber.** A reaper settles a TI as `failed`; the partitioned agent recovers and reports `success`; the row flips. The run reports green on work the system already abandoned, downstream tasks fire on it, and nothing errors or alerts.
- **Stale attempt.** `ResetTaskInstanceToNone` bumps `try_number` in place rather than inserting a row, so an earlier attempt's report lands on the current one.

## The fix, and one deliberate deviation

Keyed on `try_number` — which the agent token already carries, stamped from the row at dispatch, so no new plumbing — and on the source state.

**The state set is wider than the siblings': it also admits `none`.** This is the part worth reviewing. Those writes come from the scheduler, which only touches rows it has already advanced. This one comes from the agent, which starts reporting earlier: `launchQueued` dispatches the pod at `scheduler.go:736` and records `queued` at `:740`, so between those two statements a fast-starting task — routine under the Lite subprocess executor — legitimately reports `running` while the row is still `none`.

Copying the siblings' three-state set would have traded a rare silent corruption for a frequent one. The suite caught it: a pre-existing test went red, which is what surfaced the ordering. The SQL comment records the reasoning so the next reader does not "fix" it back.

## A rejected report is surfaced, not swallowed

The query returns its row count; the store maps zero rows to `agentrpc.ErrStaleReport`. The handler **acknowledges** the RPC — the agent did nothing wrong and retrying would never apply — and logs a warning. A late report is evidence of a partition or a slow pod; dropping it silently is the failure mode this guard exists to end.

The sentinel lives in `agentrpc` because `storage` implements that interface, not the reverse.

## Fixture correction

One pre-existing test built `auth.AgentIdentity{RunID: ..., TaskID: "t"}` with no `TryNumber`. Production never does — the only issuer (`dispatch.go:103`) stamps it from the row. Aligned the fixture to reality rather than relaxing the guard.

## Still open, deliberately out of scope

`CanTransition` still has **zero** production call sites. This PR enforces the invariant at the write, which is where it is load-bearing. Whether `CanTransition` becomes the enforcement point or gets deleted is a separate decision — dead code advertising itself as "the authoritative set of legal task state transitions" misleads the next reader either way.

## Verification

| Gate | Result |
|---|---|
| `go test -tags integration -race` — storage, agentrpc, scheduler, xcom (Postgres 16 + Redis 7) | pass ✓ |
| `go test -race ./...` | pass ✓ (except a pre-existing environment-dependent `internal/cli` test, red on `main` too) |
| `golangci-lint run` | 0 issues ✓ |
| `gofmt -l .` | clean ✓ |
| `sqlc generate` | regenerated, committed ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)