### PR TITLE
docs(adr): accept 0031 and 0045, mark 0043 accepted-but-partial

### DIFF
--- a/docs/adr/0031-scheduler-architecture.md
+++ b/docs/adr/0031-scheduler-architecture.md
@@ -1,7 +1,8 @@
 # ADR 0031: Scheduler Architecture — Reconciliation Loop, Two-Phase Dispatch, Two-Layer Reaping
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-05-28
+**Accepted:** 2026-07-31 — all three mechanisms are in production: the reconciliation loop (`internal/scheduler/`), two-phase dispatch (`launchQueued` + `BufferedDispatcher`), and two-layer reaping (`reap.go`, `heartbeat_reap.go`, `stale_queued_reap.go`). Cited as the authority for scheduler behaviour in 17 places across code and docs.
 
 ## Context
 

--- a/docs/adr/0043-taskgroup-split-fused-execution.md
+++ b/docs/adr/0043-taskgroup-split-fused-execution.md
@@ -1,6 +1,6 @@
 # ADR 0043: TaskGroup as a first-class construct with split/fused execution
 
-**Status:** Proposed — fused parallelism PoC-validated; implementation post-0042, dbt-first
+**Status:** Accepted — implementation partial. The dbt-domain split ships (`internal/dbt/`, ADR 0044); the **generic** `TaskGroup` construct in a `dag.py` remains deliberately rejected by the parser (it is in `test_unsupported_constructs_error_clearly`), so an author cannot yet use TaskGroup outside dbt. The decision — TaskGroup as a first-class construct with split/fused execution — is accepted; the general-purpose implementation is deferred. Do not read "Accepted" as "TaskGroup is available."
 **Date:** 2026-06-25
 **Companions:** ADR 0003 (DAG as immutable artifact), ADR 0024 (parser shim — currently rejects TaskGroup), ADR 0040 (operator support), ADR 0042 (dbt support), the editions split (Lite/Pro)
 

--- a/docs/adr/0045-declared-secret-delivery.md
+++ b/docs/adr/0045-declared-secret-delivery.md
@@ -1,9 +1,19 @@
 # ADR 0045: Secrets reach a task because it declared them
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-07-30
+**Accepted:** 2026-07-31
 **Relates:** ADR 0019 (encryption at rest), ADR 0021 (exposing variables/connections to pods), ADR 0004 (thin agent), ADR 0035 (Leoflow is not a key manager)
 **Issues:** #59, #388, #476, #486
+
+> **This completes the follow-up ADR 0021 scheduled**, not a defect it missed.
+> ADR 0021 (Accepted) chose on-demand fetch, shipped fetch-all as its MVP, and
+> named the gap in its own text: *"Fetch-all at boot = no least-privilege… Tracked
+> as a follow-up (scope to referenced secrets)"*, under the stated trust model
+> *"do not run untrusted code/images"*. What changed is the target — multiple
+> teams in one Pro install cannot keep "trusted code" as the model — not a
+> discovery that the old code was wrong. This ADR supersedes only ADR 0021's
+> scoping clause; the fetch mechanism and TLS prerequisite stand.
 
 ## Context
 
@@ -111,9 +121,39 @@ container it is filtering for, so anything it can fetch, user code can fetch.
 **Encrypt per task with a task-scoped key.** Moves the problem — the task needs
 its key, and the key is delivered the same way the secrets were.
 
-## Open
+## Settled (2026-07-31)
 
-- Whether declaration is per DAG, per task, or both. Per task is tighter; per DAG
-  is far less to write and matches how most DAGs actually use credentials.
-- Whether an undeclared use fails the compile or the registration. Compile is
-  friendlier, but only registration knows which connections exist.
+The two questions left open above are decided, plus four points that surfaced
+when the codebase was traced against this ADR (`leoflow-research/adr-0045-readiness.md`):
+
+1. **Per DAG, with optional per-task narrowing.** The blast radius that matters
+   is "another team's credentials", which DAG-level declaration closes. Per-task
+   is available for authors who want it tighter. Note: the existing
+   `TaskSpec.Secrets` field (`{name, source, reference}`) is the `secretKeyRef`
+   shape this ADR §4 rejects — it is dead code and is deleted here, not reused. A
+   new per-task field is added if per-task narrowing is exercised.
+
+2. **Both compile and registration reject an undeclared use** — different checks,
+   not a choice: compile knows whether a name is declared in `leoflow.yaml`;
+   only the server knows whether that connection exists.
+
+3. **Two-release arc, because this is breaking.** Eight of the 22 examples
+   (`http_load`, `postgres_load`, `mysql_load`, `mssql_load`, `redis_load`,
+   `sqlite_load`, `gcp_gcs_load`, `postgres_hook_load`) use a connection without
+   declaring one. Release N ships the declaration field + **warn-and-deliver**
+   (behaviour unchanged, but every undeclared use is recorded and surfaced) and
+   declares those examples. Release N+1 flips warn to enforce. Shipping
+   enforcement in one step would red the project's own CI.
+
+4. **The migration warning records real runtime use, not static inference.**
+   `get_connection` / `Variable.get` inside a TaskFlow `@task` is arbitrary
+   Python the parser cannot see (verified: no handling in `parser/`), so static
+   inference cannot carry the migration. The warn phase instruments the runtime's
+   resolution path so the author is told which connections a task actually read.
+   This recording is net-new runtime work and lands with the declaration field.
+
+5. **Naming: keep `connections:` / `variables:`.** They are the Airflow-native
+   words. `leoflow.yaml` already has `connectors:` (pip provider packages, ADR
+   0038) one letter away — the compile fails loud when a known provider name
+   appears under `connections`, turning the collision into an actionable error
+   rather than a silent mistake.


### PR DESCRIPTION
Maintainer-approved ADR status changes (CLAUDE.md rule 4). Each flip was **verified against the actual implementation** before editing — a bare "Accepted" on an unimplemented ADR is the same "document that lies" defect the recent docs work has been closing.

## 0031 — Scheduler Architecture → **Accepted** (clean)

All three decided mechanisms are in production:
- reconciliation loop (`internal/scheduler/`)
- two-phase dispatch (`launchQueued` + `BufferedDispatcher`)
- two-layer reaping (`reap.go`, `heartbeat_reap.go`, `stale_queued_reap.go`)

## 0043 — TaskGroup → **Accepted, implementation partial**

The dbt-domain split ships (`internal/dbt/`). The **generic** `TaskGroup` in a `dag.py` is still **deliberately rejected** by the parser — it sits in `test_unsupported_constructs_error_clearly`. The *decision* is accepted; the general-purpose *implementation* is deferred, and the status line says exactly that so nobody reads "Accepted" as "TaskGroup works."

> Correcting myself: I earlier called 0043 "implemented, cited 11 times." Those citations are the dbt path, not the construct. Verified and fixed here.

## 0045 — Declared secret delivery → **Accepted**, decisions recorded

Reframed as **completing the follow-up ADR 0021 already scheduled** (*"scope to referenced secrets"*), under a trust model that changed with the enterprise target — not a vulnerability the old code missed. Supersedes only 0021's scoping clause.

Six settled decisions recorded in the ADR: per-DAG (optional per-task), reject at both compile and registration, two-release warn-then-enforce arc (8 of 22 examples would break otherwise), runtime-recorded migration (static inference can't see `@task` bodies), keep `connections:`/`variables:` naming with a loud collision error against `connectors:`, and delete the dead `TaskSpec.Secrets` field (it is the `secretKeyRef` shape this ADR rejects).

Backing trace: `leoflow-research/adr-0045-readiness.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)