### PR TITLE
feat(cli): leoflow admin operator CLI (health, pause, drain, runs)

### DIFF
--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
+)
+
+// newAdminCommand groups the operator commands for a running control plane:
+// health checks, DAG pausing, draining, and run inspection. Unlike the
+// authoring loop (init → compile → push → deploy), these operate a deployed Pro
+// install over the typed /api/v2 client — the "operate what is already running"
+// verbs. The tree is deliberately extensible: tasks, connections, and variables
+// slot in as further subcommands without reshaping it.
+func newAdminCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "admin",
+		Short: "Operate a running control plane (health, pause, drain, runs).",
+		Long: "Operator commands for a running Leoflow control plane (Pro). These act " +
+			"over the /api/v2 API — checking health, pausing DAGs, draining the control " +
+			"plane before maintenance, and inspecting runs — and reuse the same " +
+			"--server/--token/config precedence as `leoflow deploy`.",
+	}
+	cmd.AddCommand(
+		newAdminHealthCommand(),
+		newAdminDagsCommand(),
+		newAdminDrainCommand(),
+		newAdminRunsCommand(),
+	)
+	return cmd
+}
+
+// adminFlags carries the server/token resolution flags shared by every admin
+// subcommand.
+type adminFlags struct {
+	serverURL string
+	token     string
+}
+
+// addAdminFlags registers the --server/--token flags with the deploy-style
+// precedence: the explicit flag, then the LEOFLOW_TOKEN env (as the token flag
+// default), then the persisted config written by `leoflow auth login`.
+func addAdminFlags(cmd *cobra.Command, f *adminFlags) {
+	cmd.Flags().StringVar(&f.serverURL, "server", "", "control plane base URL (default: config server_url)")
+	cmd.Flags().StringVar(&f.token, "token", os.Getenv("LEOFLOW_TOKEN"), "JWT bearer token (default: config token)")
+}
+
+// adminClient resolves the server/token precedence and builds a typed /api/v2
+// client, returning it alongside the resolved base URL (for display).
+func adminClient(cmd *cobra.Command, f adminFlags) (client *apiclient.ClientWithResponses, baseURL string, err error) {
+	serverURL, token, rerr := resolveServerToken(cmd, f.serverURL, f.token)
+	if rerr != nil {
+		return nil, "", rerr
+	}
+	c, nerr := apiclient.New(serverURL, token)
+	if nerr != nil {
+		return nil, "", nerr
+	}
+	return c, serverURL, nil
+}
+
+// writeLine writes s followed by a newline, propagating any write error so the
+// errcheck linter is satisfied at the call sites.
+func writeLine(w io.Writer, s string) error {
+	_, err := fmt.Fprintln(w, s)
+	return err
+}
+
+// listAllDags pages through GET /api/v2/dags and returns every registered DAG.
+// Draining and `pause --all` need the full set, so it follows total_entries
+// rather than trusting a single page.
+func listAllDags(ctx context.Context, c *apiclient.ClientWithResponses) ([]apiclient.DAG, error) {
+	const page = 100
+	var out []apiclient.DAG
+	offset := 0
+	for {
+		limit := page
+		off := offset
+		resp, err := c.ListDagsWithResponse(ctx, &apiclient.ListDagsParams{Limit: &limit, Offset: &off})
+		if err != nil {
+			return nil, fmt.Errorf("listing DAGs: %w", err)
+		}
+		if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+			return nil, fmt.Errorf("listing DAGs returned %d: %s", resp.StatusCode(), string(resp.Body))
+		}
+		got := 0
+		if resp.JSON200.Dags != nil {
+			out = append(out, (*resp.JSON200.Dags)...)
+			got = len(*resp.JSON200.Dags)
+		}
+		offset += got
+		total := 0
+		if resp.JSON200.TotalEntries != nil {
+			total = *resp.JSON200.TotalEntries
+		}
+		if got == 0 || offset >= total {
+			return out, nil
+		}
+	}
+}
+
+// listAllDagIDs returns the id of every registered DAG (skipping any DAG the
+// server returns without one).
+func listAllDagIDs(ctx context.Context, c *apiclient.ClientWithResponses) ([]string, error) {
+	dags, err := listAllDags(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(dags))
+	for _, d := range dags {
+		if d.DagId != nil {
+			ids = append(ids, *d.DagId)
+		}
+	}
+	return ids, nil
+}
+
+// deref returns the pointed-to string, or "" for a nil pointer.
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/internal/cli/admin_dags.go
+++ b/internal/cli/admin_dags.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
+)
+
+// newAdminDagsCommand groups the DAG pause/unpause operator commands.
+func newAdminDagsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dags",
+		Short: "Pause or unpause registered DAGs.",
+	}
+	cmd.AddCommand(newAdminSetPausedCommand(true), newAdminSetPausedCommand(false))
+	return cmd
+}
+
+// newAdminSetPausedCommand builds either `pause` or `unpause`, depending on the
+// target is_paused value, sharing one implementation. With --all it discovers
+// every registered DAG and PATCHes each; otherwise it acts on a single dag_id.
+func newAdminSetPausedCommand(paused bool) *cobra.Command {
+	var f adminFlags
+	var all bool
+	verb, titled := "unpause", "Unpause"
+	if paused {
+		verb, titled = "pause", "Pause"
+	}
+	cmd := &cobra.Command{
+		Use:   verb + " [dag_id]",
+		Short: titled + " a DAG (PATCH is_paused), or every DAG with --all.",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _, err := adminClient(cmd, f)
+			if err != nil {
+				return err
+			}
+			ctx := cmdContext(cmd)
+			ids, err := resolvePauseTargets(ctx, c, args, all, verb)
+			if err != nil {
+				return err
+			}
+			return setPausedForDAGs(ctx, cmd.OutOrStdout(), c, ids, paused)
+		},
+	}
+	addAdminFlags(cmd, &f)
+	cmd.Flags().BoolVar(&all, "all", false, verb+" every registered DAG")
+	return cmd
+}
+
+// resolvePauseTargets turns the args and --all flag into the list of dag_ids to
+// act on, erroring on the ambiguous "--all plus a dag_id" and "neither" cases.
+func resolvePauseTargets(ctx context.Context, c *apiclient.ClientWithResponses, args []string, all bool, verb string) ([]string, error) {
+	if all {
+		if len(args) > 0 {
+			return nil, fmt.Errorf("--all %ss every DAG; do not also pass a dag_id", verb)
+		}
+		return listAllDagIDs(ctx, c)
+	}
+	if len(args) != 1 {
+		return nil, fmt.Errorf("exactly one dag_id is required (or use --all)")
+	}
+	return []string{args[0]}, nil
+}
+
+// setPausedForDAGs PATCHes is_paused for each dag_id via the typed client,
+// printing a per-DAG result line and returning a non-zero error if any PATCH
+// failed (so automation catches a partial apply).
+func setPausedForDAGs(ctx context.Context, w io.Writer, c *apiclient.ClientWithResponses, ids []string, paused bool) error {
+	if len(ids) == 0 {
+		return writeLine(w, "No DAGs to update.")
+	}
+	verb := "unpaused"
+	if paused {
+		verb = "paused"
+	}
+	lines := make([]string, 0, len(ids)+1)
+	var failed []string
+	for _, id := range ids {
+		if err := patchDagPaused(ctx, c, id, paused); err != nil {
+			failed = append(failed, id)
+			lines = append(lines, fmt.Sprintf("  %-30s FAILED: %v", id, err))
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("  %-30s %s", id, verb))
+	}
+	lines = append(lines, fmt.Sprintf("%s %d/%d DAG(s)", verb, len(ids)-len(failed), len(ids)))
+	if werr := writeLine(w, strings.Join(lines, "\n")); werr != nil {
+		return werr
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("failed to %s %d DAG(s): %s", verb, len(failed), strings.Join(failed, ", "))
+	}
+	return nil
+}
+
+// patchDagPaused sends PATCH /api/v2/dags/{id} with the target is_paused value.
+func patchDagPaused(ctx context.Context, c *apiclient.ClientWithResponses, id string, paused bool) error {
+	resp, err := c.UpdateDagWithResponse(ctx, id, apiclient.DAGUpdate{IsPaused: &paused})
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return fmt.Errorf("server returned %d: %s", resp.StatusCode(), string(resp.Body))
+	}
+	return nil
+}

--- a/internal/cli/admin_dags_test.go
+++ b/internal/cli/admin_dags_test.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
+)
+
+// dagsPauseServer serves a DAG list and records every PATCH so a test can
+// assert which DAGs were (un)paused and with what is_paused value.
+func dagsPauseServer(t *testing.T, ids []string) (*httptest.Server, *pauseRecorder) {
+	t.Helper()
+	rec := &pauseRecorder{paused: map[string]bool{}}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/dags", func(w http.ResponseWriter, _ *http.Request) {
+		dags := make([]apiclient.DAG, 0, len(ids))
+		for _, id := range ids {
+			dags = append(dags, apiclient.DAG{DagId: strptr(id), IsPaused: boolptr(false)})
+		}
+		total := len(ids)
+		writeJSON(t, w, apiclient.DAGCollection{Dags: &dags, TotalEntries: &total})
+	})
+	mux.HandleFunc("/api/v2/dags/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		id := strings.TrimPrefix(r.URL.Path, "/api/v2/dags/")
+		var body apiclient.DAGUpdate
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &body)
+		rec.record(id, body.IsPaused != nil && *body.IsPaused)
+		writeJSON(t, w, apiclient.DAG{DagId: strptr(id), IsPaused: body.IsPaused})
+	})
+	return httptest.NewServer(mux), rec
+}
+
+type pauseRecorder struct {
+	mu     sync.Mutex
+	paused map[string]bool
+	order  []string
+}
+
+func (p *pauseRecorder) record(id string, paused bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if _, seen := p.paused[id]; !seen {
+		p.order = append(p.order, id)
+	}
+	p.paused[id] = paused
+}
+
+func (p *pauseRecorder) ids() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := append([]string(nil), p.order...)
+	sort.Strings(out)
+	return out
+}
+
+func TestSetPausedForDAGsPatchesEach(t *testing.T) {
+	srv, rec := dagsPauseServer(t, []string{"a", "b", "c"})
+	defer srv.Close()
+
+	var sb strings.Builder
+	err := setPausedForDAGs(context.Background(), &sb, newTestClient(t, srv.URL), []string{"a", "b", "c"}, true)
+	if err != nil {
+		t.Fatalf("setPausedForDAGs: %v", err)
+	}
+	got := rec.ids()
+	if strings.Join(got, ",") != "a,b,c" {
+		t.Errorf("patched ids = %v, want [a b c]", got)
+	}
+	for _, id := range got {
+		if !rec.paused[id] {
+			t.Errorf("dag %q was not paused (is_paused=false)", id)
+		}
+	}
+}
+
+// TestAdminPauseAllPatchesEveryDAG drives the full `admin dags pause --all`
+// command: it must discover every DAG via the list endpoint and PATCH each.
+func TestAdminPauseAllPatchesEveryDAG(t *testing.T) {
+	srv, rec := dagsPauseServer(t, []string{"etl", "reports", "sync"})
+	defer srv.Close()
+
+	_, _, err := run(t, "admin", "dags", "pause", "--all", "--server", srv.URL, "--token", "x")
+	if err != nil {
+		t.Fatalf("admin dags pause --all: %v", err)
+	}
+	if got := strings.Join(rec.ids(), ","); got != "etl,reports,sync" {
+		t.Errorf("patched ids = %q, want etl,reports,sync", got)
+	}
+	for id, paused := range rec.paused {
+		if !paused {
+			t.Errorf("dag %q not paused", id)
+		}
+	}
+}
+
+func TestAdminUnpauseSingleDAG(t *testing.T) {
+	srv, rec := dagsPauseServer(t, []string{"etl"})
+	defer srv.Close()
+
+	_, _, err := run(t, "admin", "dags", "unpause", "etl", "--server", srv.URL, "--token", "x")
+	if err != nil {
+		t.Fatalf("admin dags unpause etl: %v", err)
+	}
+	if v, ok := rec.paused["etl"]; !ok || v {
+		t.Errorf("etl is_paused = %v (ok=%v), want false", v, ok)
+	}
+}
+
+func TestAdminPauseAllRejectsPositionalArg(t *testing.T) {
+	srv, _ := dagsPauseServer(t, []string{"etl"})
+	defer srv.Close()
+
+	if _, _, err := run(t, "admin", "dags", "pause", "etl", "--all", "--server", srv.URL, "--token", "x"); err == nil {
+		t.Errorf("expected error when --all is combined with a dag_id")
+	}
+}

--- a/internal/cli/admin_drain.go
+++ b/internal/cli/admin_drain.go
@@ -1,0 +1,133 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
+)
+
+// drainDefaultTimeout bounds how long drain waits for active runs to finish
+// before reporting what is still running and exiting non-zero.
+const drainDefaultTimeout = 10 * time.Minute
+
+// drainDefaultPollInterval is how often drain re-checks for active runs.
+const drainDefaultPollInterval = 5 * time.Second
+
+// drainOptions holds the resolved flags for a drain run.
+type drainOptions struct {
+	timeout      time.Duration
+	pollInterval time.Duration
+	wait         bool
+}
+
+// newAdminDrainCommand builds `leoflow admin drain`: safely quiesce the control
+// plane before maintenance or an upgrade. It pauses every DAG (no new runs),
+// then polls active runs until none remain or --timeout elapses; on timeout it
+// reports what is still running and exits non-zero.
+func newAdminDrainCommand() *cobra.Command {
+	var f adminFlags
+	var o drainOptions
+	var noWait bool
+	cmd := &cobra.Command{
+		Use:   "drain",
+		Short: "Pause every DAG, then wait for active runs to finish (quiesce for maintenance).",
+		Long: "Safely quiesce the control plane before maintenance or an upgrade: pause " +
+			"every registered DAG so no new runs start, then poll active runs until none " +
+			"remain or --timeout elapses. On timeout it prints the still-running runs and " +
+			"exits non-zero. Use --no-wait to pause without waiting.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if noWait {
+				o.wait = false
+			}
+			c, base, err := adminClient(cmd, f)
+			if err != nil {
+				return err
+			}
+			return runDrain(cmdContext(cmd), cmd.OutOrStdout(), c, base, o)
+		},
+	}
+	addAdminFlags(cmd, &f)
+	cmd.Flags().DurationVar(&o.timeout, "timeout", drainDefaultTimeout, "max time to wait for active runs to drain")
+	cmd.Flags().DurationVar(&o.pollInterval, "poll-interval", drainDefaultPollInterval, "how often to re-check for active runs")
+	cmd.Flags().BoolVar(&o.wait, "wait", true, "poll active runs until they drain")
+	cmd.Flags().BoolVar(&noWait, "no-wait", false, "pause every DAG but do not wait for active runs")
+	return cmd
+}
+
+// runDrain executes the drain sequence: announce the plan, pause every DAG,
+// then (unless --no-wait) poll until active runs clear or the timeout fires.
+func runDrain(ctx context.Context, w io.Writer, c *apiclient.ClientWithResponses, base string, o drainOptions) error {
+	ids, err := listAllDagIDs(ctx, c)
+	if err != nil {
+		return err
+	}
+	if perr := renderDrainPlan(w, base, ids, o); perr != nil {
+		return perr
+	}
+	if serr := setPausedForDAGs(ctx, w, c, ids, true); serr != nil {
+		return serr
+	}
+	if !o.wait {
+		return writeLine(w, "Paused every DAG; not waiting for active runs (--no-wait).")
+	}
+	remaining, timedOut, werr := waitForRunsToDrain(ctx, c, o.timeout, o.pollInterval)
+	if werr != nil {
+		return werr
+	}
+	if timedOut {
+		if rerr := renderRuns(w, remaining); rerr != nil {
+			return rerr
+		}
+		return fmt.Errorf("drain timed out after %s: %d active run(s) remain", o.timeout, len(remaining))
+	}
+	return writeLine(w, "Drain complete: no active runs remain.")
+}
+
+// renderDrainPlan prints a summary of what drain is about to pause and how long
+// it will wait — the "print a summary of what it will pause" contract.
+func renderDrainPlan(w io.Writer, base string, ids []string, o drainOptions) error {
+	lines := []string{fmt.Sprintf("Draining %s", base)}
+	if len(ids) == 0 {
+		lines = append(lines, "  no registered DAGs to pause")
+	} else {
+		lines = append(lines, fmt.Sprintf("  pausing %d DAG(s): %s", len(ids), strings.Join(ids, ", ")))
+	}
+	if o.wait {
+		lines = append(lines, fmt.Sprintf("  then waiting up to %s for active runs to finish", o.timeout))
+	} else {
+		lines = append(lines, "  not waiting for active runs (--no-wait)")
+	}
+	return writeLine(w, strings.Join(lines, "\n"))
+}
+
+// waitForRunsToDrain polls for running runs across every DAG until none remain
+// or the timeout elapses. It returns the runs still active (empty when drained),
+// whether it timed out, and any hard error. A three-value return keeps the
+// drained case explicit (rather than an ambiguous nil, nil).
+func waitForRunsToDrain(ctx context.Context, c *apiclient.ClientWithResponses, timeout, pollInterval time.Duration) (remaining []adminRun, timedOut bool, err error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		running, cerr := collectRuns(ctx, c, "", string(apiclient.ListDagRunsParamsStateRunning))
+		if cerr != nil {
+			return nil, false, cerr
+		}
+		if len(running) == 0 {
+			return nil, false, nil
+		}
+		if !time.Now().Before(deadline) {
+			return running, true, nil
+		}
+		select {
+		case <-ctx.Done():
+			return running, false, ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}

--- a/internal/cli/admin_drain_test.go
+++ b/internal/cli/admin_drain_test.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
+)
+
+// drainServer serves a two-DAG control plane. It records pause PATCHes and, for
+// dagRuns, returns `runningPolls` polls' worth of a running run before draining
+// to empty — so a test can prove drain pauses first, then polls until clear.
+func drainServer(t *testing.T, runningPolls int32) (*httptest.Server, *pauseRecorder, *int32) {
+	t.Helper()
+	rec := &pauseRecorder{paused: map[string]bool{}}
+	var runsPolls int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/dags", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/dags" {
+			http.NotFound(w, r)
+			return
+		}
+		dags := []apiclient.DAG{{DagId: strptr("etl")}, {DagId: strptr("reports")}}
+		total := 2
+		writeJSON(t, w, apiclient.DAGCollection{Dags: &dags, TotalEntries: &total})
+	})
+	var mu sync.Mutex
+	mux.HandleFunc("/api/v2/dags/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			id := strings.TrimPrefix(strings.TrimSuffix(r.URL.Path, "/dagRuns"), "/api/v2/dags/")
+			rec.record(id, true)
+			writeJSON(t, w, apiclient.DAG{DagId: strptr(id), IsPaused: boolptr(true)})
+			return
+		}
+		// dagRuns listing: only "etl" ever has a running run, and only for the
+		// first runningPolls polls.
+		mu.Lock()
+		poll := atomic.AddInt32(&runsPolls, 1)
+		mu.Unlock()
+		var runs []apiclient.DAGRun
+		if strings.Contains(r.URL.Path, "/dags/etl/") && (poll+1)/2 <= runningPolls {
+			runs = []apiclient.DAGRun{{DagRunId: strptr("run-1"), DagId: strptr("etl"), State: runState(apiclient.DAGRunStateRunning)}}
+		}
+		total := len(runs)
+		writeJSON(t, w, apiclient.DAGRunCollection{DagRuns: &runs, TotalEntries: &total})
+	})
+	return httptest.NewServer(mux), rec, &runsPolls
+}
+
+func TestWaitForRunsToDrainClears(t *testing.T) {
+	// Running for the first poll round, empty afterwards.
+	srv, _, _ := drainServer(t, 1)
+	defer srv.Close()
+
+	remaining, timedOut, err := waitForRunsToDrain(context.Background(), newTestClient(t, srv.URL),
+		5*time.Second, 5*time.Millisecond)
+	if err != nil {
+		t.Fatalf("waitForRunsToDrain: %v", err)
+	}
+	if timedOut {
+		t.Errorf("timedOut = true, want the runs to drain before the deadline")
+	}
+	if len(remaining) != 0 {
+		t.Errorf("remaining = %+v, want empty", remaining)
+	}
+}
+
+func TestWaitForRunsToDrainTimesOut(t *testing.T) {
+	// A very high running-poll count means runs never drain within the window.
+	srv, _, _ := drainServer(t, 1000)
+	defer srv.Close()
+
+	remaining, timedOut, err := waitForRunsToDrain(context.Background(), newTestClient(t, srv.URL),
+		30*time.Millisecond, 5*time.Millisecond)
+	if err != nil {
+		t.Fatalf("waitForRunsToDrain: %v", err)
+	}
+	if !timedOut {
+		t.Errorf("timedOut = false, want true when runs never drain")
+	}
+	if len(remaining) == 0 {
+		t.Errorf("remaining is empty, want the still-running run reported on timeout")
+	}
+}
+
+// TestAdminDrainPausesThenDrains drives the whole command: it must pause every
+// DAG first, then poll until the active run clears, and exit zero.
+func TestAdminDrainPausesThenDrains(t *testing.T) {
+	srv, rec, _ := drainServer(t, 1)
+	defer srv.Close()
+
+	out, _, err := run(t, "admin", "drain", "--timeout", "5s", "--poll-interval", "5ms",
+		"--server", srv.URL, "--token", "x")
+	if err != nil {
+		t.Fatalf("admin drain: %v", err)
+	}
+	if got := strings.Join(rec.ids(), ","); got != "etl,reports" {
+		t.Errorf("paused ids = %q, want etl,reports", got)
+	}
+	if !strings.Contains(out, "Drain complete") {
+		t.Errorf("output = %q, want a completion line", out)
+	}
+}
+
+func TestAdminDrainTimesOutNonZero(t *testing.T) {
+	srv, rec, _ := drainServer(t, 1000)
+	defer srv.Close()
+
+	out, _, err := run(t, "admin", "drain", "--timeout", "30ms", "--poll-interval", "5ms",
+		"--server", srv.URL, "--token", "x")
+	if err == nil {
+		t.Errorf("expected non-zero exit when drain times out")
+	}
+	// It must still have paused everything before giving up.
+	if got := strings.Join(rec.ids(), ","); got != "etl,reports" {
+		t.Errorf("paused ids = %q, want etl,reports even on timeout", got)
+	}
+	if !strings.Contains(out, "run-1") {
+		t.Errorf("output = %q, want the still-running run reported", out)
+	}
+}
+
+func TestAdminDrainNoWaitSkipsPolling(t *testing.T) {
+	srv, rec, pollPtr := drainServer(t, 1000)
+	defer srv.Close()
+
+	_, _, err := run(t, "admin", "drain", "--no-wait", "--server", srv.URL, "--token", "x")
+	if err != nil {
+		t.Fatalf("admin drain --no-wait: %v", err)
+	}
+	if got := strings.Join(rec.ids(), ","); got != "etl,reports" {
+		t.Errorf("paused ids = %q, want etl,reports", got)
+	}
+	if p := atomic.LoadInt32(pollPtr); p != 0 {
+		t.Errorf("dagRuns was polled %d times, want 0 under --no-wait", p)
+	}
+}

--- a/internal/cli/admin_health.go
+++ b/internal/cli/admin_health.go
@@ -1,0 +1,170 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
+)
+
+// healthyStatus is the component status string the control plane reports for a
+// component that is up.
+const healthyStatus = "healthy"
+
+// adminComponent is one named control-plane component and its reported status.
+type adminComponent struct {
+	name   string
+	status string
+}
+
+// adminHealthReport is the compact status assembled from the monitor endpoints.
+type adminHealthReport struct {
+	components []adminComponent
+	executor   *apiclient.ExecutorInfo
+	version    *apiclient.VersionInfo
+	healthy    bool
+}
+
+// newAdminHealthCommand builds `leoflow admin health`: a post-deploy smoke test
+// that prints component health, executor capability, and version, and exits
+// non-zero when the control plane is unhealthy.
+func newAdminHealthCommand() *cobra.Command {
+	var f adminFlags
+	cmd := &cobra.Command{
+		Use:   "health",
+		Short: "Report control-plane health; non-zero exit when unhealthy.",
+		Long: "Query the monitor endpoints and print a compact status: component " +
+			"health (scheduler, metadatabase, DAG processor, triggerer), executor " +
+			"capability, and version. Exits non-zero when any component is unhealthy " +
+			"or the health endpoint is unreachable — usable as a post-deploy smoke test.",
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			c, base, err := adminClient(cmd, f)
+			if err != nil {
+				return err
+			}
+			rep, err := fetchAdminHealth(cmdContext(cmd), c)
+			if err != nil {
+				return err
+			}
+			if rerr := renderAdminHealth(cmd.OutOrStdout(), base, rep); rerr != nil {
+				return rerr
+			}
+			if !rep.healthy {
+				return fmt.Errorf("control plane is unhealthy")
+			}
+			return nil
+		},
+	}
+	addAdminFlags(cmd, &f)
+	return cmd
+}
+
+// fetchAdminHealth queries /monitor/health for component status (the source of
+// truth for the healthy/unhealthy verdict) and, best-effort, /monitor/executor
+// and /version for the informational lines — an executor or version hiccup does
+// not by itself flip the health verdict.
+func fetchAdminHealth(ctx context.Context, c *apiclient.ClientWithResponses) (*adminHealthReport, error) {
+	hresp, err := c.GetMonitorHealthWithResponse(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("querying health: %w", err)
+	}
+	if hresp.StatusCode() != http.StatusOK || hresp.JSON200 == nil {
+		return nil, fmt.Errorf("health endpoint returned %d: %s", hresp.StatusCode(), string(hresp.Body))
+	}
+	h := hresp.JSON200
+	rep := &adminHealthReport{healthy: true}
+	for _, cc := range []struct {
+		name string
+		comp *apiclient.ComponentHealth
+	}{
+		{"scheduler", h.Scheduler},
+		{"metadatabase", h.Metadatabase},
+		{"dag_processor", h.DagProcessor},
+		{"triggerer", h.Triggerer},
+	} {
+		status := componentStatus(cc.comp)
+		rep.components = append(rep.components, adminComponent{name: cc.name, status: status})
+		if status != healthyStatus {
+			rep.healthy = false
+		}
+	}
+	if eresp, eerr := c.GetMonitorExecutorWithResponse(ctx); eerr == nil && eresp.JSON200 != nil {
+		rep.executor = eresp.JSON200
+	}
+	if vresp, verr := c.GetVersionWithResponse(ctx); verr == nil && vresp.JSON200 != nil {
+		rep.version = vresp.JSON200
+	}
+	return rep, nil
+}
+
+// componentStatus reports a component's status, treating a missing component or
+// missing status as "unknown" (which counts as unhealthy).
+func componentStatus(c *apiclient.ComponentHealth) string {
+	if c == nil || c.Status == nil {
+		return "unknown"
+	}
+	return *c.Status
+}
+
+// renderAdminHealth writes the compact report as a single block, ending in a
+// HEALTHY / UNHEALTHY verdict line.
+func renderAdminHealth(w io.Writer, base string, rep *adminHealthReport) error {
+	lines := make([]string, 0, len(rep.components)+3)
+	lines = append(lines, fmt.Sprintf("Control plane: %s", base))
+	if rep.version != nil {
+		lines = append(lines, healthLine("version", versionLine(rep.version)))
+	}
+	for _, c := range rep.components {
+		lines = append(lines, healthLine(c.name, c.status))
+	}
+	if rep.executor != nil {
+		lines = append(lines, healthLine("executor", executorLine(rep.executor)))
+	}
+	verdict := "HEALTHY"
+	if !rep.healthy {
+		verdict = "UNHEALTHY"
+	}
+	lines = append(lines, "Status: "+verdict)
+	return writeLine(w, strings.Join(lines, "\n"))
+}
+
+// healthLine formats one aligned "  label:   value" row.
+func healthLine(label, value string) string {
+	return fmt.Sprintf("  %-14s %s", label+":", value)
+}
+
+// versionLine renders the version endpoint's info as "<version> (git <sha>)".
+func versionLine(v *apiclient.VersionInfo) string {
+	ver := deref(v.Version)
+	if ver == "" {
+		ver = "unknown"
+	}
+	if git := deref(v.GitVersion); git != "" {
+		return fmt.Sprintf("%s (git %s)", ver, git)
+	}
+	return ver
+}
+
+// executorLine renders executor capability as a compact key=value summary.
+func executorLine(e *apiclient.ExecutorInfo) string {
+	parts := make([]string, 0, 3)
+	if e.ExecutionModes != nil {
+		parts = append(parts, "modes=["+strings.Join(*e.ExecutionModes, ",")+"]")
+	}
+	if e.PodDispatchEnabled != nil {
+		parts = append(parts, fmt.Sprintf("pod_dispatch=%t", *e.PodDispatchEnabled))
+	}
+	if ns := deref(e.TaskNamespace); ns != "" {
+		parts = append(parts, "namespace="+ns)
+	}
+	if len(parts) == 0 {
+		return "(no capability reported)"
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/cli/admin_health_test.go
+++ b/internal/cli/admin_health_test.go
@@ -1,0 +1,106 @@
+package cli
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
+)
+
+// healthServer serves the three monitor endpoints health reads, with the
+// scheduler status controllable so a test can force an unhealthy report.
+func healthServer(t *testing.T, schedulerStatus string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/monitor/health", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, apiclient.HealthInfo{
+			Scheduler:    &apiclient.ComponentHealth{Status: strptr(schedulerStatus)},
+			Metadatabase: &apiclient.ComponentHealth{Status: strptr("healthy")},
+			DagProcessor: &apiclient.ComponentHealth{Status: strptr("healthy")},
+			Triggerer:    &apiclient.ComponentHealth{Status: strptr("healthy")},
+		})
+	})
+	mux.HandleFunc("/api/v2/monitor/executor", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, apiclient.ExecutorInfo{
+			ExecutionModes:     &[]string{"kubernetes"},
+			PodDispatchEnabled: boolptr(true),
+			TaskNamespace:      strptr("leoflow-tasks"),
+		})
+	})
+	mux.HandleFunc("/api/v2/version", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, apiclient.VersionInfo{Version: strptr("2.9.1"), GitVersion: strptr("abc1234")})
+	})
+	return httptest.NewServer(mux)
+}
+
+func TestFetchAdminHealthHealthy(t *testing.T) {
+	srv := healthServer(t, "healthy")
+	defer srv.Close()
+
+	rep, err := fetchAdminHealth(context.Background(), newTestClient(t, srv.URL))
+	if err != nil {
+		t.Fatalf("fetchAdminHealth: %v", err)
+	}
+	if !rep.healthy {
+		t.Errorf("healthy = false, want true")
+	}
+	if rep.executor == nil || rep.version == nil {
+		t.Errorf("executor/version not captured: %+v", rep)
+	}
+}
+
+func TestFetchAdminHealthUnhealthy(t *testing.T) {
+	srv := healthServer(t, "unhealthy")
+	defer srv.Close()
+
+	rep, err := fetchAdminHealth(context.Background(), newTestClient(t, srv.URL))
+	if err != nil {
+		t.Fatalf("fetchAdminHealth: %v", err)
+	}
+	if rep.healthy {
+		t.Errorf("healthy = true, want false when scheduler is unhealthy")
+	}
+}
+
+func TestFetchAdminHealthNon200IsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	if _, err := fetchAdminHealth(context.Background(), newTestClient(t, srv.URL)); err == nil {
+		t.Errorf("expected error when health endpoint returns 503")
+	}
+}
+
+// TestAdminHealthCommandExitsNonZero pins the post-deploy smoke-test contract:
+// an unhealthy control plane makes `leoflow admin health` return an error (a
+// non-zero process exit) while still printing the compact report.
+func TestAdminHealthCommandExitsNonZero(t *testing.T) {
+	srv := healthServer(t, "unhealthy")
+	defer srv.Close()
+
+	out, _, err := run(t, "admin", "health", "--server", srv.URL, "--token", "x")
+	if err == nil {
+		t.Errorf("expected non-nil error (non-zero exit) for unhealthy control plane")
+	}
+	if !strings.Contains(out, "UNHEALTHY") {
+		t.Errorf("output = %q, want it to contain UNHEALTHY", out)
+	}
+}
+
+func TestAdminHealthCommandHealthyExitsZero(t *testing.T) {
+	srv := healthServer(t, "healthy")
+	defer srv.Close()
+
+	out, _, err := run(t, "admin", "health", "--server", srv.URL, "--token", "x")
+	if err != nil {
+		t.Fatalf("healthy admin health returned error: %v", err)
+	}
+	if !strings.Contains(out, "HEALTHY") || strings.Contains(out, "UNHEALTHY") {
+		t.Errorf("output = %q, want HEALTHY and not UNHEALTHY", out)
+	}
+}

--- a/internal/cli/admin_runs.go
+++ b/internal/cli/admin_runs.go
@@ -1,0 +1,186 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
+)
+
+// adminRun is a flattened DAG run, carrying its owning DAG id so runs collected
+// across many DAGs stay attributable.
+type adminRun struct {
+	dagID string
+	runID string
+	state string
+	start *time.Time
+}
+
+// newAdminRunsCommand groups the run-inspection operator commands.
+func newAdminRunsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "runs",
+		Short: "Inspect DAG runs across the control plane.",
+	}
+	cmd.AddCommand(newAdminRunsListCommand())
+	return cmd
+}
+
+// newAdminRunsListCommand builds `leoflow admin runs list`: list runs, optionally
+// narrowed by state (server-side), by DAG, and by age — the "what is stuck?"
+// query. Because runs are exposed per DAG, an unfiltered listing walks every
+// registered DAG.
+func newAdminRunsListCommand() *cobra.Command {
+	var f adminFlags
+	var state, dagID string
+	var olderThan time.Duration
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List DAG runs, filtered by --state, --older-than, and/or --dag.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := validateRunState(state); err != nil {
+				return err
+			}
+			c, _, err := adminClient(cmd, f)
+			if err != nil {
+				return err
+			}
+			runs, err := collectRuns(cmdContext(cmd), c, dagID, state)
+			if err != nil {
+				return err
+			}
+			runs = filterRunsByAge(runs, olderThan, time.Now())
+			return renderRuns(cmd.OutOrStdout(), runs)
+		},
+	}
+	addAdminFlags(cmd, &f)
+	cmd.Flags().StringVar(&state, "state", "", "filter by run state: queued, running, success, or failed")
+	cmd.Flags().StringVar(&dagID, "dag", "", "limit to a single DAG id (default: all DAGs)")
+	cmd.Flags().DurationVar(&olderThan, "older-than", 0, "only runs whose start time is older than this (e.g. 2h)")
+	return cmd
+}
+
+// validateRunState rejects an unknown --state up front, so a typo is a loud
+// error rather than a silently-empty listing.
+func validateRunState(state string) error {
+	if state == "" {
+		return nil
+	}
+	if apiclient.ListDagRunsParamsState(state).Valid() {
+		return nil
+	}
+	return fmt.Errorf("unknown --state %q (want queued, running, success, or failed)", state)
+}
+
+// collectRuns gathers runs for a single DAG (when dagID is set) or across every
+// registered DAG, passing the state filter through to the server.
+func collectRuns(ctx context.Context, c *apiclient.ClientWithResponses, dagID, state string) ([]adminRun, error) {
+	ids := []string{dagID}
+	if dagID == "" {
+		all, err := listAllDagIDs(ctx, c)
+		if err != nil {
+			return nil, err
+		}
+		ids = all
+	}
+	var runs []adminRun
+	for _, id := range ids {
+		got, err := listRunsForDag(ctx, c, id, state)
+		if err != nil {
+			return nil, err
+		}
+		runs = append(runs, got...)
+	}
+	return runs, nil
+}
+
+// listRunsForDag lists one DAG's runs, applying the optional server-side state
+// filter.
+func listRunsForDag(ctx context.Context, c *apiclient.ClientWithResponses, dagID, state string) ([]adminRun, error) {
+	var params *apiclient.ListDagRunsParams
+	if state != "" {
+		states := []apiclient.ListDagRunsParamsState{apiclient.ListDagRunsParamsState(state)}
+		params = &apiclient.ListDagRunsParams{State: &states}
+	}
+	resp, err := c.ListDagRunsWithResponse(ctx, dagID, params)
+	if err != nil {
+		return nil, fmt.Errorf("listing runs for %q: %w", dagID, err)
+	}
+	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+		return nil, fmt.Errorf("listing runs for %q returned %d: %s", dagID, resp.StatusCode(), string(resp.Body))
+	}
+	if resp.JSON200.DagRuns == nil {
+		return []adminRun{}, nil
+	}
+	out := make([]adminRun, 0, len(*resp.JSON200.DagRuns))
+	for _, r := range *resp.JSON200.DagRuns {
+		out = append(out, adminRun{
+			dagID: fallbackDagID(deref(r.DagId), dagID),
+			runID: deref(r.DagRunId),
+			state: runStateString(r.State),
+			start: r.StartDate,
+		})
+	}
+	return out, nil
+}
+
+// fallbackDagID uses the run's own dag_id when present, else the DAG the run was
+// listed under (some responses omit the redundant field).
+func fallbackDagID(fromRun, listedUnder string) string {
+	if fromRun != "" {
+		return fromRun
+	}
+	return listedUnder
+}
+
+// runStateString renders a run state pointer, defaulting to "unknown".
+func runStateString(s *apiclient.DAGRunState) string {
+	if s == nil {
+		return "unknown"
+	}
+	return string(*s)
+}
+
+// filterRunsByAge keeps only runs whose start time is at least olderThan in the
+// past. A non-positive threshold disables the filter (every run is kept,
+// including runs with no start time yet).
+func filterRunsByAge(runs []adminRun, olderThan time.Duration, now time.Time) []adminRun {
+	if olderThan <= 0 {
+		return runs
+	}
+	out := make([]adminRun, 0, len(runs))
+	for _, r := range runs {
+		if r.start != nil && now.Sub(*r.start) >= olderThan {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// renderRuns prints the runs as an aligned table, or a friendly note when empty.
+func renderRuns(w io.Writer, runs []adminRun) error {
+	if len(runs) == 0 {
+		return writeLine(w, "No runs found.")
+	}
+	lines := make([]string, 0, len(runs)+1)
+	lines = append(lines, fmt.Sprintf("%-24s %-30s %-10s %s", "DAG", "RUN", "STATE", "AGE"))
+	for _, r := range runs {
+		lines = append(lines, fmt.Sprintf("%-24s %-30s %-10s %s", r.dagID, r.runID, r.state, ageString(r.start)))
+	}
+	return writeLine(w, strings.Join(lines, "\n"))
+}
+
+// ageString renders how long ago a run started, or "-" when it has no start.
+func ageString(start *time.Time) string {
+	if start == nil {
+		return "-"
+	}
+	return time.Since(*start).Round(time.Second).String()
+}

--- a/internal/cli/admin_runs_test.go
+++ b/internal/cli/admin_runs_test.go
@@ -11,7 +11,7 @@ import (
 	apiclient "github.com/neochaotic/leoflow/pkg/client"
 )
 
-// runsServer serves one DAG ("etl") whose dagRuns endpoint honours the ?state
+// runsServer serves one DAG ("etl") whose dagRuns endpoint honors the ?state
 // filter and returns runs with fixed start dates so age filtering is testable.
 func runsServer(t *testing.T, now time.Time) *httptest.Server {
 	t.Helper()

--- a/internal/cli/admin_runs_test.go
+++ b/internal/cli/admin_runs_test.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
+)
+
+// runsServer serves one DAG ("etl") whose dagRuns endpoint honours the ?state
+// filter and returns runs with fixed start dates so age filtering is testable.
+func runsServer(t *testing.T, now time.Time) *httptest.Server {
+	t.Helper()
+	old := now.Add(-3 * time.Hour)
+	recent := now.Add(-1 * time.Minute)
+	all := []apiclient.DAGRun{
+		{DagRunId: strptr("run-old"), DagId: strptr("etl"), State: runState(apiclient.DAGRunStateRunning), StartDate: &old},
+		{DagRunId: strptr("run-new"), DagId: strptr("etl"), State: runState(apiclient.DAGRunStateRunning), StartDate: &recent},
+		{DagRunId: strptr("run-done"), DagId: strptr("etl"), State: runState(apiclient.DAGRunStateSuccess), StartDate: &recent},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/dags", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/dags" {
+			http.NotFound(w, r)
+			return
+		}
+		dags := []apiclient.DAG{{DagId: strptr("etl")}}
+		total := 1
+		writeJSON(t, w, apiclient.DAGCollection{Dags: &dags, TotalEntries: &total})
+	})
+	mux.HandleFunc("/api/v2/dags/etl/dagRuns", func(w http.ResponseWriter, r *http.Request) {
+		state := r.URL.Query().Get("state")
+		runs := make([]apiclient.DAGRun, 0, len(all))
+		for _, run := range all {
+			if state == "" || string(*run.State) == state {
+				runs = append(runs, run)
+			}
+		}
+		total := len(runs)
+		writeJSON(t, w, apiclient.DAGRunCollection{DagRuns: &runs, TotalEntries: &total})
+	})
+	return httptest.NewServer(mux)
+}
+
+func runState(s apiclient.DAGRunState) *apiclient.DAGRunState { return &s }
+
+func TestCollectRunsFiltersByState(t *testing.T) {
+	now := time.Now()
+	srv := runsServer(t, now)
+	defer srv.Close()
+
+	runs, err := collectRuns(context.Background(), newTestClient(t, srv.URL), "", "running")
+	if err != nil {
+		t.Fatalf("collectRuns: %v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("running runs = %d, want 2", len(runs))
+	}
+	for _, r := range runs {
+		if r.state != "running" {
+			t.Errorf("run %q state = %q, want running", r.runID, r.state)
+		}
+	}
+}
+
+func TestFilterRunsByAge(t *testing.T) {
+	now := time.Now()
+	old := now.Add(-3 * time.Hour)
+	recent := now.Add(-1 * time.Minute)
+	runs := []adminRun{
+		{dagID: "etl", runID: "old", state: "running", start: &old},
+		{dagID: "etl", runID: "new", state: "running", start: &recent},
+	}
+	got := filterRunsByAge(runs, 2*time.Hour, now)
+	if len(got) != 1 || got[0].runID != "old" {
+		t.Fatalf("older-than 2h = %+v, want just the old run", got)
+	}
+	// A zero threshold keeps everything, including runs with no start time.
+	if len(filterRunsByAge(runs, 0, now)) != 2 {
+		t.Errorf("zero threshold dropped runs")
+	}
+}
+
+func TestAdminRunsListStateAndAge(t *testing.T) {
+	now := time.Now()
+	srv := runsServer(t, now)
+	defer srv.Close()
+
+	out, _, err := run(t, "admin", "runs", "list", "--state", "running", "--older-than", "2h",
+		"--server", srv.URL, "--token", "x")
+	if err != nil {
+		t.Fatalf("admin runs list: %v", err)
+	}
+	if !strings.Contains(out, "run-old") {
+		t.Errorf("output = %q, want it to include run-old", out)
+	}
+	if strings.Contains(out, "run-new") || strings.Contains(out, "run-done") {
+		t.Errorf("output = %q, should have filtered out run-new and run-done", out)
+	}
+}

--- a/internal/cli/admin_test.go
+++ b/internal/cli/admin_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
+)
+
+// writeJSON encodes v as a JSON response body for the fake control planes used
+// by the admin command tests.
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Fatalf("encoding response: %v", err)
+	}
+}
+
+// newTestClient builds a typed /api/v2 client aimed at a fake server.
+func newTestClient(t *testing.T, baseURL string) *apiclient.ClientWithResponses {
+	t.Helper()
+	c, err := apiclient.New(baseURL, "")
+	if err != nil {
+		t.Fatalf("apiclient.New: %v", err)
+	}
+	return c
+}
+
+func strptr(s string) *string { return &s }
+func boolptr(b bool) *bool    { return &b }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -36,12 +36,14 @@ func NewRootCommand() *cobra.Command {
 		&cobra.Group{ID: "authoring", Title: "Authoring loop (write → check → package → push):"},
 		&cobra.Group{ID: "runtime", Title: "Runtime (start the control plane):"},
 		&cobra.Group{ID: "inspection", Title: "Inspection (query DAGs / runs / auth):"},
+		&cobra.Group{ID: "operations", Title: "Operations (operate a running control plane):"},
 		&cobra.Group{ID: "lifecycle", Title: "Lifecycle (install, configure, repair, retire):"},
 	)
 
 	authoring := []*cobra.Command{newInitCommand(), newValidateCommand(), newCompileCommand(), newPushCommand(), newDeployCommand()}
 	runtime := []*cobra.Command{newLiteCommand(), newServerCommand()}
 	inspection := []*cobra.Command{newDagsCommand(), newRunsCommand(), newAuthCommand()}
+	operations := []*cobra.Command{newAdminCommand()}
 	lifecycle := []*cobra.Command{newSetupCommand(), newDoctorCommand(), newDBCommand(), newUninstallCommand(), newVersionCommand()}
 
 	for _, c := range authoring {
@@ -54,6 +56,10 @@ func NewRootCommand() *cobra.Command {
 	}
 	for _, c := range inspection {
 		c.GroupID = "inspection"
+		root.AddCommand(c)
+	}
+	for _, c := range operations {
+		c.GroupID = "operations"
 		root.AddCommand(c)
 	}
 	for _, c := range lifecycle {

--- a/internal/cli/root_groups_test.go
+++ b/internal/cli/root_groups_test.go
@@ -24,6 +24,8 @@ func TestRootCommandsHaveGroups(t *testing.T) {
 		"dags": "inspection",
 		"runs": "inspection",
 		"auth": "inspection",
+		// Operations — operate a running control plane.
+		"admin": "operations",
 		// Lifecycle — install, configure, repair, version, retire the host.
 		"setup":     "lifecycle",
 		"doctor":    "lifecycle",
@@ -44,11 +46,11 @@ func TestRootCommandsHaveGroups(t *testing.T) {
 	}
 }
 
-// TestRootDefinesFourGroups pins the group set itself so a typo in a GroupID
+// TestRootDefinesGroups pins the group set itself so a typo in a GroupID
 // fails the GROUP definition, not the assignment.
-func TestRootDefinesFourGroups(t *testing.T) {
+func TestRootDefinesGroups(t *testing.T) {
 	root := NewRootCommand()
-	want := map[string]bool{"authoring": false, "runtime": false, "inspection": false, "lifecycle": false}
+	want := map[string]bool{"authoring": false, "runtime": false, "inspection": false, "operations": false, "lifecycle": false}
 	for _, g := range root.Groups() {
 		if _, ok := want[g.ID]; ok {
 			want[g.ID] = true


### PR DESCRIPTION
## What
A `leoflow admin` operator CLI over the typed `pkg/client` — the operational surface that was missing (the CLI was author-only: init/compile/push/deploy). Highlight: **`admin drain`**, the "safely quiesce the control plane before maintenance/upgrade" command that had no clean equivalent.

## Commands
- `admin health` → `/monitor/health` + `/monitor/executor` + version; **non-zero exit if unhealthy** (post-deploy smoke test).
- `admin dags pause/unpause <id> [--all]` → PATCH `/dags/{id}` is_paused.
- `admin drain [--timeout 10m] [--wait/--no-wait] [--poll-interval]` → pause ALL DAGs, then poll running runs until drained or timeout (non-zero exit on timeout, reporting what's still running).
- `admin runs list [--state] [--older-than] [--dag]`.

Over `pkg/client` (no regen — uses existing generated methods). dagRuns are per-DAG in the API, so `drain`/`runs list` list DAGs then fan out per-DAG.

## Tests (strict TDD, two commits)
15 httptest-based tests (health / pause / drain / runs), red→green. golangci-lint (repo, 30-linter set) 0, gofmt, `go vet` clean. `root_groups_test.go` extended (strengthened) so a group-id typo still fails.

## Lite containment
All 12 changed files are under `internal/cli/` — an additive command tree over the HTTP API. No scheduler/executor/Lite runtime touched; no existing command's behavior changed.

## Deferred (follow-ups; tree left extensible)
`admin tasks clear/mark`, `admin conn …`, `admin var …`, `admin pods …` (last needs apiserver, out of scope for a pkg/client CLI).

Relates: #623.
