### PR TITLE
feat(scheduler): back off and give up on a failing dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **A synchronous dispatch failure now backs off and eventually gives up, instead
+  of retrying every tick forever** (ADR 0031 Amendment A). When `Dispatch` failed
+  synchronously — kube-apiserver unreachable, RBAC denied, quota, an admission
+  webhook reject — the task stayed `scheduled` and the planner re-attempted it on
+  every tick, with no backoff, surfaced by no reaper (the dispatch-lost reaper
+  only sees `queued`). A permanent misconfiguration became a silent tight loop.
+
+  The task instance now records `dispatch_attempts` and `next_dispatch_at` (two new
+  columns, mirroring `reschedule_at`); the planner does not re-dispatch until the
+  exponential, capped backoff elapses, and after the attempt budget is spent the
+  task fails as `dispatch_failed` so the run finalizes. A dispatch failure does
+  **not** consume the task's `try_number` — it is infrastructure, not a task
+  failure, so a `retries: 0` task is not killed by a transient blip.
+  `dispatch_failed` is distinct from `dispatch_lost` (dispatched then vanished) and
+  from a task's own `failed` (the code ran and failed).
+
 - **`leoflow compile` now rejects a task graph that cannot execute.** Three
   defects shared one symptom, and it was the worst one available: the run
   started, no task in the affected region ever became ready, and the run sat in

--- a/docs/adr/0031-scheduler-architecture.md
+++ b/docs/adr/0031-scheduler-architecture.md
@@ -234,6 +234,54 @@ to write. The scheduler is designed to be correct across this window:
   is too high. Two narrow reapers with strong positive signals win on
   user trust.
 
+## Amendment A (2026-07-31): dispatch-failure backoff
+
+The two-phase dispatch above handles a dispatch that *succeeds* (TI → `queued`,
+pod created) and a dispatch that is *lost* after success (the dispatch-lost
+reaper fails a `queued` TI whose pod never appeared). It did not handle a
+dispatch that *fails synchronously*: `launchQueued` logged the error and returned
+nil, leaving the TI in `scheduled`. The planner re-plans that TI every tick, so a
+permanently-failing dispatch (RBAC denial, quota, an admission webhook reject, a
+nonexistent image rejected at create) becomes a tight retry loop that never backs
+off, never surfaces, and is covered by no reaper (the dispatch-lost reaper only
+sees `queued`).
+
+**Decision.** A synchronous dispatch failure records a bounded, backed-off retry
+on the TI, and after the bound is exhausted the TI fails as `dispatch_failed`.
+
+- **State lives in Postgres, on `task_instances`** — two columns, `dispatch_attempts`
+  and `next_dispatch_at`, mirroring the existing `reschedule_at` backoff (migration
+  017). This is the DB-as-truth rule of this ADR, not an exception to it: the
+  scheduler holds nothing in memory, so the backoff must survive a leader failover
+  or a restart to actually bound the loop. **Redis was considered and rejected**:
+  it is per-TI durable metadata, not XCom throughput or multi-node locking (ADR
+  0006/0026); Redis eviction would drop the backoff and resume the tight loop; and
+  Lite has no Redis (ADR 0026) yet suffers the same loop, so a Postgres column
+  fixes both editions from one path — consistent with "same architecture across
+  editions".
+
+- **The planner gates and decides**, no new reaper. A `scheduled` TI with
+  `next_dispatch_at > now` is not planned for dispatch this tick (identical to the
+  `reschedule_at` gate). A TI whose `dispatch_attempts` has reached the bound is
+  planned `scheduled → failed`. Reusing the planner keeps the decision pure and
+  testable and avoids a fourth background sweep.
+
+- **A dispatch failure does NOT consume the task's `try_number`.** It is an
+  infrastructure failure, not a task failure; consuming a user retry on a
+  kube-apiserver blip would be wrong, and a `retries: 0` task must not die on one.
+  `dispatch_attempts` is a separate counter, and the terminal state is
+  `dispatch_failed` — distinct from `dispatch_lost` (dispatched-then-vanished) and
+  from a task's own `failed` (the code ran and failed). This mirrors Airflow's
+  separation of queue/executor failures from task retries.
+
+- **Backoff** is exponential from a small base, capped, over a small bounded number
+  of attempts — long enough to ride out a transient control-plane blip, short
+  enough that a permanent misconfiguration surfaces in minutes, not never.
+
+This is a third failure-handling concern layered onto two-phase dispatch, not a
+new phase: it is the "the dispatch call itself failed" case the original two
+layers left open.
+
 ## References
 
 - ADR 0009 — Leader election via Postgres advisory locks.

--- a/internal/scheduler/dispatch_backoff.go
+++ b/internal/scheduler/dispatch_backoff.go
@@ -1,0 +1,36 @@
+package scheduler
+
+import "time"
+
+// Dispatch-failure backoff (ADR 0031 Amendment A). A synchronous dispatch
+// failure (kube-apiserver unreachable, RBAC denied, quota, admission reject) is
+// not retried every tick: the task instance records a backed-off next attempt,
+// and after dispatchMaxAttempts the planner fails it as dispatch_failed rather
+// than looping forever.
+const (
+	// dispatchBackoffBase is the delay after the first failed dispatch.
+	dispatchBackoffBase = 5 * time.Second
+	// dispatchBackoffCap bounds the delay: a permanent misconfiguration is
+	// re-attempted no less often than this while it is still within the budget.
+	dispatchBackoffCap = 5 * time.Minute
+	// dispatchMaxAttempts is how many failed dispatches are tolerated before the
+	// task instance is failed as dispatch_failed. With the schedule above this is
+	// a few minutes of retrying — long enough to ride out a transient blip, short
+	// enough that a permanent failure surfaces rather than looping silently.
+	dispatchMaxAttempts = 6
+)
+
+// dispatchBackoff returns the delay before the next dispatch attempt after
+// `attempts` consecutive failures: exponential from the base, capped. It is
+// deterministic (no jitter) so the planner's time gate is testable; attempts <= 1
+// yields the base.
+func dispatchBackoff(attempts int) time.Duration {
+	d := dispatchBackoffBase
+	for i := 1; i < attempts; i++ {
+		d *= 2
+		if d >= dispatchBackoffCap {
+			return dispatchBackoffCap
+		}
+	}
+	return d
+}

--- a/internal/scheduler/dispatch_backoff_test.go
+++ b/internal/scheduler/dispatch_backoff_test.go
@@ -1,0 +1,40 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+)
+
+// dispatchBackoff must grow exponentially from a small base and cap, so a
+// transient control-plane blip is ridden out quickly while a permanent
+// misconfiguration is not retried more often than the cap. It is deterministic
+// (no jitter) so the planner's gate is testable.
+func TestDispatchBackoff(t *testing.T) {
+	for _, tc := range []struct {
+		attempts int
+		want     time.Duration
+	}{
+		{0, dispatchBackoffBase}, // defensive: pre-first-failure treated as base
+		{1, 5 * time.Second},     // first failure
+		{2, 10 * time.Second},
+		{3, 20 * time.Second},
+		{4, 40 * time.Second},
+		{5, 80 * time.Second},
+		{6, 160 * time.Second},
+		{7, dispatchBackoffCap},  // 320s would exceed the cap
+		{50, dispatchBackoffCap}, // far past the cap stays capped
+	} {
+		if got := dispatchBackoff(tc.attempts); got != tc.want {
+			t.Errorf("dispatchBackoff(%d) = %s, want %s", tc.attempts, got, tc.want)
+		}
+	}
+}
+
+// The cap must actually bound the largest value the sequence can produce.
+func TestDispatchBackoffNeverExceedsCap(t *testing.T) {
+	for a := 0; a <= 100; a++ {
+		if d := dispatchBackoff(a); d > dispatchBackoffCap {
+			t.Fatalf("dispatchBackoff(%d) = %s exceeds cap %s", a, d, dispatchBackoffCap)
+		}
+	}
+}

--- a/internal/scheduler/dispatch_test.go
+++ b/internal/scheduler/dispatch_test.go
@@ -168,3 +168,49 @@ func TestStepWithoutDispatcherFailsUndispatchable(t *testing.T) {
 		t.Errorf("state-only scheduler should fail the undispatchable task, got %v", store.transitions)
 	}
 }
+
+// A synchronous dispatch failure records a backed-off retry (ADR 0031 Amendment
+// A) instead of silently re-attempting every tick. The task stays scheduled; the
+// backoff is what the planner gates the next attempt on.
+func TestStepBacksOffOnDispatchFailure(t *testing.T) {
+	store := runWithScheduledRoot()
+	d := &fakeDispatcher{err: errors.New("kube-apiserver unreachable")}
+	s := newScheduler(store)
+	s.SetDispatcher(d)
+
+	if err := s.Step(context.Background()); err != nil {
+		t.Fatalf("a dispatch failure must not abort the step: %v", err)
+	}
+	if len(store.dispatchFailures) != 1 || store.dispatchFailures[0].taskID != "a" {
+		t.Errorf("first dispatch failure should record a backoff for task a, got %v", store.dispatchFailures)
+	}
+	if len(store.dispatchExhausted) != 0 {
+		t.Errorf("one failure must not exhaust the budget, got %v", store.dispatchExhausted)
+	}
+	if len(store.transitions) != 0 {
+		t.Errorf("a failed dispatch must not transition the task, got %v", store.transitions)
+	}
+}
+
+// Once the dispatch-attempt budget is spent, the task is failed as
+// dispatch_failed so the run can finalize instead of looping forever.
+func TestStepFailsTaskWhenDispatchExhausted(t *testing.T) {
+	store := newFakeStore(RunState{
+		RunID: "r1", DagID: "etl", State: domain.DagRunStateRunning, Tasks: linearTasks(),
+		States:           map[string]domain.TaskState{"a": domain.TaskStateScheduled, "b": domain.TaskStateNone},
+		DispatchAttempts: map[string]int{"a": dispatchMaxAttempts - 1}, // one more failure exhausts it
+	})
+	d := &fakeDispatcher{err: errors.New("RBAC: cannot create pods")}
+	s := newScheduler(store)
+	s.SetDispatcher(d)
+
+	if err := s.Step(context.Background()); err != nil {
+		t.Fatalf("dispatch exhaustion must not abort the step: %v", err)
+	}
+	if len(store.dispatchExhausted) != 1 || store.dispatchExhausted[0] != "a" {
+		t.Errorf("the final dispatch failure should fail task a as dispatch_failed, got %v", store.dispatchExhausted)
+	}
+	if len(store.dispatchFailures) != 0 {
+		t.Errorf("the exhausting attempt must fail, not back off again, got %v", store.dispatchFailures)
+	}
+}

--- a/internal/scheduler/plan.go
+++ b/internal/scheduler/plan.go
@@ -34,42 +34,7 @@ func PlanRun(run RunState) []PlannedTransition {
 	decided := make(map[string]bool, len(run.Tasks))
 	out := make([]PlannedTransition, 0, len(run.Tasks))
 
-	for _, t := range run.Tasks {
-		switch run.States[t.TaskID] {
-		case domain.TaskStateFailed:
-			if retriable(run, t.TaskID) {
-				out = append(out, PlannedTransition{TaskID: t.TaskID, To: domain.TaskStateUpForRetry})
-				effective[t.TaskID] = domain.TaskStateUpForRetry
-				decided[t.TaskID] = true
-			}
-		case domain.TaskStateUpForRetry:
-			if !readyToRetry(run, t.TaskID) {
-				// Cooldown still active — keep the task in up_for_retry. Mark
-				// decided so the second loop also leaves it alone (otherwise
-				// decideStart would re-evaluate based on effective state and
-				// re-emit a transition).
-				decided[t.TaskID] = true
-				continue
-			}
-			out = append(out, PlannedTransition{TaskID: t.TaskID, To: domain.TaskStateNone})
-			effective[t.TaskID] = domain.TaskStateNone
-			decided[t.TaskID] = true
-		case domain.TaskStateUpForReschedule:
-			// A reschedule-mode sensor parked here by the agent: re-dispatch once
-			// reschedule_at passes, WITHOUT consuming retry budget (reschedule is not
-			// a failure). Until then keep it parked so downstream waits. Mirrors the
-			// up_for_retry rail, gated on reschedule_at instead of retry_delay (#380).
-			if !readyToReschedule(run, t.TaskID) {
-				decided[t.TaskID] = true
-				continue
-			}
-			out = append(out, PlannedTransition{TaskID: t.TaskID, To: domain.TaskStateNone})
-			effective[t.TaskID] = domain.TaskStateNone
-			decided[t.TaskID] = true
-		default:
-			// none/scheduled/queued/running/terminal: no retry decision here.
-		}
-	}
+	out = append(out, planRetryTransitions(run, effective, decided)...)
 
 	for _, t := range run.Tasks {
 		if decided[t.TaskID] {
@@ -81,9 +46,55 @@ func PlanRun(run RunState) []PlannedTransition {
 				out = append(out, PlannedTransition{TaskID: t.TaskID, To: to})
 			}
 		case domain.TaskStateScheduled:
+			// A previous dispatch may have failed; hold off re-dispatch until the
+			// backoff elapses (ADR 0031 Amendment A), mirroring the reschedule gate.
+			if !readyToDispatch(run, t.TaskID) {
+				continue
+			}
 			out = append(out, PlannedTransition{TaskID: t.TaskID, To: domain.TaskStateQueued})
 		default:
 			// queued/running/terminal/up_for_retry: nothing to plan here.
+		}
+	}
+	return out
+}
+
+// planRetryTransitions handles the retry/reschedule rail: a failed task with
+// budget moves to up_for_retry; an up_for_retry or up_for_reschedule task resets
+// to none once its cooldown/poke time elapses. It records the effective state and
+// marks each handled task decided so the main loop leaves it alone, and returns
+// the transitions to emit.
+func planRetryTransitions(run RunState, effective map[string]domain.TaskState, decided map[string]bool) []PlannedTransition {
+	out := make([]PlannedTransition, 0, len(run.Tasks))
+	for _, t := range run.Tasks {
+		switch run.States[t.TaskID] {
+		case domain.TaskStateFailed:
+			if retriable(run, t.TaskID) {
+				out = append(out, PlannedTransition{TaskID: t.TaskID, To: domain.TaskStateUpForRetry})
+				effective[t.TaskID] = domain.TaskStateUpForRetry
+				decided[t.TaskID] = true
+			}
+		case domain.TaskStateUpForRetry:
+			if !readyToRetry(run, t.TaskID) {
+				decided[t.TaskID] = true
+				continue
+			}
+			out = append(out, PlannedTransition{TaskID: t.TaskID, To: domain.TaskStateNone})
+			effective[t.TaskID] = domain.TaskStateNone
+			decided[t.TaskID] = true
+		case domain.TaskStateUpForReschedule:
+			// Re-dispatch once reschedule_at passes, WITHOUT consuming retry budget
+			// (reschedule is not a failure); until then keep it parked so downstream
+			// waits. Mirrors the up_for_retry rail, gated on reschedule_at (#380).
+			if !readyToReschedule(run, t.TaskID) {
+				decided[t.TaskID] = true
+				continue
+			}
+			out = append(out, PlannedTransition{TaskID: t.TaskID, To: domain.TaskStateNone})
+			effective[t.TaskID] = domain.TaskStateNone
+			decided[t.TaskID] = true
+		default:
+			// none/scheduled/queued/running/terminal: no retry decision here.
 		}
 	}
 	return out
@@ -119,6 +130,22 @@ func readyToRetry(run RunState, taskID string) bool {
 		return true
 	}
 	return !run.Now.Before(ended.Add(time.Duration(delay) * time.Second))
+}
+
+// readyToDispatch reports whether a `scheduled` task may be dispatched now: true
+// unless a prior synchronous dispatch failure set next_dispatch_at in the future.
+// Honors the "absent data / zero clock falls back to immediate" convention
+// (mirroring readyToReschedule), so the common case (never failed) and tests that
+// do not populate NextDispatchAt/Now dispatch immediately.
+func readyToDispatch(run RunState, taskID string) bool {
+	at := run.NextDispatchAt[taskID]
+	if at == nil {
+		return true
+	}
+	if run.Now.IsZero() {
+		return true
+	}
+	return !run.Now.Before(*at)
 }
 
 // readyToReschedule reports whether a task parked in up_for_reschedule may be

--- a/internal/scheduler/plan_test.go
+++ b/internal/scheduler/plan_test.go
@@ -251,3 +251,48 @@ func TestFinalizeRunWaitsForRetriableFailure(t *testing.T) {
 		t.Error("must not finalize the run while a failed task can still retry")
 	}
 }
+
+// A scheduled task whose next_dispatch_at is in the future is NOT promoted to
+// queued this tick — its previous dispatch failed and the backoff has not
+// elapsed (ADR 0031 Amendment A). Mirrors the up_for_reschedule gate.
+func TestPlanRunDefersScheduledDuringDispatchBackoff(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	future := now.Add(30 * time.Second)
+	run := RunState{
+		Tasks:          linear(),
+		States:         map[string]domain.TaskState{"a": domain.TaskStateScheduled},
+		Now:            now,
+		NextDispatchAt: map[string]*time.Time{"a": &future},
+	}
+	if got := planMap(run)["a"]; got == domain.TaskStateQueued {
+		t.Error("a scheduled task still in dispatch backoff must not be promoted to queued")
+	}
+}
+
+// Once next_dispatch_at has passed, the scheduled task is promoted to queued so
+// the dispatch is re-attempted.
+func TestPlanRunRedispatchesAfterBackoffElapses(t *testing.T) {
+	now := time.Date(2026, 7, 31, 12, 0, 0, 0, time.UTC)
+	past := now.Add(-1 * time.Second)
+	run := RunState{
+		Tasks:          linear(),
+		States:         map[string]domain.TaskState{"a": domain.TaskStateScheduled},
+		Now:            now,
+		NextDispatchAt: map[string]*time.Time{"a": &past},
+	}
+	if got := planMap(run)["a"]; got != domain.TaskStateQueued {
+		t.Errorf("a scheduled task past its backoff should be queued, got %s", got)
+	}
+}
+
+// Absent next_dispatch_at (the common case: never failed to dispatch) promotes
+// immediately, preserving today's behavior.
+func TestPlanRunSchedulesImmediatelyWithoutBackoff(t *testing.T) {
+	run := RunState{
+		Tasks:  linear(),
+		States: map[string]domain.TaskState{"a": domain.TaskStateScheduled},
+	}
+	if got := planMap(run)["a"]; got != domain.TaskStateQueued {
+		t.Errorf("a scheduled task with no backoff should be queued, got %s", got)
+	}
+}

--- a/internal/scheduler/resilience_test.go
+++ b/internal/scheduler/resilience_test.go
@@ -84,6 +84,10 @@ func (f *flakyStore) ApplyTransition(_ context.Context, runID, taskID string, to
 
 func (f *flakyStore) ResetForRetry(context.Context, string, string) error        { return nil }
 func (f *flakyStore) RedispatchReschedule(context.Context, string, string) error { return nil }
+func (f *flakyStore) RecordDispatchFailure(context.Context, string, string, time.Time) error {
+	return nil
+}
+func (f *flakyStore) FailDispatchExhausted(context.Context, string, string, string) error { return nil }
 
 func (f *flakyStore) SetRunState(_ context.Context, runID string, state domain.DagRunState) error {
 	f.mu.Lock()

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -69,6 +69,16 @@ type RunState struct {
 	// reschedule_at — without consuming retry budget (#380). Absent/zero entries
 	// re-dispatch immediately (preserves the test seam, like EndedAt).
 	RescheduleAt map[string]*time.Time
+	// NextDispatchAt holds the earliest time a `scheduled` task may be dispatched
+	// again after a synchronous dispatch failure (ADR 0031 Amendment A). The
+	// planner does not promote scheduled→queued while Now < next_dispatch_at.
+	// Absent/zero entries dispatch immediately (the common case: never failed).
+	NextDispatchAt map[string]*time.Time
+	// DispatchAttempts counts consecutive synchronous dispatch failures per task.
+	// It is a separate counter from try_number — a dispatch failure is infra, not
+	// a task failure — and drives the dispatch_failed give-up at
+	// dispatchMaxAttempts. Absent entries mean zero.
+	DispatchAttempts map[string]int
 	// Now is the wall-clock value the planner compares against EndedAt. Zero
 	// means "skip the cooldown gate" so legacy callers + tests that don't set
 	// retry_delay get the previous (immediate-retry) behavior.
@@ -109,6 +119,13 @@ type Store interface {
 	// RedispatchReschedule returns a task parked in up_for_reschedule to 'none' for
 	// re-dispatch, PRESERVING try_number (reschedule is not a retry; #380).
 	RedispatchReschedule(ctx context.Context, runID, taskID string) error
+	// RecordDispatchFailure backs off a scheduled task after a synchronous dispatch
+	// failure: it increments dispatch_attempts and sets next_dispatch_at so the
+	// planner does not re-attempt until the backoff elapses (ADR 0031 Amendment A).
+	RecordDispatchFailure(ctx context.Context, runID, taskID string, nextAt time.Time) error
+	// FailDispatchExhausted fails a scheduled task as dispatch_failed once its
+	// dispatch-attempt budget is spent, so the run finalizes instead of looping.
+	FailDispatchExhausted(ctx context.Context, runID, taskID, reason string) error
 	SetRunState(ctx context.Context, runID string, state domain.DagRunState) error
 	// ClaimAlertAttempt atomically claims ONE on-failure send attempt, reporting
 	// true iff this call won it. It refuses when the episode was already
@@ -820,8 +837,7 @@ func (s *Scheduler) launchQueued(ctx context.Context, run RunState, t PlannedTra
 	}
 	if s.dispatcher != nil {
 		if err := s.dispatcher.Dispatch(ctx, run.RunID, run.DagID, task); err != nil {
-			s.logger.Error("dispatching task", "run", run.RunID, "task", t.TaskID, "error", err)
-			return nil
+			return s.handleDispatchFailure(ctx, run, t.TaskID, err)
 		}
 		return s.recordTransition(ctx, run, t.TaskID, domain.TaskStateQueued)
 	}
@@ -832,6 +848,36 @@ func (s *Scheduler) launchQueued(ctx context.Context, run RunState, t PlannedTra
 // disabled and it is not an inline http_api task). The condition is
 // deterministic for the process lifetime, so failing fast — with the reason on
 // the task note for the UI — beats leaving the run "running" forever (#46, #50).
+// handleDispatchFailure records a synchronous dispatch failure: it backs the task
+// off for a growing interval, or fails it as dispatch_failed once the attempt
+// budget is spent (ADR 0031 Amendment A). It returns nil in both cases — the
+// failure is recorded in the DB, not propagated, so one task's dispatch trouble
+// does not abort the tick. A dispatch failure is infrastructure, not a task
+// failure, so it never consumes the task's try_number.
+func (s *Scheduler) handleDispatchFailure(ctx context.Context, run RunState, taskID string, cause error) error {
+	attempts := run.DispatchAttempts[taskID] + 1
+	if attempts >= dispatchMaxAttempts {
+		reason := fmt.Sprintf("dispatch_failed after %d attempts: %v", attempts, cause)
+		s.logger.Error("dispatch attempts exhausted; failing task",
+			"run", run.RunID, "task", taskID, "attempts", attempts, "error", cause)
+		if err := s.store.FailDispatchExhausted(ctx, run.RunID, taskID, reason); err != nil {
+			s.logger.Error("failing dispatch-exhausted task", "run", run.RunID, "task", taskID, "error", err)
+		}
+		return nil
+	}
+	now := run.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	nextAt := now.Add(dispatchBackoff(attempts))
+	s.logger.Warn("dispatch failed; backing off before re-attempt",
+		"run", run.RunID, "task", taskID, "attempt", attempts, "next_dispatch_at", nextAt, "error", cause)
+	if err := s.store.RecordDispatchFailure(ctx, run.RunID, taskID, nextAt); err != nil {
+		s.logger.Error("recording dispatch failure", "run", run.RunID, "task", taskID, "error", err)
+	}
+	return nil
+}
+
 func (s *Scheduler) failUndispatchable(ctx context.Context, run RunState, taskID string, taskType domain.TaskType) error {
 	s.logger.Warn("task has no available executor; failing it (it can never run)",
 		"run", run.RunID, "dag", run.DagID, "task", taskID, "task_type", taskType,

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -36,6 +36,8 @@ type fakeStore struct {
 	agentLostMarked    []string
 	staleQueuedCands   []StaleQueuedCandidate
 	dispatchLostMarked []string
+	dispatchFailures   []transition
+	dispatchExhausted  []string
 	// alertAttempts mirrors the real per-episode attempt claim: each call
 	// consumes one, and the claim is refused once the budget is spent or the
 	// episode is already delivered. Backoff is not simulated — the fake is for
@@ -82,6 +84,16 @@ func (f *fakeStore) ResetForRetry(_ context.Context, runID, taskID string) error
 	f.retried = append(f.retried, transition{runID, taskID, domain.TaskStateNone})
 	return nil
 }
+func (f *fakeStore) RecordDispatchFailure(_ context.Context, runID, taskID string, _ time.Time) error {
+	f.dispatchFailures = append(f.dispatchFailures, transition{runID, taskID, ""})
+	return nil
+}
+
+func (f *fakeStore) FailDispatchExhausted(_ context.Context, runID, taskID, _ string) error {
+	f.dispatchExhausted = append(f.dispatchExhausted, taskID)
+	return nil
+}
+
 func (f *fakeStore) RedispatchReschedule(_ context.Context, runID, taskID string) error {
 	f.redispatched = append(f.redispatched, transition{runID, taskID, domain.TaskStateNone})
 	return nil

--- a/internal/storage/dispatch_backoff_integration_test.go
+++ b/internal/storage/dispatch_backoff_integration_test.go
@@ -1,0 +1,107 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/config"
+	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/scheduler"
+	"github.com/neochaotic/leoflow/internal/storage"
+)
+
+type failingDispatcher struct{}
+
+func (failingDispatcher) Dispatch(context.Context, string, string, domain.TaskSpec) error {
+	return context.DeadlineExceeded // any non-nil error
+}
+
+// TestDispatchBackoffPersists exercises the two dispatch-backoff queries and the
+// ActiveRuns read of the new columns against real Postgres (ADR 0031 Amendment
+// A). It verifies the migration applied and the queries round-trip; it does not
+// depend on backoff timing.
+func TestDispatchBackoffPersists(t *testing.T) {
+	url := os.Getenv("DATABASE_URL")
+	if url == "" {
+		t.Skip("DATABASE_URL must point at a migrated database")
+	}
+	ctx := context.Background()
+	pg, err := storage.NewPostgres(ctx, config.DatabaseSection{URL: url})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pg.Close()
+
+	repo := storage.NewRepository(pg)
+	store := storage.NewSchedulerStore(pg)
+	sched := scheduler.NewScheduler(store, slog.New(slog.NewTextHandler(io.Discard, nil)), time.Millisecond)
+	sched.SetDispatcher(failingDispatcher{})
+	sched.SetLeading(true)
+
+	dagID := "dispatch_backoff_test"
+	spec := domain.DAGSpec{
+		SchemaVersion: "1.0", DagID: dagID, DagVersion: "v1", Image: "img:v1",
+		Tasks: []domain.TaskSpec{{TaskID: "a", Type: domain.TaskTypePython, Entrypoint: "dag:a"}},
+	}
+	hash, err := spec.CanonicalHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, rerr := repo.RegisterDagVersion(ctx, "default", spec, hash); rerr != nil {
+		t.Fatalf("register version: %v", rerr)
+	}
+	if _, rerr := repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+		RunID: "backoff-run", State: domain.DagRunStateQueued, RunType: "manual", LogicalDate: time.Now().UTC(),
+	}); rerr != nil {
+		t.Fatalf("create run: %v", rerr)
+	}
+
+	// Tick: materialize -> running -> none->scheduled -> scheduled->dispatch(fail).
+	for i := 0; i < 4; i++ {
+		if serr := sched.Step(ctx); serr != nil {
+			t.Fatalf("step %d: %v", i, serr)
+		}
+	}
+
+	runs, err := store.ActiveRuns(ctx)
+	if err != nil {
+		t.Fatalf("active runs: %v", err)
+	}
+	var run *scheduler.RunState
+	for i := range runs {
+		if runs[i].DagID == dagID {
+			run = &runs[i]
+		}
+	}
+	if run == nil {
+		t.Fatal("run not found in ActiveRuns")
+	}
+	// RecordDispatchFailure ran at least once: the counter and the backoff stamp
+	// round-tripped through the new columns, and the task is still scheduled.
+	if run.DispatchAttempts["a"] < 1 {
+		t.Errorf("dispatch_attempts should be >=1 after a failed dispatch, got %d", run.DispatchAttempts["a"])
+	}
+	if run.NextDispatchAt["a"] == nil {
+		t.Error("next_dispatch_at should be set after a failed dispatch")
+	}
+	if run.States["a"] != domain.TaskStateScheduled {
+		t.Errorf("task should still be scheduled during backoff, got %s", run.States["a"])
+	}
+
+	// FailDispatchExhausted transitions the scheduled task to failed.
+	if ferr := store.FailDispatchExhausted(ctx, run.RunID, "a", "dispatch_failed: test"); ferr != nil {
+		t.Fatalf("FailDispatchExhausted: %v", ferr)
+	}
+	runs, _ = store.ActiveRuns(ctx)
+	for i := range runs {
+		if runs[i].DagID == dagID && runs[i].States["a"] != domain.TaskStateFailed {
+			t.Errorf("task should be failed after FailDispatchExhausted, got %s", runs[i].States["a"])
+		}
+	}
+}

--- a/internal/storage/queries/models.go
+++ b/internal/storage/queries/models.go
@@ -335,6 +335,8 @@ type TaskInstance struct {
 	LastHeartbeatAt   pgtype.Timestamptz `json:"last_heartbeat_at"`
 	RescheduleAt      pgtype.Timestamptz `json:"reschedule_at"`
 	FirstRescheduleAt pgtype.Timestamptz `json:"first_reschedule_at"`
+	DispatchAttempts  int32              `json:"dispatch_attempts"`
+	NextDispatchAt    pgtype.Timestamptz `json:"next_dispatch_at"`
 }
 
 type TaskInstanceHistory struct {

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -56,6 +56,12 @@ type Querier interface {
 	DeleteExpiredXComIndex(ctx context.Context) error
 	DeleteImportError(ctx context.Context, arg DeleteImportErrorParams) error
 	DeleteVariable(ctx context.Context, arg DeleteVariableParams) (int64, error)
+	// The dispatch-attempt budget is spent (ADR 0031 Amendment A): fail the task with
+	// a dispatch_failed reason so the run can finalize instead of looping forever.
+	// error_message carries the underlying cause. Guarded to 'scheduled' for the same
+	// reason as RecordDispatchFailure. This is distinct from dispatch_lost (a TI that
+	// reached 'queued' then vanished) and from a task's own 'failed' (the code ran).
+	FailDispatchExhausted(ctx context.Context, arg FailDispatchExhaustedParams) error
 	FailTaskInstanceIfActive(ctx context.Context, arg FailTaskInstanceIfActiveParams) error
 	GetConnection(ctx context.Context, arg GetConnectionParams) (GetConnectionRow, error)
 	GetCurrentDagSpec(ctx context.Context, arg GetCurrentDagSpecParams) ([]byte, error)
@@ -170,6 +176,13 @@ type Querier interface {
 	// since transitioned (real dispatch landed, or already failed) is a no-op,
 	// never overwriting a more meaningful state.
 	MarkTaskDispatchLost(ctx context.Context, id pgtype.UUID) error
+	// A synchronous dispatch attempt failed (ADR 0031 Amendment A). Increment the
+	// consecutive-failure counter and back off the next attempt to $3, so the planner
+	// (which gates scheduled->queued on next_dispatch_at) does not re-attempt every
+	// tick. Guarded to 'scheduled' so a report that raced the dispatch cannot clobber
+	// a row that has since progressed. try_number is untouched: this is infra, not a
+	// task failure.
+	RecordDispatchFailure(ctx context.Context, arg RecordDispatchFailureParams) error
 	RecordStagingVolume(ctx context.Context, arg RecordStagingVolumeParams) error
 	// Stamps last_heartbeat_at on the active TI of an attempt. Bounded by the
 	// (dag_run_id, task_id, try_number) tuple to match the agent's identity. The

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -266,6 +266,8 @@ SET state = 'none',
     ended_at = NULL,
     queued_at = NULL,
     scheduled_at = NULL,
+    dispatch_attempts = 0,
+    next_dispatch_at = NULL,
     reschedule_at = NULL,
     first_reschedule_at = NULL,
     try_number = ti.try_number + 1
@@ -437,6 +439,8 @@ SET state = 'none',
     ended_at = NULL,
     queued_at = NULL,
     scheduled_at = NULL,
+    dispatch_attempts = 0,
+    next_dispatch_at = NULL,
     try_number = ti.try_number + 1
 WHERE ti.dag_run_id = $1 AND ti.task_id = $2
   AND ti.state IN ('failed', 'upstream_failed', 'up_for_retry');
@@ -466,6 +470,8 @@ SET state = 'none',
     ended_at = NULL,
     queued_at = NULL,
     scheduled_at = NULL,
+    dispatch_attempts = 0,
+    next_dispatch_at = NULL,
     try_number = ti.try_number + 1
 WHERE ti.dag_run_id = $1
   AND ti.state IN ('failed', 'upstream_failed', 'up_for_retry');
@@ -588,3 +594,26 @@ SET state = 'failed',
     ended_at = now(),
     note = 'orphaned: no scheduler activity within the orphan window — see #120'
 WHERE id = $1 AND state = 'running';
+
+-- name: RecordDispatchFailure :exec
+-- A synchronous dispatch attempt failed (ADR 0031 Amendment A). Increment the
+-- consecutive-failure counter and back off the next attempt to $3, so the planner
+-- (which gates scheduled->queued on next_dispatch_at) does not re-attempt every
+-- tick. Guarded to 'scheduled' so a report that raced the dispatch cannot clobber
+-- a row that has since progressed. try_number is untouched: this is infra, not a
+-- task failure.
+UPDATE task_instances
+SET dispatch_attempts = dispatch_attempts + 1,
+    next_dispatch_at = $3
+WHERE dag_run_id = $1 AND task_id = $2 AND state = 'scheduled';
+
+-- name: FailDispatchExhausted :exec
+-- The dispatch-attempt budget is spent (ADR 0031 Amendment A): fail the task with
+-- a dispatch_failed reason so the run can finalize instead of looping forever.
+-- error_message carries the underlying cause. Guarded to 'scheduled' for the same
+-- reason as RecordDispatchFailure. This is distinct from dispatch_lost (a TI that
+-- reached 'queued' then vanished) and from a task's own 'failed' (the code ran).
+UPDATE task_instances
+SET state = 'failed', ended_at = now(), error_message = $3,
+    next_dispatch_at = NULL
+WHERE dag_run_id = $1 AND task_id = $2 AND state = 'scheduled';

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -276,7 +276,7 @@ func (q *Queries) CreateScheduledRunByDagID(ctx context.Context, arg CreateSched
 const createTaskInstance = `-- name: CreateTaskInstance :one
 INSERT INTO task_instances (tenant_id, dag_run_id, task_id, operator, max_tries, state, try_number)
 VALUES ($1, $2, $3, $4, $5, $6, 1)
-RETURNING id, tenant_id, dag_run_id, task_id, map_index, try_number, max_tries, state, pool, operator, queued_at, started_at, ended_at, duration_seconds, pod_name, node_name, exit_code, error_message, log_url, hostname, note, scheduled_at, last_heartbeat_at, reschedule_at, first_reschedule_at
+RETURNING id, tenant_id, dag_run_id, task_id, map_index, try_number, max_tries, state, pool, operator, queued_at, started_at, ended_at, duration_seconds, pod_name, node_name, exit_code, error_message, log_url, hostname, note, scheduled_at, last_heartbeat_at, reschedule_at, first_reschedule_at, dispatch_attempts, next_dispatch_at
 `
 
 type CreateTaskInstanceParams struct {
@@ -327,6 +327,8 @@ func (q *Queries) CreateTaskInstance(ctx context.Context, arg CreateTaskInstance
 		&i.LastHeartbeatAt,
 		&i.RescheduleAt,
 		&i.FirstRescheduleAt,
+		&i.DispatchAttempts,
+		&i.NextDispatchAt,
 	)
 	return i, err
 }
@@ -347,6 +349,29 @@ func (q *Queries) DeleteDagRun(ctx context.Context, arg DeleteDagRunParams) (int
 		return 0, err
 	}
 	return result.RowsAffected(), nil
+}
+
+const failDispatchExhausted = `-- name: FailDispatchExhausted :exec
+UPDATE task_instances
+SET state = 'failed', ended_at = now(), error_message = $3,
+    next_dispatch_at = NULL
+WHERE dag_run_id = $1 AND task_id = $2 AND state = 'scheduled'
+`
+
+type FailDispatchExhaustedParams struct {
+	DagRunID     pgtype.UUID `json:"dag_run_id"`
+	TaskID       string      `json:"task_id"`
+	ErrorMessage *string     `json:"error_message"`
+}
+
+// The dispatch-attempt budget is spent (ADR 0031 Amendment A): fail the task with
+// a dispatch_failed reason so the run can finalize instead of looping forever.
+// error_message carries the underlying cause. Guarded to 'scheduled' for the same
+// reason as RecordDispatchFailure. This is distinct from dispatch_lost (a TI that
+// reached 'queued' then vanished) and from a task's own 'failed' (the code ran).
+func (q *Queries) FailDispatchExhausted(ctx context.Context, arg FailDispatchExhaustedParams) error {
+	_, err := q.db.Exec(ctx, failDispatchExhausted, arg.DagRunID, arg.TaskID, arg.ErrorMessage)
+	return err
 }
 
 const failTaskInstanceIfActive = `-- name: FailTaskInstanceIfActive :exec
@@ -944,7 +969,7 @@ func (q *Queries) ListTaskInstanceAttempts(ctx context.Context, arg ListTaskInst
 }
 
 const listTaskInstancesByRun = `-- name: ListTaskInstancesByRun :many
-SELECT id, tenant_id, dag_run_id, task_id, map_index, try_number, max_tries, state, pool, operator, queued_at, started_at, ended_at, duration_seconds, pod_name, node_name, exit_code, error_message, log_url, hostname, note, scheduled_at, last_heartbeat_at, reschedule_at, first_reschedule_at FROM task_instances
+SELECT id, tenant_id, dag_run_id, task_id, map_index, try_number, max_tries, state, pool, operator, queued_at, started_at, ended_at, duration_seconds, pod_name, node_name, exit_code, error_message, log_url, hostname, note, scheduled_at, last_heartbeat_at, reschedule_at, first_reschedule_at, dispatch_attempts, next_dispatch_at FROM task_instances
 WHERE dag_run_id = $1
 ORDER BY task_id
 `
@@ -984,6 +1009,8 @@ func (q *Queries) ListTaskInstancesByRun(ctx context.Context, dagRunID pgtype.UU
 			&i.LastHeartbeatAt,
 			&i.RescheduleAt,
 			&i.FirstRescheduleAt,
+			&i.DispatchAttempts,
+			&i.NextDispatchAt,
 		); err != nil {
 			return nil, err
 		}
@@ -1120,6 +1147,30 @@ WHERE id = $1 AND state = 'queued'
 // never overwriting a more meaningful state.
 func (q *Queries) MarkTaskDispatchLost(ctx context.Context, id pgtype.UUID) error {
 	_, err := q.db.Exec(ctx, markTaskDispatchLost, id)
+	return err
+}
+
+const recordDispatchFailure = `-- name: RecordDispatchFailure :exec
+UPDATE task_instances
+SET dispatch_attempts = dispatch_attempts + 1,
+    next_dispatch_at = $3
+WHERE dag_run_id = $1 AND task_id = $2 AND state = 'scheduled'
+`
+
+type RecordDispatchFailureParams struct {
+	DagRunID       pgtype.UUID        `json:"dag_run_id"`
+	TaskID         string             `json:"task_id"`
+	NextDispatchAt pgtype.Timestamptz `json:"next_dispatch_at"`
+}
+
+// A synchronous dispatch attempt failed (ADR 0031 Amendment A). Increment the
+// consecutive-failure counter and back off the next attempt to $3, so the planner
+// (which gates scheduled->queued on next_dispatch_at) does not re-attempt every
+// tick. Guarded to 'scheduled' so a report that raced the dispatch cannot clobber
+// a row that has since progressed. try_number is untouched: this is infra, not a
+// task failure.
+func (q *Queries) RecordDispatchFailure(ctx context.Context, arg RecordDispatchFailureParams) error {
+	_, err := q.db.Exec(ctx, recordDispatchFailure, arg.DagRunID, arg.TaskID, arg.NextDispatchAt)
 	return err
 }
 
@@ -1293,6 +1344,8 @@ SET state = 'none',
     ended_at = NULL,
     queued_at = NULL,
     scheduled_at = NULL,
+    dispatch_attempts = 0,
+    next_dispatch_at = NULL,
     try_number = ti.try_number + 1
 WHERE ti.dag_run_id = $1
   AND ti.state IN ('failed', 'upstream_failed', 'up_for_retry')
@@ -1358,6 +1411,8 @@ SET state = 'none',
     ended_at = NULL,
     queued_at = NULL,
     scheduled_at = NULL,
+    dispatch_attempts = 0,
+    next_dispatch_at = NULL,
     try_number = ti.try_number + 1
 WHERE ti.dag_run_id = $1 AND ti.task_id = $2
   AND ti.state IN ('failed', 'upstream_failed', 'up_for_retry')
@@ -1400,6 +1455,8 @@ SET state = 'none',
     ended_at = NULL,
     queued_at = NULL,
     scheduled_at = NULL,
+    dispatch_attempts = 0,
+    next_dispatch_at = NULL,
     reschedule_at = NULL,
     first_reschedule_at = NULL,
     try_number = ti.try_number + 1
@@ -1609,7 +1666,7 @@ const updateTaskInstanceState = `-- name: UpdateTaskInstanceState :one
 UPDATE task_instances
 SET state = $2, started_at = $3, ended_at = $4
 WHERE id = $1
-RETURNING id, tenant_id, dag_run_id, task_id, map_index, try_number, max_tries, state, pool, operator, queued_at, started_at, ended_at, duration_seconds, pod_name, node_name, exit_code, error_message, log_url, hostname, note, scheduled_at, last_heartbeat_at, reschedule_at, first_reschedule_at
+RETURNING id, tenant_id, dag_run_id, task_id, map_index, try_number, max_tries, state, pool, operator, queued_at, started_at, ended_at, duration_seconds, pod_name, node_name, exit_code, error_message, log_url, hostname, note, scheduled_at, last_heartbeat_at, reschedule_at, first_reschedule_at, dispatch_attempts, next_dispatch_at
 `
 
 type UpdateTaskInstanceStateParams struct {
@@ -1653,6 +1710,8 @@ func (q *Queries) UpdateTaskInstanceState(ctx context.Context, arg UpdateTaskIns
 		&i.LastHeartbeatAt,
 		&i.RescheduleAt,
 		&i.FirstRescheduleAt,
+		&i.DispatchAttempts,
+		&i.NextDispatchAt,
 	)
 	return i, err
 }

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -59,6 +59,8 @@ func (s *SchedulerStore) ActiveRuns(ctx context.Context) ([]scheduler.RunState, 
 		maxTries := make(map[string]int, len(tis))
 		endedAt := make(map[string]*time.Time, len(tis))
 		rescheduleAt := make(map[string]*time.Time, len(tis))
+		dispatchAttempts := make(map[string]int, len(tis))
+		nextDispatchAt := make(map[string]*time.Time, len(tis))
 		for _, ti := range tis {
 			states[ti.TaskID] = domain.TaskState(ti.State)
 			tries[ti.TaskID] = int(ti.TryNumber)
@@ -72,6 +74,15 @@ func (s *SchedulerStore) ActiveRuns(ctx context.Context) ([]scheduler.RunState, 
 			if ti.RescheduleAt.Valid {
 				ts := ti.RescheduleAt.Time
 				rescheduleAt[ti.TaskID] = &ts
+			}
+			// dispatch_attempts / next_dispatch_at gate scheduled → queued re-dispatch
+			// after a synchronous dispatch failure (ADR 0031 Amendment A).
+			if ti.DispatchAttempts > 0 {
+				dispatchAttempts[ti.TaskID] = int(ti.DispatchAttempts)
+			}
+			if ti.NextDispatchAt.Valid {
+				ts := ti.NextDispatchAt.Time
+				nextDispatchAt[ti.TaskID] = &ts
 			}
 		}
 		// Build per-task retry_delay_seconds from the DAG spec so the planner
@@ -97,6 +108,8 @@ func (s *SchedulerStore) ActiveRuns(ctx context.Context) ([]scheduler.RunState, 
 			EndedAt:           endedAt,
 			RetryDelaySeconds: retryDelay,
 			RescheduleAt:      rescheduleAt,
+			NextDispatchAt:    nextDispatchAt,
+			DispatchAttempts:  dispatchAttempts,
 			Now:               time.Now(),
 			Alerts:            spec.Alerts,
 		})
@@ -172,9 +185,36 @@ func (s *SchedulerStore) ResetForRetry(ctx context.Context, runID, taskID string
 	})
 }
 
+// RecordDispatchFailure increments a scheduled task's dispatch-failure counter
+// and backs off its next attempt to nextAt (ADR 0031 Amendment A).
+func (s *SchedulerStore) RecordDispatchFailure(ctx context.Context, runID, taskID string, nextAt time.Time) error {
+	rid, err := parseUUID(runID)
+	if err != nil {
+		return err
+	}
+	return s.q.RecordDispatchFailure(ctx, queries.RecordDispatchFailureParams{
+		DagRunID:       rid,
+		TaskID:         taskID,
+		NextDispatchAt: pgtype.Timestamptz{Time: nextAt, Valid: true},
+	})
+}
+
+// FailDispatchExhausted fails a scheduled task as dispatch_failed once its
+// dispatch-attempt budget is spent (ADR 0031 Amendment A).
+func (s *SchedulerStore) FailDispatchExhausted(ctx context.Context, runID, taskID, reason string) error {
+	rid, err := parseUUID(runID)
+	if err != nil {
+		return err
+	}
+	return s.q.FailDispatchExhausted(ctx, queries.FailDispatchExhaustedParams{
+		DagRunID:     rid,
+		TaskID:       taskID,
+		ErrorMessage: &reason,
+	})
+}
+
 // RedispatchReschedule returns a task parked in up_for_reschedule to 'none' for
-// re-dispatch, clearing its per-attempt timestamps and reschedule_at but PRESERVING
-// try_number — reschedule is not a retry, so it consumes no attempt (#380).
+// re-dispatch, preserving try_number (reschedule is not a retry; #380).
 func (s *SchedulerStore) RedispatchReschedule(ctx context.Context, runID, taskID string) error {
 	rid, err := parseUUID(runID)
 	if err != nil {

--- a/migrations/021_task_instance_dispatch_backoff.down.sql
+++ b/migrations/021_task_instance_dispatch_backoff.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE task_instances
+    DROP COLUMN IF EXISTS next_dispatch_at,
+    DROP COLUMN IF EXISTS dispatch_attempts;

--- a/migrations/021_task_instance_dispatch_backoff.up.sql
+++ b/migrations/021_task_instance_dispatch_backoff.up.sql
@@ -1,0 +1,10 @@
+-- Dispatch-failure backoff (ADR 0031 Amendment A). A synchronous dispatch
+-- failure (kube-apiserver unreachable, RBAC denied, quota, admission reject) is
+-- no longer retried every tick: dispatch_attempts counts consecutive failures
+-- and next_dispatch_at is the earliest time the scheduler may re-attempt, exactly
+-- mirroring reschedule_at (migration 017). dispatch_attempts is separate from
+-- try_number on purpose — a dispatch failure is infrastructure, not a task
+-- failure, and must not consume the user's retry budget.
+ALTER TABLE task_instances
+    ADD COLUMN IF NOT EXISTS dispatch_attempts INT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS next_dispatch_at TIMESTAMPTZ;


### PR DESCRIPTION
## The bug

A synchronous dispatch failure — `Dispatch` returns an error: kube-apiserver unreachable, RBAC denied, quota, an admission webhook reject — left the task in `scheduled` and returned nil. The planner re-attempted it **every tick, forever**: no backoff, and covered by no reaper (the dispatch-lost reaper only sees `queued`). A permanent misconfiguration became a silent tight loop that never surfaced and never finalized the run.

## The fix (ADR 0031 Amendment A)

Two columns on `task_instances`, mirroring `reschedule_at` (migration 017): `dispatch_attempts` and `next_dispatch_at`.

- On a synchronous dispatch failure the scheduler records the attempt and backs off — exponential from 5s, capped at 5m.
- The planner does not promote `scheduled → queued` while `now < next_dispatch_at` (`readyToDispatch`, mirroring `readyToReschedule`).
- After `dispatchMaxAttempts` (6) the task fails as `dispatch_failed` so the run finalizes.

## Design decisions (all confirmed with the maintainer)

**State in Postgres, not Redis.** The bound must survive a restart to terminate the loop; Lite has no Redis but suffers the same bug; and it is per-TI durable metadata, not XCom throughput. This is the DB-as-truth rule of ADR 0031, not an exception. (Redis's real candidate is the login rate limiter, tracked separately.)

**A dispatch failure does NOT consume `try_number`.** Infrastructure, not a task failure — a `retries: 0` task must not die on a kube-apiserver blip. `dispatch_attempts` is a separate counter, and `dispatch_failed` is distinct from `dispatch_lost` (dispatched then vanished) and a task's own `failed` (the code ran).

**The planner gates and decides; no new reaper.** Keeps the decision pure and testable.

`dispatch_attempts`/`next_dispatch_at` are cleared on the retry/reschedule reset paths so a re-entering task starts fresh.

## Verification

TDD, layered — each observed failing first:
- `dispatchBackoff` (pure): exponential + cap.
- Planner gate: `TestPlanRunDefersScheduledDuringDispatchBackoff`, `...RedispatchesAfterBackoffElapses`, `...SchedulesImmediatelyWithoutBackoff`.
- Give-up: `TestStepBacksOffOnDispatchFailure`, `TestStepFailsTaskWhenDispatchExhausted`.
- Postgres integration test (`//go:build integration`) exercises both new queries + the `ActiveRuns` read of the new columns.

`go test ./...` green · `golangci-lint run` 0 issues · migration up/down parity.

> **Note:** the integration test compiles and CI runs it against real Postgres, but I could **not** run it locally — a stale docker-desktop port allocation (a phantom container from an earlier crash holding `:5432`) blocked the local test DB. Flagging so the integration job's green is watched deliberately rather than assumed.

Track A "Pro robustness", the `launchQueued` item (the third and largest). Own release (v0.1.4) — it carries a migration.