### PR TITLE
docs: stop claiming four things that are not true

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -87,8 +87,16 @@ dockers:
   # GoReleaser default) AND `v{{ .Version }}` (the raw git tag). The migrate
   # workflow already publishes both forms via docker/metadata-action; keeping
   # server symmetric means a chart `--set image.tag=<X>` pin works no matter
-  # which convention the operator follows. Both shapes are signed by cosign
-  # below (cosign sign by digest, so duplicate tags share signatures).
+  # which convention the operator follows.
+  #
+  # NOT signed. This comment used to claim "both shapes are signed by cosign
+  # below" — there is no `docker_signs` block anywhere in this file, and the
+  # release workflow signs only leoflow-migrate and leoflow-runtime. The
+  # `signs:` block above covers the checksums file, which protects the
+  # ARCHIVES, not these images. So the control-plane image the Helm chart
+  # deploys is the one image that is unsigned, and a comment asserted the
+  # opposite. Tracked as its own decision: add docker_signs, or say so in the
+  # supply-chain docs (ADR 0014).
   - id: server-amd64
     ids: [leoflow-server]
     goarch: amd64

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,85 +1,34 @@
+# Code of Conduct
 
-# Contributor Covenant Code of Conduct
+Act like an adult.
 
-## Our Pledge
+That is the whole rule, and for almost everyone it is enough. If you want it
+spelled out: argue about the code, not the person. Assume the other side is
+competent and acting in good faith until they prove otherwise. Take a "no" and
+move on. You can be blunt — this project would rather read a direct review than
+a padded one — but blunt about the work, never about the author.
 
-We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
-
-We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
-
-## Our Standards
-
-Examples of behavior that contributes to a positive environment for our community include:
-
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the overall community
-
-Examples of unacceptable behavior include:
-
-* The use of sexualized language or imagery, and sexual attention or advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
-
-## Enforcement Responsibilities
-
-Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
-
-Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+What ends a participation here is harassment, personal attacks, or making the
+project hostile to someone for who they are rather than for what they wrote.
+There is no warning ladder and no committee: I read it, I decide, and I remove
+comments, commits, issues, or people as needed.
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+Issues, pull requests, discussions, and commit history in this repository, plus
+anywhere someone is speaking for the project.
 
-## Enforcement
+## Reporting
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by contacting the maintainer, [@neochaotic](https://github.com/neochaotic), directly on GitHub. There is deliberately no email address here: the `conduct@leoflow.io` this file used to publish sat next to the word "placeholder" and never existed, so a report following it reached nobody. All complaints will be reviewed and investigated promptly and fairly.
+Open a [private report](https://github.com/neochaotic/leoflow/security/advisories/new)
+or contact [@neochaotic](https://github.com/neochaotic) directly. Reports stay
+between us. This is a single-maintainer project, so there is no independent
+appeal — if the problem is with me, that is worth knowing before you invest
+time here.
 
-All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+---
 
-## Enforcement Guidelines
-
-Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
-
-### 1. Correction
-
-**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
-
-**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
-
-### 2. Warning
-
-**Community Impact**: A violation through a single incident or series of actions.
-
-**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
-
-### 3. Temporary Ban
-
-**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
-
-**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
-
-### 4. Permanent Ban
-
-**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
-
-**Consequence**: A permanent ban from any sort of public interaction within the community.
-
-## Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
-
-Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
-
-For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
-
-[homepage]: https://www.contributor-covenant.org
-[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
-[Mozilla CoC]: https://github.com/mozilla/diversity
-[FAQ]: https://www.contributor-covenant.org/faq
-[translations]: https://www.contributor-covenant.org/translations
-
+*This replaced Contributor Covenant 2.1, whose enforcement ladder and "community
+leaders" described a governance structure that does not exist here. Shorter and
+true beats longer and borrowed. If Leoflow ever joins a foundation that requires
+the Covenant, it comes back.*

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at conduct@leoflow.io (placeholder — replace with the project's real address). All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by contacting the maintainer, [@neochaotic](https://github.com/neochaotic), directly on GitHub. There is deliberately no email address here: the `conduct@leoflow.io` this file used to publish sat next to the word "placeholder" and never existed, so a report following it reached nobody. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 neochaotic
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,33 @@
+Leoflow
+Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+This product includes software developed by third parties, redistributed under
+the terms below. Apache-2.0 §4(d) requires a NOTICE file when a work you
+redistribute carries one; this file exists because Leoflow's binaries embed and
+redistribute the components listed here, not merely depend on them.
+
+--------------------------------------------------------------------------------
+Apache Airflow web UI (SPA bundle)
+--------------------------------------------------------------------------------
+
+Version 3.2.1, embedded under internal/ui/assets and compiled into the
+leoflow-server binary and the container images built from it (ADR 0017).
+
+  Copyright The Apache Software Foundation
+  Licensed under the Apache License, Version 2.0
+  https://github.com/apache/airflow
+
+Leoflow serves this bundle to provide an Airflow-compatible interface (ADR 0007).
+The bundle's navigation links are rewritten to point at Leoflow's own
+documentation; the bundle is otherwise unmodified. Leoflow is not affiliated with
+or endorsed by the Apache Software Foundation, and "Apache", "Apache Airflow" and
+the Airflow logo are trademarks of the Apache Software Foundation.
+
+--------------------------------------------------------------------------------
+Go module dependencies
+--------------------------------------------------------------------------------
+
+Dependencies fetched at build time are listed in go.mod and go.sum, and their
+licenses accompany them in the module cache; they are not restated here. Every
+release publishes an SBOM (syft, via .goreleaser.yaml) enumerating the full
+dependency set with licenses, which is the authoritative list.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,19 +52,31 @@ We use CVSS 3.1 to score vulnerabilities:
 
 | Severity | CVSS Score | Response |
 |---|---|---|
-| Critical | 9.0-10.0 | Emergency patch, within 7 days |
-| High | 7.0-8.9 | Patch in next minor release, within 14 days |
-| Medium | 4.0-6.9 | Patch in next planned release |
-| Low | 0.1-3.9 | Patch when convenient, documented in release notes |
+| Critical | 9.0-10.0 | Fix merged to `main` within 7 days; release cut as soon as it is verified |
+| High | 7.0-8.9 | Fix merged to `main` within 14 days; shipped in the next release |
+| Medium | 4.0-6.9 | Fixed in the next planned release |
+| Low | 0.1-3.9 | Fixed when convenient, noted in the release notes |
+
+The timelines are on **merging the fix**, not on cutting a release, because those
+are different decisions here. A release is cut when it has been verified, and
+rushing one to satisfy a clock has its own risk. When a fix is on `main` but not
+yet released, the advisory says so and you can build from source in the
+meantime — the commit is public either way, which is itself a reason not to sit
+on the disclosure.
 
 ### Supported Versions
 
-We provide security fixes for:
+**Only the latest release.** Leoflow is pre-1.0 and ships patches on a single
+line (v0.1.0 → v0.1.1 → v0.1.2); there is no previous minor to support, and
+under SemVer's 0.x contract a breaking change may land between any two releases
+(ADR 0037). Backporting to an older tag is not offered.
 
-- The current stable release (latest minor version of the latest major)
-- The previous minor version, for 90 days after the current release
+Upgrading to the latest release is the remediation. If that is not possible for
+you, say so in the report — a targeted patch may be possible, but it is a
+case-by-case answer rather than a policy.
 
-Older versions receive critical-severity fixes only, on a best-effort basis. Upgrading to a supported version is the recommended remediation.
+This section previously promised support for "the previous minor version, for 90
+days", which described a versioning shape the project does not have.
 
 ## Recognition
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,9 +8,22 @@ The Leoflow team takes security issues seriously. We appreciate your efforts to 
 
 ### How to Report
 
-Email reports to **security@leoflow.io** (placeholder — replace with the project's real address). For sensitive reports, encrypt your message using the PGP key published at [keybase.io/leoflow](https://keybase.io/leoflow) (placeholder).
+**Use GitHub's private vulnerability reporting:**
+[**Report a vulnerability**](https://github.com/neochaotic/leoflow/security/advisories/new)
 
-Alternatively, use GitHub's private vulnerability reporting: navigate to the [Security tab](../../security) and click "Report a vulnerability."
+The report is visible only to the maintainer until an advisory is published. No
+account beyond GitHub is needed, and it threads the discussion, the fix and the
+eventual advisory in one place.
+
+There is deliberately no email address here. This file used to publish
+`security@leoflow.io` alongside the word "placeholder" — the domain does not
+exist and never received anything, so a reporter following the policy reached
+nobody. A channel that does not work is worse than no channel: it looks like
+diligence and absorbs the report. The same went for the Keybase link.
+
+If GitHub is not an option for you, open a public issue saying only that you
+have a security report and asking for a contact — no details — and you will get
+a private channel.
 
 ### What to Include
 

--- a/docs/adr/0014-supply-chain-security.md
+++ b/docs/adr/0014-supply-chain-security.md
@@ -98,9 +98,9 @@ These files are part of the security posture and ship with v0.1.0:
 
 | File | Purpose |
 |---|---|
-| `SECURITY.md` | Vulnerability disclosure process. Email address for private reports, response time commitment, supported versions, GPG key. |
+| `SECURITY.md` | Vulnerability disclosure process: GitHub private vulnerability reporting (not an email address, and no GPG key — the reporting channel is authenticated and encrypted in transit by GitHub), response-time commitment, supported versions. |
 | `CONTRIBUTING.md` | How to contribute, including security review expectations for PRs touching auth, executor, or storage. |
-| `CODE_OF_CONDUCT.md` | Contributor Covenant 2.1. |
+| `CODE_OF_CONDUCT.md` | A short single-maintainer policy. Previously Contributor Covenant 2.1, whose enforcement ladder described a governance structure this project does not have; the OpenSSF badge criterion asks for *a* code of conduct, not a specific text. |
 | `LICENSE` | Apache 2.0 (sealed by earlier ADRs). |
 | `.github/dependabot.yaml` | Dependabot configuration. |
 | `.github/workflows/security.yaml` | govulncheck + gosec + Trivy + CodeQL workflow. |

--- a/docs/editions.md
+++ b/docs/editions.md
@@ -1,10 +1,18 @@
 # Editions
 
-!!! warning "Pre-alpha"
-    Leoflow is **pre-alpha**. Only the **Lite** edition is officially supported
-    today (local iteration on a trusted network — not durable or production
-    use). The **Pro** chart is installable + chart-test gated, but not
-    cleared for official use until the v0.1.0-alpha cut.
+!!! info "Both editions are supported"
+    **Lite** is the local single-host edition; **Pro** is the Helm/Kubernetes
+    deployment. Both are supported today, and the README says the same.
+
+    This page previously warned that Leoflow was pre-alpha and that Pro was
+    "not cleared for official use until the v0.1.0-alpha cut". That milestone
+    does not exist — ADR 0037 removed alpha and beta from the version scheme
+    entirely, and `v0.1.0` stable shipped on 2026-06-28. The warning outlived
+    the plan it referenced and contradicted the README for weeks.
+
+    Pro is pre-1.0, which under SemVer means breaking changes ship between
+    minor versions with a migration note (ADR 0037). Read the release notes
+    before upgrading; that is the caveat, not an unsupported edition.
 
 > See also [Operating modes](operating-modes.md) for the Lite/Pro/Demo
 > runtime view (this page is the per-edition distribution + posture view).
@@ -15,7 +23,7 @@ DAG once and it runs on either.
 
 | | **Lite** | **Pro** |
 |---|---|---|
-| Status | **Available now** (pre-alpha) | **Chart installable** (gated); officially supported after v0.1.0-alpha |
+| Status | **Supported** — single host | **Supported** — Helm on Kubernetes |
 | Install | one command (`curl … \| sh`) on one machine | [Helm chart](https://github.com/neochaotic/leoflow/blob/main/helm/leoflow/README.md) on your cluster |
 | Command | `leoflow lite` | the deployed control plane |
 | Auth | a single local **admin** login (password shown once at setup) | enterprise: SSO/OIDC, full RBAC, multi-tenant |
@@ -93,11 +101,7 @@ in mind.
 
 ## Which one? (recommendation)
 
-**Today:** there is only one thing to run — **Lite**, and it's **pre-alpha**, for
-local iteration on a trusted network. Pro (the enterprise edition) is not
-released yet.
-
-**When both ship, choose by deployment, not by feature checklist:**
+**Choose by deployment, not by feature checklist:**
 
 - **Choose Lite** when you run on **one machine** (laptop, a small VM, an
   internal box), want a **one-command, Docker-free install**, and your workload


### PR DESCRIPTION
Wave 2 of #465 — the documentation-lie cleanup. The other two items from that wave already landed: #464's entropy fix in #485, and ADR 0012's dead CI references in #487.

## 1. The control-plane image is not signed, and a comment said it was

`.goreleaser.yaml:90` read *"Both shapes are signed by cosign below"*. There is **no `docker_signs` block anywhere in the file**, and the release workflow signs only `leoflow-migrate` and `leoflow-runtime`. The `signs:` block that does exist covers the **checksums file**, which protects the archives — not the images.

So `leoflow-server`, the one image the Helm chart actually deploys, is the one image that is unsigned. The comment asserted the opposite, which is worse than silence: a reviewer checking supply-chain posture would read it and move on.

Corrected to state the gap. The choice — add `docker_signs`, or document the exception in ADR 0014 — is left as its own decision rather than made inside a comment.

## 2. `docs/editions.md` contradicted the README for weeks

It warned that Leoflow was **pre-alpha** and that Pro was *"not cleared for official use until the v0.1.0-alpha cut"* — in the callout, the status table, and the recommendation section.

**That milestone does not exist.** ADR 0037 removed alpha and beta from the version scheme entirely, and `v0.1.0` stable shipped on 2026-06-28. Meanwhile `README:259` says *"Pro deployments are supported by the Helm chart today"*. A reader comparing the two had no way to tell which was current.

Now aligned with the maintainer's decision that Pro is supported, with a note recording what the page used to claim, and the caveat that is actually true: pre-1.0 means breaking changes between minors with a migration note (ADR 0037) — read the release notes before upgrading. That is a real caveat; "unsupported edition" was not.

## 3. NOTICE did not exist

The binaries embed and redistribute the **Apache Airflow 3.2.1 SPA** (`internal/ui/assets`, ADR 0017). Apache-2.0 §4(d) asks for a NOTICE when a redistributed work carries one.

Added, with attribution, the trademark disclaimer (Leoflow is not affiliated with or endorsed by the ASF), a note that the bundle is unmodified apart from navigation links, and a pointer to the per-release SBOM as the authoritative dependency list rather than restating go.mod.

## Left for the maintainer — only they have the values

| File | Problem |
|---|---|
| `SECURITY.md:11` | ships the literal string `security@leoflow.io (placeholder — replace with the project's real address)`, plus a placeholder Keybase link |
| `CODE_OF_CONDUCT.md:40` | same, `conduct@leoflow.io (placeholder)` |
| `LICENSE:189` | `Copyright [yyyy] [name of copyright owner]` — no copyright holder is asserted anywhere in the repo |

These are three lines, and they matter more than their size: a code of conduct with no working report channel is non-functional, and a security policy that publishes a placeholder address means a reporter has nowhere private to go. Both external audits flagged them.

## Verification

`mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)