### PR TITLE
feat(mcp): dbt-aware diagnose_run — downstream impact + models (part of #576)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`diagnose_run` (MCP) is now dbt-aware and shows downstream impact.** For each
+  failed task it additionally surfaces the tasks it transitively **blocks**
+  (`downstream_blocked`, from the DAG's `depends_on` graph) and, for a dbt task,
+  the **models** it runs (`models`, parsed from the task's `--select` — a single
+  model at `node` granularity, several for a fused group). The summary now
+  distinguishes root failures from the tasks they blocked. Best-effort from the
+  compiled spec — a run with no failures pays nothing extra, and a spec that can't
+  be read just omits the fields. No control-plane change (built on the existing
+  `dag://spec`).
 - **Databricks dbt profiles support OAuth M2M (service principal).** A managed
   Databricks connection whose extra carries `client_id`/`client_secret` (or an
   explicit `auth_type: oauth`) now generates a `profiles.yml` using service-principal

--- a/internal/mcp/e2e_test.go
+++ b/internal/mcp/e2e_test.go
@@ -43,6 +43,12 @@ func seededControlPlane(t *testing.T) *httptest.Server {
 				`{"task_id":"load","state":"failed","try_number":2,"duration":3.5}],"total_entries":2}`))
 		case "/api/v2/dags/etl/dagRuns/r1/taskInstances/load/logs/2":
 			_, _ = w.Write([]byte("connecting\nValueError: boom in load\ndone\n"))
+		case "/api/v2/dags/etl/spec":
+			// A dbt graph so diagnose_run can surface load's models + downstream.
+			_, _ = w.Write([]byte(`{"tasks":[` +
+				`{"task_id":"extract","entrypoint":"dbt seed --select extract"},` +
+				`{"task_id":"load","depends_on":["extract"],"entrypoint":"dbt build --select load_a load_b --project-dir /p"},` +
+				`{"task_id":"report","depends_on":["load"],"entrypoint":"dbt run --select report"}]}`))
 		default:
 			t.Errorf("control plane got unexpected path %q", r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
@@ -157,7 +163,11 @@ func TestMCPBinaryEndToEnd(t *testing.T) {
 		t.Fatalf("diagnose_run returned an error result: %s", textOf(res.Content))
 	}
 	got := textOf(res.Content)
-	for _, want := range []string{`"run_state":"failed"`, `"task_id":"load"`, "ValueError: boom in load"} {
+	for _, want := range []string{
+		`"run_state":"failed"`, `"task_id":"load"`, "ValueError: boom in load",
+		"load_a", "load_b", // dbt models parsed from the fused --select
+		"report",           // downstream task blocked by load's failure
+	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("diagnose_run output missing %q; got: %s", want, got)
 		}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -7,8 +7,10 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -202,6 +204,12 @@ type failedTask struct {
 	TryNumber       int     `json:"try_number"`
 	DurationSeconds float32 `json:"duration_seconds,omitempty"`
 	LogTail         string  `json:"log_tail,omitempty"`
+	// DownstreamBlocked are the tasks this failure transitively blocks (the DAG's
+	// depends_on graph). Models are the dbt models this task runs, parsed from its
+	// --select (empty for a non-dbt task). Both are best-effort from the compiled
+	// spec — a fetch/parse failure just leaves them empty.
+	DownstreamBlocked []string `json:"downstream_blocked,omitempty"`
+	Models            []string `json:"models,omitempty"`
 }
 
 type diagnoseRunOutput struct {
@@ -260,8 +268,104 @@ func (h *handlers) diagnoseRun(ctx context.Context, req *mcpsdk.CallToolRequest,
 	}
 	out.TotalTasks = len(tis)
 	out.FailedTasks = h.collectFailedTasks(ctx, api, in.DagID, in.RunID, tis, tail)
-	out.Summary = fmt.Sprintf("%d of %d task(s) failed", len(out.FailedTasks), out.TotalTasks)
+	enrichFromSpec(ctx, api, in.DagID, out.FailedTasks)
+	out.Summary = summarizeFailures(out.FailedTasks, out.TotalTasks)
 	return nil, out, nil
+}
+
+// summarizeFailures distinguishes root failures (state=failed) from the tasks they
+// blocked (state=upstream_failed), so the agent sees cause vs consequence at a
+// glance.
+func summarizeFailures(failed []failedTask, total int) string {
+	roots, blocked := 0, 0
+	for _, ft := range failed {
+		if ft.State == string(apiclient.TaskInstanceStateUpstreamFailed) {
+			blocked++
+		} else {
+			roots++
+		}
+	}
+	return fmt.Sprintf("%d task(s) failed, %d blocked downstream, of %d total", roots, blocked, total)
+}
+
+type specTask struct {
+	TaskID     string   `json:"task_id"`
+	DependsOn  []string `json:"depends_on"`
+	Entrypoint string   `json:"entrypoint"`
+}
+
+// enrichFromSpec adds, for each failed task, the tasks it transitively blocks
+// (downstream in the DAG's depends_on graph) and the dbt models it runs (from its
+// --select). Best-effort: a spec that can't be fetched or parsed leaves these
+// fields empty; the core diagnosis stands. One extra /api/v2 read per diagnosis.
+func enrichFromSpec(ctx context.Context, api *apiclient.ClientWithResponses, dagID string, failed []failedTask) {
+	if len(failed) == 0 {
+		return
+	}
+	resp, err := api.GetDagSpecWithResponse(ctx, dagID)
+	if err != nil || resp.StatusCode() != http.StatusOK {
+		return
+	}
+	var spec struct {
+		Tasks []specTask `json:"tasks"`
+	}
+	if json.Unmarshal(resp.Body, &spec) != nil {
+		return
+	}
+	children := make(map[string][]string, len(spec.Tasks)) // parent -> direct children
+	entrypoint := make(map[string]string, len(spec.Tasks))
+	for _, t := range spec.Tasks {
+		entrypoint[t.TaskID] = t.Entrypoint
+		for _, p := range t.DependsOn {
+			children[p] = append(children[p], t.TaskID)
+		}
+	}
+	for i := range failed {
+		failed[i].DownstreamBlocked = downstreamClosure(children, failed[i].TaskID)
+		failed[i].Models = dbtSelectModels(entrypoint[failed[i].TaskID])
+	}
+}
+
+// downstreamClosure returns every task transitively reachable from root via the
+// parent→children edges, sorted for a stable result.
+func downstreamClosure(children map[string][]string, root string) []string {
+	seen := map[string]bool{}
+	queue := append([]string{}, children[root]...)
+	var out []string
+	for len(queue) > 0 {
+		n := queue[0]
+		queue = queue[1:]
+		if seen[n] {
+			continue
+		}
+		seen[n] = true
+		out = append(out, n)
+		queue = append(queue, children[n]...)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// dbtSelectModels extracts the dbt models a task runs from its entrypoint's
+// `--select <models...>`: a single model for node granularity, several for a fused
+// group. Empty for a non-dbt task (no --select). Selection stops at the next flag
+// or a shell `&&`.
+func dbtSelectModels(entrypoint string) []string {
+	fields := strings.Fields(entrypoint)
+	var models []string
+	for i := 0; i < len(fields); i++ {
+		if fields[i] != "--select" && fields[i] != "-s" {
+			continue
+		}
+		for _, f := range fields[i+1:] {
+			if f == "&&" || strings.HasPrefix(f, "-") {
+				break
+			}
+			models = append(models, f)
+		}
+		break
+	}
+	return models
 }
 
 // collectFailedTasks returns the failed/upstream-failed task instances, each with

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -29,6 +29,8 @@ func TestDiagnoseRun(t *testing.T) {
 				`{"task_id":"load","state":"failed","try_number":2,"duration":3.5}],"total_entries":2}`)
 		case "/api/v2/dags/etl/dagRuns/r1/taskInstances/load/logs/2":
 			_, _ = io.WriteString(w, "setup\nrunning query\nTraceback (most recent call last)\nValueError: boom\x1b[0m\n")
+		case "/api/v2/dags/etl/spec": // diagnose_run enriches downstream/models best-effort
+			_, _ = io.WriteString(w, `{"tasks":[{"task_id":"extract"},{"task_id":"load","depends_on":["extract"]}]}`)
 		default:
 			t.Errorf("unexpected path %q", r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
@@ -57,6 +59,53 @@ func TestDiagnoseRun(t *testing.T) {
 	}
 	if strings.Contains(ft.LogTail, "\x1b") {
 		t.Errorf("log_tail must be sanitized of control/ANSI bytes: %q", ft.LogTail)
+	}
+}
+
+// TestDiagnoseRunDbtAware: for a failed task, diagnose_run additionally surfaces
+// the downstream tasks it blocks (from the spec's depends_on graph) and, for a dbt
+// task, the models it runs (parsed from its --select). Best-effort from the spec.
+func TestDiagnoseRunDbtAware(t *testing.T) {
+	h := testHandlers(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v2/dags/etl/dagRuns/r1":
+			_, _ = io.WriteString(w, `{"dag_id":"etl","dag_run_id":"r1","state":"failed"}`)
+		case "/api/v2/dags/etl/dagRuns/r1/taskInstances":
+			_, _ = io.WriteString(w, `{"task_instances":[`+
+				`{"task_id":"raw","state":"success","try_number":1},`+
+				`{"task_id":"stg","state":"failed","try_number":1},`+
+				`{"task_id":"mart","state":"upstream_failed","try_number":0}],"total_entries":3}`)
+		case "/api/v2/dags/etl/dagRuns/r1/taskInstances/stg/logs/1":
+			_, _ = io.WriteString(w, "boom\n")
+		case "/api/v2/dags/etl/spec":
+			_, _ = io.WriteString(w, `{"tasks":[`+
+				`{"task_id":"raw","entrypoint":"dbt seed --select raw"},`+
+				`{"task_id":"stg","depends_on":["raw"],"entrypoint":"dbt build --select stg_a stg_b --project-dir /x"},`+
+				`{"task_id":"mart","depends_on":["stg"],"entrypoint":"dbt run --select mart"}]}`)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	})
+
+	_, out, err := h.diagnoseRun(context.Background(), nil, diagnoseRunInput{DagID: "etl", RunID: "r1"})
+	if err != nil {
+		t.Fatalf("diagnoseRun: %v", err)
+	}
+	var stg *failedTask
+	for i := range out.FailedTasks {
+		if out.FailedTasks[i].TaskID == "stg" {
+			stg = &out.FailedTasks[i]
+		}
+	}
+	if stg == nil {
+		t.Fatalf("stg not in failed tasks: %+v", out.FailedTasks)
+	}
+	if len(stg.DownstreamBlocked) != 1 || stg.DownstreamBlocked[0] != "mart" {
+		t.Errorf("stg downstream_blocked = %v, want [mart]", stg.DownstreamBlocked)
+	}
+	if len(stg.Models) != 2 || stg.Models[0] != "stg_a" || stg.Models[1] != "stg_b" {
+		t.Errorf("stg models = %v, want [stg_a stg_b]", stg.Models)
 	}
 }
 


### PR DESCRIPTION
Part of #576 (dbt-aware MCP) — the cheapest, self-contained first slice, built entirely on the **existing** `dag://spec` surface (no control-plane change, no ADR).

## What
`diagnose_run` now enriches each failed task, best-effort from the compiled spec:
- **`downstream_blocked`** — the tasks this failure transitively blocks (from the DAG's `depends_on` graph). Generic; useful for any DAG.
- **`models`** — the dbt models the task runs, parsed from its `--select` (one at `node` granularity, several for a fused group).
- The **summary** now distinguishes root failures (`state=failed`) from the tasks they blocked (`state=upstream_failed`) — cause vs consequence in one call.

Previously an agent could get this only by fetching `dag://spec` and stitching the graph itself; this bakes it in.

## Why this slice
Per the pre-build review: most of #576's value was already reachable via the existing MCP resources, so the incremental win is *convenience* (server-side aggregation + task→model naming). This delivers that convenience with zero new backend and full local verifiability — the manifest-export-dependent richer features (model SQL, cross-group lineage) stay parked.

## Critical review (self)
- **Correctness:** `downstreamClosure` is cycle-safe (`seen` set) though DAGs are acyclic; `dbtSelectModels` stops at the next flag or `&&`, handles `-s`, empty for non-dbt tasks.
- **Non-breaking / cheap:** `len(failed)==0` skips the extra `dag://spec` read entirely (successful runs pay nothing); a spec that can't be fetched/parsed leaves the fields empty and the core diagnosis is unchanged (verified by an existing test whose CP 404s `/spec`).
- **Auth:** the enrichment uses the same per-request client (`apiFor`), so the caller's token still governs the spec read.
- **D10:** `task_id`s and dbt model names are charset-constrained identifiers, and the output is JSON-marshalled (control bytes escaped), so no new untrusted-content path.
- **Complexity:** extracted `summarizeFailures` to keep `diagnoseRun` under the gocyclo≤15 floor.

## Tests
Unit test (downstream + fused `--select` parsing) + the **real-binary e2e** asserts `load_a`/`load_b` models and the `report` downstream through the actual MCP protocol. `go test -race`, `-tags e2e`, golangci-lint (0), deadcode, byte-sweep all clean.