### PR TITLE
feat(executor): shared-informer read-path — kill the reaper LIST storm (ADR 0054)

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -699,8 +699,35 @@ func runGatedTicker(ctx context.Context, name string, ticks <-chan time.Time, le
 	}
 }
 
-func startReconciler(ctx context.Context, cs kubernetes.Interface, namespace string, reporter executor.OutcomeReporter, leading func() bool, logger *slog.Logger) {
+// buildPodInformer constructs and starts the shared pod informer for the
+// scheduler read-path (PR-10), returning nil when this process must NOT watch
+// pods: the api-only role (ADR 0049 — the sibling scheduler process owns the
+// read-path) or a non-Kubernetes executor (no pods to watch). A nil return leaves
+// the reapers and reconciler on their live read paths — today's behavior. The
+// informer is always-on for the process lifetime, warming the cache before
+// leadership; a not-yet-synced cache is safe because its readings only ever DEFER
+// a reap (#461), never authorize one.
+func buildPodInformer(ctx context.Context, cfg *config.ServerConfig, cs kubernetes.Interface, logger *slog.Logger) *executor.PodInformer {
+	if !cfg.Server.ServesScheduler() || cfg.Executor.Type != "kubernetes" {
+		return nil
+	}
+	pi := executor.NewPodInformer(cs, cfg.Executor.TaskNamespace)
+	pi.Start(ctx)
+	if pi.WaitForCacheSync(ctx) {
+		logger.Info("pod informer cache synced; reaper/reconciler read-path warm", "namespace", cfg.Executor.TaskNamespace)
+	} else {
+		logger.Warn("pod informer cache did not sync before shutdown; reapers use live reads until it warms")
+	}
+	return pi
+}
+
+func startReconciler(ctx context.Context, cs kubernetes.Interface, namespace string, reporter executor.OutcomeReporter, leading func() bool, logger *slog.Logger, snapshotter executor.PodSnapshotter) {
 	rec := executor.NewReconciler(cs, namespace, reporter)
+	// Read task pods from the shared informer cache instead of a live LIST every
+	// tick when the informer is wired (PR-10); nil keeps the live LIST.
+	if snapshotter != nil {
+		rec.SetPodSnapshotter(snapshotter)
+	}
 	startGatedTicker(ctx, "pod-reconcile", reconcileInterval, leading, logger, func() {
 		if err := rec.Reconcile(ctx); err != nil {
 			logger.Error("pod reconcile", "error", err)
@@ -990,7 +1017,18 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 	// decision on real pod liveness (#474, #461). Only wired on the pod path;
 	// Lite/subprocess leaves it nil and the reapers stay DB-only.
 	sched.SetPodManager(podExec)
-	startReconciler(ctx, cs, cfg.Executor.TaskNamespace, execStore, sched.IsLeading, logger)
+	// Shared informer read-path (PR-10): one long-lived watch replaces the
+	// reapers' per-running-TI LIST storm and the reconciler's 30s LIST. Consulted
+	// only to DEFER a reap; the live TaskPodActive kill path is unchanged (#461).
+	// A typed-nil pointer would defeat the reconciler's nil check, so the
+	// snapshotter interface is only populated when the informer actually built.
+	podInformer := buildPodInformer(ctx, cfg, cs, logger)
+	var snapshotter executor.PodSnapshotter
+	if podInformer != nil {
+		sched.SetPodPresenceCache(podInformer)
+		snapshotter = podInformer
+	}
+	startReconciler(ctx, cs, cfg.Executor.TaskNamespace, execStore, sched.IsLeading, logger, snapshotter)
 	startStagingGC(ctx, cs, cfg.Executor.TaskNamespace, store, sched.IsLeading, logger)
 	logger.Info("pod dispatch enabled", "namespace", cfg.Executor.TaskNamespace, "agent_control_plane_addr", controlAddr)
 	return true, closer

--- a/cmd/leoflow-server/pod_informer_wiring_test.go
+++ b/cmd/leoflow-server/pod_informer_wiring_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/neochaotic/leoflow/internal/config"
+)
+
+// TestPodInformer_NotConstructedInApiRole locks the split-role guard (ADR 0049):
+// the shared pod informer (PR-10) is built only when this process serves the
+// scheduler role AND dispatches to Kubernetes. The api-only role never watches
+// pods — its sibling scheduler process owns the read-path — and a non-pod executor
+// has no pods to watch. In those cases buildPodInformer returns nil and the reapers
+// and reconciler keep their live read paths.
+func TestPodInformer_NotConstructedInApiRole(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cs := fake.NewClientset()
+
+	cfg := func(role, execType string) *config.ServerConfig {
+		c := &config.ServerConfig{}
+		c.Server.Role = role
+		c.Executor.Type = execType
+		c.Executor.TaskNamespace = "leoflow"
+		return c
+	}
+
+	cases := []struct {
+		name      string
+		role      string
+		execType  string
+		wantBuilt bool
+	}{
+		{"api role never watches pods", config.RoleAPI, "kubernetes", false},
+		{"scheduler role with pods builds the informer", config.RoleScheduler, "kubernetes", true},
+		{"all role with pods builds the informer", config.RoleAll, "kubernetes", true},
+		{"scheduler role without pods (subprocess) builds nothing", config.RoleScheduler, "subprocess", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			pi := buildPodInformer(ctx, cfg(tc.role, tc.execType), cs, log)
+			if built := pi != nil; built != tc.wantBuilt {
+				t.Errorf("buildPodInformer built=%v, want %v", built, tc.wantBuilt)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect

--- a/internal/executor/pod_informer.go
+++ b/internal/executor/pod_informer.go
@@ -1,0 +1,147 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	listersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// Pod label keys the informer selects and filters on. They mirror exactly the
+// keys BuildPod stamps and TaskPodActive selects, sanitizeLabel-transformed —
+// reusing the same transform is load-bearing: a lookup built from a different key
+// would silently miss every pod and quietly return the storm PR-10 removes.
+const (
+	podLabelRunID  = "leoflow.io/run-id"
+	podLabelTaskID = "leoflow.io/task-id"
+)
+
+// errCacheNotSynced is returned by SnapshotTaskPods before the informer's initial
+// LIST has completed. It makes an unsynced snapshot a retriable condition rather
+// than an authoritative "no pods exist" — a cold cache must never look empty to a
+// consumer that could act on absence.
+var errCacheNotSynced = errors.New("pod informer cache not synced")
+
+// PodInformer is a shared-informer read-path over task pods, scoped by namespace
+// and the leoflow.io/run-id label (ADR 0002 pods). It replaces the reapers'
+// per-running-TI-per-second apiserver LIST storm and the reconciler's 30s LIST
+// with one long-lived watch feeding a local cache.
+//
+// Its readings are trusted only in the safe direction (#461): CachedPodActive is
+// consulted ONLY to DEFER a reap when a pod is present and Pending/Running — a
+// cache "absent" reading is never authoritative and callers MUST fall through to
+// the live TaskPodActive (quorum) read before any destructive action. Cache lag
+// can therefore only ever delay a reap by a tick, never cause a false-positive
+// one. SnapshotTaskPods is safe for the reconciler because presence of a terminal
+// pod is monotonic and every settle is attempt/state-guarded (ADR 0052).
+//
+// It is constructed only in the scheduler/all role (ADR 0049), never api-only,
+// and is nil in Lite/subprocess (no pods), where consumers keep their live paths.
+type PodInformer struct {
+	factory   informers.SharedInformerFactory
+	informer  cache.SharedIndexInformer
+	lister    listersv1.PodLister
+	namespace string
+	stopCh    chan struct{}
+	stopOnce  sync.Once
+}
+
+// NewPodInformer builds a shared pod informer over the given cluster, scoped to
+// namespace and to pods carrying the leoflow.io/run-id label (managed task pods).
+// Resync is 0: reads are level-triggered on demand, so there are no logic-bearing
+// handlers to re-fire. It does not start watching until Start is called.
+func NewPodInformer(clientset kubernetes.Interface, namespace string) *PodInformer {
+	if namespace == "" {
+		namespace = "default"
+	}
+	factory := informers.NewSharedInformerFactoryWithOptions(
+		clientset, 0,
+		informers.WithNamespace(namespace),
+		informers.WithTweakListOptions(func(o *metav1.ListOptions) {
+			// Existence selector: the reflector's chunked initial LIST and its
+			// long-lived watch only ever carry managed task pods, keeping the
+			// cache scoped and small.
+			o.LabelSelector = podLabelRunID
+		}),
+	)
+	pods := factory.Core().V1().Pods()
+	return &PodInformer{
+		factory:   factory,
+		informer:  pods.Informer(),
+		lister:    pods.Lister(),
+		namespace: namespace,
+		stopCh:    make(chan struct{}),
+	}
+}
+
+// Start begins the watch in the background and stops it when ctx is canceled, so
+// the informer is always-on for the process lifetime (warming the cache before
+// leadership). It is idempotent-safe to call once per informer.
+func (p *PodInformer) Start(ctx context.Context) {
+	p.factory.Start(p.stopCh)
+	go func() {
+		<-ctx.Done()
+		p.Shutdown()
+	}()
+}
+
+// WaitForCacheSync blocks until the initial LIST has populated the cache or ctx is
+// canceled, returning whether the sync completed. A false return (canceled or
+// timed out) is not fatal: CachedPodActive independently gates on HasSynced and
+// returns false until warm, so consumers simply keep using their live read paths.
+func (p *PodInformer) WaitForCacheSync(ctx context.Context) bool {
+	return cache.WaitForCacheSync(ctx.Done(), p.informer.HasSynced)
+}
+
+// Shutdown stops the watch and waits for the informer goroutines to exit. Safe to
+// call more than once (Start's ctx-cancel path and an explicit caller may race).
+func (p *PodInformer) Shutdown() {
+	p.stopOnce.Do(func() { close(p.stopCh) })
+	p.factory.Shutdown()
+}
+
+// CachedPodActive reports whether the cache holds a pod for (run, task) that is
+// Pending or Running — the exact predicate TaskPodActive uses. It is the safe
+// direction of the asymmetric-trust contract: a true return may DEFER a reap; a
+// false return is NEVER authoritative and the caller must fall through to the live
+// read. Before the cache has synced it returns false, so a cold cache degrades to
+// the live path rather than misreporting absence.
+func (p *PodInformer) CachedPodActive(runID, taskID string) bool {
+	if !p.informer.HasSynced() {
+		return false
+	}
+	selector := labels.SelectorFromSet(labels.Set{
+		podLabelRunID:  sanitizeLabel(runID),
+		podLabelTaskID: sanitizeLabel(taskID),
+	})
+	pods, err := p.lister.Pods(p.namespace).List(selector)
+	if err != nil {
+		return false
+	}
+	for _, pod := range pods {
+		if phase := pod.Status.Phase; phase == corev1.PodPending || phase == corev1.PodRunning {
+			return true
+		}
+	}
+	return false
+}
+
+// SnapshotTaskPods returns the managed task pods currently in the cache — the
+// reconciler's read replacement for its 30s LIST. It errors (errCacheNotSynced)
+// before the initial sync so the reconciler retries next tick instead of acting on
+// a cold cache that looks empty.
+func (p *PodInformer) SnapshotTaskPods() ([]*corev1.Pod, error) {
+	if !p.informer.HasSynced() {
+		return nil, errCacheNotSynced
+	}
+	// The cache is already scoped to the run-id label by the factory's tweak, so
+	// every pod it holds is a managed task pod.
+	return p.lister.Pods(p.namespace).List(labels.Everything())
+}

--- a/internal/executor/pod_informer_test.go
+++ b/internal/executor/pod_informer_test.go
@@ -1,0 +1,129 @@
+package executor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// informerPod builds a managed task pod with the sanitized label scheme BuildPod
+// stamps, so the informer's tweaked LIST selector and CachedPodActive lookups see
+// the same keys.
+func informerPod(name, runID, taskID string, phase corev1.PodPhase) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "leoflow",
+			Labels: map[string]string{
+				"leoflow.io/run-id":     sanitizeLabel(runID),
+				"leoflow.io/task-id":    sanitizeLabel(taskID),
+				"leoflow.io/try-number": "1",
+			},
+		},
+		Status: corev1.PodStatus{Phase: phase},
+	}
+}
+
+// waitFor polls cond every 10ms until it holds or the deadline elapses. The
+// informer applies watch events asynchronously, so a cache read after a Create/
+// Delete must be retried rather than read once.
+func waitFor(t *testing.T, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cond()
+}
+
+// TestPodInformer_SeesAddAndDelete verifies the cache reflects the live pod set
+// through the initial LIST and subsequent watch events, applies the same
+// sanitizeLabel transform BuildPod/TaskPodActive use (so a raw run-id lookup hits
+// the sanitized label), and treats only Pending/Running as active — the identical
+// predicate to TaskPodActive. A Succeeded pod is not active.
+func TestPodInformer_SeesAddAndDelete(t *testing.T) {
+	// Uppercase/underscore run-id proves the lookup sanitizes before matching.
+	cs := fake.NewClientset(
+		informerPod("p-run", "Run_A", "extract", corev1.PodRunning),
+		informerPod("p-done", "Run_A", "done-task", corev1.PodSucceeded),
+	)
+	pi := NewPodInformer(cs, "leoflow")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pi.Start(ctx)
+	if !pi.WaitForCacheSync(ctx) {
+		t.Fatal("cache did not sync")
+	}
+
+	if !pi.CachedPodActive("Run_A", "extract") {
+		t.Error("a Running pod must read as active (with sanitized labels)")
+	}
+	if pi.CachedPodActive("Run_A", "done-task") {
+		t.Error("a Succeeded pod must not read as active")
+	}
+	if pi.CachedPodActive("Run_A", "never-existed") {
+		t.Error("an unknown task must read as not active")
+	}
+
+	// Watch-driven delete: the Running pod disappears; the cache must catch up.
+	if err := cs.CoreV1().Pods("leoflow").Delete(ctx, "p-run", metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if !waitFor(t, func() bool { return !pi.CachedPodActive("Run_A", "extract") }) {
+		t.Error("cache did not observe the pod deletion")
+	}
+
+	// Watch-driven add: a new Pending pod appears; the cache must reflect it.
+	if _, err := cs.CoreV1().Pods("leoflow").Create(ctx, informerPod("p-new", "Run_A", "load", corev1.PodPending), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if !waitFor(t, func() bool { return pi.CachedPodActive("Run_A", "load") }) {
+		t.Error("cache did not observe the added Pending pod")
+	}
+}
+
+// TestPodInformer_BeforeSync_ReturnsFalse locks the safety gate: until the cache
+// has synced, CachedPodActive returns false so every candidate falls through to
+// the live TaskPodActive read (today's behavior). A cold cache is never wrong,
+// only "no speedup yet" — leader-failover safe.
+func TestPodInformer_BeforeSync_ReturnsFalse(t *testing.T) {
+	cs := fake.NewClientset(informerPod("p-run", "r1", "t1", corev1.PodRunning))
+	pi := NewPodInformer(cs, "leoflow")
+	// Deliberately NOT started / not synced.
+	if pi.CachedPodActive("r1", "t1") {
+		t.Error("an unsynced cache must return false (fall through to the live read)")
+	}
+	if _, err := pi.SnapshotTaskPods(); err == nil {
+		t.Error("an unsynced cache must not claim an authoritative empty snapshot")
+	}
+}
+
+// TestPodInformer_SnapshotTaskPods returns the managed pod set from the cache once
+// synced — the reconciler's read replacement for its 30s LIST.
+func TestPodInformer_SnapshotTaskPods(t *testing.T) {
+	cs := fake.NewClientset(
+		informerPod("p-a", "r1", "t1", corev1.PodRunning),
+		informerPod("p-b", "r1", "t2", corev1.PodSucceeded),
+	)
+	pi := NewPodInformer(cs, "leoflow")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pi.Start(ctx)
+	if !pi.WaitForCacheSync(ctx) {
+		t.Fatal("cache did not sync")
+	}
+	pods, err := pi.SnapshotTaskPods()
+	if err != nil {
+		t.Fatalf("SnapshotTaskPods: %v", err)
+	}
+	if len(pods) != 2 {
+		t.Errorf("snapshot should hold both managed pods, got %d", len(pods))
+	}
+}

--- a/internal/executor/reconcile.go
+++ b/internal/executor/reconcile.go
@@ -249,10 +249,17 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 func (r *Reconciler) listTaskPods(ctx context.Context) ([]*corev1.Pod, error) {
 	if r.snapshot != nil {
 		pods, err := r.snapshot.SnapshotTaskPods()
-		if err != nil {
-			return nil, fmt.Errorf("snapshotting task pods: %w", err)
+		if err == nil {
+			return pods, nil
 		}
-		return pods, nil
+		// The snapshot is unavailable (e.g. the informer never synced — RBAC
+		// drift denying watch, or a broken watch). Degrade to the live LIST
+		// rather than propagate: a returned error would stall Reconcile every
+		// tick and silently disable ADR-0052 lost-outcome recovery and
+		// finished-pod GC. This mirrors the reapers' cold-cache fallback; at the
+		// ~30s reconcile cadence a live LIST during an informer outage is
+		// O(P)/30s, not the per-second storm this read-path removed.
+		slog.DebugContext(ctx, "task-pod snapshot unavailable; falling back to live LIST", "err", err)
 	}
 	list, err := r.clientset.CoreV1().Pods(r.namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: "leoflow.io/run-id",

--- a/internal/executor/reconcile.go
+++ b/internal/executor/reconcile.go
@@ -150,6 +150,19 @@ type OutcomeReporter interface {
 	RescheduleTask(ctx context.Context, taskInstanceID string, tryNumber int, at time.Time) error
 }
 
+// PodSnapshotter supplies the reconciler's task-pod set from a local cache instead
+// of a live LIST every tick (PR-10). It is safe here without a live confirm: the
+// signal the reconciler acts on is presence of a terminal pod, which is monotonic
+// (a pod that reached Failed/Succeeded stays terminal), and every settle is
+// attempt- and state-guarded (ADR 0052), so at worst cache lag delays a settle by
+// a tick. A nil snapshotter (Lite/subprocess, or a cold start) keeps the live LIST.
+type PodSnapshotter interface {
+	// SnapshotTaskPods returns the managed task pods currently known, or an error
+	// (e.g. the cache has not synced) so the reconciler retries next tick rather
+	// than treating an unsynced cache as an empty cluster.
+	SnapshotTaskPods() ([]*corev1.Pod, error)
+}
+
 // podGCGracePeriod is how long a finished pod is kept before garbage collection,
 // leaving a window to inspect a failed pod with kubectl.
 const podGCGracePeriod = 10 * time.Minute
@@ -172,6 +185,10 @@ type Reconciler struct {
 	reporter  OutcomeReporter
 	now       func() time.Time
 	ttl       time.Duration
+	// snapshot, when set, replaces the per-tick live LIST with a cache read
+	// (PR-10). Nil keeps the live LIST (Lite/subprocess, or before the informer
+	// is wired). GC deletes still go straight to the apiserver.
+	snapshot PodSnapshotter
 }
 
 // NewReconciler builds a Reconciler over the given cluster and outcome reporter.
@@ -179,18 +196,20 @@ func NewReconciler(clientset kubernetes.Interface, namespace string, reporter Ou
 	return &Reconciler{clientset: clientset, namespace: namespace, reporter: reporter, now: time.Now, ttl: podGCGracePeriod}
 }
 
+// SetPodSnapshotter wires a cache-backed pod source so Reconcile reads its
+// task-pod set from the shared informer instead of a live LIST every tick
+// (PR-10). Left unset, the reconciler keeps the live LIST — today's behavior.
+func (r *Reconciler) SetPodSnapshotter(s PodSnapshotter) { r.snapshot = s }
+
 // Reconcile lists managed task pods, records each terminal one's outcome against
 // its task instance, and garbage-collects finished pods older than the grace
 // period.
 func (r *Reconciler) Reconcile(ctx context.Context) error {
-	pods, err := r.clientset.CoreV1().Pods(r.namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: "leoflow.io/run-id",
-	})
+	pods, err := r.listTaskPods(ctx)
 	if err != nil {
-		return fmt.Errorf("listing task pods: %w", err)
+		return err
 	}
-	for i := range pods.Items {
-		pod := &pods.Items[i]
+	for _, pod := range pods {
 		v := classifyPod(pod)
 		if !v.terminal {
 			continue
@@ -221,6 +240,31 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+// listTaskPods returns the managed task-pod set to reconcile, from the cache
+// snapshot when a PodSnapshotter is wired (PR-10) and from a live LIST otherwise.
+// The live path selects on the leoflow.io/run-id label, matching the informer's
+// scope, and copies to pointers so both paths share one loop shape.
+func (r *Reconciler) listTaskPods(ctx context.Context) ([]*corev1.Pod, error) {
+	if r.snapshot != nil {
+		pods, err := r.snapshot.SnapshotTaskPods()
+		if err != nil {
+			return nil, fmt.Errorf("snapshotting task pods: %w", err)
+		}
+		return pods, nil
+	}
+	list, err := r.clientset.CoreV1().Pods(r.namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "leoflow.io/run-id",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing task pods: %w", err)
+	}
+	out := make([]*corev1.Pod, 0, len(list.Items))
+	for i := range list.Items {
+		out = append(out, &list.Items[i])
+	}
+	return out, nil
 }
 
 // settlePod records the pod's recovered outcome against its task instance,

--- a/internal/executor/reconcile_snapshot_test.go
+++ b/internal/executor/reconcile_snapshot_test.go
@@ -49,13 +49,21 @@ func TestReconcile_FromSnapshot_AttemptGuarded(t *testing.T) {
 	}
 }
 
-// TestReconcile_SnapshotError_Surfaces: a snapshot error (e.g. cache not synced)
-// is returned so the reconciler retries next tick instead of acting on a cold or
-// partial view.
-func TestReconcile_SnapshotError_Surfaces(t *testing.T) {
-	r := NewReconciler(fake.NewClientset(), "leoflow", &fakeReporter{})
+// TestReconcile_SnapshotError_FallsBackToLiveList: a snapshot error (e.g. the
+// informer never synced — RBAC drift, a broken watch) must NOT stall the
+// reconciler. It degrades to the authoritative live LIST, so ADR-0052
+// lost-outcome recovery and finished-pod GC keep running during an informer
+// outage instead of being silently disabled every tick.
+func TestReconcile_SnapshotError_FallsBackToLiveList(t *testing.T) {
+	failed := managedPod("p-fail", "ti-fail", corev1.PodFailed) // live: the fallback LIST must find it
+	reporter := &fakeReporter{}
+	r := NewReconciler(fake.NewClientset(failed), "leoflow", reporter)
 	r.SetPodSnapshotter(&fakeSnapshotter{err: errCacheNotSynced})
-	if err := r.Reconcile(context.Background()); err == nil {
-		t.Error("a snapshot error must surface so the tick retries")
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("a snapshot error must fall back to the live LIST, not surface, got %v", err)
+	}
+	if got, ok := reporter.settled["ti-fail"]; !ok || got.kind != settleFailed {
+		t.Fatalf("on a snapshot error the reconciler must fall back to the live LIST and still settle the terminal pod, got %+v (ok=%v)", got, ok)
 	}
 }

--- a/internal/executor/reconcile_snapshot_test.go
+++ b/internal/executor/reconcile_snapshot_test.go
@@ -1,0 +1,61 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// fakeSnapshotter serves a fixed pod set in place of a live LIST, so a test can
+// prove the reconciler reads its terminal-pod set from the cache snapshot.
+type fakeSnapshotter struct {
+	pods []*corev1.Pod
+	err  error
+}
+
+func (f *fakeSnapshotter) SnapshotTaskPods() ([]*corev1.Pod, error) { return f.pods, f.err }
+
+// TestReconcile_FromSnapshot_AttemptGuarded: with a PodSnapshotter wired, the
+// reconciler classifies and settles from the cache snapshot rather than a live
+// LIST, and every settle still carries the pod's try-number (ADR 0052 attempt
+// guard). The live clientset is deliberately empty, so a settle can only come
+// from the snapshot — proving the 30s LIST was swapped for the cache read.
+func TestReconcile_FromSnapshot_AttemptGuarded(t *testing.T) {
+	cs := fake.NewClientset() // no pods live: a live LIST would settle nothing
+	reporter := &fakeReporter{}
+	r := NewReconciler(cs, "leoflow", reporter)
+
+	failed := managedPod("p-fail", "ti-fail", corev1.PodFailed)
+	failed.Labels["leoflow.io/try-number"] = "3"
+	r.SetPodSnapshotter(&fakeSnapshotter{pods: []*corev1.Pod{
+		failed,
+		managedPod("p-run", "ti-run", corev1.PodRunning), // not terminal: no settle
+	}})
+
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	got, ok := reporter.settled["ti-fail"]
+	if !ok || got.kind != settleFailed {
+		t.Fatalf("snapshot's failed pod must settle failed, got %+v (ok=%v)", got, ok)
+	}
+	if got.tryNumber != 3 {
+		t.Errorf("settle must be attempt-guarded on the pod's try-number, got %d", got.tryNumber)
+	}
+	if len(reporter.settled) != 1 {
+		t.Errorf("only the terminal pod should settle, got %v", reporter.settled)
+	}
+}
+
+// TestReconcile_SnapshotError_Surfaces: a snapshot error (e.g. cache not synced)
+// is returned so the reconciler retries next tick instead of acting on a cold or
+// partial view.
+func TestReconcile_SnapshotError_Surfaces(t *testing.T) {
+	r := NewReconciler(fake.NewClientset(), "leoflow", &fakeReporter{})
+	r.SetPodSnapshotter(&fakeSnapshotter{err: errCacheNotSynced})
+	if err := r.Reconcile(context.Background()); err == nil {
+		t.Error("a snapshot error must surface so the tick retries")
+	}
+}

--- a/internal/scheduler/pod_cache_reap_test.go
+++ b/internal/scheduler/pod_cache_reap_test.go
@@ -1,0 +1,246 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// fakePresenceCache is a PodPresenceCache whose readings a test controls. It is
+// the safe-direction seam (#461): a true reading may DEFER a reap; a false
+// reading is never authoritative and the reaper must fall through to the live
+// TaskPodActive read.
+type fakePresenceCache struct {
+	active map[string]bool // "runID/taskID" -> cached Pending/Running
+}
+
+func (c *fakePresenceCache) CachedPodActive(runID, taskID string) bool {
+	return c.active[runID+"/"+taskID]
+}
+
+// --- pod-lost reaper -------------------------------------------------------
+
+// TestPodLostReaper_CacheAbsentButLiveRunning_DoesNotReap is the #461 regression
+// lock, mechanized. The cache says the pod is ABSENT (a lagged/cold read), but the
+// live TaskPodActive read says it is Running. The reaper MUST fall through to the
+// live read and DEFER — cache absence is never authoritative, so cache lag can
+// only delay a reap, never cause a false-positive one. Reaping here would kill a
+// live task.
+func TestPodLostReaper_CacheAbsentButLiveRunning_DoesNotReap(t *testing.T) {
+	past := time.Now().UTC().Add(-2 * time.Minute)
+	store := &fakePodLostStore{candidates: []PodLostCandidate{
+		{TaskInstanceID: "live", DagRunID: "run-a", TaskID: "work", TryNumber: 1, RunningSince: past},
+	}}
+	pods := &fakePodManager{active: map[string]bool{"run-a/work": true}} // live says Running
+	r := newPodLostReaper(store, reapTestLogger(), 60*time.Second, nil)
+	r.pods = pods
+	r.cache = &fakePresenceCache{active: map[string]bool{}} // cache says absent (lag)
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.marked) != 0 {
+		t.Fatalf("#461: cache-absent must fall through to live; a live Running pod must NOT be reaped, got %v", store.marked)
+	}
+	if len(pods.deletedTasks) != 0 {
+		t.Fatalf("#461: no pod delete when the live read defers, got %v", pods.deletedTasks)
+	}
+	if pods.activeCalls != 1 {
+		t.Fatalf("#461: cache-absent MUST consult the live read, got %d live calls", pods.activeCalls)
+	}
+}
+
+// TestPodLostReaper_CacheActive_SkipsLiveList: a cache-present Pending/Running pod
+// defers the reap without touching the apiserver — the whole point of PR-10. The
+// live TaskPodActive read must not be called.
+func TestPodLostReaper_CacheActive_SkipsLiveList(t *testing.T) {
+	past := time.Now().UTC().Add(-2 * time.Minute)
+	store := &fakePodLostStore{candidates: []PodLostCandidate{
+		{TaskInstanceID: "live", DagRunID: "run-a", TaskID: "work", TryNumber: 1, RunningSince: past},
+	}}
+	pods := &fakePodManager{active: map[string]bool{}}
+	r := newPodLostReaper(store, reapTestLogger(), 60*time.Second, nil)
+	r.pods = pods
+	r.cache = &fakePresenceCache{active: map[string]bool{"run-a/work": true}}
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.marked) != 0 {
+		t.Fatalf("a cache-active pod must be deferred, got %v", store.marked)
+	}
+	if pods.activeCalls != 0 {
+		t.Fatalf("a cache-active defer must skip the live LIST, got %d live calls", pods.activeCalls)
+	}
+}
+
+// TestPodLostReaper_CacheAbsentAndLiveAbsent_Reaps: cache absent AND the live read
+// confirms absent — the pod is genuinely gone, so the TI is failed pod_lost and
+// its pod torn down, pinned to (run, task, try).
+func TestPodLostReaper_CacheAbsentAndLiveAbsent_Reaps(t *testing.T) {
+	past := time.Now().UTC().Add(-2 * time.Minute)
+	store := &fakePodLostStore{candidates: []PodLostCandidate{
+		{TaskInstanceID: "gone", DagRunID: "run-a", TaskID: "work", TryNumber: 2, RunningSince: past},
+	}}
+	pods := &fakePodManager{active: map[string]bool{}} // live also absent
+	r := newPodLostReaper(store, reapTestLogger(), 60*time.Second, nil)
+	r.pods = pods
+	r.cache = &fakePresenceCache{active: map[string]bool{}}
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.marked) != 1 || store.marked[0] != "gone" {
+		t.Fatalf("cache-absent + live-absent must reap, got %v", store.marked)
+	}
+	if pods.activeCalls != 1 {
+		t.Fatalf("the destructive path must confirm via the live read, got %d live calls", pods.activeCalls)
+	}
+	if len(pods.deletedTasks) != 1 || pods.deletedTasks[0] != (deletedTask{"run-a", "work", 2}) {
+		t.Fatalf("teardown must be pinned to (run-a,work,try 2), got %v", pods.deletedTasks)
+	}
+}
+
+// TestPodLostReaper_NilCache_UsesLivePathForAll: with no cache wired (Lite, or
+// before the informer warms), every candidate goes straight to the live read —
+// today's behavior, unchanged.
+func TestPodLostReaper_NilCache_UsesLivePathForAll(t *testing.T) {
+	past := time.Now().UTC().Add(-2 * time.Minute)
+	store := &fakePodLostStore{candidates: []PodLostCandidate{
+		{TaskInstanceID: "gone", DagRunID: "run-a", TaskID: "work", TryNumber: 1, RunningSince: past},
+	}}
+	pods := &fakePodManager{active: map[string]bool{}}
+	r := newPodLostReaper(store, reapTestLogger(), 60*time.Second, nil)
+	r.pods = pods
+	// r.cache stays nil.
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.marked) != 1 {
+		t.Fatalf("nil cache must use the live path and reap a genuinely-absent pod, got %v", store.marked)
+	}
+	if pods.activeCalls != 1 {
+		t.Fatalf("nil cache must consult the live read, got %d live calls", pods.activeCalls)
+	}
+}
+
+// --- dispatch-lost reaper (#461 path) --------------------------------------
+
+// TestDispatchLostReaper_CacheAbsentButLiveActive_DoesNotReap is the #461 lock on
+// the queued path: cache says absent (lag), the live read says the pod is
+// Pending/Running (slow image pull), so the reaper defers. Cache absence never
+// authorizes failing a queued TI whose dispatch actually landed.
+func TestDispatchLostReaper_CacheAbsentButLiveActive_DoesNotReap(t *testing.T) {
+	past := time.Now().UTC().Add(-10 * time.Minute)
+	store := &fakeStaleQueuedStore{candidates: []StaleQueuedCandidate{
+		{TaskInstanceID: "slow", DagRunID: "run-a", TaskID: "work", TryNumber: 1, QueuedAt: past},
+	}}
+	pods := &fakePodManager{active: map[string]bool{"run-a/work": true}}
+	r := newDispatchLostReaper(store, reapTestLogger(), 3*time.Minute, nil)
+	r.pods = pods
+	r.cache = &fakePresenceCache{active: map[string]bool{}} // cache absent
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.failed) != 0 {
+		t.Fatalf("#461: cache-absent must fall through to live; a live pod must NOT be reaped, got %v", store.failed)
+	}
+	if pods.activeCalls != 1 {
+		t.Fatalf("#461: cache-absent MUST consult the live read, got %d live calls", pods.activeCalls)
+	}
+}
+
+// TestDispatchLostReaper_CacheActive_SkipsLiveList: a cache-present pod defers the
+// dispatch-lost decision without an apiserver read.
+func TestDispatchLostReaper_CacheActive_SkipsLiveList(t *testing.T) {
+	past := time.Now().UTC().Add(-10 * time.Minute)
+	store := &fakeStaleQueuedStore{candidates: []StaleQueuedCandidate{
+		{TaskInstanceID: "slow", DagRunID: "run-a", TaskID: "work", TryNumber: 1, QueuedAt: past},
+	}}
+	pods := &fakePodManager{active: map[string]bool{}}
+	r := newDispatchLostReaper(store, reapTestLogger(), 3*time.Minute, nil)
+	r.pods = pods
+	r.cache = &fakePresenceCache{active: map[string]bool{"run-a/work": true}}
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.failed) != 0 {
+		t.Fatalf("a cache-active pod must defer, got %v", store.failed)
+	}
+	if pods.activeCalls != 0 {
+		t.Fatalf("a cache-active defer must skip the live LIST, got %d live calls", pods.activeCalls)
+	}
+}
+
+// TestDispatchLostReaper_CacheAbsentAndLiveAbsent_Reaps: cache absent AND live
+// confirms absent — the dispatch is genuinely lost, so the TI is failed and any
+// lingering pod for the attempt torn down.
+func TestDispatchLostReaper_CacheAbsentAndLiveAbsent_Reaps(t *testing.T) {
+	past := time.Now().UTC().Add(-10 * time.Minute)
+	store := &fakeStaleQueuedStore{candidates: []StaleQueuedCandidate{
+		{TaskInstanceID: "lost", DagRunID: "run-a", TaskID: "work", TryNumber: 4, QueuedAt: past},
+	}}
+	pods := &fakePodManager{active: map[string]bool{}}
+	r := newDispatchLostReaper(store, reapTestLogger(), 3*time.Minute, nil)
+	r.pods = pods
+	r.cache = &fakePresenceCache{active: map[string]bool{}}
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.failed) != 1 || store.failed[0] != "lost" {
+		t.Fatalf("cache-absent + live-absent must reap, got %v", store.failed)
+	}
+	if pods.activeCalls != 1 {
+		t.Fatalf("the destructive path must confirm via the live read, got %d live calls", pods.activeCalls)
+	}
+	if len(pods.deletedTasks) != 1 || pods.deletedTasks[0] != (deletedTask{"run-a", "work", 4}) {
+		t.Fatalf("teardown must be pinned to (run-a,work,try 4), got %v", pods.deletedTasks)
+	}
+}
+
+// TestStepThreadsPresenceCacheToReapers is the wiring check: a presence cache set
+// via SetPodPresenceCache must reach the dispatch-lost reaper through
+// Step → reapOrphansIfLeader. A stale queued TI whose pod the cache shows as
+// active is deferred, so a leader tick does NOT fail it — proving the cache is
+// threaded, not dropped on the floor.
+func TestStepThreadsPresenceCacheToReapers(t *testing.T) {
+	store := newFakeStore()
+	store.staleQueuedCands = []StaleQueuedCandidate{
+		{TaskInstanceID: "slow", DagRunID: "run-a", TaskID: "work", QueuedAt: time.Now().UTC().Add(-10 * time.Minute)},
+	}
+	s := newScheduler(store)
+	s.SetPodPresenceCache(&fakePresenceCache{active: map[string]bool{"run-a/work": true}})
+	if err := s.Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if len(store.dispatchLostMarked) != 0 {
+		t.Errorf("a cache-active queued TI must be deferred through Step, got %v", store.dispatchLostMarked)
+	}
+}
+
+// TestDispatchLostReaper_NilCache_UsesLivePathForAll: with no cache wired, the
+// reaper uses the live read for every candidate — unchanged behavior.
+func TestDispatchLostReaper_NilCache_UsesLivePathForAll(t *testing.T) {
+	past := time.Now().UTC().Add(-10 * time.Minute)
+	store := &fakeStaleQueuedStore{candidates: []StaleQueuedCandidate{
+		{TaskInstanceID: "lost", DagRunID: "run-a", TaskID: "work", TryNumber: 1, QueuedAt: past},
+	}}
+	pods := &fakePodManager{active: map[string]bool{}}
+	r := newDispatchLostReaper(store, reapTestLogger(), 3*time.Minute, nil)
+	r.pods = pods
+	// r.cache stays nil.
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.failed) != 1 {
+		t.Fatalf("nil cache must use the live path and reap, got %v", store.failed)
+	}
+	if pods.activeCalls != 1 {
+		t.Fatalf("nil cache must consult the live read, got %d live calls", pods.activeCalls)
+	}
+}

--- a/internal/scheduler/pod_lost_reap.go
+++ b/internal/scheduler/pod_lost_reap.go
@@ -71,6 +71,12 @@ type podLostReaper struct {
 	// pods is required for this reaper to do anything; nil (Lite) makes run a
 	// no-op. See the type doc.
 	pods PodManager
+	// cache is an optional informer-backed presence cache (PR-10) consulted ONLY
+	// to DEFER a reap: a cached Pending/Running pod skips the live LIST. A cache
+	// miss is never authoritative — the reaper falls through to the live
+	// TaskPodActive read below, so cache lag can only delay a reap, never cause a
+	// false-positive one (#461). Nil keeps every candidate on the live path.
+	cache PodPresenceCache
 }
 
 func newPodLostReaper(store PodLostReapStore, logger *slog.Logger, grace time.Duration, rec Recorder) *podLostReaper {
@@ -99,6 +105,13 @@ func (r *podLostReaper) run(ctx context.Context) error {
 	now := time.Now().UTC()
 	for _, c := range candidates {
 		if !IsPodLostCandidate(c, r.grace, now) {
+			continue
+		}
+		// Cache fast-path (PR-10), safe direction only: a cached Pending/Running
+		// pod defers the reap without an apiserver read. A cache MISS is NOT
+		// trusted — fall through to the live read below, preserving the #461 fix.
+		if r.cache != nil && r.cache.CachedPodActive(c.DagRunID, c.TaskID) {
+			r.record("pod_lost_cache_active")
 			continue
 		}
 		// Consult the pod before failing:

--- a/internal/scheduler/pod_manager.go
+++ b/internal/scheduler/pod_manager.go
@@ -31,3 +31,26 @@ type PodManager interface {
 	// the dispatch landed, the node is merely slow (#461).
 	TaskPodActive(ctx context.Context, runID, taskID string) (bool, error)
 }
+
+// PodPresenceCache is an optional read-through cache of pod presence — backed by
+// a shared informer (PR-10) — that the pod-lost and dispatch-lost reapers consult
+// ONLY to DEFER a reap, never to authorize one. Its trust is asymmetric (#461):
+//
+//   - CachedPodActive == true  => a pod is present and Pending/Running; the reaper
+//     may skip the live LIST and defer, because presence is monotonic-safe against
+//     cache lag (a pod the cache still shows as live cannot have been gone longer
+//     than the lag, and deferring one tick is harmless).
+//   - CachedPodActive == false => NOT authoritative. The reaper MUST fall through
+//     to the live TaskPodActive (quorum) read before any destructive action, so a
+//     lagged/cold cache can only ever delay a reap by a tick, never cause a
+//     false-positive one.
+//
+// It exists to remove the O(running-TIs)/sec apiserver LIST storm from the read
+// path while keeping the kill decision on the live read. Nil in Lite/subprocess
+// and before the informer warms: every candidate then uses the live path.
+type PodPresenceCache interface {
+	// CachedPodActive reports whether the cache holds a Pending/Running pod for
+	// (run, task). Only a true return is trusted (to defer); false is a "no
+	// speedup" signal that must not drive a reap.
+	CachedPodActive(runID, taskID string) bool
+}

--- a/internal/scheduler/reap_pod_teardown_test.go
+++ b/internal/scheduler/reap_pod_teardown_test.go
@@ -14,10 +14,13 @@ type fakePodManager struct {
 	deletedTasks []deletedTask
 	deletedRuns  []string
 	// active maps "runID/taskID" -> whether a live pod exists; absent key is false.
-	active     map[string]bool
-	activeErr  error
-	deleteErr  error
-	deleteRunE error
+	active map[string]bool
+	// activeCalls counts TaskPodActive invocations, so a test can assert the live
+	// (quorum) read was skipped when the presence cache already deferred.
+	activeCalls int
+	activeErr   error
+	deleteErr   error
+	deleteRunE  error
 }
 
 type deletedTask struct {
@@ -43,6 +46,7 @@ func (f *fakePodManager) DeleteRunPods(_ context.Context, runID string) error {
 }
 
 func (f *fakePodManager) TaskPodActive(_ context.Context, runID, taskID string) (bool, error) {
+	f.activeCalls++
 	if f.activeErr != nil {
 		return false, f.activeErr
 	}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -296,10 +296,16 @@ type Scheduler struct {
 	// podManager lets the reapers tear down a reaped task's pod and gate the
 	// dispatch-lost decision on pod liveness (#474, #461). Nil in Lite; the
 	// reapers guard the nil and fall back to DB-only behavior.
-	podManager   PodManager
-	lastTick     atomic.Int64 // unix-nano of the last loop iteration; 0 = not yet ticked
-	leading      atomic.Bool  // true only while this instance holds leadership and ticks
-	steppingDown atomic.Bool  // true only during a leader step-down — the campaign loop sets it before canceling the run-context so the expected cancel-fanout logs at WARN, not ERROR (#311 tripwire preserved when it's false)
+	podManager PodManager
+	// podPresenceCache is an optional informer-backed read cache (PR-10) the
+	// pod-lost and dispatch-lost reapers consult to DEFER a reap without an
+	// apiserver LIST. Trusted only in the safe (presence) direction; a miss falls
+	// through to podManager's live read (#461). Nil in Lite and before the
+	// informer is wired — every candidate then uses the live path.
+	podPresenceCache PodPresenceCache
+	lastTick         atomic.Int64 // unix-nano of the last loop iteration; 0 = not yet ticked
+	leading          atomic.Bool  // true only while this instance holds leadership and ticks
+	steppingDown     atomic.Bool  // true only during a leader step-down — the campaign loop sets it before canceling the run-context so the expected cancel-fanout logs at WARN, not ERROR (#311 tripwire preserved when it's false)
 	// warnedSchedules dedupes the "unparseable schedule" warning per DAG (keyed by
 	// the offending expression) so a bad cron logs once, not every tick. Accessed
 	// only from the single-threaded tick (createDueRuns), so it needs no lock.
@@ -347,6 +353,15 @@ func (s *Scheduler) SetPodLostGrace(d time.Duration) { s.podLostGrace = d }
 // queued TI's pod is actually live (#474, #461). Left unset in Lite/subprocess,
 // where the reapers stay DB-only. Called from main once the K8s client exists.
 func (s *Scheduler) SetPodManager(pm PodManager) { s.podManager = pm }
+
+// SetPodPresenceCache wires the informer-backed presence cache the pod-lost and
+// dispatch-lost reapers use to defer a reap without a live apiserver LIST (PR-10).
+// It is consulted only in the safe direction: a cached Pending/Running pod defers;
+// a miss falls through to the live TaskPodActive read, so cache lag can never
+// cause a false-positive reap (#461). Left unset in Lite/subprocess and until the
+// informer is constructed, where the reapers stay on the live path. Called from
+// main on the Pro (scheduler/all) K8s path only.
+func (s *Scheduler) SetPodPresenceCache(c PodPresenceCache) { s.podPresenceCache = c }
 
 // defaultStepTimeout bounds how long one scheduling tick may run before it is
 // canceled so the loop can recover, rather than hang forever on a stuck query.
@@ -582,6 +597,7 @@ func (s *Scheduler) reapOrphansIfLeader(ctx context.Context) {
 	// chain once the threshold elapses.
 	dispatchReaper := newDispatchLostReaper(s.store, s.logger, s.dispatchLostThreshold, s.recorder)
 	dispatchReaper.pods = s.podManager
+	dispatchReaper.cache = s.podPresenceCache
 	if err := dispatchReaper.run(ctx); err != nil {
 		logSchedulerError(s.logger, "dispatch-lost reaper", err, s.steppingDown.Load())
 		s.record("dispatch_lost_list_error")
@@ -592,6 +608,7 @@ func (s *Scheduler) reapOrphansIfLeader(ctx context.Context) {
 	// it a no-op, so a live subprocess task is never reaped.
 	podLostReaper := newPodLostReaper(s.store, s.logger, s.podLostGrace, s.recorder)
 	podLostReaper.pods = s.podManager
+	podLostReaper.cache = s.podPresenceCache
 	if err := podLostReaper.run(ctx); err != nil {
 		logSchedulerError(s.logger, "pod-lost reaper", err, s.steppingDown.Load())
 		s.record("pod_lost_list_error")

--- a/internal/scheduler/stale_queued_reap.go
+++ b/internal/scheduler/stale_queued_reap.go
@@ -67,6 +67,12 @@ type dispatchLostReaper struct {
 	// so the reaper must DEFER. Nil in Lite: with no pods, the reaper falls
 	// back to the pure time-threshold behavior.
 	pods PodManager
+	// cache is an optional informer-backed presence cache (PR-10) consulted ONLY
+	// to DEFER a reap: a cached Pending/Running pod skips the live LIST. A cache
+	// miss is never authoritative — the reaper falls through to the live
+	// TaskPodActive read, so cache lag can only delay a reap, never cause a
+	// false-positive one (#461, the queued path). Nil keeps the live path.
+	cache PodPresenceCache
 }
 
 func newDispatchLostReaper(store DispatchLostReapStore, logger *slog.Logger, threshold time.Duration, rec Recorder) *dispatchLostReaper {
@@ -101,6 +107,14 @@ func (r *dispatchLostReaper) run(ctx context.Context) error {
 		//   * no/terminal pod       -> dispatch is genuinely lost; proceed.
 		// Nil pods (Lite) has no pod concept, so it falls through to the
 		// threshold behavior unchanged.
+		//
+		// Cache fast-path (PR-10), safe direction only: a cached Pending/Running
+		// pod defers without an apiserver read. A cache MISS is NOT trusted — fall
+		// through to the live read below, preserving the #461 fix.
+		if r.cache != nil && r.cache.CachedPodActive(c.DagRunID, c.TaskID) {
+			r.record("dispatch_lost_cache_active")
+			continue
+		}
 		if r.pods != nil {
 			active, perr := r.pods.TaskPodActive(ctx, c.DagRunID, c.TaskID)
 			if perr != nil {


### PR DESCRIPTION
## What
Replace the reapers' **O(running-TIs)/sec apiserver LIST storm** + the reconciler's 30s LIST with a shared-informer read-path — the coexistence ship-gate (ADR 0054) — **without reopening #461**.

## Safety invariant
A cache "present/Running" reading is used ONLY to **defer** a reap. A cache "absent" reading is **never authoritative** → it falls through to the live `TaskPodActive` (quorum read, unchanged) before any destructive action. Cache lag can only delay a reap by a tick, never cause a false-positive one.

## Proof (negative control)
`TestPodLostReaper_CacheAbsentButLiveRunning_DoesNotReap` (+ dispatch-lost twin): cache-absent (lag) + live-Running ⇒ NO reap, and the live read *is* consulted. **Negative control:** rewriting the fast-path to trust cache-absence made the test RED (it reaped a live task); the safe fall-through makes it GREEN — so the test genuinely fails any implementation that lets a cache miss authorize a kill.

## How (per the specialist's spec)
- `pod_informer.go`: `SharedInformerFactory` scoped to `leoflow.io/run-id`, resync 0, `WaitForCacheSync` gate (unsynced→false→live), always-on Pro-only, split-role guard. `CachedPodActive` uses the same `sanitizeLabel` keys + Pending/Running predicate as `TaskPodActive`.
- Two seams (nil = today's behavior): `PodPresenceCache` (scheduler) + `PodSnapshotter` (reconcile).
- pod-lost + dispatch-lost reapers get a cache fast-path **defer**; their live `TaskPodActive` kill-path is **UNCHANGED** (`pod_terminate.go` untouched, not `ResourceVersion:"0"`). reconcile swaps its 30s LIST for the snapshot; GC Delete stays live. agent-lost/orphan-run unchanged.

## Scope guard
No `ownerReferences` (deferred PR-N1), no pod-spec changes, no `DeleteFunc` control-flow, no RBAC change (`watch` already granted).

## Lite containment
Lite passes nil cache/snapshotter, reapers stay DB-only, `subprocess.go` unchanged → byte-for-byte identical. Typed-nil guarded via an explicit interface variable.

## Impact
apiserver cost Θ(running-TIs)/sec → one watch + O(genuinely-absent)/sec live confirms (≈0 when nothing lost); 30s reconcile LIST → cache read. Kill decision stays authoritative.

Full §5 test plan green + `-race`; golangci-lint 0. Relates: ADR 0054/0053, #623.
