### PR TITLE
refactor(mcp): per-request /api/v2 client (enables HTTP token pass-through)

### DIFF
--- a/cmd/leoflow-mcp/main.go
+++ b/cmd/leoflow-mcp/main.go
@@ -41,7 +41,7 @@ func run() int {
 		return 1
 	}
 
-	srv := mcp.NewServer(apiClient, version)
+	srv := mcp.NewServer(apiClient, server, version)
 	slog.Info("leoflow-mcp starting", "server", server, "transport", "stdio", "version", version)
 	if err := srv.Run(context.Background(), &mcpsdk.StdioTransport{}); err != nil {
 		slog.Error("mcp server exited", "error", err)

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -62,7 +62,8 @@ func (h *handlers) readDagSource(ctx context.Context, req *mcpsdk.ReadResourceRe
 	if err != nil {
 		return nil, err
 	}
-	resp, err := h.api.GetDagSourceWithResponse(ctx, p[0])
+	api := apiFor(h, req)
+	resp, err := api.GetDagSourceWithResponse(ctx, p[0])
 	if err != nil {
 		return nil, fmt.Errorf("fetching dag source: %w", err)
 	}
@@ -88,7 +89,8 @@ func (h *handlers) readDagSpec(ctx context.Context, req *mcpsdk.ReadResourceRequ
 	if err != nil {
 		return nil, err
 	}
-	resp, err := h.api.GetDagSpecWithResponse(ctx, p[0])
+	api := apiFor(h, req)
+	resp, err := api.GetDagSpecWithResponse(ctx, p[0])
 	if err != nil {
 		return nil, fmt.Errorf("fetching dag spec: %w", err)
 	}
@@ -111,14 +113,15 @@ func (h *handlers) readDagSpec(ctx context.Context, req *mcpsdk.ReadResourceRequ
 // read (structured degradation, R39), and an all-empty result is an error so the
 // agent knows the control plane is unreachable rather than "healthy".
 func (h *handlers) readHealth(ctx context.Context, req *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
+	api := apiFor(h, req)
 	snap := map[string]any{}
-	if r, err := h.api.GetMonitorHealthWithResponse(ctx); err == nil && r.StatusCode() == http.StatusOK && r.JSON200 != nil {
+	if r, err := api.GetMonitorHealthWithResponse(ctx); err == nil && r.StatusCode() == http.StatusOK && r.JSON200 != nil {
 		snap["health"] = r.JSON200
 	}
-	if r, err := h.api.GetMonitorExecutorWithResponse(ctx); err == nil && r.StatusCode() == http.StatusOK && r.JSON200 != nil {
+	if r, err := api.GetMonitorExecutorWithResponse(ctx); err == nil && r.StatusCode() == http.StatusOK && r.JSON200 != nil {
 		snap["executor"] = r.JSON200
 	}
-	if r, err := h.api.GetVersionWithResponse(ctx); err == nil && r.StatusCode() == http.StatusOK && r.JSON200 != nil {
+	if r, err := api.GetVersionWithResponse(ctx); err == nil && r.StatusCode() == http.StatusOK && r.JSON200 != nil {
 		snap["version"] = r.JSON200
 	}
 	if len(snap) == 0 {
@@ -128,7 +131,7 @@ func (h *handlers) readHealth(ctx context.Context, req *mcpsdk.ReadResourceReque
 }
 
 func (h *handlers) readDagList(ctx context.Context, req *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
-	out, err := h.fetchDagList(ctx, listDagsInput{})
+	out, err := h.fetchDagList(ctx, apiFor(h, req), listDagsInput{})
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +143,8 @@ func (h *handlers) readRunDetail(ctx context.Context, req *mcpsdk.ReadResourceRe
 	if err != nil {
 		return nil, err
 	}
-	resp, err := h.api.GetDagRunWithResponse(ctx, p[0], p[1])
+	api := apiFor(h, req)
+	resp, err := api.GetDagRunWithResponse(ctx, p[0], p[1])
 	if err != nil {
 		return nil, fmt.Errorf("fetching run: %w", err)
 	}
@@ -175,7 +179,8 @@ func (h *handlers) readTaskInstances(ctx context.Context, req *mcpsdk.ReadResour
 	if err != nil {
 		return nil, err
 	}
-	resp, err := h.api.ListTaskInstancesWithResponse(ctx, p[0], p[1])
+	api := apiFor(h, req)
+	resp, err := api.ListTaskInstancesWithResponse(ctx, p[0], p[1])
 	if err != nil {
 		return nil, fmt.Errorf("listing task instances: %w", err)
 	}
@@ -207,7 +212,8 @@ func (h *handlers) readTaskLog(ctx context.Context, req *mcpsdk.ReadResourceRequ
 	if err != nil || try < 1 {
 		return nil, fmt.Errorf("uri %q: try_number must be a positive integer", req.Params.URI)
 	}
-	resp, err := h.api.GetTaskLogsWithResponse(ctx, p[0], p[1], p[2], try)
+	api := apiFor(h, req)
+	resp, err := api.GetTaskLogsWithResponse(ctx, p[0], p[1], p[2], try)
 	if err != nil {
 		return nil, fmt.Errorf("fetching task log: %w", err)
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -22,19 +22,48 @@ const (
 	maxDagLim     = 200
 )
 
-// handlers holds the dependencies the tool handlers share — currently just the
-// typed /api/v2 client.
+// handlers holds what the tool/resource handlers share. api is the base client
+// (the stdio process token, or a test client); serverURL lets a handler build a
+// PER-REQUEST client from the caller's Authorization header on the HTTP
+// transport, where one process serves many callers (ADR 0050 D9 pass-through).
 type handlers struct {
-	api *apiclient.ClientWithResponses
+	api       *apiclient.ClientWithResponses
+	serverURL string
 }
 
-// NewServer builds a read-only Leoflow MCP server over the given control-plane
-// client. It registers the read tools and returns the server; the caller runs it
+// clientFor returns the /api/v2 client for one request: on the HTTP transport a
+// per-request bearer arrives in the header, so build a client carrying THAT
+// token (pass-through — the MCP never mints one); on stdio there is no such
+// header, so fall back to the base client (built from the process token).
+func (h *handlers) clientFor(extra *mcpsdk.RequestExtra) *apiclient.ClientWithResponses {
+	if h.serverURL != "" && extra != nil && extra.Header != nil {
+		if authz := extra.Header.Get("Authorization"); authz != "" {
+			token := strings.TrimSpace(strings.TrimPrefix(authz, "Bearer "))
+			if c, err := apiclient.New(h.serverURL, token); err == nil {
+				return c
+			}
+		}
+	}
+	return h.api
+}
+
+// apiFor resolves the client for a tool/resource request, tolerating a nil
+// request (unit tests call handlers directly with nil).
+func apiFor[P mcpsdk.Params](h *handlers, req *mcpsdk.ServerRequest[P]) *apiclient.ClientWithResponses {
+	if req == nil {
+		return h.api
+	}
+	return h.clientFor(req.Extra)
+}
+
+// NewServer builds a read-only Leoflow MCP server. api is the base control-plane
+// client; serverURL is the control-plane URL used to build per-request clients on
+// the HTTP transport. It registers the read tools + resources; the caller runs it
 // over a transport (stdio for Lite dev, Streamable HTTP for Pro). Tools that
-// mutate state are deliberately absent from this skeleton (ADR 0050 D7).
-func NewServer(api *apiclient.ClientWithResponses, version string) *mcpsdk.Server {
+// mutate state are deliberately absent (ADR 0050 D7).
+func NewServer(api *apiclient.ClientWithResponses, serverURL, version string) *mcpsdk.Server {
 	s := mcpsdk.NewServer(&mcpsdk.Implementation{Name: serverName, Version: version}, nil)
-	h := &handlers{api: api}
+	h := &handlers{api: api, serverURL: serverURL}
 	mcpsdk.AddTool(s, &mcpsdk.Tool{
 		Name:        "list_dags",
 		Description: "List DAGs registered in the Leoflow control plane, with their paused state.",
@@ -69,14 +98,14 @@ type listDagsOutput struct {
 // listDags returns a compact list of DAGs. It shapes the response rather than
 // forwarding the verbose upstream payload (ADR 0050 R18), and surfaces a
 // non-200 as an error so the agent never mistakes a failed call for "no DAGs".
-func (h *handlers) listDags(ctx context.Context, _ *mcpsdk.CallToolRequest, in listDagsInput) (*mcpsdk.CallToolResult, listDagsOutput, error) {
-	out, err := h.fetchDagList(ctx, in)
+func (h *handlers) listDags(ctx context.Context, req *mcpsdk.CallToolRequest, in listDagsInput) (*mcpsdk.CallToolResult, listDagsOutput, error) {
+	out, err := h.fetchDagList(ctx, apiFor(h, req), in)
 	return nil, out, err
 }
 
 // fetchDagList is the shared read used by both the list_dags tool and the
 // dag://list resource: it calls /api/v2/dags and shapes a compact list.
-func (h *handlers) fetchDagList(ctx context.Context, in listDagsInput) (listDagsOutput, error) {
+func (h *handlers) fetchDagList(ctx context.Context, api *apiclient.ClientWithResponses, in listDagsInput) (listDagsOutput, error) {
 	limit := in.Limit
 	if limit <= 0 {
 		limit = defaultDagLim
@@ -90,7 +119,7 @@ func (h *handlers) fetchDagList(ctx context.Context, in listDagsInput) (listDags
 		params.Tags = &[]string{in.Tag}
 	}
 
-	resp, err := h.api.ListDagsWithResponse(ctx, params)
+	resp, err := api.ListDagsWithResponse(ctx, params)
 	if err != nil {
 		return listDagsOutput{}, fmt.Errorf("listing dags: %w", err)
 	}
@@ -158,7 +187,7 @@ type diagnoseRunOutput struct {
 // deliberately client-side composition for the MVP; a server-side aggregate
 // endpoint is the later optimization for chattiness. Log tails are truncated and
 // sanitized because log content is untrusted (D10).
-func (h *handlers) diagnoseRun(ctx context.Context, _ *mcpsdk.CallToolRequest, in diagnoseRunInput) (*mcpsdk.CallToolResult, diagnoseRunOutput, error) {
+func (h *handlers) diagnoseRun(ctx context.Context, req *mcpsdk.CallToolRequest, in diagnoseRunInput) (*mcpsdk.CallToolResult, diagnoseRunOutput, error) {
 	if in.DagID == "" || in.RunID == "" {
 		return nil, diagnoseRunOutput{}, fmt.Errorf("dag_id and run_id are required")
 	}
@@ -169,7 +198,8 @@ func (h *handlers) diagnoseRun(ctx context.Context, _ *mcpsdk.CallToolRequest, i
 	if tail > maxLogTail {
 		tail = maxLogTail
 	}
-	runResp, err := h.api.GetDagRunWithResponse(ctx, in.DagID, in.RunID)
+	api := apiFor(h, req)
+	runResp, err := api.GetDagRunWithResponse(ctx, in.DagID, in.RunID)
 	if err != nil {
 		return nil, diagnoseRunOutput{}, fmt.Errorf("fetching run: %w", err)
 	}
@@ -177,7 +207,7 @@ func (h *handlers) diagnoseRun(ctx context.Context, _ *mcpsdk.CallToolRequest, i
 		return nil, diagnoseRunOutput{}, fmt.Errorf("control plane returned %d for run %s/%s", runResp.StatusCode(), in.DagID, in.RunID)
 	}
 
-	tiResp, err := h.api.ListTaskInstancesWithResponse(ctx, in.DagID, in.RunID)
+	tiResp, err := api.ListTaskInstancesWithResponse(ctx, in.DagID, in.RunID)
 	if err != nil {
 		return nil, diagnoseRunOutput{}, fmt.Errorf("listing task instances: %w", err)
 	}
@@ -194,7 +224,7 @@ func (h *handlers) diagnoseRun(ctx context.Context, _ *mcpsdk.CallToolRequest, i
 		tis = *tiResp.JSON200.TaskInstances
 	}
 	out.TotalTasks = len(tis)
-	out.FailedTasks = h.collectFailedTasks(ctx, in.DagID, in.RunID, tis, tail)
+	out.FailedTasks = h.collectFailedTasks(ctx, api, in.DagID, in.RunID, tis, tail)
 	out.Summary = fmt.Sprintf("%d of %d task(s) failed", len(out.FailedTasks), out.TotalTasks)
 	return nil, out, nil
 }
@@ -202,7 +232,7 @@ func (h *handlers) diagnoseRun(ctx context.Context, _ *mcpsdk.CallToolRequest, i
 // collectFailedTasks returns the failed/upstream-failed task instances, each with
 // a truncated+sanitized log tail (only for tasks that actually ran — an
 // upstream_failed task never executed, so it has no log of its own).
-func (h *handlers) collectFailedTasks(ctx context.Context, dagID, runID string, tis []apiclient.TaskInstance, tail int) []failedTask {
+func (h *handlers) collectFailedTasks(ctx context.Context, api *apiclient.ClientWithResponses, dagID, runID string, tis []apiclient.TaskInstance, tail int) []failedTask {
 	var failed []failedTask
 	for _, ti := range tis {
 		if ti.State == nil {
@@ -220,7 +250,7 @@ func (h *handlers) collectFailedTasks(ctx context.Context, dagID, runID string, 
 			DurationSeconds: deref(ti.Duration),
 		}
 		if *ti.State == apiclient.TaskInstanceStateFailed && ft.TaskID != "" && ft.TryNumber >= 1 {
-			logResp, lerr := h.api.GetTaskLogsWithResponse(ctx, dagID, runID, ft.TaskID, ft.TryNumber)
+			logResp, lerr := api.GetTaskLogsWithResponse(ctx, dagID, runID, ft.TaskID, ft.TryNumber)
 			if lerr == nil && logResp.StatusCode() == http.StatusOK {
 				ft.LogTail = sanitizeLogTail(string(logResp.Body), tail)
 			}
@@ -266,7 +296,7 @@ type searchLogsOutput struct {
 // (ADR 0050 R16). The match is a plain substring, not a regex, to avoid handing
 // the model a ReDoS lever. Matched lines are sanitized (untrusted content, D10)
 // and the returned set is capped, but the true total is always reported.
-func (h *handlers) searchLogs(ctx context.Context, _ *mcpsdk.CallToolRequest, in searchLogsInput) (*mcpsdk.CallToolResult, searchLogsOutput, error) {
+func (h *handlers) searchLogs(ctx context.Context, req *mcpsdk.CallToolRequest, in searchLogsInput) (*mcpsdk.CallToolResult, searchLogsOutput, error) {
 	if in.DagID == "" || in.RunID == "" || in.TaskID == "" || in.Query == "" {
 		return nil, searchLogsOutput{}, fmt.Errorf("dag_id, run_id, task_id, and query are required")
 	}
@@ -282,7 +312,8 @@ func (h *handlers) searchLogs(ctx context.Context, _ *mcpsdk.CallToolRequest, in
 		maxN = maxLogMatches
 	}
 
-	resp, err := h.api.GetTaskLogsWithResponse(ctx, in.DagID, in.RunID, in.TaskID, try)
+	api := apiFor(h, req)
+	resp, err := api.GetTaskLogsWithResponse(ctx, in.DagID, in.RunID, in.TaskID, try)
 	if err != nil {
 		return nil, searchLogsOutput{}, fmt.Errorf("fetching task log: %w", err)
 	}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -134,7 +134,7 @@ func TestNewServerRegistersListDags(t *testing.T) {
 	if err != nil {
 		t.Fatalf("client: %v", err)
 	}
-	srv := NewServer(api, "test")
+	srv := NewServer(api, "", "test")
 
 	serverT, clientT := mcpsdk.NewInMemoryTransports()
 	_, err = srv.Connect(ctx, serverT, nil)
@@ -173,6 +173,62 @@ func testHandlers(t *testing.T, fn http.HandlerFunc) *handlers {
 		t.Fatalf("client: %v", err)
 	}
 	return &handlers{api: c}
+}
+
+// TestPerRequestTokenPassThrough: on a request carrying an Authorization header
+// (the HTTP transport), the handler builds a client with THAT token and the
+// control plane sees it — the pass-through the Pro transport relies on (D9).
+func TestPerRequestTokenPassThrough(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"dags":[],"total_entries":0}`)
+	}))
+	defer srv.Close()
+
+	base, err := apiclient.New(srv.URL, "") // base has NO token
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := &handlers{api: base, serverURL: srv.URL}
+	req := &mcpsdk.CallToolRequest{Extra: &mcpsdk.RequestExtra{
+		Header: http.Header{"Authorization": []string{"Bearer usertok"}},
+	}}
+	if _, _, err := h.listDags(context.Background(), req, listDagsInput{}); err != nil {
+		t.Fatalf("listDags: %v", err)
+	}
+	if gotAuth != "Bearer usertok" {
+		t.Errorf("per-request token not passed through; control plane saw %q", gotAuth)
+	}
+}
+
+// TestNoServerURLIgnoresHeader: with no serverURL (stdio mode), a stray
+// Authorization header is ignored and the base (process-token) client is used —
+// so stdio can't be tricked into re-tokening per request.
+func TestNoServerURLIgnoresHeader(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"dags":[],"total_entries":0}`)
+	}))
+	defer srv.Close()
+
+	base, err := apiclient.New(srv.URL, "basetok")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := &handlers{api: base} // serverURL empty
+	req := &mcpsdk.CallToolRequest{Extra: &mcpsdk.RequestExtra{
+		Header: http.Header{"Authorization": []string{"Bearer usertok"}},
+	}}
+	if _, _, err := h.listDags(context.Background(), req, listDagsInput{}); err != nil {
+		t.Fatalf("listDags: %v", err)
+	}
+	if gotAuth != "Bearer basetok" {
+		t.Errorf("without serverURL the base token must be used; control plane saw %q", gotAuth)
+	}
 }
 
 // TestListDagsShapesOutput: the tool calls /api/v2/dags and returns a compact


### PR DESCRIPTION
Phase 3 Part A (ADR 0050): the enabling refactor for the Pro HTTP transport. No transport yet — behavior-preserving for stdio.

## What
Handlers no longer close over a single client. They resolve one **per request** via `apiFor(h, req)`:
- **HTTP transport:** the caller's bearer arrives in `req.Extra.Header`; the handler builds a client carrying **that** token (pass-through — the MCP never mints one, D9).
- **stdio:** no such header → falls back to the base client (built from the process `LEOFLOW_TOKEN`).

`NewServer` gains a `serverURL` param (used to build per-request clients). The base client remains the unit-test injection point.

## Why now
One HTTP process serves many callers, so a single server-wide token is wrong there. This refactor makes the client per-request so Part B (the Streamable HTTP transport) can pass each caller's JWT straight through to `/api/v2`.

## Tests
- `TestPerRequestTokenPassThrough` — a header bearer reaches the control plane.
- `TestNoServerURLIgnoresHeader` — with no `serverURL` (stdio) a stray header is ignored; the base token is used (stdio can't be re-tokened per request).
- All existing handler/resource tests unchanged and green (behavior-preserving); golangci-lint 0, `-race` + `deadcode` clean, real-binary e2e green.