### PR TITLE
test(e2e): make the k3d harness + rc-smoke Linux/Lima-portable

### DIFF
--- a/scripts/rc-smoke.sh
+++ b/scripts/rc-smoke.sh
@@ -49,7 +49,44 @@ helm_docs_fresh()  {
 ui_smoke() {
   # A real ui-smoke failure must surface as FAIL; only a MISSING node is skipped.
   if ! command -v node >/dev/null; then echo "node missing; skipping ui-smoke"; return 0; fi
-  node test/e2e/ui-smoke.js
+  # The headless SPA smoke needs a running Lite control plane. Bring one up on the
+  # migrated dev DB (setup -> bootstrap hash -> server), run the smoke against it
+  # over IPv4 (localhost resolves to ::1 first; the server binds IPv4, so force
+  # 127.0.0.1 to avoid a spurious connection refusal), then tear it down.
+  local port=18080 base="http://127.0.0.1:18080"
+  local db="postgres://leoflow:leoflow@localhost:5432/leoflow?sslmode=disable"
+  local home_dir; home_dir="$(mktemp -d)"
+  local pid="" rc=0 pw hash setup_out code=""
+  # a no-op python3.11 so `setup` skips the CPython download (the parser is unused here)
+  mkdir -p "$home_dir/bin"; printf '#!/bin/sh\n' > "$home_dir/bin/python3.11"; chmod +x "$home_dir/bin/python3.11"
+  LEOFLOW_DATABASE_URL="$db" PATH="$home_dir/bin:$PATH" ./bin/leoflow db reset --yes >/dev/null 2>&1
+  setup_out="$(HOME="$home_dir" PATH="$home_dir/bin:$PATH" ./bin/leoflow setup --workspace "$home_dir/ws" </dev/null 2>&1)"
+  pw="$(printf '%s\n' "$setup_out" | sed -n 's/^[[:space:]]*password:[[:space:]]*//p' | head -1)"
+  hash="$(sed -n 's/^admin_password_hash:[[:space:]]*"\(.*\)"/\1/p' "$home_dir/.leoflow/config.yaml" 2>/dev/null)"
+  if [ -z "$pw" ] || [ -z "$hash" ]; then echo "ui-smoke: setup did not yield admin creds"; rm -rf "$home_dir"; return 1; fi
+  printf 'print("hello")\n' > "$home_dir/ws/dag.py"
+  LEOFLOW_SERVER_HTTP_ADDR="127.0.0.1:${port}" LEOFLOW_SERVER_GRPC_ADDR="127.0.0.1:19091" \
+  LEOFLOW_SERVER_METRICS_ADDR="127.0.0.1:19090" LEOFLOW_DATABASE_URL="$db" \
+  LEOFLOW_REDIS_URL="redis://localhost:6379/0" LEOFLOW_AUTH_JWT_SECRET="e2e-insecure-jwt-secret-please-change" \
+  LEOFLOW_SECRET_KEY="e2e-insecure-secret-key-32bytes!" LEOFLOW_BOOTSTRAP_PASSWORD_HASH="$hash" \
+  LEOFLOW_BOOTSTRAP_EMAIL="admin@leoflow.local" LEOFLOW_UI_EDITION="lite" \
+  LEOFLOW_UI_WORKSPACE="$home_dir/ws" LEOFLOW_LOGS_DIR="$home_dir/logs" \
+    ./bin/leoflow-server >"$home_dir/server.log" 2>&1 &
+  pid=$!
+  for _ in $(seq 1 60); do
+    code="$(curl -s -o /dev/null -w '%{http_code}' "${base}/readyz" || true)"
+    [ "$code" = "200" ] && break
+    kill -0 "$pid" 2>/dev/null || break
+    sleep 0.5
+  done
+  if [ "$code" = "200" ]; then
+    LEOFLOW_URL="$base" LEOFLOW_USER="admin@leoflow.local" LEOFLOW_PASS="$pw" node test/e2e/ui-smoke.js || rc=$?
+  else
+    echo "ui-smoke: lite control plane not ready (last /readyz=$code)"; tail -20 "$home_dir/server.log"; rc=1
+  fi
+  kill "$pid" 2>/dev/null || true
+  chmod -R u+w "$home_dir" 2>/dev/null || true; rm -rf "$home_dir"
+  return "$rc"
 }
 
 # --- preflight ---------------------------------------------------------------

--- a/test/e2e/chaos-runtime.sh
+++ b/test/e2e/chaos-runtime.sh
@@ -38,7 +38,7 @@ API_METRICS_PORT="9090"
 SCHED_METRICS_PORT="9092"
 GRPC_PORT="9091"
 API="http://localhost:${API_HTTP_PORT}"
-HOST_ADDR="${LEOFLOW_E2E_HOST_ADDR:-host.docker.internal}"
+HOST_ADDR="${LEOFLOW_E2E_HOST_ADDR:-$([ "$(uname -s)" = Linux ] && echo host.k3d.internal || echo host.docker.internal)}"
 # The dev Postgres container to restart in scenario C (future); its name differs
 # between `make dev-up` (compose) and a standalone run. Overridable.
 API_PID=""; SCHED_PID=""; TOKEN=""; FAILED=0

--- a/test/e2e/dbt-connection-e2e.sh
+++ b/test/e2e/dbt-connection-e2e.sh
@@ -20,7 +20,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CLUSTER="${LEOFLOW_E2E_CLUSTER:-leoflow-dbt-conn-e2e}"
-HOST_ADDR="${LEOFLOW_E2E_HOST_ADDR:-host.docker.internal}"
+HOST_ADDR="${LEOFLOW_E2E_HOST_ADDR:-$([ "$(uname -s)" = Linux ] && echo host.k3d.internal || echo host.docker.internal)}"
 HTTP_PORT="${LEOFLOW_E2E_HTTP_PORT:-8080}"
 GRPC_PORT="${LEOFLOW_E2E_GRPC_PORT:-9091}"
 METRICS_PORT="${LEOFLOW_E2E_METRICS_PORT:-9090}"
@@ -84,9 +84,15 @@ echo "select id, sum(v) as total from {{ ref('stg') }} group by id" >"$PROJ/mode
 log "Generating the manifest (dbt parse is offline; the bad host is fine for parse)"
 ( cd "$PROJ" && DBT_PROFILES_DIR="$PROJ" dbt parse >/dev/null 2>&1 ) || fail "dbt parse failed"
 
+# Pin the DAG image to the host arch (see e2e.sh): the loader defaults to
+# linux/amd64, which fails FROM an arm64 base on a Lima/dev host → ErrImagePull.
+case "$(uname -m)" in arm64|aarch64) HOST_PLATFORM="linux/arm64" ;; *) HOST_PLATFORM="linux/amd64" ;; esac
 cat >"$PROJ/leoflow.yaml" <<YAML
 schema_version: "1.0"
 dag_id: ${DAG_ID}
+build:
+  platforms:
+    - ${HOST_PLATFORM}
 dbt:
   project: .
   manifest: target/manifest.json
@@ -105,7 +111,7 @@ WORKDIR /home/leoflow
 DOCKER
 
 log "Building the leoflow base image"
-docker build -q -f "$ROOT/runtime/Dockerfile" --build-arg "PYTHON_VERSION=${PY_VERSION}" -t "$BASE_IMAGE" "$ROOT" >/dev/null
+docker build --provenance=false -q -f "$ROOT/runtime/Dockerfile" --build-arg "PYTHON_VERSION=${PY_VERSION}" -t "$BASE_IMAGE" "$ROOT" >/dev/null
 
 log "Creating k3d cluster '$CLUSTER' + the leoflow namespace"
 k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true

--- a/test/e2e/dbt-e2e.sh
+++ b/test/e2e/dbt-e2e.sh
@@ -25,7 +25,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CLUSTER="${LEOFLOW_E2E_CLUSTER:-leoflow-dbt-e2e}"
-HOST_ADDR="${LEOFLOW_E2E_HOST_ADDR:-host.docker.internal}"
+HOST_ADDR="${LEOFLOW_E2E_HOST_ADDR:-$([ "$(uname -s)" = Linux ] && echo host.k3d.internal || echo host.docker.internal)}"
 HTTP_PORT="${LEOFLOW_E2E_HTTP_PORT:-8080}"
 GRPC_PORT="${LEOFLOW_E2E_GRPC_PORT:-9091}"
 METRICS_PORT="${LEOFLOW_E2E_METRICS_PORT:-9090}"
@@ -98,10 +98,16 @@ echo "select id, sum(v) as total from {{ ref('stg') }} group by id" >"$PROJ/mode
 log "Generating the dbt manifest (dbt parse is offline)"
 ( cd "$PROJ" && DBT_PROFILES_DIR="$PROJ" dbt parse >/dev/null 2>&1 ) || fail "dbt parse failed"
 
+# Pin the DAG image to the host arch (see e2e.sh): the loader defaults to
+# linux/amd64, which fails FROM an arm64 base on a Lima/dev host → ErrImagePull.
+case "$(uname -m)" in arm64|aarch64) HOST_PLATFORM="linux/arm64" ;; *) HOST_PLATFORM="linux/amd64" ;; esac
 cat >"$PROJ/leoflow.yaml" <<YAML
 schema_version: "1.0"
 dag_id: ${DAG_ID}
 owner: data-team
+build:
+  platforms:
+    - ${HOST_PLATFORM}
 dbt:
   project: .
   manifest: target/manifest.json
@@ -122,7 +128,7 @@ WORKDIR /home/leoflow
 DOCKER
 
 log "Building the leoflow base image (${BASE_IMAGE})"
-docker build -q -f "$ROOT/runtime/Dockerfile" --build-arg "PYTHON_VERSION=${PY_VERSION}" \
+docker build --provenance=false -q -f "$ROOT/runtime/Dockerfile" --build-arg "PYTHON_VERSION=${PY_VERSION}" \
   -t "$BASE_IMAGE" "$ROOT" >/dev/null
 
 log "Creating k3d cluster '$CLUSTER' + the leoflow namespace"

--- a/test/e2e/dbt-mixing-e2e.sh
+++ b/test/e2e/dbt-mixing-e2e.sh
@@ -20,7 +20,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CLUSTER="${LEOFLOW_E2E_CLUSTER:-leoflow-dbt-mix-e2e}"
-HOST_ADDR="${LEOFLOW_E2E_HOST_ADDR:-host.docker.internal}"
+HOST_ADDR="${LEOFLOW_E2E_HOST_ADDR:-$([ "$(uname -s)" = Linux ] && echo host.k3d.internal || echo host.docker.internal)}"
 HTTP_PORT="${LEOFLOW_E2E_HTTP_PORT:-8080}"
 GRPC_PORT="${LEOFLOW_E2E_GRPC_PORT:-9091}"
 METRICS_PORT="${LEOFLOW_E2E_METRICS_PORT:-9090}"
@@ -82,6 +82,14 @@ dbt_groups:
     manifest: target/manifest.json
     granularity: node
 YAML
+# Pin the DAG image to the host arch (see e2e.sh): the loader defaults to
+# linux/amd64, which fails FROM an arm64 base on a Lima/dev host → ErrImagePull.
+case "$(uname -m)" in arm64|aarch64) HOST_PLATFORM="linux/arm64" ;; *) HOST_PLATFORM="linux/amd64" ;; esac
+cat >>"$PROJ/leoflow.yaml" <<YAML
+build:
+  platforms:
+    - ${HOST_PLATFORM}
+YAML
 cat >"$PROJ/transform/dbt_project.yml" <<'YAML'
 name: 'shop'
 version: '1.0.0'
@@ -115,7 +123,7 @@ WORKDIR /home/leoflow
 DOCKER
 
 log "Building the leoflow base image"
-docker build -q -f "$ROOT/runtime/Dockerfile" --build-arg "PYTHON_VERSION=${PY_VERSION}" -t "$BASE_IMAGE" "$ROOT" >/dev/null
+docker build --provenance=false -q -f "$ROOT/runtime/Dockerfile" --build-arg "PYTHON_VERSION=${PY_VERSION}" -t "$BASE_IMAGE" "$ROOT" >/dev/null
 
 log "Creating k3d cluster + namespace"
 k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true

--- a/test/e2e/deploy-e2e.sh
+++ b/test/e2e/deploy-e2e.sh
@@ -36,7 +36,7 @@ REG_HOST="${REG_FULLNAME}:${REG_PORT}" # same ref on host (loopback) and in-clus
 HTTP_PORT="${LEOFLOW_E2E_HTTP_PORT:-18080}"
 API="http://localhost:${HTTP_PORT}"
 GRPC_PORT="9091"
-HOST_ADDR="${LEOFLOW_E2E_HOST_ADDR:-host.docker.internal}"
+HOST_ADDR="${LEOFLOW_E2E_HOST_ADDR:-$([ "$(uname -s)" = Linux ] && echo host.k3d.internal || echo host.docker.internal)}"
 CFG="${WORKDIR}/leoflow-config.yaml"   # login persists token+server here
 SERVER_PID=""
 
@@ -77,7 +77,7 @@ for tool in k3d kubectl docker jq curl; do
 done
 
 log "Building the task base image ($BASE_IMAGE)"
-docker build -f "$ROOT/runtime/Dockerfile" --build-arg "PYTHON_VERSION=${PY_VERSION}" -t "$BASE_IMAGE" "$ROOT"
+docker build --provenance=false -f "$ROOT/runtime/Dockerfile" --build-arg "PYTHON_VERSION=${PY_VERSION}" -t "$BASE_IMAGE" "$ROOT"
 
 log "Creating k3d registry ($REG_HOST) + cluster '$CLUSTER' (cluster pulls from the registry)"
 k3d registry create "$REG_NAME" --port "$REG_PORT" >/dev/null

--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -34,7 +34,7 @@ GRPC_PORT="9091"
 # Address task pods dial to reach the host control plane's gRPC. On Docker
 # Desktop (macOS/Windows) host.docker.internal resolves to the host; k3d does
 # not inject host.k3d.internal into CoreDNS there. Override for Linux/CI.
-HOST_ADDR="${LEOFLOW_E2E_HOST_ADDR:-host.docker.internal}"
+HOST_ADDR="${LEOFLOW_E2E_HOST_ADDR:-$([ "$(uname -s)" = Linux ] && echo host.k3d.internal || echo host.docker.internal)}"
 SERVER_PID=""
 
 log()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
@@ -67,6 +67,15 @@ log "Scaffolding a minimal DAG project ($DAG_ID)"
 # Dockerfile below installs it into the image.
 sed -i.bak 's/^dependencies: \[\]/dependencies: [apache-airflow-providers-http]/' \
   "$WORKDIR/$DAG_ID/leoflow.yaml" && rm -f "$WORKDIR/$DAG_ID/leoflow.yaml.bak"
+# The config loader defaults build.platforms to linux/amd64 (the prod default);
+# on an arm64 dev/Lima host the DAG image must build for the host arch, else its
+# base-image FROM mismatches (InvalidBaseImagePlatform) and the pods ErrImagePull.
+case "$(uname -m)" in arm64|aarch64) HOST_PLATFORM="linux/arm64" ;; *) HOST_PLATFORM="linux/amd64" ;; esac
+cat >> "$WORKDIR/$DAG_ID/leoflow.yaml" <<YAML
+build:
+  platforms:
+    - ${HOST_PLATFORM}
+YAML
 # A real Airflow-SDK DAG (the parser requires an actual DAG object, not a bare
 # function). Two tasks in sequence prove pod-per-task AND cross-pod ordering:
 # each runs in its own pod whose agent reports state over gRPC.
@@ -184,7 +193,7 @@ ENV PYTHONPATH=/home/leoflow
 DOCKER
 
 log "Building base and DAG images"
-docker build -f "$ROOT/runtime/Dockerfile" --build-arg "PYTHON_VERSION=${PY_VERSION}" -t "$BASE_IMAGE" "$ROOT"
+docker build --provenance=false -f "$ROOT/runtime/Dockerfile" --build-arg "PYTHON_VERSION=${PY_VERSION}" -t "$BASE_IMAGE" "$ROOT"
 
 log "Creating k3d cluster '$CLUSTER'"
 k3d cluster create "$CLUSTER" --wait
@@ -419,6 +428,9 @@ mkdir -p "$WORKDIR/$CBID"
 cat > "$WORKDIR/$CBID/leoflow.yaml" <<YAML
 schema_version: "1.0"
 dag_id: cbdag
+build:
+  platforms:
+    - ${HOST_PLATFORM}
 YAML
 cat > "$WORKDIR/$CBID/dag.py" <<'PY'
 from airflow.sdk import DAG, task

--- a/test/e2e/split-two-process.sh
+++ b/test/e2e/split-two-process.sh
@@ -46,7 +46,7 @@ SCHED_METRICS_PORT="9092"
 GRPC_PORT="9091"
 API="http://localhost:${API_HTTP_PORT}"
 # Address task pods dial to reach the scheduler process's gRPC on the host.
-HOST_ADDR="${LEOFLOW_E2E_HOST_ADDR:-host.docker.internal}"
+HOST_ADDR="${LEOFLOW_E2E_HOST_ADDR:-$([ "$(uname -s)" = Linux ] && echo host.k3d.internal || echo host.docker.internal)}"
 API_PID=""
 SCHED_PID=""
 


### PR DESCRIPTION
## Why

Running the RC battery (`make rc-smoke`) on a **Linux (arm64) Lima VM** — the prod-faithful environment, not a dev Mac — surfaced that the k3d e2e harness only ran cleanly on Docker Desktop (macOS). Every k3d e2e failed for **environmental/portability** reasons (no code regressions), and the same gaps would break a real Lima gate. This fixes the four gaps so the harness runs on macOS **and** Linux/Lima.

## The four gaps (all found by the Linux run)

1. **Host callback address.** Task pods reach the host control plane via `host.docker.internal` on Docker Desktop, but Linux Docker does not inject that name. Default `HOST_ADDR` to `host.k3d.internal` on Linux (k3d adds it to CoreDNS), keeping `host.docker.internal` on macOS. Without this, tasks sit `queued` until timeout. *(e2e, split, dbt-*, deploy, chaos)*

2. **DAG image platform.** The config loader defaults `build.platforms` to `linux/amd64` (the prod default); on an arm64 host the DAG image then builds amd64 `FROM` an arm64 base → `InvalidBaseImagePlatform` → pods `ErrImagePull`. Pin the DAG build to the host arch, as `split`/`chaos` already did. *(e2e ×2, dbt-e2e, dbt-mixing, dbt-connection; deploy already pinned)*

3. **buildx provenance.** With a containerd image store, buildx tags the base image as a manifest list with attestations, which a later `FROM` cannot resolve (`no match for platform in manifest`). Build the base with `--provenance=false`, as `split`/`chaos` already did. *(e2e, dbt-e2e, dbt-mixing, dbt-connection, deploy)*

4. **rc-smoke ui-smoke never started a server.** The step ran `node ui-smoke.js` but never brought up the Lite control plane the smoke needs, so it could not pass (a bug in the rc-smoke battery, #522). Bring up a real lite server (setup → bootstrap hash → server) and drive the smoke against `127.0.0.1` (`localhost` resolves to `::1` first; the server binds IPv4).

## Verification

On a Linux (arm64) Lima VM, from a clean checkout of this branch:

- `make rc-smoke` — **14/14 PASS** (lint, unit+coverage, integration, govulncheck, all 6 helm gates, and all four k3d e2es: `e2e`, `e2e-split`, `e2e-dbt`, `ui-smoke`).
- `make chaos-runtime` — both scenarios PASS (scheduler-crash → health-flip + resume + at-most-once; task-pod kill → agent-lost reap, no orphan).

No production code touched — only `test/e2e/*.sh` and `scripts/rc-smoke.sh`. macOS/Docker-Desktop behaviour is unchanged (the Linux branches are guarded by `uname`).