### PR TITLE
Verify + retry k3d image import (kill the silent-import flake)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **k3d e2e image import is now verified + retried** (test/e2e reliability).
+  `k3d image import` prints "Successfully imported" even when the in-node
+  containerd import fails ("tarball: no such file or directory"), so a flaky
+  import left the cluster without the image and every task pod ErrImagePulled —
+  a confusing downstream failure. A shared `k3d_import` helper treats the import
+  as successful only when k3d exits 0 AND emits no error line, retrying up to 3×
+  and failing loud otherwise. Applied across the operator, split, and dbt e2es.
+
 ### Fixed
 
 - **Split api role now reports pod dispatch correctly on `/api/v2/monitor/executor`**

--- a/test/e2e/dbt-connection-e2e.sh
+++ b/test/e2e/dbt-connection-e2e.sh
@@ -15,6 +15,9 @@
 # On Linux/CI set LEOFLOW_E2E_HOST_ADDR=host.k3d.internal.
 set -euo pipefail
 
+# shellcheck source=test/e2e/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CLUSTER="${LEOFLOW_E2E_CLUSTER:-leoflow-dbt-conn-e2e}"
 HOST_ADDR="${LEOFLOW_E2E_HOST_ADDR:-host.docker.internal}"
@@ -126,7 +129,7 @@ log "Compiling (commands must be wrapped with the --dbt-profile step) + building
 "$ROOT/bin/leoflow" compile "$PROJ" --image "$DAG_IMAGE" --build --dockerfile Dockerfile -o "$PROJ/dag.json"
 jq -e '.tasks[] | select(.entrypoint | startswith("python -m leoflow_runtime --dbt-profile warehouse_pg shop &&"))' \
   "$PROJ/dag.json" >/dev/null || fail "task commands are not wrapped with the managed-profile step"
-k3d image import "$BASE_IMAGE" "$DAG_IMAGE" --cluster "$CLUSTER" >/dev/null
+k3d_import "$CLUSTER" "$BASE_IMAGE" "$DAG_IMAGE"
 
 log "Pushing the DAG and creating the managed Postgres connection"
 TOKEN="$("$ROOT/bin/leoflow" auth create-token --server "$API" --username admin@leoflow.local --password admin)"

--- a/test/e2e/dbt-e2e.sh
+++ b/test/e2e/dbt-e2e.sh
@@ -20,6 +20,9 @@
 # LEOFLOW_E2E_HOST_ADDR. Ports are overridable for hosts whose defaults are busy.
 set -euo pipefail
 
+# shellcheck source=test/e2e/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CLUSTER="${LEOFLOW_E2E_CLUSTER:-leoflow-dbt-e2e}"
 HOST_ADDR="${LEOFLOW_E2E_HOST_ADDR:-host.docker.internal}"
@@ -147,7 +150,7 @@ for want in 'raw' 'stg' 'mart'; do
 done
 jq -e '.tasks[] | select(.task_id=="mart") | .depends_on | index("stg")' "$PROJ/dag.json" >/dev/null \
   || fail "mart must depend on stg (dbt edge not carried)"
-k3d image import "$BASE_IMAGE" "$DAG_IMAGE" --cluster "$CLUSTER" >/dev/null
+k3d_import "$CLUSTER" "$BASE_IMAGE" "$DAG_IMAGE"
 
 log "Pushing the DAG and triggering a run"
 TOKEN="$("$ROOT/bin/leoflow" auth create-token --server "$API" --username admin@leoflow.local --password admin)"

--- a/test/e2e/dbt-mixing-e2e.sh
+++ b/test/e2e/dbt-mixing-e2e.sh
@@ -15,6 +15,9 @@
 # LEOFLOW_E2E_PARSER_CMD.
 set -euo pipefail
 
+# shellcheck source=test/e2e/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CLUSTER="${LEOFLOW_E2E_CLUSTER:-leoflow-dbt-mix-e2e}"
 HOST_ADDR="${LEOFLOW_E2E_HOST_ADDR:-host.docker.internal}"
@@ -140,7 +143,7 @@ jq -e '.tasks[] | select(.task_id=="transform__raw") | .depends_on | index("pre"
   || fail "group root transform__raw is not wired to the upstream operator 'pre'"
 jq -e '.tasks[] | select(.task_id=="post") | .depends_on | index("transform__mart")' "$PROJ/dag.json" >/dev/null \
   || fail "downstream operator 'post' is not wired to the group leaf"
-k3d image import "$BASE_IMAGE" "$DAG_IMAGE" --cluster "$CLUSTER" >/dev/null
+k3d_import "$CLUSTER" "$BASE_IMAGE" "$DAG_IMAGE"
 
 log "Pushing + triggering"
 TOKEN="$("$ROOT/bin/leoflow" auth create-token --server "$API" --username admin@leoflow.local --password admin)"

--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -15,6 +15,9 @@
 # Usage: test/e2e/e2e.sh [cluster-name]
 set -euo pipefail
 
+# shellcheck source=test/e2e/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
 CLUSTER="${1:-leoflow-e2e}"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WORKDIR="$(mktemp -d)"
@@ -217,7 +220,7 @@ jq -e '.tasks[] | select(.task_id=="probe" and .type=="airflow_operator")' \
 log "Asserting probe chains from endpoint_name (ti.xcom_pull, ADR 0040)"
 jq -e '.tasks[] | select(.task_id=="probe") | .depends_on | index("endpoint_name")' \
   "$WORKDIR/$DAG_ID/dag.json" >/dev/null || fail "probe does not depend on endpoint_name (chaining wire missing)"
-k3d image import "$BASE_IMAGE" "$DAG_IMAGE" --cluster "$CLUSTER"
+k3d_import "$CLUSTER" "$BASE_IMAGE" "$DAG_IMAGE"
 
 log "Pushing the DAG"
 TOKEN="$("$ROOT/bin/leoflow" auth create-token --server "$API" --username admin@leoflow.local --password admin)"
@@ -445,7 +448,7 @@ CB_IMAGE="leoflow-e2e-cbdag:local"
   --build --dockerfile Dockerfile -o "$WORKDIR/$CBID/dag.json"
 jq -e '.tasks[] | select(.task_id=="boom" and .on_failure_callback==true)' \
   "$WORKDIR/$CBID/dag.json" >/dev/null || fail "boom did not compile with on_failure_callback=true"
-k3d image import "$CB_IMAGE" --cluster "$CLUSTER"
+k3d_import "$CLUSTER" "$CB_IMAGE"
 "$ROOT/bin/leoflow" push "$WORKDIR/$CBID/dag.json" --server "$API" --token "$TOKEN"
 CB_RUN="$(curl -fsS -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
   -d '{}' "$API/api/v2/dags/cbdag/dagRuns" | jq -r '.dag_run_id')"

--- a/test/e2e/lib.sh
+++ b/test/e2e/lib.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Shared helpers for the k3d end-to-end scripts.
+
+# k3d_import imports images into a k3d cluster, working around a k3d bug where
+# `k3d image import` prints "Successfully imported" even when the in-node
+# containerd import actually failed ("ctr: open /k3d/images/...tar: no such file
+# or directory") and exits 0. A bare import then silently leaves the cluster
+# WITHOUT the image, so every task pod ErrImagePulls and the e2e fails far
+# downstream with a confusing symptom. This retries and treats the import as
+# successful only when k3d BOTH exits 0 AND wrote no error line (the ERRO /
+# "failed to import" it emits to stderr despite the misleading success line),
+# failing loud instead of proceeding into ErrImagePull.
+#
+# Usage: k3d_import <cluster> <image> [image...]
+k3d_import() {
+  local cluster="$1"; shift
+  local attempt out rc
+  for attempt in 1 2 3; do
+    out="$(k3d image import "$@" --cluster "$cluster" 2>&1)" && rc=0 || rc=$?
+    if [ "$rc" -eq 0 ] && ! printf '%s\n' "$out" | grep -qiE 'failed to import|no such file or directory|ERRO\['; then
+      return 0
+    fi
+    printf '%s\n' "$out" >&2
+    printf 'k3d_import: attempt %d hit the import flake (k3d misreported success, rc=%s); retrying...\n' "$attempt" "$rc" >&2
+    sleep 3
+  done
+  printf 'FATAL: k3d image import failed to land images in cluster %q after 3 attempts (the tarball-not-found flake)\n' "$cluster" >&2
+  return 1
+}

--- a/test/e2e/split-two-process.sh
+++ b/test/e2e/split-two-process.sh
@@ -25,6 +25,9 @@
 # Usage: test/e2e/split-two-process.sh [cluster-name]
 set -euo pipefail
 
+# shellcheck source=test/e2e/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+
 CLUSTER="${1:-leoflow-split-e2e}"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 WORKDIR="$(mktemp -d)"
@@ -183,7 +186,7 @@ log "isolation OK: api serves HTTP+metrics-health; scheduler serves metrics-heal
 log "Compiling, building, and importing the DAG image"
 "$ROOT/bin/leoflow" compile "$WORKDIR/$DAG_ID" --image "$DAG_IMAGE" \
   --build --dockerfile Dockerfile -o "$WORKDIR/$DAG_ID/dag.json"
-k3d image import "$BASE_IMAGE" "$DAG_IMAGE" --cluster "$CLUSTER"
+k3d_import "$CLUSTER" "$BASE_IMAGE" "$DAG_IMAGE"
 
 log "Pushing + triggering the DAG against the API process (never the scheduler)"
 TOKEN="$("$ROOT/bin/leoflow" auth create-token --server "$API" --username admin@leoflow.local --password admin)"


### PR DESCRIPTION
Fixes the intermittent `ErrImagePull` in the k3d e2es.

## Root cause (from the operator-e2e log)
`k3d image import` printed `Successfully imported` **even though** the in-node
import errored — `ERRO[...] failed to import images ... ctr: open
/k3d/images/...tar: no such file or directory` — and exited 0. So the cluster
had no image, every task pod `ErrImagePull`ed, and the e2e failed far downstream
with a misleading symptom. The `split-e2e` passed in the same run, confirming
it's a flaky import, not a build/provenance issue (my first hypothesis, which I
did not ship after the log disproved it).

## Fix
A shared `test/e2e/lib.sh` `k3d_import <cluster> <image...>` helper treats the
import as successful only when k3d **exits 0 AND** emits no error line, retries
up to 3×, and fails loud with the tarball-not-found signature otherwise. Wired
into the operator, split, and three dbt e2es (deploy-e2e uses a registry, not
import). `bash -n` + `shellcheck -x` clean; CI's k3d jobs are the real exercise.