### PR TITLE
release: promote v0.1.2-rc.2 to v0.1.2 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-07-30
+
+> **On-failure alerting, and a Pro install that can no longer be misconfigured into
+> silence.** A failed task notifies on its own, without an Airflow callback in the
+> loop; and three Pro misconfigurations that used to produce a healthy-looking but
+> broken deployment now fail loudly at `helm install` or at boot.
+>
+> This promotes `v0.1.2-rc.2` unchanged. The candidate was exercised by hand on
+> darwin/arm64 — the platform no CI job covers — including the alerting paths, both
+> Pro guards, and the callback fix that prompted the respin. Per-candidate detail is
+> in the `0.1.2-rc.2` and `0.1.2-rc.1` sections below.
+
+### ⚠️ Upgrade note for Pro operators
+
+`agentTLS.enabled: false` no longer yields a running deployment — it never yielded a
+working one, and now says so at install time instead of crash-looping. Full detail and
+the migration in the `0.1.2-rc.1` section below.
+
+### Known issues carried into this release
+
+- **A task can be marked `dispatch_lost` while its pod is still `Running` (#461).** The
+  mechanism is now understood (#474): no reaper consults Kubernetes, nothing deletes the
+  pod, and the `should_terminate` signal the agent honours is never sent. A slow image
+  pull is enough to trigger it. Fix in progress.
+- **Shutdown can hang when the Kubernetes API stops answering (#463).** Described in the
+  `0.1.2-rc.2` section; the fix is written and lands next.
+
 ## [0.1.2-rc.2] - 2026-07-30
 
 > Respin of `0.1.2-rc.1` for one defect, found by hands-on validation of that
@@ -353,7 +380,8 @@ Per-rc detail is in the `0.1.0-rc.1` … `0.1.0-rc.4` sections below.
 - Browser end-to-end verification (rendering, write-flow paths, screenshots) is
   the remaining Phase 5 acceptance step; see `docs/ui-compatibility.md`.
 
-[Unreleased]: https://github.com/neochaotic/leoflow/compare/v0.1.2-rc.2...HEAD
+[Unreleased]: https://github.com/neochaotic/leoflow/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/neochaotic/leoflow/compare/v0.1.2-rc.2...v0.1.2
 [0.1.2-rc.2]: https://github.com/neochaotic/leoflow/compare/v0.1.2-rc.1...v0.1.2-rc.2
 [0.1.2-rc.1]: https://github.com/neochaotic/leoflow/compare/v0.1.1...v0.1.2-rc.1
 [0.1.1]: https://github.com/neochaotic/leoflow/compare/v0.1.1-rc.1...v0.1.1

--- a/helm/leoflow/Chart.yaml
+++ b/helm/leoflow/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version is the chart version; appVersion tracks the leoflow-server image.
 # Both move in lockstep with the release tag (ADR 0028); decouple only if the
 # chart ever needs a cadence of its own for a template-only fix.
-version: 0.1.2-rc.2
-appVersion: "0.1.2-rc.2"
+version: 0.1.2
+appVersion: "0.1.2"
 home: https://github.com/neochaotic/leoflow
 sources:
   - https://github.com/neochaotic/leoflow

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -1,6 +1,6 @@
 # leoflow
 
-![Version: 0.1.2-rc.2](https://img.shields.io/badge/Version-0.1.2--rc.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.2-rc.2](https://img.shields.io/badge/AppVersion-0.1.2--rc.2-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.2](https://img.shields.io/badge/AppVersion-0.1.2-informational?style=flat-square)
 
 Leoflow control plane — a GitOps-first, container-native workflow orchestrator (Airflow 3.2.x UI/API compatible).
 


### PR DESCRIPTION
Verbatim promotion of `v0.1.2-rc.2`. No code change from the candidate — `CHANGELOG.md`, `Chart.yaml` and the generated chart README only.

## Why promote now

`v0.1.2-rc.2` was validated by hand on **darwin/arm64**, the platform no CI job covers:

- Published artifact verified against `checksums.txt`, and all three binaries confirmed to carry the tag's commit `fefe6f5`.
- The respin's one fix exercised end to end — list callbacks fire once each on the final attempt, an empty list fires nothing, and an unsupported callback in list form is now loudly rejected at compile.
- Cold start, a DAG to `success` with XCom, and a failure producing exactly one alert.
- All 14 release jobs green, including install smoke across seven distros and the rc.1 → rc.2 upgrade smoke.

`main` is byte-identical to the tag — nothing merged since the cut.

## The security question, answered explicitly

Validation demonstrated #476 against the shipped artifact: a task can read its own agent token and use it, from outside any task and after the task has ended, to retrieve every decrypted connection URI in the tenant.

**This does not block the promotion, and holding the release would not help anyone.** `v0.1.1` contains the identical leak — same `os.Environ()` pass-through, same unfiltered `mergeEnv`. Holding `v0.1.2` keeps users on an equally vulnerable version while withholding real fixes. The instinct "do not ship a known hole" assumes shipping makes things worse; here it does not.

The release notes therefore **do not** detail the exploit. The fix is not in this version, and publishing a working exfiltration path against a live release before its fix exists arms attackers for no benefit. Disclosure belongs with the fix.

**That makes `v0.1.3` a commitment, not an intention.** #478 is written, green and waiting; if `v0.1.3` slips, the reasoning above turns into an excuse for silence.

## Known issues, shipped documented

- **#461 / #474** — a task can be marked `dispatch_lost` while its pod is still running. Previously filed as an unreproducible flake; the mechanism is now understood and a slow image pull is enough to trigger it.
- **#463** — shutdown can hang when the Kubernetes API stops answering. In this specific case shutdown is worse than in `0.1.1`, where the drain never ran at all; the notes say so.

Both are pre-existing or introduced-and-named within the line, and both have fixes in flight.

## After this merges

Tagging `v0.1.2` unfreezes `main`, and the eight held PRs (#466, #467, #468, #473, #478, #479, #481, #482) can land. That is a substantial correction release in its own right and deserves the same RC discipline this one had — `v0.1.3` should not skip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)