### PR TITLE
fix(api): trust no proxy by default — X-Forwarded-For no longer spoofable (audit H1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Security
+
+- **The API now trusts no proxy by default** (`server.trusted_proxies`,
+  `LEOFLOW_SERVER_TRUSTED_PROXIES`). Previously `X-Forwarded-For` was honored
+  from any source, so the client IP behind the login rate-limiter and the audit
+  log could be spoofed. The client IP is now the direct peer unless you list the
+  reverse proxy's IP/CIDR. **Behavior change** for deployments behind an ingress:
+  set `server.trusted_proxies` to the ingress CIDR to keep per-client
+  rate-limiting and audit accurate. See
+  [Configuration → Trusted proxies](docs/configuration.md).
+
 ## [0.2.0] - 2026-08-07
 
 > The **0.2.0** line. The control plane can now run as **separate api and

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -370,6 +370,7 @@ func buildAPIServer(cfg *config.ServerConfig, tel *observability.Telemetry, auth
 		Tracer:                       tel.Tracer,
 		HealthChecks:                 checks,
 		CORSOrigins:                  cfg.Server.CORS.AllowedOrigins,
+		TrustedProxies:               cfg.Server.TrustedProxies,
 		TokenTTLSecs:                 cfg.Auth.JWT.TokenTTLSeconds,
 		InstanceName:                 cfg.UI.InstanceName,
 		UIAutoRefreshIntervalSeconds: cfg.UI.AutoRefreshIntervalSeconds,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -57,6 +57,7 @@ roadmap item.
 | `LEOFLOW_SERVER_HTTP_ADDR` | `0.0.0.0:8080` | both | HTTP/UI listener. |
 | `LEOFLOW_SERVER_GRPC_ADDR` | `0.0.0.0:9091` | both | Agent gRPC listener. |
 | `LEOFLOW_SERVER_METRICS_ADDR` | `0.0.0.0:9090` | both | Prometheus metrics. |
+| `LEOFLOW_SERVER_TRUSTED_PROXIES` | *(empty — trust none)* | both | Proxy IPs/CIDRs whose `X-Forwarded-For` is honored for the client IP (`server.trusted_proxies`, a list). See note below. |
 | `LEOFLOW_DATABASE_URL` | `postgres://…/leoflow` | both | Postgres DSN. |
 | `LEOFLOW_REDIS_URL` | `redis://…/0` | **Pro only** | Redis (XCom + locks). Lite stores both in Postgres ([ADR 0026](adr/0026-lite-datastore-no-redis.md)). |
 | `LEOFLOW_AUTH_JWT_SECRET` | — *(required for jwt)* | both | Signs API/agent tokens. |
@@ -71,3 +72,20 @@ roadmap item.
 | `LEOFLOW_OBSERVABILITY_*` | — | both | OTel endpoint, log level/format. |
 
 `leoflow lite` sets the dev-appropriate values automatically (isolated DB, port 8088, admin login on, no Redis).
+
+### Trusted proxies and the client IP
+
+By default Leoflow trusts **no** proxy: `X-Forwarded-For` is ignored and the
+client IP (used by the login rate-limiter and the audit log) is the direct peer.
+This is the safe default — it stops a spoofed `X-Forwarded-For` from forging the
+client IP — and is correct for Lite (exposed directly) and for any deployment
+reached without a reverse proxy.
+
+When the API runs **behind a reverse proxy or ingress**, set
+`server.trusted_proxies` (env `LEOFLOW_SERVER_TRUSTED_PROXIES`) to the proxy's
+IP or CIDR — e.g. your ingress controller's pod CIDR. Only then is the left-most
+`X-Forwarded-For` entry honored, so rate-limiting and audit see the real client
+instead of the proxy. **Do not** set this to a broad private range (e.g. all of
+`10.0.0.0/8`) in a cluster where task pods run: a task pod inside that range
+could then spoof the client IP. Scope it to the ingress. An invalid value fails
+secure (trust none) with a logged error.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -32,7 +32,13 @@ type Dependencies struct {
 	Tracer        trace.Tracer
 	HealthChecks  map[string]HealthChecker
 	CORSOrigins   []string
-	TokenTTLSecs  int
+	// TrustedProxies is the set of proxy IPs/CIDRs whose X-Forwarded-For header
+	// gin will honor when resolving c.ClientIP(). Empty/nil trusts NO proxy, so
+	// ClientIP is the direct peer and a spoofed XFF cannot forge the client IP
+	// (audit H1). A Pro deployment behind an ingress sets this to the ingress
+	// CIDR so per-client rate-limiting and audit see the real client.
+	TrustedProxies []string
+	TokenTTLSecs   int
 	// InstanceName is shown in the UI navbar (Airflow's instance_name). Empty
 	// falls back to "Leoflow"; `leoflow dev` sets it to mark the DEV environment.
 	InstanceName string
@@ -93,6 +99,16 @@ type Dependencies struct {
 func NewServer(deps Dependencies) *gin.Engine {
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
+	// Trust only the explicitly-configured proxies for X-Forwarded-For; the empty
+	// default trusts none, so c.ClientIP() is the direct peer and a spoofed XFF
+	// cannot forge it (audit H1). An invalid CIDR fails SECURE — trust none — not
+	// open.
+	if err := r.SetTrustedProxies(deps.TrustedProxies); err != nil {
+		deps.Logger.Error("invalid trusted_proxies; trusting no proxy", "error", err)
+		if resetErr := r.SetTrustedProxies(nil); resetErr != nil {
+			deps.Logger.Error("resetting trusted proxies to none failed", "error", resetErr)
+		}
+	}
 	// Disable auto-redirect on trailing slash (#291): the 301 it writes
 	// bypasses NoStoreOnVolatileRoutes, so the browser can cache the bare
 	// 301 and short-circuit the next request. Bare paths register explicit

--- a/internal/api/trusted_proxies_test.go
+++ b/internal/api/trusted_proxies_test.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+)
+
+// clientIPServer builds a minimal server with the given trusted-proxy list and a
+// probe route that echoes the resolved client IP.
+func clientIPServer(trusted []string) *gin.Engine {
+	r := NewServer(Dependencies{
+		Logger:         discardLogger(),
+		RateLimiter:    auth.NewRateLimiter(100, time.Minute),
+		CORSOrigins:    []string{"*"},
+		DevNoAuth:      true,
+		TrustedProxies: trusted,
+	})
+	r.GET("/_clientip", func(c *gin.Context) { c.String(http.StatusOK, c.ClientIP()) })
+	return r
+}
+
+func clientIP(t *testing.T, r *gin.Engine, remoteAddr, xff string) string {
+	t.Helper()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/_clientip", http.NoBody)
+	req.RemoteAddr = remoteAddr
+	if xff != "" {
+		req.Header.Set("X-Forwarded-For", xff)
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w.Body.String()
+}
+
+// TestTrustNoProxiesByDefault: with no trusted proxies configured, an
+// X-Forwarded-For header is attacker-controlled and must be ignored — ClientIP
+// resolves to the direct peer. This is what stops a spoofed XFF from evading or
+// poisoning the login rate-limiter and the audit log (audit H1).
+func TestTrustNoProxiesByDefault(t *testing.T) {
+	r := clientIPServer(nil)
+	if got := clientIP(t, r, "203.0.113.9:4444", "1.2.3.4"); got != "203.0.113.9" {
+		t.Errorf("with no trusted proxies, ClientIP must be the direct peer 203.0.113.9, got %q", got)
+	}
+}
+
+// TestTrustedProxyHonorsForwardedFor: when the direct peer IS a configured
+// trusted proxy, the left-most X-Forwarded-For entry is the real client and
+// ClientIP resolves to it — the intended path for a Pro deployment behind a
+// known ingress.
+func TestTrustedProxyHonorsForwardedFor(t *testing.T) {
+	r := clientIPServer([]string{"203.0.113.9/32"})
+	if got := clientIP(t, r, "203.0.113.9:4444", "1.2.3.4"); got != "1.2.3.4" {
+		t.Errorf("behind a trusted proxy, ClientIP must be the forwarded client 1.2.3.4, got %q", got)
+	}
+}

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -149,6 +149,12 @@ type ServerSection struct {
 	MetricsAddr string      `mapstructure:"metrics_addr"`
 	GRPCAddr    string      `mapstructure:"grpc_addr"`
 	CORS        CORSSection `mapstructure:"cors"`
+	// TrustedProxies lists the proxy IPs/CIDRs whose X-Forwarded-For is honored
+	// when resolving the client IP. Empty (the default) trusts no proxy, so a
+	// spoofed XFF cannot forge the client IP (audit H1); set it to the ingress
+	// CIDR when the API runs behind a reverse proxy so rate-limiting and audit
+	// see the real client.
+	TrustedProxies []string `mapstructure:"trusted_proxies"`
 	// GRPCTLSCert/GRPCTLSKey enable TLS on the agent gRPC listener (issue #58).
 	// When both are set the channel is encrypted; empty means plaintext (dev).
 	GRPCTLSCert string `mapstructure:"grpc_tls_cert"`


### PR DESCRIPTION
Security hardening from the external v0.2.0 audit (H1), part of #537. First of the cheap deny-by-default batch.

## The bug
Gin trusts **all** proxies unless `SetTrustedProxies` is called — which it never was. So `X-Forwarded-For` was honored from any source, and `c.ClientIP()` (used by the login rate-limiter in `auth_handler.go` and by the audit log) could be **spoofed**: an attacker sets `X-Forwarded-For: <whatever>` to evade or poison the login lockout and to forge the IP in audit records.

## The fix
- New `server.trusted_proxies` (`LEOFLOW_SERVER_TRUSTED_PROXIES`), threaded into `NewServer`, applied via `SetTrustedProxies`.
- **Default is empty → trust no proxy**: `ClientIP()` is the direct peer, `X-Forwarded-For` is ignored. Correct and safe for Lite (direct exposure) and any no-proxy deployment.
- Behind an ingress, set it to the proxy's IP/CIDR so the real client is resolved.
- **Fails secure**: an invalid CIDR logs an error and falls back to trust-none, never trust-all.

## Behavior change (documented)
Deployments **behind a reverse proxy/ingress** must set `trusted_proxies` to the ingress CIDR, otherwise the client IP becomes the proxy's (per-client rate-limiting and audit would key on the proxy). Documented in [docs/configuration.md → Trusted proxies](docs/configuration.md) with the explicit warning **not** to trust a broad private range in a cluster where task pods run (a task pod could then spoof). CHANGELOG updated under Security. Helm wiring of the ingress CIDR is a follow-up.

## Tests
- `TestTrustNoProxiesByDefault` — spoofed `X-Forwarded-For` ignored; `ClientIP` = direct peer.
- `TestTrustedProxyHonorsForwardedFor` — with the peer as a configured trusted proxy, `ClientIP` = the forwarded client.

golangci-lint 0 issues, full `internal/api` + `internal/config` green.