### PR TITLE
fix(cli): run the binaries that ship with this CLI, and say which ones

### DIFF
--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -37,6 +37,7 @@ import (
 	"github.com/neochaotic/leoflow/internal/config"
 	"github.com/neochaotic/leoflow/internal/domain"
 	"github.com/neochaotic/leoflow/internal/setup"
+	"github.com/neochaotic/leoflow/internal/version"
 	"github.com/neochaotic/leoflow/migrations"
 )
 
@@ -607,7 +608,7 @@ func runDev(cmd *cobra.Command, dir string, o devOptions) error {
 	if herr != nil {
 		return herr
 	}
-	serverBin, berr := resolveBinary(o.serverBin, "leoflow-server")
+	serverBin, berr := resolveAndReport(cmd.Context(), cmd, o.serverBin, "leoflow-server")
 	if berr != nil {
 		return berr
 	}
@@ -694,7 +695,7 @@ func makeDeleteDag(mintToken func() string, uiURL, home string, logf func(format
 // projects and uses the dependency-union from WorkspaceSpec.RootCfg so every
 // DAG's imports resolve from a single virtualenv.
 func devSubprocessSetup(ctx context.Context, cmd *cobra.Command, ws *WorkspaceSpec, o devOptions, home string) (env []string, makeReload func(func() string) func() error, err error) {
-	agentBin, err := resolveBinary(o.agentBin, "leoflow-agent")
+	agentBin, err := resolveAndReport(ctx, cmd, o.agentBin, "leoflow-agent")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1222,22 +1223,133 @@ func ensureProjectDockerfile(cmd *cobra.Command, dir string, cfg *domain.Leoflow
 	return nil
 }
 
-// resolveBinary returns explicit when set, otherwise the binary found on PATH,
-// otherwise ./bin/<name> if it exists, otherwise an actionable error.
+// resolveAndReport locates a companion binary and announces the choice, so the
+// two always happen together — a resolution nobody printed is what let a
+// month-old server run unnoticed (#471).
+func resolveAndReport(ctx context.Context, cmd *cobra.Command, explicit, name string) (string, error) {
+	path, err := resolveBinary(explicit, name)
+	if err != nil {
+		return "", err
+	}
+	if werr := reportCompanionBinary(ctx, cmd, name, path); werr != nil {
+		return "", werr
+	}
+	return path, nil
+}
+
+// reportCompanionBinary announces which companion binary was chosen and whether
+// its version matches this CLI's.
+//
+// The path alone is not enough. When `leoflow lite` silently ran a month-old
+// leoflow-server, every visible signal — the banner, /readyz, the logs — looked
+// correct, and the mismatch was found only by hashing the running process
+// afterwards. The trio is co-versioned (ADR 0028), so a disagreement is never
+// intentional and is worth interrupting for.
+//
+// Best-effort: a binary that will not report its version still runs. Refusing to
+// start over an unreadable version string would turn a diagnostic into an
+// outage, and the resolution order already makes the mismatch rare.
+func reportCompanionBinary(ctx context.Context, cmd *cobra.Command, kind, path string) error {
+	got := companionVersion(ctx, path)
+	mine := version.Get().Version
+	var werr error
+	switch {
+	case got == "":
+		_, werr = fmt.Fprintf(cmd.ErrOrStderr(), "  %s: %s (version unavailable)\n", kind, path)
+	case mine != "" && got != mine:
+		_, werr = fmt.Fprintf(cmd.ErrOrStderr(),
+			"  %s: %s\n  WARNING: %s reports %s but this CLI is %s. They ship together and are\n"+
+				"  meant to match; a mismatch usually means an older copy was found first.\n"+
+				"  Pass --%s to pin the one you want.\n",
+			kind, path, kind, got, mine, kind)
+	default:
+		_, werr = fmt.Fprintf(cmd.ErrOrStderr(), "  %s: %s (%s)\n", kind, path, got)
+	}
+	return werr
+}
+
+// companionVersion asks a binary for its version, returning "" when it cannot
+// be determined. Bounded so a wedged binary cannot hang startup.
+func companionVersion(ctx context.Context, path string) string {
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, path, "version").Output() //nolint:gosec // path resolved by resolveBinary, not user input
+	if err != nil {
+		return ""
+	}
+	fields := strings.Fields(string(out))
+	// Output shape: "<name> <version> (commit …, built …, go…)".
+	if len(fields) >= 2 {
+		return fields[1]
+	}
+	return ""
+}
+
+// resolveBinary locates a companion binary, preferring the copy that belongs
+// with the running CLI over whatever happens to be installed.
+//
+// Order: an explicit --flag, then the directory holding this executable, then
+// the installer's ~/.leoflow/bin, then PATH, then ./bin.
+//
+// PATH used to come first, which meant `leoflow lite` ran whatever
+// leoflow-server was installed earliest — however old. A validation run against
+// v0.1.2-rc.1 spent its first boot exercising a v0.1.0-rc.4 server that predated
+// every feature under test, and the mismatch was invisible: the banner, /readyz
+// and the logs all looked correct. The trio is co-versioned (ADR 0028), so the
+// binary shipped beside the running CLI is the one it was built and tested
+// against; an older copy earlier on PATH is never the intended answer (#471).
+//
+// PATH is still consulted, so anyone relying on it keeps working — it is simply
+// no longer the first answer.
 func resolveBinary(explicit, name string) (string, error) {
 	if explicit != "" {
 		return explicit, nil
+	}
+	for _, dir := range companionDirs() {
+		cand := filepath.Join(dir, name)
+		if isExecutableFile(cand) {
+			return cand, nil
+		}
 	}
 	if p, err := exec.LookPath(name); err == nil {
 		return p, nil
 	}
 	local := filepath.Join("bin", name)
-	if _, err := os.Stat(local); err == nil {
+	if isExecutableFile(local) {
 		// Absolute, because the subprocess executor runs the agent with a different
 		// working directory; a relative path would not resolve there.
 		return filepath.Abs(local)
 	}
-	return "", fmt.Errorf("%s not found on PATH or ./bin; run `make build` or pass --%s", name, name)
+	return "", fmt.Errorf("%s not found beside this binary, in ~/.leoflow/bin, on PATH, or in ./bin; "+
+		"run `make build` or pass --%s", name, name)
+}
+
+// companionDirs lists the directories that hold binaries shipped WITH this one,
+// most-specific first. Both are best-effort: a failure to resolve either simply
+// falls through to PATH.
+func companionDirs() []string {
+	var dirs []string
+	if exe, err := os.Executable(); err == nil {
+		if resolved, rerr := filepath.EvalSymlinks(exe); rerr == nil {
+			exe = resolved
+		}
+		dirs = append(dirs, filepath.Dir(exe))
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, filepath.Join(home, ".leoflow", "bin"))
+	}
+	return dirs
+}
+
+// isExecutableFile reports whether path is a regular file with an execute bit.
+// The directory check matters: `~/.leoflow/bin/leoflow-agent/` as a directory
+// would otherwise satisfy a plain os.Stat and be handed to exec.
+func isExecutableFile(path string) bool {
+	fi, err := os.Stat(path)
+	if err != nil || fi.IsDir() {
+		return false
+	}
+	return fi.Mode().Perm()&0o111 != 0
 }
 
 // sharedServerEnv is the Lite control plane environment common to both executor

--- a/internal/cli/dev_test.go
+++ b/internal/cli/dev_test.go
@@ -462,7 +462,15 @@ func TestEnsureProjectDockerfile(t *testing.T) {
 }
 
 func TestDevSubprocessSetupMissingAgent(t *testing.T) {
-	t.Chdir(t.TempDir()) // no agent on PATH or ./bin
+	// The comment used to promise "no agent on PATH or ./bin" while only changing
+	// the working directory, so on any machine with leoflow installed the agent
+	// WAS on PATH and this test failed — green in CI, red for every developer who
+	// had run the installer. A test that is red locally for an unrelated reason
+	// trains people to ignore a red suite, which is how a real failure gets waved
+	// through. Isolate all three lookup locations, not one.
+	t.Chdir(t.TempDir())          // nothing in ./bin
+	t.Setenv("PATH", t.TempDir()) // nothing on PATH
+	t.Setenv("HOME", t.TempDir()) // nothing in ~/.leoflow/bin
 	cmd := devTestCmd()
 	ws := &WorkspaceSpec{Path: ".", RootCfg: &domain.LeoflowConfig{DagID: "p"}}
 	ws.RootCfg.ApplyDefaults()
@@ -573,5 +581,108 @@ func TestK3dImportStubbed(t *testing.T) {
 	}
 	if !strings.Contains(got, "image import leoflow-dev-etl:dev") || !strings.Contains(got, "--cluster "+devClusterName) {
 		t.Errorf("k3dImport invoked %q", got)
+	}
+}
+
+// resolveBinary used to consult PATH before anything else, so `leoflow lite` ran
+// whatever leoflow-server happened to be installed first — however old. A
+// validation run against v0.1.2-rc.1 spent its first boot exercising a
+// v0.1.0-rc.4 server that predated every feature under test, and only noticed
+// afterwards. The binaries are co-versioned (ADR 0028), so the one shipped
+// beside the running CLI is the one it was built and tested against; an older
+// copy earlier on PATH is never the intended answer (#471).
+func TestResolveBinaryPrefersTheSiblingOverPATH(t *testing.T) {
+	name := "leoflow-sibling-probe"
+	// A stale copy on PATH, which the old order would have returned.
+	pathDir := t.TempDir()
+	writeFakeBinary(t, filepath.Join(pathDir, name))
+	t.Setenv("PATH", pathDir)
+
+	// The one shipped beside the running executable.
+	exe, err := os.Executable()
+	if err != nil {
+		t.Skipf("os.Executable unavailable: %v", err)
+	}
+	sibling := filepath.Join(filepath.Dir(exe), name)
+	writeFakeBinary(t, sibling)
+	t.Cleanup(func() { _ = os.Remove(sibling) })
+	// resolveBinary canonicalises through EvalSymlinks, and on macOS /var is a
+	// symlink to /private/var — compare canonical forms, not the raw strings.
+	if resolved, rerr := filepath.EvalSymlinks(sibling); rerr == nil {
+		sibling = resolved
+	}
+
+	got, err := resolveBinary("", name)
+	if err != nil {
+		t.Fatalf("resolveBinary: %v", err)
+	}
+	if got != sibling {
+		t.Errorf("resolveBinary = %q, want the sibling %q — a stale copy on PATH must not win", got, sibling)
+	}
+}
+
+// With no sibling present, the installer's directory is consulted before PATH:
+// `curl | sh` puts the matching trio in ~/.leoflow/bin, and those belong
+// together too.
+func TestResolveBinaryPrefersInstallDirOverPATH(t *testing.T) {
+	name := "leoflow-installdir-probe"
+	pathDir := t.TempDir()
+	writeFakeBinary(t, filepath.Join(pathDir, name))
+	t.Setenv("PATH", pathDir)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	installed := filepath.Join(home, ".leoflow", "bin", name)
+	if err := os.MkdirAll(filepath.Dir(installed), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFakeBinary(t, installed)
+
+	got, err := resolveBinary("", name)
+	if err != nil {
+		t.Fatalf("resolveBinary: %v", err)
+	}
+	if got != installed {
+		t.Errorf("resolveBinary = %q, want the install dir %q", got, installed)
+	}
+}
+
+// PATH still works when nothing better exists — this must not become a
+// regression for anyone relying on it.
+func TestResolveBinaryStillFallsBackToPATH(t *testing.T) {
+	name := "leoflow-pathonly-probe"
+	pathDir := t.TempDir()
+	want := filepath.Join(pathDir, name)
+	writeFakeBinary(t, want)
+	t.Setenv("PATH", pathDir)
+	t.Setenv("HOME", t.TempDir())
+
+	got, err := resolveBinary("", name)
+	if err != nil {
+		t.Fatalf("resolveBinary: %v", err)
+	}
+	if got != want {
+		t.Errorf("resolveBinary = %q, want %q from PATH", got, want)
+	}
+}
+
+// A directory named like the binary must not be mistaken for it.
+func TestResolveBinaryIgnoresDirectories(t *testing.T) {
+	name := "leoflow-dir-probe"
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+	if err := os.MkdirAll(filepath.Join(home, ".leoflow", "bin", name), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolveBinary("", name); err == nil {
+		t.Error("a directory with the binary's name must not resolve as the binary")
+	}
+}
+
+func writeFakeBinary(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Closes #471. Last item of tier 1 in #465.

## What went wrong twice

`resolveBinary` consulted **PATH first**, so `leoflow lite` ran whatever `leoflow-server` was installed earliest — however old.

A validation run against `v0.1.2-rc.1` spent its first boot exercising a **v0.1.0-rc.4** server that predated every feature under test. The same thing happened again on rc.2, and the second time it was only avoided because the validator had been told to check. Nothing about it was visible: the banner, `/readyz` and the logs all looked correct. The mismatch was found by hashing the running process afterwards.

## The order

`--flag` → **the directory holding this executable** → `~/.leoflow/bin` → PATH → `./bin`.

The trio is co-versioned (ADR 0028), so the copy shipped beside the running CLI is the one it was built and tested against. An older copy earlier on PATH is never the intended answer.

PATH still works for anyone relying on it. It is simply no longer the first answer.

## Order alone would not have caught it

A path looks fine. So the resolved path **and its version** are now printed, with a loud warning when the version disagrees with the CLI's:

```
  leoflow-server: /Users/…/.local/bin/leoflow-server
  WARNING: leoflow-server reports 0.1.0-rc.4 but this CLI is 0.1.2. They ship together and are
  meant to match; a mismatch usually means an older copy was found first.
  Pass --leoflow-server to pin the one you want.
```

Best-effort by design: a binary that will not report a version still runs. Refusing to start over an unreadable version string turns a diagnostic into an outage, and the resolution order already makes the mismatch rare.

`isExecutableFile` replaces a bare `os.Stat` — a directory named like the binary would otherwise have satisfied the check and been handed to `exec`.

## Also fixes the test that has been red all day

`TestDevSubprocessSetupMissingAgent` claimed *"no agent on PATH or ./bin"* while only changing the working directory. On any machine where leoflow is installed, the agent **was** on PATH — so the test passed in CI and failed for every developer who had run the installer.

That has shown up in every full-suite run in this session, and I have been explaining it away each time. A suite that is red for an unrelated reason trains people to ignore a red suite, which is exactly how a real failure gets waved through. It now isolates all three lookup locations.

**`go test -race ./...` is fully green for the first time today.**

## Verification

| Gate | Result |
|---|---|
| `go test -race ./...` | **fully green**, no exceptions ✓ |
| `golangci-lint run ./internal/cli/...` | 0 issues ✓ |
| `gofmt -l .` | clean ✓ |

Four new tests, red first: the sibling beats a stale PATH copy, the install dir beats PATH, PATH still works when nothing better exists, and a directory named like the binary does not resolve.

One implementation note: returning the write error from the reporting helper pushed `runDev` past the `gocyclo` limit, so resolution and reporting are combined into `resolveAndReport` — two branches become one, and the two steps can no longer be done separately, which is the property that failed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)