### PR TITLE
test(agent): pin ADR 0004's zero-Kubernetes property

### DIFF
--- a/cmd/leoflow-agent/deps_test.go
+++ b/cmd/leoflow-agent/deps_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// The agent is a thin static binary that runs as PID 1 inside every task pod
+// (ADR 0004). It talks to the control plane over gRPC and never to the
+// Kubernetes API, so it must not link the Kubernetes client libraries — their
+// transitive graph is large enough to dominate a binary this size.
+//
+// CI already caps the built binary at 20 MB, but that gate is a poor guard for
+// this: it needs a build, it only fires once the bloat crosses the cap (a
+// partial import that fits under it slips through), and when it does fire it
+// reports a number rather than a cause. This asserts the property directly and
+// names it, in milliseconds and without building anything.
+//
+// The realistic way this breaks is indirect: someone adds a k8s import to a
+// package the agent already depends on — internal/domain is the near miss,
+// which gained k8s.io/apimachinery for resource-quantity validation and is not
+// imported by the agent today. Nothing enforces that it stays that way except
+// this test.
+func TestAgentLinksNoKubernetesPackages(t *testing.T) {
+	out, err := exec.CommandContext(t.Context(), "go", "list", "-deps", "./").Output()
+	if err != nil {
+		t.Fatalf("go list -deps: %v", err)
+	}
+	var offenders []string
+	for _, pkg := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if strings.HasPrefix(pkg, "k8s.io/") {
+			offenders = append(offenders, pkg)
+		}
+	}
+	if len(offenders) == 0 {
+		return
+	}
+	t.Fatalf("the agent now links %d Kubernetes package(s), which ADR 0004 forbids — "+
+		"it speaks gRPC to the control plane and never touches the Kubernetes API.\n"+
+		"First few: %s\n"+
+		"This is almost always indirect: a shared package gained a k8s import. "+
+		"Run `go list -deps ./cmd/leoflow-agent | grep k8s.io` and then "+
+		"`go mod why -m k8s.io/apimachinery` to find the path in, and move the "+
+		"dependency behind an interface the agent does not import.",
+		len(offenders), strings.Join(offenders[:min(5, len(offenders))], ", "))
+}


### PR DESCRIPTION
The agent runs as PID 1 in every task pod, speaks gRPC to the control plane, and never touches the Kubernetes API (ADR 0004). Nothing asserted that.

## Why the existing gate is not enough

CI caps the built agent binary at 20 MB, which would *eventually* catch a Kubernetes import. As a guard for this property it is weak in three ways:

- it needs a build,
- it only fires once the bloat crosses the cap — a partial import that fits underneath slips through silently,
- and when it does fire it reports a number, not a cause. "exceeds 20MB" sends you looking at compiler flags, not at who imported Kubernetes.

This asserts the property directly, in milliseconds, without building. The failure message names the ADR and gives the two commands that find the path in.

## Why now

`internal/domain` just gained `k8s.io/apimachinery` (#481, for resource-quantity validation). The agent does not import `internal/domain` today, so the property holds — but nothing except this test keeps it that way, and the realistic break is exactly that shape: someone adds a k8s import to a package the agent already depends on, and the coupling arrives indirectly.

## Verified to fail

Injecting a single blank k8s import into `main.go` makes it report three packages (the transitive closure) with the intended message:

```
the agent now links 3 Kubernetes package(s), which ADR 0004 forbids — it speaks gRPC
to the control plane and never touches the Kubernetes API.
First few: k8s.io/apimachinery/pkg/runtime/serializer/cbor/internal/modes, …
```

A gate nobody has watched fail is not a gate.

## Verification

`go test`, `go vet`, `golangci-lint` (0 issues), `gofmt` — all clean. Runs as part of `go test ./...`; no CI wiring needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)