### PR TITLE
feat(executor): full placement/scheduling passthrough + DRA

### DIFF
--- a/docs/api/dag-schema.json
+++ b/docs/api/dag-schema.json
@@ -256,13 +256,20 @@
             },
             "limits": {
               "$ref": "#/$defs/resource_quantity"
+            },
+            "claims": {
+              "type": "array",
+              "description": "Dynamic Resource Allocation (DRA, GA in Kubernetes 1.34): the pod-level resource_claims this container consumes. Each entry names a claim (and optionally a request within it) declared in execution.resource_claims.",
+              "items": {
+                "type": "object"
+              }
             }
           },
           "additionalProperties": false
         },
         "execution": {
           "type": "object",
-          "description": "Executor-specific hints. Ignored if the chosen executor does not support them.",
+          "description": "Executor-specific placement and scheduling hints. Applied only by the Kubernetes executor; ignored by Lite (subprocess, no pods).",
           "properties": {
             "node_selector": {
               "type": "object",
@@ -287,6 +294,51 @@
                 "Never"
               ],
               "default": "IfNotPresent"
+            },
+            "priority_class_name": {
+              "type": "string",
+              "description": "Ranks this task pod against neighbors on a shared cluster; the named PriorityClass is platform-owned and cluster-scoped (ADR 0054)."
+            },
+            "termination_grace_period_seconds": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Seconds the pod is given to shut down before SIGKILL. Omit for the cluster default (30s)."
+            },
+            "runtime_class_name": {
+              "type": "string",
+              "description": "Selects an alternate container runtime (e.g. a sandboxed or GPU runtime) registered as a RuntimeClass."
+            },
+            "topology_spread_constraints": {
+              "type": "array",
+              "description": "Spread a DAG's task pods across failure domains (zones, nodes). Each entry is a Kubernetes TopologySpreadConstraint.",
+              "items": {
+                "type": "object"
+              }
+            },
+            "affinity": {
+              "type": "object",
+              "description": "Pins or repels a task pod relative to nodes and other pods (node/pod affinity and anti-affinity). A Kubernetes Affinity object."
+            },
+            "resource_claims": {
+              "type": "array",
+              "description": "Pod-level ResourceClaims for Dynamic Resource Allocation (DRA, GA in Kubernetes 1.34) — e.g. a GPU from a claim template. Each entry is a Kubernetes PodResourceClaim; a container consumes one via resources.claims.",
+              "items": {
+                "type": "object"
+              }
+            },
+            "labels": {
+              "type": "object",
+              "description": "Operator-declared pod labels merged onto the task pod. Leoflow's own leoflow.io/* labels win any key collision.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "annotations": {
+              "type": "object",
+              "description": "Operator-declared pod annotations merged onto the task pod. Leoflow's own task-instance-id annotation wins any key collision.",
+              "additionalProperties": {
+                "type": "string"
+              }
             }
           }
         },
@@ -350,6 +402,10 @@
         "memory": {
           "type": "string",
           "description": "Kubernetes-style: '512Mi', '2Gi'."
+        },
+        "ephemeral_storage": {
+          "type": "string",
+          "description": "Kubernetes-style node-local scratch limit, e.g. '2Gi'. Bounds writable-layer/emptyDir/log usage so a runaway task cannot evict neighbors under disk pressure (ADR 0054)."
         }
       },
       "additionalProperties": false

--- a/docs/api/leoflow-yaml-schema.json
+++ b/docs/api/leoflow-yaml-schema.json
@@ -207,7 +207,8 @@
                 "type": "object",
                 "properties": {
                   "cpu": { "type": "string" },
-                  "memory": { "type": "string" }
+                  "memory": { "type": "string" },
+                  "ephemeral_storage": { "type": "string", "description": "Node-local scratch limit, e.g. '2Gi' (ADR 0054)." }
                 },
                 "additionalProperties": false
               },
@@ -215,9 +216,15 @@
                 "type": "object",
                 "properties": {
                   "cpu": { "type": "string" },
-                  "memory": { "type": "string" }
+                  "memory": { "type": "string" },
+                  "ephemeral_storage": { "type": "string", "description": "Node-local scratch limit, e.g. '2Gi' (ADR 0054)." }
                 },
                 "additionalProperties": false
+              },
+              "claims": {
+                "type": "array",
+                "description": "Dynamic Resource Allocation: the pod-level resource_claims this container consumes (DRA, GA in Kubernetes 1.34).",
+                "items": { "type": "object" }
               }
             },
             "additionalProperties": false
@@ -231,7 +238,15 @@
               },
               "tolerations": { "type": "array" },
               "service_account": { "type": "string" },
-              "image_pull_policy": { "type": "string" }
+              "image_pull_policy": { "type": "string" },
+              "priority_class_name": { "type": "string", "description": "Ranks the task pod against neighbors on a shared cluster; the PriorityClass is platform-owned (ADR 0054)." },
+              "termination_grace_period_seconds": { "type": "integer", "minimum": 0, "description": "Seconds to shut down before SIGKILL; omit for the cluster default." },
+              "runtime_class_name": { "type": "string", "description": "Alternate container runtime registered as a RuntimeClass (e.g. sandboxed/GPU)." },
+              "topology_spread_constraints": { "type": "array", "description": "Spread task pods across failure domains; Kubernetes TopologySpreadConstraint entries." },
+              "affinity": { "type": "object", "description": "Node/pod affinity and anti-affinity; a Kubernetes Affinity object." },
+              "resource_claims": { "type": "array", "description": "Pod-level ResourceClaims for Dynamic Resource Allocation (DRA, GA in Kubernetes 1.34)." },
+              "labels": { "type": "object", "additionalProperties": { "type": "string" }, "description": "Pod labels merged onto the task pod; Leoflow's leoflow.io/* labels win collisions." },
+              "annotations": { "type": "object", "additionalProperties": { "type": "string" }, "description": "Pod annotations merged onto the task pod; Leoflow's task-instance-id annotation wins collisions." }
             },
             "additionalProperties": false
           }

--- a/internal/domain/dag.go
+++ b/internal/domain/dag.go
@@ -283,6 +283,7 @@ func (d *DAGSpec) validateResourceQuantities() error {
 			for _, f := range []struct{ name, value string }{
 				{"cpu", q.val.CPU},
 				{"memory", q.val.Memory},
+				{"ephemeral-storage", q.val.EphemeralStorage},
 			} {
 				if f.value == "" {
 					continue

--- a/internal/domain/dag.go
+++ b/internal/domain/dag.go
@@ -153,20 +153,67 @@ type Secret struct {
 type Resources struct {
 	Requests *ResourceQuantity `json:"requests,omitempty" yaml:"requests,omitempty"`
 	Limits   *ResourceQuantity `json:"limits,omitempty" yaml:"limits,omitempty"`
+	// Claims lists the ResourceClaims (declared in Execution.ResourceClaims) this
+	// task's container consumes — the container half of Dynamic Resource Allocation
+	// (DRA, GA in Kubernetes 1.34). Untyped []map[string]any carried verbatim from
+	// the DAG spec; the executor round-trips it to []corev1.ResourceClaim. Each
+	// entry names a claim (and optionally a specific request within it) that makes
+	// an accelerator available inside the container.
+	Claims []map[string]any `json:"claims,omitempty" yaml:"claims,omitempty"`
 }
 
-// ResourceQuantity expresses CPU and memory in Kubernetes notation.
+// ResourceQuantity expresses CPU, memory, and ephemeral-storage in Kubernetes
+// notation.
 type ResourceQuantity struct {
 	CPU    string `json:"cpu,omitempty" yaml:"cpu,omitempty"`
 	Memory string `json:"memory,omitempty" yaml:"memory,omitempty"`
+	// EphemeralStorage bounds the node-local scratch (writable layer, emptyDir,
+	// logs) a task may use. Setting it keeps a runaway task from filling a shared
+	// node's disk and evicting its neighbors under disk pressure (ADR 0054).
+	// Kubernetes quantity, e.g. "2Gi".
+	EphemeralStorage string `json:"ephemeral_storage,omitempty" yaml:"ephemeral_storage,omitempty"`
 }
 
-// Execution carries executor-specific placement hints for a task.
+// Execution carries executor-specific placement and scheduling hints for a task.
+// Every field beyond NodeSelector/Tolerations/ServiceAccount is applied only by
+// the Kubernetes executor; Lite (subprocess, no pods) ignores them.
 type Execution struct {
 	NodeSelector    map[string]string `json:"node_selector,omitempty" yaml:"node_selector,omitempty"`
 	Tolerations     []map[string]any  `json:"tolerations,omitempty" yaml:"tolerations,omitempty"`
 	ServiceAccount  string            `json:"service_account,omitempty" yaml:"service_account,omitempty"`
 	ImagePullPolicy string            `json:"image_pull_policy,omitempty" yaml:"image_pull_policy,omitempty"`
+
+	// PriorityClassName ranks this task pod against its neighbors on a shared
+	// cluster; the named PriorityClass is a platform-owned, cluster-scoped object,
+	// so under genuine contention the scheduler preempts Leoflow's ETL rather than
+	// production services (ADR 0054).
+	PriorityClassName string `json:"priority_class_name,omitempty" yaml:"priority_class_name,omitempty"`
+	// TerminationGracePeriodSeconds is how long the pod is given to shut down after
+	// a delete/preempt before SIGKILL. Nil leaves the cluster default (30s).
+	TerminationGracePeriodSeconds *int64 `json:"termination_grace_period_seconds,omitempty" yaml:"termination_grace_period_seconds,omitempty"`
+	// RuntimeClassName selects an alternate container runtime (e.g. a sandboxed or
+	// GPU runtime) registered as a RuntimeClass. Nil uses the cluster default.
+	RuntimeClassName *string `json:"runtime_class_name,omitempty" yaml:"runtime_class_name,omitempty"`
+	// TopologySpreadConstraints spread a DAG's task pods across failure domains
+	// (zones, nodes). Untyped []map[string]any carried verbatim from the DAG spec;
+	// the executor round-trips it to []corev1.TopologySpreadConstraint.
+	TopologySpreadConstraints []map[string]any `json:"topology_spread_constraints,omitempty" yaml:"topology_spread_constraints,omitempty"`
+	// Affinity pins or repels a task pod relative to nodes and other pods
+	// (node/pod affinity and anti-affinity). Untyped map[string]any carried verbatim
+	// from the DAG spec; the executor round-trips it to *corev1.Affinity.
+	Affinity map[string]any `json:"affinity,omitempty" yaml:"affinity,omitempty"`
+	// ResourceClaims declares the pod-level ResourceClaims (Dynamic Resource
+	// Allocation, GA in Kubernetes 1.34) an accelerator DAG needs — e.g. a GPU from
+	// a claim template. Untyped []map[string]any carried verbatim from the DAG spec;
+	// the executor round-trips it to []corev1.PodResourceClaim. A container consumes
+	// one by naming it in Resources.Claims.
+	ResourceClaims []map[string]any `json:"resource_claims,omitempty" yaml:"resource_claims,omitempty"`
+	// Labels and Annotations are operator-declared pod metadata merged onto the task
+	// pod. Leoflow's own leoflow.io/* labels and the task-instance-id annotation win
+	// any key collision (the reconciler and terminate path select on them), so a DAG
+	// cannot shadow them.
+	Labels      map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 }
 
 // EffectiveExecutionMode returns the task's execution mode, defaulting to pod

--- a/internal/domain/schemas/dag-schema.json
+++ b/internal/domain/schemas/dag-schema.json
@@ -256,13 +256,20 @@
             },
             "limits": {
               "$ref": "#/$defs/resource_quantity"
+            },
+            "claims": {
+              "type": "array",
+              "description": "Dynamic Resource Allocation (DRA, GA in Kubernetes 1.34): the pod-level resource_claims this container consumes. Each entry names a claim (and optionally a request within it) declared in execution.resource_claims.",
+              "items": {
+                "type": "object"
+              }
             }
           },
           "additionalProperties": false
         },
         "execution": {
           "type": "object",
-          "description": "Executor-specific hints. Ignored if the chosen executor does not support them.",
+          "description": "Executor-specific placement and scheduling hints. Applied only by the Kubernetes executor; ignored by Lite (subprocess, no pods).",
           "properties": {
             "node_selector": {
               "type": "object",
@@ -287,6 +294,51 @@
                 "Never"
               ],
               "default": "IfNotPresent"
+            },
+            "priority_class_name": {
+              "type": "string",
+              "description": "Ranks this task pod against neighbors on a shared cluster; the named PriorityClass is platform-owned and cluster-scoped (ADR 0054)."
+            },
+            "termination_grace_period_seconds": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Seconds the pod is given to shut down before SIGKILL. Omit for the cluster default (30s)."
+            },
+            "runtime_class_name": {
+              "type": "string",
+              "description": "Selects an alternate container runtime (e.g. a sandboxed or GPU runtime) registered as a RuntimeClass."
+            },
+            "topology_spread_constraints": {
+              "type": "array",
+              "description": "Spread a DAG's task pods across failure domains (zones, nodes). Each entry is a Kubernetes TopologySpreadConstraint.",
+              "items": {
+                "type": "object"
+              }
+            },
+            "affinity": {
+              "type": "object",
+              "description": "Pins or repels a task pod relative to nodes and other pods (node/pod affinity and anti-affinity). A Kubernetes Affinity object."
+            },
+            "resource_claims": {
+              "type": "array",
+              "description": "Pod-level ResourceClaims for Dynamic Resource Allocation (DRA, GA in Kubernetes 1.34) — e.g. a GPU from a claim template. Each entry is a Kubernetes PodResourceClaim; a container consumes one via resources.claims.",
+              "items": {
+                "type": "object"
+              }
+            },
+            "labels": {
+              "type": "object",
+              "description": "Operator-declared pod labels merged onto the task pod. Leoflow's own leoflow.io/* labels win any key collision.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "annotations": {
+              "type": "object",
+              "description": "Operator-declared pod annotations merged onto the task pod. Leoflow's own task-instance-id annotation wins any key collision.",
+              "additionalProperties": {
+                "type": "string"
+              }
             }
           }
         },
@@ -350,6 +402,10 @@
         "memory": {
           "type": "string",
           "description": "Kubernetes-style: '512Mi', '2Gi'."
+        },
+        "ephemeral_storage": {
+          "type": "string",
+          "description": "Kubernetes-style node-local scratch limit, e.g. '2Gi'. Bounds writable-layer/emptyDir/log usage so a runaway task cannot evict neighbors under disk pressure (ADR 0054)."
         }
       },
       "additionalProperties": false

--- a/internal/domain/schemas/leoflow-yaml-schema.json
+++ b/internal/domain/schemas/leoflow-yaml-schema.json
@@ -207,7 +207,8 @@
                 "type": "object",
                 "properties": {
                   "cpu": { "type": "string" },
-                  "memory": { "type": "string" }
+                  "memory": { "type": "string" },
+                  "ephemeral_storage": { "type": "string", "description": "Node-local scratch limit, e.g. '2Gi' (ADR 0054)." }
                 },
                 "additionalProperties": false
               },
@@ -215,9 +216,15 @@
                 "type": "object",
                 "properties": {
                   "cpu": { "type": "string" },
-                  "memory": { "type": "string" }
+                  "memory": { "type": "string" },
+                  "ephemeral_storage": { "type": "string", "description": "Node-local scratch limit, e.g. '2Gi' (ADR 0054)." }
                 },
                 "additionalProperties": false
+              },
+              "claims": {
+                "type": "array",
+                "description": "Dynamic Resource Allocation: the pod-level resource_claims this container consumes (DRA, GA in Kubernetes 1.34).",
+                "items": { "type": "object" }
               }
             },
             "additionalProperties": false
@@ -231,7 +238,15 @@
               },
               "tolerations": { "type": "array" },
               "service_account": { "type": "string" },
-              "image_pull_policy": { "type": "string" }
+              "image_pull_policy": { "type": "string" },
+              "priority_class_name": { "type": "string", "description": "Ranks the task pod against neighbors on a shared cluster; the PriorityClass is platform-owned (ADR 0054)." },
+              "termination_grace_period_seconds": { "type": "integer", "minimum": 0, "description": "Seconds to shut down before SIGKILL; omit for the cluster default." },
+              "runtime_class_name": { "type": "string", "description": "Alternate container runtime registered as a RuntimeClass (e.g. sandboxed/GPU)." },
+              "topology_spread_constraints": { "type": "array", "description": "Spread task pods across failure domains; Kubernetes TopologySpreadConstraint entries." },
+              "affinity": { "type": "object", "description": "Node/pod affinity and anti-affinity; a Kubernetes Affinity object." },
+              "resource_claims": { "type": "array", "description": "Pod-level ResourceClaims for Dynamic Resource Allocation (DRA, GA in Kubernetes 1.34)." },
+              "labels": { "type": "object", "additionalProperties": { "type": "string" }, "description": "Pod labels merged onto the task pod; Leoflow's leoflow.io/* labels win collisions." },
+              "annotations": { "type": "object", "additionalProperties": { "type": "string" }, "description": "Pod annotations merged onto the task pod; Leoflow's task-instance-id annotation wins collisions." }
             },
             "additionalProperties": false
           }

--- a/internal/executor/kubernetes.go
+++ b/internal/executor/kubernetes.go
@@ -81,6 +81,17 @@ func BuildPod(req Request) *corev1.Pod {
 			RestartPolicy: corev1.RestartPolicyNever,
 			NodeSelector:  req.Execution.NodeSelector,
 			Tolerations:   buildTolerations(req.Execution.Tolerations),
+			// Placement and scheduling passthrough for a shared cluster (ADR 0054):
+			// pin/spread/prioritize task pods and run accelerator (DRA) DAGs. Each
+			// is applied verbatim from the declaration, mirroring tolerations; a
+			// value left unset stays the zero value so a DAG that declares none is
+			// byte-identical to today.
+			PriorityClassName:             req.Execution.PriorityClassName,
+			TerminationGracePeriodSeconds: req.Execution.TerminationGracePeriodSeconds,
+			RuntimeClassName:              req.Execution.RuntimeClassName,
+			TopologySpreadConstraints:     decodeStructuredSlice[corev1.TopologySpreadConstraint](req.Execution.TopologySpreadConstraints),
+			Affinity:                      buildAffinity(req.Execution.Affinity),
+			ResourceClaims:                decodeStructuredSlice[corev1.PodResourceClaim](req.Execution.ResourceClaims),
 			// The task pod authenticates to the control plane with its own
 			// per-task token over gRPC and never calls the Kubernetes API, so a
 			// mounted ServiceAccount token is a credential handed to untrusted
@@ -111,6 +122,8 @@ func BuildPod(req Request) *corev1.Pod {
 	if req.Execution.ServiceAccount != "" {
 		pod.Spec.ServiceAccountName = req.Execution.ServiceAccount
 	}
+	mergeMetadata(pod.Labels, req.Execution.Labels)
+	mergeMetadata(pod.Annotations, req.Execution.Annotations)
 	mountStagingVolume(pod, req)
 	mountAgentTLSCA(pod, req)
 	mountTaskSecret(pod, req)
@@ -238,32 +251,74 @@ func ptr[T any](v T) *T { return &v }
 //
 // readOnlyRootFilesystem is opt-in for a different reason: `restricted` never
 // asks for it, and turning it on by default breaks any task that writes to /tmp.
-// buildTolerations converts a task's declared tolerations — an untyped
-// []map[string]any carried verbatim from the DAG spec — into typed pod
-// tolerations via a JSON round-trip (the map keys match corev1.Toleration's JSON
-// field names). A malformed entry is skipped rather than failing the whole pod
-// build, matching how BuildPod treats other optional placement hints. Returns nil
-// when none are declared, so the field stays unset for a DAG that declares none.
-func buildTolerations(raw []map[string]any) []corev1.Toleration {
+// decodeStructured converts one untyped map — carried verbatim from the DAG spec
+// — into a typed Kubernetes object via a JSON round-trip (the map keys match the
+// target type's JSON field names). ok is false when the entry cannot be
+// marshaled or decoded, so callers skip it rather than failing the whole pod
+// build, matching how BuildPod treats other optional placement hints.
+func decodeStructured[T any](m map[string]any) (out T, ok bool) {
+	b, err := json.Marshal(m)
+	if err != nil {
+		return out, false
+	}
+	if err := json.Unmarshal(b, &out); err != nil {
+		return out, false
+	}
+	return out, true
+}
+
+// decodeStructuredSlice maps decodeStructured over a slice of untyped entries,
+// skipping malformed ones. It returns nil when none are declared or none survive,
+// so the field stays unset for a DAG that declares none.
+func decodeStructuredSlice[T any](raw []map[string]any) []T {
 	if len(raw) == 0 {
 		return nil
 	}
-	out := make([]corev1.Toleration, 0, len(raw))
+	out := make([]T, 0, len(raw))
 	for _, m := range raw {
-		b, err := json.Marshal(m)
-		if err != nil {
-			continue
+		if v, ok := decodeStructured[T](m); ok {
+			out = append(out, v)
 		}
-		var t corev1.Toleration
-		if err := json.Unmarshal(b, &t); err != nil {
-			continue
-		}
-		out = append(out, t)
 	}
 	if len(out) == 0 {
 		return nil
 	}
 	return out
+}
+
+// buildTolerations converts a task's declared tolerations — an untyped
+// []map[string]any carried verbatim from the DAG spec — into typed pod
+// tolerations via a JSON round-trip. A malformed entry is skipped and omission
+// stays unset (nil).
+func buildTolerations(raw []map[string]any) []corev1.Toleration {
+	return decodeStructuredSlice[corev1.Toleration](raw)
+}
+
+// buildAffinity converts a task's declared affinity — an untyped map[string]any
+// carried verbatim from the DAG spec — into a typed *corev1.Affinity via a JSON
+// round-trip. Returns nil when none is declared or the entry is malformed, so the
+// field stays unset for a DAG that declares none.
+func buildAffinity(m map[string]any) *corev1.Affinity {
+	if len(m) == 0 {
+		return nil
+	}
+	if v, ok := decodeStructured[corev1.Affinity](m); ok {
+		return &v
+	}
+	return nil
+}
+
+// mergeMetadata overlays operator-declared labels or annotations onto Leoflow's
+// own pod metadata, but Leoflow's keys always win a collision: the leoflow.io/*
+// identity labels and the task-instance-id annotation are load-bearing (the
+// reconciler and terminate path select on them), so a DAG cannot shadow them. The
+// own map is mutated in place; a nil declared map is a no-op.
+func mergeMetadata(own, declared map[string]string) {
+	for k, v := range declared {
+		if _, taken := own[k]; !taken {
+			own[k] = v
+		}
+	}
 }
 
 func buildSecurityContext(ps PodSecurity) *corev1.SecurityContext {
@@ -284,21 +339,30 @@ func buildSecurityContext(ps PodSecurity) *corev1.SecurityContext {
 func buildResources(r domain.Resources) corev1.ResourceRequirements {
 	out := corev1.ResourceRequirements{}
 	if r.Requests != nil {
-		out.Requests = quantities(r.Requests.CPU, r.Requests.Memory)
+		out.Requests = quantities(*r.Requests)
 	}
 	if r.Limits != nil {
-		out.Limits = quantities(r.Limits.CPU, r.Limits.Memory)
+		out.Limits = quantities(*r.Limits)
 	}
+	// Container-side Dynamic Resource Allocation: the claims (declared pod-level in
+	// Execution.ResourceClaims) this container consumes (ADR 0054).
+	out.Claims = decodeStructuredSlice[corev1.ResourceClaim](r.Claims)
 	return out
 }
 
-func quantities(cpu, memory string) corev1.ResourceList {
+func quantities(q domain.ResourceQuantity) corev1.ResourceList {
 	list := corev1.ResourceList{}
-	if q, err := resource.ParseQuantity(cpu); err == nil && cpu != "" {
-		list[corev1.ResourceCPU] = q
-	}
-	if q, err := resource.ParseQuantity(memory); err == nil && memory != "" {
-		list[corev1.ResourceMemory] = q
+	for name, value := range map[corev1.ResourceName]string{
+		corev1.ResourceCPU:              q.CPU,
+		corev1.ResourceMemory:           q.Memory,
+		corev1.ResourceEphemeralStorage: q.EphemeralStorage,
+	} {
+		if value == "" {
+			continue
+		}
+		if parsed, err := resource.ParseQuantity(value); err == nil {
+			list[name] = parsed
+		}
 	}
 	if len(list) == 0 {
 		return nil

--- a/internal/executor/kubernetes_test.go
+++ b/internal/executor/kubernetes_test.go
@@ -119,6 +119,198 @@ func TestBuildPodPinsTerminationMessagePolicy(t *testing.T) {
 	}
 }
 
+// TestBuildPodAppliesPriorityClassName locks the shared-cluster preemption knob
+// (ADR 0054): a declared PriorityClassName must land on the PodSpec so the
+// scheduler preempts Leoflow's ETL, not production, under contention.
+func TestBuildPodAppliesPriorityClassName(t *testing.T) {
+	req := sampleReq()
+	req.Execution.PriorityClassName = "leoflow-batch"
+	if got := BuildPod(req).Spec.PriorityClassName; got != "leoflow-batch" {
+		t.Errorf("PriorityClassName = %q, want leoflow-batch", got)
+	}
+	// Omission stays the empty zero value (byte-identical to today).
+	if got := BuildPod(sampleReq()).Spec.PriorityClassName; got != "" {
+		t.Errorf("PriorityClassName = %q, want empty when none declared", got)
+	}
+}
+
+// TestBuildPodAppliesTerminationGracePeriod asserts a declared grace period lands
+// on the PodSpec, and omission leaves it nil (cluster default).
+func TestBuildPodAppliesTerminationGracePeriod(t *testing.T) {
+	req := sampleReq()
+	req.Execution.TerminationGracePeriodSeconds = ptr(int64(45))
+	got := BuildPod(req).Spec.TerminationGracePeriodSeconds
+	if got == nil || *got != 45 {
+		t.Errorf("TerminationGracePeriodSeconds = %v, want 45", got)
+	}
+	if got := BuildPod(sampleReq()).Spec.TerminationGracePeriodSeconds; got != nil {
+		t.Errorf("TerminationGracePeriodSeconds = %v, want nil when none declared", got)
+	}
+}
+
+// TestBuildPodAppliesRuntimeClassName asserts a declared RuntimeClassName lands on
+// the PodSpec (e.g. a sandboxed or GPU runtime), and omission leaves it nil.
+func TestBuildPodAppliesRuntimeClassName(t *testing.T) {
+	req := sampleReq()
+	req.Execution.RuntimeClassName = ptr("gvisor")
+	got := BuildPod(req).Spec.RuntimeClassName
+	if got == nil || *got != "gvisor" {
+		t.Errorf("RuntimeClassName = %v, want gvisor", got)
+	}
+	if got := BuildPod(sampleReq()).Spec.RuntimeClassName; got != nil {
+		t.Errorf("RuntimeClassName = %v, want nil when none declared", got)
+	}
+}
+
+// TestBuildPodAppliesTopologySpreadConstraints locks the JSON round-trip of the
+// untyped spread constraints onto typed pod constraints. A malformed entry is
+// skipped, and omission stays nil.
+func TestBuildPodAppliesTopologySpreadConstraints(t *testing.T) {
+	req := sampleReq()
+	req.Execution.TopologySpreadConstraints = []map[string]any{
+		{
+			"maxSkew":           1,
+			"topologyKey":       "topology.kubernetes.io/zone",
+			"whenUnsatisfiable": "DoNotSchedule",
+			"labelSelector":     map[string]any{"matchLabels": map[string]any{"leoflow.io/dag-id": "etl"}},
+		},
+	}
+	tscs := BuildPod(req).Spec.TopologySpreadConstraints
+	if len(tscs) != 1 {
+		t.Fatalf("topologySpreadConstraints = %v, want 1", tscs)
+	}
+	if tscs[0].MaxSkew != 1 || tscs[0].TopologyKey != "topology.kubernetes.io/zone" ||
+		tscs[0].WhenUnsatisfiable != corev1.DoNotSchedule {
+		t.Errorf("topologySpreadConstraints[0] = %+v", tscs[0])
+	}
+	if tscs[0].LabelSelector == nil || tscs[0].LabelSelector.MatchLabels["leoflow.io/dag-id"] != "etl" {
+		t.Errorf("labelSelector not round-tripped: %+v", tscs[0].LabelSelector)
+	}
+	// Omission stays nil.
+	if tscs := BuildPod(sampleReq()).Spec.TopologySpreadConstraints; tscs != nil {
+		t.Errorf("topologySpreadConstraints = %v, want nil when none declared", tscs)
+	}
+}
+
+// TestBuildPodAppliesAffinity locks the JSON round-trip of the untyped affinity
+// object onto *corev1.Affinity, and asserts omission stays nil.
+func TestBuildPodAppliesAffinity(t *testing.T) {
+	req := sampleReq()
+	req.Execution.Affinity = map[string]any{
+		"nodeAffinity": map[string]any{
+			"requiredDuringSchedulingIgnoredDuringExecution": map[string]any{
+				"nodeSelectorTerms": []any{
+					map[string]any{
+						"matchExpressions": []any{
+							map[string]any{"key": "accelerator", "operator": "In", "values": []any{"gpu"}},
+						},
+					},
+				},
+			},
+		},
+	}
+	aff := BuildPod(req).Spec.Affinity
+	if aff == nil || aff.NodeAffinity == nil || aff.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		t.Fatalf("affinity not round-tripped: %+v", aff)
+	}
+	terms := aff.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(terms) != 1 || len(terms[0].MatchExpressions) != 1 || terms[0].MatchExpressions[0].Key != "accelerator" {
+		t.Errorf("nodeAffinity term = %+v", terms)
+	}
+	// Omission stays nil.
+	if aff := BuildPod(sampleReq()).Spec.Affinity; aff != nil {
+		t.Errorf("affinity = %v, want nil when none declared", aff)
+	}
+}
+
+// TestBuildPodAppliesResourceClaims locks Dynamic Resource Allocation passthrough
+// (DRA, GA in Kubernetes 1.34): pod-level ResourceClaims and the container's
+// resources.claims that reference them, both round-tripped from the untyped spec.
+func TestBuildPodAppliesResourceClaims(t *testing.T) {
+	req := sampleReq()
+	req.Execution.ResourceClaims = []map[string]any{
+		{"name": "gpu", "resourceClaimTemplateName": "single-gpu"},
+	}
+	req.Resources.Claims = []map[string]any{
+		{"name": "gpu", "request": "gpu-req"},
+	}
+	pod := BuildPod(req)
+	claims := pod.Spec.ResourceClaims
+	if len(claims) != 1 || claims[0].Name != "gpu" ||
+		claims[0].ResourceClaimTemplateName == nil || *claims[0].ResourceClaimTemplateName != "single-gpu" {
+		t.Fatalf("pod resourceClaims = %+v", claims)
+	}
+	cclaims := pod.Spec.Containers[0].Resources.Claims
+	if len(cclaims) != 1 || cclaims[0].Name != "gpu" || cclaims[0].Request != "gpu-req" {
+		t.Errorf("container resources.claims = %+v", cclaims)
+	}
+	// Omission stays nil on both.
+	base := BuildPod(sampleReq())
+	if base.Spec.ResourceClaims != nil {
+		t.Errorf("pod resourceClaims = %v, want nil when none declared", base.Spec.ResourceClaims)
+	}
+	if base.Spec.Containers[0].Resources.Claims != nil {
+		t.Errorf("container resources.claims = %v, want nil when none declared", base.Spec.Containers[0].Resources.Claims)
+	}
+}
+
+// TestBuildPodAppliesEphemeralStorage asserts ephemeral-storage requests/limits
+// reach the container ResourceList, so a runaway task cannot evict its neighbors
+// under disk pressure (ADR 0054). Omission leaves the key absent.
+func TestBuildPodAppliesEphemeralStorage(t *testing.T) {
+	req := sampleReq()
+	req.Resources = domain.Resources{
+		Requests: &domain.ResourceQuantity{CPU: "500m", Memory: "512Mi", EphemeralStorage: "1Gi"},
+		Limits:   &domain.ResourceQuantity{EphemeralStorage: "2Gi"},
+	}
+	c := BuildPod(req).Spec.Containers[0]
+	if got := c.Resources.Requests[corev1.ResourceEphemeralStorage]; got.String() != "1Gi" {
+		t.Errorf("requests ephemeral-storage = %q, want 1Gi", got.String())
+	}
+	if got := c.Resources.Limits[corev1.ResourceEphemeralStorage]; got.String() != "2Gi" {
+		t.Errorf("limits ephemeral-storage = %q, want 2Gi", got.String())
+	}
+	// Omission: sampleReq declares no ephemeral-storage, so the key is absent.
+	base := BuildPod(sampleReq()).Spec.Containers[0]
+	if _, ok := base.Resources.Requests[corev1.ResourceEphemeralStorage]; ok {
+		t.Error("ephemeral-storage present when none declared")
+	}
+}
+
+// TestBuildPodMergesLabelsAndAnnotations asserts operator-declared labels and
+// annotations are merged onto the task pod, but Leoflow's own leoflow.io/* labels
+// and the task-instance-id annotation win any key collision — a DAG must not be
+// able to shadow the identity the reconciler and terminate path select on.
+func TestBuildPodMergesLabelsAndAnnotations(t *testing.T) {
+	req := sampleReq()
+	req.Execution.Labels = map[string]string{
+		"team":              "data-eng",
+		"leoflow.io/dag-id": "hijacked", // collision: Leoflow must win
+	}
+	req.Execution.Annotations = map[string]string{
+		"cost-center":                 "1234",
+		"leoflow.io/task-instance-id": "hijacked", // collision: Leoflow must win
+	}
+	pod := BuildPod(req)
+	if pod.Labels["team"] != "data-eng" {
+		t.Errorf("declared label not merged: %v", pod.Labels)
+	}
+	if pod.Labels["leoflow.io/dag-id"] != "etl" {
+		t.Errorf("Leoflow label overridden by DAG: %q, want etl", pod.Labels["leoflow.io/dag-id"])
+	}
+	if pod.Annotations["cost-center"] != "1234" {
+		t.Errorf("declared annotation not merged: %v", pod.Annotations)
+	}
+	if pod.Annotations["leoflow.io/task-instance-id"] != "ti-1" {
+		t.Errorf("Leoflow annotation overridden by DAG: %q, want ti-1", pod.Annotations["leoflow.io/task-instance-id"])
+	}
+	// Omission leaves only Leoflow's own metadata (5 labels, 1 annotation).
+	base := BuildPod(sampleReq())
+	if len(base.Labels) != 5 || len(base.Annotations) != 1 {
+		t.Errorf("unexpected base metadata: labels=%v annotations=%v", base.Labels, base.Annotations)
+	}
+}
+
 func TestBuildPodMountsStagingVolume(t *testing.T) {
 	// Without a staging claim, no extra volume is added.
 	if vols := BuildPod(sampleReq()).Spec.Volumes; len(vols) != 0 {


### PR DESCRIPTION
## What
Complete the task-pod scheduling passthrough (extends PR-1's tolerations fix). `BuildPod` now applies every placement/scheduling field a shared cluster needs, all previously declared-but-dropped:
`priorityClassName`, `terminationGracePeriodSeconds`, `runtimeClassName`, `topologySpreadConstraints`, `affinity`, **`resourceClaims` (DRA, GA k8s 1.34)**, **`ephemeral-storage`** (requests/limits), and custom **labels/annotations** merge (Leoflow's `leoflow.io/*` + task-instance-id win collisions).

## How
Structured untyped fields reuse PR-1's JSON-round-trip (factored into `decodeStructured[T]`/`decodeStructuredSlice[T]`; `buildTolerations` delegates). k8s types verified vs `k8s.io/api v0.36.3`. `quantities()` reworked to cover ephemeral-storage; `validateResourceQuantities` rejects an unparseable one. Both JSON schemas (embedded + `docs/api/`) updated (they're `additionalProperties:false`).

## Tests (strict TDD, two commits)
Per-field red→green (8 fields); each asserts omission stays unset (byte-identical to today) and Leoflow labels/annotations win collisions. `gofmt`/`go vet`/golangci-lint (repo) 0; `internal/domain`+`internal/executor`+`internal/dispatch` green.

## Lite containment
K8s-executor-only (`BuildPod`/`quantities`) + additive domain fields Lite ignores (`subprocess.go` references none). Confirmed.

## Design flag — operator allowlist deferred (see follow-up)
Implemented as declared→applied (like tolerations). A real **operator allowlist** (which placement fields a DAG author may set) needs a new config surface plumbed through `PlatformDefaultsSection`→`Request`→`BuildPod`; a default "allow-all" unwired to config would be dead code. Deferred to a dedicated follow-up — **it is a multi-tenancy control that gates multi-team production** (unconstrained `priorityClassName`/`affinity`/`tolerations` let a DAG author jump the queue or target another team's dedicated nodes).

Relates: ADR 0054, ADR 0053, #623, PR-1 #621.
