### PR TITLE
fix(api): /metrics off the public listener + /readyz stops leaking dep errors (audit H2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   set `server.trusted_proxies` to the ingress CIDR to keep per-client
   rate-limiting and audit accurate. See
   [Configuration → Trusted proxies](docs/configuration.md).
+- **`/metrics` is no longer served on the public API/UI listener; `/readyz`
+  no longer leaks dependency errors** (audit H2). Prometheus `/metrics` was
+  exposed unauthenticated on the API port in addition to the dedicated metrics
+  listener; it is now served **only** on the observability listener (the metrics
+  port, which every role runs), so it can be firewalled separately from the API.
+  And a failing `/readyz` returned the raw dependency error (which can carry a
+  DSN, credentials, or internal hostnames) to an unauthenticated caller; it now
+  names only the unready dependency and logs the full error server-side. Scrapers
+  must target the metrics port (`LEOFLOW_SERVER_METRICS_ADDR`, default `:9090`),
+  not the API port.
 
 ## [0.2.0] - 2026-08-07
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -258,16 +258,6 @@ paths:
         "503":
           description: Not ready
 
-  /metrics:
-    get:
-      summary: Prometheus metrics
-      tags: [Observability]
-      security: []
-      responses:
-        "200":
-          description: Prometheus exposition format
-          content: { text/plain: { schema: { type: string } } }
-
 components:
   securitySchemes:
     bearerAuth:

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -20,7 +21,12 @@ func readinessHandler(checks map[string]HealthChecker) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		for name, hc := range checks {
 			if err := hc.Ping(c.Request.Context()); err != nil {
-				AbortProblem(c, http.StatusServiceUnavailable, "not ready", name+": "+err.Error())
+				// /readyz is unauthenticated (probes carry no token), so the raw
+				// dependency error — which can carry a DSN, credentials, or internal
+				// hostnames — must not go in the response (audit H2). Log the real
+				// cause server-side; tell the caller only which dependency is unready.
+				slog.WarnContext(c.Request.Context(), "readiness check failed", "dependency", name, "error", err)
+				AbortProblem(c, http.StatusServiceUnavailable, "not ready", name+" unavailable")
 				return
 			}
 		}

--- a/internal/api/health_test.go
+++ b/internal/api/health_test.go
@@ -42,10 +42,10 @@ func TestReadinessHandlerSurfacesDependencyHealth(t *testing.T) {
 		}
 	})
 
-	t.Run("one check fails → 503 with the dep name + error", func(t *testing.T) {
+	t.Run("one check fails → 503 with the dep name but NOT the raw error", func(t *testing.T) {
 		r := gin.New()
 		r.GET("/readyz", readinessHandler(map[string]HealthChecker{
-			"postgres": &fakeHealthCheck{err: errors.New("connection refused")},
+			"postgres": &fakeHealthCheck{err: errors.New("connection refused to secret.host")},
 		}))
 		rec := httptest.NewRecorder()
 		r.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", http.NoBody))
@@ -56,8 +56,10 @@ func TestReadinessHandlerSurfacesDependencyHealth(t *testing.T) {
 		if !strings.Contains(body, "postgres") {
 			t.Errorf("body missing the failed dep name 'postgres': %q", body)
 		}
-		if !strings.Contains(body, "connection refused") {
-			t.Errorf("body missing the underlying error message: %q", body)
+		// The raw dependency error must NOT leak into an unauthenticated response
+		// (audit H2). It is logged server-side instead.
+		if strings.Contains(body, "connection refused") || strings.Contains(body, "secret.host") {
+			t.Errorf("body leaked the raw dependency error: %q", body)
 		}
 	})
 

--- a/internal/api/metrics_readyz_test.go
+++ b/internal/api/metrics_readyz_test.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+)
+
+// TestMetricsNotServedOnAPIPort locks audit H2: even when a Prometheus registry
+// is wired, the public HTTP/UI listener must NOT expose /metrics — scraping
+// lives on the dedicated observability listener (ObservabilityHandler, the
+// metrics port), so an operator can firewall it separately from the API/UI.
+func TestMetricsNotServedOnAPIPort(t *testing.T) {
+	r := NewServer(Dependencies{
+		Logger:        discardLogger(),
+		Authenticator: &fakeAuthn{user: &auth.User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}},
+		RateLimiter:   auth.NewRateLimiter(100, time.Minute),
+		CORSOrigins:   []string{"*"},
+		Registry:      prometheus.NewRegistry(),
+		DevNoAuth:     true,
+	})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/metrics", http.NoBody)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code == http.StatusOK {
+		t.Errorf("/metrics must not be served on the API port (use the observability listener); got %d", w.Code)
+	}
+}
+
+// TestReadyzDoesNotLeakDependencyError locks audit H2: /readyz is unauthenticated
+// (probes carry no token), so a failing check must not echo the raw dependency
+// error — which can carry a DSN, credentials, or internal hostnames — into the
+// response body. The caller learns which dependency is unready, nothing more.
+func TestReadyzDoesNotLeakDependencyError(t *testing.T) {
+	const secret = "postgres://user:hunter2@db.internal:5432/leoflow"
+	srv := apiStubServer(map[string]HealthChecker{
+		"postgres": fakePinger{err: errors.New("dial " + secret + " connection refused")},
+	})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", http.NoBody)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("a failing readiness check must be 503, got %d", w.Code)
+	}
+	if strings.Contains(w.Body.String(), secret) {
+		t.Errorf("/readyz leaked the raw dependency error into the response body: %s", w.Body.String())
+	}
+	// It should still name the failing dependency (safe, and operationally useful).
+	if !strings.Contains(w.Body.String(), "postgres") {
+		t.Errorf("/readyz should name the unready dependency; body = %s", w.Body.String())
+	}
+}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -102,10 +102,12 @@ func CORS(allowed []string) gin.HandlerFunc {
 }
 
 // alwaysPublic are non-data paths reachable without a token: the login/logout
-// endpoints, health/metrics/docs, and the pre-login UI config (read before
+// endpoints, health/docs, and the pre-login UI config (read before
 // authentication). "/api/v2/auth/" covers the Airflow UI's login + logout, which
-// must be reachable precisely when the user has no token yet.
-var alwaysPublic = []string{"/auth/", "/api/v2/auth/", "/healthz", "/readyz", "/metrics", "/docs", "/openapi", "/ui/config"}
+// must be reachable precisely when the user has no token yet. /metrics is not
+// listed: it is not served on this listener at all (audit H2) — scraping lives on
+// the dedicated observability listener.
+var alwaysPublic = []string{"/auth/", "/api/v2/auth/", "/healthz", "/readyz", "/docs", "/openapi", "/ui/config"}
 
 // authTokenCookie is the cookie the Airflow 3.2.1 UI carries the JWT in (set by
 // the login flow). JWTAuth accepts it as a fallback to the Authorization header.

--- a/internal/api/observability_handler_test.go
+++ b/internal/api/observability_handler_test.go
@@ -44,8 +44,12 @@ func TestObservabilityHandler(t *testing.T) {
 		if rec.Code != http.StatusServiceUnavailable {
 			t.Fatalf("/readyz degraded = %d, want 503", rec.Code)
 		}
-		if !strings.Contains(rec.Body.String(), "postgres") || !strings.Contains(rec.Body.String(), "connection refused") {
-			t.Errorf("/readyz body should name the failed dep + error, got %q", rec.Body.String())
+		// Names the failed dep, but must not leak the raw error (audit H2).
+		if !strings.Contains(rec.Body.String(), "postgres") {
+			t.Errorf("/readyz body should name the failed dep, got %q", rec.Body.String())
+		}
+		if strings.Contains(rec.Body.String(), "connection refused") {
+			t.Errorf("/readyz leaked the raw dependency error, got %q", rec.Body.String())
 		}
 	})
 

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -258,16 +258,6 @@ paths:
         "503":
           description: Not ready
 
-  /metrics:
-    get:
-      summary: Prometheus metrics
-      tags: [Observability]
-      security: []
-      responses:
-        "200":
-          description: Prometheus exposition format
-          content: { text/plain: { schema: { type: string } } }
-
 components:
   securitySchemes:
     bearerAuth:

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/neochaotic/leoflow/internal/auth"
@@ -128,9 +127,10 @@ func NewServer(deps Dependencies) *gin.Engine {
 
 	r.GET("/healthz", livenessHandler)
 	r.GET("/readyz", readinessHandler(deps.HealthChecks))
-	if deps.Registry != nil {
-		r.GET("/metrics", gin.WrapH(promhttp.HandlerFor(deps.Registry, promhttp.HandlerOpts{})))
-	}
+	// /metrics is intentionally NOT served here (audit H2): scraping lives on the
+	// dedicated observability listener (ObservabilityHandler on the metrics port),
+	// which every role runs, so metrics can be firewalled separately from the
+	// public API/UI surface. deps.Registry is retained for that listener's wiring.
 	registerDocs(r)
 
 	r.POST("/auth/token", authTokenHandler(deps.Authenticator, deps.RateLimiter, deps.TokenTTLSecs))


### PR DESCRIPTION
Security hardening from the external v0.2.0 audit (H2), part of #537. Two unauthenticated-surface fixes on the HTTP/UI listener.

## /metrics off the public API port
`/metrics` was registered on the public API listener (unauthenticated, via the `alwaysPublic` list) **in addition to** the dedicated observability listener (`ObservabilityHandler` on `LEOFLOW_SERVER_METRICS_ADDR`, which every role already runs). It is now served **only** on the observability listener, so an operator can firewall metrics separately from the API/UI. `deps.Registry` is retained (the observability listener uses it). Also removed `/metrics` from the OpenAPI spec (both copies, kept in sync) and from the auth always-public list.

**Behavior change:** Prometheus scrapers must target the metrics port (default `:9090`), not the API port.

## /readyz stops leaking dependency errors
A failing `/readyz` returned `name + ": " + err.Error()` to an **unauthenticated** caller (probes carry no token) — the raw dependency error can carry a DSN, credentials, or internal hostnames. It now returns only the unready dependency **name** and logs the full error server-side.

## Tests
- `TestMetricsNotServedOnAPIPort` — even with a Prometheus registry wired, `/metrics` on the API engine is not 200.
- `TestReadyzDoesNotLeakDependencyError` — a failing check yields 503 that names the dep but does **not** contain the raw error.
- Updated `TestReadinessHandlerSurfacesDependencyHealth` and `TestObservabilityHandler` — they asserted the old leaking contract; now they assert the dep name is present and the raw error is absent. (Contract change, not a weakening: the old assertion tested the vulnerable behavior.)

golangci-lint 0 issues; full `internal/api` green. OpenAPI YAML validated locally; `redocly lint` runs in CI.