### PR TITLE
fix(cli): leoflow-server and leoflow-agent answer --help (part of #593)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- **`leoflow-server`, `leoflow-agent`, and `leoflow-mcp` now answer `--version`.**
-  Previously only the main `leoflow` CLI could report its version; the companion
-  binaries responded to `--version`/`version` by trying to boot and erroring on
-  missing config or an unreachable control plane. They now print their build
-  version and exit 0 before any config load or network connect, so an operator
-  can identify a deployed binary. (#593)
+- **`leoflow-server`, `leoflow-agent`, and `leoflow-mcp` now answer `--version`
+  and `--help`.** Previously only the main `leoflow` CLI could report its
+  version, and the companion binaries responded to `--version`/`--help` by
+  trying to boot and erroring on missing config or an unreachable control plane.
+  They now print their build version (`--version`) or a usage message
+  (`--help`) and exit 0 before any config load or network connect, so an
+  operator can identify and inspect a deployed binary. (#593)
 - **The UI's "Learn more" documentation links no longer 404.** `GET
   /api/v2/version` (the Airflow VersionInfo endpoint the embedded SPA reads to
   build `https://airflow.apache.org/docs/apache-airflow/<version>/…` links)

--- a/cmd/leoflow-agent/main.go
+++ b/cmd/leoflow-agent/main.go
@@ -17,13 +17,33 @@ import (
 	"github.com/neochaotic/leoflow/internal/version"
 )
 
+// usage is printed for `--help`. leoflow-agent takes no positional args; it is
+// configured via environment and normally launched by the control plane.
+const usage = `leoflow-agent — runs as PID 1 inside a task pod: connects to the control plane
+over gRPC, runs the task, streams logs, and reports the result.
+
+Configured via environment (LEOFLOW_CONTROL_PLANE_ADDR, LEOFLOW_AGENT_TOKEN, …);
+there are no positional arguments. Normally launched by the control plane, not
+by hand.
+
+Flags:
+  --version   print version and exit
+  --help, -h  print this help and exit
+`
+
 func main() { os.Exit(run()) }
 
 func run() int {
-	// Answer `--version` before connecting, so an operator can ask a deployed
-	// agent its version without a reachable control plane (#593).
-	if version.WantsVersion(os.Args[1:]) {
+	// Answer `--version`/`--help` before connecting, so an operator can query a
+	// deployed agent without a reachable control plane (#593). Without this,
+	// `--help` falls through to a Dial that errors on a missing address.
+	args := os.Args[1:]
+	switch {
+	case version.WantsVersion(args):
 		fmt.Println(version.Get().String())
+		return 0
+	case version.WantsHelp(args):
+		fmt.Print(usage)
 		return 0
 	}
 

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -44,11 +44,30 @@ import (
 	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
 )
 
+// usage is printed for `--help`. leoflow-server takes no positional args; it is
+// configured entirely via environment and an optional LEOFLOW_CONFIG file.
+const usage = `leoflow-server — the Leoflow control plane (HTTP API, auth, metrics, scheduler).
+
+Configured via environment variables and an optional config file (LEOFLOW_CONFIG);
+there are no positional arguments. See docs/configuration.md.
+
+Flags:
+  --version   print version and exit
+  --help, -h  print this help and exit
+`
+
 func main() {
-	// Answer `--version` before loading any config, so an operator can ask a
-	// deployed binary its version without a runnable environment (#593).
-	if version.WantsVersion(os.Args[1:]) {
+	// Answer `--version`/`--help` before loading any config, so an operator can
+	// query a deployed binary without a runnable environment (#593). Without
+	// this, `--help` falls through to a boot attempt that errors on missing
+	// config.
+	args := os.Args[1:]
+	switch {
+	case version.WantsVersion(args):
 		fmt.Println(version.Get().String())
+		return
+	case version.WantsHelp(args):
+		fmt.Print(usage)
 		return
 	}
 	if err := run(); err != nil {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -54,3 +54,18 @@ func WantsVersion(args []string) bool {
 	}
 	return false
 }
+
+// WantsHelp reports whether args ask for usage help. Like WantsVersion, it lets
+// the config-less companion daemons (leoflow-server / -agent) answer `--help`
+// with a usage message and exit 0, instead of falling through to a boot attempt
+// that errors on missing config. Accepts the conventional `-h`, `-help`, and
+// `--help`; exact match, no substring.
+func WantsHelp(args []string) bool {
+	for _, a := range args {
+		switch a {
+		case "-h", "-help", "--help":
+			return true
+		}
+	}
+	return false
+}

--- a/internal/version/version_wants_test.go
+++ b/internal/version/version_wants_test.go
@@ -25,3 +25,26 @@ func TestWantsVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestWantsHelp(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"long flag", []string{"--help"}, true},
+		{"short flag", []string{"-h"}, true},
+		{"single-dash long", []string{"-help"}, true},
+		{"amid other args", []string{"--transport", "stdio", "--help"}, true},
+		{"none", []string{"--transport", "stdio"}, false},
+		{"empty", nil, false},
+		{"not a help flag", []string{"--host"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := WantsHelp(tc.args); got != tc.want {
+				t.Errorf("WantsHelp(%v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}

--- a/test/e2e/binary-only-install.sh
+++ b/test/e2e/binary-only-install.sh
@@ -69,4 +69,16 @@ for b in leoflow-server leoflow-agent leoflow-mcp; do
 done
 pass "leoflow-server/agent/mcp all answer --version and exit 0"
 
+# --help must print usage and exit 0 WITHOUT trying to boot (#593). Guard against
+# the regression where --help fell through to a config load / connect that errored.
+echo "==> asserting --help prints usage and exits 0 (no boot attempt)"
+for b in leoflow-server leoflow-agent leoflow-mcp; do
+  out="$("$BINDIR/$b" --help 2>&1)" || fail "$b --help exited non-zero: $out"
+  printf '%s' "$out" | grep -qiE 'usage|flags|leoflow-' \
+    || fail "$b --help did not print usage (got: $out)"
+  printf '%s' "$out" | grep -qiE 'required|connecting to control plane|jwt.secret' \
+    && fail "$b --help attempted to boot instead of printing help (got: $out)"
+done
+pass "leoflow-server/agent/mcp all print --help usage and exit 0"
+
 echo "ALL PASS"


### PR DESCRIPTION
Completes the `--help` half of #593 (the `--version` half shipped in #595).

Refs #593 — **deliberately not** `Closes` it: per our new convention, bug issues stay open until the fix is in a **published release**, not merely merged to `main`. I'll close #593 when it ships in the next tag.

## What was still broken
`leoflow-server --help` / `leoflow-agent --help` fell through to a boot attempt and errored on missing config / unreachable control plane (exit 1, no usage). (`leoflow-mcp --help` already prints usage via the flag package — no change needed.)

## Fix
- Add `version.WantsHelp(args)` (accepts `-h`, `-help`, `--help`), sibling to `WantsVersion`.
- `leoflow-server` (main) and `leoflow-agent` (run) now print a usage message and exit 0 on `--help`, **before** any config load or connect — same short-circuit as `--version`.
- Genuine boot errors still exit 1 (verified); `--help`/`--version` exit 0.

## Tests
- `TestWantsHelp` unit coverage.
- `binary-only-install.sh` e2e extended: asserts each companion's `--help` prints usage, exits 0, and does **not** attempt to boot.
- `golangci-lint` 0 issues; `gofmt` clean; version + cmd packages green.