### PR TITLE
fix(scheduler): guard retry reset to up_for_retry (audit #13)

### DIFF
--- a/internal/scheduler/resilience_test.go
+++ b/internal/scheduler/resilience_test.go
@@ -82,8 +82,8 @@ func (f *flakyStore) ApplyTransition(_ context.Context, runID, taskID string, to
 	return nil
 }
 
-func (f *flakyStore) ResetForRetry(context.Context, string, string) error        { return nil }
-func (f *flakyStore) RedispatchReschedule(context.Context, string, string) error { return nil }
+func (f *flakyStore) ResetForRetry(context.Context, string, string) (bool, error) { return true, nil }
+func (f *flakyStore) RedispatchReschedule(context.Context, string, string) error  { return nil }
 func (f *flakyStore) RecordDispatchFailure(context.Context, string, string, time.Time) error {
 	return nil
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -114,8 +114,11 @@ type Store interface {
 	MaterializeTasks(ctx context.Context, runID string, tasks []domain.TaskSpec) error
 	ApplyTransition(ctx context.Context, runID, taskID string, to domain.TaskState) error
 	// ResetForRetry returns a task to 'none' and increments its try number so a
-	// retry re-evaluates and re-runs it.
-	ResetForRetry(ctx context.Context, runID, taskID string) error
+	// retry re-evaluates and re-runs it. It is guarded to the up_for_retry source
+	// state; the bool reports whether the reset actually fired (false = the TI was
+	// no longer up_for_retry, nothing reset) so the caller does not record a
+	// phantom retry on a lost race.
+	ResetForRetry(ctx context.Context, runID, taskID string) (bool, error)
 	// RedispatchReschedule returns a task parked in up_for_reschedule to 'none' for
 	// re-dispatch, PRESERVING try_number (reschedule is not a retry; #380).
 	RedispatchReschedule(ctx context.Context, runID, taskID string) error
@@ -832,8 +835,18 @@ func (s *Scheduler) applyPlanned(ctx context.Context, run RunState, t PlannedTra
 // resetForRetry returns a task to 'none' with an incremented try number so the
 // next tick re-evaluates and re-runs it.
 func (s *Scheduler) resetForRetry(ctx context.Context, run RunState, taskID string) error {
-	if err := s.store.ResetForRetry(ctx, run.RunID, taskID); err != nil {
+	applied, err := s.store.ResetForRetry(ctx, run.RunID, taskID)
+	if err != nil {
 		return fmt.Errorf("resetting %s for retry: %w", taskID, err)
+	}
+	// The guarded reset no-ops when the TI is no longer up_for_retry — a stale
+	// decision that raced a concurrent writer (e.g. a re-dispatch). Do not record
+	// a retry we did not perform; surface the lost race instead.
+	if !applied {
+		if s.recorder != nil {
+			s.recorder.RecordSchedulerDecision("retry_noop")
+		}
+		return nil
 	}
 	if s.recorder != nil {
 		s.recorder.RecordSchedulerDecision("retry")

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -80,9 +80,9 @@ func (f *fakeStore) ApplyTransition(_ context.Context, runID, taskID string, to 
 	f.transitions = append(f.transitions, transition{runID, taskID, to})
 	return nil
 }
-func (f *fakeStore) ResetForRetry(_ context.Context, runID, taskID string) error {
+func (f *fakeStore) ResetForRetry(_ context.Context, runID, taskID string) (bool, error) {
 	f.retried = append(f.retried, transition{runID, taskID, domain.TaskStateNone})
-	return nil
+	return true, nil
 }
 func (f *fakeStore) RecordDispatchFailure(_ context.Context, runID, taskID string, _ time.Time) error {
 	f.dispatchFailures = append(f.dispatchFailures, transition{runID, taskID, ""})

--- a/internal/storage/heartbeat_guard_integration_test.go
+++ b/internal/storage/heartbeat_guard_integration_test.go
@@ -65,13 +65,20 @@ func TestRecordHeartbeatStaleTryNumberSignalsStale(t *testing.T) {
 	dagID := fmt.Sprintf("hb_stale_try_%d", time.Now().UnixNano())
 	runUUID := seedRunningTask(t, repo, sched, ctx, dagID, "load")
 
-	// Attempt 1 fails and is retried: try_number becomes 2, row back to none →
-	// queued → running for attempt 2.
+	// Attempt 1 fails and is retried along the real rail failed → up_for_retry →
+	// none: try_number becomes 2, row back to none → queued → running for
+	// attempt 2. ResetForRetry is guarded to up_for_retry, so the intermediate
+	// transition is required (a direct failed → reset would no-op).
 	if err := sched.ApplyTransition(ctx, runUUID, "load", domain.TaskStateFailed); err != nil {
 		t.Fatalf("ApplyTransition to failed: %v", err)
 	}
-	if err := sched.ResetForRetry(ctx, runUUID, "load"); err != nil {
+	if err := sched.ApplyTransition(ctx, runUUID, "load", domain.TaskStateUpForRetry); err != nil {
+		t.Fatalf("ApplyTransition to up_for_retry: %v", err)
+	}
+	if applied, err := sched.ResetForRetry(ctx, runUUID, "load"); err != nil {
 		t.Fatalf("ResetForRetry: %v", err)
+	} else if !applied {
+		t.Fatalf("ResetForRetry on up_for_retry must apply")
 	}
 	for _, st := range []domain.TaskState{domain.TaskStateQueued, domain.TaskStateRunning} {
 		if err := sched.ApplyTransition(ctx, runUUID, "load", st); err != nil {

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -271,6 +271,14 @@ type Querier interface {
 	// Archives the current attempt into task_instance_history then resets the
 	// live row. See ResetTaskInstanceToNone for the per-attempt rationale.
 	ResetFailedTaskInstance(ctx context.Context, arg ResetFailedTaskInstanceParams) (int64, error)
+	// The scheduler retry rail's reset: identical to ResetTaskInstanceToNone but
+	// GUARDED to state='up_for_retry' on both the history snapshot and the update.
+	// The planner emits up_for_retry → none, but by apply time the TI may have been
+	// re-dispatched (a stale/concurrent decision); without this guard the reset
+	// would yank a now-running TI back to none and bump try_number, orphaning its
+	// live pod. Mirrors the source-state guard on RedispatchRescheduledTaskInstance.
+	// The admin clear-task path deliberately uses the unguarded primitive above.
+	ResetTaskInstanceForRetry(ctx context.Context, arg ResetTaskInstanceForRetryParams) (int64, error)
 	// Resets a TI for retry: snapshot the current per-attempt state into
 	// task_instance_history (so the UI's /tries endpoint can render one tab per
 	// attempt, Lima bug #241), then state back to `none`, all per-attempt
@@ -278,6 +286,11 @@ type Querier interface {
 	// MUST be NULLed so the next TransitionTaskState(queued) stamps a fresh now()
 	// — without that, the dispatch-lost reaper sees the stale pre-clear timestamp
 	// and re-marks the TI dispatch_lost on every tick (Lima Bug 1).
+	// This is the UNCONDITIONAL clear primitive: the admin "clear task" action
+	// (ClearTaskInstances, onlyFailed=false) resets a TI to none from ANY state, so
+	// it carries no source-state guard. The scheduler's retry rail uses the guarded
+	// ResetTaskInstanceForRetry instead — do not add a guard here or clear-task
+	// silently no-ops on non-up_for_retry tasks.
 	ResetTaskInstanceToNone(ctx context.Context, arg ResetTaskInstanceToNoneParams) error
 	ResolveRunRef(ctx context.Context, arg ResolveRunRefParams) (ResolveRunRefRow, error)
 	SetCurrentDagVersion(ctx context.Context, arg SetCurrentDagVersionParams) error

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -246,6 +246,11 @@ WHERE dag_run_id = sqlc.arg(dag_run_id) AND task_id = sqlc.arg(task_id);
 -- MUST be NULLed so the next TransitionTaskState(queued) stamps a fresh now()
 -- — without that, the dispatch-lost reaper sees the stale pre-clear timestamp
 -- and re-marks the TI dispatch_lost on every tick (Lima Bug 1).
+-- This is the UNCONDITIONAL clear primitive: the admin "clear task" action
+-- (ClearTaskInstances, onlyFailed=false) resets a TI to none from ANY state, so
+-- it carries no source-state guard. The scheduler's retry rail uses the guarded
+-- ResetTaskInstanceForRetry instead — do not add a guard here or clear-task
+-- silently no-ops on non-up_for_retry tasks.
 WITH archived AS (
     INSERT INTO task_instance_history (
         task_instance_id, try_number, state,
@@ -273,6 +278,42 @@ SET state = 'none',
     first_reschedule_at = NULL,
     try_number = ti.try_number + 1
 WHERE ti.dag_run_id = $1 AND ti.task_id = $2;
+
+-- name: ResetTaskInstanceForRetry :execrows
+-- The scheduler retry rail's reset: identical to ResetTaskInstanceToNone but
+-- GUARDED to state='up_for_retry' on both the history snapshot and the update.
+-- The planner emits up_for_retry → none, but by apply time the TI may have been
+-- re-dispatched (a stale/concurrent decision); without this guard the reset
+-- would yank a now-running TI back to none and bump try_number, orphaning its
+-- live pod. Mirrors the source-state guard on RedispatchRescheduledTaskInstance.
+-- The admin clear-task path deliberately uses the unguarded primitive above.
+WITH archived AS (
+    INSERT INTO task_instance_history (
+        task_instance_id, try_number, state,
+        queued_at, scheduled_at, started_at, ended_at, duration_seconds,
+        exit_code, error_message, hostname, pod_name, node_name, note
+    )
+    SELECT
+        src.id, src.try_number, src.state,
+        src.queued_at, src.scheduled_at, src.started_at, src.ended_at, src.duration_seconds,
+        src.exit_code, src.error_message, src.hostname, src.pod_name, src.node_name, src.note
+    FROM task_instances src
+    WHERE src.dag_run_id = $1 AND src.task_id = $2 AND src.state = 'up_for_retry'
+    ON CONFLICT (task_instance_id, try_number) DO NOTHING
+    RETURNING task_instance_id
+)
+UPDATE task_instances ti
+SET state = 'none',
+    started_at = NULL,
+    ended_at = NULL,
+    queued_at = NULL,
+    scheduled_at = NULL,
+    dispatch_attempts = 0,
+    next_dispatch_at = NULL,
+    reschedule_at = NULL,
+    first_reschedule_at = NULL,
+    try_number = ti.try_number + 1
+WHERE ti.dag_run_id = $1 AND ti.task_id = $2 AND ti.state = 'up_for_retry';
 
 -- name: RedispatchRescheduledTaskInstance :exec
 -- Re-dispatch a task parked in up_for_reschedule once its reschedule_at has passed:

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -1527,6 +1527,56 @@ func (q *Queries) ResetFailedTaskInstance(ctx context.Context, arg ResetFailedTa
 	return result.RowsAffected(), nil
 }
 
+const resetTaskInstanceForRetry = `-- name: ResetTaskInstanceForRetry :execrows
+WITH archived AS (
+    INSERT INTO task_instance_history (
+        task_instance_id, try_number, state,
+        queued_at, scheduled_at, started_at, ended_at, duration_seconds,
+        exit_code, error_message, hostname, pod_name, node_name, note
+    )
+    SELECT
+        src.id, src.try_number, src.state,
+        src.queued_at, src.scheduled_at, src.started_at, src.ended_at, src.duration_seconds,
+        src.exit_code, src.error_message, src.hostname, src.pod_name, src.node_name, src.note
+    FROM task_instances src
+    WHERE src.dag_run_id = $1 AND src.task_id = $2 AND src.state = 'up_for_retry'
+    ON CONFLICT (task_instance_id, try_number) DO NOTHING
+    RETURNING task_instance_id
+)
+UPDATE task_instances ti
+SET state = 'none',
+    started_at = NULL,
+    ended_at = NULL,
+    queued_at = NULL,
+    scheduled_at = NULL,
+    dispatch_attempts = 0,
+    next_dispatch_at = NULL,
+    reschedule_at = NULL,
+    first_reschedule_at = NULL,
+    try_number = ti.try_number + 1
+WHERE ti.dag_run_id = $1 AND ti.task_id = $2 AND ti.state = 'up_for_retry'
+`
+
+type ResetTaskInstanceForRetryParams struct {
+	DagRunID pgtype.UUID `json:"dag_run_id"`
+	TaskID   string      `json:"task_id"`
+}
+
+// The scheduler retry rail's reset: identical to ResetTaskInstanceToNone but
+// GUARDED to state='up_for_retry' on both the history snapshot and the update.
+// The planner emits up_for_retry → none, but by apply time the TI may have been
+// re-dispatched (a stale/concurrent decision); without this guard the reset
+// would yank a now-running TI back to none and bump try_number, orphaning its
+// live pod. Mirrors the source-state guard on RedispatchRescheduledTaskInstance.
+// The admin clear-task path deliberately uses the unguarded primitive above.
+func (q *Queries) ResetTaskInstanceForRetry(ctx context.Context, arg ResetTaskInstanceForRetryParams) (int64, error) {
+	result, err := q.db.Exec(ctx, resetTaskInstanceForRetry, arg.DagRunID, arg.TaskID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const resetTaskInstanceToNone = `-- name: ResetTaskInstanceToNone :exec
 WITH archived AS (
     INSERT INTO task_instance_history (
@@ -1569,6 +1619,11 @@ type ResetTaskInstanceToNoneParams struct {
 // MUST be NULLed so the next TransitionTaskState(queued) stamps a fresh now()
 // — without that, the dispatch-lost reaper sees the stale pre-clear timestamp
 // and re-marks the TI dispatch_lost on every tick (Lima Bug 1).
+// This is the UNCONDITIONAL clear primitive: the admin "clear task" action
+// (ClearTaskInstances, onlyFailed=false) resets a TI to none from ANY state, so
+// it carries no source-state guard. The scheduler's retry rail uses the guarded
+// ResetTaskInstanceForRetry instead — do not add a guard here or clear-task
+// silently no-ops on non-up_for_retry tasks.
 func (q *Queries) ResetTaskInstanceToNone(ctx context.Context, arg ResetTaskInstanceToNoneParams) error {
 	_, err := q.db.Exec(ctx, resetTaskInstanceToNone, arg.DagRunID, arg.TaskID)
 	return err

--- a/internal/storage/report_state_guard_integration_test.go
+++ b/internal/storage/report_state_guard_integration_test.go
@@ -96,13 +96,21 @@ func TestReportStateIgnoresStaleTryNumberIntegration(t *testing.T) {
 	dagID := fmt.Sprintf("guard_stale_try_%d", time.Now().UnixNano())
 	runUUID := seedRunningTask(t, repo, sched, ctx, dagID, "load")
 
-	// Attempt 1 fails and the scheduler retries: try_number becomes 2, and the
-	// row goes back to none for re-dispatch.
+	// Attempt 1 fails and the scheduler retries. The real retry rail is
+	// failed → up_for_retry → none: the planner parks a retriable failure in
+	// up_for_retry, then ResetForRetry (guarded to up_for_retry) releases it to
+	// none with try_number bumped to 2. Going straight from failed would not
+	// match production and the guarded reset would (correctly) no-op.
 	if err := sched.ApplyTransition(ctx, runUUID, "load", domain.TaskStateFailed); err != nil {
 		t.Fatalf("ApplyTransition to failed: %v", err)
 	}
-	if err := sched.ResetForRetry(ctx, runUUID, "load"); err != nil {
+	if err := sched.ApplyTransition(ctx, runUUID, "load", domain.TaskStateUpForRetry); err != nil {
+		t.Fatalf("ApplyTransition to up_for_retry: %v", err)
+	}
+	if applied, err := sched.ResetForRetry(ctx, runUUID, "load"); err != nil {
 		t.Fatalf("ResetForRetry: %v", err)
+	} else if !applied {
+		t.Fatalf("ResetForRetry on up_for_retry must apply")
 	}
 	if err := sched.ApplyTransition(ctx, runUUID, "load", domain.TaskStateQueued); err != nil {
 		t.Fatalf("ApplyTransition to queued: %v", err)

--- a/internal/storage/reset_retry_guard_integration_test.go
+++ b/internal/storage/reset_retry_guard_integration_test.go
@@ -1,0 +1,109 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// TestResetForRetryGuardsSourceState locks the audit-#13 fix: ResetForRetry
+// (ResetTaskInstanceToNone) must only reset a TI that is actually parked in
+// up_for_retry. The failure it guards against: the planner computes a
+// up_for_retry → none transition, but by the time it is applied the TI has been
+// re-dispatched and is `running` again (a stale/concurrent decision). Without a
+// source-state guard the reset would yank the live TI back to none and bump
+// try_number, orphaning its running pod. The sibling RedispatchReschedule is
+// guarded to its parked state for the same reason; this brings the retry rail
+// into line.
+func TestResetForRetryGuardsSourceState(t *testing.T) {
+	repo, sched, _, ctx := openExec(t)
+	dagID := fmt.Sprintf("reset_guard_%d", time.Now().UnixNano())
+	tasks := []domain.TaskSpec{{TaskID: "t", Type: domain.TaskTypePython}}
+	registerSpec(t, repo, ctx, dagID, tasks)
+	if _, err := repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+		RunID: "r1", State: domain.DagRunStateRunning, RunType: "manual", LogicalDate: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	runUUID := resolveRunUUID(t, sched, ctx, dagID)
+	if err := sched.MaterializeTasks(ctx, runUUID, tasks); err != nil {
+		t.Fatalf("MaterializeTasks: %v", err)
+	}
+
+	// The TI is live (running) — NOT parked in up_for_retry. A reset here is the
+	// stale-decision case and must be a no-op.
+	if err := sched.ApplyTransition(ctx, runUUID, "t", domain.TaskStateRunning); err != nil {
+		t.Fatal(err)
+	}
+	applied, err := sched.ResetForRetry(ctx, runUUID, "t")
+	if err != nil {
+		t.Fatalf("ResetForRetry (guarded no-op) must not error; got %v", err)
+	}
+	if applied {
+		t.Fatalf("ResetForRetry on a running TI must report applied=false (no reset)")
+	}
+	tis, _ := repo.TaskInstancesForRuns(ctx, "default", dagID, []string{"r1"})
+	if len(tis) != 1 || tis[0].State != domain.TaskStateRunning {
+		t.Fatalf("a running TI must survive ResetForRetry, got %+v", tis)
+	}
+
+	// Now legitimately parked in up_for_retry — the reset must fire.
+	if err := sched.ApplyTransition(ctx, runUUID, "t", domain.TaskStateUpForRetry); err != nil {
+		t.Fatal(err)
+	}
+	applied, err = sched.ResetForRetry(ctx, runUUID, "t")
+	if err != nil {
+		t.Fatalf("ResetForRetry on up_for_retry: %v", err)
+	}
+	if !applied {
+		t.Fatalf("ResetForRetry on an up_for_retry TI must report applied=true")
+	}
+	tis, _ = repo.TaskInstancesForRuns(ctx, "default", dagID, []string{"r1"})
+	if len(tis) != 1 || tis[0].State != domain.TaskStateNone {
+		t.Fatalf("an up_for_retry TI must reset to none, got %+v", tis)
+	}
+}
+
+// TestClearTaskInstancesResetsAnyState guards the OTHER side of the audit-#13
+// split: the admin "clear task" action (ClearTaskInstances, onlyFailed=false)
+// must still reset a TI from any state — it uses the deliberately-unguarded
+// ResetTaskInstanceToNone primitive, NOT the up_for_retry-guarded retry query.
+// This locks that adding the retry guard did not silently no-op clear-task on a
+// succeeded (or otherwise non-up_for_retry) task.
+func TestClearTaskInstancesResetsAnyState(t *testing.T) {
+	repo, sched, _, ctx := openExec(t)
+	dagID := fmt.Sprintf("clear_anystate_%d", time.Now().UnixNano())
+	tasks := []domain.TaskSpec{{TaskID: "t", Type: domain.TaskTypePython}}
+	registerSpec(t, repo, ctx, dagID, tasks)
+	if _, err := repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+		RunID: "r1", State: domain.DagRunStateRunning, RunType: "manual", LogicalDate: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+	runUUID := resolveRunUUID(t, sched, ctx, dagID)
+	if err := sched.MaterializeTasks(ctx, runUUID, tasks); err != nil {
+		t.Fatalf("MaterializeTasks: %v", err)
+	}
+	// A succeeded task — NOT up_for_retry. The guarded retry query would no-op
+	// here; the admin clear primitive must not.
+	if err := sched.ApplyTransition(ctx, runUUID, "t", domain.TaskStateSuccess); err != nil {
+		t.Fatal(err)
+	}
+
+	cleared, err := repo.ClearTaskInstances(ctx, "default", dagID, "r1",
+		[]string{"t"}, false /*onlyFailed*/, false /*resetDagRun*/)
+	if err != nil {
+		t.Fatalf("ClearTaskInstances: %v", err)
+	}
+	if cleared != 1 {
+		t.Fatalf("ClearTaskInstances cleared %d, want 1", cleared)
+	}
+	tis, _ := repo.TaskInstancesForRuns(ctx, "default", dagID, []string{"r1"})
+	if len(tis) != 1 || tis[0].State != domain.TaskStateNone {
+		t.Fatalf("clear-task must reset a succeeded TI to none, got %+v", tis)
+	}
+}

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -173,16 +173,25 @@ func (s *SchedulerStore) SetTaskNote(ctx context.Context, runID, taskID, note st
 }
 
 // ResetForRetry returns a task instance to 'none', clears its timestamps, and
-// increments its try number so the scheduler re-evaluates and re-runs it.
-func (s *SchedulerStore) ResetForRetry(ctx context.Context, runID, taskID string) error {
+// increments its try number so the scheduler re-evaluates and re-runs it. It
+// uses the up_for_retry-guarded query so a stale retry decision cannot reset a
+// TI that has since been re-dispatched (audit follow-up; see the query doc). The
+// bool reports whether the guarded update actually fired (exactly one row): a
+// false means the TI was no longer up_for_retry and nothing was reset, so the
+// caller must not record a retry it did not perform.
+func (s *SchedulerStore) ResetForRetry(ctx context.Context, runID, taskID string) (bool, error) {
 	rid, err := parseUUID(runID)
 	if err != nil {
-		return err
+		return false, err
 	}
-	return s.q.ResetTaskInstanceToNone(ctx, queries.ResetTaskInstanceToNoneParams{
+	n, err := s.q.ResetTaskInstanceForRetry(ctx, queries.ResetTaskInstanceForRetryParams{
 		DagRunID: rid,
 		TaskID:   taskID,
 	})
+	if err != nil {
+		return false, err
+	}
+	return n == 1, nil
 }
 
 // RecordDispatchFailure increments a scheduled task's dispatch-failure counter


### PR DESCRIPTION
Correctness follow-up from the external v0.2.0 audit (§6 #13), part of #538.

## The bug
The scheduler's retry rail is `failed → up_for_retry → none`: the planner parks a retriable failure in `up_for_retry`, then `ResetForRetry` releases it to `none` with `try_number` bumped. `ResetForRetry` called `ResetTaskInstanceToNone`, which had **no source-state guard**. If a retry decision is computed while the TI is `up_for_retry` but applied after it has already been re-dispatched (a stale/concurrent tick), the unguarded reset yanks the now-`running` TI back to `none` and bumps `try_number` — orphaning its live pod. This is the same class the sibling `RedispatchRescheduledTaskInstance` already guards against.

## The fix — split the callers, don't guard the shared query
`ResetTaskInstanceToNone` is **also** the admin "clear task" primitive (`ClearTaskInstances`, `onlyFailed=false`), which deliberately resets a TI from **any** state (e.g. a succeeded task the operator wants to re-run). Guarding the shared query to `up_for_retry` would silently no-op clear-task. So:

- `ResetTaskInstanceToNone` stays **unconditional** (admin clear primitive; doc clarified).
- New `ResetTaskInstanceForRetry` is **guarded to `state='up_for_retry'`** on both the history snapshot and the update. `SchedulerStore.ResetForRetry` now uses it.

## Tests (real Postgres, integration)
- **new** `TestResetForRetryGuardsSourceState` — a `running` TI survives `ResetForRetry` (guard no-ops); an `up_for_retry` TI still resets to `none`.
- **new** `TestClearTaskInstancesResetsAnyState` — clear-task still resets a **succeeded** TI to `none` (locks the unguarded primitive was not regressed).
- Corrected two existing guard tests (`report_state_guard`, `heartbeat_guard`) that set up their scenario with a `failed → ResetForRetry` shortcut skipping `up_for_retry` — now they drive the real transition sequence. Assertions unchanged.

golangci-lint: 0 issues. Full `internal/storage` integration suite green on real Postgres.