### PR TITLE
feat(mcp): add search_logs tool (ADR 0050)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **Experimental MCP server skeleton (`leoflow-mcp`)** — the first slice of the
   Model Context Protocol server (ADR 0050): a read-only, stdio server built on
-  the official `modelcontextprotocol/go-sdk`, exposing `list_dags` and `diagnose_run` (one call: run state + failed tasks +
+  the official `modelcontextprotocol/go-sdk`, exposing `list_dags`, `diagnose_run`, and `search_logs` (one call: run state + failed tasks +
   each failed task's truncated, sanitized log tail) — reaching the control plane
   only through `pkg/client` (the caller's token is
   passed through; the server holds no privilege of its own). Optional and never
-  part of `leoflow-server`. More read tools (`search_logs`, resources) and the Pro HTTP transport follow.
+  part of `leoflow-server`. More read resources and the Pro HTTP transport follow.
 - **A generated, typed Go client for the `/api/v2` surface (`pkg/client`)** — the
   single control-plane client the CLI, the coming MCP server, and smoke tests
   share instead of hand-rolling HTTP (ADR 0050). Generated from the OpenAPI spec

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -43,6 +43,10 @@ func NewServer(api *apiclient.ClientWithResponses, version string) *mcpsdk.Serve
 		Name:        "diagnose_run",
 		Description: "Diagnose a DAG run: its state, which task instances failed, and a truncated tail of each failed task's log — one call instead of list-runs/get-run/list-tasks/get-logs.",
 	}, h.diagnoseRun)
+	mcpsdk.AddTool(s, &mcpsdk.Tool{
+		Name:        "search_logs",
+		Description: "Search one task attempt's log for a case-insensitive substring, returning the matching lines (with line numbers) instead of the whole log.",
+	}, h.searchLogs)
 	return s
 }
 
@@ -216,6 +220,82 @@ func (h *handlers) collectFailedTasks(ctx context.Context, dagID, runID string, 
 		failed = append(failed, ft)
 	}
 	return failed
+}
+
+const (
+	defaultLogMatches = 20
+	maxLogMatches     = 100
+)
+
+type searchLogsInput struct {
+	DagID      string `json:"dag_id" jsonschema:"the DAG id"`
+	RunID      string `json:"run_id" jsonschema:"the DAG run id"`
+	TaskID     string `json:"task_id" jsonschema:"the task id whose log to search"`
+	TryNumber  int    `json:"try_number,omitempty" jsonschema:"attempt to search (default 1)"`
+	Query      string `json:"query" jsonschema:"case-insensitive substring to match"`
+	MaxMatches int    `json:"max_matches,omitempty" jsonschema:"maximum matching lines to return (default 20, max 100)"`
+}
+
+type logMatch struct {
+	LineNumber int    `json:"line_number"`
+	Line       string `json:"line"`
+}
+
+type searchLogsOutput struct {
+	DagID        string     `json:"dag_id"`
+	RunID        string     `json:"run_id"`
+	TaskID       string     `json:"task_id"`
+	TryNumber    int        `json:"try_number"`
+	Query        string     `json:"query"`
+	Matches      []logMatch `json:"matches"`
+	TotalMatches int        `json:"total_matches"`
+	Truncated    bool       `json:"truncated"`
+}
+
+// searchLogs fetches one task attempt's log and returns the lines matching a
+// case-insensitive substring, with 1-based line numbers — so an agent can find
+// the relevant lines of a long log without pulling the whole thing into context
+// (ADR 0050 R16). The match is a plain substring, not a regex, to avoid handing
+// the model a ReDoS lever. Matched lines are sanitized (untrusted content, D10)
+// and the returned set is capped, but the true total is always reported.
+func (h *handlers) searchLogs(ctx context.Context, _ *mcpsdk.CallToolRequest, in searchLogsInput) (*mcpsdk.CallToolResult, searchLogsOutput, error) {
+	if in.DagID == "" || in.RunID == "" || in.TaskID == "" || in.Query == "" {
+		return nil, searchLogsOutput{}, fmt.Errorf("dag_id, run_id, task_id, and query are required")
+	}
+	try := in.TryNumber
+	if try < 1 {
+		try = 1
+	}
+	maxN := in.MaxMatches
+	if maxN <= 0 {
+		maxN = defaultLogMatches
+	}
+	if maxN > maxLogMatches {
+		maxN = maxLogMatches
+	}
+
+	resp, err := h.api.GetTaskLogsWithResponse(ctx, in.DagID, in.RunID, in.TaskID, try)
+	if err != nil {
+		return nil, searchLogsOutput{}, fmt.Errorf("fetching task log: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, searchLogsOutput{}, fmt.Errorf("control plane returned %d fetching task log", resp.StatusCode())
+	}
+
+	out := searchLogsOutput{DagID: in.DagID, RunID: in.RunID, TaskID: in.TaskID, TryNumber: try, Query: in.Query}
+	needle := strings.ToLower(in.Query)
+	lines := strings.Split(strings.ReplaceAll(string(resp.Body), "\r\n", "\n"), "\n")
+	for i, ln := range lines {
+		if !strings.Contains(strings.ToLower(ln), needle) {
+			continue
+		}
+		out.TotalMatches++
+		if len(out.Matches) < maxN {
+			out.Matches = append(out.Matches, logMatch{LineNumber: i + 1, Line: stripControl(ln)})
+		}
+	}
+	out.Truncated = out.TotalMatches > len(out.Matches)
+	return nil, out, nil
 }
 
 // sanitizeLogTail returns at most the last n lines of raw log output, stripped of

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -60,6 +60,62 @@ func TestDiagnoseRun(t *testing.T) {
 	}
 }
 
+// TestSearchLogs finds case-insensitive substring matches in one task's log,
+// reports 1-based line numbers, sanitizes control/ANSI bytes, and returns the
+// total found even when the returned set is capped.
+func TestSearchLogs(t *testing.T) {
+	h := testHandlers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/dags/etl/dagRuns/r1/taskInstances/load/logs/2" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, "starting\nERROR: connection refused\nretrying\nerror: timeout\x1b[0m\ndone\n")
+	})
+
+	_, out, err := h.searchLogs(context.Background(), nil, searchLogsInput{
+		DagID: "etl", RunID: "r1", TaskID: "load", TryNumber: 2, Query: "error",
+	})
+	if err != nil {
+		t.Fatalf("searchLogs: %v", err)
+	}
+	if out.TotalMatches != 2 || len(out.Matches) != 2 {
+		t.Fatalf("matches = %+v (total %d), want 2", out.Matches, out.TotalMatches)
+	}
+	if out.Matches[0].LineNumber != 2 || out.Matches[1].LineNumber != 4 {
+		t.Errorf("line numbers = %d,%d, want 2,4", out.Matches[0].LineNumber, out.Matches[1].LineNumber)
+	}
+	if strings.Contains(out.Matches[1].Line, "\x1b") {
+		t.Errorf("match line must be sanitized: %q", out.Matches[1].Line)
+	}
+	if out.Truncated {
+		t.Error("should not be truncated with the default cap")
+	}
+}
+
+// TestSearchLogsTruncates caps the returned matches but still reports the true
+// total, so the agent knows there is more.
+func TestSearchLogsTruncates(t *testing.T) {
+	h := testHandlers(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "error a\nerror b\nerror c\n")
+	})
+	_, out, err := h.searchLogs(context.Background(), nil, searchLogsInput{
+		DagID: "d", RunID: "r", TaskID: "t", Query: "error", MaxMatches: 1,
+	})
+	if err != nil {
+		t.Fatalf("searchLogs: %v", err)
+	}
+	if len(out.Matches) != 1 || out.TotalMatches != 3 || !out.Truncated {
+		t.Errorf("want 1 returned / 3 total / truncated, got %d / %d / %v", len(out.Matches), out.TotalMatches, out.Truncated)
+	}
+}
+
+// TestSearchLogsMissingArgs: the locators and the query are required.
+func TestSearchLogsMissingArgs(t *testing.T) {
+	h := &handlers{}
+	if _, _, err := h.searchLogs(context.Background(), nil, searchLogsInput{DagID: "d", RunID: "r", TaskID: "t"}); err == nil {
+		t.Error("expected an error when query is missing")
+	}
+}
+
 // TestDiagnoseRunMissingArgs: dag_id and run_id are required.
 func TestDiagnoseRunMissingArgs(t *testing.T) {
 	h := &handlers{}


### PR DESCRIPTION
The second read tool on the MCP skeleton, complementing `diagnose_run` (#554).

## What
`search_logs(dag_id, run_id, task_id, try_number?, query, max_matches?)` fetches one task attempt's log and returns the **matching lines** (with 1-based line numbers) for a **case-insensitive substring** `query` — so an agent finds the relevant lines of a long log without pulling the whole thing into context (R16). Where `diagnose_run` gives the failed task + a tail, `search_logs` targets a specific pattern in a specific task's full log.

## Security / robustness
- **Substring, not regex** — no ReDoS lever from model-supplied input.
- **Sanitized** matched lines (control/ANSI stripped) — untrusted content (D10).
- **Capped** returned set (default 20, max 100), but the **true total** and a `truncated` flag are always reported, so the agent knows there is more.

## Tests
- `TestSearchLogs` — case-insensitive matches, correct line numbers, ANSI byte stripped, correct total.
- `TestSearchLogsTruncates` — cap returns 1 but reports total 3 + truncated.
- `TestSearchLogsMissingArgs` — locators + query required.
- golangci-lint 0, `deadcode` + `-race` clean, `internal/mcp` coverage 86.1%.

Composes one endpoint (`GetTaskLogs`); client-side search is bounded per call.