### PR TITLE
ci: exclude generated *.gen.go from the coverage floor

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,7 +153,7 @@ jobs:
           # process-orchestration of external binaries (Docker/initdb/pg_ctl)
           # that only integration/e2e can exercise honestly, per ADR 0011.
           FLOOR=80
-          EXCLUDE='(/internal/storage/queries/|/internal/storage/repository\.go:|/internal/storage/postgres\.go:|/internal/storage/redis\.go:|/internal/storage/scheduler_store\.go:|/internal/storage/agent_store\.go:|/internal/storage/xcom_index\.go:|/internal/xcom/redis_backend\.go:|/internal/logs/tail\.go:|/internal/scheduler/leader\.go:|/internal/cli/managed_postgres\.go:|/internal/cli/backup_cmd\.go:|/internal/cli/restore_cmd\.go:|/internal/cli/forget\.go:|/internal/cli/dbt_manifest\.go:|\.pb\.go:|/internal/version/|/cmd/)'
+          EXCLUDE='(/internal/storage/queries/|/internal/storage/repository\.go:|/internal/storage/postgres\.go:|/internal/storage/redis\.go:|/internal/storage/scheduler_store\.go:|/internal/storage/agent_store\.go:|/internal/storage/xcom_index\.go:|/internal/xcom/redis_backend\.go:|/internal/logs/tail\.go:|/internal/scheduler/leader\.go:|/internal/cli/managed_postgres\.go:|/internal/cli/backup_cmd\.go:|/internal/cli/restore_cmd\.go:|/internal/cli/forget\.go:|/internal/cli/dbt_manifest\.go:|\.pb\.go:|\.gen\.go:|/internal/version/|/cmd/)'
           grep -vE "$EXCLUDE" coverage.out > coverage.filtered.out
           TOTAL=$(go tool cover -func=coverage.filtered.out | tail -1 | awk '{print $3}' | sed 's/%//')
           echo "Total coverage (filtered): ${TOTAL}% (floor: ${FLOOR}%)"

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -46,7 +46,7 @@ go test -coverprofile="$profile" ./... >/dev/null
 # packages, version, and the thin process/lock-binding files (DB, locks, and
 # external-binary orchestration like Docker/initdb/pg_ctl) that are exercised
 # by integration/e2e tests rather than unit tests.
-exclude='(/internal/storage/queries/|/internal/storage/repository\.go:|/internal/storage/postgres\.go:|/internal/storage/redis\.go:|/internal/storage/scheduler_store\.go:|/internal/storage/agent_store\.go:|/internal/storage/xcom_index\.go:|/internal/xcom/redis_backend\.go:|/internal/logs/tail\.go:|/internal/scheduler/leader\.go:|/internal/cli/managed_postgres\.go:|/internal/cli/backup_cmd\.go:|/internal/cli/restore_cmd\.go:|/internal/cli/dbt_manifest\.go:|\.pb\.go:|/internal/version/|/cmd/)'
+exclude='(/internal/storage/queries/|/internal/storage/repository\.go:|/internal/storage/postgres\.go:|/internal/storage/redis\.go:|/internal/storage/scheduler_store\.go:|/internal/storage/agent_store\.go:|/internal/storage/xcom_index\.go:|/internal/xcom/redis_backend\.go:|/internal/logs/tail\.go:|/internal/scheduler/leader\.go:|/internal/cli/managed_postgres\.go:|/internal/cli/backup_cmd\.go:|/internal/cli/restore_cmd\.go:|/internal/cli/dbt_manifest\.go:|\.pb\.go:|\.gen\.go:|/internal/version/|/cmd/)'
 grep -vE "$exclude" "$profile" >"$filtered"
 current=$(go tool cover -func="$filtered" | tail -1 | awk '{print $3}' | tr -d '%')
 rm -f "$profile" "$filtered"


### PR DESCRIPTION
Fixes the `Test + Coverage` failure on `main` introduced by #550.

## Cause
`pkg/client/client.gen.go` (oapi-codegen output, ~2000 statements, 8.8% covered) is counted in the coverage denominator, dropping the filtered total to **73.5%**, below the **80%** floor.

## Fix
Generated code is already excluded from the floor everywhere else (`.pb.go`, sqlc `queries/`). Add the general `\.gen\.go:` pattern to the EXCLUDE regex so the oapi-generated client is treated the same class. Applied to **both** the CI gate (`.github/workflows/ci.yaml`) and `scripts/pre-commit` (the comment says to keep them in sync). The hand-written `pkg/client/client.go` (tested) stays counted.

## Verified
Reproduced the coverage computation: with the old exclude the total is 73.1% (matches CI's 73.5%); with `\.gen\.go:` added it returns to **85.2%** (> 80% floor), and `client.gen.go`'s 706 coverage lines drop to 0 in the filtered profile.