### PR TITLE
fix(scheduler): reapers must not treat a 0-row mark as a reap (audit #14)

### DIFF
--- a/internal/scheduler/heartbeat_reap.go
+++ b/internal/scheduler/heartbeat_reap.go
@@ -50,8 +50,10 @@ type HeartbeatReapStore interface {
 	ListAgentLostCandidates(ctx context.Context) ([]AgentLostCandidate, error)
 	// MarkTaskAgentLost transitions one TI to `failed` with
 	// error_message='agent_lost'. The WHERE state='running' guard makes this
-	// idempotent: a second call on a now-failed TI is a no-op.
-	MarkTaskAgentLost(ctx context.Context, taskInstanceID string) error
+	// idempotent. It returns whether a row was actually updated: false means a
+	// late terminal report transitioned the TI between the list and this write,
+	// so the caller must NOT treat it as reaped (no false log, no pod delete).
+	MarkTaskAgentLost(ctx context.Context, taskInstanceID string) (bool, error)
 }
 
 // agentLostReaper is the scheduler-internal worker that fails TIs whose agent
@@ -92,10 +94,18 @@ func (r *agentLostReaper) run(ctx context.Context) error {
 		if !IsAgentLost(c, r.threshold, now) {
 			continue
 		}
-		if ferr := r.store.MarkTaskAgentLost(ctx, c.TaskInstanceID); ferr != nil {
+		applied, ferr := r.store.MarkTaskAgentLost(ctx, c.TaskInstanceID)
+		if ferr != nil {
 			r.logger.Error("marking task agent-lost",
 				"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID, "error", ferr)
 			r.record("agent_lost_error")
+			continue
+		}
+		if !applied {
+			// A late terminal report transitioned the TI between our list and our
+			// write (WHERE state='running' matched 0 rows). It is no longer ours
+			// to reap — do not log a false reap or delete a pod for a settled TI.
+			r.record("agent_lost_noop")
 			continue
 		}
 		r.logger.Warn("task agent silent past threshold; failing as agent_lost",

--- a/internal/scheduler/heartbeat_reap_test.go
+++ b/internal/scheduler/heartbeat_reap_test.go
@@ -44,18 +44,22 @@ type fakeHeartbeatStore struct {
 	listErr    error
 	failed     []string
 	failErr    error
+	markNoop   bool // when true, MarkTaskAgentLost reports 0 rows updated (a late terminal report won the race)
 }
 
 func (f *fakeHeartbeatStore) ListAgentLostCandidates(context.Context) ([]AgentLostCandidate, error) {
 	return f.candidates, f.listErr
 }
 
-func (f *fakeHeartbeatStore) MarkTaskAgentLost(_ context.Context, tiID string) error {
+func (f *fakeHeartbeatStore) MarkTaskAgentLost(_ context.Context, tiID string) (bool, error) {
 	if f.failErr != nil {
-		return f.failErr
+		return false, f.failErr
+	}
+	if f.markNoop {
+		return false, nil
 	}
 	f.failed = append(f.failed, tiID)
-	return nil
+	return true, nil
 }
 
 // TestReapAgentLost_MarksStaleTIs covers the success path: only candidates
@@ -79,6 +83,36 @@ func TestReapAgentLost_MarksStaleTIs(t *testing.T) {
 	}
 	if got := rec.count("agent_lost"); got != 1 {
 		t.Errorf("agent_lost decisions = %d, want 1", got)
+	}
+}
+
+// TestReapAgentLost_NoopWhenAlreadyTransitioned: if MarkTaskAgentLost updates 0
+// rows (a late terminal report transitioned the TI between the list and the
+// write, WHERE state='running'), the reaper must NOT log a false reap or delete
+// the pod for the now-settled TI (audit finding: the rowcount was discarded).
+func TestReapAgentLost_NoopWhenAlreadyTransitioned(t *testing.T) {
+	now := time.Now().UTC()
+	store := &fakeHeartbeatStore{
+		candidates: []AgentLostCandidate{
+			{TaskInstanceID: "raced", DagRunID: "r", TaskID: "t", TryNumber: 1, LastHeartbeat: now.Add(-5 * time.Minute)},
+		},
+		markNoop: true,
+	}
+	rec := &capturingRecorder{}
+	pods := &fakePodManager{active: map[string]bool{}}
+	r := newAgentLostReaper(store, reapTestLogger(), 90*time.Second, rec)
+	r.pods = pods
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := rec.count("agent_lost"); got != 0 {
+		t.Errorf("a no-op mark must not record a reap; agent_lost = %d, want 0", got)
+	}
+	if got := rec.count("agent_lost_noop"); got != 1 {
+		t.Errorf("agent_lost_noop = %d, want 1", got)
+	}
+	if len(pods.deletedTasks) != 0 {
+		t.Errorf("no pod should be deleted for a settled TI, got %v", pods.deletedTasks)
 	}
 }
 
@@ -124,11 +158,11 @@ func (p *panicHeartbeatStore) ListAgentLostCandidates(context.Context) ([]AgentL
 	}
 	return []AgentLostCandidate{{TaskInstanceID: "doomed", LastHeartbeat: time.Now().Add(-1 * time.Hour)}}, nil
 }
-func (p *panicHeartbeatStore) MarkTaskAgentLost(context.Context, string) error {
+func (p *panicHeartbeatStore) MarkTaskAgentLost(context.Context, string) (bool, error) {
 	if p.panicOnFail {
 		panic("boom: MarkTaskAgentLost")
 	}
-	return nil
+	return true, nil
 }
 
 func TestReapAgentLost_PanicInListDoesNotCrash(t *testing.T) {

--- a/internal/scheduler/pod_lost_reap.go
+++ b/internal/scheduler/pod_lost_reap.go
@@ -46,8 +46,10 @@ type PodLostReapStore interface {
 	ListRunningTasks(ctx context.Context) ([]PodLostCandidate, error)
 	// MarkTaskPodLost transitions one TI to `failed` with
 	// error_message='pod_lost'. The WHERE state='running' guard makes this
-	// idempotent: a second call on a now-non-running TI is a no-op.
-	MarkTaskPodLost(ctx context.Context, taskInstanceID string) error
+	// idempotent. It returns whether a row was actually updated: false means a
+	// late terminal report transitioned the TI between the list and this write,
+	// so the caller must NOT treat it as reaped (no false log, no pod delete).
+	MarkTaskPodLost(ctx context.Context, taskInstanceID string) (bool, error)
 }
 
 // podLostReaper fails `running` TIs whose pod has vanished — the gap between the
@@ -114,10 +116,18 @@ func (r *podLostReaper) run(ctx context.Context) error {
 		if active {
 			continue
 		}
-		if ferr := r.store.MarkTaskPodLost(ctx, c.TaskInstanceID); ferr != nil {
+		applied, ferr := r.store.MarkTaskPodLost(ctx, c.TaskInstanceID)
+		if ferr != nil {
 			r.logger.Error("marking task pod-lost",
 				"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID, "error", ferr)
 			r.record("pod_lost_error")
+			continue
+		}
+		if !applied {
+			// A late terminal report transitioned the TI between our list and our
+			// write (WHERE state='running' matched 0 rows) — it settled on its own,
+			// so do not log a false reap or run the teardown.
+			r.record("pod_lost_noop")
 			continue
 		}
 		r.logger.Warn("running task has no live pod past grace; failing as pod_lost",

--- a/internal/scheduler/pod_lost_reap_test.go
+++ b/internal/scheduler/pod_lost_reap_test.go
@@ -13,18 +13,22 @@ type fakePodLostStore struct {
 	listErr    error
 	marked     []string
 	markErr    error
+	markNoop   bool // when true, MarkTaskPodLost reports 0 rows updated (a late terminal report won the race)
 }
 
 func (f *fakePodLostStore) ListRunningTasks(context.Context) ([]PodLostCandidate, error) {
 	return f.candidates, f.listErr
 }
 
-func (f *fakePodLostStore) MarkTaskPodLost(_ context.Context, id string) error {
+func (f *fakePodLostStore) MarkTaskPodLost(_ context.Context, id string) (bool, error) {
 	if f.markErr != nil {
-		return f.markErr
+		return false, f.markErr
+	}
+	if f.markNoop {
+		return false, nil
 	}
 	f.marked = append(f.marked, id)
-	return nil
+	return true, nil
 }
 
 func TestIsPodLostCandidate(t *testing.T) {
@@ -127,6 +131,22 @@ func TestPodLostReaper(t *testing.T) {
 		}
 		if len(store.marked) != 0 {
 			t.Fatalf("Lite must not reap on 'no pod' (there are no pods), got %v", store.marked)
+		}
+	})
+
+	t.Run("a no-op mark (late terminal report won) skips the teardown", func(t *testing.T) {
+		store := &fakePodLostStore{
+			candidates: []PodLostCandidate{
+				{TaskInstanceID: "raced", DagRunID: "run-a", TaskID: "work", TryNumber: 1, RunningSince: past},
+			},
+			markNoop: true,
+		}
+		pods := &fakePodManager{active: map[string]bool{}} // no live pod → would reap, but the mark no-ops
+		if err := newReaper(store, pods).run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if len(pods.deletedTasks) != 0 {
+			t.Fatalf("a no-op mark (0 rows) must not tear down a pod, got %v", pods.deletedTasks)
 		}
 	})
 

--- a/internal/scheduler/resilience_test.go
+++ b/internal/scheduler/resilience_test.go
@@ -109,7 +109,7 @@ func (f *flakyStore) ReapRun(context.Context, string) error { return nil }
 func (f *flakyStore) ListAgentLostCandidates(context.Context) ([]AgentLostCandidate, error) {
 	return nil, nil
 }
-func (f *flakyStore) MarkTaskAgentLost(context.Context, string) error { return nil }
+func (f *flakyStore) MarkTaskAgentLost(context.Context, string) (bool, error) { return true, nil }
 func (f *flakyStore) ListStaleQueuedCandidates(context.Context) ([]StaleQueuedCandidate, error) {
 	return nil, nil
 }
@@ -117,7 +117,7 @@ func (f *flakyStore) MarkTaskDispatchLost(context.Context, string) error { retur
 func (f *flakyStore) ListRunningTasks(context.Context) ([]PodLostCandidate, error) {
 	return nil, nil
 }
-func (f *flakyStore) MarkTaskPodLost(context.Context, string) error { return nil }
+func (f *flakyStore) MarkTaskPodLost(context.Context, string) (bool, error) { return true, nil }
 
 func (f *flakyStore) snapshotMaterialized() []string {
 	f.mu.Lock()

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -174,9 +174,9 @@ func (f *fakeStore) ReapRun(_ context.Context, runID string) error {
 func (f *fakeStore) ListAgentLostCandidates(context.Context) ([]AgentLostCandidate, error) {
 	return f.agentLostCands, nil
 }
-func (f *fakeStore) MarkTaskAgentLost(_ context.Context, tiID string) error {
+func (f *fakeStore) MarkTaskAgentLost(_ context.Context, tiID string) (bool, error) {
 	f.agentLostMarked = append(f.agentLostMarked, tiID)
-	return nil
+	return true, nil
 }
 func (f *fakeStore) ListStaleQueuedCandidates(context.Context) ([]StaleQueuedCandidate, error) {
 	return f.staleQueuedCands, nil
@@ -186,7 +186,7 @@ func (f *fakeStore) MarkTaskDispatchLost(_ context.Context, tiID string) error {
 	return nil
 }
 func (f *fakeStore) ListRunningTasks(context.Context) ([]PodLostCandidate, error) { return nil, nil }
-func (f *fakeStore) MarkTaskPodLost(context.Context, string) error                { return nil }
+func (f *fakeStore) MarkTaskPodLost(context.Context, string) (bool, error)        { return true, nil }
 
 func newScheduler(store Store) *Scheduler {
 	s := NewScheduler(store, slog.New(slog.NewTextHandler(io.Discard, nil)), time.Millisecond)

--- a/internal/storage/heartbeat_reap_integration_test.go
+++ b/internal/storage/heartbeat_reap_integration_test.go
@@ -126,9 +126,13 @@ func TestMarkTaskAgentLostIntegration(t *testing.T) {
 		t.Fatalf("expected candidate after heartbeat")
 	}
 
-	// Reap.
-	if err := sched.MarkTaskAgentLost(ctx, c.TaskInstanceID); err != nil {
+	// Reap — the first mark applies (a running row transitions).
+	applied, err := sched.MarkTaskAgentLost(ctx, c.TaskInstanceID)
+	if err != nil {
 		t.Fatalf("MarkTaskAgentLost: %v", err)
+	}
+	if !applied {
+		t.Errorf("first MarkTaskAgentLost on a running TI must report applied=true")
 	}
 
 	// The TI is now failed and out of the candidate set.
@@ -137,9 +141,14 @@ func TestMarkTaskAgentLostIntegration(t *testing.T) {
 		t.Errorf("after MarkTaskAgentLost, TI state = %+v, want failed", tis)
 	}
 
-	// Second call is a no-op (WHERE state='running' updates zero rows).
-	if err := sched.MarkTaskAgentLost(ctx, c.TaskInstanceID); err != nil {
-		t.Errorf("second MarkTaskAgentLost must be a no-op; got %v", err)
+	// Second call is a no-op (WHERE state='running' now matches 0 rows) — and
+	// that is observable: applied must be false.
+	applied, err = sched.MarkTaskAgentLost(ctx, c.TaskInstanceID)
+	if err != nil {
+		t.Errorf("second MarkTaskAgentLost errored: %v", err)
+	}
+	if applied {
+		t.Errorf("second MarkTaskAgentLost on a failed TI must report applied=false (0 rows)")
 	}
 }
 

--- a/internal/storage/pod_lost_reap_integration_test.go
+++ b/internal/storage/pod_lost_reap_integration_test.go
@@ -83,8 +83,12 @@ func TestMarkTaskPodLostIntegration(t *testing.T) {
 		t.Fatalf("expected a running candidate")
 	}
 
-	if err := sched.MarkTaskPodLost(ctx, c.TaskInstanceID); err != nil {
+	applied, err := sched.MarkTaskPodLost(ctx, c.TaskInstanceID)
+	if err != nil {
 		t.Fatalf("MarkTaskPodLost: %v", err)
+	}
+	if !applied {
+		t.Errorf("first MarkTaskPodLost on a running TI must report applied=true")
 	}
 	tis, _ := repo.TaskInstancesForRuns(ctx, "default", dagID, []string{"r1"})
 	if len(tis) != 1 || tis[0].State != domain.TaskStateFailed {
@@ -95,9 +99,14 @@ func TestMarkTaskPodLostIntegration(t *testing.T) {
 	if findPodLostCandidate(cands, runUUID, "t") != nil {
 		t.Errorf("a failed TI must no longer appear in ListRunningTasks")
 	}
-	// Idempotent: the WHERE state='running' guard no-ops the second call.
-	if err := sched.MarkTaskPodLost(ctx, c.TaskInstanceID); err != nil {
-		t.Errorf("second MarkTaskPodLost must be a no-op; got %v", err)
+	// Idempotent: the WHERE state='running' guard now matches 0 rows on the
+	// second call — observable via applied=false.
+	applied, err = sched.MarkTaskPodLost(ctx, c.TaskInstanceID)
+	if err != nil {
+		t.Errorf("second MarkTaskPodLost errored: %v", err)
+	}
+	if applied {
+		t.Errorf("second MarkTaskPodLost on a failed TI must report applied=false (0 rows)")
 	}
 }
 

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -474,15 +474,16 @@ func (s *SchedulerStore) MarkTaskDispatchFailed(ctx context.Context, runID, task
 // reason. The WHERE state='running' guard makes this idempotent and prevents
 // a late terminal report being overwritten — if the row already moved, we
 // touch zero rows and return nil.
-func (s *SchedulerStore) MarkTaskAgentLost(ctx context.Context, taskInstanceID string) error {
+func (s *SchedulerStore) MarkTaskAgentLost(ctx context.Context, taskInstanceID string) (bool, error) {
 	tid, err := parseUUID(taskInstanceID)
 	if err != nil {
-		return err
+		return false, err
 	}
-	if _, err := s.q.MarkTaskAgentLost(ctx, tid); err != nil {
-		return fmt.Errorf("marking task agent-lost: %w", err)
+	n, err := s.q.MarkTaskAgentLost(ctx, tid)
+	if err != nil {
+		return false, fmt.Errorf("marking task agent-lost: %w", err)
 	}
-	return nil
+	return n == 1, nil
 }
 
 // ListStaleQueuedCandidates returns every `queued` TI with its queued_at, for
@@ -554,15 +555,16 @@ func (s *SchedulerStore) ListRunningTasks(ctx context.Context) ([]scheduler.PodL
 // MarkTaskPodLost transitions one TI to `failed` with the pod_lost reason. The
 // WHERE state='running' guard makes it idempotent: a TI that has since moved on
 // (a late terminal report landed) is left alone.
-func (s *SchedulerStore) MarkTaskPodLost(ctx context.Context, taskInstanceID string) error {
+func (s *SchedulerStore) MarkTaskPodLost(ctx context.Context, taskInstanceID string) (bool, error) {
 	tid, err := parseUUID(taskInstanceID)
 	if err != nil {
-		return err
+		return false, err
 	}
-	if _, err := s.q.MarkTaskPodLost(ctx, tid); err != nil {
-		return fmt.Errorf("marking task pod-lost: %w", err)
+	n, err := s.q.MarkTaskPodLost(ctx, tid)
+	if err != nil {
+		return false, fmt.Errorf("marking task pod-lost: %w", err)
 	}
-	return nil
+	return n == 1, nil
 }
 
 // ListActiveStagingVolumes returns active staging volumes joined with their DAG


### PR DESCRIPTION
From the external v0.2.0 audit (§6 item 14).

`MarkTaskAgentLost` / `MarkTaskPodLost` are sqlc `:execrows`, but the store methods discarded the rowcount (`if _, err := s.q...`). When the `WHERE state='running'` guard matched **0 rows** — a late terminal report transitioned the TI between the reaper's *list* and its *write* — the reaper still logged a reap, recorded the metric, and (agent-lost) **deleted the pod** for a TI that had already settled.

**Fix:** both store methods return whether a row was updated; the agent-lost and pod-lost reapers skip the log/metric/teardown on a no-op (recording `agent_lost_noop` / `pod_lost_noop`).

The pod-lost reaper (#527, just merged) inherited the same discard — fixed here too.

**Tests:** unit adds the no-op path (a 0-row mark must not tear down a pod); the real-Postgres integration tests now assert the returned `applied` flag (first mark `true`, second `false` — idempotency is now observable). Verified locally: build, `go vet`, scheduler unit, integration (real PG), `golangci-lint` (0 issues).