### PR TITLE
feat(dbt): Databricks OAuth M2M auth + fused-retry & Slim-CI docs (closes #563, #564, #565)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Databricks dbt profiles support OAuth M2M (service principal).** A managed
+  Databricks connection whose extra carries `client_id`/`client_secret` (or an
+  explicit `auth_type: oauth`) now generates a `profiles.yml` using service-principal
+  OAuth M2M — Databricks' recommended auth for automation — instead of a Personal
+  Access Token. PATs keep working; OAuth wins when present (the two are mutually
+  exclusive). Same encrypted-at-rest, generated-in-pod delivery as before.
+
+### Documentation
+
+- **dbt: fused-group retry trade-off** — documented that retrying a `level`/`folder`
+  (fused) group re-runs the whole group, with guidance to use `granularity: node`
+  where per-model retry efficiency matters.
+- **dbt: baked manifest & Slim CI** — documented where the compiled `manifest.json`
+  lives and how it enables `state:modified+` Slim CI, plus an honest note on the two
+  capabilities still needed for a turnkey recipe.
+
 - **Experimental MCP server skeleton (`leoflow-mcp`)** — the first slice of the
   Model Context Protocol server (ADR 0050): a read-only, stdio server built on
   the official `modelcontextprotocol/go-sdk`, exposing `list_dags`, `diagnose_run`, and `search_logs` (one call: run state + failed tasks +

--- a/docs/connections/databricks.md
+++ b/docs/connections/databricks.md
@@ -25,6 +25,26 @@ connectors:
 The PAT round-trip (reserved characters) + host + `http_path` Extra are pinned by
 `TestDatabricksConnectionURIShapeIntegration`.
 
+## dbt auth: PAT or OAuth M2M (service principal)
+
+When a dbt task uses this connection, Leoflow generates its `profiles.yml` from the
+connection at runtime (nothing baked in the image). Two auth modes are supported:
+
+| Mode | What to set in Extra | dbt profile emitted |
+|---|---|---|
+| **PAT** (default) | `http_path`, and the token in Password (or `token` in Extra) | `token: <pat>` |
+| **OAuth M2M** (service principal) | `http_path`, `client_id`, `client_secret` (and optionally `auth_type: oauth`) | `auth_type: oauth` + `client_id` + `client_secret` |
+
+```json
+// Extra for OAuth M2M — Databricks' recommended auth for automation/CI
+{"http_path": "/sql/1.0/warehouses/abc", "client_id": "…", "client_secret": "…", "auth_type": "oauth"}
+```
+
+OAuth M2M is selected whenever `client_id`/`client_secret` are present (or
+`auth_type: oauth` is explicit) and takes precedence over a PAT; the two are
+mutually exclusive, so exactly one lands in the profile. `client_secret` is part
+of Extra, which is encrypted at rest exactly like the PAT.
+
 ## Example DAG (copy-paste)
 
 Docs-only recipe (needs a real Databricks workspace). The hook is imported
@@ -75,7 +95,9 @@ connectors:
 
 - **Scope the PAT** to the workspace and rotate it regularly; it is encrypted at
   rest and never echoed back.
-- Prefer a **service principal** token over a personal one for production jobs.
+- Prefer a **service principal** over a personal identity for production jobs — for
+  dbt, that means OAuth M2M (`client_id`/`client_secret`) rather than a PAT (see
+  *dbt auth* above).
 - **Never `print()` the URI** — it carries the PAT.
 
 ## Related

--- a/docs/dbt.md
+++ b/docs/dbt.md
@@ -242,6 +242,29 @@ naive setups, break *every* task. Leoflow stops that at the **build parse-gate**
 So a syntax error fails **loudly and early**, never at 5am. Baking the manifest +
 `partial_parse` reinforces this: runtime pods reuse the build-time parse.
 
+### The baked manifest, and Slim CI (`state:modified+`)
+
+The manifest that Leoflow compiles from is `dbt parse`'s `target/manifest.json`. On
+**Pro** it is produced at image-build time and copied into the DAG image (alongside
+`partial_parse.msgpack`), immutable with that artifact; on **Lite** `leoflow compile`
+parses on save. Leoflow reads it **at compile time** to render tasks — dbt itself
+reuses the baked copy at runtime.
+
+That baked manifest is exactly the ingredient dbt's **Slim CI**
+(`dbt build --select state:modified+ --defer --state <prod-artifacts>`) needs — build
+only changed models and their downstreams, deferring unchanged refs to production
+relations. Leoflow does **not** yet offer this as a turnkey recipe, because two pieces
+are missing:
+
+1. **No supported way to fetch the deployed manifest** to diff against — it currently
+   lives only baked inside the immutable DAG image, with no export CLI/API.
+2. **The compiler never emits `--state`/`--defer`/`state:modified+`** selectors — it
+   selects by node/level/folder only.
+
+If you drive dbt yourself in CI (outside Leoflow's compilation) you can already run
+Slim CI by supplying your own prior `manifest.json` as `--state`. A first-class
+recipe wired to Leoflow's artifacts is tracked as a future enhancement.
+
 **Run-time errors** (a model that compiles but fails against the warehouse) are
 isolated by granularity:
 
@@ -249,6 +272,28 @@ isolated by granularity:
   only its downstream subtree is blocked.
 - **fused:** dbt still materializes the group's good models, but the group task
   fails as a unit (coarser blast radius).
+
+### Retrying a fused group re-runs the whole group
+
+A fused group is one `dbt build --select <members>` task. If it fails mid-way, dbt
+keeps the models it already built — but **retrying the task re-runs the entire
+group from scratch**, including the models that already succeeded. dbt is not
+resumed from its failure point here (that would need `dbt retry`, which reads the
+previous run's `target/run_results.json` — an artifact Leoflow does not yet persist
+across pod attempts). On warehouses billed per compute-second, retrying a
+mostly-green group re-bills the green models.
+
+This is the flip side of the fused trade-off. If retry efficiency matters more than
+pod count for a given DAG, use **`granularity: node`**: each model is its own task,
+so a retry re-runs only the failed model (and its blocked downstream), exactly like
+Airflow's per-task retry. Choose per DAG:
+
+- **Expensive warehouse + flaky sources → `node`** — pay in pods, save on recompute.
+- **Cheap/idempotent models at scale → `level`/`folder`** — pay a little recompute
+  on the rare retry, save on pod startups.
+
+Resumable fused retries (persisting `run_results.json` so `dbt retry` can skip the
+already-built models) are tracked as a future enhancement.
 
 ---
 

--- a/runtime/python/leoflow_runtime/dbt.py
+++ b/runtime/python/leoflow_runtime/dbt.py
@@ -77,11 +77,26 @@ def _databricks(parts, ct, _login, password, path, extra):
     http_path = _eget(extra, ct, "http_path")
     if not http_path:
         raise ValueError("databricks connection needs `http_path` in its extra")
-    return {
+    profile = {
         "type": "databricks", "host": parts.hostname or "", "http_path": http_path,
-        "token": password or _eget(extra, ct, "token"), "catalog": _eget(extra, ct, "catalog"),
+        "catalog": _eget(extra, ct, "catalog"),
         "schema": path or _eget(extra, ct, "schema"), "threads": _threads(extra),
     }
+    # Auth: service-principal OAuth M2M (client_id/client_secret) is Databricks'
+    # guidance for automation and is preferred when present; otherwise fall back to
+    # a Personal Access Token. dbt-databricks treats auth_type=oauth and token as
+    # mutually exclusive, so emit exactly one.
+    client_id = _eget(extra, ct, "client_id")
+    client_secret = _eget(extra, ct, "client_secret")
+    if _eget(extra, ct, "auth_type") == "oauth" or client_id or client_secret:
+        if not (client_id and client_secret):
+            raise ValueError(
+                "databricks OAuth M2M needs both `client_id` and `client_secret` in its extra"
+            )
+        profile.update(auth_type="oauth", client_id=client_id, client_secret=client_secret)
+    else:
+        profile["token"] = password or _eget(extra, ct, "token")
+    return profile
 
 
 def _duckdb(_parts, ct, _login, _password, path, extra):

--- a/runtime/python/tests/test_dbt.py
+++ b/runtime/python/tests/test_dbt.py
@@ -132,6 +132,53 @@ def test_databricks_uri_maps_to_dbt_profile():
     }
 
 
+def test_databricks_oauth_m2m_maps_to_service_principal_profile():
+    # Service-principal OAuth M2M (client_id/client_secret) is Databricks' guidance
+    # for automation. When present it wins over a PAT and emits auth_type=oauth
+    # INSTEAD of token (the two are mutually exclusive in dbt-databricks).
+    uri = _conn_uri(
+        "databricks", host="dbc.databricks.com", schema="analytics",
+        extra={
+            "http_path": "/sql/1.0/warehouses/abc", "catalog": "main",
+            "auth_type": "oauth", "client_id": "svc-123", "client_secret": "sekret",
+        },
+    )
+    assert dbt_profile_from_uri(uri) == {
+        "type": "databricks", "host": "dbc.databricks.com", "http_path": "/sql/1.0/warehouses/abc",
+        "auth_type": "oauth", "client_id": "svc-123", "client_secret": "sekret",
+        "catalog": "main", "schema": "analytics", "threads": 4,
+    }
+
+
+def test_databricks_oauth_selected_by_credentials_without_explicit_auth_type():
+    # client_id/client_secret present (no explicit auth_type) selects OAuth too, and
+    # a stray PAT is ignored in favor of the service principal.
+    uri = _conn_uri(
+        "databricks", password="dapi-ignored", host="h",
+        extra={"http_path": "/sql/x", "client_id": "svc", "client_secret": "sek"},
+    )
+    out = dbt_profile_from_uri(uri)
+    assert out["auth_type"] == "oauth"
+    assert out["client_id"] == "svc" and out["client_secret"] == "sek"
+    assert "token" not in out
+
+
+def test_databricks_oauth_needs_both_client_id_and_secret():
+    uri = _conn_uri("databricks", host="h",
+                    extra={"http_path": "/sql/x", "client_id": "svc"})  # secret missing
+    with pytest.raises(ValueError):
+        dbt_profile_from_uri(uri)
+
+
+def test_databricks_pat_still_works():
+    # Backward compatibility: a plain PAT connection keeps emitting token, no OAuth keys.
+    uri = _conn_uri("databricks", password="dapitoken", host="h",
+                    extra={"http_path": "/sql/x"})
+    out = dbt_profile_from_uri(uri)
+    assert out["token"] == "dapitoken"
+    assert "auth_type" not in out and "client_id" not in out
+
+
 def test_airflow_prefixed_extra_keys_are_accepted():
     # Older Airflow exports extra as extra__<conn_type>__<key>; accept both forms.
     uri = _conn_uri("databricks", password="t", host="h",


### PR DESCRIPTION
Closes #563. Closes #564. Closes #565.

## What

Closes #563, #564, #565 (all three `alissonrosa-lang` dbt issues), evaluated against the current code before implementing.

### #563 — Databricks OAuth M2M (service principal) — **implemented**
`_databricks` in `runtime/python/leoflow_runtime/dbt.py` now emits a service-principal OAuth profile (`auth_type: oauth` + `client_id`/`client_secret`) when those are present in the connection extra (or `auth_type: oauth` is explicit), instead of a PAT `token`. The two are mutually exclusive; a plain PAT connection is unchanged. The OAuth fields ride the existing encrypted `Extra` blob, so there is **no** connection-schema, delivery, or encryption change — the whole change is the mapper branch + tests + a doc row. Tests: explicit oauth, oauth-selected-by-credentials (stray PAT ignored), the both-`client_id`-and-`client_secret`-or-error guard, and PAT backward-compat.

### #564 — fused-group retry — **documented per decision**
Evaluated: full `dbt retry` support is **not** a knob — it needs persisting `run_results.json` across pod attempts, which breaks the "each attempt is an independent, image-reproducible pod" invariant and risks silently *skipping* models on a partial/inconsistent artifact. So for now `docs/dbt.md` documents the trade-off (a fused group re-runs wholesale on retry; use `granularity: node` for per-model retry). Full feature tracked in #569.

### #565 — Slim CI — **documentable part written, honest gap noted**
Not a pure-docs issue: the recipe needs (1) a way to export the deployed manifest and (2) `--state`/`--defer` compile support, neither of which exists. `docs/dbt.md` now documents where the baked manifest lives + the parse-gate, notes manual Slim CI is possible today with a bring-your-own `--state`, and defers the turnkey recipe to #570.

## Follow-ups filed from this evaluation + the solidity/Lite-vs-Pro review
- Auth modernization on the focus adapters: #571 (Snowflake key-pair), #572 (BigQuery keyless / Workload Identity)
- Reliability: #573 (Lite duckdb e2e + Pro failure-path + ungate connection e2e + error-branch unit tests), #574 (real-warehouse verification strategy for Snowflake/BigQuery/Databricks), #575 (bug: top-level dbt project never sets `Local` -> Lite bare `dbt run`)
- Deferred features: #569 (resumable fused retry), #570 (Slim CI enablement)
- Exploration: #576 (dbt-aware MCP surface)

## Tests
`runtime/python`: 93 pass (4 new dbt-auth tests), ruff clean. No Go changes.

