### PR TITLE
feat(scheduler): per-DAG max_active_tasks admission gate (ADR 0053)

### DIFF
--- a/docs/api/dag-schema.json
+++ b/docs/api/dag-schema.json
@@ -71,6 +71,10 @@
       "minimum": 1,
       "default": 16
     },
+    "max_active_tasks": {
+      "type": "integer",
+      "minimum": 1
+    },
     "catchup": {
       "type": "boolean",
       "default": false

--- a/internal/domain/dag.go
+++ b/internal/domain/dag.go
@@ -58,20 +58,27 @@ const (
 // DAGSpec is the canonical serialized representation of a DAG consumed by the
 // control plane. It mirrors docs/api/dag-schema.json.
 type DAGSpec struct {
-	SchemaVersion string       `json:"schema_version"`
-	DagID         string       `json:"dag_id"`
-	DagVersion    string       `json:"dag_version"`
-	Image         string       `json:"image"`
-	Description   string       `json:"description,omitempty"`
-	Owner         string       `json:"owner,omitempty"`
-	Tags          []string     `json:"tags,omitempty"`
-	Schedule      *string      `json:"schedule,omitempty"`
-	ScheduleTZ    string       `json:"schedule_timezone,omitempty"`
-	StartDate     string       `json:"start_date,omitempty"`
-	EndDate       *string      `json:"end_date,omitempty"`
-	MaxActiveRuns int          `json:"max_active_runs,omitempty"`
-	Catchup       bool         `json:"catchup,omitempty"`
-	DefaultArgs   *DefaultArgs `json:"default_args,omitempty"`
+	SchemaVersion string   `json:"schema_version"`
+	DagID         string   `json:"dag_id"`
+	DagVersion    string   `json:"dag_version"`
+	Image         string   `json:"image"`
+	Description   string   `json:"description,omitempty"`
+	Owner         string   `json:"owner,omitempty"`
+	Tags          []string `json:"tags,omitempty"`
+	Schedule      *string  `json:"schedule,omitempty"`
+	ScheduleTZ    string   `json:"schedule_timezone,omitempty"`
+	StartDate     string   `json:"start_date,omitempty"`
+	EndDate       *string  `json:"end_date,omitempty"`
+	MaxActiveRuns int      `json:"max_active_runs,omitempty"`
+	// MaxActiveTasks caps how many of this DAG's task instances may be
+	// concurrently non-terminal (queued or running) across all of its active
+	// runs — Airflow's per-DAG max_active_tasks (ADR 0053 Stage 1). Zero (the
+	// default) means unlimited: a DAG that never sets it, and all of Lite, plans
+	// exactly as before. The scheduler enforces it in PlanRun's scheduled→queued
+	// admission gate.
+	MaxActiveTasks int          `json:"max_active_tasks,omitempty"`
+	Catchup        bool         `json:"catchup,omitempty"`
+	DefaultArgs    *DefaultArgs `json:"default_args,omitempty"`
 	// Staging, when enabled, requests an ephemeral RWX volume shared by the run's
 	// tasks at /staging (ADR 0022). nil/disabled means no staging volume.
 	Staging *StagingConfig `json:"staging,omitempty"`

--- a/internal/domain/schemas/dag-schema.json
+++ b/internal/domain/schemas/dag-schema.json
@@ -71,6 +71,10 @@
       "minimum": 1,
       "default": 16
     },
+    "max_active_tasks": {
+      "type": "integer",
+      "minimum": 1
+    },
     "catchup": {
       "type": "boolean",
       "default": false

--- a/internal/scheduler/plan.go
+++ b/internal/scheduler/plan.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"math"
 	"time"
 
 	"github.com/neochaotic/leoflow/internal/domain"
@@ -36,6 +37,12 @@ func PlanRun(run RunState) []PlannedTransition {
 
 	out = append(out, planRetryTransitions(run, effective, decided)...)
 
+	// Admission gate (ADR 0053 Stage 1): headroom is how many scheduled tasks may
+	// still be promoted to queued for this DAG this tick under max_active_tasks;
+	// promoted tracks what we spend against it. An unset cap yields math.MaxInt,
+	// so the gate never trips and the loop behaves exactly as before.
+	headroom := admissionHeadroom(run)
+	promoted := 0
 	for _, t := range run.Tasks {
 		if decided[t.TaskID] {
 			continue
@@ -51,12 +58,38 @@ func PlanRun(run RunState) []PlannedTransition {
 			if !readyToDispatch(run, t.TaskID) {
 				continue
 			}
+			if promoted >= headroom {
+				// DAG is at max_active_tasks: leave the task scheduled so a
+				// finishing sibling frees a slot and a later tick promotes it —
+				// the same "park it, downstream waits" discipline the retry and
+				// reschedule rails use.
+				continue
+			}
 			out = append(out, PlannedTransition{TaskID: t.TaskID, To: domain.TaskStateQueued})
+			promoted++
 		default:
 			// queued/running/terminal/up_for_retry: nothing to plan here.
 		}
 	}
 	return out
+}
+
+// admissionHeadroom returns how many more of this DAG's scheduled tasks PlanRun
+// may promote to queued this tick under the per-DAG max_active_tasks cap (ADR
+// 0053 Stage 1). A non-positive cap means unlimited — the gate is a no-op, so an
+// unset DAG (and all of Lite, which never sets the field) plans byte-identically
+// to today; math.MaxInt is the "unbounded" sentinel the promotion loop compares
+// against. Otherwise it is the cap minus the DAG's already-active (queued+
+// running) task instances, floored at zero (never negative, so a DAG over its
+// cap simply admits nothing rather than wrapping).
+func admissionHeadroom(run RunState) int {
+	if run.MaxActiveTasks <= 0 {
+		return math.MaxInt
+	}
+	if headroom := run.MaxActiveTasks - run.ActiveTaskCount; headroom > 0 {
+		return headroom
+	}
+	return 0
 }
 
 // planRetryTransitions handles the retry/reschedule rail: a failed task with

--- a/internal/scheduler/plan_test.go
+++ b/internal/scheduler/plan_test.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -365,5 +366,104 @@ func TestPlanRunSchedulesImmediatelyWithoutBackoff(t *testing.T) {
 	}
 	if got := planMap(run)["a"]; got != domain.TaskStateQueued {
 		t.Errorf("a scheduled task with no backoff should be queued, got %s", got)
+	}
+}
+
+// independent returns n root tasks with no dependencies — a fan-out whose tasks
+// are all simultaneously ready, the shape the per-DAG max_active_tasks cap
+// bounds (ADR 0053 Stage 1).
+func independent(n int) []domain.TaskSpec {
+	tasks := make([]domain.TaskSpec, n)
+	for i := range tasks {
+		tasks[i] = domain.TaskSpec{TaskID: fmt.Sprintf("t%d", i), Type: domain.TaskTypePython}
+	}
+	return tasks
+}
+
+// scheduledStates marks every task `scheduled` — all ready to promote to queued.
+func scheduledStates(tasks []domain.TaskSpec) map[string]domain.TaskState {
+	states := make(map[string]domain.TaskState, len(tasks))
+	for _, t := range tasks {
+		states[t.TaskID] = domain.TaskStateScheduled
+	}
+	return states
+}
+
+// countQueued tallies the scheduled→queued promotions in a plan.
+func countQueued(transitions []PlannedTransition) int {
+	n := 0
+	for _, p := range transitions {
+		if p.To == domain.TaskStateQueued {
+			n++
+		}
+	}
+	return n
+}
+
+// TestPlanRunMaxActiveTasksGatesPromotion: a fan-out of T ready tasks under
+// max_active_tasks=k promotes exactly k to queued this tick; the rest stay
+// scheduled and are re-evaluated next tick (ADR 0053 Stage 1).
+func TestPlanRunMaxActiveTasksGatesPromotion(t *testing.T) {
+	tasks := independent(5)
+	run := RunState{Tasks: tasks, States: scheduledStates(tasks), MaxActiveTasks: 2}
+	if got := countQueued(PlanRun(run)); got != 2 {
+		t.Errorf("promoted %d tasks, want 2 (max_active_tasks cap)", got)
+	}
+}
+
+// TestPlanRunMaxActiveTasksCountsActiveSiblings: the cap is against the DAG-wide
+// count of already-active (queued+running) task instances (ActiveTaskCount), so
+// a DAG holding 2 active TIs under a cap of 3 admits only one more this tick.
+func TestPlanRunMaxActiveTasksCountsActiveSiblings(t *testing.T) {
+	tasks := independent(5)
+	run := RunState{Tasks: tasks, States: scheduledStates(tasks), MaxActiveTasks: 3, ActiveTaskCount: 2}
+	if got := countQueued(PlanRun(run)); got != 1 {
+		t.Errorf("promoted %d, want 1 (3 cap − 2 already active)", got)
+	}
+}
+
+// TestPlanRunMaxActiveTasksFullAdmitsNone: at the cap no scheduled task is
+// promoted; they stay parked until a sibling finishes and frees a slot.
+func TestPlanRunMaxActiveTasksFullAdmitsNone(t *testing.T) {
+	tasks := independent(4)
+	run := RunState{Tasks: tasks, States: scheduledStates(tasks), MaxActiveTasks: 2, ActiveTaskCount: 2}
+	if got := countQueued(PlanRun(run)); got != 0 {
+		t.Errorf("promoted %d, want 0 (DAG at max_active_tasks)", got)
+	}
+}
+
+// TestPlanRunMaxActiveTasksReleasesAsTasksFinish: once active TIs drain
+// (finished → terminal, no longer counted in ActiveTaskCount), headroom reopens
+// and the parked tasks promote on a later tick.
+func TestPlanRunMaxActiveTasksReleasesAsTasksFinish(t *testing.T) {
+	tasks := independent(4)
+	full := RunState{Tasks: tasks, States: scheduledStates(tasks), MaxActiveTasks: 2, ActiveTaskCount: 2}
+	if got := countQueued(PlanRun(full)); got != 0 {
+		t.Fatalf("full DAG promoted %d, want 0", got)
+	}
+	drained := RunState{Tasks: tasks, States: scheduledStates(tasks), MaxActiveTasks: 2, ActiveTaskCount: 0}
+	if got := countQueued(PlanRun(drained)); got != 2 {
+		t.Errorf("after tasks finished promoted %d, want 2", got)
+	}
+}
+
+// TestPlanRunMaxActiveTasksUnsetPromotesAll: an unset cap (0) is unlimited —
+// today's behavior — so every ready task promotes. This is the Lite-safety
+// invariant: a DAG that never sets max_active_tasks plans byte-identically.
+func TestPlanRunMaxActiveTasksUnsetPromotesAll(t *testing.T) {
+	tasks := independent(5)
+	run := RunState{Tasks: tasks, States: scheduledStates(tasks)} // MaxActiveTasks 0 = unlimited
+	if got := countQueued(PlanRun(run)); got != 5 {
+		t.Errorf("unset cap promoted %d, want all 5", got)
+	}
+}
+
+// TestPlanRunMaxActiveTasksNonPositiveUnlimited: a non-positive cap (defensive,
+// e.g. a hand-edited spec) also means unlimited — fail open, never lock a DAG out.
+func TestPlanRunMaxActiveTasksNonPositiveUnlimited(t *testing.T) {
+	tasks := independent(3)
+	run := RunState{Tasks: tasks, States: scheduledStates(tasks), MaxActiveTasks: -1}
+	if got := countQueued(PlanRun(run)); got != 3 {
+		t.Errorf("negative cap promoted %d, want all 3 (unlimited)", got)
 	}
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -97,6 +97,19 @@ type RunState struct {
 	// from the dag.json alongside Tasks. nil means no alerting; the scheduler
 	// dispatches these rules once the run finalizes as failed.
 	Alerts *domain.AlertsConfig
+	// MaxActiveTasks is the DAG's per-DAG task-concurrency cap (Airflow's
+	// max_active_tasks, ADR 0053 Stage 1), loaded from the spec. Zero or negative
+	// means unlimited — the admission gate is a no-op, so a DAG that never sets it
+	// (and all of Lite) plans exactly as before.
+	MaxActiveTasks int
+	// ActiveTaskCount is the DAG-wide number of currently non-terminal (queued or
+	// running) task instances across every active run of this DAG, plus any this
+	// tick already admitted for the same DAG in earlier sibling runs. PlanRun
+	// subtracts it from MaxActiveTasks to derive this run's admission headroom, so
+	// the cap holds per-DAG across runs and one tick cannot breach it. The Step
+	// loop populates it; it defaults to zero, leaving the gate unlimited when
+	// MaxActiveTasks is unset.
+	ActiveTaskCount int
 }
 
 // ScheduledDAG is a cron-scheduled DAG and the logical date of its latest run.
@@ -521,9 +534,18 @@ func (s *Scheduler) Step(ctx context.Context) error {
 		return fmt.Errorf("listing active runs: %w", err)
 	}
 	activeByDAG := make(map[string]int, len(runs))
-	for _, run := range runs {
+	// Per-DAG task-admission budget (max_active_tasks, ADR 0053 Stage 1).
+	// activeTasksByDAG is the snapshot of currently non-terminal (queued+running)
+	// TIs per DAG; admittedTasksByDAG folds in what earlier sibling runs already
+	// promoted this tick so a single tick cannot breach the cap across runs —
+	// mirroring how createDueRuns folds justCreated into the max_active_runs cap.
+	activeTasksByDAG := activeTaskCounts(runs)
+	admittedTasksByDAG := make(map[string]int, len(runs))
+	for i := range runs {
+		run := runs[i]
 		activeByDAG[run.DagID]++
-		s.advanceSafely(ctx, run)
+		run.ActiveTaskCount = activeTasksByDAG[run.DagID] + admittedTasksByDAG[run.DagID]
+		admittedTasksByDAG[run.DagID] += s.advanceSafely(ctx, run)
 	}
 	createErr := s.createDueRuns(ctx, activeByDAG)
 	s.reapOrphansIfLeader(ctx)
@@ -576,23 +598,46 @@ func (s *Scheduler) reapOrphansIfLeader(ctx context.Context) {
 	}
 }
 
+// activeTaskCounts tallies, per DAG, the task instances that already occupy a
+// max_active_tasks slot — those in a non-terminal active state (queued or
+// running) across every active run of the DAG. It is the snapshot the admission
+// gate subtracts from max_active_tasks to size per-run headroom (ADR 0053 Stage
+// 1). Reuses the runs Step already loaded, so it adds no per-tick query.
+func activeTaskCounts(runs []RunState) map[string]int {
+	counts := make(map[string]int, len(runs))
+	for i := range runs {
+		for _, st := range runs[i].States {
+			if st == domain.TaskStateQueued || st == domain.TaskStateRunning {
+				counts[runs[i].DagID]++
+			}
+		}
+	}
+	return counts
+}
+
 // advanceSafely advances one run, isolating it: a panic or error in a single run
 // is recovered, logged, and metered, but never aborts the tick. This keeps one
 // poison run (a malformed spec, a panicking dispatcher, a transient per-run DB
 // error) from stalling every other run or crashing the process — the scheduler
-// may fall behind on that run, but it stays alive and keeps the rest moving.
-func (s *Scheduler) advanceSafely(ctx context.Context, run RunState) {
+// may fall behind on that run, but it stays alive and keeps the rest moving. It
+// returns how many tasks it admitted to queued (zero on a panic or error), which
+// the caller folds into the per-DAG max_active_tasks budget for sibling runs.
+func (s *Scheduler) advanceSafely(ctx context.Context, run RunState) (admitted int) {
 	defer func() {
 		if r := recover(); r != nil {
 			s.logger.Error("scheduler run panic recovered",
 				"run", run.RunID, "dag", run.DagID, "panic", r, "stack", string(debug.Stack()))
 			s.record("panic")
+			admitted = 0
 		}
 	}()
-	if err := s.advance(ctx, run); err != nil {
+	admitted, err := s.advance(ctx, run)
+	if err != nil {
 		s.logger.Error("advancing run", "run", run.RunID, "dag", run.DagID, "error", err)
 		s.record("run_error")
+		return 0
 	}
+	return admitted
 }
 
 // createDueRuns creates a new run for each scheduled DAG whose next cron slot
@@ -706,29 +751,37 @@ func (s *Scheduler) createScheduledRun(ctx context.Context, dagID string, logica
 	s.record("create_run")
 }
 
-func (s *Scheduler) advance(ctx context.Context, run RunState) error {
+// advance plans and applies one run's transitions, returning how many tasks it
+// promoted to queued this tick — the number that spent against the DAG's
+// max_active_tasks budget (ADR 0053 Stage 1), which the caller folds into
+// sibling runs of the same DAG so the per-DAG cap holds across runs.
+func (s *Scheduler) advance(ctx context.Context, run RunState) (int, error) {
 	// Materialize task instances on first sight of a queued run, then start it.
 	if run.State == domain.DagRunStateQueued && len(run.States) == 0 {
 		if err := s.store.MaterializeTasks(ctx, run.RunID, run.Tasks); err != nil {
-			return fmt.Errorf("materializing tasks: %w", err)
+			return 0, fmt.Errorf("materializing tasks: %w", err)
 		}
 		if err := s.store.SetRunState(ctx, run.RunID, domain.DagRunStateRunning); err != nil {
-			return fmt.Errorf("starting run: %w", err)
+			return 0, fmt.Errorf("starting run: %w", err)
 		}
-		return nil
+		return 0, nil
 	}
+	admitted := 0
 	for _, t := range PlanRun(run) {
+		if t.To == domain.TaskStateQueued {
+			admitted++
+		}
 		if err := s.applyPlanned(ctx, run, t); err != nil {
-			return err
+			return admitted, err
 		}
 	}
 	if state, done := FinalizeRun(run); done {
 		if err := s.store.SetRunState(ctx, run.RunID, state); err != nil {
-			return fmt.Errorf("finalizing run: %w", err)
+			return admitted, fmt.Errorf("finalizing run: %w", err)
 		}
 		s.maybeAlertFailure(ctx, state, run)
 	}
-	return nil
+	return admitted, nil
 }
 
 // alertMaxAttempts bounds how many times one failure episode may be sent before

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -364,6 +364,32 @@ func TestStepSchedulesRootTask(t *testing.T) {
 	}
 }
 
+// TestStepMaxActiveTasksCapsAcrossSiblingRuns: two runs of the SAME DAG, each
+// with ready tasks, draw on ONE per-DAG max_active_tasks budget. A single tick
+// must not promote more than the cap across both runs — the per-DAG (not
+// per-run) semantics of Airflow's max_active_tasks (ADR 0053 Stage 1). Without
+// the within-tick admission threading, each run would independently promote up
+// to the cap and the DAG would overshoot.
+func TestStepMaxActiveTasksCapsAcrossSiblingRuns(t *testing.T) {
+	mk := func(runID string) RunState {
+		tasks := independent(3)
+		return RunState{
+			RunID: runID, DagID: "etl", State: domain.DagRunStateRunning,
+			Tasks: tasks, States: scheduledStates(tasks), MaxActiveTasks: 2,
+		}
+	}
+	store := newFakeStore(mk("r1"), mk("r2"))
+	d := &fakeDispatcher{}
+	s := newScheduler(store)
+	s.SetDispatcher(d)
+	if err := s.Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(d.dispatched) != 2 {
+		t.Errorf("dispatched %d tasks across sibling runs, want 2 (per-DAG max_active_tasks)", len(d.dispatched))
+	}
+}
+
 func TestStepFinalizesCompletedRun(t *testing.T) {
 	store := newFakeStore(RunState{
 		RunID: "r1", State: domain.DagRunStateRunning, Tasks: linearTasks(),

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -153,6 +153,7 @@ func (s *SchedulerStore) ActiveRuns(ctx context.Context) ([]scheduler.RunState, 
 			InfraAttempts:     ts.infraAttempts,
 			Now:               time.Now(),
 			Alerts:            spec.Alerts,
+			MaxActiveTasks:    spec.MaxActiveTasks,
 		})
 	}
 	return out, nil


### PR DESCRIPTION
## What
Per-DAG **`max_active_tasks`** admission gate in `PlanRun` (ADR 0053 Stage 1). Today no task-level concurrency gate exists — a 500-task fan-out is promoted to `queued` in one tick. This caps the number of concurrently non-terminal (queued+running) tasks per DAG, matching Airflow's `max_active_tasks`.

## How
`Step` tallies the DAG-wide non-terminal TI count from the runs `ActiveRuns` already loads (no new query) and threads a within-tick `admittedTasksByDAG` budget across sibling runs (mirroring how `createDueRuns` folds `justCreated` into `max_active_runs`), so a single tick can't breach the cap even with multiple runs of one DAG. The cap rides `domain.DAGSpec.MaxActiveTasks` + a schema property (both copies) — **no DB column, no migration** (the gate only fires in `PlanRun`).

## Tests (strict TDD, two commits)
7 tests: gates promotion, counts active siblings, full→0, releases as tasks finish, unset→all (today's behavior), negative→unlimited (fail-open), and the per-DAG-across-sibling-runs cap. golangci-lint 0, gofmt, GoDoc.

## Lite containment
`max_active_tasks` is edition-neutral & additive (ADR 0053 §0.1): unset/`<=0` → `admissionHeadroom` returns `MaxInt`, so `promoted >= headroom` never trips and every ready task promotes exactly as before — a DAG without the field (every Lite DAG today) plans **byte-identically**. `TestPlanRunMaxActiveTasksUnsetPromotesAll` locks it. Only *named pools* (PR-8) are Pro-gated.

## PR-8 hook
The ordered gate chain lives in `PlanRun`'s `TaskStateScheduled` branch: `readyToDispatch → max_active_tasks headroom → queued`. PR-8 (named pools) adds a cross-DAG pool-slot gate as one more condition right after the headroom check, threaded from `Step` like `activeTaskCounts` (a per-pool map). Seam left clean — no pools table/column here.

Relates: ADR 0053, #623.
