### PR TITLE
feat(scheduler): treat cluster backpressure as retriable-forever, off budget

### DIFF
--- a/internal/scheduler/dispatch_backpressure_test.go
+++ b/internal/scheduler/dispatch_backpressure_test.go
@@ -1,0 +1,74 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// A retriable-forever dispatch failure (cluster backpressure) must back the task
+// off WITHOUT advancing DispatchAttempts toward the cap and must NEVER fail the
+// task as dispatch_failed — even when the task's dispatch-attempt counter has
+// already reached the exhaustion budget. This is the load-bearing guarantee of
+// ADR 0053: backpressure never drives a task terminal, no matter how long the
+// cluster stays full.
+func TestStepBackpressureRetriesForeverOffBudget(t *testing.T) {
+	store := newFakeStore(RunState{
+		RunID: "r1", DagID: "etl", State: domain.DagRunStateRunning, Tasks: linearTasks(),
+		States: map[string]domain.TaskState{"a": domain.TaskStateScheduled, "b": domain.TaskStateNone},
+		// Already at the budget: a permanent error here would fail the task this
+		// tick. A backpressure error must not.
+		DispatchAttempts: map[string]int{"a": dispatchMaxAttempts},
+	})
+	quota := apierrors.NewForbidden(podsGR, "etl-a-0", errors.New(
+		"exceeded quota: compute-resources, requested: requests.cpu=1, used: requests.cpu=4, limited: requests.cpu=4"))
+	d := &fakeDispatcher{err: fmt.Errorf("creating pod for task a: %w", quota)}
+	s := newScheduler(store)
+	s.SetDispatcher(d)
+
+	if err := s.Step(context.Background()); err != nil {
+		t.Fatalf("a dispatch failure must not abort the step: %v", err)
+	}
+	if len(store.dispatchExhausted) != 0 {
+		t.Errorf("backpressure must NEVER fail the task as dispatch_failed, got %v", store.dispatchExhausted)
+	}
+	if len(store.dispatchBackpressure) != 1 || store.dispatchBackpressure[0].taskID != "a" {
+		t.Errorf("backpressure should record a no-increment backoff for task a, got %v", store.dispatchBackpressure)
+	}
+	if len(store.dispatchFailures) != 0 {
+		t.Errorf("backpressure must NOT use the attempt-incrementing dispatch-failure path, got %v", store.dispatchFailures)
+	}
+	if len(store.transitions) != 0 {
+		t.Errorf("a backed-off dispatch must not transition the task, got %v", store.transitions)
+	}
+}
+
+// A permanent dispatch error at the same already-exhausted counter DOES fail the
+// task, proving the off-budget behavior above is specific to backpressure and the
+// bounded path is unchanged for everything else.
+func TestStepPermanentErrorStillExhausts(t *testing.T) {
+	store := newFakeStore(RunState{
+		RunID: "r1", DagID: "etl", State: domain.DagRunStateRunning, Tasks: linearTasks(),
+		States:           map[string]domain.TaskState{"a": domain.TaskStateScheduled, "b": domain.TaskStateNone},
+		DispatchAttempts: map[string]int{"a": dispatchMaxAttempts - 1},
+	})
+	rbac := apierrors.NewForbidden(podsGR, "", errors.New(
+		`cannot create resource "pods" in API group "" in the namespace "prod"`))
+	d := &fakeDispatcher{err: fmt.Errorf("creating pod for task a: %w", rbac)}
+	s := newScheduler(store)
+	s.SetDispatcher(d)
+
+	if err := s.Step(context.Background()); err != nil {
+		t.Fatalf("dispatch exhaustion must not abort the step: %v", err)
+	}
+	if len(store.dispatchExhausted) != 1 || store.dispatchExhausted[0] != "a" {
+		t.Errorf("a permanent RBAC denial at the budget should fail task a, got %v", store.dispatchExhausted)
+	}
+	if len(store.dispatchBackpressure) != 0 {
+		t.Errorf("a permanent error must not take the backpressure path, got %v", store.dispatchBackpressure)
+	}
+}

--- a/internal/scheduler/dispatch_classify.go
+++ b/internal/scheduler/dispatch_classify.go
@@ -1,0 +1,80 @@
+package scheduler
+
+import (
+	"strings"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// dispatchErrorClass tells the planner why a synchronous dispatch failed, so it
+// can hold transient cluster backpressure apart from a permanent condition. See
+// ADR 0053.
+type dispatchErrorClass int
+
+const (
+	// dispatchPermanent is a dispatch failure that will not clear on its own: an
+	// invalid image, an RBAC denial, an admission-webhook rejection, a bad spec,
+	// or any error the classifier does not recognize (including every error a Lite
+	// subprocess executor can return). It keeps the historical bounded-backoff →
+	// dispatch_failed behavior (ADR 0031 Amendment A).
+	dispatchPermanent dispatchErrorClass = iota
+	// dispatchRetriableForever is a dispatch failure caused by transient cluster
+	// backpressure from the Kubernetes apiserver — a ResourceQuota 403 or an API
+	// Priority & Fairness 429 — that clears once the cluster has headroom again.
+	// It is backed off and re-offered indefinitely, never counts against the
+	// dispatch-attempt budget, and never drives a task to dispatch_failed: the
+	// cluster asking Leoflow to slow down is not the user's task failing.
+	dispatchRetriableForever
+)
+
+// classifyDispatchError decides whether a synchronous dispatch failure is
+// transient cluster backpressure (retry forever, off the attempt budget) or a
+// permanent condition (bounded retry → dispatch_failed). Only Kubernetes
+// apiserver error types can yield the retriable-forever verdict; every other
+// error is permanent, which preserves today's path exactly for the Lite
+// subprocess executor — its errors are never apiserver StatusErrors, so its
+// dispatch handling is unreachable by the retriable-forever branch (ADR 0053).
+//
+// The two backpressure signals:
+//   - 429 Too Many Requests: API Priority & Fairness shed the request. Always
+//     transient.
+//   - 403 Forbidden carrying the ResourceQuota admission plugin's "exceeded
+//     quota" marker: the namespace quota is full. Transient — it clears as the
+//     namespace's running pods complete.
+//
+// A 403 Forbidden WITHOUT the quota marker is an RBAC denial: permanent, and
+// deliberately not conflated with quota (apierrors.IsForbidden covers both — the
+// message is the only discriminator). An admission-webhook rejection ("denied the
+// request") also arrives as Forbidden and is likewise treated as permanent: a
+// webhook that rejects a spec rejects every re-offer of that same spec, so
+// retrying forever would loop silently — a bounded retry surfaces it as
+// dispatch_failed instead. A genuinely transient webhook (call timeout under a
+// Fail policy) is not special-cased; it falls to the permanent default, matching
+// today's behavior, rather than risking an infinite re-offer loop on a poison
+// spec.
+func classifyDispatchError(err error) dispatchErrorClass {
+	if err == nil {
+		// Not a real input: handleDispatchFailure is only called on a non-nil
+		// dispatch error. Guarded so the classifier is total and defaults to the
+		// safe (bounded) path.
+		return dispatchPermanent
+	}
+	if apierrors.IsTooManyRequests(err) {
+		return dispatchRetriableForever
+	}
+	if apierrors.IsForbidden(err) && isQuotaExceeded(err) {
+		return dispatchRetriableForever
+	}
+	return dispatchPermanent
+}
+
+// isQuotaExceeded reports whether a Forbidden error is a ResourceQuota rejection
+// rather than an RBAC denial. Both surface as reason=Forbidden, so the message is
+// the discriminator: the ResourceQuota admission plugin formats its rejection as
+// "exceeded quota: <name>, requested: ...", while an RBAC denial reads "... cannot
+// create resource ...", which lacks the marker. The caller gates this on
+// IsForbidden, so a non-apiserver error whose text merely mentions quota can
+// never reach it.
+func isQuotaExceeded(err error) bool {
+	return strings.Contains(strings.ToLower(err.Error()), "exceeded quota")
+}

--- a/internal/scheduler/dispatch_classify_test.go
+++ b/internal/scheduler/dispatch_classify_test.go
@@ -1,0 +1,74 @@
+package scheduler
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// podsGR is the GroupResource a pod CREATE is rejected against, matching what the
+// apiserver puts in a real ResourceQuota / RBAC Forbidden status.
+var podsGR = schema.GroupResource{Group: "", Resource: "pods"}
+
+// quota403 builds the Forbidden error the ResourceQuota admission plugin returns
+// when a pod CREATE would breach a namespace quota: reason=Forbidden, message
+// carrying the canonical "exceeded quota:" marker.
+func quota403() error {
+	return apierrors.NewForbidden(podsGR, "etl-a-0-abcd1234", errors.New(
+		"exceeded quota: compute-resources, requested: requests.cpu=1, used: requests.cpu=4, limited: requests.cpu=4"))
+}
+
+// rbac403 builds the Forbidden error the apiserver returns when RBAC denies the
+// pod CREATE: reason=Forbidden as well, but the message is an authorization
+// denial with no quota marker — the case the classifier must NOT conflate.
+func rbac403() error {
+	return apierrors.NewForbidden(podsGR, "", errors.New(
+		`User "system:serviceaccount:leoflow:executor" cannot create resource "pods" in API group "" in the namespace "prod"`))
+}
+
+// admissionDenied builds a validating-admission-webhook rejection. The apiserver
+// surfaces it as Forbidden with the canonical "denied the request" phrasing.
+func admissionDenied() error {
+	return &apierrors.StatusError{ErrStatus: metav1.Status{
+		Status:  metav1.StatusFailure,
+		Code:    403,
+		Reason:  metav1.StatusReasonForbidden,
+		Message: `admission webhook "validate.example.com" denied the request: pods using hostNetwork are not allowed`,
+	}}
+}
+
+// TestClassifyDispatchError pins the classification each dispatch-failure shape
+// gets: only genuine cluster backpressure (quota 403, APF 429) is
+// retriable-forever; RBAC denials, admission-webhook rejections, and every
+// unrecognized error keep the permanent (bounded → dispatch_failed) path.
+func TestClassifyDispatchError(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want dispatchErrorClass
+	}{
+		{"quota_403_retriable", quota403(), dispatchRetriableForever},
+		{"quota_403_wrapped_retriable", fmt.Errorf("creating pod for task a: %w", quota403()), dispatchRetriableForever},
+		{"apf_429_retriable", apierrors.NewTooManyRequests("Priority and Fairness: request rejected", 1), dispatchRetriableForever},
+		{"apf_429_wrapped_retriable", fmt.Errorf("creating pod for task a: %w", apierrors.NewTooManyRequests("APF", 1)), dispatchRetriableForever},
+		{"rbac_403_permanent", rbac403(), dispatchPermanent},
+		{"admission_denied_permanent", admissionDenied(), dispatchPermanent},
+		{"invalid_spec_permanent", apierrors.NewInvalid(schema.GroupKind{Kind: "Pod"}, "a", nil), dispatchPermanent},
+		{"generic_error_permanent", errors.New("kube-apiserver unreachable"), dispatchPermanent},
+		// A plain (non-apiserver) error whose text happens to mention quota must
+		// stay permanent: the quota verdict keys on the Forbidden status, never on
+		// message text alone, so a Lite subprocess error can never trip it.
+		{"non_apierror_quota_text_permanent", errors.New("job failed: exceeded quota on disk"), dispatchPermanent},
+		{"nil_permanent", nil, dispatchPermanent},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyDispatchError(tc.err); got != tc.want {
+				t.Errorf("classifyDispatchError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/scheduler/resilience_test.go
+++ b/internal/scheduler/resilience_test.go
@@ -90,6 +90,9 @@ func (f *flakyStore) RedispatchReschedule(context.Context, string, string) error
 func (f *flakyStore) RecordDispatchFailure(context.Context, string, string, time.Time) error {
 	return nil
 }
+func (f *flakyStore) RecordDispatchBackpressure(context.Context, string, string, time.Time) error {
+	return nil
+}
 func (f *flakyStore) FailDispatchExhausted(context.Context, string, string, string) error { return nil }
 
 func (f *flakyStore) SetRunState(_ context.Context, runID string, state domain.DagRunState) error {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -143,6 +143,12 @@ type Store interface {
 	// failure: it increments dispatch_attempts and sets next_dispatch_at so the
 	// planner does not re-attempt until the backoff elapses (ADR 0031 Amendment A).
 	RecordDispatchFailure(ctx context.Context, runID, taskID string, nextAt time.Time) error
+	// RecordDispatchBackpressure backs off a scheduled task after a retriable-
+	// forever cluster-backpressure dispatch failure (quota 403 / APF 429): it sets
+	// next_dispatch_at WITHOUT incrementing dispatch_attempts, so the task is
+	// re-offered once the backoff elapses but never accumulates toward the
+	// dispatch_failed cap (ADR 0053).
+	RecordDispatchBackpressure(ctx context.Context, runID, taskID string, nextAt time.Time) error
 	// FailDispatchExhausted fails a scheduled task as dispatch_failed once its
 	// dispatch-attempt budget is spent, so the run finalizes instead of looping.
 	FailDispatchExhausted(ctx context.Context, runID, taskID, reason string) error
@@ -941,7 +947,16 @@ func (s *Scheduler) launchQueued(ctx context.Context, run RunState, t PlannedTra
 // failure is recorded in the DB, not propagated, so one task's dispatch trouble
 // does not abort the tick. A dispatch failure is infrastructure, not a task
 // failure, so it never consumes the task's try_number.
+//
+// Cluster backpressure (a ResourceQuota 403 or an APF 429) is split out first
+// (ADR 0053): it is retriable-forever, so it is backed off WITHOUT touching the
+// dispatch-attempt counter and can never reach the dispatch_failed give-up below.
+// Leoflow holds the task and re-offers it until the cluster has room, rather than
+// failing the user's task because the cluster asked it to slow down.
 func (s *Scheduler) handleDispatchFailure(ctx context.Context, run RunState, taskID string, cause error) error {
+	if classifyDispatchError(cause) == dispatchRetriableForever {
+		return s.backoffBackpressure(ctx, run, taskID, cause)
+	}
 	attempts := run.DispatchAttempts[taskID] + 1
 	if attempts >= dispatchMaxAttempts {
 		reason := fmt.Sprintf("dispatch_failed after %d attempts: %v", attempts, cause)
@@ -961,6 +976,34 @@ func (s *Scheduler) handleDispatchFailure(ctx context.Context, run RunState, tas
 		"run", run.RunID, "task", taskID, "attempt", attempts, "next_dispatch_at", nextAt, "error", cause)
 	if err := s.store.RecordDispatchFailure(ctx, run.RunID, taskID, nextAt); err != nil {
 		s.logger.Error("recording dispatch failure", "run", run.RunID, "task", taskID, "error", err)
+	}
+	return nil
+}
+
+// backoffBackpressure handles a retriable-forever dispatch failure caused by
+// cluster backpressure (ADR 0053). It sets next_dispatch_at so the planner holds
+// the task `scheduled` and re-offers it once the backoff elapses, but it does NOT
+// increment dispatch_attempts — backpressure is a temporary "no room," not a
+// poison placement, so it must never accumulate toward the dispatch_failed cap.
+//
+// The backoff reuses dispatchBackoff over the task's EXISTING (un-incremented)
+// attempt count: a task hitting only backpressure keeps a steady base-interval
+// re-offer cadence rather than a growing one — the right trade-off for a
+// condition expected to clear, since it recovers fast when the cluster frees room
+// without hammering the apiserver every tick, and without inflating a counter
+// that could later fail the task. Returns nil: like every dispatch outcome, the
+// result is recorded, never propagated, so one task's backpressure cannot abort
+// the tick.
+func (s *Scheduler) backoffBackpressure(ctx context.Context, run RunState, taskID string, cause error) error {
+	now := run.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	nextAt := now.Add(dispatchBackoff(run.DispatchAttempts[taskID] + 1))
+	s.logger.Warn("dispatch hit cluster backpressure; backing off and re-offering (not counted against dispatch budget)",
+		"run", run.RunID, "task", taskID, "next_dispatch_at", nextAt, "error", cause)
+	if err := s.store.RecordDispatchBackpressure(ctx, run.RunID, taskID, nextAt); err != nil {
+		s.logger.Error("recording dispatch backpressure", "run", run.RunID, "task", taskID, "error", err)
 	}
 	return nil
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -20,25 +20,26 @@ type transition struct {
 }
 
 type fakeStore struct {
-	runs               []RunState
-	materialize        []string
-	transitions        []transition
-	retried            []transition
-	resetInfra         []transition
-	redispatched       []transition
-	runStates          map[string]domain.DagRunState
-	scheduled          []ScheduledDAG
-	createdRuns        []string
-	notes              map[string]string
-	reapCands          []ReapCandidate
-	reaped             []string
-	createErr          bool
-	agentLostCands     []AgentLostCandidate
-	agentLostMarked    []string
-	staleQueuedCands   []StaleQueuedCandidate
-	dispatchLostMarked []string
-	dispatchFailures   []transition
-	dispatchExhausted  []string
+	runs                 []RunState
+	materialize          []string
+	transitions          []transition
+	retried              []transition
+	resetInfra           []transition
+	redispatched         []transition
+	runStates            map[string]domain.DagRunState
+	scheduled            []ScheduledDAG
+	createdRuns          []string
+	notes                map[string]string
+	reapCands            []ReapCandidate
+	reaped               []string
+	createErr            bool
+	agentLostCands       []AgentLostCandidate
+	agentLostMarked      []string
+	staleQueuedCands     []StaleQueuedCandidate
+	dispatchLostMarked   []string
+	dispatchFailures     []transition
+	dispatchBackpressure []transition
+	dispatchExhausted    []string
 	// alertAttempts mirrors the real per-episode attempt claim: each call
 	// consumes one, and the claim is refused once the budget is spent or the
 	// episode is already delivered. Backoff is not simulated — the fake is for
@@ -91,6 +92,11 @@ func (f *fakeStore) ResetForInfraReplace(_ context.Context, runID, taskID string
 }
 func (f *fakeStore) RecordDispatchFailure(_ context.Context, runID, taskID string, _ time.Time) error {
 	f.dispatchFailures = append(f.dispatchFailures, transition{runID, taskID, ""})
+	return nil
+}
+
+func (f *fakeStore) RecordDispatchBackpressure(_ context.Context, runID, taskID string, _ time.Time) error {
+	f.dispatchBackpressure = append(f.dispatchBackpressure, transition{runID, taskID, ""})
 	return nil
 }
 

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -195,6 +195,16 @@ type Querier interface {
 	// late terminal report that landed between our list and our write (a live
 	// report wins over the reaper). Idempotent on a second call.
 	MarkTaskPodLost(ctx context.Context, id pgtype.UUID) (int64, error)
+	// A pod CREATE was refused by cluster backpressure — a ResourceQuota 403 or an
+	// API Priority & Fairness 429 (ADR 0053). Back off the next attempt to $3 WITHOUT
+	// touching dispatch_attempts: backpressure is a temporary "no room," retriable
+	// forever, and must never accumulate toward the dispatch_failed budget the way a
+	// permanent failure does (RecordDispatchFailure). The planner gates
+	// scheduled->queued on next_dispatch_at alone, so setting it holds and re-offers
+	// the task without a counter bump. Guarded to 'scheduled' for the same reason as
+	// RecordDispatchFailure; try_number is untouched — this is infra, not a task
+	// failure.
+	RecordDispatchBackpressure(ctx context.Context, arg RecordDispatchBackpressureParams) error
 	// A synchronous dispatch attempt failed (ADR 0031 Amendment A). Increment the
 	// consecutive-failure counter and back off the next attempt to $3, so the planner
 	// (which gates scheduled->queued on next_dispatch_at) does not re-attempt every

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -768,6 +768,20 @@ SET dispatch_attempts = dispatch_attempts + 1,
     next_dispatch_at = $3
 WHERE dag_run_id = $1 AND task_id = $2 AND state = 'scheduled';
 
+-- name: RecordDispatchBackpressure :exec
+-- A pod CREATE was refused by cluster backpressure — a ResourceQuota 403 or an
+-- API Priority & Fairness 429 (ADR 0053). Back off the next attempt to $3 WITHOUT
+-- touching dispatch_attempts: backpressure is a temporary "no room," retriable
+-- forever, and must never accumulate toward the dispatch_failed budget the way a
+-- permanent failure does (RecordDispatchFailure). The planner gates
+-- scheduled->queued on next_dispatch_at alone, so setting it holds and re-offers
+-- the task without a counter bump. Guarded to 'scheduled' for the same reason as
+-- RecordDispatchFailure; try_number is untouched — this is infra, not a task
+-- failure.
+UPDATE task_instances
+SET next_dispatch_at = $3
+WHERE dag_run_id = $1 AND task_id = $2 AND state = 'scheduled';
+
 -- name: FailDispatchExhausted :exec
 -- The dispatch-attempt budget is spent (ADR 0031 Amendment A): fail the task with
 -- a dispatch_failed reason so the run can finalize instead of looping forever.

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -1249,6 +1249,32 @@ func (q *Queries) MarkTaskPodLost(ctx context.Context, id pgtype.UUID) (int64, e
 	return result.RowsAffected(), nil
 }
 
+const recordDispatchBackpressure = `-- name: RecordDispatchBackpressure :exec
+UPDATE task_instances
+SET next_dispatch_at = $3
+WHERE dag_run_id = $1 AND task_id = $2 AND state = 'scheduled'
+`
+
+type RecordDispatchBackpressureParams struct {
+	DagRunID       pgtype.UUID        `json:"dag_run_id"`
+	TaskID         string             `json:"task_id"`
+	NextDispatchAt pgtype.Timestamptz `json:"next_dispatch_at"`
+}
+
+// A pod CREATE was refused by cluster backpressure — a ResourceQuota 403 or an
+// API Priority & Fairness 429 (ADR 0053). Back off the next attempt to $3 WITHOUT
+// touching dispatch_attempts: backpressure is a temporary "no room," retriable
+// forever, and must never accumulate toward the dispatch_failed budget the way a
+// permanent failure does (RecordDispatchFailure). The planner gates
+// scheduled->queued on next_dispatch_at alone, so setting it holds and re-offers
+// the task without a counter bump. Guarded to 'scheduled' for the same reason as
+// RecordDispatchFailure; try_number is untouched — this is infra, not a task
+// failure.
+func (q *Queries) RecordDispatchBackpressure(ctx context.Context, arg RecordDispatchBackpressureParams) error {
+	_, err := q.db.Exec(ctx, recordDispatchBackpressure, arg.DagRunID, arg.TaskID, arg.NextDispatchAt)
+	return err
+}
+
 const recordDispatchFailure = `-- name: RecordDispatchFailure :exec
 UPDATE task_instances
 SET dispatch_attempts = dispatch_attempts + 1,

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -273,6 +273,22 @@ func (s *SchedulerStore) RecordDispatchFailure(ctx context.Context, runID, taskI
 	})
 }
 
+// RecordDispatchBackpressure backs off a scheduled task after a retriable-forever
+// cluster-backpressure dispatch failure (quota 403 / APF 429), setting nextAt
+// WITHOUT incrementing dispatch_attempts so it never accumulates toward the
+// dispatch_failed cap (ADR 0053).
+func (s *SchedulerStore) RecordDispatchBackpressure(ctx context.Context, runID, taskID string, nextAt time.Time) error {
+	rid, err := parseUUID(runID)
+	if err != nil {
+		return err
+	}
+	return s.q.RecordDispatchBackpressure(ctx, queries.RecordDispatchBackpressureParams{
+		DagRunID:       rid,
+		TaskID:         taskID,
+		NextDispatchAt: pgtype.Timestamptz{Time: nextAt, Valid: true},
+	})
+}
+
 // FailDispatchExhausted fails a scheduled task as dispatch_failed once its
 // dispatch-attempt budget is spent (ADR 0031 Amendment A).
 func (s *SchedulerStore) FailDispatchExhausted(ctx context.Context, runID, taskID, reason string) error {


### PR DESCRIPTION
## What
Classify a dispatch failure caused by **cluster backpressure** — apiserver quota `403` / APF `429` / admission — as **retriable-forever, off the attempt budget**, so under pressure a task WAITS for capacity instead of → `dispatch_failed` (ADR 0053). A permanent error (RBAC, invalid spec, admission-deny) keeps today's bounded-backoff → `dispatch_failed`.

## How
`classifyDispatchError`: `IsTooManyRequests`(429) → retriable; `IsForbidden` + `"exceeded quota"` marker (marker **gated on IsForbidden**, so text alone can't trip it) → retriable; RBAC-403 / admission-denied / everything else → permanent. Retriable-forever routes to a new `RecordDispatchBackpressure` store method that sets `next_dispatch_at` **without incrementing `dispatch_attempts`** — `try_number` is never charged and the task can never reach the cap.

Admission-webhook = permanent (a poison spec rejected on every re-offer would loop silently; a bounded retry surfaces it as an operator-visible failure).

## Tests (strict TDD, two commits)
10-subtest classifier (quota/APF→retriable, RBAC/admission/generic/nil→permanent, wrapped variants) + `StepBackpressureRetriesForeverOffBudget` (at the cap, never `dispatch_failed`) + `StepPermanentErrorStillExhausts` (RBAC still exhausts). `-race` clean; golangci-lint 0; gocyclo ≤10.

## Lite containment
The retriable branch requires a `k8s.io/apimachinery` `*StatusError` (429 / quota-403), produced only by `KubernetesExecutor`. Lite's `SubprocessExecutor` returns only filesystem / exec-start errors — never a `StatusError` — so every Lite dispatch error classifies `permanent` and takes the exact pre-existing branch; `RecordDispatchBackpressure` is unreachable on Lite. Byte-identical. Traced.

Relates: ADR 0053, #623.
