### PR TITLE
release: prepare v0.2.0-rc.1 (api/scheduler split + SSRF removal + at-most-once reaping)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.0-rc.1] - 2026-08-06
+
+> First release candidate of the **0.2.0** line. The control plane can now run as
+> **separate api and scheduler processes** (ADR 0049, `split.enabled`, off by
+> default), the inline **`http_api` task type is removed** — closing an SSRF
+> surface (**breaking** only for a hand-authored `http_api` DAG) — and **task
+> reaping is now at-most-once**: a reaped task's pod is actually torn down instead
+> of running user code to completion. Plus a pod-aware dispatch-lost reaper, a
+> configurable task namespace, shell-quoted bash templating, and an e2e/chaos
+> harness that runs on Linux/Lima, not only Docker Desktop.
+
 ### Changed
 
 - **k3d e2e image import is now verified + retried** (test/e2e reliability).
@@ -662,7 +673,8 @@ Per-rc detail is in the `0.1.0-rc.1` … `0.1.0-rc.4` sections below.
 - Browser end-to-end verification (rendering, write-flow paths, screenshots) is
   the remaining Phase 5 acceptance step; see `docs/ui-compatibility.md`.
 
-[Unreleased]: https://github.com/neochaotic/leoflow/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/neochaotic/leoflow/compare/v0.2.0-rc.1...HEAD
+[0.2.0-rc.1]: https://github.com/neochaotic/leoflow/compare/v0.1.2...v0.2.0-rc.1
 [0.1.2]: https://github.com/neochaotic/leoflow/compare/v0.1.2-rc.2...v0.1.2
 [0.1.2-rc.2]: https://github.com/neochaotic/leoflow/compare/v0.1.2-rc.1...v0.1.2-rc.2
 [0.1.2-rc.1]: https://github.com/neochaotic/leoflow/compare/v0.1.1...v0.1.2-rc.1

--- a/helm/leoflow/Chart.yaml
+++ b/helm/leoflow/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version is the chart version; appVersion tracks the leoflow-server image.
 # Both move in lockstep with the release tag (ADR 0028); decouple only if the
 # chart ever needs a cadence of its own for a template-only fix.
-version: 0.1.2
-appVersion: "0.1.2"
+version: 0.2.0-rc.1
+appVersion: "0.2.0-rc.1"
 home: https://github.com/neochaotic/leoflow
 sources:
   - https://github.com/neochaotic/leoflow

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -1,6 +1,6 @@
 # leoflow
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.2](https://img.shields.io/badge/AppVersion-0.1.2-informational?style=flat-square)
+![Version: 0.2.0-rc.1](https://img.shields.io/badge/Version-0.2.0--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0-rc.1](https://img.shields.io/badge/AppVersion-0.2.0--rc.1-informational?style=flat-square)
 
 Leoflow control plane — a GitOps-first, container-native workflow orchestrator (Airflow 3.2.x UI/API compatible).
 


### PR DESCRIPTION
Release-prep for **v0.2.0-rc.1** (ADR 0033 flow). Promotes the CHANGELOG `Unreleased` section to `## [0.2.0-rc.1]`, moves `helm/leoflow/Chart.yaml` `version` + `appVersion` in lockstep (ADR 0028), and regenerates the chart README.

**Why 0.2.0 (minor), not 0.1.3:** the `Unreleased` section carries a **Breaking** entry — the inline `http_api` task type is removed (SSRF H5, ADR 0047/0048). A breaking change is a minor bump in SemVer even in 0.x.

**Headline changes since v0.1.2:** ADR 0049 api/scheduler split (`split.enabled`, off by default); `http_api` removal; reaper at-most-once teardown (#474) + pod-aware dispatch-lost (#461); configurable task namespace (#480); shell-quoted bash templating (#489); Linux/Lima-portable e2e + chaos harness (#524, #528).

**Mechanical gate:** verified green on a Linux (arm64) Lima VM — `make rc-smoke` 14/14, `make chaos-runtime` both scenarios, and a live Pro-split helm smoke (api+scheduler up, `/readyz`, RBAC isolation: api SA cannot create pods, scheduler can).

On merge, `v0.2.0-rc.1` is tagged on main → goreleaser publishes a **prerelease draft** (ADR 0033).