### PR TITLE
fix(config): fail closed on unknown or unimplemented auth.provider

### DIFF
--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -369,12 +369,27 @@ func LoadServer(configFile string, flags *pflag.FlagSet) (*ServerConfig, error) 
 	return &c, nil
 }
 
+// Auth providers (auth.provider allowlist). "jwt" is the only implemented
+// authenticator; "oidc" is a recognized-but-unimplemented value that is
+// rejected at boot rather than silently falling back to JWT.
+const (
+	// AuthProviderJWT is the only auth.provider main.go can build an
+	// Authenticator for today.
+	AuthProviderJWT = "jwt"
+	// AuthProviderOIDC is a declared future provider with no implementation;
+	// selecting it is a boot failure, not a silent JWT fallback.
+	AuthProviderOIDC = "oidc"
+)
+
 // Validate reports configuration errors that must abort startup.
 func (c *ServerConfig) Validate() error {
 	if err := c.validateRole(); err != nil {
 		return err
 	}
-	if c.Auth.Provider == "jwt" && c.Auth.JWT.Secret == "" {
+	if err := c.validateProvider(); err != nil {
+		return err
+	}
+	if c.Auth.Provider == AuthProviderJWT && c.Auth.JWT.Secret == "" {
 		return errors.New("auth.jwt.secret is required (set LEOFLOW_AUTH_JWT_SECRET)")
 	}
 	// auth.dev_no_auth disables authentication entirely; permit it only when the
@@ -398,6 +413,24 @@ func isLoopbackListenAddr(addr string) bool {
 	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
+}
+
+// validateProvider rejects an unknown or unimplemented auth.provider, failing
+// closed at boot instead of letting main.go build a JWTAuthenticator regardless
+// of what was configured. Empty is valid: serverDefaults sets auth.provider to
+// "jwt", so an unset provider in an existing config keeps defaulting to JWT and
+// is unaffected. "oidc" is recognized but has no implementation, so it is
+// rejected with an actionable hint rather than a silent JWT fallback.
+func (c *ServerConfig) validateProvider() error {
+	switch c.Auth.Provider {
+	case "", AuthProviderJWT:
+		return nil
+	case AuthProviderOIDC:
+		return errors.New("auth.provider: oidc is declared but not yet implemented; set provider: jwt")
+	default:
+		return fmt.Errorf("invalid auth.provider %q: must be %q (or empty = %q)",
+			c.Auth.Provider, AuthProviderJWT, AuthProviderJWT)
+	}
 }
 
 // validateRole rejects an unknown server.role (ADR 0049). Empty is valid (defaults

--- a/internal/config/server_test.go
+++ b/internal/config/server_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -130,6 +131,53 @@ func TestServerConfigValidateRequiresJWTSecret(t *testing.T) {
 	c.Auth.JWT.Secret = "set"
 	if err := c.Validate(); err != nil {
 		t.Errorf("Validate() = %v with JWT secret set, want nil", err)
+	}
+}
+
+// TestServerConfigValidateProviderAllowlist locks the auth.provider allowlist so
+// an unimplemented or misspelled provider fails closed at boot rather than
+// silently falling back to the JWT authenticator main.go always builds.
+func TestServerConfigValidateProviderAllowlist(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		provider string
+		secret   string
+		wantErr  bool
+	}{
+		{"unset defaults to jwt", "", "set", false},
+		{"jwt with secret", "jwt", "set", false},
+		{"jwt without secret", "jwt", "", true},
+		{"oidc known but unimplemented", "oidc", "set", true},
+		{"garbage unknown provider", "garbage", "set", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &ServerConfig{}
+			c.Auth.Provider = tc.provider
+			c.Auth.JWT.Secret = tc.secret
+			err := c.Validate()
+			if tc.wantErr && err == nil {
+				t.Errorf("provider %q secret %q: Validate() = nil, want error", tc.provider, tc.secret)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("provider %q secret %q: Validate() = %v, want nil", tc.provider, tc.secret, err)
+			}
+		})
+	}
+}
+
+// TestServerConfigValidateOIDCMessage locks the actionable hint for the known
+// but unimplemented oidc provider, so an operator is told to switch to jwt
+// rather than left guessing why boot failed.
+func TestServerConfigValidateOIDCMessage(t *testing.T) {
+	c := &ServerConfig{}
+	c.Auth.Provider = "oidc"
+	c.Auth.JWT.Secret = "set"
+	err := c.Validate()
+	if err == nil {
+		t.Fatal("Validate() = nil for oidc provider, want error")
+	}
+	if !strings.Contains(err.Error(), "not yet implemented") {
+		t.Errorf("oidc error = %q, want it to mention it is not yet implemented", err.Error())
 	}
 }
 

--- a/internal/config/server_test.go
+++ b/internal/config/server_test.go
@@ -184,7 +184,8 @@ func TestServerConfigValidateOIDCMessage(t *testing.T) {
 func TestValidateRejectsDevNoAuthOnNonLoopback(t *testing.T) {
 	base := func() *ServerConfig {
 		c := &ServerConfig{}
-		c.Auth.Provider = "none" // skip the jwt-secret requirement
+		c.Auth.Provider = "jwt"
+		c.Auth.JWT.Secret = "set" // satisfy the jwt-secret requirement
 		c.Auth.DevNoAuth = true
 		return c
 	}


### PR DESCRIPTION
## What
Fail-closed on an unknown or unimplemented `auth.provider`. Today `provider` has no allowlist: `provider: oidc` (or any unknown value) passes `Validate()` and the server silently builds a `JWTAuthenticator` anyway — a silent misconfiguration rather than a boot-time error.

## Fix
`validateProvider()` (mirroring the existing `validateRole()` pattern), wired into `Validate()` before the jwt-secret check:
- `""` / `jwt` → accepted (empty defaults to `jwt`)
- `oidc` → rejected: *"declared but not yet implemented; set provider: jwt"*
- anything else → rejected as unknown

## Tests (strict TDD, two commits)
- `test:` — `TestServerConfigValidateProviderAllowlist` (5 cases) + `TestServerConfigValidateOIDCMessage` (failing first).
- `feat:` — the allowlist.
- Adjusted `TestValidateRejectsDevNoAuthOnNonLoopback`: it used `provider:"none"` as a shortcut to skip the jwt-secret check; "none" is now correctly rejected by the allowlist, so its base switched to a valid `jwt`+secret — it still exercises the dev-no-auth-on-non-loopback rejection for the right reason. **Not a weakening.**

gofmt / `go vet` / golangci-lint (repo config) clean.

## Lite containment
Shared config code, but **behavior-neutral**: `serverDefaults` sets `auth.provider=jwt` and Lite defaults to `jwt` (valid) — a default/`jwt` config (Lite included) boots exactly as before. Only previously-silent misconfiguration (`oidc`/unknown) is now rejected.
