### PR TITLE
feat(mcp): make search_logs task_id optional for run-wide search (#607)

### DIFF
--- a/internal/mcp/e2e_test.go
+++ b/internal/mcp/e2e_test.go
@@ -41,6 +41,10 @@ func seededControlPlane(t *testing.T) *httptest.Server {
 			_, _ = w.Write([]byte(`{"task_instances":[` +
 				`{"task_id":"extract","state":"success","try_number":1},` +
 				`{"task_id":"load","state":"failed","try_number":2,"duration":3.5}],"total_entries":2}`))
+		case "/api/v2/dags/etl/dagRuns/r1/taskInstances/extract/logs/1":
+			// A clean log for the successful task; a run-wide search must scan it
+			// too, but it carries no "boom".
+			_, _ = w.Write([]byte("extract connecting\nextract done\n"))
 		case "/api/v2/dags/etl/dagRuns/r1/taskInstances/load/logs/2":
 			_, _ = w.Write([]byte("connecting\nValueError: boom in load\ndone\n"))
 		case "/api/v2/dags/etl/spec":
@@ -166,10 +170,30 @@ func TestMCPBinaryEndToEnd(t *testing.T) {
 	for _, want := range []string{
 		`"run_state":"failed"`, `"task_id":"load"`, "ValueError: boom in load",
 		"load_a", "load_b", // dbt models parsed from the fused --select
-		"report",           // downstream task blocked by load's failure
+		"report", // downstream task blocked by load's failure
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("diagnose_run output missing %q; got: %s", want, got)
+		}
+	}
+
+	// search_logs run-wide — omit task_id so the binary enumerates the run's
+	// task instances and searches every task's log, tagging each match with its
+	// task_id. Only "load" carries the boom, so the match must be tagged load.
+	sr, err := sess.CallTool(ctx, &mcpsdk.CallToolParams{
+		Name:      "search_logs",
+		Arguments: map[string]any{"dag_id": "etl", "run_id": "r1", "query": "boom"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool search_logs (run-wide): %v", err)
+	}
+	if sr.IsError {
+		t.Fatalf("search_logs run-wide returned an error result: %s", textOf(sr.Content))
+	}
+	sgot := textOf(sr.Content)
+	for _, want := range []string{`"task_id":"load"`, "ValueError: boom in load"} {
+		if !strings.Contains(sgot, want) {
+			t.Errorf("run-wide search_logs output missing %q; got: %s", want, sgot)
 		}
 	}
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -89,7 +89,7 @@ func NewServer(api *apiclient.ClientWithResponses, serverURL, version string, re
 	}, h.diagnoseRun)
 	mcpsdk.AddTool(s, &mcpsdk.Tool{
 		Name:        "search_logs",
-		Description: "Search one task attempt's log for a case-insensitive substring, returning the matching lines (with line numbers) instead of the whole log.",
+		Description: "Search a DAG run's logs for a case-insensitive substring, returning the matching lines (with line numbers) instead of the whole log. Give task_id to search that one task's attempt (fast path); OMIT task_id to search every task instance's log across the whole run — each match is then tagged with the task_id it came from. Returned matches are capped (truncated=true when there are more), but the true total is always reported.",
 	}, h.searchLogs)
 	h.registerResources(s)
 	return s
@@ -407,13 +407,18 @@ const (
 type searchLogsInput struct {
 	DagID      string `json:"dag_id" jsonschema:"the DAG id"`
 	RunID      string `json:"run_id" jsonschema:"the DAG run id"`
-	TaskID     string `json:"task_id" jsonschema:"the task id whose log to search"`
-	TryNumber  int    `json:"try_number,omitempty" jsonschema:"attempt to search (default 1)"`
+	TaskID     string `json:"task_id,omitempty" jsonschema:"the task id whose log to search; omit to search every task instance's log across the whole run"`
+	TryNumber  int    `json:"try_number,omitempty" jsonschema:"attempt to search when task_id is given (default 1); ignored for a run-wide search, which searches each task instance's own attempt"`
 	Query      string `json:"query" jsonschema:"case-insensitive substring to match"`
-	MaxMatches int    `json:"max_matches,omitempty" jsonschema:"maximum matching lines to return (default 20, max 100)"`
+	MaxMatches int    `json:"max_matches,omitempty" jsonschema:"maximum matching lines to return, across all tasks (default 20, max 100)"`
 }
 
 type logMatch struct {
+	// TaskID and TryNumber are populated for a run-wide search (task_id omitted),
+	// so each match carries the task instance it came from; they are empty for a
+	// task-scoped search, where the output's top-level task_id/try_number apply.
+	TaskID     string `json:"task_id,omitempty"`
+	TryNumber  int    `json:"try_number,omitempty"`
 	LineNumber int    `json:"line_number"`
 	Line       string `json:"line"`
 }
@@ -429,19 +434,17 @@ type searchLogsOutput struct {
 	Truncated    bool       `json:"truncated"`
 }
 
-// searchLogs fetches one task attempt's log and returns the lines matching a
-// case-insensitive substring, with 1-based line numbers — so an agent can find
-// the relevant lines of a long log without pulling the whole thing into context
-// (ADR 0050 D7). The match is a plain substring, not a regex, to avoid handing
-// the model a ReDoS lever. Matched lines are sanitized (untrusted content, D10)
-// and the returned set is capped, but the true total is always reported.
+// searchLogs returns the lines of a run's logs matching a case-insensitive
+// substring, with 1-based line numbers — so an agent can find the relevant lines
+// of a long log without pulling the whole thing into context (ADR 0050 D7). With
+// task_id it searches that one attempt (fast path); without task_id it searches
+// every task instance's log across the run, tagging each match with its task_id.
+// The match is a plain substring, not a regex, to avoid handing the model a
+// ReDoS lever. Matched lines are sanitized (untrusted content, D10) and the
+// returned set is capped across all tasks, but the true total is always reported.
 func (h *handlers) searchLogs(ctx context.Context, req *mcpsdk.CallToolRequest, in searchLogsInput) (*mcpsdk.CallToolResult, searchLogsOutput, error) {
-	if in.DagID == "" || in.RunID == "" || in.TaskID == "" || in.Query == "" {
-		return nil, searchLogsOutput{}, fmt.Errorf("dag_id, run_id, task_id, and query are required")
-	}
-	try := in.TryNumber
-	if try < 1 {
-		try = 1
+	if in.DagID == "" || in.RunID == "" || in.Query == "" {
+		return nil, searchLogsOutput{}, fmt.Errorf("dag_id, run_id, and query are required")
 	}
 	maxN := in.MaxMatches
 	if maxN <= 0 {
@@ -455,28 +458,96 @@ func (h *handlers) searchLogs(ctx context.Context, req *mcpsdk.CallToolRequest, 
 	if err != nil {
 		return nil, searchLogsOutput{}, err
 	}
-	resp, err := api.GetTaskLogsWithResponse(ctx, in.DagID, in.RunID, in.TaskID, try)
-	if err != nil {
-		return nil, searchLogsOutput{}, fmt.Errorf("fetching task log: %w", err)
-	}
-	if resp.StatusCode() != http.StatusOK {
-		return nil, searchLogsOutput{}, fmt.Errorf("control plane returned %d fetching task log", resp.StatusCode())
+
+	out := searchLogsOutput{DagID: in.DagID, RunID: in.RunID, Query: in.Query}
+	needle := strings.ToLower(in.Query)
+
+	if in.TaskID != "" {
+		try := in.TryNumber
+		if try < 1 {
+			try = 1
+		}
+		out.TaskID = in.TaskID
+		out.TryNumber = try
+		resp, err := api.GetTaskLogsWithResponse(ctx, in.DagID, in.RunID, in.TaskID, try)
+		if err != nil {
+			return nil, searchLogsOutput{}, fmt.Errorf("fetching task log: %w", err)
+		}
+		if resp.StatusCode() != http.StatusOK {
+			return nil, searchLogsOutput{}, fmt.Errorf("control plane returned %d fetching task log", resp.StatusCode())
+		}
+		// Task-scoped: the top-level task_id/try_number carry provenance, so the
+		// per-match tags stay empty to keep the fast-path output unchanged.
+		scanLog(&out, string(resp.Body), needle, "", 0, maxN)
+		out.Truncated = out.TotalMatches > len(out.Matches)
+		return nil, out, nil
 	}
 
-	out := searchLogsOutput{DagID: in.DagID, RunID: in.RunID, TaskID: in.TaskID, TryNumber: try, Query: in.Query}
-	needle := strings.ToLower(in.Query)
-	lines := strings.Split(strings.ReplaceAll(string(resp.Body), "\r\n", "\n"), "\n")
+	// Run-wide: enumerate the run's task instances (same list diagnose_run uses)
+	// and search each one's own attempt, tagging matches with their task_id.
+	if err := h.searchRunLogs(ctx, api, &out, needle, maxN); err != nil {
+		return nil, searchLogsOutput{}, err
+	}
+	out.Truncated = out.TotalMatches > len(out.Matches)
+	return nil, out, nil
+}
+
+// searchRunLogs lists a run's task instances and scans each one's log for the
+// needle, tagging every match with its task_id and attempt. A task whose log
+// can't be fetched (never ran, or a per-task read error) is skipped rather than
+// failing the whole search — the matches from the other tasks still come back;
+// only the initial task-instance listing is fatal. The returned-match cap is
+// shared across all tasks, but every task is still scanned so TotalMatches
+// reports the true run-wide total.
+func (h *handlers) searchRunLogs(ctx context.Context, api *apiclient.ClientWithResponses, out *searchLogsOutput, needle string, maxN int) error {
+	tiResp, err := api.ListTaskInstancesWithResponse(ctx, out.DagID, out.RunID)
+	if err != nil {
+		return fmt.Errorf("listing task instances: %w", err)
+	}
+	if tiResp.StatusCode() != http.StatusOK || tiResp.JSON200 == nil {
+		return fmt.Errorf("control plane returned %d listing task instances", tiResp.StatusCode())
+	}
+	var tis []apiclient.TaskInstance
+	if tiResp.JSON200.TaskInstances != nil {
+		tis = *tiResp.JSON200.TaskInstances
+	}
+	for _, ti := range tis {
+		taskID := deref(ti.TaskId)
+		try := deref(ti.TryNumber)
+		if taskID == "" || try < 1 { // a task that never ran has no log to search
+			continue
+		}
+		logResp, lerr := api.GetTaskLogsWithResponse(ctx, out.DagID, out.RunID, taskID, try)
+		if lerr != nil || logResp.StatusCode() != http.StatusOK {
+			continue
+		}
+		scanLog(out, string(logResp.Body), needle, taskID, try, maxN)
+	}
+	return nil
+}
+
+// scanLog appends every needle match in body to out.Matches (up to maxN total,
+// counting matches already collected from other tasks) and always increments
+// out.TotalMatches, so the cap bounds what is returned while the true total is
+// still counted. taskID/tryNumber tag each match for a run-wide search and are
+// empty/zero for a task-scoped one. Matched lines are control/ANSI-stripped and
+// length-capped (untrusted content, D10).
+func scanLog(out *searchLogsOutput, body, needle, taskID string, tryNumber, maxN int) {
+	lines := strings.Split(strings.ReplaceAll(body, "\r\n", "\n"), "\n")
 	for i, ln := range lines {
 		if !strings.Contains(strings.ToLower(ln), needle) {
 			continue
 		}
 		out.TotalMatches++
 		if len(out.Matches) < maxN {
-			out.Matches = append(out.Matches, logMatch{LineNumber: i + 1, Line: capLine(stripControl(ln))})
+			out.Matches = append(out.Matches, logMatch{
+				TaskID:     taskID,
+				TryNumber:  tryNumber,
+				LineNumber: i + 1,
+				Line:       capLine(stripControl(ln)),
+			})
 		}
 	}
-	out.Truncated = out.TotalMatches > len(out.Matches)
-	return nil, out, nil
 }
 
 // sanitizeLogTail returns at most the last n lines of raw log output, stripped of

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -140,6 +140,113 @@ func TestSearchLogs(t *testing.T) {
 	}
 }
 
+// TestSearchLogsRunWide: with task_id OMITTED, search_logs enumerates the run's
+// task instances and searches every task's log, tagging each match with the
+// task_id it came from (and a 1-based line number). Matches are sanitized.
+func TestSearchLogsRunWide(t *testing.T) {
+	h := testHandlers(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v2/dags/etl/dagRuns/r1/taskInstances":
+			_, _ = io.WriteString(w, `{"task_instances":[`+
+				`{"task_id":"extract","state":"success","try_number":1},`+
+				`{"task_id":"load","state":"failed","try_number":2}],"total_entries":2}`)
+		case "/api/v2/dags/etl/dagRuns/r1/taskInstances/extract/logs/1":
+			_, _ = io.WriteString(w, "connecting\nerror in extract\ndone\n")
+		case "/api/v2/dags/etl/dagRuns/r1/taskInstances/load/logs/2":
+			_, _ = io.WriteString(w, "load starting\nERROR: boom\x1b[0m\ndone\n")
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	})
+
+	_, out, err := h.searchLogs(context.Background(), nil, searchLogsInput{
+		DagID: "etl", RunID: "r1", Query: "error", // no TaskID -> run-wide
+	})
+	if err != nil {
+		t.Fatalf("searchLogs run-wide: %v", err)
+	}
+	if out.TotalMatches != 2 || len(out.Matches) != 2 {
+		t.Fatalf("matches = %+v (total %d), want 2 across the run", out.Matches, out.TotalMatches)
+	}
+	// Matches are tagged with the task they came from, in task-instance order.
+	if out.Matches[0].TaskID != "extract" || out.Matches[0].LineNumber != 2 {
+		t.Errorf("match[0] = %+v, want extract@line2", out.Matches[0])
+	}
+	if out.Matches[1].TaskID != "load" || out.Matches[1].LineNumber != 2 {
+		t.Errorf("match[1] = %+v, want load@line2", out.Matches[1])
+	}
+	if out.Matches[1].TryNumber != 2 {
+		t.Errorf("match[1] try_number = %d, want 2 (the searched attempt)", out.Matches[1].TryNumber)
+	}
+	if strings.Contains(out.Matches[1].Line, "\x1b") {
+		t.Errorf("run-wide match line must be sanitized: %q", out.Matches[1].Line)
+	}
+	if out.Truncated {
+		t.Error("should not be truncated with the default cap")
+	}
+}
+
+// TestSearchLogsRunWideCaps: the cap on returned matches is applied across the
+// WHOLE run, and the true total (over all tasks) is still reported so the agent
+// knows there is more.
+func TestSearchLogsRunWideCaps(t *testing.T) {
+	h := testHandlers(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v2/dags/d/dagRuns/r/taskInstances":
+			_, _ = io.WriteString(w, `{"task_instances":[`+
+				`{"task_id":"a","state":"failed","try_number":1},`+
+				`{"task_id":"b","state":"failed","try_number":1}],"total_entries":2}`)
+		case "/api/v2/dags/d/dagRuns/r/taskInstances/a/logs/1":
+			_, _ = io.WriteString(w, "error a1\nerror a2\n")
+		case "/api/v2/dags/d/dagRuns/r/taskInstances/b/logs/1":
+			_, _ = io.WriteString(w, "error b1\nerror b2\n")
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	})
+	_, out, err := h.searchLogs(context.Background(), nil, searchLogsInput{
+		DagID: "d", RunID: "r", Query: "error", MaxMatches: 2,
+	})
+	if err != nil {
+		t.Fatalf("searchLogs run-wide: %v", err)
+	}
+	if len(out.Matches) != 2 || out.TotalMatches != 4 || !out.Truncated {
+		t.Errorf("want 2 returned / 4 total / truncated, got %d / %d / %v", len(out.Matches), out.TotalMatches, out.Truncated)
+	}
+}
+
+// TestSearchLogsRunWideToleratesMissingLog: in run-wide mode a task whose log
+// can't be fetched (never ran, or the endpoint errors) is skipped rather than
+// failing the whole search — the matches from the other tasks still come back.
+func TestSearchLogsRunWideToleratesMissingLog(t *testing.T) {
+	h := testHandlers(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v2/dags/d/dagRuns/r/taskInstances":
+			_, _ = io.WriteString(w, `{"task_instances":[`+
+				`{"task_id":"a","state":"failed","try_number":1},`+
+				`{"task_id":"b","state":"upstream_failed","try_number":0}],"total_entries":2}`)
+		case "/api/v2/dags/d/dagRuns/r/taskInstances/a/logs/1":
+			_, _ = io.WriteString(w, "error a1\n")
+		default:
+			// b has try_number 0 (never ran); its log must never be requested.
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	_, out, err := h.searchLogs(context.Background(), nil, searchLogsInput{
+		DagID: "d", RunID: "r", Query: "error",
+	})
+	if err != nil {
+		t.Fatalf("searchLogs run-wide: %v", err)
+	}
+	if out.TotalMatches != 1 || len(out.Matches) != 1 || out.Matches[0].TaskID != "a" {
+		t.Errorf("want 1 match tagged a, got %+v (total %d)", out.Matches, out.TotalMatches)
+	}
+}
+
 // TestSearchLogsTruncates caps the returned matches but still reports the true
 // total, so the agent knows there is more.
 func TestSearchLogsTruncates(t *testing.T) {
@@ -211,11 +318,18 @@ func TestSearchLogsCapsGiantLine(t *testing.T) {
 	}
 }
 
-// TestSearchLogsMissingArgs: the locators and the query are required.
+// TestSearchLogsMissingArgs: the run locators and the query are required, but
+// task_id is now optional (omitting it means a run-wide search, not an error).
 func TestSearchLogsMissingArgs(t *testing.T) {
 	h := &handlers{}
 	if _, _, err := h.searchLogs(context.Background(), nil, searchLogsInput{DagID: "d", RunID: "r", TaskID: "t"}); err == nil {
 		t.Error("expected an error when query is missing")
+	}
+	if _, _, err := h.searchLogs(context.Background(), nil, searchLogsInput{RunID: "r", Query: "q"}); err == nil {
+		t.Error("expected an error when dag_id is missing")
+	}
+	if _, _, err := h.searchLogs(context.Background(), nil, searchLogsInput{DagID: "d", Query: "q"}); err == nil {
+		t.Error("expected an error when run_id is missing")
 	}
 }
 


### PR DESCRIPTION
## What

`search_logs` required `dag_id`, `run_id`, `task_id` **and** `query`, so an agent could not search a run's logs without already knowing which task to inspect. This makes `task_id` optional.

- **`task_id` given** — unchanged task-scoped fast path (searches that one attempt).
- **`task_id` omitted** — run-wide search: the tool enumerates the run's task instances (the same `ListTaskInstances` call `diagnose_run` and the `task://instances` resource use) and searches each instance's own attempt. Every match is tagged with the `task_id` and `try_number` it came from, alongside the 1-based line number.
- A task that never ran (`try_number < 1`) or whose log fetch errors is **skipped**, not fatal — matches from the other tasks still return. Only the initial task-instance listing is fatal.

## Bounded output

The `max_matches` cap (default 20, max 100) now applies **across the whole run**. `truncated=true` is set when there are more, while `total_matches` still reports the true run-wide total (every task is scanned to count it). Matched lines remain control/ANSI-stripped and length-capped (D10).

## Tests (strict TDD — tests written first, then implementation)

Unit (`internal/mcp/server_test.go`):
- `TestSearchLogsRunWide` — omit `task_id`; matches from multiple tasks are tagged with their `task_id`/`try_number`/line number and sanitized.
- `TestSearchLogsRunWideCaps` — the cap applies across the whole run; true total still reported with `truncated`.
- `TestSearchLogsRunWideToleratesMissingLog` — a never-ran/upstream_failed task is skipped, no log fetched, other tasks' matches returned.
- `TestSearchLogsMissingArgs` — extended: `dag_id`/`run_id`/`query` still required, `task_id` now optional.

E2E (`internal/mcp/e2e_test.go`, `-tags e2e`, real binary over stdio):
- `TestMCPBinaryEndToEnd` — extended with a run-wide `search_logs` call (no `task_id`) against the seeded control plane; asserts the match is tagged with the correct `task_id`.

No existing assertion was weakened.

## Verification

- `gofmt -l internal/mcp/` clean
- `go test ./internal/mcp/...` and `go test -tags e2e ./internal/mcp/...` green
- `golangci-lint run ./internal/mcp/...` — 0 issues

Closes #607