### PR TITLE
fix(release): build + ship the leoflow-mcp binary (closes #586)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,12 +44,26 @@ builds:
     goos: [linux, darwin]
     goarch: [amd64, arm64]
     ldflags: *ldflags
+  - id: leoflow-mcp
+    main: ./cmd/leoflow-mcp
+    binary: leoflow-mcp
+    env: [CGO_ENABLED=0]
+    flags: [-trimpath]
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    goos: [linux, darwin]
+    goarch: [amd64, arm64]
+    # leoflow-mcp carries its version in `package main` (var version), so it needs
+    # the unqualified `main.version` ldflag — the shared *ldflags anchor targets
+    # internal/version.* and would leave main.version at its "dev" default.
+    ldflags:
+      - -s -w
+      - -X main.version={{ .Version }}
 
 archives:
   - id: leoflow
-    # One archive per platform containing all three binaries; install.sh extracts
+    # One archive per platform containing all four binaries; install.sh extracts
     # them into ~/.leoflow/bin.
-    ids: [leoflow, leoflow-server, leoflow-agent]
+    ids: [leoflow, leoflow-server, leoflow-agent, leoflow-mcp]
     formats: [tar.gz]
     name_template: "leoflow_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The `leoflow-mcp` binary is now built and shipped in the release archives.**
+  GoReleaser built `leoflow`/`leoflow-server`/`leoflow-agent` but not
+  `leoflow-mcp`, so v0.3.0-rc.1 shipped the MCP server as source with no
+  distributable binary. It now builds for the same platform matrix, carries its
+  version via the `main.version` ldflag, and is included in the per-platform
+  archive. (#586)
+
 ## [0.3.0-rc.1] - 2026-08-12
 
 > First RC of the **0.3.0** line. Adds the experimental **`leoflow-mcp`** Model


### PR DESCRIPTION
Closes #586 — first rc.2 blocker fix.

The v0.3.0-rc.1 soak found the release archives ship `leoflow`/`leoflow-server`/`leoflow-agent` but **not `leoflow-mcp`** — the MCP server, the 0.3.0 headline feature, had no distributable binary.

## Fix
- Add a `leoflow-mcp` build id in `.goreleaser.yaml` (`main: ./cmd/leoflow-mcp`) for the same `linux,darwin × amd64,arm64` matrix.
- Include it in the per-platform archive (`ids: [..., leoflow-mcp]`).
- Use the **unqualified `-X main.version`** ldflag — leoflow-mcp keeps its version in `package main`, so the shared `*ldflags` anchor (which targets `internal/version.*`) would leave it at `dev`.

## Verified
- `goreleaser check` → validated.
- `go build -ldflags "-X main.version=…"` → the value **injects** (strings-confirmed), dodging the fully-qualified-ldflag no-op trap.