### PR TITLE
docs: scheduler SANs for split+TLS, ADR 0045 status honesty

### DIFF
--- a/docs/adr/0045-declared-secret-delivery.md
+++ b/docs/adr/0045-declared-secret-delivery.md
@@ -1,6 +1,12 @@
 # ADR 0045: Secrets reach a task because it declared them
 
-**Status:** Accepted
+**Status:** Accepted — not yet implemented. The decision (deliver a task only
+the secrets it declares) stands; **no code ships it yet.** The runtime still
+hands every task its whole tenant vault — `GetVariables`/`GetConnections` pass
+only the tenant id (`internal/agentrpc/secrets.go`), exactly the behaviour the
+Context section describes. An external audit of v0.2.0 re-confirmed the C1
+exfiltration this ADR exists to close is live. Do not read "Accepted" as "a task
+only receives what it declares" — that guarantee does not exist until #59 lands.
 **Date:** 2026-07-30
 **Accepted:** 2026-07-31
 **Relates:** ADR 0019 (encryption at rest), ADR 0021 (exposing variables/connections to pods), ADR 0004 (thin agent), ADR 0035 (Leoflow is not a key manager)

--- a/docs/pro-tls.md
+++ b/docs/pro-tls.md
@@ -59,7 +59,19 @@ spec:
   dnsNames:
     - leoflow.leoflow.svc                 # the control-plane Service DNS
     - leoflow.leoflow.svc.cluster.local
+    # When split.enabled=true (ADR 0049) the scheduler runs as its own
+    # Service and task pods dial IT, not the api Service. The agent verifies
+    # the server hostname, so the cert MUST also carry the scheduler DNS or
+    # every task's connection fails verification and hangs. Drop these two
+    # SANs only if you run the fused `all` role (split.enabled=false).
+    - leoflow-scheduler.leoflow.svc
+    - leoflow-scheduler.leoflow.svc.cluster.local
 ```
+
+> The Service names above assume a release named `leoflow` in namespace
+> `leoflow`; both derive from the chart fullname. If you install under a
+> different release/namespace, substitute `<fullname>` and `<fullname>-scheduler`
+> (run `helm template` and read the `Service` names) into every SAN.
 
 ## 4. The CA trust bundle for task pods
 


### PR DESCRIPTION
Two documentation corrections surfaced by the external v0.2.0 audit and the split rollout.

## 1. `docs/pro-tls.md` — split+TLS was silently broken for anyone following the doc
The example agent cert listed only the control-plane (`leoflow`) Service DNS. With `split.enabled=true` (ADR 0049) task pods dial the **scheduler** Service, and the agent does full server-hostname verification — so a cert minted from the doc has no matching SAN and every task connection fails verification and hangs. Added the two `leoflow-scheduler...` SANs plus a note to substitute `<fullname>`/`<fullname>-scheduler` for non-default release/namespace.

## 2. ADR 0045 — `Accepted` implied a guarantee that does not exist
ADR 0045 ("secrets reach a task because it declared them") was marked `Accepted` but has **zero implementation** — the runtime still delivers the entire tenant vault to every task (`internal/agentrpc/secrets.go`). The audit re-confirmed the C1 exfiltration this ADR exists to close is live on v0.2.0. Reworded the status (mirroring the ADR 0043 "implementation partial" convention) so a reader can't mistake the accepted decision for a shipped control. Tracked by #59.

Docs-only; no code paths touched.