### PR TITLE
feat(mcp): add diagnose_run tool (ADR 0050 R19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **Experimental MCP server skeleton (`leoflow-mcp`)** — the first slice of the
   Model Context Protocol server (ADR 0050): a read-only, stdio server built on
-  the official `modelcontextprotocol/go-sdk`, exposing a `list_dags` tool that
-  reaches the control plane only through `pkg/client` (the caller's token is
+  the official `modelcontextprotocol/go-sdk`, exposing `list_dags` and `diagnose_run` (one call: run state + failed tasks +
+  each failed task's truncated, sanitized log tail) — reaching the control plane
+  only through `pkg/client` (the caller's token is
   passed through; the server holds no privilege of its own). Optional and never
-  part of `leoflow-server`. This is a skeleton — more read tools (`diagnose_run`,
-  `search_logs`) and the Pro HTTP transport follow.
+  part of `leoflow-server`. More read tools (`search_logs`, resources) and the Pro HTTP transport follow.
 - **A generated, typed Go client for the `/api/v2` surface (`pkg/client`)** — the
   single control-plane client the CLI, the coming MCP server, and smoke tests
   share instead of hand-rolling HTTP (ADR 0050). Generated from the OpenAPI spec

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -38,6 +39,10 @@ func NewServer(api *apiclient.ClientWithResponses, version string) *mcpsdk.Serve
 		Name:        "list_dags",
 		Description: "List DAGs registered in the Leoflow control plane, with their paused state.",
 	}, h.listDags)
+	mcpsdk.AddTool(s, &mcpsdk.Tool{
+		Name:        "diagnose_run",
+		Description: "Diagnose a DAG run: its state, which task instances failed, and a truncated tail of each failed task's log — one call instead of list-runs/get-run/list-tasks/get-logs.",
+	}, h.diagnoseRun)
 	return s
 }
 
@@ -105,4 +110,147 @@ func deref[T any](p *T) T {
 		return zero
 	}
 	return *p
+}
+
+const (
+	defaultLogTail = 40
+	maxLogTail     = 200
+)
+
+type diagnoseRunInput struct {
+	DagID        string `json:"dag_id" jsonschema:"the DAG id"`
+	RunID        string `json:"run_id" jsonschema:"the DAG run id to diagnose"`
+	LogTailLines int    `json:"log_tail_lines,omitempty" jsonschema:"log lines to include per failed task (default 40, max 200)"`
+}
+
+type failedTask struct {
+	TaskID          string  `json:"task_id"`
+	State           string  `json:"state"`
+	TryNumber       int     `json:"try_number"`
+	DurationSeconds float32 `json:"duration_seconds,omitempty"`
+	LogTail         string  `json:"log_tail,omitempty"`
+}
+
+type diagnoseRunOutput struct {
+	DagID       string       `json:"dag_id"`
+	RunID       string       `json:"run_id"`
+	RunState    string       `json:"run_state"`
+	TotalTasks  int          `json:"total_tasks"`
+	FailedTasks []failedTask `json:"failed_tasks"`
+	Summary     string       `json:"summary"`
+}
+
+// diagnoseRun composes the run, its task instances, and each failed task's log
+// tail into a single diagnosis (ADR 0050 R19), so an agent gets one answer
+// instead of chaining four calls it would likely mis-sequence. It is
+// deliberately client-side composition for the MVP; a server-side aggregate
+// endpoint is the later optimization for chattiness. Log tails are truncated and
+// sanitized because log content is untrusted (D10).
+func (h *handlers) diagnoseRun(ctx context.Context, _ *mcpsdk.CallToolRequest, in diagnoseRunInput) (*mcpsdk.CallToolResult, diagnoseRunOutput, error) {
+	if in.DagID == "" || in.RunID == "" {
+		return nil, diagnoseRunOutput{}, fmt.Errorf("dag_id and run_id are required")
+	}
+	tail := in.LogTailLines
+	if tail <= 0 {
+		tail = defaultLogTail
+	}
+	if tail > maxLogTail {
+		tail = maxLogTail
+	}
+	runResp, err := h.api.GetDagRunWithResponse(ctx, in.DagID, in.RunID)
+	if err != nil {
+		return nil, diagnoseRunOutput{}, fmt.Errorf("fetching run: %w", err)
+	}
+	if runResp.StatusCode() != http.StatusOK || runResp.JSON200 == nil {
+		return nil, diagnoseRunOutput{}, fmt.Errorf("control plane returned %d for run %s/%s", runResp.StatusCode(), in.DagID, in.RunID)
+	}
+
+	tiResp, err := h.api.ListTaskInstancesWithResponse(ctx, in.DagID, in.RunID)
+	if err != nil {
+		return nil, diagnoseRunOutput{}, fmt.Errorf("listing task instances: %w", err)
+	}
+	if tiResp.StatusCode() != http.StatusOK || tiResp.JSON200 == nil {
+		return nil, diagnoseRunOutput{}, fmt.Errorf("control plane returned %d listing task instances", tiResp.StatusCode())
+	}
+
+	out := diagnoseRunOutput{DagID: in.DagID, RunID: in.RunID}
+	if runResp.JSON200.State != nil {
+		out.RunState = string(*runResp.JSON200.State)
+	}
+	var tis []apiclient.TaskInstance
+	if tiResp.JSON200.TaskInstances != nil {
+		tis = *tiResp.JSON200.TaskInstances
+	}
+	out.TotalTasks = len(tis)
+	out.FailedTasks = h.collectFailedTasks(ctx, in.DagID, in.RunID, tis, tail)
+	out.Summary = fmt.Sprintf("%d of %d task(s) failed", len(out.FailedTasks), out.TotalTasks)
+	return nil, out, nil
+}
+
+// collectFailedTasks returns the failed/upstream-failed task instances, each with
+// a truncated+sanitized log tail (only for tasks that actually ran — an
+// upstream_failed task never executed, so it has no log of its own).
+func (h *handlers) collectFailedTasks(ctx context.Context, dagID, runID string, tis []apiclient.TaskInstance, tail int) []failedTask {
+	var failed []failedTask
+	for _, ti := range tis {
+		if ti.State == nil {
+			continue
+		}
+		switch *ti.State {
+		case apiclient.TaskInstanceStateFailed, apiclient.TaskInstanceStateUpstreamFailed:
+		default:
+			continue
+		}
+		ft := failedTask{
+			TaskID:          deref(ti.TaskId),
+			State:           string(*ti.State),
+			TryNumber:       deref(ti.TryNumber),
+			DurationSeconds: deref(ti.Duration),
+		}
+		if *ti.State == apiclient.TaskInstanceStateFailed && ft.TaskID != "" && ft.TryNumber >= 1 {
+			logResp, lerr := h.api.GetTaskLogsWithResponse(ctx, dagID, runID, ft.TaskID, ft.TryNumber)
+			if lerr == nil && logResp.StatusCode() == http.StatusOK {
+				ft.LogTail = sanitizeLogTail(string(logResp.Body), tail)
+			}
+		}
+		failed = append(failed, ft)
+	}
+	return failed
+}
+
+// sanitizeLogTail returns at most the last n lines of raw log output, stripped of
+// control and ANSI bytes (keeping \n and \t). Log content is untrusted (D10): an
+// ANSI/control payload in a task's stderr must not reach the agent's context
+// intact, and an unbounded tail would blow the context window (R16).
+func sanitizeLogTail(raw string, n int) string {
+	lines := strings.Split(strings.ReplaceAll(raw, "\r\n", "\n"), "\n")
+	// Drop a trailing empty line from a final newline so "n lines" is intuitive.
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	var b strings.Builder
+	for i, ln := range lines {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(stripControl(ln))
+	}
+	return b.String()
+}
+
+// stripControl removes ASCII control bytes (< 0x20) except tab; this also breaks
+// ANSI escape sequences by removing their leading ESC (0x1b).
+func stripControl(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\t' {
+			return r
+		}
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, s)
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -2,14 +2,71 @@ package mcp
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	apiclient "github.com/neochaotic/leoflow/pkg/client"
 )
+
+// TestDiagnoseRun composes run + task-instances + logs into one diagnosis: it
+// reports the run state, isolates the failed task, and returns a truncated,
+// sanitized tail of that task's log (ADR 0050 R19). It must not treat a
+// successful task as failed, and must surface the failing task's log.
+func TestDiagnoseRun(t *testing.T) {
+	h := testHandlers(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v2/dags/etl/dagRuns/r1":
+			_, _ = io.WriteString(w, `{"dag_id":"etl","dag_run_id":"r1","state":"failed"}`)
+		case "/api/v2/dags/etl/dagRuns/r1/taskInstances":
+			_, _ = io.WriteString(w, `{"task_instances":[`+
+				`{"task_id":"extract","state":"success","try_number":1},`+
+				`{"task_id":"load","state":"failed","try_number":2,"duration":3.5}],"total_entries":2}`)
+		case "/api/v2/dags/etl/dagRuns/r1/taskInstances/load/logs/2":
+			_, _ = io.WriteString(w, "setup\nrunning query\nTraceback (most recent call last)\nValueError: boom\x1b[0m\n")
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	_, out, err := h.diagnoseRun(context.Background(), nil, diagnoseRunInput{DagID: "etl", RunID: "r1"})
+	if err != nil {
+		t.Fatalf("diagnoseRun: %v", err)
+	}
+	if out.RunState != "failed" {
+		t.Errorf("run_state = %q, want failed", out.RunState)
+	}
+	if out.TotalTasks != 2 {
+		t.Errorf("total_tasks = %d, want 2", out.TotalTasks)
+	}
+	if len(out.FailedTasks) != 1 || out.FailedTasks[0].TaskID != "load" {
+		t.Fatalf("failed_tasks = %+v, want exactly [load]", out.FailedTasks)
+	}
+	ft := out.FailedTasks[0]
+	if ft.TryNumber != 2 {
+		t.Errorf("try_number = %d, want 2", ft.TryNumber)
+	}
+	if !strings.Contains(ft.LogTail, "ValueError: boom") {
+		t.Errorf("log_tail missing the failure line: %q", ft.LogTail)
+	}
+	if strings.Contains(ft.LogTail, "\x1b") {
+		t.Errorf("log_tail must be sanitized of control/ANSI bytes: %q", ft.LogTail)
+	}
+}
+
+// TestDiagnoseRunMissingArgs: dag_id and run_id are required.
+func TestDiagnoseRunMissingArgs(t *testing.T) {
+	h := &handlers{}
+	if _, _, err := h.diagnoseRun(context.Background(), nil, diagnoseRunInput{DagID: "etl"}); err == nil {
+		t.Error("expected an error when run_id is missing")
+	}
+}
 
 // TestNewServerRegistersListDags connects a client to the server over an
 // in-memory transport and asserts list_dags is discoverable via tools/list —


### PR DESCRIPTION
The highest-value read tool (ADR 0050 R19), on top of the MCP skeleton (#553).

## What
`diagnose_run(dag_id, run_id, log_tail_lines?)` composes three `/api/v2` calls into one diagnosis:
- the run's state,
- the failed / `upstream_failed` task instances (task_id, state, try_number, duration),
- for a task that actually ran (`state=failed`, `try>=1`), a **truncated, sanitized** tail of its log.

Replaces the `list_runs → get_run → list_task_instances → get_task_logs` chain an agent would otherwise mis-sequence.

## Security (ADR 0050 D10 — untrusted content)
Log content is untrusted. `sanitizeLogTail` keeps only the last N lines (default 40, max 200 — R16) and strips ASCII control bytes, which also breaks ANSI escape sequences — a control/ANSI payload in a task's stderr cannot reach the agent's context intact. `upstream_failed` tasks never executed, so no log is fetched for them.

## Tests
- `TestDiagnoseRun` — composition against a fake control plane: run state, exactly one failed task isolated (not the succeeded one), the failing task's log tail present, and the ANSI byte stripped.
- `TestDiagnoseRunMissingArgs` — `dag_id`/`run_id` required.
- golangci-lint 0 (refactored under the gocyclo limit via `collectFailedTasks`; dropped the unnecessary `DagID`/`TaskID` alias conversions), `deadcode` + `-race` clean, `internal/mcp` coverage 84.9%.

Client-side composition is deliberate for the MVP; a server-side aggregate endpoint is the later chattiness optimization (noted in the ADR).