### PR TITLE
Shell-quote interpolated values in bash tasks (#489)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Security
+
+- **Bash task templating now shell-quotes interpolated values** (issue #489). A
+  `bash_command` Jinja-renders the run context, and `params` is the run's `conf` —
+  supplied by anyone with `execute:dag`, a lower bar than authoring the DAG. A
+  value with shell metacharacters (`x; rm -rf /`, `$(...)`) was interpolated into
+  the command string unquoted, so a trigger could run arbitrary commands in the
+  task pod (privilege escalation from "may run this pipeline" to "may run any
+  command"). Every interpolated value is now `shlex.quote`d before `bash -c`; the
+  trusted template text is unchanged and safe values render byte-identically.
+  Behavior change: a value can no longer expand into multiple shell words — write
+  interpolations unquoted (`--name {{ params.x }}`).
+
 ### Added
 
 - **Optional api/scheduler split for Pro (`split.enabled`, off by default; ADR

--- a/docs/airflow-operators.md
+++ b/docs/airflow-operators.md
@@ -206,7 +206,11 @@ changing existing behaviour:
 `{{ var.value.X }}`, `{{ params.region }}`) when the command contains `{{` — a
 plain command stays a direct `bash -c` so bash-only images need no Python. Jinja2
 is optional at runtime: if it is absent the command falls back to its raw form and
-the `$LEOFLOW_DS` / `$AIRFLOW_VAR_*` env vars still reach the shell.
+the `$LEOFLOW_DS` / `$AIRFLOW_VAR_*` env vars still reach the shell. Every
+interpolated **value** is shell-quoted (`shlex.quote`) before exec, so a `params`
+value from an untrusted `conf` cannot inject shell — write interpolations unquoted
+(`--name {{ params.x }}`, not `--name "{{ params.x }}"`). See
+[DAG authoring](dag-authoring.md) (issue #489).
 
 ## Not yet supported (loud, not silent)
 

--- a/docs/dag-authoring.md
+++ b/docs/dag-authoring.md
@@ -102,6 +102,25 @@ executor**, native-first by type. Nothing is silently dropped or mistranslated.
 | ~~`http_api`~~ (removed) | — | — | **Removed (ADR 0047/0048, #512).** `HttpOperator` now compiles to `airflow_operator` and runs in a **pod**, like any other provider operator — declare `connectors: [http]`. The old inline path ran the request in the control-plane process (an SSRF surface) and is gone. |
 | `airflow_operator` | **any provider operator/sensor** (Snowflake, S3, Postgres, BigQuery, …) | agent in a pod | The generic executor (ADR 0040): the runtime imports the class, instantiates it with your args, and calls `execute()`. Declare the provider or compile fails. |
 
+!!! warning "Bash templating: values are shell-quoted, the template text is not"
+    A `bash_command` is Jinja-rendered with the run context (`{{ ds }}`,
+    `{{ params.x }}`, `{{ var.value.x }}`). The **command text you write** is the
+    shell structure and is used verbatim; every **interpolated value** is
+    automatically shell-quoted (`shlex.quote`) before it reaches `bash -c`. This is
+    a security boundary: `params` is the run's `conf`, which anyone who can
+    *trigger* the DAG supplies (`execute:dag`, a lower bar than authoring it), so an
+    un-quoted value would let a trigger inject arbitrary shell (issue #489).
+
+    Practical consequence — **write interpolations unquoted**, and do not wrap them
+    in your own quotes:
+
+    - ✅ `process --name {{ params.name }}` — the value is quoted for you.
+    - ❌ `process --name "{{ params.name }}"` — your quotes fight the auto-quoting.
+    - A value can no longer expand into multiple shell words/flags; if you need
+      that, pass the pieces as separate `params` and interpolate each. For secrets,
+      reference `$AIRFLOW_VAR_*` / `$AIRFLOW_CONN_*` env vars instead of rendering
+      them into the command.
+
 Also supported:
 
 - **Trigger rules**: `all_success`, `all_failed`, `all_done`, `one_success`, `one_failed`.

--- a/runtime/python/leoflow_runtime/runner.py
+++ b/runtime/python/leoflow_runtime/runner.py
@@ -6,6 +6,7 @@ import importlib
 import inspect
 import json
 import os
+import shlex
 import sys
 from datetime import datetime
 
@@ -208,7 +209,18 @@ def _render_bash(command: str, context: dict) -> str:
         # renders a shell command, not HTML — HTML-escaping would corrupt it. Secrets
         # should be referenced as $AIRFLOW_VAR_*/$AIRFLOW_CONN_* env vars rather than
         # rendered into the command string (see the env-secrets delivery path).
-        return SandboxedEnvironment().from_string(command).render(**context)
+        #
+        # finalize shell-quotes every interpolated VALUE (issue #489). The template
+        # text is the DAG author's (write:dag) trusted structure; the values it
+        # interpolates — `params` is the run's `conf`, which anyone with execute:dag
+        # supplies — are untrusted data. Quoting each rendered value with shlex.quote
+        # keeps a metacharacter payload ("x; rm -rf /", "$(...)") a single inert
+        # argument instead of shell syntax. Safe values (dates, plain words) contain
+        # no metacharacters, so shlex.quote returns them unchanged — the common case
+        # is byte-identical. This is the boundary the sandbox does NOT cover: it
+        # governs what the template may evaluate, not what the result means to bash.
+        env = SandboxedEnvironment(finalize=lambda value: shlex.quote(str(value)))
+        return env.from_string(command).render(**context)
     except Exception:  # noqa: BLE001 — a broken/blocked template must not fail the task
         return command
 

--- a/runtime/python/tests/test_runner.py
+++ b/runtime/python/tests/test_runner.py
@@ -506,3 +506,32 @@ def test_maybe_fire_skips_when_retries_remain(monkeypatch):
     monkeypatch.setenv("LEOFLOW_MAX_TRIES", "3")
     runner._maybe_fire_on_failure_callback({}, [lambda ctx: calls.append(ctx)])
     assert calls == []
+
+
+def test_render_bash_quotes_conf_value_blocks_shell_injection(tmp_path):
+    # `params` comes from the DAG-run conf, which anyone with execute:dag supplies
+    # (a lower bar than write:dag). A value carrying shell metacharacters must be
+    # neutralized: only the trusted template text is shell syntax; interpolated
+    # values are quoted. Realistic payload — a command substitution that would
+    # create a file — run through the real bash the task uses (issue #489).
+    import subprocess
+
+    sentinel = tmp_path / "pwned"
+    payload = f"$(touch {sentinel})"
+    rendered = runner._render_bash("true {{ params.name }}", {"params": {"name": payload}})
+    subprocess.run(["bash", "-c", rendered], check=False)
+    assert not sentinel.exists(), (
+        f"shell injection executed via conf: rendered={rendered!r} created {sentinel}")
+
+
+def test_render_bash_quotes_metachars_as_single_token(tmp_path):
+    # A ';'-based payload must stay a single argument to the trusted command, not
+    # become a second command. Proven by executing: the injected `touch` must not run.
+    import subprocess
+
+    sentinel = tmp_path / "pwned2"
+    payload = f"x; touch {sentinel}"
+    rendered = runner._render_bash("echo {{ params.name }}", {"params": {"name": payload}})
+    subprocess.run(["bash", "-c", rendered], check=False)
+    assert not sentinel.exists(), (
+        f"';' in conf started a new command: rendered={rendered!r} created {sentinel}")

--- a/runtime/python/tests/test_runner.py
+++ b/runtime/python/tests/test_runner.py
@@ -519,7 +519,7 @@ def test_render_bash_quotes_conf_value_blocks_shell_injection(tmp_path):
     sentinel = tmp_path / "pwned"
     payload = f"$(touch {sentinel})"
     rendered = runner._render_bash("true {{ params.name }}", {"params": {"name": payload}})
-    subprocess.run(["bash", "-c", rendered], check=False)
+    subprocess.run(["bash", "-c", rendered], check=False)  # noqa: S603,S607 — deliberately exec bash to prove the payload is inert
     assert not sentinel.exists(), (
         f"shell injection executed via conf: rendered={rendered!r} created {sentinel}")
 
@@ -532,6 +532,6 @@ def test_render_bash_quotes_metachars_as_single_token(tmp_path):
     sentinel = tmp_path / "pwned2"
     payload = f"x; touch {sentinel}"
     rendered = runner._render_bash("echo {{ params.name }}", {"params": {"name": payload}})
-    subprocess.run(["bash", "-c", rendered], check=False)
+    subprocess.run(["bash", "-c", rendered], check=False)  # noqa: S603,S607 — deliberately exec bash to prove the payload is inert
     assert not sentinel.exists(), (
         f"';' in conf started a new command: rendered={rendered!r} created {sentinel}")


### PR DESCRIPTION
Closes #489. Fixes a shell-injection / privilege escalation in native bash tasks.

## The bug
`run_bash` Jinja-renders a `bash_command` with the run context and `exec`s
`bash -c`. `params` is the run's `conf`, supplied by anyone with `execute:dag`
(a lower bar than `write:dag`). Values were interpolated into the command string
**unquoted**, so a trigger with a metacharacter payload — `{"name": "x; curl … | sh"}`
against `process --name {{ params.name }}` — executed arbitrary commands in the
task pod. The `SandboxedEnvironment` guards *template* injection (Python internals),
not *shell* injection: it has no opinion about what the rendered string means to bash.

## The fix
A Jinja `finalize` hook shell-quotes every interpolated **value** with
`shlex.quote`. The template text (the `write:dag` author's trusted shell structure)
is unchanged; only the untrusted interpolated values are quoted. Safe values (dates,
plain words) have no metacharacters, so `shlex.quote` returns them unchanged — the
common case renders **byte-identically** (the existing macro test passes untouched).

Behavior change (the bug, fixed): a value can no longer expand into multiple shell
words. Write interpolations **unquoted** — `--name {{ params.x }}`, not
`--name "{{ params.x }}"`. Documented in dag-authoring + airflow-operators.

## Tests
Two tests execute a real `bash -c` on a rendered command carrying `$(touch …)` and
`; touch …` `conf` payloads and assert the sentinel file is never created — red on
the old behavior, green now (realistic payloads, not marker strings, per the issue).

Relates: same class as the http_api SSRF removed in #515. Options considered in #489;
this is "quote on interpolation" (closest to Airflow templating semantics).