### PR TITLE
fix(executor): guard the inline http_api executor against SSRF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,15 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Security
 
+- **The inline `http_api` executor could be steered at internal addresses (SSRF).**
+  An inline task runs in the control-plane process, so a DAG author (`write:dag`)
+  could point its request at the cloud metadata endpoint (169.254.169.254), the
+  kube-apiserver, or any private/in-cluster service and read the response back as
+  XCom. The executor now allows only `http`/`https` schemes and refuses to connect
+  to a loopback, link-local, private (RFC1918/IPv6-ULA), or unspecified address.
+  The address check runs on the resolved IP at dial time, so it also defeats DNS
+  rebinding and applies to redirects.
+
 - **Hardened the log sink against path escape.** `DiskSink` interpolated every
   `logs.Ref` field straight into a filesystem path
   (`{root}/{tenant}/{dag}/{run}/{task}/{try}.log`) with no containment, so any

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -50,7 +50,7 @@ func TestInlineHTTPSuccess(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
-	if err := NewInlineHTTPExecutor(nil, 2).Execute(context.Background(), httpReq(srv.URL, http.MethodGet, nil)); err != nil {
+	if err := NewInlineHTTPExecutor(&http.Client{}, 2).Execute(context.Background(), httpReq(srv.URL, http.MethodGet, nil)); err != nil {
 		t.Errorf("2xx should succeed: %v", err)
 	}
 }
@@ -62,7 +62,7 @@ func TestInlineHTTPRetriesThenFails(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer srv.Close()
-	err := NewInlineHTTPExecutor(nil, 2).Execute(context.Background(), httpReq(srv.URL, http.MethodPost, nil))
+	err := NewInlineHTTPExecutor(&http.Client{}, 2).Execute(context.Background(), httpReq(srv.URL, http.MethodPost, nil))
 	if err == nil {
 		t.Error("persistent 500 should fail")
 	}
@@ -76,13 +76,13 @@ func TestInlineHTTPCustomSuccessCode(t *testing.T) {
 		w.WriteHeader(http.StatusTeapot)
 	}))
 	defer srv.Close()
-	if err := NewInlineHTTPExecutor(nil, 0).Execute(context.Background(), httpReq(srv.URL, http.MethodGet, []int{http.StatusTeapot})); err != nil {
+	if err := NewInlineHTTPExecutor(&http.Client{}, 0).Execute(context.Background(), httpReq(srv.URL, http.MethodGet, []int{http.StatusTeapot})); err != nil {
 		t.Errorf("418 should succeed when listed as a success code: %v", err)
 	}
 }
 
 func TestInlineHTTPMissingRequest(t *testing.T) {
-	if err := NewInlineHTTPExecutor(nil, 0).Execute(context.Background(), Request{Operator: "http_api"}); err == nil {
+	if err := NewInlineHTTPExecutor(&http.Client{}, 0).Execute(context.Background(), Request{Operator: "http_api"}); err == nil {
 		t.Error("missing http_request should error")
 	}
 }

--- a/internal/executor/inline_http.go
+++ b/internal/executor/inline_http.go
@@ -26,7 +26,7 @@ type InlineHTTPExecutor struct {
 // (nil uses a default) and retry count.
 func NewInlineHTTPExecutor(client *http.Client, maxRetries int) *InlineHTTPExecutor {
 	if client == nil {
-		client = &http.Client{}
+		client = newGuardedHTTPClient()
 	}
 	return &InlineHTTPExecutor{client: client, maxRetries: maxRetries}
 }
@@ -71,6 +71,9 @@ func (e *InlineHTTPExecutor) do(ctx context.Context, hr *domain.HTTPRequest) (st
 	timeout := time.Duration(hr.TimeoutSeconds) * time.Second
 	if timeout <= 0 {
 		timeout = 60 * time.Second
+	}
+	if serr := allowedScheme(hr.URL); serr != nil {
+		return 0, nil, serr
 	}
 	rctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/executor/inline_http_test.go
+++ b/internal/executor/inline_http_test.go
@@ -20,7 +20,7 @@ func TestInlineHTTPRunSuccess(t *testing.T) {
 		_, _ = w.Write([]byte(`{"ok":true}`))
 	}))
 	defer srv.Close()
-	body, err := NewInlineHTTPExecutor(nil, 0).Run(context.Background(),
+	body, err := NewInlineHTTPExecutor(&http.Client{}, 0).Run(context.Background(),
 		inlineReq(&domain.HTTPRequest{Method: http.MethodGet, URL: srv.URL}))
 	if err != nil || string(body) != `{"ok":true}` {
 		t.Fatalf("Run = %q, err=%v", body, err)
@@ -28,7 +28,7 @@ func TestInlineHTTPRunSuccess(t *testing.T) {
 }
 
 func TestInlineHTTPRunNoRequest(t *testing.T) {
-	if _, err := NewInlineHTTPExecutor(nil, 0).Run(context.Background(), inlineReq(nil)); err == nil {
+	if _, err := NewInlineHTTPExecutor(&http.Client{}, 0).Run(context.Background(), inlineReq(nil)); err == nil {
 		t.Error("a task with no http_request must error")
 	}
 }
@@ -38,7 +38,7 @@ func TestInlineHTTPRunNon2xxFails(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer srv.Close()
-	if _, err := NewInlineHTTPExecutor(nil, 0).Run(context.Background(),
+	if _, err := NewInlineHTTPExecutor(&http.Client{}, 0).Run(context.Background(),
 		inlineReq(&domain.HTTPRequest{Method: http.MethodGet, URL: srv.URL})); err == nil {
 		t.Error("a 500 must fail the task")
 	}
@@ -49,7 +49,7 @@ func TestInlineHTTPRunHonorsCustomSuccessCodes(t *testing.T) {
 		w.WriteHeader(http.StatusTeapot) // 418
 	}))
 	defer srv.Close()
-	if _, err := NewInlineHTTPExecutor(nil, 0).Run(context.Background(),
+	if _, err := NewInlineHTTPExecutor(&http.Client{}, 0).Run(context.Background(),
 		inlineReq(&domain.HTTPRequest{Method: http.MethodGet, URL: srv.URL, SuccessStatusCodes: []int{418}})); err != nil {
 		t.Errorf("418 should be a success when declared, got %v", err)
 	}
@@ -57,7 +57,7 @@ func TestInlineHTTPRunHonorsCustomSuccessCodes(t *testing.T) {
 
 func TestInlineHTTPRunBuildRequestError(t *testing.T) {
 	// An invalid method makes http.NewRequestWithContext fail (a build error).
-	if _, err := NewInlineHTTPExecutor(nil, 0).Run(context.Background(),
+	if _, err := NewInlineHTTPExecutor(&http.Client{}, 0).Run(context.Background(),
 		inlineReq(&domain.HTTPRequest{Method: "INVALID METHOD", URL: "http://x"})); err == nil {
 		t.Error("an invalid method should produce a build error")
 	}
@@ -65,14 +65,14 @@ func TestInlineHTTPRunBuildRequestError(t *testing.T) {
 
 func TestInlineHTTPRunMarshalError(t *testing.T) {
 	// A body that cannot be JSON-encoded (a channel) fails before sending.
-	if _, err := NewInlineHTTPExecutor(nil, 0).Run(context.Background(),
+	if _, err := NewInlineHTTPExecutor(&http.Client{}, 0).Run(context.Background(),
 		inlineReq(&domain.HTTPRequest{Method: http.MethodPost, URL: "http://x", Body: make(chan int)})); err == nil {
 		t.Error("an unmarshalable body should error")
 	}
 }
 
 func TestInlineHTTPRunNetworkError(t *testing.T) {
-	if _, err := NewInlineHTTPExecutor(nil, 0).Run(context.Background(),
+	if _, err := NewInlineHTTPExecutor(&http.Client{}, 0).Run(context.Background(),
 		inlineReq(&domain.HTTPRequest{Method: http.MethodGet, URL: "http://127.0.0.1:1"})); err == nil {
 		t.Error("an unreachable host should error")
 	}
@@ -87,7 +87,7 @@ func TestInlineHTTPRunSendsHeadersAndBody(t *testing.T) {
 		_, _ = w.Write([]byte("ok"))
 	}))
 	defer srv.Close()
-	_, err := NewInlineHTTPExecutor(nil, 0).Run(context.Background(), inlineReq(&domain.HTTPRequest{
+	_, err := NewInlineHTTPExecutor(&http.Client{}, 0).Run(context.Background(), inlineReq(&domain.HTTPRequest{
 		Method: http.MethodPost, URL: srv.URL,
 		Headers: map[string]string{"Authorization": "Bearer xyz"},
 		Body:    map[string]any{"k": "v"},

--- a/internal/executor/inline_runner_test.go
+++ b/internal/executor/inline_runner_test.go
@@ -105,6 +105,10 @@ func newInline(t *testing.T) (*InlineRunner, *fakeSink, *fakeXComPusher, *fakeLo
 		Sink: sink, Metrics: &fakeMetrics{}, XCom: px, Logs: ls,
 		Concurrency: 4, MaxSeconds: 300, UserAgent: "leoflow/test",
 	})
+	// The tests hit a loopback httptest server, which the production SSRF guard
+	// (rightly) blocks; use an unguarded client for the local test server. The
+	// guard itself is covered by ssrf_guard_test.go.
+	r.exec = NewInlineHTTPExecutor(&http.Client{}, 0).Run
 	return r, sink, px, ls
 }
 

--- a/internal/executor/ssrf_guard.go
+++ b/internal/executor/ssrf_guard.go
@@ -1,0 +1,86 @@
+package executor
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"syscall"
+	"time"
+)
+
+// An inline http_api task runs in the control-plane process (ADR 0021/0031), so
+// its outbound request is made with the control plane's network reach. Without a
+// guard, a DAG author (write:dag) could point it at the cloud metadata endpoint
+// (169.254.169.254), the kube-apiserver, or any in-cluster/private service, and
+// read the response back as XCom — a server-side request forgery. These two
+// guards close that: only http/https schemes, and a dialer that refuses to
+// connect to a private, loopback, or link-local address. The dial check runs on
+// the RESOLVED ip at connect time, so it also defeats DNS rebinding and follows
+// through redirects (each redirect re-dials through the same transport).
+var (
+	// ErrBlockedAddress reports a dial to a private/loopback/link-local address.
+	ErrBlockedAddress = errors.New("blocked address (SSRF guard)")
+	// ErrBlockedScheme reports a non-http(s) request URL.
+	ErrBlockedScheme = errors.New("blocked url scheme (SSRF guard)")
+)
+
+// deniedIP reports whether dialing ip would reach an address an inline task must
+// not: loopback, link-local (cloud metadata lives at 169.254.169.254), private
+// (RFC1918 and IPv6 unique-local), or the unspecified address.
+func deniedIP(ip net.IP) bool {
+	return ip == nil ||
+		ip.IsLoopback() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsInterfaceLocalMulticast() ||
+		ip.IsPrivate() ||
+		ip.IsUnspecified()
+}
+
+// guardedDialControl is a net.Dialer.Control hook. address is host:port with the
+// host already resolved to an IP literal, so checking it here is rebinding-safe:
+// the value checked is the value dialed.
+func guardedDialControl(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return err
+	}
+	ip := net.ParseIP(host)
+	if deniedIP(ip) {
+		return fmt.Errorf("%w: %s", ErrBlockedAddress, host)
+	}
+	return nil
+}
+
+// allowedScheme rejects any request URL that is not http or https, before a
+// request is built. It blocks file://, gopher://, and similar exfiltration or
+// local-file schemes.
+func allowedScheme(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("%w: unparseable url: %w", ErrBlockedScheme, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("%w: %q", ErrBlockedScheme, u.Scheme)
+	}
+	return nil
+}
+
+// newGuardedHTTPClient builds the http.Client the inline executor uses by
+// default: an ordinary transport whose dialer refuses private/loopback/link-local
+// destinations via guardedDialControl.
+func newGuardedHTTPClient() *http.Client {
+	dialer := &net.Dialer{Timeout: 30 * time.Second, Control: guardedDialControl}
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext:           dialer.DialContext,
+			ForceAttemptHTTP2:     true,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: time.Second,
+		},
+	}
+}

--- a/internal/executor/ssrf_guard_test.go
+++ b/internal/executor/ssrf_guard_test.go
@@ -1,0 +1,105 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+func TestDeniedIP(t *testing.T) {
+	for _, tc := range []struct {
+		ip     string
+		denied bool
+	}{
+		{"169.254.169.254", true}, // cloud metadata (link-local) — the headline SSRF target
+		{"127.0.0.1", true},       // loopback
+		{"::1", true},             // loopback v6
+		{"10.0.0.5", true},        // RFC1918
+		{"172.16.3.4", true},      // RFC1918
+		{"192.168.1.1", true},     // RFC1918
+		{"fd00::1", true},         // IPv6 unique-local
+		{"fe80::1", true},         // IPv6 link-local
+		{"0.0.0.0", true},         // unspecified
+		{"8.8.8.8", false},        // public
+		{"1.1.1.1", false},        // public
+		{"93.184.216.34", false},  // public (example.com)
+	} {
+		if got := deniedIP(net.ParseIP(tc.ip)); got != tc.denied {
+			t.Errorf("deniedIP(%s) = %v, want %v", tc.ip, got, tc.denied)
+		}
+	}
+}
+
+func TestGuardedDialControlBlocksPrivate(t *testing.T) {
+	if err := guardedDialControl("tcp", "169.254.169.254:80", nil); !errors.Is(err, ErrBlockedAddress) {
+		t.Errorf("metadata IP should be blocked, got %v", err)
+	}
+	if err := guardedDialControl("tcp", "8.8.8.8:443", nil); err != nil {
+		t.Errorf("a public IP should be allowed, got %v", err)
+	}
+}
+
+func TestAllowedSchemeRejectsNonHTTP(t *testing.T) {
+	for _, u := range []string{"file:///etc/passwd", "gopher://x", "ftp://h/f", "s3://b/k"} {
+		if err := allowedScheme(u); !errors.Is(err, ErrBlockedScheme) {
+			t.Errorf("%s should be blocked, got %v", u, err)
+		}
+	}
+	for _, u := range []string{"http://example.com", "https://api.example.com/x"} {
+		if err := allowedScheme(u); err != nil {
+			t.Errorf("%s should be allowed, got %v", u, err)
+		}
+	}
+}
+
+// The default (production) executor's client refuses to reach a loopback server:
+// the SSRF guard is wired into the client the control plane actually uses.
+func TestInlineHTTPDefaultClientBlocksLoopback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	exec := NewInlineHTTPExecutor(nil, 0) // nil = the guarded default
+	_, err := exec.Run(context.Background(), Request{
+		HTTPRequest: &domain.HTTPRequest{Method: "GET", URL: srv.URL},
+	})
+	if err == nil {
+		t.Fatal("the guarded default client must not reach a loopback address")
+	}
+}
+
+// A non-http scheme is rejected before any request is made, regardless of client.
+func TestInlineHTTPRejectsNonHTTPScheme(t *testing.T) {
+	exec := NewInlineHTTPExecutor(&http.Client{}, 0)
+	_, err := exec.Run(context.Background(), Request{
+		HTTPRequest: &domain.HTTPRequest{Method: "GET", URL: "file:///etc/passwd"},
+	})
+	if !errors.Is(err, ErrBlockedScheme) {
+		t.Errorf("a file:// URL must be rejected, got %v", err)
+	}
+}
+
+// The error paths: a malformed dial address and an unparseable URL. Covering
+// them keeps the guard's coverage complete (the SSRF guard sits on the razor
+// edge of the aggregate floor, so its own lines must be fully exercised).
+func TestGuardedDialControlMalformedAddress(t *testing.T) {
+	if err := guardedDialControl("tcp", "no-port-here", nil); err == nil {
+		t.Error("an address without host:port should error")
+	}
+	// A non-IP host at the control stage (should not happen post-resolution) is denied.
+	if err := guardedDialControl("tcp", "example.com:80", nil); !errors.Is(err, ErrBlockedAddress) {
+		t.Errorf("a non-IP host must be blocked (fail closed), got %v", err)
+	}
+}
+
+func TestAllowedSchemeUnparseable(t *testing.T) {
+	if err := allowedScheme("://missing-scheme"); !errors.Is(err, ErrBlockedScheme) {
+		t.Errorf("an unparseable url must be blocked, got %v", err)
+	}
+}


### PR DESCRIPTION
## The bug (H5)

An inline `http_api` task runs **in the control-plane process** (ADR 0021/0031), so its outbound request carries the control plane's network reach. The URL comes from the DAG, so a `write:dag` author could point it at:

- the cloud metadata endpoint `http://169.254.169.254/…`
- the kube-apiserver
- any private / in-cluster service (`*.svc.cluster.local`)

…and read the response body back as the task's `return_value` XCom. Server-side request forgery, from the orchestrator, in the default execution mode (`http_api` defaults to inline).

## The fix — two guards

**Scheme allowlist.** `allowedScheme` rejects any URL that is not `http`/`https` before a request is built (no `file://`, `gopher://`, …).

**Address deny, rebinding-safe.** A `net.Dialer.Control` hook refuses to connect to a **loopback, link-local (metadata = 169.254.169.254), private (RFC1918 + IPv6 ULA), or unspecified** address. It runs on the **resolved IP at dial time** — the value checked is the value dialed — so it defeats DNS rebinding and covers redirects (each re-dials through the same transport).

## Design

The dial guard lives on the **default client** `NewInlineHTTPExecutor` builds when none is injected — the production path (`inline_runner.go` passes `nil`). An **injected client is the test seam**: tests reach loopback httptest servers with an unguarded client, while the guard is covered directly against the real default (a guarded client **cannot** reach a loopback httptest server — `TestInlineHTTPDefaultClientBlocksLoopback`).

`deniedIP` is the pure, table-tested core: metadata, loopback, RFC1918, IPv6-ULA/link-local, unspecified → denied; public IPs → allowed.

## Scope

The **inline executor only**. The alert notifier posts to an operator-configured managed connection (`write:connection`) — a different trust level — and is out of scope here.

## Verification

- Tests written first: `TestDeniedIP`, `TestGuardedDialControlBlocksPrivate`, `TestAllowedSchemeRejectsNonHTTP`, `TestInlineHTTPDefaultClientBlocksLoopback`, `TestInlineHTTPRejectsNonHTTPScheme`.
- `go test ./...` green · `golangci-lint run` 0 issues.

Track B "multi-team boundary" — general security (not multi-tenancy-gated). Accumulates in `[Unreleased]`; no release cut.