### PR TITLE
docs(adr): shared-cluster / multi-tenant + N:1 execution ADR set

### DIFF
--- a/docs/adr/0002-pod-per-task.md
+++ b/docs/adr/0002-pod-per-task.md
@@ -29,7 +29,7 @@ In standalone mode, each task is either a Docker container (default) or a subpro
 ## Consequences
 
 - **Cold start matters more.** Because every task pays the container startup cost, the base images must stay small and the agent must be a tiny static binary. See ADR 0004.
-- **No `pool` or `queue` abstraction in the API.** These concepts from Celery-era orchestrators do not map to K8s and would mislead users. The Airflow-compatible API translates accordingly.
+- **No `pool` or `queue` abstraction in the API.** These concepts from Celery-era orchestrators do not map to K8s and would mislead users. The Airflow-compatible API translates accordingly. **[SUPERSEDED 2026-08 — see Amendment below. This clause is withdrawn: under N:1 a `pool` is a placement + concurrency abstraction, not a worker queue, and `max_active_tasks` is a `PlanRun` admission gate. The abstraction is now first-class; see ADR 0053.]**
 - **HTTP API operator has two execution modes (hybrid).** By default, `type=http_api` tasks execute inline as goroutines in the Control Plane, paying no pod startup cost. This is the right choice for short-lived calls (webhooks, notifications, lightweight API triggers). For longer-running HTTP tasks (paginated fetches, batch endpoints, long-polling), the DAG author can opt into pod-based execution via the per-task `execution_mode` field. The Control Plane enforces a server-side maximum duration (`LEOFLOW_INLINE_HTTP_MAX_DURATION`, default 300s) on inline tasks; tasks that declare a longer `execution_timeout_seconds` and do not set `execution_mode: pod` fail validation at DAG push time with a clear error message pointing to the fix.
 - **Tasks must declare resources.** CPU and memory requests are mandatory in the DAG spec for K8s placement to work.
 
@@ -43,3 +43,95 @@ The hybrid model resolves this without forcing every HTTP call to pay pod startu
 
 - **Persistent worker pool:** rejected because it reintroduces every problem Leoflow is trying to solve.
 - **Hybrid pool + ephemeral:** rejected as added complexity without clear benefit.
+
+## Amendment (2026-08) — pool/queue abstraction superseded
+
+**Amends:** exactly one consequence of this ADR. Everything else stands.
+**Relates:** ADR 0051 (separate the orchestration and execution state machines), ADR 0052 (durable task outcome), ADR 0053 (admission + placement — the layer this amendment clears the ground for).
+
+ADR 0002 stands. Ephemeral-container-per-task remains the default and only *baseline*
+execution model; native isolation, per-DAG dependencies (ADR 0003), free K8s
+scheduling, and zero idle cost are all preserved verbatim. This is a **surgical
+supersede of one consequence**, not a teardown.
+
+### The superseded clause
+
+The Consequences section stated:
+
+> **No `pool` or `queue` abstraction in the API.** These concepts from Celery-era
+> orchestrators do not map to K8s and would mislead users. The Airflow-compatible
+> API translates accordingly.
+
+**This clause is withdrawn.** A per-DAG `max_active_tasks` gate and real named
+`pool`s are hereby admitted into the model.
+
+### Why the clause is now wrong
+
+The clause was sound under its own premise: when a "pool" means *a fixed set of
+long-lived Celery workers draining a queue*, it genuinely does not map to
+pod-per-task, and exposing it would have misled users into expecting idle
+workers. That premise no longer holds.
+
+Under the N:1 execution direction — a task lives in exactly ONE pod; a DAG spans
+1..N pods; task→pod is a function, N:1 — a pod is no longer identically "one
+task's ephemeral container." It is a **placement target** that is either
+*dedicated* (today's ADR 0002 model, unique to one task) or *shared* (a warm
+worker hosting sibling tasks of the same DAG). Once a pod can be a placement
+target rather than a synonym for a task, the two Celery concepts split cleanly
+and each maps:
+
+- A **pool becomes a placement + concurrency abstraction, not a worker queue.** In
+  the warm-worker case the pool literally *is* the set of warm pods for a DAG —
+  membership is a placement decision, resolved by an O(1) per-task free-slot
+  lookup, not a queue a worker drains. The abstraction the original clause
+  rejected as unmappable is exactly the one the new topology needs a name for.
+- **`max_active_tasks` becomes a scheduler admission gate, not a queue depth.** It
+  is enforced in `PlanRun` *before* a task becomes `queued` — an admission
+  decision on the orchestration side (ADR 0051's orchestration state machine),
+  with no worker and no queue involved. It gates how many of a DAG's tasks may be
+  in flight; it says nothing Celery-style about *where* they run.
+
+So the original "does not map to K8s" premise is **invalidated by the new
+execution model**, not merely re-weighed. ADR 0051 is what makes this safe to
+say: the admission gate lives entirely in the orchestration state machine, and
+the placement/pool lives entirely in the execution state machine, across the seam
+ADR 0051 draws. The pool never leaks back into being a Celery worker because
+orchestration consumes a task's outcome through the execution seam
+(`ExecutionStore` / the durable record of ADR 0052), never through pod phase or
+pod identity.
+
+### Zero idle cost is preserved
+
+The one property that made the original clause attractive is kept. Warm pools are
+per-DAG with **`min-idle=0` (scale-to-zero)**: when a DAG has no ready work its
+pool holds no pods, so admitting pools reintroduces **no idle cost**. ADR 0002's
+zero-idle guarantee is a floor the pool abstraction sits on top of, not a promise
+it breaks — a pool with zero members is indistinguishable from today's
+ephemeral-only model.
+
+### The revised consequence
+
+Replace the withdrawn clause with:
+
+> **`pool` and per-DAG `max_active_tasks` are first-class concurrency
+> abstractions.** They are the **admission layer** specified in ADR 0053
+> (admission + placement). `max_active_tasks` is a per-DAG scheduler admission
+> gate applied in `PlanRun`; a named `pool` is a cross-DAG admission gate over the
+> same layer. Neither is a Celery worker queue: admission is an orchestration-side
+> decision (ADR 0051), and placement onto a *warm pool* — the only thing that
+> resembles a "worker" — is an execution-side decision that scales to zero
+> (`min-idle=0`), preserving ADR 0002's zero-idle-cost property. The
+> Airflow-compatible API may now surface both rather than translating them away;
+> `/api/v2/pools` graduates from stub to real.
+
+### Lite-containment constraint
+
+The admission gates live in `PlanRun`, which is **shared scheduler core** between
+Lite (single binary, subprocess executor, in-process delivery) and Pro. Per the
+Lite-containment rule, any change on this path must leave Lite's observable
+behavior byte-for-byte unchanged. Therefore the `max_active_tasks` and `pool`
+gates **default to today's Lite behavior behind an edition/config flag** — no gate
+applied unless explicitly configured — so an unconfigured Lite install plans and
+admits exactly as it does today. The warm-worker placement target this amendment
+names is Pro/Kubernetes-only and out of scope for Lite; ADR 0053 carries the flag
+and the containment proof.

--- a/docs/adr/0051-separate-orchestration-and-execution-state-machines.md
+++ b/docs/adr/0051-separate-orchestration-and-execution-state-machines.md
@@ -1,9 +1,78 @@
 # ADR 0051: Separate the orchestration and execution state machines
 
-**Status:** Proposed
-**Date:** 2026-08-12
+**Status:** Accepted
+**Date:** 2026-08-12 (proposed); accepted 2026-08-17
+**Accepted because:** the N:1 execution direction (a task is atomic to one pod;
+a DAG spans 1..N pods; a pod is dedicated *or* a shared warm worker) makes the
+two machines genuinely different in cardinality — so pod phase can never be a
+proxy for a single task's outcome. See "Why now" below. This is the foundation
+that makes the warm-pool safe; it is a prerequisite for ADR 0053 (admission +
+placement) and for PR-N1 (the warm-worker / shared-pod executor).
 **Relates:** ADR 0031 (scheduler architecture — reconciliation loop, two-phase dispatch, two-layer reaping), ADR 0027 (editions: executors + delivery), ADR 0015 (Kubernetes-only container execution), ADR 0002 (pod-per-task), ADR 0004 (thin agent), ADR 0010 (observability), ADR 0049 (split API/scheduler roles)
 **Issues:** #543 (agent exit code conflates task outcome with report delivery), infra-vs-task retry conflation (this ADR)
+
+## Why now — the motivation, strengthened
+
+When this ADR was proposed, the case for the seam read as cleanup: name the
+second state machine the scheduler had quietly absorbed, stop infra faults from
+billing the user's `retries`, and untangle #543. All true, all still the
+immediate wins — but they undersell the decision. The decisive reason to draw
+this seam is **cardinality**, and it only becomes visible under the N:1
+execution direction the product is now committed to.
+
+**The N:1 direction.** A task is **atomic to one pod** — it always runs whole,
+on exactly one pod. But a **DAG spans 1..N pods**, and a pod is either
+**dedicated** (runs one task, exits at its end) **or a shared warm worker**
+(a long-lived process that runs many task-attempts and does *not* exit per task).
+So the moment pods are reused, orchestration and execution stop being two views
+of the same lifecycle and become two machines with **genuinely different
+cardinality**: one pod ⟷ many tasks.
+
+**Why that is dispositive.** Under a dedicated pod you can *almost* get away with
+reading the substrate — one pod, one task, one exit, so pod phase looks like the
+task's outcome (it is not — that conflation is exactly #543 — but the 1:1
+cardinality hides the error). Under a shared worker the illusion collapses
+completely: **a pod's phase describes the pod, never any single task that ran on
+it.** A warm worker that is `Running` has already finished tasks; one that dies
+carries an unbounded set of in-flight attempts down with it. There is no
+function from pod phase, and no function from pod identity, to *one task's*
+result. Pod-as-proxy was always wrong; N:1 makes it unrepresentable.
+
+**The invariant this forces.** Orchestration must consume a task's outcome
+**only through the execution seam** — the `ExecutionOutcome` up the seam, and its
+durable record (`ExecutionStore`) — and **must never read pod phase or pod
+identity to decide a task's result.** That is not a stylistic preference; it is
+the single rule that keeps the two machines correct once their cardinality
+diverges. Everything the Decision specifies (the opaque `Correlation` bag,
+`Unexecutable` off the task-retry rail, the at-most-once guards) is the machinery
+that makes this one invariant hold.
+
+**Foundation, not a peer.** This is why 0051 is accepted now rather than left to
+mature alongside the work it enables:
+
+- It is the **foundation that makes the warm-pool (N:1 impl #2) safe.** Losing a
+  warm pod is *one* infra event that must fan out to *all* in-flight
+  task-instances on it, each re-placed without consuming the user's retry budget
+  — the exact generalization of `Unexecutable` / `DispatchAttempts` this ADR
+  draws. Without the seam there is nowhere correct for that fan-out to live.
+- It is a **prerequisite for ADR 0053 (admission + placement).** Placement
+  ("reuse a warm pod of the same DAG, else spin one, else defer") is an execution
+  concern; admission (`max_active_tasks`, pools) is an orchestration concern. They
+  compose only across a named seam. 0053 assumes this split exists.
+- It is a **prerequisite for PR-N1 (the warm-worker executor).** The shared pod
+  is simply a *second outcome transport* — a long-lived worker reporting each
+  attempt in-band and durably — behind the same `WorkItem` / `ExecutionOutcome`
+  contract. That substitution is only invisible to orchestration because the
+  seam already hides the transport.
+
+**ADR 0052 already accepted this split one layer up.** 0052 (durable task
+outcome, this ADR's Phase 2) explicitly separates the outcome *contract* from its
+*transport*: dedicated pod → termination message (impl #1); shared warm worker →
+in-band per-attempt record (impl #2); "orchestration consumes the outcome through
+the execution seam (`ExecutionStore`), never pod phase or the transport
+directly." Accepting 0051 **formalizes the state-machine separation underneath
+that contract** — 0052 split contract-vs-transport on this exact basis, and 0051
+is the machine boundary that makes the split load-bearing rather than incidental.
 
 ## Context
 

--- a/docs/adr/0053-admission-and-placement.md
+++ b/docs/adr/0053-admission-and-placement.md
@@ -1,0 +1,415 @@
+# ADR 0053: Admission + placement — one scheduler-side layer for task concurrency and pod assignment
+
+**Status:** Proposed
+**Date:** 2026-08-17
+**Relates:** ADR 0002 (pod-per-task — amended here: the "no `pool`/`queue` abstraction" consequence is superseded), ADR 0051 (separate the orchestration and execution state machines — the foundation this layer sits on), ADR 0052 (durable task outcome — a warm pod uses its in-band per-attempt transport, impl #2), ADR 0055 (secret scoping + token liveness — the security gate that orders PR-N1), ADR 0031 (scheduler reconciliation loop, `max_active_runs`, `DispatchAttempts`), ADR 0027 (editions: Lite subprocess vs Pro Kubernetes), ADR 0015 (Kubernetes-only container execution)
+**Issues:** `max_active_tasks` enforcement (PR-4; memory-note only today, no issue yet); real task pools (PR-8; #31 **closed** as stub-only, needs a fresh issue); quota/APF backpressure classification (PR-2; #127 closed & different, needs a fresh issue). Warm-worker implementation (PR-N1) is tracked separately and **gated** behind ADR 0055 (secret scoping #59 + token liveness/revocation, remainder of #476/ADR 0045).
+
+## Context
+
+Three things that look like separate features are the same subsystem, and Leoflow
+has built exactly **one third of it**:
+
+1. **Run-level concurrency exists.** `max_active_runs` per DAG is enforced —
+   `hasHeadroom` gates how many runs of a DAG may be active before a due slot is
+   created (`internal/scheduler/scheduler.go:666-679`; `#200`), and `PlanRun`
+   advances tasks off the resulting run set (`internal/scheduler/plan.go:22-60`).
+
+2. **Task-level concurrency does not.** There is **no** `max_active_tasks`
+   enforcement anywhere in the backend. The Airflow-compat UI even *renders the
+   label* — `maxActiveTasks` ships in every locale bundle
+   (`internal/ui/assets/i18n/locales/*/common.json`) — but no Go code reads it. A
+   DAG that fans out 500 parallel tasks gets 500 dispatches; the only cap is the
+   run count, which is the wrong axis.
+
+3. **Pools are a decorative stub.** `GET /api/v2/pools` returns a schema-valid
+   empty collection so the 3.2.1 UI does not 404 (`internal/api/api_stubs.go:34`,
+   `#31`), and there is **no `pool` column read anywhere** in the domain, storage,
+   or scheduler. `#31` was *closed as stub-only*. ADR 0002 went further and made
+   this a stated non-goal: *"No `pool` or `queue` abstraction in the API. These
+   concepts from Celery-era orchestrators do not map to K8s and would mislead
+   users."*
+
+That ADR-0002 clause was right for a **1:1 dedicated-pod** world where the
+Kubernetes scheduler owns every placement decision and Leoflow owns none.
+`spec/shared-cluster-multitenant-spec.md` changes the world. Its cardinality
+invariant (§1) is that **a task lives in exactly one pod (atomic), a DAG spans
+1..N pods**, and the evolution is that a pod may be **dedicated** (unique to one
+task — today) *or* **shared** (a warm worker hosting sibling tasks of the same
+DAG). The moment a pod can be *reused*, Leoflow acquires a placement decision of
+its own — *which* pod does this task go to — and that decision is meaningless
+without a concurrency layer above it deciding *whether* the task may run at all.
+
+**The two are one subsystem, joined at `queued`.** Admission decides whether a
+ready task becomes `queued`; placement decides where an admitted task's work
+lands. They share a boundary (the `queued` transition in `PlanRun`), share the
+scale variables (§2's **N** runs · **T** tasks/run · **D** active DAGs), and only
+make sense together: admission without placement throttles into a dispatcher that
+still creates a pod per task; placement without admission is an unbounded warm
+pool with no backpressure. Building them as three tickets ("add `max_active_tasks`",
+"implement pools", "add warm workers") would draw the seam in the wrong place
+three times. This ADR names the subsystem so it is drawn once.
+
+There is also a **cluster-facing** admission concern the current dispatcher gets
+wrong. Above Leoflow's own gates sits the shared cluster's: a tight
+`ResourceQuota` answers a pod `CREATE` with **403**, and API Priority & Fairness
+answers with **429**. Today a fan-out of R ready tasks issues R pod `CREATE`s in a
+burst with no task-level throttle (§2.2), and a quota 403 drives the task to the
+*permanent* terminal `dispatch_failed` (spec B2) — Leoflow **fails the user's task
+because the cluster asked it to slow down.** That is a backpressure signal
+misread as a fatal error. Self-throttling against the cluster is part of
+admission, not a separate networking concern.
+
+### Why the algorithmics make this the lever, not a nicety
+
+§2.3 of the spec is the load-bearing argument. Under the 1:1 model, live pods
+`P = Σ dispatched tasks` grows with **task volume**, and the dominant apiserver
+cost — the pod-lost reaper's per-running-TI-per-second namespace `LIST` (§2.2,
+the headline finding) — grows with it. Under N:1 warm pools,
+`P = Σ (warm pools per DAG)` grows with **concurrent-DAG count**, decoupled from
+task volume; cold start is paid per pool spin-up and amortized across M tasks, and
+(if the pod-lost check is reworked per-pod) the apiserver term collapses from
+Θ(running TIs) to Θ(pools) = Θ(D). **Placement moves the dominant infra cost from
+task volume to concurrent-DAG count.** That is the whole reason the placement
+decision is worth building rather than leaving to `kubectl`-style implicit
+pod-creation.
+
+## Decision
+
+Build **admission + placement as one scheduler-side subsystem** with two stages
+that meet at the `queued` transition. Admission lives in the shared `PlanRun`
+path; placement lives behind the execution seam (ADR 0051) on the
+Kubernetes-only path.
+
+### Stage 1 — Admission (concurrency gates), in `PlanRun` before `queued`
+
+A ready task passes an ordered chain of gates before `PlanRun` emits its
+`scheduled → queued` transition. The gates are counters against a cap; a task that
+fails a gate stays `scheduled` and is re-evaluated next tick (the same
+"leave it parked, downstream waits" discipline `PlanRun` already uses for
+`readyToDispatch`/`readyToReschedule`, `plan.go:48-54, 98-108`):
+
+```
+task ready → [ max_active_runs   ]  RUN-level, per DAG   — EXISTS (hasHeadroom, #200)
+           → [ max_active_tasks  ]  TASK-level, per DAG  — NEW (PR-4)
+           → [ named pool slots  ]  cross-DAG            — NEW (PR-8; /pools is a stub today)
+           → admitted → queued
+```
+
+- **`max_active_tasks` (per-DAG):** caps concurrently-active (`queued` +
+  `running`) task instances across all runs of one DAG. This is the axis
+  `max_active_runs` cannot express — it bounds the fan-out, not the run count.
+- **Named pools (cross-DAG):** a pool is a named slot budget that tasks from
+  *different* DAGs draw against (the Airflow semantic the stub UI already
+  advertises). The `pool` column becomes a real, read column on the task spec;
+  `/pools` becomes a real endpoint over real storage. A task with no pool uses an
+  implicit default pool, so the gate is always well-defined.
+
+**Above Leoflow's gates: cluster backpressure is retriable-forever, distinct from
+permanent errors (PR-2 — a hard requirement).** When a pod `CREATE` returns a
+`ResourceQuota` **403** or an APF **429**, the dispatcher must classify it as a
+**retriable-forever infra condition**, backed off, *distinct from a permanent
+error*, and it **must not** drive the task to `dispatch_failed`. This makes Leoflow
+**self-throttle against the shared cluster** — it holds the task and re-offers it
+until the cluster has headroom, instead of failing the task (bad for the user) or
+hammering the apiserver (bad for neighbors). This reuses exactly the shape ADR
+0051 Phase 1 / ADR 0031 Amendment A already established: an infra condition routes
+to a bounded backoff counter, **never** the user's `try_number`. The distinction
+from `DispatchAttempts`' *bounded* exhaustion is deliberate — a quota 403 is not a
+poison placement, it is a *temporary* "no room," so the correct policy is
+retry-forever-with-backoff, gated by admission rather than a fatal counter.
+
+### Stage 2 — Placement (pod as target), behind the execution seam
+
+For a task **admitted** by Stage 1 and belonging to DAG *d*, placement chooses the
+pod — the O(1)-amortized algorithm from §2.3:
+
+```
+slot ← freeSlotIndex[d].pop()                 # O(1) amortized: a warm pod of the SAME DAG with a free slot
+if slot exists:        dispatch the attempt in-band to that warm worker      # shared pod
+else if pool[d].size < max[d]:  create a new warm pod (dedicated until it gains siblings)
+else:                  leave the task 'scheduled'; admission re-offers next tick
+```
+
+- **Same-DAG reuse only.** A warm pod hosts 1..M tasks of **one** DAG (the
+  cardinality invariant); cross-DAG reuse is never allowed — it would break
+  per-DAG image/dependency isolation (ADR 0002/0003) and secret scope.
+- **A new pod is dedicated until it gains siblings** — identical to today's model,
+  so the 1:1 path is the degenerate case of the N:1 one, not a separate code path.
+- **Bookkeeping is O(pools) = O(D), not O(tasks).** The free-slot index is keyed
+  by DAG; the per-task cost is a pop/push. Idle pools scale to zero
+  (`min-idle=0`), preserving ADR 0002's zero-idle-cost property when there is no
+  work — the warm pool is an amortization of cold start, not a persistent worker
+  pool (ADR 0002's rejected alternative stays rejected).
+- **Outcome transport follows the pod kind (ADR 0052).** A dedicated pod exits at
+  the task's end and reports via the **termination message** (impl #1, today). A
+  shared warm worker does *not* exit per task, so it reports each attempt's outcome
+  **in-band, per attempt, durably** (impl #2). The orchestration layer consumes
+  the outcome through the ADR 0051 execution seam **either way** and never reads
+  pod phase or pod identity to decide a task's result — which is precisely what
+  makes N:1 safe.
+
+### Pod ownership and GC (bare Pod today; per-DAG owner for warm pods later)
+
+Placement raises a concrete substrate question the drafts left implicit: *what
+Kubernetes object owns a task pod, and how is it garbage-collected?* The answer
+differs by pod kind, and getting it wrong re-fuses concerns ADR 0051 and ADR 0052
+just separated.
+
+**Dedicated task pod (today + this release): a bare `Pod`, kept. Reject `Job`.**
+The dedicated task pod stays a bare `Pod` created via `client-go`, GC'd
+event-drivenly by the informer (ADR 0054's PR-10: terminal + age → delete). A
+`Job` wrapper is **rejected** — it buys only `ttlSecondsAfterFinished`, which the
+informer reproduces, and it introduces **three collisions**:
+
+1. **`Job` status is derived from pod phase**, which re-introduces exactly the
+   *phase-as-truth* conflation ADR 0052 overrules. A `Job` that reads its pod's
+   `Failed` phase would settle a lost-report success as a failure — the #543 bug,
+   re-imported at the substrate layer.
+2. **`ttlSecondsAfterFinished` races the ADR 0052 success-recovery read.** The
+   reconciler recovers a lost success by reading the terminated container's
+   termination message off pod status; a `Job` TTL that deletes the finished pod
+   can win that race and take the durable record with it before it is read.
+3. **`Job` pod-recreation breaks the `try_number`-owns-the-attempt invariant.** A
+   `Job` recreates its pod on failure with its own backoff, outside Leoflow's
+   retry accounting — so an attempt Leoflow believes it owns is silently re-run by
+   the `Job` controller, colliding with the `try_number`-guarded settle (ADR 0052)
+   and the infra-vs-task retry split (ADR 0051).
+
+**No `ownerReferences` on dedicated pods.** For an ephemeral pod that exits at its
+task's end, cascade-GC via `ownerReferences` is near-worthless, and there is no
+stable owner object to point at (a run is not a Kubernetes object). The informer's
+terminal-plus-age delete is the GC mechanism; it needs no owner. (This is why ADR
+0054 removes `ownerReferences` from PR-10's scope.)
+
+**Warm pod (PR-N1): owned by a per-DAG, Θ(D), low-churn owner object.** A warm pod
+outlives any single task, so it *does* need cascade GC — but keyed by DAG, not by
+task. Its owner is a per-DAG object at Θ(active DAGs) grain, and `ownerReferences`
+on the warm pods give cascade GC when the pool is torn down:
+
+- **Default: a native ConfigMap GC-anchor** — `leoflow-pool-<dag>` in the task
+  namespace, the warm pods' `ownerReference`. Deleting the anchor cascade-deletes
+  the pool. This adds `configmaps:[create,delete]` to the executor `Role`, caught
+  by `scripts/rbac-covers-executor.sh` on every CI run. No CRD, no cluster-scoped
+  privilege.
+- **Upgrade to a pool-CR only if/when ADR 0051 alternative 2 (the read-only CRD
+  *projection* for `kubectl`/GitOps visibility) ships** — then the CRD is
+  justified by the visibility feature it carries, not smuggled in as a GC anchor.
+- **Never a per-task CR.** That is Θ(tasks) high-churn custom-resource load — the
+  etcd worst-case ADR 0051 rejected outright. The per-DAG grain dodges it: pool
+  churn is Θ(D), not Θ(tasks).
+
+### Lite containment (hard constraint, §0.1)
+
+Admission gates live in `PlanRun`, which Lite and Pro **share**. Therefore, per
+the spec's §0.1 rule, the admission layer **must default to today's exact Lite
+behavior behind an edition/config flag** and leave Lite byte-for-byte unchanged:
+
+- **`max_active_tasks`** is additive — with no cap configured the gate is a no-op,
+  so an existing Lite (or Pro) DAG behaves exactly as today. Enabling it is opt-in.
+- **Named pools are a Pro concept.** Lite is a single subprocess executor with
+  no cluster and no cross-node slot budget to arbitrate; **Lite has no pools.** The
+  pool gate is gated on the Pro edition and defaults off. Lite's admission chain is
+  `max_active_runs → (optional max_active_tasks) → admitted`, unchanged in shape.
+- **Placement / warm pools are Kubernetes-only**, entirely behind the execution
+  seam (ADR 0051). Lite dispatches a subprocess in-process, as it does today; the
+  free-slot index, warm-pool lifecycle, in-band transport, and ConfigMap GC-anchor
+  are never constructed on the Lite path. This is containment technique (1) — put
+  the change behind the executor interface — layered under technique (2) — the Pro
+  flag on the shared `PlanRun` gate.
+
+The net Lite guarantee: with the flag at its default, no observable Lite behavior
+changes. Any change that would alter that requires the maintainer conversation
+§0.1 mandates.
+
+### Amends ADR 0002
+
+ADR 0002's consequence — *"No `pool` or `queue` abstraction in the API"* — is
+**superseded** by this ADR (see ADR 0002's 2026-08 Amendment). The ephemeral-default
+and zero-idle-cost framing is **kept** (warm pools scale to zero; a task is still
+atomic to one pod). What changes is only that a pod may be a *reused* placement
+target and that Leoflow now owns a task-level concurrency and placement decision
+the Kubernetes scheduler cannot make for it.
+
+## Key properties
+
+- **One subsystem, one seam.** Admission and placement meet at the `queued`
+  transition. Admission is edition-shared (`PlanRun`); placement is Pro-only
+  (execution seam). Neither is useful alone; both are specified together so the
+  `queued` boundary is drawn once.
+- **O(1) amortized placement; O(D) bookkeeping.** Per-task cost is a slot
+  pop/push against a per-DAG index; pool state is Θ(active DAGs), not Θ(tasks).
+  This is the property that decouples infra cost from task volume (§2.3).
+- **Bare Pod today, per-DAG owner for warm pods.** Dedicated pods are bare `Pod`s
+  GC'd by the informer with no `ownerReferences`; `Job` is rejected for the three
+  collisions above; warm pods are cascade-GC'd via a per-DAG ConfigMap anchor at
+  Θ(D) grain, never a per-task CR.
+- **Cluster backpressure is a first-class, non-terminal condition.** Quota 403 /
+  APF 429 → retriable-forever with backoff, never `dispatch_failed`, never a
+  `try_number` charge. Leoflow becomes a self-throttling good tenant (§3, §4.2).
+- **Retry-budget discipline is inherited, not reinvented.** Every no-budget rail
+  this ADR needs already exists: `DispatchAttempts` (dispatch-failed backoff, ADR
+  0031 Amendment A), the infra-attempt counter (ADR 0051 Phase 1). Admission's
+  backpressure counter is one more member of that family — bounded backoff for a
+  *temporary* condition, terminating in a named, operator-visible state only if it
+  must terminate at all.
+- **Same-DAG-only reuse preserves isolation and secret scope.** A warm pod never
+  crosses DAG boundaries, so per-DAG image/dependency isolation and per-tenant
+  secret scope are unweakened by reuse.
+- **Airflow-compatible surface.** `max_active_tasks` and pools are Airflow
+  concepts the compat UI already renders; this makes the backend honour what the
+  UI promises, instead of showing a control that does nothing.
+
+## Consequences
+
+- **Fixes the fan-out-vs-quota bug (spec B2).** A 500-task fan-out under a tight
+  quota stops producing 500 permanent `dispatch_failed`s; it self-throttles and
+  drains as the cluster frees room. This is the operational blocker PR-2 targets.
+- **`max_active_tasks` becomes real.** The UI label stops lying; DAG authors get
+  the fan-out cap Airflow users expect.
+- **`/pools` and the `pool` column become load-bearing.** A closed-as-stub feature
+  (`#31`) is reopened as real storage + a real endpoint + a read column. This is a
+  schema addition (a `pool` column on the task spec, pool definitions in storage)
+  — additive, defaulting to an implicit default pool so existing DAGs are
+  unaffected.
+- **The scheduler grows a concurrency layer, but stays orchestration-only.**
+  Admission is planning (`PlanRun`), which is squarely orchestration. Placement
+  lives behind the execution seam and does **not** re-fuse pod knowledge into the
+  scheduler — it respects the ADR 0051 boundary. The scheduler still never reads
+  pod phase to decide a task outcome.
+- **The executor `Role` grows one grant only when warm pods land.** The per-DAG
+  ConfigMap GC-anchor adds `configmaps:[create,delete]` to the namespaced executor
+  `Role` at PR-N1 — checked by `scripts/rbac-covers-executor.sh`, no cluster-scoped
+  privilege, no CRD. Dedicated-pod GC (this release) needs no new grant.
+- **Warm workers are gated on security, and this ADR does not unlock them.** The
+  admission half (PR-4/PR-8) and the placement *interface* can land without warm
+  pods; the shared-pod warm worker (PR-N1, impl #2) holds a long-lived tenant
+  token and therefore **widens the B1 exfiltration window**. Per spec §4.4 it is
+  **gated behind ADR 0055 (secret scoping #59 + token liveness/revocation, remainder
+  of #476/ADR 0045)** and must not precede it. This ADR specifies the layer; it does
+  not authorize turning on shared pods.
+
+### Honest hard parts
+
+- **Admission fairness under contention.** With `max_active_tasks` and pool caps,
+  tasks compete for slots. A naive "first ready wins" gate can starve a DAG whose
+  tasks always lose the race. The gate needs a defined ordering (at minimum stable,
+  ideally priority/FIFO-aware) so admission is not accidentally unfair. Deciding
+  that ordering is real design, not a config default.
+- **Backpressure vs. poison placement.** A quota 403 (temporary, retry forever)
+  and an unschedulable pod (bad image, unsatisfiable resources — poison, must
+  terminate) can look similar at the `CREATE` call. Misclassifying poison as
+  backpressure is an infinite re-offer loop; misclassifying backpressure as poison
+  is the B2 bug we are fixing. The classifier must distinguish 403/429 (retry
+  forever) from `Invalid`/`Forbidden`-for-policy and from a pod that admits but
+  never schedules (bound the latter, exactly as `DispatchAttempts` bounds dispatch
+  failure).
+- **Warm-pod reaping fans one infra event out to many TIs.** Losing a warm pod is
+  **one** infra event affecting **all** in-flight task instances on it; each must
+  be re-placed **without** consuming its user retry budget (ADR 0051 Phase 1
+  generalizes to the fan-out; the infra marker stays per-TI). GC is coarser too —
+  a warm pod is owned by a per-DAG ConfigMap anchor (PR-N1) via `ownerReferences`,
+  not by a single run. Both are §4.3 concerns this ADR flags but leaves to PR-N1.
+- **The free-slot index is scheduler state that must survive leader failover.** An
+  in-memory per-DAG index is a cache of a truth that must be reconstructible from
+  Postgres (the single source of truth, ADR 0031). A new leader must rebuild it
+  from live pod/TI state without double-placing. This is tractable under the
+  reconciliation model (DB-derived every tick) but each phase must prove it.
+
+## Alternatives considered
+
+1. **Three separate features (`max_active_tasks`, pools, warm workers as
+   independent tickets).** Rejected. They share the `queued` seam, the scale
+   variables, and the retry-budget discipline; built separately, the boundary is
+   drawn three times and inconsistently. The spec (§4.2, §6 PR-4+PR-8 explicitly
+   *merged*) treats them as one layer for exactly this reason.
+
+2. **Keep ADR 0002's "no pools" stance; rely on `max_active_runs` + the
+   Kubernetes scheduler.** Rejected. `max_active_runs` bounds the wrong axis (run
+   count, not fan-out), and the kube-scheduler cannot express *task-level*
+   concurrency or *reuse* — it places pods, it does not decide whether a pod should
+   exist. This is precisely the "where Kubernetes cannot, Leoflow must" boundary
+   (§3). It also leaves the B2 quota bug unfixed.
+
+3. **Let the cluster's quota/APF be the only task-concurrency control.** Rejected.
+   That is the current behavior, and it produces the B2 bug: the cluster's "no room"
+   (403/429) is a *backpressure* signal, but the dispatcher reads it as a *fatal*
+   error and permanently fails the user's task. Leoflow must own admission so it can
+   translate backpressure into self-throttle instead of failure.
+
+4. **A persistent worker pool (Celery-style) instead of warm-per-DAG pods.**
+   Rejected — same grounds as ADR 0002's original rejection. Warm pools scale to
+   zero (`min-idle=0`), keep per-DAG isolation, and are an *amortization* of cold
+   start, not a standing fleet of idle workers sharing one Python process.
+
+5. **Admission in the dispatcher instead of `PlanRun`.** Rejected. Admission is a
+   planning decision — "should this task become `queued`" — and belongs with the
+   other planning gates (`max_active_runs`, `readyToDispatch`,
+   `readyToReschedule`) that already live in `PlanRun`. Putting it in the
+   dispatcher would split the concurrency decision across two layers and duplicate
+   the "leave it parked, downstream waits" discipline `PlanRun` already owns.
+
+6. **Wrap the task pod in a `Job` for GC/retry.** Rejected. A `Job` buys only
+   `ttlSecondsAfterFinished` (which the informer reproduces) and imports three
+   collisions: `Job` status is derived from pod phase (re-introducing the
+   phase-as-truth ADR 0052 overrules); `ttlSecondsAfterFinished` races the ADR 0052
+   success-recovery read of the termination message; and `Job` pod-recreation runs
+   attempts outside Leoflow's `try_number` accounting, breaking the
+   `try_number`-owns-the-attempt invariant. The bare `Pod` + informer GC keeps all
+   three under Leoflow's control.
+
+## Phased path
+
+Each phase ships **independently**, **failing-test-first** (ADR 0011), behind the
+edition/config flag, and is **ADR-gated where it changes observable behavior**.
+Ordered by value-over-blast and by the §5.1 security gate:
+
+- **Phase 1 — cluster backpressure classification (PR-2; highest value, lowest
+  blast).** Classify quota 403 / APF 429 as retriable-forever, distinct from
+  permanent errors; a fan-out under a tight quota self-throttles instead of failing.
+  Fixes B2. Touches shared dispatch classification → **Lite's subprocess errors
+  must classify exactly as before** (§0.1 🔴 discuss-first item).
+- **Phase 2 — `max_active_tasks` (PR-4).** Per-DAG task-level admission gate in
+  `PlanRun`, additive, no-op when unconfigured. File the enforcement issue
+  (memory-note only today).
+- **Phase 3 — named pools (PR-8).** Real `pool` column (read), real `/pools`
+  storage + endpoint; implicit default pool so existing DAGs are unaffected.
+  Reopen the closed-as-stub `#31`. Pro-only gate; Lite has no pools.
+- **Phase 4 — placement interface (Kubernetes-only).** Introduce the per-DAG
+  free-slot index and the placement decision behind the execution seam, with the
+  dedicated-pod path as the degenerate `max[d]=1` case — no warm reuse yet, so no
+  security exposure. Dedicated pods stay bare `Pod`s GC'd by the informer, no
+  `ownerReferences`. Proves failover-safe index reconstruction.
+- **Phase 5 — warm-worker shared pods (PR-N1). GATED.** In-band per-attempt
+  durable outcome (ADR 0052 impl #2) + warm-pool lifecycle (§4.3) + the per-DAG
+  ConfigMap GC-anchor with `ownerReferences` cascade GC. **Blocked on ADR 0055
+  (secret scoping #59 + token liveness/revocation, remainder of #476/ADR 0045)** —
+  must not land until a warm pod cannot widen the B1 exfiltration window.
+
+## References
+
+- `spec/shared-cluster-multitenant-spec.md` §2.3 (the N:1 regime change — infra
+  cost from task volume → concurrent-DAG count), §4.2 (admission + placement as one
+  subsystem), §4.3 (warm-pool lifecycle), §4.4 (the security gate that orders the
+  roadmap), §0.1 (Lite containment), §6 (PR-2, PR-4+PR-8 merged, PR-N1), §7 (ADR
+  moves — this is the "New ADR — Admission + placement layer").
+- ADR 0002 — pod-per-task (the "no pools" consequence amended here).
+- ADR 0051 — separate the orchestration and execution state machines (the seam
+  placement sits behind; the no-budget infra-retry rail admission generalizes; the
+  read-only CRD projection, alternative 2, that would later justify a pool-CR).
+- ADR 0052 — durable task outcome (impl #1 termination message / impl #2 warm
+  in-band per-attempt; the success-recovery read `Job` TTL would race).
+- ADR 0054 — shared-cluster coexistence (PR-10 informer GC; `ownerReferences`
+  deferred to PR-N1).
+- ADR 0055 — secret scoping + token liveness (the security gate that orders PR-N1).
+- ADR 0031 — scheduler reconciliation loop; `hasHeadroom`/`max_active_runs`;
+  `DispatchAttempts` / Amendment A (infra ≠ task failure).
+- `internal/scheduler/plan.go:22-60, 98-108` — `PlanRun`, the `queued` transition,
+  and the "leave it parked" gates admission joins.
+- `internal/scheduler/scheduler.go:666-679` — `hasHeadroom` (`max_active_runs`,
+  the one existing concurrency gate).
+- `internal/api/api_stubs.go:34` — the empty `/api/v2/pools` stub (`#31`).
+- `internal/ui/assets/i18n/locales/*/common.json` — the `maxActiveTasks` label the
+  UI renders and the backend never reads.
+- `scripts/rbac-covers-executor.sh` — the CI guard that catches the
+  `configmaps:[create,delete]` grant the warm-pool GC-anchor adds.

--- a/docs/adr/0054-shared-cluster-coexistence.md
+++ b/docs/adr/0054-shared-cluster-coexistence.md
@@ -1,0 +1,320 @@
+# ADR 0054: Coexistence in a shared, multi-team Kubernetes cluster
+
+**Status:** Proposed
+**Date:** 2026-08-17
+**Relates:** ADR 0049 (split API/scheduler roles), ADR 0035 (keyless-first cloud auth; Leoflow is not a key manager), ADR 0015 (Kubernetes as the sole execution path), ADR 0002 (pod-per-task, ephemeral, zero idle cost), ADR 0053 (admission + placement — task-level concurrency, the Leoflow-owned half of the ownership line), ADR 0055 (secret scoping + token liveness — closes the B1 the namespace split only shrinks)
+
+## Context
+
+Enterprise adopters do not hand Leoflow its own cluster. They drop it into a
+shared, multi-team Kubernetes cluster next to online services, other batch
+systems, and other teams' namespaces — all drawing on the *same* finite pools:
+node capacity, the kube-apiserver's request budget (API Priority & Fairness),
+the CNI, and whatever ResourceQuota the platform team has already carved out.
+In that setting Leoflow is a **guest**, and the platform team's first question
+is not "what can it do?" but "what will it do to my neighbors?"
+
+Leoflow's cluster footprint today is deliberately minimal, and that is a
+load-bearing strength we must not regress: a single namespaced `Role`
+(`helm/leoflow/templates/rbac.yaml`), no ClusterRole, no CRD, no admission
+webhook, no DaemonSet, no node agent. It creates task pods; the cluster does the
+rest. But "minimal footprint" is not the same as "good tenant." A good tenant
+also has to **bound** what it consumes and **stay in its lane** under contention,
+and there the current shape has real gaps (spelled out in
+`spec/shared-cluster-multitenant-spec.md` §2 and §3):
+
+- The dominant apiserver cost Leoflow imposes on neighbors is **unbounded** in
+  the number of concurrently-running tasks (§2.2).
+- Two of the isolation controls a platform team would reach for are **blocked**
+  by contract bugs / missing passthrough in `BuildPod`
+  (`internal/executor/kubernetes.go`).
+- There is no ADR that says *which* of these coexistence controls Leoflow owns
+  and which the platform owns — so the temptation is to grow the chart to manage
+  all of them, which is exactly how a minimal guest turns into a cluster-wide
+  operator.
+
+This ADR draws that ownership line and ratifies the isolation model from the
+spec's §3. It is a *coexistence* decision, not an execution-topology one
+(warm-pool / N:1 lives in ADR 0053).
+
+## Decision
+
+### 1. The ownership principle
+
+> **Where Kubernetes already solves it, it is a platform (GitOps) object, NOT
+> chart-managed by Leoflow. Where Kubernetes cannot — task-level concurrency,
+> secret scope — Leoflow owns it.**
+
+Concretely, the Leoflow chart **must not** manage the controls that are
+properties of the *cluster and its other tenants*, not of Leoflow:
+
+- **ResourceQuota** — it bounds a namespace's total consumption, a budget the
+  platform team allocates across all tenants. Leoflow does not get to set its own
+  allowance.
+- **LimitRange** — the same: a namespace default-and-cap policy the platform owns.
+- **PriorityClass** — a *cluster-scoped* object whose whole point is to rank
+  Leoflow's pods **relative to the neighbors' pods**. A tenant cannot self-assign
+  its priority relative to production without the ranking being meaningless;
+  worse, creating cluster-scoped objects would require cluster-scoped RBAC, which
+  is precisely the footprint ADR 0015's minimalism buys us out of.
+- **NetworkPolicy governing the neighbors** — a policy that constrains what *other*
+  namespaces may do, or that encodes the cluster's trust zones, belongs to the
+  platform. (Leoflow's chart *does* ship a NetworkPolicy for its **own** task and
+  control-plane pods — its own lane — which is a different thing; see the ladder.)
+
+What Leoflow owns is what Kubernetes has no concept of: **task-level admission
+and concurrency** (`max_active_tasks`, real pools — ADR 0053) and **secret scope**
+(which subset of a tenant's vault a given task may resolve — ADR 0055). Those are
+Leoflow-domain decisions with no cluster primitive to defer to.
+
+The consequence of the principle is a chart that stays a *workload manifest*, not
+a cluster policy bundle. When an operator needs a ResourceQuota, we document the
+GitOps object they apply — we do not template it.
+
+### 2. Leoflow provisions no nodes — it is a pure workload
+
+Leoflow **creates Pods and nothing more**. It never provisions, cordons, drains,
+labels, taints, or otherwise touches nodes. When a task pod is created, the
+cluster's own `kube-scheduler` places it, and the cluster's Cluster
+Autoscaler / Karpenter provisions a node if none fits. Leoflow is on neither the
+placement nor the provisioning path.
+
+This is verifiable in the RBAC, and the claim is a deliberate invariant:
+
+- The executor `Role` (`helm/leoflow/templates/rbac.yaml`) grants verbs on
+  `pods`, `pods/log`, and `persistentvolumeclaims` **only**. It has **no `nodes`
+  verbs**, and it is a namespaced `Role`, **not a ClusterRole**.
+- There is **no DaemonSet and no node agent** anywhere in the chart. The only
+  cluster-side components are the control-plane Deployment(s) and the ephemeral
+  task pods.
+- `scripts/rbac-covers-executor.sh` checks the grant against the executor's
+  actual apiserver calls both ways on every CI run, so a `nodes` call could not
+  be added without either a failing build or a conspicuous new grant landing in
+  this file.
+
+A **dedicated node pool** for Leoflow is therefore an **operator GitOps choice**,
+not a Leoflow feature: the operator taints a node pool
+(e.g. `workload=leoflow:NoSchedule`) and Leoflow's task pods opt in via
+`tolerations` + `nodeSelector`. This is the strongest form of noisy-neighbor
+isolation and it costs Leoflow no new privilege — but it is **blocked today by a
+contract bug**: `tolerations` is declared on the execution spec
+(`internal/domain/dag.go:167`, carried into `req.Execution`) and then **silently
+dropped** by `BuildPod`, which reads only `NodeSelector` and `ServiceAccount`
+(`internal/executor/kubernetes.go` — the pod's `Spec.Tolerations` is never set).
+So a pod tolerating the taint is never produced, and the taint keeps it off the
+dedicated pool entirely. **`nodeSelector` IS applied today** (`BuildPod` sets
+`Spec.NodeSelector = req.Execution.NodeSelector`), but a `nodeSelector` alone
+cannot land a pod on a *tainted* pool. The taint-based dedicated pool is thus
+**gated on PR-1** (apply `tolerations` in `BuildPod`). An untainted, merely
+labeled pool works today via `nodeSelector`.
+
+### 3. The isolation ladder (strongest → cheapest)
+
+The following controls compose; an operator adopts as many rungs as their risk
+posture requires. Each names its owner and, where it depends on Leoflow work, the
+gating PR.
+
+1. **Dedicated node pool** — taint + toleration. Physical isolation: Leoflow's
+   noisy neighbors are only *other Leoflow tasks*. Owner: platform GitOps (the
+   taint) + Leoflow **PR-1** (apply `tolerations`; the taint side is blocked
+   without it). `nodeSelector` half works today.
+
+2. **Namespace split + ResourceQuota + LimitRange** — run the control plane in
+   `leoflow-system` and task pods in `leoflow-tasks` (the chart already separates
+   `taskNamespace` from the release namespace — `values.yaml`), then let the
+   platform apply a `ResourceQuota` and a `LimitRange` to `leoflow-tasks`. The
+   **`LimitRange` is not optional dressing**: without default requests/limits a
+   task pod is **BestEffort**, which is invisible to the Cluster Autoscaler's
+   scale-up math and first in line for eviction under pressure; the `LimitRange`
+   also **caps `ephemeral-storage`**, the resource a runaway task most easily
+   exhausts on a shared node. Owner: platform GitOps (zero Leoflow PR — this is
+   the principle in action).
+
+3. **PriorityClass below online services** — so that under genuine contention the
+   kube-scheduler preempts Leoflow's ETL, never production. The `PriorityClass`
+   object is platform-owned (cluster-scoped, ranks neighbors — §1); Leoflow's
+   part is only to **stamp `priorityClassName` onto its task pods**, which
+   `BuildPod` does not do today. Gated on **PR-3** (`priorityClassName`
+   passthrough, alongside affinity / topologySpread / ephemeral-storage /
+   terminationGracePeriod / `resourceClaims` (DRA, GA 1.34), as an operator
+   allowlist mirroring `taskPodSecurity`).
+
+4. **Informer + APF FlowSchema** — bound Leoflow's share of the apiserver. The
+   `FlowSchema`/`PriorityLevelConfiguration` is platform GitOps; the Leoflow side
+   is **PR-10**: replace the per-task-instance polling LISTs with a shared pod
+   **informer/watch**. This is a *correctness-of-scale* requirement in a shared
+   cluster, not a nicety — see §4.
+
+5. **NetworkPolicy (Leoflow's own lane)** — deny ingress by default, allow egress
+   only to what tasks legitimately need (DNS + the control-plane gRPC), and
+   **block the cloud metadata endpoint + RFC1918** so a DAG cannot pivot to
+   internal services or steal the node's cloud identity (this is why ADR 0035's
+   keyless posture pairs with it — no key to steal, and no metadata reach to abuse
+   the node identity). The chart ships this (`taskNetworkPolicy`,
+   `networkPolicy`) **off by default**; turning it on is an operator decision.
+   Requires a CNI that enforces policy. Note this is Leoflow policing *its own*
+   pods — distinct from the neighbor-governing NetworkPolicy the chart must not
+   manage (§1). See the egress trajectory note in §4.1.
+
+6. **Split API / scheduler roles (`split.enabled`, ADR 0049)** — the cheapest and
+   most orthogonal rung: give the internet-facing API a restricted identity with
+   **no apiserver RBAC**, so a compromised or SSRF'd API cannot reach the
+   apiserver at all; only the scheduler SA is bound to the executor `Role`. Chart
+   value, off by default.
+
+### 4. The apiserver-cost driver — why PR-10 is a scale requirement, not a nicety
+
+The dominant, steady-state apiserver cost Leoflow imposes on a shared cluster is
+**not** the periodic reconcile LIST one would guess. It is the **pod-lost
+reaper**: every ~1s tick it issues **one namespace-wide pod `LIST` per running
+task-instance older than 60s — healthy ones included** (the liveness check runs
+*after* the LIST, so a healthy pod does not spare the call). That is:
+
+```
+apiserver LIST/sec  ≈  O(running task-instances)   — per second, every second, unbounded by cluster size
+```
+
+~200 running tasks ⇒ ~200 namespace LISTs **per second**, most of them on pods
+that are perfectly fine. In a shared cluster this dwarfs every other apiserver
+term Leoflow contributes (reconcile's one LIST / 30s, staging-GC's one / 60s) and
+lands directly on the APF budget the platform team is trying to protect.
+
+Therefore this ADR records that **PR-10 (shared pod informer/watch) is a
+correctness-of-scale requirement for a shared cluster, not a performance nicety.**
+An informer turns per-task-instance liveness into an O(1) cache read and reaping
+into event-driven O(Δ), collapsing the O(running-TIs)/sec LIST storm to a single
+long-lived watch. Rung 4 of the ladder (APF FlowSchema) *bounds* Leoflow's share;
+PR-10 *removes the reason it would ever blow that bound*. A Leoflow that stays on
+the polling path cannot honestly promise good-tenant behavior at even moderate
+task concurrency.
+
+**PR-10 scope this release: informer/watch ONLY.** PR-10 ships the informer and
+nothing more this release: liveness becomes a lister-cache read; GC becomes an
+event-driven delete on terminal-phase + age; and the ADR 0052 termination-status
+recovery read is served from the informer cache too (so success-recovery is also
+a cache read, not a fresh GET). **`ownerReferences`-based cascade GC is explicitly
+removed from PR-10's scope** and **deferred to PR-N1** (the warm-worker release),
+because for today's ephemeral dedicated pods there is no per-DAG owner object to
+point at — a bare `Pod` GC'd by the informer's terminal+age delete needs no owner
+(ADR 0053, "Pod ownership and GC"). The per-DAG ConfigMap GC-anchor and its
+`ownerReferences` arrive with the warm pool that actually needs cascade GC, not
+before.
+
+#### 4.1. Egress trajectory — per-pod NetworkPolicy is not the whole story
+
+Rung 5's per-pod egress block (metadata endpoint + RFC1918) is real defense in
+depth, but two facts bound it, and this ADR records the trajectory so the control
+is not over-trusted:
+
+- **Cluster-wide egress guardrails are migrating to `AdminNetworkPolicy`
+  (KEP-2091, beta).** A per-namespace `NetworkPolicy` Leoflow ships for its own
+  lane cannot express a cluster-operator's baseline egress deny that applies
+  across tenants; that is what `AdminNetworkPolicy` / `BaselineAdminNetworkPolicy`
+  are for, and they are platform-owned (§1). Leoflow keeps shipping its per-pod
+  `NetworkPolicy` for its own pods, but notes it is one layer, not the whole
+  story — the cluster's ANP baseline is where cross-tenant egress belongs.
+- **The per-pod metadata `ipBlock.except` is CNI-dependent.** Whether a
+  `NetworkPolicy` `ipBlock` actually blocks the `169.254.169.254` metadata IP
+  depends on the CNI's enforcement of `ipBlock` egress; not every CNI honours it
+  identically. So the metadata block is best-effort at the NetworkPolicy layer.
+
+The durable defense is **keyless credentials (ADR 0035)**: if there is no
+long-lived cloud key on the node to steal and no static credential the metadata
+endpoint would hand out, the egress block's failure mode is far less severe. The
+NetworkPolicy narrows reach; ADR 0035 removes the prize.
+
+### 5. The namespace split also shrinks the B1 blast radius
+
+Beyond bounding resource consumption, the namespace split (rung 2) has a security
+payoff for the open whole-tenant-secret-exfiltration risk (B1, spec §5.1). Even
+after ADR 0055 moves the token off the pod spec, isolating task pods in a
+dedicated `leoflow-tasks` namespace means **fewer principals hold `get pods` on
+the task-bearing pods** than if tasks ran in a busy shared namespace — a smaller
+set of identities that can inspect task pods, i.e. a smaller B1 blast radius. This
+does not *close* B1 (that needs the secret scoping + token liveness of ADR 0055,
+a separate ADR), but it is a real, free reduction and a reason the split is on the
+ladder rather than orthogonal to it.
+
+## Open items
+
+- **APF FlowSchema should split reaper LISTs from dispatch/leader calls into
+  different flows.** Today Leoflow's control-plane calls the apiserver under a
+  single ServiceAccount, so a platform `FlowSchema` matching that SA puts *all* of
+  Leoflow's apiserver traffic — the reaper's residual LISTs, the dispatch
+  `CREATE`s, and the leader-election calls — into **one flow**. Under contention,
+  a burst of reaper LIST load can then starve dispatch and leader-election of
+  their APF share, i.e. Leoflow throttles *itself* into scheduling lag and, worse,
+  risks losing leadership. Even after PR-10 collapses the LIST storm, the residual
+  LIST load should be classified into a **separate, lower-priority flow** from the
+  latency-sensitive dispatch/leader calls (distinct `FlowSchema` matchers, e.g. by
+  verb/resource or a dedicated SA), so reaping can never starve dispatch. The
+  `FlowSchema` objects are platform GitOps; the Leoflow side is making its calls
+  *distinguishable* (SA or user-agent) so the platform can write the matchers.
+  Flagged here, not yet a PR.
+
+## Consequences
+
+- **The chart stays a workload manifest.** We do not template ResourceQuota,
+  LimitRange, PriorityClass, or neighbor-governing NetworkPolicy; we document the
+  GitOps objects an operator applies. The minimal-footprint property (one
+  namespaced Role, no cluster-scoped objects, no CRD/webhook/DaemonSet) that makes
+  Leoflow a viable guest is preserved by construction.
+- **Two ladder rungs are gated on Leoflow work.** The dedicated node pool needs
+  **PR-1** (`tolerations` in `BuildPod`); PriorityClass placement needs **PR-3**
+  (`priorityClassName` passthrough, now including `resourceClaims`). Until then, an
+  operator can only reach rungs 2, 5, 6 fully, plus a labeled-not-tainted pool via
+  `nodeSelector`.
+- **PR-10 is promoted from "optimization" to "coexistence blocker" — and scoped to
+  the informer alone this release.** It is the single highest-impact change for
+  shared-cluster viability, because the current reaper's O(running-TIs)/sec LIST is
+  an unbounded tax on the shared apiserver. `ownerReferences` cascade GC is *not*
+  in PR-10; it is deferred to PR-N1 where a per-DAG owner object exists (ADR 0053).
+- **Node provisioning stays the cluster's job, forever.** By recording "Leoflow
+  provisions no nodes" as an invariant with a CI-checked RBAC guardrail, we keep
+  the door shut on a node agent / DaemonSet / cluster-autoscaler integration
+  creeping in — any such thing would demand cluster-scoped privilege and break the
+  guest posture.
+- **Egress defense is layered, and the layers are named.** The per-pod
+  `NetworkPolicy` is one layer with CNI-dependent metadata blocking; cluster-wide
+  egress belongs to platform `AdminNetworkPolicy` (KEP-2091); keyless creds
+  (ADR 0035) is the durable defense. None is trusted as the whole answer.
+- **Lite is unaffected.** All of this is the Kubernetes execution path (ADR 0015);
+  Lite is single-host, subprocess/in-process, no cluster, no pods, no neighbors.
+  The ladder, the node-provisioning invariant, and the reaper cost are Pro-only
+  concerns.
+- **The line is now citable.** When a contributor proposes "let's have the chart
+  set up the quota," or an operator asks "can Leoflow autoscale its nodes," the
+  answer and its reasoning are written down, not re-litigated.
+
+## Alternatives considered
+
+- **Chart-manage the whole isolation stack (quota, limitrange, priorityclass,
+  network policy).** Superficially convenient — one `helm install` and you are
+  "isolated." Rejected: it inverts the ownership of shared-cluster budget (the
+  platform team, not the tenant, allocates it), forces cluster-scoped RBAC for the
+  PriorityClass, and turns a minimal guest into a cluster operator. It also fights
+  GitOps: platform teams already manage quotas/policies declaratively and do not
+  want a Helm chart racing them.
+- **A Leoflow node agent / DaemonSet for placement or capacity.** Rejected
+  outright: it would require cluster-scoped `nodes` privilege, add a per-node
+  component to a system whose whole value proposition is a minimal footprint, and
+  duplicate what the kube-scheduler and Cluster Autoscaler already do well. Leoflow
+  creates pods; the cluster places and provisions. That division is the decision.
+- **Leave coexistence undocumented and handle it per-deployment.** Rejected: the
+  ownership line and the "PR-10 is a scale blocker" finding are non-obvious (the
+  reaper cost in particular is a headline correction to the intuitive guess), and
+  without an ADR they get re-discovered painfully in each pilot. The controls
+  exist across the chart, the spec, and several PRs; this ADR is what makes them a
+  coherent model.
+- **Rely on APF FlowSchema alone to contain apiserver cost.** Rejected as
+  sufficient: APF *throttles* Leoflow when it exceeds its share, which under the
+  current reaper means Leoflow throttles *itself* into scheduling lag at moderate
+  concurrency. Bounding the symptom is not fixing the cause; PR-10 removes the
+  LIST storm so the FlowSchema rarely has to bite. (And even then, the single-flow
+  problem in Open items means the FlowSchema must be *split* so reaping cannot
+  starve dispatch.)
+- **Ship `ownerReferences` cascade GC in PR-10 now.** Rejected for this release:
+  today's dedicated pods are ephemeral bare `Pod`s with no per-DAG owner object to
+  reference, so `ownerReferences` would be near-worthless churn. Cascade GC is
+  deferred to PR-N1, where the warm pool introduces a per-DAG ConfigMap anchor
+  that actually needs it (ADR 0053).

--- a/docs/adr/0055-secret-scoping-and-token-liveness.md
+++ b/docs/adr/0055-secret-scoping-and-token-liveness.md
@@ -1,0 +1,318 @@
+# ADR 0055: Secret scoping and token liveness — scope by declaration, exchange the token, bind it to task liveness
+
+**Status:** Proposed
+**Date:** 2026-08-17
+**Relates:** ADR 0045 (secrets reach a task because it declared it — this ADR is the code that ships its open half), ADR 0021 (exposing variables/connections to pods — the MVP that shipped fetch-all), ADR 0008 (JWT auth — the token this ADR binds to liveness), ADR 0052 (durable task outcome — the same liveness signal, on a different path), ADR 0053 (admission + placement — the warm-worker roadmap this ADR gates), ADR 0054 (shared-cluster coexistence — the namespace split that shrinks, but does not close, B1)
+**Issues:** #59 (scope to declared secrets), #388 (declaration in `leoflow.yaml` → storage), #486 (Lite fixed encryption key — bounded here, not fixed), #507 (token liveness / revocation)
+
+> **This is not a new decision. It is the implementation ADR for the half of
+> ADR 0045 that never shipped.** ADR 0045 is marked *Accepted — not yet
+> implemented*, and it is precise about why: the runtime still hands every task
+> its whole tenant vault, and an external audit of v0.2.0 re-confirmed the
+> exfiltration live. ADR 0045 is **not stale** — its Context describes today's
+> code exactly. What this ADR adds is (a) the concrete mechanism for the token
+> half ADR 0045 left as "should additionally be refused once the task instance is
+> no longer live", (b) the transport fix (stop shipping the token as a plaintext
+> env var) ADR 0045 explicitly deferred, and (c) the hard ordering constraint the
+> warm-worker roadmap (N:1, impl #2, ADR 0053 PR-N1) now depends on. ADR 0045's
+> Decision stands unchanged; this ADR supersedes only its "tracked separately"
+> hand-waves by pinning them to code.
+
+## Context
+
+Two ADRs converge here. ADR 0021 chose on-demand gRPC fetch as the target and
+shipped **fetch-all env-export** as its MVP, naming the gap in its own text:
+*"Fetch-all at boot = no least-privilege… Tracked as a follow-up."* ADR 0045
+accepted the follow-up — deliver a task only the secrets it declares — but no
+code ships it. The gap is not theoretical; it was demonstrated end-to-end.
+
+**Current state, verified against the tree (not remembered).** There are three
+exfiltration links. One is closed; two are open.
+
+**CLOSED — #476 / PR #478.** Task code can no longer read the agent's bearer
+token from its own process environment. The agent runs inside the task's pod
+(ADR 0004), so its environment *is* the task's environment unless something
+removes the difference; `stripAgentOnly` (`internal/agent/runner.go:756`) is that
+something — it strips every `LEOFLOW_`-prefixed variable except a two-name
+allowlist (`LEOFLOW_STAGING_DIR`, `LEOFLOW_TASK_INSTANCE_ID`) before user code is
+exec'd, so `LEOFLOW_AGENT_TOKEN` never reaches the task. This landed. It is the
+reason the environment filter went first: scoping delivery is worthless while the
+credential that bypasses the scoping is handed to user code.
+
+**OPEN #1 — the token is still a plaintext env var on the pod spec.**
+`podEnv` sets `LEOFLOW_AGENT_TOKEN` as `corev1.EnvVar{Value: req.AgentToken}`
+(`internal/executor/kubernetes.go:197`) — a literal value, not a `SecretKeyRef`
+or a projected volume. `stripAgentOnly` keeps it out of the *task process*, but
+it is still sitting in plaintext on the `Pod` object in etcd. **Any principal
+with `get pods` in the task namespace reads it** (`kubectl get pod -o yaml`, the
+K8s API, any controller or audit sink that logs pod specs) — exactly the exposure
+ADR 0021 named when it rejected env-injection-at-dispatch as the default. The
+in-process strip closed the task's own read path; it did nothing for the cluster
+read path.
+
+**OPEN #2 — the token is a whole-vault, no-liveness, 24h capability.** Two facts
+compound:
+
+- **Whole-vault delivery.** `GetVariables` / `GetConnections`
+  (`internal/agentrpc/secrets.go:47,64`) take *empty* request messages and
+  resolve on `id.TenantID` alone — `SecretVariables(ctx, id.TenantID)` /
+  `SecretConnectionURIs(ctx, id.TenantID)`. They return the entire tenant's
+  Variables and Connections, decrypted. A DAG that declares no connections still
+  receives, decrypted, every database password and webhook URL the tenant holds.
+- **Signature-only auth, no liveness, no revocation, 24h TTL.**
+  `AuthenticateAgent` (`internal/auth/agent_token.go:63`) validates the JWT by
+  signature, issuer, `leoflow-agent` audience, and `HS256` method — and nothing
+  else. It never asks whether the task instance is still running. `identify`
+  (`internal/agentrpc/server.go:449`) calls it and returns the identity; there is
+  no revocation list and no heartbeat consult on the secret path. The token's TTL
+  is `agentTokenTTL = 24 * time.Hour` (issued at dispatch).
+
+Put together: **a token captured from a pod spec (OPEN #1) is a bearer credential
+for the whole tenant vault, valid for 24 hours, usable from anywhere that can
+reach the control-plane gRPC port, *after the task that carried it has already
+finished*.** This is the B1 exfiltration ADR 0045 exists to close, and the
+external audit re-confirmed it on v0.2.0. Note the audit's path: it retrieved
+every connection URI in the tenant *from outside any task*, with a token
+exfiltrated from one, after that task finished. Scoping delivery alone does not
+close it — the token bypasses the scoping — which is why the two open links are
+one ADR, not two.
+
+**The codebase already does the hard parts correctly elsewhere.** `FetchXCom`
+(`internal/agentrpc/server.go:296`) authorizes per task: a task may read XCom
+only from an upstream it *declared* (`declaresUpstream`) or a direct dependency.
+And the per-TI liveness signal already exists — `RecordHeartbeat`
+(`server.go:243-266`, #128) stamps `last_heartbeat_at` and already returns
+`ErrStaleReport` / `should_terminate` for a superseded attempt (reaped, or
+`try_number` moved past this attempt). Both capabilities are present. The secret
+path simply does not use either one.
+
+## Decision
+
+Close both open links, keeping ADR 0045's Decision (a task receives a secret only
+if its DAG declared it) intact and adding the token, liveness, and transport fixes
+it deferred. Four fixes plus one rejection, tracked by the four open issues. The
+transport fix is a **token exchange**, not a raw credential handoff — the key
+mechanical change from the earlier draft.
+
+**Fix #1 — scope by declaration (#59, #388). PRIMARY risk reduction.** The DAG
+declares `variables:` / `connections:` in `leoflow.yaml` (per DAG, optional
+per-task narrowing, per ADR 0045 §Settled). Compiled into `dag.json`,
+schema-validated, rejected at registration if a name is unknown. Enforcement is
+**server-side**: `GetVariables` / `GetConnections` resolve the caller's task from
+its token identity and return only that task's declared subset — never the whole
+vault. Concretely:
+
+- The declared set is threaded into the **today-empty** `GetVariablesRequest` /
+  `GetConnectionsRequest`, and — because the agent is not trusted to filter for
+  itself (it runs inside the task's blast radius) — the authoritative filter is
+  applied against what storage returns for the caller's resolved task identity,
+  not against what the agent claims.
+- The `SecretsStore` interface (`internal/agentrpc/secrets.go:16`) grows from
+  `SecretVariables(ctx, tenant)` / `SecretConnectionURIs(ctx, tenant)` to a form
+  that takes the declared set (or the task identity from which the declared set is
+  resolved), so the scoping is enforced in the query, not post-filtered in the
+  handler.
+- The `[]` case is explicit and load-bearing: **a DAG that declares no
+  connections gets none** — not "all", which is today's behaviour and the bug.
+
+**Scoping is only enforceable because the token reliably identifies the task —
+so #59 ships WITH token liveness (Fix #2/#3), never alone.** Server-side scoping
+keyed on the JWT's task identity is only meaningful if that identity is trustworthy
+and current. A non-identifying or stale token makes the per-task filter bypassable
+(the audit's exact path: a still-valid token fetching from outside its task). The
+scope filter and the identity/liveness fixes are one shipment, not a sequence.
+
+**Fix #2 — bind the token to task-instance liveness, and add revocation (#507).
+No apiserver on this path.** `identify` (`server.go:449`) — or a wrapper the secret
+RPCs call — additionally consults the **existing DB liveness predicate** already
+stamped by `RecordHeartbeat` / surfaced as `ErrStaleReport`
+(`server.go:243-266` — "reaped, or `try_number` moved past this attempt") plus a
+revocation set. A token whose task instance is no longer live (terminal,
+superseded by a later attempt, or reaped) **stops resolving secrets**, even though
+its signature is still valid and its clock has not run out. So an exfiltrated
+token expires with the *work*, not with the *clock*. This is the same liveness
+signal `RecordHeartbeat` and `ReportState` already use for the `should_terminate`
+kill-switch (#474), extended to the secret path where today there is none — a
+**pure DB read, no `TokenReview`, no apiserver call**. Revocation covers the "task
+still shows live but the operator wants the credential killed" case.
+
+**Fix #3 — transport = token exchange (PRIMARY transport mechanism).** Replace the
+plaintext `corev1.EnvVar{Value: req.AgentToken}` at `kubernetes.go:197` with a
+**projected ServiceAccount token** the Pro task pod mounts (audience
+`leoflow-control-plane`, pod-bound, short-lived, auto-rotated) — **nothing secret
+sits on the `Pod` object.** The agent uses it *once*:
+
+- At **`Register`**, the control plane calls Kubernetes **`TokenReview` once per
+  pod** to validate the projected SA token. This call happens **inside the window
+  the apiserver was already required to create the pod**, so the net added
+  apiserver coupling is **≈ 0**.
+- The control plane resolves **pod → task-instance** from the pod annotation and
+  returns a **task-scoped Leoflow JWT** (the identity Fix #1 filters on and Fix #2
+  checks for liveness).
+- Steady-state secret RPCs (`GetVariables` / `GetConnections`, XCom, heartbeat)
+  authenticate with **that Leoflow JWT** — so the **secret hot path is
+  apiserver-free**. The projected SA token is a bootstrap credential exchanged
+  exactly once, not a per-fetch capability.
+- **`SecretKeyRef` is demoted to a fallback** for clusters that cannot project a
+  service-account token; it leans on etcd encryption + RBAC (the hardening path
+  ADR 0021 anticipated) and still keeps the credential off the *plaintext* pod
+  spec.
+
+The invariant this fixes is unconditional: **no bearer credential is ever a
+plaintext field on the `Pod` object.** Both the projected-token path (primary) and
+the `SecretKeyRef` path (fallback) satisfy it; the old `EnvVar{Value:...}` did not.
+
+**Fix #4 — per-attempt TTL at dispatch.** The 24h `agentTokenTTL` issued at
+`dispatch.go:109` is far longer than any task needs and is the window an
+exfiltrated token exploits. Bind the TTL to the attempt's expected lifetime (with
+headroom for retries/reschedule) rather than a flat day, replacing the
+`agentTokenTTL=24h` value at the dispatch site. A warm worker (see Ordering) needs
+a *rotating* per-attempt credential, not a 24h one, so this fix is also a
+prerequisite for the pool design, not merely a hardening nicety.
+
+**Rejected — pure `TokenReview`-per-fetch.** The tempting shortcut is to skip the
+Leoflow JWT and have every secret RPC present the projected SA token, validated by
+a `TokenReview` on each call. Rejected for two reasons: (1) it puts a `TokenReview`
+on the **secret hot path**, loading exactly the **APF apiserver budget PR-10 exists
+to protect** (ADR 0054 §4) — the reaper LIST storm's sibling; and (2) an SA token
+**identifies the ServiceAccount, not the attempt**, so it cannot carry the
+per-attempt identity Fix #1's scoping and Fix #2's liveness require. The exchange
+(validate once, mint a task-scoped JWT) gets both: apiserver-free steady state and
+an attempt-scoped identity.
+
+Fixes 1+2 are the substance; 3+4 remove the transport and time exposure that make
+a captured token dangerous. None of the four is a reason to defer the others —
+each narrows a different dimension (what a token can fetch, when it works, who can
+read it, how long it lives) — and Fix #1 is not independently shippable, because
+the token must identify the task for the scope filter to bind (Fix #3).
+
+## Ordering (hard — this gates the warm-worker roadmap)
+
+**This ADR's fixes (scope #59 + token liveness + exchange) are a prerequisite for
+the warm-worker regime (N:1, impl #2, ADR 0053 PR-N1 in the shared-cluster spec
+§4.3–4.4).** The reason is structural, not stylistic:
+
+- Today's dedicated pod (ADR 0002) holds a token for **one task instance's**
+  lifetime. The exfil window is per-task.
+- A warm worker holds a credential for the **whole pool's lifetime**, servicing
+  many sibling tasks. With B1 open — 24h TTL, whole vault, no liveness — a warm
+  pool turns a per-task exfil window into a **per-pool-lifetime** one, over the
+  *entire* tenant vault. The regime change *widens* the exact hole this ADR closes.
+
+**Therefore: warm-pool (impl #2) MUST NOT precede these fixes.** The enablers can
+land first — the admission/placement layer (ADR 0053), the ADR 0051 state-machine
+split, the GC work — but the shared-pod worker cannot ship until secret scoping,
+token liveness, and the exchange transport are in.
+
+**Warm-pool interaction — the exchange is exactly the shape a pool needs.** Under
+a warm pool the two credentials cleanly separate:
+
+- The **pool holds the projected SA token as a long-lived bootstrap** — audience
+  `leoflow-control-plane`, pod-bound, used to authenticate the pool to the control
+  plane, not to fetch any tenant's secrets.
+- **Each task-attempt gets a fresh, per-attempt task-scoped Leoflow JWT delivered
+  in-band** (the ADR 0052 / ADR 0053 impl-#2 transport — the same in-band,
+  per-attempt channel the warm worker uses to report outcomes). That JWT **dies
+  with the attempt** via the DB liveness predicate (Fix #2), which is precisely the
+  property a warm pool requires: a credential that outlives the pool would recreate
+  the per-pool-lifetime exposure. This is why the exchange design (not a static
+  long-lived tenant token) is what makes the warm pool safe, and it confirms the
+  ordering gate above.
+
+## Consequences
+
+- **A DAG that used an undeclared connection breaks.** This is the point, and it
+  is breaking — same consequence ADR 0045 recorded. It needs the two-release arc
+  ADR 0045 §Settled already specified: warn-and-deliver for one release (recording
+  every undeclared runtime use, since static inference cannot see `get_connection`
+  inside a `@task`), then flip warn to enforce. Eight of the 22 examples currently
+  use a connection without declaring one; they are declared as part of the warn
+  release so CI stays green.
+- **The token can now be rejected mid-life.** A liveness/revocation consult means
+  a valid-signature token can be refused — a new failure mode on the secret path.
+  It must fail closed and legibly (the agent already tolerates a secret-fetch
+  refusal: `secretsEnv` logs and skips, so a task that uses no secrets still runs),
+  but a task that *needs* a secret after its TI is marked non-live now fails where
+  before it silently succeeded from a stale token. That is the intended trade.
+- **Transport change touches the pod spec, the agent bootstrap, and adds one
+  apiserver call at Register.** Moving to the projected-token exchange (Fix #3)
+  changes how the in-pod agent obtains its credential (`LEOFLOW_AGENT_TOKEN` becomes
+  a mounted projected token exchanged for a Leoflow JWT at `Register`); the
+  `SecretKeyRef` fallback is still an env var but sourced from a Secret. The one
+  added apiserver `TokenReview` per pod lands inside the pod-creation window, so net
+  added coupling is ≈ 0, and the secret hot path stays apiserver-free.
+  `stripAgentOnly`'s allowlist stays as defence-in-depth regardless.
+- **It does not fix Lite's fixed encryption key (#486).** Scoping reduces what one
+  leak yields; it does not remove the at-rest key problem. Tracked separately; not
+  a reason to defer this. (See Lite note.)
+- **Two more places to keep in sync.** A connection renamed in the UI but not in
+  `leoflow.yaml` now fails at registration rather than at run time — better, but
+  new friction, and the error must name both sides. (Carried from ADR 0045.)
+
+### Lite note (single-tenant, in-process delivery)
+
+Lite runs the agent as a subprocess of the server, not in a pod, and delivery is
+in-process. The **identity, liveness, and TTL fixes are uniform across editions** —
+they are shared control-plane code and reuse the same `RecordHeartbeat` signal Lite
+already stamps, so Fix #1 (scope by declaration), Fix #2 (liveness/revocation), and
+Fix #4 (per-attempt TTL) apply to Lite unchanged in shape. **Only the transport
+forks:** the projected-SA-token exchange (Fix #3) is **Pro-executor-only**, behind
+the executor interface — Lite has no pod, no pod spec, and no `podEnv`, so there is
+no plaintext-on-the-Pod-object exposure to fix and no `TokenReview` to call; Lite's
+in-process credential handoff is unchanged. The **whole-vault issue also does not
+bite the same way** on Lite: it is single-tenant, so "the whole tenant vault" is
+"this operator's own vault" — no other team's credentials to leak across — and the
+dangerous cross-namespace `get pods` read (OPEN #1) has no Kubernetes pod object to
+read from at all. The design goal is that a Lite install sees **no behavioural
+change** from this ADR: scoping to declared names is a tightening (not a break) for
+a single tenant, liveness reuses a signal Lite already has, and the transport fork
+never runs on the Lite path. Note the *separate* Lite exposure — the subprocess
+executor appends to `os.Environ()`, so the agent inherits `LEOFLOW_SECRET_KEY` /
+`LEOFLOW_AUTH_JWT_SECRET` — is handled by `stripAgentOnly`'s allowlist (already
+landed, #476), not by this ADR.
+
+## Alternatives
+
+- **Ship scoping (Fix #1) alone, defer the token fixes.** Rejected — it is the trap
+  ADR 0045 already named, and it is now *structurally* impossible: server-side
+  scoping is keyed on the token's task identity, so a non-identifying or stale token
+  makes the filter bypassable. Whole-vault delivery restricted to declared names is
+  worthless while a captured, still-live token fetches the vault directly from
+  outside any task. The audit proved this exact path. Scope and liveness/identity
+  ship together or the scope is decorative.
+- **Pure `TokenReview`-per-fetch (no Leoflow JWT).** Rejected — see the Decision's
+  rejection: it loads the APF budget PR-10 protects (a `TokenReview` on the secret
+  hot path) and an SA token identifies the SA, not the attempt, so it cannot carry
+  the per-attempt identity scoping and liveness need. The exchange validates once
+  and mints an attempt-scoped JWT, getting both properties.
+- **Filter in the agent.** Cheaper and worthless: the agent runs inside the
+  container it is filtering for, so anything it can fetch, user code can fetch
+  (ADR 0004). Enforcement is server-side. (Carried from ADR 0045.)
+- **Argo-style `secretKeyRef` for the secrets themselves.** Good and wrong for us —
+  it requires the DAG author to know Kubernetes Secret names and keys, which breaks
+  the Airflow connection abstraction Leoflow exists to preserve. We take the
+  *declaration* idea and keep our own resolution. (Note: `secretKeyRef` remains the
+  right *fallback* for the agent-token transport in Fix #3 — a Kubernetes
+  credential, not a user-facing connection — which is a different object.)
+- **Namespace-per-tenant as the boundary.** Kubeflow's posture; presumes
+  multi-tenancy that is future here, and the comparative study showed it delivers no
+  isolation its API appears to promise (the pipeline SA gets `secrets:
+  [get,list,watch]` on the whole namespace). Rejected for the same reason ADR 0045
+  rejected it. (ADR 0054's namespace split *shrinks* the B1 blast radius but does
+  not pretend to close it — that is this ADR's job.)
+- **Leave the 24h TTL, rely on signature + audience.** Rejected — audience
+  separation (an agent token cannot be replayed as an API token) is real and
+  confirmed, but it does not bound *time* or *scope*. A 24h whole-vault token that
+  outlives its task is the finding, not a mitigation of it.
+- **Do warm-pool first, harden later.** Rejected explicitly — it inverts the
+  ordering above and converts a per-task window into a per-pool-lifetime one. The
+  hardening is the gate, not a follow-up.
+
+## Verify at implementation
+
+- Exact `TokenReview` bound-token `extra` keys
+  (`authentication.kubernetes.io/pod-name`, `authentication.kubernetes.io/pod-uid`)
+  for the target apiserver version, used to resolve pod → task-instance.
+- Projected-token minimum-TTL floor (~10 min) versus the shortest expected
+  attempt, so a very short task's bootstrap token has not already expired at
+  `Register`.

--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -55,4 +55,7 @@ The *why* behind Leoflow's design. ADRs are immutable once accepted.
 - [ADR 0050: Model Context Protocol (MCP) server](adr/0050-mcp-server.md)
 - [ADR 0051: Separate the orchestration and execution state machines](adr/0051-separate-orchestration-and-execution-state-machines.md)
 - [ADR 0052: Durable task outcome — decouple the task result from report delivery](adr/0052-durable-task-outcome.md)
+- [ADR 0053: Admission + placement — one scheduler-side layer for task concurrency and pod assignment](adr/0053-admission-and-placement.md)
+- [ADR 0054: Coexistence in a shared, multi-team Kubernetes cluster](adr/0054-shared-cluster-coexistence.md)
+- [ADR 0055: Secret scoping and token liveness — scope by declaration, exchange the token, bind it to task liveness](adr/0055-secret-scoping-and-token-liveness.md)
 <!-- END ADR INDEX -->


### PR DESCRIPTION
## What

The ADR set for the shared-cluster / multi-team release, with the N:1 execution evolution. Grounded in source verification + a Kubernetes-roadmap alignment review + specialist deep-dives.

## ADRs

- **0002 (amend):** supersede the *"no pool/queue abstraction"* consequence. Under N:1 a pool is a placement + concurrency abstraction (the warm worker IS the pool); `max_active_tasks` is a `PlanRun` admission gate, not a Celery queue; `min-idle=0` preserves zero-idle. Clause left visible, annotated, with a pointer to ADR 0053.
- **0051 (Proposed → Accepted):** separate the orchestration and execution state machines. Under pod reuse the two have different cardinality, so pod phase can never proxy a single task's outcome — orchestration consumes outcomes only through the execution seam.
- **0053 (new):** admission + placement as one scheduler-side subsystem (`max_active_tasks` + named pools + warm-pool placement). Cluster backpressure (quota 403 / APF 429) is retriable-forever, distinct from permanent errors. Ownership: dedicated pod = bare `Pod` + informer GC (reject `Job`, 3 named collisions); warm pod = per-DAG `ConfigMap` GC-anchor (Θ(active DAGs), never a per-task CR).
- **0054 (new):** shared-cluster coexistence. Leoflow provisions no nodes; platform objects (quota/limitrange/priorityclass) stay GitOps, not chart-managed. **PR-10 = informer/watch only this release** (`ownerReferences` deferred to the warm-worker release); AdminNetworkPolicy egress trajectory noted; APF FlowSchema flow-split open item.
- **0055 (new):** least-privilege secret delivery. Scope by declaration (#59); DB-backed token liveness/revocation (no apiserver); **projected SA token exchanged once at `Register` via `TokenReview` for a task-scoped Leoflow JWT** — no bearer credential is ever a plaintext field on the `Pod` object; per-attempt TTL. Completes the open half of ADR 0045.

## Notes

Docs-only. The design spec, algorithmic evaluation, K8s alignment audit, and reconciliation that produced these live locally (not in this PR by design). Verify-at-implementation flags are recorded in ADR 0055 / 0053 (TokenReview bound-token extras per API-server version; projected-token min-TTL vs shortest attempt).
