### PR TITLE
release: prepare v0.3.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.0-rc.2] - 2026-08-13
+
+> Second RC of the **0.3.0** line — a fix-and-polish pass over `rc.1`. Repairs two
+> distribution bugs the `rc.1` soak surfaced (the **`leoflow-mcp`** binary is now
+> built and shipped in the release archives; a fresh **binary-only install** —
+> `leoflow compile` and `leoflow lite` — works without a repo or `PYTHONPATH`), and
+> closes the discoverability gap on the new dbt cloud auth: the **connection form
+> now surfaces** the Snowflake key-pair, BigQuery keyless, and Databricks OAuth M2M
+> fields, with matching docs. No functional change to the MCP server or the
+> control plane since `rc.1`. Docker-free gates green locally; full CI battery
+> gated the cut.
+
 ### Added
 
 - **The connection form now surfaces dbt cloud-auth fields with inline help.**

--- a/helm/leoflow/Chart.yaml
+++ b/helm/leoflow/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version is the chart version; appVersion tracks the leoflow-server image.
 # Both move in lockstep with the release tag (ADR 0028); decouple only if the
 # chart ever needs a cadence of its own for a template-only fix.
-version: 0.3.0-rc.1
-appVersion: "0.3.0-rc.1"
+version: 0.3.0-rc.2
+appVersion: "0.3.0-rc.2"
 home: https://github.com/neochaotic/leoflow
 sources:
   - https://github.com/neochaotic/leoflow

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -1,6 +1,6 @@
 # leoflow
 
-![Version: 0.3.0-rc.1](https://img.shields.io/badge/Version-0.3.0--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0-rc.1](https://img.shields.io/badge/AppVersion-0.3.0--rc.1-informational?style=flat-square)
+![Version: 0.3.0-rc.2](https://img.shields.io/badge/Version-0.3.0--rc.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0-rc.2](https://img.shields.io/badge/AppVersion-0.3.0--rc.2-informational?style=flat-square)
 
 Leoflow control plane — a GitOps-first, container-native workflow orchestrator (Airflow 3.2.x UI/API compatible).
 


### PR DESCRIPTION
Release-prep for **v0.3.0-rc.2** — a fix-and-polish RC over rc.1. No code here: CHANGELOG promotion + helm version bump only (the code shipped via #588/#589/#590, all merged green).

## What rc.2 contains (over rc.1)
- **#586** — GoReleaser now builds + ships the `leoflow-mcp` binary in the release archives.
- **#587** — fresh binary-only install works without a repo or `PYTHONPATH`: `leoflow compile` resolves the embedded parser, and `leoflow lite` extracts pysrc before building the venv. New de-masked `binary-only-install` CI gate.
- **#590** — the connection form now surfaces the dbt cloud-auth fields (Snowflake key-pair, BigQuery keyless, Databricks OAuth M2M) via a leoflow catalog overlay, with refreshed `docs/dbt.md`.

No functional change to the MCP server or control plane since rc.1.

## Prep (ADR 0028 lockstep)
- `CHANGELOG.md`: `[Unreleased]` → `[0.3.0-rc.2] - 2026-08-13` + summary; fresh empty Unreleased.
- `helm/leoflow/Chart.yaml`: `version` + `appVersion` → `0.3.0-rc.2`.
- `helm/leoflow/README.md`: regenerated by helm-docs (version badge only).

Once this is green I'll tag `v0.3.0-rc.2` on the merge commit, which triggers the GoReleaser release workflow.