### PR TITLE
feat(connectors): surface dbt cloud-auth fields in the connection form (overlay) + refresh dbt docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **The connection form now surfaces dbt cloud-auth fields with inline help.**
+  The three modern service-account auth modes shipped in 0.3.0-rc.1 were only
+  reachable by hand-typing keys into the raw `extra` JSON box, because the form
+  catalog is generated from Airflow's provider introspection, which does not
+  describe them. A hand-curated leoflow overlay
+  (`internal/connectors/catalog.overlay.json`, merged over the generated catalog
+  at load) adds them as labeled fields: Snowflake `private_key_passphrase`,
+  BigQuery's keyless `method` selector, and the full Databricks form
+  (`http_path`, `client_id`/`client_secret`, `auth_type`, plus a labeled
+  workspace URL and access-token field — Airflow shipped it empty). The generated
+  `catalog.json` is untouched; the overlay survives regeneration.
+
+### Documentation
+
+- **dbt: the warehouse-connection section now documents modern cloud auth.**
+  `docs/dbt.md` §4 described only the legacy password/key-file modes; it now has
+  a per-warehouse table (Snowflake key-pair, BigQuery keyless, Databricks OAuth
+  M2M) and links to the connection reference pages that carry the full setup.
+
 ### Fixed
 
 - **Fresh binary-only install: `leoflow compile` and `leoflow lite` now work

--- a/docs/dbt.md
+++ b/docs/dbt.md
@@ -223,9 +223,24 @@ image). Simple for Lite; you own the credential delivery.
 zero-server local dev) are supported — Leoflow maps the managed connection to each
 adapter's profile. Declare the adapter package
 (`dbt-snowflake`, `dbt-bigquery`, `dbt-databricks`, …) as a dependency so it lands
-in the image. BigQuery uses the connection's `keyfile_dict`; Snowflake its
-`account`/`warehouse`; Databricks its `http_path` — all from the connection's
-`extra`, so nothing secret is baked in.
+in the image.
+
+Each cloud adapter supports modern, service-account auth — Leoflow's recommended
+mode for automation — alongside the legacy password/key-file mode. Everything is
+driven by the connection's `extra`, so nothing secret is baked into the image, and
+the connection form surfaces these fields with inline help:
+
+| Warehouse | Recommended auth | Set in the connection | Legacy fallback |
+|---|---|---|---|
+| **Snowflake** | key-pair | `private_key_content` (inline PEM) or `private_key_file` (path), optional `private_key_passphrase` | `password` |
+| **BigQuery** | keyless (Workload Identity / ADC) | `method: oauth` | `keyfile_dict` |
+| **Databricks** | OAuth M2M (service principal) | `client_id` + `client_secret` (or `auth_type: oauth`) | access token (PAT) |
+
+The recommended mode wins when its fields are present; otherwise the legacy mode
+is used. Per-warehouse setup — required fields (`account`/`warehouse`, `http_path`,
+…), example payloads, and precedence — lives in the connection reference:
+[Snowflake](connections/snowflake.md), [BigQuery](connections/google_cloud_platform.md),
+[Databricks](connections/databricks.md).
 
 ---
 

--- a/internal/connectors/catalog.go
+++ b/internal/connectors/catalog.go
@@ -18,6 +18,9 @@ import (
 //go:embed catalog.json
 var catalogJSON []byte
 
+//go:embed catalog.overlay.json
+var catalogOverlayJSON []byte
+
 // Connector is one curated connector type, mirroring a catalog.json entry. The
 // field metadata (StandardFields/ExtraFields) is the precise shape the Airflow
 // 3.2 SPA renders via its FlexibleForm component, so the admin form can serve it
@@ -59,15 +62,67 @@ var aliasOverlay = map[string][]string{
 	"google_cloud_platform": {"gcp", "google"},
 }
 
+// connectorOverlay is a leoflow-owned augmentation for one conn_type.
+type connectorOverlay struct {
+	StandardFields map[string]any `json:"standard_fields"`
+	ExtraFields    map[string]any `json:"extra_fields"`
+}
+
+// fieldOverlay augments generated catalog entries with leoflow-owned form
+// fields — the dbt-auth fields Airflow's provider introspection does not emit
+// (BigQuery's leoflow-invented `method` selector, Snowflake's key passphrase,
+// the whole Databricks form). It is loaded from catalog.overlay.json, which —
+// unlike the generated catalog.json — is hand-curated and safe to edit. Keyed
+// by conn_type; only StandardFields and ExtraFields are merged.
+var fieldOverlay map[string]connectorOverlay
+
 var catalog []Connector
 
 func init() {
 	if err := json.Unmarshal(catalogJSON, &catalog); err != nil {
 		panic("connectors: parsing embedded catalog.json: " + err.Error())
 	}
+	// The overlay file carries a leading "_comment" key documenting itself; it
+	// names no connector. Decode raw, drop it, then type each entry so the
+	// self-documenting comment does not have to satisfy connectorOverlay.
+	rawOverlay := map[string]json.RawMessage{}
+	if err := json.Unmarshal(catalogOverlayJSON, &rawOverlay); err != nil {
+		panic("connectors: parsing embedded catalog.overlay.json: " + err.Error())
+	}
+	delete(rawOverlay, "_comment")
+	fieldOverlay = make(map[string]connectorOverlay, len(rawOverlay))
+	for ct, raw := range rawOverlay {
+		var ov connectorOverlay
+		if err := json.Unmarshal(raw, &ov); err != nil {
+			panic("connectors: parsing overlay for " + ct + ": " + err.Error())
+		}
+		fieldOverlay[ct] = ov
+	}
 	for i := range catalog {
 		catalog[i].Aliases = aliasOverlay[catalog[i].ConnectionType]
+		if ov, ok := fieldOverlay[catalog[i].ConnectionType]; ok {
+			catalog[i].StandardFields = mergeFields(catalog[i].StandardFields, ov.StandardFields)
+			catalog[i].ExtraFields = mergeFields(catalog[i].ExtraFields, ov.ExtraFields)
+		}
 	}
+}
+
+// mergeFields returns base with every key from overlay added or replaced. The
+// overlay augments the generated fields (never wholesale-replaces the map), so
+// the provider's own fields survive; a nil base (Airflow emitted none, e.g.
+// databricks) is allocated. base is not mutated.
+func mergeFields(base, overlay map[string]any) map[string]any {
+	if len(overlay) == 0 {
+		return base
+	}
+	out := make(map[string]any, len(base)+len(overlay))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range overlay {
+		out[k] = v
+	}
+	return out
 }
 
 // Catalog returns every connector entry, including core types with no pip package

--- a/internal/connectors/catalog.overlay.json
+++ b/internal/connectors/catalog.overlay.json
@@ -1,0 +1,61 @@
+{
+  "_comment": "Leoflow-owned overlay merged over the GENERATED catalog.json at load (see catalog.go). These are dbt-auth fields that Airflow's provider introspection does not emit — either leoflow-invented selectors (BigQuery `method`) or fields Airflow's form omits (Snowflake key passphrase, the whole Databricks form). Each field mirrors the FlexibleForm shape the SPA renders; `description` becomes the field's help text. Hand-curated on purpose: unlike catalog.json, this file is safe to edit. Keep field names in sync with runtime/python/leoflow_runtime/dbt.py.",
+  "snowflake": {
+    "extra_fields": {
+      "private_key_passphrase": {
+        "description": "Passphrase for an encrypted key-pair private key. Leave blank for an unencrypted key or password auth.",
+        "schema": {"title": "Private key passphrase", "type": ["string", "null"]},
+        "source": null,
+        "value": null
+      }
+    }
+  },
+  "google_cloud_platform": {
+    "extra_fields": {
+      "method": {
+        "description": "dbt auth method. Set to `oauth` for keyless auth via Application Default Credentials / GKE Workload Identity (no key file shipped). Leave blank to authenticate with keyfile_dict.",
+        "schema": {"title": "dbt auth method (oauth = keyless)", "type": ["string", "null"]},
+        "source": null,
+        "value": null
+      }
+    }
+  },
+  "databricks": {
+    "standard_fields": {
+      "host": {"hidden": false, "title": "Workspace URL", "placeholder": "https://dbc-xxxxxxxx.cloud.databricks.com"},
+      "password": {"hidden": false, "title": "Access token (PAT)", "placeholder": "dapi… — leave blank when using OAuth M2M"}
+    },
+    "extra_fields": {
+      "http_path": {
+        "description": "SQL warehouse or cluster HTTP path, e.g. /sql/1.0/warehouses/abc123.",
+        "schema": {"title": "HTTP path", "type": ["string", "null"]},
+        "source": null,
+        "value": null
+      },
+      "catalog": {
+        "description": "Unity Catalog catalog to run dbt against (optional).",
+        "schema": {"title": "Catalog", "type": ["string", "null"]},
+        "source": null,
+        "value": null
+      },
+      "auth_type": {
+        "description": "Set to `oauth` for service-principal OAuth M2M (Databricks' recommended automation auth). Leave blank to authenticate with the access token above.",
+        "schema": {"title": "Auth type (oauth = service principal)", "type": ["string", "null"]},
+        "source": null,
+        "value": null
+      },
+      "client_id": {
+        "description": "Service-principal client ID (OAuth M2M). Required with client_secret when auth_type is oauth.",
+        "schema": {"title": "Client ID (OAuth M2M)", "type": ["string", "null"]},
+        "source": null,
+        "value": null
+      },
+      "client_secret": {
+        "description": "Service-principal client secret (OAuth M2M).",
+        "schema": {"title": "Client secret (OAuth M2M)", "type": ["string", "null"]},
+        "source": null,
+        "value": null
+      }
+    }
+  }
+}

--- a/internal/connectors/catalog_overlay_test.go
+++ b/internal/connectors/catalog_overlay_test.go
@@ -1,0 +1,72 @@
+package connectors
+
+import "testing"
+
+func mustConn(t *testing.T, ct string) Connector {
+	t.Helper()
+	for _, c := range Catalog() {
+		if c.ConnectionType == ct {
+			return c
+		}
+	}
+	t.Fatalf("connector %q not in catalog", ct)
+	return Connector{}
+}
+
+// TestDBTAuthOverlayMergesLeoflowFields pins the leoflow field overlay: the
+// generated catalog carries only what Airflow's provider introspection emits,
+// but leoflow's dbt profile mapping accepts auth fields Airflow does not
+// describe — Snowflake's key-pair passphrase, BigQuery's keyless `method`
+// selector, and Databricks' OAuth-M2M service-principal fields. Without a
+// labeled form field a user must hand-type these into the raw `extra` JSON box
+// (#587 follow-up). The overlay adds them; this asserts they surface AND that
+// the generated fields are preserved (overlay augments, never replaces).
+func TestDBTAuthOverlayMergesLeoflowFields(t *testing.T) {
+	// Snowflake: the encrypted-key passphrase, added next to the generated
+	// private_key_content / private_key_file fields.
+	sf := mustConn(t, "snowflake")
+	if _, ok := sf.ExtraFields["private_key_passphrase"]; !ok {
+		t.Error("snowflake overlay must add private_key_passphrase")
+	}
+	for _, base := range []string{"account", "private_key_content", "private_key_file", "warehouse"} {
+		if _, ok := sf.ExtraFields[base]; !ok {
+			t.Errorf("overlay dropped the generated snowflake field %q", base)
+		}
+	}
+
+	// BigQuery (google_cloud_platform): the keyless auth selector.
+	gcp := mustConn(t, "google_cloud_platform")
+	if _, ok := gcp.ExtraFields["method"]; !ok {
+		t.Error("google_cloud_platform overlay must add the keyless `method` selector")
+	}
+	if _, ok := gcp.ExtraFields["keyfile_dict"]; !ok {
+		t.Error("overlay dropped the generated google_cloud_platform keyfile_dict field")
+	}
+
+	// Databricks: Airflow ships an empty form for it, so the overlay supplies
+	// the whole dbt-auth field set — including a labeled host + PAT.
+	db := mustConn(t, "databricks")
+	for _, k := range []string{"http_path", "client_id", "client_secret", "auth_type"} {
+		if _, ok := db.ExtraFields[k]; !ok {
+			t.Errorf("databricks overlay must add extra field %q", k)
+		}
+	}
+	if db.StandardFields["host"] == nil {
+		t.Error("databricks overlay must surface a labeled host (workspace URL) field")
+	}
+}
+
+// TestDBTAuthOverlayTargetsRealConnectors guards against a typo'd conn_type in
+// the overlay silently doing nothing: every overlay key must name a connector
+// that exists in the generated catalog.
+func TestDBTAuthOverlayTargetsRealConnectors(t *testing.T) {
+	known := map[string]bool{}
+	for _, c := range Catalog() {
+		known[c.ConnectionType] = true
+	}
+	for ct := range fieldOverlay {
+		if !known[ct] {
+			t.Errorf("overlay targets unknown connector %q (typo? provider not installed when catalog was generated?)", ct)
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to the rc.1 dbt cloud-auth work: the auth *code* shipped, but the fields were undiscoverable in the UI and the docs page a dbt user reads was stale. This closes both.

## The gap
The three modern service-account modes (Snowflake key-pair, BigQuery keyless, Databricks OAuth M2M) were reachable **only by hand-typing keys into the raw `extra` JSON box**, because the connection form catalog is generated from Airflow's provider introspection — which doesn't describe:
- leoflow-invented selectors: BigQuery's `method: oauth` (keyless),
- fields Airflow's form omits: Snowflake's `private_key_passphrase`,
- the entire Databricks form (Airflow ships it empty — no `http_path`, no fields at all).

## Fix — a leoflow overlay (the path we chose)
`internal/connectors/catalog.overlay.json` — hand-curated, leoflow-owned — is merged over the **generated** `catalog.json` at load in `catalog.go`, mirroring the existing `aliasOverlay` pattern. It adds labeled, help-texted fields:
- **Snowflake**: `private_key_passphrase`
- **BigQuery**: `method` (keyless selector, with help pointing at `oauth`)
- **Databricks**: `http_path`, `catalog`, `client_id`, `client_secret`, `auth_type`, plus a labeled workspace-URL host and access-token field.

The generated `catalog.json` is untouched (the "never hand-edit" rule holds) and the overlay survives regeneration. Airflow owns the base catalog; leoflow owns the auth semantics it introduced. No UI/API change — the form endpoint already serves `connectors.Catalog()` verbatim.

## Docs
`docs/dbt.md` §4 documented only legacy password/key-file auth. Now it has a per-warehouse auth table and links to the connection reference pages ([Snowflake](../docs/connections/snowflake.md) / [BigQuery](../docs/connections/google_cloud_platform.md) / [Databricks](../docs/connections/databricks.md)) that carry the full setup.

## Tests
- `TestDBTAuthOverlayMergesLeoflowFields` — asserts each mode's fields surface AND the generated fields are preserved (augment, never replace). Verified red before the overlay, green after.
- `TestDBTAuthOverlayTargetsRealConnectors` — guards a typo'd conn_type from silently no-op'ing.
- `golangci-lint` 0 issues; connectors + api + compile consumer tests green.

## Not in this PR
OpenAPI still documents no `/connections` endpoint or `extra` schema — filed separately.