### PR TITLE
fix(alerts): stop losing pages — split the claim from the delivery

### DIFF
--- a/internal/failurealert/dispatcher.go
+++ b/internal/failurealert/dispatcher.go
@@ -72,13 +72,22 @@ func (d *Dispatcher) record(dagID, channelType, result string) {
 	}
 }
 
-// AlertRunFailed dispatches every on_failure rule of a failed run. Each rule is
-// resolved, rendered, and sent independently: a resolver or send error on one
-// rule is logged and skipped so the remaining rules still fire (best-effort).
-func (d *Dispatcher) AlertRunFailed(ctx context.Context, run scheduler.RunState) {
+// AlertRunFailed dispatches every on_failure rule of a failed run and reports
+// whether ALL of them were delivered. Each rule is resolved, rendered, and sent
+// independently: a resolver or send error on one rule is logged and skipped so
+// the remaining rules still fire.
+//
+// The boolean is what lets the caller distinguish a delivered page from a lost
+// one. Before it existed the caller marked the run alerted before sending, so any
+// failure here was permanent (#470 validation: a 500 left the run marked with no
+// retry). All-or-nothing is deliberate: a partial success is retried in full, so
+// a rule that already landed pages twice. That is the trade-off this code already
+// declares — a duplicate beats a missed page.
+func (d *Dispatcher) AlertRunFailed(ctx context.Context, run scheduler.RunState) bool {
 	if run.Alerts == nil {
-		return
+		return true
 	}
+	delivered := true
 	ev := alerts.Event{DagID: run.DagID, RunID: run.RunID, FailedTasks: failedTasks(run)}
 	for _, rule := range run.Alerts.OnFailure {
 		endpoint, err := d.resolver.ResolveAlertEndpoint(ctx, run.TenantID, rule.Conn)
@@ -86,6 +95,7 @@ func (d *Dispatcher) AlertRunFailed(ctx context.Context, run scheduler.RunState)
 			d.logger.Error("resolving alert connection",
 				"dag", run.DagID, "run", run.RunID, "conn", rule.Conn, "error", err)
 			d.record(run.DagID, rule.Type, resultFailed)
+			delivered = false
 			continue
 		}
 		message := alerts.Render(rule.Message, ev)
@@ -93,12 +103,14 @@ func (d *Dispatcher) AlertRunFailed(ctx context.Context, run scheduler.RunState)
 			d.logger.Error("sending on-failure alert",
 				"dag", run.DagID, "run", run.RunID, "type", rule.Type, "conn", rule.Conn, "error", serr)
 			d.record(run.DagID, rule.Type, resultFailed)
+			delivered = false
 			continue
 		}
 		d.logger.Info("on-failure alert sent",
 			"dag", run.DagID, "run", run.RunID, "type", rule.Type, "conn", rule.Conn)
 		d.record(run.DagID, rule.Type, resultSent)
 	}
+	return delivered
 }
 
 // failedTasks returns the task_ids that actually failed (not merely upstream-

--- a/internal/scheduler/resilience_test.go
+++ b/internal/scheduler/resilience_test.go
@@ -91,10 +91,10 @@ func (f *flakyStore) SetRunState(_ context.Context, runID string, state domain.D
 	f.runStates[runID] = state
 	return nil
 }
-func (f *flakyStore) ClaimAlertAttempt(context.Context, string, int, time.Duration) (bool, error) {
-	return true, nil
+func (f *flakyStore) ClaimAlertAttempt(context.Context, string, int, time.Duration) (int, error) {
+	return 1, nil
 }
-func (f *flakyStore) MarkRunAlertDelivered(context.Context, string) error { return nil }
+func (f *flakyStore) MarkRunAlertDelivered(context.Context, string, int) error { return nil }
 
 func (f *flakyStore) SetTaskNote(context.Context, string, string, string) error { return nil }
 

--- a/internal/scheduler/resilience_test.go
+++ b/internal/scheduler/resilience_test.go
@@ -91,7 +91,10 @@ func (f *flakyStore) SetRunState(_ context.Context, runID string, state domain.D
 	f.runStates[runID] = state
 	return nil
 }
-func (f *flakyStore) MarkRunAlerted(context.Context, string) (bool, error) { return true, nil }
+func (f *flakyStore) ClaimAlertAttempt(context.Context, string, int, time.Duration) (bool, error) {
+	return true, nil
+}
+func (f *flakyStore) MarkRunAlertDelivered(context.Context, string) error { return nil }
 
 func (f *flakyStore) SetTaskNote(context.Context, string, string, string) error { return nil }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -99,11 +99,16 @@ type Store interface {
 	// re-dispatch, PRESERVING try_number (reschedule is not a retry; #380).
 	RedispatchReschedule(ctx context.Context, runID, taskID string) error
 	SetRunState(ctx context.Context, runID string, state domain.DagRunState) error
-	// MarkRunAlerted atomically claims a run's on-failure alert (#431): it reports
-	// true iff this call is the one that set alerted_at (it was NULL), and false
-	// when the run was already alerted for this failure episode. A clear resets
-	// the marker, so a genuine re-failure re-claims. Dedups duplicate pages.
-	MarkRunAlerted(ctx context.Context, runID string) (bool, error)
+	// ClaimAlertAttempt atomically claims ONE on-failure send attempt, reporting
+	// true iff this call won it. It refuses when the episode was already
+	// delivered, when the attempt budget is spent, or when the backoff has not
+	// elapsed — so a dead endpoint stops being retried instead of being hit once
+	// per tick for the life of the run (#431, and the delivery split below).
+	ClaimAlertAttempt(ctx context.Context, runID string, maxAttempts int, backoff time.Duration) (bool, error)
+	// MarkRunAlertDelivered stamps the episode as paged. Called only after a
+	// successful send: claiming and stamping were once the same operation, which
+	// meant every failed send was a page lost with no retry.
+	MarkRunAlertDelivered(ctx context.Context, runID string) error
 	ScheduledDAGs(ctx context.Context) ([]ScheduledDAG, error)
 	CreateScheduledRun(ctx context.Context, dagID string, logical time.Time) error
 	// SetTaskNote attaches operational context to a task instance (shown in the
@@ -343,7 +348,10 @@ func (s *Scheduler) SetAlertConcurrency(n int) {
 // tick; it MUST treat every send as best-effort — a delivery failure is logged,
 // never propagated, so alerting can never fail a run.
 type Alerter interface {
-	AlertRunFailed(ctx context.Context, run RunState)
+	// AlertRunFailed sends every on_failure rule and reports whether all of them
+	// were delivered. The caller stamps delivery only on true, so a failed send
+	// stays retryable instead of being marked and lost.
+	AlertRunFailed(ctx context.Context, run RunState) bool
 }
 
 // Run drives the scheduling loop until ctx is canceled. The loop is crash-proof:
@@ -627,6 +635,20 @@ func (s *Scheduler) advance(ctx context.Context, run RunState) error {
 	return nil
 }
 
+// alertMaxAttempts bounds how many times one failure episode may be sent before
+// Leoflow gives up. A failed run stays failed forever, so without a ceiling a dead
+// alert endpoint is retried once per scheduler tick for the life of the run — the
+// alert path would DoS the very endpoint it is trying to reach. Five attempts
+// spread over the backoff below survives a restart or a brief outage of the
+// channel without becoming a hammer.
+const alertMaxAttempts = 5
+
+// alertRetryBackoff is the wait between attempts for one episode. Deliberately far
+// longer than the scheduler tick (1s by default): the retry exists to ride out a
+// transient channel outage, and an outage of the alert channel is frequently
+// correlated with the incident being reported, so retrying hard makes both worse.
+const alertRetryBackoff = 2 * time.Minute
+
 // maybeAlertFailure fires the DAG's on-failure alert rules when a run finalizes
 // failed. It runs in a detached goroutine (WithoutCancel) so a slow endpoint
 // never stalls the tick, and the alerter's own best-effort contract means a
@@ -639,12 +661,13 @@ func (s *Scheduler) maybeAlertFailure(ctx context.Context, state domain.DagRunSt
 	if run.Alerts == nil || len(run.Alerts.OnFailure) == 0 {
 		return
 	}
-	// Dedup per failure episode (#431): atomically claim the alert. Skip if this
-	// episode was already alerted (a re-tick of the same failed state); a clear
-	// resets the marker so a genuine re-failure re-claims. Fail OPEN on a store
-	// error — a missed page is worse than a rare duplicate — but log it.
-	if won, err := s.store.MarkRunAlerted(ctx, run.RunID); err != nil {
-		s.logger.Error("claiming on-failure alert (alerting anyway)",
+	// Claim one ATTEMPT for this failure episode. The claim no longer means
+	// "paged" — it means "we are about to try" — so a send that fails leaves the
+	// episode claimable and the next tick retries it after the backoff. Refused
+	// when already delivered, out of budget, or still backing off. Fail OPEN on a
+	// store error: a missed page is worse than a rare duplicate.
+	if won, err := s.store.ClaimAlertAttempt(ctx, run.RunID, alertMaxAttempts, alertRetryBackoff); err != nil {
+		s.logger.Error("claiming on-failure alert attempt (alerting anyway)",
 			"dag", run.DagID, "run", run.RunID, "error", err)
 	} else if !won {
 		return
@@ -656,7 +679,21 @@ func (s *Scheduler) maybeAlertFailure(ctx context.Context, state domain.DagRunSt
 	case s.alertSem <- struct{}{}:
 		go func() {
 			defer func() { <-s.alertSem }()
-			s.alerter.AlertRunFailed(context.WithoutCancel(ctx), run)
+			// Stamp delivery only when every rule landed. On anything less the
+			// episode stays unstamped, so the next tick retries it once the
+			// backoff elapses — until the attempt budget runs out.
+			detached := context.WithoutCancel(ctx)
+			if !s.alerter.AlertRunFailed(detached, run) {
+				s.logger.Warn("on-failure alert not fully delivered; will retry after backoff",
+					"dag", run.DagID, "run", run.RunID, "backoff", alertRetryBackoff)
+				return
+			}
+			if err := s.store.MarkRunAlertDelivered(detached, run.RunID); err != nil {
+				// The page went out; failing to record it costs a duplicate on the
+				// next tick, which is the trade-off this path already prefers.
+				s.logger.Error("recording on-failure alert delivery",
+					"dag", run.DagID, "run", run.RunID, "error", err)
+			}
 		}()
 	default:
 		s.logger.Warn("dropping on-failure alert: dispatch saturated",

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -104,11 +104,14 @@ type Store interface {
 	// delivered, when the attempt budget is spent, or when the backoff has not
 	// elapsed — so a dead endpoint stops being retried instead of being hit once
 	// per tick for the life of the run (#431, and the delivery split below).
-	ClaimAlertAttempt(ctx context.Context, runID string, maxAttempts int, backoff time.Duration) (bool, error)
-	// MarkRunAlertDelivered stamps the episode as paged. Called only after a
-	// successful send: claiming and stamping were once the same operation, which
-	// meant every failed send was a page lost with no retry.
-	MarkRunAlertDelivered(ctx context.Context, runID string) error
+	// It returns the attempt number won, or 0 when the claim was refused.
+	ClaimAlertAttempt(ctx context.Context, runID string, maxAttempts int, backoff time.Duration) (int, error)
+	// MarkRunAlertDelivered stamps the episode as paged, for the attempt the
+	// caller won. Claiming and stamping were once the same operation, which meant
+	// every failed send was a page lost with no retry. The attempt is part of the
+	// call because the send is detached from the tick: an operator clear can start
+	// a new episode mid-send, and a stamp from the superseded one must not land.
+	MarkRunAlertDelivered(ctx context.Context, runID string, attempt int) error
 	ScheduledDAGs(ctx context.Context) ([]ScheduledDAG, error)
 	CreateScheduledRun(ctx context.Context, dagID string, logical time.Time) error
 	// SetTaskNote attaches operational context to a task instance (shown in the
@@ -649,6 +652,13 @@ const alertMaxAttempts = 5
 // correlated with the incident being reported, so retrying hard makes both worse.
 const alertRetryBackoff = 2 * time.Minute
 
+// alertAttemptUnknown is the attempt number used when the claim itself errored
+// and we alert anyway (fail open). It is deliberately outside the real attempt
+// range so the delivery stamp, which is guarded on the attempt, matches no row —
+// the page goes out, but a bookkeeping write derived from an unknown attempt
+// never overwrites state we cannot reason about.
+const alertAttemptUnknown = -1
+
 // maybeAlertFailure fires the DAG's on-failure alert rules when a run finalizes
 // failed. It runs in a detached goroutine (WithoutCancel) so a slow endpoint
 // never stalls the tick, and the alerter's own best-effort contract means a
@@ -666,11 +676,22 @@ func (s *Scheduler) maybeAlertFailure(ctx context.Context, state domain.DagRunSt
 	// episode claimable and the next tick retries it after the backoff. Refused
 	// when already delivered, out of budget, or still backing off. Fail OPEN on a
 	// store error: a missed page is worse than a rare duplicate.
-	if won, err := s.store.ClaimAlertAttempt(ctx, run.RunID, alertMaxAttempts, alertRetryBackoff); err != nil {
+	attempt, err := s.store.ClaimAlertAttempt(ctx, run.RunID, alertMaxAttempts, alertRetryBackoff)
+	if err != nil {
 		s.logger.Error("claiming on-failure alert attempt (alerting anyway)",
 			"dag", run.DagID, "run", run.RunID, "error", err)
-	} else if !won {
+		attempt = alertAttemptUnknown
+	} else if attempt == 0 {
 		return
+	}
+	// The last attempt is the one nobody hears about if it fails, so say so while
+	// it is still happening. Without this, a run whose every attempt failed is
+	// indistinguishable in the database from one that has not been tried — the
+	// alerting system failing silently, which is the same shape as the failure it
+	// exists to report.
+	if attempt >= alertMaxAttempts {
+		s.logger.Warn("final on-failure alert attempt for this run; no further retries after this one",
+			"dag", run.DagID, "run", run.RunID, "attempt", attempt, "max", alertMaxAttempts)
 	}
 	// Acquire a dispatch slot without blocking the tick. A saturated semaphore
 	// means a burst of failures is already sending; dropping this one (with a
@@ -684,11 +705,20 @@ func (s *Scheduler) maybeAlertFailure(ctx context.Context, state domain.DagRunSt
 			// backoff elapses — until the attempt budget runs out.
 			detached := context.WithoutCancel(ctx)
 			if !s.alerter.AlertRunFailed(detached, run) {
+				if attempt >= alertMaxAttempts {
+					// Terminal: the budget is spent and nothing got through. This is
+					// the line an operator needs when asking "why was I never paged",
+					// so it says exactly that rather than reporting a failed send.
+					s.logger.Error("on-failure alert GAVE UP: no attempt was delivered, nobody was paged",
+						"dag", run.DagID, "run", run.RunID, "attempts", attempt)
+					return
+				}
 				s.logger.Warn("on-failure alert not fully delivered; will retry after backoff",
-					"dag", run.DagID, "run", run.RunID, "backoff", alertRetryBackoff)
+					"dag", run.DagID, "run", run.RunID,
+					"attempt", attempt, "max", alertMaxAttempts, "backoff", alertRetryBackoff)
 				return
 			}
-			if err := s.store.MarkRunAlertDelivered(detached, run.RunID); err != nil {
+			if err := s.store.MarkRunAlertDelivered(detached, run.RunID, attempt); err != nil {
 				// The page went out; failing to record it costs a duplicate on the
 				// next tick, which is the trade-off this path already prefers.
 				s.logger.Error("recording on-failure alert delivery",

--- a/internal/scheduler/scheduler_alerts_test.go
+++ b/internal/scheduler/scheduler_alerts_test.go
@@ -201,3 +201,98 @@ func TestStepNoAlertWhenNoRules(t *testing.T) {
 	case <-time.After(150 * time.Millisecond):
 	}
 }
+
+// failingAlerter reports that delivery did not complete, the way the real
+// dispatcher does when a channel returns 500 or a rule's connection cannot be
+// resolved.
+type failingAlerter struct{ calls chan RunState }
+
+func (f *failingAlerter) AlertRunFailed(_ context.Context, run RunState) bool {
+	f.calls <- run
+	return false
+}
+
+// A send that fails must leave the episode CLAIMABLE. Before the delivery split,
+// the claim was taken before sending, so a 500 marked the run alerted and the
+// page was lost for good — measured on v0.1.2-rc.1: a receiver answering 500 left
+// the run marked with no retry, and a burst of 15 failures marked all 15 while
+// delivering none.
+func TestStepDoesNotMarkDeliveredWhenSendFails(t *testing.T) {
+	store := newFakeStore(exhaustedFailedRun("r1"))
+	al := &failingAlerter{calls: make(chan RunState, 4)}
+	s := newScheduler(store)
+	s.SetAlerter(al)
+	if err := s.Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-al.calls:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected the alerter to be called")
+	}
+	// The goroutine stamps (or does not) after the alerter returns; give it a beat.
+	waitFor(t, func() bool { return store.attemptsFor("r1") == 1 })
+	if store.wasDelivered("r1") {
+		t.Fatal("a failed send must NOT be recorded as delivered — that is what loses the page")
+	}
+}
+
+// The counterpart: a successful send IS recorded, so the next tick does not
+// re-page for the same episode.
+func TestStepMarksDeliveredWhenSendSucceeds(t *testing.T) {
+	store := newFakeStore(exhaustedFailedRun("r1"))
+	al := &recordingAlerter{ch: make(chan RunState, 2)}
+	s := newScheduler(store)
+	s.SetAlerter(al)
+	if err := s.Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-al.ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected the alerter to be called")
+	}
+	waitFor(t, func() bool { return store.wasDelivered("r1") })
+}
+
+// A failed episode is retried, but not forever: a run stays failed for good, so
+// without a ceiling a dead endpoint would be hit once per tick for the life of
+// the run — the alert path DoSing the endpoint it is trying to reach.
+func TestStepStopsRetryingAfterAttemptBudget(t *testing.T) {
+	store := newFakeStore(exhaustedFailedRun("r1"))
+	al := &failingAlerter{calls: make(chan RunState, 32)}
+	s := newScheduler(store)
+	s.SetAlerter(al)
+	// Tick well past the budget. The fake does not simulate backoff, so every
+	// tick that is allowed to claim will claim — which makes the ceiling the only
+	// thing that can stop it.
+	for i := 0; i < alertMaxAttempts+4; i++ {
+		if err := s.Step(context.Background()); err != nil {
+			t.Fatal(err)
+		}
+		waitFor(t, func() bool { return len(al.calls) > 0 || store.attemptsFor("r1") >= alertMaxAttempts })
+		for len(al.calls) > 0 {
+			<-al.calls
+		}
+	}
+	if got := store.attemptsFor("r1"); got != alertMaxAttempts {
+		t.Fatalf("attempts = %d, want exactly %d — the budget must cap retries", got, alertMaxAttempts)
+	}
+	if store.wasDelivered("r1") {
+		t.Fatal("nothing was ever delivered; the episode must not be marked paged")
+	}
+}
+
+// waitFor polls a condition briefly. The send runs in a goroutine detached from
+// the tick, so an assertion about its effect cannot be made synchronously.
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("condition not met within 2s")
+}

--- a/internal/scheduler/scheduler_alerts_test.go
+++ b/internal/scheduler/scheduler_alerts_test.go
@@ -12,7 +12,10 @@ import (
 // test can observe the scheduler's fire-and-forget dispatch deterministically.
 type recordingAlerter struct{ ch chan RunState }
 
-func (r *recordingAlerter) AlertRunFailed(_ context.Context, run RunState) { r.ch <- run }
+func (r *recordingAlerter) AlertRunFailed(_ context.Context, run RunState) bool {
+	r.ch <- run
+	return true
+}
 
 // blockingAlerter signals when a dispatch starts and then holds the concurrency
 // slot until released, so a test can prove the scheduler bounds concurrency.
@@ -21,9 +24,10 @@ type blockingAlerter struct {
 	release chan struct{}
 }
 
-func (b *blockingAlerter) AlertRunFailed(_ context.Context, run RunState) {
+func (b *blockingAlerter) AlertRunFailed(_ context.Context, run RunState) bool {
 	b.started <- run
 	<-b.release
+	return true
 }
 
 func exhaustedFailedRun(id string) RunState {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -35,9 +35,12 @@ type fakeStore struct {
 	agentLostMarked    []string
 	staleQueuedCands   []StaleQueuedCandidate
 	dispatchLostMarked []string
-	// alertedRuns mirrors the real once-per-episode CAS (#431): the first
-	// MarkRunAlerted per runID wins (true), a repeat loses (false).
-	alertedRuns    map[string]bool
+	// alertAttempts mirrors the real per-episode attempt claim: each call
+	// consumes one, and the claim is refused once the budget is spent or the
+	// episode is already delivered. Backoff is not simulated — the fake is for
+	// the state machine; the timing predicate is proven in integration.
+	alertAttempts  map[string]int
+	deliveredRuns  map[string]bool
 	markAlertedErr bool
 	// activeRunsCalls counts ActiveRuns invocations so the follower-side gate
 	// can be asserted: a follower must NOT read run state (single-writer
@@ -83,18 +86,29 @@ func (f *fakeStore) SetRunState(_ context.Context, runID string, state domain.Da
 	f.runStates[runID] = state
 	return nil
 }
-func (f *fakeStore) MarkRunAlerted(_ context.Context, runID string) (bool, error) {
+func (f *fakeStore) ClaimAlertAttempt(_ context.Context, runID string, maxAttempts int, _ time.Duration) (bool, error) {
 	if f.markAlertedErr {
 		return false, errors.New("mark alerted failed")
 	}
-	if f.alertedRuns == nil {
-		f.alertedRuns = map[string]bool{}
+	if f.alertAttempts == nil {
+		f.alertAttempts = map[string]int{}
 	}
-	if f.alertedRuns[runID] {
-		return false, nil // already claimed this failure episode
+	if f.deliveredRuns[runID] {
+		return false, nil // already paged for this failure episode
 	}
-	f.alertedRuns[runID] = true
+	if f.alertAttempts[runID] >= maxAttempts {
+		return false, nil // attempt budget spent; stop hammering the endpoint
+	}
+	f.alertAttempts[runID]++
 	return true, nil
+}
+
+func (f *fakeStore) MarkRunAlertDelivered(_ context.Context, runID string) error {
+	if f.deliveredRuns == nil {
+		f.deliveredRuns = map[string]bool{}
+	}
+	f.deliveredRuns[runID] = true
+	return nil
 }
 func (f *fakeStore) SetTaskNote(_ context.Context, _, taskID, note string) error {
 	if f.notes == nil {

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -42,6 +43,9 @@ type fakeStore struct {
 	alertAttempts  map[string]int
 	deliveredRuns  map[string]bool
 	markAlertedErr bool
+	// alertMu guards the two maps above: the tick claims while the detached send
+	// goroutine stamps. Real Postgres serializes this; the fake must too.
+	alertMu sync.Mutex
 	// activeRunsCalls counts ActiveRuns invocations so the follower-side gate
 	// can be asserted: a follower must NOT read run state (single-writer
 	// invariant, ADR 0031 / issue #208).
@@ -86,29 +90,60 @@ func (f *fakeStore) SetRunState(_ context.Context, runID string, state domain.Da
 	f.runStates[runID] = state
 	return nil
 }
-func (f *fakeStore) ClaimAlertAttempt(_ context.Context, runID string, maxAttempts int, _ time.Duration) (bool, error) {
+
+// The alert bookkeeping is the one part of this fake touched from two
+// goroutines: the tick claims an attempt, while the detached send goroutine
+// stamps delivery. Postgres serializes that in production; here a mutex stands
+// in for it, so `-race` reports real defects rather than the fake's own.
+func (f *fakeStore) ClaimAlertAttempt(_ context.Context, runID string, maxAttempts int, _ time.Duration) (int, error) {
+	f.alertMu.Lock()
+	defer f.alertMu.Unlock()
 	if f.markAlertedErr {
-		return false, errors.New("mark alerted failed")
+		return 0, errors.New("mark alerted failed")
 	}
 	if f.alertAttempts == nil {
 		f.alertAttempts = map[string]int{}
 	}
 	if f.deliveredRuns[runID] {
-		return false, nil // already paged for this failure episode
+		return 0, nil // already paged for this failure episode
 	}
 	if f.alertAttempts[runID] >= maxAttempts {
-		return false, nil // attempt budget spent; stop hammering the endpoint
+		return 0, nil // attempt budget spent; stop hammering the endpoint
 	}
+	// Backoff is deliberately not simulated: this fake exercises the state
+	// machine, and the timing predicate is proven against real Postgres in
+	// internal/storage's integration suite.
 	f.alertAttempts[runID]++
-	return true, nil
+	return f.alertAttempts[runID], nil
 }
 
-func (f *fakeStore) MarkRunAlertDelivered(_ context.Context, runID string) error {
+func (f *fakeStore) MarkRunAlertDelivered(_ context.Context, runID string, attempt int) error {
+	f.alertMu.Lock()
+	defer f.alertMu.Unlock()
+	if f.alertAttempts[runID] != attempt {
+		// Mirrors the SQL guard: a stamp from a superseded episode matches no row.
+		return nil
+	}
 	if f.deliveredRuns == nil {
 		f.deliveredRuns = map[string]bool{}
 	}
 	f.deliveredRuns[runID] = true
 	return nil
+}
+
+// attemptsFor reports how many attempts a run has consumed, under the same lock
+// the scheduler's two goroutines contend on.
+func (f *fakeStore) attemptsFor(runID string) int {
+	f.alertMu.Lock()
+	defer f.alertMu.Unlock()
+	return f.alertAttempts[runID]
+}
+
+// wasDelivered reports whether the episode was stamped as paged.
+func (f *fakeStore) wasDelivered(runID string) bool {
+	f.alertMu.Lock()
+	defer f.alertMu.Unlock()
+	return f.deliveredRuns[runID]
 }
 func (f *fakeStore) SetTaskNote(_ context.Context, _, taskID, note string) error {
 	if f.notes == nil {

--- a/internal/storage/alert_delivery_integration_test.go
+++ b/internal/storage/alert_delivery_integration_test.go
@@ -1,0 +1,143 @@
+//go:build integration
+
+// Package storage_test — the on-failure alert claim/deliver split.
+//
+// The scheduler-level tests use a fake that models the state machine but not
+// time; the backoff and the attempt guard live entirely in the UPDATE's WHERE
+// clause, so only real Postgres can show they hold. These pin the predicates the
+// fake cannot: that a claim is refused while backing off, allowed once the
+// backoff elapses, refused once delivered or out of budget, and that a delivery
+// stamp from a superseded episode lands nowhere.
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/storage"
+)
+
+// seedFailedRun creates a DAG with one failed run and returns its UUID.
+func seedFailedRun(t *testing.T, repo *storage.Repository, sched *storage.SchedulerStore, ctx context.Context, dagID string) string {
+	t.Helper()
+	tasks := []domain.TaskSpec{{TaskID: "t", Type: domain.TaskTypePython}}
+	registerSpec(t, repo, ctx, dagID, tasks)
+	if _, err := repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+		RunID: "r1", State: domain.DagRunStateRunning, RunType: "manual",
+		LogicalDate: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateDagRun: %v", err)
+	}
+	return resolveRunUUID(t, sched, ctx, dagID)
+}
+
+// A claim consumes an attempt and then refuses the next one until the backoff
+// elapses. Without this the retry runs at the scheduler tick — once per second by
+// default — so a dead alert endpoint would be hit thousands of times for a single
+// failed run, by the very system meant to report that failure.
+func TestClaimAlertAttemptRespectsBackoffIntegration(t *testing.T) {
+	repo, sched, _, ctx := openExec(t)
+	runUUID := seedFailedRun(t, repo, sched, ctx, fmt.Sprintf("alert_backoff_%d", time.Now().UnixNano()))
+
+	attempt, err := sched.ClaimAlertAttempt(ctx, runUUID, 5, time.Hour)
+	if err != nil || attempt != 1 {
+		t.Fatalf("first claim = (%d, %v), want (1, nil)", attempt, err)
+	}
+	again, err := sched.ClaimAlertAttempt(ctx, runUUID, 5, time.Hour)
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	if again != 0 {
+		t.Fatalf("second claim = %d, want 0 — the backoff has not elapsed", again)
+	}
+}
+
+// Once the backoff has elapsed the episode is claimable again. A negative
+// backoff puts next_alert_attempt_at in the past, which is how the previous
+// attempt looks after waiting, without making the test sleep.
+func TestClaimAlertAttemptAllowsRetryAfterBackoffIntegration(t *testing.T) {
+	repo, sched, _, ctx := openExec(t)
+	runUUID := seedFailedRun(t, repo, sched, ctx, fmt.Sprintf("alert_retry_%d", time.Now().UnixNano()))
+
+	if a, err := sched.ClaimAlertAttempt(ctx, runUUID, 5, -time.Minute); err != nil || a != 1 {
+		t.Fatalf("first claim = (%d, %v), want (1, nil)", a, err)
+	}
+	second, err := sched.ClaimAlertAttempt(ctx, runUUID, 5, -time.Minute)
+	if err != nil {
+		t.Fatalf("second claim: %v", err)
+	}
+	if second != 2 {
+		t.Fatalf("second claim = %d, want 2 — an elapsed backoff must allow the retry", second)
+	}
+}
+
+// The budget is a hard ceiling: past it the episode stops being claimable, so a
+// permanently unreachable endpoint is abandoned rather than retried forever.
+func TestClaimAlertAttemptStopsAtBudgetIntegration(t *testing.T) {
+	repo, sched, _, ctx := openExec(t)
+	runUUID := seedFailedRun(t, repo, sched, ctx, fmt.Sprintf("alert_budget_%d", time.Now().UnixNano()))
+
+	const max = 3
+	for i := 1; i <= max; i++ {
+		got, err := sched.ClaimAlertAttempt(ctx, runUUID, max, -time.Minute)
+		if err != nil || got != i {
+			t.Fatalf("claim %d = (%d, %v), want (%d, nil)", i, got, err, i)
+		}
+	}
+	if got, err := sched.ClaimAlertAttempt(ctx, runUUID, max, -time.Minute); err != nil || got != 0 {
+		t.Fatalf("claim past the budget = (%d, %v), want (0, nil)", got, err)
+	}
+}
+
+// A delivered episode is never claimed again — the dedup this whole mechanism
+// exists for (#431) still holds after the split.
+func TestClaimAlertAttemptRefusedAfterDeliveryIntegration(t *testing.T) {
+	repo, sched, _, ctx := openExec(t)
+	runUUID := seedFailedRun(t, repo, sched, ctx, fmt.Sprintf("alert_delivered_%d", time.Now().UnixNano()))
+
+	attempt, err := sched.ClaimAlertAttempt(ctx, runUUID, 5, -time.Minute)
+	if err != nil || attempt != 1 {
+		t.Fatalf("claim = (%d, %v), want (1, nil)", attempt, err)
+	}
+	if err := sched.MarkRunAlertDelivered(ctx, runUUID, attempt); err != nil {
+		t.Fatalf("MarkRunAlertDelivered: %v", err)
+	}
+	if got, err := sched.ClaimAlertAttempt(ctx, runUUID, 5, -time.Minute); err != nil || got != 0 {
+		t.Fatalf("claim after delivery = (%d, %v), want (0, nil) — one page per episode", got, err)
+	}
+}
+
+// The send is detached from the tick, so an operator clear can start a NEW
+// failure episode while an old send is still in flight. A stamp carrying the
+// superseded attempt must land nowhere: otherwise the new episode is recorded as
+// paged without anyone having been paged for it.
+func TestMarkRunAlertDeliveredIgnoresSupersededAttemptIntegration(t *testing.T) {
+	repo, sched, _, ctx := openExec(t)
+	dagID := fmt.Sprintf("alert_superseded_%d", time.Now().UnixNano())
+	runUUID := seedFailedRun(t, repo, sched, ctx, dagID)
+
+	stale, err := sched.ClaimAlertAttempt(ctx, runUUID, 5, -time.Minute)
+	if err != nil || stale != 1 {
+		t.Fatalf("claim = (%d, %v), want (1, nil)", stale, err)
+	}
+	// An operator clears the run: a new episode, with a fresh attempt budget.
+	if _, err := repo.ClearTaskInstances(ctx, "default", dagID, "r1", nil, false, true); err != nil {
+		t.Fatalf("ClearTaskInstances: %v", err)
+	}
+	// The in-flight send from the old episode finally reports success.
+	if err := sched.MarkRunAlertDelivered(ctx, runUUID, stale); err != nil {
+		t.Fatalf("MarkRunAlertDelivered (superseded): %v", err)
+	}
+	// The new episode must still be claimable — nothing was paged for it.
+	got, err := sched.ClaimAlertAttempt(ctx, runUUID, 5, -time.Minute)
+	if err != nil {
+		t.Fatalf("claim after clear: %v", err)
+	}
+	if got == 0 {
+		t.Fatal("a stamp from the superseded episode marked the new one delivered; " +
+			"the new episode would never be paged")
+	}
+}

--- a/internal/storage/lima_bugs_integration_test.go
+++ b/internal/storage/lima_bugs_integration_test.go
@@ -255,10 +255,15 @@ func taskInstanceID(t *testing.T, sched *storage.SchedulerStore, ctx context.Con
 }
 
 // TestOnFailureAlertDedupResetsOnClearIntegration pins the #431 "once per failure
-// episode" contract at the SQL layer: MarkRunAlerted is an atomic claim (wins once
-// while alerted_at is NULL, loses on a re-tick of the same episode), and a Clear
-// (ResetDagRunToVersion) NULLs alerted_at so a genuine re-failure re-claims. A unit
-// test on a fake store can't prove the CAS or the reset — they live in the SQL.
+// episode" contract at the SQL layer: a delivered episode is never claimed again
+// (no duplicate page on a re-tick), and a Clear (ResetDagRunToVersion) reopens the
+// episode so a genuine re-failure pages again. A unit test on a fake store can't
+// prove either — both live in the UPDATE's WHERE clause.
+//
+// The contract survived the claim/deliver split unchanged; only what "alerted"
+// means moved. It used to be stamped BEFORE the send, so a failed send counted as
+// a page. Now the claim consumes an attempt and delivery is stamped after a
+// successful send, so this test delivers explicitly where it used to just claim.
 func TestOnFailureAlertDedupResetsOnClearIntegration(t *testing.T) {
 	repo, sched, ctx := openRepo(t)
 
@@ -279,12 +284,19 @@ func TestOnFailureAlertDedupResetsOnClearIntegration(t *testing.T) {
 		t.Fatalf("ApplyTransition to failed: %v", err)
 	}
 
-	// First claim wins; the immediate re-tick (same failed episode, no clear) loses.
-	if won, err := sched.MarkRunAlerted(ctx, runUUID); err != nil || !won {
-		t.Fatalf("first MarkRunAlerted = (%v, %v), want (true, nil)", won, err)
+	// First claim wins and the send succeeds, so the episode is stamped delivered.
+	attempt, err := sched.ClaimAlertAttempt(ctx, runUUID, 5, -time.Minute)
+	if err != nil || attempt != 1 {
+		t.Fatalf("first ClaimAlertAttempt = (%d, %v), want (1, nil)", attempt, err)
 	}
-	if won, err := sched.MarkRunAlerted(ctx, runUUID); err != nil || won {
-		t.Fatalf("re-tick MarkRunAlerted = (%v, %v), want (false, nil) — no duplicate page", won, err)
+	if err := sched.MarkRunAlertDelivered(ctx, runUUID, attempt); err != nil {
+		t.Fatalf("MarkRunAlertDelivered: %v", err)
+	}
+	// The immediate re-tick (same failed episode, no clear) must not page again.
+	// The backoff is set negative so an elapsed backoff cannot be what refuses the
+	// claim — delivery has to be the reason, which is the contract under test.
+	if got, err := sched.ClaimAlertAttempt(ctx, runUUID, 5, -time.Minute); err != nil || got != 0 {
+		t.Fatalf("re-tick claim = (%d, %v), want (0, nil) — no duplicate page", got, err)
 	}
 
 	// A Clear (resetDagRun=true) opens a new failure episode by NULLing alerted_at.
@@ -293,8 +305,14 @@ func TestOnFailureAlertDedupResetsOnClearIntegration(t *testing.T) {
 		t.Fatalf("ClearTaskInstances: %v", err)
 	}
 
-	// The genuine re-failure after the clear re-claims and re-alerts.
-	if won, err := sched.MarkRunAlerted(ctx, runUUID); err != nil || !won {
-		t.Fatalf("post-clear MarkRunAlerted = (%v, %v), want (true, nil) — a clear must re-open the episode (#431)", won, err)
+	// The genuine re-failure after the clear re-claims and re-alerts. The attempt
+	// counter resets too, so the new episode gets a full retry budget rather than
+	// inheriting a spent one.
+	got, err := sched.ClaimAlertAttempt(ctx, runUUID, 5, -time.Minute)
+	if err != nil {
+		t.Fatalf("post-clear claim: %v", err)
+	}
+	if got != 1 {
+		t.Fatalf("post-clear claim = %d, want 1 — a clear must reopen the episode with a fresh budget (#431)", got)
 	}
 }

--- a/internal/storage/queries/models.go
+++ b/internal/storage/queries/models.go
@@ -209,23 +209,25 @@ type DagFavorite struct {
 }
 
 type DagRun struct {
-	ID                pgtype.UUID        `json:"id"`
-	TenantID          pgtype.UUID        `json:"tenant_id"`
-	DagID             pgtype.UUID        `json:"dag_id"`
-	DagVersionID      pgtype.UUID        `json:"dag_version_id"`
-	RunID             string             `json:"run_id"`
-	LogicalDate       pgtype.Timestamptz `json:"logical_date"`
-	DataIntervalStart pgtype.Timestamptz `json:"data_interval_start"`
-	DataIntervalEnd   pgtype.Timestamptz `json:"data_interval_end"`
-	State             DagRunState        `json:"state"`
-	Trigger           DagRunTrigger      `json:"trigger"`
-	Conf              []byte             `json:"conf"`
-	TriggeredBy       pgtype.UUID        `json:"triggered_by"`
-	QueuedAt          pgtype.Timestamptz `json:"queued_at"`
-	StartedAt         pgtype.Timestamptz `json:"started_at"`
-	EndedAt           pgtype.Timestamptz `json:"ended_at"`
-	Note              *string            `json:"note"`
-	AlertedAt         pgtype.Timestamptz `json:"alerted_at"`
+	ID                 pgtype.UUID        `json:"id"`
+	TenantID           pgtype.UUID        `json:"tenant_id"`
+	DagID              pgtype.UUID        `json:"dag_id"`
+	DagVersionID       pgtype.UUID        `json:"dag_version_id"`
+	RunID              string             `json:"run_id"`
+	LogicalDate        pgtype.Timestamptz `json:"logical_date"`
+	DataIntervalStart  pgtype.Timestamptz `json:"data_interval_start"`
+	DataIntervalEnd    pgtype.Timestamptz `json:"data_interval_end"`
+	State              DagRunState        `json:"state"`
+	Trigger            DagRunTrigger      `json:"trigger"`
+	Conf               []byte             `json:"conf"`
+	TriggeredBy        pgtype.UUID        `json:"triggered_by"`
+	QueuedAt           pgtype.Timestamptz `json:"queued_at"`
+	StartedAt          pgtype.Timestamptz `json:"started_at"`
+	EndedAt            pgtype.Timestamptz `json:"ended_at"`
+	Note               *string            `json:"note"`
+	AlertedAt          pgtype.Timestamptz `json:"alerted_at"`
+	AlertAttempts      int32              `json:"alert_attempts"`
+	NextAlertAttemptAt pgtype.Timestamptz `json:"next_alert_attempt_at"`
 }
 
 type DagVersion struct {

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -13,6 +13,20 @@ import (
 type Querier interface {
 	AddFavorite(ctx context.Context, arg AddFavoriteParams) error
 	AssignUserRole(ctx context.Context, arg AssignUserRoleParams) error
+	// Atomically claim one on-failure ATTEMPT for a run, returning the row iff this
+	// call won it. Replaces the old claim-then-send (#431), which set alerted_at
+	// before the send and so lost the page whenever the send failed.
+	//
+	// Three predicates, one per way an attempt should be refused:
+	//   * alerted_at IS NULL  — already delivered; never page twice for one episode.
+	//   * alert_attempts < $2 — the budget is spent; a dead endpoint stops being
+	//     retried instead of being hit once per tick for the life of the run.
+	//   * next_alert_attempt_at — backoff has not elapsed yet.
+	//
+	// The attempt is consumed up front, before the send, so a crash mid-send costs one
+	// attempt rather than looping. A clear resets all three (ResetDagRunToVersion),
+	// making the next genuine failure a fresh episode with a fresh budget.
+	ClaimAlertAttempt(ctx context.Context, arg ClaimAlertAttemptParams) (ClaimAlertAttemptRow, error)
 	ClearDagRuns(ctx context.Context, dagID pgtype.UUID) (int64, error)
 	// Counts queued+running runs for a single DAG; used by the manual-trigger
 	// path to enforce max_active_runs (#200) before insert.
@@ -117,12 +131,18 @@ type Querier interface {
 	ListTaskInstancesByRun(ctx context.Context, dagRunID pgtype.UUID) ([]TaskInstance, error)
 	ListVariables(ctx context.Context, arg ListVariablesParams) ([]ListVariablesRow, error)
 	ListXComEntries(ctx context.Context, arg ListXComEntriesParams) ([]ListXComEntriesRow, error)
-	// Atomically claim the on-failure alert for a run (#431): set alerted_at once,
-	// only while it is NULL, and return the row iff this call won the claim. A second
-	// call (same failed episode, no clear) matches no row and reports "already
-	// alerted", so the scheduler skips the duplicate page. A clear nulls alerted_at,
-	// letting the next genuine failure re-claim.
-	MarkRunAlerted(ctx context.Context, id pgtype.UUID) (pgtype.UUID, error)
+	// Stamp a run's on-failure alert as DELIVERED. Called only after a successful
+	// send, which is the whole point of the split: alerted_at now answers "did the
+	// page get through", not "did we try".
+	//
+	// Guarded on the attempt it is reporting for. The send runs in a goroutine
+	// detached from the tick, so an operator clear can land between the claim and the
+	// stamp: the clear resets alert_attempts to 0 and starts a NEW failure episode,
+	// and an unguarded stamp from the old in-flight send would mark that new episode
+	// delivered without ever paging it. Requiring the attempt to still match means a
+	// stamp from a superseded episode simply matches no row. Same shape as the guard
+	// on ReportTaskResult: a late writer must never clobber newer state.
+	MarkRunAlertDelivered(ctx context.Context, arg MarkRunAlertDeliveredParams) error
 	// Fails an orphaned dag run. The `state = 'running'` guard makes the reap a
 	// safety net, never a takeover: a competing finalizer (the normal scheduler
 	// path) cannot be overwritten. Idempotent: a second call on a run already
@@ -183,9 +203,12 @@ type Querier interface {
 	// Clear re-binds the run to the DAG's current registered version (ADR 0020): a
 	// re-run after a code/yaml fix picks up the newest image and config — in dev that
 	// is the last hot-reload, in prod the last deploy — while everything within a
-	// version stays reproducible. Clearing alerted_at (#431) makes the clear a new
-	// failure episode, so a genuine re-failure re-pages while a re-tick of the same
-	// failed state does not.
+	// version stays reproducible. Clearing the alert bookkeeping (#431) makes the clear
+	// a new failure episode, so a genuine re-failure re-pages while a re-tick of the
+	// same failed state does not. All three columns reset together: leaving
+	// alert_attempts behind would carry a spent retry budget into an episode that has
+	// not been attempted, so a cleared run could exhaust its attempts without ever
+	// having tried.
 	ResetDagRunToVersion(ctx context.Context, arg ResetDagRunToVersionParams) error
 	// Archives the current attempt into task_instance_history then resets the
 	// live row. See ResetTaskInstanceToNone for the per-attempt rationale.

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -69,24 +69,56 @@ RETURNING *;
 -- Clear re-binds the run to the DAG's current registered version (ADR 0020): a
 -- re-run after a code/yaml fix picks up the newest image and config — in dev that
 -- is the last hot-reload, in prod the last deploy — while everything within a
--- version stays reproducible. Clearing alerted_at (#431) makes the clear a new
--- failure episode, so a genuine re-failure re-pages while a re-tick of the same
--- failed state does not.
+-- version stays reproducible. Clearing the alert bookkeeping (#431) makes the clear
+-- a new failure episode, so a genuine re-failure re-pages while a re-tick of the
+-- same failed state does not. All three columns reset together: leaving
+-- alert_attempts behind would carry a spent retry budget into an episode that has
+-- not been attempted, so a cleared run could exhaust its attempts without ever
+-- having tried.
 UPDATE dag_runs
 SET state = 'queued', started_at = NULL, ended_at = NULL, alerted_at = NULL,
+    alert_attempts = 0, next_alert_attempt_at = NULL,
     dag_version_id = $2
 WHERE id = $1;
 
--- name: MarkRunAlerted :one
--- Atomically claim the on-failure alert for a run (#431): set alerted_at once,
--- only while it is NULL, and return the row iff this call won the claim. A second
--- call (same failed episode, no clear) matches no row and reports "already
--- alerted", so the scheduler skips the duplicate page. A clear nulls alerted_at,
--- letting the next genuine failure re-claim.
+-- name: ClaimAlertAttempt :one
+-- Atomically claim one on-failure ATTEMPT for a run, returning the row iff this
+-- call won it. Replaces the old claim-then-send (#431), which set alerted_at
+-- before the send and so lost the page whenever the send failed.
+--
+-- Three predicates, one per way an attempt should be refused:
+--   * alerted_at IS NULL  — already delivered; never page twice for one episode.
+--   * alert_attempts < $2 — the budget is spent; a dead endpoint stops being
+--     retried instead of being hit once per tick for the life of the run.
+--   * next_alert_attempt_at — backoff has not elapsed yet.
+--
+-- The attempt is consumed up front, before the send, so a crash mid-send costs one
+-- attempt rather than looping. A clear resets all three (ResetDagRunToVersion),
+-- making the next genuine failure a fresh episode with a fresh budget.
 UPDATE dag_runs
-SET alerted_at = now()
-WHERE id = $1 AND alerted_at IS NULL
-RETURNING id;
+SET alert_attempts = alert_attempts + 1,
+    next_alert_attempt_at = now() + sqlc.arg(backoff)::interval
+WHERE id = $1
+  AND alerted_at IS NULL
+  AND alert_attempts < sqlc.arg(max_attempts)
+  AND (next_alert_attempt_at IS NULL OR next_alert_attempt_at <= now())
+RETURNING id, alert_attempts;
+
+-- name: MarkRunAlertDelivered :exec
+-- Stamp a run's on-failure alert as DELIVERED. Called only after a successful
+-- send, which is the whole point of the split: alerted_at now answers "did the
+-- page get through", not "did we try".
+--
+-- Guarded on the attempt it is reporting for. The send runs in a goroutine
+-- detached from the tick, so an operator clear can land between the claim and the
+-- stamp: the clear resets alert_attempts to 0 and starts a NEW failure episode,
+-- and an unguarded stamp from the old in-flight send would mark that new episode
+-- delivered without ever paging it. Requiring the attempt to still match means a
+-- stamp from a superseded episode simply matches no row. Same shape as the guard
+-- on ReportTaskResult: a late writer must never clobber newer state.
+UPDATE dag_runs
+SET alerted_at = now(), next_alert_attempt_at = NULL
+WHERE id = $1 AND alert_attempts = sqlc.arg(attempt);
 
 -- name: StampDagRunState :exec
 -- Transitions a run's state and stamps the run's own timestamps so the UI can

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -11,6 +11,48 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const claimAlertAttempt = `-- name: ClaimAlertAttempt :one
+UPDATE dag_runs
+SET alert_attempts = alert_attempts + 1,
+    next_alert_attempt_at = now() + $2::interval
+WHERE id = $1
+  AND alerted_at IS NULL
+  AND alert_attempts < $3
+  AND (next_alert_attempt_at IS NULL OR next_alert_attempt_at <= now())
+RETURNING id, alert_attempts
+`
+
+type ClaimAlertAttemptParams struct {
+	ID          pgtype.UUID     `json:"id"`
+	Backoff     pgtype.Interval `json:"backoff"`
+	MaxAttempts int32           `json:"max_attempts"`
+}
+
+type ClaimAlertAttemptRow struct {
+	ID            pgtype.UUID `json:"id"`
+	AlertAttempts int32       `json:"alert_attempts"`
+}
+
+// Atomically claim one on-failure ATTEMPT for a run, returning the row iff this
+// call won it. Replaces the old claim-then-send (#431), which set alerted_at
+// before the send and so lost the page whenever the send failed.
+//
+// Three predicates, one per way an attempt should be refused:
+//   - alerted_at IS NULL  — already delivered; never page twice for one episode.
+//   - alert_attempts < $2 — the budget is spent; a dead endpoint stops being
+//     retried instead of being hit once per tick for the life of the run.
+//   - next_alert_attempt_at — backoff has not elapsed yet.
+//
+// The attempt is consumed up front, before the send, so a crash mid-send costs one
+// attempt rather than looping. A clear resets all three (ResetDagRunToVersion),
+// making the next genuine failure a fresh episode with a fresh budget.
+func (q *Queries) ClaimAlertAttempt(ctx context.Context, arg ClaimAlertAttemptParams) (ClaimAlertAttemptRow, error) {
+	row := q.db.QueryRow(ctx, claimAlertAttempt, arg.ID, arg.Backoff, arg.MaxAttempts)
+	var i ClaimAlertAttemptRow
+	err := row.Scan(&i.ID, &i.AlertAttempts)
+	return i, err
+}
+
 const countActiveDagRunsByDagID = `-- name: CountActiveDagRunsByDagID :one
 SELECT count(*) FROM dag_runs
 WHERE dag_id = $1 AND state IN ('queued', 'running')
@@ -155,7 +197,7 @@ func (q *Queries) CountTaskInstanceStatesInWindow(ctx context.Context, arg Count
 const createDagRun = `-- name: CreateDagRun :one
 INSERT INTO dag_runs (tenant_id, dag_id, dag_version_id, run_id, logical_date, state, trigger, note)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-RETURNING id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note, alerted_at
+RETURNING id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note, alerted_at, alert_attempts, next_alert_attempt_at
 `
 
 type CreateDagRunParams struct {
@@ -199,6 +241,8 @@ func (q *Queries) CreateDagRun(ctx context.Context, arg CreateDagRunParams) (Dag
 		&i.EndedAt,
 		&i.Note,
 		&i.AlertedAt,
+		&i.AlertAttempts,
+		&i.NextAlertAttemptAt,
 	)
 	return i, err
 }
@@ -322,7 +366,7 @@ func (q *Queries) FailTaskInstanceIfActive(ctx context.Context, arg FailTaskInst
 }
 
 const getDagRun = `-- name: GetDagRun :one
-SELECT id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note, alerted_at FROM dag_runs WHERE dag_id = $1 AND run_id = $2
+SELECT id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note, alerted_at, alert_attempts, next_alert_attempt_at FROM dag_runs WHERE dag_id = $1 AND run_id = $2
 `
 
 type GetDagRunParams struct {
@@ -351,12 +395,14 @@ func (q *Queries) GetDagRun(ctx context.Context, arg GetDagRunParams) (DagRun, e
 		&i.EndedAt,
 		&i.Note,
 		&i.AlertedAt,
+		&i.AlertAttempts,
+		&i.NextAlertAttemptAt,
 	)
 	return i, err
 }
 
 const getDagRunByID = `-- name: GetDagRunByID :one
-SELECT id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note, alerted_at FROM dag_runs WHERE id = $1
+SELECT id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note, alerted_at, alert_attempts, next_alert_attempt_at FROM dag_runs WHERE id = $1
 `
 
 func (q *Queries) GetDagRunByID(ctx context.Context, id pgtype.UUID) (DagRun, error) {
@@ -380,6 +426,8 @@ func (q *Queries) GetDagRunByID(ctx context.Context, id pgtype.UUID) (DagRun, er
 		&i.EndedAt,
 		&i.Note,
 		&i.AlertedAt,
+		&i.AlertAttempts,
+		&i.NextAlertAttemptAt,
 	)
 	return i, err
 }
@@ -466,7 +514,7 @@ func (q *Queries) LatestRunsForDags(ctx context.Context, arg LatestRunsForDagsPa
 }
 
 const listActiveDagRuns = `-- name: ListActiveDagRuns :many
-SELECT id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note, alerted_at FROM dag_runs
+SELECT id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note, alerted_at, alert_attempts, next_alert_attempt_at FROM dag_runs
 WHERE state IN ('queued', 'running')
 ORDER BY queued_at
 `
@@ -498,6 +546,8 @@ func (q *Queries) ListActiveDagRuns(ctx context.Context) ([]DagRun, error) {
 			&i.EndedAt,
 			&i.Note,
 			&i.AlertedAt,
+			&i.AlertAttempts,
+			&i.NextAlertAttemptAt,
 		); err != nil {
 			return nil, err
 		}
@@ -565,7 +615,7 @@ func (q *Queries) ListAgentLostCandidates(ctx context.Context) ([]ListAgentLostC
 }
 
 const listDagRunsByDag = `-- name: ListDagRunsByDag :many
-SELECT id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note, alerted_at FROM dag_runs
+SELECT id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note, alerted_at, alert_attempts, next_alert_attempt_at FROM dag_runs
 WHERE dag_id = $1
 ORDER BY logical_date DESC
 LIMIT $2 OFFSET $3
@@ -604,6 +654,8 @@ func (q *Queries) ListDagRunsByDag(ctx context.Context, arg ListDagRunsByDagPara
 			&i.EndedAt,
 			&i.Note,
 			&i.AlertedAt,
+			&i.AlertAttempts,
+			&i.NextAlertAttemptAt,
 		); err != nil {
 			return nil, err
 		}
@@ -943,23 +995,31 @@ func (q *Queries) ListTaskInstancesByRun(ctx context.Context, dagRunID pgtype.UU
 	return items, nil
 }
 
-const markRunAlerted = `-- name: MarkRunAlerted :one
+const markRunAlertDelivered = `-- name: MarkRunAlertDelivered :exec
 UPDATE dag_runs
-SET alerted_at = now()
-WHERE id = $1 AND alerted_at IS NULL
-RETURNING id
+SET alerted_at = now(), next_alert_attempt_at = NULL
+WHERE id = $1 AND alert_attempts = $2
 `
 
-// Atomically claim the on-failure alert for a run (#431): set alerted_at once,
-// only while it is NULL, and return the row iff this call won the claim. A second
-// call (same failed episode, no clear) matches no row and reports "already
-// alerted", so the scheduler skips the duplicate page. A clear nulls alerted_at,
-// letting the next genuine failure re-claim.
-func (q *Queries) MarkRunAlerted(ctx context.Context, id pgtype.UUID) (pgtype.UUID, error) {
-	row := q.db.QueryRow(ctx, markRunAlerted, id)
-	var id_2 pgtype.UUID
-	err := row.Scan(&id_2)
-	return id_2, err
+type MarkRunAlertDeliveredParams struct {
+	ID      pgtype.UUID `json:"id"`
+	Attempt int32       `json:"attempt"`
+}
+
+// Stamp a run's on-failure alert as DELIVERED. Called only after a successful
+// send, which is the whole point of the split: alerted_at now answers "did the
+// page get through", not "did we try".
+//
+// Guarded on the attempt it is reporting for. The send runs in a goroutine
+// detached from the tick, so an operator clear can land between the claim and the
+// stamp: the clear resets alert_attempts to 0 and starts a NEW failure episode,
+// and an unguarded stamp from the old in-flight send would mark that new episode
+// delivered without ever paging it. Requiring the attempt to still match means a
+// stamp from a superseded episode simply matches no row. Same shape as the guard
+// on ReportTaskResult: a late writer must never clobber newer state.
+func (q *Queries) MarkRunAlertDelivered(ctx context.Context, arg MarkRunAlertDeliveredParams) error {
+	_, err := q.db.Exec(ctx, markRunAlertDelivered, arg.ID, arg.Attempt)
+	return err
 }
 
 const markRunOrphanedRun = `-- name: MarkRunOrphanedRun :execrows
@@ -1218,6 +1278,7 @@ func (q *Queries) ResetAllFailedTaskInstances(ctx context.Context, dagRunID pgty
 const resetDagRunToVersion = `-- name: ResetDagRunToVersion :exec
 UPDATE dag_runs
 SET state = 'queued', started_at = NULL, ended_at = NULL, alerted_at = NULL,
+    alert_attempts = 0, next_alert_attempt_at = NULL,
     dag_version_id = $2
 WHERE id = $1
 `
@@ -1230,9 +1291,12 @@ type ResetDagRunToVersionParams struct {
 // Clear re-binds the run to the DAG's current registered version (ADR 0020): a
 // re-run after a code/yaml fix picks up the newest image and config — in dev that
 // is the last hot-reload, in prod the last deploy — while everything within a
-// version stays reproducible. Clearing alerted_at (#431) makes the clear a new
-// failure episode, so a genuine re-failure re-pages while a re-tick of the same
-// failed state does not.
+// version stays reproducible. Clearing the alert bookkeeping (#431) makes the clear
+// a new failure episode, so a genuine re-failure re-pages while a re-tick of the
+// same failed state does not. All three columns reset together: leaving
+// alert_attempts behind would carry a spent retry budget into an episode that has
+// not been attempted, so a cleared run could exhaust its attempts without ever
+// having tried.
 func (q *Queries) ResetDagRunToVersion(ctx context.Context, arg ResetDagRunToVersionParams) error {
 	_, err := q.db.Exec(ctx, resetDagRunToVersion, arg.ID, arg.DagVersionID)
 	return err
@@ -1466,7 +1530,7 @@ const updateDagRunState = `-- name: UpdateDagRunState :one
 UPDATE dag_runs
 SET state = $2, started_at = $3, ended_at = $4
 WHERE id = $1
-RETURNING id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note, alerted_at
+RETURNING id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note, alerted_at, alert_attempts, next_alert_attempt_at
 `
 
 type UpdateDagRunStateParams struct {
@@ -1502,6 +1566,8 @@ func (q *Queries) UpdateDagRunState(ctx context.Context, arg UpdateDagRunStatePa
 		&i.EndedAt,
 		&i.Note,
 		&i.AlertedAt,
+		&i.AlertAttempts,
+		&i.NextAlertAttemptAt,
 	)
 	return i, err
 }

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -196,22 +196,49 @@ func (s *SchedulerStore) SetRunState(ctx context.Context, runID string, state do
 	})
 }
 
-// MarkRunAlerted atomically claims a run's on-failure alert (#431): the UPDATE
-// sets alerted_at only while it is NULL and returns the row iff this call won.
-// pgx.ErrNoRows means the row already had alerted_at (already alerted this
-// episode) — not an error, just a lost claim, so report won=false.
-func (s *SchedulerStore) MarkRunAlerted(ctx context.Context, runID string) (bool, error) {
+// ClaimAlertAttempt atomically claims one on-failure send attempt for a run
+// (#431). The UPDATE consumes an attempt and sets the next-attempt time, but only
+// while the episode is undelivered, within budget, and past its backoff — see the
+// query for why each predicate exists. pgx.ErrNoRows means the claim was refused
+// on one of those grounds: not an error, just a lost claim, so report won=false.
+//
+// Claiming an attempt is NOT the same as recording delivery; that is
+// MarkRunAlertDelivered. Conflating the two is what made a failed send a
+// permanently lost page.
+// Returns the attempt number won (0 when the claim was refused), which the caller
+// passes back to MarkRunAlertDelivered so a superseded send cannot stamp.
+func (s *SchedulerStore) ClaimAlertAttempt(ctx context.Context, runID string, maxAttempts int, backoff time.Duration) (int, error) {
 	rid, err := parseUUID(runID)
 	if err != nil {
-		return false, err
+		return 0, err
 	}
-	if _, err := s.q.MarkRunAlerted(ctx, rid); err != nil {
+	iv := pgtype.Interval{Microseconds: backoff.Microseconds(), Valid: true}
+	row, err := s.q.ClaimAlertAttempt(ctx, queries.ClaimAlertAttemptParams{
+		ID:          rid,
+		Backoff:     iv,
+		MaxAttempts: int32(maxAttempts), //nolint:gosec // a small configured constant, never attacker-controlled
+	})
+	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return false, nil
+			return 0, nil
 		}
-		return false, err
+		return 0, err
 	}
-	return true, nil
+	return int(row.AlertAttempts), nil
+}
+
+// MarkRunAlertDelivered stamps a run's on-failure alert as delivered, for the
+// attempt the caller won. The attempt is part of the predicate so a stamp from a
+// send that an operator clear has since superseded matches no row — see the query.
+func (s *SchedulerStore) MarkRunAlertDelivered(ctx context.Context, runID string, attempt int) error {
+	rid, err := parseUUID(runID)
+	if err != nil {
+		return err
+	}
+	return s.q.MarkRunAlertDelivered(ctx, queries.MarkRunAlertDeliveredParams{
+		ID:      rid,
+		Attempt: int32(attempt), //nolint:gosec // a small bounded counter, never attacker-controlled
+	})
 }
 
 // ScheduledDAGs returns active, unpaused, cron-scheduled DAGs with the logical

--- a/migrations/020_dag_run_alert_delivery.down.sql
+++ b/migrations/020_dag_run_alert_delivery.down.sql
@@ -1,0 +1,9 @@
+-- Reverse 020: drop the delivery-retry bookkeeping, returning to 019's single
+-- claim-before-send marker. Runs mid-retry lose their attempt count and are
+-- treated as never attempted by the older code, which claims and sends once.
+BEGIN;
+
+ALTER TABLE dag_runs DROP COLUMN IF EXISTS next_alert_attempt_at;
+ALTER TABLE dag_runs DROP COLUMN IF EXISTS alert_attempts;
+
+COMMIT;

--- a/migrations/020_dag_run_alert_delivery.up.sql
+++ b/migrations/020_dag_run_alert_delivery.up.sql
@@ -1,0 +1,29 @@
+-- 020_dag_run_alert_delivery.up.sql
+-- Stop losing on-failure pages (#463 sibling; found by hands-on validation of
+-- v0.1.2-rc.1).
+--
+-- 019 gave dag_runs a single `alerted_at`, claimed BEFORE the send. That conflated
+-- two different questions — "have we already tried this episode?" (dedup) and "did
+-- the page get through?" (delivery) — so any send that failed after the claim was
+-- lost for good. Measured on rc.1: a receiver answering 500 left the run marked
+-- alerted with no retry, and 15 simultaneous failures produced 7 semaphore drops
+-- plus 8 send failures with all 15 rows marked alerted — zero delivered, nothing
+-- retryable. That is a correlated failure: the alert path is least reliable exactly
+-- during the mass-failure incident it exists to report.
+--
+-- Split the two meanings. `alerted_at` now means DELIVERED and is stamped only
+-- after a successful send, so an undelivered episode stays claimable. The attempt
+-- itself is tracked separately, with a next-attempt time, so a retry cannot become
+-- a hammer: a run stays failed forever, and without backoff a dead endpoint would
+-- be retried once per scheduler tick (1s by default) for as long as the run exists.
+
+BEGIN;
+
+ALTER TABLE dag_runs ADD COLUMN IF NOT EXISTS alert_attempts integer NOT NULL DEFAULT 0;
+ALTER TABLE dag_runs ADD COLUMN IF NOT EXISTS next_alert_attempt_at timestamptz;
+
+-- Runs that already alerted under the 019 semantics keep counting as delivered:
+-- alerted_at is non-NULL for them, and the new claim predicate requires it to be
+-- NULL, so no historical run re-pages on upgrade.
+
+COMMIT;


### PR DESCRIPTION
Wave 1 item 4 of #465, the last of that wave. **Do not merge until `v0.1.2` is promoted** — like the other three, this is parallel-track work.

## Measured, not inferred

Hands-on validation of `v0.1.2-rc.1` produced these numbers:

- A receiver answering **500** → one attempt, no retry, `alerted_at` set anyway. The page is gone.
- **15 simultaneous failures** → 7 semaphore drops, 8 send failures, and **all 15 rows marked alerted. Zero delivered, nothing retryable.**

That second one is why this was re-sized from Low to Medium. It is a *correlated* failure: the alert path is least reliable during exactly the mass-failure incident it exists to report, and an outage of the alert channel is frequently the same outage being reported.

## Root cause is semantic

`alerted_at` carried two meanings at once — "we already handled this episode" (dedup) and "the page got through" (delivery). Claiming it before the send made the two inseparable, so any send failure was permanent.

## The split

| Column | Means |
|---|---|
| `alerted_at` | delivered — stamped **only** after a successful send |
| `alert_attempts` | attempts consumed for this episode |
| `next_alert_attempt_at` | when the next attempt is allowed |

Reordering alone would have been wrong. A failed run stays failed forever, so an undelivered episode would be retried **once per scheduler tick** — 1s by default — for the life of the run. The alert path would DoS the endpoint it is trying to reach. Hence the ceiling (5) and the backoff (2 min), which ride out a control-plane restart or a brief channel outage without hammering.

## Two guards the shape demanded

**A superseded stamp must land nowhere.** The send is detached from the tick, so an operator clear can start a new episode mid-send; an unguarded stamp from the old one would mark the new episode paged without anyone being paged. `MarkRunAlertDelivered` is keyed on the attempt it reports for. Same shape as the `ReportTaskResult` guard in #467 — a late writer must never clobber newer state.

**Giving up is loud.** Previously a run whose every attempt failed looked identical in the database to one not yet tried, so the alerting system failed exactly as silently as the failure it reports. The terminal attempt now logs at ERROR, in the words an operator asking *"why was I never paged"* would search for.

## Tests

Scheduler level: a failed send is **not** recorded as delivered; a successful one is; the budget caps retries at exactly the ceiling.

Integration, for the predicates only real Postgres can prove: backoff refuses a claim, an elapsed backoff allows it, the budget stops it, delivery refuses it, and a stamp carrying a superseded attempt lands nowhere.

The fake's alert maps are now mutex-guarded — the tick claims while the detached goroutine stamps, which Postgres serializes in production and `-race` correctly flagged in the fake.

The #431 dedup contract is unchanged; its integration test still proves it, translated to deliver explicitly where it previously only claimed.

## Honest note on process

Unlike #466, #467 and #468, this one was **not** written test-first. The design changed substantially after the validation data (reordering turned out to be insufficient), and I implemented from the design and then wrote the tests. They pass and they pin the right invariants, but the red-first discipline was not followed here.

## Verification

| Gate | Result |
|---|---|
| `go test -tags integration -race` — storage, scheduler, failurealert | pass ✓ |
| `go test -race ./...` | pass ✓ (except the pre-existing environment-dependent `internal/cli` test, red on `main` too) |
| `golangci-lint run` | 0 issues ✓ |
| `gofmt -l .` | clean ✓ |
| migration 020 up **and** down against Postgres 16 | clean ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)