### PR TITLE
fix(secrets): stop recommending a key with half the intended entropy

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ helm install lf leoflow/leoflow -n leoflow \
   --set database.url='postgres://USER:PASS@HOST:5432/leoflow?sslmode=verify-full' \
   --set redis.url='rediss://HOST:6380/0' \
   --set auth.jwtSecret="$(openssl rand -base64 64)" \
-  --set secretKey="$(openssl rand -hex 16)" \
+  --set secretKey="$(openssl rand -hex 32)" \
   --set bootstrap.password='change-me'
 ```
 

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -280,6 +280,18 @@ func configureSecretCipher(repo *storage.Repository, secretKey string, logger *s
 		return fmt.Errorf("building secret cipher: %w", cerr)
 	}
 	repo.SetCipher(cipher)
+	// A 32-character all-hex key is what `openssl rand -hex 16` produces, which
+	// this project's own docs recommended until they were corrected. ParseKey
+	// takes those 32 characters as 32 raw bytes, so the cipher is AES-256 over
+	// 128 bits of entropy and nothing else would ever mention it. Warn rather
+	// than refuse: the shape is indistinguishable from a legitimate 32-character
+	// passphrase, and breaking an operator who did nothing wrong is worse.
+	if secrets.LooksLikeHalfEntropyHexKey(secretKey) {
+		logger.Warn("LEOFLOW_SECRET_KEY looks like `openssl rand -hex 16` output: "+
+			"32 hex characters are consumed as 32 raw bytes, giving 128 bits of entropy where AES-256 expects 256. "+
+			"Generate a replacement with `openssl rand -hex 32` (64 characters) and re-encrypt existing connections",
+			"key_length", len(secretKey))
+	}
 	logger.Info("connection secret encryption enabled (AES-256-GCM)")
 	return nil
 }

--- a/deploy/gke/02-install-leoflow.sh
+++ b/deploy/gke/02-install-leoflow.sh
@@ -71,7 +71,10 @@ else
   log "Generating credentials -> $VALUES_LOCAL (gitignored, never committed)"
   PG_PASSWORD="$(openssl rand -hex 16)"
   JWT_SECRET="$(openssl rand -base64 64 | tr -d '\n')"
-  SECRET_KEY="$(openssl rand -hex 16)"          # 32 bytes (64 hex) for AES-256
+  # -hex 32, not -hex 16: `-hex 16` emits 32 characters, which the server accepts
+  # as 32 RAW bytes — a valid AES-256 key holding only 128 bits of entropy, with
+  # nothing to say so. -hex 32 emits 64 characters that decode to 32 real bytes.
+  SECRET_KEY="$(openssl rand -hex 32)"          # 64 hex chars -> 32 bytes for AES-256
   BOOTSTRAP_PASSWORD="$(openssl rand -hex 12)"  # initial admin password
 
   cat > "$VALUES_LOCAL" <<EOF

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -234,7 +234,7 @@ helm install lf ./helm/leoflow -n leoflow \
   --set database.url='postgres://USER:PASS@HOST:5432/leoflow?sslmode=verify-full' \
   --set redis.url='rediss://HOST:6380/0' \
   --set auth.jwtSecret="$(openssl rand -base64 64)" \
-  --set secretKey="$(openssl rand -hex 16)" \
+  --set secretKey="$(openssl rand -hex 32)" \
   --set bootstrap.password='change-me'
 ```
 

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -184,7 +184,7 @@ helm template lf ./helm/leoflow -n leoflow \
   --set database.url=postgres://x \
   --set redis.url=redis://r/0 \
   --set auth.jwtSecret=s \
-  --set "secretKey=$(openssl rand -hex 16)"
+  --set "secretKey=$(openssl rand -hex 32)"
 bash scripts/helm-template-checks.sh   # contract assertions (env wiring, Job hardening, fixture lengths)
 ```
 

--- a/helm/leoflow/README.md.gotmpl
+++ b/helm/leoflow/README.md.gotmpl
@@ -184,7 +184,7 @@ helm template lf ./helm/leoflow -n leoflow \
   --set database.url=postgres://x \
   --set redis.url=redis://r/0 \
   --set auth.jwtSecret=s \
-  --set "secretKey=$(openssl rand -hex 16)"
+  --set "secretKey=$(openssl rand -hex 32)"
 bash scripts/helm-template-checks.sh   # contract assertions (env wiring, Job hardening, fixture lengths)
 ```
 

--- a/helm/leoflow/examples/README.md
+++ b/helm/leoflow/examples/README.md
@@ -183,7 +183,7 @@ helm install leoflow ./helm/leoflow -n leoflow \
   --set database.url='postgres://...@<managed-pg>:5432/leoflow?sslmode=require' \
   --set redis.url='rediss://...@<managed-redis>:6380/0' \
   --set auth.jwtSecret="$(openssl rand -base64 64)" \
-  --set secretKey="$(openssl rand -hex 16)"  # 32 raw bytes via hex
+  --set secretKey="$(openssl rand -hex 32)"  # 64 hex chars -> 32 bytes
 ```
 
 See the main chart README (`helm/leoflow/README.md`) for the full values

--- a/helm/leoflow/examples/poc.yaml
+++ b/helm/leoflow/examples/poc.yaml
@@ -31,7 +31,8 @@ redis:
 # 256-GCM init in the server succeeds out-of-the-box; without that, the
 # server logs a warning and the Connections API returns 503 — the recipe's
 # Connection-management evaluation fails silently. Generate a real key
-# with `openssl rand -hex 16` (64 hex chars = 32 bytes).
+# with `openssl rand -hex 32` (64 hex chars = 32 bytes). NOT -hex 16: that
+# emits 32 chars, taken as 32 RAW bytes — 128 bits of entropy, silently.
 auth:
   jwtSecret: leoflow-poc-jwt-please-replace-32B
 secretKey: leoflow-poc-replace-with-32B-key

--- a/helm/leoflow/examples/values-pro-tls.yaml
+++ b/helm/leoflow/examples/values-pro-tls.yaml
@@ -20,7 +20,7 @@ redis:
 
 auth:
   jwtSecret: "CHANGEME-jwt-signing-secret"
-# 32 raw bytes or 64-char hex. Generate: openssl rand -hex 16
+# 32 raw bytes or 64-char hex. Generate: openssl rand -hex 32
 secretKey: "CHANGEME-leoflow-secret-key-32by"
 
 agentTLS:

--- a/helm/leoflow/templates/deployment.yaml
+++ b/helm/leoflow/templates/deployment.yaml
@@ -24,7 +24,7 @@ out-of-band Secret to validate its contents (operator's responsibility).
 {{- if and .Values.secretKey (not .Values.secretKeyExistingSecret) -}}
 {{- $len := len .Values.secretKey -}}
 {{- if and (ne $len 32) (ne $len 64) -}}
-{{- fail (printf "secretKey must be exactly 32 raw bytes or 64-char hex (got %d chars). Generate with: openssl rand -hex 16. See ADR 0019." $len) -}}
+{{- fail (printf "secretKey must be exactly 32 raw bytes or 64-char hex (got %d chars). Generate with: openssl rand -hex 32 (64 hex chars). See ADR 0019." $len) -}}
 {{- end -}}
 {{- end -}}
 {{- /*

--- a/helm/leoflow/tests/deployment_test.yaml
+++ b/helm/leoflow/tests/deployment_test.yaml
@@ -92,7 +92,7 @@ tests:
       secretKey: too-short-12345
     asserts:
       - failedTemplate:
-          errorMessage: "secretKey must be exactly 32 raw bytes or 64-char hex (got 15 chars). Generate with: openssl rand -hex 16. See ADR 0019."
+          errorMessage: "secretKey must be exactly 32 raw bytes or 64-char hex (got 15 chars). Generate with: openssl rand -hex 32 (64 hex chars). See ADR 0019."
 
   - it: accepts 32-byte raw secretKey (AES-256)
     template: deployment.yaml

--- a/helm/leoflow/values.yaml
+++ b/helm/leoflow/values.yaml
@@ -129,7 +129,10 @@ auth:
 # Connection management is disabled and the API rejects writes with 503
 # (Variables still work). Set it, or reference an existing secret.
 #
-# Generate one with:  openssl rand -hex 16   (64 hex chars = 32 bytes)
+# Generate one with:  openssl rand -hex 32   (64 hex chars = 32 bytes)
+# NOT `-hex 16`: that yields 32 characters, which the server accepts as 32
+# RAW bytes — a valid AES-256 key carrying only 128 bits of entropy, with
+# nothing to tell you. The server warns at boot if it sees that shape.
 # -- AES-256 key encrypting Connection passwords + Extra at rest (ADR 0019). MUST be exactly 32 raw bytes OR 64-char hex OR base64-of-32-bytes. Without it, Connection management is disabled (Variables still work).
 secretKey: ""
 # -- Name of a Secret with key `secretKey` (takes precedence over `secretKey`).

--- a/internal/secrets/cipher.go
+++ b/internal/secrets/cipher.go
@@ -96,3 +96,33 @@ func (c *aesGCM) Decrypt(ciphertext string) (string, error) {
 	}
 	return string(plain), nil
 }
+
+// LooksLikeHalfEntropyHexKey reports whether a key is 32 characters of pure
+// hexadecimal — the signature of `openssl rand -hex 16`, which the project's own
+// docs recommended until they were corrected.
+//
+// ParseKey accepts a 32-character string as 32 RAW bytes, so such a key is used
+// as an AES-256 key carrying 128 bits of entropy. The cipher is still AES-256;
+// the secret behind it is half the size intended, and nothing about the
+// configuration says so.
+//
+// This is a warning and not a rejection because the two shapes cannot be told
+// apart with certainty: a legitimate 32-character passphrase made only of the
+// characters 0-9a-f is unlikely but perfectly valid, and refusing it would break
+// an operator who did nothing wrong. Reporting it lets the caller say something
+// while still starting.
+func LooksLikeHalfEntropyHexKey(s string) bool {
+	if len(s) != 32 {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		case r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/secrets/cipher_test.go
+++ b/internal/secrets/cipher_test.go
@@ -77,3 +77,28 @@ func TestParseKey(t *testing.T) {
 		t.Error("expected error for short key")
 	}
 }
+
+// A 32-character key made entirely of hex digits is almost certainly the output
+// of `openssl rand -hex 16` — the command the docs used to recommend. ParseKey
+// accepts it as 32 RAW bytes, so the cipher is AES-256 over 128 bits of
+// entropy, and nothing says so. The two shapes are indistinguishable by length,
+// so this cannot be a rejection without also rejecting a legitimate 32-character
+// passphrase; it is a warning the caller can surface.
+func TestLooksLikeHalfEntropyHexKey(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		key  string
+		want bool
+	}{
+		{"openssl rand -hex 16 output", "0123456789abcdef0123456789abcdef", true},
+		{"uppercase hex is the same mistake", "0123456789ABCDEF0123456789ABCDEF", true},
+		{"a real 32-char passphrase is not", "leoflow-unittest-secretkey-32by!", false},
+		{"64-char hex is the correct form", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", false},
+		{"short strings are someone else's problem", "abc", false},
+		{"empty", "", false},
+	} {
+		if got := LooksLikeHalfEntropyHexKey(tc.key); got != tc.want {
+			t.Errorf("%s: LooksLikeHalfEntropyHexKey(%q) = %v, want %v", tc.name, tc.key, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #464. Tier 1 of #465.

## The arithmetic

`openssl rand -hex 16` emits **32 characters**. `ParseKey` takes a 32-character string as **32 raw bytes** (`internal/secrets/cipher.go:56`), so it becomes a valid AES-256 key carrying **128 bits** of entropy. The cipher is AES-256; the secret behind it is half the size intended, and nothing says so.

`openssl rand -hex 32` emits 64 characters, which `ParseKey` decodes to 32 real bytes.

## The issue said three sites. There were seven.

And the worst was not a document — it **generated the key**:

```bash
# deploy/gke/02-install-leoflow.sh, before
SECRET_KEY="$(openssl rand -hex 16)"          # 32 bytes (64 hex) for AES-256
```

The documented production install path produced a 128-bit key on every run, with a comment stating the correct target beside a command that misses it. That is the same wrong arithmetic `values.yaml` carried, which suggests the original author knew what they wanted and mistyped the argument — and every later copy inherited it.

Corrected: the chart's `fail` message, `values.yaml`, the chart README **template** (the rendered README is generated), `docs/installation.md`, the root `README.md`, `examples/poc.yaml`, `examples/README.md`, `examples/values-pro-tls.yaml`, and the GKE install script.

## Deliberately not changed

- `openssl rand -hex 16` for `PG_PASSWORD` / `PGPW` in the deploy scripts. 128 bits is fine for a database password, and those are not AES keys.
- `articles/2026-06-leoflow-v0-0-1-devto.md` — a published dev.to post kept as a historical snapshot, with a workflow that republishes on change. It still carries the wrong command, so it needs a decision rather than a silent edit: correct it and accept a republish, or leave it as a dated artifact. **Flagging rather than choosing.**

## Fixing the docs does nothing for whoever already followed them

So the server now warns at boot when it sees a 32-character all-hex key, naming the likely cause and the replacement command:

```
LEOFLOW_SECRET_KEY looks like `openssl rand -hex 16` output: 32 hex characters are
consumed as 32 raw bytes, giving 128 bits of entropy where AES-256 expects 256.
Generate a replacement with `openssl rand -hex 32` (64 characters) and re-encrypt
existing connections
```

**A warning, not a rejection.** The two shapes cannot be told apart with certainty: a legitimate 32-character passphrase drawn only from `0-9a-f` is unlikely but valid, and refusing it would break an operator who did nothing wrong. Reporting it lets the server say something and still start.

## Verification

| Gate | Result |
|---|---|
| `go test -race` — secrets, cmd | pass ✓ |
| `golangci-lint run` | 0 issues ✓ |
| `helm unittest` | 59/59 (the message assertion updated with the message) ✓ |
| `helm lint` · `helm-template-checks.sh` · chart README sync | green ✓ |

Detector tests written red first: it recognises lower- and upper-case hex, and does not fire on a real passphrase, on correct 64-character hex, or on short input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)