### PR TITLE
feat(executor): apply declared tolerations to the task pod

### DIFF
--- a/internal/executor/kubernetes.go
+++ b/internal/executor/kubernetes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -79,6 +80,7 @@ func BuildPod(req Request) *corev1.Pod {
 		Spec: corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyNever,
 			NodeSelector:  req.Execution.NodeSelector,
+			Tolerations:   buildTolerations(req.Execution.Tolerations),
 			// The task pod authenticates to the control plane with its own
 			// per-task token over gRPC and never calls the Kubernetes API, so a
 			// mounted ServiceAccount token is a credential handed to untrusted
@@ -236,6 +238,34 @@ func ptr[T any](v T) *T { return &v }
 //
 // readOnlyRootFilesystem is opt-in for a different reason: `restricted` never
 // asks for it, and turning it on by default breaks any task that writes to /tmp.
+// buildTolerations converts a task's declared tolerations — an untyped
+// []map[string]any carried verbatim from the DAG spec — into typed pod
+// tolerations via a JSON round-trip (the map keys match corev1.Toleration's JSON
+// field names). A malformed entry is skipped rather than failing the whole pod
+// build, matching how BuildPod treats other optional placement hints. Returns nil
+// when none are declared, so the field stays unset for a DAG that declares none.
+func buildTolerations(raw []map[string]any) []corev1.Toleration {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]corev1.Toleration, 0, len(raw))
+	for _, m := range raw {
+		b, err := json.Marshal(m)
+		if err != nil {
+			continue
+		}
+		var t corev1.Toleration
+		if err := json.Unmarshal(b, &t); err != nil {
+			continue
+		}
+		out = append(out, t)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 func buildSecurityContext(ps PodSecurity) *corev1.SecurityContext {
 	sc := &corev1.SecurityContext{
 		AllowPrivilegeEscalation: ptr(false),

--- a/internal/executor/kubernetes_test.go
+++ b/internal/executor/kubernetes_test.go
@@ -61,6 +61,38 @@ func TestBuildPod(t *testing.T) {
 	}
 }
 
+// TestBuildPodAppliesTolerations locks the fix for the dropped-tolerations contract
+// bug: a task's declared tolerations (domain.Execution.Tolerations, an untyped
+// []map[string]any) must land on pod.Spec.Tolerations. Without this a DAG that
+// declares a toleration is accepted at push and silently mis-scheduled — a tainted
+// dedicated node pool becomes unreachable.
+func TestBuildPodAppliesTolerations(t *testing.T) {
+	req := sampleReq()
+	req.Execution.Tolerations = []map[string]any{
+		{"key": "workload", "operator": "Equal", "value": "leoflow", "effect": "NoSchedule"},
+		{"key": "dedicated", "operator": "Exists", "effect": "NoExecute"},
+	}
+
+	tols := BuildPod(req).Spec.Tolerations
+	if len(tols) != 2 {
+		t.Fatalf("tolerations = %v, want 2", tols)
+	}
+	if want := (corev1.Toleration{Key: "workload", Operator: corev1.TolerationOpEqual, Value: "leoflow", Effect: corev1.TaintEffectNoSchedule}); tols[0] != want {
+		t.Errorf("tolerations[0] = %+v, want %+v", tols[0], want)
+	}
+	if want := (corev1.Toleration{Key: "dedicated", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoExecute}); tols[1] != want {
+		t.Errorf("tolerations[1] = %+v, want %+v", tols[1], want)
+	}
+}
+
+// TestBuildPodNoTolerations confirms omission stays unset (nil) rather than an
+// empty non-nil slice, so a task that declares none is byte-identical to today.
+func TestBuildPodNoTolerations(t *testing.T) {
+	if tols := BuildPod(sampleReq()).Spec.Tolerations; tols != nil {
+		t.Errorf("tolerations = %v, want nil when none declared", tols)
+	}
+}
+
 // TestBuildPodPinsTerminationMessagePolicy locks the ADR 0052 prerequisite: the
 // task container must explicitly pin TerminationMessagePolicy=File and the path,
 // so the agent's durable outcome record is surfaced on pod status. Relying on the


### PR DESCRIPTION
## What

Apply a task's declared `tolerations` to the pod spec. `BuildPod` read `NodeSelector` and `ServiceAccount` from `Execution` but silently **dropped `Tolerations`** — so a DAG that declares a toleration was accepted at `push` and then mis-scheduled, and a **tainted dedicated node pool was unreachable** despite a valid declaration. This is the contract bug that blocks the strongest isolation rung in ADR 0054.

## Change

- `buildTolerations` converts the untyped `[]map[string]any` (the DAG-spec representation) into `[]corev1.Toleration` via a JSON round-trip (map keys match `corev1.Toleration`'s JSON field names). A malformed entry is **skipped** rather than failing the whole pod build; omission stays **unset (`nil`)** so a DAG that declares none is byte-identical to today.
- Wired into `BuildPod` alongside `NodeSelector`.

## Tests (strict TDD, two commits)

- `test:` — `TestBuildPodAppliesTolerations` (failing first): asserts declared tolerations land on `pod.Spec.Tolerations` (single + multiple). `TestBuildPodNoTolerations`: omission stays `nil`.
- `feat:` — the minimal `BuildPod` change to pass.

gofmt / `go vet` / golangci-lint (repo config) all clean; full `internal/executor` package green.

## Lite containment

Kubernetes-executor path only (`BuildPod`); Lite (subprocess, no pods) is untouched.

Relates: ADR 0054 (dedicated node pool via taint + toleration), ADR 0053.
