### PR TITLE
release: prepare v0.3.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.0-rc.1] - 2026-08-12
+
+> First RC of the **0.3.0** line. Adds the experimental **`leoflow-mcp`** Model
+> Context Protocol server (read tools + resources over stdio and Streamable HTTP,
+> ADR 0050) and a typed **`pkg/client`** for `/api/v2`; brings **dbt** cloud-adapter
+> auth up to modern service-account standards (Databricks OAuth M2M, Snowflake
+> key-pair, BigQuery keyless), a dbt-aware `diagnose_run`, and adapter contract
+> tests; plus security hardening (seccomp, trusted-proxy default, `/metrics`
+> isolation). Docker-free gates green locally; full CI battery green on the tagged
+> commit (`f3ded10`).
+
 ### Added
 
 - **`diagnose_run` (MCP) is now dbt-aware and shows downstream impact.** For each

--- a/helm/leoflow/Chart.yaml
+++ b/helm/leoflow/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version is the chart version; appVersion tracks the leoflow-server image.
 # Both move in lockstep with the release tag (ADR 0028); decouple only if the
 # chart ever needs a cadence of its own for a template-only fix.
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.3.0-rc.1
+appVersion: "0.3.0-rc.1"
 home: https://github.com/neochaotic/leoflow
 sources:
   - https://github.com/neochaotic/leoflow

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -1,6 +1,6 @@
 # leoflow
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.0](https://img.shields.io/badge/AppVersion-0.2.0-informational?style=flat-square)
+![Version: 0.3.0-rc.1](https://img.shields.io/badge/Version-0.3.0--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0-rc.1](https://img.shields.io/badge/AppVersion-0.3.0--rc.1-informational?style=flat-square)
 
 Leoflow control plane — a GitOps-first, container-native workflow orchestrator (Airflow 3.2.x UI/API compatible).
 


### PR DESCRIPTION
Release-prep for **v0.3.0-rc.1** — first RC of the 0.3.0 line.

- Promote CHANGELOG `[Unreleased]` → `[0.3.0-rc.1] - 2026-08-12` (dated).
- Bump `helm/leoflow/Chart.yaml` `version` + `appVersion` to `0.3.0-rc.1` in lockstep (ADR 0028); chart README regenerated (helm-docs).

**Why 0.3.0 (minor), not 0.2.1:** the line adds new features — the experimental `leoflow-mcp` MCP server + typed `pkg/client`, three dbt cloud-adapter auth modes (Databricks OAuth M2M / Snowflake key-pair / BigQuery keyless), dbt-aware `diagnose_run`, adapter contract tests — plus security hardening. That's a minor bump under the scheme used for 0.1.x→0.2.0.

**Gate:** Docker-free gates green locally (build, golangci-lint 0, ruff, dependabot-dirs); the **full CI battery is green on the base commit `f3ded10`** (integration, all k3d e2es, helm checks, govulncheck, security scans). `make rc-smoke`'s k3d/Docker steps can't run in the authoring sandbox but are covered by that green CI.

On merge, tagging `v0.3.0-rc.1` triggers the GoReleaser release workflow (build/sign/publish).