### PR TITLE
test(dbt): adapter contract tests for Snowflake/BigQuery/Databricks (part of #574)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -639,6 +639,33 @@ jobs:
       - name: Run the dbt managed-connection e2e (in-pod profile generation, #573)
         run: bash test/e2e/dbt-connection-e2e.sh
 
+  # dbt-adapter-contracts (#574): the profiles.yml Leoflow emits for each cloud
+  # warehouse must be accepted by that warehouse's REAL dbt adapter — right field
+  # names, alias resolution, required fields, auth-mode wiring — validated by
+  # constructing the adapter's own Credentials from our emitted profile (no live
+  # query, no credentials). One adapter per leg (they pin conflicting deps).
+  # A live-query gate needs real warehouse secrets and is maintainer-owned.
+  dbt-adapter-contracts:
+    name: dbt adapter contracts (${{ matrix.adapter }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # dbt-core is pinned to 1.9.* on every leg — that keeps the resolver off the
+        # 2.0 pre-release parser (a source build that fetches a wheel at build time),
+        # so a plain source/wheel install is enough. One adapter per leg: their dep
+        # pins conflict in a shared venv.
+        adapter: [snowflake, bigquery, databricks]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install ${{ matrix.adapter }} adapter + pytest
+        run: python -m pip install --quiet pytest "dbt-core==1.9.*" "dbt-${{ matrix.adapter }}==1.9.*"
+      - name: Contract test (${{ matrix.adapter }})
+        run: PYTHONPATH=runtime/python python -m pytest runtime/python/tests/test_dbt_adapter_contracts.py -q -k ${{ matrix.adapter }}
+
   # deploy-e2e: the real `leoflow deploy` path on k3d with a registry the cluster
   # pulls from (test/e2e/deploy-e2e.sh, ADR 0041). One `leoflow deploy` builds for
   # the cluster arch, pushes to a k3d-managed registry, captures the digest,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (GKE Workload Identity on Pro) — no service-account key file is shipped.
   `keyfile_dict` (inline key) still works for the service-account-json method.
 
+### Testing
+
+- **dbt adapter contract tests (Snowflake / BigQuery / Databricks).** CI now feeds
+  the `profiles.yml` Leoflow emits for each cloud warehouse through that warehouse's
+  *real* dbt adapter credential parsing — validating field names, alias resolution,
+  required fields, and each auth mode (key-pair / keyless / OAuth M2M) without a live
+  query or credentials (`dbt-adapter-contracts` matrix). This is the credential-free
+  half of cloud-adapter assurance; a live-query gate remains maintainer-owned (needs
+  warehouse secrets). See the new "Adapter assurance" section in docs/dbt.md.
+
 ### Documentation
 
 - **dbt: fused-group retry trade-off** — documented that retrying a `level`/`folder`

--- a/docs/dbt.md
+++ b/docs/dbt.md
@@ -310,6 +310,33 @@ Power User, dbt Cloud IDE); Leoflow only adds orchestration and packing.
 
 ---
 
+## 7. Adapter assurance — what's verified how
+
+Leoflow generates each warehouse's `profiles.yml`. How thoroughly that generation
+is tested varies by adapter:
+
+| Adapter | Profile shape | Live query in CI |
+|---|---|---|
+| **postgres** | contract + live | ✅ real dbt on k3d (`e2e-dbt`) |
+| **duckdb** | contract + live | ✅ real dbt on Lite (`e2e-lite-dbt`) |
+| **snowflake** | ✅ contract-tested | ⚠️ hand-verified only |
+| **bigquery** | ✅ contract-tested | ⚠️ hand-verified only |
+| **databricks** | ✅ contract-tested | ⚠️ hand-verified only |
+
+**Contract-tested** means CI feeds Leoflow's emitted profile through the *real* dbt
+adapter's own credential parsing (`dbt-adapter-contracts` job): correct field
+names, alias resolution, required fields, and each auth mode (Snowflake key-pair,
+BigQuery keyless, Databricks OAuth M2M) are validated against the actual adapter —
+without connecting to a warehouse. What it does **not** prove is that a real query
+succeeds against your account.
+
+**Live-query verification for the cloud adapters is maintainer-owned** — it needs
+real warehouse accounts + CI secrets. The template is `test/e2e/dbt-connection-e2e.sh`
+(today it runs against a local Postgres warehouse); pointing it at a real Snowflake/
+BigQuery/Databricks account, gated on org secrets, is the remaining step.
+
+---
+
 ## Reference
 
 `leoflow.yaml` `dbt:` (whole-DAG) and each `dbt_groups:` entry (embedded) accept:

--- a/runtime/python/tests/test_dbt_adapter_contracts.py
+++ b/runtime/python/tests/test_dbt_adapter_contracts.py
@@ -1,0 +1,123 @@
+"""Adapter contract tests: the profiles.yml Leoflow emits for each cloud warehouse
+must be accepted by that warehouse's *real* dbt adapter.
+
+The mapper (leoflow_runtime.dbt) emits a profile dict; the unit tests in test_dbt.py
+lock its shape, but only the adapter itself knows whether that shape is valid — the
+right field names, the alias resolution (project→database, catalog→database,
+dataset→schema), the required fields, and the auth-mode wiring. Here we feed our
+emitted profile through the adapter's own credential parsing (translate_aliases +
+the Credentials dataclass), which validates the shape WITHOUT connecting to a
+warehouse. This is the credential-free half of the cloud-adapter assurance (#574);
+a live-query gate needs real secrets and is the maintainer's (see docs/dbt.md).
+
+Each adapter is optional: the test skips when its package is not installed, so the
+default runtime suite (no cloud adapters) is unaffected. CI installs one adapter per
+matrix leg — see .github/workflows/ci.yaml `dbt-adapter-contracts`.
+"""
+from __future__ import annotations
+
+import json
+from urllib.parse import urlencode
+
+import pytest
+
+from leoflow_runtime.dbt import dbt_profile_from_uri
+
+
+def _conn_uri(scheme, login="", password="", host="", schema="", extra=None):
+    """Build an Airflow connection URI the way Leoflow delivers it (conn_type with
+    _->-, extra as a single __extra__ JSON query param). Mirrors test_dbt._conn_uri."""
+    netloc = f"{login}:{password}@" if (login or password) else ""
+    netloc += host
+    path = f"/{schema}" if schema else ""
+    query = "?" + urlencode({"__extra__": json.dumps(extra)}) if extra else ""
+    return f"{scheme.replace('_', '-')}://{netloc}{path}{query}"
+
+
+def _as_credentials(cls, profile):
+    """Feed a Leoflow-emitted profile through the adapter's real credential parsing:
+    drop the profile-level keys the Credentials dataclass doesn't take (type,
+    threads), apply the adapter's own alias resolution, and construct. Raises exactly
+    as the adapter would when dbt loads the profile — no network."""
+    kwargs = {k: v for k, v in profile.items() if k not in ("type", "threads")}
+    return cls(**cls.translate_aliases(kwargs))
+
+
+# --- Snowflake ------------------------------------------------------------------
+
+def _snowflake_creds():
+    return pytest.importorskip("dbt.adapters.snowflake.connections").SnowflakeCredentials
+
+
+def test_snowflake_password_profile_is_valid():
+    cls = _snowflake_creds()
+    prof = dbt_profile_from_uri(_conn_uri(
+        "snowflake", login="u", password="pw", schema="ANALYTICS",
+        extra={"account": "ab12345", "warehouse": "WH", "database": "DB", "role": "R"}))
+    c = _as_credentials(cls, prof)
+    assert c.account == "ab12345" and c.user == "u" and c.password == "pw"
+
+
+def test_snowflake_key_pair_profile_is_valid():
+    cls = _snowflake_creds()
+    pem = "not-a-real-key"  # the adapter stores it verbatim on the dataclass
+    prof = dbt_profile_from_uri(_conn_uri(
+        "snowflake", login="svc", schema="ANALYTICS",
+        extra={"account": "ab12345", "warehouse": "WH", "database": "DB",
+               "private_key_content": pem, "private_key_passphrase": "pp"}))
+    c = _as_credentials(cls, prof)
+    assert c.private_key == pem and c.private_key_passphrase == "pp"
+    assert not c.password  # key-pair drops the password
+
+
+# --- BigQuery -------------------------------------------------------------------
+
+def _bigquery_creds():
+    return pytest.importorskip("dbt.adapters.bigquery.credentials").BigQueryCredentials
+
+
+def test_bigquery_keyless_oauth_profile_is_valid():
+    cls = _bigquery_creds()
+    prof = dbt_profile_from_uri(_conn_uri(
+        "google_cloud_platform", schema="my_dataset",
+        extra={"method": "oauth", "project": "my-proj"}))
+    c = _as_credentials(cls, prof)
+    # project→database, dataset→schema are resolved by the adapter's aliases.
+    assert str(c.method) == "oauth" and c.database == "my-proj" and c.schema == "my_dataset"
+
+
+def test_bigquery_service_account_json_profile_is_valid():
+    cls = _bigquery_creds()
+    keyfile = json.dumps({"type": "service_account", "project_id": "p"})
+    prof = dbt_profile_from_uri(_conn_uri(
+        "google_cloud_platform", schema="ds",
+        extra={"project": "my-proj", "keyfile_dict": keyfile}))
+    c = _as_credentials(cls, prof)
+    assert "service-account" in str(c.method) and c.database == "my-proj"
+
+
+# --- Databricks -----------------------------------------------------------------
+
+def _databricks_creds():
+    return pytest.importorskip("dbt.adapters.databricks.credentials").DatabricksCredentials
+
+
+def test_databricks_oauth_m2m_profile_is_valid():
+    cls = _databricks_creds()
+    prof = dbt_profile_from_uri(_conn_uri(
+        "databricks", host="dbc.databricks.com", schema="analytics",
+        extra={"http_path": "/sql/1.0/warehouses/abc", "catalog": "main",
+               "auth_type": "oauth", "client_id": "svc", "client_secret": "sek"}))
+    c = _as_credentials(cls, prof)
+    # catalog→database is resolved by the adapter's aliases.
+    assert c.auth_type == "oauth" and c.client_id == "svc"
+    assert c.http_path == "/sql/1.0/warehouses/abc" and c.database == "main"
+
+
+def test_databricks_pat_profile_is_valid():
+    cls = _databricks_creds()
+    prof = dbt_profile_from_uri(_conn_uri(
+        "databricks", password="dapitoken", host="h", schema="s",
+        extra={"http_path": "/sql/x", "catalog": "main"}))
+    c = _as_credentials(cls, prof)
+    assert c.token == "dapitoken" and c.http_path == "/sql/x"


### PR DESCRIPTION
Part of #574 (real-warehouse verification strategy). Delivers the credential-free half — adapter contract tests — and documents the maintainer-owned live-query part.

## What
The mapper emits a `profiles.yml` per warehouse; the unit tests lock its shape, but only the *adapter* knows whether that shape is valid. This job feeds Leoflow's emitted profile through each cloud adapter's **real** credential parsing (`translate_aliases` + the `Credentials` dataclass), which validates — **without connecting to a warehouse or needing credentials**:
- correct field names (unknown fields are rejected by the dataclass),
- alias resolution (`project`→`database`, `catalog`→`database`, `dataset`→`schema`),
- required fields (missing `account`/`schema` raises),
- and every auth mode: Snowflake **key-pair** (#571), BigQuery **keyless** (#572), Databricks **OAuth M2M** (#563).

This is the first automated validation the cloud adapters have ever had — previously they were dict-shape unit tests only.

## Pieces
- `runtime/python/tests/test_dbt_adapter_contracts.py` — `importorskip` per adapter, so the default runtime suite (no cloud adapters) skips them cleanly (verified: `ssssss`).
- CI `dbt-adapter-contracts` matrix (snowflake/bigquery/databricks) — one adapter per leg (their deps conflict in a shared venv); `dbt-core` pinned to `1.9.*` to keep the resolver off the 2.0 pre-release parser.
- `docs/dbt.md` "Adapter assurance" — a table of what's contract-tested vs live-verified.

## Critical review (self)
- **Does it catch real bugs?** Yes — it constructs the real `Credentials`; unknown/renamed fields and missing required fields raise (proven). It already forced correct handling of the `project`/`dataset`/`catalog` alias subtlety.
- **Scope honesty:** it validates *shape*, not that a live query succeeds — explicitly documented; the live-query gate needs real warehouse secrets and is maintainer-owned (template: `dbt-connection-e2e.sh`).
- **Robustness:** simplified the install to a plain pinned install (no `--only-binary`) after confirming the `dbt-core==1.9.*` pin alone prevents the beta-parser source build — removing a Linux wheel-availability risk. `fail-fast: false` so one adapter's failure doesn't mask the others.

## Verification
Ran the contract tests against the **real installed** dbt-snowflake / dbt-bigquery / dbt-databricks 1.9 locally: all green; all skip in the default env; full runtime suite unaffected; ruff + actionlint clean.

**Remaining in #574 (maintainer-owned):** the live-query gate against real Snowflake/BigQuery/Databricks accounts (org secrets + billing).
