### PR TITLE
docs: fix front-door for the v0.3.0 line (#601, #602, #603)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Documentation
+
+- **Front-door docs fixed for the v0.3.0 line.** The README's flagship example
+  imported `from leoflow import DAG, task` (which does not parse — the shim only
+  exports `dbt_group`); it now uses `from airflow.sdk import DAG, task`. Broken
+  README links to `docs/api-reference.md` and `docs/helm-chart.md` now point to
+  the published API reference and `helm/leoflow/README.md`. Install commands no
+  longer pin the removed `v0.0.1*`/pre-alpha tags. Pro's readiness is now stated
+  consistently across the README, index, quickstart, editions, and operating-modes
+  pages ("Helm-installable and in active validation"), and the Status section
+  reflects v0.3.0 (dbt, `leoflow-mcp`, `pkg/client`). (#601, #602, #603)
+
 ## [0.3.0-rc.4] - 2026-08-13
 
 > Fourth RC of the **0.3.0** line — a one-line CLI consistency fix over `rc.3`:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 | [**Map-reduce for ML**](docs/cookbook/map-reduce.md) | fan-out + reduce as a Python list comprehension |
 | [CI/CD & deploy examples](docs/deploy.md) | GitHub Actions · GitLab · Cloud Build/Run · generic |
 | [Helm chart](helm/leoflow/README.md) | Pro install: values reference, hardening, PoC recipe |
-| [HTTP API (Scalar)](docs/api-reference.md) · [Go packages](docs/go-api.md) | API references |
+| [HTTP API (Scalar)](https://neochaotic.github.io/leoflow/api-reference.html) · [Go packages](docs/go-api.md) | API references |
 | [Concepts & glossary](docs/concepts.md) · [Architecture](docs/architecture.md) | the model & the *why* |
 
 ---
@@ -71,8 +71,8 @@ coexist out of the box.
 helm repo add leoflow https://neochaotic.github.io/leoflow   # (charts published per release)
 kubectl create namespace leoflow
 helm install lf leoflow/leoflow -n leoflow \
-  --set image.tag=v0.0.1 \
-  --set migrations.image.tag=v0.0.1 \
+  --set image.tag=v0.3.0 \
+  --set migrations.image.tag=v0.3.0 \
   --set database.url='postgres://USER:PASS@HOST:5432/leoflow?sslmode=verify-full' \
   --set redis.url='rediss://HOST:6380/0' \
   --set auth.jwtSecret="$(openssl rand -base64 64)" \
@@ -86,7 +86,7 @@ Postgres 13+ and Redis 6+ are required (the chart fails the install otherwise �
 embedded datastores are Lite-only). Managed datastores work out of the box
 (Cloud SQL / RDS / Memorystore / ElastiCache / Azure Cache), with optional
 `caConfigMap` knobs for verified TLS. See the
-**[chart docs](docs/helm-chart.md)**.
+**[chart docs](helm/leoflow/README.md)**.
 
 Full guide for both tracks → **[Installation](docs/installation.md)**.
 
@@ -145,7 +145,7 @@ dependencies:
 
 ```python
 # dag.py
-from leoflow import DAG, task
+from airflow.sdk import DAG, task
 
 @task
 def fetch():
@@ -255,28 +255,30 @@ in its own pod like any other (ADR 0040). Read
 ## Status
 
 🧪 **Experimental — pre-1.0.** The HTTP API (`/api/v2`), CLI, and Helm chart
-values may change between minor versions until **v1.0.0** locks them. Production
-Pro deployments are supported by the Helm chart today, with the usual caveats
-that come with a pre-1.0 codebase: pin to a specific tag, read the
+values may change between minor versions until **v1.0.0** locks them. **Lite**
+(single host) is the recommended way to run Leoflow today. **Pro** (Kubernetes)
+is Helm-installable and in **active validation** — tested against GKE, not yet
+certified for production; pin to a specific tag, read the
 [upgrades guide](docs/upgrades.md) before bumping, and exercise
 [backup/restore](docs/backup-restore.md) before you need to.
 
 Versioning follows [ADR 0037](docs/adr/0037-release-version-scheme.md):
-`v0.0.1` ends the pre-alpha series; every release after is
-`vX.Y.Z-rc.N → vX.Y.Z`.
+`vX.Y.Z-rc.N → vX.Y.Z`, no separate alpha/beta.
 
-**Implemented today (Phases 1–4):**
+**Implemented today:**
 
 - **CLI + parser** — `leoflow init / validate / compile / push / runs trigger / runs status / auth create-token`; the Python DAG parser; `compile --build / --push` builds and pushes the DAG image (out-of-process).
 - **Control plane** — Airflow-compatible `/api/v2` API, JWT auth + RBAC + multi-tenant, the scheduler state machine with cron scheduling, Postgres advisory-lock leader election, **task retries**, embedded Scalar API docs, and Prometheus + OpenTelemetry observability.
 - **Execution** — real pod-per-task execution via the `leoflow-agent` over gRPC (Kubernetes, ADR 0015); orphaned-pod reconciliation and completed-pod garbage collection.
 - **Data flow** — XCom on Redis (256 KB limit, TTL, optional schema validation) passed between tasks; log shipping to disk with a read API and live tailing over Redis pub/sub.
+- **dbt** — a dbt project runs as a DAG (pod-per-model or fused groups); managed warehouse connections generate `profiles.yml` in-pod, with modern service-account auth (Snowflake key-pair, BigQuery keyless / Workload Identity, Databricks OAuth M2M).
+- **MCP + typed client** — an experimental [`leoflow-mcp`](docs/adr/0050-mcp-server.md) Model Context Protocol server (read tools + resources over stdio / Streamable HTTP) and a generated, typed Go client for `/api/v2` (`pkg/client`).
 
-**Not yet implemented:** load tests (Phase 6) and S3/GCS log sinks. Tracked refinements live in the [issue tracker](https://github.com/neochaotic/leoflow/issues).
+**Not yet implemented:** load tests and S3/GCS log sinks. Tracked refinements live in the [issue tracker](https://github.com/neochaotic/leoflow/issues).
 
-## Features in the MVP
+## Features
 
-**Shipping in v0.1.0:**
+- Python, Bash, and HTTP API operators
 
 - Python, Bash, and HTTP API operators
 - DAG-as-Image model with automatic image build via `leoflow.yaml`
@@ -370,7 +372,7 @@ We borrow from Argo Workflows (container-native), from Prefect (modern developer
 
 - [Architecture overview](docs/architecture.md)
 - [Architecture Decision Records](docs/adr/) — every major decision, with its reasoning
-- [HTTP API reference (Scalar)](docs/api-reference.md) — also rendered interactively at `/docs` in the running server
+- [HTTP API reference (Scalar)](https://neochaotic.github.io/leoflow/api-reference.html) — also rendered interactively at `/docs` in the running server
 - [DAG authoring](docs/dag-authoring.md) — writing your first DAG, the Lite → deploy lifecycle
 - [Quickstart](docs/quickstart.md) and [Installation](docs/installation.md) — getting Leoflow running locally
 - [Map-reduce for ML](docs/cookbook/map-reduce.md) · [Variables & Connections](docs/variables-connections.md) · [Troubleshooting](docs/troubleshooting.md)

--- a/docs/editions.md
+++ b/docs/editions.md
@@ -23,7 +23,7 @@ DAG once and it runs on either.
 
 | | **Lite** | **Pro** |
 |---|---|---|
-| Status | **Supported** — single host | **Supported** — Helm on Kubernetes |
+| Status | **Supported** — single host | **In validation** — Helm on Kubernetes (tested against GKE; pin a tag) |
 | Install | one command (`curl … \| sh`) on one machine | [Helm chart](https://github.com/neochaotic/leoflow/blob/main/helm/leoflow/README.md) on your cluster |
 | Command | `leoflow lite` | the deployed control plane |
 | Auth | a single local **admin** login (password shown once at setup) | enterprise: SSO/OIDC, full RBAC, multi-tenant |

--- a/docs/index.md
+++ b/docs/index.md
@@ -134,6 +134,7 @@ leoflow init dags/my_dag     # scaffold a project
 leoflow lite dags/my_dag      # hot-reload at http://localhost:8088 (Lite edition)
 ```
 
-**Lite** ships today (pre-alpha, local on a trusted network); **Pro**
-(the Kubernetes edition) is a near-term goal — see the
+**Lite** is the recommended way to run Leoflow today (single host, on a trusted
+network); **Pro** (the Kubernetes edition) is Helm-installable and in active
+validation — see the
 [roadmap](roadmap-to-release.md) and [Editions](editions.md) for the split.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -145,7 +145,7 @@ leoflow doctor
 
 | Variable | Effect |
 |---|---|
-| `LEOFLOW_VERSION=v0.0.1-prealpha.1` | install a specific release (default: newest, including pre-releases) |
+| `LEOFLOW_VERSION=v0.3.0` | install a specific release (default: newest, including pre-releases). See [Releases](https://github.com/neochaotic/leoflow/releases) for the current tag. |
 | `LEOFLOW_NO_SETUP=1` | install binaries only; run `leoflow setup` yourself later |
 | `LEOFLOW_INSTALL_DIR=~/.leoflow/bin` | where to put the binaries |
 
@@ -219,18 +219,18 @@ respectively) for verified TLS.
 ### Install with Helm
 
 The chart is published per release (and built from `helm/leoflow` in the
-repo). For pre-alpha cadence, the simplest path is to install directly from
-the cloned repo at a checked-out tag:
+repo). One simple path is to install directly from the cloned repo at a
+checked-out tag (replace `v0.3.0` with the [latest release](https://github.com/neochaotic/leoflow/releases)):
 
 ```bash
-git clone --depth 1 --branch v0.0.1-prealpha.27 https://github.com/neochaotic/leoflow
+git clone --depth 1 --branch v0.3.0 https://github.com/neochaotic/leoflow
 cd leoflow
 
 kubectl create namespace leoflow
 
 helm install lf ./helm/leoflow -n leoflow \
-  --set image.tag=v0.0.1-prealpha.27 \
-  --set migrations.image.tag=v0.0.1-prealpha.27 \
+  --set image.tag=v0.3.0 \
+  --set migrations.image.tag=v0.3.0 \
   --set database.url='postgres://USER:PASS@HOST:5432/leoflow?sslmode=verify-full' \
   --set redis.url='rediss://HOST:6380/0' \
   --set auth.jwtSecret="$(openssl rand -base64 64)" \
@@ -289,7 +289,7 @@ plus `leoflow` and `leoflow-agent` binaries) are published by
 
 ```bash
 # Verify the server image at a release tag.
-cosign verify ghcr.io/neochaotic/leoflow-server:v0.0.1-prealpha.27 \
+cosign verify ghcr.io/neochaotic/leoflow-server:v0.3.0 \
   --certificate-identity-regexp 'https://github.com/neochaotic/leoflow' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```

--- a/docs/operating-modes.md
+++ b/docs/operating-modes.md
@@ -2,8 +2,8 @@
 
 Leoflow has three runtime modes. The two user-facing ones are **Lite** (the full control plane on one host — laptop, VM, or internal server) and **Pro** (Helm-installed Kubernetes); **Demo** is a
 contributor-facing reference environment used to validate UI compatibility
-against the production-shaped control plane. **Lite ships today** (pre-alpha,
-trusted networks only); Pro is in active validation — the Helm chart is
+against the production-shaped control plane. **Lite is the recommended way to
+run Leoflow today** (trusted networks only); Pro is in active validation — the Helm chart is
 installable + chart-test gated and is being tested against GKE today, but not
 blessed for official use until the v0.1.0-alpha cut.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -94,4 +94,4 @@ leoflow uninstall                    # remove the install (--purge for workspace
 - [DAG authoring](dag-authoring.md) — the dialect, `leoflow.yaml`, overrides.
 - [The `leoflow lite` workflow](dev-workflow.md) — the edit→reload loop, executors.
 - [CI/CD & deploy examples](deploy.md) — ship it.
-- [Editions](editions.md) — Lite (now) vs Pro (coming).
+- [Editions](editions.md) — Lite (now) vs Pro (in validation).


### PR DESCRIPTION
Front-door doc fixes ahead of promoting v0.3.0 stable. Closes #601, closes #603, refs #602.

## #601 — broken flagship example + links (verified)
- README example imported `from leoflow import DAG, task` → **does not parse** (the parser shim only exports `dbt_group`). Now `from airflow.sdk import DAG, task`.
- `docs/api-reference.md` → `https://neochaotic.github.io/leoflow/api-reference.html` (verified **200**).
- `docs/helm-chart.md` → `helm/leoflow/README.md` (exists in-repo; the `docs/` copy only exists post-CI).

## #603 — stale versions + Status
- Removed `v0.0.1`/`v0.0.1-prealpha.*` pins from README + `installation.md` install/clone/cosign commands; point at the releases page.
- Refreshed README Status for v0.3.0 (dbt cloud auth, `leoflow-mcp`, `pkg/client`); dropped stale "Phases 1–4 / Shipping in v0.1.0" framing; purged residual "pre-alpha".

## #602 — Pro readiness unified (refs)
Replaced 4 contradictory statements ("supported today" / "near-term goal" / "coming" / "Supported") with one consistent line — **"Helm-installable and in active validation (tested against GKE; pin a tag)"** — across README, index, quickstart, editions, operating-modes. (Left `refs` in case any residual `editions.md` phrasing wants a follow pass.)

## Verified
- All README relative links resolve; new API-ref URL returns 200; no `v0.0.1*` literals remain in install docs.
- `mkdocs --strict` (docs CI) gates internal links.