### PR TITLE
fix(dbt): leoflow lite discovers pure dbt projects + Lite duckdb e2e (part of #573)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -385,6 +385,41 @@ jobs:
       - name: Airflow on_failure_callback (#424)
         run: bash test/e2e/lite-callback.sh
 
+  # Lite dbt gate (#573): a duckdb dbt project — the credential-free focus adapter
+  # — must compile with the zero-config profile step (#575), run through the
+  # subprocess executor, and materialize its models. Pro dbt is covered by e2e-dbt
+  # (k3d); this is the Lite half, which had no e2e at all.
+  e2e-lite-dbt:
+    name: E2E Lite (dbt duckdb)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: public.ecr.aws/docker/library/postgres:16
+        env:
+          POSTGRES_USER: leoflow
+          POSTGRES_PASSWORD: leoflow
+          POSTGRES_DB: leoflow_dev
+        ports: [5432:5432]
+        options: >-
+          --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
+    env:
+      # leoflow lite spawns the parser via `python3 -m leoflow_parser`; ship its
+      # source on PYTHONPATH so the import resolves on a bare runner.
+      PYTHONPATH: parser
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install jq
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq jq
+      - name: Lite dbt (duckdb) e2e (#573)
+        run: bash test/e2e/lite-dbt.sh
+
   # ─────────────────────────────────────────────────────────────────────
   # Headless SPA crash smoke (test/e2e/ui-smoke.js): boots Lite (managed PG, no
   # Docker), drives the embedded Airflow 3.2 UI with a real browser, and fails on
@@ -548,12 +583,13 @@ jobs:
       - name: Run the k3d two-process split e2e (ADR 0049)
         run: bash test/e2e/split-two-process.sh
 
-  # e2e-dbt: dbt-native orchestration on a real k3d cluster (test/e2e/dbt-e2e.sh +
-  # dbt-mixing-e2e.sh). A dbt project compiles to one pod per model; the mixing
-  # script proves a dbt project in a subdir (transform/) wired around operators,
-  # scoped with --project-dir (#401), against a shared Postgres warehouse. The
-  # cloud adapters (snowflake/bigquery/databricks) are validated by hand in the RC
-  # soak -- dbt-connection-e2e.sh needs real cloud credentials and is not gated here.
+  # e2e-dbt: dbt-native orchestration on a real k3d cluster. dbt-e2e.sh compiles a
+  # project to one pod per model; dbt-mixing-e2e.sh proves a subdir project (#401);
+  # dbt-connection-e2e.sh proves the managed-connection in-pod profile generation
+  # (adversarial: a deliberately-broken baked profiles.yml, regenerated from the
+  # connection). All three use a LOCAL postgres warehouse — no cloud credentials.
+  # The cloud adapters (snowflake/bigquery/databricks) are still hand-validated in
+  # the RC soak; a gated credentialed strategy is tracked in #574.
   e2e-dbt:
     name: E2E dbt (k3d pod-per-model)
     runs-on: ubuntu-latest
@@ -600,6 +636,8 @@ jobs:
         run: bash test/e2e/dbt-e2e.sh
       - name: Run the dbt mixing e2e (subdir + --project-dir, #401)
         run: bash test/e2e/dbt-mixing-e2e.sh
+      - name: Run the dbt managed-connection e2e (in-pod profile generation, #573)
+        run: bash test/e2e/dbt-connection-e2e.sh
 
   # deploy-e2e: the real `leoflow deploy` path on k3d with a registry the cluster
   # pulls from (test/e2e/deploy-e2e.sh, ADR 0041). One `leoflow deploy` builds for

--- a/internal/cli/discover.go
+++ b/internal/cli/discover.go
@@ -130,14 +130,20 @@ func pathDepth(p string) int {
 	return strings.Count(filepath.Clean(p), string(os.PathSeparator))
 }
 
-// projectAt builds a Project for path iff path contains a dag.py. The
-// returned Project's Config is fully defaulted; when no leoflow.yaml exists
-// the DagID falls back to filepath.Base(path).
+// projectAt builds a Project for path when the directory is a DAG project. A
+// project is marked by either a dag.py (a Python DAG; leoflow.yaml optional) OR
+// a leoflow.yaml carrying a dbt: block with no dag.py (a pure dbt project, whose
+// DAG is generated from the dbt manifest — the zero-config Lite path documented
+// in docs/dbt.md). The returned Project's Config is fully defaulted; when no
+// leoflow.yaml exists the DagID falls back to filepath.Base(path).
 func projectAt(path string) (Project, bool) {
-	if _, err := os.Stat(filepath.Join(path, dagSourceFile)); err != nil {
-		return Project{}, false
-	}
 	yamlPath := filepath.Join(path, "leoflow.yaml")
+	if _, err := os.Stat(filepath.Join(path, dagSourceFile)); err != nil {
+		// No dag.py: the only other kind of project is a pure dbt project — a
+		// leoflow.yaml with a dbt: block. Anything else (no yaml, or a yaml with
+		// neither dag.py nor dbt:) is not a project.
+		return dbtOnlyProjectAt(path, yamlPath)
+	}
 	if _, err := os.Stat(yamlPath); err == nil {
 		cfg, lerr := loadProjectConfig(path)
 		if lerr != nil {
@@ -175,6 +181,33 @@ func projectAt(path string) (Project, bool) {
 		DagID:      filepath.Base(path),
 		ConfigPath: "",
 		HasYAML:    false,
+		Config:     cfg,
+	}, true
+}
+
+// dbtOnlyProjectAt recognizes a pure dbt project: a leoflow.yaml carrying a dbt:
+// block, with no dag.py. Its DAG is generated from the dbt manifest at compile
+// time, so it has no Python source. A directory with no leoflow.yaml, or a
+// leoflow.yaml without a dbt: block (or one that fails to parse — we can't tell
+// it's dbt without parsing), is not a project.
+func dbtOnlyProjectAt(path, yamlPath string) (Project, bool) {
+	if _, err := os.Stat(yamlPath); err != nil {
+		return Project{}, false
+	}
+	cfg, lerr := loadProjectConfig(path)
+	if lerr != nil || cfg.Dbt == nil {
+		return Project{}, false
+	}
+	id := cfg.DagID
+	if id == "" {
+		id = filepath.Base(path)
+		cfg.DagID = id
+	}
+	return Project{
+		Path:       path,
+		DagID:      id,
+		ConfigPath: yamlPath,
+		HasYAML:    true,
 		Config:     cfg,
 	}, true
 }

--- a/internal/cli/discover_test.go
+++ b/internal/cli/discover_test.go
@@ -59,6 +59,21 @@ func TestDiscoverProjects_TableDriven(t *testing.T) {
 			want: want{projects: []string{"yamlless"}, dagIDs: []string{"yamlless"}},
 		},
 		{
+			name: "dbt-only project (leoflow.yaml with dbt:, no dag.py) is discovered",
+			files: map[string]string{
+				"shopdbt/leoflow.yaml":    "dag_id: shopdbt\ndbt:\n  project: .\n",
+				"shopdbt/dbt_project.yml": "name: shop\n",
+			},
+			want: want{projects: []string{"shopdbt"}, dagIDs: []string{"shopdbt"}},
+		},
+		{
+			name: "leoflow.yaml without dag.py and without a dbt: block is NOT a project",
+			files: map[string]string{
+				"notaproj/leoflow.yaml": "dag_id: notaproj\n",
+			},
+			want: want{projects: nil},
+		},
+		{
 			name: "root project (backward compat) is discovered",
 			files: map[string]string{
 				"leoflow.yaml": "dag_id: root_dag\n",

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -85,7 +85,13 @@ func (w *WorkspaceSpec) WatchedPaths() []string {
 		if p.HasYAML {
 			paths = append(paths, p.ConfigPath)
 		}
-		paths = append(paths, filepath.Join(p.Path, p.Config.DagSource))
+		if p.Config.Dbt != nil {
+			// A pure dbt project has no dag.py; watch its dbt project file so a
+			// model/config edit still triggers a reload.
+			paths = append(paths, filepath.Join(p.Path, p.Config.Dbt.Project, "dbt_project.yml"))
+		} else {
+			paths = append(paths, filepath.Join(p.Path, p.Config.DagSource))
+		}
 	}
 	return paths
 }

--- a/test/e2e/lite-dbt.sh
+++ b/test/e2e/lite-dbt.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# End-to-end gate for dbt on the LITE edition (subprocess executor) against duckdb
+# — the credential-free focus adapter that had no e2e (#573). Pro dbt is covered
+# by dbt-e2e.sh (k3d + Postgres); this is the Lite half: a duckdb dbt project must
+# compile with the zero-config duckdb profile step (#575), run through the
+# subprocess executor, and actually materialize its models in the duckdb file.
+#
+# What the unit tests can't prove is the wiring composed end to end: leoflow
+# compiles the project with the `--dbt-default-duckdb` prefix + absolute
+# --project-dir (#575), Lite provisions the per-DAG venv from `dependencies:`
+# (so `dbt` resolves on PATH), and the task's `python -m leoflow_runtime
+# --dbt-default-duckdb … && dbt …` command writes profiles.yml and materializes.
+#
+# The manifest is pre-parsed here (like dbt-e2e.sh) so Lite reads a baked
+# target/manifest.json rather than depending on parse-on-save ordering.
+#
+# Needs a local Postgres (docker-compose.dev.yaml) and dbt-duckdb available to
+# pre-parse. Run from the repo root:  bash test/e2e/lite-dbt.sh
+set -euo pipefail
+
+PORT=18096
+DB_URL="${LEOFLOW_E2E_DB_URL:-postgres://leoflow:leoflow@localhost:5432/leoflow_dev?sslmode=disable}"
+BASE="http://127.0.0.1:${PORT}"
+DAG_ID="shopdbt"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+WS="$TMP/ws"
+PROJ="$WS/$DAG_ID"
+LITE_PID=""
+pass() { printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+fail() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; [ -n "${2:-}" ] && tail -60 "$2"; cleanup; exit 1; }
+cleanup() {
+  [ -n "$LITE_PID" ] && kill "$LITE_PID" 2>/dev/null || true
+  chmod -R u+w "$TMP" 2>/dev/null || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+# Isolate HOME so Lite runs no-auth loopback and owns a clean per-DAG venv root.
+export HOME="$TMP/home"; mkdir -p "$HOME"
+export LEOFLOW_DATABASE_URL="$DB_URL"
+export LEOFLOW_LOGS_DIR="$TMP/logs"
+# leoflow lite spawns the parser via `python3 -m leoflow_parser`; put it on PYTHONPATH.
+export PYTHONPATH="${PYTHONPATH:-$ROOT/parser}"
+
+echo "==> building binaries"
+go build -o "$TMP/leoflow" ./cmd/leoflow
+go build -o "$TMP/leoflow-server" ./cmd/leoflow-server
+go build -o "$TMP/leoflow-agent" ./cmd/leoflow-agent
+export PATH="$TMP:$PATH"
+
+echo "==> a duckdb dbt project with NO profiles.yml (zero-config), plus leoflow.yaml"
+mkdir -p "$PROJ/models" "$PROJ/seeds"
+cat >"$PROJ/dbt_project.yml" <<'YAML'
+name: 'shop'
+version: '1.0.0'
+profile: 'shop'
+model-paths: ["models"]
+seed-paths: ["seeds"]
+models: { shop: { +materialized: table } }
+YAML
+printf 'id,v\n1,10\n2,20\n3,30\n' >"$PROJ/seeds/raw.csv"
+echo "select id, v from {{ ref('raw') }}" >"$PROJ/models/stg.sql"
+echo "select id, sum(v) as total from {{ ref('stg') }} group by id" >"$PROJ/models/mart.sql"
+cat >"$PROJ/leoflow.yaml" <<YAML
+schema_version: "1.0"
+dag_id: ${DAG_ID}
+dbt:
+  project: .
+  manifest: target/manifest.json
+  granularity: node
+# Lite installs these into the per-DAG venv, so \`dbt\` resolves on PATH for the task.
+dependencies:
+  - "dbt-duckdb==1.9.*"
+YAML
+
+echo "==> pre-parsing the manifest with dbt-duckdb (profile in a separate dir; project stays profiles-less)"
+PARSE_VENV="$TMP/parsevenv"
+python3 -m venv "$PARSE_VENV"
+"$PARSE_VENV/bin/pip" install -q "dbt-core==1.9.*" "dbt-duckdb==1.9.*"
+mkdir -p "$TMP/parseprofiles"
+cat >"$TMP/parseprofiles/profiles.yml" <<YAML
+shop:
+  target: dev
+  outputs:
+    dev: { type: duckdb, path: "${PROJ}/leoflow_local.duckdb", threads: 4 }
+YAML
+( cd "$PROJ" && DBT_PROFILES_DIR="$TMP/parseprofiles" "$PARSE_VENV/bin/dbt" parse >/dev/null 2>&1 ) \
+  || fail "dbt parse failed"
+[ -f "$PROJ/target/manifest.json" ] || fail "manifest.json was not produced"
+[ -f "$PROJ/profiles.yml" ] && fail "project must NOT ship a profiles.yml (zero-config duckdb path)"
+pass "manifest pre-parsed; project is profiles-less"
+
+echo "==> resetting the database"
+"$TMP/leoflow" db reset --yes >/dev/null
+
+start_lite() {
+  "$TMP/leoflow" lite --no-up --executor subprocess --port "$PORT" "$WS" >"$1" 2>&1 &
+  LITE_PID=$!
+  disown "$LITE_PID" 2>/dev/null || true
+  for _ in $(seq 1 "${LITE_READY_TRIES:-600}"); do
+    curl -fsS "${BASE}/readyz" >/dev/null 2>&1 && return 0
+    kill -0 "$LITE_PID" 2>/dev/null || { tail -80 "$1"; return 1; }
+    sleep 1
+  done
+  return 1
+}
+
+echo "==> booting Lite (subprocess executor) — provisions the per-DAG venv from dependencies"
+start_lite "$TMP/lite.log" || fail "Lite did not become ready" "$TMP/lite.log"
+for _ in $(seq 1 300); do grep -q "registered \"${DAG_ID}\"" "$TMP/lite.log" && break; sleep 1; done
+grep -q "registered \"${DAG_ID}\"" "$TMP/lite.log" || fail "${DAG_ID} was not registered" "$TMP/lite.log"
+pass "Lite is ready and registered ${DAG_ID}"
+
+echo "==> triggering a run"
+RUN_ID="$(curl -fsS -X POST "${BASE}/api/v2/dags/${DAG_ID}/dagRuns" -H 'content-type: application/json' -d '{}' | jq -r '.dag_run_id')"
+[ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ] || fail "no dag_run_id returned"
+pass "triggered run $RUN_ID"
+
+echo "==> waiting for all tasks to succeed (first Lite dbt run also installs dbt-duckdb into the venv)"
+ok=""
+for _ in $(seq 1 600); do
+  states="$(curl -fsS "${BASE}/api/v2/dags/${DAG_ID}/dagRuns/${RUN_ID}/taskInstances" 2>/dev/null \
+    | jq -r '.task_instances[] | "\(.task_id):\(.state)"' 2>/dev/null | tr '\n' ',' || true)"
+  case "$states" in
+    *failed*) fail "a task failed (also matches upstream_failed)\nstates: ${states}" "$TMP/lite.log" ;;
+  esac
+  # all three present and success?
+  if [ "$(printf '%s' "$states" | grep -o 'success' | wc -l | tr -d ' ')" = "3" ]; then ok=1; break; fi
+  sleep 1
+done
+[ -n "$ok" ] || fail "tasks did not all succeed\nlast states: ${states:-<none>}" "$TMP/lite.log"
+pass "all three dbt tasks succeeded (raw, stg, mart)"
+
+echo "==> models actually materialized in the duckdb file"
+DB="$PROJ/leoflow_local.duckdb"
+[ -f "$DB" ] || fail "duckdb file not created at $DB — the zero-config profile step did not run" "$TMP/lite.log"
+ROWS="$("$PARSE_VENV/bin/python" - "$DB" <<'PY'
+import sys, duckdb
+con = duckdb.connect(sys.argv[1])
+print(con.execute("select count(*) from mart").fetchone()[0])
+PY
+)"
+[ "$ROWS" = "3" ] || fail "mart has $ROWS rows, want 3 (models did not materialize)" "$TMP/lite.log"
+pass "mart materialized with 3 rows in duckdb"
+
+echo
+echo "  ✅ Lite dbt (duckdb) verified end to end: zero-config compile (#575) -> subprocess"
+echo "     execution -> models materialized, no warehouse and no profiles.yml needed."


### PR DESCRIPTION
Part of #573 (the credential-free e2e gaps). Adds the missing Lite dbt coverage and ungates an e2e that was wrongly assumed to need cloud creds.

## New: `test/e2e/lite-dbt.sh` + `e2e-lite-dbt` CI job
The dbt feature targets Snowflake/BigQuery/Databricks **+ duckdb**, yet duckdb (the only credential-free focus adapter) and the whole **Lite** (subprocess) edition had **no e2e**. This closes that: a duckdb dbt project with no `profiles.yml` must
1. compile with the zero-config duckdb profile step (the #575 fix),
2. run through the subprocess executor, and
3. materialize its models in the duckdb file (asserts `mart` = 3 rows).

Design choices that de-risk it:
- **Manifest pre-parsed + pinned** via `dbt.manifest` — `loadDbtManifest` reads it as-is (no re-parse), so there's no venv-readiness ordering dependency for compile.
- **`dbt-duckdb` declared in `dependencies:`** — verified this reaches the per-DAG venv (`dev.go` → `EffectiveDependencies` → `ensureDagVenv`), so `dbt` resolves on PATH for the task.
- Modeled on the proven `lite-callback.sh` (boot/trigger/poll) + `dbt-e2e.sh` (project shape, pre-parse).

## Ungate: `dbt-connection-e2e.sh`
Its CI comment claimed it "needs real cloud credentials"; it actually uses a local `docker run postgres:16-alpine` (verified, line 56). It proves the managed-connection **in-pod profile generation** (adversarial: a deliberately-broken baked `profiles.yml`, regenerated from the connection). Now a step in `e2e-dbt`; comment corrected.

## Verification
`shellcheck test/e2e/lite-dbt.sh` clean; `actionlint` clean; YAML parses. The e2e themselves are **CI-validated** — they need Postgres/k3d/docker not present in my local sandbox (same as every lite/dbt e2e in this repo). The #575 fix the Lite e2e exercises was already proven locally end-to-end (real dbt-duckdb materialization) in #579.

## Remaining in #573 (not this PR)
The Pro **failure-path** assertion in `dbt-e2e.sh` (failing model → `failed` + downstream `upstream_failed`) touches the passing k3d happy-path script; I can't run k3d locally to de-risk it, so it stays tracked rather than blind-pushed to expensive k3d CI.
