### PR TITLE
feat(mcp): dag://spec resource + GET /api/v2/dags/{dag_id}/spec (closes Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   part of `leoflow-server`. It also serves addressable read resources —
   `dag://list`, `run://detail/{dag_id}/{run_id}`, `task://instances/{dag_id}/{run_id}`,
   `log://task/{dag_id}/{run_id}/{task_id}/{try_number}` (truncated + sanitized),
-  `dag://source/{dag_id}` (the dag.py text), and `health://control-plane`
-  (component health + executor + version). The Pro HTTP transport and authoring follow.
+  `dag://source/{dag_id}` (the dag.py text), `dag://spec/{dag_id}` (the compiled
+  dag.json artifact, via a new GET /api/v2/dags/{dag_id}/spec endpoint), and
+  `health://control-plane` (component health + executor + version). The Pro HTTP transport and authoring follow.
 - **A generated, typed Go client for the `/api/v2` surface (`pkg/client`)** — the
   single control-plane client the CLI, the coming MCP server, and smoke tests
   share instead of hand-rolling HTTP (ADR 0050). Generated from the OpenAPI spec

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -298,6 +298,24 @@ paths:
               schema: { $ref: "#/components/schemas/DagSource" }
         "404": { $ref: "#/components/responses/NotFound" }
 
+  /api/v2/dags/{dag_id}/spec:
+    parameters:
+      - $ref: "#/components/parameters/DagID"
+    get:
+      summary: Get a DAG's compiled spec (the dag.json artifact)
+      operationId: getDagSpec
+      tags: [DAGs]
+      responses:
+        "200":
+          description: The compiled dag.json (the structured graph the scheduler runs)
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                description: The compiled dag.json artifact (DAGSpec shape).
+        "404": { $ref: "#/components/responses/NotFound" }
+
   /api/v2/monitor/health:
     get:
       summary: Control-plane health (Airflow HealthInfoResponse shape)

--- a/internal/api/dagspec_test.go
+++ b/internal/api/dagspec_test.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestDagSpecHandler: GET /api/v2/dags/{dag_id}/spec returns the compiled
+// dag.json (the structured graph), including the task list — distinct from
+// dagSources, which returns the dag.py text.
+func TestDagSpecHandler(t *testing.T) {
+	srv := structureServer(&fakeSpecReader{spec: diamondSpec()})
+	rec := authGet(srv, http.MethodGet, "/api/v2/dags/etl/spec", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `"dag_id":"etl"`) {
+		t.Errorf("spec missing dag_id: %s", body)
+	}
+	if !strings.Contains(body, `"load"`) || !strings.Contains(body, `"transform_a"`) {
+		t.Errorf("spec missing the task graph: %s", body)
+	}
+}
+
+// TestDagSpecHandlerNotFound: an unknown DAG surfaces the repo's not-found.
+func TestDagSpecHandlerNotFound(t *testing.T) {
+	srv := structureServer(&fakeSpecReader{err: ErrNotFound})
+	rec := authGet(srv, http.MethodGet, "/api/v2/dags/ghost/spec", "")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -298,6 +298,24 @@ paths:
               schema: { $ref: "#/components/schemas/DagSource" }
         "404": { $ref: "#/components/responses/NotFound" }
 
+  /api/v2/dags/{dag_id}/spec:
+    parameters:
+      - $ref: "#/components/parameters/DagID"
+    get:
+      summary: Get a DAG's compiled spec (the dag.json artifact)
+      operationId: getDagSpec
+      tags: [DAGs]
+      responses:
+        "200":
+          description: The compiled dag.json (the structured graph the scheduler runs)
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                description: The compiled dag.json artifact (DAGSpec shape).
+        "404": { $ref: "#/components/responses/NotFound" }
+
   /api/v2/monitor/health:
     get:
       summary: Control-plane health (Airflow HealthInfoResponse shape)

--- a/internal/api/ui_tasks.go
+++ b/internal/api/ui_tasks.go
@@ -242,4 +242,20 @@ func registerUITasks(r gin.IRouter, specs DagSpecReader) {
 	r.GET("/api/v2/dags/:dag_id/tasks", RequirePermission("read", "task"), tasksHandler(specs))
 	r.GET("/api/v2/dags/:dag_id/tasks/:task_id", RequirePermission("read", "task"), taskDetailHandler(specs))
 	r.GET("/api/v2/dagSources/:dag_id", RequirePermission("read", "dag"), dagSourceHandler(specs))
+	r.GET("/api/v2/dags/:dag_id/spec", RequirePermission("read", "dag"), dagSpecHandler(specs))
+}
+
+// dagSpecHandler implements GET /api/v2/dags/{dag_id}/spec: the compiled dag.json
+// artifact (the immutable spec the scheduler runs), for tools and agents that
+// need the structured graph rather than the dag.py source that dagSourceHandler
+// serves. The DAGSpec marshals with its own json tags.
+func dagSpecHandler(specs DagSpecReader) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		spec, err := specs.GetCurrentSpec(c.Request.Context(), tenantOf(c), c.Param("dag_id"))
+		if err != nil {
+			handleRepoError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, spec)
+	}
 }

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -43,6 +43,10 @@ func (h *handlers) registerResources(s *mcpsdk.Server) {
 		Name: "dag-source", URITemplate: "dag://source/{dag_id}", MIMEType: "text/plain",
 		Description: "A DAG's source (the dag.py text), sanitized and size-capped.",
 	}, h.readDagSource)
+	s.AddResourceTemplate(&mcpsdk.ResourceTemplate{
+		Name: "dag-spec", URITemplate: "dag://spec/{dag_id}", MIMEType: "application/json",
+		Description: "A DAG's compiled spec (the dag.json artifact: the structured task graph).",
+	}, h.readDagSpec)
 	s.AddResource(&mcpsdk.Resource{
 		Name: "control-plane-health", URI: "health://control-plane", MIMEType: "application/json",
 		Description: "Control-plane health: component status, executor capability, and version (best-effort per section).",
@@ -71,6 +75,34 @@ func (h *handlers) readDagSource(ctx context.Context, req *mcpsdk.ReadResourceRe
 	}
 	return &mcpsdk.ReadResourceResult{Contents: []*mcpsdk.ResourceContents{{
 		URI: req.Params.URI, MIMEType: "text/plain", Text: src,
+	}}}, nil
+}
+
+// maxSpecBytes guards a dag.json resource read; the compiled artifact is small
+// in practice, but a runaway must not blow the context window (R40). JSON can't
+// be safely truncated, so an oversize spec yields a structured note instead.
+const maxSpecBytes = 128 * 1024
+
+func (h *handlers) readDagSpec(ctx context.Context, req *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
+	p, err := uriParams(req.Params.URI, "dag://spec/", 1)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := h.api.GetDagSpecWithResponse(ctx, p[0])
+	if err != nil {
+		return nil, fmt.Errorf("fetching dag spec: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("control plane returned %d fetching dag spec for %s", resp.StatusCode(), p[0])
+	}
+	if len(resp.Body) > maxSpecBytes {
+		return jsonResource(req.Params.URI, map[string]any{
+			"error": "compiled spec too large for a resource read", "bytes": len(resp.Body), "dag_id": p[0],
+		})
+	}
+	// Return the compiled dag.json verbatim (already a clean structured artifact).
+	return &mcpsdk.ReadResourceResult{Contents: []*mcpsdk.ResourceContents{{
+		URI: req.Params.URI, MIMEType: "application/json", Text: string(resp.Body),
 	}}}, nil
 }
 

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -114,6 +114,27 @@ func TestReadDagSourceResource(t *testing.T) {
 	}
 }
 
+func TestReadDagSpecResource(t *testing.T) {
+	h := testHandlers(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/dags/etl/spec" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"dag_id":"etl","tasks":[{"task_id":"load","type":"python"}]}`)
+	})
+	res, err := h.readDagSpec(context.Background(), readReq("dag://spec/etl"))
+	if err != nil {
+		t.Fatalf("readDagSpec: %v", err)
+	}
+	if res.Contents[0].MIMEType != "application/json" {
+		t.Errorf("mime = %q, want application/json", res.Contents[0].MIMEType)
+	}
+	// Returned verbatim (the compiled artifact), so the graph is intact.
+	if !strings.Contains(res.Contents[0].Text, `"task_id":"load"`) {
+		t.Errorf("spec content missing the task graph: %s", res.Contents[0].Text)
+	}
+}
+
 func TestReadHealthResource(t *testing.T) {
 	h := testHandlers(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/client/client.gen.go
+++ b/pkg/client/client.gen.go
@@ -541,6 +541,11 @@ type ClientInterface interface {
 	// Corresponds with GET /api/v2/dags/{dag_id}/dagVersions/{version_number} (the `GetDagVersion` operationId).
 	GetDagVersion(ctx context.Context, dagId DagID, versionNumber int, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetDagSpec Get a DAG's compiled spec (the dag.json artifact)
+	//
+	// Corresponds with GET /api/v2/dags/{dag_id}/spec (the `GetDagSpec` operationId).
+	GetDagSpec(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetMonitorExecutor Executor capability and configuration
 	//
 	// Corresponds with GET /api/v2/monitor/executor (the `GetMonitorExecutor` operationId).
@@ -828,6 +833,21 @@ func (c *Client) ListDagVersions(ctx context.Context, dagId DagID, reqEditors ..
 // Corresponds with GET /api/v2/dags/{dag_id}/dagVersions/{version_number} (the `GetDagVersion` operationId).
 func (c *Client) GetDagVersion(ctx context.Context, dagId DagID, versionNumber int, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetDagVersionRequest(c.Server, dagId, versionNumber)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// GetDagSpec Get a DAG's compiled spec (the dag.json artifact)
+//
+// Corresponds with GET /api/v2/dags/{dag_id}/spec (the `GetDagSpec` operationId).
+func (c *Client) GetDagSpec(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetDagSpecRequest(c.Server, dagId)
 	if err != nil {
 		return nil, err
 	}
@@ -1618,6 +1638,40 @@ func NewGetDagVersionRequest(server string, dagId DagID, versionNumber int) (*ht
 	return req, nil
 }
 
+// NewGetDagSpecRequest constructs an http.Request for the GetDagSpec method
+func NewGetDagSpecRequest(server string, dagId DagID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "dag_id", dagId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v2/dags/%s/spec", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetMonitorExecutorRequest constructs an http.Request for the GetMonitorExecutor method
 func NewGetMonitorExecutorRequest(server string) (*http.Request, error) {
 	var err error
@@ -2003,6 +2057,13 @@ type ClientWithResponsesInterface interface {
 	//
 	// Corresponds with GET /api/v2/dags/{dag_id}/dagVersions/{version_number} (the `GetDagVersion` operationId).
 	GetDagVersionWithResponse(ctx context.Context, dagId DagID, versionNumber int, reqEditors ...RequestEditorFn) (*GetDagVersionResponse, error)
+
+	// GetDagSpecWithResponse Get a DAG's compiled spec (the dag.json artifact)
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with GET /api/v2/dags/{dag_id}/spec (the `GetDagSpec` operationId).
+	GetDagSpecWithResponse(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn) (*GetDagSpecResponse, error)
 
 	// GetMonitorExecutorWithResponse Executor capability and configuration
 	//
@@ -2615,6 +2676,54 @@ func (r GetDagVersionResponse) ContentType() string {
 	return ""
 }
 
+type GetDagSpecResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *map[string]interface{}
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFound
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r GetDagSpecResponse) GetJSON200() *map[string]interface{} {
+	return r.JSON200
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r GetDagSpecResponse) GetJSON404() *NotFound {
+	return r.JSON404
+}
+
+// GetBody returns the raw response body bytes
+func (r GetDagSpecResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r GetDagSpecResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetDagSpecResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetDagSpecResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type GetMonitorExecutorResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -3110,6 +3219,19 @@ func (c *ClientWithResponses) GetDagVersionWithResponse(ctx context.Context, dag
 	return ParseGetDagVersionResponse(rsp)
 }
 
+// GetDagSpecWithResponse Get a DAG's compiled spec (the dag.json artifact)
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with GET /api/v2/dags/{dag_id}/spec (the `GetDagSpec` operationId).
+func (c *ClientWithResponses) GetDagSpecWithResponse(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn) (*GetDagSpecResponse, error) {
+	rsp, err := c.GetDagSpec(ctx, dagId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetDagSpecResponse(rsp)
+}
+
 // GetMonitorExecutorWithResponse Executor capability and configuration
 //
 // Returns a wrapper object for the known response body format(s).
@@ -3553,6 +3675,39 @@ func ParseGetDagVersionResponse(rsp *http.Response) (*GetDagVersionResponse, err
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest DagVersion
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetDagSpecResponse parses an HTTP response from a GetDagSpecWithResponse call
+func ParseGetDagSpecResponse(rsp *http.Response) (*GetDagSpecResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetDagSpecResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest map[string]interface{}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Closes MCP Phase 2 (ADR 0050): the compiled-artifact half of the DAG read surface.

## What
- **New control-plane endpoint** `GET /api/v2/dags/{dag_id}/spec` (`RequirePermission read:dag`) — serves the compiled **dag.json** (the structured graph the scheduler runs) via the same `DagSpecReader.GetCurrentSpec` the source handler uses. Mirrors `dagSourceHandler`.
- **OpenAPI + `pkg/client`**: `getDagSpec` (freeform-object response → the artifact as-is).
- **MCP resource** `dag://spec/{dag_id}` — returns the dag.json **verbatim** (faithful structured artifact); a 128KB guard yields a structured note rather than truncated, unparseable JSON. Distinct from `dag://source` (the dag.py text).

## Tests
- api: `dagSpecHandler` returns the task graph; 404 on unknown DAG.
- mcp: `dag://spec` resource returns the artifact intact.
- golangci-lint 0, **full `internal/api` suite green** (endpoint addition), `-race` + `deadcode` clean, `pkg-client-drift` regenerates clean, `internal/mcp` coverage 83.0%, real-binary e2e green.

With this, Phase 2 is complete: `health://control-plane`, `dag://source`, `dag://spec`, plus the `/monitor`+`/version`+`/dagSources`+`/spec` endpoints now specced.