### PR TITLE
fix(dbt): top-level dbt project sets Local on Lite (closes #575)

### DIFF
--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -143,6 +143,11 @@ func runDbtCompile(cmd *cobra.Command, dir string, o compileOptions, cfg *domain
 	if perr != nil {
 		return perr
 	}
+	// A non-build compile is a Lite/host build (subprocess executor), same as the
+	// dbt_group path. On Lite: --project-dir must be absolute (the task runs from a
+	// temp workdir), and with no managed connection each task gets the zero-config
+	// duckdb profile step — unless the project ships its own profiles.yml (#575).
+	local := !o.build
 	spec, err := dbt.Compile(manifest, dbt.Meta{
 		DagID:       cfg.DagID,
 		DagVersion:  o.dagVersion,
@@ -155,7 +160,8 @@ func runDbtCompile(cmd *cobra.Command, dir string, o compileOptions, cfg *domain
 		Connection:  conn,
 		Profile:     profile,
 		Schema:      cfg.Dbt.Schema,
-		ProjectDir:  cfg.Dbt.Project,
+		ProjectDir:  dbtProjectDir(dir, cfg.Dbt.Project, local),
+		Local:       local && !dbtProjectHasProfiles(filepath.Join(dir, cfg.Dbt.Project)),
 	})
 	if err != nil {
 		return fmt.Errorf("dbt compile: %w", err)

--- a/internal/dbt/compile.go
+++ b/internal/dbt/compile.go
@@ -26,6 +26,10 @@ type Meta struct {
 	Schema string
 	// ProjectDir scopes the dbt commands with --project-dir for a subdir project.
 	ProjectDir string
+	// Local marks a Lite/host build: with no Connection, each task is prefixed with
+	// the step that writes a default duckdb profiles.yml (the zero-config local
+	// warehouse). Ignored on the Pro/image path. See Options.Local.
+	Local bool
 }
 
 // Compile renders a dbt manifest.json into tasks and assembles a complete
@@ -41,6 +45,7 @@ func Compile(manifestJSON []byte, meta Meta) (domain.DAGSpec, error) {
 		Profile:     meta.Profile,
 		Schema:      meta.Schema,
 		ProjectDir:  meta.ProjectDir,
+		Local:       meta.Local,
 	})
 	if err != nil {
 		return domain.DAGSpec{}, err

--- a/internal/dbt/compile_test.go
+++ b/internal/dbt/compile_test.go
@@ -61,6 +61,41 @@ func TestCompileNoScheduleIsNil(t *testing.T) {
 	}
 }
 
+// TestCompileLocalEmitsDuckdbPrefix locks the Lite wiring: Meta.Local threads into
+// the render options, so a top-level dbt project built for Lite (no managed
+// connection) gets the zero-config duckdb profile step — the same behavior the
+// dbt_group path already has. Without it, a Lite build emits a bare `dbt run` with
+// no profiles.yml and silently assumes the user supplied one (#575).
+func TestCompileLocalEmitsDuckdbPrefix(t *testing.T) {
+	spec, err := Compile(loadManifest(t, "manifest_chain.json"), Meta{
+		DagID: "shop", Image: "img", Profile: "transform", Local: true,
+	})
+	if err != nil {
+		t.Fatalf("Compile() error: %v", err)
+	}
+	for _, task := range spec.Tasks {
+		if !strings.Contains(task.Entrypoint, "--dbt-default-duckdb transform") {
+			t.Errorf("Lite task must inject the duckdb profile step; got %q", task.Entrypoint)
+		}
+	}
+}
+
+// TestCompileNonLocalNoDuckdbPrefix: the Pro/image path (Local=false) must NOT
+// inject the duckdb step — the baked profiles.yml is used instead.
+func TestCompileNonLocalNoDuckdbPrefix(t *testing.T) {
+	spec, err := Compile(loadManifest(t, "manifest_chain.json"), Meta{
+		DagID: "shop", Image: "img", Profile: "transform", Local: false,
+	})
+	if err != nil {
+		t.Fatalf("Compile() error: %v", err)
+	}
+	for _, task := range spec.Tasks {
+		if strings.Contains(task.Entrypoint, "--dbt-default-duckdb") {
+			t.Errorf("Pro task must not inject the duckdb step; got %q", task.Entrypoint)
+		}
+	}
+}
+
 // dag_id is required — a dbt DAG with no id is a loud error, not a silent default.
 func TestCompileRequiresDagID(t *testing.T) {
 	if _, err := Compile(loadManifest(t, "manifest_chain.json"), Meta{Image: "img"}); err == nil {

--- a/runtime/python/tests/test_dbt.py
+++ b/runtime/python/tests/test_dbt.py
@@ -186,6 +186,32 @@ def test_airflow_prefixed_extra_keys_are_accepted():
     assert dbt_profile_from_uri(uri)["http_path"] == "/sql/x"
 
 
+def test_snowflake_missing_account_is_loud():
+    # A misconfigured cloud connection must fail loudly, not produce a broken profile.
+    uri = _conn_uri("snowflake", login="u", password="p", extra={"warehouse": "WH"})
+    with pytest.raises(ValueError):
+        dbt_profile_from_uri(uri)
+
+
+def test_bigquery_missing_keyfile_is_loud():
+    uri = _conn_uri("google_cloud_platform", schema="ds", extra={"project": "p"})
+    with pytest.raises(ValueError):
+        dbt_profile_from_uri(uri)
+
+
+def test_databricks_missing_http_path_is_loud():
+    uri = _conn_uri("databricks", password="t", host="h", extra={"catalog": "main"})
+    with pytest.raises(ValueError):
+        dbt_profile_from_uri(uri)
+
+
+def test_malformed_extra_degrades_to_missing_field_error():
+    # A non-JSON __extra__ is ignored (not a crash); the normal missing-required-field
+    # error then surfaces, rather than a confusing JSON parse traceback.
+    with pytest.raises(ValueError):
+        dbt_profile_from_uri("databricks://t@h?__extra__=not-json")  # http_path missing
+
+
 def test_write_dbt_profile_from_env(tmp_path, monkeypatch):
     monkeypatch.setenv("AIRFLOW_CONN_WAREHOUSE_PG", "postgres://u:p@h:5432/wh?schema=analytics")
     path = write_dbt_profile("warehouse_pg", "analytics", str(tmp_path))


### PR DESCRIPTION
Closes #575.

## The bug
`runDbtCompile` (top-level pure-dbt-project path) never set `Meta.Local`, so a **Lite** build emitted a bare `dbt run --select X` — no duckdb profile step and a *relative* `--project-dir` (which breaks from Lite's per-task temp workdir). It silently assumed a user-supplied `profiles.yml`, unlike the `dbt_group` path's zero-config duckdb promise. Only one `Local` assignment existed in `compile.go`, on the `dbt_group` path.

## The fix
Mirror the `dbt_group` path: a non-build compile is Lite → `--project-dir` absolute, and with no managed connection each task gets the zero-config duckdb step unless the project ships its own `profiles.yml`. New `Meta.Local` threads into the render `Options`.

## Verification (local, end-to-end)
- New `dbt` unit tests lock the wiring: `Meta{Local:true}` emits the duckdb prefix, `Local:false` (Pro) does not.
- Ran a real `leoflow compile` of a duckdb project on the Lite path → entrypoints now:
  `python -m leoflow_runtime --dbt-default-duckdb shop <abs>/leoflow_local.duckdb && dbt seed/run --select X --project-dir <abs>`
- Executed those compiled commands with **real dbt-duckdb 1.9** → models materialized (`raw=3, stg=3`).

## Also (part of #573)
Unit tests for the previously-untested loud-error branches in the profile mapper: snowflake missing `account`, bigquery missing `keyfile_dict`, databricks missing `http_path`, malformed `__extra__`.

## Not in this PR (rest of #573, stays open)
The runtime e2e scripts — `lite-dbt.sh`, the Pro failure-path assertion, ungating `dbt-connection-e2e.sh` — need Postgres/docker/k3d not available in my sandbox. Per the repo's "run E2E locally first" rule I'm not bundling un-locally-run e2e with this verified fix; they'll land separately (CI-gated).
