### PR TITLE
docs(adr): 0052 — durable task outcome (ADR 0051 Phase 2, #543)

### DIFF
--- a/cmd/leoflow-agent/main.go
+++ b/cmd/leoflow-agent/main.go
@@ -99,8 +99,11 @@ func run() int {
 		// Custom-keyed XCom pushes, same per-task temp dir (multi-key XCom).
 		PushesPath: filepath.Join(filepath.Dir(returnPath), "xcom_pushes.json"),
 		// A reschedule-mode sensor's next-poke time, same per-task temp dir (#380).
-		ReschedulePath:    filepath.Join(filepath.Dir(returnPath), "reschedule.txt"),
-		HeartbeatInterval: 15 * time.Second,
+		ReschedulePath: filepath.Join(filepath.Dir(returnPath), "reschedule.txt"),
+		// The durable outcome record's destination (the container termination
+		// message), set by the executor's podEnv; empty outside a pod (ADR 0052).
+		TerminationLogPath: os.Getenv("LEOFLOW_TERMINATION_LOG_PATH"),
+		HeartbeatInterval:  15 * time.Second,
 	}
 	if rerr := runner.Run(ctx); rerr != nil {
 		slog.Error("task failed", "error", rerr)

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -697,7 +697,7 @@ func runGatedTicker(ctx context.Context, name string, ticks <-chan time.Time, le
 	}
 }
 
-func startReconciler(ctx context.Context, cs kubernetes.Interface, namespace string, reporter executor.FailureReporter, leading func() bool, logger *slog.Logger) {
+func startReconciler(ctx context.Context, cs kubernetes.Interface, namespace string, reporter executor.OutcomeReporter, leading func() bool, logger *slog.Logger) {
 	rec := executor.NewReconciler(cs, namespace, reporter)
 	startGatedTicker(ctx, "pod-reconcile", reconcileInterval, leading, logger, func() {
 		if err := rec.Reconcile(ctx); err != nil {

--- a/docs/adr/0052-durable-task-outcome.md
+++ b/docs/adr/0052-durable-task-outcome.md
@@ -2,7 +2,7 @@
 
 **Status:** Proposed
 **Date:** 2026-08-13
-**Relates:** ADR 0051 (separate the orchestration and execution state machines — this ADR is its Phase 2), ADR 0031 (scheduler reconciliation loop + two-layer reaping), ADR 0015 (Kubernetes-only container execution), ADR 0004 (thin agent), ADR 0002 (pod-per-task)
+**Relates:** ADR 0051 (separate the orchestration and execution state machines — this ADR is its Phase 2), ADR 0031 (scheduler reconciliation loop + two-layer reaping), ADR 0015 (Kubernetes-only container execution), ADR 0004 (thin agent), ADR 0002 (pod-per-task — an assumption this ADR is careful not to deepen)
 **Issues:** #543 (agent exit code conflates task outcome with report delivery); follow-up to #542 (in-process report retry)
 
 ## Context
@@ -14,31 +14,67 @@ The agent runs the user process, then delivers the result over gRPC. If the
 terminal report — or one of the pre-report pushes (return value, extra links,
 XCom) — fails, the agent routes to `fail` and exits non-zero
 (`internal/agent/runner.go:408-420`). So a pod **killed mid-report** (OOM,
-eviction, node loss) shows Kubernetes phase `Failed` **even when the user task
-itself succeeded**.
+eviction) shows Kubernetes phase `Failed` **even when the user task itself
+succeeded**.
 
 The reconciler is the backstop for a pod that never delivered, but it can only
 read **pod phase** (`internal/executor/reconcile.go:103-116`): a `Failed` pod is
 settled as a task failure via `reportFailure`. It has no way to recover a success
 from phase alone, because the only durable signal — the pod — says `Failed`.
 
-#542 adds an in-process retry of the report, which fixes the common case (a
-transient blip while the pod is still alive). It cannot fix the case where the
-pod is gone before the retry budget is spent. That backstop is this ADR.
+### This is a classic distributed-systems problem, and there are two schools
+
+At bottom this is the *atomicity of a side effect and its record*: the work
+happened, but the record of it did not survive the worker's death. The industry
+answers it in one of two ways.
+
+- **School A — recover the lost outcome.** Extract the truth from a durable,
+  per-worker artifact left behind at exit. Best-effort: it only works while the
+  node/kubelet survives to surface the artifact. It cannot survive node loss.
+- **School B — the outcome does not exist until the orchestrator durably records
+  it; on ambiguity, re-drive.** The source of truth is a store the orchestrator
+  owns; a result is real only once written there; a lost report means *not done*,
+  so the task is retried. Correctness comes from **at-least-once execution +
+  idempotency**, not from autopsying the worker. Correct under *any* failure,
+  node loss included. This is the durable-execution lineage (Temporal/Cadence)
+  and the Borg/Spanner "durable intent + idempotent re-drive" pattern.
+
+Apache Airflow — our UI/API compatibility target — is worse than School A here:
+its KubernetesExecutor does not even try to recover. A pod that dies without
+reporting becomes a **zombie task**, is marked `failed`, and is re-run; the whole
+"tasks must be idempotent" doctrine exists precisely because the framework
+re-drives on ambiguity. It accepts the false-negative and pushes the burden to
+the user.
+
+**leoflow is already on School B.** The reconciliation loop and two-layer reaper
+(ADR 0031) re-drive on ambiguity, and ADR 0051 Phase 1 re-places an infra fault
+*without consuming the user's retry budget*. That is the correctness foundation,
+and it holds under node loss. This ADR does **not** replace it. This ADR adds a
+**School-A optimization on top of the School-B floor**: when the kubelet survives,
+recover a lost *success* so an expensive or non-idempotent task is not needlessly
+re-run.
 
 > "Have the reconciler settle a `Succeeded` pod as success" is nearly a no-op:
 > when the success report fails the agent exits non-zero, so the pod is `Failed`,
 > never `Succeeded`. The bug is the conflation, not the reconciler's reading of a
 > `Succeeded` phase.
 
-This is the execution-state-machine's outcome signal that ADR 0051 named but did
-not yet make durable. This ADR makes it durable.
+#542 adds an in-process retry of the report, which fixes the common transient
+blip while the pod is still alive. It cannot fix the case where the pod is gone
+before the retry budget is spent. That surviving-kubelet backstop is this ADR.
 
 ## Decision
 
-**The agent writes the true task outcome to a durable, pod-local location
-*before* it attempts to deliver the report; the reconciler reads that record as
-the source of truth, falling back to pod phase only when it is absent.**
+**Correctness rests on School B — idempotent re-drive (ADR 0031 + ADR 0051 Phase
+1) — which this ADR does not change. On top of it, the agent writes the true task
+outcome to a durable, pod-local location *before* it attempts to deliver the
+report; the reconciler reads that record as the source of truth over pod phase,
+recovering a lost success so a costly or non-idempotent task is not re-run
+needlessly.**
+
+The record is an **optimization that reduces spurious re-runs**, not the
+mechanism that guarantees correctness. Where the record is absent (node loss, old
+agent), the School-B floor still settles the task safely by re-drive.
 
 ### The durable outcome record
 
@@ -49,89 +85,207 @@ A compact JSON document written to the container **termination message**
 ```json
 {"v":1,"outcome":"success"}
 {"v":1,"outcome":"failed","exit_code":1}
-{"v":1,"outcome":"reschedule"}
+{"v":1,"outcome":"reschedule","reschedule_at":"2026-08-13T12:34:56Z"}
 ```
 
 - `outcome` ∈ `success | failed | reschedule` — the *task's* result, independent
   of whether the report was delivered.
 - `exit_code` — the user process exit code, for a `failed` outcome.
+- `reschedule_at` — RFC3339 next-poke time, **required** for a `reschedule`
+  outcome (see "Reschedule carries its next-poke time" below).
 - Kept well under the Kubernetes termination-message cap (~4 KiB); it carries the
-  outcome, not logs or the return value (those keep their existing paths).
+  outcome, never logs or the return value (those keep their existing paths).
 
-The agent writes this record at the moment it *decides* the outcome — before the
-`report(...)` / `fail(...)` gRPC call — so a kill during delivery still leaves the
-truth behind.
+### Prerequisite: the container must pin the termination-message policy
 
-### The reconciler reads it as source of truth
+The whole contract rests on the container surfacing `/dev/termination-log` on pod
+status. Today `BuildPod` (`internal/executor/kubernetes.go:81-88`) sets **neither**
+`TerminationMessagePolicy` nor `TerminationMessagePath`; it works only by the
+Kubernetes API default (`File` / `/dev/termination-log`), which an admission
+webhook or PodSecurity policy could mutate without notice. This ADR makes it an
+**explicit, tested contract**: `BuildPod` pins
+`TerminationMessagePolicy: corev1.TerminationMessageReadFile` and
+`TerminationMessagePath: "/dev/termination-log"` on the task container, with a
+unit test asserting both. The k3d/chaos step additionally asserts the agent can
+*write* the file under the operator-configurable `RunAsNonRoot` +
+`ReadOnlyRootFilesystem` security context (`buildSecurityContext`,
+`kubernetes.go:221-234`). We do **not** set `FallbackToLogsOnError`: it would let
+a failed pod populate the message from the log tail, which the reader would then
+try (and safely fail) to decode — avoided outright.
 
-`classifyPod` (`internal/executor/reconcile.go:39`) is extended: when a
-terminated container carries a decodable outcome record, it is trusted over the
-pod phase.
+### Write ordering: the success record follows the pushes
+
+The record is written **path-specifically at the point the outcome becomes true**,
+not on a single "user process exited" event:
+
+- The `success` record is written **only after every pre-report push (return
+  value, extra links, custom XComs) has been accepted** — immediately before
+  `report(SUCCESS)`. A kill *during* the pushes therefore leaves **no** success
+  record → fallback → failure → idempotent re-drive. This closes the gap where a
+  recovered "success" could have missing downstream XCom/return-value.
+- The `failed` record is written immediately before each `fail(...)`.
+- The `reschedule` record is written immediately before `reportReschedule(...)`,
+  carrying the parsed next-poke time.
+
+### The reconciler reads it as source of truth (attempt-guarded)
+
+`classifyPod` (`internal/executor/reconcile.go:39`) is extended: when a terminated
+container carries a decodable outcome record, it is trusted over the pod phase.
 
 - Record says `success` on a `Failed` pod → settle the task **succeeded** (the
   report was lost, the work was not).
-- Record says `failed` → settle failed with the recorded `exit_code` (same as
-  today, now authoritative rather than inferred).
-- Record says `reschedule` → route to `up_for_reschedule`; the reconciler **never
-  settles a reschedule as a failure** (excludes the exit-75 path, #386).
-- **No record** (old agent, non-graceful kill before the write, a crash that
-  never reached the decision) → fall back to today's phase-based behavior.
+- Record says `failed` → settle failed with the recorded `exit_code` (now
+  authoritative rather than inferred).
+- Record says `reschedule` → route to `up_for_reschedule` using the record's
+  `reschedule_at`; the reconciler **never settles a reschedule as a failure**
+  (excludes the bare exit-75 path, #386).
+- **No record** (old agent, non-graceful kill before the write, node loss) → fall
+  back to today's phase-based behavior; the School-B floor re-drives safely.
 
-### Idempotent, single-outcome settle
-
-The reconciler's settle and a late agent report must converge to exactly one
-outcome. Reuse the existing `WHERE state='running' [AND try_number=…]` guard
-(the #541/#542 groundwork): whichever writes first wins; the other is a no-op.
-`on_failure_callback` (#424) fires consistently for a reconciler-driven failure,
-exactly as for an agent-driven one.
+**Idempotent, attempt-guarded settle.** The reconciler's settle must not clobber a
+*different attempt*. The current reconciler path — `FailTaskInstanceIfActive`
+(`internal/storage/queries/runs.sql:341-344`) — guards on `id AND state IN
+(...)`, with **no `try_number`**, unlike the agent path `ReportTaskResult`
+(`runs.sql:346+`), which guards on state **and** try_number precisely because
+retries bump `try_number` **in place** on the same row. Because the pod annotation
+carries a specific attempt, a stale reconciler acting on a previous attempt's
+lingering `Failed` pod could match `id AND state='running'` on the **new** running
+attempt. Today that only fails a live retry (recoverable); once the reconciler also
+writes **success**, the same stale match could mark a live retry *succeeded* and
+fire downstream on incomplete work — strictly worse than the bug being fixed.
+This ADR therefore specifies a **new try_number-guarded settle for the reconciler**
+(both the success and failure paths): `WHERE id=$1 AND try_number=$2 AND state IN
+(...)`, threading the `leoflow.io/try-number` pod label (already set in `BuildPod`)
+into the settle. Whichever of the reconciler and a late agent report writes first
+wins; the other is a no-op. `on_failure_callback` (#424) fires consistently for a
+reconciler-driven failure, exactly as for an agent-driven one. (The claim in the
+earlier draft that we could "reuse the existing guard" was wrong — that guard is
+not on the reconciler path.)
 
 ## Key properties
 
-- **Exactly one outcome per attempt**, recoverable even if the report is never
-  delivered.
+- **Correctness is School B; this is an optimization.** Absent the record, tasks
+  still settle safely by idempotent re-drive; the record only spares needless
+  re-runs when the kubelet survived.
+- **Recovers surviving-kubelet kills only.** OOM kill, node-pressure eviction, and
+  `ActiveDeadline` — where the kubelet lives to flush the termination message — are
+  recovered. **Node loss / non-graceful shutdown successes remain unrecoverable**
+  by this mechanism (dead kubelet → no ContainerStatuses update → no record); they
+  degrade to phase → failure → idempotent re-drive. Stated honestly rather than
+  over-claimed.
 - **Kubernetes-only.** Lite (subprocess, no pod, in-process delivery) gains
   nothing and is unchanged — #542's in-process retry is Lite's primary fix.
-- **Additive and back-compatible.** An agent that does not write the record, or a
-  pod killed before the write, degrades to today's phase-based behavior; no
-  schema change.
-- **Bounded.** The record is a few bytes; it never carries logs or return values.
+- **Additive and back-compatible.** No schema change; an agent that does not write
+  the record degrades to phase-based behavior.
+- **Transport is bound to the dedicated-pod case; the contract is not.** The
+  termination message is a per-container-*exit* artifact: it can carry a task's
+  outcome only because today the pod runs exactly one task and exits at that task's
+  end (ADR 0002). The planned model keeps a task **atomic to one pod** but lets that
+  pod be **dedicated** (exits at the task's end — termination message still works)
+  **or shared** with sibling tasks (a warm worker that does *not* exit per task —
+  the termination message cannot carry a per-task outcome). The orchestration side
+  consumes the outcome through the execution seam (`ExecutionStore`), **never pod
+  phase or the transport directly**, so a shared pod simply adds a *second*
+  transport — a long-lived worker reporting each task-attempt's outcome in-band and
+  durably, which is precisely Temporal's worker model — without touching the
+  orchestration side. This ADR is careful not to deepen the pod-per-task assumption.
 
 ## Consequences
 
-- A task that succeeds but loses its report is no longer marked failed — the
-  most damaging false-negative in the execution path is closed.
+- The most damaging false-negative in the execution path — a task that succeeded
+  but lost its report — is closed for the common kill classes; the residue is
+  safe re-drive. This is the concrete answer to Airflow's zombie-task false
+  negative.
 - Small, contained change: a write in the agent's terminal path and a read in
-  `classifyPod`; no new coordination substrate, no control-plane schema change.
+  `classifyPod`; a policy pin in `BuildPod`; a try_number-guarded settle. No new
+  coordination substrate, no control-plane schema change.
 - The termination message becomes a **contract** between agent and reconciler,
   versioned by `v` so the format can evolve.
-- The reconciler grows one dependency on a Kubernetes-surfaced field; the
-  fallback keeps it correct where the field is absent.
+- The reconciler grows one dependency on a Kubernetes-surfaced field; the fallback
+  keeps it correct where the field is absent.
 
 ## Alternatives considered
 
 - **Trust pod phase (the naive backstop).** Rejected: a lost success report makes
   the pod `Failed`, so phase can never recover the success. This is the no-op the
   issue calls out.
-- **A file in a shared `emptyDir`.** Viable, but needs a shared mount and a
-  reader with pod-filesystem access (a sidecar or exec), plus cleanup. The
-  termination message is Kubernetes-native, surfaced on the pod status the
-  reconciler already lists, and needs no extra mount.
+- **A file in a shared `emptyDir`.** Viable, but needs a shared mount and a reader
+  with pod-filesystem access (a sidecar or exec), plus cleanup. The termination
+  message is Kubernetes-native, rides the pod status the reconciler already lists,
+  and needs no extra mount.
+- **A pod annotation/label patch written by the agent (downward API / API write).**
+  Rejected: it needs a live kubelet and a Kubernetes API write, and the task pod
+  sets `AutomountServiceAccountToken: false` (`kubernetes.go:80`) to deny the
+  agent API access by design. Same node-loss limit as the termination message,
+  with more privilege.
 - **Push the outcome to the control plane before exit.** That *is* the report —
   circular; the whole problem is that this delivery can fail.
+- **Temporal / Cadence durable execution (School B, pure).** The Temporal Service
+  owns all durable state as an event-sourced history in a database
+  (Cassandra/MySQL/PostgreSQL); the worker holds no authoritative state. An
+  activity is complete **only once the Service durably records the completion** the
+  worker reports (`RespondActivityTaskCompleted`, keyed by a task token), not when
+  the worker's code returns. A worker that finishes the work but dies before that
+  record is written is simply invisible to the Service: Temporal **does not detect
+  or salvage the lost success** — it relies on the Start-To-Close / Heartbeat
+  timeout to notice the missing signal and **retries the activity** per policy.
+  Execution is **at-least-once**; safety of the repeat is the developer's job via
+  **idempotency keys** (there is no exactly-once *side-effect* primitive — the docs
+  call it "effectively exactly-once"). We do not adopt this wholesale: leoflow is
+  Airflow-compatible — a task is an **opaque user process in a pod**, not an
+  activity in a durable-execution SDK that owns the code's structure and can replay
+  it. But we adopt its **principle as our correctness floor** (School B: re-drive on
+  ambiguity + idempotent tasks), which we already have via ADR 0031 + ADR 0051. Its
+  long-lived worker (one process polling and reporting many attempts in-band) is
+  exactly the *shared-pod* transport our N:1 future points at — further reason the
+  outcome must be transport-abstract, not pinned to the termination message.
+  (Sources: docs.temporal.io — architecture, activity-execution, detecting-activity-failures; temporal.io/blog/idempotency-and-durable-execution.)
+- **Argo Workflows wait/emissary sidecar.** Argo's emissary executor runs the user
+  command as a sub-process and writes its exit code to a file on a shared `emptyDir`
+  (`/var/run/argo/ctr/<container>/exitcode`); a `wait` sidecar reads it, uploads
+  artifacts, and reports outputs via a `WorkflowTaskResult` resource, while the
+  controller reads **pod status from an informer** as the success/fail source of
+  truth. This is an *intra-pod* artifact plus an extra container per task, and it
+  has the **same node-loss blind spot** as ours: if the whole pod/node dies the
+  sidecar dies too, no exitcode is written, and the controller marks the node
+  **Error ("pod deleted")** — it never reconstructs a success; recovery is left to
+  `retryStrategy` (notably `retryPolicy: OnError`), a full re-run assuming
+  idempotency. We reject it because the termination message rides the pod status we
+  **already `List`**, needing no sidecar, shared mount, or extra container — and it
+  buys us nothing Argo's sidecar would past the same kubelet-alive boundary.
+  (Sources: argoproj/argo-workflows — workflow-executors.md, emissary.go, operator.go; argo-workflows.readthedocs.io — tolerating-pod-deletion, retries.)
+- **Apache Airflow KubernetesExecutor zombie handling (the anti-pattern we beat).**
+  Airflow's source of truth is `TaskInstance.state` in the metadata DB, written by
+  the **in-pod process itself**. A pod that dies before committing `success`
+  becomes a **zombie**: the scheduler notices missing heartbeats (the "task
+  instance heartbeat timeout", historically `scheduler_zombie_task_threshold`,
+  default 300s) and **marks it failed or retries it — it never reconstructs a
+  success from a dead pod**. `adopt_or_reset_orphaned_tasks` covers a dead
+  *scheduler*, not a dead worker. This is exactly the false-negative this ADR
+  closes for the surviving-kubelet case, and the basis of the "kill the zombie
+  task" story: leoflow settles a succeeded-but-unreported task correctly instead of
+  failing-and-re-running it. (Sources: airflow.apache.org — core-concepts/tasks,
+  administration-and-deployment/scheduler.)
 
 ## Phased path
 
-1. **This ADR** — the durable-outcome mechanism and the seam contract.
-2. **Core (no cluster).** Agent writes the termination-message record; `classifyPod`
-   + the reconciler read and settle it; reschedule-exclusion; idempotent
-   double-settle. Unit-tested with a fake clientset and synthetic pod statuses.
+1. **This ADR** — the durable-outcome mechanism, the seam contract, and the
+   School-B-floor / School-A-optimization framing.
+2. **Core (no cluster).** `BuildPod` pins the termination-message policy (tested);
+   agent writes the record path-specifically after the pushes; `classifyPod` +
+   the reconciler read it and settle with a try_number-guarded query;
+   reschedule-exclusion with `reschedule_at`; idempotent double-settle. Unit-tested
+   with a fake clientset and synthetic pod statuses.
 3. **E2E / chaos (k3d).** Inject a pod kill mid-report on the operator/split E2E
-   and the runtime chaos harness (#524); assert the correct terminal state.
+   and the runtime chaos harness (#524); assert the correct terminal state, and
+   assert the agent can write the termination file under the hardened security
+   context.
 
 ## References
 
 - ADR 0051 — Separate the orchestration and execution state machines (this is its Phase 2)
+- ADR 0031 — Scheduler reconciliation loop + two-layer reaping (the School-B re-drive floor)
 - #543 — Pro: durable task-outcome signal read by the reconciler
 - #542 — in-process report retry (the primary, Lite-and-Pro fix); #541 — settle idempotency groundwork
 - #424 — native on_failure_callback gating
-- `internal/agent/runner.go` (terminal path), `internal/executor/reconcile.go` (`classifyPod`, `reportFailure`)
+- `internal/agent/runner.go` (terminal path), `internal/executor/reconcile.go` (`classifyPod`, `reportFailure`), `internal/executor/kubernetes.go` (container spec / policy prerequisite), `internal/storage/queries/runs.sql` (the `ReportTaskResult` vs `FailTaskInstanceIfActive` guard asymmetry)

--- a/docs/adr/0052-durable-task-outcome.md
+++ b/docs/adr/0052-durable-task-outcome.md
@@ -1,0 +1,137 @@
+# ADR 0052: Durable task outcome — decouple the task result from report delivery
+
+**Status:** Proposed
+**Date:** 2026-08-13
+**Relates:** ADR 0051 (separate the orchestration and execution state machines — this ADR is its Phase 2), ADR 0031 (scheduler reconciliation loop + two-layer reaping), ADR 0015 (Kubernetes-only container execution), ADR 0004 (thin agent), ADR 0002 (pod-per-task)
+**Issues:** #543 (agent exit code conflates task outcome with report delivery); follow-up to #542 (in-process report retry)
+
+## Context
+
+A task pod's true outcome and the *delivery* of that outcome are tangled into one
+value: the agent process's exit code.
+
+The agent runs the user process, then delivers the result over gRPC. If the
+terminal report — or one of the pre-report pushes (return value, extra links,
+XCom) — fails, the agent routes to `fail` and exits non-zero
+(`internal/agent/runner.go:408-420`). So a pod **killed mid-report** (OOM,
+eviction, node loss) shows Kubernetes phase `Failed` **even when the user task
+itself succeeded**.
+
+The reconciler is the backstop for a pod that never delivered, but it can only
+read **pod phase** (`internal/executor/reconcile.go:103-116`): a `Failed` pod is
+settled as a task failure via `reportFailure`. It has no way to recover a success
+from phase alone, because the only durable signal — the pod — says `Failed`.
+
+#542 adds an in-process retry of the report, which fixes the common case (a
+transient blip while the pod is still alive). It cannot fix the case where the
+pod is gone before the retry budget is spent. That backstop is this ADR.
+
+> "Have the reconciler settle a `Succeeded` pod as success" is nearly a no-op:
+> when the success report fails the agent exits non-zero, so the pod is `Failed`,
+> never `Succeeded`. The bug is the conflation, not the reconciler's reading of a
+> `Succeeded` phase.
+
+This is the execution-state-machine's outcome signal that ADR 0051 named but did
+not yet make durable. This ADR makes it durable.
+
+## Decision
+
+**The agent writes the true task outcome to a durable, pod-local location
+*before* it attempts to deliver the report; the reconciler reads that record as
+the source of truth, falling back to pod phase only when it is absent.**
+
+### The durable outcome record
+
+A compact JSON document written to the container **termination message**
+(`/dev/termination-log`, surfaced by Kubernetes on
+`pod.Status.ContainerStatuses[].State.Terminated.Message`):
+
+```json
+{"v":1,"outcome":"success"}
+{"v":1,"outcome":"failed","exit_code":1}
+{"v":1,"outcome":"reschedule"}
+```
+
+- `outcome` ∈ `success | failed | reschedule` — the *task's* result, independent
+  of whether the report was delivered.
+- `exit_code` — the user process exit code, for a `failed` outcome.
+- Kept well under the Kubernetes termination-message cap (~4 KiB); it carries the
+  outcome, not logs or the return value (those keep their existing paths).
+
+The agent writes this record at the moment it *decides* the outcome — before the
+`report(...)` / `fail(...)` gRPC call — so a kill during delivery still leaves the
+truth behind.
+
+### The reconciler reads it as source of truth
+
+`classifyPod` (`internal/executor/reconcile.go:39`) is extended: when a
+terminated container carries a decodable outcome record, it is trusted over the
+pod phase.
+
+- Record says `success` on a `Failed` pod → settle the task **succeeded** (the
+  report was lost, the work was not).
+- Record says `failed` → settle failed with the recorded `exit_code` (same as
+  today, now authoritative rather than inferred).
+- Record says `reschedule` → route to `up_for_reschedule`; the reconciler **never
+  settles a reschedule as a failure** (excludes the exit-75 path, #386).
+- **No record** (old agent, non-graceful kill before the write, a crash that
+  never reached the decision) → fall back to today's phase-based behavior.
+
+### Idempotent, single-outcome settle
+
+The reconciler's settle and a late agent report must converge to exactly one
+outcome. Reuse the existing `WHERE state='running' [AND try_number=…]` guard
+(the #541/#542 groundwork): whichever writes first wins; the other is a no-op.
+`on_failure_callback` (#424) fires consistently for a reconciler-driven failure,
+exactly as for an agent-driven one.
+
+## Key properties
+
+- **Exactly one outcome per attempt**, recoverable even if the report is never
+  delivered.
+- **Kubernetes-only.** Lite (subprocess, no pod, in-process delivery) gains
+  nothing and is unchanged — #542's in-process retry is Lite's primary fix.
+- **Additive and back-compatible.** An agent that does not write the record, or a
+  pod killed before the write, degrades to today's phase-based behavior; no
+  schema change.
+- **Bounded.** The record is a few bytes; it never carries logs or return values.
+
+## Consequences
+
+- A task that succeeds but loses its report is no longer marked failed — the
+  most damaging false-negative in the execution path is closed.
+- Small, contained change: a write in the agent's terminal path and a read in
+  `classifyPod`; no new coordination substrate, no control-plane schema change.
+- The termination message becomes a **contract** between agent and reconciler,
+  versioned by `v` so the format can evolve.
+- The reconciler grows one dependency on a Kubernetes-surfaced field; the
+  fallback keeps it correct where the field is absent.
+
+## Alternatives considered
+
+- **Trust pod phase (the naive backstop).** Rejected: a lost success report makes
+  the pod `Failed`, so phase can never recover the success. This is the no-op the
+  issue calls out.
+- **A file in a shared `emptyDir`.** Viable, but needs a shared mount and a
+  reader with pod-filesystem access (a sidecar or exec), plus cleanup. The
+  termination message is Kubernetes-native, surfaced on the pod status the
+  reconciler already lists, and needs no extra mount.
+- **Push the outcome to the control plane before exit.** That *is* the report —
+  circular; the whole problem is that this delivery can fail.
+
+## Phased path
+
+1. **This ADR** — the durable-outcome mechanism and the seam contract.
+2. **Core (no cluster).** Agent writes the termination-message record; `classifyPod`
+   + the reconciler read and settle it; reschedule-exclusion; idempotent
+   double-settle. Unit-tested with a fake clientset and synthetic pod statuses.
+3. **E2E / chaos (k3d).** Inject a pod kill mid-report on the operator/split E2E
+   and the runtime chaos harness (#524); assert the correct terminal state.
+
+## References
+
+- ADR 0051 — Separate the orchestration and execution state machines (this is its Phase 2)
+- #543 — Pro: durable task-outcome signal read by the reconciler
+- #542 — in-process report retry (the primary, Lite-and-Pro fix); #541 — settle idempotency groundwork
+- #424 — native on_failure_callback gating
+- `internal/agent/runner.go` (terminal path), `internal/executor/reconcile.go` (`classifyPod`, `reportFailure`)

--- a/docs/adr/0052-durable-task-outcome.md
+++ b/docs/adr/0052-durable-task-outcome.md
@@ -18,8 +18,9 @@ eviction) shows Kubernetes phase `Failed` **even when the user task itself
 succeeded**.
 
 The reconciler is the backstop for a pod that never delivered, but it can only
-read **pod phase** (`internal/executor/reconcile.go:103-116`): a `Failed` pod is
-settled as a task failure via `reportFailure`. It has no way to recover a success
+read **pod phase** (`classifyPod`, `internal/executor/reconcile.go:39-55`, invoked
+in the loop at `:103-116`): a `Failed` pod is settled as a task failure via
+`reportFailure`. It has no way to recover a success
 from phase alone, because the only durable signal — the pod — says `Failed`.
 
 ### This is a classic distributed-systems problem, and there are two schools
@@ -116,21 +117,48 @@ try (and safely fail) to decode — avoided outright.
 ### Write ordering: the success record follows the pushes
 
 The record is written **path-specifically at the point the outcome becomes true**,
-not on a single "user process exited" event:
+not on a single "user process exited" event. To avoid missing a terminal sink, the
+write is keyed off the `state` the agent is about to report inside the terminal
+path — not bolted onto individual call sites:
 
 - The `success` record is written **only after every pre-report push (return
   value, extra links, custom XComs) has been accepted** — immediately before
   `report(SUCCESS)`. A kill *during* the pushes therefore leaves **no** success
-  record → fallback → failure → idempotent re-drive. This closes the gap where a
-  recovered "success" could have missing downstream XCom/return-value.
-- The `failed` record is written immediately before each `fail(...)`.
+  record → fallback → failure → idempotent re-drive.
+- The `failed` record must cover **every** failure sink: the `fail(...)` calls
+  (`runner.go:409-418`) **and** the execution-timeout path `failWithReason(...)`
+  (`runner.go:396, 426-431`), which reports `FAILED` without going through
+  `fail()`. Keying the write off the reported state (rather than enumerating call
+  sites) is what guarantees the timeout sink is not missed.
 - The `reschedule` record is written immediately before `reportReschedule(...)`,
   carrying the parsed next-poke time.
+
+**This ordering is forward-looking, not a present-day fix.** Return-value,
+extra-links, and custom-XCom persistence is **not implemented today** — those
+pushes short-circuit on `codes.Unimplemented` and store nothing
+(`runner.go:463-468`; XCom lands in a later phase). So "success only after the
+pushes" currently guards a gap that **cannot occur yet** (the pushes always
+"succeed" by being skipped). The constraint hardens the write site now so that
+when persistence lands, a recovered success cannot have missing downstream data;
+it buys nothing until then. Called out so the win is not mistaken for a
+present-day correctness improvement.
 
 ### The reconciler reads it as source of truth (attempt-guarded)
 
 `classifyPod` (`internal/executor/reconcile.go:39`) is extended: when a terminated
 container carries a decodable outcome record, it is trusted over the pod phase.
+
+**This is a reconciler-seam expansion, not merely a read.** Today `classifyPod`
+returns a 3-valued phase enum (`podPending | podFailed | podSucceeded`,
+`reconcile.go:14-25`) and `Reconcile` only ever *settles* a `podFailed` pod, via a
+single `FailureReporter.FailTask` (`reconcile.go:67-69, 113-117`) — a `Succeeded`
+pod is merely GC'd on age, with no success- or reschedule-settle path at all.
+Consuming the record therefore requires: (a) a richer `classifyPod` return that
+carries the outcome, `exit_code`, and `reschedule_at`; (b) new settle methods
+beyond `FailTask` for the success and reschedule paths; (c) **two new
+`try_number`-guarded queries** — a succeed and a reschedule settle — alongside the
+existing `FailTaskInstanceIfActive`; and (d) new branches in the `Reconcile` loop.
+This is scoped in Step 2 below.
 
 - Record says `success` on a `Failed` pod → settle the task **succeeded** (the
   report was lost, the work was not).
@@ -157,10 +185,12 @@ This ADR therefore specifies a **new try_number-guarded settle for the reconcile
 (both the success and failure paths): `WHERE id=$1 AND try_number=$2 AND state IN
 (...)`, threading the `leoflow.io/try-number` pod label (already set in `BuildPod`)
 into the settle. Whichever of the reconciler and a late agent report writes first
-wins; the other is a no-op. `on_failure_callback` (#424) fires consistently for a
-reconciler-driven failure, exactly as for an agent-driven one. (The claim in the
-earlier draft that we could "reuse the existing guard" was wrong — that guard is
-not on the reconciler path.)
+wins; the other is a no-op. `on_failure_callback` (#424) should fire via the
+standard `failed`-state handling for a reconciler-driven failure, exactly as for
+an agent-driven one — Step 2 must assert this, since the settle is a bare `UPDATE`
+and the callback dispatch keys off the transition, not the query. (The claim in
+the earlier draft that we could "reuse the existing guard" was wrong — that guard
+is not on the reconciler path.)
 
 ## Key properties
 
@@ -196,9 +226,12 @@ not on the reconciler path.)
   but lost its report — is closed for the common kill classes; the residue is
   safe re-drive. This is the concrete answer to Airflow's zombie-task false
   negative.
-- Small, contained change: a write in the agent's terminal path and a read in
-  `classifyPod`; a policy pin in `BuildPod`; a try_number-guarded settle. No new
-  coordination substrate, no control-plane schema change.
+- Contained but not trivial. On the execution side: a write in the agent's
+  terminal path and a policy pin in `BuildPod`. On the orchestration side: a richer
+  `classifyPod` return, new success/reschedule settle methods, two new
+  `try_number`-guarded queries, and new `Reconcile` branches. No new coordination
+  substrate and no control-plane schema change — but this **expands the reconciler
+  seam**, it is not "just a read".
 - The termination message becomes a **contract** between agent and reconciler,
   versioned by `v` so the format can evolve.
 - The reconciler grows one dependency on a Kubernetes-surfaced field; the fallback
@@ -271,11 +304,15 @@ not on the reconciler path.)
 
 1. **This ADR** — the durable-outcome mechanism, the seam contract, and the
    School-B-floor / School-A-optimization framing.
-2. **Core (no cluster).** `BuildPod` pins the termination-message policy (tested);
-   agent writes the record path-specifically after the pushes; `classifyPod` +
-   the reconciler read it and settle with a try_number-guarded query;
-   reschedule-exclusion with `reschedule_at`; idempotent double-settle. Unit-tested
-   with a fake clientset and synthetic pod statuses.
+2. **Core (no cluster).** Execution side: `BuildPod` pins the termination-message
+   policy (tested); the agent writes the record keyed off the reported state,
+   covering `fail(...)` **and** the `failWithReason(...)` timeout sink, the success
+   record after the pushes. Orchestration side: a richer `classifyPod` return; new
+   success/reschedule settle methods; two new `try_number`-guarded queries (succeed
+   + reschedule) beside `FailTaskInstanceIfActive`; new `Reconcile` branches;
+   reschedule-exclusion with `reschedule_at`; idempotent double-settle; and an
+   assertion that `on_failure_callback` fires on the reconciler-driven `failed`
+   transition. Unit-tested with a fake clientset and synthetic pod statuses.
 3. **E2E / chaos (k3d).** Inject a pod kill mid-report on the operator/split E2E
    and the runtime chaos harness (#524); assert the correct terminal state, and
    assert the agent can write the termination file under the hardened security

--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -54,4 +54,5 @@ The *why* behind Leoflow's design. ADRs are immutable once accepted.
 - [ADR 0049: Split the API/UI and scheduler into separate roles of one binary](adr/0049-split-api-and-scheduler-roles.md)
 - [ADR 0050: Model Context Protocol (MCP) server](adr/0050-mcp-server.md)
 - [ADR 0051: Separate the orchestration and execution state machines](adr/0051-separate-orchestration-and-execution-state-machines.md)
+- [ADR 0052: Durable task outcome — decouple the task result from report delivery](adr/0052-durable-task-outcome.md)
 <!-- END ADR INDEX -->

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -8,11 +8,13 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 	"slices"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/neochaotic/leoflow/internal/taskoutcome"
 	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -65,6 +67,11 @@ type Runner struct {
 	// ReschedulePath is the file a reschedule-mode sensor writes its next-poke time
 	// to before exiting with rescheduleExitCode; empty disables reschedule (#380).
 	ReschedulePath string
+	// TerminationLogPath is where the agent writes its durable outcome record just
+	// before delivering the report, so a pod killed mid-report still leaves the
+	// task's true result behind for the reconciler to recover (ADR 0052). Empty
+	// disables it — Lite (subprocess, in-process report) needs no such record.
+	TerminationLogPath string
 	// HeartbeatInterval is how often to ping the control plane while the task
 	// runs; zero disables heartbeats.
 	HeartbeatInterval time.Duration
@@ -574,12 +581,46 @@ func (r *Runner) heartbeat(ctx context.Context, cancel context.CancelFunc) {
 }
 
 func (r *Runner) report(ctx context.Context, state agentv1.TaskState, exitCode int32, msg string) error {
+	r.recordOutcome(state, exitCode)
 	return r.reportRequest(ctx, &agentv1.ReportStateRequest{
 		State:        state,
 		ExitCode:     exitCode,
 		ErrorMessage: msg,
 		OccurredAt:   timestamppb.Now(),
 	})
+}
+
+// recordOutcome writes the durable outcome record for a terminal report state,
+// before the report is delivered (ADR 0052). Keying off the reported state — not
+// the individual fail()/failWithReason() call sites — guarantees every failure
+// sink is covered. Non-terminal states are a no-op.
+func (r *Runner) recordOutcome(state agentv1.TaskState, exitCode int32) {
+	switch state {
+	case agentv1.TaskState_TASK_STATE_SUCCESS:
+		r.writeOutcome(taskoutcome.Succeeded())
+	case agentv1.TaskState_TASK_STATE_FAILED:
+		r.writeOutcome(taskoutcome.FailedWith(exitCode))
+	default:
+		// Non-terminal states (RUNNING, and the reschedule handled separately in
+		// reportReschedule) carry no durable outcome.
+	}
+}
+
+// writeOutcome persists the task's true outcome to the termination-log path. It is
+// best-effort: the report remains the primary delivery channel, so an encode or
+// write failure is logged, never fatal. A no-op when the path is unset (Lite).
+func (r *Runner) writeOutcome(rec taskoutcome.Record) {
+	if r.TerminationLogPath == "" {
+		return
+	}
+	enc, err := rec.Encode()
+	if err != nil {
+		slog.Warn("encoding task outcome record", "error", err)
+		return
+	}
+	if err := os.WriteFile(r.TerminationLogPath, []byte(enc), 0o644); err != nil {
+		slog.Warn("writing task outcome record", "path", r.TerminationLogPath, "error", err)
+	}
 }
 
 // reportRequest sends a ReportState request and translates the response's
@@ -665,6 +706,7 @@ func (r *Runner) readReschedule() (time.Time, bool) {
 // reportReschedule reports up_for_reschedule with the next-poke time so the
 // scheduler re-dispatches the task later, consuming no retry budget (#380).
 func (r *Runner) reportReschedule(ctx context.Context, when time.Time) error {
+	r.writeOutcome(taskoutcome.RescheduledAt(when))
 	return r.reportRequest(ctx, &agentv1.ReportStateRequest{
 		State:        agentv1.TaskState_TASK_STATE_UP_FOR_RESCHEDULE,
 		OccurredAt:   timestamppb.Now(),

--- a/internal/agent/runner_outcome_test.go
+++ b/internal/agent/runner_outcome_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -136,6 +137,48 @@ func TestRunnerWritesOutcomeBeforeReport(t *testing.T) {
 	// Even though the report never landed, the outcome is durable.
 	if rec := readOutcome(t, path); rec.Outcome != taskoutcome.Success {
 		t.Errorf("outcome = %q, want success recorded before the (failed) report", rec.Outcome)
+	}
+}
+
+// TestRunnerSuccessPathPushFailureWritesFailedRecord locks the write ordering the
+// design leans on: a task whose user code exited 0 but whose pre-report XCom push
+// fails routes to fail(), which must leave a FAILED record — never a stale SUCCESS.
+// A recovered success must only ever be written after the pushes were accepted.
+func TestRunnerSuccessPathPushFailureWritesFailedRecord(t *testing.T) {
+	dir := t.TempDir()
+	returnPath := filepath.Join(dir, "return.json")
+	if err := os.WriteFile(returnPath, []byte(`{"x":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "termination-log")
+	client := &fakeClient{
+		spec:    &agentv1.TaskSpec{Operator: "python", Entrypoint: "dag:ok"},
+		pushErr: errors.New("xcom backend down"), // a non-Unimplemented push failure
+	}
+	r := newRunner(client, &fakeCmd{exitCode: 0}, &recordingSink{})
+	r.ReturnPath = returnPath
+	r.TerminationLogPath = path
+
+	if err := r.Run(context.Background()); err == nil {
+		t.Fatal("a failed pre-report push must fail the task")
+	}
+	if rec := readOutcome(t, path); rec.Outcome != taskoutcome.Failed {
+		t.Errorf("a push failure on the success path must write a FAILED record, not a stale success, got %q", rec.Outcome)
+	}
+}
+
+// TestRunnerRunningStateWritesNoRecord: a non-terminal RUNNING report must never
+// write an outcome record — only the terminal states carry a durable outcome.
+func TestRunnerRunningStateWritesNoRecord(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "termination-log")
+	r := newRunner(&fakeClient{}, &fakeCmd{}, &recordingSink{})
+	r.TerminationLogPath = path
+
+	if err := r.report(context.Background(), agentv1.TaskState_TASK_STATE_RUNNING, 0, ""); err != nil {
+		t.Fatalf("report RUNNING: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("a RUNNING report must not write an outcome record")
 	}
 }
 

--- a/internal/agent/runner_outcome_test.go
+++ b/internal/agent/runner_outcome_test.go
@@ -1,0 +1,152 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/taskoutcome"
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+)
+
+// readOutcome reads and decodes the durable outcome record the agent wrote to its
+// termination-log path, failing the test if it is absent or undecodable.
+func readOutcome(t *testing.T, path string) taskoutcome.Record {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("termination log not written: %v", err)
+	}
+	rec, ok := taskoutcome.Decode(string(data))
+	if !ok {
+		t.Fatalf("termination log is not a decodable outcome record: %q", data)
+	}
+	return rec
+}
+
+// TestRunnerWritesSuccessOutcome: a task that succeeds leaves a `success` record
+// in the termination log, so a reconciler can recover the success even if the
+// report is lost (ADR 0052). The success record is written only after the
+// pre-report pushes, since report(SUCCESS) is the last step of the terminal path.
+func TestRunnerWritesSuccessOutcome(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "termination-log")
+	client := &fakeClient{spec: &agentv1.TaskSpec{Operator: "python", Entrypoint: "dag:ok"}}
+	r := newRunner(client, &fakeCmd{exitCode: 0}, &recordingSink{})
+	r.TerminationLogPath = path
+
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if rec := readOutcome(t, path); rec.Outcome != taskoutcome.Success {
+		t.Errorf("outcome = %q, want success", rec.Outcome)
+	}
+}
+
+// TestRunnerWritesFailedOutcome: a task that exits non-zero leaves a `failed`
+// record carrying the exit code.
+func TestRunnerWritesFailedOutcome(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "termination-log")
+	client := &fakeClient{spec: &agentv1.TaskSpec{Operator: "python", Entrypoint: "dag:boom"}}
+	r := newRunner(client, &fakeCmd{exitCode: 1}, &recordingSink{})
+	r.TerminationLogPath = path
+
+	if err := r.Run(context.Background()); err == nil {
+		t.Fatal("a non-zero exit must fail")
+	}
+	rec := readOutcome(t, path)
+	if rec.Outcome != taskoutcome.Failed {
+		t.Errorf("outcome = %q, want failed", rec.Outcome)
+	}
+	if rec.ExitCode == nil || *rec.ExitCode != 1 {
+		t.Errorf("exit_code = %v, want 1", rec.ExitCode)
+	}
+}
+
+// TestRunnerWritesFailedOutcomeOnTimeout pins that the execution-timeout sink
+// (failWithReason, not fail) also leaves a durable record. The record is keyed off
+// the reported state inside report(), so every failure sink is covered — the exact
+// gap a "write before each fail()" approach would miss (ADR 0052 review).
+func TestRunnerWritesFailedOutcomeOnTimeout(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "termination-log")
+	client := &fakeClient{spec: &agentv1.TaskSpec{
+		Operator:                "bash",
+		Entrypoint:              "sleep 1000",
+		ExecutionTimeoutSeconds: 1,
+	}}
+	r := newRunner(client, &fakeCmd{blockUntilCancel: true}, &recordingSink{})
+	r.TerminationLogPath = path
+
+	if err := r.Run(context.Background()); err == nil {
+		t.Fatal("a task exceeding its execution timeout must fail")
+	}
+	if rec := readOutcome(t, path); rec.Outcome != taskoutcome.Failed {
+		t.Errorf("timeout outcome = %q, want failed", rec.Outcome)
+	}
+}
+
+// TestRunnerWritesRescheduleOutcome: a reschedule-mode sensor leaves a
+// `reschedule` record carrying the next-poke time, so a lost report can still be
+// settled as up_for_reschedule with the real time rather than an invented one.
+func TestRunnerWritesRescheduleOutcome(t *testing.T) {
+	dir := t.TempDir()
+	rp := filepath.Join(dir, "reschedule.txt")
+	if err := os.WriteFile(rp, []byte("2099-01-02T03:04:05+00:00\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "termination-log")
+	client := &fakeClient{spec: &agentv1.TaskSpec{Operator: "python", Entrypoint: "dag:sensor"}}
+	r := newRunner(client, &fakeCmd{exitCode: rescheduleExitCode}, &recordingSink{})
+	r.ReschedulePath = rp
+	r.TerminationLogPath = path
+
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: reschedule must not surface as an error: %v", err)
+	}
+	rec := readOutcome(t, path)
+	if rec.Outcome != taskoutcome.Reschedule {
+		t.Fatalf("outcome = %q, want reschedule", rec.Outcome)
+	}
+	when, ok := rec.At()
+	if !ok {
+		t.Fatal("reschedule record must carry a parseable next-poke time")
+	}
+	if got := when.UTC().Format("2006-01-02T15:04:05Z"); got != "2099-01-02T03:04:05Z" {
+		t.Errorf("reschedule_at = %s, want 2099-01-02T03:04:05Z", got)
+	}
+}
+
+// TestRunnerWritesOutcomeBeforeReport is the durability property: the record is on
+// disk even when the report delivery itself fails. This is the whole point — a pod
+// killed mid-report still leaves the truth behind.
+func TestRunnerWritesOutcomeBeforeReport(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "termination-log")
+	client := &fakeClient{
+		spec: &agentv1.TaskSpec{Operator: "python", Entrypoint: "dag:ok"},
+		// Let the RUNNING report land, then lose the terminal SUCCESS report —
+		// exactly the pod-killed-mid-report case the record exists to survive.
+		failReportState: agentv1.TaskState_TASK_STATE_SUCCESS,
+	}
+	r := newRunner(client, &fakeCmd{exitCode: 0}, &recordingSink{})
+	r.TerminationLogPath = path
+
+	if err := r.Run(context.Background()); err == nil {
+		t.Fatal("a failed report must surface as an error")
+	}
+	// Even though the report never landed, the outcome is durable.
+	if rec := readOutcome(t, path); rec.Outcome != taskoutcome.Success {
+		t.Errorf("outcome = %q, want success recorded before the (failed) report", rec.Outcome)
+	}
+}
+
+// TestRunnerNoTerminationLogWhenPathUnset: Lite (subprocess, no pod, in-process
+// report) sets no termination-log path and must be entirely unaffected — no file,
+// no error.
+func TestRunnerNoTerminationLogWhenPathUnset(t *testing.T) {
+	client := &fakeClient{spec: &agentv1.TaskSpec{Operator: "python", Entrypoint: "dag:ok"}}
+	r := newRunner(client, &fakeCmd{exitCode: 0}, &recordingSink{})
+	// TerminationLogPath left empty.
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run with no termination-log path must be unaffected: %v", err)
+	}
+}

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -29,9 +29,13 @@ type fakeClient struct {
 	pushErr     error
 	// reportFailCode + reportFailTimes make the first reportFailTimes ReportState
 	// calls fail with that gRPC code, then succeed — to exercise the report retry.
-	reportFailCode     codes.Code
-	reportFailTimes    int
-	reportAttempts     int
+	reportFailCode  codes.Code
+	reportFailTimes int
+	reportAttempts  int
+	// failReportState, when set, makes ReportState fail for that state only (e.g.
+	// fail the terminal SUCCESS report but let the earlier RUNNING report land) —
+	// used to prove the outcome record is durable even when its report is lost.
+	failReportState    agentv1.TaskState
 	heartbeatTerminate bool
 	vars               map[string]string
 	conns              map[string]string
@@ -80,6 +84,9 @@ func (f *fakeClient) ReportState(_ context.Context, in *agentv1.ReportStateReque
 	f.reportAttempts++
 	if f.reportAttempts <= f.reportFailTimes {
 		return nil, status.Error(f.reportFailCode, "injected report failure")
+	}
+	if f.failReportState != agentv1.TaskState_TASK_STATE_UNSPECIFIED && in.GetState() == f.failReportState {
+		return nil, status.Error(codes.Internal, "injected terminal report failure")
 	}
 	f.states = append(f.states, in.GetState())
 	f.reports = append(f.reports, in)

--- a/internal/executor/kubernetes.go
+++ b/internal/executor/kubernetes.go
@@ -51,6 +51,12 @@ func (e *KubernetesExecutor) Execute(ctx context.Context, req Request) error {
 	return nil
 }
 
+// terminationMessagePath is where the task container surfaces its termination
+// message. The agent writes its durable outcome record here and the reconciler
+// reads it from pod status (ADR 0052); it is the Kubernetes default path, pinned
+// explicitly so the contract does not rely on an implicit default.
+const terminationMessagePath = "/dev/termination-log"
+
 // BuildPod constructs the pod spec for a task instance. It is pure (modulo the
 // random name suffix) and unit-tested independently of any cluster.
 func BuildPod(req Request) *corev1.Pod {
@@ -85,6 +91,14 @@ func BuildPod(req Request) *corev1.Pod {
 				Env:             podEnv(req),
 				Resources:       buildResources(req.Resources),
 				SecurityContext: buildSecurityContext(req.PodSecurity),
+				// Pin the termination-message contract explicitly rather than relying
+				// on the Kubernetes default: the agent writes its durable outcome
+				// record here before delivering the report, and the reconciler reads
+				// it from pod status to recover a success whose report was lost (ADR
+				// 0052). FallbackToLogsOnError is deliberately NOT set — it would
+				// populate the message from the log tail, which is not a record.
+				TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+				TerminationMessagePath:   terminationMessagePath,
 			}},
 		},
 	}
@@ -182,6 +196,10 @@ func podEnv(req Request) []corev1.EnvVar {
 		corev1.EnvVar{Name: "LEOFLOW_CONTROL_PLANE_ADDR", Value: req.ControlPlaneAddr},
 		corev1.EnvVar{Name: "LEOFLOW_AGENT_TOKEN", Value: req.AgentToken},
 		corev1.EnvVar{Name: "LEOFLOW_TASK_INSTANCE_ID", Value: req.TaskInstanceID},
+		// Tell the pod agent where to write its durable outcome record; it matches
+		// the container's TerminationMessagePath. Only the pod path sets this, so
+		// Lite (subprocess, no pod) leaves the agent's record writing disabled.
+		corev1.EnvVar{Name: "LEOFLOW_TERMINATION_LOG_PATH", Value: terminationMessagePath},
 	)
 	if req.StagingClaim != "" {
 		env = append(env, corev1.EnvVar{Name: "LEOFLOW_STAGING_DIR", Value: stagingMountPath})

--- a/internal/executor/kubernetes_test.go
+++ b/internal/executor/kubernetes_test.go
@@ -61,6 +61,32 @@ func TestBuildPod(t *testing.T) {
 	}
 }
 
+// TestBuildPodPinsTerminationMessagePolicy locks the ADR 0052 prerequisite: the
+// task container must explicitly pin TerminationMessagePolicy=File and the path,
+// so the agent's durable outcome record is surfaced on pod status. Relying on the
+// Kubernetes default is fragile — an admission webhook or PodSecurity policy could
+// mutate it and silently revert outcome recovery to phase-based failure.
+func TestBuildPodPinsTerminationMessagePolicy(t *testing.T) {
+	c := BuildPod(sampleReq()).Spec.Containers[0]
+	if c.TerminationMessagePolicy != corev1.TerminationMessageReadFile {
+		t.Errorf("TerminationMessagePolicy = %q, want File (ADR 0052)", c.TerminationMessagePolicy)
+	}
+	if c.TerminationMessagePath != "/dev/termination-log" {
+		t.Errorf("TerminationMessagePath = %q, want /dev/termination-log", c.TerminationMessagePath)
+	}
+	// The agent must be told to write its record to the same path the container
+	// surfaces, so the reader and writer agree.
+	var envPath string
+	for _, e := range c.Env {
+		if e.Name == "LEOFLOW_TERMINATION_LOG_PATH" {
+			envPath = e.Value
+		}
+	}
+	if envPath != c.TerminationMessagePath {
+		t.Errorf("LEOFLOW_TERMINATION_LOG_PATH = %q, want it to match TerminationMessagePath %q", envPath, c.TerminationMessagePath)
+	}
+}
+
 func TestBuildPodMountsStagingVolume(t *testing.T) {
 	// Without a staging claim, no extra volume is added.
 	if vols := BuildPod(sampleReq()).Spec.Volumes; len(vols) != 0 {

--- a/internal/executor/reconcile.go
+++ b/internal/executor/reconcile.go
@@ -4,25 +4,42 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	"github.com/neochaotic/leoflow/internal/taskoutcome"
 )
 
-// podOutcome is the reconciler's classification of a task pod's status.
-type podOutcome int
+// settleKind is what the reconciler must record for a terminal task pod.
+type settleKind int
 
 const (
-	// podPending means the pod is still starting or running; no action.
-	podPending podOutcome = iota
-	// podFailed means the pod failed in a way the agent will never report
-	// (terminal phase or an unrecoverable container start error).
-	podFailed
-	// podSucceeded means the pod completed successfully.
-	podSucceeded
+	// settleNothing means there is nothing to record (a succeeded pod with no
+	// outcome record — its report already settled the task; the reconciler only
+	// garbage-collects it).
+	settleNothing settleKind = iota
+	// settleFailed records the task instance as failed.
+	settleFailed
+	// settleSucceeded records the task instance as succeeded — recovering a success
+	// whose report was lost (ADR 0052).
+	settleSucceeded
+	// settleReschedule parks the task instance in up_for_reschedule.
+	settleReschedule
 )
+
+// verdict is the reconciler's classification of a task pod: whether it is terminal
+// (garbage-collectable on age) and what, if anything, to record for it.
+type verdict struct {
+	terminal   bool       // the pod is done; eligible for GC on age
+	settle     settleKind // what to record for the task instance
+	reason     string     // failure reason (settleFailed)
+	at         time.Time  // next-poke time (settleReschedule)
+	fromRecord bool       // a durable outcome record drove this, not pod phase
+}
 
 // unrecoverableWaiting lists container "waiting" reasons that never self-resolve
 // and mean the agent never started, so no state will be reported.
@@ -34,24 +51,70 @@ var unrecoverableWaiting = map[string]bool{
 	"CrashLoopBackOff":     true,
 }
 
-// classifyPod determines whether a task pod has failed, succeeded, or is still
-// in progress, returning a human-readable reason for failures.
-func classifyPod(pod *corev1.Pod) (outcome podOutcome, reason string) {
+// taskContainerName is the task pod's single container (see BuildPod).
+const taskContainerName = "task"
+
+// classifyPod determines what the reconciler should do with a task pod. It trusts
+// a durable outcome record on the terminated task container over pod phase (ADR
+// 0052) — recovering a success whose report was lost — and falls back to
+// phase-based classification when no decodable record is present.
+func classifyPod(pod *corev1.Pod) verdict {
+	// The durable outcome record is authoritative when present: the agent wrote it
+	// before attempting the report, so it survives a pod killed mid-report.
+	if rec, ok := outcomeRecord(pod); ok {
+		switch rec.Outcome {
+		case taskoutcome.Success:
+			return verdict{terminal: true, settle: settleSucceeded, fromRecord: true}
+		case taskoutcome.Failed:
+			return verdict{terminal: true, settle: settleFailed, reason: recordFailureReason(rec), fromRecord: true}
+		case taskoutcome.Reschedule:
+			at, _ := rec.At() // Decode guaranteed a parseable time
+			return verdict{terminal: true, settle: settleReschedule, at: at, fromRecord: true}
+		}
+	}
+
+	// No record — fall back to pod phase (pre-0052 behavior). A record-less
+	// succeeded pod has nothing to settle; its report already ran. A failed pod is
+	// recorded as failed so retries and finalization proceed.
 	switch pod.Status.Phase {
 	case corev1.PodFailed:
-		return podFailed, podFailureReason(pod)
+		return verdict{terminal: true, settle: settleFailed, reason: podFailureReason(pod)}
 	case corev1.PodSucceeded:
-		return podSucceeded, ""
+		return verdict{terminal: true, settle: settleNothing}
 	case corev1.PodPending, corev1.PodRunning, corev1.PodUnknown:
 		for _, cs := range pod.Status.ContainerStatuses {
 			if w := cs.State.Waiting; w != nil && unrecoverableWaiting[w.Reason] {
-				return podFailed, w.Reason
+				return verdict{terminal: true, settle: settleFailed, reason: w.Reason}
 			}
 		}
-		return podPending, ""
+		return verdict{terminal: false}
 	default:
-		return podPending, ""
+		return verdict{terminal: false}
 	}
+}
+
+// outcomeRecord decodes the durable outcome record from the terminated task
+// container's termination message, if present and valid. A missing, running, or
+// undecodable message returns false so the caller falls back to pod phase.
+func outcomeRecord(pod *corev1.Pod) (taskoutcome.Record, bool) {
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name != taskContainerName {
+			continue
+		}
+		if t := cs.State.Terminated; t != nil && t.Message != "" {
+			return taskoutcome.Decode(t.Message)
+		}
+	}
+	return taskoutcome.Record{}, false
+}
+
+// recordFailureReason renders a failure reason from an outcome record, naming the
+// exit code when the record carries one.
+func recordFailureReason(rec taskoutcome.Record) string {
+	if rec.ExitCode != nil {
+		return fmt.Sprintf("task failed (exit %d)", *rec.ExitCode)
+	}
+	return "task failed"
 }
 
 func podFailureReason(pod *corev1.Pod) string {
@@ -61,36 +124,57 @@ func podFailureReason(pod *corev1.Pod) string {
 	return "pod failed"
 }
 
-// FailureReporter marks a task instance failed when its pod failed without the
-// agent reporting. The implementation must be idempotent and only act on a
-// non-terminal task instance.
-type FailureReporter interface {
-	FailTask(ctx context.Context, taskInstanceID, reason string) error
+// tryNumberOf reads the attempt the pod ran, from the leoflow.io/try-number label
+// BuildPod sets. It guards the settle against clobbering a different attempt, so a
+// pod whose label is missing or unparseable is not settled (ok is false).
+func tryNumberOf(pod *corev1.Pod) (int, bool) {
+	s := pod.Labels["leoflow.io/try-number"]
+	if s == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// OutcomeReporter records a terminal task-instance outcome the reconciler
+// recovered from a pod (its durable outcome record, or its phase). Every method is
+// guarded by the attempt (try_number) so a stale reconciler acting on a previous
+// attempt's pod never clobbers a live retry, and is idempotent: a settle on an
+// already-terminal instance is a no-op, not an error.
+type OutcomeReporter interface {
+	FailTask(ctx context.Context, taskInstanceID string, tryNumber int, reason string) error
+	SucceedTask(ctx context.Context, taskInstanceID string, tryNumber int) error
+	RescheduleTask(ctx context.Context, taskInstanceID string, tryNumber int, at time.Time) error
 }
 
 // podGCGracePeriod is how long a finished pod is kept before garbage collection,
 // leaving a window to inspect a failed pod with kubectl.
 const podGCGracePeriod = 10 * time.Minute
 
-// Reconciler detects task pods that failed without the agent reporting state and
-// marks the corresponding task instance failed, so retries and run finalization
-// can proceed instead of stranding the task. It also garbage-collects finished
-// pods once they age out.
+// Reconciler detects task pods whose task instance was never settled by the agent
+// (a pod killed before or during its report) and records the true outcome — from
+// the pod's durable outcome record where present, else its phase — so retries and
+// run finalization proceed instead of stranding the task. It also garbage-collects
+// finished pods once they age out.
 type Reconciler struct {
 	clientset kubernetes.Interface
 	namespace string
-	reporter  FailureReporter
+	reporter  OutcomeReporter
 	now       func() time.Time
 	ttl       time.Duration
 }
 
-// NewReconciler builds a Reconciler over the given cluster and failure reporter.
-func NewReconciler(clientset kubernetes.Interface, namespace string, reporter FailureReporter) *Reconciler {
+// NewReconciler builds a Reconciler over the given cluster and outcome reporter.
+func NewReconciler(clientset kubernetes.Interface, namespace string, reporter OutcomeReporter) *Reconciler {
 	return &Reconciler{clientset: clientset, namespace: namespace, reporter: reporter, now: time.Now, ttl: podGCGracePeriod}
 }
 
-// Reconcile lists managed task pods, reports each failed one's task instance,
-// and garbage-collects finished pods older than the grace period.
+// Reconcile lists managed task pods, records each terminal one's outcome against
+// its task instance, and garbage-collects finished pods older than the grace
+// period.
 func (r *Reconciler) Reconcile(ctx context.Context) error {
 	pods, err := r.clientset.CoreV1().Pods(r.namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: "leoflow.io/run-id",
@@ -100,18 +184,17 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 	}
 	for i := range pods.Items {
 		pod := &pods.Items[i]
-		outcome, reason := classifyPod(pod)
-		if outcome == podPending {
+		v := classifyPod(pod)
+		if !v.terminal {
 			continue
 		}
-		// A failed pod must have its failure durably recorded before it is
+		// A terminal pod must have its outcome durably recorded before it is
 		// collected: the pod is the only signal that lets the next tick retry the
-		// report, so deleting it after a failed report strands the task instance
-		// in `running` until the heartbeat reaper catches it. If the report does
-		// not succeed, leave the pod and try again next tick. A succeeded pod has
-		// nothing to record, so it is collected on age alone.
-		if outcome == podFailed {
-			if err := r.reportFailure(ctx, pod, reason); err != nil {
+		// record, so deleting it after a failed settle strands the task instance
+		// until the heartbeat reaper catches it. If the settle does not succeed,
+		// leave the pod and try again next tick.
+		if v.settle != settleNothing {
+			if err := r.settlePod(ctx, pod, v); err != nil {
 				continue
 			}
 		}
@@ -122,21 +205,46 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 	return nil
 }
 
-// reportFailure records the pod's failure against its task instance. It returns
-// nil when there is nothing to record (a pod with no task-instance annotation is
-// an orphan with no terminal state to preserve, so its caller may collect it) and
-// the reporter's error otherwise, so the caller can defer collection until the
-// failure is durably recorded.
-func (r *Reconciler) reportFailure(ctx context.Context, pod *corev1.Pod, reason string) error {
+// settlePod records the pod's recovered outcome against its task instance,
+// attempt-guarded. It returns nil when there is nothing to record (an orphan pod
+// with no task-instance annotation) so the caller may collect it, and an error
+// when the outcome could not be durably recorded, so the caller defers collection
+// until a later tick succeeds.
+func (r *Reconciler) settlePod(ctx context.Context, pod *corev1.Pod, v verdict) error {
 	tiID := pod.Annotations["leoflow.io/task-instance-id"]
 	if tiID == "" {
 		return nil
 	}
-	if err := r.reporter.FailTask(ctx, tiID, reason); err != nil {
-		slog.Error("reporting failed pod", "pod", pod.Name, "task_instance", tiID, "error", err)
+	tryNumber, ok := tryNumberOf(pod)
+	if !ok {
+		// Without the attempt we cannot guard the settle, and settling unguarded
+		// could clobber a different attempt. Leave the pod for a later tick / the
+		// heartbeat reaper rather than risk a wrong write.
+		err := fmt.Errorf("pod %s has no parseable leoflow.io/try-number label", pod.Name)
+		slog.Error("cannot settle task pod without a try-number", "pod", pod.Name, "task_instance", tiID)
+		return err
+	}
+	if err := r.recordOutcome(ctx, tiID, tryNumber, v); err != nil {
+		slog.Error("recording task pod outcome", "pod", pod.Name, "task_instance", tiID,
+			"settle", v.settle, "from_record", v.fromRecord, "error", err)
 		return err
 	}
 	return nil
+}
+
+func (r *Reconciler) recordOutcome(ctx context.Context, tiID string, tryNumber int, v verdict) error {
+	switch v.settle {
+	case settleSucceeded:
+		return r.reporter.SucceedTask(ctx, tiID, tryNumber)
+	case settleReschedule:
+		return r.reporter.RescheduleTask(ctx, tiID, tryNumber, v.at)
+	case settleFailed:
+		return r.reporter.FailTask(ctx, tiID, tryNumber, v.reason)
+	case settleNothing:
+		return nil
+	default:
+		return nil
+	}
 }
 
 func (r *Reconciler) collect(ctx context.Context, pod *corev1.Pod) {

--- a/internal/executor/reconcile.go
+++ b/internal/executor/reconcile.go
@@ -159,6 +159,13 @@ const podGCGracePeriod = 10 * time.Minute
 // the pod's durable outcome record where present, else its phase — so retries and
 // run finalization proceed instead of stranding the task. It also garbage-collects
 // finished pods once they age out.
+//
+// Outcome recovery is best-effort (ADR 0052 is a School-A optimization on the
+// School-B re-drive floor): the settle guards on the active states, so if a reaper
+// settles the still-running TI failed first (heartbeat timeout, ~90s) before this
+// loop recovers the success record (~30s), the recovered success is dropped and the
+// task degrades to the safe retry path. The 30s vs 90s cadence makes the reconciler
+// win the common case; the loss is a correctness-safe re-run, not a wrong result.
 type Reconciler struct {
 	clientset kubernetes.Interface
 	namespace string
@@ -189,12 +196,23 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 			continue
 		}
 		// A terminal pod must have its outcome durably recorded before it is
-		// collected: the pod is the only signal that lets the next tick retry the
-		// record, so deleting it after a failed settle strands the task instance
-		// until the heartbeat reaper catches it. If the settle does not succeed,
-		// leave the pod and try again next tick.
+		// collected: while a settle can still be retried, the pod is the only signal,
+		// so deleting it after a failed settle would strand the task instance until
+		// the heartbeat reaper catches it. On a genuine DB error, leave the pod and
+		// try again next tick.
 		if v.settle != settleNothing {
 			if err := r.settlePod(ctx, pod, v); err != nil {
+				continue
+			}
+			// A reschedule pod's record must NOT linger to be re-applied. Reschedule
+			// redispatch reuses the same try_number (it consumes no attempt, #380), so
+			// the attempt guard cannot tell a stale poke pod from the re-dispatched
+			// live one — a lingering poke pod would re-park the live attempt with an
+			// already-elapsed reschedule_at and flap the sensor. It exited cleanly
+			// (nothing to inspect), so collect it now instead of after the grace
+			// period, well before the next redispatch. (ADR 0052)
+			if v.settle == settleReschedule {
+				r.collect(ctx, pod)
 				continue
 			}
 		}
@@ -217,12 +235,15 @@ func (r *Reconciler) settlePod(ctx context.Context, pod *corev1.Pod, v verdict) 
 	}
 	tryNumber, ok := tryNumberOf(pod)
 	if !ok {
-		// Without the attempt we cannot guard the settle, and settling unguarded
-		// could clobber a different attempt. Leave the pod for a later tick / the
-		// heartbeat reaper rather than risk a wrong write.
-		err := fmt.Errorf("pod %s has no parseable leoflow.io/try-number label", pod.Name)
-		slog.Error("cannot settle task pod without a try-number", "pod", pod.Name, "task_instance", tiID)
-		return err
+		// Anomalous pod — BuildPod always sets the label, so this is a hand-created
+		// or old-version pod. Without the attempt we cannot guard the settle, and
+		// settling unguarded could clobber a different attempt. Skip the settle and
+		// let the pod age out normally (the heartbeat reaper is the task instance's
+		// backstop); returning an error here would leak the pod forever, since the
+		// label will never appear on a later tick.
+		slog.Error("cannot settle task pod without a try-number; leaving the TI to the reaper",
+			"pod", pod.Name, "task_instance", tiID)
+		return nil
 	}
 	if err := r.recordOutcome(ctx, tiID, tryNumber, v); err != nil {
 		slog.Error("recording task pod outcome", "pod", pod.Name, "task_instance", tiID,

--- a/internal/executor/reconcile_extra_test.go
+++ b/internal/executor/reconcile_extra_test.go
@@ -32,8 +32,8 @@ func TestPodFailureReasonSurfacesCause(t *testing.T) {
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			if _, reason := classifyPod(c.pod); reason != c.want {
-				t.Errorf("reason = %q, want %q", reason, c.want)
+			if got := classifyPod(c.pod).reason; got != c.want {
+				t.Errorf("reason = %q, want %q", got, c.want)
 			}
 		})
 	}
@@ -49,14 +49,22 @@ func TestReconcileSkipsPodWithoutTaskInstance(t *testing.T) {
 	if err := r.Reconcile(context.Background()); err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
-	if len(reporter.failed) != 0 {
-		t.Errorf("a pod without a task-instance annotation must not be reported, got %v", reporter.failed)
+	if len(reporter.settled) != 0 {
+		t.Errorf("a pod without a task-instance annotation must not be reported, got %v", reporter.settled)
 	}
 }
 
 type errReporter struct{}
 
-func (errReporter) FailTask(context.Context, string, string) error {
+func (errReporter) FailTask(context.Context, string, int, string) error {
+	return errors.New("metadatabase unavailable")
+}
+
+func (errReporter) SucceedTask(context.Context, string, int) error {
+	return errors.New("metadatabase unavailable")
+}
+
+func (errReporter) RescheduleTask(context.Context, string, int, time.Time) error {
 	return errors.New("metadatabase unavailable")
 }
 

--- a/internal/executor/reconcile_test.go
+++ b/internal/executor/reconcile_test.go
@@ -204,12 +204,12 @@ func TestReconcileUndecodableRecordFallsBackToPhase(t *testing.T) {
 
 // TestReconcileSkipsSettleWithoutTryNumber: a pod missing the try-number label
 // cannot be attempt-guarded, so the reconciler must NOT settle it (risking a
-// clobber of a different attempt) and must NOT collect it — it leaves it for a
-// later tick / the heartbeat reaper.
+// clobber of a different attempt) — but it must still age out normally rather than
+// leak forever (the label will never appear); the heartbeat reaper settles the TI.
 func TestReconcileSkipsSettleWithoutTryNumber(t *testing.T) {
 	pod := withRecord(managedPod("p-nolabel", "ti-nolabel", corev1.PodFailed), taskoutcome.Succeeded())
 	delete(pod.Labels, "leoflow.io/try-number")
-	pod.CreationTimestamp = metav1.NewTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)) // old enough to GC
+	pod.CreationTimestamp = metav1.NewTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)) // aged past the grace period
 	cs := fake.NewClientset(pod)
 	reporter := &fakeReporter{}
 	r := NewReconciler(cs, "leoflow", reporter)
@@ -221,8 +221,33 @@ func TestReconcileSkipsSettleWithoutTryNumber(t *testing.T) {
 	if len(reporter.settled) != 0 {
 		t.Errorf("a pod without a try-number must not be settled, got %v", reporter.settled)
 	}
-	if _, err := cs.CoreV1().Pods("leoflow").Get(context.Background(), "p-nolabel", metav1.GetOptions{}); err != nil {
-		t.Errorf("an unsettled pod must not be garbage-collected: %v", err)
+	if _, err := cs.CoreV1().Pods("leoflow").Get(context.Background(), "p-nolabel", metav1.GetOptions{}); err == nil {
+		t.Error("an aged label-less pod must still be garbage-collected (no forever-leak)")
+	}
+}
+
+// TestReconcileCollectsReschedulePodImmediately pins the ADR 0052 B1 fix: a
+// reschedule pod is collected as soon as its outcome is settled — NOT kept for the
+// grace period — because reschedule redispatch reuses the same try_number, so a
+// lingering poke pod would re-park the re-dispatched live attempt and flap the
+// sensor. Here the pod is young (well within the grace period) yet must be gone.
+func TestReconcileCollectsReschedulePodImmediately(t *testing.T) {
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	pod := withRecord(managedPod("p-poke", "ti-poke", corev1.PodFailed), taskoutcome.RescheduledAt(now.Add(time.Minute)))
+	pod.CreationTimestamp = metav1.NewTime(now.Add(-time.Second)) // brand new
+	cs := fake.NewClientset(pod)
+	reporter := &fakeReporter{}
+	r := NewReconciler(cs, "leoflow", reporter)
+	r.now = func() time.Time { return now }
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if got := reporter.settled["ti-poke"]; got.kind != settleReschedule {
+		t.Errorf("reschedule pod must be settled up_for_reschedule, got %+v", got)
+	}
+	if _, err := cs.CoreV1().Pods("leoflow").Get(context.Background(), "p-poke", metav1.GetOptions{}); err == nil {
+		t.Error("a settled reschedule pod must be collected immediately, not left to linger and re-park the next attempt")
 	}
 }
 

--- a/internal/executor/reconcile_test.go
+++ b/internal/executor/reconcile_test.go
@@ -2,12 +2,15 @@ package executor
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/neochaotic/leoflow/internal/taskoutcome"
 )
 
 func podPhase(phase corev1.PodPhase) *corev1.Pod {
@@ -25,47 +28,91 @@ func podWaiting(reason string) *corev1.Pod {
 
 func TestClassifyPod(t *testing.T) {
 	cases := map[string]struct {
-		pod  *corev1.Pod
-		want podOutcome
+		pod          *corev1.Pod
+		wantTerminal bool
+		wantSettle   settleKind
 	}{
-		"failed phase":       {podPhase(corev1.PodFailed), podFailed},
-		"succeeded phase":    {podPhase(corev1.PodSucceeded), podSucceeded},
-		"running":            {podPhase(corev1.PodRunning), podPending},
-		"pending":            {podPhase(corev1.PodPending), podPending},
-		"image pull backoff": {podWaiting("ImagePullBackOff"), podFailed},
-		"err image pull":     {podWaiting("ErrImagePull"), podFailed},
-		"crash loop":         {podWaiting("CrashLoopBackOff"), podFailed},
-		"benign waiting":     {podWaiting("ContainerCreating"), podPending},
+		"failed phase":       {podPhase(corev1.PodFailed), true, settleFailed},
+		"succeeded phase":    {podPhase(corev1.PodSucceeded), true, settleNothing},
+		"running":            {podPhase(corev1.PodRunning), false, settleNothing},
+		"pending":            {podPhase(corev1.PodPending), false, settleNothing},
+		"image pull backoff": {podWaiting("ImagePullBackOff"), true, settleFailed},
+		"err image pull":     {podWaiting("ErrImagePull"), true, settleFailed},
+		"crash loop":         {podWaiting("CrashLoopBackOff"), true, settleFailed},
+		"benign waiting":     {podWaiting("ContainerCreating"), false, settleNothing},
 	}
 	for name, c := range cases {
 		t.Run(name, func(t *testing.T) {
-			if got, _ := classifyPod(c.pod); got != c.want {
-				t.Errorf("classifyPod = %v, want %v", got, c.want)
+			got := classifyPod(c.pod)
+			if got.terminal != c.wantTerminal || got.settle != c.wantSettle {
+				t.Errorf("classifyPod = {terminal:%v settle:%v}, want {terminal:%v settle:%v}",
+					got.terminal, got.settle, c.wantTerminal, c.wantSettle)
 			}
 		})
 	}
 }
 
-type fakeReporter struct{ failed map[string]string }
+// settledOutcome captures one call the reconciler made to the outcome reporter.
+type settledOutcome struct {
+	kind      settleKind
+	tryNumber int
+	reason    string
+	at        time.Time
+}
 
-func (f *fakeReporter) FailTask(_ context.Context, taskInstanceID, reason string) error {
-	if f.failed == nil {
-		f.failed = map[string]string{}
+type fakeReporter struct{ settled map[string]settledOutcome }
+
+func (f *fakeReporter) put(id string, o settledOutcome) {
+	if f.settled == nil {
+		f.settled = map[string]settledOutcome{}
 	}
-	f.failed[taskInstanceID] = reason
+	f.settled[id] = o
+}
+
+func (f *fakeReporter) FailTask(_ context.Context, id string, tryNumber int, reason string) error {
+	f.put(id, settledOutcome{kind: settleFailed, tryNumber: tryNumber, reason: reason})
+	return nil
+}
+
+func (f *fakeReporter) SucceedTask(_ context.Context, id string, tryNumber int) error {
+	f.put(id, settledOutcome{kind: settleSucceeded, tryNumber: tryNumber})
+	return nil
+}
+
+func (f *fakeReporter) RescheduleTask(_ context.Context, id string, tryNumber int, at time.Time) error {
+	f.put(id, settledOutcome{kind: settleReschedule, tryNumber: tryNumber, at: at})
 	return nil
 }
 
 func managedPod(name, tiID string, phase corev1.PodPhase) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   "leoflow",
-			Labels:      map[string]string{"leoflow.io/run-id": "r1"},
+			Name:      name,
+			Namespace: "leoflow",
+			Labels: map[string]string{
+				"leoflow.io/run-id":     "r1",
+				"leoflow.io/try-number": "1",
+			},
 			Annotations: map[string]string{"leoflow.io/task-instance-id": tiID},
 		},
 		Status: corev1.PodStatus{Phase: phase},
 	}
+}
+
+// withRecord attaches a terminated task container carrying the encoded outcome
+// record to a pod, so classifyPod reads it as the source of truth (ADR 0052).
+func withRecord(pod *corev1.Pod, rec taskoutcome.Record) *corev1.Pod {
+	enc, err := rec.Encode()
+	if err != nil {
+		panic(err)
+	}
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name: "task",
+		State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+			Message: enc,
+		}},
+	}}
+	return pod
 }
 
 func TestReconcileReportsOnlyFailedPods(t *testing.T) {
@@ -80,11 +127,102 @@ func TestReconcileReportsOnlyFailedPods(t *testing.T) {
 	if err := r.Reconcile(context.Background()); err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
-	if _, ok := reporter.failed["ti-fail"]; !ok {
-		t.Error("failed pod's task instance should be reported")
+	got, ok := reporter.settled["ti-fail"]
+	if !ok || got.kind != settleFailed {
+		t.Errorf("failed pod's task instance should be settled failed, got %+v (ok=%v)", got, ok)
 	}
-	if len(reporter.failed) != 1 {
-		t.Errorf("only the failed pod should be reported, got %v", reporter.failed)
+	if got.tryNumber != 1 {
+		t.Errorf("settle must carry the pod's try-number, got %d", got.tryNumber)
+	}
+	if len(reporter.settled) != 1 {
+		t.Errorf("only the failed pod should be settled, got %v", reporter.settled)
+	}
+}
+
+// TestReconcileRecoversSuccessFromRecord is the headline of ADR 0052: a pod that
+// Kubernetes reports as Failed, but whose task container left a `success` outcome
+// record (the report was lost, the work was not), is settled SUCCEEDED — not
+// failed. This is the zombie-task false-negative, closed.
+func TestReconcileRecoversSuccessFromRecord(t *testing.T) {
+	cs := fake.NewClientset(
+		withRecord(managedPod("p-lost", "ti-lost", corev1.PodFailed), taskoutcome.Succeeded()),
+	)
+	reporter := &fakeReporter{}
+	r := NewReconciler(cs, "leoflow", reporter)
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	got, ok := reporter.settled["ti-lost"]
+	if !ok || got.kind != settleSucceeded {
+		t.Errorf("a Failed pod with a success record must settle succeeded, got %+v (ok=%v)", got, ok)
+	}
+}
+
+// TestReconcileRecordDrivesFailedAndReschedule: a `failed` record settles failed
+// (naming the exit code), and a `reschedule` record settles up_for_reschedule with
+// the record's next-poke time — never as a failure (#386 exclusion holds).
+func TestReconcileRecordDrivesFailedAndReschedule(t *testing.T) {
+	at := time.Date(2099, 1, 2, 3, 4, 5, 0, time.UTC)
+	cs := fake.NewClientset(
+		withRecord(managedPod("p-fail", "ti-fail", corev1.PodFailed), taskoutcome.FailedWith(42)),
+		withRecord(managedPod("p-resched", "ti-resched", corev1.PodRunning), taskoutcome.RescheduledAt(at)),
+	)
+	reporter := &fakeReporter{}
+	r := NewReconciler(cs, "leoflow", reporter)
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if got := reporter.settled["ti-fail"]; got.kind != settleFailed || !strings.Contains(got.reason, "exit 42") {
+		t.Errorf("failed record should settle failed naming the exit code, got %+v", got)
+	}
+	got := reporter.settled["ti-resched"]
+	if got.kind != settleReschedule || !got.at.Equal(at) {
+		t.Errorf("reschedule record should settle up_for_reschedule at %v, got %+v", at, got)
+	}
+}
+
+// TestReconcileUndecodableRecordFallsBackToPhase: a termination message that is not
+// a valid outcome record (an old agent, a log tail) is ignored and the pod is
+// classified by phase — here a Failed pod settles failed.
+func TestReconcileUndecodableRecordFallsBackToPhase(t *testing.T) {
+	pod := managedPod("p-garbage", "ti-garbage", corev1.PodFailed)
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name:  "task",
+		State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Message: "Traceback (most recent call last): ..."}},
+	}}
+	cs := fake.NewClientset(pod)
+	reporter := &fakeReporter{}
+	r := NewReconciler(cs, "leoflow", reporter)
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if got := reporter.settled["ti-garbage"]; got.kind != settleFailed {
+		t.Errorf("an undecodable message must fall back to phase (failed), got %+v", got)
+	}
+}
+
+// TestReconcileSkipsSettleWithoutTryNumber: a pod missing the try-number label
+// cannot be attempt-guarded, so the reconciler must NOT settle it (risking a
+// clobber of a different attempt) and must NOT collect it — it leaves it for a
+// later tick / the heartbeat reaper.
+func TestReconcileSkipsSettleWithoutTryNumber(t *testing.T) {
+	pod := withRecord(managedPod("p-nolabel", "ti-nolabel", corev1.PodFailed), taskoutcome.Succeeded())
+	delete(pod.Labels, "leoflow.io/try-number")
+	pod.CreationTimestamp = metav1.NewTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)) // old enough to GC
+	cs := fake.NewClientset(pod)
+	reporter := &fakeReporter{}
+	r := NewReconciler(cs, "leoflow", reporter)
+	r.now = func() time.Time { return time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC) }
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if len(reporter.settled) != 0 {
+		t.Errorf("a pod without a try-number must not be settled, got %v", reporter.settled)
+	}
+	if _, err := cs.CoreV1().Pods("leoflow").Get(context.Background(), "p-nolabel", metav1.GetOptions{}); err != nil {
+		t.Errorf("an unsettled pod must not be garbage-collected: %v", err)
 	}
 }
 

--- a/internal/storage/agent_store.go
+++ b/internal/storage/agent_store.go
@@ -197,10 +197,11 @@ func (s *ExecutionStore) RecordHeartbeat(ctx context.Context, id auth.AgentIdent
 	return nil
 }
 
-// FailTask marks a task instance failed by its ID, but only while it is still
-// active (scheduled/queued/running), so it never clobbers a terminal state. It
-// implements executor.FailureReporter for the pod reconciler.
-func (s *ExecutionStore) FailTask(ctx context.Context, taskInstanceID, reason string) error {
+// FailTask marks a task instance failed by its ID, guarded by the attempt
+// (try_number) and the active states so it never clobbers a different attempt or a
+// terminal row. It implements part of executor.OutcomeReporter for the pod
+// reconciler (ADR 0052).
+func (s *ExecutionStore) FailTask(ctx context.Context, taskInstanceID string, tryNumber int, reason string) error {
 	tid, err := parseUUID(taskInstanceID)
 	if err != nil {
 		return err
@@ -208,7 +209,37 @@ func (s *ExecutionStore) FailTask(ctx context.Context, taskInstanceID, reason st
 	msg := reason
 	return s.q.FailTaskInstanceIfActive(ctx, queries.FailTaskInstanceIfActiveParams{
 		ID:           tid,
+		TryNumber:    toInt32(tryNumber),
 		ErrorMessage: &msg,
+	})
+}
+
+// SucceedTask marks a task instance succeeded by its ID — recovering a success
+// whose report was lost (ADR 0052) — guarded by the attempt and the active states.
+// A settle on an already-terminal or superseded row is a no-op.
+func (s *ExecutionStore) SucceedTask(ctx context.Context, taskInstanceID string, tryNumber int) error {
+	tid, err := parseUUID(taskInstanceID)
+	if err != nil {
+		return err
+	}
+	return s.q.SucceedTaskInstanceIfActive(ctx, queries.SucceedTaskInstanceIfActiveParams{
+		ID:        tid,
+		TryNumber: toInt32(tryNumber),
+	})
+}
+
+// RescheduleTask parks a task instance in up_for_reschedule with the recovered
+// next-poke time, guarded by the attempt and the active states, consuming no retry
+// budget (ADR 0052). Used by the reconciler when a reschedule report was lost.
+func (s *ExecutionStore) RescheduleTask(ctx context.Context, taskInstanceID string, tryNumber int, at time.Time) error {
+	tid, err := parseUUID(taskInstanceID)
+	if err != nil {
+		return err
+	}
+	return s.q.RescheduleTaskInstanceByIDIfActive(ctx, queries.RescheduleTaskInstanceByIDIfActiveParams{
+		ID:           tid,
+		TryNumber:    toInt32(tryNumber),
+		RescheduleAt: pgtype.Timestamptz{Time: at, Valid: true},
 	})
 }
 

--- a/internal/storage/durable_outcome_integration_test.go
+++ b/internal/storage/durable_outcome_integration_test.go
@@ -1,0 +1,158 @@
+//go:build integration
+
+// Package storage_test — the reconciler's attempt-guarded outcome settles (ADR 0052).
+//
+// The pod reconciler recovers a task's outcome from its durable record (or pod
+// phase) and settles it: SucceedTaskInstanceIfActive, FailTaskInstanceIfActive,
+// and RescheduleTaskInstanceByIDIfActive. Each is guarded by BOTH the row id and
+// try_number, because try_number bumps IN PLACE on retry (same row id) — so a
+// stale reconciler acting on a previous attempt's lingering pod must not match the
+// live attempt. Settling SUCCESS through an unguarded path would be the worst
+// shape: a live retry marked succeeded, firing downstream on incomplete work.
+//
+// A fake-store unit test cannot prove this — the guard lives in the UPDATE's WHERE
+// clause, so only real Postgres shows the row did not move.
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/config"
+	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/storage"
+)
+
+// outcomeTIID reads a task instance's UUID directly, for a TI in any state (the
+// shared taskInstanceID helper only lists queued candidates).
+func outcomeTIID(t *testing.T, ctx context.Context, runUUID, taskID string) string {
+	t.Helper()
+	pg, err := storage.NewPostgres(ctx, config.DatabaseSection{URL: os.Getenv("DATABASE_URL")})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pg.Close()
+	var id string
+	if err := pg.Pool.QueryRow(ctx,
+		"SELECT id::text FROM task_instances WHERE dag_run_id=$1::uuid AND task_id=$2", runUUID, taskID).Scan(&id); err != nil {
+		t.Fatalf("select ti id for %s/%s: %v", runUUID, taskID, err)
+	}
+	return id
+}
+
+// TestReconcilerRecoversLostSuccessIntegration is the headline of ADR 0052: the
+// reconciler settles a running TI succeeded from its recovered outcome record,
+// recovering a success whose report was lost.
+func TestReconcilerRecoversLostSuccessIntegration(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("outcome_success_%d", time.Now().UnixNano())
+	runUUID := seedRunningTask(t, repo, sched, ctx, dagID, "load")
+	tiID := outcomeTIID(t, ctx, runUUID, "load")
+
+	if err := exec.SucceedTask(ctx, tiID, 1); err != nil {
+		t.Fatalf("SucceedTask: %v", err)
+	}
+	if st := taskInstanceState(t, sched, ctx, runUUID, "load"); st != domain.TaskStateSuccess {
+		t.Fatalf("TI 'load' = %q, want success — the reconciler must recover the lost success", st)
+	}
+}
+
+// TestReconcilerSucceedIgnoresStaleTryNumberIntegration is the crux: a success
+// settle for a PREVIOUS attempt must not land on the live retry. Without the
+// try_number guard it would mark a running attempt succeeded and fire downstream
+// on work that never ran — strictly worse than the bug being fixed.
+func TestReconcilerSucceedIgnoresStaleTryNumberIntegration(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("outcome_stale_try_%d", time.Now().UnixNano())
+	runUUID := seedRunningTask(t, repo, sched, ctx, dagID, "load")
+	tiID := outcomeTIID(t, ctx, runUUID, "load")
+
+	// Attempt 1 fails and the scheduler retries to attempt 2 (failed → up_for_retry
+	// → none → queued), bumping try_number in place on the same row.
+	for _, st := range []domain.TaskState{domain.TaskStateFailed, domain.TaskStateUpForRetry} {
+		if err := sched.ApplyTransition(ctx, runUUID, "load", st); err != nil {
+			t.Fatalf("ApplyTransition to %s: %v", st, err)
+		}
+	}
+	if applied, err := sched.ResetForRetry(ctx, runUUID, "load"); err != nil || !applied {
+		t.Fatalf("ResetForRetry applied=%v err=%v", applied, err)
+	}
+	if err := sched.ApplyTransition(ctx, runUUID, "load", domain.TaskStateQueued); err != nil {
+		t.Fatalf("ApplyTransition to queued: %v", err)
+	}
+
+	// The reconciler acts on attempt 1's lingering pod — a stale success settle.
+	if err := exec.SucceedTask(ctx, tiID, 1); err != nil {
+		t.Fatalf("SucceedTask (stale): %v", err)
+	}
+	if st := taskInstanceState(t, sched, ctx, runUUID, "load"); st != domain.TaskStateQueued {
+		t.Fatalf("TI 'load' = %q, want queued — a stale attempt's success must NOT clobber the live retry", st)
+	}
+}
+
+// TestReconcilerSucceedDoesNotClobberTerminalIntegration: the active-state guard
+// stops a recovered success from resurrecting a row a reaper already settled.
+func TestReconcilerSucceedDoesNotClobberTerminalIntegration(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("outcome_terminal_%d", time.Now().UnixNano())
+	runUUID := seedRunningTask(t, repo, sched, ctx, dagID, "load")
+	tiID := outcomeTIID(t, ctx, runUUID, "load")
+
+	if err := sched.ApplyTransition(ctx, runUUID, "load", domain.TaskStateFailed); err != nil {
+		t.Fatalf("ApplyTransition to failed: %v", err)
+	}
+	if err := exec.SucceedTask(ctx, tiID, 1); err != nil {
+		t.Fatalf("SucceedTask: %v", err)
+	}
+	if st := taskInstanceState(t, sched, ctx, runUUID, "load"); st != domain.TaskStateFailed {
+		t.Fatalf("TI 'load' = %q, want failed — a recovered success must not resurrect a terminal row", st)
+	}
+}
+
+// TestReconcilerFailIgnoresStaleTryNumberIntegration: the same attempt guard on
+// the failure settle — a stale reconciler must not fail the live retry.
+func TestReconcilerFailIgnoresStaleTryNumberIntegration(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("outcome_fail_stale_%d", time.Now().UnixNano())
+	runUUID := seedRunningTask(t, repo, sched, ctx, dagID, "load")
+	tiID := outcomeTIID(t, ctx, runUUID, "load")
+
+	for _, st := range []domain.TaskState{domain.TaskStateFailed, domain.TaskStateUpForRetry} {
+		if err := sched.ApplyTransition(ctx, runUUID, "load", st); err != nil {
+			t.Fatalf("ApplyTransition to %s: %v", st, err)
+		}
+	}
+	if applied, err := sched.ResetForRetry(ctx, runUUID, "load"); err != nil || !applied {
+		t.Fatalf("ResetForRetry applied=%v err=%v", applied, err)
+	}
+	if err := sched.ApplyTransition(ctx, runUUID, "load", domain.TaskStateQueued); err != nil {
+		t.Fatalf("ApplyTransition to queued: %v", err)
+	}
+
+	if err := exec.FailTask(ctx, tiID, 1, "stale pod failure"); err != nil {
+		t.Fatalf("FailTask (stale): %v", err)
+	}
+	if st := taskInstanceState(t, sched, ctx, runUUID, "load"); st != domain.TaskStateQueued {
+		t.Fatalf("TI 'load' = %q, want queued — a stale attempt's failure must NOT clobber the live retry", st)
+	}
+}
+
+// TestReconcilerRescheduleByIDIntegration: a recovered reschedule parks the live
+// running TI in up_for_reschedule with its next-poke time, keyed by id.
+func TestReconcilerRescheduleByIDIntegration(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("outcome_resched_%d", time.Now().UnixNano())
+	runUUID := seedRunningTask(t, repo, sched, ctx, dagID, "sensor")
+	tiID := outcomeTIID(t, ctx, runUUID, "sensor")
+
+	at := time.Now().UTC().Add(5 * time.Minute)
+	if err := exec.RescheduleTask(ctx, tiID, 1, at); err != nil {
+		t.Fatalf("RescheduleTask: %v", err)
+	}
+	if st := taskInstanceState(t, sched, ctx, runUUID, "sensor"); st != domain.TaskStateUpForReschedule {
+		t.Fatalf("TI 'sensor' = %q, want up_for_reschedule", st)
+	}
+}

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -62,6 +62,11 @@ type Querier interface {
 	// reason as RecordDispatchFailure. This is distinct from dispatch_lost (a TI that
 	// reached 'queued' then vanished) and from a task's own 'failed' (the code ran).
 	FailDispatchExhausted(ctx context.Context, arg FailDispatchExhaustedParams) error
+	// Settle a task instance failed from the pod reconciler, guarded by BOTH id and
+	// try_number (ADR 0052): try_number bumps IN PLACE on retry (same row id), so a
+	// stale reconciler acting on a previous attempt's lingering pod must not match the
+	// new running attempt and clobber it. The active-state guard prevents clobbering a
+	// terminal row.
 	FailTaskInstanceIfActive(ctx context.Context, arg FailTaskInstanceIfActiveParams) error
 	GetConnection(ctx context.Context, arg GetConnectionParams) (GetConnectionRow, error)
 	GetCurrentDagSpec(ctx context.Context, arg GetCurrentDagSpecParams) ([]byte, error)
@@ -255,6 +260,11 @@ type Querier interface {
 	// the active states so a late report never clobbers a terminal row. ended_at is
 	// left untouched (the task is not finished); started_at is preserved.
 	RescheduleTaskInstance(ctx context.Context, arg RescheduleTaskInstanceParams) error
+	// Settle a lost reschedule from the durable outcome record (ADR 0052): park the TI
+	// in up_for_reschedule with the record's next-poke time, guarded by id AND
+	// try_number (never clobber a different attempt or a terminal row), consuming no
+	// retry budget. Mirrors RescheduleTaskInstance but keyed by id, for the reconciler.
+	RescheduleTaskInstanceByIDIfActive(ctx context.Context, arg RescheduleTaskInstanceByIDIfActiveParams) error
 	// Archives every failed attempt in the run into task_instance_history then
 	// resets. See ResetTaskInstanceToNone for the per-attempt rationale.
 	ResetAllFailedTaskInstances(ctx context.Context, dagRunID pgtype.UUID) (int64, error)
@@ -300,6 +310,12 @@ type Querier interface {
 	// show its duration: started_at on first entry into 'running', ended_at on a
 	// terminal state. Other timestamps are preserved (the scheduler may re-run).
 	StampDagRunState(ctx context.Context, arg StampDagRunStateParams) error
+	// Settle a task instance succeeded from its durable outcome record (ADR 0052),
+	// recovering a success whose report was lost. Guarded by id AND try_number so a
+	// stale reconciler never marks a LIVE retry succeeded — which would fire downstream
+	// tasks on incomplete work, strictly worse than the bug being fixed. The
+	// active-state guard prevents clobbering a terminal row.
+	SucceedTaskInstanceIfActive(ctx context.Context, arg SucceedTaskInstanceIfActiveParams) error
 	// The time a reschedule-mode sensor first entered reschedule (NULL until it does).
 	// Delivered to each re-dispatched pod so get_first_reschedule_date returns the real
 	// value and the sensor honors its cumulative timeout across pokes (#380).

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -339,9 +339,38 @@ SELECT first_reschedule_at FROM task_instances
 WHERE dag_run_id = $1 AND task_id = $2;
 
 -- name: FailTaskInstanceIfActive :exec
+-- Settle a task instance failed from the pod reconciler, guarded by BOTH id and
+-- try_number (ADR 0052): try_number bumps IN PLACE on retry (same row id), so a
+-- stale reconciler acting on a previous attempt's lingering pod must not match the
+-- new running attempt and clobber it. The active-state guard prevents clobbering a
+-- terminal row.
 UPDATE task_instances
-SET state = 'failed', ended_at = now(), error_message = $2
-WHERE id = $1 AND state IN ('scheduled', 'queued', 'running');
+SET state = 'failed', ended_at = now(), error_message = sqlc.arg(error_message)
+WHERE id = sqlc.arg(id) AND try_number = sqlc.arg(try_number)
+  AND state IN ('scheduled', 'queued', 'running');
+
+-- name: SucceedTaskInstanceIfActive :exec
+-- Settle a task instance succeeded from its durable outcome record (ADR 0052),
+-- recovering a success whose report was lost. Guarded by id AND try_number so a
+-- stale reconciler never marks a LIVE retry succeeded — which would fire downstream
+-- tasks on incomplete work, strictly worse than the bug being fixed. The
+-- active-state guard prevents clobbering a terminal row.
+UPDATE task_instances
+SET state = 'success', ended_at = now(), error_message = NULL
+WHERE id = sqlc.arg(id) AND try_number = sqlc.arg(try_number)
+  AND state IN ('scheduled', 'queued', 'running');
+
+-- name: RescheduleTaskInstanceByIDIfActive :exec
+-- Settle a lost reschedule from the durable outcome record (ADR 0052): park the TI
+-- in up_for_reschedule with the record's next-poke time, guarded by id AND
+-- try_number (never clobber a different attempt or a terminal row), consuming no
+-- retry budget. Mirrors RescheduleTaskInstance but keyed by id, for the reconciler.
+UPDATE task_instances
+SET state = 'up_for_reschedule'::task_state,
+    reschedule_at = sqlc.arg(reschedule_at),
+    first_reschedule_at = COALESCE(first_reschedule_at, now())
+WHERE id = sqlc.arg(id) AND try_number = sqlc.arg(try_number)
+  AND state IN ('running', 'queued', 'scheduled');
 
 -- name: ReportTaskResult :execrows
 -- $3 is cast to task_state in every usage: without the cast Postgres deduces an

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -376,17 +376,24 @@ func (q *Queries) FailDispatchExhausted(ctx context.Context, arg FailDispatchExh
 
 const failTaskInstanceIfActive = `-- name: FailTaskInstanceIfActive :exec
 UPDATE task_instances
-SET state = 'failed', ended_at = now(), error_message = $2
-WHERE id = $1 AND state IN ('scheduled', 'queued', 'running')
+SET state = 'failed', ended_at = now(), error_message = $1
+WHERE id = $2 AND try_number = $3
+  AND state IN ('scheduled', 'queued', 'running')
 `
 
 type FailTaskInstanceIfActiveParams struct {
-	ID           pgtype.UUID `json:"id"`
 	ErrorMessage *string     `json:"error_message"`
+	ID           pgtype.UUID `json:"id"`
+	TryNumber    int32       `json:"try_number"`
 }
 
+// Settle a task instance failed from the pod reconciler, guarded by BOTH id and
+// try_number (ADR 0052): try_number bumps IN PLACE on retry (same row id), so a
+// stale reconciler acting on a previous attempt's lingering pod must not match the
+// new running attempt and clobber it. The active-state guard prevents clobbering a
+// terminal row.
 func (q *Queries) FailTaskInstanceIfActive(ctx context.Context, arg FailTaskInstanceIfActiveParams) error {
-	_, err := q.db.Exec(ctx, failTaskInstanceIfActive, arg.ID, arg.ErrorMessage)
+	_, err := q.db.Exec(ctx, failTaskInstanceIfActive, arg.ErrorMessage, arg.ID, arg.TryNumber)
 	return err
 }
 
@@ -1415,6 +1422,30 @@ func (q *Queries) RescheduleTaskInstance(ctx context.Context, arg RescheduleTask
 	return err
 }
 
+const rescheduleTaskInstanceByIDIfActive = `-- name: RescheduleTaskInstanceByIDIfActive :exec
+UPDATE task_instances
+SET state = 'up_for_reschedule'::task_state,
+    reschedule_at = $1,
+    first_reschedule_at = COALESCE(first_reschedule_at, now())
+WHERE id = $2 AND try_number = $3
+  AND state IN ('running', 'queued', 'scheduled')
+`
+
+type RescheduleTaskInstanceByIDIfActiveParams struct {
+	RescheduleAt pgtype.Timestamptz `json:"reschedule_at"`
+	ID           pgtype.UUID        `json:"id"`
+	TryNumber    int32              `json:"try_number"`
+}
+
+// Settle a lost reschedule from the durable outcome record (ADR 0052): park the TI
+// in up_for_reschedule with the record's next-poke time, guarded by id AND
+// try_number (never clobber a different attempt or a terminal row), consuming no
+// retry budget. Mirrors RescheduleTaskInstance but keyed by id, for the reconciler.
+func (q *Queries) RescheduleTaskInstanceByIDIfActive(ctx context.Context, arg RescheduleTaskInstanceByIDIfActiveParams) error {
+	_, err := q.db.Exec(ctx, rescheduleTaskInstanceByIDIfActive, arg.RescheduleAt, arg.ID, arg.TryNumber)
+	return err
+}
+
 const resetAllFailedTaskInstances = `-- name: ResetAllFailedTaskInstances :execrows
 WITH archived AS (
     INSERT INTO task_instance_history (
@@ -1690,6 +1721,28 @@ type StampDagRunStateParams struct {
 // terminal state. Other timestamps are preserved (the scheduler may re-run).
 func (q *Queries) StampDagRunState(ctx context.Context, arg StampDagRunStateParams) error {
 	_, err := q.db.Exec(ctx, stampDagRunState, arg.State, arg.ID)
+	return err
+}
+
+const succeedTaskInstanceIfActive = `-- name: SucceedTaskInstanceIfActive :exec
+UPDATE task_instances
+SET state = 'success', ended_at = now(), error_message = NULL
+WHERE id = $1 AND try_number = $2
+  AND state IN ('scheduled', 'queued', 'running')
+`
+
+type SucceedTaskInstanceIfActiveParams struct {
+	ID        pgtype.UUID `json:"id"`
+	TryNumber int32       `json:"try_number"`
+}
+
+// Settle a task instance succeeded from its durable outcome record (ADR 0052),
+// recovering a success whose report was lost. Guarded by id AND try_number so a
+// stale reconciler never marks a LIVE retry succeeded — which would fire downstream
+// tasks on incomplete work, strictly worse than the bug being fixed. The
+// active-state guard prevents clobbering a terminal row.
+func (q *Queries) SucceedTaskInstanceIfActive(ctx context.Context, arg SucceedTaskInstanceIfActiveParams) error {
+	_, err := q.db.Exec(ctx, succeedTaskInstanceIfActive, arg.ID, arg.TryNumber)
 	return err
 }
 

--- a/internal/taskoutcome/record.go
+++ b/internal/taskoutcome/record.go
@@ -1,0 +1,120 @@
+// Package taskoutcome defines the durable task-outcome record the agent writes to
+// its container termination message before delivering the report, and the
+// reconciler reads back as the source of truth over pod phase (ADR 0052).
+//
+// The record decouples a task's true result from the delivery of that result: a
+// pod killed mid-report still leaves the outcome behind, so a task that succeeded
+// but lost its report is not misread as a failure. The format is a compact,
+// versioned JSON document kept far under the Kubernetes termination-message cap;
+// it carries the outcome only, never logs or return values.
+package taskoutcome
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+)
+
+// Version is the record schema version. The reader rejects any other version so
+// the format can evolve without a stale reader misinterpreting a newer record.
+const Version = 1
+
+// maxRecordBytes bounds an encoded record. The real Kubernetes cap is ~4 KiB; a
+// record is a few dozen bytes, so a value far above any real record but well under
+// the cap catches a programming error (a giant field) without false positives.
+const maxRecordBytes = 1024
+
+// Outcome is a task's true result, independent of report delivery.
+type Outcome string
+
+const (
+	// Success means the user task completed successfully.
+	Success Outcome = "success"
+	// Failed means the user task failed; ExitCode carries the process exit code.
+	Failed Outcome = "failed"
+	// Reschedule means a reschedule-mode sensor poked not-ready; RescheduleAt
+	// carries the next-poke time. Never settled as a failure by the reconciler.
+	Reschedule Outcome = "reschedule"
+)
+
+// Record is the durable outcome document. Only the fields relevant to an outcome
+// are populated: ExitCode for Failed, RescheduleAt for Reschedule.
+type Record struct {
+	V            int     `json:"v"`
+	Outcome      Outcome `json:"outcome"`
+	ExitCode     *int32  `json:"exit_code,omitempty"`
+	RescheduleAt string  `json:"reschedule_at,omitempty"`
+}
+
+// Succeeded returns a success record.
+func Succeeded() Record { return Record{V: Version, Outcome: Success} }
+
+// FailedWith returns a failure record carrying the user process exit code.
+func FailedWith(exitCode int32) Record {
+	return Record{V: Version, Outcome: Failed, ExitCode: &exitCode}
+}
+
+// RescheduledAt returns a reschedule record carrying the next-poke time. The time
+// is stored in RFC3339Nano (UTC) so the reconciler can settle up_for_reschedule
+// with the real poke time rather than inventing one.
+func RescheduledAt(when time.Time) Record {
+	return Record{V: Version, Outcome: Reschedule, RescheduleAt: when.UTC().Format(time.RFC3339Nano)}
+}
+
+// Encode renders the record as the string to write to the termination message.
+// It errors on an unexpectedly large result, which would signal a programming
+// error rather than a real outcome.
+func (r Record) Encode() (string, error) {
+	b, err := json.Marshal(r)
+	if err != nil {
+		return "", err
+	}
+	if len(b) > maxRecordBytes {
+		return "", errors.New("taskoutcome: encoded record exceeds size cap")
+	}
+	return string(b), nil
+}
+
+// At parses the reschedule time; ok is false unless the record is a reschedule
+// carrying a parseable RFC3339 time.
+func (r Record) At() (time.Time, bool) {
+	if r.Outcome != Reschedule || r.RescheduleAt == "" {
+		return time.Time{}, false
+	}
+	when, err := time.Parse(time.RFC3339Nano, r.RescheduleAt)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return when, true
+}
+
+// Decode parses a termination message into a Record. ok is false for anything
+// that is not a valid, current-version record with a known outcome — an empty
+// message, arbitrary text, a log tail, an unknown version, or a reschedule with no
+// parseable time — so the caller falls back to pod phase. Decode never errors; a
+// malformed message is simply "no record".
+func Decode(msg string) (Record, bool) {
+	msg = strings.TrimSpace(msg)
+	if msg == "" || msg[0] != '{' {
+		return Record{}, false
+	}
+	var r Record
+	if err := json.Unmarshal([]byte(msg), &r); err != nil {
+		return Record{}, false
+	}
+	if r.V != Version {
+		return Record{}, false
+	}
+	switch r.Outcome {
+	case Success, Failed:
+		return r, true
+	case Reschedule:
+		if _, ok := r.At(); !ok {
+			return Record{}, false
+		}
+		return r, true
+	default:
+		return Record{}, false
+	}
+}

--- a/internal/taskoutcome/record_test.go
+++ b/internal/taskoutcome/record_test.go
@@ -1,0 +1,104 @@
+package taskoutcome
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	at := time.Date(2026, 8, 13, 22, 6, 3, 0, time.UTC)
+	cases := []struct {
+		name string
+		rec  Record
+	}{
+		{"success", Succeeded()},
+		{"failed", FailedWith(1)},
+		{"failed-zero-exit", FailedWith(0)},
+		{"reschedule", RescheduledAt(at)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			enc, err := c.rec.Encode()
+			if err != nil {
+				t.Fatalf("Encode: %v", err)
+			}
+			got, ok := Decode(enc)
+			if !ok {
+				t.Fatalf("Decode(%q) not ok", enc)
+			}
+			if got.Outcome != c.rec.Outcome {
+				t.Errorf("outcome = %q, want %q", got.Outcome, c.rec.Outcome)
+			}
+		})
+	}
+}
+
+func TestDecodeExitCode(t *testing.T) {
+	enc, _ := FailedWith(42).Encode()
+	got, ok := Decode(enc)
+	if !ok {
+		t.Fatal("not ok")
+	}
+	if got.ExitCode == nil || *got.ExitCode != 42 {
+		t.Errorf("exit_code = %v, want 42", got.ExitCode)
+	}
+	// A success carries no exit code.
+	sEnc, _ := Succeeded().Encode()
+	s, _ := Decode(sEnc)
+	if s.ExitCode != nil {
+		t.Errorf("success exit_code = %v, want nil", *s.ExitCode)
+	}
+}
+
+func TestDecodeRescheduleAt(t *testing.T) {
+	at := time.Date(2026, 8, 13, 22, 30, 0, 0, time.UTC)
+	enc, _ := RescheduledAt(at).Encode()
+	got, ok := Decode(enc)
+	if !ok {
+		t.Fatal("not ok")
+	}
+	when, ok := got.At()
+	if !ok {
+		t.Fatal("At() not ok for a reschedule record")
+	}
+	if !when.Equal(at) {
+		t.Errorf("At() = %v, want %v", when, at)
+	}
+}
+
+func TestDecodeRejectsGarbage(t *testing.T) {
+	// The termination message may be empty, a truncated log tail (if an operator
+	// ever set FallbackToLogsOnError), or an old-agent's arbitrary text. Decode
+	// must reject all of it so the reconciler falls back to pod phase.
+	bad := []string{
+		"",
+		"   ",
+		"not json at all",
+		`{"v":1}`,                        // no outcome
+		`{"v":2,"outcome":"success"}`,    // unknown version
+		`{"v":1,"outcome":"exploded"}`,   // unknown outcome
+		`{"v":1,"outcome":"reschedule"}`, // reschedule without a time
+		`{"v":1,"outcome":"reschedule","reschedule_at":"soon"}`, // unparseable time
+		"Traceback (most recent call last):\n  File ...",        // a log tail
+	}
+	for _, b := range bad {
+		if _, ok := Decode(b); ok {
+			t.Errorf("Decode(%q) = ok, want rejected", b)
+		}
+	}
+}
+
+func TestEncodeStaysUnderCap(t *testing.T) {
+	// Kubernetes caps the termination message; the record must be a few bytes.
+	enc, err := FailedWith(255).Encode()
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if len(enc) > 256 {
+		t.Errorf("encoded record is %d bytes; expected well under the K8s cap", len(enc))
+	}
+	if !strings.Contains(enc, `"v":1`) {
+		t.Errorf("encoded record must carry the version tag: %q", enc)
+	}
+}


### PR DESCRIPTION
Step 1 of ADR 0051 Phase 2 (#543): the design ADR the issue asks for, before any code.

## The problem
The agent's process exit code conflates **what the task did** with **whether the report was delivered** (`internal/agent/runner.go:408-420`). A pod killed mid-report shows K8s phase `Failed` even when the task **succeeded**, and the reconciler can only read pod phase (`internal/executor/reconcile.go:103-116`), so it settles a lost-report success as a failure. #542's in-process retry fixes the transient case; this is the backstop for the pod-is-gone case.

## The decision
The agent writes a compact, versioned outcome record — `{"v":1,"outcome":"success|failed|reschedule","exit_code":N}` — to the container **termination message** (`/dev/termination-log`) **before** attempting the report. The reconciler reads it as source of truth, falling back to pod phase when absent. K8s-only (Lite unchanged), additive/back-compat, idempotent settle reusing the `running`/`try_number` guard, reschedule-excluded.

## Phased path (this PR = step 1)
1. **ADR** (this PR).
2. **Core (no cluster):** agent write + `classifyPod` read + reschedule-exclusion + idempotent double-settle, unit-tested with a fake clientset.
3. **E2E/chaos (k3d):** pod kill mid-report.

Status **Proposed** — please review the design before I implement the core (step 2). It's already in flight on a branch; I'll adjust to whatever the review lands on.