### PR TITLE
docs(operators): #489 shell-quoting is the native bash path only (audit #16)

### DIFF
--- a/docs/airflow-operators.md
+++ b/docs/airflow-operators.md
@@ -212,6 +212,18 @@ value from an untrusted `conf` cannot inject shell — write interpolations unqu
 (`--name {{ params.x }}`, not `--name "{{ params.x }}"`). See
 [DAG authoring](dag-authoring.md) (issue #489).
 
+> **Security — the auto-quoting is the native `bash` path only.** A captured
+> provider operator (`airflow_operator`) renders its `template_fields` with
+> Airflow's own Jinja, exactly as upstream Airflow does — leoflow does **not**
+> (and cannot, without breaking non-shell operators and Airflow parity) inject
+> `shlex.quote` into that render. So if you use a provider operator that executes
+> a shell (e.g. a `BashOperator`) and template an **untrusted** value into a
+> shell field — `params`/`conf` supplied by anyone with `execute:dag` — the same
+> rules as upstream Airflow apply: quote it yourself, or, preferably, pass the
+> value through the environment (`$AIRFLOW_VAR_*`, `$AIRFLOW_CONN_*`, an env kwarg)
+> instead of rendering it into the command string. Trusted, author-written
+> template structure is fine; untrusted interpolated values are the hazard.
+
 ## Not yet supported (loud, not silent)
 
 Capabilities that need scheduler/control-plane work are rejected loudly rather


### PR DESCRIPTION
Resolution of the external v0.2.0 audit §16 (part of #538) — a **documentation** fix, not a code change, after investigation.

## Why not the proposed code fix
The audit suggested adding `shlex.quote` at `runner.py:509`. Investigation shows that is misplaced and infeasible:
- `runner.py:509` is `op.render_template_fields(context)` / `op.execute(context)` — the **provider-operator** path (`airflow_operator`, ADR 0040), not a shell render.
- That path renders `template_fields` with **Airflow's own Jinja**, exactly as upstream Airflow. Injecting `shlex.quote` there would **corrupt non-shell operators** (a templated SQL statement, an HTTP URL, a JSON body) and **break Airflow parity**.
- The native `bash` path — the one leoflow itself execs — is **already** quoted via the #489 `SandboxedEnvironment(finalize=shlex.quote)`; provider operators route through `op.execute`, not `run_bash`.

## The actual, bounded surface
Untrusted `params`/`conf` (suppliable by `execute:dag`) rendered into a shell-executing provider operator's templated field is **identical to upstream Airflow behavior** and is the DAG author's responsibility — not a leoflow-introduced defect. The gap was purely that the operator docs did not state the #489 auto-quoting stops at the native bash path.

## The fix
Add a security note to `docs/airflow-operators.md`: the auto-quoting is native-`bash`-only; on the provider-operator path, quote untrusted values yourself or (preferably) pass them via the environment (`$AIRFLOW_VAR_*`/`$AIRFLOW_CONN_*`/env kwarg) instead of rendering into a command string.

Docs-only. If the enterprise multi-tenant model later makes `execute:dag` an untrusted boundary, this rejoins the tenant-isolation cluster (#508/#209/#228) — noted there, not here.