### PR TITLE
test(e2e): durable-outcome recovery chaos scenario (ADR 0052 Phase 2 Step 3)

### DIFF
--- a/cmd/leoflow-agent/main.go
+++ b/cmd/leoflow-agent/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/neochaotic/leoflow/internal/agent"
 	"github.com/neochaotic/leoflow/internal/version"
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
 )
 
 // usage is printed for `--help`. leoflow-agent takes no positional args; it is
@@ -104,6 +105,19 @@ func run() int {
 		// message), set by the executor's podEnv; empty outside a pod (ADR 0052).
 		TerminationLogPath: os.Getenv("LEOFLOW_TERMINATION_LOG_PATH"),
 		HeartbeatInterval:  15 * time.Second,
+	}
+	// Fault-injection seam for the durable-outcome chaos E2E (ADR 0052): when a DAG
+	// sets LEOFLOW_CHAOS_DIE_BEFORE_REPORT to a task state, the agent writes the
+	// outcome record and then exits without delivering the report — simulating a pod
+	// killed mid-report (OOM/eviction) with the record already on disk. Never set in
+	// production; the reconciler must then recover the outcome from the record.
+	if want := os.Getenv("LEOFLOW_CHAOS_DIE_BEFORE_REPORT"); want != "" {
+		runner.BeforeReport = func(state agentv1.TaskState) {
+			if state.String() == want {
+				slog.Warn("chaos: exiting before report to simulate a pod killed mid-report", "state", state.String())
+				os.Exit(137)
+			}
+		}
 	}
 	if rerr := runner.Run(ctx); rerr != nil {
 		slog.Error("task failed", "error", rerr)

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -75,6 +75,12 @@ type Runner struct {
 	// HeartbeatInterval is how often to ping the control plane while the task
 	// runs; zero disables heartbeats.
 	HeartbeatInterval time.Duration
+	// BeforeReport, if set, is invoked with the terminal state AFTER the durable
+	// outcome record is written and BEFORE the report is delivered. It is a
+	// fault-injection seam for the durable-outcome E2E (ADR 0052) — the agent
+	// binary wires it, from an env var, to exit the process, simulating a pod
+	// killed mid-report with the record already on disk. Nil in production.
+	BeforeReport func(agentv1.TaskState)
 	// afterFunc returns a channel that fires after the given delay; it exists so
 	// tests can make the report-retry backoff instant. Nil uses time.After.
 	afterFunc func(time.Duration) <-chan time.Time
@@ -582,6 +588,9 @@ func (r *Runner) heartbeat(ctx context.Context, cancel context.CancelFunc) {
 
 func (r *Runner) report(ctx context.Context, state agentv1.TaskState, exitCode int32, msg string) error {
 	r.recordOutcome(state, exitCode)
+	if r.BeforeReport != nil {
+		r.BeforeReport(state)
+	}
 	return r.reportRequest(ctx, &agentv1.ReportStateRequest{
 		State:        state,
 		ExitCode:     exitCode,

--- a/internal/agent/runner_outcome_test.go
+++ b/internal/agent/runner_outcome_test.go
@@ -167,6 +167,45 @@ func TestRunnerSuccessPathPushFailureWritesFailedRecord(t *testing.T) {
 	}
 }
 
+// TestRunnerBeforeReportHookFiresAfterRecordBeforeReport locks the fault-injection
+// seam the ADR 0052 E2E relies on: BeforeReport is invoked with the terminal state
+// after the durable record is on disk but before the report is delivered — so the
+// E2E can simulate a pod killed mid-report with the record already written.
+func TestRunnerBeforeReportHookFiresAfterRecordBeforeReport(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "termination-log")
+	client := &fakeClient{spec: &agentv1.TaskSpec{Operator: "python", Entrypoint: "dag:ok"}}
+	r := newRunner(client, &fakeCmd{exitCode: 0}, &recordingSink{})
+	r.TerminationLogPath = path
+
+	var gotState agentv1.TaskState
+	var recordOnDisk, reportSeenYet bool
+	r.BeforeReport = func(state agentv1.TaskState) {
+		gotState = state
+		if _, err := os.Stat(path); err == nil {
+			recordOnDisk = true
+		}
+		// Only the RUNNING report has been sent by now; the terminal SUCCESS report
+		// is what this hook precedes.
+		for _, rep := range client.reports {
+			if rep.GetState() == agentv1.TaskState_TASK_STATE_SUCCESS {
+				reportSeenYet = true
+			}
+		}
+	}
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if gotState != agentv1.TaskState_TASK_STATE_SUCCESS {
+		t.Errorf("hook state = %v, want SUCCESS", gotState)
+	}
+	if !recordOnDisk {
+		t.Error("the outcome record must be on disk before BeforeReport fires")
+	}
+	if reportSeenYet {
+		t.Error("the SUCCESS report must NOT have been delivered before BeforeReport fires")
+	}
+}
+
 // TestRunnerRunningStateWritesNoRecord: a non-terminal RUNNING report must never
 // write an outcome record — only the terminal states carry a durable outcome.
 func TestRunnerRunningStateWritesNoRecord(t *testing.T) {

--- a/test/e2e/chaos-runtime.sh
+++ b/test/e2e/chaos-runtime.sh
@@ -151,7 +151,19 @@ ENV PYTHONPATH=/home/leoflow
 DOCKER
 
 log "Building base image + cluster"
-docker build --provenance=false -f "$ROOT/runtime/Dockerfile" --build-arg "PYTHON_VERSION=${PY_VERSION}" -t "$BASE_IMAGE" "$ROOT"
+docker build --provenance=false -f "$ROOT/runtime/Dockerfile" --build-arg "PYTHON_VERSION=${PY_VERSION}" -t "$BASE_IMAGE" "$ROOT" \
+  || fatal "base image build failed — refusing to continue against a possibly stale $BASE_IMAGE"
+
+# A build that fails (e.g. a transient registry timeout pulling layers) used to
+# leave any pre-existing $BASE_IMAGE tag in place, so the run silently proceeded on
+# a stale agent binary. When that agent predates the fault-injection seam, the
+# durable-outcome scenario runs the ordinary report path and passes for the wrong
+# reason. Assert the freshly-built agent carries the seam the scenario depends on,
+# so a stale image can never masquerade as a green run.
+docker run --rm --entrypoint sh "$BASE_IMAGE" \
+  -c 'grep -aq LEOFLOW_CHAOS_DIE_BEFORE_REPORT /usr/local/bin/leoflow-agent' \
+  || fatal "$BASE_IMAGE has a stale leoflow-agent (missing the LEOFLOW_CHAOS_DIE_BEFORE_REPORT seam); run 'docker rmi -f $BASE_IMAGE' and re-run to force a fresh build"
+
 k3d cluster create "$CLUSTER" --wait
 kubectl create namespace leoflow
 

--- a/test/e2e/chaos-runtime.sh
+++ b/test/e2e/chaos-runtime.sh
@@ -339,13 +339,27 @@ scenario_durable_outcome_recovery() {
     -d '{}' "$API/api/v2/dags/$RECOVER_DAG_ID/dagRuns" | jq -r '.dag_run_id')"
   [ -n "$run" ] && [ "$run" != "null" ] || { bad "C: no run id"; return; }
 
-  # The task pod must end NON-successfully at the k8s level (agent exit 137) — the
-  # whole point is that pod phase says failure while the record says success.
-  local deadline; deadline=$(( $(date +%s) + 90 ))
+  # The task pod MUST end non-successfully at the k8s level (agent exit 137) — the
+  # whole point is that pod phase says failure while the record says success. This
+  # is fail-closed: if the pod ends `Completed` (exit 0) the fault-injection seam
+  # did NOT fire (e.g. a stale agent image without the seam), so the recovery path
+  # was never exercised — a false green — and the scenario must fail loudly rather
+  # than let the run reach success via the ordinary report path.
+  local deadline status=""; deadline=$(( $(date +%s) + 120 ))
   while [ "$(date +%s)" -lt "$deadline" ]; do
-    kubectl get pods -n leoflow --no-headers 2>/dev/null | grep -qE 'recoverdag-quick-.*(Error|Failed)' && break
+    status="$(kubectl get pods -n leoflow --no-headers 2>/dev/null | awk '/recoverdag-quick-/{print $3; exit}')"
+    case "$status" in
+      Error|Failed) break ;;
+      Completed|Succeeded)
+        bad "C: recoverdag pod ended '$status' (exit 0) — the fault-injection seam did NOT fire, so recovery was never exercised (stale agent image?). Refusing to pass on the ordinary report path."
+        return ;;
+    esac
     sleep 3
   done
+  case "$status" in
+    Error|Failed) ok "C: fault injected — the pod ended '$status' (agent exited mid-report, record already written)" ;;
+    *) bad "C: recoverdag pod never reached a terminal failed state (status='$status') — cannot confirm the fault fired"; return ;;
+  esac
 
   # The reconciler (30s sweep) must settle the TI SUCCEEDED from the durable record,
   # winning the race against the agent-lost reaper (90s, and disarmed here: a sub-15s

--- a/test/e2e/chaos-runtime.sh
+++ b/test/e2e/chaos-runtime.sh
@@ -13,6 +13,10 @@
 #   B) task-pod kill (#474/#518) — delete a running task's pod; assert the reaper
 #      moves the TI off `running` to a terminal state (not stuck forever) and
 #      leaves no orphaned pod for that attempt.
+#   C) durable outcome recovery (ADR 0052) — a task succeeds but the agent is told
+#      to exit mid-report AFTER writing the durable outcome record; assert the
+#      reconciler recovers the SUCCESS from the record (the pod is Failed and no
+#      report ever landed), settling the run success instead of failing/retrying.
 #
 # NOT a `go test`; destructive; not gated in CI (slow). It mirrors the proven
 # host-process split harness (split-two-process.sh) and reuses the k3d_import
@@ -32,6 +36,8 @@ PY_VERSION="3.11"
 BASE_IMAGE="leoflow-base:py${PY_VERSION}"
 DAG_IMAGE="leoflow-chaos-dag:dev"
 DAG_ID="chaosdag"
+RECOVER_DAG_IMAGE="leoflow-recover-dag:dev"
+RECOVER_DAG_ID="recoverdag"
 
 API_HTTP_PORT="${LEOFLOW_E2E_API_HTTP_PORT:-8080}"
 API_METRICS_PORT="9090"
@@ -275,8 +281,106 @@ scenario_task_pod_kill() {
   fi
 }
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Scenario C — durable outcome recovery (ADR 0052)
+# ─────────────────────────────────────────────────────────────────────────────
+setup_recoverdag() {
+  log "C-setup: scaffolding recoverdag (succeeds, but the agent dies mid-report)"
+  "$ROOT/bin/leoflow" init "$WORKDIR/$RECOVER_DAG_ID" >/dev/null
+  cat >> "$WORKDIR/$RECOVER_DAG_ID/leoflow.yaml" <<YAML
+build:
+  platforms:
+    - ${HOST_PLATFORM}
+tasks:
+  quick:
+    # The agent runs the task to success and writes the durable outcome record to
+    # the termination message, then exits 137 WITHOUT delivering the report —
+    # simulating a pod killed mid-report (OOM/eviction). Test-only seam (ADR 0052).
+    env:
+      LEOFLOW_CHAOS_DIE_BEFORE_REPORT: TASK_STATE_SUCCESS
+YAML
+  cat > "$WORKDIR/$RECOVER_DAG_ID/dag.py" <<'PY'
+"""recoverdag — the task succeeds; the agent is told to die mid-report, so the
+reconciler must recover the success from the durable outcome record (ADR 0052)."""
+from __future__ import annotations
+from airflow.sdk import DAG, task
+
+
+@task
+def quick() -> str:
+    print("recover: task body ran to success", flush=True)
+    return "ok"
+
+
+with DAG("recoverdag", schedule=None, catchup=False, tags=["chaos"]):
+    quick()
+PY
+  cat > "$WORKDIR/$RECOVER_DAG_ID/Dockerfile" <<DOCKER
+FROM ${BASE_IMAGE}
+COPY dag.py /home/leoflow/dag.py
+ENV PYTHONPATH=/home/leoflow
+DOCKER
+  "$ROOT/bin/leoflow" compile "$WORKDIR/$RECOVER_DAG_ID" --image "$RECOVER_DAG_IMAGE" --build --dockerfile Dockerfile -o "$WORKDIR/$RECOVER_DAG_ID/dag.json" >/dev/null
+  k3d_import "$CLUSTER" "$RECOVER_DAG_IMAGE" || fatal "C: k3d import of recoverdag failed"
+  "$ROOT/bin/leoflow" push "$WORKDIR/$RECOVER_DAG_ID/dag.json" --server "$API" --token "$TOKEN" >/dev/null
+}
+
+recover_run_state() {  # $1=run
+  curl -fsS -H "Authorization: Bearer $TOKEN" \
+    "$API/api/v2/dags/$RECOVER_DAG_ID/dagRuns/$1" 2>/dev/null | jq -r '.state // "unknown"'
+}
+
+scenario_durable_outcome_recovery() {
+  log "SCENARIO C — pod killed mid-report after writing the outcome record; reconciler recovers the SUCCESS (ADR 0052)"
+  setup_recoverdag
+
+  local run
+  run="$(curl -fsS -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+    -d '{}' "$API/api/v2/dags/$RECOVER_DAG_ID/dagRuns" | jq -r '.dag_run_id')"
+  [ -n "$run" ] && [ "$run" != "null" ] || { bad "C: no run id"; return; }
+
+  # The task pod must end NON-successfully at the k8s level (agent exit 137) — the
+  # whole point is that pod phase says failure while the record says success.
+  local deadline; deadline=$(( $(date +%s) + 90 ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    kubectl get pods -n leoflow --no-headers 2>/dev/null | grep -qE 'recoverdag-quick-.*(Error|Failed)' && break
+    sleep 3
+  done
+
+  # The reconciler (30s sweep) must settle the TI SUCCEEDED from the durable record,
+  # winning the race against the agent-lost reaper (90s, and disarmed here: a sub-15s
+  # task never heartbeats, so the zero-heartbeat guard skips it). Assert the run
+  # reaches success and does NOT fail.
+  deadline=$(( $(date +%s) + 150 )); local state=""
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    state="$(recover_run_state "$run")"
+    [ "$state" = success ] && break
+    [ "$state" = failed ] && { bad "C: run FAILED — the reconciler did not recover the success from the durable record"; return; }
+    sleep 5
+  done
+  if [ "$state" = success ]; then
+    ok "C: run recovered to SUCCESS from the durable outcome record, despite the Failed pod and the lost report"
+  else
+    bad "C: run did not reach success within the recovery window (state=$state)"
+    return
+  fi
+
+  # Recovery is a SETTLE, not a retry: the durable record settles the current
+  # attempt succeeded (try_number unchanged), so there is exactly one attempt.
+  local tries
+  tries="$(curl -fsS -H "Authorization: Bearer $TOKEN" \
+    "$API/api/v2/dags/$RECOVER_DAG_ID/dagRuns/$run/taskInstances" 2>/dev/null \
+    | jq -r '[.task_instances[].try_number] | max')"
+  if [ "$tries" = "1" ]; then
+    ok "C: recovery settled the current attempt (try_number=1) — no wasteful retry of already-done work"
+  else
+    bad "C: expected a single attempt (recovery is a settle, not a retry), got max try_number=$tries"
+  fi
+}
+
 scenario_scheduler_crash
 scenario_task_pod_kill
+scenario_durable_outcome_recovery
 
 printf '\n\033[1m===== chaos-runtime summary =====\033[0m\n'
 if [ "$FAILED" -ne 0 ]; then


### PR DESCRIPTION
Closes the ADR 0052 loop: a full-cluster chaos scenario proving the reconciler recovers a task's success from the durable outcome record when the pod is killed mid-report.

## What

**Scenario C** in `test/e2e/chaos-runtime.sh`: a `recoverdag` whose `quick` task succeeds, but whose agent is told (via the task env `LEOFLOW_CHAOS_DIE_BEFORE_REPORT=TASK_STATE_SUCCESS`) to exit 137 **after** writing the durable outcome record and **before** delivering the report — a faithful OOM/eviction-mid-report. The pod ends Failed with no report; the scenario asserts the run **recovers to SUCCESS** from the record (not fail/retry), and that recovery is a **settle, not a retry** (try_number stays 1).

**The seam:** `Runner.BeforeReport` fires after the record is on disk and before the report RPC; the agent binary wires it from the env var to `os.Exit(137)`. The library core stays free of `os.Exit`/env. Never set in production.

## Verified here
- Unit: `TestRunnerBeforeReportHookFiresAfterRecordBeforeReport` locks the ordering (record on disk, terminal report not yet sent when the hook fires).
- The `recoverdag` + `leoflow.yaml` compile and the chaos env binds to the `quick` task in `dag.json`.
- `bash -n` + shellcheck clean; full build + agent unit + golangci-lint 0.
- (Step 2's reconciler recovery + attempt guard are already unit + integration tested on main.)

## Needs a cluster run
The runtime chaos harness is **not CI-gated** (destructive, slow) — run it on the Lima Linux VM:
```bash
test/e2e/chaos-runtime.sh
```
This PR's CI validates the code (agent seam, build, lint, all unit + integration + the CI-gated k3d E2Es), but **not** Scenario C itself. The final green for Step 3 is a Lima run of the harness.