### PR TITLE
release: prepare v0.3.0-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.0-rc.3] - 2026-08-13
+
+> Third RC of the **0.3.0** line — operability polish surfaced by the `rc.2`
+> soak. The companion binaries (`leoflow-server`/`-agent`/`-mcp`) now answer
+> `--version` and `--help` without a runnable config, and the embedded UI's
+> documentation links resolve (the Airflow VersionInfo endpoint reports the
+> pinned Airflow UI version, not leoflow's build version). No control-plane,
+> MCP, or dbt functional change since `rc.2`. Docker-free gates green locally;
+> full CI battery gated the cut.
+
 ### Fixed
 
 - **`leoflow-server`, `leoflow-agent`, and `leoflow-mcp` now answer `--version`

--- a/helm/leoflow/Chart.yaml
+++ b/helm/leoflow/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version is the chart version; appVersion tracks the leoflow-server image.
 # Both move in lockstep with the release tag (ADR 0028); decouple only if the
 # chart ever needs a cadence of its own for a template-only fix.
-version: 0.3.0-rc.2
-appVersion: "0.3.0-rc.2"
+version: 0.3.0-rc.3
+appVersion: "0.3.0-rc.3"
 home: https://github.com/neochaotic/leoflow
 sources:
   - https://github.com/neochaotic/leoflow

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -1,6 +1,6 @@
 # leoflow
 
-![Version: 0.3.0-rc.2](https://img.shields.io/badge/Version-0.3.0--rc.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0-rc.2](https://img.shields.io/badge/AppVersion-0.3.0--rc.2-informational?style=flat-square)
+![Version: 0.3.0-rc.3](https://img.shields.io/badge/Version-0.3.0--rc.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0-rc.3](https://img.shields.io/badge/AppVersion-0.3.0--rc.3-informational?style=flat-square)
 
 Leoflow control plane — a GitOps-first, container-native workflow orchestrator (Airflow 3.2.x UI/API compatible).
 


### PR DESCRIPTION
Release-prep for **v0.3.0-rc.3** — operability polish over rc.2. No code here: CHANGELOG promotion + helm version bump only (the fixes shipped via #595/#596, both merged green).

## What rc.3 contains (over rc.2)
- **#593** — `leoflow-server`/`-agent`/`-mcp` answer `--version` and `--help` without a runnable config (before: they booted and errored).
- **#594** — the embedded UI's "Learn more" / Docs links resolve: `/api/v2/version` reports the pinned Airflow UI version (so `apache-airflow/<version>/…` is valid), not leoflow's build version.

No control-plane, MCP, or dbt functional change since rc.2.

## Prep (ADR 0028 lockstep)
- `CHANGELOG.md`: `[Unreleased]` → `[0.3.0-rc.3] - 2026-08-13` + summary; fresh empty Unreleased.
- `helm/leoflow/Chart.yaml`: `version` + `appVersion` → `0.3.0-rc.3`.
- `helm/leoflow/README.md`: regenerated by helm-docs (version badge only).

Once green I'll tag `v0.3.0-rc.3` on the merge commit (triggers GoReleaser), then close #593 and #594 citing the release.