### PR TITLE
Reap now tears down the task's pod and signals terminate; dispatch-lost defers to pod liveness (#474)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Reaping a task now actually stops it** (#474). The three scheduler reapers
+  (`agent_lost`, `dispatch_lost`, `orphaned`) only wrote metadatabase state, so a
+  reaped task's pod kept running user code to completion — breaking at-most-once
+  execution when that work committed or a retry re-ran it. Each reaper now tears
+  the pod down **after** the durable DB transition: the per-TI reapers delete
+  exactly the reaped `(run-id, task-id, try-number)` pod (a retry's newer pod has
+  a different try-number label, so it can never be the one deleted), and the
+  orphan-run reaper deletes every pod of the abandoned run. As a belt-and-suspenders
+  layer for pods we couldn't delete (e.g. a K8s API outage), the control plane now
+  answers a **stale** agent `ReportState`/`Heartbeat` — one whose attempt no longer
+  matches the live row — with `should_terminate`, so a reaped-but-alive pod cancels
+  its own work. The "stale" test reuses the exact source-state + `try_number` guard
+  the state write already carries (#467): a live, matching attempt always applies,
+  so a live execution is never torn down or told to stop. Deletion uses only the
+  `list`+`delete` pod verbs the executor Role already grants; Lite (subprocess) has
+  no pods, so only the DB transition and the terminate signal apply.
+- **Dispatch-lost reaper is now pod-aware, ending the cold-node false positive**
+  (#461). A slow image pull on a cold node could leave a TI in `queued` past the
+  3-minute threshold while its pod was actually `Pending`/`Running`, so the reaper
+  failed a live dispatch as `dispatch_lost`. On Kubernetes the reaper now checks
+  pod liveness first: if a pod for the TI is `Pending`/`Running` (the dispatch
+  landed, the node is just slow) — or if liveness can't be read (K8s API error) —
+  it defers instead of reaping. It only fails a TI when no live pod exists. Lite
+  keeps the pure time-threshold behavior. New metrics: `dispatch_lost_deferred`,
+  `dispatch_lost_pod_query_error`.
 - **`taskNamespace` now actually moves the control plane** (#480). The chart
   granted the executor Role in `.Values.taskNamespace` while the server created
   task pods in a hardcoded `leoflow` namespace, so any override installed cleanly

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -943,6 +943,10 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 	dispatcher.SetPlatformDefaults(platformDefaults(cfg.Executor.Defaults))
 	disp, closer := wrapBuffered(dispatcher, store, logger, metrics, cfg.Scheduler.Dispatch) //nolint:contextcheck // buffered worker deliberately detaches from caller ctx
 	sched.SetDispatcher(disp)
+	// Let the reapers tear down a reaped task's pod and gate the dispatch-lost
+	// decision on real pod liveness (#474, #461). Only wired on the pod path;
+	// Lite/subprocess leaves it nil and the reapers stay DB-only.
+	sched.SetPodManager(podExec)
 	startReconciler(ctx, cs, cfg.Executor.TaskNamespace, execStore, sched.IsLeading, logger)
 	startStagingGC(ctx, cs, cfg.Executor.TaskNamespace, store, sched.IsLeading, logger)
 	logger.Info("pod dispatch enabled", "namespace", cfg.Executor.TaskNamespace, "agent_control_plane_addr", controlAddr)

--- a/docs/scheduler-resilience.md
+++ b/docs/scheduler-resilience.md
@@ -16,9 +16,9 @@ across the fleet.
 | Failure mode | Detected by | Default SLA | What happens |
 |---|---|---|---|
 | **Task code wedged past its declared `execution_timeout_seconds`** | **Agent itself** ([#194](https://github.com/neochaotic/leoflow/issues/194)) | **`execution_timeout_seconds`** (per-task) | **TI failed with `execution_timeout: task exceeded N`. Retries kick in if budget remains.** |
-| Agent process crashed mid-task (TI in `running`, no heartbeat) | TI heartbeat reaper ([#128](https://github.com/neochaotic/leoflow/issues/128)) | **90 s** | TI failed with `agent_lost`. Retries kick in if budget remains. |
-| Scheduler crashed before dispatching (TI stuck in `queued`) | Dispatch-lost reaper ([#202](https://github.com/neochaotic/leoflow/issues/202)) | **3 min** | TI failed with `dispatch_lost`. Frees the run for the orphan reaper on the next tick. |
-| Run stuck `running` with no active TIs (post-crash limbo) | Orphan-run reaper ([#120](https://github.com/neochaotic/leoflow/issues/120)) | **5 min** | Run failed with `orphaned`; any remaining active TIs flipped to `failed`. |
+| Agent process crashed mid-task (TI in `running`, no heartbeat) | TI heartbeat reaper ([#128](https://github.com/neochaotic/leoflow/issues/128)) | **90 s** | TI failed with `agent_lost`; the TI's pod is deleted so a partitioned-but-alive container stops. Retries kick in if budget remains. |
+| Scheduler crashed before dispatching (TI stuck in `queued`) | Dispatch-lost reaper ([#202](https://github.com/neochaotic/leoflow/issues/202)) | **3 min** | TI failed with `dispatch_lost` — but only if no live pod for it exists (see below); the pod is torn down. Frees the run for the orphan reaper on the next tick. |
+| Run stuck `running` with no active TIs (post-crash limbo) | Orphan-run reaper ([#120](https://github.com/neochaotic/leoflow/issues/120)) | **5 min** | Run failed with `orphaned`; any remaining active TIs flipped to `failed` and every pod of the run is deleted. |
 
 Worst case end-to-end: a mid-tick scheduler crash that leaves TIs queued is
 fully reaped within **`max(3 min, 5 min) = 5 min`** — the dispatch-lost reaper
@@ -49,16 +49,58 @@ anything:
   once and then went silent. A TI that never heartbeated (e.g. a pod that never
   started, so no agent ever reported) is left alone.
 - **Dispatch-lost reaper** — requires a non-zero `queued_at` older than the
-  threshold. A TI without that stamp is too poorly observed to reap.
+  threshold AND, on Kubernetes, confirmation that no live pod for the TI
+  exists. If a pod for the TI is `Pending`/`Running`, the dispatch actually
+  landed and the node is just slow to pull the image (a cold-node false
+  positive, [#461](https://github.com/neochaotic/leoflow/issues/461)) — the
+  reaper defers. If pod liveness can't be determined (K8s API error), it also
+  defers. A TI without a `queued_at` stamp is too poorly observed to reap.
 - **Orphan-run reaper** — requires `state = 'running'` AND no active TI on
   the run. A run with any TI in `scheduled`/`queued`/`running` is left alone
   (the dispatch-lost reaper unblocks this case by failing the stuck queued
   TIs first, so the next tick sees no active TIs).
 
-This rule is the load-bearing invariant: **the reapers can never kill a live
-execution** (ADR [0031](adr/0031-scheduler-architecture.md)). The cost is
-that recovery is bounded by the slowest reaper that applies, not the
-fastest — usually fine, sometimes worth tuning.
+## Tearing down the reaped task's pod
+
+Failing a TI in the metadatabase is not enough on its own: a reaped task's
+pod can still be running user code, which breaks at-most-once execution if
+that work commits or a retry runs it again
+([#474](https://github.com/neochaotic/leoflow/issues/474)). So, **after** the
+durable DB transition, each reaper tears the pod down:
+
+- The **heartbeat** and **dispatch-lost** reapers delete exactly the reaped
+  TI's pod, pinned by `(run-id, task-id, try-number)` labels — a retry
+  dispatches a new pod with a new try-number, so a newer live attempt can
+  never be the one deleted.
+- The **orphan-run** reaper deletes every pod of the abandoned run (the
+  run-id is unique per run, so no other run's pod can match).
+- Belt and suspenders: the control plane also answers a **stale** agent
+  `ReportState`/`Heartbeat` — one whose attempt no longer matches the live
+  row — with `should_terminate`, so a reaped-but-still-alive pod that we
+  couldn't delete (e.g. during a K8s API outage) cancels its own work. The
+  "stale" test is exactly the source-state + `try_number` guard the state
+  write already uses ([#467](https://github.com/neochaotic/leoflow/issues/467)):
+  the report applies for the live, matching attempt, so a live execution is
+  never told to stop.
+
+These teardown steps are best-effort and off the critical path: a delete
+failure is logged and metered but never undoes the DB reap, and the pod's own
+`activeDeadlineSeconds` plus the reconciler's GC remain backstops. In Lite
+(subprocess executor) there are no pods, so only the DB transition and the
+`should_terminate` signal apply.
+
+## The load-bearing invariant
+
+Recovery is bounded by the slowest reaper that applies, not the fastest —
+usually fine, sometimes worth tuning
+(ADR [0031](adr/0031-scheduler-architecture.md)). The invariant that governs
+every reap decision is **never fail or tear down the live current attempt —
+only one that is genuinely stale or lost**. It is preserved end-to-end: the DB
+transitions are guarded on source state (`WHERE state IN (...)`), pod deletes
+are pinned to the exact `(run, task, try)` reaped, the dispatch-lost reaper
+defers whenever a pod is live or its liveness is unknown, and the
+`should_terminate` signal fires only when the reporting attempt has provably
+moved on. When in doubt, a reaper defers rather than reap.
 
 ## Observability
 
@@ -69,8 +111,11 @@ your Prometheus dashboard:
 |---|---|
 | `agent_lost` | TI failed by the heartbeat reaper |
 | `dispatch_lost` | TI failed by the dispatch-lost reaper |
+| `dispatch_lost_deferred` | Dispatch-lost skipped because the TI's pod is live (slow start, [#461](https://github.com/neochaotic/leoflow/issues/461)) — a healthy signal, not a fault |
 | `orphan_reaped` | Run failed by the orphan-run reaper |
 | `agent_lost_list_error`, `dispatch_lost_list_error`, `orphan_list_error` | Reaper's list query failed; next tick will retry |
+| `dispatch_lost_pod_query_error` | Pod liveness could not be read (K8s API error); the reaper deferred rather than risk a false positive |
+| `agent_lost_pod_delete_error`, `dispatch_lost_pod_delete_error`, `orphan_pod_delete_error` | Pod teardown after a reap failed; the DB reap stands and the pod's `activeDeadlineSeconds`/GC are backstops |
 
 A sustained non-zero rate on any of these is worth investigating — reapers
 are backstops, not the primary path; if they fire often, something upstream
@@ -87,8 +132,11 @@ is broken.
 - **K8s API outage** — pods stay where they are; new dispatches fail at the
   executor layer (visible as `dispatch_failed` metric on the
   [BufferedDispatcher](adr/0031-scheduler-architecture.md)); the
-  dispatch-lost reaper does NOT fire (queued_at is fresh, the issue is the
-  API, not the scheduler).
+  dispatch-lost reaper does NOT fail TIs during the outage — it cannot read
+  pod liveness, so it defers (`dispatch_lost_pod_query_error`) rather than
+  risk a false positive. Reap-time pod teardown is likewise skipped and
+  retried once the API returns; a reaped-but-alive pod stops itself via the
+  `should_terminate` signal on its next heartbeat.
 
 See also: [ADR 0009 (leader election)](adr/0009-leader-election.md),
 [ADR 0031 (scheduler architecture)](adr/0031-scheduler-architecture.md).

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -479,6 +479,30 @@ func TestRunnerHeartbeatCancelsOnTerminate(t *testing.T) {
 	}
 }
 
+// TestRunnerStopsOnReportStateTerminate covers the #474 kill switch on the
+// report path: when the control plane answers a state report with
+// should_terminate (the reporting attempt no longer matches the live row — a
+// reaper settled it, or a retry moved past it), the agent must abort rather than
+// keep running abandoned work. The very first report is RUNNING, so a terminate
+// there stops the task before the user process ever runs.
+func TestRunnerStopsOnReportStateTerminate(t *testing.T) {
+	client := &fakeClient{
+		spec:        &agentv1.TaskSpec{Operator: "bash", Entrypoint: "sleep 1000"},
+		terminateAt: agentv1.TaskState_TASK_STATE_RUNNING,
+	}
+	cmd := &fakeCmd{blockUntilCancel: true}
+	r := newRunner(client, cmd, &recordingSink{})
+
+	if err := r.Run(context.Background()); err == nil {
+		t.Fatal("a task told to terminate on its RUNNING report must not proceed")
+	}
+	// The user command must never have been invoked: terminate fired on the
+	// RUNNING report, before execute() runs the process.
+	if cmd.argv != nil {
+		t.Errorf("user command ran despite terminate signal: argv=%v", cmd.argv)
+	}
+}
+
 // TestRunnerEnforcesExecutionTimeout covers issue #194: the pod-path agent must
 // stop a task that exceeds its declared execution_timeout_seconds, not rely on
 // the scheduler's 90 s heartbeat reaper (which leaves the wedged user code

--- a/internal/agentrpc/server.go
+++ b/internal/agentrpc/server.go
@@ -218,10 +218,16 @@ func (s *Server) ReportState(ctx context.Context, req *agentv1.ReportStateReques
 		// evidence of a partition or a slow pod, and dropping it silently is the
 		// failure mode the guard exists to end.
 		if errors.Is(rerr, ErrStaleReport) {
-			slog.Warn("ignoring stale task state report",
+			slog.Warn("ignoring stale task state report; signaling terminate",
 				"ti", id.TaskInstanceID, "run", id.RunID, "task", id.TaskID,
 				"try", id.TryNumber, "reported_state", state)
-			return &agentv1.ReportStateResponse{Acknowledged: true}, nil
+			// The row already moved on (a reaper settled it, or a later attempt
+			// bumped try_number). Acknowledge so the agent stops retrying, and set
+			// should_terminate so a reaped-but-still-running pod cancels its work —
+			// the at-most-once kill switch (#474). Safe by construction: the report
+			// applies (rows>0, not stale) for the live, matching attempt, so a live
+			// execution is never told to terminate.
+			return &agentv1.ReportStateResponse{Acknowledged: true, ShouldTerminate: true}, nil
 		}
 		return nil, status.Errorf(codes.Internal, "recording state: %v", rerr)
 	}
@@ -240,6 +246,19 @@ func (s *Server) Heartbeat(ctx context.Context, _ *agentv1.HeartbeatRequest) (*a
 		return nil, err
 	}
 	if hbErr := s.store.RecordHeartbeat(ctx, *id); hbErr != nil {
+		// A stale heartbeat is the guard working, not a fault: the row moved on —
+		// a reaper settled it, or a later attempt bumped try_number past this one
+		// (the same "moved on" predicate the state report is guarded by, #467).
+		// Signal terminate so a reaped-but-alive pod stops itself (#474). The live,
+		// matching attempt stamps a row (no error), so it never gets the signal.
+		if errors.Is(hbErr, ErrStaleReport) {
+			slog.Warn("stale heartbeat from a superseded attempt; signaling terminate",
+				"ti", id.TaskInstanceID, "run", id.RunID, "task", id.TaskID, "try", id.TryNumber)
+			return &agentv1.HeartbeatResponse{ServerTime: timestamppb.New(s.now()), ShouldTerminate: true}, nil
+		}
+		// A genuine (non-stale) store error is logged but does not fail the RPC or
+		// signal terminate — failing would risk the agent killing a live task on a
+		// transient DB blip. The scheduler's heartbeat reaper is the backstop.
 		slog.Warn("recording heartbeat",
 			"ti", id.TaskInstanceID, "run", id.RunID, "task", id.TaskID, "error", hbErr)
 	}

--- a/internal/agentrpc/server_test.go
+++ b/internal/agentrpc/server_test.go
@@ -460,6 +460,87 @@ func TestHeartbeatSucceedsWhenStoreFails(t *testing.T) {
 	}
 }
 
+// TestHeartbeatSignalsTerminateOnStaleAttempt is the #474 kill switch: when the
+// heartbeating agent's attempt no longer matches the live row (a reaper settled
+// it, or try_number moved on), RecordHeartbeat reports ErrStaleReport and the
+// handler answers should_terminate=true so the reaped-but-alive pod stops
+// itself. The predicate is exactly #467's "moved on" guard — no second notion
+// of stale. A stale heartbeat must NEVER be a hard RPC error (the agent would
+// then keep running), only a terminate signal.
+func TestHeartbeatSignalsTerminateOnStaleAttempt(t *testing.T) {
+	store := &fakeStore{heartbeatErr: ErrStaleReport}
+	srv, authn := newServer(store)
+	resp, err := srv.Heartbeat(ctxWithToken(t, authn), &agentv1.HeartbeatRequest{})
+	if err != nil {
+		t.Fatalf("stale heartbeat must not be an RPC error: %v", err)
+	}
+	if !resp.GetShouldTerminate() {
+		t.Errorf("stale heartbeat: should_terminate = false, want true")
+	}
+}
+
+// TestHeartbeatDoesNotTerminateLiveAttempt: the live, matching attempt (the
+// happy path, nil store error) must get should_terminate=false — the invariant
+// that a live execution is never told to stop.
+func TestHeartbeatDoesNotTerminateLiveAttempt(t *testing.T) {
+	srv, authn := newServer(&fakeStore{})
+	resp, err := srv.Heartbeat(ctxWithToken(t, authn), &agentv1.HeartbeatRequest{})
+	if err != nil {
+		t.Fatalf("Heartbeat: %v", err)
+	}
+	if resp.GetShouldTerminate() {
+		t.Errorf("live heartbeat: should_terminate = true, want false")
+	}
+}
+
+// TestHeartbeatTransientErrorDoesNotTerminate: a genuine (non-stale) DB error is
+// logged and swallowed, and must NOT signal terminate — otherwise a DB blip
+// would kill a live task. Distinct from the stale case above.
+func TestHeartbeatTransientErrorDoesNotTerminate(t *testing.T) {
+	srv, authn := newServer(&fakeStore{heartbeatErr: errors.New("db transient blip")})
+	resp, err := srv.Heartbeat(ctxWithToken(t, authn), &agentv1.HeartbeatRequest{})
+	if err != nil {
+		t.Fatalf("transient heartbeat error must not surface as RPC error: %v", err)
+	}
+	if resp.GetShouldTerminate() {
+		t.Errorf("transient DB error: should_terminate = true, want false")
+	}
+}
+
+// TestReportStateSignalsTerminateOnStaleReport: a state report from an attempt
+// that has moved on (ErrStaleReport from the #467 guard) is acknowledged AND
+// carries should_terminate=true, so a reaped pod stops (#474).
+func TestReportStateSignalsTerminateOnStaleReport(t *testing.T) {
+	srv, authn := newServer(&fakeStore{reportErr: ErrStaleReport})
+	resp, err := srv.ReportState(ctxWithToken(t, authn), &agentv1.ReportStateRequest{
+		State: agentv1.TaskState_TASK_STATE_RUNNING,
+	})
+	if err != nil {
+		t.Fatalf("stale report must be acknowledged, not errored: %v", err)
+	}
+	if !resp.GetAcknowledged() {
+		t.Errorf("stale report: acknowledged = false, want true")
+	}
+	if !resp.GetShouldTerminate() {
+		t.Errorf("stale report: should_terminate = false, want true")
+	}
+}
+
+// TestReportStateDoesNotTerminateLiveAttempt: a report that applies (live
+// attempt) must not carry should_terminate — the live-execution invariant.
+func TestReportStateDoesNotTerminateLiveAttempt(t *testing.T) {
+	srv, authn := newServer(&fakeStore{})
+	resp, err := srv.ReportState(ctxWithToken(t, authn), &agentv1.ReportStateRequest{
+		State: agentv1.TaskState_TASK_STATE_RUNNING,
+	})
+	if err != nil {
+		t.Fatalf("ReportState: %v", err)
+	}
+	if resp.GetShouldTerminate() {
+		t.Errorf("live report: should_terminate = true, want false")
+	}
+}
+
 func TestRegisterAndHeartbeatReturnServerTime(t *testing.T) {
 	srv, a := newServer(&fakeStore{})
 	ctx := ctxWithToken(t, a)

--- a/internal/executor/pod_terminate.go
+++ b/internal/executor/pod_terminate.go
@@ -1,0 +1,93 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// This file gives the Kubernetes executor the ability to tear down a reaped
+// task's pod (#474). Before this, the three scheduler reapers only wrote DB
+// state — a reaped TI's pod kept running to completion, doing at-most-once work
+// twice. The reapers now call these methods after the DB transition so the pod
+// is actually stopped.
+//
+// Every selector below reuses the exact label scheme BuildPod stamps
+// (leoflow.io/run-id, /task-id, /try-number). Deletion is by List-then-Delete,
+// not DeleteCollection: the executor Role grants the `list` and `delete` verbs
+// but NOT `deletecollection` (helm/leoflow/templates/rbac.yaml), so a
+// DeleteCollection call would 403 in production. NotFound is always tolerated —
+// a pod may have been garbage-collected between the list and the delete.
+
+// DeleteTaskPod deletes the pod(s) for exactly one reaped task instance: the
+// (run, task, try) tuple. Pinning try-number is the invariant guard — a retry
+// bumps try_number in place and dispatches a new pod with a new try-number
+// label, so a newer live attempt can never match this selector and is never
+// deleted. Tolerates NotFound.
+func (e *KubernetesExecutor) DeleteTaskPod(ctx context.Context, runID, taskID string, tryNumber int) error {
+	selector := fmt.Sprintf("leoflow.io/run-id=%s,leoflow.io/task-id=%s,leoflow.io/try-number=%s",
+		sanitizeLabel(runID), sanitizeLabel(taskID), strconv.Itoa(tryNumber))
+	return e.deletePodsBySelector(ctx, selector)
+}
+
+// DeleteRunPods deletes every task pod belonging to a single reaped run. The
+// orphan-run reaper abandons a whole run (failing all its still-active TIs), so
+// every pod of that run must be torn down. The run-id is a unique per-run UUID,
+// so this selector can only ever match pods of the one abandoned run — never a
+// different run's live pod. Tolerates NotFound.
+func (e *KubernetesExecutor) DeleteRunPods(ctx context.Context, runID string) error {
+	selector := fmt.Sprintf("leoflow.io/run-id=%s", sanitizeLabel(runID))
+	return e.deletePodsBySelector(ctx, selector)
+}
+
+// deletePodsBySelector lists the pods matching selector and deletes each by
+// name. It uses only the `list` and `delete` verbs the executor Role grants;
+// a NotFound on either the list target or an individual delete is treated as
+// success (the pod is already gone). Per-pod delete errors are collected so one
+// failure does not skip the rest.
+func (e *KubernetesExecutor) deletePodsBySelector(ctx context.Context, selector string) error {
+	pods, err := e.clientset.CoreV1().Pods(e.namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("listing pods to delete (%s): %w", selector, err)
+	}
+	var errs []error
+	for i := range pods.Items {
+		name := pods.Items[i].Name
+		if derr := e.clientset.CoreV1().Pods(e.namespace).Delete(ctx, name, metav1.DeleteOptions{}); derr != nil && !apierrors.IsNotFound(derr) {
+			errs = append(errs, fmt.Errorf("deleting pod %s: %w", name, derr))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// TaskPodActive reports whether a pod for the given (run, task) exists and is
+// still Pending or Running. The dispatch-lost reaper consults this before
+// failing a `queued` TI: a live pod means the dispatch actually landed and the
+// node is merely slow to pull the image (#461), so the reaper must DEFER. No
+// pod, or only terminal (Failed/Succeeded/Unknown) pods, means the dispatch is
+// genuinely lost and the reaper may proceed. Try-number is deliberately NOT
+// pinned here: a `queued` TI has not been retried, so run-id+task-id already
+// identifies its single pod, and matching any live pod for the task is the
+// safer (more deferring) choice.
+func (e *KubernetesExecutor) TaskPodActive(ctx context.Context, runID, taskID string) (bool, error) {
+	selector := fmt.Sprintf("leoflow.io/run-id=%s,leoflow.io/task-id=%s",
+		sanitizeLabel(runID), sanitizeLabel(taskID))
+	pods, err := e.clientset.CoreV1().Pods(e.namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return false, fmt.Errorf("listing pods for liveness (%s): %w", selector, err)
+	}
+	for i := range pods.Items {
+		if phase := pods.Items[i].Status.Phase; phase == corev1.PodPending || phase == corev1.PodRunning {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/executor/pod_terminate_test.go
+++ b/internal/executor/pod_terminate_test.go
@@ -1,0 +1,155 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// taskPod builds a minimal pod carrying the label scheme the dispatcher stamps
+// (see BuildPod), so the reaper's label-selector deletes can find it.
+func taskPod(name, runID, taskID string, try int, phase corev1.PodPhase) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "leoflow",
+			Labels: map[string]string{
+				"leoflow.io/run-id":     sanitizeLabel(runID),
+				"leoflow.io/task-id":    sanitizeLabel(taskID),
+				"leoflow.io/try-number": itoa(try),
+			},
+		},
+		Status: corev1.PodStatus{Phase: phase},
+	}
+}
+
+func itoa(n int) string {
+	// tiny helper so the test does not import strconv just for one call.
+	if n == 0 {
+		return "0"
+	}
+	digits := ""
+	for n > 0 {
+		digits = string(rune('0'+n%10)) + digits
+		n /= 10
+	}
+	return digits
+}
+
+func podNames(t *testing.T, cs *fake.Clientset) map[string]bool {
+	t.Helper()
+	list, err := cs.CoreV1().Pods("leoflow").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("listing pods: %v", err)
+	}
+	out := map[string]bool{}
+	for i := range list.Items {
+		out[list.Items[i].Name] = true
+	}
+	return out
+}
+
+// TestDeleteTaskPod_TargetsExactlyTheReapedTI is the load-bearing invariant for
+// #474: a reaped TI's pod is deleted, but a DIFFERENT run's pod and a DIFFERENT
+// attempt's pod are left untouched. The reaper must only tear down the exact
+// (run, task, try) it just settled — never a live neighbor.
+func TestDeleteTaskPod_TargetsExactlyTheReapedTI(t *testing.T) {
+	cs := fake.NewSimpleClientset(
+		taskPod("victim", "run-a", "extract", 2, corev1.PodRunning),
+		taskPod("other-run", "run-b", "extract", 2, corev1.PodRunning),    // different run
+		taskPod("other-task", "run-a", "transform", 2, corev1.PodRunning), // different task
+		taskPod("newer-try", "run-a", "extract", 3, corev1.PodRunning),    // different (newer) attempt
+	)
+	e := NewKubernetesExecutor(cs, "leoflow")
+
+	if err := e.DeleteTaskPod(context.Background(), "run-a", "extract", 2); err != nil {
+		t.Fatalf("DeleteTaskPod: %v", err)
+	}
+	got := podNames(t, cs)
+	if got["victim"] {
+		t.Errorf("reaped TI's pod was NOT deleted: %v", got)
+	}
+	for _, keep := range []string{"other-run", "other-task", "newer-try"} {
+		if !got[keep] {
+			t.Errorf("pod %q was wrongly deleted (must survive): %v", keep, got)
+		}
+	}
+}
+
+// TestDeleteTaskPod_ToleratesNotFound: deleting when no matching pod exists is a
+// no-op, not an error — the pod may already have been GC'd.
+func TestDeleteTaskPod_ToleratesNotFound(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	e := NewKubernetesExecutor(cs, "leoflow")
+	if err := e.DeleteTaskPod(context.Background(), "run-a", "extract", 1); err != nil {
+		t.Errorf("DeleteTaskPod on absent pod = %v, want nil", err)
+	}
+}
+
+// TestDeleteRunPods_DeletesAllOfTheRunOnly: the orphan reaper abandons a whole
+// run, so every pod of that run is torn down — and no other run's is.
+func TestDeleteRunPods_DeletesAllOfTheRunOnly(t *testing.T) {
+	cs := fake.NewSimpleClientset(
+		taskPod("a1", "run-a", "extract", 1, corev1.PodRunning),
+		taskPod("a2", "run-a", "transform", 1, corev1.PodPending),
+		taskPod("b1", "run-b", "extract", 1, corev1.PodRunning),
+	)
+	e := NewKubernetesExecutor(cs, "leoflow")
+	if err := e.DeleteRunPods(context.Background(), "run-a"); err != nil {
+		t.Fatalf("DeleteRunPods: %v", err)
+	}
+	got := podNames(t, cs)
+	if got["a1"] || got["a2"] {
+		t.Errorf("run-a pods survived: %v", got)
+	}
+	if !got["b1"] {
+		t.Errorf("run-b pod wrongly deleted: %v", got)
+	}
+}
+
+// TestTaskPodActive covers the dispatch-lost deferral signal (#461): a pod that
+// exists and is Pending/Running means the dispatch landed and the node is just
+// slow, so the reaper must DEFER. A gone/failed/absent pod means the dispatch is
+// truly lost and the reaper may proceed.
+func TestTaskPodActive(t *testing.T) {
+	tests := []struct {
+		name  string
+		phase corev1.PodPhase
+		want  bool
+	}{
+		{"pending pod is active (defer)", corev1.PodPending, true},
+		{"running pod is active (defer)", corev1.PodRunning, true},
+		{"failed pod is not active (reap)", corev1.PodFailed, false},
+		{"succeeded pod is not active (reap)", corev1.PodSucceeded, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := fake.NewSimpleClientset(taskPod("p", "run-a", "extract", 1, tc.phase))
+			e := NewKubernetesExecutor(cs, "leoflow")
+			active, err := e.TaskPodActive(context.Background(), "run-a", "extract")
+			if err != nil {
+				t.Fatalf("TaskPodActive: %v", err)
+			}
+			if active != tc.want {
+				t.Errorf("TaskPodActive(phase=%s) = %v, want %v", tc.phase, active, tc.want)
+			}
+		})
+	}
+}
+
+// TestTaskPodActive_AbsentIsNotActive: no pod at all means the dispatch never
+// landed — not active, so the reaper proceeds.
+func TestTaskPodActive_AbsentIsNotActive(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	e := NewKubernetesExecutor(cs, "leoflow")
+	active, err := e.TaskPodActive(context.Background(), "run-a", "extract")
+	if err != nil {
+		t.Fatalf("TaskPodActive: %v", err)
+	}
+	if active {
+		t.Errorf("TaskPodActive with no pods = true, want false")
+	}
+}

--- a/internal/scheduler/heartbeat_reap.go
+++ b/internal/scheduler/heartbeat_reap.go
@@ -17,7 +17,13 @@ type AgentLostCandidate struct {
 	DagRunID       string
 	DagID          string
 	TaskID         string
-	LastHeartbeat  time.Time
+	// TryNumber is the attempt the candidate row is on, so the reaper can
+	// tear down EXACTLY that attempt's pod after failing it (#474). A retry
+	// bumps try_number in place and dispatches a new pod with a new
+	// try-number label, so pinning it here means a newer live attempt's pod
+	// can never be deleted by mistake.
+	TryNumber     int
+	LastHeartbeat time.Time
 }
 
 // IsAgentLost reports whether the agent has been silent long enough to be
@@ -57,6 +63,10 @@ type agentLostReaper struct {
 	logger    *slog.Logger
 	threshold time.Duration
 	recorder  Recorder
+	// pods tears down the reaped TI's pod after the DB transition (#474). A
+	// silent agent may be a network-partitioned but still-running container;
+	// deleting the pod is what actually stops the abandoned work. Nil in Lite.
+	pods PodManager
 }
 
 func newAgentLostReaper(store HeartbeatReapStore, logger *slog.Logger, threshold time.Duration, rec Recorder) *agentLostReaper {
@@ -92,6 +102,17 @@ func (r *agentLostReaper) run(ctx context.Context) error {
 			"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID,
 			"last_heartbeat", c.LastHeartbeat)
 		r.record("agent_lost")
+		// The TI is now durably failed; delete its pod so a partitioned-but-alive
+		// container stops (#474). Pinned to (run, task, try) so a retry's newer
+		// pod is never touched. Only reached after the DB mark, so we never delete
+		// a pod for a TI we did not settle. Best-effort: a delete error is logged.
+		if r.pods != nil {
+			if derr := r.pods.DeleteTaskPod(ctx, c.DagRunID, c.TaskID, c.TryNumber); derr != nil {
+				r.logger.Error("deleting agent-lost task pod",
+					"ti", c.TaskInstanceID, "run", c.DagRunID, "task", c.TaskID, "try", c.TryNumber, "error", derr)
+				r.record("agent_lost_pod_delete_error")
+			}
+		}
 	}
 	return nil
 }

--- a/internal/scheduler/pod_manager.go
+++ b/internal/scheduler/pod_manager.go
@@ -1,0 +1,33 @@
+package scheduler
+
+import "context"
+
+// PodManager is the slice of the Kubernetes executor the reapers use to (1)
+// tear down a reaped task's pod and (2) check whether a queued TI's pod is
+// actually live before declaring its dispatch lost (#474, #461).
+//
+// Before #474 the reapers only wrote DB state, so a reaped TI's pod kept
+// running to completion — breaking at-most-once execution. The reapers now
+// call these AFTER the durable DB transition so the pod is actually stopped.
+//
+// It is nil in Lite/subprocess, where tasks are host processes with no pods.
+// Every call site guards the nil: a nil PodManager means "no pods to manage",
+// and the dispatch-lost reaper falls back to its pure time-threshold behavior.
+//
+// The Kubernetes executor implements this; the interface lives here so the
+// scheduler depends on a capability, not on the executor package.
+type PodManager interface {
+	// DeleteTaskPod deletes the pod for exactly one reaped task instance —
+	// the (run, task, try) tuple. Pinning try-number guarantees a newer live
+	// attempt (dispatched with a new try-number) is never deleted. Tolerates
+	// a missing pod.
+	DeleteTaskPod(ctx context.Context, runID, taskID string, tryNumber int) error
+	// DeleteRunPods deletes every task pod of one reaped run. Used by the
+	// orphan-run reaper, which abandons the whole run. The run-id is unique
+	// per run, so no other run's pod can match. Tolerates missing pods.
+	DeleteRunPods(ctx context.Context, runID string) error
+	// TaskPodActive reports whether a pod for (run, task) exists and is
+	// Pending or Running. The dispatch-lost reaper defers when it is true —
+	// the dispatch landed, the node is merely slow (#461).
+	TaskPodActive(ctx context.Context, runID, taskID string) (bool, error)
+}

--- a/internal/scheduler/reap.go
+++ b/internal/scheduler/reap.go
@@ -54,6 +54,9 @@ type orphanReaper struct {
 	logger    *slog.Logger
 	threshold time.Duration
 	recorder  Recorder
+	// pods tears down the reaped run's pods after the DB transition (#474).
+	// Nil in Lite (no pods); the delete is skipped.
+	pods PodManager
 }
 
 func newOrphanReaper(store ReapStore, logger *slog.Logger, threshold time.Duration, rec Recorder) *orphanReaper {
@@ -87,6 +90,17 @@ func (r *orphanReaper) run(ctx context.Context) error {
 		}
 		r.logger.Warn("reaped orphan run", "run", c.RunID, "dag", c.DagID, "last_activity", c.LastActivity)
 		r.record("orphan_reaped")
+		// The run is now durably failed; tear down its pods so any still-running
+		// task containers stop instead of finishing abandoned work (#474). The
+		// run-id is unique, so this can only ever hit this run's pods. Best-effort:
+		// a delete failure is logged but does not undo the DB reap — the pod's own
+		// ActiveDeadline and the reconciler's GC remain backstops.
+		if r.pods != nil {
+			if derr := r.pods.DeleteRunPods(ctx, c.RunID); derr != nil {
+				r.logger.Error("deleting orphaned run pods", "run", c.RunID, "dag", c.DagID, "error", derr)
+				r.record("orphan_pod_delete_error")
+			}
+		}
 	}
 	return nil
 }

--- a/internal/scheduler/reap_pod_teardown_test.go
+++ b/internal/scheduler/reap_pod_teardown_test.go
@@ -1,0 +1,200 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakePodManager records the pod-teardown / liveness calls the reapers make, so
+// the tests can assert exactly which pods were deleted and that the dispatch-lost
+// reaper consulted pod liveness before failing a queued TI.
+type fakePodManager struct {
+	deletedTasks []deletedTask
+	deletedRuns  []string
+	// active maps "runID/taskID" -> whether a live pod exists; absent key is false.
+	active     map[string]bool
+	activeErr  error
+	deleteErr  error
+	deleteRunE error
+}
+
+type deletedTask struct {
+	runID  string
+	taskID string
+	try    int
+}
+
+func (f *fakePodManager) DeleteTaskPod(_ context.Context, runID, taskID string, try int) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	f.deletedTasks = append(f.deletedTasks, deletedTask{runID, taskID, try})
+	return nil
+}
+
+func (f *fakePodManager) DeleteRunPods(_ context.Context, runID string) error {
+	if f.deleteRunE != nil {
+		return f.deleteRunE
+	}
+	f.deletedRuns = append(f.deletedRuns, runID)
+	return nil
+}
+
+func (f *fakePodManager) TaskPodActive(_ context.Context, runID, taskID string) (bool, error) {
+	if f.activeErr != nil {
+		return false, f.activeErr
+	}
+	return f.active[runID+"/"+taskID], nil
+}
+
+// --- Dispatch-lost reaper: K8s-aware deferral (part C) ---------------------
+
+// TestDispatchLostReaper_DefersWhenPodLive is the #461 false-positive fix: a TI
+// that has been `queued` past the threshold is NOT failed if its pod is actually
+// Pending/Running — the dispatch landed, the node is just slow to pull the
+// image. The invariant: never mark dispatch_lost while a live pod for the TI
+// exists.
+func TestDispatchLostReaper_DefersWhenPodLive(t *testing.T) {
+	now := time.Now().UTC()
+	store := &fakeStaleQueuedStore{candidates: []StaleQueuedCandidate{
+		{TaskInstanceID: "slow-pull", DagRunID: "run-a", TaskID: "extract", TryNumber: 1, QueuedAt: now.Add(-10 * time.Minute)},
+	}}
+	pods := &fakePodManager{active: map[string]bool{"run-a/extract": true}}
+	r := newDispatchLostReaper(store, reapTestLogger(), 3*time.Minute, nil)
+	r.pods = pods
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run err = %v", err)
+	}
+	if len(store.failed) != 0 {
+		t.Errorf("dispatch_lost fired on a TI with a live pod: %v", store.failed)
+	}
+	if len(pods.deletedTasks) != 0 {
+		t.Errorf("a live TI's pod was deleted: %v", pods.deletedTasks)
+	}
+}
+
+// TestDispatchLostReaper_ReapsWhenNoPod: no pod exists for a long-queued TI, so
+// the dispatch is genuinely lost — mark it and (best-effort) delete any pod.
+func TestDispatchLostReaper_ReapsWhenNoPod(t *testing.T) {
+	now := time.Now().UTC()
+	store := &fakeStaleQueuedStore{candidates: []StaleQueuedCandidate{
+		{TaskInstanceID: "lost", DagRunID: "run-a", TaskID: "extract", TryNumber: 2, QueuedAt: now.Add(-10 * time.Minute)},
+	}}
+	pods := &fakePodManager{active: map[string]bool{}} // no live pod
+	r := newDispatchLostReaper(store, reapTestLogger(), 3*time.Minute, nil)
+	r.pods = pods
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run err = %v", err)
+	}
+	if len(store.failed) != 1 || store.failed[0] != "lost" {
+		t.Errorf("expected the lost TI to be failed, got %v", store.failed)
+	}
+	if len(pods.deletedTasks) != 1 || pods.deletedTasks[0] != (deletedTask{"run-a", "extract", 2}) {
+		t.Errorf("expected the reaped TI's pod (run-a/extract/try2) deleted, got %v", pods.deletedTasks)
+	}
+}
+
+// TestDispatchLostReaper_DefersWhenPodQueryFails: if pod liveness cannot be
+// determined (K8s API error), the reaper must DEFER rather than risk failing a
+// live TI. "When in doubt, do not reap."
+func TestDispatchLostReaper_DefersWhenPodQueryFails(t *testing.T) {
+	now := time.Now().UTC()
+	store := &fakeStaleQueuedStore{candidates: []StaleQueuedCandidate{
+		{TaskInstanceID: "unknown", DagRunID: "run-a", TaskID: "extract", TryNumber: 1, QueuedAt: now.Add(-10 * time.Minute)},
+	}}
+	pods := &fakePodManager{activeErr: errors.New("apiserver down")}
+	r := newDispatchLostReaper(store, reapTestLogger(), 3*time.Minute, nil)
+	r.pods = pods
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run err = %v", err)
+	}
+	if len(store.failed) != 0 {
+		t.Errorf("dispatch_lost fired despite an unknown pod state: %v", store.failed)
+	}
+}
+
+// TestDispatchLostReaper_NilPodManagerFallsBack: in Lite/subprocess there is no
+// K8s client, so the reaper falls back to the pure time-threshold behavior.
+func TestDispatchLostReaper_NilPodManagerFallsBack(t *testing.T) {
+	now := time.Now().UTC()
+	store := &fakeStaleQueuedStore{candidates: []StaleQueuedCandidate{
+		{TaskInstanceID: "lost", DagRunID: "run-a", TaskID: "extract", TryNumber: 1, QueuedAt: now.Add(-10 * time.Minute)},
+	}}
+	r := newDispatchLostReaper(store, reapTestLogger(), 3*time.Minute, nil) // r.pods stays nil
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run err = %v", err)
+	}
+	if len(store.failed) != 1 {
+		t.Errorf("nil pod manager should fall back to threshold reaping, got %v", store.failed)
+	}
+}
+
+// --- Agent-lost reaper: pod teardown (part A) ------------------------------
+
+// TestAgentLostReaper_DeletesReapedPod: after failing a silent-agent TI, the
+// reaper tears down its pod (the zombie the agent was running in). Only the
+// reaped (run, task, try) is targeted.
+func TestAgentLostReaper_DeletesReapedPod(t *testing.T) {
+	now := time.Now().UTC()
+	store := &fakeHeartbeatStore{candidates: []AgentLostCandidate{
+		{TaskInstanceID: "zombie", DagRunID: "run-a", TaskID: "extract", TryNumber: 2, LastHeartbeat: now.Add(-10 * time.Minute)},
+	}}
+	pods := &fakePodManager{}
+	r := newAgentLostReaper(store, reapTestLogger(), 90*time.Second, nil)
+	r.pods = pods
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run err = %v", err)
+	}
+	if len(store.failed) != 1 {
+		t.Fatalf("expected the silent TI failed, got %v", store.failed)
+	}
+	if len(pods.deletedTasks) != 1 || pods.deletedTasks[0] != (deletedTask{"run-a", "extract", 2}) {
+		t.Errorf("expected reaped pod (run-a/extract/try2) deleted, got %v", pods.deletedTasks)
+	}
+}
+
+// TestAgentLostReaper_NoDeleteWhenMarkFails: if the DB mark fails, the pod is
+// NOT deleted — we only ever tear down a pod for a TI we durably settled.
+func TestAgentLostReaper_NoDeleteWhenMarkFails(t *testing.T) {
+	now := time.Now().UTC()
+	store := &fakeHeartbeatStore{
+		candidates: []AgentLostCandidate{{TaskInstanceID: "x", DagRunID: "run-a", TaskID: "extract", TryNumber: 1, LastHeartbeat: now.Add(-10 * time.Minute)}},
+		failErr:    errors.New("db down"),
+	}
+	pods := &fakePodManager{}
+	r := newAgentLostReaper(store, reapTestLogger(), 90*time.Second, nil)
+	r.pods = pods
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run err = %v", err)
+	}
+	if len(pods.deletedTasks) != 0 {
+		t.Errorf("pod deleted despite a failed DB mark: %v", pods.deletedTasks)
+	}
+}
+
+// --- Orphan reaper: run-level pod teardown (part A) ------------------------
+
+// TestOrphanReaper_DeletesRunPods: reaping an orphaned run tears down every pod
+// of that run.
+func TestOrphanReaper_DeletesRunPods(t *testing.T) {
+	now := time.Now().UTC()
+	store := &fakeReapStore{candidates: []ReapCandidate{
+		{RunID: "run-a", DagID: "etl", LastActivity: now.Add(-10 * time.Minute)},
+	}}
+	pods := &fakePodManager{}
+	r := newOrphanReaper(store, reapTestLogger(), 5*time.Minute, nil)
+	r.pods = pods
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run err = %v", err)
+	}
+	if len(pods.deletedRuns) != 1 || pods.deletedRuns[0] != "run-a" {
+		t.Errorf("expected run-a pods deleted, got %v", pods.deletedRuns)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -239,9 +239,13 @@ type Scheduler struct {
 	orphanThreshold       time.Duration
 	agentLostThreshold    time.Duration
 	dispatchLostThreshold time.Duration
-	lastTick              atomic.Int64 // unix-nano of the last loop iteration; 0 = not yet ticked
-	leading               atomic.Bool  // true only while this instance holds leadership and ticks
-	steppingDown          atomic.Bool  // true only during a leader step-down — the campaign loop sets it before canceling the run-context so the expected cancel-fanout logs at WARN, not ERROR (#311 tripwire preserved when it's false)
+	// podManager lets the reapers tear down a reaped task's pod and gate the
+	// dispatch-lost decision on pod liveness (#474, #461). Nil in Lite; the
+	// reapers guard the nil and fall back to DB-only behavior.
+	podManager   PodManager
+	lastTick     atomic.Int64 // unix-nano of the last loop iteration; 0 = not yet ticked
+	leading      atomic.Bool  // true only while this instance holds leadership and ticks
+	steppingDown atomic.Bool  // true only during a leader step-down — the campaign loop sets it before canceling the run-context so the expected cancel-fanout logs at WARN, not ERROR (#311 tripwire preserved when it's false)
 	// warnedSchedules dedupes the "unparseable schedule" warning per DAG (keyed by
 	// the offending expression) so a bad cron logs once, not every tick. Accessed
 	// only from the single-threaded tick (createDueRuns), so it needs no lock.
@@ -277,6 +281,12 @@ func (s *Scheduler) SetAgentLostThreshold(d time.Duration) { s.agentLostThreshol
 // uses to declare a queued task's dispatch lost (optional; mainly for tests).
 // The default is defaultDispatchLostThreshold.
 func (s *Scheduler) SetDispatchLostThreshold(d time.Duration) { s.dispatchLostThreshold = d }
+
+// SetPodManager wires the pod-teardown / liveness capability the reapers use to
+// stop a reaped task's pod and to defer the dispatch-lost decision when a
+// queued TI's pod is actually live (#474, #461). Left unset in Lite/subprocess,
+// where the reapers stay DB-only. Called from main once the K8s client exists.
+func (s *Scheduler) SetPodManager(pm PodManager) { s.podManager = pm }
 
 // defaultStepTimeout bounds how long one scheduling tick may run before it is
 // canceled so the loop can recover, rather than hang forever on a stuck query.
@@ -484,11 +494,13 @@ func (s *Scheduler) reapOrphansIfLeader(ctx context.Context) {
 		return
 	}
 	runReaper := newOrphanReaper(s.store, s.logger, s.orphanThreshold, s.recorder)
+	runReaper.pods = s.podManager
 	if err := runReaper.run(ctx); err != nil {
 		logSchedulerError(s.logger, "orphan reaper", err, s.steppingDown.Load())
 		s.record("orphan_list_error")
 	}
 	tiReaper := newAgentLostReaper(s.store, s.logger, s.agentLostThreshold, s.recorder)
+	tiReaper.pods = s.podManager
 	if err := tiReaper.run(ctx); err != nil {
 		logSchedulerError(s.logger, "agent-lost reaper", err, s.steppingDown.Load())
 		s.record("agent_lost_list_error")
@@ -500,6 +512,7 @@ func (s *Scheduler) reapOrphansIfLeader(ctx context.Context) {
 	// chain takes two ticks; running here in the same tick gives a one-tick
 	// chain once the threshold elapses.
 	dispatchReaper := newDispatchLostReaper(s.store, s.logger, s.dispatchLostThreshold, s.recorder)
+	dispatchReaper.pods = s.podManager
 	if err := dispatchReaper.run(ctx); err != nil {
 		logSchedulerError(s.logger, "dispatch-lost reaper", err, s.steppingDown.Load())
 		s.record("dispatch_lost_list_error")

--- a/internal/scheduler/stale_queued_reap.go
+++ b/internal/scheduler/stale_queued_reap.go
@@ -20,7 +20,10 @@ type StaleQueuedCandidate struct {
 	DagRunID       string
 	DagID          string
 	TaskID         string
-	QueuedAt       time.Time
+	// TryNumber is the attempt the queued row is on, so a best-effort pod
+	// delete after the mark targets exactly that attempt's pod (#474).
+	TryNumber int
+	QueuedAt  time.Time
 }
 
 // IsDispatchLost reports whether a queued TI has been waiting long enough to
@@ -58,6 +61,12 @@ type dispatchLostReaper struct {
 	logger    *slog.Logger
 	threshold time.Duration
 	recorder  Recorder
+	// pods makes the reaper K8s-aware (#461): before failing a past-threshold
+	// queued TI, it checks whether the TI's pod is actually live (Pending/
+	// Running) — a slow image pull on a cold node means the dispatch DID land,
+	// so the reaper must DEFER. Nil in Lite: with no pods, the reaper falls
+	// back to the pure time-threshold behavior.
+	pods PodManager
 }
 
 func newDispatchLostReaper(store DispatchLostReapStore, logger *slog.Logger, threshold time.Duration, rec Recorder) *dispatchLostReaper {
@@ -83,6 +92,30 @@ func (r *dispatchLostReaper) run(ctx context.Context) error {
 		if !IsDispatchLost(c, r.threshold, now) {
 			continue
 		}
+		// K8s-aware liveness gate (#461): a TI can sit in `queued` past the
+		// threshold while its pod is alive and just slow to pull the image on a
+		// cold node. The pure time threshold cannot tell that apart from a truly
+		// lost dispatch, so before failing, consult the pod:
+		//   * pod Pending/Running  -> the dispatch landed; DEFER (do not reap).
+		//   * pod query failed      -> liveness unknown; DEFER ("do no harm").
+		//   * no/terminal pod       -> dispatch is genuinely lost; proceed.
+		// Nil pods (Lite) has no pod concept, so it falls through to the
+		// threshold behavior unchanged.
+		if r.pods != nil {
+			active, perr := r.pods.TaskPodActive(ctx, c.DagRunID, c.TaskID)
+			if perr != nil {
+				r.logger.Warn("dispatch-lost: pod liveness unknown; deferring",
+					"ti", c.TaskInstanceID, "run", c.DagRunID, "task", c.TaskID, "error", perr)
+				r.record("dispatch_lost_pod_query_error")
+				continue
+			}
+			if active {
+				r.logger.Info("dispatch-lost: pod is live (slow start); deferring",
+					"ti", c.TaskInstanceID, "run", c.DagRunID, "task", c.TaskID)
+				r.record("dispatch_lost_deferred")
+				continue
+			}
+		}
 		if ferr := r.store.MarkTaskDispatchLost(ctx, c.TaskInstanceID); ferr != nil {
 			r.logger.Error("marking task dispatch-lost",
 				"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID, "error", ferr)
@@ -93,6 +126,16 @@ func (r *dispatchLostReaper) run(ctx context.Context) error {
 			"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID,
 			"queued_at", c.QueuedAt)
 		r.record("dispatch_lost")
+		// Best-effort teardown of any lingering pod for this attempt (#474). By
+		// here TaskPodActive said no live pod exists (or pods is nil), so this
+		// only cleans up a terminal/failed pod; pinned to (run, task, try).
+		if r.pods != nil {
+			if derr := r.pods.DeleteTaskPod(ctx, c.DagRunID, c.TaskID, c.TryNumber); derr != nil {
+				r.logger.Error("deleting dispatch-lost task pod",
+					"ti", c.TaskInstanceID, "run", c.DagRunID, "task", c.TaskID, "try", c.TryNumber, "error", derr)
+				r.record("dispatch_lost_pod_delete_error")
+			}
+		}
 	}
 	return nil
 }

--- a/internal/storage/agent_store.go
+++ b/internal/storage/agent_store.go
@@ -178,11 +178,23 @@ func (s *ExecutionStore) RecordHeartbeat(ctx context.Context, id auth.AgentIdent
 	if err != nil {
 		return err
 	}
-	return s.q.RecordTaskHeartbeat(ctx, queries.RecordTaskHeartbeatParams{
+	rows, err := s.q.RecordTaskHeartbeat(ctx, queries.RecordTaskHeartbeatParams{
 		DagRunID:  rid,
 		TaskID:    id.TaskID,
 		TryNumber: toInt32(id.TryNumber),
 	})
+	if err != nil {
+		return err
+	}
+	// Zero rows means the heartbeat did not apply: the row moved on — a reaper
+	// settled it terminal, or a later attempt bumped try_number past this one.
+	// Same "moved on" predicate ReportState uses; surfaced as ErrStaleReport so
+	// the agent RPC turns it into a should_terminate signal (#474). Nothing
+	// failed, so this is not a DB error.
+	if rows == 0 {
+		return agentrpc.ErrStaleReport
+	}
+	return nil
 }
 
 // FailTask marks a task instance failed by its ID, but only while it is still

--- a/internal/storage/heartbeat_guard_integration_test.go
+++ b/internal/storage/heartbeat_guard_integration_test.go
@@ -1,0 +1,93 @@
+//go:build integration
+
+// Package storage_test — the write-side guard on the agent's heartbeat.
+//
+// RecordTaskHeartbeat stamps last_heartbeat_at only while the (dag_run_id,
+// task_id, try_number) tuple is still active (queued/running). #474 makes the
+// zero-rows outcome observable: when the heartbeating attempt no longer matches
+// the live row — a reaper settled it terminal, or a retry moved past it —
+// RecordHeartbeat returns ErrStaleReport so the agent RPC can answer
+// should_terminate and stop a reaped-but-alive pod. A live, matching attempt
+// stamps a row and gets no error, so a live execution is never told to stop.
+//
+// A fake-store unit test cannot prove this: the predicate lives in the UPDATE's
+// WHERE clause, so only real Postgres shows that the row did not move.
+package storage_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/agentrpc"
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// TestRecordHeartbeatLiveAttemptStampsNoError: the ordinary path — a running,
+// matching attempt heartbeats, stamps its row, and gets no error (the invariant
+// that a live execution is never told to terminate).
+func TestRecordHeartbeatLiveAttemptStampsNoError(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("hb_live_%d", time.Now().UnixNano())
+	runUUID := seedRunningTask(t, repo, sched, ctx, dagID, "load")
+
+	id := auth.AgentIdentity{TenantID: "default", DagID: dagID, RunID: runUUID, TaskID: "load", TryNumber: 1}
+	if err := exec.RecordHeartbeat(ctx, id); err != nil {
+		t.Fatalf("RecordHeartbeat on a live attempt = %v, want nil (must never signal terminate)", err)
+	}
+}
+
+// TestRecordHeartbeatTerminalRowSignalsStale: once a reaper settles the row
+// terminal, a heartbeat from the abandoned-but-alive agent no longer applies —
+// RecordHeartbeat returns ErrStaleReport so the RPC answers should_terminate.
+func TestRecordHeartbeatTerminalRowSignalsStale(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("hb_terminal_%d", time.Now().UnixNano())
+	runUUID := seedRunningTask(t, repo, sched, ctx, dagID, "load")
+
+	if err := sched.ApplyTransition(ctx, runUUID, "load", domain.TaskStateFailed); err != nil {
+		t.Fatalf("ApplyTransition to failed: %v", err)
+	}
+
+	id := auth.AgentIdentity{TenantID: "default", DagID: dagID, RunID: runUUID, TaskID: "load", TryNumber: 1}
+	if err := exec.RecordHeartbeat(ctx, id); !errors.Is(err, agentrpc.ErrStaleReport) {
+		t.Fatalf("RecordHeartbeat after a reap = %v, want ErrStaleReport (the terminate signal source)", err)
+	}
+}
+
+// TestRecordHeartbeatStaleTryNumberSignalsStale: a heartbeat from an attempt the
+// scheduler already retried past must not stamp the current attempt; it reports
+// ErrStaleReport so only the superseded pod is told to terminate.
+func TestRecordHeartbeatStaleTryNumberSignalsStale(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("hb_stale_try_%d", time.Now().UnixNano())
+	runUUID := seedRunningTask(t, repo, sched, ctx, dagID, "load")
+
+	// Attempt 1 fails and is retried: try_number becomes 2, row back to none →
+	// queued → running for attempt 2.
+	if err := sched.ApplyTransition(ctx, runUUID, "load", domain.TaskStateFailed); err != nil {
+		t.Fatalf("ApplyTransition to failed: %v", err)
+	}
+	if err := sched.ResetForRetry(ctx, runUUID, "load"); err != nil {
+		t.Fatalf("ResetForRetry: %v", err)
+	}
+	for _, st := range []domain.TaskState{domain.TaskStateQueued, domain.TaskStateRunning} {
+		if err := sched.ApplyTransition(ctx, runUUID, "load", st); err != nil {
+			t.Fatalf("ApplyTransition to %s: %v", st, err)
+		}
+	}
+
+	// Attempt 1's straggler heartbeats — it is behind, so it is told to stop.
+	stale := auth.AgentIdentity{TenantID: "default", DagID: dagID, RunID: runUUID, TaskID: "load", TryNumber: 1}
+	if err := exec.RecordHeartbeat(ctx, stale); !errors.Is(err, agentrpc.ErrStaleReport) {
+		t.Fatalf("RecordHeartbeat (stale attempt) = %v, want ErrStaleReport", err)
+	}
+
+	// Attempt 2 (the live one) heartbeats and applies cleanly — never terminated.
+	live := auth.AgentIdentity{TenantID: "default", DagID: dagID, RunID: runUUID, TaskID: "load", TryNumber: 2}
+	if err := exec.RecordHeartbeat(ctx, live); err != nil {
+		t.Fatalf("RecordHeartbeat (live attempt 2) = %v, want nil", err)
+	}
+}

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -189,7 +189,13 @@ type Querier interface {
 	// state IN guard avoids stamping a heartbeat on a TI the scheduler already
 	// transitioned to terminal between the agent's last heartbeat and now — a
 	// terminal TI must stay terminal even if a late heartbeat arrives.
-	RecordTaskHeartbeat(ctx context.Context, arg RecordTaskHeartbeatParams) error
+	//
+	// Returns the affected row count. Zero means the heartbeating agent's attempt
+	// no longer matches the live row — its try_number is behind, or a reaper
+	// already settled the row terminal — the same "moved on" predicate the state
+	// report is guarded by (#467). The agent RPC turns a zero here into a
+	// should_terminate signal so a reaped-but-alive pod stops itself (#474).
+	RecordTaskHeartbeat(ctx context.Context, arg RecordTaskHeartbeatParams) (int64, error)
 	RecordXCom(ctx context.Context, arg RecordXComParams) error
 	// Re-dispatch a task parked in up_for_reschedule once its reschedule_at has passed:
 	// back to 'none' with the per-attempt timestamps cleared (so the next dispatch

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -35,6 +35,7 @@ SELECT ti.id AS task_instance_id,
        ti.dag_run_id,
        d.dag_id AS dag_id_text,
        ti.task_id,
+       ti.try_number,
        ti.queued_at
 FROM task_instances ti
 JOIN dag_runs dr ON dr.id = ti.dag_run_id
@@ -526,12 +527,18 @@ SET state = 'failed',
 WHERE dag_run_id = $1
   AND state IN ('scheduled', 'queued', 'running');
 
--- name: RecordTaskHeartbeat :exec
+-- name: RecordTaskHeartbeat :execrows
 -- Stamps last_heartbeat_at on the active TI of an attempt. Bounded by the
 -- (dag_run_id, task_id, try_number) tuple to match the agent's identity. The
 -- state IN guard avoids stamping a heartbeat on a TI the scheduler already
 -- transitioned to terminal between the agent's last heartbeat and now — a
 -- terminal TI must stay terminal even if a late heartbeat arrives.
+--
+-- Returns the affected row count. Zero means the heartbeating agent's attempt
+-- no longer matches the live row — its try_number is behind, or a reaper
+-- already settled the row terminal — the same "moved on" predicate the state
+-- report is guarded by (#467). The agent RPC turns a zero here into a
+-- should_terminate signal so a reaped-but-alive pod stops itself (#474).
 UPDATE task_instances
 SET last_heartbeat_at = now()
 WHERE dag_run_id = $1
@@ -550,6 +557,7 @@ SELECT ti.id AS task_instance_id,
        ti.dag_run_id AS dag_run_id,
        d.dag_id AS dag_id_text,
        ti.task_id AS task_id,
+       ti.try_number AS try_number,
        ti.last_heartbeat_at AS last_heartbeat_at
 FROM task_instances ti
 JOIN dag_runs dr ON dr.id = ti.dag_run_id

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -589,6 +589,7 @@ SELECT ti.id AS task_instance_id,
        ti.dag_run_id AS dag_run_id,
        d.dag_id AS dag_id_text,
        ti.task_id AS task_id,
+       ti.try_number AS try_number,
        ti.last_heartbeat_at AS last_heartbeat_at
 FROM task_instances ti
 JOIN dag_runs dr ON dr.id = ti.dag_run_id
@@ -604,6 +605,7 @@ type ListAgentLostCandidatesRow struct {
 	DagRunID        pgtype.UUID        `json:"dag_run_id"`
 	DagIDText       string             `json:"dag_id_text"`
 	TaskID          string             `json:"task_id"`
+	TryNumber       int32              `json:"try_number"`
 	LastHeartbeatAt pgtype.Timestamptz `json:"last_heartbeat_at"`
 }
 
@@ -627,6 +629,7 @@ func (q *Queries) ListAgentLostCandidates(ctx context.Context) ([]ListAgentLostC
 			&i.DagRunID,
 			&i.DagIDText,
 			&i.TaskID,
+			&i.TryNumber,
 			&i.LastHeartbeatAt,
 		); err != nil {
 			return nil, err
@@ -805,6 +808,7 @@ SELECT ti.id AS task_instance_id,
        ti.dag_run_id,
        d.dag_id AS dag_id_text,
        ti.task_id,
+       ti.try_number,
        ti.queued_at
 FROM task_instances ti
 JOIN dag_runs dr ON dr.id = ti.dag_run_id
@@ -819,6 +823,7 @@ type ListStaleQueuedTaskInstancesRow struct {
 	DagRunID       pgtype.UUID        `json:"dag_run_id"`
 	DagIDText      string             `json:"dag_id_text"`
 	TaskID         string             `json:"task_id"`
+	TryNumber      int32              `json:"try_number"`
 	QueuedAt       pgtype.Timestamptz `json:"queued_at"`
 }
 
@@ -841,6 +846,7 @@ func (q *Queries) ListStaleQueuedTaskInstances(ctx context.Context) ([]ListStale
 			&i.DagRunID,
 			&i.DagIDText,
 			&i.TaskID,
+			&i.TryNumber,
 			&i.QueuedAt,
 		); err != nil {
 			return nil, err
@@ -1174,7 +1180,7 @@ func (q *Queries) RecordDispatchFailure(ctx context.Context, arg RecordDispatchF
 	return err
 }
 
-const recordTaskHeartbeat = `-- name: RecordTaskHeartbeat :exec
+const recordTaskHeartbeat = `-- name: RecordTaskHeartbeat :execrows
 UPDATE task_instances
 SET last_heartbeat_at = now()
 WHERE dag_run_id = $1
@@ -1194,9 +1200,18 @@ type RecordTaskHeartbeatParams struct {
 // state IN guard avoids stamping a heartbeat on a TI the scheduler already
 // transitioned to terminal between the agent's last heartbeat and now — a
 // terminal TI must stay terminal even if a late heartbeat arrives.
-func (q *Queries) RecordTaskHeartbeat(ctx context.Context, arg RecordTaskHeartbeatParams) error {
-	_, err := q.db.Exec(ctx, recordTaskHeartbeat, arg.DagRunID, arg.TaskID, arg.TryNumber)
-	return err
+//
+// Returns the affected row count. Zero means the heartbeating agent's attempt
+// no longer matches the live row — its try_number is behind, or a reaper
+// already settled the row terminal — the same "moved on" predicate the state
+// report is guarded by (#467). The agent RPC turns a zero here into a
+// should_terminate signal so a reaped-but-alive pod stops itself (#474).
+func (q *Queries) RecordTaskHeartbeat(ctx context.Context, arg RecordTaskHeartbeatParams) (int64, error) {
+	result, err := q.db.Exec(ctx, recordTaskHeartbeat, arg.DagRunID, arg.TaskID, arg.TryNumber)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const redispatchRescheduledTaskInstance = `-- name: RedispatchRescheduledTaskInstance :exec

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -445,6 +445,7 @@ func (s *SchedulerStore) ListAgentLostCandidates(ctx context.Context) ([]schedul
 			DagRunID:       uuidToString(r.DagRunID),
 			DagID:          r.DagIDText,
 			TaskID:         r.TaskID,
+			TryNumber:      int(r.TryNumber),
 			LastHeartbeat:  last,
 		})
 	}
@@ -503,6 +504,7 @@ func (s *SchedulerStore) ListStaleQueuedCandidates(ctx context.Context) ([]sched
 			DagRunID:       uuidToString(r.DagRunID),
 			DagID:          r.DagIDText,
 			TaskID:         r.TaskID,
+			TryNumber:      int(r.TryNumber),
 			QueuedAt:       qed,
 		})
 	}


### PR DESCRIPTION
Closes #474. A reaped task no longer keeps running: the reapers now actually tear
down the pod, and the dispatch-lost reaper stops false-failing live tasks (#461).

## The gap (verified on main)
The reapers were DB-only — marking a TI failed/lost never touched its pod, so it
ran to completion (an at-most-once violation), and the dispatch-lost reaper failed
a `queued` TI purely on a timer even when its pod was alive and just slow to pull
(#461). `#467` had already stopped a stale report from overwriting a newer attempt.

## Fix — invariant: never kill a live attempt (defer when in doubt)
- **Pod teardown on reap.** `KubernetesExecutor.DeleteTaskPod(run,task,try)` (and
  `DeleteRunPods(run)` for orphaned runs) deletes by the labels `BuildPod` stamps.
  The delete is pinned to `try-number`, so a retry (new try, new label) can never
  be matched — only the genuinely-reaped attempt's pod is removed. List+Delete
  (not DeleteCollection: the Role grants list/delete, not deletecollection);
  NotFound tolerated. Wired into all three reapers; nil in Lite (no pods).
- **`should_terminate` kill-switch.** `ReportState`/`Heartbeat` set it **only** on
  the exact stale predicate #467 added (row count 0 = attempt superseded). A live,
  matching attempt gets false; a transient DB error gets false (a blip never kills
  a live task).
- **Dispatch-lost defers to pod liveness (#461).** Before failing a past-threshold
  `queued` TI, it checks the pod: Pending/Running → defer; query error → defer
  (do no harm); no/terminal pod → reap. Lite (nil pods) keeps the time threshold.

## Tests (safety properties, not happy path)
DefersWhenPodLive, DefersWhenPodQueryFails, NoDeleteWhenMarkFails,
Heartbeat/ReportState DoesNotTerminateLiveAttempt, TransientErrorDoesNotTerminate,
plus a real-Postgres heartbeat-guard integration test. Docs corrected
(scheduler-resilience.md no longer claims the reapers can never kill a live task).

Same "the chart/code each look right, the contract between them isn't checked"
class as #469/#475. Follow-up (pre-existing, unrelated): TestDispatchBackoffPersists
leaves a fixed-id row (test hygiene).