### PR TITLE
feat(mcp): Streamable HTTP transport for the Pro deployment (closes Phase 3)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,7 +98,7 @@ jobs:
   # Hermetic (the control plane is an httptest server), so it runs in CI.
   # ─────────────────────────────────────────────────────────────────────
   mcp-e2e:
-    name: MCP server e2e (real binary over stdio)
+    name: MCP server e2e (real binary over stdio + http)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -107,7 +107,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
       - name: MCP binary e2e
-        run: go test -tags e2e -run TestMCPBinaryEndToEnd ./internal/mcp/
+        run: go test -tags e2e ./internal/mcp/
 
   # ─────────────────────────────────────────────────────────────────────
   # Lint the GitHub Actions workflows themselves (actionlint). A malformed

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ COPILOT.md
 # Compiled binaries
 bin/
 dist/
+/leoflow-mcp
+/leoflow
 *.exe
 *.exe~
 *.dll

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,12 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `log://task/{dag_id}/{run_id}/{task_id}/{try_number}` (truncated + sanitized),
   `dag://source/{dag_id}` (the dag.py text), `dag://spec/{dag_id}` (the compiled
   dag.json artifact, via a new GET /api/v2/dags/{dag_id}/spec endpoint), and
-  `health://control-plane` (component health + executor + version). The Pro HTTP transport and authoring follow.
+  `health://control-plane` (component health + executor + version). Beyond stdio
+  it also speaks **Streamable HTTP** (`--transport http`, `POST /mcp`, stateless)
+  as an optional Pro service, where each request carries its own bearer and the
+  server mints a per-request control-plane client from it — the token
+  pass-through the Pro deployment relies on, with no ambient privilege. Authoring
+  follows.
 - **A generated, typed Go client for the `/api/v2` surface (`pkg/client`)** — the
   single control-plane client the CLI, the coming MCP server, and smoke tests
   share instead of hand-rolling HTTP (ADR 0050). Generated from the OpenAPI spec

--- a/Makefile
+++ b/Makefile
@@ -315,5 +315,5 @@ clean: ## Remove build artifacts
 	rm -rf $(BIN_DIR) coverage.out
 
 .PHONY: test-mcp-e2e
-test-mcp-e2e: ## Build leoflow-mcp and drive it over the real MCP protocol (stdio) against a seeded control plane
-	go test -tags e2e -run TestMCPBinaryEndToEnd ./internal/mcp/
+test-mcp-e2e: ## Build leoflow-mcp and drive it over the real MCP protocol (stdio + http) against a seeded control plane
+	go test -tags e2e ./internal/mcp/

--- a/cmd/leoflow-mcp/main.go
+++ b/cmd/leoflow-mcp/main.go
@@ -41,30 +41,35 @@ func run() int {
 		"listen address for the http transport")
 	flag.Parse()
 
-	// On stdio the process carries one token (LEOFLOW_TOKEN). On http each request
-	// carries its own bearer (pass-through, ADR 0050 D9), so the base client is
-	// only a fallback; serverURL lets the server mint a per-request client.
-	apiClient, err := apiclient.New(server, os.Getenv("LEOFLOW_TOKEN"))
+	if transport != "stdio" && transport != "http" {
+		slog.Error("unknown transport (want stdio | http)", "transport", transport)
+		return 2
+	}
+	httpMode := transport == "http"
+
+	// stdio: the process token IS the caller's identity. http: identity is the
+	// per-request bearer (ADR 0050 D9), so the base client holds NO ambient token
+	// — a bearer-less request is refused, never served with a process credential.
+	token := os.Getenv("LEOFLOW_TOKEN")
+	if httpMode {
+		token = ""
+	}
+	apiClient, err := apiclient.New(server, token)
 	if err != nil {
 		slog.Error("building control-plane client", "error", err)
 		return 1
 	}
-	srv := mcp.NewServer(apiClient, server, version)
+	srv := mcp.NewServer(apiClient, server, version, httpMode)
 
-	switch transport {
-	case "stdio":
-		slog.Info("leoflow-mcp starting", "server", server, "transport", "stdio", "version", version)
-		if err := srv.Run(context.Background(), &mcpsdk.StdioTransport{}); err != nil {
-			slog.Error("mcp server exited", "error", err)
-			return 1
-		}
-		return 0
-	case "http":
+	if httpMode {
 		return runHTTP(srv, listen, server)
-	default:
-		slog.Error("unknown transport (want stdio | http)", "transport", transport)
-		return 2
 	}
+	slog.Info("leoflow-mcp starting", "server", server, "transport", "stdio", "version", version)
+	if err := srv.Run(context.Background(), &mcpsdk.StdioTransport{}); err != nil {
+		slog.Error("mcp server exited", "error", err)
+		return 1
+	}
+	return 0
 }
 
 // runHTTP serves the MCP over Streamable HTTP at POST /mcp. Stateless: no session

--- a/cmd/leoflow-mcp/main.go
+++ b/cmd/leoflow-mcp/main.go
@@ -1,14 +1,20 @@
 // Command leoflow-mcp runs the Leoflow Model Context Protocol server (ADR 0050).
-// By default it speaks stdio, for a local agent (Claude Desktop/Code) against a
-// Lite control plane; it reaches the control plane only through /api/v2, carrying
-// the caller's token. It is optional and never part of leoflow-server.
+// It speaks stdio by default (a local agent — Claude Desktop/Code — against a Lite
+// control plane) or Streamable HTTP as an optional Pro service (POST /mcp). Either
+// way it reaches the control plane only through /api/v2, carrying the caller's
+// token, and is never part of leoflow-server.
 package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"log/slog"
+	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -22,29 +28,75 @@ var version = "dev"
 func main() { os.Exit(run()) }
 
 func run() int {
-	// Logs go to stderr: stdout is the MCP stdio protocol channel and must carry
-	// nothing but protocol frames.
+	// Logs go to stderr: on stdio, stdout is the MCP protocol channel and must
+	// carry nothing else.
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
 
-	var server string
+	var server, transport, listen string
 	flag.StringVar(&server, "server", envOr("LEOFLOW_SERVER_URL", "http://localhost:8080"),
 		"control plane base URL")
+	flag.StringVar(&transport, "transport", envOr("LEOFLOW_MCP_TRANSPORT", "stdio"),
+		"transport: stdio | http")
+	flag.StringVar(&listen, "listen", envOr("LEOFLOW_MCP_LISTEN", ":9099"),
+		"listen address for the http transport")
 	flag.Parse()
 
-	// The caller's JWT is passed through to /api/v2 (ADR 0050 D9); empty is
-	// acceptable for a loopback Lite with dev auth.
-	token := os.Getenv("LEOFLOW_TOKEN")
-
-	apiClient, err := apiclient.New(server, token)
+	// On stdio the process carries one token (LEOFLOW_TOKEN). On http each request
+	// carries its own bearer (pass-through, ADR 0050 D9), so the base client is
+	// only a fallback; serverURL lets the server mint a per-request client.
+	apiClient, err := apiclient.New(server, os.Getenv("LEOFLOW_TOKEN"))
 	if err != nil {
 		slog.Error("building control-plane client", "error", err)
 		return 1
 	}
-
 	srv := mcp.NewServer(apiClient, server, version)
-	slog.Info("leoflow-mcp starting", "server", server, "transport", "stdio", "version", version)
-	if err := srv.Run(context.Background(), &mcpsdk.StdioTransport{}); err != nil {
-		slog.Error("mcp server exited", "error", err)
+
+	switch transport {
+	case "stdio":
+		slog.Info("leoflow-mcp starting", "server", server, "transport", "stdio", "version", version)
+		if err := srv.Run(context.Background(), &mcpsdk.StdioTransport{}); err != nil {
+			slog.Error("mcp server exited", "error", err)
+			return 1
+		}
+		return 0
+	case "http":
+		return runHTTP(srv, listen, server)
+	default:
+		slog.Error("unknown transport (want stdio | http)", "transport", transport)
+		return 2
+	}
+}
+
+// runHTTP serves the MCP over Streamable HTTP at POST /mcp. Stateless: no session
+// state is kept, so a request is authorized purely by its own bearer and the
+// service scales active-active. A stray GET/DELETE returns 405 (spec-compliant in
+// stateless mode). Shuts down gracefully on SIGINT/SIGTERM.
+func runHTTP(srv *mcpsdk.Server, listen, server string) int {
+	handler := mcpsdk.NewStreamableHTTPHandler(
+		func(*http.Request) *mcpsdk.Server { return srv },
+		&mcpsdk.StreamableHTTPOptions{Stateless: true},
+	)
+	mux := http.NewServeMux()
+	mux.Handle("/mcp", handler)
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	httpSrv := &http.Server{Addr: listen, Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+	go func() {
+		<-ctx.Done()
+		// Fresh deadline for the drain — ctx is already canceled (that's what woke
+		// this goroutine), but WithoutCancel keeps its lineage for contextcheck.
+		shutCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		if err := httpSrv.Shutdown(shutCtx); err != nil {
+			slog.Warn("http server shutdown", "error", err)
+		}
+	}()
+
+	slog.Info("leoflow-mcp starting", "server", server, "transport", "http", "listen", listen, "version", version)
+	if err := httpSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		slog.Error("http server exited", "error", err)
 		return 1
 	}
 	return 0

--- a/internal/mcp/e2e_test.go
+++ b/internal/mcp/e2e_test.go
@@ -13,11 +13,13 @@ package mcp_test
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -56,6 +58,47 @@ func buildMCPBinary(t *testing.T) string {
 		t.Fatalf("building leoflow-mcp: %v\n%s", err, out)
 	}
 	return bin
+}
+
+// freePort asks the OS for an unused TCP port and hands it back. There is an
+// inherent bind race, but the window is tiny and this is standard for spawning a
+// child that needs a known address.
+func freePort(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserving a port: %v", err)
+	}
+	defer func() { _ = l.Close() }()
+	return l.Addr().String()
+}
+
+// waitHealthy polls the binary's /healthz until it answers or the deadline hits.
+func waitHealthy(t *testing.T, ctx context.Context, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+addr+"/healthz", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatal("leoflow-mcp http transport never became healthy")
+}
+
+type e2eAuthRT struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (a e2eAuthRT) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.Header.Set("Authorization", "Bearer "+a.token)
+	return a.base.RoundTrip(r)
 }
 
 func textOf(contents []mcpsdk.Content) string {
@@ -127,5 +170,67 @@ func TestMCPBinaryEndToEnd(t *testing.T) {
 	}
 	if len(rr.Contents) == 0 || !strings.Contains(rr.Contents[0].Text, `"state":"failed"`) {
 		t.Errorf("run://detail content missing state; got %+v", rr.Contents)
+	}
+}
+
+// TestMCPBinaryHTTPTransport is the Pro-transport gate (ADR 0050 Phase 3): the
+// real binary is launched with --transport http, a real MCP client connects over
+// Streamable HTTP carrying its own bearer, and the token reaches the control
+// plane on the resulting tool call — the whole per-request pass-through (D9)
+// through the actual binary, not the in-process handler.
+func TestMCPBinaryHTTPTransport(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		gotAuth string
+	)
+	cp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/dags" {
+			mu.Lock()
+			gotAuth = r.Header.Get("Authorization")
+			mu.Unlock()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"dags":[{"dag_id":"etl","is_paused":false}],"total_entries":1}`))
+	}))
+	defer cp.Close()
+	bin := buildMCPBinary(t)
+	addr := freePort(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, bin, "--transport", "http", "--listen", addr, "--server", cp.URL)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting http binary: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+	waitHealthy(t, ctx, addr)
+
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "e2e-http-client", Version: "0"}, nil)
+	transport := &mcpsdk.StreamableClientTransport{
+		Endpoint:   "http://" + addr + "/mcp",
+		HTTPClient: &http.Client{Transport: e2eAuthRT{token: "usertok", base: http.DefaultTransport}},
+	}
+	sess, err := client.Connect(ctx, transport, nil)
+	if err != nil {
+		t.Fatalf("connecting over http: %v", err)
+	}
+	defer func() { _ = sess.Close() }()
+
+	res, err := sess.CallTool(ctx, &mcpsdk.CallToolParams{Name: "list_dags"})
+	if err != nil {
+		t.Fatalf("CallTool list_dags over http: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("list_dags returned an error result: %s", textOf(res.Content))
+	}
+	mu.Lock()
+	seen := gotAuth
+	mu.Unlock()
+	if seen != "Bearer usertok" {
+		t.Errorf("caller token did not reach the control plane via the http binary; saw %q", seen)
 	}
 }

--- a/internal/mcp/http_test.go
+++ b/internal/mcp/http_test.go
@@ -1,0 +1,86 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
+)
+
+// authRoundTripper stamps every outbound request with a bearer token — the job
+// an MCP HTTP client (or a Pro gateway) does for the caller.
+type authRoundTripper struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (a authRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.Header.Set("Authorization", "Bearer "+a.token)
+	return a.base.RoundTrip(r)
+}
+
+// TestHTTPTransportPassesTokenThrough is the Streamable-HTTP end-to-end (ADR 0050
+// Phase 3): a real MCP client talks to NewStreamableHTTPHandler over HTTP carrying
+// its own bearer, and the token reaches the control plane on the resulting tool
+// call. This exercises the whole chain server-side — HTTP handler → session →
+// tool handler → per-request client — that the Pro transport depends on (D9),
+// without spawning a binary.
+func TestHTTPTransportPassesTokenThrough(t *testing.T) {
+	ctx := context.Background()
+
+	// Mock control plane: records the bearer it was called with.
+	var gotAuth string
+	cp := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/dags" {
+			gotAuth = r.Header.Get("Authorization")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"dags":[{"dag_id":"etl","is_paused":false}],"total_entries":1}`))
+	}))
+	defer cp.Close()
+
+	// Base client has NO token; serverURL points at the mock control plane so the
+	// server can mint a per-request client from the caller's header.
+	base, err := apiclient.New(cp.URL, "")
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	srv := NewServer(base, cp.URL, "test")
+
+	// The MCP server, served over Streamable HTTP exactly as cmd/leoflow-mcp does.
+	mcpHandler := mcpsdk.NewStreamableHTTPHandler(
+		func(*http.Request) *mcpsdk.Server { return srv },
+		&mcpsdk.StreamableHTTPOptions{Stateless: true},
+	)
+	mcpHTTP := httptest.NewServer(mcpHandler)
+	defer mcpHTTP.Close()
+
+	// An MCP client that carries a caller bearer on every HTTP request.
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "http-test-client", Version: "0"}, nil)
+	transport := &mcpsdk.StreamableClientTransport{
+		Endpoint: mcpHTTP.URL,
+		HTTPClient: &http.Client{Transport: authRoundTripper{
+			token: "usertok", base: http.DefaultTransport,
+		}},
+	}
+	sess, err := client.Connect(ctx, transport, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer func() { _ = sess.Close() }()
+
+	res, err := sess.CallTool(ctx, &mcpsdk.CallToolParams{Name: "list_dags"})
+	if err != nil {
+		t.Fatalf("CallTool(list_dags): %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool returned an error result: %+v", res.Content)
+	}
+	if gotAuth != "Bearer usertok" {
+		t.Errorf("caller token did not reach the control plane over HTTP; saw %q", gotAuth)
+	}
+}

--- a/internal/mcp/http_test.go
+++ b/internal/mcp/http_test.go
@@ -49,7 +49,7 @@ func TestHTTPTransportPassesTokenThrough(t *testing.T) {
 	if err != nil {
 		t.Fatalf("client: %v", err)
 	}
-	srv := NewServer(base, cp.URL, "test")
+	srv := NewServer(base, cp.URL, "test", true) // http transport: per-request bearer
 
 	// The MCP server, served over Streamable HTTP exactly as cmd/leoflow-mcp does.
 	mcpHandler := mcpsdk.NewStreamableHTTPHandler(

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -14,14 +14,14 @@ import (
 	apiclient "github.com/neochaotic/leoflow/pkg/client"
 )
 
-// resourceLogTail bounds a log resource read (R16); a task log an agent fetches
+// resourceLogTail bounds a log resource read; a task log an agent fetches
 // wholesale still must not blow the context window.
 const resourceLogTail = 200
 
-// registerResources wires the read-only addressable resources (ADR 0050 D7/R12).
+// registerResources wires the read-only addressable resources (ADR 0050 D7).
 // The agent chooses the URI; the control plane authorizes each read via the
 // pass-through token, so a resource can only surface what the caller already may
-// see. Templates carry their parameters IN the URI (R05).
+// see. Templates carry their parameters IN the URI.
 func (h *handlers) registerResources(s *mcpsdk.Server) {
 	s.AddResource(&mcpsdk.Resource{
 		Name: "dags", URI: "dag://list", MIMEType: "application/json",
@@ -54,7 +54,7 @@ func (h *handlers) registerResources(s *mcpsdk.Server) {
 }
 
 // maxSourceBytes caps a dag.py source resource read so a large DAG file can't
-// blow the agent's context window (R40).
+// blow the agent's context window.
 const maxSourceBytes = 64 * 1024
 
 func (h *handlers) readDagSource(ctx context.Context, req *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
@@ -62,7 +62,10 @@ func (h *handlers) readDagSource(ctx context.Context, req *mcpsdk.ReadResourceRe
 	if err != nil {
 		return nil, err
 	}
-	api := apiFor(h, req)
+	api, err := apiFor(h, req)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := api.GetDagSourceWithResponse(ctx, p[0])
 	if err != nil {
 		return nil, fmt.Errorf("fetching dag source: %w", err)
@@ -80,7 +83,7 @@ func (h *handlers) readDagSource(ctx context.Context, req *mcpsdk.ReadResourceRe
 }
 
 // maxSpecBytes guards a dag.json resource read; the compiled artifact is small
-// in practice, but a runaway must not blow the context window (R40). JSON can't
+// in practice, but a runaway must not blow the context window. JSON can't
 // be safely truncated, so an oversize spec yields a structured note instead.
 const maxSpecBytes = 128 * 1024
 
@@ -89,7 +92,10 @@ func (h *handlers) readDagSpec(ctx context.Context, req *mcpsdk.ReadResourceRequ
 	if err != nil {
 		return nil, err
 	}
-	api := apiFor(h, req)
+	api, err := apiFor(h, req)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := api.GetDagSpecWithResponse(ctx, p[0])
 	if err != nil {
 		return nil, fmt.Errorf("fetching dag spec: %w", err)
@@ -102,18 +108,50 @@ func (h *handlers) readDagSpec(ctx context.Context, req *mcpsdk.ReadResourceRequ
 			"error": "compiled spec too large for a resource read", "bytes": len(resp.Body), "dag_id": p[0],
 		})
 	}
-	// Return the compiled dag.json verbatim (already a clean structured artifact).
-	return &mcpsdk.ReadResourceResult{Contents: []*mcpsdk.ResourceContents{{
-		URI: req.Params.URI, MIMEType: "application/json", Text: string(resp.Body),
-	}}}, nil
+	// The spec is structured, but its string values (task descriptions, owners,
+	// tags) are author-controlled free text; an ANSI/control byte stored as the JSON escape \u001b
+	// would decode to a live escape in the agent's context (D10). Decode, strip
+	// control bytes from every string value, and re-encode — and treat a
+	// non-JSON 200 as an error rather than forwarding it as application/json.
+	var spec any
+	if err := json.Unmarshal(resp.Body, &spec); err != nil {
+		return nil, fmt.Errorf("control plane returned a non-JSON spec for %s: %w", p[0], err)
+	}
+	return jsonResource(req.Params.URI, sanitizeJSONValue(spec))
+}
+
+// sanitizeJSONValue recursively strips control/ANSI bytes from every string in a
+// decoded JSON tree (map values, slice elements, nested strings), leaving
+// structure and non-string scalars untouched. Map keys are field names from the
+// compiler, not author free text, so they are left as-is.
+func sanitizeJSONValue(v any) any {
+	switch t := v.(type) {
+	case string:
+		return stripControl(t)
+	case []any:
+		for i := range t {
+			t[i] = sanitizeJSONValue(t[i])
+		}
+		return t
+	case map[string]any:
+		for k, val := range t {
+			t[k] = sanitizeJSONValue(val)
+		}
+		return t
+	default:
+		return v
+	}
 }
 
 // readHealth composes the three monitor endpoints into one snapshot, best-effort
 // per section: a section that fails is omitted rather than failing the whole
-// read (structured degradation, R39), and an all-empty result is an error so the
+// read (structured degradation), and an all-empty result is an error so the
 // agent knows the control plane is unreachable rather than "healthy".
 func (h *handlers) readHealth(ctx context.Context, req *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
-	api := apiFor(h, req)
+	api, err := apiFor(h, req)
+	if err != nil {
+		return nil, err
+	}
 	snap := map[string]any{}
 	if r, err := api.GetMonitorHealthWithResponse(ctx); err == nil && r.StatusCode() == http.StatusOK && r.JSON200 != nil {
 		snap["health"] = r.JSON200
@@ -131,7 +169,11 @@ func (h *handlers) readHealth(ctx context.Context, req *mcpsdk.ReadResourceReque
 }
 
 func (h *handlers) readDagList(ctx context.Context, req *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
-	out, err := h.fetchDagList(ctx, apiFor(h, req), listDagsInput{})
+	api, err := apiFor(h, req)
+	if err != nil {
+		return nil, err
+	}
+	out, err := h.fetchDagList(ctx, api, listDagsInput{})
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +185,10 @@ func (h *handlers) readRunDetail(ctx context.Context, req *mcpsdk.ReadResourceRe
 	if err != nil {
 		return nil, err
 	}
-	api := apiFor(h, req)
+	api, err := apiFor(h, req)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := api.GetDagRunWithResponse(ctx, p[0], p[1])
 	if err != nil {
 		return nil, fmt.Errorf("fetching run: %w", err)
@@ -179,7 +224,10 @@ func (h *handlers) readTaskInstances(ctx context.Context, req *mcpsdk.ReadResour
 	if err != nil {
 		return nil, err
 	}
-	api := apiFor(h, req)
+	api, err := apiFor(h, req)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := api.ListTaskInstancesWithResponse(ctx, p[0], p[1])
 	if err != nil {
 		return nil, fmt.Errorf("listing task instances: %w", err)
@@ -212,7 +260,10 @@ func (h *handlers) readTaskLog(ctx context.Context, req *mcpsdk.ReadResourceRequ
 	if err != nil || try < 1 {
 		return nil, fmt.Errorf("uri %q: try_number must be a positive integer", req.Params.URI)
 	}
-	api := apiFor(h, req)
+	api, err := apiFor(h, req)
+	if err != nil {
+		return nil, err
+	}
 	resp, err := api.GetTaskLogsWithResponse(ctx, p[0], p[1], p[2], try)
 	if err != nil {
 		return nil, fmt.Errorf("fetching task log: %w", err)
@@ -227,7 +278,7 @@ func (h *handlers) readTaskLog(ctx context.Context, req *mcpsdk.ReadResourceRequ
 
 // uriParams strips scheme+prefix from a resource URI and returns exactly n
 // non-empty, URL-decoded path segments. A path segment supplied by the agent is
-// data, never a raw selector (R05): it is decoded here and passed to the typed
+// data, never a raw selector: it is decoded here and passed to the typed
 // client, which URL-encodes it back into the request path — so a "../" or a stray
 // slash cannot escape the intended endpoint.
 func uriParams(uri, prefix string, n int) ([]string, error) {

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -135,6 +135,43 @@ func TestReadDagSpecResource(t *testing.T) {
 	}
 }
 
+// TestReadDagSpecSanitizesValues: the compiled spec is author-controlled free
+// text (task descriptions, owners). A control/ANSI byte stored in a string value
+// (as the JSON escape \u001b) must be stripped before the agent's JSON
+// can turn it back into a live escape (D10) — the spec is not exempt just
+// because it is structured.
+func TestReadDagSpecSanitizesValues(t *testing.T) {
+	h := testHandlers(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// A task description carrying an ANSI escape as the JSON escape \u001b —
+		// valid JSON on the wire; the decoder turns it into a real ESC byte.
+		_, _ = io.WriteString(w, `{"dag_id":"etl","tasks":[{"task_id":"load","description":"evil\u001b[31mred"}]}`)
+	})
+	res, err := h.readDagSpec(context.Background(), readReq("dag://spec/etl"))
+	if err != nil {
+		t.Fatalf("readDagSpec: %v", err)
+	}
+	txt := res.Contents[0].Text
+	if strings.Contains(txt, "\x1b") {
+		t.Errorf("spec must be sanitized of control bytes; got %q", txt)
+	}
+	if !strings.Contains(txt, `"task_id":"load"`) || !strings.Contains(txt, "red") {
+		t.Errorf("sanitizing must keep the graph and surrounding text: %s", txt)
+	}
+}
+
+// TestReadDagSpecNonJSON: a 200 whose body is not JSON is reported as an error,
+// not forwarded verbatim as application/json.
+func TestReadDagSpecNonJSON(t *testing.T) {
+	h := testHandlers(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `<html>not json</html>`)
+	})
+	if _, err := h.readDagSpec(context.Background(), readReq("dag://spec/etl")); err == nil {
+		t.Error("a non-JSON spec body should surface as an error")
+	}
+}
+
 func TestReadHealthResource(t *testing.T) {
 	h := testHandlers(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -22,48 +22,61 @@ const (
 	maxDagLim     = 200
 )
 
-// handlers holds what the tool/resource handlers share. api is the base client
-// (the stdio process token, or a test client); serverURL lets a handler build a
-// PER-REQUEST client from the caller's Authorization header on the HTTP
-// transport, where one process serves many callers (ADR 0050 D9 pass-through).
+// handlers holds what the tool/resource handlers share. api is the base client;
+// serverURL is the control-plane URL used to build per-request clients.
+//
+// requireBearer is the identity policy, and it keys off the TRANSPORT, not off
+// whether serverURL happens to be set:
+//   - HTTP transport (requireBearer=true): one process serves many callers, so
+//     every request MUST carry its own bearer; the server builds a client from
+//     THAT token and holds no ambient identity (ADR 0050 D9). A bearer-less
+//     request is refused, never served with the base client — otherwise an
+//     anonymous caller could ride a process-level token.
+//   - stdio transport (requireBearer=false): single local caller whose identity
+//     is the process token in the base client; any inbound header is ignored, so
+//     stdio can't be coaxed into per-request re-tokening.
 type handlers struct {
-	api       *apiclient.ClientWithResponses
-	serverURL string
+	api           *apiclient.ClientWithResponses
+	serverURL     string
+	requireBearer bool
 }
 
-// clientFor returns the /api/v2 client for one request: on the HTTP transport a
-// per-request bearer arrives in the header, so build a client carrying THAT
-// token (pass-through — the MCP never mints one); on stdio there is no such
-// header, so fall back to the base client (built from the process token).
-func (h *handlers) clientFor(extra *mcpsdk.RequestExtra) *apiclient.ClientWithResponses {
-	if h.serverURL != "" && extra != nil && extra.Header != nil {
-		if authz := extra.Header.Get("Authorization"); authz != "" {
-			token := strings.TrimSpace(strings.TrimPrefix(authz, "Bearer "))
-			if c, err := apiclient.New(h.serverURL, token); err == nil {
-				return c
-			}
-		}
+// clientFor returns the /api/v2 client for one request per the identity policy
+// above. On the HTTP transport it demands a bearer and never falls back to the
+// base client; on stdio it always uses the base client and ignores any header.
+func (h *handlers) clientFor(extra *mcpsdk.RequestExtra) (*apiclient.ClientWithResponses, error) {
+	if !h.requireBearer {
+		return h.api, nil
 	}
-	return h.api
+	if extra == nil || extra.Header == nil {
+		return nil, fmt.Errorf("missing Authorization header (the http transport requires a per-request bearer)")
+	}
+	token := strings.TrimSpace(strings.TrimPrefix(extra.Header.Get("Authorization"), "Bearer "))
+	if token == "" {
+		return nil, fmt.Errorf("missing bearer token (the http transport requires a per-request bearer)")
+	}
+	return apiclient.New(h.serverURL, token)
 }
 
 // apiFor resolves the client for a tool/resource request, tolerating a nil
 // request (unit tests call handlers directly with nil).
-func apiFor[P mcpsdk.Params](h *handlers, req *mcpsdk.ServerRequest[P]) *apiclient.ClientWithResponses {
+func apiFor[P mcpsdk.Params](h *handlers, req *mcpsdk.ServerRequest[P]) (*apiclient.ClientWithResponses, error) {
 	if req == nil {
-		return h.api
+		return h.api, nil
 	}
 	return h.clientFor(req.Extra)
 }
 
 // NewServer builds a read-only Leoflow MCP server. api is the base control-plane
-// client; serverURL is the control-plane URL used to build per-request clients on
-// the HTTP transport. It registers the read tools + resources; the caller runs it
-// over a transport (stdio for Lite dev, Streamable HTTP for Pro). Tools that
-// mutate state are deliberately absent (ADR 0050 D7).
-func NewServer(api *apiclient.ClientWithResponses, serverURL, version string) *mcpsdk.Server {
+// client; serverURL is the control-plane URL used to build per-request clients.
+// requireBearer selects the identity policy (true for the HTTP transport, where
+// each request carries its own token; false for stdio) — see handlers. It
+// registers the read tools + resources; the caller runs it over a transport
+// (stdio for Lite dev, Streamable HTTP for Pro). Tools that mutate state are
+// deliberately absent (ADR 0050 D7).
+func NewServer(api *apiclient.ClientWithResponses, serverURL, version string, requireBearer bool) *mcpsdk.Server {
 	s := mcpsdk.NewServer(&mcpsdk.Implementation{Name: serverName, Version: version}, nil)
-	h := &handlers{api: api, serverURL: serverURL}
+	h := &handlers{api: api, serverURL: serverURL, requireBearer: requireBearer}
 	mcpsdk.AddTool(s, &mcpsdk.Tool{
 		Name:        "list_dags",
 		Description: "List DAGs registered in the Leoflow control plane, with their paused state.",
@@ -96,10 +109,14 @@ type listDagsOutput struct {
 }
 
 // listDags returns a compact list of DAGs. It shapes the response rather than
-// forwarding the verbose upstream payload (ADR 0050 R18), and surfaces a
+// forwarding the verbose upstream payload (ADR 0050 D7), and surfaces a
 // non-200 as an error so the agent never mistakes a failed call for "no DAGs".
 func (h *handlers) listDags(ctx context.Context, req *mcpsdk.CallToolRequest, in listDagsInput) (*mcpsdk.CallToolResult, listDagsOutput, error) {
-	out, err := h.fetchDagList(ctx, apiFor(h, req), in)
+	api, err := apiFor(h, req)
+	if err != nil {
+		return nil, listDagsOutput{}, err
+	}
+	out, err := h.fetchDagList(ctx, api, in)
 	return nil, out, err
 }
 
@@ -156,7 +173,22 @@ func deref[T any](p *T) T {
 const (
 	defaultLogTail = 40
 	maxLogTail     = 200
+	// maxLineRunes caps a SINGLE line's length. Tail/match limits are by line
+	// count, so one newline-free megabyte line (a serialized frame, a no-newline
+	// progress bar) would otherwise slip the whole thing into the agent's context
+	// (D10 "cap line length"). Applied after control-stripping, on a rune boundary.
+	maxLineRunes = 2000
 )
+
+// capLine truncates one line to maxLineRunes on a rune boundary, appending a
+// marker so the agent knows the line was cut rather than actually short.
+func capLine(s string) string {
+	r := []rune(s)
+	if len(r) <= maxLineRunes {
+		return s
+	}
+	return string(r[:maxLineRunes]) + " …[line truncated]"
+}
 
 type diagnoseRunInput struct {
 	DagID        string `json:"dag_id" jsonschema:"the DAG id"`
@@ -182,7 +214,7 @@ type diagnoseRunOutput struct {
 }
 
 // diagnoseRun composes the run, its task instances, and each failed task's log
-// tail into a single diagnosis (ADR 0050 R19), so an agent gets one answer
+// tail into a single diagnosis (ADR 0050 D7), so an agent gets one answer
 // instead of chaining four calls it would likely mis-sequence. It is
 // deliberately client-side composition for the MVP; a server-side aggregate
 // endpoint is the later optimization for chattiness. Log tails are truncated and
@@ -198,7 +230,10 @@ func (h *handlers) diagnoseRun(ctx context.Context, req *mcpsdk.CallToolRequest,
 	if tail > maxLogTail {
 		tail = maxLogTail
 	}
-	api := apiFor(h, req)
+	api, err := apiFor(h, req)
+	if err != nil {
+		return nil, diagnoseRunOutput{}, err
+	}
 	runResp, err := api.GetDagRunWithResponse(ctx, in.DagID, in.RunID)
 	if err != nil {
 		return nil, diagnoseRunOutput{}, fmt.Errorf("fetching run: %w", err)
@@ -293,7 +328,7 @@ type searchLogsOutput struct {
 // searchLogs fetches one task attempt's log and returns the lines matching a
 // case-insensitive substring, with 1-based line numbers — so an agent can find
 // the relevant lines of a long log without pulling the whole thing into context
-// (ADR 0050 R16). The match is a plain substring, not a regex, to avoid handing
+// (ADR 0050 D7). The match is a plain substring, not a regex, to avoid handing
 // the model a ReDoS lever. Matched lines are sanitized (untrusted content, D10)
 // and the returned set is capped, but the true total is always reported.
 func (h *handlers) searchLogs(ctx context.Context, req *mcpsdk.CallToolRequest, in searchLogsInput) (*mcpsdk.CallToolResult, searchLogsOutput, error) {
@@ -312,7 +347,10 @@ func (h *handlers) searchLogs(ctx context.Context, req *mcpsdk.CallToolRequest, 
 		maxN = maxLogMatches
 	}
 
-	api := apiFor(h, req)
+	api, err := apiFor(h, req)
+	if err != nil {
+		return nil, searchLogsOutput{}, err
+	}
 	resp, err := api.GetTaskLogsWithResponse(ctx, in.DagID, in.RunID, in.TaskID, try)
 	if err != nil {
 		return nil, searchLogsOutput{}, fmt.Errorf("fetching task log: %w", err)
@@ -330,7 +368,7 @@ func (h *handlers) searchLogs(ctx context.Context, req *mcpsdk.CallToolRequest, 
 		}
 		out.TotalMatches++
 		if len(out.Matches) < maxN {
-			out.Matches = append(out.Matches, logMatch{LineNumber: i + 1, Line: stripControl(ln)})
+			out.Matches = append(out.Matches, logMatch{LineNumber: i + 1, Line: capLine(stripControl(ln))})
 		}
 	}
 	out.Truncated = out.TotalMatches > len(out.Matches)
@@ -340,7 +378,7 @@ func (h *handlers) searchLogs(ctx context.Context, req *mcpsdk.CallToolRequest, 
 // sanitizeLogTail returns at most the last n lines of raw log output, stripped of
 // control and ANSI bytes (keeping \n and \t). Log content is untrusted (D10): an
 // ANSI/control payload in a task's stderr must not reach the agent's context
-// intact, and an unbounded tail would blow the context window (R16).
+// intact, and an unbounded tail would blow the context window (D10).
 func sanitizeLogTail(raw string, n int) string {
 	lines := strings.Split(strings.ReplaceAll(raw, "\r\n", "\n"), "\n")
 	// Drop a trailing empty line from a final newline so "n lines" is intuitive.
@@ -355,7 +393,7 @@ func sanitizeLogTail(raw string, n int) string {
 		if i > 0 {
 			b.WriteByte('\n')
 		}
-		b.WriteString(stripControl(ln))
+		b.WriteString(capLine(stripControl(ln)))
 	}
 	return b.String()
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -108,6 +108,60 @@ func TestSearchLogsTruncates(t *testing.T) {
 	}
 }
 
+// TestDiagnoseRunCapsGiantLine: a single newline-free megabyte line must not
+// slip into the agent context whole — line-count truncation doesn't catch it, so
+// each line is length-capped (D10 "cap line length").
+func TestDiagnoseRunCapsGiantLine(t *testing.T) {
+	giant := strings.Repeat("A", 5_000_000)
+	h := testHandlers(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v2/dags/etl/dagRuns/r1":
+			_, _ = io.WriteString(w, `{"dag_id":"etl","dag_run_id":"r1","state":"failed"}`)
+		case "/api/v2/dags/etl/dagRuns/r1/taskInstances":
+			_, _ = io.WriteString(w, `{"task_instances":[{"task_id":"load","state":"failed","try_number":1}],"total_entries":1}`)
+		case "/api/v2/dags/etl/dagRuns/r1/taskInstances/load/logs/1":
+			_, _ = io.WriteString(w, giant) // one line, no newline
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	_, out, err := h.diagnoseRun(context.Background(), nil, diagnoseRunInput{DagID: "etl", RunID: "r1"})
+	if err != nil {
+		t.Fatalf("diagnoseRun: %v", err)
+	}
+	if len(out.FailedTasks) != 1 {
+		t.Fatalf("want 1 failed task, got %d", len(out.FailedTasks))
+	}
+	if n := len([]rune(out.FailedTasks[0].LogTail)); n > maxLineRunes+64 {
+		t.Errorf("log_tail not length-capped: %d runes (cap %d)", n, maxLineRunes)
+	}
+	if !strings.Contains(out.FailedTasks[0].LogTail, "line truncated") {
+		t.Error("a truncated line should carry the truncation marker")
+	}
+}
+
+// TestSearchLogsCapsGiantLine: a matching line that is enormous is length-capped
+// in the returned match, not surfaced whole.
+func TestSearchLogsCapsGiantLine(t *testing.T) {
+	giant := "error " + strings.Repeat("B", 5_000_000)
+	h := testHandlers(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, giant)
+	})
+	_, out, err := h.searchLogs(context.Background(), nil, searchLogsInput{
+		DagID: "d", RunID: "r", TaskID: "t", Query: "error",
+	})
+	if err != nil {
+		t.Fatalf("searchLogs: %v", err)
+	}
+	if len(out.Matches) != 1 {
+		t.Fatalf("want 1 match, got %d", len(out.Matches))
+	}
+	if n := len([]rune(out.Matches[0].Line)); n > maxLineRunes+64 {
+		t.Errorf("match line not length-capped: %d runes (cap %d)", n, maxLineRunes)
+	}
+}
+
 // TestSearchLogsMissingArgs: the locators and the query are required.
 func TestSearchLogsMissingArgs(t *testing.T) {
 	h := &handlers{}
@@ -134,7 +188,7 @@ func TestNewServerRegistersListDags(t *testing.T) {
 	if err != nil {
 		t.Fatalf("client: %v", err)
 	}
-	srv := NewServer(api, "", "test")
+	srv := NewServer(api, "", "test", false)
 
 	serverT, clientT := mcpsdk.NewInMemoryTransports()
 	_, err = srv.Connect(ctx, serverT, nil)
@@ -163,6 +217,64 @@ func TestNewServerRegistersListDags(t *testing.T) {
 	}
 }
 
+// TestNewServerAdvertisesResources connects a client and asserts every resource
+// is discoverable via resources/list (static) and resources/templates/list
+// (templated). This is the same "registered-but-invisible" guard the tools test
+// applies — a resource clients can't enumerate is a resource they won't use.
+func TestNewServerAdvertisesResources(t *testing.T) {
+	ctx := context.Background()
+	api, err := apiclient.New("http://control-plane.invalid", "")
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	srv := NewServer(api, "", "test", false)
+
+	serverT, clientT := mcpsdk.NewInMemoryTransports()
+	if _, err = srv.Connect(ctx, serverT, nil); err != nil {
+		t.Fatalf("server connect: %v", err)
+	}
+	client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "test-client", Version: "0"}, nil)
+	sess, err := client.Connect(ctx, clientT, nil)
+	if err != nil {
+		t.Fatalf("client connect: %v", err)
+	}
+	defer func() { _ = sess.Close() }()
+
+	seen := map[string]bool{}
+	resList, err := sess.ListResources(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListResources: %v", err)
+	}
+	for _, r := range resList.Resources {
+		seen[r.URI] = true
+	}
+	for _, want := range []string{"dag://list", "health://control-plane"} {
+		if !seen[want] {
+			t.Errorf("static resource %q not advertised via resources/list", want)
+		}
+	}
+
+	tmpl := map[string]bool{}
+	tmplList, err := sess.ListResourceTemplates(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListResourceTemplates: %v", err)
+	}
+	for _, r := range tmplList.ResourceTemplates {
+		tmpl[r.URITemplate] = true
+	}
+	for _, want := range []string{
+		"run://detail/{dag_id}/{run_id}",
+		"task://instances/{dag_id}/{run_id}",
+		"log://task/{dag_id}/{run_id}/{task_id}/{try_number}",
+		"dag://source/{dag_id}",
+		"dag://spec/{dag_id}",
+	} {
+		if !tmpl[want] {
+			t.Errorf("resource template %q not advertised via resources/templates/list", want)
+		}
+	}
+}
+
 // testHandlers spins up a fake control plane and returns handlers wired to it.
 func testHandlers(t *testing.T, fn http.HandlerFunc) *handlers {
 	t.Helper()
@@ -175,9 +287,10 @@ func testHandlers(t *testing.T, fn http.HandlerFunc) *handlers {
 	return &handlers{api: c}
 }
 
-// TestPerRequestTokenPassThrough: on a request carrying an Authorization header
-// (the HTTP transport), the handler builds a client with THAT token and the
-// control plane sees it — the pass-through the Pro transport relies on (D9).
+// TestPerRequestTokenPassThrough: in http mode (requireBearer), a request
+// carrying an Authorization header makes the handler build a client with THAT
+// token, and the control plane sees it — the pass-through the Pro transport
+// relies on (D9).
 func TestPerRequestTokenPassThrough(t *testing.T) {
 	var gotAuth string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -191,7 +304,7 @@ func TestPerRequestTokenPassThrough(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := &handlers{api: base, serverURL: srv.URL}
+	h := &handlers{api: base, serverURL: srv.URL, requireBearer: true}
 	req := &mcpsdk.CallToolRequest{Extra: &mcpsdk.RequestExtra{
 		Header: http.Header{"Authorization": []string{"Bearer usertok"}},
 	}}
@@ -203,10 +316,44 @@ func TestPerRequestTokenPassThrough(t *testing.T) {
 	}
 }
 
-// TestNoServerURLIgnoresHeader: with no serverURL (stdio mode), a stray
-// Authorization header is ignored and the base (process-token) client is used —
-// so stdio can't be tricked into re-tokening per request.
-func TestNoServerURLIgnoresHeader(t *testing.T) {
+// TestHTTPModeRefusesMissingBearer: in http mode a bearer-less request is
+// refused, NOT served with the base client — otherwise an anonymous caller could
+// ride an ambient process token (the D9 defect the review caught). The control
+// plane must never be touched.
+func TestHTTPModeRefusesMissingBearer(t *testing.T) {
+	var touched bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		touched = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"dags":[],"total_entries":0}`)
+	}))
+	defer srv.Close()
+
+	base, err := apiclient.New(srv.URL, "ambient-should-not-be-used")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := &handlers{api: base, serverURL: srv.URL, requireBearer: true}
+
+	// No Extra at all, and an explicitly empty header — both must be refused.
+	for _, req := range []*mcpsdk.CallToolRequest{
+		{},
+		{Extra: &mcpsdk.RequestExtra{Header: http.Header{}}},
+		{Extra: &mcpsdk.RequestExtra{Header: http.Header{"Authorization": []string{"Bearer "}}}},
+	} {
+		if _, _, err := h.listDags(context.Background(), req, listDagsInput{}); err == nil {
+			t.Errorf("bearer-less http request should be refused, req=%+v", req)
+		}
+	}
+	if touched {
+		t.Error("a refused request must never reach the control plane")
+	}
+}
+
+// TestStdioIgnoresHeader: in stdio mode (requireBearer=false) the base
+// (process-token) client is always used and any inbound Authorization header is
+// ignored — so stdio can't be coaxed into per-request re-tokening.
+func TestStdioIgnoresHeader(t *testing.T) {
 	var gotAuth string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Authorization")
@@ -219,7 +366,7 @@ func TestNoServerURLIgnoresHeader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := &handlers{api: base} // serverURL empty
+	h := &handlers{api: base, serverURL: srv.URL} // requireBearer=false (stdio)
 	req := &mcpsdk.CallToolRequest{Extra: &mcpsdk.RequestExtra{
 		Header: http.Header{"Authorization": []string{"Bearer usertok"}},
 	}}
@@ -227,7 +374,7 @@ func TestNoServerURLIgnoresHeader(t *testing.T) {
 		t.Fatalf("listDags: %v", err)
 	}
 	if gotAuth != "Bearer basetok" {
-		t.Errorf("without serverURL the base token must be used; control plane saw %q", gotAuth)
+		t.Errorf("stdio must use the base token and ignore the header; control plane saw %q", gotAuth)
 	}
 }
 


### PR DESCRIPTION
## What

`leoflow-mcp` now speaks **Streamable HTTP** in addition to stdio, closing Phase 3 of ADR 0050. Selected with `--transport http` (`POST /mcp`, stateless), listening on `--listen` (default `:9099`), with `/healthz` for liveness and graceful drain on `SIGINT`/`SIGTERM`.

This is the optional **Pro** transport. Each HTTP request carries its own bearer; the server mints a per-request `/api/v2` client from it (the D9 pass-through that #560 Part A refactored the handlers to support). The server therefore holds **no ambient privilege of its own**, and — being stateless — scales active-active behind an HPA.

| flag | env | default |
|---|---|---|
| `--transport stdio\|http` | `LEOFLOW_MCP_TRANSPORT` | `stdio` |
| `--listen` | `LEOFLOW_MCP_LISTEN` | `:9099` |
| `--server` | `LEOFLOW_SERVER_URL` | `http://localhost:8080` |

## Why stateless

No session state means a request is authorized purely by its own bearer — the right posture for a Pro gateway fronting a multi-user control plane, and no sticky-session coupling for horizontal scale. Stray `GET`/`DELETE` to `/mcp` return `405` (verified), consistent with stateless Streamable HTTP.

## Tests

- **In-process e2e** (`internal/mcp/http_test.go`): a real MCP client → `NewStreamableHTTPHandler` over `httptest` carrying `Authorization: Bearer usertok` → tool handler → per-request client → mock control plane, asserting the token arrives. Exercises the whole server-side chain without a subprocess.
- **Binary e2e** (`TestMCPBinaryHTTPTransport`, `-tags e2e`): spawns the **real binary** in `--transport http`, polls `/healthz`, connects a `StreamableClientTransport` with a bearer, calls `list_dags`, and asserts the caller token reaches the control plane over the wire.
- **Coverage gap fixed**: `make test-mcp-e2e` and the CI `mcp-e2e` job had a pinned `-run TestMCPBinaryEndToEnd` and would have silently skipped the new HTTP e2e. Both now run the whole `-tags e2e` package.

Local gate green: `go build ./...`, `go test ./internal/mcp/` (incl. `-race`), `go test -tags e2e ./internal/mcp/`, `golangci-lint` (0 issues), `deadcode`, pre-commit coverage 80.8% ≥ 80%.