### PR TITLE
fix(parser): recognise a callback declared as a list; respin as v0.1.2-rc.2 (#470)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.2-rc.2] - 2026-07-30
+
+> Respin of `0.1.2-rc.1` for one defect, found by hands-on validation of that
+> candidate: a task declaring `on_failure_callback` as a **list** — the shape Airflow
+> itself produces — had it dropped silently. Nothing else changed; every other item
+> in the 0.1.2 line is described in the `0.1.2-rc.1` section below and was verified
+> against that candidate.
+
+### Fixed
+
+- **`on_failure_callback` written as a list now runs (#470).** Airflow 3 normalises a
+  task's callback attributes to a list, so `@task(on_failure_callback=[notify])` — and
+  any DAG copied from a real Airflow deployment — carries `[fn]`, not `fn`. The runtime
+  already accepted both shapes; the compiler's gate tested only `callable()`, so the
+  list form produced no marker in `dag.json`, no warning, and no callback at run time.
+  A bare callable was unaffected.
+- **An *unsupported* callback written as a list is loudly rejected again (#470).** The
+  same gate guards the compile-time refusal for `on_success_callback` and
+  `on_retry_callback`. In list form they slipped past it and were dropped in silence —
+  the precise outcome the refusal exists to prevent, and worse than the case it was
+  written for, because the author was told nothing.
+
+### Corrected from the rc.1 notes
+
+The `0.1.2-rc.1` section claims, under Fixed, that `on_failure_callback` runs for
+"list-normalised callbacks". Unbound DAGs did work; **lists did not**. Tags are
+immutable (ADR 0033), so that section stands as published — the claim it makes is true
+of this candidate, not of rc.1.
+
 ## [0.1.2-rc.1] - 2026-07-30
 
 > First release candidate of the **0.1.2** line — **native on-failure alerting** and a
@@ -310,7 +339,8 @@ Per-rc detail is in the `0.1.0-rc.1` … `0.1.0-rc.4` sections below.
 - Browser end-to-end verification (rendering, write-flow paths, screenshots) is
   the remaining Phase 5 acceptance step; see `docs/ui-compatibility.md`.
 
-[Unreleased]: https://github.com/neochaotic/leoflow/compare/v0.1.2-rc.1...HEAD
+[Unreleased]: https://github.com/neochaotic/leoflow/compare/v0.1.2-rc.2...HEAD
+[0.1.2-rc.2]: https://github.com/neochaotic/leoflow/compare/v0.1.2-rc.1...v0.1.2-rc.2
 [0.1.2-rc.1]: https://github.com/neochaotic/leoflow/compare/v0.1.1...v0.1.2-rc.1
 [0.1.1]: https://github.com/neochaotic/leoflow/compare/v0.1.1-rc.1...v0.1.1
 [0.1.1-rc.1]: https://github.com/neochaotic/leoflow/compare/v0.1.0...v0.1.1-rc.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the precise outcome the refusal exists to prevent, and worse than the case it was
   written for, because the author was told nothing.
 
+### Known issues
+
+- **Shutdown can hang when the Kubernetes API stops answering (#463).** The 0.1.2
+  line wires the buffered dispatch drain into shutdown (#133) so in-flight dispatches
+  settle instead of leaking — but the wait is unbounded and the Kubernetes client
+  carries no per-call timeout. An apiserver that accepts the connection and never
+  answers pins a worker, and with it the drain, until the runtime kills the process.
+  In that specific case shutdown is worse than in 0.1.1, where the drain never ran at
+  all. The fix is written and held for the next release rather than folded in here,
+  to keep this candidate a targeted respin. Workaround: none needed unless your
+  apiserver hangs; the pod is SIGKILLed at the end of its termination grace period.
+- **A task can be marked `dispatch_lost` while its pod is still `Running` (#461)** —
+  carried over from rc.1, still under investigation.
+
 ### Corrected from the rc.1 notes
 
 The `0.1.2-rc.1` section claims, under Fixed, that `on_failure_callback` runs for

--- a/helm/leoflow/Chart.yaml
+++ b/helm/leoflow/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version is the chart version; appVersion tracks the leoflow-server image.
 # Both move in lockstep with the release tag (ADR 0028); decouple only if the
 # chart ever needs a cadence of its own for a template-only fix.
-version: 0.1.2-rc.1
-appVersion: "0.1.2-rc.1"
+version: 0.1.2-rc.2
+appVersion: "0.1.2-rc.2"
 home: https://github.com/neochaotic/leoflow
 sources:
   - https://github.com/neochaotic/leoflow

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -1,6 +1,6 @@
 # leoflow
 
-![Version: 0.1.2-rc.1](https://img.shields.io/badge/Version-0.1.2--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.2-rc.1](https://img.shields.io/badge/AppVersion-0.1.2--rc.1-informational?style=flat-square)
+![Version: 0.1.2-rc.2](https://img.shields.io/badge/Version-0.1.2--rc.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.2-rc.2](https://img.shields.io/badge/AppVersion-0.1.2--rc.2-informational?style=flat-square)
 
 Leoflow control plane — a GitOps-first, container-native workflow orchestrator (Airflow 3.2.x UI/API compatible).
 

--- a/parser/leoflow_parser/compiler.py
+++ b/parser/leoflow_parser/compiler.py
@@ -315,13 +315,37 @@ _SCHEDULING_ATTR_NAMES = frozenset(
 _CALLBACK_CAPABLE_TYPES = ("airflow_operator", "python")
 
 
-def _has_callback(task, name: str) -> bool:
-    """Report whether the task declares a callable ``name``. Native tasks store it
-    as an attribute (the shim setattrs every kwarg); a generically-captured operator
-    carries it in ``__leoflow_args__``. Check both."""
-    if callable(getattr(task, name, None)):
+def _is_callback(value) -> bool:
+    """Report whether ``value`` declares at least one callback.
+
+    Airflow 3 normalises a task's callback attributes to a LIST (``[fn]``), while a
+    bare ``@task(on_failure_callback=fn)`` keeps whatever was passed. Both forms are
+    real, so both count. This mirrors the runtime's ``_normalize_callbacks``
+    (#442) — the two must agree, or the compiler marks what the runtime cannot run,
+    or drops what it could.
+
+    An empty list declares nothing: marking it would make the runtime re-import
+    dag.py on every failure to call no one."""
+    if callable(value):
         return True
-    return callable((getattr(task, "__leoflow_args__", {}) or {}).get(name))
+    if isinstance(value, (list, tuple)):
+        return any(callable(item) for item in value)
+    return False
+
+
+def _has_callback(task, name: str) -> bool:
+    """Report whether the task declares ``name``. Native tasks store it as an
+    attribute (the shim setattrs every kwarg); a generically-captured operator
+    carries it in ``__leoflow_args__``. Check both, in either shape.
+
+    Recognising the list shape matters twice over: it is what marks a supported
+    callback so the runtime runs it, AND what makes an UNSUPPORTED one hit the loud
+    reject below. A predicate that only accepted a bare callable let the list form
+    slip past both — the callback silently never ran, and the error promising that
+    would never happen never fired (#470)."""
+    if _is_callback(getattr(task, name, None)):
+        return True
+    return _is_callback((getattr(task, "__leoflow_args__", {}) or {}).get(name))
 
 
 def _check_callbacks(task, task_type: str, entry: dict) -> None:
@@ -379,11 +403,16 @@ def _split_operator_args(task) -> tuple[dict[str, list[str]], dict[str, Any]]:
         # reject below and fail an otherwise-valid provider operator at compile.
         if name in _SCHEDULING_ATTR_NAMES:
             continue
-        # on_failure_callback is a callable that cannot be serialised into
-        # dag.json, but it is SUPPORTED (#424 inc 4): the runtime re-imports dag.py
-        # and calls it in the task process on failure. Accept it here as a marker
-        # (see _has_on_failure_callback) instead of the non-serialisable reject.
-        if name == _ON_FAILURE_CALLBACK and callable(value):
+        # on_failure_callback cannot be serialised into dag.json, but it is
+        # SUPPORTED (#424 inc 4): the runtime re-imports dag.py and calls it in the
+        # task process on failure. Accept it here as a marker (see _has_callback)
+        # instead of the non-serialisable reject.
+        #
+        # Both shapes, because Airflow 3 normalises the attribute to a list. Testing
+        # only `callable` sent the list form on to the serialiser, which rejected it
+        # as "a list Leoflow cannot carry" — an error naming the wrong cause for a
+        # construct that is in fact supported (#470).
+        if name == _ON_FAILURE_CALLBACK and _is_callback(value):
             continue
         single_upstream = getattr(getattr(value, "operator", None), "task_id", None)
         if single_upstream:

--- a/parser/tests/test_shim_edges.py
+++ b/parser/tests/test_shim_edges.py
@@ -460,3 +460,68 @@ def test_oversized_operator_arg_is_a_loud_compile_error(monkeypatch, tmp_path):
     msg = str(ei.value)
     assert "q" in msg and "operator_args" in msg
     assert "Connection" in msg or "external" in msg
+
+
+def test_python_task_on_failure_callback_as_list_is_marked(monkeypatch, tmp_path):
+    """Airflow 3 normalises a task's on_failure_callback to a LIST, so a DAG copied
+    from a real Airflow deployment carries `[fn]`, not `fn`. The runtime already
+    handles both (_normalize_callbacks, #442); the compiler gate must too, or the
+    flag never reaches dag.json and the callback is dropped in silence — the exact
+    outcome _check_callbacks' docstring promises will never happen (#470)."""
+    spec = _compile(monkeypatch, tmp_path, """
+        from airflow.sdk import DAG, task
+        def notify_a(ctx): pass
+        def notify_b(ctx): pass
+        @task(on_failure_callback=[notify_a, notify_b])
+        def a() -> None: ...
+        with DAG("g"):
+            a()
+    """)
+    a = _task(spec, "a")
+    assert a["type"] == "python"
+    assert a.get("on_failure_callback") is True
+
+
+def test_operator_on_failure_callback_as_list_is_marked(monkeypatch, tmp_path):
+    """Same for a generically-captured provider operator, whose kwargs arrive via
+    __leoflow_args__ rather than as attributes."""
+    spec = _compile(monkeypatch, tmp_path, """
+        from airflow.sdk import DAG
+        from airflow.providers.snowflake.operators.snowflake import SQLExecuteQueryOperator
+        def notify(context): pass
+        with DAG("g"):
+            SQLExecuteQueryOperator(task_id="q", conn_id="sf", sql="SELECT 1",
+                                    on_failure_callback=[notify])
+    """)
+    q = _task(spec, "q")
+    assert q.get("on_failure_callback") is True
+    assert "on_failure_callback" not in q.get("operator_args", {})
+
+
+def test_unsupported_callback_as_list_is_still_loudly_rejected(monkeypatch, tmp_path):
+    """The same predicate guards the loud reject for callbacks Leoflow does not
+    support. In list form they slipped past it and were dropped silently, which is
+    worse than the unsupported case it was written for: the author is told nothing
+    while the error text promises they would be (ADR 0024, #470)."""
+    with pytest.raises(ValueError, match="on_success_callback"):
+        _compile(monkeypatch, tmp_path, """
+            from airflow.sdk import DAG, task
+            def notify(ctx): pass
+            @task(on_success_callback=[notify])
+            def a() -> None: ...
+            with DAG("g"):
+                a()
+        """)
+
+
+def test_empty_callback_list_is_not_marked(monkeypatch, tmp_path):
+    """An empty list declares no callback. Marking it would make the runtime
+    re-import dag.py on every failure to call nothing."""
+    spec = _compile(monkeypatch, tmp_path, """
+        from airflow.sdk import DAG, task
+        @task(on_failure_callback=[])
+        def a() -> None: ...
+        with DAG("g"):
+            a()
+    """)
+    assert _task(spec, "a").get("on_failure_callback") is None


### PR DESCRIPTION
Closes #470. Respins `v0.1.2-rc.1` for one defect. **This one merges** — it is the rc.2 content, unlike the Wave 1 branches on hold.

## The defect

Hands-on validation of `v0.1.2-rc.1` found that `@task(on_failure_callback=[notify])` produces **no marker in `dag.json`, no warning, and no callback at run time**. A bare callable works.

Airflow 3 normalises a task's callback attributes to a list, so this is the shape a DAG copied from a real Airflow deployment carries — the failure hits by default, not by accident.

`_normalize_callbacks` in the runtime already accepted both shapes (#442). The compiler's gate tested only `callable()`, which a list is not, so the runtime never received the flag it had learned to handle. Half the fix shipped.

## The wider half

The same predicate guards the compile-time refusal for `on_success_callback` and `on_retry_callback`. In list form those **slipped past the refusal and were dropped in silence** — worse than the unsupported case it was written for, because `_check_callbacks`' own docstring promises:

> never a silent drop, which would leave the author thinking their callback runs

Fixing the predicate closes both paths.

The operator path needed the same widening for a third reason: a list reached the arg serialiser and was rejected as *"a list Leoflow cannot carry in dag.json"* — an error naming the wrong cause for a construct that is actually supported.

## Scope of the respin

**rc.2 = rc.1 + this fix. Nothing else.** The Wave 1 branches (#466, #467, #468) stay unmerged deliberately: folding them in would invalidate the validation already performed against rc.1, and the point of a respin is that everything else remains described by work already done.

## The rc.1 notes stay as published

`CHANGELOG.md`'s `[0.1.2-rc.1]` section claims under **Fixed** that `on_failure_callback` runs for "list-normalised callbacks". Unbound DAGs did; lists did not. Tags are immutable (ADR 0033), so that section stands, and the rc.2 section says so in as many words rather than quietly rewriting history.

## Tests

Four new cases, all red before the fix:

- `@task` with a list → marked
- generically-captured provider operator with a list → marked, and the callable does not leak into `operator_args`
- `on_success_callback` as a list → **raises**, closing the silent-drop hole
- empty list → **not** marked, so the runtime does not re-import `dag.py` on every failure to call no one

## Verification

| Gate | Result |
|---|---|
| `pytest` parser | 76 pass (4 new) ✓ |
| parser coverage | 91.56% against a 70% floor ✓ |
| `pytest` runtime | 87 pass ✓ |
| `go build ./...` | clean ✓ |
| `helm unittest` · `helm lint` · `helm-template-checks` · helm-docs sync | green ✓ |

`Chart.yaml` moved to `0.1.2-rc.2` in lockstep (ADR 0028).

🤖 Generated with [Claude Code](https://claude.com/claude-code)