### PR TITLE
docs: stable CHANGELOG section owns the full change list (not the rc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,22 +8,15 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.2.0] - 2026-08-07
 
-> Promotes `v0.2.0-rc.1` unchanged. The candidate was validated end-to-end on a
-> Linux VM (the full RC battery — gates + all k3d e2es — plus the runtime chaos
-> harness) and by a hands-on UI journey against the published artifact: install
-> via `install.sh`, create a DAG, trigger it from the UI, and read the rendered
-> task logs. See the `0.2.0-rc.1` section below for the full change list.
-
-## [0.2.0-rc.1] - 2026-08-06
-
-> First release candidate of the **0.2.0** line. The control plane can now run as
-> **separate api and scheduler processes** (ADR 0049, `split.enabled`, off by
-> default), the inline **`http_api` task type is removed** — closing an SSRF
-> surface (**breaking** only for a hand-authored `http_api` DAG) — and **task
-> reaping is now at-most-once**: a reaped task's pod is actually torn down instead
-> of running user code to completion. Plus a pod-aware dispatch-lost reaper, a
-> configurable task namespace, shell-quoted bash templating, and an e2e/chaos
-> harness that runs on Linux/Lima, not only Docker Desktop.
+> The **0.2.0** line. The control plane can now run as **separate api and
+> scheduler processes** (ADR 0049, `split.enabled`, off by default), the inline
+> **`http_api` task type is removed** — closing an SSRF surface (**breaking**
+> only for a hand-authored `http_api` DAG) — and **task reaping is now
+> at-most-once**: a reaped task's pod is actually torn down instead of running
+> user code to completion. Plus a pod-aware dispatch-lost reaper, a configurable
+> task namespace, shell-quoted bash templating, and an e2e/chaos harness that
+> runs on Linux/Lima, not only Docker Desktop. (Shipped through `v0.2.0-rc.1`,
+> validated on a Linux VM and a hands-on UI journey, then promoted unchanged.)
 
 ### Changed
 
@@ -682,8 +675,7 @@ Per-rc detail is in the `0.1.0-rc.1` … `0.1.0-rc.4` sections below.
   the remaining Phase 5 acceptance step; see `docs/ui-compatibility.md`.
 
 [Unreleased]: https://github.com/neochaotic/leoflow/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/neochaotic/leoflow/compare/v0.2.0-rc.1...v0.2.0
-[0.2.0-rc.1]: https://github.com/neochaotic/leoflow/compare/v0.1.2...v0.2.0-rc.1
+[0.2.0]: https://github.com/neochaotic/leoflow/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/neochaotic/leoflow/compare/v0.1.2-rc.2...v0.1.2
 [0.1.2-rc.2]: https://github.com/neochaotic/leoflow/compare/v0.1.2-rc.1...v0.1.2-rc.2
 [0.1.2-rc.1]: https://github.com/neochaotic/leoflow/compare/v0.1.1...v0.1.2-rc.1

--- a/docs/adr/0033-release-flow-rc-tags-and-e2e-gates.md
+++ b/docs/adr/0033-release-flow-rc-tags-and-e2e-gates.md
@@ -128,6 +128,19 @@ fast enough to run on every PR (target <60s), reality-anchored (no mocks at
 the boundary it gates), and named to match what it gates (the bug it would
 have caught — not how the test happens to be implemented).
 
+### 4. The CHANGELOG records stable versions; the stable section owns the changes.
+
+`CHANGELOG.md` (Keep a Changelog) documents shipped **stable** releases. When
+cutting an `-rc.N`, promote `[Unreleased]` → `[X.Y.Z-rc.N]` with the full change
+list (so validators have notes). When **promoting** an rc to stable, do NOT leave
+a thin `[X.Y.Z]` pointer above the rc section — instead **rename the
+`[X.Y.Z-rc.N]` section to `[X.Y.Z]`** (re-dated), consolidating any fixes that
+landed between rcs, so the stable version is a single, self-contained record. The
+release is what people install, so the release section — not the rc — carries the
+changes. RCs stay discoverable via their git tag and the goreleaser-generated
+GitHub pre-release notes (`changelog: use: github`), which is where per-rc
+granularity belongs; `CHANGELOG.md` need not retain rc sections.
+
 ## Consequences
 
 ### Positive


### PR DESCRIPTION
Follow-up to the v0.2.0 promote. The promote followed the old pattern (from the v0.1.2 promote): the full change list lived under `## [0.2.0-rc.1]` and `## [0.2.0]` was a thin "promotes the rc unchanged, see below" pointer. So the **release** — the artifact people install and the canonical entry in a Keep-a-Changelog — did not carry its own changes; readers had to scroll to the rc section.

**This PR:**
- Folds the rc content into a single, self-contained `## [0.2.0]` section (drops the separate rc section and the pointer); fixes the compare links.
- Codifies the convention in **ADR 0033 (§4)**: on promotion, **rename** the `[X.Y.Z-rc.N]` section to `[X.Y.Z]` (consolidating any inter-rc fixes) rather than adding a pointer. RC granularity stays discoverable via the git tag + the goreleaser-generated GitHub pre-release notes.

Docs-only. The **published v0.2.0 release notes** (goreleaser, generated from commits) and the **immutable `v0.2.0` tag** are unaffected — this only tidies `CHANGELOG.md` on main for future readers, and sets the rule so future promotes get it right.