### PR TITLE
fix(domain): reject a resource quantity Kubernetes cannot parse

### DIFF
--- a/internal/domain/dag.go
+++ b/internal/domain/dag.go
@@ -2,7 +2,11 @@
 // and validates them against the canonical JSON Schemas in docs/api.
 package domain
 
-import "fmt"
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
 
 // DefaultInlineMaxDurationSeconds is the fallback cap on inline http_api task
 // duration when the server does not configure one. See ADR 0002.
@@ -222,5 +226,55 @@ func (d *DAGSpec) Validate() error {
 	if err != nil {
 		return err
 	}
-	return validateAgainst(s.dag, d)
+	if err := validateAgainst(s.dag, d); err != nil {
+		return err
+	}
+	return d.validateResourceQuantities()
+}
+
+// validateResourceQuantities rejects a CPU or memory value Kubernetes cannot
+// parse. The schema types these as strings — a JSON Schema cannot express the
+// quantity grammar — so without this they pass validation and are dropped at pod
+// build (executor.quantities keeps only what ParseQuantity accepts).
+//
+// Dropping is the dangerous outcome, not the parse failure: a task declaring
+// `memory: 2GB` got a pod with NO memory limit, which is the opposite of what it
+// asked for, on a shared node, silently. And `2GB` is the plausible typo — it is
+// how memory is written everywhere except Kubernetes, which wants `2Gi` or `2G`.
+//
+// Checked here so `leoflow compile` fails while the author is still looking at
+// it, rather than at registration or, worse, at dispatch.
+func (d *DAGSpec) validateResourceQuantities() error {
+	for _, t := range d.Tasks {
+		if t.Resources == nil {
+			continue
+		}
+		for _, q := range []struct {
+			field string
+			val   *ResourceQuantity
+		}{
+			{"requests", t.Resources.Requests},
+			{"limits", t.Resources.Limits},
+		} {
+			if q.val == nil {
+				continue
+			}
+			for _, f := range []struct{ name, value string }{
+				{"cpu", q.val.CPU},
+				{"memory", q.val.Memory},
+			} {
+				if f.value == "" {
+					continue
+				}
+				if _, err := resource.ParseQuantity(f.value); err != nil {
+					return fmt.Errorf(
+						"task %q declares resources.%s.%s = %q, which is not a valid Kubernetes quantity: %w. "+
+							"Use Kubernetes notation — CPU as cores or millicores (\"2\", \"500m\"), memory with a binary or decimal suffix (\"2Gi\", \"2G\", \"512Mi\"). "+
+							"Note \"2GB\" is not valid; Kubernetes spells it \"2Gi\" (1024-based) or \"2G\" (1000-based)",
+						t.TaskID, q.field, f.name, f.value, err)
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/internal/domain/domain_test.go
+++ b/internal/domain/domain_test.go
@@ -1,6 +1,9 @@
 package domain
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func ptr[T any](v T) *T { return &v }
 
@@ -194,5 +197,58 @@ func TestLeoflowConfigValidateRejectsInvalidConfigs(t *testing.T) {
 				t.Errorf("Validate() = nil, want error for %q", name)
 			}
 		})
+	}
+}
+
+// A resource quantity Kubernetes cannot parse must be rejected where the author
+// is still watching. It used to be dropped in silence at pod build
+// (internal/executor/kubernetes.go quantities()), so a DAG asking for a 2 GB
+// memory limit got a pod with NO limit — the opposite of what was requested, on
+// a shared node, with nothing said. "2GB" is exactly the plausible typo: it is
+// how memory is written everywhere except Kubernetes, which wants 2Gi or 2G.
+func TestDAGSpecValidateRejectsUnparseableResourceQuantities(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		res  Resources
+		want string
+	}{
+		{"memory limit", Resources{Limits: &ResourceQuantity{Memory: "2GB"}}, "2GB"},
+		{"cpu limit", Resources{Limits: &ResourceQuantity{CPU: "half"}}, "half"},
+		{"memory request", Resources{Requests: &ResourceQuantity{Memory: "512 MB"}}, "512 MB"},
+		{"cpu request", Resources{Requests: &ResourceQuantity{CPU: "1 core"}}, "1 core"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := validDAGSpec()
+			spec.Tasks[0].Resources = &tc.res
+			err := spec.Validate()
+			if err == nil {
+				t.Fatalf("Validate() = nil, want an error naming %q", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not quote the offending value %q", err, tc.want)
+			}
+			if !strings.Contains(err.Error(), spec.Tasks[0].TaskID) {
+				t.Errorf("error %q does not name the task", err)
+			}
+		})
+	}
+}
+
+// The forms Kubernetes accepts must keep working — this validation must not
+// become a second, stricter grammar that rejects legitimate specs.
+func TestDAGSpecValidateAcceptsKubernetesQuantities(t *testing.T) {
+	for _, q := range []Resources{
+		{Limits: &ResourceQuantity{CPU: "500m", Memory: "512Mi"}},
+		{Limits: &ResourceQuantity{CPU: "2", Memory: "2Gi"}},
+		{Requests: &ResourceQuantity{CPU: "0.5", Memory: "1G"}},
+		{Limits: &ResourceQuantity{Memory: "1500k"}},
+		{}, // nothing declared is valid: the platform default applies
+	} {
+		spec := validDAGSpec()
+		r := q
+		spec.Tasks[0].Resources = &r
+		if err := spec.Validate(); err != nil {
+			t.Errorf("Validate() with %+v = %v, want nil", q, err)
+		}
 	}
 }


### PR DESCRIPTION
Closes #477. Tier 1 of #465.

## The defect

`quantities()` in the executor keeps only what `ParseQuantity` accepts and drops the rest without a word. So:

```yaml
resources:
  limits:
    memory: "2GB"     # invalid — Kubernetes wants 2Gi or 2G
```

produced a pod with **no memory limit**. The author asked for a bound and got the opposite: an unbounded task on a shared node, silently.

`2GB` is the plausible typo, not an exotic one — it is how memory is written everywhere except Kubernetes.

The schema types these as strings because JSON Schema cannot express the quantity grammar, so nothing between the author and the apiserver re-checked them. And the apiserver never saw the field, because the executor had already dropped it.

## Where it is validated, and why there

`DAGSpec.Validate`, which runs in **`leoflow compile`** (`internal/cli/compile.go:713`) as well as at registration (`internal/api/versions.go:41`). The error lands while the author is still looking at the DAG, rather than at dispatch.

The message quotes the offending value, names the task and the field, and gives the correct forms — including that `2GB` means `2Gi` (1024-based) or `2G` (1000-based), since that is the specific confusion.

## Reusing ParseQuantity rather than writing a pattern

A hand-written regex would be a **second, stricter grammar**: it risks rejecting values the apiserver would accept, trading a silent-drop bug for a false-rejection bug. One of the new tests exists specifically to pin that — `500m`, `2`, `0.5`, `2Gi`, `1G`, `1500k` and the empty case must all keep validating.

## On the k8s.io dependency in `internal/domain`

Worth raising, since `internal/domain` is the core of a ports-and-adapters design and both external reviews praised this repo for keeping those directions clean.

Measured before committing:

| Check | Result |
|---|---|
| `cmd/leoflow-agent` k8s.io packages | **0** — it does not import `internal/domain` at all, so ADR 0004's zero-k8s property and the <20 MB CI assertion are untouched |
| `cmd/leoflow` k8s.io packages, before | 259 |
| `cmd/leoflow` k8s.io packages, after | **259** — the CLI already embeds the executor for Lite, so this adds nothing |

The architectural point stands on its own though, so: `ResourceQuantity` is *already* a Kubernetes concept in the domain — the field is documented as "CPU and memory in Kubernetes notation". The domain had borrowed the grammar and simply was not checking it. Importing the parser for a grammar the type already declares it follows is a smaller inversion than importing Kubernetes for something genuinely domain-owned.

**What would change this:** if any binary that must stay k8s-free ever imports `internal/domain`, the validation should move behind an injected validator so the domain goes back to not knowing. Not the case today.

## Verification

| Gate | Result |
|---|---|
| `go test -race ./...` | pass ✓ (except the pre-existing environment-dependent `internal/cli` test, red on `main` too) |
| `golangci-lint run ./internal/domain/...` | 0 issues ✓ |
| `gofmt -l .` | clean ✓ |

Tests written red first: four unparseable values rejected with the value and task named, and the valid Kubernetes forms that must keep passing.

## Related, not fixed here

`tolerations` is parsed, validated and then never read by `BuildPod` — the same "accepted, dropped, nobody told" shape, found independently by two of the comparative studies. It needs its own decision: implement it, or reject it at compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)