### PR TITLE
fix(alerts): make the failure alert say something an operator can act on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,29 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Validated at compile and again at registration, so a hand-written or
   machine-generated `dag.json` cannot bypass the compiler.
 
+- **A typo in an alert template is now a compile error.** An unknown placeholder
+  is not a rendering failure — `Render` leaves it alone — so `{{taskk}}` used to
+  survive compile and reach the operator verbatim, discovered in the alert that
+  was supposed to explain an outage. `leoflow compile` now rejects it, naming the
+  offending placeholder and listing the supported set. Airflow-style names
+  (`{{ ds }}`) are reported by name rather than passing through as text.
+
+### Fixed
+
+- **Alert messages carried a UUID where the run id belongs.** `{{run_id}}`
+  rendered `RunState.RunID`, which is the `dag_runs` primary key — not the
+  `run_id` an operator sees in the UI and passes to the API. The alert named a
+  run nobody could look up. It now renders the user-facing id.
+
+- **`{{logical_date}}` always rendered empty.** The placeholder was documented and
+  substituted, but the dispatcher never populated the field, so every alert using
+  it produced a dangling `for `. `RunState` now carries the logical date and the
+  dispatcher passes it through.
+
+- **A placeholder with no value renders `(none)`** instead of an empty string —
+  `{{logical_date}}` on a manually triggered run, for example. `failed for
+  logical date ` is indistinguishable from a truncated message.
+
 ### Security
 
 - **Hardened the log sink against path escape.** `DiskSink` interpolated every

--- a/docs/alerting.md
+++ b/docs/alerting.md
@@ -88,11 +88,21 @@ time; when omitted, Leoflow sends a default one-line summary.
 
 | Placeholder        | Becomes                                             |
 | ------------------ | --------------------------------------------------- |
-| `{{dag}}`          | the DAG id                                          |
-| `{{run_id}}`       | the failed run id                                   |
-| `{{logical_date}}` | the run's logical date (empty for unscheduled runs) |
-| `{{task}}`         | the first task that failed                          |
-| `{{tasks}}`        | every failed task, comma-separated                  |
+| `{{dag}}`          | the DAG id                                              |
+| `{{run_id}}`       | the run id you see in the UI (`manual__2026-07-30T…`)   |
+| `{{logical_date}}` | the run's logical date, RFC3339                         |
+| `{{task}}`         | the first task that failed                              |
+| `{{tasks}}`        | every failed task, comma-separated                      |
+
+A placeholder with no value for this run renders `(none)` rather than an empty
+string — `{{logical_date}}` on a manually triggered run, for example. An alert
+reading `failed for logical date ` is indistinguishable from a truncated one, so
+the marker is deliberate.
+
+Anything else in `{{…}}` is a **compile error**, naming the offending placeholder
+and listing what is available. A typo used to survive compile and reach the
+alert verbatim, which meant discovering it in the message that was supposed to
+explain an outage.
 
 **What each channel receives:**
 

--- a/internal/alerts/alerts.go
+++ b/internal/alerts/alerts.go
@@ -40,18 +40,54 @@ func Render(tmpl string, ev Event) string {
 			tmpl += ": {{tasks}}"
 		}
 	}
-	firstTask := ""
-	if len(ev.FailedTasks) > 0 {
-		firstTask = ev.FailedTasks[0]
+	pairs := make([]string, 0, 2*len(Placeholders))
+	for _, name := range Placeholders {
+		pairs = append(pairs, "{{"+name+"}}", ev.value(name))
 	}
-	r := strings.NewReplacer(
-		"{{dag}}", ev.DagID,
-		"{{run_id}}", ev.RunID,
-		"{{logical_date}}", ev.LogicalDate,
-		"{{task}}", firstTask,
-		"{{tasks}}", strings.Join(ev.FailedTasks, ", "),
-	)
-	return r.Replace(tmpl)
+	return strings.NewReplacer(pairs...).Replace(tmpl)
+}
+
+// Placeholders names every substitution Render performs, in the order it
+// documents them. Template validation reads this list, so a placeholder added to
+// value() and here is supported everywhere at once — and one added to only one of
+// them fails the round-trip test rather than silently half-working.
+var Placeholders = []string{"dag", "run_id", "logical_date", "task", "tasks"}
+
+// absent is what a placeholder renders when the run carries no value for it. A
+// literal marker beats an empty string: "failed for logical date " reads as a
+// broken alert, and an operator cannot tell it from a truncated one.
+const absent = "(none)"
+
+// value resolves one placeholder name against the event.
+func (ev Event) value(name string) string {
+	switch name {
+	case "dag":
+		return orAbsent(ev.DagID)
+	case "run_id":
+		return orAbsent(ev.RunID)
+	case "logical_date":
+		// Empty on an unscheduled (manually triggered) run, which is legitimate.
+		return orAbsent(ev.LogicalDate)
+	case "task":
+		if len(ev.FailedTasks) == 0 {
+			return absent
+		}
+		return ev.FailedTasks[0]
+	case "tasks":
+		if len(ev.FailedTasks) == 0 {
+			return absent
+		}
+		return strings.Join(ev.FailedTasks, ", ")
+	default:
+		return ""
+	}
+}
+
+func orAbsent(v string) string {
+	if v == "" {
+		return absent
+	}
+	return v
 }
 
 // Notifier posts resolved alerts over HTTP. It is safe for concurrent use.

--- a/internal/alerts/alerts_test.go
+++ b/internal/alerts/alerts_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -112,4 +113,40 @@ func contains(s, sub string) bool {
 		}
 	}
 	return false
+}
+
+// Placeholders and value() are two halves of one vocabulary. If a name is added
+// to the list without a case in value(), Render substitutes an empty string and
+// the alert silently loses a field; if it is added to value() without the list,
+// template validation rejects a placeholder that actually works. This ties them.
+func TestEveryPlaceholderIsSubstituted(t *testing.T) {
+	ev := Event{
+		DagID:       "etl",
+		RunID:       "manual__2026-07-30T12:00:00+00:00",
+		LogicalDate: "2026-07-30T00:00:00Z",
+		FailedTasks: []string{"extract", "load"},
+	}
+	for _, name := range Placeholders {
+		tmpl := "{{" + name + "}}"
+		got := Render(tmpl, ev)
+		if got == tmpl {
+			t.Errorf("%s was left literal — declared in Placeholders with no case in value()", tmpl)
+		}
+		if got == "" {
+			t.Errorf("%s rendered empty on a fully-populated event", tmpl)
+		}
+	}
+}
+
+// A populated event must never render the absent marker.
+func TestAbsentMarkerOnlyForMissingValues(t *testing.T) {
+	full := Event{DagID: "etl", RunID: "r1", LogicalDate: "2026-07-30T00:00:00Z", FailedTasks: []string{"x"}}
+	if got := Render("{{dag}} {{run_id}} {{logical_date}} {{task}} {{tasks}}", full); strings.Contains(got, "(none)") {
+		t.Errorf("a fully-populated event rendered the absent marker: %q", got)
+	}
+	empty := Event{}
+	got := Render("{{dag}}|{{run_id}}|{{logical_date}}|{{task}}|{{tasks}}", empty)
+	if got != "(none)|(none)|(none)|(none)|(none)" {
+		t.Errorf("empty event rendered %q, want the marker for every field", got)
+	}
 }

--- a/internal/domain/alert_template.go
+++ b/internal/domain/alert_template.go
@@ -1,0 +1,59 @@
+package domain
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/neochaotic/leoflow/internal/alerts"
+)
+
+// ErrUnknownAlertPlaceholder reports an alert message template referencing a
+// substitution Leoflow does not perform.
+var ErrUnknownAlertPlaceholder = errors.New("unknown alert placeholder")
+
+// placeholderRe matches a {{name}} span, tolerating inner spaces so an
+// Airflow-style "{{ ds }}" is reported by name rather than passing through as
+// unrecognized text.
+var placeholderRe = regexp.MustCompile(`\{\{\s*([^{}]*?)\s*\}\}`)
+
+// validateAlertTemplates rejects a placeholder Render will not substitute.
+//
+// An unknown placeholder is not a rendering error — Render leaves it alone — so
+// it survives compile and reaches the operator verbatim. "etl failed on
+// {{taskk}}" is a silent misconfiguration that only shows itself in the alert
+// that was supposed to explain an outage, which is the worst moment to find it.
+//
+// The check runs at compile, while the author is still looking at the file.
+func (c *LeoflowConfig) validateAlertTemplates() error {
+	if c.Alerts == nil {
+		return nil
+	}
+	known := make(map[string]bool, len(alerts.Placeholders))
+	for _, name := range alerts.Placeholders {
+		known[name] = true
+	}
+	for i, rule := range c.Alerts.OnFailure {
+		var unknown []string
+		for _, m := range placeholderRe.FindAllStringSubmatch(rule.Message, -1) {
+			if name := m[1]; !known[name] {
+				unknown = append(unknown, name)
+			}
+		}
+		if len(unknown) > 0 {
+			return fmt.Errorf("%w in alerts.on_failure[%d].message: %s; supported: %s",
+				ErrUnknownAlertPlaceholder, i, strings.Join(unknown, ", "), supportedList())
+		}
+	}
+	return nil
+}
+
+// supportedList renders the placeholder vocabulary for an error message.
+func supportedList() string {
+	out := make([]string, 0, len(alerts.Placeholders))
+	for _, name := range alerts.Placeholders {
+		out = append(out, "{{"+name+"}}")
+	}
+	return strings.Join(out, " ")
+}

--- a/internal/domain/alert_template_test.go
+++ b/internal/domain/alert_template_test.go
@@ -1,0 +1,65 @@
+package domain
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// A typo in an alert template used to survive compile and reach the operator
+// verbatim: an alert reading "etl failed on {{taskk}}" is a silent misconfig
+// discovered at the worst moment. Compile is the place to catch it.
+func TestValidateAlertTemplates(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		message string
+		valid   bool
+		wants   string
+	}{
+		{name: "empty is fine", message: "", valid: true},
+		{name: "no placeholders", message: "something broke", valid: true},
+		{name: "every known placeholder", valid: true,
+			message: "{{dag}} {{run_id}} {{logical_date}} {{task}} {{tasks}}"},
+		{name: "typo", message: "failed on {{taskk}}", valid: false, wants: "taskk"},
+		{name: "airflow-style name we do not support", message: "{{ ds }}", valid: false, wants: "ds"},
+		{name: "invented", message: "{{owner}} should look", valid: false, wants: "owner"},
+		{name: "reports every unknown, not just the first", valid: false,
+			message: "{{nope}} and {{alsonope}}", wants: "alsonope"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &LeoflowConfig{Alerts: &AlertsConfig{OnFailure: []AlertRule{
+				{Type: "slack", Conn: "c", Message: tc.message},
+			}}}
+			err := cfg.validateAlertTemplates()
+			if tc.valid {
+				if err != nil {
+					t.Fatalf("validateAlertTemplates(%q) = %v, want nil", tc.message, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateAlertTemplates(%q) = nil, want an error", tc.message)
+			}
+			if !errors.Is(err, ErrUnknownAlertPlaceholder) {
+				t.Errorf("error does not wrap ErrUnknownAlertPlaceholder: %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.wants) {
+				t.Errorf("error %q does not name %q", err, tc.wants)
+			}
+			// The message must tell the author what they may use instead.
+			if !strings.Contains(err.Error(), "{{dag}}") {
+				t.Errorf("error %q does not list the supported placeholders", err)
+			}
+		})
+	}
+}
+
+// The rule must survive a nil Alerts block and a config with no rules.
+func TestValidateAlertTemplatesNoAlerts(t *testing.T) {
+	if err := (&LeoflowConfig{}).validateAlertTemplates(); err != nil {
+		t.Errorf("a config with no alerts should validate: %v", err)
+	}
+	if err := (&LeoflowConfig{Alerts: &AlertsConfig{}}).validateAlertTemplates(); err != nil {
+		t.Errorf("an empty on_failure list should validate: %v", err)
+	}
+}

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -224,5 +224,8 @@ func (c *LeoflowConfig) Validate() error {
 	if err != nil {
 		return err
 	}
-	return validateAgainst(s.leoflow, c)
+	if err := validateAgainst(s.leoflow, c); err != nil {
+		return err
+	}
+	return c.validateAlertTemplates()
 }

--- a/internal/failurealert/dispatcher.go
+++ b/internal/failurealert/dispatcher.go
@@ -88,7 +88,14 @@ func (d *Dispatcher) AlertRunFailed(ctx context.Context, run scheduler.RunState)
 		return true
 	}
 	delivered := true
-	ev := alerts.Event{DagID: run.DagID, RunID: run.RunID, FailedTasks: failedTasks(run)}
+	ev := alerts.Event{
+		DagID: run.DagID,
+		// The user-facing run id, not RunState.RunID: an operator cannot paste a
+		// UUID into the UI or the API.
+		RunID:       run.DisplayRunID,
+		LogicalDate: run.LogicalDate,
+		FailedTasks: failedTasks(run),
+	}
 	for _, rule := range run.Alerts.OnFailure {
 		endpoint, err := d.resolver.ResolveAlertEndpoint(ctx, run.TenantID, rule.Conn)
 		if err != nil {

--- a/internal/failurealert/dispatcher_test.go
+++ b/internal/failurealert/dispatcher_test.go
@@ -198,3 +198,59 @@ func TestAlertRunFailedForwardsHeaders(t *testing.T) {
 func TestDispatcherImplementsAlerter(t *testing.T) {
 	var _ scheduler.Alerter = New(&fakeSender{}, &fakeResolver{}, nil, quietLogger())
 }
+
+// An operator reading the alert needs the run identifier they can paste into the
+// UI or the API. RunState.RunID is the database UUID; the user-facing id is the
+// dag_runs.run_id column, which is what {{run_id}} must render.
+func TestAlertRunFailedRendersUserFacingRunID(t *testing.T) {
+	run := failedRun()
+	run.RunID = "018f3a1c-7e6b-7c3a-9f21-4d5e6f7a8b9c" // the UUID the scheduler carries
+	run.DisplayRunID = "manual__2026-07-30T12:00:00+00:00"
+	run.Alerts.OnFailure = []domain.AlertRule{{Type: "slack", Conn: "slack_prod", Message: "run {{run_id}}"}}
+
+	snd := &fakeSender{}
+	d := New(snd, &fakeResolver{urls: map[string]string{"slack_prod": "https://example.invalid/hook"}}, nil, quietLogger())
+	d.AlertRunFailed(context.Background(), run)
+
+	if len(snd.sent) != 1 {
+		t.Fatalf("sent %d alerts, want 1", len(snd.sent))
+	}
+	if got := snd.sent[0].message; got != "run manual__2026-07-30T12:00:00+00:00" {
+		t.Errorf("message = %q, want the user-facing run id, not the UUID", got)
+	}
+}
+
+// {{logical_date}} is a documented placeholder, so it must not render empty on a
+// scheduled run: an alert saying "failed for logical date " is worse than useless
+// for the operator deciding whether to backfill.
+func TestAlertRunFailedRendersLogicalDate(t *testing.T) {
+	run := failedRun()
+	run.LogicalDate = "2026-07-30T00:00:00Z"
+	run.Alerts.OnFailure = []domain.AlertRule{{Type: "slack", Conn: "slack_prod", Message: "for {{logical_date}}"}}
+
+	snd := &fakeSender{}
+	d := New(snd, &fakeResolver{urls: map[string]string{"slack_prod": "https://example.invalid/hook"}}, nil, quietLogger())
+	d.AlertRunFailed(context.Background(), run)
+
+	if len(snd.sent) != 1 {
+		t.Fatalf("sent %d alerts, want 1", len(snd.sent))
+	}
+	if got := snd.sent[0].message; got != "for 2026-07-30T00:00:00Z" {
+		t.Errorf("message = %q, want the logical date substituted", got)
+	}
+}
+
+// An unscheduled run has no logical date. Rather than leaving a dangling "for ",
+// the placeholder renders a legible marker.
+func TestAlertRunFailedLogicalDateAbsent(t *testing.T) {
+	run := failedRun()
+	run.Alerts.OnFailure = []domain.AlertRule{{Type: "slack", Conn: "slack_prod", Message: "for {{logical_date}}"}}
+
+	snd := &fakeSender{}
+	d := New(snd, &fakeResolver{urls: map[string]string{"slack_prod": "https://example.invalid/hook"}}, nil, quietLogger())
+	d.AlertRunFailed(context.Background(), run)
+
+	if got := snd.sent[0].message; got != "for (none)" {
+		t.Errorf("message = %q, want a legible marker for an absent logical date", got)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -37,12 +37,23 @@ func logSchedulerError(logger *slog.Logger, msg string, err error, inStepDown bo
 // RunState is the scheduler's snapshot of a dag run: its topology and the
 // current state of each task.
 type RunState struct {
-	RunID    string
-	DagID    string
-	TenantID string
-	State    domain.DagRunState
-	Tasks    []domain.TaskSpec
-	States   map[string]domain.TaskState
+	// RunID is the dag_runs primary key (a UUID). It is what dispatch, the agent
+	// token and the log sink key on, so it must not be swapped for the
+	// user-facing id.
+	RunID string
+	// DisplayRunID is the dag_runs.run_id column — the identifier an operator
+	// sees in the UI and passes to the API ("manual__2026-07-30T12:00:00+00:00").
+	// Alerts render this one: a UUID is not something anyone can act on.
+	DisplayRunID string
+	// LogicalDate is the run's logical date in RFC3339, empty for an unscheduled
+	// run. Carried here so an alert can say which interval failed without a
+	// second query.
+	LogicalDate string
+	DagID       string
+	TenantID    string
+	State       domain.DagRunState
+	Tasks       []domain.TaskSpec
+	States      map[string]domain.TaskState
 	// Tries and MaxTries hold the current and maximum attempt counts per task,
 	// driving retry decisions. Absent entries mean no retry budget.
 	Tries    map[string]int

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -85,6 +85,8 @@ func (s *SchedulerStore) ActiveRuns(ctx context.Context) ([]scheduler.RunState, 
 		}
 		out = append(out, scheduler.RunState{
 			RunID:             uuidToString(run.ID),
+			DisplayRunID:      run.RunID,
+			LogicalDate:       rfc3339OrEmpty(run.LogicalDate),
 			DagID:             spec.DagID,
 			TenantID:          uuidToString(run.TenantID),
 			State:             domain.DagRunState(run.State),
@@ -499,4 +501,14 @@ func (s *SchedulerStore) ListActiveStagingVolumes(ctx context.Context) ([]domain
 		})
 	}
 	return out, nil
+}
+
+// rfc3339OrEmpty renders a nullable timestamp for display, empty when absent.
+// Alerts show this value, so the format is the one the API already emits rather
+// than Go's default.
+func rfc3339OrEmpty(ts pgtype.Timestamptz) string {
+	if !ts.Valid {
+		return ""
+	}
+	return ts.Time.UTC().Format(time.RFC3339)
 }


### PR DESCRIPTION
Three defects in the same payload, each of which made the alert less useful than the log line it was meant to save someone from reading — plus the fourth that explains why the first two survived.

## `{{run_id}}` rendered a UUID

It substituted `RunState.RunID`, which is the `dag_runs` **primary key**. The identifier an operator needs is the `dag_runs.run_id` column — the one the UI shows and the API accepts (`/api/v2/dags/etl/dagRuns/manual__2026-…`). The alert named a run nobody could look up.

`RunState` now carries both, and both are documented for what they are: `DisplayRunID` as the user-facing id, `RunID` as the key dispatch, the agent token and the log sink depend on. That comment is the point — swapping them is an easy and quiet mistake.

## `{{logical_date}}` always rendered empty

Documented in `docs/alerting.md`, substituted by `Render`, and **never populated** by the dispatcher. Every template using it produced a dangling `for `. The value is on the run row the scheduler already reads.

## An absent value rendered as nothing

`failed for logical date ` is indistinguishable from a truncated message. An absent value now renders `(none)` — legitimate for `{{logical_date}}` on a manually triggered run.

## The one that let the others survive: unknown placeholders were never an error

`Render` leaves `{{taskk}}` alone, so a typo passed compile, passed registration, and was discovered **in the alert that was supposed to explain an outage**.

`leoflow compile` now rejects it, naming the offending placeholder and listing the supported set. Airflow-style spellings are matched with inner whitespace, so `{{ ds }}` is reported by name rather than passing through as prose.

## Root cause: the vocabulary had no owner

A documented placeholder could go unpopulated because the list of names lived in the docs, the substitution lived in `Render`, and nothing tied them.

`alerts.Placeholders` is now the single list. `Render` builds its replacer from it via `Event.value`, and the domain validator reads it. A test walks the list and fails if any entry is left literal or renders empty on a fully-populated event:

```go
for _, name := range Placeholders {
    tmpl := "{{" + name + "}}"
    if got := Render(tmpl, ev); got == tmpl {
        t.Errorf("%s was left literal — declared in Placeholders with no case in value()", tmpl)
    }
}
```

So a name added to one half without the other cannot ship.

## Verification

- All new tests written first and observed failing (the two `RunState` ones at compile, the rest on assertions)
- `go test ./...` green
- `golangci-lint run` — 0 issues
- `mkdocs build --strict` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)