### PR TITLE
fix(security): bump Go toolchain 1.26.5 → 1.26.6 (4 stdlib CVEs)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.6"
   PYTHON_VERSION: "3.11"
   GOLANGCI_LINT_VERSION: "v2.12.2"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.6"
   REGISTRY: ghcr.io
 
 jobs:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -13,7 +13,7 @@ permissions:
   security-events: write    # Required for SARIF upload to GitHub Security tab
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.6"
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/neochaotic/leoflow
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/gin-gonic/gin v1.12.0


### PR DESCRIPTION
## Why

`govulncheck` is failing on **every** open PR and `main` — it is **not** any PR's code. Four **called** standard-library vulnerabilities in `go1.26.5`, all **fixed in `go1.26.6`**:

| ID | stdlib package |
|---|---|
| [GO-2026-6089](https://pkg.go.dev/vuln/GO-2026-6089) | `net/http` |
| [GO-2026-6090](https://pkg.go.dev/vuln/GO-2026-6090) | `crypto/tls` |
| [GO-2026-6091](https://pkg.go.dev/vuln/GO-2026-6091) | `html/template` |
| [GO-2026-6218](https://pkg.go.dev/vuln/GO-2026-6218) | `net/url` |

## Change

Bump the toolchain 1.26.5 → 1.26.6 in the four pins: `go.mod` `toolchain` + `GO_VERSION` in the ci / security / release workflows.

## Verified locally (go1.26.6)

- `go build ./...` — OK
- `golangci-lint run` (v2.12.2) — **0 issues**
- `govulncheck ./...` — **0 called vulnerabilities**

## Transitive advisory (non-blocking, no action)

One informational line remains: [GO-2026-5932](https://pkg.go.dev/vuln/GO-2026-5932) — `golang.org/x/crypto/openpgp` is *unmaintained/unsafe by design*, **Fixed: N/A**. It is **transitive and uncalled** — we import only `x/crypto/bcrypt`, never `openpgp` — so govulncheck does not fail on it and there is no fixed release to bump to.

Unblocks #614 and #615 (and any other open PR) once merged into their base.