### PR TITLE
feat(dbt): Snowflake key-pair + BigQuery keyless auth (closes #571, #572)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   OAuth M2M — Databricks' recommended auth for automation — instead of a Personal
   Access Token. PATs keep working; OAuth wins when present (the two are mutually
   exclusive). Same encrypted-at-rest, generated-in-pod delivery as before.
+- **Snowflake dbt profiles support key-pair auth (service account).** A managed
+  Snowflake connection whose extra carries `private_key_content` (inline PEM) or
+  `private_key_file` (path) — with an optional `private_key_passphrase` — now
+  generates a `profiles.yml` using key-pair auth instead of a password. Passwords
+  keep working; key-pair wins when a key is present (password/token dropped).
+  Prefer it for automation — Snowflake is deprecating single-factor password auth.
+- **BigQuery dbt profiles support keyless auth (Workload Identity).** Setting
+  `method: oauth` in a `google_cloud_platform` connection's extra now generates a
+  BigQuery `profiles.yml` that authenticates via Application Default Credentials
+  (GKE Workload Identity on Pro) — no service-account key file is shipped.
+  `keyfile_dict` (inline key) still works for the service-account-json method.
 
 ### Documentation
 

--- a/docs/connections/google_cloud_platform.md
+++ b/docs/connections/google_cloud_platform.md
@@ -71,6 +71,18 @@ Workload Identity — to *read* the secret). Grant the task's GSA
 The SA JSON in the connection's Extra (encrypted at rest). Convenient for
 dev/low-criticality; **not** recommended (see Security below).
 
+### dbt (BigQuery) profile mapping
+When a **dbt** task uses this connection, Leoflow generates the BigQuery
+`profiles.yml` from it:
+
+| Extra | dbt profile |
+|---|---|
+| `method: oauth` | `method: oauth` — **keyless**, via Application Default Credentials (Workload Identity on Pro). No key shipped. `dataset` required; `project` optional (defers to the ADC project). |
+| `keyfile_dict` (inline SA JSON) | `method: service-account-json` + `keyfile_json` |
+
+Set **`method: oauth`** in Extra to get the keyless profile; otherwise the mapper
+expects `keyfile_dict`. Prefer keyless — it ships no downloadable key.
+
 ## Lite vs Pro
 
 | | Lite (subprocess) | Lite (k3d) | Pro (GKE) |

--- a/docs/connections/snowflake.md
+++ b/docs/connections/snowflake.md
@@ -37,6 +37,24 @@ The account/warehouse/role fields are delivered to the task inside the
 `extra_dejson`. The round-trip (password with reserved characters + the Extra
 blob) is pinned by `TestSnowflakeConnectionURIShapeIntegration`.
 
+## dbt auth: password or key-pair (service account)
+
+When a dbt task uses this connection, Leoflow generates its `profiles.yml` from the
+connection at runtime. Two auth modes are supported:
+
+| Mode | What to set in Extra | dbt profile emitted |
+|---|---|---|
+| **Password** (default) | the password in Password | `password: <pw>` |
+| **Key-pair** (service account) | `private_key_content` (inline PEM) **or** `private_key_file` (path), plus optional `private_key_passphrase` | `private_key` / `private_key_path` (+ `private_key_passphrase`) |
+
+Key-pair is selected whenever a private key is present and takes precedence over the
+password (the two are mutually exclusive, so exactly one lands in the profile;
+`private_key_content` and `private_key_file` cannot both be set). Inline keys are
+emitted as-is — provide the full PEM (with the `-----BEGIN … -----` armor). The key
+is part of Extra, encrypted at rest exactly like the password. Prefer key-pair for
+automation — Snowflake is deprecating single-factor password auth for programmatic
+access.
+
 ## Example DAG (copy-paste)
 
 This recipe lives only here in the docs (it needs a real Snowflake account, so it

--- a/runtime/python/leoflow_runtime/dbt.py
+++ b/runtime/python/leoflow_runtime/dbt.py
@@ -53,21 +53,63 @@ def _snowflake(_parts, ct, login, password, path, extra):
     account = _eget(extra, ct, "account")
     if not account:
         raise ValueError("snowflake connection needs `account` in its extra")
-    return {
-        "type": "snowflake", "account": account, "user": login, "password": password,
+    profile = {
+        "type": "snowflake", "account": account, "user": login,
         "role": _eget(extra, ct, "role"), "database": _eget(extra, ct, "database"),
         "warehouse": _eget(extra, ct, "warehouse"),
         "schema": path or _eget(extra, ct, "schema", "PUBLIC"), "threads": _threads(extra),
     }
+    # Auth: key-pair (service account) is Snowflake's guidance for automation and
+    # is preferred when a private key is present; otherwise fall back to a password.
+    # The Airflow snowflake provider carries the key in Extra as private_key_content
+    # (inline PEM) / private_key_file (path) — accept those, plus the dbt-native
+    # aliases. These (and private_key_passphrase) ride the connection's free-form
+    # extra pass-through, so they need no catalog field. The two forms are mutually
+    # exclusive in the adapter, and password/token are dropped for key-pair.
+    private_key = _eget(extra, ct, "private_key_content") or _eget(extra, ct, "private_key")
+    private_key_path = _eget(extra, ct, "private_key_file") or _eget(extra, ct, "private_key_path")
+    if private_key and private_key_path:
+        raise ValueError(
+            "snowflake connection: set only one of `private_key` or `private_key_path`"
+        )
+    if private_key or private_key_path:
+        if private_key:
+            profile["private_key"] = private_key
+        else:
+            profile["private_key_path"] = private_key_path
+        passphrase = _eget(extra, ct, "private_key_passphrase")
+        if passphrase:
+            profile["private_key_passphrase"] = passphrase
+    else:
+        profile["password"] = password
+    return profile
 
 
 def _bigquery(_parts, ct, _login, _password, path, extra):
+    project = _eget(extra, ct, "project")
+    dataset = path or _eget(extra, ct, "dataset")
+    # Keyless: method=oauth uses Application Default Credentials — the pod's
+    # identity via GKE Workload Identity on Pro — so no key file is shipped.
+    # `method` is a leoflow dbt-mapping selector carried in the free-form extra
+    # (not a catalog field). dataset is required by the adapter; project is
+    # optional (defers to the ADC environment project when absent).
+    if _eget(extra, ct, "method") == "oauth":
+        out = {
+            "type": "bigquery", "method": "oauth",
+            "dataset": dataset, "threads": _threads(extra),
+        }
+        if project:
+            out["project"] = project
+        return out
     keyfile = _eget(extra, ct, "keyfile_dict")
     if not keyfile:
-        raise ValueError("bigquery connection needs `keyfile_dict` in its extra")
+        raise ValueError(
+            "bigquery connection needs `keyfile_dict` in its extra "
+            "(or set `method: oauth` for keyless / Workload Identity)"
+        )
     return {
         "type": "bigquery", "method": "service-account-json",
-        "project": _eget(extra, ct, "project"), "dataset": path or _eget(extra, ct, "dataset"),
+        "project": project, "dataset": dataset,
         "keyfile_json": json.loads(keyfile) if isinstance(keyfile, str) else keyfile,
         "threads": _threads(extra),
     }

--- a/runtime/python/tests/test_dbt.py
+++ b/runtime/python/tests/test_dbt.py
@@ -109,6 +109,100 @@ def test_snowflake_uri_maps_to_dbt_profile():
     }
 
 
+def test_snowflake_key_pair_auth_maps_to_private_key():
+    # Key-pair (service principal) is Snowflake's guidance for automation. When a
+    # private key is present it wins over a password and emits `private_key`
+    # (inline PEM), dropping `password`/`token`. `user` is still required.
+    pem = "-----BEGIN PRIVATE KEY-----\nMIIBVgIBADANBgkq\n-----END PRIVATE KEY-----\n"
+    # private_key_content is the Airflow snowflake provider's Extra field.
+    uri = _conn_uri(
+        "snowflake", login="svc_user", schema="analytics",
+        extra={"account": "ab12345", "warehouse": "WH", "database": "DB",
+               "private_key_content": pem, "private_key_passphrase": "sekret"},
+    )
+    out = dbt_profile_from_uri(uri)
+    assert out["type"] == "snowflake"
+    assert out["user"] == "svc_user"
+    assert out["private_key"] == pem
+    assert out["private_key_passphrase"] == "sekret"
+    assert "password" not in out and "token" not in out
+
+
+def test_snowflake_key_pair_dbt_native_alias():
+    # The dbt-native name `private_key` is accepted as an alias of the provider's
+    # private_key_content (for a connection whose Extra was written by hand).
+    pem = "-----BEGIN PRIVATE KEY-----\nAAAA\n-----END PRIVATE KEY-----\n"
+    uri = _conn_uri("snowflake", login="u", extra={"account": "a", "private_key": pem})
+    assert dbt_profile_from_uri(uri)["private_key"] == pem
+
+
+def test_snowflake_key_pair_path_variant():
+    # private_key_file is the Airflow provider's path field.
+    uri = _conn_uri("snowflake", login="svc",
+                    extra={"account": "a", "private_key_file": "/keys/rsa_key.p8"})
+    out = dbt_profile_from_uri(uri)
+    assert out["private_key_path"] == "/keys/rsa_key.p8"
+    assert "private_key" not in out and "password" not in out
+    assert "private_key_passphrase" not in out  # omitted when unset
+
+
+def test_snowflake_key_pair_path_dbt_native_alias():
+    # private_key_path is the dbt-native alias of the provider's private_key_file.
+    uri = _conn_uri("snowflake", login="u", extra={"account": "a", "private_key_path": "/k.p8"})
+    assert dbt_profile_from_uri(uri)["private_key_path"] == "/k.p8"
+
+
+def test_snowflake_key_pair_via_airflow_prefixed_extra():
+    # Legacy Airflow export form extra__<conn_type>__<key> must also deliver the key.
+    pem = "-----BEGIN PRIVATE KEY-----\nZZZ\n-----END PRIVATE KEY-----\n"
+    uri = _conn_uri("snowflake", login="u",
+                    extra={"account": "a", "extra__snowflake__private_key_content": pem})
+    assert dbt_profile_from_uri(uri)["private_key"] == pem
+
+
+def test_bigquery_keyless_via_airflow_prefixed_extra():
+    # The keyless selector must also arrive via the prefixed extra form.
+    uri = _conn_uri("google_cloud_platform", schema="ds",
+                    extra={"extra__google_cloud_platform__method": "oauth"})
+    out = dbt_profile_from_uri(uri)
+    assert out["method"] == "oauth" and "keyfile_json" not in out
+
+
+def test_snowflake_rejects_both_private_key_forms():
+    # The adapter errors if both inline and path keys are set; reject early.
+    pem = "-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----\n"
+    uri = _conn_uri("snowflake", extra={
+        "account": "a", "private_key_content": pem, "private_key_file": "/k.p8"})
+    with pytest.raises(ValueError):
+        dbt_profile_from_uri(uri)
+
+
+def test_snowflake_password_still_works():
+    # Backward compatibility: no private key → password auth, no key-pair keys.
+    uri = _conn_uri("snowflake", login="u", password="p", extra={"account": "a"})
+    out = dbt_profile_from_uri(uri)
+    assert out["password"] == "p"
+    assert "private_key" not in out and "private_key_path" not in out
+
+
+def test_bigquery_keyless_oauth_maps_to_adc():
+    # Keyless: method=oauth uses Application Default Credentials (GKE Workload
+    # Identity on Pro) — no key file shipped. dataset required, project optional.
+    uri = _conn_uri("google_cloud_platform", schema="my_dataset",
+                    extra={"method": "oauth", "project": "my-proj"})
+    out = dbt_profile_from_uri(uri)
+    assert out == {"type": "bigquery", "method": "oauth",
+                   "project": "my-proj", "dataset": "my_dataset", "threads": 4}
+    assert "keyfile_json" not in out
+
+
+def test_bigquery_keyless_project_optional():
+    uri = _conn_uri("google_cloud_platform", schema="ds", extra={"method": "oauth"})
+    out = dbt_profile_from_uri(uri)
+    assert out["method"] == "oauth" and out["dataset"] == "ds"
+    assert "project" not in out  # deferred to the ADC environment project
+
+
 def test_bigquery_uri_maps_to_dbt_profile():
     keyfile = '{"type": "service_account", "project_id": "p"}'
     uri = _conn_uri("google_cloud_platform", schema="my_dataset",

--- a/runtime/python/tests/test_dbt.py
+++ b/runtime/python/tests/test_dbt.py
@@ -8,6 +8,12 @@ import pytest
 
 from leoflow_runtime.dbt import dbt_profile_from_uri, write_dbt_profile
 
+# Stand-in for a private key. The mapper passes the value through verbatim (it does
+# not parse it), so a real PEM body is unnecessary here — and a real PEM armor block
+# would trip secret scanners (gitleaks) on a test fixture. The real PEM format users
+# provide is documented in the connection docs.
+FAKE_PRIVATE_KEY = "test-private-key-material-xxxx-not-a-real-key"
+
 
 def _conn_uri(scheme, login="", password="", host="", port=None, schema="", extra=None):
     """Build an Airflow connection URI the way Leoflow delivers it (conn_type with
@@ -113,7 +119,7 @@ def test_snowflake_key_pair_auth_maps_to_private_key():
     # Key-pair (service principal) is Snowflake's guidance for automation. When a
     # private key is present it wins over a password and emits `private_key`
     # (inline PEM), dropping `password`/`token`. `user` is still required.
-    pem = "-----BEGIN PRIVATE KEY-----\nMIIBVgIBADANBgkq\n-----END PRIVATE KEY-----\n"
+    pem = FAKE_PRIVATE_KEY
     # private_key_content is the Airflow snowflake provider's Extra field.
     uri = _conn_uri(
         "snowflake", login="svc_user", schema="analytics",
@@ -131,7 +137,7 @@ def test_snowflake_key_pair_auth_maps_to_private_key():
 def test_snowflake_key_pair_dbt_native_alias():
     # The dbt-native name `private_key` is accepted as an alias of the provider's
     # private_key_content (for a connection whose Extra was written by hand).
-    pem = "-----BEGIN PRIVATE KEY-----\nAAAA\n-----END PRIVATE KEY-----\n"
+    pem = FAKE_PRIVATE_KEY
     uri = _conn_uri("snowflake", login="u", extra={"account": "a", "private_key": pem})
     assert dbt_profile_from_uri(uri)["private_key"] == pem
 
@@ -154,7 +160,7 @@ def test_snowflake_key_pair_path_dbt_native_alias():
 
 def test_snowflake_key_pair_via_airflow_prefixed_extra():
     # Legacy Airflow export form extra__<conn_type>__<key> must also deliver the key.
-    pem = "-----BEGIN PRIVATE KEY-----\nZZZ\n-----END PRIVATE KEY-----\n"
+    pem = FAKE_PRIVATE_KEY
     uri = _conn_uri("snowflake", login="u",
                     extra={"account": "a", "extra__snowflake__private_key_content": pem})
     assert dbt_profile_from_uri(uri)["private_key"] == pem
@@ -170,7 +176,7 @@ def test_bigquery_keyless_via_airflow_prefixed_extra():
 
 def test_snowflake_rejects_both_private_key_forms():
     # The adapter errors if both inline and path keys are set; reject early.
-    pem = "-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----\n"
+    pem = FAKE_PRIVATE_KEY
     uri = _conn_uri("snowflake", extra={
         "account": "a", "private_key_content": pem, "private_key_file": "/k.p8"})
     with pytest.raises(ValueError):


### PR DESCRIPTION
Closes #571, closes #572. Phase 2 of the dbt roadmap (#578) — modern service-account auth for the two remaining focus adapters, same shape as the merged #563 (Databricks OAuth M2M).

## #571 — Snowflake key-pair auth
`_snowflake` now emits key-pair auth when the connection extra carries a private key:
- Reads `private_key_content` (inline PEM) / `private_key_file` (path) — the **Airflow snowflake provider's** Extra field names (verified against `internal/connectors/catalog.json`) — plus the dbt-native `private_key`/`private_key_path` aliases.
- Optional `private_key_passphrase`. The two key forms are **mutually exclusive** (the adapter errors on both) → exactly one emitted; `password`/`token` dropped.
- Passwords still work; key-pair wins when a key is present. Snowflake is deprecating single-factor password auth for automation.

## #572 — BigQuery keyless auth
`_bigquery` now supports `method: oauth` → **Application Default Credentials** (GKE Workload Identity on Pro), no key file shipped, `keyfile_json` dropped. `dataset` required, `project` optional (defers to the ADC project). `keyfile_dict` still maps to `method: service-account-json`.

## Verification
Adapter contracts confirmed against **installed dbt-snowflake 1.9.4 / dbt-bigquery 1.9.2** (credentials dataclasses inspected, not docs/memory), and both-ends reachability confirmed against the connector catalog. Tests (34 pass, ruff clean): both auth modes, dbt-native aliases, legacy `extra__<conn_type>__<key>` delivery, mutual exclusion, absent-passphrase, and byte-for-byte backward-compat for the existing password / keyfile_dict paths. An adversarial review of the diff returned "safe to merge"; its optional hardening suggestions (alias + prefixed-form tests, free-form-extra code comment) are included.

Real-warehouse verification of these auth modes is tracked in #574 (no live creds locally).

Docs: dbt-auth mapping tables added to `docs/connections/snowflake.md` and `docs/connections/google_cloud_platform.md`.
