### PR TITLE
fix: companion --version flags (#593) + Airflow-compat version for UI docs links (#594)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`leoflow-server`, `leoflow-agent`, and `leoflow-mcp` now answer `--version`.**
+  Previously only the main `leoflow` CLI could report its version; the companion
+  binaries responded to `--version`/`version` by trying to boot and erroring on
+  missing config or an unreachable control plane. They now print their build
+  version and exit 0 before any config load or network connect, so an operator
+  can identify a deployed binary. (#593)
+- **The UI's "Learn more" documentation links no longer 404.** `GET
+  /api/v2/version` (the Airflow VersionInfo endpoint the embedded SPA reads to
+  build `https://airflow.apache.org/docs/apache-airflow/<version>/…` links)
+  reported leoflow's build version, so the SPA pointed at a nonexistent Airflow
+  docs release. It now reports the pinned Airflow UI version. leoflow's own
+  version remains on the CLI, health endpoints, and the MCP
+  `health://control-plane` resource. (#594)
+
 ## [0.3.0-rc.2] - 2026-08-13
 
 > Second RC of the **0.3.0** line — a fix-and-polish pass over `rc.1`. Repairs two

--- a/cmd/leoflow-agent/main.go
+++ b/cmd/leoflow-agent/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -13,14 +14,19 @@ import (
 	"time"
 
 	"github.com/neochaotic/leoflow/internal/agent"
+	"github.com/neochaotic/leoflow/internal/version"
 )
-
-// version is overridden at build time via -ldflags.
-var version = "dev"
 
 func main() { os.Exit(run()) }
 
 func run() int {
+	// Answer `--version` before connecting, so an operator can ask a deployed
+	// agent its version without a reachable control plane (#593).
+	if version.WantsVersion(os.Args[1:]) {
+		fmt.Println(version.Get().String())
+		return 0
+	}
+
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
 
 	addr := os.Getenv("LEOFLOW_CONTROL_PLANE_ADDR")
@@ -65,7 +71,7 @@ func run() int {
 		Cmd:        agent.NewExecRunner(),
 		Sink:       sink,
 		Hostname:   hostname,
-		Version:    version,
+		Version:    version.Get().Version,
 		Env:        os.Environ(),
 		ReturnPath: returnPath,
 		// Operator extra-links share the return value's per-task temp dir (#375).

--- a/cmd/leoflow-mcp/main.go
+++ b/cmd/leoflow-mcp/main.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -19,15 +20,27 @@ import (
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/neochaotic/leoflow/internal/mcp"
+	versioninfo "github.com/neochaotic/leoflow/internal/version"
 	apiclient "github.com/neochaotic/leoflow/pkg/client"
 )
 
-// version is overridden at build time via -ldflags "-X main.version=...".
+// version is overridden at build time via -ldflags "-X main.version=...". This
+// binary carries its version in package main (not internal/version), so
+// -X main.version is the only injection that lands (see .goreleaser.yaml).
 var version = "dev"
 
 func main() { os.Exit(run()) }
 
 func run() int {
+	// Answer `--version` before parsing flags — flag.Parse would reject an
+	// unknown --version — and before any stdout goes to the MCP channel, so an
+	// operator can ask the binary its version (#593). Print main.version: this
+	// binary's own ldflag target.
+	if versioninfo.WantsVersion(os.Args[1:]) {
+		fmt.Println("leoflow-mcp", version)
+		return 0
+	}
+
 	// Logs go to stderr: on stdio, stdout is the MCP protocol channel and must
 	// carry nothing else.
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -38,12 +38,19 @@ import (
 	"github.com/neochaotic/leoflow/internal/secrets"
 	"github.com/neochaotic/leoflow/internal/storage"
 	"github.com/neochaotic/leoflow/internal/ui"
+	"github.com/neochaotic/leoflow/internal/version"
 	"github.com/neochaotic/leoflow/internal/workspace"
 	"github.com/neochaotic/leoflow/internal/xcom"
 	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
 )
 
 func main() {
+	// Answer `--version` before loading any config, so an operator can ask a
+	// deployed binary its version without a runnable environment (#593).
+	if version.WantsVersion(os.Args[1:]) {
+		fmt.Println(version.Get().String())
+		return
+	}
 	if err := run(); err != nil {
 		fmt.Fprintln(os.Stderr, "leoflow-server:", err)
 		os.Exit(1)

--- a/internal/api/ui_views.go
+++ b/internal/api/ui_views.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/ui"
 	"github.com/neochaotic/leoflow/internal/version"
 )
 
@@ -109,11 +110,17 @@ func synthRunID(runID string) uint32 {
 	return h.Sum32()
 }
 
-// versionHandler implements GET /api/v2/version (Airflow VersionInfo).
+// versionHandler implements GET /api/v2/version (Airflow VersionInfo). The
+// embedded SPA reads `version` to build its documentation links
+// (https://airflow.apache.org/docs/apache-airflow/<version>/…), so this MUST be
+// the pinned Airflow UI version, not leoflow's build version — otherwise the UI
+// points users at a nonexistent Airflow docs release (#594). leoflow's own
+// version is surfaced on the CLI (`leoflow version`), the health endpoints, and
+// the MCP `health://control-plane` resource. git_version keeps leoflow's commit
+// as a build reference for the control plane actually serving this compat UI.
 func versionHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		info := version.Get()
-		c.JSON(http.StatusOK, gin.H{"version": info.Version, "git_version": info.GitCommit})
+		c.JSON(http.StatusOK, gin.H{"version": ui.Version(), "git_version": version.Get().GitCommit})
 	}
 }
 

--- a/internal/api/ui_views_test.go
+++ b/internal/api/ui_views_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/neochaotic/leoflow/internal/auth"
 	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/ui"
+	"github.com/neochaotic/leoflow/internal/version"
 )
 
 func viewsServer(runs []domain.DagRun, user *auth.User) *gin.Engine {
@@ -39,6 +41,27 @@ func TestVersionEndpoint(t *testing.T) {
 	}
 	if _, ok := v["git_version"]; !ok {
 		t.Errorf("missing git_version field: %v", v)
+	}
+}
+
+// TestVersionEndpointReportsAirflowCompatVersion pins #594: /api/v2/version is
+// the Airflow VersionInfo endpoint the embedded SPA reads to build its docs
+// links (https://airflow.apache.org/docs/apache-airflow/<version>/…). It must
+// report the pinned Airflow UI version, NOT leoflow's build version — otherwise
+// the SPA points users at a nonexistent Airflow docs release (a 404). leoflow's
+// own version stays on the CLI, health, and MCP surfaces.
+func TestVersionEndpointReportsAirflowCompatVersion(t *testing.T) {
+	rec := authGet(viewsServer(nil, nil), http.MethodGet, "/api/v2/version", "")
+	var v map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &v); err != nil {
+		t.Fatal(err)
+	}
+	want := ui.Version() // the pinned Airflow tag (e.g. "3.2.1")
+	if got := v["version"]; got != want {
+		t.Errorf("version = %v, want the Airflow-compat version %q (so SPA docs links resolve)", got, want)
+	}
+	if v["version"] == version.Get().Version {
+		t.Errorf("version must not be leoflow's build version %q — it drives Airflow docs URLs", version.Get().Version)
 	}
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -38,3 +38,19 @@ func (i Info) String() string {
 	return fmt.Sprintf("leoflow %s (commit %s, built %s, %s)",
 		i.Version, i.GitCommit, i.BuildDate, i.GoVersion)
 }
+
+// WantsVersion reports whether args ask for the version (and nothing else runs).
+// It accepts `version`, `-version`, and `--version` so the long-running
+// companion binaries (leoflow-server / -agent / -mcp) can answer "what version
+// are you?" without a full runnable config — checked before any config load or
+// network connect. Kept deliberately narrow (no `-v`, which conventionally means
+// verbose) and exact (no substring match).
+func WantsVersion(args []string) bool {
+	for _, a := range args {
+		switch a {
+		case "version", "-version", "--version":
+			return true
+		}
+	}
+	return false
+}

--- a/internal/version/version_wants_test.go
+++ b/internal/version/version_wants_test.go
@@ -1,0 +1,27 @@
+package version
+
+import "testing"
+
+func TestWantsVersion(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"long flag", []string{"--version"}, true},
+		{"single-dash flag", []string{"-version"}, true},
+		{"bare subcommand", []string{"version"}, true},
+		{"amid other args", []string{"--transport", "stdio", "--version"}, true},
+		{"none", []string{"--transport", "stdio"}, false},
+		{"empty", nil, false},
+		{"not a version-looking flag", []string{"--verbose"}, false},
+		{"substring is not a match", []string{"versioning"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := WantsVersion(tc.args); got != tc.want {
+				t.Errorf("WantsVersion(%v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}

--- a/test/e2e/binary-only-install.sh
+++ b/test/e2e/binary-only-install.sh
@@ -50,4 +50,23 @@ echo "==> asserting the binary self-extracted parser + runtime sources"
   || fail "runtime sources not extracted — the Lite venv build would abort with 'does not exist'"
 pass "binary extracted both parser and runtime sources for a binary-only install"
 
+# The companion binaries must answer --version WITHOUT a runnable config (#593):
+# an operator has to be able to ask a deployed binary its version. server/agent
+# carry it in internal/version; leoflow-mcp in package main.
+echo "==> building companion binaries and asserting they report a version"
+( cd "$REPO" && go build \
+    -ldflags "-X github.com/neochaotic/leoflow/internal/version.version=e2e-ver -X main.version=e2e-ver" \
+    -o "$BINDIR/leoflow-server" ./cmd/leoflow-server )
+( cd "$REPO" && go build \
+    -ldflags "-X github.com/neochaotic/leoflow/internal/version.version=e2e-ver" \
+    -o "$BINDIR/leoflow-agent" ./cmd/leoflow-agent )
+( cd "$REPO" && go build -ldflags "-X main.version=e2e-ver" \
+    -o "$BINDIR/leoflow-mcp" ./cmd/leoflow-mcp )
+for b in leoflow-server leoflow-agent leoflow-mcp; do
+  out="$("$BINDIR/$b" --version 2>&1)" || fail "$b --version exited non-zero: $out"
+  printf '%s' "$out" | grep -q 'e2e-ver' \
+    || fail "$b --version did not report the injected version (got: $out)"
+done
+pass "leoflow-server/agent/mcp all answer --version and exit 0"
+
 echo "ALL PASS"


### PR DESCRIPTION
Closes #593. Closes #594.

Folds the two v0.3.0-rc.2 soak polish findings into the next patch.

## #593 — companion binaries now answer `--version`
`leoflow-server`, `leoflow-agent`, `leoflow-mcp` had no version affordance — `--version`/`version` made them try to boot and error on missing config / unreachable control plane. Added `version.WantsVersion(args)`, checked **before** any config load, connect, or `flag.Parse`:
- server + agent print `internal/version` (their ldflag target),
- `leoflow-mcp` prints `package main`'s `version` (its own `-X main.version` target — `internal/version` isn't injected into that binary, per #586).

## #594 — UI "Learn more" links no longer 404
`GET /api/v2/version` is the Airflow VersionInfo endpoint the embedded SPA reads to build `https://airflow.apache.org/docs/apache-airflow/<version>/…` links. It reported **leoflow's** build version, so every doc link pointed at a nonexistent Airflow release. It now returns the **pinned Airflow UI version** (`ui.Version()` → `3.2.1`); `git_version` keeps leoflow's commit. leoflow's own version stays on the CLI (`leoflow version`), health endpoints, and the MCP `health://control-plane` resource — consistent with the "serve the unmodified Airflow 3.2.1 UI" decision (ADR 0017).

## Tests (all red-before / green-after where applicable)
- `TestWantsVersion` — unit coverage of the arg predicate.
- `TestVersionEndpointReportsAirflowCompatVersion` — `/api/v2/version` must report the Airflow-compat version, not leoflow's build version.
- `binary-only-install.sh` e2e extended to build all three companions and assert each `--version` prints the injected version and exits 0.
- `golangci-lint` 0 issues; `gofmt` clean; touched packages green.

Verified locally: built binaries print `--version` / `version` / `-version` and exit 0.