### PR TITLE
Split control plane into api/scheduler roles (ADR 0049) + deprecate inline http_api (ADR 0047)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -453,6 +453,15 @@ jobs:
       - name: Run the k3d operator e2e
         run: bash test/e2e/e2e.sh
 
+      # ADR 0049: the same runner, datastores, and images also gate the two-process
+      # api/scheduler split — boots role=api + role=scheduler as separate processes
+      # against the shared Postgres/Redis and asserts a run flows across them via
+      # the DB (the api accepts the trigger; the SEPARATE scheduler dispatches the
+      # pods). Runs its own k3d cluster; reuses the admin the operator e2e seeded,
+      # which also exercises the concurrent-bootstrap idempotency fix.
+      - name: Run the k3d two-process split e2e (ADR 0049)
+        run: bash test/e2e/split-two-process.sh
+
   # e2e-dbt: dbt-native orchestration on a real k3d cluster (test/e2e/dbt-e2e.sh +
   # dbt-mixing-e2e.sh). A dbt project compiles to one pod per model; the mixing
   # script proves a dbt project in a subdir (transform/) wired around operators,

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -453,12 +453,57 @@ jobs:
       - name: Run the k3d operator e2e
         run: bash test/e2e/e2e.sh
 
-      # ADR 0049: the same runner, datastores, and images also gate the two-process
-      # api/scheduler split — boots role=api + role=scheduler as separate processes
-      # against the shared Postgres/Redis and asserts a run flows across them via
-      # the DB (the api accepts the trigger; the SEPARATE scheduler dispatches the
-      # pods). Runs its own k3d cluster; reuses the admin the operator e2e seeded,
-      # which also exercises the concurrent-bootstrap idempotency fix.
+  # ─────────────────────────────────────────────────────────────────────
+  # Two-process api/scheduler split e2e (ADR 0049; test/e2e/split-two-process.sh):
+  # boots role=api + role=scheduler as SEPARATE processes against a shared
+  # Postgres/Redis and drives a run that must flow across them via the DB (the api
+  # accepts the trigger; the SEPARATE scheduler dispatches the task pods). Also
+  # asserts socket-level role isolation. A DEDICATED job with its OWN fresh
+  # datastores — deliberately not sharing the operator-e2e DB, so the split
+  # scheduler is not handed leftover queued task instances from another run's
+  # cluster (which would ImagePullBackOff and add noise/flakiness). ~8 min.
+  # ─────────────────────────────────────────────────────────────────────
+  split-e2e:
+    name: E2E split (k3d two-process api/scheduler)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: public.ecr.aws/docker/library/postgres:16
+        env:
+          POSTGRES_USER: leoflow
+          POSTGRES_PASSWORD: leoflow
+          POSTGRES_DB: leoflow
+        ports: [5432:5432]
+        options: >-
+          --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
+      redis:
+        image: public.ecr.aws/docker/library/redis:7
+        ports: [6379:6379]
+        options: --health-cmd "redis-cli ping" --health-interval 5s --health-timeout 3s --health-retries 10
+    env:
+      LEOFLOW_E2E_HOST_ADDR: host.k3d.internal
+      PYTHONPATH: parser
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install k3d + kubectl + jq + migrate
+        run: |
+          set -euo pipefail
+          curl -fsSL https://raw.githubusercontent.com/k3d-io/k3d/v5.7.4/install.sh | TAG=v5.7.4 bash
+          curl -fsSLO "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          sudo install -m 0755 kubectl /usr/local/bin/kubectl
+          sudo apt-get update -qq && sudo apt-get install -y -qq jq
+          go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+      - name: Apply migrations
+        run: ~/go/bin/migrate -path migrations -database "postgres://leoflow:leoflow@localhost:5432/leoflow?sslmode=disable" up
+      - name: Build binaries
+        run: make build
       - name: Run the k3d two-process split e2e (ADR 0049)
         run: bash test/e2e/split-two-process.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Optional api/scheduler split for Pro (`split.enabled`, off by default; ADR
+  0049).** `leoflow-server` gains a role (`LEOFLOW_SERVER_ROLE`: `all` (default,
+  and Lite's only mode — behavior-identical to before), `api`, `scheduler`). When
+  the chart's `split.enabled` is set, it renders a restricted-identity api
+  Deployment (HTTP + UI, active-active, its ServiceAccount unbound from the
+  pod-create Role) and a privileged single-leader scheduler Deployment (reconciler
+  + dispatch + agent gRPC), each with its own Service/RBAC/NetworkPolicy and
+  role-appropriate probes. Isolates API load from scheduling and shrinks the
+  API's blast radius. Lite and existing monolith installs are unaffected.
+
+### Changed
+
+- **The metrics listener (`:9090`) now also serves `/healthz` and `/readyz`**, and
+  is scoped to those plus `/metrics` (a request to another path returns 404,
+  where the bare Prometheus handler previously answered on any path). This gives a
+  scheduler-only pod a probe target (ADR 0049) and is additive for the standard
+  `/metrics` scrape; adjust any scrape configured against `:9090/` (non-`/metrics`).
+
 ### Deprecated
 
 - **The native inline `http_api` task type is deprecated and will be removed next

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Deprecated
+
+- **The native inline `http_api` task type is deprecated and will be removed next
+  release** (ADR 0047, issue #512). It runs an author-supplied HTTP request
+  *inline in the control-plane process*, which carries the control plane's network
+  position — the SSRF surface (audit finding H5). The parser no longer emits it
+  (an `HttpOperator` compiles to a captured provider operator that runs in a task
+  pod, ADR 0040), so it can now only arrive via a hand-written `dag.json`.
+  Registering a spec that still uses it succeeds but returns a deprecation warning
+  that `leoflow push` prints; next release the registration rejects it and the
+  inline executor is removed (the guard becomes structural, ADR 0048). Migrate to
+  an `HttpOperator`, which runs in a pod.
+
 ### Added
 
 - **A task-pod egress NetworkPolicy** (`taskNetworkPolicy`, off by default). Task

--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,10 @@ migrate-image: ## Build the migrate image (migrations + golang-migrate) for the 
 e2e: ## Run the k3d end-to-end smoke test (needs k3d, kubectl, docker, jq; run make dev-up + make build first)
 	bash test/e2e/e2e.sh
 
+.PHONY: e2e-split
+e2e-split: ## Run the k3d two-process api/scheduler split e2e (ADR 0049; needs k3d, kubectl, docker, jq; run make dev-up + make build first)
+	bash test/e2e/split-two-process.sh
+
 .PHONY: e2e-dbt
 e2e-dbt: ## Run the k3d dbt pod-per-node e2e (ADR 0042; needs k3d, kubectl, docker, jq, dbt; run make dev-up + make build first)
 	bash test/e2e/dbt-e2e.sh

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -16,7 +16,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"k8s.io/client-go/kubernetes"
@@ -150,61 +149,23 @@ func run() error {
 		InlineConcurrency:     cfg.Executor.HTTP.InlineConcurrencyLimit,
 	}
 
-	if cfg.Auth.DevNoAuth {
-		tel.Logger.Warn("AUTHENTICATION DISABLED (auth.dev_no_auth): every request is treated as admin. Dev only — NEVER use in production")
+	// Dependency health probes (Postgres, and Redis when configured). Built once
+	// and shared read-only by the API's /readyz and the metrics-port /readyz.
+	checks := healthChecks(pg, redisHealth)
+
+	// The API side (HTTP + embedded UI) is built only in the api/"all" role. The
+	// scheduler role serves no API, so none of the UI/handler machinery is even
+	// constructed — apiSrv stays nil and serveHTTP omits it.
+	var apiSrv *http.Server
+	if servesAPI {
+		apiSrv = buildAPIServer(cfg, tel, authn, pg, repo, xcomReader, logSink, logTailer, checks, executorInfo, schedulerHealth)
 	}
-	// Show the LITE badge for the Lite edition (independent of the auth mode), and
-	// also when the legacy dev auth bypass is on. The demo/production show neither.
-	uiSrv := ui.New()
-	uiSrv.SetLiteBanner(showLiteBadge(cfg))
-	uiSrv.SetProBanner(showProBadge(cfg))
-	uiSrv.SetInstanceName(cfg.UI.InstanceName)
 
-	editorFS := liteEditorFS(cfg, tel.Logger)
-	uiSrv.SetEditorButton(editorFS != nil)
-
-	handler := api.NewServer(api.Dependencies{
-		Logger:                       tel.Logger,
-		Authenticator:                authn,
-		RateLimiter:                  auth.NewRateLimiter(loginRateLimit(cfg), time.Minute),
-		Registry:                     tel.Registry,
-		Metrics:                      tel.Metrics,
-		Tracer:                       tel.Tracer,
-		HealthChecks:                 healthChecks(pg, redisHealth),
-		CORSOrigins:                  cfg.Server.CORS.AllowedOrigins,
-		TokenTTLSecs:                 cfg.Auth.JWT.TokenTTLSeconds,
-		InstanceName:                 cfg.UI.InstanceName,
-		UIAutoRefreshIntervalSeconds: cfg.UI.AutoRefreshIntervalSeconds,
-		DevNoAuth:                    cfg.Auth.DevNoAuth,
-
-		InlineHTTPMaxDurationSeconds: cfg.Executor.HTTP.InlineMaxDurationSeconds,
-		Dags:                         repo,
-		DagRuns:                      repo,
-		Tasks:                        repo,
-		Versions:                     repo,
-		Xcoms:                        xcomReader,
-		Logs:                         storage.NewLogReader(pg, logSink, logTailer),
-		Specs:                        repo,
-		LatestRuns:                   repo,
-		TaskSummary:                  repo,
-		DagVersions:                  repo,
-		DashboardStats:               repo,
-		AuditLog:                     repo,
-		Variables:                    repo,
-		Connections:                  repo,
-		Favorites:                    repo,
-		ImportErrors:                 repo,
-		Audit:                        repo,
-		ExecutorInfo:                 executorInfo,
-		SchedulerHealth:              schedulerHealth,
-		UI:                           uiSrv,
-		Workspace:                    editorFS,
-		MonacoDir:                    cfg.UI.MonacoDir,
-		ExamplesFS:                   leoflow.ExampleDAGs(),
-	})
-
-	apiSrv := &http.Server{Addr: cfg.Server.HTTPAddr, Handler: handler, ReadHeaderTimeout: 10 * time.Second}
-	metricsSrv := &http.Server{Addr: cfg.Server.MetricsAddr, Handler: promhttp.HandlerFor(tel.Registry, promhttp.HandlerOpts{}), ReadHeaderTimeout: 10 * time.Second}
+	// The metrics listener also serves /healthz + /readyz in every role so a
+	// scheduler-only pod (ADR 0049), which serves no API, still has a probe target
+	// for the kubelet. Additive on the api/"all" role, whose probes still hit the
+	// HTTP port.
+	metricsSrv := &http.Server{Addr: cfg.Server.MetricsAddr, Handler: api.ObservabilityHandler(tel.Registry, checks), ReadHeaderTimeout: 10 * time.Second}
 
 	tel.Logger.Info("leoflow-server started", "role", cfg.Server.EffectiveRole(), "http_addr", cfg.Server.HTTPAddr, "metrics_addr", cfg.Server.MetricsAddr, "serves_api", servesAPI, "serves_scheduler", servesScheduler)
 	return serveHTTP(ctx, tel.Logger, servesAPI, apiSrv, metricsSrv)
@@ -382,6 +343,66 @@ func startSchedulerSide(ctx context.Context, cfg *config.ServerConfig, pg *stora
 		grpcSrv.GracefulStop()
 	}
 	return health, podDispatch, stop, nil
+}
+
+// buildAPIServer assembles the HTTP API + embedded UI server for the api/"all"
+// role (ADR 0049). It is called only when the role serves the API, so the UI
+// shell, editor FS, rate limiter, and full route set are never constructed in a
+// scheduler-only process.
+func buildAPIServer(cfg *config.ServerConfig, tel *observability.Telemetry, authn *auth.JWTAuthenticator, pg *storage.Postgres, repo *storage.Repository, xcomReader *storage.XComReader, logSink *logs.DiskSink, logTailer logs.Tailer, checks map[string]api.HealthChecker, executorInfo api.ExecutorInfo, schedulerHealth api.Heartbeater) *http.Server {
+	if cfg.Auth.DevNoAuth {
+		tel.Logger.Warn("AUTHENTICATION DISABLED (auth.dev_no_auth): every request is treated as admin. Dev only — NEVER use in production")
+	}
+	// Show the LITE badge for the Lite edition (independent of the auth mode), and
+	// also when the legacy dev auth bypass is on. The demo/production show neither.
+	uiSrv := ui.New()
+	uiSrv.SetLiteBanner(showLiteBadge(cfg))
+	uiSrv.SetProBanner(showProBadge(cfg))
+	uiSrv.SetInstanceName(cfg.UI.InstanceName)
+
+	editorFS := liteEditorFS(cfg, tel.Logger)
+	uiSrv.SetEditorButton(editorFS != nil)
+
+	handler := api.NewServer(api.Dependencies{
+		Logger:                       tel.Logger,
+		Authenticator:                authn,
+		RateLimiter:                  auth.NewRateLimiter(loginRateLimit(cfg), time.Minute),
+		Registry:                     tel.Registry,
+		Metrics:                      tel.Metrics,
+		Tracer:                       tel.Tracer,
+		HealthChecks:                 checks,
+		CORSOrigins:                  cfg.Server.CORS.AllowedOrigins,
+		TokenTTLSecs:                 cfg.Auth.JWT.TokenTTLSeconds,
+		InstanceName:                 cfg.UI.InstanceName,
+		UIAutoRefreshIntervalSeconds: cfg.UI.AutoRefreshIntervalSeconds,
+		DevNoAuth:                    cfg.Auth.DevNoAuth,
+
+		InlineHTTPMaxDurationSeconds: cfg.Executor.HTTP.InlineMaxDurationSeconds,
+		Dags:                         repo,
+		DagRuns:                      repo,
+		Tasks:                        repo,
+		Versions:                     repo,
+		Xcoms:                        xcomReader,
+		Logs:                         storage.NewLogReader(pg, logSink, logTailer),
+		Specs:                        repo,
+		LatestRuns:                   repo,
+		TaskSummary:                  repo,
+		DagVersions:                  repo,
+		DashboardStats:               repo,
+		AuditLog:                     repo,
+		Variables:                    repo,
+		Connections:                  repo,
+		Favorites:                    repo,
+		ImportErrors:                 repo,
+		Audit:                        repo,
+		ExecutorInfo:                 executorInfo,
+		SchedulerHealth:              schedulerHealth,
+		UI:                           uiSrv,
+		Workspace:                    editorFS,
+		MonacoDir:                    cfg.UI.MonacoDir,
+		ExamplesFS:                   leoflow.ExampleDAGs(),
+	})
+	return &http.Server{Addr: cfg.Server.HTTPAddr, Handler: handler, ReadHeaderTimeout: 10 * time.Second}
 }
 
 // serveHTTP starts the process's HTTP listeners — the api role's API+UI (when

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -121,28 +121,24 @@ func run() error {
 	if err := guardTLSForEdition(cfg.UI.Edition, cfg.Server.GRPCTLSCert, cfg.Server.GRPCTLSKey); err != nil {
 		return err
 	}
-	grpcSrv, gerr := startAgentGRPC(ctx, cfg.Server.GRPCAddr, authn, execStore, repo, xcomSvc, logSink, logTailer, allowInsecureSecrets, cfg.Server.GRPCTLSCert, cfg.Server.GRPCTLSKey, tel.Logger)
-	if gerr != nil {
-		return gerr
-	}
-	defer grpcSrv.GracefulStop()
+	// Role gating (ADR 0049). "all" (the default, and Lite's only mode) serves both
+	// sides, so both predicates are true and the wiring below is identical to the
+	// pre-0049 monolith. The "scheduler" role runs the agent gRPC, the scheduler
+	// loop, and the janitors; the "api" role runs the HTTP API + UI. Metrics run in
+	// every role. The Helm two-Deployment rendering that lets an operator select a
+	// role is a later phase; today the flag is process-level and covered by tests.
+	servesAPI := cfg.Server.ServesAPI()
+	servesScheduler := cfg.Server.ServesScheduler()
 
-	startCleanup(ctx, storage.NewXComIndex(pg), logSink, cfg.Logs.Dir, tel.Logger)
-
-	var schedulerHealth api.Heartbeater
-	podDispatch := false
-	if cfg.Scheduler.Enabled {
-		sched, dispatchOn, dispatchCloser, serr := startScheduler(ctx, cfg, pg, repo, execStore, authn, xcomSvc, logSink, tel.Logger, tel.Metrics)
-		if serr != nil {
-			return serr
-		}
-		// On shutdown, drain the buffered dispatch pool (if any) so in-flight
-		// dispatches settle (success or failed via the sink) instead of leaking
-		// workers and leaving TIs stuck `queued` (#133). nil in Lite/passthrough.
-		defer drainDispatch(dispatchCloser, tel.Logger)
-		schedulerHealth = sched
-		podDispatch = dispatchOn
+	// Start the scheduler-role components (agent gRPC, janitors, scheduler loop +
+	// dispatch). In the api role this starts nothing and returns a nil health handle
+	// + no-op stop; in "all"/"scheduler" it is the pre-0049 wiring unchanged.
+	schedulerHealth, podDispatch, stopScheduler, serr := startSchedulerSide(ctx, cfg, pg, repo, execStore, authn, xcomSvc, logSink, logTailer, allowInsecureSecrets, servesScheduler, tel.Logger, tel.Metrics)
+	if serr != nil {
+		return serr
 	}
+	defer stopScheduler()
+
 	agentAddr := cfg.Executor.AgentControlPlaneAddr
 	if agentAddr == "" {
 		agentAddr = cfg.Server.GRPCAddr
@@ -210,12 +206,8 @@ func run() error {
 	apiSrv := &http.Server{Addr: cfg.Server.HTTPAddr, Handler: handler, ReadHeaderTimeout: 10 * time.Second}
 	metricsSrv := &http.Server{Addr: cfg.Server.MetricsAddr, Handler: promhttp.HandlerFor(tel.Registry, promhttp.HandlerOpts{}), ReadHeaderTimeout: 10 * time.Second}
 
-	errCh := make(chan error, 2)
-	go serve(apiSrv, errCh)
-	go serve(metricsSrv, errCh)
-	tel.Logger.Info("leoflow-server started", "http_addr", cfg.Server.HTTPAddr, "metrics_addr", cfg.Server.MetricsAddr)
-
-	return awaitShutdown(ctx, errCh, tel.Logger, apiSrv, metricsSrv)
+	tel.Logger.Info("leoflow-server started", "role", cfg.Server.EffectiveRole(), "http_addr", cfg.Server.HTTPAddr, "metrics_addr", cfg.Server.MetricsAddr, "serves_api", servesAPI, "serves_scheduler", servesScheduler)
+	return serveHTTP(ctx, tel.Logger, servesAPI, apiSrv, metricsSrv)
 }
 
 // awaitShutdown blocks until a server errors or the context is canceled, then
@@ -349,6 +341,62 @@ type inlineStateSink struct{ store *storage.SchedulerStore }
 
 func (s inlineStateSink) Transition(ctx context.Context, runID, taskID string, state domain.TaskState) error {
 	return s.store.ApplyTransition(ctx, runID, taskID, state)
+}
+
+// startSchedulerSide starts the scheduler-role components (ADR 0049): the agent
+// gRPC endpoint, the XCom/log janitors, and — when cfg.Scheduler.Enabled — the
+// scheduler loop + dispatch pool. It returns the scheduler's health handle (nil
+// when the loop is off; the API reports scheduler health as healthy on nil),
+// whether pod dispatch is on, and a stop func to defer. When servesScheduler is
+// false (the api role) it starts nothing and returns a nil handle + no-op stop, so
+// the caller defers unconditionally. The stop func fires drain-then-gRPC-stop,
+// matching the pre-0049 defer order (LIFO: drainDispatch before GracefulStop).
+func startSchedulerSide(ctx context.Context, cfg *config.ServerConfig, pg *storage.Postgres, repo *storage.Repository, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, xcomSvc *xcom.Service, logSink *logs.DiskSink, logTailer logs.Tailer, allowInsecureSecrets bool, servesScheduler bool, logger *slog.Logger, metrics *observability.Metrics) (health api.Heartbeater, podDispatch bool, stop func(), err error) {
+	if !servesScheduler {
+		return nil, false, func() {}, nil
+	}
+	grpcSrv, gerr := startAgentGRPC(ctx, cfg.Server.GRPCAddr, authn, execStore, repo, xcomSvc, logSink, logTailer, allowInsecureSecrets, cfg.Server.GRPCTLSCert, cfg.Server.GRPCTLSKey, logger)
+	if gerr != nil {
+		return nil, false, nil, gerr
+	}
+	// XCom-TTL and log-retention janitors are maintenance the scheduler owns; the
+	// api role runs no background writers.
+	startCleanup(ctx, storage.NewXComIndex(pg), logSink, cfg.Logs.Dir, logger)
+
+	drain := func() {}
+	if cfg.Scheduler.Enabled {
+		sched, dispatchOn, dispatchCloser, serr := startScheduler(ctx, cfg, pg, repo, execStore, authn, xcomSvc, logSink, logger, metrics)
+		if serr != nil {
+			grpcSrv.GracefulStop()
+			return nil, false, nil, serr
+		}
+		// On shutdown, drain the buffered dispatch pool (if any) so in-flight
+		// dispatches settle (success or failed via the sink) instead of leaking
+		// workers and leaving TIs stuck `queued` (#133). nil in Lite/passthrough.
+		drain = func() { drainDispatch(dispatchCloser, logger) }
+		health = sched
+		podDispatch = dispatchOn
+	}
+	stop = func() {
+		drain()
+		grpcSrv.GracefulStop()
+	}
+	return health, podDispatch, stop, nil
+}
+
+// serveHTTP starts the process's HTTP listeners — the api role's API+UI (when
+// servesAPI) plus /metrics in every role, so a scheduler-only pod stays scrapable
+// — and blocks until one errors or ctx is canceled, then shuts them down.
+func serveHTTP(ctx context.Context, logger *slog.Logger, servesAPI bool, apiSrv, metricsSrv *http.Server) error {
+	servers := []*http.Server{metricsSrv}
+	if servesAPI {
+		servers = append([]*http.Server{apiSrv}, servers...)
+	}
+	errCh := make(chan error, len(servers))
+	for _, srv := range servers {
+		go serve(srv, errCh)
+	}
+	return awaitShutdown(ctx, errCh, logger, servers...)
 }
 
 // startAgentGRPC starts the AgentService gRPC server and returns it for graceful

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -153,6 +153,16 @@ func run() error {
 	// and shared read-only by the API's /readyz and the metrics-port /readyz.
 	checks := healthChecks(pg, redisHealth)
 
+	// In the split api role the scheduler runs in another process, so
+	// startSchedulerSide returned a nil health handle. Reporting the scheduler as
+	// healthy from nil would be a lie (finding F1) — instead read its liveness
+	// from shared DB state: a live scheduler leader holds the leadership advisory
+	// lock (ADR 0009). The "all" role keeps its in-process handle (real tick
+	// health), unchanged.
+	if servesAPI && !servesScheduler {
+		schedulerHealth = scheduler.NewLeaderHealthReader(pg.Pool)
+	}
+
 	// The API side (HTTP + embedded UI) is built only in the api/"all" role. The
 	// scheduler role serves no API, so none of the UI/handler machinery is even
 	// constructed — apiSrv stays nil and serveHTTP omits it.

--- a/docs/adr/0047-deprecate-native-inline-http.md
+++ b/docs/adr/0047-deprecate-native-inline-http.md
@@ -47,8 +47,17 @@ generic pod executor (ADR 0040 Phase A), like any other provider operator.**
 
 2. **Deprecate the inline path.** The `http_api` task type and its inline executor
    (`internal/executor/inline_http.go`, `inline_runner.go`, the scheduler's
-   `s.inline`/`runInline` wiring) are deprecated: kept one release behind a compile
+   `s.inline`/`runInline` wiring) are deprecated: kept one release behind a
    warning, then removed.
+
+   *Cadence (maintainer decision, 2026-08-04).* One-release deprecation, not an
+   immediate break. Because the parser no longer emits `http_api` (step 1), it can
+   only arrive via a hand-written `dag.json`, so the warning lives at
+   **registration**, not compile: `DAGSpec.DeprecationWarnings()` feeds the
+   register response and `leoflow push` prints it (the CLI is the only place the
+   author sees it). The **removal** — reject `http_api` at registration (400) and
+   delete the inline executor + scheduler wiring so the guard is structural (ADR
+   0048) — is tracked in **issue #512** for the next release.
 
 3. **Remove the app-level SSRF guard.** The inline dial-control (#504) goes with
    the inline executor. It is unnecessary once HTTP runs in a pod.

--- a/docs/adr/0049-split-api-and-scheduler-roles.md
+++ b/docs/adr/0049-split-api-and-scheduler-roles.md
@@ -1,6 +1,6 @@
 # ADR 0049: Split the API/UI and scheduler into separate roles of one binary
 
-**Status:** Accepted
+**Status:** Accepted — implemented (role gating + Helm split + two-process e2e), behind `split.enabled` (off by default).
 **Accepted:** 2026-08-03 — maintainer greenlit the split for enterprise scale, a conscious override of the KFP study's "keep the monolith" (correct at small scale). Implementation is phased and must be well-tested before it rides a release.
 **Date:** 2026-08-03
 **Relates:** ADR 0001 (one Go control plane), ADR 0007 + 0017 (single binary, embedded SPA), ADR 0028 (one tag = both editions), ADR 0031 (DB-as-truth scheduler), ADR 0048 (no user code in the control plane), ADR 0009 (leader election)
@@ -130,6 +130,53 @@ not from memory — a small behaviour change to name in the upgrade notes.
    security invariant), and the `scheduler` role can.
 5. **Upgrade** — a monolith (`all`) deployment upgraded to split roles keeps
    serving (no data migration; it is a topology change).
+
+## Known residuals (the split does not close these)
+
+The split inverts privilege×exposure (the exposed API gets the restricted
+identity; the privileged scheduler gets the least exposure). It does **not** make
+the control plane fully isolated. Two residuals are stated here so they are not
+mistaken as solved:
+
+1. **The scheduler trusts the DB (indirect blast radius).** The api holds DB write
+   credentials, and the scheduler acts on what it reads from the DB (DB-as-truth,
+   ADR 0031). So a compromised api cannot reach the apiserver *directly* (its SA is
+   unbound), but it can still influence what the scheduler dispatches by writing to
+   the DB. The restricted identity shrinks the direct blast radius, not this
+   indirect one. A tighter design would have the scheduler re-authorize/validate
+   task specs (e.g. only dispatch registered, integrity-checked specs) rather than
+   trust DB rows. Tracked as future hardening.
+
+2. **Task logs on a shared RWX PVC.** The scheduler writes task logs to disk (from
+   the agent gRPC stream) and the api reads them for the UI — today via the same
+   RWX logs PVC. At scale, N api replicas + the scheduler contending on one RWX
+   volume is an I/O bottleneck, and it is the one seam that is *not* DB-as-truth
+   (shared filesystem). The fix is reading logs via an object store / the tailer,
+   not a shared PVC. Tracked separately.
+
+Lesser notes: one binary carries both roles' code (ADR 0028 one-tag simplicity
+over a minimal per-role artifact — a deliberate trade), and the api mutates some
+run state directly (should stay "desired state" the scheduler reconciles, not
+imperative actions).
+
+## Verification
+
+Implemented and proven live, not just rendered:
+
+- **Unit** — role parsing/defaulting/validation (`internal/config`), and the
+  every-role `/healthz`+`/readyz` on the metrics port (`api.ObservabilityHandler`).
+- **Helm** — `helm-unittest` locks the per-role Deployment/Service/RBAC/SA/
+  NetworkPolicy/HPA/PDB split; the non-split render stays byte-identical (existing
+  suite is the regression guard).
+- **Integration (real Postgres)** — `TestBootstrapAdminConcurrentIntegration`
+  reproduces and guards the concurrent-bootstrap race the split exposed (several
+  processes/replicas bootstrapping the admin at once).
+- **E2E (k3d, two processes)** — `test/e2e/split-two-process.sh` (`make e2e-split`,
+  gated in CI) boots `role=api` + `role=scheduler` as separate processes against a
+  shared Postgres/Redis, asserts socket-level role isolation (api serves no gRPC,
+  scheduler serves no HTTP API, both answer `/healthz` on the metrics port), and
+  drives a run whose task pods the *separate* scheduler process dispatches — the
+  api accepts the trigger and serves the terminal state, all through the DB.
 
 ## Alternatives rejected
 

--- a/docs/adr/0049-split-api-and-scheduler-roles.md
+++ b/docs/adr/0049-split-api-and-scheduler-roles.md
@@ -1,0 +1,145 @@
+# ADR 0049: Split the API/UI and scheduler into separate roles of one binary
+
+**Status:** Accepted
+**Accepted:** 2026-08-03 — maintainer greenlit the split for enterprise scale, a conscious override of the KFP study's "keep the monolith" (correct at small scale). Implementation is phased and must be well-tested before it rides a release.
+**Date:** 2026-08-03
+**Relates:** ADR 0001 (one Go control plane), ADR 0007 + 0017 (single binary, embedded SPA), ADR 0028 (one tag = both editions), ADR 0031 (DB-as-truth scheduler), ADR 0048 (no user code in the control plane), ADR 0009 (leader election)
+**Supersedes (partial):** the implicit "one process serves everything" shape of ADR 0007/0017 — the binary and the embedded SPA are unchanged; only the process topology in Pro changes.
+
+## Context
+
+`leoflow-server` runs everything in one process: the HTTP API + embedded SPA, the
+scheduler reconciliation loop + reapers, the dispatch worker pool, the pod
+reconciler/staging GC, and the agent gRPC endpoint. That monolith is the right
+call at small scale (a comparative Kubeflow study concluded exactly this — "do not
+decompose the binary; the monolith is the competitive position" — against KFP's
+15-Deployment sprawl).
+
+Two forces push against it as the target moves to enterprise scale:
+
+1. **Scalability.** The API is active-active (every replica serves HTTP; only the
+   leader schedules — ADR 0009). But the leader pod serves API traffic *and* runs
+   the scheduler tick, so hundreds of logged-in users hammering the API contend
+   with scheduling on that one pod; and every replica carries idle scheduler
+   machinery. Argo splits `argo-server` (API, active-active) from
+   `workflow-controller` (single) precisely to isolate these.
+
+2. **Security (ADR 0048).** The API is the internet-facing surface, yet it shares
+   the control plane's privileged network identity (apiserver reach, datastore
+   credentials, cluster network). A compromised or SSRF'd API process inherits all
+   of it. The API does not need apiserver reach; the scheduler does. One identity
+   for both is the widest possible blast radius.
+
+This is a deliberate, forward-looking override of the "keep the monolith"
+recommendation: it was correct for current scale, and the split earns its keep at
+the enterprise scale now targeted.
+
+## Decision
+
+**One binary, selectable roles.** `leoflow-server` gains a role
+(`LEOFLOW_ROLE` / `--role`):
+
+- **`api`** — HTTP API + UI (the embedded Airflow SPA, ADR 0007/0017 unchanged) +
+  `/metrics`. Serves users. **Active-active** (HPA). Given a **restricted network
+  identity**: it reaches Postgres/Redis, not the apiserver or metadata.
+
+  *Embedded now, not rigidified.* The SPA stays `go:embed`ded in this role today
+  (the right call — §Alternatives). But the static-serving stays a **distinct,
+  replaceable layer** (its own route group + `WorkspaceFS`-style seam, not fused
+  into the API handler) and the origin/CORS/cookie config stays **configurable,
+  not hardcoded same-origin**. So the ADR 0018 north star — a custom Leoflow UI,
+  and/or a CDN in front of the static path — is a later swap, not a rewrite. This
+  ADR picks embedding for the first cut without closing that door.
+- **`scheduler`** — the reconciliation loop, reapers, dispatch pool, pod
+  reconciler + staging GC, and the **agent gRPC** endpoint (agents dial in to
+  report state). **Active-passive** (one leader, ADR 0009). Keeps the privileged
+  identity (creates pods → needs the apiserver).
+- **`all`** — everything in one process. The **default**, and what Lite always
+  runs (single host, one process). Backward-compatible: existing deployments are
+  unaffected until they opt into split roles.
+
+**The split is possible because the API already talks to the scheduler through
+Postgres, not in-process** (DB-as-truth, ADR 0031). The API reads/writes the DB;
+the scheduler reconciles from it. Two in-process couplings must become DB reads:
+
+1. `api.Heartbeater` / `SchedulerHealth` — the API's health endpoint reads the
+   scheduler's in-memory liveness. The scheduler already writes its heartbeat to
+   the DB; the API reads it from there (or from a scheduler `/healthz` it polls).
+2. `api.ExecutorInfo` — namespace + control-plane address, today an in-process
+   struct; becomes config the API reads directly.
+
+The agent gRPC stays with the `scheduler` role (it is about task state, which the
+scheduler owns). The dispatch pool, reconciler, and staging GC are already
+leader-gated (ADR 0031 + the recent leader-gating fix), so they belong to the
+`scheduler` role unchanged.
+
+**This aligns with removing in-control-plane execution.** ADR 0047/0048 remove
+user-influenced execution from the control plane; the residual inline `http_api`
+executor (still reachable via a crafted `dag.json`) is removed as part of this
+work — the `api` role must not execute anything author-influenced, and the
+`scheduler` role runs no user HTTP either (it dispatches pods).
+
+## Consequences
+
+**Pro gains a second Deployment.** The Helm chart renders `api` (N replicas + HPA)
+and `scheduler` (1 replica + leader election + PDB) when split is enabled; a single
+`all` Deployment otherwise. Each role gets its own ServiceAccount and
+NetworkPolicy — the `api` SA has no pod-create/apiserver RBAC, the `scheduler` SA
+keeps it. This is the security payoff: a compromised API cannot reach the
+apiserver.
+
+**One binary, one tag (ADR 0028 preserved).** No second artifact to build, sign,
+or version. The SPA stays embedded in the Go server.
+
+**Lite is unaffected — this is a Pro-only topology.** Lite is single-host: there
+is no cluster to split across, no second pod, no cross-replica leadership to gain.
+Lite runs the `all` role, which is **behaviour-identical to today's monolith** —
+the same in-process wiring, including the direct in-process `SchedulerHealth`
+handle and `ExecutorInfo` struct (the DB-backed indirection is only needed when
+the roles are in separate processes, so `all` keeps the direct path). The split's
+new surface (role selection, the DB-backed health read, the second Deployment)
+lives entirely on the `api`/`scheduler` paths. The guard is the existing Lite e2e:
+it runs under `all` and must stay green unchanged, so a refactor that touched
+Lite's behaviour fails loudly. `leoflow lite` / `leoflow dev` never set a role, so
+they get `all` by default and never see the split.
+
+**More moving parts to operate in Pro.** Two Deployments, two Services (the api
+HTTP/UI Service; the scheduler's agent-gRPC Service that task pods dial). Argo's
+two-process shape is the reference; KFP's 15-Deployment sprawl is the anti-pattern
+to avoid — this adds exactly one split, not a fleet.
+
+**Health/observability shifts.** The API's readiness must reflect "can I serve"
+(DB reachable), and scheduler health becomes a value the API reports from the DB,
+not from memory — a small behaviour change to name in the upgrade notes.
+
+## Test plan (this must be well-tested before it rides a release)
+
+1. **Unit** — role parsing/defaulting (`all` default; unknown role fails loud);
+   the DB-backed health read replacing the in-process `Heartbeater`.
+2. **Integration (real Postgres)** — an `api`-role process with **no scheduler in
+   the process**: registration, connection/variable CRUD, run trigger, and
+   `/healthz`/scheduler-health all work purely through the DB.
+3. **E2E (k3d, two processes)** — deploy `api` + `scheduler` as separate pods:
+   trigger a run on the api pod, assert the scheduler pod dispatches it, a task pod
+   runs, the agent reports back over gRPC to the scheduler, and the UI on the api
+   pod shows the terminal state. The existing single-process e2e stays green under
+   the `all` role (backward-compat).
+4. **NetworkPolicy** — assert the `api` role cannot reach the apiserver (the
+   security invariant), and the `scheduler` role can.
+5. **Upgrade** — a monolith (`all`) deployment upgraded to split roles keeps
+   serving (no data migration; it is a topology change).
+
+## Alternatives rejected
+
+**Two separate binaries** (Argo's literal shape). More build/release/signing
+surface, and it breaks ADR 0028's one-tag contract. A role flag on one binary
+gives the same process isolation without the second artifact.
+
+**Keep the monolith.** The KFP study's recommendation, correct for small scale.
+Rejected here only because the target is enterprise scale, where API load
+isolation and a restricted API identity both matter — stated as a conscious
+override, revisited if the scale assumption changes.
+
+**A separate UI service (KFP's `ml-pipeline-ui`).** Unnecessary: the SPA is
+embedded in the Go server (ADR 0017) and served by the `api` role. A separate
+frontend process would add a component for no benefit.

--- a/docs/adr/0049-split-api-and-scheduler-roles.md
+++ b/docs/adr/0049-split-api-and-scheduler-roles.md
@@ -36,8 +36,10 @@ the enterprise scale now targeted.
 
 ## Decision
 
-**One binary, selectable roles.** `leoflow-server` gains a role
-(`LEOFLOW_ROLE` / `--role`):
+**One binary, selectable roles.** `leoflow-server` gains a role, set via the
+`server.role` config key or the `LEOFLOW_SERVER_ROLE` environment variable (the
+server reads config from file + env only; it registers no CLI flags today, so
+there is no `--role` flag):
 
 - **`api`** — HTTP API + UI (the embedded Airflow SPA, ADR 0007/0017 unchanged) +
   `/metrics`. Serves users. **Active-active** (HPA). Given a **restricted network

--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -51,4 +51,5 @@ The *why* behind Leoflow's design. ADRs are immutable once accepted.
 - [ADR 0046: Coverage — one rule, per package, counting the tests we already wrote](adr/0046-coverage-policy.md)
 - [ADR 0047: Deprecate the native inline http_api; run HTTP through the generic pod executor](adr/0047-deprecate-native-inline-http.md)
 - [ADR 0048: The control plane executes no user-influenced code or network requests](adr/0048-no-user-code-in-control-plane.md)
+- [ADR 0049: Split the API/UI and scheduler into separate roles of one binary](adr/0049-split-api-and-scheduler-roles.md)
 <!-- END ADR INDEX -->

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -27,10 +27,11 @@ leoflow lite examples/<name>      # hot-reload at http://localhost:8088, then Tr
 | `bash_pipeline` | shell tasks | **bash** (BashOperator) | — |
 | `http_operator` | HTTP request run **in a pod** | **airflow_operator** (HttpOperator, ADR 0047) | — |
 
-All three Leoflow task types are represented — **python** (TaskFlow `@task` /
-PythonOperator), **bash** (BashOperator), and **http_api** (HttpOperator, executed
-inline by the control plane). For a measured ~1 GB pipeline see the
-[ETL case study](etl-staging-case-study.md).
+The core Leoflow task types are represented — **python** (TaskFlow `@task` /
+PythonOperator) and **bash** (BashOperator), both run in a pod. An `HttpOperator`
+compiles to an **`airflow_operator`** and runs in a pod too (ADR 0040); the old
+native inline `http_api` type is deprecated and being removed (ADR 0047, #512).
+For a measured ~1 GB pipeline see the [ETL case study](etl-staging-case-study.md).
 
 !!! tip "Import heavy deps inside the task"
     `import duckdb` / `import requests` go **inside** the task function — the DAG

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -301,6 +301,9 @@ differ from what's committed.
 | serviceAccount.annotations | object | `{}` | ServiceAccount annotations (e.g. AWS IAM role: `eks.amazonaws.com/role-arn`). |
 | serviceAccount.create | bool | `true` | Create a dedicated ServiceAccount for the leoflow-server. Set `false` only if you bring your own via `name`. |
 | serviceAccount.name | string | `""` | Override the ServiceAccount name. Defaults to the chart fullname when empty. |
+| split.api.replicaCount | int | `2` | API Deployment replicas (active-active; HPA-friendly). Ignored unless split.enabled. |
+| split.enabled | bool | `false` | Render separate `api` and `scheduler` Deployments instead of one `all` Deployment. Pro-only (Lite is single-host and never splits). |
+| split.scheduler.replicaCount | int | `1` | Scheduler Deployment replicas. Pinned to 1 by the chart regardless of this value — the scheduler is a single leader (ADR 0009); a field is kept only for clarity. Ignored unless split.enabled. |
 | taskNamespace | string | `"leoflow"` | Namespace where the control plane creates task pods. MUST match the namespace the server expects (server code currently targets `leoflow`). The chart grants the control plane RBAC to manage pods here; if you override this, the RBAC follows but the server still looks at `leoflow`. |
 | taskNetworkPolicy.blockPrivateNetworks | bool | `false` | ALSO deny RFC1918 private ranges + the apiserver. OFF by default: a DAG calling an internal service is legitimate, and the policy cannot tell that from the apiserver by IP (ADR 0047). Turn on for high-security clusters; the control-plane gRPC is re-allowed explicitly. |
 | taskNetworkPolicy.enabled | bool | `false` | Enable the task-pod egress NetworkPolicy in `taskNamespace`. Denies ingress, allows DNS + the control-plane gRPC, then all other egress except the blocked ranges below. |

--- a/helm/leoflow/templates/NOTES.txt
+++ b/helm/leoflow/templates/NOTES.txt
@@ -10,7 +10,7 @@ Leoflow control plane "{{ include "leoflow.fullname" . }}" is installing into na
 {{- if .Values.ingress.enabled }}
      via the configured Ingress host(s).
 {{- else }}
-     kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "leoflow.fullname" . }} {{ .Values.ports.http }}:{{ .Values.ports.http }}
+     kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "leoflow.roleName" (dict "ctx" . "role" (ternary "api" "all" .Values.split.enabled)) }} {{ .Values.ports.http }}:{{ .Values.ports.http }}
      # then open http://localhost:{{ .Values.ports.http }}
 {{- end }}
 

--- a/helm/leoflow/templates/_controlplane-deployment.tpl
+++ b/helm/leoflow/templates/_controlplane-deployment.tpl
@@ -39,7 +39,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ include "leoflow.serviceAccountName" .ctx }}
+      serviceAccountName: {{ include "leoflow.roleServiceAccountName" (dict "ctx" .ctx "role" .role) }}
       {{- with .ctx.Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm/leoflow/templates/_controlplane-deployment.tpl
+++ b/helm/leoflow/templates/_controlplane-deployment.tpl
@@ -1,0 +1,259 @@
+{{/*
+Control-plane Deployment (ADR 0049), parameterized by role so one template
+renders the monolith ("all") and the split api/scheduler Deployments. Takes a
+dict {ctx, role, replicas}. The "all" role reproduces the pre-split Deployment
+byte-for-byte (same name, selector, env, ports, probes); api/scheduler differ
+only where the role demands (name suffix, component selector label, role env,
+served ports, and the scheduler's health probes on the metrics port since it
+serves no HTTP API).
+*/}}
+{{- define "leoflow.controlPlaneDeployment" -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "leoflow.roleName" (dict "ctx" .ctx "role" .role) }}
+  namespace: {{ .ctx.Release.Namespace }}
+  labels:
+    {{- include "leoflow.labels" .ctx | nindent 4 }}
+spec:
+  replicas: {{ .replicas }}
+  selector:
+    matchLabels:
+      {{- include "leoflow.roleSelectorLabels" (dict "ctx" .ctx "role" .role) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "leoflow.roleSelectorLabels" (dict "ctx" .ctx "role" .role) | nindent 8 }}
+      annotations:
+        # #316: tie the podTemplate hash to the rendered Secret so `helm
+        # upgrade` rolls the pod whenever a Secret-backed value
+        # (database.url, redis.url, auth.jwtSecret, secretKey,
+        # bootstrap.password) changes. Without this annotation the Secret
+        # is updated but K8s leaves the running pod on the OLD values
+        # until a manual `kubectl rollout restart`. Note: this only covers
+        # the chart-managed Secret; credentials wired via
+        # `*.existingSecret` are outside the chart's visibility and still
+        # require a manual restart on rotation (callout in chart README).
+        checksum/secret: {{ include (print .ctx.Template.BasePath "/secret.yaml") .ctx | sha256sum }}
+        {{- with .ctx.Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "leoflow.serviceAccountName" .ctx }}
+      {{- with .ctx.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .ctx.Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: leoflow-server
+          image: {{ include "leoflow.image" .ctx | quote }}
+          imagePullPolicy: {{ .ctx.Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .ctx.Values.securityContext | nindent 12 }}
+          ports:
+            {{- if or (eq .role "all") (eq .role "api") }}
+            - name: http
+              containerPort: {{ .ctx.Values.ports.http }}
+            {{- end }}
+            - name: metrics
+              containerPort: {{ .ctx.Values.ports.metrics }}
+            {{- if or (eq .role "all") (eq .role "scheduler") }}
+            - name: grpc
+              containerPort: {{ .ctx.Values.ports.grpc }}
+            {{- end }}
+          env:
+            {{- if ne .role "all" }}
+            # ADR 0049 — select this process's role. Omitted for the "all"
+            # Deployment so its rendered env is identical to the pre-split chart.
+            - name: LEOFLOW_SERVER_ROLE
+              value: {{ .role | quote }}
+            {{- end }}
+            # Mark this deployment as the Pro edition. The control plane uses
+            # this signal for two things: (a) refuse the
+            # LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS=true dev escape hatch at boot
+            # (#58 / ADR 0014) so a Pro install cannot accidentally ship secrets
+            # over a plaintext gRPC channel; (b) inject the gold PRO badge into
+            # the served SPA shell, mirroring Lite's silver LITE pill.
+            - name: LEOFLOW_UI_EDITION
+              value: "pro"
+            - name: LEOFLOW_SERVER_HTTP_ADDR
+              value: ":{{ .ctx.Values.ports.http }}"
+            - name: LEOFLOW_SERVER_METRICS_ADDR
+              value: ":{{ .ctx.Values.ports.metrics }}"
+            - name: LEOFLOW_SERVER_GRPC_ADDR
+              value: ":{{ .ctx.Values.ports.grpc }}"
+            - name: LEOFLOW_EXECUTOR_AGENT_CONTROL_PLANE_ADDR
+              value: {{ include "leoflow.agentControlPlaneAddr" .ctx | quote }}
+            - name: LEOFLOW_LOGS_DIR
+              value: {{ .ctx.Values.config.logsDir | quote }}
+            - name: LEOFLOW_SCHEDULER_ENABLED
+              value: {{ .ctx.Values.config.scheduler.enabled | quote }}
+            - name: LEOFLOW_SCHEDULER_LOOP_INTERVAL_MS
+              value: {{ .ctx.Values.config.scheduler.loopIntervalMs | quote }}
+            - name: LEOFLOW_DATABASE_MAX_OPEN_CONNS
+              value: {{ .ctx.Values.database.maxOpenConns | quote }}
+            - name: LEOFLOW_DATABASE_MAX_IDLE_CONNS
+              value: {{ .ctx.Values.database.maxIdleConns | quote }}
+            - name: LEOFLOW_AUTH_JWT_TOKEN_TTL_SECONDS
+              value: {{ .ctx.Values.auth.tokenTtlSeconds | quote }}
+            - name: LEOFLOW_OBSERVABILITY_LOG_FORMAT
+              value: {{ .ctx.Values.observability.logFormat | quote }}
+            - name: LEOFLOW_OBSERVABILITY_LOG_LEVEL
+              value: {{ .ctx.Values.observability.logLevel | quote }}
+            {{- if .ctx.Values.observability.otel.enabled }}
+            - name: LEOFLOW_OBSERVABILITY_OTEL_ENABLED
+              value: "true"
+            - name: LEOFLOW_OBSERVABILITY_OTEL_ENDPOINT
+              value: {{ .ctx.Values.observability.otel.endpoint | quote }}
+            {{- end }}
+            {{- if .ctx.Values.agentTLS.enabled }}
+            # TLS on the agent gRPC channel (issue #58). The server cert is
+            # mounted from agentTLS.serverCertSecret; the agent CA is delivered to
+            # task pods via agentTLS.caConfigMap (the dispatcher mounts + selects it).
+            - name: LEOFLOW_SERVER_GRPC_TLS_CERT
+              value: /etc/leoflow/grpc-tls/tls.crt
+            - name: LEOFLOW_SERVER_GRPC_TLS_KEY
+              value: /etc/leoflow/grpc-tls/tls.key
+            - name: LEOFLOW_EXECUTOR_AGENT_TLS_CA_CONFIGMAP
+              value: {{ .ctx.Values.agentTLS.caConfigMap | quote }}
+            {{- end }}
+            {{- if .ctx.Values.taskSecret.name }}
+            # Mount a Kubernetes Secret read-only into every task pod so a task can
+            # read a credential (e.g. a GCP service-account key referenced by a
+            # connection's key_path) from the cluster's secret store — Leoflow
+            # never stores the key itself (ADR 0035).
+            - name: LEOFLOW_EXECUTOR_TASK_SECRET_NAME
+              value: {{ .ctx.Values.taskSecret.name | quote }}
+            - name: LEOFLOW_EXECUTOR_TASK_SECRET_MOUNT_PATH
+              value: {{ .ctx.Values.taskSecret.mountPath | quote }}
+            {{- end }}
+            # Task-pod hardening. Always stamped, both directions: leaving the
+            # secure value implicit would mean a chart upgrade could not turn an
+            # opt-out back off without an operator noticing.
+            - name: LEOFLOW_EXECUTOR_DEFAULTS_RUN_TASKS_AS_NON_ROOT
+              value: {{ .ctx.Values.taskPodSecurity.runAsNonRoot | quote }}
+            - name: LEOFLOW_EXECUTOR_DEFAULTS_READ_ONLY_TASK_ROOT_FILESYSTEM
+              value: {{ .ctx.Values.taskPodSecurity.readOnlyRootFilesystem | quote }}
+            - name: LEOFLOW_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .ctx.Values.database.existingSecret | default (include "leoflow.secretName" .ctx) }}
+                  key: databaseUrl
+            - name: LEOFLOW_REDIS_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .ctx.Values.redis.existingSecret | default (include "leoflow.secretName" .ctx) }}
+                  key: redisUrl
+            {{- if .ctx.Values.redis.caConfigMap }}
+            # #312 — Verified TLS to managed Redis (Memorystore
+            # SERVER_AUTHENTICATION, ElastiCache in-transit, Azure Cache).
+            # The CA bundle from the named ConfigMap is mounted read-only at
+            # /etc/leoflow/redis-ca/ca.crt and the server is told where to
+            # find it via LEOFLOW_REDIS_CA_FILE.
+            - name: LEOFLOW_REDIS_CA_FILE
+              value: /etc/leoflow/redis-ca/ca.crt
+            {{- end }}
+            - name: LEOFLOW_AUTH_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .ctx.Values.auth.existingSecret | default (include "leoflow.secretName" .ctx) }}
+                  key: jwtSecret
+            {{- if or .ctx.Values.secretKeyExistingSecret .ctx.Values.secretKey }}
+            # LEOFLOW_SECRET_KEY (ADR 0019) — Connection password / Extra
+            # encryption-at-rest key. Without it, the API refuses Connection
+            # writes (Variables still work). Optional so users who only use
+            # Variables can omit it; recommended for any real Pro install.
+            - name: LEOFLOW_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .ctx.Values.secretKeyExistingSecret | default (include "leoflow.secretName" .ctx) }}
+                  key: secretKey
+            {{- end }}
+            {{- if or .ctx.Values.bootstrap.existingSecret .ctx.Values.bootstrap.password }}
+            - name: LEOFLOW_BOOTSTRAP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .ctx.Values.bootstrap.existingSecret | default (include "leoflow.secretName" .ctx) }}
+                  key: bootstrapPassword
+            {{- end }}
+          {{- $probePort := "http" }}
+          {{- if eq .role "scheduler" }}{{ $probePort = "metrics" }}{{ end }}
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: {{ $probePort }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ $probePort }}
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          resources:
+            {{- toYaml .ctx.Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: logs
+              mountPath: {{ .ctx.Values.config.logsDir }}
+            {{- if .ctx.Values.agentTLS.enabled }}
+            - name: grpc-tls
+              mountPath: /etc/leoflow/grpc-tls
+              readOnly: true
+            {{- end }}
+            {{- if .ctx.Values.database.caConfigMap }}
+            # Managed-Postgres CA bundle (#315). The DSN references this path
+            # via `sslmode=verify-full&sslrootcert=/etc/leoflow/db-ca/ca.crt` —
+            # pgx reads sslrootcert natively, so no Go-side wiring is needed.
+            - name: db-ca
+              mountPath: /etc/leoflow/db-ca
+              readOnly: true
+            {{- end }}
+            {{- if .ctx.Values.redis.caConfigMap }}
+            - name: redis-ca
+              mountPath: /etc/leoflow/redis-ca
+              readOnly: true
+            {{- end }}
+      volumes:
+        - name: logs
+          {{- if .ctx.Values.logs.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "leoflow.fullname" .ctx }}-logs
+          {{- else }}
+          # Dev-only fallback: logs vanish on pod restart. Enable
+          # `logs.persistence.enabled` for durable storage (#227).
+          emptyDir: {}
+          {{- end }}
+        {{- if .ctx.Values.agentTLS.enabled }}
+        - name: grpc-tls
+          secret:
+            secretName: {{ required "agentTLS.serverCertSecret is required when agentTLS.enabled" .ctx.Values.agentTLS.serverCertSecret }}
+        {{- end }}
+        {{- if .ctx.Values.database.caConfigMap }}
+        - name: db-ca
+          configMap:
+            name: {{ .ctx.Values.database.caConfigMap }}
+            items:
+              - key: ca.crt
+                path: ca.crt
+        {{- end }}
+        {{- if .ctx.Values.redis.caConfigMap }}
+        - name: redis-ca
+          configMap:
+            name: {{ .ctx.Values.redis.caConfigMap }}
+        {{- end }}
+      {{- with .ctx.Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .ctx.Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .ctx.Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+{{- end -}}

--- a/helm/leoflow/templates/_controlplane-networkpolicy.tpl
+++ b/helm/leoflow/templates/_controlplane-networkpolicy.tpl
@@ -1,0 +1,69 @@
+{{- /*
+Control-plane NetworkPolicy (DRAFT, Production track), parameterized by role —
+ADR 0049. Takes {ctx, role}. The "all" role reproduces the pre-split policy
+byte-for-byte. Split roles select only their own pods and open only the ingress
+their role serves:
+  - api:       http (clients/ingress) + metrics
+  - scheduler: grpc (task pods dial back) + metrics
+Egress stays permissive-by-default in every role (DNS always; then the operator's
+explicit rules, or allow-all) so enabling the policy never silently breaks the
+control plane. Real apiserver isolation for the api is enforced by RBAC (the api
+SA is unbound — ADR 0049), with this policy as environment-specific defense in
+depth. metrics ingress is gated on networkPolicy.metricsFrom in every role.
+*/ -}}
+{{- define "leoflow.controlPlaneNetworkPolicy" -}}
+{{- $ctx := .ctx -}}
+{{- $role := .role -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "leoflow.roleName" (dict "ctx" $ctx "role" $role) }}
+  namespace: {{ $ctx.Release.Namespace }}
+  labels:
+    {{- include "leoflow.labels" $ctx | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "leoflow.roleSelectorLabels" (dict "ctx" $ctx "role" $role) | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        {{- if or (eq $role "all") (eq $role "api") }}
+        # HTTP/UI. Restrict sources via networkPolicy.ingressFrom.
+        - port: {{ $ctx.Values.ports.http }}
+          protocol: TCP
+        {{- end }}
+        {{- if or (eq $role "all") (eq $role "scheduler") }}
+        # Task pods dial the agent gRPC back (ADR 0002/0004).
+        - port: {{ $ctx.Values.ports.grpc }}
+          protocol: TCP
+        {{- end }}
+      {{- with $ctx.Values.networkPolicy.ingressFrom }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with $ctx.Values.networkPolicy.metricsFrom }}
+    # Metrics scrape (e.g. the Prometheus pods' namespace/labels).
+    - ports:
+        - port: {{ $ctx.Values.ports.metrics }}
+          protocol: TCP
+      from:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+  egress:
+    # DNS is always required for service discovery.
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    {{- with $ctx.Values.networkPolicy.egress }}
+    {{- toYaml . | nindent 4 }}
+    {{- else }}
+    # Default: allow all other egress (Postgres, Redis, kube-apiserver). Tighten
+    # by setting networkPolicy.egress to explicit rules for your data stores + API.
+    - {}
+    {{- end }}
+{{- end -}}

--- a/helm/leoflow/templates/_controlplane-service.tpl
+++ b/helm/leoflow/templates/_controlplane-service.tpl
@@ -1,0 +1,43 @@
+{{/*
+Control-plane Service (ADR 0049), parameterized by role. Takes a dict {ctx, role}.
+The "all" role reproduces the pre-split Service byte-for-byte (bare fullname,
+selector without a component label, http+metrics+grpc). The split roles each
+expose only the ports their role serves and select only their own pods:
+  - api:       http + metrics   (the user-facing API + UI; ingress targets this)
+  - scheduler: grpc + metrics   (task pods dial grpc here to report state)
+metrics is exposed in every role so Prometheus can scrape each Deployment.
+*/}}
+{{- define "leoflow.controlPlaneService" -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "leoflow.roleName" (dict "ctx" .ctx "role" .role) }}
+  namespace: {{ .ctx.Release.Namespace }}
+  labels:
+    {{- include "leoflow.labels" .ctx | nindent 4 }}
+  {{- with .ctx.Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .ctx.Values.service.type }}
+  selector:
+    {{- include "leoflow.roleSelectorLabels" (dict "ctx" .ctx "role" .role) | nindent 4 }}
+  ports:
+    {{- if or (eq .role "all") (eq .role "api") }}
+    - name: http
+      port: {{ .ctx.Values.ports.http }}
+      targetPort: http
+      protocol: TCP
+    {{- end }}
+    - name: metrics
+      port: {{ .ctx.Values.ports.metrics }}
+      targetPort: metrics
+      protocol: TCP
+    {{- if or (eq .role "all") (eq .role "scheduler") }}
+    - name: grpc
+      port: {{ .ctx.Values.ports.grpc }}
+      targetPort: grpc
+      protocol: TCP
+    {{- end }}
+{{- end -}}

--- a/helm/leoflow/templates/_helpers.tpl
+++ b/helm/leoflow/templates/_helpers.tpl
@@ -33,6 +33,35 @@ app.kubernetes.io/name: {{ include "leoflow.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
+{{/*
+Role-aware selector labels (ADR 0049). Takes a dict {ctx, role}. For the "all"
+role (the default, non-split monolith) this is EXACTLY leoflow.selectorLabels —
+no extra label — so the single Deployment's immutable selector is unchanged and
+`helm upgrade` from a pre-split install does not trip "field is immutable". For
+the api/scheduler roles it adds app.kubernetes.io/component so each Deployment
+selects only its own pods and Services can target one role.
+*/}}
+{{- define "leoflow.roleSelectorLabels" -}}
+{{ include "leoflow.selectorLabels" .ctx }}
+{{- if and .role (ne .role "all") }}
+app.kubernetes.io/component: {{ .role }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Role-suffixed resource name. "all" keeps the bare fullname (byte-identical to the
+non-split Deployment/Service names); api/scheduler get a "-api"/"-scheduler"
+suffix so the two Deployments, Services, SAs, etc. do not collide.
+*/}}
+{{- define "leoflow.roleName" -}}
+{{- $full := include "leoflow.fullname" .ctx -}}
+{{- if and .role (ne .role "all") -}}
+{{- printf "%s-%s" $full .role | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $full -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "leoflow.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
 {{- default (include "leoflow.fullname" .) .Values.serviceAccount.name -}}

--- a/helm/leoflow/templates/_helpers.tpl
+++ b/helm/leoflow/templates/_helpers.tpl
@@ -81,11 +81,20 @@ suffix so the two Deployments, Services, SAs, etc. do not collide.
 {{- printf "%s:%s" .Values.image.repository $tag -}}
 {{- end -}}
 
-{{/* In-cluster gRPC address task pods dial, unless overridden. */}}
+{{/*
+In-cluster gRPC address task pods dial, unless overridden. When split.enabled
+(ADR 0049) the agent gRPC endpoint lives on the scheduler Service, so task pods
+must dial "<fullname>-scheduler", not the bare fullname (which in split mode is
+the api Service and serves no gRPC).
+*/}}
 {{- define "leoflow.agentControlPlaneAddr" -}}
 {{- if .Values.config.agentControlPlaneAddr -}}
 {{- .Values.config.agentControlPlaneAddr -}}
 {{- else -}}
-{{- printf "%s.%s.svc.cluster.local:%d" (include "leoflow.fullname" .) .Release.Namespace (int .Values.ports.grpc) -}}
+{{- $svc := include "leoflow.fullname" . -}}
+{{- if .Values.split.enabled -}}
+{{- $svc = printf "%s-scheduler" $svc -}}
+{{- end -}}
+{{- printf "%s.%s.svc.cluster.local:%d" $svc .Release.Namespace (int .Values.ports.grpc) -}}
 {{- end -}}
 {{- end -}}

--- a/helm/leoflow/templates/_helpers.tpl
+++ b/helm/leoflow/templates/_helpers.tpl
@@ -108,7 +108,10 @@ the api Service and serves no gRPC).
 {{- else -}}
 {{- $svc := include "leoflow.fullname" . -}}
 {{- if .Values.split.enabled -}}
-{{- $svc = printf "%s-scheduler" $svc -}}
+{{- /* Use roleName (not a raw printf) so this DNS name matches the scheduler
+Service exactly, including its trunc-63 — a long release name would otherwise
+diverge and agents would dial a name no Service answers to. */ -}}
+{{- $svc = include "leoflow.roleName" (dict "ctx" . "role" "scheduler") -}}
 {{- end -}}
 {{- printf "%s.%s.svc.cluster.local:%d" $svc .Release.Namespace (int .Values.ports.grpc) -}}
 {{- end -}}

--- a/helm/leoflow/templates/_helpers.tpl
+++ b/helm/leoflow/templates/_helpers.tpl
@@ -49,17 +49,28 @@ app.kubernetes.io/component: {{ .role }}
 {{- end -}}
 
 {{/*
+suffixRole appends "-<role>" to a base name. It truncates the BASE to 53 first,
+so even with a max-length base the result fits in 63 chars AND the "-api" /
+"-scheduler" suffix survives — without this, a ~62-char base truncates the suffix
+off and api and scheduler collapse to the same name (an install-time collision).
+An empty or "all" role returns the base unchanged (byte-identical to non-split).
+Takes {base, role}.
+*/}}
+{{- define "leoflow.suffixRole" -}}
+{{- if and .role (ne .role "all") -}}
+{{- printf "%s-%s" (.base | trunc 53 | trimSuffix "-") .role | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- .base -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Role-suffixed resource name. "all" keeps the bare fullname (byte-identical to the
 non-split Deployment/Service names); api/scheduler get a "-api"/"-scheduler"
-suffix so the two Deployments, Services, SAs, etc. do not collide.
+suffix so the two Deployments, Services, SAs, etc. do not collide. Takes {ctx, role}.
 */}}
 {{- define "leoflow.roleName" -}}
-{{- $full := include "leoflow.fullname" .ctx -}}
-{{- if and .role (ne .role "all") -}}
-{{- printf "%s-%s" $full .role | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $full -}}
-{{- end -}}
+{{- include "leoflow.suffixRole" (dict "base" (include "leoflow.fullname" .ctx) "role" .role) -}}
 {{- end -}}
 
 {{- define "leoflow.serviceAccountName" -}}
@@ -79,7 +90,11 @@ while the scheduler keeps the privileged one — the split's security payoff.
 */}}
 {{- define "leoflow.roleServiceAccountName" -}}
 {{- if and .role (ne .role "all") -}}
-{{- include "leoflow.roleName" (dict "ctx" .ctx "role" .role) -}}
+{{- /* Honor serviceAccount.name as the base (default fullname), then suffix by
+role. So `serviceAccount.name=X` yields X-api / X-scheduler — the names an
+operator using create=false must pre-provision (IRSA / Workload Identity). */ -}}
+{{- $base := default (include "leoflow.fullname" .ctx) .ctx.Values.serviceAccount.name -}}
+{{- include "leoflow.suffixRole" (dict "base" $base "role" .role) -}}
 {{- else -}}
 {{- include "leoflow.serviceAccountName" .ctx -}}
 {{- end -}}

--- a/helm/leoflow/templates/_helpers.tpl
+++ b/helm/leoflow/templates/_helpers.tpl
@@ -70,6 +70,21 @@ suffix so the two Deployments, Services, SAs, etc. do not collide.
 {{- end -}}
 {{- end -}}
 
+{{/*
+Role-aware ServiceAccount name (ADR 0049). Takes {ctx, role}. "all" keeps the
+existing leoflow.serviceAccountName (honoring serviceAccount.create/name), so the
+non-split chart is unchanged. api/scheduler each get their own SA named after the
+role, so the api can carry a RESTRICTED identity (no pod-create/apiserver RBAC)
+while the scheduler keeps the privileged one — the split's security payoff.
+*/}}
+{{- define "leoflow.roleServiceAccountName" -}}
+{{- if and .role (ne .role "all") -}}
+{{- include "leoflow.roleName" (dict "ctx" .ctx "role" .role) -}}
+{{- else -}}
+{{- include "leoflow.serviceAccountName" .ctx -}}
+{{- end -}}
+{{- end -}}
+
 {{/* Name of the Secret holding generated/inline credentials. */}}
 {{- define "leoflow.secretName" -}}
 {{- printf "%s-secrets" (include "leoflow.fullname" .) -}}

--- a/helm/leoflow/templates/deployment.yaml
+++ b/helm/leoflow/templates/deployment.yaml
@@ -61,241 +61,26 @@ See #282.
 {{- if .Values.autoscaling.enabled -}}
 {{- $maxReplicas = .Values.autoscaling.maxReplicas -}}
 {{- end -}}
+{{- /* Split (ADR 0049): the scheduler writes logs and every api replica reads
+them from the same PVC, so at least scheduler+api pods mount it at once — RWO can
+never satisfy that. Treat the mounter count as api replicas + 1 (the scheduler). */ -}}
+{{- if .Values.split.enabled -}}
+{{- $maxReplicas = add (int .Values.split.api.replicaCount) 1 -}}
+{{- end -}}
 {{- if and (gt (int $maxReplicas) 1) .Values.logs.persistence.enabled (eq .Values.logs.persistence.accessMode "ReadWriteOnce") -}}
 {{- fail "a ReadWriteOnce logs PVC attaches to only one pod, so more than one control-plane replica — replicaCount > 1, or autoscaling.enabled with maxReplicas > 1 — hangs the extra pods in ContainerCreating (Multi-Attach error), silently. Set logs.persistence.accessMode=ReadWriteMany with an RWX StorageClass (NFS / Longhorn-rwx / CephFS / EFS / Azure Files / GCP Filestore); or keep a single replica; or set logs.persistence.enabled=false (ephemeral emptyDir). See #282." -}}
 {{- end -}}
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: {{ include "leoflow.fullname" . }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "leoflow.labels" . | nindent 4 }}
-spec:
-  replicas: {{ .Values.replicaCount }}
-  selector:
-    matchLabels:
-      {{- include "leoflow.selectorLabels" . | nindent 6 }}
-  template:
-    metadata:
-      labels:
-        {{- include "leoflow.selectorLabels" . | nindent 8 }}
-      annotations:
-        # #316: tie the podTemplate hash to the rendered Secret so `helm
-        # upgrade` rolls the pod whenever a Secret-backed value
-        # (database.url, redis.url, auth.jwtSecret, secretKey,
-        # bootstrap.password) changes. Without this annotation the Secret
-        # is updated but K8s leaves the running pod on the OLD values
-        # until a manual `kubectl rollout restart`. Note: this only covers
-        # the chart-managed Secret; credentials wired via
-        # `*.existingSecret` are outside the chart's visibility and still
-        # require a manual restart on rotation (callout in chart README).
-        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-        {{- with .Values.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-    spec:
-      serviceAccountName: {{ include "leoflow.serviceAccountName" . }}
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      containers:
-        - name: leoflow-server
-          image: {{ include "leoflow.image" . | quote }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          ports:
-            - name: http
-              containerPort: {{ .Values.ports.http }}
-            - name: metrics
-              containerPort: {{ .Values.ports.metrics }}
-            - name: grpc
-              containerPort: {{ .Values.ports.grpc }}
-          env:
-            # Mark this deployment as the Pro edition. The control plane uses
-            # this signal for two things: (a) refuse the
-            # LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS=true dev escape hatch at boot
-            # (#58 / ADR 0014) so a Pro install cannot accidentally ship secrets
-            # over a plaintext gRPC channel; (b) inject the gold PRO badge into
-            # the served SPA shell, mirroring Lite's silver LITE pill.
-            - name: LEOFLOW_UI_EDITION
-              value: "pro"
-            - name: LEOFLOW_SERVER_HTTP_ADDR
-              value: ":{{ .Values.ports.http }}"
-            - name: LEOFLOW_SERVER_METRICS_ADDR
-              value: ":{{ .Values.ports.metrics }}"
-            - name: LEOFLOW_SERVER_GRPC_ADDR
-              value: ":{{ .Values.ports.grpc }}"
-            - name: LEOFLOW_EXECUTOR_AGENT_CONTROL_PLANE_ADDR
-              value: {{ include "leoflow.agentControlPlaneAddr" . | quote }}
-            - name: LEOFLOW_LOGS_DIR
-              value: {{ .Values.config.logsDir | quote }}
-            - name: LEOFLOW_SCHEDULER_ENABLED
-              value: {{ .Values.config.scheduler.enabled | quote }}
-            - name: LEOFLOW_SCHEDULER_LOOP_INTERVAL_MS
-              value: {{ .Values.config.scheduler.loopIntervalMs | quote }}
-            - name: LEOFLOW_DATABASE_MAX_OPEN_CONNS
-              value: {{ .Values.database.maxOpenConns | quote }}
-            - name: LEOFLOW_DATABASE_MAX_IDLE_CONNS
-              value: {{ .Values.database.maxIdleConns | quote }}
-            - name: LEOFLOW_AUTH_JWT_TOKEN_TTL_SECONDS
-              value: {{ .Values.auth.tokenTtlSeconds | quote }}
-            - name: LEOFLOW_OBSERVABILITY_LOG_FORMAT
-              value: {{ .Values.observability.logFormat | quote }}
-            - name: LEOFLOW_OBSERVABILITY_LOG_LEVEL
-              value: {{ .Values.observability.logLevel | quote }}
-            {{- if .Values.observability.otel.enabled }}
-            - name: LEOFLOW_OBSERVABILITY_OTEL_ENABLED
-              value: "true"
-            - name: LEOFLOW_OBSERVABILITY_OTEL_ENDPOINT
-              value: {{ .Values.observability.otel.endpoint | quote }}
-            {{- end }}
-            {{- if .Values.agentTLS.enabled }}
-            # TLS on the agent gRPC channel (issue #58). The server cert is
-            # mounted from agentTLS.serverCertSecret; the agent CA is delivered to
-            # task pods via agentTLS.caConfigMap (the dispatcher mounts + selects it).
-            - name: LEOFLOW_SERVER_GRPC_TLS_CERT
-              value: /etc/leoflow/grpc-tls/tls.crt
-            - name: LEOFLOW_SERVER_GRPC_TLS_KEY
-              value: /etc/leoflow/grpc-tls/tls.key
-            - name: LEOFLOW_EXECUTOR_AGENT_TLS_CA_CONFIGMAP
-              value: {{ .Values.agentTLS.caConfigMap | quote }}
-            {{- end }}
-            {{- if .Values.taskSecret.name }}
-            # Mount a Kubernetes Secret read-only into every task pod so a task can
-            # read a credential (e.g. a GCP service-account key referenced by a
-            # connection's key_path) from the cluster's secret store — Leoflow
-            # never stores the key itself (ADR 0035).
-            - name: LEOFLOW_EXECUTOR_TASK_SECRET_NAME
-              value: {{ .Values.taskSecret.name | quote }}
-            - name: LEOFLOW_EXECUTOR_TASK_SECRET_MOUNT_PATH
-              value: {{ .Values.taskSecret.mountPath | quote }}
-            {{- end }}
-            # Task-pod hardening. Always stamped, both directions: leaving the
-            # secure value implicit would mean a chart upgrade could not turn an
-            # opt-out back off without an operator noticing.
-            - name: LEOFLOW_EXECUTOR_DEFAULTS_RUN_TASKS_AS_NON_ROOT
-              value: {{ .Values.taskPodSecurity.runAsNonRoot | quote }}
-            - name: LEOFLOW_EXECUTOR_DEFAULTS_READ_ONLY_TASK_ROOT_FILESYSTEM
-              value: {{ .Values.taskPodSecurity.readOnlyRootFilesystem | quote }}
-            - name: LEOFLOW_DATABASE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.database.existingSecret | default (include "leoflow.secretName" .) }}
-                  key: databaseUrl
-            - name: LEOFLOW_REDIS_URL
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.redis.existingSecret | default (include "leoflow.secretName" .) }}
-                  key: redisUrl
-            {{- if .Values.redis.caConfigMap }}
-            # #312 — Verified TLS to managed Redis (Memorystore
-            # SERVER_AUTHENTICATION, ElastiCache in-transit, Azure Cache).
-            # The CA bundle from the named ConfigMap is mounted read-only at
-            # /etc/leoflow/redis-ca/ca.crt and the server is told where to
-            # find it via LEOFLOW_REDIS_CA_FILE.
-            - name: LEOFLOW_REDIS_CA_FILE
-              value: /etc/leoflow/redis-ca/ca.crt
-            {{- end }}
-            - name: LEOFLOW_AUTH_JWT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.auth.existingSecret | default (include "leoflow.secretName" .) }}
-                  key: jwtSecret
-            {{- if or .Values.secretKeyExistingSecret .Values.secretKey }}
-            # LEOFLOW_SECRET_KEY (ADR 0019) — Connection password / Extra
-            # encryption-at-rest key. Without it, the API refuses Connection
-            # writes (Variables still work). Optional so users who only use
-            # Variables can omit it; recommended for any real Pro install.
-            - name: LEOFLOW_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.secretKeyExistingSecret | default (include "leoflow.secretName" .) }}
-                  key: secretKey
-            {{- end }}
-            {{- if or .Values.bootstrap.existingSecret .Values.bootstrap.password }}
-            - name: LEOFLOW_BOOTSTRAP_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.bootstrap.existingSecret | default (include "leoflow.secretName" .) }}
-                  key: bootstrapPassword
-            {{- end }}
-          readinessProbe:
-            httpGet:
-              path: /readyz
-              port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: http
-            initialDelaySeconds: 10
-            periodSeconds: 20
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
-          volumeMounts:
-            - name: logs
-              mountPath: {{ .Values.config.logsDir }}
-            {{- if .Values.agentTLS.enabled }}
-            - name: grpc-tls
-              mountPath: /etc/leoflow/grpc-tls
-              readOnly: true
-            {{- end }}
-            {{- if .Values.database.caConfigMap }}
-            # Managed-Postgres CA bundle (#315). The DSN references this path
-            # via `sslmode=verify-full&sslrootcert=/etc/leoflow/db-ca/ca.crt` —
-            # pgx reads sslrootcert natively, so no Go-side wiring is needed.
-            - name: db-ca
-              mountPath: /etc/leoflow/db-ca
-              readOnly: true
-            {{- end }}
-            {{- if .Values.redis.caConfigMap }}
-            - name: redis-ca
-              mountPath: /etc/leoflow/redis-ca
-              readOnly: true
-            {{- end }}
-      volumes:
-        - name: logs
-          {{- if .Values.logs.persistence.enabled }}
-          persistentVolumeClaim:
-            claimName: {{ include "leoflow.fullname" . }}-logs
-          {{- else }}
-          # Dev-only fallback: logs vanish on pod restart. Enable
-          # `logs.persistence.enabled` for durable storage (#227).
-          emptyDir: {}
-          {{- end }}
-        {{- if .Values.agentTLS.enabled }}
-        - name: grpc-tls
-          secret:
-            secretName: {{ required "agentTLS.serverCertSecret is required when agentTLS.enabled" .Values.agentTLS.serverCertSecret }}
-        {{- end }}
-        {{- if .Values.database.caConfigMap }}
-        - name: db-ca
-          configMap:
-            name: {{ .Values.database.caConfigMap }}
-            items:
-              - key: ca.crt
-                path: ca.crt
-        {{- end }}
-        {{- if .Values.redis.caConfigMap }}
-        - name: redis-ca
-          configMap:
-            name: {{ .Values.redis.caConfigMap }}
-        {{- end }}
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+
+{{- /*
+Render one "all" Deployment (default, byte-identical to the pre-0049 monolith) or,
+when split.enabled, separate api and scheduler Deployments — ADR 0049. The
+scheduler is always a single leader (ADR 0009), so its replica count is pinned to 1
+here regardless of split.scheduler.replicaCount.
+*/ -}}
+{{- if .Values.split.enabled }}
+{{- include "leoflow.controlPlaneDeployment" (dict "ctx" . "role" "api" "replicas" .Values.split.api.replicaCount) | nindent 0 }}
+---
+{{- include "leoflow.controlPlaneDeployment" (dict "ctx" . "role" "scheduler" "replicas" 1) | nindent 0 }}
+{{- else }}
+{{- include "leoflow.controlPlaneDeployment" (dict "ctx" . "role" "all" "replicas" .Values.replicaCount) | nindent 0 }}
+{{- end }}

--- a/helm/leoflow/templates/hpa.yaml
+++ b/helm/leoflow/templates/hpa.yaml
@@ -4,10 +4,14 @@ Safe because the scheduler leader-elects (ADR 0009): scaling the Deployment adds
 API/UI replicas while exactly one scheduler stays active. Disabled by default.
 */ -}}
 {{- if .Values.autoscaling.enabled }}
+{{- /* ADR 0049: in split mode the autoscaler targets the api Deployment (the
+active-active role). The scheduler is a single leader (ADR 0009) and is never
+autoscaled. Non-split targets the single "all" Deployment, unchanged. */ -}}
+{{- $role := ternary "api" "all" .Values.split.enabled -}}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "leoflow.fullname" . }}
+  name: {{ include "leoflow.roleName" (dict "ctx" . "role" $role) }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "leoflow.labels" . | nindent 4 }}
@@ -15,7 +19,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "leoflow.fullname" . }}
+    name: {{ include "leoflow.roleName" (dict "ctx" . "role" $role) }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:

--- a/helm/leoflow/templates/ingress.yaml
+++ b/helm/leoflow/templates/ingress.yaml
@@ -28,7 +28,9 @@ spec:
             pathType: {{ .pathType }}
             backend:
               service:
-                name: {{ include "leoflow.fullname" $ }}
+                # ADR 0049: in split mode the HTTP API lives on the api Service
+                # ("<fullname>-api"); the bare fullname Service does not exist.
+                name: {{ include "leoflow.roleName" (dict "ctx" $ "role" (ternary "api" "all" $.Values.split.enabled)) }}
                 port:
                   name: http
           {{- end }}

--- a/helm/leoflow/templates/networkpolicy.yaml
+++ b/helm/leoflow/templates/networkpolicy.yaml
@@ -1,60 +1,14 @@
 {{- /*
-DRAFT (Production track) — NetworkPolicy for the control plane. In our scenario
-the trust boundary is: clients/ingress hit HTTP; Prometheus scrapes metrics; and
-TASK PODS dial the gRPC port back (the pod-per-task agent, ADR 0002/0004). Egress
-must reach Postgres, Redis, the Kubernetes API (to create task pods), and DNS.
-
-This is a STARTING POINT — NetworkPolicy is environment-specific (CNI must
-enforce it). Defaults are permissive on egress (DNS + all) so enabling it does not
-silently break the control plane; tighten `egress` per your cluster. Disabled by
-default.
+Control-plane NetworkPolicy — disabled by default (draft; CNI must enforce it).
+One "all" policy, or per-role policies when split.enabled (ADR 0049). See
+_controlplane-networkpolicy.tpl for the per-role ingress/selector split.
 */ -}}
 {{- if .Values.networkPolicy.enabled }}
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: {{ include "leoflow.fullname" . }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "leoflow.labels" . | nindent 4 }}
-spec:
-  podSelector:
-    matchLabels:
-      {{- include "leoflow.selectorLabels" . | nindent 6 }}
-  policyTypes:
-    - Ingress
-    - Egress
-  ingress:
-    # HTTP/UI + gRPC (task pods dial back). Restrict sources via networkPolicy.ingressFrom.
-    - ports:
-        - port: {{ .Values.ports.http }}
-          protocol: TCP
-        - port: {{ .Values.ports.grpc }}
-          protocol: TCP
-      {{- with .Values.networkPolicy.ingressFrom }}
-      from:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-    {{- with .Values.networkPolicy.metricsFrom }}
-    # Metrics scrape (e.g. the Prometheus pods' namespace/labels).
-    - ports:
-        - port: {{ $.Values.ports.metrics }}
-          protocol: TCP
-      from:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-  egress:
-    # DNS is always required for service discovery.
-    - ports:
-        - port: 53
-          protocol: UDP
-        - port: 53
-          protocol: TCP
-    {{- with .Values.networkPolicy.egress }}
-    {{- toYaml . | nindent 4 }}
-    {{- else }}
-    # Default: allow all other egress (Postgres, Redis, kube-apiserver). Tighten
-    # by setting networkPolicy.egress to explicit rules for your data stores + API.
-    - {}
-    {{- end }}
+{{- if .Values.split.enabled }}
+{{- include "leoflow.controlPlaneNetworkPolicy" (dict "ctx" . "role" "api") | nindent 0 }}
+---
+{{- include "leoflow.controlPlaneNetworkPolicy" (dict "ctx" . "role" "scheduler") | nindent 0 }}
+{{- else }}
+{{- include "leoflow.controlPlaneNetworkPolicy" (dict "ctx" . "role" "all") | nindent 0 }}
+{{- end }}
 {{- end }}

--- a/helm/leoflow/templates/pdb.yaml
+++ b/helm/leoflow/templates/pdb.yaml
@@ -4,10 +4,15 @@ drains, upgrades) keep enough control-plane replicas serving the API. Disabled b
 default; set replicaCount > 1 (HA, leader-elected) before enabling.
 */ -}}
 {{- if .Values.podDisruptionBudget.enabled }}
+{{- /* ADR 0049: in split mode the PDB protects the api Deployment (the
+multi-replica, active-active role). The scheduler is a single leader (ADR 0009);
+a PDB over one pod would block node drains, so it is deliberately excluded.
+Non-split covers the single "all" Deployment, unchanged. */ -}}
+{{- $role := ternary "api" "all" .Values.split.enabled -}}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
-  name: {{ include "leoflow.fullname" . }}
+  name: {{ include "leoflow.roleName" (dict "ctx" . "role" $role) }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "leoflow.labels" . | nindent 4 }}
@@ -20,5 +25,5 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      {{- include "leoflow.selectorLabels" . | nindent 6 }}
+      {{- include "leoflow.roleSelectorLabels" (dict "ctx" . "role" $role) | nindent 6 }}
 {{- end }}

--- a/helm/leoflow/templates/rbac.yaml
+++ b/helm/leoflow/templates/rbac.yaml
@@ -43,11 +43,14 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ include "leoflow.fullname" . }}-executor
+{{- /*
+ADR 0049: in split mode ONLY the scheduler SA is granted the executor Role — the
+scheduler is what creates task pods. The api SA is deliberately left unbound so a
+compromised/SSRF'd API cannot reach the apiserver. Non-split binds the single
+"all" SA, unchanged. (A template comment, not a "#" line, so the non-split
+rendered output stays byte-identical to the pre-0049 chart.)
+*/}}
 subjects:
-  # ADR 0049: in split mode ONLY the scheduler SA is granted the executor Role —
-  # the scheduler is what creates task pods. The api SA is deliberately left
-  # unbound so a compromised/SSRF'd API cannot reach the apiserver. Non-split
-  # binds the single "all" SA, unchanged.
   - kind: ServiceAccount
     name: {{ include "leoflow.roleServiceAccountName" (dict "ctx" . "role" (ternary "scheduler" "all" .Values.split.enabled)) }}
     namespace: {{ .Release.Namespace }}

--- a/helm/leoflow/templates/rbac.yaml
+++ b/helm/leoflow/templates/rbac.yaml
@@ -44,7 +44,11 @@ roleRef:
   kind: Role
   name: {{ include "leoflow.fullname" . }}-executor
 subjects:
+  # ADR 0049: in split mode ONLY the scheduler SA is granted the executor Role —
+  # the scheduler is what creates task pods. The api SA is deliberately left
+  # unbound so a compromised/SSRF'd API cannot reach the apiserver. Non-split
+  # binds the single "all" SA, unchanged.
   - kind: ServiceAccount
-    name: {{ include "leoflow.serviceAccountName" . }}
+    name: {{ include "leoflow.roleServiceAccountName" (dict "ctx" . "role" (ternary "scheduler" "all" .Values.split.enabled)) }}
     namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/helm/leoflow/templates/service.yaml
+++ b/helm/leoflow/templates/service.yaml
@@ -1,28 +1,12 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "leoflow.fullname" . }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "leoflow.labels" . | nindent 4 }}
-  {{- with .Values.service.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  type: {{ .Values.service.type }}
-  selector:
-    {{- include "leoflow.selectorLabels" . | nindent 4 }}
-  ports:
-    - name: http
-      port: {{ .Values.ports.http }}
-      targetPort: http
-      protocol: TCP
-    - name: metrics
-      port: {{ .Values.ports.metrics }}
-      targetPort: metrics
-      protocol: TCP
-    - name: grpc
-      port: {{ .Values.ports.grpc }}
-      targetPort: grpc
-      protocol: TCP
+{{- /*
+One "all" Service (default, identical to the pre-0049 chart) or, when
+split.enabled, separate api and scheduler Services — ADR 0049. See
+_controlplane-service.tpl for the per-role port/selector split.
+*/ -}}
+{{- if .Values.split.enabled }}
+{{- include "leoflow.controlPlaneService" (dict "ctx" . "role" "api") | nindent 0 }}
+---
+{{- include "leoflow.controlPlaneService" (dict "ctx" . "role" "scheduler") | nindent 0 }}
+{{- else }}
+{{- include "leoflow.controlPlaneService" (dict "ctx" . "role" "all") | nindent 0 }}
+{{- end }}

--- a/helm/leoflow/templates/serviceaccount.yaml
+++ b/helm/leoflow/templates/serviceaccount.yaml
@@ -1,13 +1,27 @@
-{{- if .Values.serviceAccount.create -}}
+{{- /*
+ServiceAccount(s) for the control plane. Non-split: one SA (byte-identical to the
+pre-0049 chart). Split (ADR 0049): a restricted api SA (no executor RBAC bound to
+it) and a privileged scheduler SA (bound to the executor Role in rbac.yaml).
+*/ -}}
+{{- define "leoflow.controlPlaneServiceAccount" -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "leoflow.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "leoflow.roleServiceAccountName" (dict "ctx" .ctx "role" .role) }}
+  namespace: {{ .ctx.Release.Namespace }}
   labels:
-    {{- include "leoflow.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+    {{- include "leoflow.labels" .ctx | nindent 4 }}
+  {{- with .ctx.Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end -}}
+{{- if .Values.serviceAccount.create -}}
+{{- if .Values.split.enabled }}
+{{- include "leoflow.controlPlaneServiceAccount" (dict "ctx" . "role" "api") | nindent 0 }}
+---
+{{- include "leoflow.controlPlaneServiceAccount" (dict "ctx" . "role" "scheduler") | nindent 0 }}
+{{- else }}
+{{- include "leoflow.controlPlaneServiceAccount" (dict "ctx" . "role" "all") | nindent 0 }}
+{{- end }}
 {{- end -}}

--- a/helm/leoflow/tests/split_naming_test.yaml
+++ b/helm/leoflow/tests/split_naming_test.yaml
@@ -1,0 +1,83 @@
+suite: split naming edge cases — truncation collision (F2) and SA name override (F3)
+release:
+  name: leoflow
+set:
+  database.url: postgres://h/d
+  redis.url: redis://h/0
+  auth.jwtSecret: jwt
+  agentTLS.enabled: true
+  agentTLS.serverCertSecret: leoflow-tls
+  agentTLS.caConfigMap: leoflow-ca
+  split.enabled: true
+  logs.persistence.accessMode: ReadWriteMany
+tests:
+  # F2: a fullnameOverride of 62 chars makes roleName truncate the "-api"/
+  # "-scheduler" suffix off, collapsing BOTH Deployments to the same 63-char
+  # name → helm install conflict / silent clobber. The api and scheduler names
+  # MUST stay distinct at any name length.
+  - it: api and scheduler Deployment names stay distinct under 62-char fullname truncation
+    template: deployment.yaml
+    set:
+      fullnameOverride: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: "-api$"
+        documentIndex: 0
+      - matchRegex:
+          path: metadata.name
+          pattern: "-scheduler$"
+        documentIndex: 1
+
+  - it: api and scheduler Service names also stay distinct under truncation
+    template: service.yaml
+    set:
+      fullnameOverride: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: "-api$"
+        documentIndex: 0
+      - matchRegex:
+          path: metadata.name
+          pattern: "-scheduler$"
+        documentIndex: 1
+
+  # F3: with a serviceAccount.name override, the split ServiceAccounts and the
+  # Deployments' serviceAccountName must reflect that base (role-suffixed), not
+  # the chart fullname — otherwise create=false + name=<pre-provisioned SA>
+  # (IRSA / Workload Identity) references SAs that do not exist and pods never
+  # schedule.
+  - it: split ServiceAccount names honor serviceAccount.name (base + role suffix)
+    template: serviceaccount.yaml
+    set:
+      serviceAccount.name: byo-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: byo-sa-api
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: byo-sa-scheduler
+        documentIndex: 1
+
+  - it: the api Deployment runs as the overridden SA name (base + role suffix)
+    template: deployment.yaml
+    set:
+      serviceAccount.name: byo-sa
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: byo-sa-api
+
+  - it: the scheduler Deployment runs as the overridden SA name
+    template: deployment.yaml
+    set:
+      serviceAccount.name: byo-sa
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: byo-sa-scheduler

--- a/helm/leoflow/tests/split_networkpolicy_test.yaml
+++ b/helm/leoflow/tests/split_networkpolicy_test.yaml
@@ -1,0 +1,53 @@
+suite: split NetworkPolicies scope ingress to each role's served ports (ADR 0049)
+templates:
+  - networkpolicy.yaml
+release:
+  name: leoflow
+set:
+  split.enabled: true
+  networkPolicy.enabled: true
+tests:
+  - it: renders one NetworkPolicy per role
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: the api policy selects api pods and opens http ingress, not grpc
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.name
+          value: leoflow-api
+      - equal:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/component"]
+          value: api
+      - contains:
+          path: spec.ingress[0].ports
+          content:
+            port: 8080
+            protocol: TCP
+      - notContains:
+          path: spec.ingress[0].ports
+          content:
+            port: 9091
+            protocol: TCP
+
+  - it: the scheduler policy selects scheduler pods and opens grpc ingress, not http
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: metadata.name
+          value: leoflow-scheduler
+      - equal:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/component"]
+          value: scheduler
+      - contains:
+          path: spec.ingress[0].ports
+          content:
+            port: 9091
+            protocol: TCP
+      - notContains:
+          path: spec.ingress[0].ports
+          content:
+            port: 8080
+            protocol: TCP

--- a/helm/leoflow/tests/split_rbac_test.yaml
+++ b/helm/leoflow/tests/split_rbac_test.yaml
@@ -1,0 +1,50 @@
+suite: split gives the API a restricted identity, the scheduler the privileged one (ADR 0049)
+templates:
+  - serviceaccount.yaml
+  - rbac.yaml
+release:
+  name: leoflow
+  namespace: leoflow
+set:
+  split.enabled: true
+tests:
+  - it: renders a ServiceAccount per role
+    template: serviceaccount.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: leoflow-api
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: leoflow-scheduler
+        documentIndex: 1
+
+  - it: binds the executor Role ONLY to the scheduler SA — the api SA stays unbound (restricted)
+    template: rbac.yaml
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      # The privileged pod-create grant goes to the scheduler, never the api.
+      - equal:
+          path: subjects[0].name
+          value: leoflow-scheduler
+      - equal:
+          path: subjects[0].namespace
+          value: leoflow
+
+  - it: still binds the single SA in non-split mode (regression)
+    template: rbac.yaml
+    documentIndex: 1
+    set:
+      split.enabled: false
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: leoflow

--- a/helm/leoflow/tests/split_scaling_test.yaml
+++ b/helm/leoflow/tests/split_scaling_test.yaml
@@ -1,0 +1,35 @@
+suite: split HPA + PDB target the api Deployment, never the single-leader scheduler (ADR 0049)
+templates:
+  - hpa.yaml
+  - pdb.yaml
+release:
+  name: leoflow
+set:
+  split.enabled: true
+tests:
+  - it: the HPA scales the api Deployment (the scheduler is a single leader, never autoscaled)
+    template: hpa.yaml
+    set:
+      autoscaling.enabled: true
+      autoscaling.minReplicas: 2
+      autoscaling.maxReplicas: 5
+    asserts:
+      - equal:
+          path: metadata.name
+          value: leoflow-api
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: leoflow-api
+
+  - it: the PDB protects the api Deployment's pods (component=api)
+    template: pdb.yaml
+    set:
+      podDisruptionBudget.enabled: true
+      podDisruptionBudget.minAvailable: 1
+    asserts:
+      - equal:
+          path: metadata.name
+          value: leoflow-api
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: api

--- a/helm/leoflow/tests/split_service_test.yaml
+++ b/helm/leoflow/tests/split_service_test.yaml
@@ -1,0 +1,63 @@
+suite: split Services route each role's ports to its own pods (ADR 0049)
+templates:
+  - service.yaml
+release:
+  name: leoflow
+set:
+  split.enabled: true
+tests:
+  - it: renders two Services when split.enabled
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: the api Service exposes http + metrics and selects only api pods
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.name
+          value: leoflow-api
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: api
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 8080
+            targetPort: http
+            protocol: TCP
+      # The api serves no gRPC — that port belongs to the scheduler Service.
+      - notContains:
+          path: spec.ports
+          content:
+            name: grpc
+            port: 9091
+            targetPort: grpc
+            protocol: TCP
+
+  - it: the scheduler Service exposes grpc + metrics and selects only scheduler pods
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: metadata.name
+          value: leoflow-scheduler
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: scheduler
+      # Task pods dial this Service's gRPC to report state (agentControlPlaneAddr).
+      - contains:
+          path: spec.ports
+          content:
+            name: grpc
+            port: 9091
+            targetPort: grpc
+            protocol: TCP
+      # The scheduler serves no HTTP API, so its Service exposes no http port.
+      - notContains:
+          path: spec.ports
+          content:
+            name: http
+            port: 8080
+            targetPort: http
+            protocol: TCP

--- a/helm/leoflow/tests/split_test.yaml
+++ b/helm/leoflow/tests/split_test.yaml
@@ -129,6 +129,24 @@ tests:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.port
           value: metrics
 
+  # Task pods must dial the scheduler Service for the agent gRPC — not the bare
+  # fullname (which is the api Service in split mode and serves no gRPC). The
+  # helper derives this from leoflow.roleName, the same source the scheduler
+  # Service name uses, so the two always agree even under the 63-char truncation.
+  - it: task pods are told to dial the scheduler Service for the agent gRPC
+    template: deployment.yaml
+    documentIndex: 0
+    set:
+      split.enabled: true
+      logs.persistence.accessMode: ReadWriteMany
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LEOFLOW_EXECUTOR_AGENT_CONTROL_PLANE_ADDR
+            value: leoflow-scheduler.NAMESPACE.svc.cluster.local:9091
+          # helm-unittest renders release namespace as "NAMESPACE" in tests.
+
   # --- Split with the default ReadWriteOnce logs PVC must fail loudly: the
   # scheduler writes logs and the api replicas read them from the SAME PVC, so
   # >=2 pods mount it at once and RWO can never satisfy that (#282 generalized).

--- a/helm/leoflow/tests/split_test.yaml
+++ b/helm/leoflow/tests/split_test.yaml
@@ -1,0 +1,143 @@
+suite: control-plane split into api + scheduler Deployments (ADR 0049)
+templates:
+  - deployment.yaml
+  - secret.yaml
+release:
+  name: leoflow
+# Every case needs the mandatory Pro cert pair (the chart refuses to render
+# without agent TLS, #459) and external datastores.
+set:
+  database.url: postgres://h/d
+  redis.url: redis://h/0
+  auth.jwtSecret: jwt
+  agentTLS.enabled: true
+  agentTLS.serverCertSecret: leoflow-tls
+  agentTLS.caConfigMap: leoflow-ca
+tests:
+  # --- Default (split OFF): one "all" Deployment, byte-identical shape to pre-0049.
+  - it: renders a single Deployment with no role env or component label when split is off
+    template: deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: leoflow
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LEOFLOW_SERVER_ROLE
+            value: all
+      # The selector must NOT gain a component label — it is immutable, and adding
+      # one would break `helm upgrade` from a pre-split install.
+      - notExists:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+
+  # --- Split ON: two Deployments. Logs PVC must be RWX (both roles share it).
+  - it: renders two Deployments (api + scheduler) when split.enabled
+    template: deployment.yaml
+    set:
+      split.enabled: true
+      logs.persistence.accessMode: ReadWriteMany
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: the api Deployment serves the HTTP API — role=api, http+metrics ports, http probes, active-active
+    template: deployment.yaml
+    documentIndex: 0
+    set:
+      split.enabled: true
+      logs.persistence.accessMode: ReadWriteMany
+      split.api.replicaCount: 4
+    asserts:
+      - equal:
+          path: metadata.name
+          value: leoflow-api
+      - equal:
+          path: spec.replicas
+          value: 4
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: api
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: api
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LEOFLOW_SERVER_ROLE
+            value: api
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: http
+            containerPort: 8080
+      # The api serves no agent gRPC — that endpoint belongs to the scheduler.
+      - notContains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: grpc
+            containerPort: 9091
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: http
+
+  - it: the scheduler Deployment is a single leader — role=scheduler, grpc+metrics ports, health probed on the metrics port (no HTTP API)
+    template: deployment.yaml
+    documentIndex: 1
+    set:
+      split.enabled: true
+      logs.persistence.accessMode: ReadWriteMany
+      # Even if an operator bumps this, the scheduler stays a single leader (ADR 0009).
+      split.scheduler.replicaCount: 5
+    asserts:
+      - equal:
+          path: metadata.name
+          value: leoflow-scheduler
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: scheduler
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LEOFLOW_SERVER_ROLE
+            value: scheduler
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: grpc
+            containerPort: 9091
+      # The scheduler serves no HTTP API, so it exposes no http port …
+      - notContains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: http
+            containerPort: 8080
+      # … and its kubelet probes hit /healthz + /readyz on the metrics port
+      # (served by api.ObservabilityHandler in every role).
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: metrics
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: metrics
+
+  # --- Split with the default ReadWriteOnce logs PVC must fail loudly: the
+  # scheduler writes logs and the api replicas read them from the SAME PVC, so
+  # >=2 pods mount it at once and RWO can never satisfy that (#282 generalized).
+  - it: fails when split.enabled with a ReadWriteOnce logs PVC (shared by both roles)
+    template: deployment.yaml
+    set:
+      split.enabled: true
+      logs.persistence.enabled: true
+      logs.persistence.accessMode: ReadWriteOnce
+    asserts:
+      - failedTemplate:
+          errorMessage: "a ReadWriteOnce logs PVC attaches to only one pod, so more than one control-plane replica — replicaCount > 1, or autoscaling.enabled with maxReplicas > 1 — hangs the extra pods in ContainerCreating (Multi-Attach error), silently. Set logs.persistence.accessMode=ReadWriteMany with an RWX StorageClass (NFS / Longhorn-rwx / CephFS / EFS / Azure Files / GCP Filestore); or keep a single replica; or set logs.persistence.enabled=false (ephemeral emptyDir). See #282."

--- a/helm/leoflow/values.yaml
+++ b/helm/leoflow/values.yaml
@@ -11,6 +11,24 @@ imagePullSecrets: []
 # -- Number of control-plane replicas. The scheduler leader-elects (ADR 0009), so `>1` is HA-safe (active-passive scheduler, active-active API).
 replicaCount: 1
 
+# ADR 0049 — split the control plane into two Deployments by role. OFF by default:
+# the chart renders a single `all`-role Deployment that is byte-identical to the
+# pre-0049 monolith, so existing installs upgrade in place with no topology change.
+# Turn it on for enterprise scale: the API (HTTP + UI) becomes its own active-active
+# Deployment with a RESTRICTED identity (no pod-create / apiserver RBAC), and the
+# scheduler (reconciler + dispatch + agent gRPC) becomes a single-leader Deployment
+# that keeps the privileged identity. The security payoff is that a compromised or
+# SSRF'd API cannot reach the apiserver — see ADR 0048/0049.
+split:
+  # -- Render separate `api` and `scheduler` Deployments instead of one `all` Deployment. Pro-only (Lite is single-host and never splits).
+  enabled: false
+  api:
+    # -- API Deployment replicas (active-active; HPA-friendly). Ignored unless split.enabled.
+    replicaCount: 2
+  scheduler:
+    # -- Scheduler Deployment replicas. Pinned to 1 by the chart regardless of this value — the scheduler is a single leader (ADR 0009); a field is kept only for clarity. Ignored unless split.enabled.
+    replicaCount: 1
+
 # -- Namespace where the control plane creates task pods. MUST match the
 # namespace the server expects (server code currently targets `leoflow`).
 # The chart grants the control plane RBAC to manage pods here; if you

--- a/internal/api/observability_handler.go
+++ b/internal/api/observability_handler.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// ObservabilityHandler builds the handler served on the metrics listener: the
+// Prometheus /metrics endpoint plus the same /healthz and /readyz the full API
+// exposes (reusing the very same handlers, so the semantics are identical —
+// trivial liveness, dependency-pinging readiness).
+//
+// Roles that do not serve the full API — the ADR 0049 scheduler role — still need
+// a liveness/readiness surface for the kubelet's probes. The metrics listener runs
+// in every role, so mounting health here gives a scheduler-only pod a probe target
+// without exposing the API, auth, or UI. The full API keeps its own /healthz and
+// /readyz on the HTTP port, so the "all" role is unchanged; this is purely
+// additive on the metrics port.
+//
+// This handler is intentionally unauthenticated (probes carry no token) and does
+// not run the API middleware chain; it is the same trust level as scraping
+// /metrics, which is already public.
+func ObservabilityHandler(registry *prometheus.Registry, checks map[string]HealthChecker) http.Handler {
+	r := gin.New()
+	r.GET("/healthz", livenessHandler)
+	r.GET("/readyz", readinessHandler(checks))
+	if registry != nil {
+		r.GET("/metrics", gin.WrapH(promhttp.HandlerFor(registry, promhttp.HandlerOpts{})))
+	}
+	return r
+}

--- a/internal/api/observability_handler_test.go
+++ b/internal/api/observability_handler_test.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// TestObservabilityHandler pins the surface the metrics listener serves in every
+// role (ADR 0049): /metrics plus the same /healthz and /readyz the full API
+// exposes. The scheduler role serves no API, so this is the only liveness/
+// readiness surface its pod's kubelet probes can reach — it must behave exactly
+// like the API's copy (trivial liveness; readiness pings every dependency).
+func TestObservabilityHandler(t *testing.T) {
+	reg := prometheus.NewRegistry()
+
+	do := func(h http.Handler, path string) *httptest.ResponseRecorder {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, http.NoBody))
+		return rec
+	}
+
+	t.Run("healthz is trivial 200", func(t *testing.T) {
+		h := ObservabilityHandler(reg, map[string]HealthChecker{"postgres": &fakeHealthCheck{err: errors.New("down")}})
+		// Liveness must NOT reach dependencies: a down postgres still returns 200
+		// so kubelet does not restart a healthy scheduler over a flaky datastore.
+		if rec := do(h, "/healthz"); rec.Code != http.StatusOK {
+			t.Fatalf("/healthz = %d, want 200", rec.Code)
+		}
+	})
+
+	t.Run("readyz reflects dependency health", func(t *testing.T) {
+		ok := ObservabilityHandler(reg, map[string]HealthChecker{"postgres": &fakeHealthCheck{}})
+		if rec := do(ok, "/readyz"); rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "ready") {
+			t.Fatalf("/readyz healthy = %d %q, want 200 ready", rec.Code, rec.Body.String())
+		}
+		bad := ObservabilityHandler(reg, map[string]HealthChecker{"postgres": &fakeHealthCheck{err: errors.New("connection refused")}})
+		rec := do(bad, "/readyz")
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("/readyz degraded = %d, want 503", rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "postgres") || !strings.Contains(rec.Body.String(), "connection refused") {
+			t.Errorf("/readyz body should name the failed dep + error, got %q", rec.Body.String())
+		}
+	})
+
+	t.Run("metrics is served", func(t *testing.T) {
+		h := ObservabilityHandler(reg, nil)
+		if rec := do(h, "/metrics"); rec.Code != http.StatusOK {
+			t.Fatalf("/metrics = %d, want 200", rec.Code)
+		}
+	})
+
+	t.Run("nil registry omits metrics but keeps health", func(t *testing.T) {
+		h := ObservabilityHandler(nil, nil)
+		if rec := do(h, "/healthz"); rec.Code != http.StatusOK {
+			t.Errorf("/healthz with nil registry = %d, want 200", rec.Code)
+		}
+	})
+}

--- a/internal/api/versions.go
+++ b/internal/api/versions.go
@@ -22,6 +22,9 @@ type versionResponse struct {
 	Version  string `json:"version"`
 	SpecHash string `json:"spec_hash"`
 	Created  bool   `json:"created"`
+	// Warnings carries non-fatal deprecation notices (e.g. the http_api task
+	// type, ADR 0047) so `leoflow push` can show the author. Omitted when empty.
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 func registerVersionHandler(repo DagVersionRepository, inlineMaxSeconds int) gin.HandlerFunc {
@@ -60,6 +63,6 @@ func registerVersionHandler(repo DagVersionRepository, inlineMaxSeconds int) gin
 		if created {
 			status = http.StatusCreated
 		}
-		c.JSON(status, versionResponse{DagID: spec.DagID, Version: spec.DagVersion, SpecHash: hash, Created: created})
+		c.JSON(status, versionResponse{DagID: spec.DagID, Version: spec.DagVersion, SpecHash: hash, Created: created, Warnings: spec.DeprecationWarnings()})
 	}
 }

--- a/internal/cli/push.go
+++ b/internal/cli/push.go
@@ -54,6 +54,19 @@ func newPushCommand() *cobra.Command {
 			if status >= http.StatusMultipleChoices {
 				return fmt.Errorf("server returned %d: %s", status, body)
 			}
+			// Surface any non-fatal deprecation warnings the server returned (e.g.
+			// the http_api task type, ADR 0047) — the CLI is where the author sees
+			// them. Best-effort: a body that does not parse just prints no warnings.
+			var resp struct {
+				Warnings []string `json:"warnings"`
+			}
+			if json.Unmarshal([]byte(body), &resp) == nil {
+				for _, w := range resp.Warnings {
+					if _, werr := fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s\n", w); werr != nil {
+						return werr
+					}
+				}
+			}
 			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Registered %q with %s (HTTP %d)\n", spec.DagID, serverURL, status)
 			return err
 		},

--- a/internal/cli/push_deprecation_test.go
+++ b/internal/cli/push_deprecation_test.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestPushPrintsServerWarnings: the register response may carry non-fatal
+// deprecation warnings (ADR 0047 http_api). `leoflow push` must surface them to
+// the author on stderr — the CLI is the only place the http_api deprecation is
+// visible, since the parser no longer emits it (it can only arrive via a
+// hand-written dag.json). Without this the warning dies in the server log.
+func TestPushPrintsServerWarnings(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"dag_id":"pushdag","version":"v1","spec_hash":"abc","created":true,` +
+			`"warnings":["task \"fetch\" uses the deprecated task type \"http_api\"; use an HttpOperator"]}`))
+	}))
+	defer srv.Close()
+
+	f := filepath.Join(t.TempDir(), "dag.json")
+	if err := os.WriteFile(f, []byte(pushSpec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, errOut, err := run(t, "push", f, "--server", srv.URL, "--token", "x")
+	if err != nil {
+		t.Fatalf("push: %v", err)
+	}
+	if !strings.Contains(out, "Registered") {
+		t.Errorf("stdout should still confirm registration, got %q", out)
+	}
+	combined := out + errOut
+	if !strings.Contains(combined, "deprecated") || !strings.Contains(combined, "HttpOperator") {
+		t.Errorf("push did not surface the server deprecation warning; stdout=%q stderr=%q", out, errOut)
+	}
+}

--- a/internal/config/role_test.go
+++ b/internal/config/role_test.go
@@ -2,6 +2,31 @@ package config
 
 import "testing"
 
+// TestLoadServerRoleFromEnv locks the env binding for server.role. viper's
+// AutomaticEnv only binds keys it has seen via SetDefault, so the role field is
+// silently dropped from LEOFLOW_SERVER_ROLE unless "server.role" is in
+// serverDefaults — the same trap the ui.auto_refresh default comment documents.
+func TestLoadServerRoleFromEnv(t *testing.T) {
+	c, err := LoadServer("", nil)
+	if err != nil {
+		t.Fatalf("LoadServer() error = %v", err)
+	}
+	if c.Server.EffectiveRole() != RoleAll {
+		t.Errorf("default EffectiveRole() = %q, want %q", c.Server.EffectiveRole(), RoleAll)
+	}
+	t.Setenv("LEOFLOW_SERVER_ROLE", RoleScheduler)
+	c, err = LoadServer("", nil)
+	if err != nil {
+		t.Fatalf("LoadServer() error = %v", err)
+	}
+	if c.Server.Role != RoleScheduler {
+		t.Errorf("server.role from env = %q, want %q", c.Server.Role, RoleScheduler)
+	}
+	if c.Server.ServesAPI() {
+		t.Error("scheduler role from env must not serve the API")
+	}
+}
+
 func TestServerRoleDefaultsToAll(t *testing.T) {
 	c := &ServerConfig{}
 	if got := c.Server.EffectiveRole(); got != RoleAll {

--- a/internal/config/role_test.go
+++ b/internal/config/role_test.go
@@ -1,0 +1,43 @@
+package config
+
+import "testing"
+
+func TestServerRoleDefaultsToAll(t *testing.T) {
+	c := &ServerConfig{}
+	if got := c.Server.EffectiveRole(); got != RoleAll {
+		t.Errorf("empty role should default to %q, got %q", RoleAll, got)
+	}
+}
+
+func TestServerRolePredicates(t *testing.T) {
+	for _, tc := range []struct {
+		role                       string
+		servesAPI, servesScheduler bool
+	}{
+		{"all", true, true},
+		{"", true, true}, // empty == all (Lite / backward-compat)
+		{"api", true, false},
+		{"scheduler", false, true},
+	} {
+		s := ServerSection{Role: tc.role}
+		if s.ServesAPI() != tc.servesAPI {
+			t.Errorf("role %q: ServesAPI = %v, want %v", tc.role, s.ServesAPI(), tc.servesAPI)
+		}
+		if s.ServesScheduler() != tc.servesScheduler {
+			t.Errorf("role %q: ServesScheduler = %v, want %v", tc.role, s.ServesScheduler(), tc.servesScheduler)
+		}
+	}
+}
+
+func TestServerRoleValidationRejectsUnknown(t *testing.T) {
+	c := &ServerConfig{Server: ServerSection{Role: "worker"}}
+	if err := c.validateRole(); err == nil {
+		t.Error("an unknown role must be rejected loudly")
+	}
+	for _, ok := range []string{"", "all", "api", "scheduler"} {
+		c := &ServerConfig{Server: ServerSection{Role: ok}}
+		if err := c.validateRole(); err != nil {
+			t.Errorf("role %q should be valid, got %v", ok, err)
+		}
+	}
+}

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -139,6 +139,11 @@ type HTTPExecutorSection struct {
 
 // ServerSection configures the HTTP, metrics, and agent gRPC listeners.
 type ServerSection struct {
+	// Role selects which components this process runs (ADR 0049): "all" (default;
+	// the monolith Lite always runs), "api" (HTTP + UI, restricted identity), or
+	// "scheduler" (reconciler + dispatch + agent gRPC, privileged). Splitting is a
+	// Pro-only topology; "all" is behavior-identical to the pre-0049 monolith.
+	Role        string      `mapstructure:"role"`
 	HTTPAddr    string      `mapstructure:"http_addr"`
 	MetricsAddr string      `mapstructure:"metrics_addr"`
 	GRPCAddr    string      `mapstructure:"grpc_addr"`
@@ -147,6 +152,38 @@ type ServerSection struct {
 	// When both are set the channel is encrypted; empty means plaintext (dev).
 	GRPCTLSCert string `mapstructure:"grpc_tls_cert"`
 	GRPCTLSKey  string `mapstructure:"grpc_tls_key"`
+}
+
+// Server roles (ADR 0049).
+const (
+	// RoleAll runs every component in one process (the default; Lite's only mode).
+	RoleAll = "all"
+	// RoleAPI runs the HTTP API + UI only (restricted network identity).
+	RoleAPI = "api"
+	// RoleScheduler runs the reconciler + dispatch + agent gRPC (privileged).
+	RoleScheduler = "scheduler"
+)
+
+// EffectiveRole returns the configured role, defaulting empty to RoleAll so an
+// unset role (Lite, and every pre-0049 deployment) keeps the monolith behavior.
+func (s ServerSection) EffectiveRole() string {
+	if s.Role == "" {
+		return RoleAll
+	}
+	return s.Role
+}
+
+// ServesAPI reports whether this process runs the HTTP API + UI.
+func (s ServerSection) ServesAPI() bool {
+	r := s.EffectiveRole()
+	return r == RoleAll || r == RoleAPI
+}
+
+// ServesScheduler reports whether this process runs the scheduler, dispatch, and
+// the agent gRPC endpoint.
+func (s ServerSection) ServesScheduler() bool {
+	r := s.EffectiveRole()
+	return r == RoleAll || r == RoleScheduler
 }
 
 // CORSSection configures cross-origin access.
@@ -325,6 +362,9 @@ func LoadServer(configFile string, flags *pflag.FlagSet) (*ServerConfig, error) 
 
 // Validate reports configuration errors that must abort startup.
 func (c *ServerConfig) Validate() error {
+	if err := c.validateRole(); err != nil {
+		return err
+	}
 	if c.Auth.Provider == "jwt" && c.Auth.JWT.Secret == "" {
 		return errors.New("auth.jwt.secret is required (set LEOFLOW_AUTH_JWT_SECRET)")
 	}
@@ -349,4 +389,16 @@ func isLoopbackListenAddr(addr string) bool {
 	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
+}
+
+// validateRole rejects an unknown server.role (ADR 0049). Empty is valid (defaults
+// to "all"). A typo like "worker" is a loud boot failure, not a silent monolith.
+func (c *ServerConfig) validateRole() error {
+	switch c.Server.Role {
+	case "", RoleAll, RoleAPI, RoleScheduler:
+		return nil
+	default:
+		return fmt.Errorf("invalid server.role %q: must be one of %q, %q, %q (or empty = %q)",
+			c.Server.Role, RoleAll, RoleAPI, RoleScheduler, RoleAll)
+	}
 }

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -273,6 +273,9 @@ type OTelSection struct {
 // serverDefaults lists every leaf key with its default so that AutomaticEnv and
 // Unmarshal resolve nested keys correctly.
 var serverDefaults = map[string]any{
+	// Empty defaults to RoleAll (EffectiveRole). This entry must exist so viper's
+	// AutomaticEnv binds LEOFLOW_SERVER_ROLE — see the ui.auto_refresh note below.
+	"server.role":                 "",
 	"server.http_addr":            "0.0.0.0:8080",
 	"server.metrics_addr":         "0.0.0.0:9090",
 	"server.grpc_addr":            "0.0.0.0:9091",

--- a/internal/domain/dag.go
+++ b/internal/domain/dag.go
@@ -219,6 +219,26 @@ func (d *DAGSpec) ValidateInlineExecution(maxInlineSeconds int) error {
 	return nil
 }
 
+// DeprecationWarnings returns non-fatal warnings for a spec that registers
+// successfully but uses a deprecated shape. Today the only one is the native
+// inline http_api task type (ADR 0047): the parser no longer emits it, so it can
+// only arrive via a hand-written dag.json — and it runs the request inline in the
+// control plane (the SSRF surface, H5). It is deprecated for one release, then
+// rejected and its inline executor removed (issue #512). The registration handler
+// surfaces these through the API response so `leoflow push` shows the author.
+func (d *DAGSpec) DeprecationWarnings() []string {
+	var warns []string
+	for _, t := range d.Tasks {
+		if t.Type == TaskTypeHTTPAPI {
+			warns = append(warns, fmt.Sprintf(
+				"task %q uses the deprecated task type %q, which runs the request inline in the control plane; "+
+					"it will be removed next release (issue #512). Use an HttpOperator, which runs in a task pod (ADR 0047).",
+				t.TaskID, TaskTypeHTTPAPI))
+		}
+	}
+	return warns
+}
+
 // Validate checks the DAGSpec against the canonical dag.json schema and
 // returns a joined error describing every schema violation, or nil when valid.
 func (d *DAGSpec) Validate() error {

--- a/internal/domain/dag_deprecation_test.go
+++ b/internal/domain/dag_deprecation_test.go
@@ -1,0 +1,36 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDeprecationWarnings pins the http_api deprecation surface (ADR 0047): a
+// registered spec containing an http_api task must yield a warning naming the
+// task and pointing to HttpOperator, so `leoflow push` can show it. Other task
+// types yield nothing. The warning is the one-release courtesy before http_api
+// is rejected outright and the inline executor removed (issue #512).
+func TestDeprecationWarnings(t *testing.T) {
+	spec := &DAGSpec{
+		SchemaVersion: "1.0", DagID: "d", DagVersion: "v1", Image: "img:v1",
+		Tasks: []TaskSpec{
+			{TaskID: "fetch", Type: TaskTypeHTTPAPI},
+			{TaskID: "run", Type: TaskTypePython},
+		},
+	}
+	warns := spec.DeprecationWarnings()
+	if len(warns) != 1 {
+		t.Fatalf("want 1 warning (the http_api task), got %d: %v", len(warns), warns)
+	}
+	w := warns[0]
+	for _, want := range []string{"fetch", "http_api", "deprecated", "HttpOperator"} {
+		if !strings.Contains(w, want) {
+			t.Errorf("warning missing %q: %s", want, w)
+		}
+	}
+
+	clean := &DAGSpec{Tasks: []TaskSpec{{TaskID: "run", Type: TaskTypePython}}}
+	if got := clean.DeprecationWarnings(); len(got) != 0 {
+		t.Errorf("a spec with no http_api task must yield no warnings, got %v", got)
+	}
+}

--- a/internal/scheduler/leader_health.go
+++ b/internal/scheduler/leader_health.go
@@ -1,0 +1,57 @@
+package scheduler
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// LeaderHealthReader answers "is a live scheduler leading?" from shared DB state,
+// for a process that does NOT run the scheduler itself — the split api role (ADR
+// 0049), whose /api/v2/monitor/health must not report a fake-healthy scheduler
+// from a nil in-process handle (finding F1). A live scheduler leader holds the
+// leadership advisory lock (ADR 0009) on its own session; when its process dies
+// the session drops and the lock releases, so lock presence is a real
+// cross-process liveness signal with no extra heartbeat table.
+//
+// It intentionally does NOT filter by pg_backend_pid (that is Leader.HoldsLock's
+// job, confirming THIS session's own hold) — here any live holder means a
+// scheduler is up. Limitation: it detects a dead/absent leader, not a leader that
+// is alive but stalled (lock held, loop wedged); the in-process Heartbeat still
+// covers stalls in the all/scheduler role. Tick-accurate cross-process health
+// would need a persisted heartbeat (future work).
+type LeaderHealthReader struct {
+	pool *pgxpool.Pool
+	// timeout bounds the pg_locks probe so a slow/stuck DB does not hang the
+	// health endpoint; a probe error is treated as "cannot confirm" → unhealthy.
+	timeout time.Duration
+}
+
+// NewLeaderHealthReader builds a reader over the given (api-role) pool.
+func NewLeaderHealthReader(pool *pgxpool.Pool) *LeaderHealthReader {
+	return &LeaderHealthReader{pool: pool, timeout: 2 * time.Second}
+}
+
+// Heartbeat implements api.Heartbeater. healthy is true iff some live session
+// holds the scheduler leadership lock. The timestamp is best-effort "now" when
+// healthy (the reader has no cross-process tick time); it is unused by the
+// handler when the status is unhealthy.
+func (r *LeaderHealthReader) Heartbeat() (healthy bool, last time.Time) {
+	ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
+	defer cancel()
+	// Same (classid, objid, objsubid=1) encoding of the 64-bit advisory key as
+	// Leader.HoldsLock, but WITHOUT the pid filter: any holder = a live leader.
+	classid := int32(LockID >> 32)
+	objid := int32(LockID & 0xFFFFFFFF)
+	var held bool
+	err := r.pool.QueryRow(ctx,
+		`SELECT EXISTS (
+		   SELECT 1 FROM pg_locks
+		   WHERE locktype = 'advisory' AND classid = $1 AND objid = $2 AND objsubid = 1
+		 )`, classid, objid).Scan(&held)
+	if err != nil {
+		return false, time.Now().UTC()
+	}
+	return held, time.Now().UTC()
+}

--- a/internal/scheduler/leader_health_integration_test.go
+++ b/internal/scheduler/leader_health_integration_test.go
@@ -1,0 +1,68 @@
+//go:build integration
+
+package scheduler_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/config"
+	"github.com/neochaotic/leoflow/internal/scheduler"
+	"github.com/neochaotic/leoflow/internal/storage"
+)
+
+// TestLeaderHealthReaderReflectsLockPresence pins the F1 fix (ADR 0049): in the
+// split api role the scheduler runs in ANOTHER process, so the api's
+// /monitor/health must derive scheduler liveness from shared state, not report a
+// fake "healthy" from a nil handle. A live scheduler holds the leadership
+// advisory lock (ADR 0009); when its process dies the session drops and the lock
+// releases. The reader (running on the api's pool) reports healthy iff some live
+// session holds the lock — so a dead scheduler shows unhealthy, which is exactly
+// what the fake-healthy nil handle failed to do.
+func TestLeaderHealthReaderReflectsLockPresence(t *testing.T) {
+	url := os.Getenv("DATABASE_URL")
+	if url == "" {
+		t.Skip("DATABASE_URL must point at a migrated database for integration tests")
+	}
+	ctx := context.Background()
+	cfg := config.DatabaseSection{URL: url}
+
+	pg, err := storage.NewPostgres(ctx, cfg)
+	if err != nil {
+		t.Fatalf("reader pool: %v", err)
+	}
+	t.Cleanup(pg.Close)
+	reader := scheduler.NewLeaderHealthReader(pg.Pool)
+
+	// No leader holds the lock yet → the api must report the scheduler unhealthy,
+	// NOT fake-healthy.
+	if healthy, _ := reader.Heartbeat(); healthy {
+		t.Fatal("with no scheduler holding the leadership lock, the reader must report unhealthy (the fake-healthy nil-handle bug, F1)")
+	}
+
+	// Simulate a live scheduler taking leadership on its own session.
+	leaderPool, err := storage.NewLeaderPool(ctx, cfg)
+	if err != nil {
+		t.Fatalf("leader pool: %v", err)
+	}
+	t.Cleanup(leaderPool.Close)
+	leader := scheduler.NewLeader(leaderPool)
+	acquired, err := leader.TryAcquire(ctx)
+	if err != nil || !acquired {
+		t.Fatalf("acquire leadership lock: acquired=%v err=%v", acquired, err)
+	}
+
+	if healthy, _ := reader.Heartbeat(); !healthy {
+		t.Error("a live leader holds the lock → the reader must report the scheduler healthy")
+	}
+
+	// Leader steps down (or its process dies → session drops); the api must now
+	// report unhealthy.
+	if err := leader.Release(ctx); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if healthy, _ := reader.Heartbeat(); healthy {
+		t.Error("after the leader released the lock, the reader must report the scheduler unhealthy")
+	}
+}

--- a/internal/storage/bootstrap_concurrent_integration_test.go
+++ b/internal/storage/bootstrap_concurrent_integration_test.go
@@ -1,0 +1,100 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+)
+
+// TestBootstrapAdminConcurrentIntegration reproduces the split-topology race
+// (ADR 0049): the api and scheduler roles — and every active-active api replica —
+// run bootstrapAdmin on startup, so several processes create the same admin at
+// once. Before the fix the loser of the INSERT crashed the process with a raw
+// unique-constraint 23505 ("duplicate key value violates ..."), taking down the
+// scheduler in the split e2e. BootstrapAdminHash must instead treat a concurrent
+// create as success (reconcile + report not-newly-created) so NO caller errors.
+func TestBootstrapAdminConcurrentIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	hash, err := auth.HashPassword("concurrent-pw-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The TOCTOU window (reconcile-check → insert) is tiny, so a single small
+	// fan-out reproduces the create-create race only intermittently. Run several
+	// rounds, each with a FRESH email (so every caller races the CREATE path, not
+	// the reconcile path) and a wide barrier-released fan-out, to hit the window
+	// reliably. Without the fix at least one round errors with a raw 23505.
+	const rounds, n = 12, 24
+	for r := 0; r < rounds; r++ {
+		email := fmt.Sprintf("concurrent-bootstrap-%d-%d@leoflow.local", time.Now().UnixNano(), r)
+		t.Cleanup(func() { deleteUserByEmail(t, email) })
+
+		var wg sync.WaitGroup
+		errs := make([]error, n)
+		created := make([]bool, n)
+		start := make(chan struct{})
+		for i := 0; i < n; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				<-start // release all at once to maximize the create-create overlap
+				created[i], errs[i] = repo.BootstrapAdminHash(ctx, "default", email, hash)
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+
+		nCreated := 0
+		for i := 0; i < n; i++ {
+			if errs[i] != nil {
+				t.Fatalf("round %d goroutine %d: BootstrapAdminHash errored on the concurrent race (must be idempotent): %v", r, i, errs[i])
+			}
+			if created[i] {
+				nCreated++
+			}
+		}
+		if nCreated != 1 {
+			t.Errorf("round %d: exactly one caller should report the admin as newly created, got %d", r, nCreated)
+		}
+		_, stored, ferr := repo.FindUserByLogin(ctx, "default", email)
+		if ferr != nil {
+			t.Fatalf("round %d: admin not found after concurrent bootstrap: %v", r, ferr)
+		}
+		if !auth.VerifyPassword(stored, "concurrent-pw-1") {
+			t.Errorf("round %d: admin password does not verify after concurrent bootstrap", r)
+		}
+	}
+}
+
+// deleteUserByEmail removes a planted test admin (and its role links) so the
+// concurrent-bootstrap test leaves no orphan behind.
+func deleteUserByEmail(t *testing.T, email string) {
+	t.Helper()
+	url := os.Getenv("DATABASE_URL")
+	if url == "" {
+		return
+	}
+	pool, err := pgxpool.New(context.Background(), url)
+	if err != nil {
+		t.Logf("cleanup: pool: %v", err)
+		return
+	}
+	defer pool.Close()
+	if _, err := pool.Exec(context.Background(),
+		`DELETE FROM user_roles WHERE user_id IN (SELECT id FROM users WHERE email=$1)`, email); err != nil {
+		t.Logf("cleanup user_roles: %v", err)
+	}
+	if _, err := pool.Exec(context.Background(), `DELETE FROM users WHERE email=$1`, email); err != nil {
+		t.Logf("cleanup users: %v", err)
+	}
+}

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -671,6 +671,21 @@ func (r *Repository) BootstrapAdminHash(ctx context.Context, tenant, email, hash
 	// No such admin yet — create it and grant the admin role.
 	uid, err := r.q.CreateUser(ctx, queries.CreateUserParams{TenantID: tid, Email: email, PasswordHash: strPtr(hash)})
 	if err != nil {
+		// Concurrent bootstrap race: between the reconcile check above and this
+		// insert, another process created the admin. This is expected under ADR
+		// 0049 (the api and scheduler roles boot at once) and with multiple
+		// active-active api replicas — every replica runs bootstrap on startup.
+		// It is not a failure: reconcile to the configured hash and report "not
+		// newly created", so no process crashes on the unique-constraint 23505.
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == pgUniqueViolation {
+			if _, uerr := r.q.UpdateUserPassword(ctx, queries.UpdateUserPasswordParams{
+				Name: tenant, Email: email, PasswordHash: strPtr(hash),
+			}); uerr != nil {
+				return false, fmt.Errorf("reconciling admin after concurrent create: %w", uerr)
+			}
+			return false, nil
+		}
 		return false, fmt.Errorf("creating admin user: %w", err)
 	}
 	roleID, err := r.q.GetRoleByName(ctx, queries.GetRoleByNameParams{TenantID: tid, Name: "admin"})

--- a/test/e2e/split-two-process.sh
+++ b/test/e2e/split-two-process.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+#
+# Two-process split end-to-end test (ADR 0049).
+#
+# Proves the api/scheduler role split works as SEPARATE processes cooperating
+# only through Postgres (DB-as-truth, ADR 0031): an api-role process (HTTP + UI,
+# no scheduler, no agent gRPC) accepts a trigger and writes it to the DB; a
+# distinct scheduler-role process (reconciler + dispatch + agent gRPC, no HTTP
+# API) picks it up from the DB, dispatches a task pod, and the pod's agent reports
+# state back over the scheduler's gRPC; then the api process serves the terminal
+# state — all read/written through the shared DB, never in-process.
+#
+# This reuses the host-process harness of e2e.sh (control plane on the host, task
+# pods in k3d dialing back) rather than the Helm chart, so it isolates the Go
+# role-gating from cert-manager / in-cluster datastore concerns. The chart's split
+# topology is validated separately by helm-unittest + the kind e2e.
+#
+# It also asserts role ISOLATION at the socket level: the api process serves no
+# gRPC and the scheduler process serves no HTTP API; each still answers /healthz
+# on its metrics port (the kubelet probe target for a scheduler-only pod).
+#
+# Requirements: k3d, kubectl, docker, jq, curl, the leoflow binaries
+# (`make build`), and a running dev database (`make dev-up`). Developer/CI tool.
+#
+# Usage: test/e2e/split-two-process.sh [cluster-name]
+set -euo pipefail
+
+CLUSTER="${1:-leoflow-split-e2e}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKDIR="$(mktemp -d)"
+PY_VERSION="3.11"
+BASE_IMAGE="leoflow-base:py${PY_VERSION}"
+DAG_IMAGE="leoflow-split-dag:dev"
+DAG_ID="splitdag"
+
+# The api process serves HTTP here; the scheduler serves gRPC + its own metrics.
+API_HTTP_PORT="${LEOFLOW_E2E_API_HTTP_PORT:-8080}"
+API_METRICS_PORT="9090"
+# The scheduler binds gRPC + metrics only. Its HTTP addr is set to a port we then
+# assert is NOT listening (role=scheduler serves no API).
+SCHED_HTTP_PORT="8081"
+SCHED_METRICS_PORT="9092"
+GRPC_PORT="9091"
+API="http://localhost:${API_HTTP_PORT}"
+# Address task pods dial to reach the scheduler process's gRPC on the host.
+HOST_ADDR="${LEOFLOW_E2E_HOST_ADDR:-host.docker.internal}"
+API_PID=""
+SCHED_PID=""
+
+log()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+dump_pods() {
+  printf '\033[1;33m--- task pods (namespace leoflow) ---\033[0m\n' >&2
+  kubectl get pods -n leoflow -o wide >&2 2>&1 || true
+  for p in $(kubectl get pods -n leoflow -o name 2>/dev/null); do
+    printf '\033[1;33m--- logs %s ---\033[0m\n' "$p" >&2
+    kubectl logs -n leoflow "$p" --all-containers --tail=80 >&2 2>&1 || true
+  done
+}
+fail() { printf '\033[1;31mFAIL:\033[0m %s\n' "$*" >&2; dump_pods; exit 1; }
+
+cleanup() {
+  [ -n "$API_PID" ] && kill "$API_PID" 2>/dev/null || true
+  [ -n "$SCHED_PID" ] && kill "$SCHED_PID" 2>/dev/null || true
+  k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+for tool in k3d kubectl docker jq curl; do
+  command -v "$tool" >/dev/null || fail "missing required tool: $tool"
+done
+
+log "Scaffolding a minimal two-task DAG ($DAG_ID)"
+"$ROOT/bin/leoflow" init "$WORKDIR/$DAG_ID"
+# The DAG image must match the k3d node arch, else the pod ErrImagePulls. The
+# config loader defaults build.platforms to linux/amd64 (the prod default), which
+# breaks on an arm64 host (e.g. Apple Silicon). Pin it to the host arch so this
+# e2e runs on any machine (arm64 locally, amd64 in CI).
+case "$(uname -m)" in
+  arm64|aarch64) HOST_PLATFORM="linux/arm64" ;;
+  *)             HOST_PLATFORM="linux/amd64" ;;
+esac
+cat >> "$WORKDIR/$DAG_ID/leoflow.yaml" <<YAML
+build:
+  platforms:
+    - ${HOST_PLATFORM}
+YAML
+log "DAG image platform pinned to ${HOST_PLATFORM} (host arch)"
+cat > "$WORKDIR/$DAG_ID/dag.py" <<'PY'
+"""splitdag — proves a run flows across two role processes via the DB."""
+from __future__ import annotations
+
+from airflow.sdk import DAG, task
+
+
+@task
+def extract() -> str:
+    print("split e2e: extract ran in a pod")
+    return "payload-split"
+
+
+@task
+def transform(value: str) -> str:
+    # Consuming extract's output across two pods proves the scheduler (a separate
+    # process from the API) dispatched both and wired their XCom through the DB.
+    print(f"split e2e: transform received {value}")
+    return value.upper()
+
+
+with DAG("splitdag", schedule=None, catchup=False, tags=["e2e", "split"]):
+    transform(extract())
+PY
+cat > "$WORKDIR/$DAG_ID/Dockerfile" <<DOCKER
+FROM ${BASE_IMAGE}
+COPY dag.py /home/leoflow/dag.py
+ENV PYTHONPATH=/home/leoflow
+DOCKER
+
+log "Building the base image"
+# --provenance=false: with Docker Desktop's containerd image store, buildx adds
+# an attestation manifest that turns the image into a manifest list the DAG's
+# `FROM leoflow-base` cannot resolve ("no match for platform in manifest"). A
+# plain single-platform image is what the downstream build + k3d import expect.
+docker build --provenance=false -f "$ROOT/runtime/Dockerfile" --build-arg "PYTHON_VERSION=${PY_VERSION}" -t "$BASE_IMAGE" "$ROOT"
+
+log "Creating k3d cluster '$CLUSTER'"
+k3d cluster create "$CLUSTER" --wait
+kubectl create namespace leoflow
+
+# Shared env for BOTH processes — same DB/Redis/secrets so they are one logical
+# control plane split across two processes (mirrors the shared datastores + RWX
+# logs PVC of the Helm split).
+export LEOFLOW_AUTH_JWT_SECRET="split-e2e-secret"
+export LEOFLOW_BOOTSTRAP_PASSWORD="admin"
+export LEOFLOW_SECRET_KEY="split-e2e-key-32-bytes-padding!!"
+export LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS=true
+# Split REQUIRES a shared datastore: with no Redis each process would use its own
+# in-process XCom backend and the api could not read XCom the scheduler's pods
+# produced. The Helm chart mandates Redis for exactly this reason; mirror it here.
+export LEOFLOW_REDIS_URL="${LEOFLOW_E2E_REDIS_URL:-redis://localhost:6379/0}"
+# Both processes write/read task logs from the same dir (the scheduler receives
+# them over gRPC and writes; the api reads them for the UI) — the host-process
+# analogue of the shared RWX logs PVC.
+export LEOFLOW_LOGS_DIR="${WORKDIR}/logs"
+mkdir -p "$LEOFLOW_LOGS_DIR"
+
+log "Starting the SCHEDULER process (role=scheduler: gRPC + dispatch, no HTTP API)"
+# Task pods dial THIS process's gRPC. It runs the scheduler loop + agent gRPC and
+# serves /healthz on its metrics port, but binds no HTTP API (role gate).
+LEOFLOW_SERVER_ROLE=scheduler \
+LEOFLOW_SERVER_HTTP_ADDR="0.0.0.0:${SCHED_HTTP_PORT}" \
+LEOFLOW_SERVER_METRICS_ADDR="0.0.0.0:${SCHED_METRICS_PORT}" \
+LEOFLOW_SERVER_GRPC_ADDR="0.0.0.0:${GRPC_PORT}" \
+LEOFLOW_EXECUTOR_AGENT_CONTROL_PLANE_ADDR="${HOST_ADDR}:${GRPC_PORT}" \
+  "$ROOT/bin/leoflow-server" &
+SCHED_PID=$!
+
+log "Starting the API process (role=api: HTTP + UI, no scheduler, no agent gRPC)"
+LEOFLOW_SERVER_ROLE=api \
+LEOFLOW_SERVER_HTTP_ADDR="0.0.0.0:${API_HTTP_PORT}" \
+LEOFLOW_SERVER_METRICS_ADDR="0.0.0.0:${API_METRICS_PORT}" \
+  "$ROOT/bin/leoflow-server" &
+API_PID=$!
+sleep 5
+
+# ── Role isolation assertions ────────────────────────────────────────────────
+log "Asserting role isolation at the socket level"
+# api serves the HTTP API …
+curl -fsS "${API}/healthz" >/dev/null || fail "api process /healthz (http :${API_HTTP_PORT}) not serving"
+# … and /healthz on its metrics port (the every-role probe surface, ADR 0049).
+curl -fsS "http://localhost:${API_METRICS_PORT}/healthz" >/dev/null \
+  || fail "api process /healthz (metrics :${API_METRICS_PORT}) not serving"
+# The scheduler serves /healthz on its metrics port (the kubelet probe target for
+# a scheduler-only pod, since it has no HTTP API) …
+curl -fsS "http://localhost:${SCHED_METRICS_PORT}/healthz" >/dev/null \
+  || fail "scheduler process /healthz (metrics :${SCHED_METRICS_PORT}) not serving — the scheduler pod would have no probe target"
+# … but binds NO HTTP API: a request to its http port must be refused.
+if curl -fsS --max-time 3 "http://localhost:${SCHED_HTTP_PORT}/healthz" >/dev/null 2>&1; then
+  fail "scheduler process is serving an HTTP API on :${SCHED_HTTP_PORT} — role=scheduler must not serve the API"
+fi
+log "isolation OK: api serves HTTP+metrics-health; scheduler serves metrics-health only (no HTTP API), gRPC on :${GRPC_PORT}"
+
+log "Compiling, building, and importing the DAG image"
+"$ROOT/bin/leoflow" compile "$WORKDIR/$DAG_ID" --image "$DAG_IMAGE" \
+  --build --dockerfile Dockerfile -o "$WORKDIR/$DAG_ID/dag.json"
+k3d image import "$BASE_IMAGE" "$DAG_IMAGE" --cluster "$CLUSTER"
+
+log "Pushing + triggering the DAG against the API process (never the scheduler)"
+TOKEN="$("$ROOT/bin/leoflow" auth create-token --server "$API" --username admin@leoflow.local --password admin)"
+"$ROOT/bin/leoflow" push "$WORKDIR/$DAG_ID/dag.json" --server "$API" --token "$TOKEN"
+RUN_ID="$(curl -fsS -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{}' "$API/api/v2/dags/$DAG_ID/dagRuns" | jq -r '.dag_run_id')"
+[ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ] || fail "no dag_run_id returned from the api process"
+log "run = $RUN_ID"
+
+log "Waiting for all task instances to succeed (dispatched by the SEPARATE scheduler process, via the DB)"
+deadline=$(( $(date +%s) + 300 ))
+while :; do
+  states="$(curl -fsS -H "Authorization: Bearer $TOKEN" \
+    "$API/api/v2/dags/$DAG_ID/dagRuns/$RUN_ID/taskInstances" | jq -r '.task_instances[].state')"
+  log "task states: [$(echo "$states" | tr '\n' ' ')] pods: [$(kubectl get pods -n leoflow --no-headers 2>/dev/null | awk '{print $1"="$3}' | tr '\n' ' ')]"
+  echo "$states" | grep -qE 'failed|upstream_failed' && fail "a task failed: $states"
+  if [ -n "$states" ] && ! echo "$states" | grep -qvE 'success|skipped'; then
+    log "all tasks terminal-success: $states"
+    break
+  fi
+  [ "$(date +%s)" -gt "$deadline" ] && fail "timed out; last states: ${states:-<none>}"
+  sleep 3
+done
+
+log "Asserting TaskFlow value passing across two pods (proves cross-pod XCom via the DB)"
+tlog=""
+for try in 0 1 2; do
+  body="$(curl -fsS -H "Authorization: Bearer $TOKEN" \
+    "$API/api/v2/dags/$DAG_ID/dagRuns/$RUN_ID/taskInstances/transform/logs/$try" 2>/dev/null || true)"
+  if echo "$body" | grep -q "split e2e: transform received payload-split"; then tlog="$body"; break; fi
+done
+[ -n "$tlog" ] || fail "transform did not receive extract's output — the two processes did not cooperate through the DB"
+log "value passing OK: transform received payload-split (API served logs the scheduler's pods produced)"
+
+log "SPLIT E2E passed — api and scheduler ran as separate processes cooperating via the DB (ADR 0049)"


### PR DESCRIPTION
Two related fronts, both behind flags that are **off by default** — a pre-split
monolith install upgrades in place with no change. **Lite is unaffected** (it runs
the `all` role; verified with a live `all`-role boot smoke + the existing Lite e2e).

## 1. API/scheduler split (ADR 0049)

`leoflow-server` gains a role (`LEOFLOW_SERVER_ROLE` / `server.role`):
- **`all`** — default, and Lite's only mode. **Behavior-identical to the
  pre-0049 monolith** (guarded by the existing Lite e2e + the byte-identical
  non-split Helm render).
- **`api`** — HTTP API + embedded UI, restricted network identity (its
  ServiceAccount is left unbound from the executor Role → cannot reach the
  apiserver), active-active.
- **`scheduler`** — reconciler + dispatch + agent gRPC, privileged identity,
  single leader (ADR 0009).

Follows Argo's shape (argo-server embeds the UI + splits from workflow-controller),
not KFP's separate-frontend sprawl. The split is clean because api and scheduler
already cooperate only through Postgres (DB-as-truth, ADR 0031).

**Helm** (`split.enabled`, off by default): renders one `all` Deployment
(byte-identical to before) or per-role Deployment/Service/ServiceAccount/RBAC/
NetworkPolicy/HPA/PDB. The scheduler serves no HTTP API, so its kubelet probes hit
`/healthz`+`/readyz` on the metrics port (`api.ObservabilityHandler`, served in
every role).

**Proven live**, not just rendered: `test/e2e/split-two-process.sh` (`make
e2e-split`, gated in a dedicated CI job) boots `role=api` + `role=scheduler` as
separate processes against a shared Postgres/Redis and drives a run whose task
pods the *separate* scheduler process dispatches — the api accepts the trigger and
serves the terminal state, all through the DB. Asserts socket-level role
isolation.

**Bug the e2e caught (fixed here):** concurrent admin bootstrap. In split mode
the api and scheduler (and every active-active api replica) run bootstrapAdmin at
once; the check-then-insert TOCTOU crashed the loser on a unique 23505.
`BootstrapAdminHash` now reconciles on conflict; a real-Postgres integration test
reproduces the race (red without the fix).

**Known residuals (documented in the ADR, NOT closed by the split):**
1. The scheduler trusts DB writes — a compromised api (holds DB creds) can still
   influence dispatch via the DB; only the *direct* apiserver path is cut.
2. Task logs on a shared RWX PVC — a scale bottleneck and the one non-DB-as-truth
   seam.

## 2. Deprecate the native inline http_api (ADR 0047/0048)

The inline `http_api` executor runs an author-supplied request in the
control-plane process (SSRF, H5). The parser already stopped emitting it (an
HttpOperator compiles to a pod-run `airflow_operator`), so it can now only arrive
via a hand-written `dag.json`. Maintainer chose a **one-release deprecation**:
this release warns, next release removes.

- `DAGSpec.DeprecationWarnings()` → a `warnings` field on the register response →
  `leoflow push` prints it (the CLI is where the author sees it).
- Removal (reject at registration + delete the inline executor so the guard is
  structural, ADR 0048) is tracked in #512.

## Verification
- Unit: role parsing/validation, ObservabilityHandler, DeprecationWarnings, push
  surfacing.
- Helm: helm-unittest locks the per-role split; non-split render byte-identical.
- Integration (real Postgres): concurrent-bootstrap race guard.
- E2E (k3d, two processes): the split e2e above, CI-gated.

## Independent review

An adversarial code review ran over the whole branch (all gates green). Its
findings were addressed here, each TDD (a test reproduces the defect first):
- **F1** — the split api role reported a fake-healthy scheduler (nil handle); now
  reads scheduler liveness from the leadership advisory lock.
- **F2** — role name truncation could collide api/scheduler at ~62-char names;
  the base is now truncated before the suffix.
- **F3** — split ignored `serviceAccount.name`; it now honors it (`X-api`/`X-scheduler`).
- **F4** — a `#` comment broke the non-split "byte-identical" claim; now a
  non-rendering template comment.
- **F5** — the metrics port is now path-scoped; noted in the changelog.
- **F6** — a pre-existing role-less-bootstrap crash window: filed as #513.

Relates: ADR 0047, 0048, 0049, 0040, 0031, 0009, 0028.
Follow-ups: #512 (remove inline http_api next release), #513 (bootstrap role-less race).
