### PR TITLE
fix(ci): point dependabot at directories that exist, and gate that

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -22,26 +22,40 @@ updates:
       day: monday
     labels: ["dependencies", "ci"]
 
-  # Docker base images
+  # Docker base images.
+  #
+  # These three entries previously pointed at /runtime/python-3.10, -3.11 and
+  # -3.12, none of which exist in this repository. Dependabot silently finds no
+  # manifest at a missing directory, so base-image updates never ran at all —
+  # the config looked configured and did nothing. scripts/check-dependabot-dirs.sh
+  # now fails CI on a path that does not resolve.
+  #
+  # Scoped to the images that ship: the two deploy images and the task runtime
+  # base. examples/*/Dockerfile is deliberately excluded — 24 demo images would
+  # produce weekly PR noise for artifacts nobody deploys, and each is generated
+  # from its leoflow.yaml by scripts/sync-example-dockerfiles.sh anyway.
   - package-ecosystem: docker
-    directory: "/runtime/python-3.10"
+    directories:
+      - "/deploy"
+      - "/runtime"
     schedule:
       interval: weekly
-    labels: ["dependencies", "docker"]
-  - package-ecosystem: docker
-    directory: "/runtime/python-3.11"
-    schedule:
-      interval: weekly
-    labels: ["dependencies", "docker"]
-  - package-ecosystem: docker
-    directory: "/runtime/python-3.12"
-    schedule:
-      interval: weekly
+      day: monday
+    groups:
+      docker-base-images:
+        patterns: ["*"]
     labels: ["dependencies", "docker"]
 
-  # Python parser dependencies
+  # Python dependencies. Both projects carry their own pyproject.toml; only
+  # /parser was covered before, so runtime/python's dependencies went unwatched.
   - package-ecosystem: pip
-    directory: "/parser"
+    directories:
+      - "/parser"
+      - "/runtime/python"
     schedule:
       interval: weekly
+      day: monday
+    groups:
+      python:
+        patterns: ["*"]
     labels: ["dependencies", "python"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -651,6 +651,24 @@ jobs:
         run: bash scripts/sync-example-dockerfiles.sh --check
 
   # ─────────────────────────────────────────────────────────────────────
+  # Dependabot directory check. Dependabot does not report a directory
+  # with no manifest — it finds nothing and says nothing — so an entry
+  # for a renamed or nonexistent path looks configured and updates
+  # nothing. Three docker entries pointed at /runtime/python-3.1{0,1,2},
+  # none of which are in the tree, and no base image was ever updated.
+  # A missing update is invisible by definition, so it needs a gate.
+  # ─────────────────────────────────────────────────────────────────────
+  dependabot-dirs:
+    name: Dependabot directories resolve
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install PyYAML
+        run: python3 -m pip install --user pyyaml
+      - name: Check every dependabot directory exists
+        run: bash scripts/check-dependabot-dirs.sh
+
+  # ─────────────────────────────────────────────────────────────────────
   # Python parser tests — matrix across every Python the host detector
   # claims to support (`internal/setup/detect.go` pythonCandidates). If a
   # new minor is added to that list, add it here too — otherwise the

--- a/scripts/check-dependabot-dirs.sh
+++ b/scripts/check-dependabot-dirs.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Verify every directory .github/dependabot.yaml points at actually exists.
+#
+# Dependabot does not complain about a directory with no manifest — it finds
+# nothing and reports nothing. A config entry for a path that was renamed or
+# never existed therefore looks configured and silently updates nothing, which
+# is how this repository went its whole life without a single base-image update:
+# three docker entries pointed at /runtime/python-3.1{0,1,2}, none of which are
+# in the tree.
+#
+# Nothing else can catch this. Dependabot's own validation checks syntax, not
+# whether the path resolves, and a missing update is invisible by definition.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+config=".github/dependabot.yaml"
+
+if [[ ! -f "$config" ]]; then
+	echo "FAIL: $config not found" >&2
+	exit 1
+fi
+
+python3 - "$config" <<'PY'
+import os
+import sys
+
+try:
+	import yaml
+except ImportError:
+	sys.exit("SKIP: PyYAML unavailable; cannot verify dependabot directories")
+
+config = sys.argv[1]
+with open(config, encoding="utf-8") as fh:
+	cfg = yaml.safe_load(fh)
+
+missing = []
+checked = 0
+for update in cfg.get("updates", []):
+	eco = update.get("package-ecosystem", "?")
+	dirs = update.get("directories") or [update.get("directory")]
+	for d in dirs:
+		if d is None or "*" in d:
+			# A glob is resolved by Dependabot at run time; nothing to verify.
+			continue
+		checked += 1
+		# "/" is the repo root: lstrip leaves an empty string, which is not a dir.
+		if not os.path.isdir(d.lstrip("/") or "."):
+			missing.append(f"  {eco}: {d}")
+
+if missing:
+	print(f"FAIL: {config} points at directories that do not exist:")
+	print("\n".join(missing))
+	print("\nDependabot silently finds no manifest there, so those updates never run.")
+	sys.exit(1)
+
+print(f"OK: all {checked} dependabot directories resolve")
+PY


### PR DESCRIPTION
## The bug

Three `docker` entries in `.github/dependabot.yaml` pointed at:

```
/runtime/python-3.10
/runtime/python-3.11
/runtime/python-3.12
```

**None of those directories are in the tree, and none ever were.** Dependabot does not report a directory with no manifest — it finds nothing and says nothing. The config looked configured and did nothing.

This repository has never had a base-image update.

Also: the `pip` entry listed only `/parser`, so `runtime/python` — which has its own `pyproject.toml` — was never watched.

## The fix

Rescoped to the images that actually ship, grouped so a week's bumps arrive as one PR:

| directory | what's there |
|---|---|
| `/deploy` | `Dockerfile.server`, `.migrate`, `.server.release` |
| `/runtime` | the task runtime base image |

`examples/*/Dockerfile` is **deliberately excluded**. 24 demo images would mean weekly PR noise for artifacts nobody deploys, and each one is generated from its `leoflow.yaml` by `scripts/sync-example-dockerfiles.sh` — so the base there follows the YAML, not a Dependabot bump.

## The gate matters more than the fix

A missing update is **invisible by definition**: nothing fails, no PR appears, and the file reads as correct. Dependabot's own validation checks syntax, not whether a path resolves. That is why this survived from the repository's first commit.

`scripts/check-dependabot-dirs.sh` walks every entry and fails when a directory does not exist. Verified by pointing one back at `/runtime/python-3.10`:

```
FAIL: .github/dependabot.yaml points at directories that do not exist:
  docker: /runtime/python-3.10

Dependabot silently finds no manifest there, so those updates never run.
```

## One note on the checker itself

Its first version reported the two legitimate `"/"` entries as missing — `lstrip("/")` on the repo root yields an empty string, and `os.path.isdir("")` is false. A checker whose failure output is wrong is worse than no checker, so the root case is handled explicitly.

## Verification

- `scripts/check-dependabot-dirs.sh` → `OK: all 6 dependabot directories resolve`
- Fails as shown above when a path is broken
- `actionlint` clean on the modified workflow

Found while triaging the 96 code-scanning alerts. 🤖 Generated with [Claude Code](https://claude.com/claude-code)