### PR TITLE
fix(#527): pod-lost reaper — fail running TIs whose pod vanished before any other reaper catches it

### DIFF
--- a/internal/scheduler/pod_lost_reap.go
+++ b/internal/scheduler/pod_lost_reap.go
@@ -1,0 +1,142 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"runtime/debug"
+	"time"
+)
+
+// PodLostCandidate is one task instance in `running` whose backing pod may have
+// vanished — deleted, evicted, OOM-killed, or lost with its node — before any
+// other reaper could catch it. RunningSince is when the TI entered `running`;
+// the reaper only checks pod liveness once the TI has been running past a grace
+// period, so a just-dispatched TI whose pod is still materializing is never
+// reaped on a transient "no pod yet".
+type PodLostCandidate struct {
+	TaskInstanceID string
+	DagRunID       string
+	DagID          string
+	TaskID         string
+	// TryNumber pins the best-effort pod delete to exactly this attempt, so a
+	// retry's newer pod is never touched (same invariant as the #474 teardown).
+	TryNumber    int
+	RunningSince time.Time
+}
+
+// IsPodLostCandidate reports whether a running TI has been running long enough
+// to warrant a pod-liveness check. A zero RunningSince is treated as alive (too
+// poorly observed to reap — the "do no harm" rule of ADR 0031), and a future
+// RunningSince (clock skew) is treated as alive. This gate is purely about
+// elapsed time; the actual lost-vs-alive decision is the pod-liveness check.
+func IsPodLostCandidate(c PodLostCandidate, grace time.Duration, now time.Time) bool {
+	if c.RunningSince.IsZero() {
+		return false
+	}
+	return now.Sub(c.RunningSince) >= grace
+}
+
+// PodLostReapStore is the slice of scheduler.Store the pod-lost reaper needs.
+// The full scheduler.Store embeds this interface so production wires through one
+// type; unit tests fake just this surface.
+type PodLostReapStore interface {
+	// ListRunningTasks returns every `running` TI with the timestamp it entered
+	// running, so the reaper applies the grace period in Go and the SQL stays
+	// simple.
+	ListRunningTasks(ctx context.Context) ([]PodLostCandidate, error)
+	// MarkTaskPodLost transitions one TI to `failed` with
+	// error_message='pod_lost'. The WHERE state='running' guard makes this
+	// idempotent: a second call on a now-non-running TI is a no-op.
+	MarkTaskPodLost(ctx context.Context, taskInstanceID string) error
+}
+
+// podLostReaper fails `running` TIs whose pod has vanished — the gap between the
+// agent-lost reaper (which skips a TI that never heartbeated, the ADR 0031
+// zero-guard) and the reconciler (which only sees pods that still exist), so a
+// pod killed before its first heartbeat used to sit `running` until the 5-minute
+// orphan reaper failed the whole run (#527). Invoked once per scheduler tick,
+// leader-only. Mirrors the other reapers' resilience: panic-safe, per-candidate
+// isolated, metered.
+//
+// It is Kubernetes-ONLY. With no PodManager (Lite/subprocess) there is no pod to
+// lose and a subprocess task legitimately has none, so the reaper is a no-op —
+// it must never reap live subprocess work on a "no pod" signal.
+type podLostReaper struct {
+	store    PodLostReapStore
+	logger   *slog.Logger
+	grace    time.Duration
+	recorder Recorder
+	// pods is required for this reaper to do anything; nil (Lite) makes run a
+	// no-op. See the type doc.
+	pods PodManager
+}
+
+func newPodLostReaper(store PodLostReapStore, logger *slog.Logger, grace time.Duration, rec Recorder) *podLostReaper {
+	return &podLostReaper{store: store, logger: logger, grace: grace, recorder: rec}
+}
+
+// run lists every running TI, checks pod liveness for the ones past the grace
+// period, and fails those with no live pod as pod_lost. Per-TI failures are
+// isolated; a panic anywhere is recovered so the scheduler tick stays alive.
+func (r *podLostReaper) run(ctx context.Context) error {
+	defer func() {
+		if rec := recover(); rec != nil {
+			r.logger.Error("pod-lost reaper panic recovered", "panic", rec, "stack", string(debug.Stack()))
+			r.record("pod_lost_panic")
+		}
+	}()
+	// K8s-only: without pods there is nothing to lose, and reaping a Lite
+	// subprocess task on "no pod" would kill live work. Skip entirely.
+	if r.pods == nil {
+		return nil
+	}
+	candidates, err := r.store.ListRunningTasks(ctx)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	for _, c := range candidates {
+		if !IsPodLostCandidate(c, r.grace, now) {
+			continue
+		}
+		// Consult the pod before failing:
+		//   * query failed     -> liveness unknown; DEFER ("do no harm").
+		//   * pod Pending/Running -> a pod exists; not lost. Silence, if any, is
+		//                            the agent-lost reaper's job.
+		//   * no live pod       -> the pod is genuinely gone; fail as pod_lost.
+		active, perr := r.pods.TaskPodActive(ctx, c.DagRunID, c.TaskID)
+		if perr != nil {
+			r.logger.Warn("pod-lost: pod liveness unknown; deferring",
+				"ti", c.TaskInstanceID, "run", c.DagRunID, "task", c.TaskID, "error", perr)
+			r.record("pod_lost_pod_query_error")
+			continue
+		}
+		if active {
+			continue
+		}
+		if ferr := r.store.MarkTaskPodLost(ctx, c.TaskInstanceID); ferr != nil {
+			r.logger.Error("marking task pod-lost",
+				"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID, "error", ferr)
+			r.record("pod_lost_error")
+			continue
+		}
+		r.logger.Warn("running task has no live pod past grace; failing as pod_lost",
+			"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID, "running_since", c.RunningSince)
+		r.record("pod_lost")
+		// Best-effort teardown pinned to (run, task, try). TaskPodActive said no
+		// live pod, so this only sweeps a lingering terminal pod at most; a
+		// retry's newer pod has a different try-number label and is never touched.
+		if derr := r.pods.DeleteTaskPod(ctx, c.DagRunID, c.TaskID, c.TryNumber); derr != nil {
+			r.logger.Error("deleting pod-lost task pod",
+				"ti", c.TaskInstanceID, "run", c.DagRunID, "task", c.TaskID, "try", c.TryNumber, "error", derr)
+			r.record("pod_lost_pod_delete_error")
+		}
+	}
+	return nil
+}
+
+func (r *podLostReaper) record(decision string) {
+	if r.recorder != nil {
+		r.recorder.RecordSchedulerDecision(decision)
+	}
+}

--- a/internal/scheduler/pod_lost_reap_test.go
+++ b/internal/scheduler/pod_lost_reap_test.go
@@ -1,0 +1,143 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakePodLostStore serves running-TI candidates and records pod_lost marks.
+type fakePodLostStore struct {
+	candidates []PodLostCandidate
+	listErr    error
+	marked     []string
+	markErr    error
+}
+
+func (f *fakePodLostStore) ListRunningTasks(context.Context) ([]PodLostCandidate, error) {
+	return f.candidates, f.listErr
+}
+
+func (f *fakePodLostStore) MarkTaskPodLost(_ context.Context, id string) error {
+	if f.markErr != nil {
+		return f.markErr
+	}
+	f.marked = append(f.marked, id)
+	return nil
+}
+
+func TestIsPodLostCandidate(t *testing.T) {
+	const grace = 60 * time.Second
+	now := time.Now().UTC()
+	cases := []struct {
+		name  string
+		since time.Time
+		want  bool
+	}{
+		{"zero running-since is alive (do no harm)", time.Time{}, false},
+		{"within grace is not yet a candidate", now.Add(-30 * time.Second), false},
+		{"exactly at grace is a candidate", now.Add(-60 * time.Second), true},
+		{"well past grace is a candidate", now.Add(-5 * time.Minute), true},
+		{"future running-since (clock skew) is alive", now.Add(1 * time.Second), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsPodLostCandidate(PodLostCandidate{RunningSince: tc.since}, grace, now); got != tc.want {
+				t.Errorf("IsPodLostCandidate = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPodLostReaper(t *testing.T) {
+	const grace = 60 * time.Second
+	now := time.Now().UTC()
+	past := now.Add(-2 * time.Minute) // comfortably past the grace period
+
+	// newReaper wires a K8s reaper (pods set); the Lite case sets pods=nil.
+	newReaper := func(store PodLostReapStore, pods PodManager) *podLostReaper {
+		r := newPodLostReaper(store, reapTestLogger(), grace, nil)
+		r.pods = pods
+		return r
+	}
+
+	t.Run("running TI past grace with no live pod is failed as pod_lost + torn down", func(t *testing.T) {
+		store := &fakePodLostStore{candidates: []PodLostCandidate{
+			{TaskInstanceID: "lost", DagRunID: "run-a", TaskID: "work", TryNumber: 1, RunningSince: past},
+		}}
+		pods := &fakePodManager{active: map[string]bool{}} // no live pod for run-a/work
+		if err := newReaper(store, pods).run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if len(store.marked) != 1 || store.marked[0] != "lost" {
+			t.Fatalf("expected TI 'lost' marked pod_lost, got %v", store.marked)
+		}
+		if len(pods.deletedTasks) != 1 || pods.deletedTasks[0] != (deletedTask{"run-a", "work", 1}) {
+			t.Fatalf("expected best-effort teardown of (run-a,work,try 1), got %v", pods.deletedTasks)
+		}
+	})
+
+	t.Run("a live pod defers — never reaped", func(t *testing.T) {
+		store := &fakePodLostStore{candidates: []PodLostCandidate{
+			{TaskInstanceID: "live", DagRunID: "run-a", TaskID: "work", TryNumber: 1, RunningSince: past},
+		}}
+		pods := &fakePodManager{active: map[string]bool{"run-a/work": true}}
+		if err := newReaper(store, pods).run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if len(store.marked) != 0 {
+			t.Fatalf("a running TI with a live pod must not be reaped, got %v", store.marked)
+		}
+	})
+
+	t.Run("within the grace period is not reaped (do no harm)", func(t *testing.T) {
+		store := &fakePodLostStore{candidates: []PodLostCandidate{
+			{TaskInstanceID: "fresh", DagRunID: "run-a", TaskID: "work", TryNumber: 1, RunningSince: now.Add(-10 * time.Second)},
+		}}
+		pods := &fakePodManager{active: map[string]bool{}}
+		if err := newReaper(store, pods).run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if len(store.marked) != 0 {
+			t.Fatalf("a freshly-running TI must not be reaped, got %v", store.marked)
+		}
+	})
+
+	t.Run("pod liveness query error defers (do no harm)", func(t *testing.T) {
+		store := &fakePodLostStore{candidates: []PodLostCandidate{
+			{TaskInstanceID: "unknown", DagRunID: "run-a", TaskID: "work", TryNumber: 1, RunningSince: past},
+		}}
+		pods := &fakePodManager{activeErr: errors.New("apiserver unavailable")}
+		if err := newReaper(store, pods).run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if len(store.marked) != 0 {
+			t.Fatalf("liveness-unknown must defer, got %v", store.marked)
+		}
+	})
+
+	t.Run("Lite (nil PodManager) is a no-op — never reaps a subprocess task", func(t *testing.T) {
+		store := &fakePodLostStore{candidates: []PodLostCandidate{
+			{TaskInstanceID: "subproc", DagRunID: "run-a", TaskID: "work", TryNumber: 1, RunningSince: past},
+		}}
+		r := newPodLostReaper(store, reapTestLogger(), grace, nil) // r.pods stays nil
+		if err := r.run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if len(store.marked) != 0 {
+			t.Fatalf("Lite must not reap on 'no pod' (there are no pods), got %v", store.marked)
+		}
+	})
+
+	t.Run("a list error surfaces and reaps nothing", func(t *testing.T) {
+		store := &fakePodLostStore{listErr: errors.New("db down")}
+		pods := &fakePodManager{active: map[string]bool{}}
+		if err := newReaper(store, pods).run(context.Background()); err == nil {
+			t.Fatal("expected the list error to surface")
+		}
+		if len(store.marked) != 0 {
+			t.Fatalf("nothing should be reaped on a list error, got %v", store.marked)
+		}
+	})
+}

--- a/internal/scheduler/resilience_test.go
+++ b/internal/scheduler/resilience_test.go
@@ -114,6 +114,10 @@ func (f *flakyStore) ListStaleQueuedCandidates(context.Context) ([]StaleQueuedCa
 	return nil, nil
 }
 func (f *flakyStore) MarkTaskDispatchLost(context.Context, string) error { return nil }
+func (f *flakyStore) ListRunningTasks(context.Context) ([]PodLostCandidate, error) {
+	return nil, nil
+}
+func (f *flakyStore) MarkTaskPodLost(context.Context, string) error { return nil }
 
 func (f *flakyStore) snapshotMaterialized() []string {
 	f.mu.Lock()

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -159,6 +159,11 @@ type Store interface {
 	// would otherwise keep stuck queued TIs out of the candidate set forever
 	// (the orphan reaper's "no active TI" safety guard).
 	DispatchLostReapStore
+	// PodLostReapStore methods drive the pod-lost reaper (#527): they list
+	// `running` task instances and fail as `pod_lost` any whose backing pod has
+	// vanished past a grace period, closing the window where a pod killed before
+	// its first heartbeat sat `running` until the 5-minute orphan reaper.
+	PodLostReapStore
 }
 
 // Recorder records scheduler metrics. observability.Metrics implements it.
@@ -222,6 +227,15 @@ const defaultAgentLostThreshold = 90 * time.Second
 // mid-tick scheduler crash is reaped before the operator notices (#202).
 const defaultDispatchLostThreshold = 3 * time.Minute
 
+// defaultPodLostGrace is how long a TI may be `running` before the pod-lost
+// reaper checks whether its pod still exists (#527). It only matters as a floor
+// against a transient "pod not listed yet" blip right after the running
+// transition — the actual reap needs TaskPodActive to report NO live pod, so a
+// slow-starting (Pending) pod is deferred regardless. 60 s catches a pod that
+// vanished in its first seconds ~5x faster than the 5-minute orphan reaper,
+// while staying well clear of any real pod lifecycle timing. Kubernetes-only.
+const defaultPodLostGrace = 60 * time.Second
+
 // Scheduler advances dag runs by applying the planning rules each tick.
 type Scheduler struct {
 	store       Store
@@ -239,6 +253,7 @@ type Scheduler struct {
 	orphanThreshold       time.Duration
 	agentLostThreshold    time.Duration
 	dispatchLostThreshold time.Duration
+	podLostGrace          time.Duration
 	// podManager lets the reapers tear down a reaped task's pod and gate the
 	// dispatch-lost decision on pod liveness (#474, #461). Nil in Lite; the
 	// reapers guard the nil and fall back to DB-only behavior.
@@ -262,6 +277,7 @@ func NewScheduler(store Store, logger *slog.Logger, interval time.Duration) *Sch
 		orphanThreshold:       defaultOrphanThreshold,
 		agentLostThreshold:    defaultAgentLostThreshold,
 		dispatchLostThreshold: defaultDispatchLostThreshold,
+		podLostGrace:          defaultPodLostGrace,
 		warnedSchedules:       map[string]string{},
 		alertSem:              make(chan struct{}, defaultAlertConcurrency),
 	}
@@ -281,6 +297,11 @@ func (s *Scheduler) SetAgentLostThreshold(d time.Duration) { s.agentLostThreshol
 // uses to declare a queued task's dispatch lost (optional; mainly for tests).
 // The default is defaultDispatchLostThreshold.
 func (s *Scheduler) SetDispatchLostThreshold(d time.Duration) { s.dispatchLostThreshold = d }
+
+// SetPodLostGrace overrides how long a TI may be `running` before the pod-lost
+// reaper checks pod liveness (optional; mainly for tests). The default is
+// defaultPodLostGrace.
+func (s *Scheduler) SetPodLostGrace(d time.Duration) { s.podLostGrace = d }
 
 // SetPodManager wires the pod-teardown / liveness capability the reapers use to
 // stop a reaped task's pod and to defer the dispatch-lost decision when a
@@ -516,6 +537,16 @@ func (s *Scheduler) reapOrphansIfLeader(ctx context.Context) {
 	if err := dispatchReaper.run(ctx); err != nil {
 		logSchedulerError(s.logger, "dispatch-lost reaper", err, s.steppingDown.Load())
 		s.record("dispatch_lost_list_error")
+	}
+
+	// Pod-lost reaper (#527): fails a running TI whose pod vanished before any
+	// other reaper could catch it. Kubernetes-only — nil podManager (Lite) makes
+	// it a no-op, so a live subprocess task is never reaped.
+	podLostReaper := newPodLostReaper(s.store, s.logger, s.podLostGrace, s.recorder)
+	podLostReaper.pods = s.podManager
+	if err := podLostReaper.run(ctx); err != nil {
+		logSchedulerError(s.logger, "pod-lost reaper", err, s.steppingDown.Load())
+		s.record("pod_lost_list_error")
 	}
 }
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -185,6 +185,8 @@ func (f *fakeStore) MarkTaskDispatchLost(_ context.Context, tiID string) error {
 	f.dispatchLostMarked = append(f.dispatchLostMarked, tiID)
 	return nil
 }
+func (f *fakeStore) ListRunningTasks(context.Context) ([]PodLostCandidate, error) { return nil, nil }
+func (f *fakeStore) MarkTaskPodLost(context.Context, string) error                { return nil }
 
 func newScheduler(store Store) *Scheduler {
 	s := NewScheduler(store, slog.New(slog.NewTextHandler(io.Discard, nil)), time.Millisecond)

--- a/internal/storage/pod_lost_reap_integration_test.go
+++ b/internal/storage/pod_lost_reap_integration_test.go
@@ -1,0 +1,112 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/scheduler"
+)
+
+// TestListRunningTasksIntegration is the query contract for the pod-lost reaper
+// (#527): a TI transitioned to `running` appears in ListRunningTasks with a
+// non-zero RunningSince (its started_at stamp), and a TI in any other state
+// does not — the reaper only considers running TIs.
+func TestListRunningTasksIntegration(t *testing.T) {
+	repo, sched, _, ctx := openExec(t)
+	dagID := fmt.Sprintf("podlost_list_%d", time.Now().UnixNano())
+	tasks := []domain.TaskSpec{
+		{TaskID: "run_me", Type: domain.TaskTypePython},
+		{TaskID: "still_scheduled", Type: domain.TaskTypePython},
+	}
+	registerSpec(t, repo, ctx, dagID, tasks)
+	if _, err := repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+		RunID: "r1", State: domain.DagRunStateRunning, RunType: "manual", LogicalDate: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	runUUID := resolveRunUUID(t, sched, ctx, dagID)
+	if err := sched.MaterializeTasks(ctx, runUUID, tasks); err != nil {
+		t.Fatalf("MaterializeTasks: %v", err)
+	}
+	// Only run_me goes to running; still_scheduled stays in its materialized
+	// (non-running) state and must be absent from the candidate set.
+	if err := sched.ApplyTransition(ctx, runUUID, "run_me", domain.TaskStateRunning); err != nil {
+		t.Fatal(err)
+	}
+
+	cands, err := sched.ListRunningTasks(ctx)
+	if err != nil {
+		t.Fatalf("ListRunningTasks: %v", err)
+	}
+	c := findPodLostCandidate(cands, runUUID, "run_me")
+	if c == nil {
+		t.Fatalf("a running TI must appear in ListRunningTasks; got %+v", cands)
+	}
+	if c.RunningSince.IsZero() {
+		t.Errorf("RunningSince must be the started_at stamp, got zero")
+	}
+	if c.DagID != dagID || c.TryNumber != 1 {
+		t.Errorf("candidate identity = %+v, want dag=%s try=1", c, dagID)
+	}
+	if findPodLostCandidate(cands, runUUID, "still_scheduled") != nil {
+		t.Errorf("a non-running TI must NOT appear in ListRunningTasks")
+	}
+}
+
+// TestMarkTaskPodLostIntegration: marking a running TI pod_lost transitions it
+// to `failed` and is idempotent — the WHERE state='running' guard no-ops a
+// second call, defense in depth against a late terminal report overwriting.
+func TestMarkTaskPodLostIntegration(t *testing.T) {
+	repo, sched, _, ctx := openExec(t)
+	dagID := fmt.Sprintf("podlost_mark_%d", time.Now().UnixNano())
+	tasks := []domain.TaskSpec{{TaskID: "t", Type: domain.TaskTypePython}}
+	registerSpec(t, repo, ctx, dagID, tasks)
+	if _, err := repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+		RunID: "r1", State: domain.DagRunStateRunning, RunType: "manual", LogicalDate: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	runUUID := resolveRunUUID(t, sched, ctx, dagID)
+	if err := sched.MaterializeTasks(ctx, runUUID, tasks); err != nil {
+		t.Fatalf("MaterializeTasks: %v", err)
+	}
+	if err := sched.ApplyTransition(ctx, runUUID, "t", domain.TaskStateRunning); err != nil {
+		t.Fatal(err)
+	}
+	cands, _ := sched.ListRunningTasks(ctx)
+	c := findPodLostCandidate(cands, runUUID, "t")
+	if c == nil {
+		t.Fatalf("expected a running candidate")
+	}
+
+	if err := sched.MarkTaskPodLost(ctx, c.TaskInstanceID); err != nil {
+		t.Fatalf("MarkTaskPodLost: %v", err)
+	}
+	tis, _ := repo.TaskInstancesForRuns(ctx, "default", dagID, []string{"r1"})
+	if len(tis) != 1 || tis[0].State != domain.TaskStateFailed {
+		t.Errorf("after MarkTaskPodLost, TI state = %+v, want failed", tis)
+	}
+	// A failed TI is no longer in the running candidate set.
+	cands, _ = sched.ListRunningTasks(ctx)
+	if findPodLostCandidate(cands, runUUID, "t") != nil {
+		t.Errorf("a failed TI must no longer appear in ListRunningTasks")
+	}
+	// Idempotent: the WHERE state='running' guard no-ops the second call.
+	if err := sched.MarkTaskPodLost(ctx, c.TaskInstanceID); err != nil {
+		t.Errorf("second MarkTaskPodLost must be a no-op; got %v", err)
+	}
+}
+
+// findPodLostCandidate returns the candidate matching (run uuid, task id), or nil.
+func findPodLostCandidate(cands []scheduler.PodLostCandidate, runUUID, taskID string) *scheduler.PodLostCandidate {
+	for i := range cands {
+		if cands[i].DagRunID == runUUID && cands[i].TaskID == taskID {
+			return &cands[i]
+		}
+	}
+	return nil
+}

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -116,6 +116,15 @@ type Querier interface {
 	// tick's reap work even after a multi-hour outage; the rest are picked up
 	// on the next tick (the reaper is a backstop, not a sprint).
 	ListOrphanCandidates(ctx context.Context) ([]ListOrphanCandidatesRow, error)
+	// Lists every TI currently in `running` alongside the timestamp it entered
+	// running, for the pod-lost reaper (#527). A running TI whose backing pod
+	// vanished before its first heartbeat is invisible to the agent-lost reaper
+	// (its null-heartbeat zero-guard) and to the reconciler (which only sees pods
+	// that still exist), so it would sit `running` until the 5-minute orphan reaper.
+	// The reaper applies the grace period + a pod-liveness check per candidate in
+	// Go, so the SQL stays simple. The LIMIT bounds a single tick's reap work even
+	// after a large outage; the rest are picked up next tick.
+	ListRunningTasks(ctx context.Context) ([]ListRunningTasksRow, error)
 	// Returns each cron-scheduled DAG with the bits the scheduler needs to decide
 	// both "is there a slot due?" (schedule + last_logical), "how many slots
 	// should I backfill on this tick?" (catchup + start_date, see #129), and
@@ -176,6 +185,11 @@ type Querier interface {
 	// since transitioned (real dispatch landed, or already failed) is a no-op,
 	// never overwriting a more meaningful state.
 	MarkTaskDispatchLost(ctx context.Context, id pgtype.UUID) error
+	// Fails a running TI whose pod has vanished (deleted/evicted/node lost). The
+	// WHERE state='running' guard makes it idempotent and prevents overwriting a
+	// late terminal report that landed between our list and our write (a live
+	// report wins over the reaper). Idempotent on a second call.
+	MarkTaskPodLost(ctx context.Context, id pgtype.UUID) (int64, error)
 	// A synchronous dispatch attempt failed (ADR 0031 Amendment A). Increment the
 	// consecutive-failure counter and back off the next attempt to $3, so the planner
 	// (which gates scheduled->queued on next_dispatch_at) does not re-attempt every

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -592,6 +592,39 @@ SET state = 'failed',
     error_message = 'agent_lost: no heartbeat within the threshold — see #128'
 WHERE id = $1 AND state = 'running';
 
+-- name: ListRunningTasks :many
+-- Lists every TI currently in `running` alongside the timestamp it entered
+-- running, for the pod-lost reaper (#527). A running TI whose backing pod
+-- vanished before its first heartbeat is invisible to the agent-lost reaper
+-- (its null-heartbeat zero-guard) and to the reconciler (which only sees pods
+-- that still exist), so it would sit `running` until the 5-minute orphan reaper.
+-- The reaper applies the grace period + a pod-liveness check per candidate in
+-- Go, so the SQL stays simple. The LIMIT bounds a single tick's reap work even
+-- after a large outage; the rest are picked up next tick.
+SELECT ti.id AS task_instance_id,
+       ti.dag_run_id AS dag_run_id,
+       d.dag_id AS dag_id_text,
+       ti.task_id AS task_id,
+       ti.try_number AS try_number,
+       ti.started_at AS started_at
+FROM task_instances ti
+JOIN dag_runs dr ON dr.id = ti.dag_run_id
+JOIN dags d ON d.id = dr.dag_id
+WHERE ti.state = 'running'
+ORDER BY ti.started_at NULLS LAST
+LIMIT 100;
+
+-- name: MarkTaskPodLost :execrows
+-- Fails a running TI whose pod has vanished (deleted/evicted/node lost). The
+-- WHERE state='running' guard makes it idempotent and prevents overwriting a
+-- late terminal report that landed between our list and our write (a live
+-- report wins over the reaper). Idempotent on a second call.
+UPDATE task_instances
+SET state = 'failed',
+    ended_at = now(),
+    error_message = 'pod_lost: the task pod vanished with no live pod past the grace period — see #527'
+WHERE id = $1 AND state = 'running';
+
 -- name: MarkRunOrphanedRun :execrows
 -- Fails an orphaned dag run. The `state = 'running'` guard makes the reap a
 -- safety net, never a takeover: a competing finalizer (the normal scheduler

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -755,6 +755,65 @@ func (q *Queries) ListOrphanCandidates(ctx context.Context) ([]ListOrphanCandida
 	return items, nil
 }
 
+const listRunningTasks = `-- name: ListRunningTasks :many
+SELECT ti.id AS task_instance_id,
+       ti.dag_run_id AS dag_run_id,
+       d.dag_id AS dag_id_text,
+       ti.task_id AS task_id,
+       ti.try_number AS try_number,
+       ti.started_at AS started_at
+FROM task_instances ti
+JOIN dag_runs dr ON dr.id = ti.dag_run_id
+JOIN dags d ON d.id = dr.dag_id
+WHERE ti.state = 'running'
+ORDER BY ti.started_at NULLS LAST
+LIMIT 100
+`
+
+type ListRunningTasksRow struct {
+	TaskInstanceID pgtype.UUID        `json:"task_instance_id"`
+	DagRunID       pgtype.UUID        `json:"dag_run_id"`
+	DagIDText      string             `json:"dag_id_text"`
+	TaskID         string             `json:"task_id"`
+	TryNumber      int32              `json:"try_number"`
+	StartedAt      pgtype.Timestamptz `json:"started_at"`
+}
+
+// Lists every TI currently in `running` alongside the timestamp it entered
+// running, for the pod-lost reaper (#527). A running TI whose backing pod
+// vanished before its first heartbeat is invisible to the agent-lost reaper
+// (its null-heartbeat zero-guard) and to the reconciler (which only sees pods
+// that still exist), so it would sit `running` until the 5-minute orphan reaper.
+// The reaper applies the grace period + a pod-liveness check per candidate in
+// Go, so the SQL stays simple. The LIMIT bounds a single tick's reap work even
+// after a large outage; the rest are picked up next tick.
+func (q *Queries) ListRunningTasks(ctx context.Context) ([]ListRunningTasksRow, error) {
+	rows, err := q.db.Query(ctx, listRunningTasks)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListRunningTasksRow{}
+	for rows.Next() {
+		var i ListRunningTasksRow
+		if err := rows.Scan(
+			&i.TaskInstanceID,
+			&i.DagRunID,
+			&i.DagIDText,
+			&i.TaskID,
+			&i.TryNumber,
+			&i.StartedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listScheduledDags = `-- name: ListScheduledDags :many
 SELECT d.dag_id, d.schedule, d.catchup, d.start_date, d.max_active_runs,
   (SELECT max(dr.logical_date) FROM dag_runs dr WHERE dr.dag_id = d.id) AS last_logical
@@ -1154,6 +1213,26 @@ WHERE id = $1 AND state = 'queued'
 func (q *Queries) MarkTaskDispatchLost(ctx context.Context, id pgtype.UUID) error {
 	_, err := q.db.Exec(ctx, markTaskDispatchLost, id)
 	return err
+}
+
+const markTaskPodLost = `-- name: MarkTaskPodLost :execrows
+UPDATE task_instances
+SET state = 'failed',
+    ended_at = now(),
+    error_message = 'pod_lost: the task pod vanished with no live pod past the grace period — see #527'
+WHERE id = $1 AND state = 'running'
+`
+
+// Fails a running TI whose pod has vanished (deleted/evicted/node lost). The
+// WHERE state='running' guard makes it idempotent and prevents overwriting a
+// late terminal report that landed between our list and our write (a live
+// report wins over the reaper). Idempotent on a second call.
+func (q *Queries) MarkTaskPodLost(ctx context.Context, id pgtype.UUID) (int64, error) {
+	result, err := q.db.Exec(ctx, markTaskPodLost, id)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const recordDispatchFailure = `-- name: RecordDispatchFailure :exec

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -525,6 +525,46 @@ func (s *SchedulerStore) MarkTaskDispatchLost(ctx context.Context, taskInstanceI
 	return nil
 }
 
+// ListRunningTasks returns every `running` TI with the timestamp it entered
+// running, for the pod-lost reaper (#527). The reaper applies the grace period
+// and the pod-liveness check per row, so the SQL stays simple.
+func (s *SchedulerStore) ListRunningTasks(ctx context.Context) ([]scheduler.PodLostCandidate, error) {
+	rows, err := s.q.ListRunningTasks(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing running tasks: %w", err)
+	}
+	out := make([]scheduler.PodLostCandidate, 0, len(rows))
+	for _, r := range rows {
+		var since time.Time
+		if r.StartedAt.Valid {
+			since = r.StartedAt.Time.UTC()
+		}
+		out = append(out, scheduler.PodLostCandidate{
+			TaskInstanceID: uuidToString(r.TaskInstanceID),
+			DagRunID:       uuidToString(r.DagRunID),
+			DagID:          r.DagIDText,
+			TaskID:         r.TaskID,
+			TryNumber:      int(r.TryNumber),
+			RunningSince:   since,
+		})
+	}
+	return out, nil
+}
+
+// MarkTaskPodLost transitions one TI to `failed` with the pod_lost reason. The
+// WHERE state='running' guard makes it idempotent: a TI that has since moved on
+// (a late terminal report landed) is left alone.
+func (s *SchedulerStore) MarkTaskPodLost(ctx context.Context, taskInstanceID string) error {
+	tid, err := parseUUID(taskInstanceID)
+	if err != nil {
+		return err
+	}
+	if _, err := s.q.MarkTaskPodLost(ctx, tid); err != nil {
+		return fmt.Errorf("marking task pod-lost: %w", err)
+	}
+	return nil
+}
+
 // ListActiveStagingVolumes returns active staging volumes joined with their DAG
 // run's state (empty when the run row is gone), for the GC (ADR 0022).
 func (s *SchedulerStore) ListActiveStagingVolumes(ctx context.Context) ([]domain.StagingVolumeState, error) {


### PR DESCRIPTION
Closes #527.

**The gap** (found by the chaos harness, #524 Scenario B): a `running` task whose pod is deleted/evicted/OOM-killed/node-lost in its first ~15s falls through every backstop and sits `running` for up to **5 minutes**, then fails the whole **run** (orphan reaper) instead of the **task**:
- **agent-lost** skips it — its `last_heartbeat_at` is NULL (the ADR-0031 zero-guard; `running` doesn't stamp a heartbeat, the agent's first ping is at +15s);
- **the reconciler** only lists pods that still exist, so a deleted pod is invisible;
- **dispatch-lost** covers `queued`, not `running`; **orphan** is run-level + 5 min.

**The fix** — a new **pod-lost reaper**: for each `running` TI past a grace period, if `TaskPodActive` reports **no live pod**, fail it as `pod_lost` (+ best-effort teardown pinned to `(run, task, try)`). Two load-bearing safety properties:
- **Kubernetes-only** — a nil `PodManager` (Lite/subprocess) makes it a **no-op**, so a live subprocess task with no pod is never reaped;
- **do-no-harm** — zero `RunningSince` = alive; a pod-liveness query error or a live/Pending pod **defers**; the grace (60s) clears a transient "pod not listed yet" blip. `at-most-once` is unaffected (this only fails a task whose pod is already gone; the `state='running'` mark guard is idempotent).

Catches a vanished pod in ~60s vs the previous ~5 min, and fails the **task** (normal retry) instead of the run.

**Verified locally** (all green): `go build ./...`, `go vet`, scheduler unit tests (7-case reaper: reap + all do-no-harm guards + the Lite no-op), the real-Postgres integration test (`ListRunningTasks` running-only + `MarkTaskPodLost` idempotency), and `golangci-lint` (0 issues). Mirrors the dispatch-lost reaper's shape (panic-safe, per-candidate isolated, metered: `pod_lost`, `pod_lost_deferred`-style decisions).