### PR TITLE
test(load): scheduler-ceiling load harness (Experiment 1)

### DIFF
--- a/test/load/README.md
+++ b/test/load/README.md
@@ -1,0 +1,103 @@
+# Load tests
+
+Load/scale harnesses for Leoflow's control plane. The README calls load tests
+the remaining Phase 6 gap; this directory is where they land, one experiment at
+a time.
+
+Each experiment is a small `package main` that drives the **real** control-plane
+code (not a mock) against a **real** Postgres and prints a table. They boot no
+cluster and no executor, so they run on a laptop with just Postgres up.
+
+## Experiments
+
+| # | Name | Dir | Status |
+|---|------|-----|--------|
+| 1 | Scheduler ceiling — per-tick cost vs. active runs `N` | [`scheduler_ceiling/`](scheduler_ceiling/) | ✅ implemented |
+| 2 | Dispatch throughput — queue depth vs. arrival rate | — | not yet (see _Adding an experiment_) |
+| 3 | Reaper cost — orphan/heartbeat sweep vs. run count | — | not yet |
+| 4 | API read fan-out — dashboard queries under many DAGs | — | not yet |
+| 5 | Log tailer — SSE fan-out under many concurrent viewers | — | not yet |
+
+Only Experiment 1 is built. The others are documented extension points.
+
+## Prerequisites
+
+A migrated Postgres with the `default` tenant (migration `001` seeds it).
+
+```sh
+# 1. Postgres (leoflow/leoflow on :5432, database `leoflow`)
+docker compose -f docker-compose.dev.yaml up -d postgres
+
+# 2. Apply migrations (installs the migrate CLI first if you don't have it:
+#    make install-migrate)
+export DATABASE_URL='postgres://leoflow:leoflow@localhost:5432/leoflow?sslmode=disable'
+migrate -path migrations -database "$DATABASE_URL" up
+```
+
+Any migrated database works — point `DATABASE_URL` at it. `make test-db` (the
+`leoflow_test` database) is a fine target too.
+
+## Experiment 1: scheduler ceiling
+
+The leader scheduler runs `Scheduler.Step` once per tick (~1s). `Step`'s dominant
+read is `Store.ActiveRuns`, which issues **1 + 2N** DB queries (one list, then
+`GetDagVersionByID` + `ListTaskInstancesByRun` per run) and **N** spec unmarshals,
+then advances every run **serially**. Experiment 1 measures how one tick's
+wall-time grows with the number of active runs `N`, so we can find where a tick
+approaches the loop interval (the ceiling).
+
+The harness seeds `N` synthetic DAGs, each with one run pinned `running` and a
+`running` task instance. Such a run stays in the active set every tick while
+`advance` stays a no-op for it (nothing to dispatch, nothing to finalize) — so
+what is timed is the steady-state read + per-run advance cost. `N` values are
+seeded **incrementally** (ascending), so measuring `50,200,500,1000` seeds 1000
+DAGs total, not 1750.
+
+```sh
+DATABASE_URL='postgres://leoflow:leoflow@localhost:5432/leoflow?sslmode=disable' \
+  go run ./test/load/scheduler_ceiling --n 50,200,500,1000 --window 5s
+```
+
+Flags:
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--db` | `$DATABASE_URL`, then `$LEOFLOW_DATABASE_URL` | Postgres URL |
+| `--n` | `50,200,500,1000` | active-run counts to measure (sorted ascending) |
+| `--window` | `5s` | per-`N` window; `Step` is called back-to-back until it elapses |
+| `--tasks` | `1` | task instances per synthetic run |
+| `--warmup` | `3` | warm-up ticks discarded before timing each `N` |
+| `--keep` | `false` | keep the synthetic DAGs/runs instead of deleting them on exit |
+
+Output is a table of `N → loop-duration p50/p95/p99/max/mean` plus the step-down
+delta observed during each window. The harness cleans up every DAG it created on
+exit (best-effort); a fresh `migrate up` on an empty database is always the clean
+slate.
+
+### Known limitation: `leoflow_scheduler_loop_duration_seconds` is not wired
+
+The declared SLI `leoflow_scheduler_loop_duration_seconds` is **defined** in
+`internal/observability/metrics.go` but is **never `Observe`d inside the scheduler
+loop** (grep confirms: only `metrics_test.go` observes it). A `/metrics` scrape
+today would therefore report an empty histogram for it. Until that observation is
+wired into `Scheduler.tick`/`Step`, this harness times `Step` **directly** (the
+faithful equivalent) and also feeds each measured duration into the real
+histogram object, so a future scrape — or a one-line follow-up that moves the
+`Observe` into the loop — sees the same distribution. `leoflow_scheduler_step_downs_total`
+**is** scraped from the live registry (it stays 0 here: leadership never churns in
+the harness). `leoflow_dispatch_queue_depth` is a dispatcher gauge and is out of
+scope for Experiment 1 (no dispatcher is wired).
+
+## Adding an experiment
+
+1. Create `test/load/<name>/main.go` as its own `package main`.
+2. Reuse the storage/scheduler/observability packages the way
+   `scheduler_ceiling` does — connect with `storage.NewPostgres`, seed via
+   `storage.Repository` / `storage.SchedulerStore`, and read metrics from a
+   `prometheus.NewRegistry()` you own. Do **not** modify product code.
+3. Keep it cluster-free: prefer seeding rows directly over booting executors.
+   If a signal genuinely needs the full server (e.g. the SSE tailer for
+   Experiment 5), boot `leoflow lite` the way `test/e2e/lite-*.sh` does and
+   scrape its `/metrics`, and say so in this table.
+4. Add a row to the _Experiments_ table above and a section here.
+5. It must `go build`, `go vet`, and `gofmt` clean, and actually run.

--- a/test/load/scheduler_ceiling/main.go
+++ b/test/load/scheduler_ceiling/main.go
@@ -1,0 +1,392 @@
+// Command scheduler_ceiling is Load Experiment 1: the scheduler ceiling.
+//
+// It measures how the leader scheduler's per-tick wall-time scales with the
+// number of active runs N, so we can find where a tick's cost approaches the
+// loop interval (~1s by default). The leader loop calls Scheduler.Step once per
+// tick; Step's dominant read is Store.ActiveRuns, which issues 1 + 2N DB queries
+// (one list, then GetDagVersionByID + ListTaskInstancesByRun per run) plus N
+// spec unmarshals, and then advances every run serially. This harness drives the
+// REAL scheduler over a REAL Postgres so those costs are measured, not modeled.
+//
+// It boots no cluster and no executor: it seeds N synthetic DAGs, each with one
+// run pinned in `running` with a `running` task instance. Such a run stays in the
+// active set across ticks and Step's advance is a cheap no-op for it (nothing to
+// dispatch, nothing to finalize) — so what we time is the steady-state read +
+// per-run advance cost, which is exactly Experiment 1's target.
+//
+// It is harness-only: it imports the storage/scheduler packages the same way the
+// integration tests do and touches no product code path.
+//
+// Usage (see test/load/README.md for the full runbook):
+//
+//	# 1. bring up Postgres and migrate + seed the `default` tenant
+//	docker compose -f docker-compose.dev.yaml up -d
+//	go run ./cmd/leoflow db reset --yes
+//	# 2. run the experiment
+//	DATABASE_URL='postgres://leoflow:leoflow@localhost:5432/leoflow_dev?sslmode=disable' \
+//	  go run ./test/load/scheduler_ceiling --n 50,200,500,1000 --window 5s
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/neochaotic/leoflow/internal/config"
+	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/observability"
+	"github.com/neochaotic/leoflow/internal/scheduler"
+	"github.com/neochaotic/leoflow/internal/storage"
+)
+
+// neverReap is a threshold long enough that none of Step's reapers touch our
+// synthetic runs during a measurement window, so the active set stays fixed at N.
+const neverReap = 1000 * time.Hour
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "scheduler_ceiling: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var (
+		dbURL       = flag.String("db", firstEnv("DATABASE_URL", "LEOFLOW_DATABASE_URL"), "Postgres URL of a migrated database with a `default` tenant (falls back to $DATABASE_URL then $LEOFLOW_DATABASE_URL)")
+		nCSVFlag    = flag.String("n", "50,200,500,1000", "comma-separated active-run counts to measure, e.g. 50,200,500,1000")
+		window      = flag.Duration("window", 5*time.Second, "measurement window per N: Step is called back-to-back until it elapses")
+		tasksPerRun = flag.Int("tasks", 1, "task instances per synthetic run (all pinned `running`)")
+		warmup      = flag.Int("warmup", 3, "warm-up ticks discarded before timing each N")
+		keep        = flag.Bool("keep", false, "do not delete the synthetic DAGs/runs on exit (default cleans up)")
+	)
+	flag.Parse()
+
+	if *dbURL == "" {
+		return fmt.Errorf("no database URL: pass --db or set $DATABASE_URL (see test/load/README.md)")
+	}
+	targets, err := parseNs(*nCSVFlag)
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	pg, err := storage.NewPostgres(ctx, config.DatabaseSection{URL: *dbURL})
+	if err != nil {
+		return fmt.Errorf("connecting to Postgres (is it up and migrated? `leoflow db reset --yes`): %w", err)
+	}
+	defer pg.Close()
+
+	repo := storage.NewRepository(pg)
+	store := storage.NewSchedulerStore(pg)
+
+	// Errors/warnings from the scheduler go to stderr; its INFO chatter is muted
+	// so the results table is the only thing on stdout.
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	reg := prometheus.NewRegistry()
+	metrics := observability.NewMetrics(reg)
+
+	sched := scheduler.NewScheduler(store, logger, time.Second)
+	sched.SetRecorder(metrics) // captures step-downs; scraped per N below
+	sched.SetLeading(true)     // Step is a no-op for a follower
+	// Keep every reaper off our synthetic runs for the run of the experiment.
+	sched.SetOrphanThreshold(neverReap)
+	sched.SetAgentLostThreshold(neverReap)
+	sched.SetDispatchLostThreshold(neverReap)
+	sched.SetPodLostGrace(neverReap)
+	// No dispatcher is wired: a `running` task is never re-dispatched, so the
+	// scheduler advances state only and launches nothing.
+
+	prefix := fmt.Sprintf("loadtest%dx%d", os.Getpid(), time.Now().UnixNano())
+	if !*keep {
+		defer cleanup(ctx, pg, prefix, logger)
+	}
+
+	fmt.Printf("# Experiment 1: scheduler ceiling\n")
+	fmt.Printf("# db=%s window=%s tasks/run=%d warmup=%d dagPrefix=%s\n",
+		redactURL(*dbURL), *window, *tasksPerRun, *warmup, prefix)
+	fmt.Printf("# NOTE: the product does not yet Observe leoflow_scheduler_loop_duration_seconds\n")
+	fmt.Printf("#       inside the loop, so this harness times Step() directly (see README).\n\n")
+
+	seeded := 0
+	var rows []result
+	for _, n := range targets {
+		// Incremental seeding: nList is ascending, so we only add the delta and
+		// the cumulative active set is exactly N when we measure.
+		if err := seedRuns(ctx, repo, store, prefix, seeded, n-seeded, *tasksPerRun); err != nil {
+			return fmt.Errorf("seeding up to N=%d: %w", n, err)
+		}
+		seeded = n
+
+		r, err := measure(ctx, sched, metrics, reg, n, *window, *warmup)
+		if err != nil {
+			return fmt.Errorf("measuring N=%d: %w", n, err)
+		}
+		rows = append(rows, r)
+		fmt.Printf("  measured N=%-5d ticks=%-5d p50=%-9s p95=%-9s\n",
+			r.n, r.ticks, fmtDur(r.p50), fmtDur(r.p95))
+	}
+
+	printTable(rows, *window)
+	return nil
+}
+
+// seedRuns registers `count` synthetic DAGs (ids prefixed with `prefix`, numbered
+// from `startIdx`) and, for each, creates one run pinned in `running` with
+// `tasksPerRun` task instances in the `running` state. Such a run stays in the
+// active set and makes Step's advance a no-op — steady state for measuring the
+// per-tick read cost.
+func seedRuns(ctx context.Context, repo *storage.Repository, store *storage.SchedulerStore, prefix string, startIdx, count, tasksPerRun int) error {
+	if count <= 0 {
+		return nil
+	}
+	tasks := make([]domain.TaskSpec, tasksPerRun)
+	for i := range tasks {
+		tasks[i] = domain.TaskSpec{TaskID: fmt.Sprintf("t%d", i), Type: domain.TaskTypePython}
+	}
+	now := time.Now().UTC()
+
+	newDAGs := make(map[string]bool, count)
+	for i := 0; i < count; i++ {
+		dagID := fmt.Sprintf("%s_%d", prefix, startIdx+i)
+		spec := domain.DAGSpec{
+			SchemaVersion: "1.0",
+			DagID:         dagID,
+			DagVersion:    "v1",
+			Image:         "img:v1",
+			// Large cap so the per-DAG max_active_runs guard never rejects a run;
+			// no schedule so createDueRuns never fabricates extra runs.
+			MaxActiveRuns: 1_000_000,
+			Tasks:         tasks,
+		}
+		hash, herr := spec.CanonicalHash()
+		if herr != nil {
+			return fmt.Errorf("hashing spec %s: %w", dagID, herr)
+		}
+		created, rerr := repo.RegisterDagVersion(ctx, "default", spec, hash)
+		if rerr != nil {
+			return fmt.Errorf("registering %s (is the `default` tenant seeded? `leoflow db reset --yes`): %w", dagID, rerr)
+		}
+		if !created {
+			return fmt.Errorf("registering %s: version already existed (stale data? try `leoflow db reset --yes`)", dagID)
+		}
+		if _, cerr := repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+			RunID: "r1", State: domain.DagRunStateRunning, RunType: "manual", LogicalDate: now,
+		}); cerr != nil {
+			return fmt.Errorf("creating run for %s: %w", dagID, cerr)
+		}
+		newDAGs[dagID] = true
+	}
+
+	// Resolve the internal run UUIDs (MaterializeTasks keys by them) via one
+	// ActiveRuns read, then materialize + pin each new run's tasks `running`.
+	runs, err := store.ActiveRuns(ctx)
+	if err != nil {
+		return fmt.Errorf("resolving run UUIDs: %w", err)
+	}
+	for _, r := range runs {
+		if !newDAGs[r.DagID] {
+			continue
+		}
+		if merr := store.MaterializeTasks(ctx, r.RunID, tasks); merr != nil {
+			return fmt.Errorf("materializing %s: %w", r.DagID, merr)
+		}
+		for _, t := range tasks {
+			if aerr := store.ApplyTransition(ctx, r.RunID, t.TaskID, domain.TaskStateRunning); aerr != nil {
+				return fmt.Errorf("pinning %s/%s running: %w", r.DagID, t.TaskID, aerr)
+			}
+		}
+	}
+	return nil
+}
+
+// result holds one N's measured per-tick distribution.
+type result struct {
+	n         int
+	ticks     int
+	p50       time.Duration
+	p95       time.Duration
+	p99       time.Duration
+	max       time.Duration
+	mean      time.Duration
+	stepDowns float64
+}
+
+// measure calls Step back-to-back for `window`, timing each call, and returns the
+// per-tick distribution plus the step-down delta observed during the window.
+func measure(ctx context.Context, sched *scheduler.Scheduler, metrics *observability.Metrics, reg *prometheus.Registry, n int, window time.Duration, warmup int) (result, error) {
+	for i := 0; i < warmup; i++ {
+		if err := sched.Step(ctx); err != nil {
+			return result{}, fmt.Errorf("warm-up step: %w", err)
+		}
+	}
+
+	stepDownsBefore := counterTotal(reg, "leoflow_scheduler_step_downs_total")
+
+	var samples []time.Duration
+	deadline := time.Now().Add(window)
+	for time.Now().Before(deadline) {
+		start := time.Now()
+		err := sched.Step(ctx)
+		d := time.Since(start)
+		if err != nil {
+			return result{}, fmt.Errorf("step: %w", err)
+		}
+		samples = append(samples, d)
+		// Feed the real histogram too, so a future /metrics scrape (or a follow-up
+		// that wires Observe into the loop) sees the same distribution.
+		metrics.SchedulerLoopDuration.Observe(d.Seconds())
+	}
+	if len(samples) == 0 {
+		return result{}, fmt.Errorf("no ticks completed in %s", window)
+	}
+
+	sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
+	var sum time.Duration
+	for _, d := range samples {
+		sum += d
+	}
+	return result{
+		n:         n,
+		ticks:     len(samples),
+		p50:       percentile(samples, 0.50),
+		p95:       percentile(samples, 0.95),
+		p99:       percentile(samples, 0.99),
+		max:       samples[len(samples)-1],
+		mean:      sum / time.Duration(len(samples)),
+		stepDowns: counterTotal(reg, "leoflow_scheduler_step_downs_total") - stepDownsBefore,
+	}, nil
+}
+
+// percentile returns the p-quantile (0..1) of an ascending-sorted slice using
+// nearest-rank.
+func percentile(sorted []time.Duration, p float64) time.Duration {
+	if len(sorted) == 0 {
+		return 0
+	}
+	rank := int(p*float64(len(sorted)-1) + 0.5)
+	if rank < 0 {
+		rank = 0
+	}
+	if rank >= len(sorted) {
+		rank = len(sorted) - 1
+	}
+	return sorted[rank]
+}
+
+// counterTotal sums every sample of a counter family in the registry (our
+// step-down counter is labeled by reason, so we sum across reasons).
+func counterTotal(reg *prometheus.Registry, name string) float64 {
+	families, err := reg.Gather()
+	if err != nil {
+		return 0
+	}
+	var total float64
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			if c := m.GetCounter(); c != nil {
+				total += c.GetValue()
+			}
+		}
+	}
+	return total
+}
+
+func printTable(rows []result, window time.Duration) {
+	fmt.Printf("\n%-7s %-7s %-10s %-10s %-10s %-10s %-10s %-10s\n",
+		"N", "ticks", "p50", "p95", "p99", "max", "mean", "step_downs")
+	fmt.Printf("%s\n", strings.Repeat("-", 78))
+	for _, r := range rows {
+		fmt.Printf("%-7d %-7d %-10s %-10s %-10s %-10s %-10s %-10.0f\n",
+			r.n, r.ticks, fmtDur(r.p50), fmtDur(r.p95), fmtDur(r.p99),
+			fmtDur(r.max), fmtDur(r.mean), r.stepDowns)
+	}
+	fmt.Printf("\n# The loop interval is ~1s by default. The ceiling is the N at which p95\n")
+	fmt.Printf("# approaches that interval; extrapolate from the growth across rows.\n")
+}
+
+// cleanup removes every DAG (and its cascaded versions/runs/task instances) this
+// run created. Best-effort: a failure is logged, not fatal — `leoflow db reset`
+// is always the clean slate.
+func cleanup(ctx context.Context, pg *storage.Postgres, prefix string, logger *slog.Logger) {
+	like := prefix + "%"
+	// Delete runs first: dag_runs.dag_version_id → dag_versions is RESTRICT, and
+	// dropping the DAG cascades versions, so runs must go before their versions.
+	if _, err := pg.Pool.Exec(ctx,
+		`DELETE FROM dag_runs WHERE dag_id IN (SELECT id FROM dags WHERE dag_id LIKE $1)`, like); err != nil {
+		logger.Warn("load cleanup: deleting dag_runs failed; run `leoflow db reset --yes`", "error", err)
+	}
+	if _, err := pg.Pool.Exec(ctx, `DELETE FROM dags WHERE dag_id LIKE $1`, like); err != nil {
+		logger.Warn("load cleanup: deleting dags failed; run `leoflow db reset --yes`", "error", err)
+	}
+}
+
+// --- small helpers ---
+
+func parseNs(csv string) ([]int, error) {
+	fields := strings.Split(csv, ",")
+	out := make([]int, 0, len(fields))
+	for _, f := range fields {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
+		n, err := strconv.Atoi(f)
+		if err != nil || n <= 0 {
+			return nil, fmt.Errorf("invalid --n value %q (want positive integers)", f)
+		}
+		out = append(out, n)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("--n produced no values")
+	}
+	// Ascending so incremental seeding grows the active set to each target.
+	sort.Ints(out)
+	return out, nil
+}
+
+func firstEnv(keys ...string) string {
+	for _, k := range keys {
+		if v := os.Getenv(k); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// redactURL hides any password in the DSN before printing it.
+func redactURL(url string) string {
+	at := strings.LastIndex(url, "@")
+	slashes := strings.Index(url, "//")
+	if at < 0 || slashes < 0 || slashes+2 > at {
+		return url
+	}
+	creds := url[slashes+2 : at]
+	if colon := strings.Index(creds, ":"); colon >= 0 {
+		return url[:slashes+2] + creds[:colon] + ":***" + url[at:]
+	}
+	return url
+}
+
+// fmtDur renders a duration with microsecond-ish precision for the table.
+func fmtDur(d time.Duration) string {
+	switch {
+	case d >= time.Second:
+		return fmt.Sprintf("%.3fs", d.Seconds())
+	case d >= time.Millisecond:
+		return fmt.Sprintf("%.2fms", float64(d)/float64(time.Millisecond))
+	default:
+		return fmt.Sprintf("%.0fµs", float64(d)/float64(time.Microsecond))
+	}
+}


### PR DESCRIPTION
## What
A cluster-free load-test harness for **Experiment 1 (scheduler ceiling)** — the README-declared load-test gap. It measures how the leader scheduler's per-tick wall-time scales with the number of active runs N.

## How it works
Connects to a real Postgres (the integration-test seam: `storage.NewPostgres`/`Repository`/`SchedulerStore`), seeds N synthetic DAGs each with one run pinned `running` (so `advance` is a steady-state no-op and the active set stays exactly N), drives the real `scheduler.Step()` back-to-back over a fixed window per N, and prints N → loop-duration p50/p95/p99/max/mean + step-down delta. Every synthetic DAG is deleted on exit (0 rows left behind). Reaper thresholds pinned high so nothing drains the set.

## Real sample output
```
N       p50        p95        p99        mean       step_downs
50      12.01ms    13.10ms    14.21ms    11.76ms    0
200     48.08ms    61.51ms    82.73ms    49.75ms    0
500     123.10ms   129.93ms   137.84ms   120.19ms   0
1000    260.88ms   266.81ms   330.16ms   266.83ms   0
```
Clean linear scaling (~0.25 ms per active run); extrapolated ceiling ≈ N 3,500–4,000 on this box (where tick > 1s loop interval). This is the empirical baseline PR-11 (kill the ActiveRuns N+1) will move.

## Finding (follow-up)
`leoflow_scheduler_loop_duration_seconds` — the declared SLI #1 — is **defined but never `Observe`d in the scheduler loop** (`internal/observability/metrics.go`; grep confirms only `metrics_test.go` touches it). A live `/metrics` scrape reports an empty histogram for it today. The harness times `Step()` directly (the faithful equivalent). Recommended one-line follow-up: move the `Observe` into `Scheduler.tick`/`Step`.

## Scope
Tooling only (`test/load/`) — no product code path touched. Not TDD (a harness); builds, `go vet`, `gofmt`, and golangci-lint (repo config) all clean; runs end-to-end. README documents extension points for experiments 2–5.
