### PR TITLE
fix(agent): retry terminal report with backoff on transient errors (audit #15)

### DIFF
--- a/internal/agent/report_retry_test.go
+++ b/internal/agent/report_retry_test.go
@@ -1,0 +1,100 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+	"google.golang.org/grpc/codes"
+)
+
+// instantRunner builds a Runner whose report retry sleeps are instant, so the
+// backoff logic is exercised without real wall-clock delay.
+func instantRunner(client *fakeClient) *Runner {
+	return &Runner{
+		Client:   client,
+		Hostname: "pod-1",
+		Version:  "test",
+		afterFunc: func(time.Duration) <-chan time.Time {
+			ch := make(chan time.Time, 1)
+			ch <- time.Time{}
+			return ch
+		},
+	}
+}
+
+// TestReportRetriesTransientThenSucceeds: a terminal report that hits a
+// transient gRPC error (api momentarily Unavailable) is retried with backoff
+// and eventually lands — the task result is not lost to a network blip, and no
+// reaper has to fail a task that actually succeeded.
+func TestReportRetriesTransientThenSucceeds(t *testing.T) {
+	client := &fakeClient{reportFailCode: codes.Unavailable, reportFailTimes: 2}
+	r := instantRunner(client)
+
+	if err := r.report(context.Background(), agentv1.TaskState_TASK_STATE_SUCCESS, 0, ""); err != nil {
+		t.Fatalf("report should succeed after transient failures, got %v", err)
+	}
+	if client.reportAttempts != 3 {
+		t.Errorf("expected 3 attempts (2 transient + 1 success), got %d", client.reportAttempts)
+	}
+	if len(client.reports) != 1 || client.reports[0].GetState() != agentv1.TaskState_TASK_STATE_SUCCESS {
+		t.Errorf("exactly one successful SUCCESS report expected, got %+v", client.reports)
+	}
+}
+
+// TestReportGivesUpAfterMaxAttempts: a report that never recovers stops after
+// the bounded number of attempts and returns an error — it must not loop
+// forever holding the task.
+func TestReportGivesUpAfterMaxAttempts(t *testing.T) {
+	client := &fakeClient{reportFailCode: codes.Unavailable, reportFailTimes: 1000}
+	r := instantRunner(client)
+
+	if err := r.report(context.Background(), agentv1.TaskState_TASK_STATE_SUCCESS, 0, ""); err == nil {
+		t.Fatal("report should fail after exhausting attempts")
+	}
+	// One initial attempt plus maxRetryAttempts retries (Backoff yields a delay
+	// for attempts 1..maxRetryAttempts, then exhausts on the next), bounding the
+	// total at maxRetryAttempts+1 calls / ~31s of backoff.
+	if want := maxRetryAttempts + 1; client.reportAttempts != want {
+		t.Errorf("expected exactly %d attempts, got %d", want, client.reportAttempts)
+	}
+}
+
+// TestReportDoesNotRetryNonRetryable: a logical rejection (e.g. InvalidArgument)
+// is returned immediately — retrying it would never apply and would only delay
+// the failure.
+func TestReportDoesNotRetryNonRetryable(t *testing.T) {
+	client := &fakeClient{reportFailCode: codes.InvalidArgument, reportFailTimes: 1000}
+	r := instantRunner(client)
+
+	if err := r.report(context.Background(), agentv1.TaskState_TASK_STATE_SUCCESS, 0, ""); err == nil {
+		t.Fatal("a non-retryable report error must be returned")
+	}
+	if client.reportAttempts != 1 {
+		t.Errorf("a non-retryable error must not be retried, got %d attempts", client.reportAttempts)
+	}
+}
+
+// TestReportRetryAbortsOnContextCancel: while backing off, a canceled context
+// (parent shutdown / SIGTERM) aborts the retry promptly rather than sleeping
+// out the whole backoff schedule.
+func TestReportRetryAbortsOnContextCancel(t *testing.T) {
+	client := &fakeClient{reportFailCode: codes.Unavailable, reportFailTimes: 1000}
+	r := &Runner{
+		Client:   client,
+		Hostname: "pod-1",
+		Version:  "test",
+		// Never fires, so the retry can only leave via ctx cancellation.
+		afterFunc: func(time.Duration) <-chan time.Time { return make(chan time.Time) },
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := r.report(ctx, agentv1.TaskState_TASK_STATE_SUCCESS, 0, ""); err == nil {
+		t.Fatal("report must return the context error when canceled mid-backoff")
+	}
+	if client.reportAttempts != 1 {
+		t.Errorf("expected 1 attempt before the canceled backoff aborted, got %d", client.reportAttempts)
+	}
+}

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -68,6 +68,18 @@ type Runner struct {
 	// HeartbeatInterval is how often to ping the control plane while the task
 	// runs; zero disables heartbeats.
 	HeartbeatInterval time.Duration
+	// afterFunc returns a channel that fires after the given delay; it exists so
+	// tests can make the report-retry backoff instant. Nil uses time.After.
+	afterFunc func(time.Duration) <-chan time.Time
+}
+
+// after waits for d, using the injected afterFunc when set (tests) and time.After
+// otherwise.
+func (r *Runner) after(d time.Duration) <-chan time.Time {
+	if r.afterFunc != nil {
+		return r.afterFunc(d)
+	}
+	return time.After(d)
 }
 
 // Run executes the task lifecycle and returns an error if the task failed.
@@ -571,16 +583,60 @@ func (r *Runner) report(ctx context.Context, state agentv1.TaskState, exitCode i
 }
 
 // reportRequest sends a ReportState request and translates the response's
-// should_terminate signal into an error.
+// should_terminate signal into an error. A transient RPC failure (the api pod
+// momentarily Unavailable, a deadline) is retried with exponential backoff so a
+// task's terminal result is not lost to a network blip — which would otherwise
+// leave the TI to be failed as agent_lost by a reaper even though it succeeded.
+// The server's ReportState is idempotent (a report that already applied comes
+// back as a stale ack, not a double-apply), so retrying is safe. A logical
+// rejection is returned immediately, and a canceled context (parent shutdown,
+// SIGTERM) aborts the backoff at once.
 func (r *Runner) reportRequest(ctx context.Context, req *agentv1.ReportStateRequest) error {
-	resp, err := r.Client.ReportState(ctx, req)
-	if err != nil {
-		return fmt.Errorf("reporting state %v: %w", req.GetState(), err)
+	for attempt := 1; ; attempt++ {
+		resp, err := r.Client.ReportState(ctx, req)
+		if err == nil {
+			// should_terminate means the row already moved on — a reaper settled it,
+			// a later attempt superseded it, or (on a retry here) our own earlier
+			// attempt applied but its ack was lost. We cannot tell "superseded" from
+			// "we already won" locally, so we conservatively surface it as an error
+			// and stop. The DB is authoritative and already terminal either way; when
+			// it was our own win, the state is correct and the reconciler no-ops on
+			// the now-terminal TI, so the only cost is a non-zero agent exit.
+			if resp.GetShouldTerminate() {
+				return errors.New("control plane requested task termination")
+			}
+			return nil
+		}
+		if !retryableReportErr(err) {
+			return fmt.Errorf("reporting state %v: %w", req.GetState(), err)
+		}
+		delay, ok := Backoff(attempt)
+		if !ok {
+			return fmt.Errorf("reporting state %v after %d attempts: %w", req.GetState(), attempt, err)
+		}
+		slog.Warn("report failed; retrying after backoff",
+			"state", req.GetState(), "attempt", attempt, "delay", delay, "error", err)
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("reporting state %v: %w", req.GetState(), ctx.Err())
+		case <-r.after(delay):
+		}
 	}
-	if resp.GetShouldTerminate() {
-		return errors.New("control plane requested task termination")
+}
+
+// retryableReportErr reports whether a ReportState error is a transient
+// infrastructure failure worth retrying. The set is the canonical
+// safe-to-retry gRPC codes: everything else (InvalidArgument, PermissionDenied,
+// a logical rejection) is returned to the caller unretried. A stale report is
+// never seen here — the server acknowledges it (with should_terminate) rather
+// than returning an error.
+func retryableReportErr(err error) bool {
+	switch status.Code(err) {
+	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted, codes.Aborted:
+		return true
+	default:
+		return false
 	}
-	return nil
 }
 
 // reschedule reads the next-poke time a reschedule-mode sensor wrote to

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -18,15 +18,20 @@ import (
 
 // fakeClient is a test double for the generated AgentServiceClient.
 type fakeClient struct {
-	spec               *agentv1.TaskSpec
-	xcom               map[string]*agentv1.FetchXComResponse
-	states             []agentv1.TaskState
-	reports            []*agentv1.ReportStateRequest
-	pushed             []*agentv1.PushXComRequest
-	registered         bool
-	terminateAt        agentv1.TaskState // state for which ReportState returns should_terminate
-	getSpecErr         error
-	pushErr            error
+	spec        *agentv1.TaskSpec
+	xcom        map[string]*agentv1.FetchXComResponse
+	states      []agentv1.TaskState
+	reports     []*agentv1.ReportStateRequest
+	pushed      []*agentv1.PushXComRequest
+	registered  bool
+	terminateAt agentv1.TaskState // state for which ReportState returns should_terminate
+	getSpecErr  error
+	pushErr     error
+	// reportFailCode + reportFailTimes make the first reportFailTimes ReportState
+	// calls fail with that gRPC code, then succeed — to exercise the report retry.
+	reportFailCode     codes.Code
+	reportFailTimes    int
+	reportAttempts     int
 	heartbeatTerminate bool
 	vars               map[string]string
 	conns              map[string]string
@@ -72,6 +77,10 @@ func (f *fakeClient) StreamLogs(context.Context, ...grpc.CallOption) (grpc.BidiS
 }
 
 func (f *fakeClient) ReportState(_ context.Context, in *agentv1.ReportStateRequest, _ ...grpc.CallOption) (*agentv1.ReportStateResponse, error) {
+	f.reportAttempts++
+	if f.reportAttempts <= f.reportFailTimes {
+		return nil, status.Error(f.reportFailCode, "injected report failure")
+	}
 	f.states = append(f.states, in.GetState())
 	f.reports = append(f.reports, in)
 	return &agentv1.ReportStateResponse{Acknowledged: true, ShouldTerminate: in.GetState() == f.terminateAt}, nil


### PR DESCRIPTION
Correctness/robustness follow-up from the external v0.2.0 audit (§15), part of #538.

## The gap
A task's terminal `ReportState` (`SUCCESS`/`FAILED`) was a **single RPC**. On a transient failure — the api pod momentarily `Unavailable`, a deadline — the result was dropped: the agent exits non-zero → pod goes `Failed` → the reconciler records a task that **actually succeeded** as failed (or, if the pod stays up, a reaper fails it as `agent_lost`). Either way a green task is reported red on a network blip.

`agent.Backoff()` (1s..16s, bounded) already existed **and was tested but had zero callers** — the intended-but-never-wired report retry.

> Note: the audit's literal framing ("buffered/retried path hot-loops") does **not** reproduce — there was no retry loop at all. The real defect is the opposite: no retry. This PR fixes that.

## The fix
`reportRequest` now retries on the canonical transient gRPC codes (`Unavailable`, `DeadlineExceeded`, `ResourceExhausted`, `Aborted`) with exponential backoff, returns a logical rejection (e.g. `InvalidArgument`) immediately, and aborts the backoff at once on context cancellation (parent shutdown / SIGTERM). It covers every report path — start, terminal, and reschedule.

**Safe to retry:** the server's `ReportState` is idempotent — a report that already applied comes back as a *stale ack* (`should_terminate`), never a double-apply. So a lost-response retry can only either apply (first delivery) or be acknowledged as stale.

**Lite and Pro:** this is the fast path and does not depend on pod-phase inspection, so Lite (no pod) is covered too. The reconciler-as-durable-source-of-truth backstop for a pod killed *mid-report* (OOM/evict) is a separate Pro/K8s redesign (needs the agent to write a durable outcome signal the reconciler reads, not the agent's process exit code) — to be filed as its own ADR-gated item.

## Tests (unit, deterministic — backoff time injected, no real delay)
- `TestReportRetriesTransientThenSucceeds` — 2 transient failures then success; result lands, 3 attempts.
- `TestReportGivesUpAfterMaxAttempts` — never recovers; bounded at `maxRetryAttempts+1` calls (~31s of backoff).
- `TestReportDoesNotRetryNonRetryable` — `InvalidArgument` returned after 1 attempt.
- `TestReportRetryAbortsOnContextCancel` — canceled context aborts the backoff after the first attempt.

`-race` clean, golangci-lint 0 issues, full `internal/agent` package green.