### PR TITLE
fix(server): leader-gate the pod reconciler and staging GC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,6 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### Fixed
-
-- **The pod reconciler could garbage-collect a failed pod before its failure was
-  recorded.** `Reconcile` reported a failed pod's task instance and then deleted
-  the pod if it had aged out — but the delete ran whether or not the report
-  succeeded. A transient metadatabase error during `FailTask` meant the pod (the
-  only signal that would let the next tick retry) was deleted anyway, stranding
-  the task instance in `running` until the slower heartbeat reaper caught it. The
-  reconciler now defers collection of a failed pod until its failure is durably
-  recorded; a succeeded pod, which has nothing to record, is still collected on
-  age alone. (One component was both the state-recorder and the garbage-collector
-  with no ordering between them.)
-
 ### Added
 
 - **`leoflow compile` now rejects a task graph that cannot execute.** Three
@@ -75,6 +62,27 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   back inside are unaffected.
 
 ### Fixed
+
+- **The pod reconciler could garbage-collect a failed pod before its failure was
+  recorded.** `Reconcile` reported a failed pod's task instance and then deleted
+  the pod if it had aged out — but the delete ran whether or not the report
+  succeeded. A transient metadatabase error during `FailTask` meant the pod (the
+  only signal that would let the next tick retry) was deleted anyway, stranding
+  the task instance in `running` until the slower heartbeat reaper caught it. The
+  reconciler now defers collection of a failed pod until its failure is durably
+  recorded; a succeeded pod, which has nothing to record, is still collected on
+  age alone. (One component was both the state-recorder and the garbage-collector
+  with no ordering between them.)
+
+- **The pod reconciler and staging-volume GC ran on every replica, not just the
+  leader.** The scheduler loop and its reapers are leader-gated (ADR 0009), but
+  `startReconciler` and `startStagingGC` spawned unconditional tickers, so at
+  `replicaCount > 1` every replica would list, reconcile, and delete the same task
+  pods and staging PVCs — a follower racing the leader's provisioning. Both now
+  gate on the same leadership signal (`scheduler.IsLeading`) the scheduler loop
+  uses. No behaviour change at the default `replicaCount: 1`, where the single
+  replica is always the leader; this is the correctness base that makes running
+  Pro with more than one replica safe.
 
 - **Alert messages carried a UUID where the run id belongs.** `{{run_id}}`
   rendered `RunState.RunID`, which is the `dag_runs` primary key — not the

--- a/cmd/leoflow-server/gated_ticker_test.go
+++ b/cmd/leoflow-server/gated_ticker_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// runGatedTicker must run its cycle only while leading() is true, so at
+// replicaCount>1 a follower's reconciler/GC does not sweep and delete pods the
+// leader owns. Deterministic: an unbuffered ticks channel means the send of the
+// next tick blocks until the previous one is fully processed, so no sleeps.
+func TestRunGatedTickerRunsOnlyWhileLeading(t *testing.T) {
+	ticks := make(chan time.Time)
+	ran := make(chan struct{}, 8)
+	var leading atomic.Bool
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go runGatedTicker(ctx, "test", ticks, leading.Load, discardLog(), func() {
+		ran <- struct{}{}
+	})
+
+	// Follower: the tick is processed but the cycle must not run.
+	leading.Store(false)
+	ticks <- time.Now()
+	// Leader: this send blocks until the follower tick above was processed
+	// (sequential select loop, unbuffered channel), so ordering is guaranteed.
+	leading.Store(true)
+	ticks <- time.Now()
+
+	select {
+	case <-ran:
+	case <-time.After(2 * time.Second):
+		t.Fatal("leader tick did not run the cycle")
+	}
+	// Exactly one run: the follower tick contributed nothing.
+	select {
+	case <-ran:
+		t.Error("a follower tick ran the cycle; it must be skipped when not leading")
+	default:
+	}
+}
+
+// A nil gate means "always run" — single-replica / no election.
+func TestRunGatedTickerNilGateAlwaysRuns(t *testing.T) {
+	ticks := make(chan time.Time)
+	ran := make(chan struct{}, 4)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go runGatedTicker(ctx, "test", ticks, nil, discardLog(), func() { ran <- struct{}{} })
+
+	ticks <- time.Now()
+	select {
+	case <-ran:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a nil gate should always run the cycle")
+	}
+}

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -559,24 +559,44 @@ func startXComSweep(ctx context.Context, backend *xcom.PostgresBackend, logger *
 
 // startReconciler runs a periodic pod reconciler that marks task instances
 // failed when their pod failed without the agent reporting (feeding retries).
-func startReconciler(ctx context.Context, cs kubernetes.Interface, reporter executor.FailureReporter, logger *slog.Logger) {
-	rec := executor.NewReconciler(cs, podNamespace, reporter)
+// startGatedTicker runs fn every interval on a background goroutine, but only
+// while leading() reports this instance holds leadership. It stops when ctx is
+// done. The pod reconciler and staging GC mutate cluster state, so at
+// replicaCount>1 they must run on the leader alone (ADR 0009/0031); a nil gate
+// means "always run" (single-replica / no election).
+func startGatedTicker(ctx context.Context, name string, interval time.Duration, leading func() bool, logger *slog.Logger, fn func()) {
+	t := time.NewTicker(interval)
 	go func() {
-		t := time.NewTicker(reconcileInterval)
 		defer t.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-t.C:
-				safeCycle("pod-reconcile", logger, func() {
-					if err := rec.Reconcile(ctx); err != nil {
-						logger.Error("pod reconcile", "error", err)
-					}
-				})
-			}
-		}
+		runGatedTicker(ctx, name, t.C, leading, logger, fn)
 	}()
+}
+
+// runGatedTicker is the loop of startGatedTicker with the tick source injected,
+// so the leadership gate is testable without a real timer. Each cycle is
+// panic-isolated by safeCycle. A tick that arrives while not leading is dropped,
+// not queued.
+func runGatedTicker(ctx context.Context, name string, ticks <-chan time.Time, leading func() bool, logger *slog.Logger, fn func()) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticks:
+			if leading != nil && !leading() {
+				continue
+			}
+			safeCycle(name, logger, fn)
+		}
+	}
+}
+
+func startReconciler(ctx context.Context, cs kubernetes.Interface, reporter executor.FailureReporter, leading func() bool, logger *slog.Logger) {
+	rec := executor.NewReconciler(cs, podNamespace, reporter)
+	startGatedTicker(ctx, "pod-reconcile", reconcileInterval, leading, logger, func() {
+		if err := rec.Reconcile(ctx); err != nil {
+			logger.Error("pod reconcile", "error", err)
+		}
+	})
 }
 
 // stagingGCInterval is how often the per-run staging-volume GC sweeps; stagingTTL
@@ -591,25 +611,14 @@ const (
 // startStagingGC periodically reclaims per-run staging PVCs from the
 // metadatabase-tracked lifecycle: succeeded runs immediately, failed runs after
 // the TTL, orphaned volumes (run gone) on sight (ADR 0022).
-func startStagingGC(ctx context.Context, cs kubernetes.Interface, store executor.StagingStore, logger *slog.Logger) {
+func startStagingGC(ctx context.Context, cs kubernetes.Interface, store executor.StagingStore, leading func() bool, logger *slog.Logger) {
 	exec := executor.NewKubernetesExecutor(cs, podNamespace)
 	exec.SetStagingStore(store)
-	go func() {
-		t := time.NewTicker(stagingGCInterval)
-		defer t.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-t.C:
-				safeCycle("staging-gc", logger, func() {
-					if err := exec.GCStagingClaims(ctx, stagingTTL); err != nil {
-						logger.Error("staging gc", "error", err)
-					}
-				})
-			}
+	startGatedTicker(ctx, "staging-gc", stagingGCInterval, leading, logger, func() {
+		if err := exec.GCStagingClaims(ctx, stagingTTL); err != nil {
+			logger.Error("staging gc", "error", err)
 		}
-	}()
+	})
 }
 
 func startScheduler(ctx context.Context, cfg *config.ServerConfig, pg *storage.Postgres, repo *storage.Repository, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, xcomSvc executor.XComPusher, logSink logs.Sink, logger *slog.Logger, metrics *observability.Metrics) (*scheduler.Scheduler, bool, io.Closer, error) {
@@ -876,8 +885,8 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 	dispatcher.SetPlatformDefaults(platformDefaults(cfg.Executor.Defaults))
 	disp, closer := wrapBuffered(dispatcher, store, logger, metrics, cfg.Scheduler.Dispatch) //nolint:contextcheck // buffered worker deliberately detaches from caller ctx
 	sched.SetDispatcher(disp)
-	startReconciler(ctx, cs, execStore, logger)
-	startStagingGC(ctx, cs, store, logger)
+	startReconciler(ctx, cs, execStore, sched.IsLeading, logger)
+	startStagingGC(ctx, cs, store, sched.IsLeading, logger)
 	logger.Info("pod dispatch enabled", "namespace", podNamespace, "agent_control_plane_addr", controlAddr)
 	return true, closer
 }

--- a/internal/scheduler/leading_test.go
+++ b/internal/scheduler/leading_test.go
@@ -1,0 +1,21 @@
+package scheduler
+
+import "testing"
+
+// IsLeading must reflect SetLeading, so background sweeps (pod reconciler,
+// staging GC) can gate on the same leadership signal the scheduler loop uses —
+// otherwise at replicaCount>1 every replica sweeps and deletes.
+func TestIsLeadingReflectsSetLeading(t *testing.T) {
+	s := &Scheduler{}
+	if s.IsLeading() {
+		t.Error("a fresh scheduler is not leading")
+	}
+	s.SetLeading(true)
+	if !s.IsLeading() {
+		t.Error("IsLeading should be true after SetLeading(true)")
+	}
+	s.SetLeading(false)
+	if s.IsLeading() {
+		t.Error("IsLeading should be false after SetLeading(false)")
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -295,6 +295,14 @@ func (s *Scheduler) SetLeading(on bool) {
 	s.leading.Store(on)
 }
 
+// IsLeading reports whether this instance currently holds scheduler leadership.
+// Background sweeps that mutate cluster state — the pod reconciler and the
+// staging-volume GC — gate on this so that at replicaCount>1 only the leader
+// sweeps; otherwise every replica would reconcile and delete the same pods.
+func (s *Scheduler) IsLeading() bool {
+	return s.leading.Load()
+}
+
 // MarkSteppingDown records that a graceful step-down has begun. The campaign
 // loop calls this BEFORE canceling the scheduler's run-context, so any
 // in-flight reaper/Step that returns "context canceled" inside the window logs


### PR DESCRIPTION
## The bug

The scheduler loop and both reapers run only while this instance holds leadership (ADR 0009): `campaignAndRun` → `runAsLeader` → `sched.SetLeading`, and the reapers check `s.leading` at `scheduler.go:418/447/471`.

The **pod reconciler** (`startReconciler`) and the **staging-volume GC** (`startStagingGC`) did **not**. `setupK8sDispatch` runs on every replica at boot and spawned their tickers unconditionally (`main.go:888-889`).

So at `replicaCount > 1`, **every replica** lists managed pods, reports failures, and deletes aged pods and staging PVCs. `FailTask` is guarded (`FailTaskInstanceIfActive`) and duplicate deletes are `NotFound`-tolerant, so state corruption is unlikely today — but a follower's staging GC racing the leader's per-run PVC provisioning is a sharper edge, and "every replica sweeps and deletes" is a surprising, unstated invariant.

This is the **base that must land before `replicaCount > 1` is recommended** as the Pro HA posture, so the recommendation doesn't activate a latent bug. (HA posture itself is deferred per the maintainer.)

## The fix

Both starters take a `leading func() bool` and gate each cycle on it, wired to `sched.IsLeading` — a new reader over the same `atomic.Bool` that `SetLeading` already sets. **No behaviour change at the default `replicaCount: 1`**: the single replica is always the leader.

The two starters were near-identical copy-paste ticker loops; they now share `startGatedTicker`. Its loop is `runGatedTicker` with the tick channel **injected**, so the gate is unit-tested deterministically (an unbuffered ticks channel orders the assertions with no sleeps) instead of against a real timer.

## Verification

- `TestIsLeadingReflectsSetLeading` (scheduler) and `TestRunGatedTickerRunsOnlyWhileLeading` / `...NilGateAlwaysRuns` (main) — written first, observed failing
- `go test ./...` green · `golangci-lint run` 0 issues

Track A "Pro robustness" controller-correctness, PR 2 of 3. (PR 1: #501 report-before-collect.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)