### PR TITLE
fix(cli): accept --version flag on the root leoflow command (#598)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`leoflow --version` (flag) now works, matching the `version` subcommand and
+  the companion binaries.** Previously the root CLI accepted only `leoflow
+  version`; `leoflow --version` errored with `unknown flag`. The flag now prints
+  the same build info and exits 0. (#598)
+
 ## [0.3.0-rc.3] - 2026-08-13
 
 > Third RC of the **0.3.0** line — operability polish surfaced by the `rc.2`

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -36,6 +36,26 @@ func TestVersionCommandPrintsInfo(t *testing.T) {
 	}
 }
 
+// TestVersionFlagMatchesSubcommand pins #598: `leoflow --version` (flag) must
+// work and print exactly what `leoflow version` (subcommand) prints — the
+// companion binaries accept the --version flag, so the root CLI must too.
+func TestVersionFlagMatchesSubcommand(t *testing.T) {
+	flagOut, _, err := run(t, "--version")
+	if err != nil {
+		t.Fatalf("`leoflow --version` should be accepted, got error: %v", err)
+	}
+	subOut, _, err := run(t, "version")
+	if err != nil {
+		t.Fatalf("version subcommand: %v", err)
+	}
+	if strings.TrimSpace(flagOut) != strings.TrimSpace(subOut) {
+		t.Errorf("--version = %q, want identical to `version` subcommand = %q", flagOut, subOut)
+	}
+	if !strings.Contains(flagOut, "leoflow") {
+		t.Errorf("--version output missing 'leoflow': %q", flagOut)
+	}
+}
+
 func TestVersionCommandJSON(t *testing.T) {
 	out, _, err := run(t, "version", "--json")
 	if err != nil {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -6,6 +6,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
+	"github.com/neochaotic/leoflow/internal/version"
 )
 
 // NewRootCommand builds the root leoflow command with its global flags and
@@ -16,7 +18,13 @@ func NewRootCommand() *cobra.Command {
 		Short:         "Leoflow is a GitOps-first, container-native workflow orchestrator.",
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		// Setting Version makes cobra accept the `--version` flag, matching the
+		// companion binaries (#598). The template prints exactly what the
+		// `version` subcommand does (info.String()), so the flag and the
+		// subcommand are interchangeable.
+		Version: version.Get().String(),
 	}
+	root.SetVersionTemplate("{{.Version}}\n")
 	root.PersistentFlags().String("config", "", "config file path (default ~/.leoflow/config.yaml)")
 	root.PersistentFlags().String("log-level", "", "log level: debug, info, warn, error")
 	root.PersistentFlags().String("server-url", "", "control plane API base URL")


### PR DESCRIPTION
Refs #598 — **not** `Closes` (close-on-release convention).

The companion binaries answer `--version` (rc.3), but `leoflow --version` still errored `unknown flag` — only `leoflow version` (subcommand) worked. Set the cobra root `Version` (from `internal/version`) plus a template that prints exactly what the subcommand prints, so `--version` and `version` are interchangeable.

## Verified
- `TestVersionFlagMatchesSubcommand` — `leoflow --version` succeeds and its output equals `leoflow version`. Red before, green after.
- Built binary: `leoflow --version` == `leoflow version`, both exit 0.
- `golangci-lint` 0 issues; `gofmt` clean; full `internal/cli` package green.