### PR TITLE
release: promote v0.2.0-rc.1 to v0.2.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-07
+
+> Promotes `v0.2.0-rc.1` unchanged. The candidate was validated end-to-end on a
+> Linux VM (the full RC battery — gates + all k3d e2es — plus the runtime chaos
+> harness) and by a hands-on UI journey against the published artifact: install
+> via `install.sh`, create a DAG, trigger it from the UI, and read the rendered
+> task logs. See the `0.2.0-rc.1` section below for the full change list.
+
 ## [0.2.0-rc.1] - 2026-08-06
 
 > First release candidate of the **0.2.0** line. The control plane can now run as
@@ -673,7 +681,8 @@ Per-rc detail is in the `0.1.0-rc.1` … `0.1.0-rc.4` sections below.
 - Browser end-to-end verification (rendering, write-flow paths, screenshots) is
   the remaining Phase 5 acceptance step; see `docs/ui-compatibility.md`.
 
-[Unreleased]: https://github.com/neochaotic/leoflow/compare/v0.2.0-rc.1...HEAD
+[Unreleased]: https://github.com/neochaotic/leoflow/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/neochaotic/leoflow/compare/v0.2.0-rc.1...v0.2.0
 [0.2.0-rc.1]: https://github.com/neochaotic/leoflow/compare/v0.1.2...v0.2.0-rc.1
 [0.1.2]: https://github.com/neochaotic/leoflow/compare/v0.1.2-rc.2...v0.1.2
 [0.1.2-rc.2]: https://github.com/neochaotic/leoflow/compare/v0.1.2-rc.1...v0.1.2-rc.2

--- a/helm/leoflow/Chart.yaml
+++ b/helm/leoflow/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version is the chart version; appVersion tracks the leoflow-server image.
 # Both move in lockstep with the release tag (ADR 0028); decouple only if the
 # chart ever needs a cadence of its own for a template-only fix.
-version: 0.2.0-rc.1
-appVersion: "0.2.0-rc.1"
+version: 0.2.0
+appVersion: "0.2.0"
 home: https://github.com/neochaotic/leoflow
 sources:
   - https://github.com/neochaotic/leoflow

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -1,6 +1,6 @@
 # leoflow
 
-![Version: 0.2.0-rc.1](https://img.shields.io/badge/Version-0.2.0--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0-rc.1](https://img.shields.io/badge/AppVersion-0.2.0--rc.1-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
 
 Leoflow control plane — a GitOps-first, container-native workflow orchestrator (Airflow 3.2.x UI/API compatible).
 


### PR DESCRIPTION
Promotes **v0.2.0-rc.1 → v0.2.0** (ADR 0033). Adds the CHANGELOG `## [0.2.0]` section (promotes the RC unchanged, references the `0.2.0-rc.1` change list below), moves `helm/leoflow/Chart.yaml` `version` + `appVersion` to `0.2.0`, and regenerates the chart README.

**Validation of the RC before promotion:**
- Release pipeline (rc tag): install smoke across 7 distros + Lite cold-start + upgrade smoke — all green.
- Linux (arm64) Lima VM: `make rc-smoke` 14/14 + `make chaos-runtime` both scenarios + a live Pro-split helm smoke (RBAC isolation holds).
- Hands-on UI journey against the **published** artifact: `install.sh` (version stamping correct) → login → create a DAG → trigger from the UI → run succeeded → task logs render.

On merge, `v0.2.0` is tagged on main → goreleaser publishes the **full stable release** (non-prerelease); `install.sh` without a pinned version resolves to it.