### PR TITLE
release: promote v0.3.0-rc.4 to v0.3.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-13
+
+> Promotes the **0.3.0** release line (`v0.3.0-rc.1` → `v0.3.0-rc.4`) to stable.
+> The candidate was validated end-to-end on the published artifact: checksum +
+> cosign signature verification, a binary-only install (managed Postgres, no repo
+> or `PYTHONPATH`), the full UI journey (trigger, failure-path traceback,
+> connection CRUD with encryption verified at the database), the `leoflow-mcp`
+> server over stdio, and a dbt-duckdb run. See the `0.3.0-rc.1` … `0.3.0-rc.4`
+> sections below for the full change list. The only change since `rc.4` is the
+> front-door documentation fix below.
+
 ### Documentation
 
 - **Front-door docs fixed for the v0.3.0 line.** The README's flagship example
@@ -893,7 +904,8 @@ Per-rc detail is in the `0.1.0-rc.1` … `0.1.0-rc.4` sections below.
 - Browser end-to-end verification (rendering, write-flow paths, screenshots) is
   the remaining Phase 5 acceptance step; see `docs/ui-compatibility.md`.
 
-[Unreleased]: https://github.com/neochaotic/leoflow/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/neochaotic/leoflow/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/neochaotic/leoflow/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/neochaotic/leoflow/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/neochaotic/leoflow/compare/v0.1.2-rc.2...v0.1.2
 [0.1.2-rc.2]: https://github.com/neochaotic/leoflow/compare/v0.1.2-rc.1...v0.1.2-rc.2

--- a/helm/leoflow/Chart.yaml
+++ b/helm/leoflow/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version is the chart version; appVersion tracks the leoflow-server image.
 # Both move in lockstep with the release tag (ADR 0028); decouple only if the
 # chart ever needs a cadence of its own for a template-only fix.
-version: 0.3.0-rc.4
-appVersion: "0.3.0-rc.4"
+version: 0.3.0
+appVersion: "0.3.0"
 home: https://github.com/neochaotic/leoflow
 sources:
   - https://github.com/neochaotic/leoflow

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -1,6 +1,6 @@
 # leoflow
 
-![Version: 0.3.0-rc.4](https://img.shields.io/badge/Version-0.3.0--rc.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0-rc.4](https://img.shields.io/badge/AppVersion-0.3.0--rc.4-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
 
 Leoflow control plane — a GitOps-first, container-native workflow orchestrator (Airflow 3.2.x UI/API compatible).
 


### PR DESCRIPTION
Promotes the **0.3.0** RC line (rc.1 → rc.4) to **stable**. No code here: CHANGELOG `[0.3.0]` section + helm version bump only. The release artifact is byte-for-byte the rc.4 artifact (the only repo delta since rc.4 was the front-door docs fix in #608, which doesn't enter any binary).

## Why stable now (not rc.5)
The fixes since rc.4 are docs-only — they don't touch the binaries, chart behavior, or images that rc.4 validated. RCs validate the artifact; rc.4's artifact was soaked rigorously (cosign verify, binary-only install, failure-path UX, MCP, dbt, connection encryption verified at the DB). Same pattern as the v0.2.0 promotion.

## Prep (ADR 0028 lockstep)
- `CHANGELOG.md`: new `## [0.3.0]` section (references the rc sections; carries the docs delta); `[Unreleased]` emptied; compare-links updated.
- `helm/leoflow/Chart.yaml`: `version` + `appVersion` → `0.3.0`.
- `helm/leoflow/README.md`: regenerated by helm-docs.

Once green I tag `v0.3.0` (triggers GoReleaser → the stable release).