### PR TITLE
feat(mcp): read-only addressable resources (dag/run/task/log)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   each failed task's truncated, sanitized log tail) — reaching the control plane
   only through `pkg/client` (the caller's token is
   passed through; the server holds no privilege of its own). Optional and never
-  part of `leoflow-server`. More read resources and the Pro HTTP transport follow.
+  part of `leoflow-server`. It also serves addressable read resources —
+  `dag://list`, `run://detail/{dag_id}/{run_id}`, `task://instances/{dag_id}/{run_id}`,
+  and `log://task/{dag_id}/{run_id}/{task_id}/{try_number}` (truncated + sanitized).
+  The Pro HTTP transport and authoring follow.
 - **A generated, typed Go client for the `/api/v2` surface (`pkg/client`)** — the
   single control-plane client the CLI, the coming MCP server, and smoke tests
   share instead of hand-rolling HTTP (ADR 0050). Generated from the OpenAPI spec

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -1,0 +1,186 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
+)
+
+// resourceLogTail bounds a log resource read (R16); a task log an agent fetches
+// wholesale still must not blow the context window.
+const resourceLogTail = 200
+
+// registerResources wires the read-only addressable resources (ADR 0050 D7/R12).
+// The agent chooses the URI; the control plane authorizes each read via the
+// pass-through token, so a resource can only surface what the caller already may
+// see. Templates carry their parameters IN the URI (R05).
+func (h *handlers) registerResources(s *mcpsdk.Server) {
+	s.AddResource(&mcpsdk.Resource{
+		Name: "dags", URI: "dag://list", MIMEType: "application/json",
+		Description: "All DAGs registered in the control plane (compact).",
+	}, h.readDagList)
+	s.AddResourceTemplate(&mcpsdk.ResourceTemplate{
+		Name: "run-detail", URITemplate: "run://detail/{dag_id}/{run_id}", MIMEType: "application/json",
+		Description: "A DAG run's detail (state, type, timing).",
+	}, h.readRunDetail)
+	s.AddResourceTemplate(&mcpsdk.ResourceTemplate{
+		Name: "task-instances", URITemplate: "task://instances/{dag_id}/{run_id}", MIMEType: "application/json",
+		Description: "The task instances of a DAG run (state, try, duration).",
+	}, h.readTaskInstances)
+	s.AddResourceTemplate(&mcpsdk.ResourceTemplate{
+		Name: "task-log", URITemplate: "log://task/{dag_id}/{run_id}/{task_id}/{try_number}", MIMEType: "text/plain",
+		Description: "A task attempt's log, truncated to the last lines and sanitized.",
+	}, h.readTaskLog)
+}
+
+func (h *handlers) readDagList(ctx context.Context, req *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
+	out, err := h.fetchDagList(ctx, listDagsInput{})
+	if err != nil {
+		return nil, err
+	}
+	return jsonResource(req.Params.URI, out)
+}
+
+func (h *handlers) readRunDetail(ctx context.Context, req *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
+	p, err := uriParams(req.Params.URI, "run://detail/", 2)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := h.api.GetDagRunWithResponse(ctx, p[0], p[1])
+	if err != nil {
+		return nil, fmt.Errorf("fetching run: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+		return nil, fmt.Errorf("control plane returned %d for run %s/%s", resp.StatusCode(), p[0], p[1])
+	}
+	r := resp.JSON200
+	detail := map[string]any{
+		"dag_id":   deref(r.DagId),
+		"run_id":   deref(r.DagRunId),
+		"state":    stateString(r.State),
+		"run_type": runTypeString(r.RunType),
+	}
+	if r.StartDate != nil {
+		detail["start_date"] = r.StartDate
+	}
+	if r.EndDate != nil {
+		detail["end_date"] = r.EndDate
+	}
+	return jsonResource(req.Params.URI, detail)
+}
+
+type taskInstanceSummary struct {
+	TaskID          string  `json:"task_id"`
+	State           string  `json:"state"`
+	TryNumber       int     `json:"try_number"`
+	DurationSeconds float32 `json:"duration_seconds,omitempty"`
+}
+
+func (h *handlers) readTaskInstances(ctx context.Context, req *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
+	p, err := uriParams(req.Params.URI, "task://instances/", 2)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := h.api.ListTaskInstancesWithResponse(ctx, p[0], p[1])
+	if err != nil {
+		return nil, fmt.Errorf("listing task instances: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+		return nil, fmt.Errorf("control plane returned %d listing task instances", resp.StatusCode())
+	}
+	var tis []apiclient.TaskInstance
+	if resp.JSON200.TaskInstances != nil {
+		tis = *resp.JSON200.TaskInstances
+	}
+	out := make([]taskInstanceSummary, 0, len(tis))
+	for _, ti := range tis {
+		out = append(out, taskInstanceSummary{
+			TaskID:          deref(ti.TaskId),
+			State:           stateString(ti.State),
+			TryNumber:       deref(ti.TryNumber),
+			DurationSeconds: deref(ti.Duration),
+		})
+	}
+	return jsonResource(req.Params.URI, map[string]any{"task_instances": out, "total_entries": len(out)})
+}
+
+func (h *handlers) readTaskLog(ctx context.Context, req *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
+	p, err := uriParams(req.Params.URI, "log://task/", 4)
+	if err != nil {
+		return nil, err
+	}
+	try, err := strconv.Atoi(p[3])
+	if err != nil || try < 1 {
+		return nil, fmt.Errorf("uri %q: try_number must be a positive integer", req.Params.URI)
+	}
+	resp, err := h.api.GetTaskLogsWithResponse(ctx, p[0], p[1], p[2], try)
+	if err != nil {
+		return nil, fmt.Errorf("fetching task log: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("control plane returned %d fetching task log", resp.StatusCode())
+	}
+	return &mcpsdk.ReadResourceResult{Contents: []*mcpsdk.ResourceContents{{
+		URI: req.Params.URI, MIMEType: "text/plain", Text: sanitizeLogTail(string(resp.Body), resourceLogTail),
+	}}}, nil
+}
+
+// uriParams strips scheme+prefix from a resource URI and returns exactly n
+// non-empty, URL-decoded path segments. A path segment supplied by the agent is
+// data, never a raw selector (R05): it is decoded here and passed to the typed
+// client, which URL-encodes it back into the request path — so a "../" or a stray
+// slash cannot escape the intended endpoint.
+func uriParams(uri, prefix string, n int) ([]string, error) {
+	rest, ok := strings.CutPrefix(uri, prefix)
+	if !ok {
+		return nil, fmt.Errorf("uri %q does not match template %q", uri, prefix)
+	}
+	segs := strings.Split(rest, "/")
+	if len(segs) != n {
+		return nil, fmt.Errorf("uri %q: want %d segments after %q, got %d", uri, n, prefix, len(segs))
+	}
+	out := make([]string, n)
+	for i, s := range segs {
+		d, derr := url.PathUnescape(s)
+		if derr != nil {
+			return nil, fmt.Errorf("uri %q: bad segment %q: %w", uri, s, derr)
+		}
+		if d == "" {
+			return nil, fmt.Errorf("uri %q: empty path segment", uri)
+		}
+		out[i] = d
+	}
+	return out, nil
+}
+
+func jsonResource(uri string, v any) (*mcpsdk.ReadResourceResult, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("encoding resource %q: %w", uri, err)
+	}
+	return &mcpsdk.ReadResourceResult{Contents: []*mcpsdk.ResourceContents{{
+		URI: uri, MIMEType: "application/json", Text: string(b),
+	}}}, nil
+}
+
+func stateString[T ~string](p *T) string {
+	if p == nil {
+		return ""
+	}
+	return string(*p)
+}
+
+func runTypeString(p *apiclient.DAGRunRunType) string {
+	if p == nil {
+		return ""
+	}
+	return string(*p)
+}

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -1,0 +1,100 @@
+package mcp
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func readReq(uri string) *mcpsdk.ReadResourceRequest {
+	return &mcpsdk.ReadResourceRequest{Params: &mcpsdk.ReadResourceParams{URI: uri}}
+}
+
+func TestReadDagListResource(t *testing.T) {
+	h := testHandlers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/dags" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"dags":[{"dag_id":"etl","is_paused":false}],"total_entries":1}`)
+	})
+	res, err := h.readDagList(context.Background(), readReq("dag://list"))
+	if err != nil {
+		t.Fatalf("readDagList: %v", err)
+	}
+	if len(res.Contents) != 1 || !strings.Contains(res.Contents[0].Text, `"dag_id":"etl"`) {
+		t.Errorf("contents = %+v, want the etl dag", res.Contents)
+	}
+	if res.Contents[0].URI != "dag://list" {
+		t.Errorf("content URI = %q", res.Contents[0].URI)
+	}
+}
+
+func TestReadRunDetailResource(t *testing.T) {
+	h := testHandlers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/dags/etl/dagRuns/r1" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"dag_id":"etl","dag_run_id":"r1","state":"success","run_type":"manual"}`)
+	})
+	res, err := h.readRunDetail(context.Background(), readReq("run://detail/etl/r1"))
+	if err != nil {
+		t.Fatalf("readRunDetail: %v", err)
+	}
+	if !strings.Contains(res.Contents[0].Text, `"state":"success"`) {
+		t.Errorf("detail missing state: %s", res.Contents[0].Text)
+	}
+}
+
+func TestReadTaskInstancesResource(t *testing.T) {
+	h := testHandlers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/dags/etl/dagRuns/r1/taskInstances" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"task_instances":[{"task_id":"load","state":"failed","try_number":2}],"total_entries":1}`)
+	})
+	res, err := h.readTaskInstances(context.Background(), readReq("task://instances/etl/r1"))
+	if err != nil {
+		t.Fatalf("readTaskInstances: %v", err)
+	}
+	if !strings.Contains(res.Contents[0].Text, `"task_id":"load"`) {
+		t.Errorf("missing task: %s", res.Contents[0].Text)
+	}
+}
+
+func TestReadTaskLogResource(t *testing.T) {
+	h := testHandlers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/dags/etl/dagRuns/r1/taskInstances/load/logs/2" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, "boot\nrunning\x1b[0m\ndone\n")
+	})
+	res, err := h.readTaskLog(context.Background(), readReq("log://task/etl/r1/load/2"))
+	if err != nil {
+		t.Fatalf("readTaskLog: %v", err)
+	}
+	if res.Contents[0].MIMEType != "text/plain" {
+		t.Errorf("mime = %q, want text/plain", res.Contents[0].MIMEType)
+	}
+	if strings.Contains(res.Contents[0].Text, "\x1b") {
+		t.Errorf("log resource must be sanitized: %q", res.Contents[0].Text)
+	}
+}
+
+// TestReadResourceBadURI: a URI that does not match the template (wrong segment
+// count) is a clear error, not a wrong-endpoint read.
+func TestReadResourceBadURI(t *testing.T) {
+	h := &handlers{}
+	if _, err := h.readRunDetail(context.Background(), readReq("run://detail/etl")); err == nil {
+		t.Error("expected an error for a run URI missing the run_id segment")
+	}
+	if _, err := h.readTaskLog(context.Background(), readReq("log://task/etl/r1/load/notanint")); err == nil {
+		t.Error("expected an error for a non-integer try_number")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -47,6 +47,7 @@ func NewServer(api *apiclient.ClientWithResponses, version string) *mcpsdk.Serve
 		Name:        "search_logs",
 		Description: "Search one task attempt's log for a case-insensitive substring, returning the matching lines (with line numbers) instead of the whole log.",
 	}, h.searchLogs)
+	h.registerResources(s)
 	return s
 }
 
@@ -69,6 +70,13 @@ type listDagsOutput struct {
 // forwarding the verbose upstream payload (ADR 0050 R18), and surfaces a
 // non-200 as an error so the agent never mistakes a failed call for "no DAGs".
 func (h *handlers) listDags(ctx context.Context, _ *mcpsdk.CallToolRequest, in listDagsInput) (*mcpsdk.CallToolResult, listDagsOutput, error) {
+	out, err := h.fetchDagList(ctx, in)
+	return nil, out, err
+}
+
+// fetchDagList is the shared read used by both the list_dags tool and the
+// dag://list resource: it calls /api/v2/dags and shapes a compact list.
+func (h *handlers) fetchDagList(ctx context.Context, in listDagsInput) (listDagsOutput, error) {
 	limit := in.Limit
 	if limit <= 0 {
 		limit = defaultDagLim
@@ -84,10 +92,10 @@ func (h *handlers) listDags(ctx context.Context, _ *mcpsdk.CallToolRequest, in l
 
 	resp, err := h.api.ListDagsWithResponse(ctx, params)
 	if err != nil {
-		return nil, listDagsOutput{}, fmt.Errorf("listing dags: %w", err)
+		return listDagsOutput{}, fmt.Errorf("listing dags: %w", err)
 	}
 	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
-		return nil, listDagsOutput{}, fmt.Errorf("control plane returned %d listing dags", resp.StatusCode())
+		return listDagsOutput{}, fmt.Errorf("control plane returned %d listing dags", resp.StatusCode())
 	}
 
 	out := listDagsOutput{}
@@ -103,7 +111,7 @@ func (h *handlers) listDags(ctx context.Context, _ *mcpsdk.CallToolRequest, in l
 			})
 		}
 	}
-	return nil, out, nil
+	return out, nil
 }
 
 // deref returns the pointed-to value or the zero value when nil — the generated


### PR DESCRIPTION
The addressable-read half of the MCP surface (ADR 0050 D7/R12), alongside the tools (#553–#555).

## What
- `dag://list` (static) — all DAGs, compact.
- `run://detail/{dag_id}/{run_id}` — a run's state/type/timing.
- `task://instances/{dag_id}/{run_id}` — the run's task instances (state/try/duration).
- `log://task/{dag_id}/{run_id}/{task_id}/{try_number}` — a task attempt's log, **truncated + sanitized**.

Each reaches the control plane only through `pkg/client` with the caller's token — a read can only surface what the caller may already see (the control plane authorizes; the agent picks the URI, R05). `list_dags`'s read is extracted to a shared `fetchDagList` reused by `dag://list`.

## Security
- URI path segments are decoded and passed as **typed path params** (`pkg/client` re-encodes them), so a `../` or stray slash in an agent-chosen URI can't escape the intended endpoint. Bad URIs (wrong segment count, non-integer `try_number`) are clear errors.
- Compact shaping (R18); the log resource is tail-truncated + control/ANSI-stripped (untrusted content, D10/R16).

## Tests
A read test per resource + bad-URI guards. golangci-lint 0, `deadcode` + `-race` clean, `internal/mcp` coverage 83.9%.

> Note (from the powerlab MCP experience): some clients under-render Resources vs Tools, so these are incremental context on top of the debug tools, not the primary surface. `health://` is deferred until `/monitor` is added to the spec+client.