### PR TITLE
fix(executor): record a pod's failure before garbage-collecting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The pod reconciler could garbage-collect a failed pod before its failure was
+  recorded.** `Reconcile` reported a failed pod's task instance and then deleted
+  the pod if it had aged out — but the delete ran whether or not the report
+  succeeded. A transient metadatabase error during `FailTask` meant the pod (the
+  only signal that would let the next tick retry) was deleted anyway, stranding
+  the task instance in `running` until the slower heartbeat reaper caught it. The
+  reconciler now defers collection of a failed pod until its failure is durably
+  recorded; a succeeded pod, which has nothing to record, is still collected on
+  age alone. (One component was both the state-recorder and the garbage-collector
+  with no ordering between them.)
+
 ### Added
 
 - **`leoflow compile` now rejects a task graph that cannot execute.** Three

--- a/internal/executor/reconcile.go
+++ b/internal/executor/reconcile.go
@@ -101,24 +101,42 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 	for i := range pods.Items {
 		pod := &pods.Items[i]
 		outcome, reason := classifyPod(pod)
-		if outcome == podFailed {
-			r.reportFailure(ctx, pod, reason)
+		if outcome == podPending {
+			continue
 		}
-		if outcome != podPending && r.now().Sub(pod.CreationTimestamp.Time) > r.ttl {
+		// A failed pod must have its failure durably recorded before it is
+		// collected: the pod is the only signal that lets the next tick retry the
+		// report, so deleting it after a failed report strands the task instance
+		// in `running` until the heartbeat reaper catches it. If the report does
+		// not succeed, leave the pod and try again next tick. A succeeded pod has
+		// nothing to record, so it is collected on age alone.
+		if outcome == podFailed {
+			if err := r.reportFailure(ctx, pod, reason); err != nil {
+				continue
+			}
+		}
+		if r.now().Sub(pod.CreationTimestamp.Time) > r.ttl {
 			r.collect(ctx, pod)
 		}
 	}
 	return nil
 }
 
-func (r *Reconciler) reportFailure(ctx context.Context, pod *corev1.Pod, reason string) {
+// reportFailure records the pod's failure against its task instance. It returns
+// nil when there is nothing to record (a pod with no task-instance annotation is
+// an orphan with no terminal state to preserve, so its caller may collect it) and
+// the reporter's error otherwise, so the caller can defer collection until the
+// failure is durably recorded.
+func (r *Reconciler) reportFailure(ctx context.Context, pod *corev1.Pod, reason string) error {
 	tiID := pod.Annotations["leoflow.io/task-instance-id"]
 	if tiID == "" {
-		return
+		return nil
 	}
 	if err := r.reporter.FailTask(ctx, tiID, reason); err != nil {
 		slog.Error("reporting failed pod", "pod", pod.Name, "task_instance", tiID, "error", err)
+		return err
 	}
+	return nil
 }
 
 func (r *Reconciler) collect(ctx context.Context, pod *corev1.Pod) {

--- a/internal/executor/reconcile_extra_test.go
+++ b/internal/executor/reconcile_extra_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	ktesting "k8s.io/client-go/testing"
@@ -82,5 +83,58 @@ func TestReconcileToleratesGCDeleteError(t *testing.T) {
 	r.ttl = 10 * time.Minute
 	if err := r.Reconcile(context.Background()); err != nil {
 		t.Errorf("a GC delete error must not fail the reconcile, got %v", err)
+	}
+}
+
+// TestReconcileKeepsFailedPodWhenReportErrors: a failed pod must not be
+// garbage-collected until its failure has been durably recorded. The pod is the
+// only signal that lets the next tick retry the report; deleting it after a
+// failed FailTask strands the task instance in `running` until the heartbeat
+// reaper (the slower backstop) catches it. So a failed report on an aged pod
+// skips collection and the next tick tries again. Never let one component be
+// both the state-recorder and the garbage-collector without ordering the two.
+func TestReconcileKeepsFailedPodWhenReportErrors(t *testing.T) {
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	cs := fake.NewClientset(agedPod("old-failed", corev1.PodFailed, now.Add(-30*time.Minute)))
+	r := NewReconciler(cs, "leoflow", errReporter{})
+	r.now = func() time.Time { return now }
+	r.ttl = 10 * time.Minute
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	pods, _ := cs.CoreV1().Pods("leoflow").List(context.Background(), metav1.ListOptions{})
+	found := false
+	for _, p := range pods.Items {
+		if p.Name == "old-failed" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("a failed pod whose report errored was garbage-collected; it must be kept so the next tick can retry the report")
+	}
+}
+
+// TestReconcileCollectsAgedOrphanFailedPod: a failed pod with no task-instance
+// annotation has no terminal state to preserve, so reportFailure reports "nothing
+// to do" (nil) and the aged orphan is still collected — the report-before-collect
+// ordering must not strand orphan garbage.
+func TestReconcileCollectsAgedOrphanFailedPod(t *testing.T) {
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	orphan := managedPod("orphan", "", corev1.PodFailed) // empty tiID
+	orphan.CreationTimestamp = metav1.NewTime(now.Add(-30 * time.Minute))
+	cs := fake.NewClientset(orphan)
+	r := NewReconciler(cs, "leoflow", &fakeReporter{})
+	r.now = func() time.Time { return now }
+	r.ttl = 10 * time.Minute
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	pods, _ := cs.CoreV1().Pods("leoflow").List(context.Background(), metav1.ListOptions{})
+	for _, p := range pods.Items {
+		if p.Name == "orphan" {
+			t.Error("an aged orphan failed pod (no task instance) should still be garbage-collected")
+		}
 	}
 }


### PR DESCRIPTION
## The bug

`Reconcile` reports a failed pod's task instance, then deletes the pod if it has aged past the GC grace period — but the delete ran **regardless of whether the report succeeded** ([reconcile.go:104-109](https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L104)). `reportFailure` only logged its error and returned nothing.

So a transient `FailTask` error (a metadatabase blip) let the pod be deleted anyway. **The pod is the only signal that lets the next tick retry the report** — deleting it strands the task instance in `running` until the heartbeat reaper (the slower backstop) catches it.

Latent, not live: the 10-minute grace period makes the window narrow. But it is the exact shape Kubeflow is *still* patching in 2026 (report-then-collect, [KFP #5722](https://github.com/kubeflow/pipelines/issues/5722)), and the fix is one conditional.

> **Never let one component be both the state-recorder and the garbage-collector without ordering the two.**

## The fix

`reportFailure` now returns an error. A **failed** pod is collected only once its failure is durably recorded; otherwise the next tick retries. A **succeeded** pod has nothing to record and is still collected on age alone. An **orphan** failed pod (no task-instance annotation) has no terminal state to preserve, so `reportFailure` returns nil and it is still collected.

## Verification

- `TestReconcileKeepsFailedPodWhenReportErrors` — written first, observed failing (pod deleted despite the report erroring)
- `TestReconcileCollectsAgedOrphanFailedPod` — guards against regressing orphan cleanup
- Existing `TestReconcileGarbageCollectsOldTerminalPods` still green (failed+aged+success → collected)
- `go test ./...` green · `golangci-lint run` 0 issues

First of the Track A "Pro robustness" controller-correctness fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)