### PR TITLE
feat(auth): create-user API + CLI (POST /api/v2/users)

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -415,6 +415,7 @@ func buildAPIServer(cfg *config.ServerConfig, tel *observability.Telemetry, auth
 		DashboardStats:  repo,
 		AuditLog:        repo,
 		Variables:       repo,
+		Users:           repo,
 		Connections:     repo,
 		Favorites:       repo,
 		ImportErrors:    repo,

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -416,6 +416,7 @@ func buildAPIServer(cfg *config.ServerConfig, tel *observability.Telemetry, auth
 		AuditLog:        repo,
 		Variables:       repo,
 		Users:           repo,
+		UserAudit:       repo,
 		Connections:     repo,
 		Favorites:       repo,
 		ImportErrors:    repo,

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -39,6 +39,40 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 
+  /api/v2/users:
+    post:
+      summary: Create a user
+      description: |
+        Admin-only. Creates a control-plane account with the given email and
+        password and grants at most one role. The password is write-only and is
+        never returned. Requires the admin:tenant permission.
+      operationId: createUser
+      tags: [Users]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateUserRequest"
+      responses:
+        "201":
+          description: User created
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/User" }
+        "400":
+          description: Invalid input (missing fields or unknown role)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          description: A user with this email already exists in the tenant
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
   /api/v2/dags:
     get:
       summary: List DAGs
@@ -442,6 +476,29 @@ components:
         access_token: { type: string }
         token_type: { type: string, example: "bearer" }
         expires_in: { type: integer, example: 3600 }
+
+    CreateUserRequest:
+      type: object
+      required: [email, password]
+      properties:
+        email: { type: string }
+        password: { type: string }
+        role:
+          type: string
+          description: >-
+            Name of an existing role to grant (e.g. "admin"). Omit to grant no
+            role — the most restrictive default; the user then holds no
+            permissions until an admin grants one.
+
+    User:
+      type: object
+      required: [id, email]
+      properties:
+        id: { type: string }
+        email: { type: string }
+        role: { type: string }
+        is_active: { type: boolean }
+        created_at: { type: string, format: date-time }
 
     DAG:
       type: object

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -481,8 +481,19 @@ components:
       type: object
       required: [email, password]
       properties:
-        email: { type: string }
-        password: { type: string }
+        email:
+          type: string
+          description: >-
+            Login email. Normalized to lowercase, so it is unique
+            case-insensitively within the tenant.
+        password:
+          type: string
+          format: password
+          writeOnly: true
+          minLength: 8
+          description: >-
+            Plaintext password (write-only; never returned). Must be at least 8
+            characters — the server rejects anything shorter with 400.
         role:
           type: string
           description: >-

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -39,6 +39,40 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 
+  /api/v2/users:
+    post:
+      summary: Create a user
+      description: |
+        Admin-only. Creates a control-plane account with the given email and
+        password and grants at most one role. The password is write-only and is
+        never returned. Requires the admin:tenant permission.
+      operationId: createUser
+      tags: [Users]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateUserRequest"
+      responses:
+        "201":
+          description: User created
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/User" }
+        "400":
+          description: Invalid input (missing fields or unknown role)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "409":
+          description: A user with this email already exists in the tenant
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+
   /api/v2/dags:
     get:
       summary: List DAGs
@@ -442,6 +476,29 @@ components:
         access_token: { type: string }
         token_type: { type: string, example: "bearer" }
         expires_in: { type: integer, example: 3600 }
+
+    CreateUserRequest:
+      type: object
+      required: [email, password]
+      properties:
+        email: { type: string }
+        password: { type: string }
+        role:
+          type: string
+          description: >-
+            Name of an existing role to grant (e.g. "admin"). Omit to grant no
+            role — the most restrictive default; the user then holds no
+            permissions until an admin grants one.
+
+    User:
+      type: object
+      required: [id, email]
+      properties:
+        id: { type: string }
+        email: { type: string }
+        role: { type: string }
+        is_active: { type: boolean }
+        created_at: { type: string, format: date-time }
 
     DAG:
       type: object

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -481,8 +481,19 @@ components:
       type: object
       required: [email, password]
       properties:
-        email: { type: string }
-        password: { type: string }
+        email:
+          type: string
+          description: >-
+            Login email. Normalized to lowercase, so it is unique
+            case-insensitively within the tenant.
+        password:
+          type: string
+          format: password
+          writeOnly: true
+          minLength: 8
+          description: >-
+            Plaintext password (write-only; never returned). Must be at least 8
+            characters — the server rejects anything shorter with 400.
         role:
           type: string
           description: >-

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -66,6 +66,7 @@ type Dependencies struct {
 	AuditLog       AuditLogReader
 	Variables      VariableStore
 	Users          UserStore
+	UserAudit      UserAuditWriter
 	Connections    ConnectionStore
 	ConnectionTest ConnectionTester
 	Favorites      FavoriteStore
@@ -150,7 +151,7 @@ func NewServer(deps Dependencies) *gin.Engine {
 	registerUIDashboard(r, deps.DashboardStats)
 	registerUIAudit(r, deps.AuditLog)
 	registerUIVariables(r, deps.Variables)
-	registerUsers(r, deps.Users)
+	registerUsers(r, deps.Users, deps.UserAudit)
 	registerUIConnections(r, deps.Connections, deps.ConnectionTest)
 	registerUIFavorites(r, deps.Favorites)
 	registerImportErrors(r, deps.ImportErrors)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -65,6 +65,7 @@ type Dependencies struct {
 	DashboardStats DashboardStatsReader
 	AuditLog       AuditLogReader
 	Variables      VariableStore
+	Users          UserStore
 	Connections    ConnectionStore
 	ConnectionTest ConnectionTester
 	Favorites      FavoriteStore
@@ -149,6 +150,7 @@ func NewServer(deps Dependencies) *gin.Engine {
 	registerUIDashboard(r, deps.DashboardStats)
 	registerUIAudit(r, deps.AuditLog)
 	registerUIVariables(r, deps.Variables)
+	registerUsers(r, deps.Users)
 	registerUIConnections(r, deps.Connections, deps.ConnectionTest)
 	registerUIFavorites(r, deps.Favorites)
 	registerImportErrors(r, deps.ImportErrors)

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// minPasswordLength is the minimum length the create-user API accepts. It is a
+// deliberately conservative floor, not a full password policy — the maintainer
+// may tighten it later without breaking the endpoint's contract.
+const minPasswordLength = 8
+
+// UserStore creates control-plane accounts for the admin create-user API. The
+// store hashes the plaintext password (reusing the bootstrap admin's bcrypt
+// scheme) and returns the created user without any secret. A duplicate email
+// must surface as domain.ErrConflict and an unknown role as domain.ErrValidation.
+type UserStore interface {
+	CreateUser(ctx context.Context, tenant, email, password, role string) (domain.User, error)
+}
+
+// createUserBody is the POST /api/v2/users payload. Password is write-only.
+type createUserBody struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+	Role     string `json:"role"`
+}
+
+// userDTO is the create-user response. It never includes the password or hash.
+type userDTO struct {
+	ID        string `json:"id"`
+	Email     string `json:"email"`
+	Role      string `json:"role"`
+	IsActive  bool   `json:"is_active"`
+	CreatedAt string `json:"created_at"`
+}
+
+func toUserDTO(u domain.User) userDTO {
+	return userDTO{
+		ID:        u.ID,
+		Email:     u.Email,
+		Role:      u.Role,
+		IsActive:  u.IsActive,
+		CreatedAt: u.CreatedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+func createUserHandler(store UserStore) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var body createUserBody
+		if err := c.ShouldBindJSON(&body); err != nil {
+			AbortProblem(c, http.StatusBadRequest, "bad request", err.Error())
+			return
+		}
+		if body.Email == "" || body.Password == "" {
+			AbortProblem(c, http.StatusBadRequest, "bad request", "email and password are required")
+			return
+		}
+		if len(body.Password) < minPasswordLength {
+			AbortProblem(c, http.StatusBadRequest, "bad request",
+				fmt.Sprintf("password must be at least %d characters", minPasswordLength))
+			return
+		}
+		user, err := store.CreateUser(c.Request.Context(), tenantOf(c), body.Email, body.Password, body.Role)
+		if err != nil {
+			handleUserWriteError(c, err)
+			return
+		}
+		c.JSON(http.StatusCreated, toUserDTO(user))
+	}
+}
+
+// handleUserWriteError maps a rejected create to the right status: a bad role (or
+// other input the caller can fix) is a 400, and everything else flows through
+// handleRepoError (duplicate email -> 409, cancellation -> 499, else 500).
+func handleUserWriteError(c *gin.Context, err error) {
+	if errors.Is(err, domain.ErrValidation) {
+		AbortProblem(c, http.StatusBadRequest, "bad request", err.Error())
+		return
+	}
+	handleRepoError(c, err)
+}
+
+// registerUsers mounts the admin create-user route when a store is wired. It is
+// gated with the admin:tenant permission, matching how other privileged /api/v2
+// mutations are gated (RequirePermission), so only administrators may create
+// users. With no store it is left unregistered (unknown route -> 404).
+func registerUsers(r gin.IRouter, store UserStore) {
+	if store == nil {
+		return
+	}
+	r.POST("/api/v2/users", RequirePermission("admin", "tenant"), createUserHandler(store))
+}

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -17,12 +20,31 @@ import (
 // may tighten it later without breaking the endpoint's contract.
 const minPasswordLength = 8
 
+// emailPattern is a deliberately basic sanity check — one "@", a dotted domain,
+// and no whitespace. It rejects obvious garbage; it is not a full RFC 5322
+// validator (real deliverability is out of scope for account creation).
+var emailPattern = regexp.MustCompile(`^[^@\s]+@[^@\s]+\.[^@\s]+$`)
+
+// normalizeEmail lowercases and trims the address so uniqueness (which is
+// exact-text at the database) treats "Alice@X.com" and "alice@x.com" as one
+// account rather than two.
+func normalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}
+
 // UserStore creates control-plane accounts for the admin create-user API. The
 // store hashes the plaintext password (reusing the bootstrap admin's bcrypt
 // scheme) and returns the created user without any secret. A duplicate email
 // must surface as domain.ErrConflict and an unknown role as domain.ErrValidation.
 type UserStore interface {
 	CreateUser(ctx context.Context, tenant, email, password, role string) (domain.User, error)
+}
+
+// UserAuditWriter records account-creation events for the Audit Log. It is a
+// separate, narrow interface (not the task-shaped AuditWriter) so account
+// management writes a "user" resource entry with the acting admin as owner.
+type UserAuditWriter interface {
+	RecordUserCreatedAudit(ctx context.Context, tenant, actorUserID, createdUserID, email, role string) error
 }
 
 // createUserBody is the POST /api/v2/users payload. Password is write-only.
@@ -51,15 +73,20 @@ func toUserDTO(u domain.User) userDTO {
 	}
 }
 
-func createUserHandler(store UserStore) gin.HandlerFunc {
+func createUserHandler(store UserStore, audit UserAuditWriter) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var body createUserBody
 		if err := c.ShouldBindJSON(&body); err != nil {
 			AbortProblem(c, http.StatusBadRequest, "bad request", err.Error())
 			return
 		}
-		if body.Email == "" || body.Password == "" {
+		email := normalizeEmail(body.Email)
+		if email == "" || body.Password == "" {
 			AbortProblem(c, http.StatusBadRequest, "bad request", "email and password are required")
+			return
+		}
+		if !emailPattern.MatchString(email) {
+			AbortProblem(c, http.StatusBadRequest, "bad request", "email is not a valid address")
 			return
 		}
 		if len(body.Password) < minPasswordLength {
@@ -67,12 +94,29 @@ func createUserHandler(store UserStore) gin.HandlerFunc {
 				fmt.Sprintf("password must be at least %d characters", minPasswordLength))
 			return
 		}
-		user, err := store.CreateUser(c.Request.Context(), tenantOf(c), body.Email, body.Password, body.Role)
+		user, err := store.CreateUser(c.Request.Context(), tenantOf(c), email, body.Password, body.Role)
 		if err != nil {
 			handleUserWriteError(c, err)
 			return
 		}
+		recordUserCreatedAudit(c, audit, user)
 		c.JSON(http.StatusCreated, toUserDTO(user))
+	}
+}
+
+// recordUserCreatedAudit writes a best-effort audit entry for a successful
+// account creation; an audit failure must not fail the create the admin
+// requested, so it is logged rather than surfaced.
+func recordUserCreatedAudit(c *gin.Context, audit UserAuditWriter, u domain.User) {
+	if audit == nil {
+		return
+	}
+	actorID := ""
+	if actor, ok := UserFromContext(c); ok {
+		actorID = actor.ID
+	}
+	if err := audit.RecordUserCreatedAudit(c.Request.Context(), tenantOf(c), actorID, u.ID, u.Email, u.Role); err != nil {
+		slog.Warn("recording user-created audit", "user", u.ID, "error", err)
 	}
 }
 
@@ -91,9 +135,9 @@ func handleUserWriteError(c *gin.Context, err error) {
 // gated with the admin:tenant permission, matching how other privileged /api/v2
 // mutations are gated (RequirePermission), so only administrators may create
 // users. With no store it is left unregistered (unknown route -> 404).
-func registerUsers(r gin.IRouter, store UserStore) {
+func registerUsers(r gin.IRouter, store UserStore, audit UserAuditWriter) {
 	if store == nil {
 		return
 	}
-	r.POST("/api/v2/users", RequirePermission("admin", "tenant"), createUserHandler(store))
+	r.POST("/api/v2/users", RequirePermission("admin", "tenant"), createUserHandler(store, audit))
 }

--- a/internal/api/users_test.go
+++ b/internal/api/users_test.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// fakeUserStore records the arguments it received so the handler tests can assert
+// that the plaintext password is delegated to the store (which hashes it) and
+// never echoed back in the response.
+type fakeUserStore struct {
+	created                        domain.User
+	err                            error
+	called                         bool
+	gotEmail, gotPassword, gotRole string
+}
+
+func (f *fakeUserStore) CreateUser(_ context.Context, _, email, password, role string) (domain.User, error) {
+	f.called = true
+	f.gotEmail, f.gotPassword, f.gotRole = email, password, role
+	if f.err != nil {
+		return domain.User{}, f.err
+	}
+	return f.created, nil
+}
+
+func userServer(store UserStore, user *auth.User) *gin.Engine {
+	return NewServer(Dependencies{
+		Logger:        discardLogger(),
+		Authenticator: &fakeAuthn{user: user},
+		RateLimiter:   auth.NewRateLimiter(100, time.Minute),
+		CORSOrigins:   []string{"*"},
+		Users:         store,
+	})
+}
+
+func adminUser() *auth.User {
+	return &auth.User{ID: "admin-1", TenantID: "default", Roles: []string{"admin"}}
+}
+
+func TestCreateUserReturnsCreatedUserWithoutSecret(t *testing.T) {
+	store := &fakeUserStore{created: domain.User{
+		ID: "u-1", Email: "alice@example.com", Role: "admin", IsActive: true,
+		CreatedAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+	}}
+	srv := userServer(store, adminUser())
+
+	body := `{"email":"alice@example.com","password":"s3cret-pass","role":"admin"}`
+	rec := authGet(srv, http.MethodPost, "/api/v2/users", body)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create = %d (%s)", rec.Code, rec.Body.String())
+	}
+	// The store received the plaintext password (to hash), but the response must
+	// never echo it or any hash.
+	if store.gotPassword != "s3cret-pass" {
+		t.Errorf("store should receive the plaintext password, got %q", store.gotPassword)
+	}
+	if strings.Contains(rec.Body.String(), "s3cret-pass") ||
+		strings.Contains(rec.Body.String(), "password") ||
+		strings.Contains(rec.Body.String(), "hash") {
+		t.Errorf("response leaked a secret: %s", rec.Body.String())
+	}
+	var dto userDTO
+	if err := json.Unmarshal(rec.Body.Bytes(), &dto); err != nil {
+		t.Fatal(err)
+	}
+	if dto.ID != "u-1" || dto.Email != "alice@example.com" || dto.Role != "admin" || !dto.IsActive {
+		t.Errorf("unexpected user dto: %+v", dto)
+	}
+	if dto.CreatedAt != "2026-01-02T03:04:05Z" {
+		t.Errorf("created_at = %q, want RFC3339", dto.CreatedAt)
+	}
+}
+
+func TestCreateUserDuplicateEmailConflict(t *testing.T) {
+	store := &fakeUserStore{err: domain.ErrConflict}
+	rec := authGet(userServer(store, adminUser()), http.MethodPost, "/api/v2/users",
+		`{"email":"dupe@example.com","password":"pw-12345678"}`)
+	if rec.Code != http.StatusConflict {
+		t.Errorf("duplicate email = %d, want 409", rec.Code)
+	}
+}
+
+func TestCreateUserUnknownRoleIsBadRequest(t *testing.T) {
+	store := &fakeUserStore{err: domain.ErrValidation}
+	rec := authGet(userServer(store, adminUser()), http.MethodPost, "/api/v2/users",
+		`{"email":"bob@example.com","password":"pw-12345678","role":"wizard"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("unknown role = %d, want 400", rec.Code)
+	}
+}
+
+func TestCreateUserRequiresAdmin(t *testing.T) {
+	// A non-admin principal (no admin role, no admin permission) is forbidden.
+	viewer := &auth.User{ID: "v-1", TenantID: "default", Roles: []string{"viewer"}}
+	store := &fakeUserStore{}
+	rec := authGet(userServer(store, viewer), http.MethodPost, "/api/v2/users",
+		`{"email":"x@example.com","password":"pw-12345678"}`)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("non-admin create = %d, want 403", rec.Code)
+	}
+	if store.called {
+		t.Error("store must not be reached when the caller lacks permission")
+	}
+}
+
+func TestCreateUserValidatesRequiredFields(t *testing.T) {
+	cases := map[string]string{
+		"missing email":    `{"password":"pw-12345678"}`,
+		"missing password": `{"email":"a@example.com"}`,
+		"short password":   `{"email":"a@example.com","password":"short"}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			store := &fakeUserStore{}
+			rec := authGet(userServer(store, adminUser()), http.MethodPost, "/api/v2/users", body)
+			if rec.Code != http.StatusBadRequest {
+				t.Errorf("%s = %d, want 400", name, rec.Code)
+			}
+			if store.called {
+				t.Errorf("%s: store must not be reached on invalid input", name)
+			}
+		})
+	}
+}
+
+func TestCreateUserWithoutStoreNotRegistered(t *testing.T) {
+	// With no user store wired, the route is absent (404), never a 500.
+	rec := authGet(userServer(nil, adminUser()), http.MethodPost, "/api/v2/users",
+		`{"email":"a@example.com","password":"pw-12345678"}`)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("nil store = %d, want 404", rec.Code)
+	}
+}

--- a/internal/api/users_test.go
+++ b/internal/api/users_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
@@ -22,6 +23,8 @@ type fakeUserStore struct {
 	err                            error
 	called                         bool
 	gotEmail, gotPassword, gotRole string
+	enforceUnique                  bool
+	seen                           map[string]bool
 }
 
 func (f *fakeUserStore) CreateUser(_ context.Context, _, email, password, role string) (domain.User, error) {
@@ -30,16 +33,43 @@ func (f *fakeUserStore) CreateUser(_ context.Context, _, email, password, role s
 	if f.err != nil {
 		return domain.User{}, f.err
 	}
+	if f.enforceUnique {
+		if f.seen == nil {
+			f.seen = map[string]bool{}
+		}
+		if f.seen[email] {
+			return domain.User{}, domain.ErrConflict
+		}
+		f.seen[email] = true
+	}
 	return f.created, nil
 }
 
+// fakeUserAudit records the audit entries the handler writes on success.
+type fakeUserAudit struct {
+	entries []userAuditEntry
+	err     error
+}
+
+type userAuditEntry struct{ tenant, actorID, createdID, email, role string }
+
+func (f *fakeUserAudit) RecordUserCreatedAudit(_ context.Context, tenant, actorUserID, createdUserID, email, role string) error {
+	f.entries = append(f.entries, userAuditEntry{tenant, actorUserID, createdUserID, email, role})
+	return f.err
+}
+
 func userServer(store UserStore, user *auth.User) *gin.Engine {
+	return userServerAudit(store, nil, user)
+}
+
+func userServerAudit(store UserStore, audit UserAuditWriter, user *auth.User) *gin.Engine {
 	return NewServer(Dependencies{
 		Logger:        discardLogger(),
 		Authenticator: &fakeAuthn{user: user},
 		RateLimiter:   auth.NewRateLimiter(100, time.Minute),
 		CORSOrigins:   []string{"*"},
 		Users:         store,
+		UserAudit:     audit,
 	})
 }
 
@@ -130,6 +160,65 @@ func TestCreateUserValidatesRequiredFields(t *testing.T) {
 				t.Errorf("%s: store must not be reached on invalid input", name)
 			}
 		})
+	}
+}
+
+func TestCreateUserWritesAuditOnSuccess(t *testing.T) {
+	store := &fakeUserStore{created: domain.User{ID: "u-7", Email: "alice@example.com", Role: "admin", IsActive: true}}
+	audit := &fakeUserAudit{}
+	rec := authGet(userServerAudit(store, audit, adminUser()), http.MethodPost, "/api/v2/users",
+		`{"email":"alice@example.com","password":"pw-12345678","role":"admin"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create = %d (%s)", rec.Code, rec.Body.String())
+	}
+	if len(audit.entries) != 1 {
+		t.Fatalf("audit entries = %d, want exactly 1", len(audit.entries))
+	}
+	e := audit.entries[0]
+	if e.actorID != "admin-1" || e.createdID != "u-7" || e.email != "alice@example.com" || e.role != "admin" || e.tenant != "default" {
+		t.Errorf("unexpected audit entry: %+v", e)
+	}
+}
+
+func TestCreateUserAuditFailureDoesNotFailRequest(t *testing.T) {
+	store := &fakeUserStore{created: domain.User{ID: "u-8", Email: "z@example.com"}}
+	audit := &fakeUserAudit{err: errors.New("audit sink down")}
+	rec := authGet(userServerAudit(store, audit, adminUser()), http.MethodPost, "/api/v2/users",
+		`{"email":"z@example.com","password":"pw-12345678"}`)
+	if rec.Code != http.StatusCreated {
+		t.Errorf("a best-effort audit failure must not fail the request, got %d", rec.Code)
+	}
+}
+
+func TestCreateUserNormalizesEmailForUniqueness(t *testing.T) {
+	// Uniqueness is exact-text at the DB, so the handler must lowercase-normalize
+	// before the store sees the email — otherwise "A@X.COM" and "a@x.com" would
+	// become two distinct accounts.
+	store := &fakeUserStore{enforceUnique: true, created: domain.User{ID: "u-1", Email: "a@x.com"}}
+	srv := userServer(store, adminUser())
+
+	if rec := authGet(srv, http.MethodPost, "/api/v2/users",
+		`{"email":"A@X.COM","password":"pw-12345678"}`); rec.Code != http.StatusCreated {
+		t.Fatalf("first create = %d (%s)", rec.Code, rec.Body.String())
+	}
+	if store.gotEmail != "a@x.com" {
+		t.Errorf("store saw %q, want normalized a@x.com", store.gotEmail)
+	}
+	if rec := authGet(srv, http.MethodPost, "/api/v2/users",
+		`{"email":"a@x.com","password":"pw-12345678"}`); rec.Code != http.StatusConflict {
+		t.Errorf("normalized duplicate = %d, want 409", rec.Code)
+	}
+}
+
+func TestCreateUserRejectsMalformedEmail(t *testing.T) {
+	store := &fakeUserStore{}
+	rec := authGet(userServer(store, adminUser()), http.MethodPost, "/api/v2/users",
+		`{"email":"not-an-email","password":"pw-12345678"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("malformed email = %d, want 400", rec.Code)
+	}
+	if store.called {
+		t.Error("store must not be reached on a malformed email")
 	}
 }
 

--- a/internal/cli/token.go
+++ b/internal/cli/token.go
@@ -69,7 +69,7 @@ func createUser(ctx context.Context, serverURL, token, email, password, role str
 	if err != nil {
 		return apiclient.User{}, err
 	}
-	body := apiclient.CreateUserRequest{Email: email, Password: password}
+	body := apiclient.CreateUserRequest{Email: email, Password: &password}
 	if role != "" {
 		body.Role = &role
 	}

--- a/internal/cli/token.go
+++ b/internal/cli/token.go
@@ -19,7 +19,80 @@ func newAuthCommand() *cobra.Command {
 	}
 	auth.AddCommand(newCreateTokenCommand())
 	auth.AddCommand(newLoginCommand())
+	auth.AddCommand(newCreateUserCommand())
 	return auth
+}
+
+// newCreateUserCommand builds `leoflow auth create-user`: it creates an account
+// on the control plane via the admin-only POST /api/v2/users endpoint. It is the
+// long-promised counterpart to bootstrap (ADR 0008) — until now the only way to
+// mint a user was the Lite bootstrap admin. Unlike create-token/login (which
+// exchange credentials for a token), this call is privileged, so it carries an
+// existing admin's bearer token, resolved with the same precedence as `deploy`:
+// --token, then LEOFLOW_TOKEN, then the session saved by `auth login`.
+func newCreateUserCommand() *cobra.Command {
+	var serverURL, token, email, password, role string
+	cmd := &cobra.Command{
+		Use:   "create-user",
+		Short: "Create a user on the control plane (admin only).",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			resolvedServer, resolvedToken, rerr := resolveServerToken(cmd, serverURL, token)
+			if rerr != nil {
+				return rerr
+			}
+			if email == "" || password == "" {
+				return fmt.Errorf("--email and --password are required")
+			}
+			created, err := createUser(cmdContext(cmd), resolvedServer, resolvedToken, email, password, role)
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Created user %s (id %s, role %s)\n",
+				created.Email, created.Id, roleOrNone(created.Role))
+			return err
+		},
+	}
+	cmd.Flags().StringVar(&serverURL, "server", "", "control plane base URL (default: config server_url)")
+	cmd.Flags().StringVar(&token, "token", os.Getenv("LEOFLOW_TOKEN"), "admin JWT bearer token (default: config token)")
+	cmd.Flags().StringVar(&email, "email", "", "email of the user to create")
+	cmd.Flags().StringVar(&password, "password", os.Getenv("LEOFLOW_PASSWORD"), "password for the new user")
+	cmd.Flags().StringVar(&role, "role", "", "existing role to grant (e.g. admin); empty grants none")
+	return cmd
+}
+
+// createUser posts to /api/v2/users through the shared typed client, carrying the
+// admin bearer, and returns the created user. It mirrors requestToken's use of
+// the generated client (ADR 0050 D8) rather than hand-rolling HTTP.
+func createUser(ctx context.Context, serverURL, token, email, password, role string) (apiclient.User, error) {
+	c, err := apiclient.New(serverURL, token)
+	if err != nil {
+		return apiclient.User{}, err
+	}
+	body := apiclient.CreateUserRequest{Email: email, Password: password}
+	if role != "" {
+		body.Role = &role
+	}
+	resp, err := c.CreateUserWithResponse(ctx, body)
+	if err != nil {
+		return apiclient.User{}, fmt.Errorf("posting to %s/api/v2/users: %w", serverURL, err)
+	}
+	if resp.StatusCode() != http.StatusCreated {
+		return apiclient.User{}, fmt.Errorf("server returned %d: %s", resp.StatusCode(), string(resp.Body))
+	}
+	if resp.JSON201 == nil {
+		return apiclient.User{}, fmt.Errorf("server returned no user")
+	}
+	return *resp.JSON201, nil
+}
+
+// roleOrNone renders an optional role for CLI output, showing "(none)" when the
+// user was created without one.
+func roleOrNone(role *string) string {
+	if role == nil || *role == "" {
+		return "(none)"
+	}
+	return *role
 }
 
 func newCreateTokenCommand() *cobra.Command {

--- a/internal/cli/token_test.go
+++ b/internal/cli/token_test.go
@@ -37,6 +37,45 @@ func TestRequestTokenRejectsBadStatus(t *testing.T) {
 	}
 }
 
+func TestCreateUserSendsRoleAndReturnsUser(t *testing.T) {
+	var gotAuth, gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"id":"u-9","email":"alice@example.com","role":"admin","is_active":true}`)
+	}))
+	defer srv.Close()
+
+	user, err := createUser(context.Background(), srv.URL, "admin-jwt", "alice@example.com", "pw-12345678", "admin")
+	if err != nil {
+		t.Fatalf("createUser: %v", err)
+	}
+	if user.Id != "u-9" || user.Email != "alice@example.com" {
+		t.Errorf("unexpected user: %+v", user)
+	}
+	if gotAuth != "Bearer admin-jwt" {
+		t.Errorf("Authorization = %q, want the admin bearer", gotAuth)
+	}
+	if !strings.Contains(gotBody, `"role":"admin"`) {
+		t.Errorf("request body missing role: %s", gotBody)
+	}
+}
+
+func TestCreateUserRejectsBadStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = io.WriteString(w, `{"detail":"resource already exists"}`)
+	}))
+	defer srv.Close()
+
+	if _, err := createUser(context.Background(), srv.URL, "t", "dupe@example.com", "pw-12345678", ""); err == nil {
+		t.Error("expected error on 409")
+	}
+}
+
 func TestCreateTokenCommand(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -8,3 +8,8 @@ var ErrNotFound = errors.New("resource not found")
 // ErrConflict is returned when a write conflicts with an existing resource (e.g.
 // a duplicate dag run for the same logical date). The API maps it to 409.
 var ErrConflict = errors.New("resource already exists")
+
+// ErrValidation is returned when input fails a business-rule check that the
+// caller can fix (e.g. creating a user with a role that does not exist). The API
+// maps it to 400.
+var ErrValidation = errors.New("invalid input")

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -1,0 +1,15 @@
+package domain
+
+import "time"
+
+// User is a control-plane account as returned by the admin create-user API. It
+// never carries the password or its hash — those are write-only. Role is the
+// single role granted at creation ("" when none was assigned); the RBAC model
+// supports multiple roles per user, but create-user grants at most one.
+type User struct {
+	ID        string
+	Email     string
+	Role      string
+	IsActive  bool
+	CreatedAt time.Time
+}

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -85,6 +85,9 @@ type Querier interface {
 	GetXComByNames(ctx context.Context, arg GetXComByNamesParams) (GetXComByNamesRow, error)
 	GetXComEntry(ctx context.Context, arg GetXComEntryParams) (GetXComEntryRow, error)
 	InsertDagVersion(ctx context.Context, arg InsertDagVersionParams) (DagVersion, error)
+	// Mirrors the bootstrap CreateUser insert (tenant_id, email, password_hash) but
+	// returns the columns the admin create-user API echoes back to the caller.
+	InsertUser(ctx context.Context, arg InsertUserParams) (InsertUserRow, error)
 	LatestRunsForDags(ctx context.Context, arg LatestRunsForDagsParams) ([]LatestRunsForDagsRow, error)
 	ListActiveDagRuns(ctx context.Context) ([]DagRun, error)
 	// run_id is the dag_run's UUID (StagingClaimName uses it), so join on dag_runs.id,

--- a/internal/storage/queries/users.sql
+++ b/internal/storage/queries/users.sql
@@ -4,6 +4,13 @@ SELECT id, name FROM tenants WHERE name = 'default';
 -- name: GetTenantByName :one
 SELECT id, name FROM tenants WHERE name = $1;
 
+-- name: InsertUser :one
+-- Mirrors the bootstrap CreateUser insert (tenant_id, email, password_hash) but
+-- returns the columns the admin create-user API echoes back to the caller.
+INSERT INTO users (tenant_id, email, password_hash)
+VALUES ($1, $2, $3)
+RETURNING id, email, is_active, created_at;
+
 -- name: GetUserByEmail :one
 SELECT u.id, u.tenant_id, u.email, u.password_hash, u.is_active
 FROM users u

--- a/internal/storage/queries/users.sql.go
+++ b/internal/storage/queries/users.sql.go
@@ -136,6 +136,39 @@ func (q *Queries) GetUserRoles(ctx context.Context, userID pgtype.UUID) ([]strin
 	return items, nil
 }
 
+const insertUser = `-- name: InsertUser :one
+INSERT INTO users (tenant_id, email, password_hash)
+VALUES ($1, $2, $3)
+RETURNING id, email, is_active, created_at
+`
+
+type InsertUserParams struct {
+	TenantID     pgtype.UUID `json:"tenant_id"`
+	Email        string      `json:"email"`
+	PasswordHash *string     `json:"password_hash"`
+}
+
+type InsertUserRow struct {
+	ID        pgtype.UUID        `json:"id"`
+	Email     string             `json:"email"`
+	IsActive  bool               `json:"is_active"`
+	CreatedAt pgtype.Timestamptz `json:"created_at"`
+}
+
+// Mirrors the bootstrap CreateUser insert (tenant_id, email, password_hash) but
+// returns the columns the admin create-user API echoes back to the caller.
+func (q *Queries) InsertUser(ctx context.Context, arg InsertUserParams) (InsertUserRow, error) {
+	row := q.db.QueryRow(ctx, insertUser, arg.TenantID, arg.Email, arg.PasswordHash)
+	var i InsertUserRow
+	err := row.Scan(
+		&i.ID,
+		&i.Email,
+		&i.IsActive,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const updateUserPassword = `-- name: UpdateUserPassword :execrows
 UPDATE users
 SET password_hash = $3

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -631,6 +631,53 @@ func (r *Repository) BootstrapAdmin(ctx context.Context, tenant, email, password
 	return r.BootstrapAdminHash(ctx, tenant, email, hash)
 }
 
+// CreateUser provisions a new account in the tenant and grants it at most one
+// role, returning the created user (never its password or hash). It reuses the
+// same bcrypt hashing as the bootstrap admin path (auth.HashPassword) and the
+// same email uniqueness guarantee, so a duplicate email surfaces as
+// domain.ErrConflict (the API maps it to 409). The role is resolved BEFORE the
+// insert so an unknown role fails cleanly as domain.ErrValidation without
+// leaving an orphaned account; an empty role grants none — the most restrictive
+// default, leaving the user with no permissions until an admin grants a role.
+// This backs `leoflow auth create-user` (ADR 0008) and is purely additive: it
+// does not touch the bootstrap/reconcile path.
+func (r *Repository) CreateUser(ctx context.Context, tenant, email, password, role string) (domain.User, error) {
+	tid, err := r.tenantID(ctx, tenant)
+	if err != nil {
+		return domain.User{}, err
+	}
+	var roleID pgtype.UUID
+	if role != "" {
+		roleID, err = r.q.GetRoleByName(ctx, queries.GetRoleByNameParams{TenantID: tid, Name: role})
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return domain.User{}, fmt.Errorf("unknown role %q: %w", role, domain.ErrValidation)
+			}
+			return domain.User{}, fmt.Errorf("looking up role: %w", err)
+		}
+	}
+	hash, err := auth.HashPassword(password)
+	if err != nil {
+		return domain.User{}, err
+	}
+	row, err := r.q.InsertUser(ctx, queries.InsertUserParams{TenantID: tid, Email: email, PasswordHash: strPtr(hash)})
+	if err != nil {
+		return domain.User{}, mapConflict(err)
+	}
+	if role != "" {
+		if aerr := r.q.AssignUserRole(ctx, queries.AssignUserRoleParams{UserID: row.ID, RoleID: roleID}); aerr != nil {
+			return domain.User{}, fmt.Errorf("assigning role: %w", aerr)
+		}
+	}
+	return domain.User{
+		ID:        uuidToString(row.ID),
+		Email:     row.Email,
+		Role:      role,
+		IsActive:  row.IsActive,
+		CreatedAt: timeVal(row.CreatedAt),
+	}, nil
+}
+
 // SetUserPassword sets a user's bcrypt hash by email, returning whether a user
 // was updated (false when no such user exists). Used by `leoflow lite
 // reset-password`.

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -21,16 +21,23 @@ import (
 
 const defaultMaxActiveRuns = 16
 
+// txBeginner opens a transaction. *pgxpool.Pool satisfies it; tests inject a
+// fake so the transactional paths can be exercised without a database.
+type txBeginner interface {
+	Begin(ctx context.Context) (pgx.Tx, error)
+}
+
 // Repository implements the API resource and auth user-store interfaces over
 // Postgres using the sqlc-generated query set.
 type Repository struct {
 	q      *queries.Queries
+	pool   txBeginner
 	cipher secrets.Cipher
 }
 
 // NewRepository builds a Repository backed by the given Postgres connection.
 func NewRepository(pg *Postgres) *Repository {
-	return &Repository{q: pg.Queries}
+	return &Repository{q: pg.Queries, pool: pg.Pool}
 }
 
 // SetCipher attaches the encryption cipher used for connection secrets (ADR
@@ -437,6 +444,35 @@ func (r *Repository) RecordTaskActionAudit(ctx context.Context, tenant, userID, 
 	return nil
 }
 
+// RecordUserCreatedAudit logs an account creation with the acting admin as the
+// owner and the new account's email and role in metadata, scoped to the "user"
+// resource so account-management actions are visible in the Audit Log.
+func (r *Repository) RecordUserCreatedAudit(ctx context.Context, tenant, actorUserID, createdUserID, email, role string) error {
+	tid, err := r.tenantID(ctx, tenant)
+	if err != nil {
+		return err
+	}
+	var uid pgtype.UUID
+	if u, perr := parseUUID(actorUserID); perr == nil {
+		uid = u
+	}
+	fields := map[string]any{"email": email}
+	if role != "" {
+		fields["role"] = role
+	}
+	meta, err := json.Marshal(fields)
+	if err != nil {
+		return fmt.Errorf("encoding audit metadata: %w", err)
+	}
+	if err := r.q.CreateAuditLog(ctx, queries.CreateAuditLogParams{
+		TenantID: tid, UserID: uid, Action: "user.create",
+		ResourceType: strPtr("user"), ResourceID: strPtr(createdUserID), Metadata: meta,
+	}); err != nil {
+		return fmt.Errorf("writing user-created audit: %w", err)
+	}
+	return nil
+}
+
 // SetTaskInstanceState sets a task instance's state directly, backing the UI's
 // "mark success"/"mark failed" actions. It does not run the task.
 func (r *Repository) SetTaskInstanceState(ctx context.Context, tenant, dagID, runID, taskID, state string) error {
@@ -639,6 +675,12 @@ func (r *Repository) BootstrapAdmin(ctx context.Context, tenant, email, password
 // insert so an unknown role fails cleanly as domain.ErrValidation without
 // leaving an orphaned account; an empty role grants none — the most restrictive
 // default, leaving the user with no permissions until an admin grants a role.
+//
+// The insert and the role grant run in a single transaction, so a failure in the
+// grant rolls the user insert back. Without that atomicity a failed grant would
+// leave a role-less account that the (tenant_id, email) UNIQUE makes impossible
+// to recreate — every retry would 409 forever with no recovery path.
+//
 // This backs `leoflow auth create-user` (ADR 0008) and is purely additive: it
 // does not touch the bootstrap/reconcile path.
 func (r *Repository) CreateUser(ctx context.Context, tenant, email, password, role string) (domain.User, error) {
@@ -660,14 +702,25 @@ func (r *Repository) CreateUser(ctx context.Context, tenant, email, password, ro
 	if err != nil {
 		return domain.User{}, err
 	}
-	row, err := r.q.InsertUser(ctx, queries.InsertUserParams{TenantID: tid, Email: email, PasswordHash: strPtr(hash)})
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return domain.User{}, fmt.Errorf("beginning create-user tx: %w", err)
+	}
+	// Rollback after a successful commit is a no-op; on any early return it undoes
+	// the user insert so a failed role grant leaves nothing behind.
+	defer func() { _ = tx.Rollback(ctx) }() //nolint:errcheck // best-effort; the commit path returns the meaningful error
+	qtx := r.q.WithTx(tx)
+	row, err := qtx.InsertUser(ctx, queries.InsertUserParams{TenantID: tid, Email: email, PasswordHash: strPtr(hash)})
 	if err != nil {
 		return domain.User{}, mapConflict(err)
 	}
 	if role != "" {
-		if aerr := r.q.AssignUserRole(ctx, queries.AssignUserRoleParams{UserID: row.ID, RoleID: roleID}); aerr != nil {
+		if aerr := qtx.AssignUserRole(ctx, queries.AssignUserRoleParams{UserID: row.ID, RoleID: roleID}); aerr != nil {
 			return domain.User{}, fmt.Errorf("assigning role: %w", aerr)
 		}
+	}
+	if cerr := tx.Commit(ctx); cerr != nil {
+		return domain.User{}, fmt.Errorf("committing create-user tx: %w", cerr)
 	}
 	return domain.User{
 		ID:        uuidToString(row.ID),

--- a/internal/storage/users_integration_test.go
+++ b/internal/storage/users_integration_test.go
@@ -3,7 +3,6 @@
 package storage_test
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"

--- a/internal/storage/users_integration_test.go
+++ b/internal/storage/users_integration_test.go
@@ -1,0 +1,69 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// TestCreateUserIntegration exercises the admin create-user query end to end:
+// the new user is persisted, granted the requested role, and can authenticate
+// with the supplied password (proving the reused bcrypt hashing round-trips).
+func TestCreateUserIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	email := fmt.Sprintf("newuser_%d@example.com", time.Now().UnixNano())
+	const password = "create-user-secret-1"
+
+	got, err := repo.CreateUser(ctx, "default", email, password, "admin")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if got.ID == "" || got.Email != email || got.Role != "admin" || !got.IsActive {
+		t.Fatalf("unexpected created user: %+v", got)
+	}
+
+	// The created user can log in with the plaintext password (hash round-trips),
+	// and inherits the admin role's permissions.
+	authn := auth.NewJWTAuthenticator(repo, "create-user-test-secret", time.Hour)
+	if _, lerr := authn.IssueToken(ctx, auth.Credentials{Tenant: "default", Username: email, Password: password}); lerr != nil {
+		t.Errorf("created user cannot log in: %v", lerr)
+	}
+}
+
+// TestCreateUserDuplicateEmailIntegration proves the unique-constraint violation
+// surfaces as domain.ErrConflict (the API maps it to 409), not a raw 500.
+func TestCreateUserDuplicateEmailIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	email := fmt.Sprintf("dupe_%d@example.com", time.Now().UnixNano())
+
+	if _, err := repo.CreateUser(ctx, "default", email, "pw-first-1234", "admin"); err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	if _, err := repo.CreateUser(ctx, "default", email, "pw-second-1234", "admin"); !errors.Is(err, domain.ErrConflict) {
+		t.Errorf("duplicate create err = %v, want ErrConflict", err)
+	}
+}
+
+// TestCreateUserUnknownRoleIntegration proves an unknown role is rejected as a
+// validation error and leaves no orphaned account behind (the role is resolved
+// before the user is inserted).
+func TestCreateUserUnknownRoleIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	email := fmt.Sprintf("norole_%d@example.com", time.Now().UnixNano())
+
+	if _, err := repo.CreateUser(ctx, "default", email, "pw-12345678", "wizard"); !errors.Is(err, domain.ErrValidation) {
+		t.Fatalf("unknown role err = %v, want ErrValidation", err)
+	}
+	// No account was created, so a subsequent create with a valid (empty) role
+	// succeeds rather than colliding.
+	if _, err := repo.CreateUser(ctx, "default", email, "pw-12345678", ""); err != nil {
+		t.Errorf("create after rejected role: %v", err)
+	}
+}

--- a/internal/storage/users_test.go
+++ b/internal/storage/users_test.go
@@ -1,0 +1,99 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/neochaotic/leoflow/internal/storage/queries"
+)
+
+// fakeConn is a white-box double that satisfies both queries.DBTX (for the
+// non-transactional reads) and pgx.Tx (for the transactional writes). It lets
+// CreateUser run its full path with no database: reads are answered from canned
+// rows, the role-assignment Exec is forced to fail, and Commit/Rollback are
+// recorded so the test can assert the whole thing rolled back.
+type fakeConn struct {
+	pgx.Tx // embedded so the fake satisfies the full pgx.Tx surface; only the
+	//        methods overridden below are ever called.
+	committed  bool
+	rolledBack bool
+}
+
+func validUUID() pgtype.UUID {
+	return pgtype.UUID{Bytes: [16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, Valid: true}
+}
+
+type fakeRow struct{ scan func(dest ...any) error }
+
+func (r fakeRow) Scan(dest ...any) error { return r.scan(dest...) }
+
+func (f *fakeConn) QueryRow(_ context.Context, sql string, _ ...any) pgx.Row {
+	switch {
+	case strings.Contains(sql, "FROM tenants"):
+		return fakeRow{func(d ...any) error {
+			*(d[0].(*pgtype.UUID)) = validUUID()
+			*(d[1].(*string)) = "default"
+			return nil
+		}}
+	case strings.Contains(sql, "FROM roles"):
+		return fakeRow{func(d ...any) error {
+			*(d[0].(*pgtype.UUID)) = validUUID()
+			return nil
+		}}
+	case strings.Contains(sql, "INSERT INTO users"):
+		return fakeRow{func(d ...any) error {
+			*(d[0].(*pgtype.UUID)) = validUUID()
+			*(d[1].(*string)) = "alice@example.com"
+			*(d[2].(*bool)) = true
+			*(d[3].(*pgtype.Timestamptz)) = pgtype.Timestamptz{Time: time.Now(), Valid: true}
+			return nil
+		}}
+	}
+	return fakeRow{func(...any) error { return errors.New("unexpected QueryRow: " + sql) }}
+}
+
+func (f *fakeConn) Exec(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+	if strings.Contains(sql, "user_roles") {
+		return pgconn.CommandTag{}, errors.New("forced role-assignment failure")
+	}
+	return pgconn.CommandTag{}, nil
+}
+
+func (f *fakeConn) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+	return nil, errors.New("unexpected Query")
+}
+
+func (f *fakeConn) Commit(context.Context) error   { f.committed = true; return nil }
+func (f *fakeConn) Rollback(context.Context) error { f.rolledBack = true; return nil }
+
+type fakeBeginner struct{ tx pgx.Tx }
+
+func (b fakeBeginner) Begin(context.Context) (pgx.Tx, error) { return b.tx, nil }
+
+// TestCreateUserRollsBackWhenRoleAssignFails guards MEDIUM-1: the user insert and
+// the role grant must be one atomic transaction. If the grant fails after the
+// insert, the transaction must roll back (never commit) so no role-less account
+// is left behind — otherwise the (tenant_id, email) UNIQUE would make every retry
+// 409 forever with no recovery.
+func TestCreateUserRollsBackWhenRoleAssignFails(t *testing.T) {
+	fc := &fakeConn{}
+	repo := &Repository{q: queries.New(fc), pool: fakeBeginner{tx: fc}}
+
+	_, err := repo.CreateUser(context.Background(), "default", "alice@example.com", "pw-12345678", "admin")
+	if err == nil {
+		t.Fatal("expected an error when the role assignment fails")
+	}
+	if fc.committed {
+		t.Error("transaction was committed despite the role-assignment failure")
+	}
+	if !fc.rolledBack {
+		t.Error("transaction was not rolled back after the role-assignment failure")
+	}
+}

--- a/pkg/client/client.gen.go
+++ b/pkg/client/client.gen.go
@@ -147,8 +147,11 @@ type ComponentHealth struct {
 
 // CreateUserRequest defines model for CreateUserRequest.
 type CreateUserRequest struct {
-	Email    string `json:"email"`
-	Password string `json:"password"`
+	// Email Login email. Normalized to lowercase, so it is unique case-insensitively within the tenant.
+	Email string `json:"email"`
+
+	// Password Plaintext password (write-only; never returned). Must be at least 8 characters — the server rejects anything shorter with 400.
+	Password *string `json:"password,omitempty"`
 
 	// Role Name of an existing role to grant (e.g. "admin"). Omit to grant no role — the most restrictive default; the user then holds no permissions until an admin grants one.
 	Role *string `json:"role,omitempty"`

--- a/pkg/client/client.gen.go
+++ b/pkg/client/client.gen.go
@@ -145,6 +145,15 @@ type ComponentHealth struct {
 	Status                      *string `json:"status,omitempty"`
 }
 
+// CreateUserRequest defines model for CreateUserRequest.
+type CreateUserRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+
+	// Role Name of an existing role to grant (e.g. "admin"). Omit to grant no role — the most restrictive default; the user then holds no permissions until an admin grants one.
+	Role *string `json:"role,omitempty"`
+}
+
 // DAG defines model for DAG.
 type DAG struct {
 	Catchup                  *bool                   `json:"catchup,omitempty"`
@@ -307,6 +316,15 @@ type TokenResponse struct {
 	TokenType *string `json:"token_type,omitempty"`
 }
 
+// User defines model for User.
+type User struct {
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+	Email     string     `json:"email"`
+	Id        string     `json:"id"`
+	IsActive  *bool      `json:"is_active,omitempty"`
+	Role      *string    `json:"role,omitempty"`
+}
+
 // VersionInfo defines model for VersionInfo.
 type VersionInfo struct {
 	GitVersion *string `json:"git_version,omitempty"`
@@ -371,6 +389,9 @@ type ClearTaskInstancesJSONRequestBody = ClearTaskInstancesRequest
 
 // TriggerDagRunJSONRequestBody defines body for TriggerDagRun for application/json ContentType.
 type TriggerDagRunJSONRequestBody = DAGRunCreate
+
+// CreateUserJSONRequestBody defines body for CreateUser for application/json ContentType.
+type CreateUserJSONRequestBody = CreateUserRequest
 
 // IssueTokenJSONRequestBody defines body for IssueToken for application/json ContentType.
 type IssueTokenJSONRequestBody = TokenRequest
@@ -555,6 +576,28 @@ type ClientInterface interface {
 	//
 	// Corresponds with GET /api/v2/monitor/health (the `GetMonitorHealth` operationId).
 	GetMonitorHealth(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateUserWithBody Create a user
+	//
+	// Admin-only. Creates a control-plane account with the given email and
+	// password and grants at most one role. The password is write-only and is
+	// never returned. Requires the admin:tenant permission.
+	//
+	// Takes any type of body and a specified content type.
+	//
+	// Corresponds with POST /api/v2/users (the `CreateUser` operationId).
+	CreateUserWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateUser Create a user
+	//
+	// Admin-only. Creates a control-plane account with the given email and
+	// password and grants at most one role. The password is write-only and is
+	// never returned. Requires the admin:tenant permission.
+	//
+	// Takes a body of the `application/json` content type.
+	//
+	// Corresponds with POST /api/v2/users (the `CreateUser` operationId).
+	CreateUser(ctx context.Context, body CreateUserJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetVersion Control-plane version (Airflow VersionInfo shape)
 	//
@@ -878,6 +921,48 @@ func (c *Client) GetMonitorExecutor(ctx context.Context, reqEditors ...RequestEd
 // Corresponds with GET /api/v2/monitor/health (the `GetMonitorHealth` operationId).
 func (c *Client) GetMonitorHealth(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetMonitorHealthRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// CreateUserWithBody Create a user
+//
+// Admin-only. Creates a control-plane account with the given email and
+// password and grants at most one role. The password is write-only and is
+// never returned. Requires the admin:tenant permission.
+//
+// Takes any type of body and a specified content type.
+//
+// Corresponds with POST /api/v2/users (the `CreateUser` operationId).
+func (c *Client) CreateUserWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateUserRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// CreateUser Create a user
+//
+// Admin-only. Creates a control-plane account with the given email and
+// password and grants at most one role. The password is write-only and is
+// never returned. Requires the admin:tenant permission.
+//
+// Takes a body of the `application/json` content type.
+//
+// Corresponds with POST /api/v2/users (the `CreateUser` operationId).
+func (c *Client) CreateUser(ctx context.Context, body CreateUserJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateUserRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1726,6 +1811,46 @@ func NewGetMonitorHealthRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewCreateUserRequest calls the generic CreateUser builder with application/json body
+func NewCreateUserRequest(server string, body CreateUserJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateUserRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateUserRequestWithBody constructs an http.Request for the CreateUser method, with any body, and a specified content type
+func NewCreateUserRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v2/users")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewGetVersionRequest constructs an http.Request for the GetVersion method
 func NewGetVersionRequest(server string) (*http.Request, error) {
 	var err error
@@ -2078,6 +2203,28 @@ type ClientWithResponsesInterface interface {
 	//
 	// Corresponds with GET /api/v2/monitor/health (the `GetMonitorHealth` operationId).
 	GetMonitorHealthWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetMonitorHealthResponse, error)
+
+	// CreateUserWithBodyWithResponse Create a user
+	//
+	// Admin-only. Creates a control-plane account with the given email and
+	// password and grants at most one role. The password is write-only and is
+	// never returned. Requires the admin:tenant permission.
+	//
+	// Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with POST /api/v2/users (the `CreateUser` operationId).
+	CreateUserWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateUserResponse, error)
+
+	// CreateUserWithResponse Create a user
+	//
+	// Admin-only. Creates a control-plane account with the given email and
+	// password and grants at most one role. The password is write-only and is
+	// never returned. Requires the admin:tenant permission.
+	//
+	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with POST /api/v2/users (the `CreateUser` operationId).
+	CreateUserWithResponse(ctx context.Context, body CreateUserJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateUserResponse, error)
 
 	// GetVersionWithResponse Control-plane version (Airflow VersionInfo shape)
 	//
@@ -2806,6 +2953,68 @@ func (r GetMonitorHealthResponse) ContentType() string {
 	return ""
 }
 
+type CreateUserResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON201 the response for an HTTP 201 `application/json` response
+	JSON201 *User
+	// JSON400 the response for an HTTP 400 `application/json` response
+	JSON400 *Error
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *Unauthorized
+	// JSON409 the response for an HTTP 409 `application/json` response
+	JSON409 *Error
+}
+
+// GetJSON201 returns the response for an HTTP 201 `application/json` response
+func (r CreateUserResponse) GetJSON201() *User {
+	return r.JSON201
+}
+
+// GetJSON400 returns the response for an HTTP 400 `application/json` response
+func (r CreateUserResponse) GetJSON400() *Error {
+	return r.JSON400
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r CreateUserResponse) GetJSON401() *Unauthorized {
+	return r.JSON401
+}
+
+// GetJSON409 returns the response for an HTTP 409 `application/json` response
+func (r CreateUserResponse) GetJSON409() *Error {
+	return r.JSON409
+}
+
+// GetBody returns the raw response body bytes
+func (r CreateUserResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateUserResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateUserResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CreateUserResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type GetVersionResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -3256,6 +3465,40 @@ func (c *ClientWithResponses) GetMonitorHealthWithResponse(ctx context.Context, 
 		return nil, err
 	}
 	return ParseGetMonitorHealthResponse(rsp)
+}
+
+// CreateUserWithBodyWithResponse Create a user
+//
+// Admin-only. Creates a control-plane account with the given email and
+// password and grants at most one role. The password is write-only and is
+// never returned. Requires the admin:tenant permission.
+//
+// Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
+//
+// Corresponds with POST /api/v2/users (the `CreateUser` operationId).
+func (c *ClientWithResponses) CreateUserWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateUserResponse, error) {
+	rsp, err := c.CreateUserWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateUserResponse(rsp)
+}
+
+// CreateUserWithResponse Create a user
+//
+// Admin-only. Creates a control-plane account with the given email and
+// password and grants at most one role. The password is write-only and is
+// never returned. Requires the admin:tenant permission.
+//
+// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+//
+// Corresponds with POST /api/v2/users (the `CreateUser` operationId).
+func (c *ClientWithResponses) CreateUserWithResponse(ctx context.Context, body CreateUserJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateUserResponse, error) {
+	rsp, err := c.CreateUser(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateUserResponse(rsp)
 }
 
 // GetVersionWithResponse Control-plane version (Airflow VersionInfo shape)
@@ -3771,6 +4014,53 @@ func ParseGetMonitorHealthResponse(rsp *http.Response) (*GetMonitorHealthRespons
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateUserResponse parses an HTTP response from a CreateUserWithResponse call
+func ParseCreateUserResponse(rsp *http.Response) (*CreateUserResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateUserResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest User
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
 
 	}
 


### PR DESCRIPTION
## What
User management — fulfils ADR 0008's never-built `leoflow auth create-user`, plus the API it needs.
- `POST /api/v2/users` (admin-only): create `{email, password, role}` → `{id, email, role, is_active, created_at}` (never the password/hash). 409 on duplicate email, 400 on invalid role/fields.
- `leoflow auth create-user --email --password [--role]` CLI, over the typed `pkg/client`.
- Reuses `auth.HashPassword` (bcrypt cost 12 — the exact `BootstrapAdminHash` scheme); new `InsertUser` sqlc query; role granted via the existing `GetRoleByName`/`AssignUserRole`.

## Design (maintainer-approved)
- **Default role = none** — an inert user (authenticates, holds zero permissions) until an admin grants a role. Anti-footgun: the only way to mint another admin is an explicit `--role admin`.
- **Permission gate = `admin:tenant`** (same as connections/dags mutations).
- **Password floor ≥ 8 chars** (placeholder; real policy later).
- Only the `admin` role exists today; the fuller **role / group / access model is discovery #626**.

## Tests (strict TDD, two commits)
Handler unit (fake store) + integration (real migrated Postgres) + CLI. `go build`/`gofmt`/`go vet`/golangci-lint (repo config) all clean; cyclomatic ≤15; GoDoc on new exported ids.

## Lite containment
Purely additive — `bootstrap.sql`/`.go` and login are **untouched (0 changes)**; the route registers only when a `Users` store is wired (404 otherwise). No existing Lite or Pro behavior changes.

Relates: ADR 0008, #623 (release tracker), #626 (RBAC discovery).
