### PR TITLE
release: prepare v0.3.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.0-rc.4] - 2026-08-13
+
+> Fourth RC of the **0.3.0** line — a one-line CLI consistency fix over `rc.3`:
+> `leoflow --version` (flag) now works, matching the `version` subcommand and the
+> companion binaries. No control-plane, MCP, dbt, or UI change since `rc.3`.
+
 ### Fixed
 
 - **`leoflow --version` (flag) now works, matching the `version` subcommand and

--- a/helm/leoflow/Chart.yaml
+++ b/helm/leoflow/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version is the chart version; appVersion tracks the leoflow-server image.
 # Both move in lockstep with the release tag (ADR 0028); decouple only if the
 # chart ever needs a cadence of its own for a template-only fix.
-version: 0.3.0-rc.3
-appVersion: "0.3.0-rc.3"
+version: 0.3.0-rc.4
+appVersion: "0.3.0-rc.4"
 home: https://github.com/neochaotic/leoflow
 sources:
   - https://github.com/neochaotic/leoflow

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -1,6 +1,6 @@
 # leoflow
 
-![Version: 0.3.0-rc.3](https://img.shields.io/badge/Version-0.3.0--rc.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0-rc.3](https://img.shields.io/badge/AppVersion-0.3.0--rc.3-informational?style=flat-square)
+![Version: 0.3.0-rc.4](https://img.shields.io/badge/Version-0.3.0--rc.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0-rc.4](https://img.shields.io/badge/AppVersion-0.3.0--rc.4-informational?style=flat-square)
 
 Leoflow control plane — a GitOps-first, container-native workflow orchestrator (Airflow 3.2.x UI/API compatible).
 


### PR DESCRIPTION
Release-prep for **v0.3.0-rc.4** — a one-line CLI consistency fix over rc.3 (`leoflow --version` flag, #598, merged via #599). No code here: CHANGELOG promotion + helm version bump only.

## Prep (ADR 0028 lockstep)
- `CHANGELOG.md`: `[Unreleased]` → `[0.3.0-rc.4] - 2026-08-13` + summary; fresh empty Unreleased.
- `helm/leoflow/Chart.yaml`: `version` + `appVersion` → `0.3.0-rc.4`.
- `helm/leoflow/README.md`: regenerated by helm-docs (version badge only).

Once green I tag `v0.3.0-rc.4` (triggers GoReleaser), then close #598 citing the release.