### PR TITLE
feat(mcp): health:// + dag://source resources (+ OpenAPI for monitor/version/dagSources)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   passed through; the server holds no privilege of its own). Optional and never
   part of `leoflow-server`. It also serves addressable read resources —
   `dag://list`, `run://detail/{dag_id}/{run_id}`, `task://instances/{dag_id}/{run_id}`,
-  and `log://task/{dag_id}/{run_id}/{task_id}/{try_number}` (truncated + sanitized).
-  The Pro HTTP transport and authoring follow.
+  `log://task/{dag_id}/{run_id}/{task_id}/{try_number}` (truncated + sanitized),
+  `dag://source/{dag_id}` (the dag.py text), and `health://control-plane`
+  (component health + executor + version). The Pro HTTP transport and authoring follow.
 - **A generated, typed Go client for the `/api/v2` surface (`pkg/client`)** — the
   single control-plane client the CLI, the coming MCP server, and smoke tests
   share instead of hand-rolling HTTP (ADR 0050). Generated from the OpenAPI spec

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -283,6 +283,57 @@ paths:
               schema: { $ref: "#/components/schemas/XComEntry" }
         "404": { $ref: "#/components/responses/NotFound" }
 
+  /api/v2/dagSources/{dag_id}:
+    parameters:
+      - $ref: "#/components/parameters/DagID"
+    get:
+      summary: Get a DAG's source (the dag.py text)
+      operationId: getDagSource
+      tags: [DAGs]
+      responses:
+        "200":
+          description: DAG source
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/DagSource" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /api/v2/monitor/health:
+    get:
+      summary: Control-plane health (Airflow HealthInfoResponse shape)
+      operationId: getMonitorHealth
+      tags: [Monitor]
+      responses:
+        "200":
+          description: Component health
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/HealthInfo" }
+
+  /api/v2/monitor/executor:
+    get:
+      summary: Executor capability and configuration
+      operationId: getMonitorExecutor
+      tags: [Monitor]
+      responses:
+        "200":
+          description: Executor info
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ExecutorInfo" }
+
+  /api/v2/version:
+    get:
+      summary: Control-plane version (Airflow VersionInfo shape)
+      operationId: getVersion
+      tags: [Monitor]
+      responses:
+        "200":
+          description: Version info
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/VersionInfo" }
+
   /healthz:
     get:
       summary: Liveness probe
@@ -426,6 +477,44 @@ components:
           type: array
           items: { $ref: "#/components/schemas/DagVersion" }
         total_entries: { type: integer }
+
+    DagSource:
+      type: object
+      properties:
+        content: { type: string, description: "The dag.py source text (compiled-spec JSON fallback for pre-source-capture versions)." }
+        dag_id: { type: string }
+        version_number: { type: integer }
+        dag_display_name: { type: string }
+
+    ComponentHealth:
+      type: object
+      properties:
+        status: { type: string }
+        latest_scheduler_heartbeat: { type: string, nullable: true }
+        latest_triggerer_heartbeat: { type: string, nullable: true }
+        latest_dag_processor_heartbeat: { type: string, nullable: true }
+
+    HealthInfo:
+      type: object
+      properties:
+        metadatabase: { $ref: "#/components/schemas/ComponentHealth" }
+        scheduler: { $ref: "#/components/schemas/ComponentHealth" }
+        triggerer: { $ref: "#/components/schemas/ComponentHealth" }
+        dag_processor: { $ref: "#/components/schemas/ComponentHealth" }
+
+    ExecutorInfo:
+      type: object
+      properties:
+        pod_dispatch_enabled: { type: boolean }
+        task_namespace: { type: string }
+        agent_control_plane_addr: { type: string }
+        execution_modes: { type: array, items: { type: string } }
+
+    VersionInfo:
+      type: object
+      properties:
+        version: { type: string }
+        git_version: { type: string }
 
     DAGUpdate:
       type: object

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -283,6 +283,57 @@ paths:
               schema: { $ref: "#/components/schemas/XComEntry" }
         "404": { $ref: "#/components/responses/NotFound" }
 
+  /api/v2/dagSources/{dag_id}:
+    parameters:
+      - $ref: "#/components/parameters/DagID"
+    get:
+      summary: Get a DAG's source (the dag.py text)
+      operationId: getDagSource
+      tags: [DAGs]
+      responses:
+        "200":
+          description: DAG source
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/DagSource" }
+        "404": { $ref: "#/components/responses/NotFound" }
+
+  /api/v2/monitor/health:
+    get:
+      summary: Control-plane health (Airflow HealthInfoResponse shape)
+      operationId: getMonitorHealth
+      tags: [Monitor]
+      responses:
+        "200":
+          description: Component health
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/HealthInfo" }
+
+  /api/v2/monitor/executor:
+    get:
+      summary: Executor capability and configuration
+      operationId: getMonitorExecutor
+      tags: [Monitor]
+      responses:
+        "200":
+          description: Executor info
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ExecutorInfo" }
+
+  /api/v2/version:
+    get:
+      summary: Control-plane version (Airflow VersionInfo shape)
+      operationId: getVersion
+      tags: [Monitor]
+      responses:
+        "200":
+          description: Version info
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/VersionInfo" }
+
   /healthz:
     get:
       summary: Liveness probe
@@ -426,6 +477,44 @@ components:
           type: array
           items: { $ref: "#/components/schemas/DagVersion" }
         total_entries: { type: integer }
+
+    DagSource:
+      type: object
+      properties:
+        content: { type: string, description: "The dag.py source text (compiled-spec JSON fallback for pre-source-capture versions)." }
+        dag_id: { type: string }
+        version_number: { type: integer }
+        dag_display_name: { type: string }
+
+    ComponentHealth:
+      type: object
+      properties:
+        status: { type: string }
+        latest_scheduler_heartbeat: { type: string, nullable: true }
+        latest_triggerer_heartbeat: { type: string, nullable: true }
+        latest_dag_processor_heartbeat: { type: string, nullable: true }
+
+    HealthInfo:
+      type: object
+      properties:
+        metadatabase: { $ref: "#/components/schemas/ComponentHealth" }
+        scheduler: { $ref: "#/components/schemas/ComponentHealth" }
+        triggerer: { $ref: "#/components/schemas/ComponentHealth" }
+        dag_processor: { $ref: "#/components/schemas/ComponentHealth" }
+
+    ExecutorInfo:
+      type: object
+      properties:
+        pod_dispatch_enabled: { type: boolean }
+        task_namespace: { type: string }
+        agent_control_plane_addr: { type: string }
+        execution_modes: { type: array, items: { type: string } }
+
+    VersionInfo:
+      type: object
+      properties:
+        version: { type: string }
+        git_version: { type: string }
 
     DAGUpdate:
       type: object

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -39,6 +39,60 @@ func (h *handlers) registerResources(s *mcpsdk.Server) {
 		Name: "task-log", URITemplate: "log://task/{dag_id}/{run_id}/{task_id}/{try_number}", MIMEType: "text/plain",
 		Description: "A task attempt's log, truncated to the last lines and sanitized.",
 	}, h.readTaskLog)
+	s.AddResourceTemplate(&mcpsdk.ResourceTemplate{
+		Name: "dag-source", URITemplate: "dag://source/{dag_id}", MIMEType: "text/plain",
+		Description: "A DAG's source (the dag.py text), sanitized and size-capped.",
+	}, h.readDagSource)
+	s.AddResource(&mcpsdk.Resource{
+		Name: "control-plane-health", URI: "health://control-plane", MIMEType: "application/json",
+		Description: "Control-plane health: component status, executor capability, and version (best-effort per section).",
+	}, h.readHealth)
+}
+
+// maxSourceBytes caps a dag.py source resource read so a large DAG file can't
+// blow the agent's context window (R40).
+const maxSourceBytes = 64 * 1024
+
+func (h *handlers) readDagSource(ctx context.Context, req *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
+	p, err := uriParams(req.Params.URI, "dag://source/", 1)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := h.api.GetDagSourceWithResponse(ctx, p[0])
+	if err != nil {
+		return nil, fmt.Errorf("fetching dag source: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+		return nil, fmt.Errorf("control plane returned %d fetching dag source for %s", resp.StatusCode(), p[0])
+	}
+	src := stripControl(deref(resp.JSON200.Content))
+	if len(src) > maxSourceBytes {
+		src = src[:maxSourceBytes] + "\n... [truncated]"
+	}
+	return &mcpsdk.ReadResourceResult{Contents: []*mcpsdk.ResourceContents{{
+		URI: req.Params.URI, MIMEType: "text/plain", Text: src,
+	}}}, nil
+}
+
+// readHealth composes the three monitor endpoints into one snapshot, best-effort
+// per section: a section that fails is omitted rather than failing the whole
+// read (structured degradation, R39), and an all-empty result is an error so the
+// agent knows the control plane is unreachable rather than "healthy".
+func (h *handlers) readHealth(ctx context.Context, req *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
+	snap := map[string]any{}
+	if r, err := h.api.GetMonitorHealthWithResponse(ctx); err == nil && r.StatusCode() == http.StatusOK && r.JSON200 != nil {
+		snap["health"] = r.JSON200
+	}
+	if r, err := h.api.GetMonitorExecutorWithResponse(ctx); err == nil && r.StatusCode() == http.StatusOK && r.JSON200 != nil {
+		snap["executor"] = r.JSON200
+	}
+	if r, err := h.api.GetVersionWithResponse(ctx); err == nil && r.StatusCode() == http.StatusOK && r.JSON200 != nil {
+		snap["version"] = r.JSON200
+	}
+	if len(snap) == 0 {
+		return nil, fmt.Errorf("control plane unreachable (no monitor section responded)")
+	}
+	return jsonResource(req.Params.URI, snap)
 }
 
 func (h *handlers) readDagList(ctx context.Context, req *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -73,6 +73,7 @@ func TestReadTaskLogResource(t *testing.T) {
 		if r.URL.Path != "/api/v2/dags/etl/dagRuns/r1/taskInstances/load/logs/2" {
 			t.Errorf("path = %q", r.URL.Path)
 		}
+		// text/plain body with a real ESC byte (Go \x1b escape) — sanitizer strips it.
 		_, _ = io.WriteString(w, "boot\nrunning\x1b[0m\ndone\n")
 	})
 	res, err := h.readTaskLog(context.Background(), readReq("log://task/etl/r1/load/2"))
@@ -84,6 +85,78 @@ func TestReadTaskLogResource(t *testing.T) {
 	}
 	if strings.Contains(res.Contents[0].Text, "\x1b") {
 		t.Errorf("log resource must be sanitized: %q", res.Contents[0].Text)
+	}
+}
+
+func TestReadDagSourceResource(t *testing.T) {
+	h := testHandlers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/dagSources/etl" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// \r is a JSON-valid control-char escape (CR, 0x0d); the sanitizer must
+		// strip it while keeping the \n line breaks of the multi-line source.
+		_, _ = io.WriteString(w, `{"content":"def hi():\n    print('hi')\r\n","dag_id":"etl","version_number":1}`)
+	})
+	res, err := h.readDagSource(context.Background(), readReq("dag://source/etl"))
+	if err != nil {
+		t.Fatalf("readDagSource: %v", err)
+	}
+	txt := res.Contents[0].Text
+	if !strings.Contains(txt, "def hi()") || !strings.Contains(txt, "print") {
+		t.Errorf("source content wrong: %q", txt)
+	}
+	if !strings.Contains(txt, "\n") {
+		t.Errorf("multi-line source must keep newlines: %q", txt)
+	}
+	if strings.Contains(txt, "\r") {
+		t.Errorf("source must be sanitized of control bytes: %q", txt)
+	}
+}
+
+func TestReadHealthResource(t *testing.T) {
+	h := testHandlers(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v2/monitor/health":
+			_, _ = io.WriteString(w, `{"scheduler":{"status":"healthy"},"metadatabase":{"status":"healthy"}}`)
+		case "/api/v2/monitor/executor":
+			_, _ = io.WriteString(w, `{"pod_dispatch_enabled":true,"task_namespace":"leoflow","execution_modes":["kubernetes_pod"]}`)
+		case "/api/v2/version":
+			_, _ = io.WriteString(w, `{"version":"v0.2.0","git_version":"abc123"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	res, err := h.readHealth(context.Background(), readReq("health://control-plane"))
+	if err != nil {
+		t.Fatalf("readHealth: %v", err)
+	}
+	txt := res.Contents[0].Text
+	for _, want := range []string{`"health"`, `"executor"`, `"version"`, "kubernetes_pod", "v0.2.0"} {
+		if !strings.Contains(txt, want) {
+			t.Errorf("health snapshot missing %q; got %s", want, txt)
+		}
+	}
+}
+
+// TestReadHealthDegrades: if some monitor sections fail, the snapshot still
+// returns what responded (structured degradation), not a hard error.
+func TestReadHealthDegrades(t *testing.T) {
+	h := testHandlers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/version" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"version":"v0.2.0"}`)
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError) // health + executor down
+	})
+	res, err := h.readHealth(context.Background(), readReq("health://control-plane"))
+	if err != nil {
+		t.Fatalf("readHealth should degrade, not error: %v", err)
+	}
+	if !strings.Contains(res.Contents[0].Text, "v0.2.0") || strings.Contains(res.Contents[0].Text, `"health"`) {
+		t.Errorf("degraded snapshot should carry version only; got %s", res.Contents[0].Text)
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -329,11 +329,13 @@ func sanitizeLogTail(raw string, n int) string {
 	return b.String()
 }
 
-// stripControl removes ASCII control bytes (< 0x20) except tab; this also breaks
-// ANSI escape sequences by removing their leading ESC (0x1b).
+// stripControl removes ASCII control bytes (< 0x20) except tab and newline; this
+// also breaks ANSI escape sequences by removing their leading ESC (0x1b). Newline
+// is kept so multi-line text (a task log, a dag.py source) survives; log-tail
+// callers split on newlines first, so a single line never contains one anyway.
 func stripControl(s string) string {
 	return strings.Map(func(r rune) rune {
-		if r == '\t' {
+		if r == '\t' || r == '\n' {
 			return r
 		}
 		if r < 0x20 || r == 0x7f {

--- a/pkg/client/client.gen.go
+++ b/pkg/client/client.gen.go
@@ -137,6 +137,14 @@ type ClearTaskInstancesRequest struct {
 	TaskIds      *[]string `json:"task_ids,omitempty"`
 }
 
+// ComponentHealth defines model for ComponentHealth.
+type ComponentHealth struct {
+	LatestDagProcessorHeartbeat *string `json:"latest_dag_processor_heartbeat,omitempty"`
+	LatestSchedulerHeartbeat    *string `json:"latest_scheduler_heartbeat,omitempty"`
+	LatestTriggererHeartbeat    *string `json:"latest_triggerer_heartbeat,omitempty"`
+	Status                      *string `json:"status,omitempty"`
+}
+
 // DAG defines model for DAG.
 type DAG struct {
 	Catchup                  *bool                   `json:"catchup,omitempty"`
@@ -204,6 +212,15 @@ type DAGUpdate struct {
 	IsPaused *bool `json:"is_paused,omitempty"`
 }
 
+// DagSource defines model for DagSource.
+type DagSource struct {
+	// Content The dag.py source text (compiled-spec JSON fallback for pre-source-capture versions).
+	Content        *string `json:"content,omitempty"`
+	DagDisplayName *string `json:"dag_display_name,omitempty"`
+	DagId          *string `json:"dag_id,omitempty"`
+	VersionNumber  *int    `json:"version_number,omitempty"`
+}
+
 // DagVersion defines model for DagVersion.
 type DagVersion struct {
 	BundleName     *string    `json:"bundle_name,omitempty"`
@@ -229,6 +246,22 @@ type Error struct {
 	Status   *int    `json:"status,omitempty"`
 	Title    *string `json:"title,omitempty"`
 	Type     *string `json:"type,omitempty"`
+}
+
+// ExecutorInfo defines model for ExecutorInfo.
+type ExecutorInfo struct {
+	AgentControlPlaneAddr *string   `json:"agent_control_plane_addr,omitempty"`
+	ExecutionModes        *[]string `json:"execution_modes,omitempty"`
+	PodDispatchEnabled    *bool     `json:"pod_dispatch_enabled,omitempty"`
+	TaskNamespace         *string   `json:"task_namespace,omitempty"`
+}
+
+// HealthInfo defines model for HealthInfo.
+type HealthInfo struct {
+	DagProcessor *ComponentHealth `json:"dag_processor,omitempty"`
+	Metadatabase *ComponentHealth `json:"metadatabase,omitempty"`
+	Scheduler    *ComponentHealth `json:"scheduler,omitempty"`
+	Triggerer    *ComponentHealth `json:"triggerer,omitempty"`
 }
 
 // TaskInstance defines model for TaskInstance.
@@ -272,6 +305,12 @@ type TokenResponse struct {
 
 	// TokenType Example: bearer
 	TokenType *string `json:"token_type,omitempty"`
+}
+
+// VersionInfo defines model for VersionInfo.
+type VersionInfo struct {
+	GitVersion *string `json:"git_version,omitempty"`
+	Version    *string `json:"version,omitempty"`
 }
 
 // XComEntry defines model for XComEntry.
@@ -410,6 +449,11 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 // The interface specification for the client above.
 type ClientInterface interface {
 
+	// GetDagSource Get a DAG's source (the dag.py text)
+	//
+	// Corresponds with GET /api/v2/dagSources/{dag_id} (the `GetDagSource` operationId).
+	GetDagSource(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListDags List DAGs
 	//
 	// Corresponds with GET /api/v2/dags (the `ListDags` operationId).
@@ -497,6 +541,21 @@ type ClientInterface interface {
 	// Corresponds with GET /api/v2/dags/{dag_id}/dagVersions/{version_number} (the `GetDagVersion` operationId).
 	GetDagVersion(ctx context.Context, dagId DagID, versionNumber int, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetMonitorExecutor Executor capability and configuration
+	//
+	// Corresponds with GET /api/v2/monitor/executor (the `GetMonitorExecutor` operationId).
+	GetMonitorExecutor(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetMonitorHealth Control-plane health (Airflow HealthInfoResponse shape)
+	//
+	// Corresponds with GET /api/v2/monitor/health (the `GetMonitorHealth` operationId).
+	GetMonitorHealth(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetVersion Control-plane version (Airflow VersionInfo shape)
+	//
+	// Corresponds with GET /api/v2/version (the `GetVersion` operationId).
+	GetVersion(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetXcomEntry Read XCom value (read-only proxy for the Redis backend)
 	//
 	// Corresponds with GET /api/v2/xcoms/{dag_id}/{dag_run_id}/{task_id}/{key} (the `GetXcomEntry` operationId).
@@ -525,6 +584,21 @@ type ClientInterface interface {
 	//
 	// Corresponds with GET /readyz (the `GetReadyz` operationId).
 	GetReadyz(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+}
+
+// GetDagSource Get a DAG's source (the dag.py text)
+//
+// Corresponds with GET /api/v2/dagSources/{dag_id} (the `GetDagSource` operationId).
+func (c *Client) GetDagSource(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetDagSourceRequest(c.Server, dagId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
 }
 
 // ListDags List DAGs
@@ -764,6 +838,51 @@ func (c *Client) GetDagVersion(ctx context.Context, dagId DagID, versionNumber i
 	return c.Client.Do(req)
 }
 
+// GetMonitorExecutor Executor capability and configuration
+//
+// Corresponds with GET /api/v2/monitor/executor (the `GetMonitorExecutor` operationId).
+func (c *Client) GetMonitorExecutor(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetMonitorExecutorRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// GetMonitorHealth Control-plane health (Airflow HealthInfoResponse shape)
+//
+// Corresponds with GET /api/v2/monitor/health (the `GetMonitorHealth` operationId).
+func (c *Client) GetMonitorHealth(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetMonitorHealthRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// GetVersion Control-plane version (Airflow VersionInfo shape)
+//
+// Corresponds with GET /api/v2/version (the `GetVersion` operationId).
+func (c *Client) GetVersion(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetVersionRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 // GetXcomEntry Read XCom value (read-only proxy for the Redis backend)
 //
 // Corresponds with GET /api/v2/xcoms/{dag_id}/{dag_run_id}/{task_id}/{key} (the `GetXcomEntry` operationId).
@@ -841,6 +960,40 @@ func (c *Client) GetReadyz(ctx context.Context, reqEditors ...RequestEditorFn) (
 		return nil, err
 	}
 	return c.Client.Do(req)
+}
+
+// NewGetDagSourceRequest constructs an http.Request for the GetDagSource method
+func NewGetDagSourceRequest(server string, dagId DagID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "dag_id", dagId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v2/dagSources/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
 }
 
 // NewListDagsRequest constructs an http.Request for the ListDags method
@@ -1465,6 +1618,87 @@ func NewGetDagVersionRequest(server string, dagId DagID, versionNumber int) (*ht
 	return req, nil
 }
 
+// NewGetMonitorExecutorRequest constructs an http.Request for the GetMonitorExecutor method
+func NewGetMonitorExecutorRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v2/monitor/executor")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetMonitorHealthRequest constructs an http.Request for the GetMonitorHealth method
+func NewGetMonitorHealthRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v2/monitor/health")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetVersionRequest constructs an http.Request for the GetVersion method
+func NewGetVersionRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v2/version")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetXcomEntryRequest constructs an http.Request for the GetXcomEntry method
 func NewGetXcomEntryRequest(server string, dagId DagID, dagRunId DagRunID, taskId TaskID, key string) (*http.Request, error) {
 	var err error
@@ -1658,6 +1892,13 @@ func WithBaseURL(baseURL string) ClientOption {
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
 
+	// GetDagSourceWithResponse Get a DAG's source (the dag.py text)
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with GET /api/v2/dagSources/{dag_id} (the `GetDagSource` operationId).
+	GetDagSourceWithResponse(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn) (*GetDagSourceResponse, error)
+
 	// ListDagsWithResponse List DAGs
 	//
 	// Returns a wrapper object for the known response body format(s).
@@ -1763,6 +2004,27 @@ type ClientWithResponsesInterface interface {
 	// Corresponds with GET /api/v2/dags/{dag_id}/dagVersions/{version_number} (the `GetDagVersion` operationId).
 	GetDagVersionWithResponse(ctx context.Context, dagId DagID, versionNumber int, reqEditors ...RequestEditorFn) (*GetDagVersionResponse, error)
 
+	// GetMonitorExecutorWithResponse Executor capability and configuration
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with GET /api/v2/monitor/executor (the `GetMonitorExecutor` operationId).
+	GetMonitorExecutorWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetMonitorExecutorResponse, error)
+
+	// GetMonitorHealthWithResponse Control-plane health (Airflow HealthInfoResponse shape)
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with GET /api/v2/monitor/health (the `GetMonitorHealth` operationId).
+	GetMonitorHealthWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetMonitorHealthResponse, error)
+
+	// GetVersionWithResponse Control-plane version (Airflow VersionInfo shape)
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with GET /api/v2/version (the `GetVersion` operationId).
+	GetVersionWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetVersionResponse, error)
+
 	// GetXcomEntryWithResponse Read XCom value (read-only proxy for the Redis backend)
 	//
 	// Returns a wrapper object for the known response body format(s).
@@ -1797,6 +2059,54 @@ type ClientWithResponsesInterface interface {
 	//
 	// Corresponds with GET /readyz (the `GetReadyz` operationId).
 	GetReadyzWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetReadyzResponse, error)
+}
+
+type GetDagSourceResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *DagSource
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFound
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r GetDagSourceResponse) GetJSON200() *DagSource {
+	return r.JSON200
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r GetDagSourceResponse) GetJSON404() *NotFound {
+	return r.JSON404
+}
+
+// GetBody returns the raw response body bytes
+func (r GetDagSourceResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r GetDagSourceResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetDagSourceResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetDagSourceResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
 }
 
 type ListDagsResponse struct {
@@ -2305,6 +2615,129 @@ func (r GetDagVersionResponse) ContentType() string {
 	return ""
 }
 
+type GetMonitorExecutorResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *ExecutorInfo
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r GetMonitorExecutorResponse) GetJSON200() *ExecutorInfo {
+	return r.JSON200
+}
+
+// GetBody returns the raw response body bytes
+func (r GetMonitorExecutorResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r GetMonitorExecutorResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetMonitorExecutorResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetMonitorExecutorResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetMonitorHealthResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *HealthInfo
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r GetMonitorHealthResponse) GetJSON200() *HealthInfo {
+	return r.JSON200
+}
+
+// GetBody returns the raw response body bytes
+func (r GetMonitorHealthResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r GetMonitorHealthResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetMonitorHealthResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetMonitorHealthResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetVersionResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *VersionInfo
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r GetVersionResponse) GetJSON200() *VersionInfo {
+	return r.JSON200
+}
+
+// GetBody returns the raw response body bytes
+func (r GetVersionResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r GetVersionResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetVersionResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetVersionResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type GetXcomEntryResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -2467,6 +2900,19 @@ func (r GetReadyzResponse) ContentType() string {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
 	return ""
+}
+
+// GetDagSourceWithResponse Get a DAG's source (the dag.py text)
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with GET /api/v2/dagSources/{dag_id} (the `GetDagSource` operationId).
+func (c *ClientWithResponses) GetDagSourceWithResponse(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn) (*GetDagSourceResponse, error) {
+	rsp, err := c.GetDagSource(ctx, dagId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetDagSourceResponse(rsp)
 }
 
 // ListDagsWithResponse List DAGs
@@ -2664,6 +3110,45 @@ func (c *ClientWithResponses) GetDagVersionWithResponse(ctx context.Context, dag
 	return ParseGetDagVersionResponse(rsp)
 }
 
+// GetMonitorExecutorWithResponse Executor capability and configuration
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with GET /api/v2/monitor/executor (the `GetMonitorExecutor` operationId).
+func (c *ClientWithResponses) GetMonitorExecutorWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetMonitorExecutorResponse, error) {
+	rsp, err := c.GetMonitorExecutor(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetMonitorExecutorResponse(rsp)
+}
+
+// GetMonitorHealthWithResponse Control-plane health (Airflow HealthInfoResponse shape)
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with GET /api/v2/monitor/health (the `GetMonitorHealth` operationId).
+func (c *ClientWithResponses) GetMonitorHealthWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetMonitorHealthResponse, error) {
+	rsp, err := c.GetMonitorHealth(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetMonitorHealthResponse(rsp)
+}
+
+// GetVersionWithResponse Control-plane version (Airflow VersionInfo shape)
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with GET /api/v2/version (the `GetVersion` operationId).
+func (c *ClientWithResponses) GetVersionWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetVersionResponse, error) {
+	rsp, err := c.GetVersion(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetVersionResponse(rsp)
+}
+
 // GetXcomEntryWithResponse Read XCom value (read-only proxy for the Redis backend)
 //
 // Returns a wrapper object for the known response body format(s).
@@ -2727,6 +3212,39 @@ func (c *ClientWithResponses) GetReadyzWithResponse(ctx context.Context, reqEdit
 		return nil, err
 	}
 	return ParseGetReadyzResponse(rsp)
+}
+
+// ParseGetDagSourceResponse parses an HTTP response from a GetDagSourceWithResponse call
+func ParseGetDagSourceResponse(rsp *http.Response) (*GetDagSourceResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetDagSourceResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest DagSource
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
 }
 
 // ParseListDagsResponse parses an HTTP response from a ListDagsWithResponse call
@@ -3046,6 +3564,84 @@ func ParseGetDagVersionResponse(rsp *http.Response) (*GetDagVersionResponse, err
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetMonitorExecutorResponse parses an HTTP response from a GetMonitorExecutorWithResponse call
+func ParseGetMonitorExecutorResponse(rsp *http.Response) (*GetMonitorExecutorResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetMonitorExecutorResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ExecutorInfo
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetMonitorHealthResponse parses an HTTP response from a GetMonitorHealthWithResponse call
+func ParseGetMonitorHealthResponse(rsp *http.Response) (*GetMonitorHealthResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetMonitorHealthResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest HealthInfo
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetVersionResponse parses an HTTP response from a GetVersionWithResponse call
+func ParseGetVersionResponse(rsp *http.Response) (*GetVersionResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetVersionResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest VersionInfo
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
 
 	}
 


### PR DESCRIPTION
MCP Phase 2 (ADR 0050): document the leoflow-specific control-plane endpoints in the OpenAPI spec and expose them as resources.

## What
- **OpenAPI + `pkg/client`:** `GET /api/v2/monitor/health`, `/api/v2/monitor/executor`, `/api/v2/version`, `/api/v2/dagSources/{dag_id}` — all already served by the control plane, now specced (operationIds + schemas) so the generated client has typed methods.
- **New resources:**
  - `dag://source/{dag_id}` — the dag.py text, sanitized (control/ANSI stripped) and size-capped at 64KB (R40).
  - `health://control-plane` — composes health + executor + version into one snapshot, **best-effort per section**: a section that fails is omitted (structured degradation, R39); an all-empty result is an error, so "unreachable" never reads as "healthy".
- **Fix:** `stripControl` now keeps `\n` (not just `\t`), so multi-line content (dag.py source, log bodies) survives sanitization; log-tail callers split on newlines first, so their per-line use is unchanged.

## Deferred
`dag://spec/{dag_id}` (the full compiled `dag.json`) needs a new ~10-line control-plane handler (the data is in `GetCurrentSpec`); split to a follow-up so this PR touches no control-plane code.

## Tests
Read test per resource + a health-degradation test. golangci-lint 0 (default + `e2e` tags), `-race` + `deadcode` clean, `pkg-client-drift` regenerates clean, `internal/mcp` coverage 83.9%, the real-binary e2e still green.