### PR TITLE
fix(lite): binary-only install — wire parser PYTHONPATH + extract pysrc before venv (closes #587)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -258,6 +258,27 @@ jobs:
         run: bash test/e2e/lite-login.sh
 
   # ─────────────────────────────────────────────────────────────────────
+  # Genuine binary-only install gate (#587). A built binary, a clean HOME, NO
+  # repo on any path, and — deliberately — NO `PYTHONPATH` env. Every other
+  # e2e job presets `PYTHONPATH: parser`, which masks the real "download the
+  # release and run it" path: `leoflow compile` must resolve the embedded
+  # parser from the binary's own ~/.leoflow/pysrc extraction, and the binary
+  # must extract the runtime sources the Lite venv builds from. No Postgres —
+  # the bug was in resolution + extraction, not runtime state. ~15 s.
+  # ─────────────────────────────────────────────────────────────────────
+  binary-only-install:
+    name: Binary-only install (no repo, no PYTHONPATH)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+      - name: Binary-only install (compile + self-extract)
+        run: bash test/e2e/binary-only-install.sh
+
+  # ─────────────────────────────────────────────────────────────────────
   # Multi-DAG materialization gate (ADR 0033).
   # Asserts the contract `dag.json.source` carries dag.py byte-for-byte for
   # subdir projects, the parser→spec property the subprocess executor depends

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Fresh binary-only install: `leoflow compile` and `leoflow lite` now work
+  without a repo or `PYTHONPATH`.** The primary "download the release and run
+  it" path was broken: the binary extracts the Python parser to
+  `~/.leoflow/pysrc/parser`, but spawned it as a bare `python3 -m leoflow_parser`
+  without putting that directory on `PYTHONPATH`, so compile failed with
+  `No module named leoflow_parser`. And the Lite boot referenced the extracted
+  `pysrc/runtime/python` (to build the per-DAG venv) *before* anything extracted
+  it, aborting with `does not exist`. The parser invocation now always wires the
+  extracted sources onto `PYTHONPATH`, and the Lite boot self-heals the
+  extraction before provisioning the venv. Every existing e2e job preset
+  `PYTHONPATH=parser` (repo-relative), which masked both — a new
+  binary-only-install CI gate exercises the genuine path (built binary, clean
+  HOME, no repo, no `PYTHONPATH`).
+
 ## [0.3.0-rc.1] - 2026-08-12
 
 > First RC of the **0.3.0** line. Adds the experimental **`leoflow-mcp`** Model

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -541,6 +541,11 @@ func runParser(cmd *cobra.Command, command string, a parserArgs) error {
 		"--dag-version", a.dagVersion)
 	//nolint:gosec // G204: the parser command is operator-configured by design (ADR 0005).
 	pc := exec.CommandContext(cmdContext(cmd), fields[0], argv...)
+	// Build the child environment. Guarantee the extracted parser sources are
+	// importable: on a binary-only install the default command is a bare
+	// `python3 -m leoflow_parser` and nothing else wires ~/.leoflow/pysrc/parser
+	// onto PYTHONPATH, so the parser fails with ModuleNotFoundError (#587).
+	env := withParserPythonPath(os.Environ())
 	// Hand the resolved project config to the parser as JSON via an env var.
 	// The parser uses this instead of re-parsing leoflow.yaml in-process, so
 	// Go owns the schema and the parser ships zero third-party deps.
@@ -549,8 +554,9 @@ func runParser(cmd *cobra.Command, command string, a parserArgs) error {
 		if merr != nil {
 			return fmt.Errorf("marshaling project config for parser: %w", merr)
 		}
-		pc.Env = append(os.Environ(), parserConfigEnv+"="+string(raw))
+		env = append(env, parserConfigEnv+"="+string(raw))
 	}
+	pc.Env = env
 	pc.Stdout = cmd.OutOrStdout()
 	// Stream the parser's stderr to the terminal and capture it, so a parse
 	// failure carries the real traceback (e.g. the SyntaxError + file:line) in

--- a/internal/cli/compile_binary_install_test.go
+++ b/internal/cli/compile_binary_install_test.go
@@ -1,0 +1,118 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// TestDevSubprocessSetupExtractsPysrcBeforeVenv locks the ordering half of #587:
+// on a binary-only install the per-DAG venv is built from the path
+// resolveRuntimeSrc returns (~/.leoflow/pysrc/runtime/python), so the Lite boot
+// must extract the bundled sources before it references that path — otherwise
+// pip aborts with "'<home>/.leoflow/pysrc/runtime/python' does not exist".
+//
+// We exercise the real boot helper with an EMPTY workspace (zero projects), so
+// no pip runs and the test stays fast and hermetic, and assert the boot has
+// materialized the runtime source. Before the fix devSubprocessSetup never
+// extracts pysrc, so this path stays absent and the test fails.
+func TestDevSubprocessSetupExtractsPysrcBeforeVenv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	dh, err := devHome()
+	if err != nil {
+		t.Fatalf("devHome: %v", err)
+	}
+	// The binary-only branch: no repo checkout, so resolveRuntimeSrc resolves
+	// into the extracted pysrc tree.
+	runtimeSrc := resolveRuntimeSrc("", dh)
+	// Precondition: the runtime source does not exist yet — the exact state that
+	// made the venv build fail during the soak.
+	if _, statErr := os.Stat(filepath.Join(runtimeSrc, "pyproject.toml")); statErr == nil {
+		t.Fatalf("precondition: %s must NOT exist before boot", runtimeSrc)
+	}
+
+	wsDir := t.TempDir()
+	ws := &WorkspaceSpec{Path: wsDir} // zero projects → the boot provisions no venv
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(os.Stderr)
+	cmd.SetErr(os.Stderr)
+
+	o := devOptions{host: "127.0.0.1", port: 18077, agentBin: "/bin/true"}
+	if _, _, serr := devSubprocessSetup(t.Context(), cmd, ws, o, dh); serr != nil {
+		t.Fatalf("devSubprocessSetup: %v", serr)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(runtimeSrc, "pyproject.toml")); statErr != nil {
+		t.Fatalf("boot must extract the runtime source at %s before provisioning the venv: %v", runtimeSrc, statErr)
+	}
+}
+
+// TestCompileResolvesParserOnBinaryOnlyInstall is the #587 regression: on a
+// fresh binary-only install (the release archive, no repo checkout) `leoflow
+// compile` must find the Python parser without any PYTHONPATH set by the user.
+//
+// The only thing that puts `leoflow_parser` on the import path there is the
+// binary's own extraction to ~/.leoflow/pysrc/parser (ensurePysrc, #239) — the
+// default parser command is a bare `python3 -m leoflow_parser`, and nothing
+// else wires that directory onto PYTHONPATH. CI masks the gap by exporting
+// PYTHONPATH=parser from the repo root, so it only bit a real download.
+//
+// We reproduce the real environment faithfully: a clean HOME, the parser
+// sources extracted exactly as the binary does it, the default parser_cmd (no
+// config override, no --parser-cmd flag), and PYTHONPATH scrubbed. Before the
+// fix this fails with ModuleNotFoundError: No module named leoflow_parser.
+func TestCompileResolvesParserOnBinaryOnlyInstall(t *testing.T) {
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH; resolving the real parser needs an interpreter")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	// Extract the bundled parser+runtime exactly as the binary does on first
+	// use, so ~/.leoflow/pysrc/parser holds the importable leoflow_parser.
+	if err := ensurePysrcIn(filepath.Join(home, ".leoflow", "pysrc"), nil); err != nil {
+		t.Fatalf("extracting bundled parser sources: %v", err)
+	}
+
+	// A binary-only install has no repo on PYTHONPATH and the user sets none —
+	// scrub any leaked from the dev shell so the only resolvable copy is the
+	// extracted one under HOME.
+	t.Setenv("PYTHONPATH", "")
+	if err := os.Unsetenv("PYTHONPATH"); err != nil {
+		t.Fatalf("unset PYTHONPATH: %v", err)
+	}
+
+	dir := filepath.Join(t.TempDir(), "proj")
+	if _, _, err := run(t, "init", dir); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	out := filepath.Join(dir, "dag.json")
+
+	// No parser_cmd in config and no --parser-cmd flag: resolveParserCommand
+	// falls back to the default `python3 -m leoflow_parser`.
+	if _, stderr, err := run(t, "compile", dir, "--output", out, "--image", "test:v1"); err != nil {
+		t.Fatalf("compile on a binary-only install must resolve the extracted parser, got %v\nstderr=%s", err, stderr)
+	}
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("dag.json missing after compile: %v", err)
+	}
+	var spec domain.DAGSpec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("compiled dag.json is invalid JSON: %v", err)
+	}
+	if err := spec.Validate(); err != nil {
+		t.Errorf("compiled dag.json does not pass schema validation: %v", err)
+	}
+}

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -699,6 +699,12 @@ func devSubprocessSetup(ctx context.Context, cmd *cobra.Command, ws *WorkspaceSp
 	if err != nil {
 		return nil, nil, err
 	}
+	// Self-heal the extracted Python sources before anything references them.
+	// On a binary-only install (no repo) resolveRuntimeSrc points the per-DAG
+	// venv at ~/.leoflow/pysrc/runtime/python; if the boot provisions that venv
+	// before the sources are extracted, pip aborts with "does not exist" (#587).
+	// Checksum-gated, so a warm install pays nothing.
+	ensurePysrc(cmd)
 	runtimeSrc := resolveRuntimeSrc(o.runtimeSrc, home)
 	// Per-DAG venvs: every project gets its own ~/.leoflow/dev/venvs/<dag_id>/.
 	// Editing one project's `dependencies:` only re-runs pip for THAT project,

--- a/internal/cli/pysrc.go
+++ b/internal/cli/pysrc.go
@@ -29,6 +29,54 @@ func pysrcRoot() (string, error) {
 	return filepath.Join(home, ".leoflow", "pysrc"), nil
 }
 
+// parserPysrcDir returns the extracted parser-sources directory
+// (~/.leoflow/pysrc/parser) that ensurePysrc writes and the bundled
+// `python3 -m leoflow_parser` imports from. It is empty when the home
+// directory cannot be resolved — the caller then leaves PYTHONPATH untouched
+// and falls back to the ambient environment.
+func parserPysrcDir() string {
+	root, err := pysrcRoot()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(root, "parser")
+}
+
+// withParserPythonPath returns env with the extracted parser-sources directory
+// guaranteed on PYTHONPATH, preserving any entries already there (a caller's
+// own PYTHONPATH, or CI's repo-root `parser`). On a binary-only install the
+// default parser command is a bare `python3 -m leoflow_parser` and nothing
+// else puts leoflow_parser on the import path, so the parser fails with
+// ModuleNotFoundError (#587); this closes that gap without depending on the
+// parser_cmd string carrying the path. The bundled parser is pure Python with
+// vendored deps (ADR 0024), so this directory is all it needs to import.
+// Idempotent: the directory is never added twice.
+func withParserPythonPath(env []string) []string {
+	dir := parserPysrcDir()
+	if dir == "" {
+		return env
+	}
+	const key = "PYTHONPATH="
+	for i, e := range env {
+		if !strings.HasPrefix(e, key) {
+			continue
+		}
+		existing := e[len(key):]
+		for _, p := range filepath.SplitList(existing) {
+			if p == dir {
+				return env // already present; nothing to do
+			}
+		}
+		if existing == "" {
+			env[i] = key + dir
+		} else {
+			env[i] = key + dir + string(os.PathListSeparator) + existing
+		}
+		return env
+	}
+	return append(env, key+dir)
+}
+
 // pythonSourcesChecksum hashes this binary's embedded parser+runtime sources, so a
 // drifted on-disk extraction (the binary-upgrade case, #239) can be detected
 // without re-extracting on every invocation.

--- a/test/e2e/binary-only-install.sh
+++ b/test/e2e/binary-only-install.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Genuine binary-only install of Leoflow (#587): a built binary run from OUTSIDE
+# the repo, with a clean HOME and NO PYTHONPATH — the real "download the release
+# and run it" UX. Every other e2e job presets `PYTHONPATH: parser` (repo path),
+# which masks the exact parser-resolution path this exercises.
+#
+# Asserts:
+#   1. `leoflow compile` resolves the embedded parser with no PYTHONPATH and no
+#      repo on any path (the primary symptom: `No module named leoflow_parser`).
+#   2. the binary self-extracts BOTH the parser AND the runtime sources the Lite
+#      per-DAG venv is built from — the venv-before-extract ordering precondition
+#      (the second symptom: `'<home>/.leoflow/pysrc/runtime/python' does not exist`).
+#
+# No Postgres/Redis/agent needed: the failure was in resolution + extraction, not
+# in any runtime state, so this gate stays fast and deterministic.
+set -euo pipefail
+
+fail() { printf '  \033[31mFAIL\033[0m %b\n' "$1"; exit 1; }
+pass() { printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+
+REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+BINDIR="$(mktemp -d)"
+HOME_DIR="$(mktemp -d)"
+WORK="$(mktemp -d)"
+cleanup() { chmod -R u+w "$HOME_DIR" 2>/dev/null || true; rm -rf "$BINDIR" "$HOME_DIR" "$WORK"; }
+trap cleanup EXIT
+
+echo "==> building the leoflow binary (parser + runtime embedded)"
+( cd "$REPO" && go build -o "$BINDIR/leoflow" ./cmd/leoflow )
+
+# The genuine binary-only environment: a clean HOME, NO PYTHONPATH, and a working
+# directory OUTSIDE the repo so the repo-relative parser/ and runtime/python are
+# never on any path. Only the binary's own extraction can satisfy the parser.
+unset PYTHONPATH
+export HOME="$HOME_DIR"
+cd "$WORK"
+
+echo "==> leoflow init + compile (no PYTHONPATH, outside the repo)"
+"$BINDIR/leoflow" init proj >/dev/null || fail "leoflow init failed"
+"$BINDIR/leoflow" compile proj --output proj/dag.json --image test:v1 \
+  >compile.log 2>&1 || fail "leoflow compile failed:\n$(cat compile.log)"
+grep -q '"dag_id"' proj/dag.json \
+  || fail "compile produced no valid dag.json:\n$(cat compile.log)"
+pass "compile resolved the embedded parser without PYTHONPATH"
+
+echo "==> asserting the binary self-extracted parser + runtime sources"
+[ -d "$HOME_DIR/.leoflow/pysrc/parser/leoflow_parser" ] \
+  || fail "parser sources not extracted under ~/.leoflow/pysrc/parser"
+[ -f "$HOME_DIR/.leoflow/pysrc/runtime/python/pyproject.toml" ] \
+  || fail "runtime sources not extracted — the Lite venv build would abort with 'does not exist'"
+pass "binary extracted both parser and runtime sources for a binary-only install"
+
+echo "ALL PASS"


### PR DESCRIPTION
Closes #587 — the second rc.2 blocker. The primary "download the release and run it" UX was broken, and CI masked it.

## Two root causes (both hidden by a preset `PYTHONPATH=parser` in every e2e job)

1. **Parser not on the import path.** The binary extracts the parser to `~/.leoflow/pysrc/parser`, but spawned it as a bare `python3 -m leoflow_parser` with no `PYTHONPATH` → `leoflow compile` failed with `No module named leoflow_parser`.
2. **Venv-before-extract ordering.** The Lite boot builds the per-DAG venv from `~/.leoflow/pysrc/runtime/python`, but provisioned it *before* anything extracted the sources → pip aborted with `'<home>/.leoflow/pysrc/runtime/python' does not exist`.

## Fix
- `runParser` now always puts the extracted parser dir on `PYTHONPATH`, merged with any inherited value (CI's repo-root `parser`, a caller's own entries) and idempotent — independent of whatever `parser_cmd` string was configured.
- `devSubprocessSetup` self-heals the pysrc extraction (checksum-gated, so a warm install pays nothing) **before** it resolves the runtime source or provisions the venv.

## Regression coverage
- `TestCompileResolvesParserOnBinaryOnlyInstall` — extracted pysrc, clean HOME, **no** `PYTHONPATH`, default `parser_cmd` → real parser must resolve. Red before, green after.
- `TestDevSubprocessSetupExtractsPysrcBeforeVenv` — exercises the real boot helper with an empty workspace (no pip), asserts the runtime source exists after boot. Red before, green after.
- **New `binary-only-install` CI gate** — a genuinely built binary run from outside the repo, clean HOME, **no `PYTHONPATH`** (`test/e2e/binary-only-install.sh`). This is the exact path every other e2e job masked with `PYTHONPATH=parser`.

Verified locally: `golangci-lint` 0 issues, `gofmt` clean, `actionlint` clean, `go test ./internal/cli/…` green, and the new e2e script passes.