### PR TITLE
fix(helm): seccompProfile RuntimeDefault on control-plane + migration pods (restricted PSA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Security
 
+- **Control-plane and migration-Job pods now set `seccompProfile: RuntimeDefault`**
+  (audit follow-up). The chart hardened these pods with `runAsNonRoot`, dropped
+  capabilities, and `allowPrivilegeEscalation: false`, and a comment claimed a
+  RuntimeDefault seccomp profile — but it was never rendered, so a cluster
+  enforcing the `restricted` Pod Security Standard would reject the pods. The
+  profile is now set at the pod level (inherited by every container) on the api,
+  scheduler, monolith, and migration-Job pods. Task pods already carried it.
 - **The API now trusts no proxy by default** (`server.trusted_proxies`,
   `LEOFLOW_SERVER_TRUSTED_PROXIES`). Previously `X-Forwarded-For` was honored
   from any source, so the client IP behind the login rate-limiter and the audit

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -260,6 +260,7 @@ differ from what's committed.
 | migrations.podSecurityContext.runAsGroup | int | `65532` |  |
 | migrations.podSecurityContext.runAsNonRoot | bool | `true` |  |
 | migrations.podSecurityContext.runAsUser | int | `65532` |  |
+| migrations.podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | migrations.securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | migrations.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
 | migrations.securityContext.readOnlyRootFilesystem | bool | `true` |  |
@@ -282,6 +283,7 @@ differ from what's committed.
 | podSecurityContext.runAsGroup | int | `65532` |  |
 | podSecurityContext.runAsNonRoot | bool | `true` |  |
 | podSecurityContext.runAsUser | int | `65532` |  |
+| podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
 | ports | object | `{"grpc":9091,"http":8080,"metrics":9090}` | Ports the leoflow-server listens on. http: API + UI, metrics: Prometheus /metrics, grpc: agent ↔ control plane channel (task pods dial back here). |
 | rbac.create | bool | `true` | Create the Role + RoleBinding the pod-per-task executor needs in `taskNamespace`: create/get/list/watch/delete on pods, get on pods/log, and create/delete on persistentvolumeclaims for the per-run staging volume (ADR 0022). The grant is checked against the executor's actual API calls by `scripts/rbac-covers-executor.sh` in CI, so this list cannot silently fall behind the code again. Set `false` only if you bring your own Role — and then that check does not protect you. |
 | redis.caConfigMap | string | `""` | Name of a ConfigMap with a `ca.crt` key containing the PEM CA bundle the client trusts when negotiating TLS to a `rediss://` URL (#312). Required when the managed-Redis server cert is signed by a provider / per-instance CA that is not in the system roots — Memorystore SERVER_AUTHENTICATION, ElastiCache in-transit encryption, Azure Cache for Redis. Mounted read-only at `/etc/leoflow/redis-ca` and exposed to the server via `LEOFLOW_REDIS_CA_FILE`. Leave empty when Redis uses a public CA or no TLS. |

--- a/helm/leoflow/tests/deployment_test.yaml
+++ b/helm/leoflow/tests/deployment_test.yaml
@@ -440,3 +440,16 @@ tests:
           content:
             name: LEOFLOW_EXECUTOR_DEFAULTS_READ_ONLY_TASK_ROOT_FILESYSTEM
             value: "true"
+
+  - it: "audit H2 — control-plane pod sets seccompProfile RuntimeDefault (restricted PSA)"
+    template: deployment.yaml
+    set:
+      database.url: postgres://h/d
+      redis.url: redis://h/0
+    asserts:
+      # restricted Pod Security Admission requires a RuntimeDefault (or Localhost)
+      # seccomp profile at the pod or container level. The chart claimed this
+      # posture in a comment but never rendered it.
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault

--- a/helm/leoflow/tests/migration_job_test.yaml
+++ b/helm/leoflow/tests/migration_job_test.yaml
@@ -71,3 +71,11 @@ tests:
       - equal:
           path: metadata.annotations["helm.sh/hook-weight"]
           value: "0"   # Secret is at "-5"; Job at "0" → Secret runs first ✓
+
+  - it: "audit H2 — migration Job pod sets seccompProfile RuntimeDefault (restricted PSA)"
+    set:
+      database.url: postgres://h/d
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault

--- a/helm/leoflow/values.yaml
+++ b/helm/leoflow/values.yaml
@@ -203,6 +203,9 @@ migrations:
     runAsUser: 65532
     runAsGroup: 65532
     fsGroup: 65532
+    # restricted PSA requires a RuntimeDefault seccomp profile; set pod-level.
+    seccompProfile:
+      type: RuntimeDefault
   securityContext:
     allowPrivilegeEscalation: false
     # migrate is a static Go binary writing only to the DB (advisory lock for
@@ -362,6 +365,10 @@ podSecurityContext:
   runAsUser: 65532
   runAsGroup: 65532
   fsGroup: 65532
+  # restricted Pod Security Admission requires a RuntimeDefault (or Localhost)
+  # seccomp profile. Set at the pod level so every container inherits it.
+  seccompProfile:
+    type: RuntimeDefault
 securityContext:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: false


### PR DESCRIPTION
Security hardening (audit follow-up), part of #537 containment.

## Gap
The chart hardens the control-plane and migration-Job pods with `runAsNonRoot`, dropped capabilities, and `allowPrivilegeEscalation: false`, and a `values.yaml` comment claimed a **RuntimeDefault seccomp profile** as part of the posture — but it was **never rendered** (`helm template … | grep seccompProfile` = 0). A cluster enforcing the `restricted` Pod Security Standard rejects a pod with no seccomp profile, so the control plane would fail to start there.

## Fix
Set `seccompProfile: { type: RuntimeDefault }` at the **pod level** (inherited by every container) in `values.yaml` for both the shared control-plane pod template (api / scheduler / monolith `all` roles) and the pre-install migration Job. Task pods already carried it via the executor's `buildSecurityContext`.

## Tests (helm-unittest)
- Deployment: assert `spec.template.spec.securityContext.seccompProfile.type == RuntimeDefault` (red before, green after).
- Migration Job: same assertion.
- Split render manually verified: both the api and scheduler pods (and the migration Job) render the profile.

Full helm-unittest suite green (92/92); `helm lint` clean.