### PR TITLE
ci: per-job timeouts + hardened apt-get (kill the 6h hang)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
   lint:
     name: Lint (golangci-lint A+ enforcement)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -42,6 +43,7 @@ jobs:
   proto-drift:
     name: Proto generated code is in sync
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -76,6 +78,7 @@ jobs:
   pkg-client-drift:
     name: pkg/client is in sync with the OpenAPI spec
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -100,6 +103,7 @@ jobs:
   mcp-e2e:
     name: MCP server e2e (real binary over stdio + http)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -117,6 +121,7 @@ jobs:
   workflow-lint:
     name: Lint workflows (actionlint)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -134,6 +139,7 @@ jobs:
   test:
     name: Test + Coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     services:
       postgres:
         image: public.ecr.aws/docker/library/postgres:16
@@ -194,6 +200,7 @@ jobs:
   integration:
     name: Integration tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     services:
       postgres:
         image: public.ecr.aws/docker/library/postgres:16
@@ -234,6 +241,7 @@ jobs:
   e2e-lite:
     name: E2E Lite (setup → login)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     services:
       postgres:
         image: public.ecr.aws/docker/library/postgres:16
@@ -269,6 +277,7 @@ jobs:
   binary-only-install:
     name: Binary-only install (no repo, no PYTHONPATH)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -290,6 +299,7 @@ jobs:
   e2e-lite-multidag:
     name: E2E Lite (multi-DAG materialization gate)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       # The script runs `leoflow compile`, which spawns the parser via
       # `python3 -m leoflow_parser`. The repo ships the parser source under
@@ -315,6 +325,7 @@ jobs:
   e2e-lite-selfheal:
     name: E2E Lite (boot self-heal gate)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     services:
       postgres:
         image: public.ecr.aws/docker/library/postgres:16
@@ -349,6 +360,7 @@ jobs:
   e2e-lite-alerts:
     name: E2E Lite (on-failure alerting gate)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     services:
       postgres:
         image: public.ecr.aws/docker/library/postgres:16
@@ -383,6 +395,7 @@ jobs:
   e2e-lite-callback:
     name: E2E Lite (on_failure_callback gate)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     services:
       postgres:
         image: public.ecr.aws/docker/library/postgres:16
@@ -413,6 +426,7 @@ jobs:
   e2e-lite-dbt:
     name: E2E Lite (dbt duckdb)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     services:
       postgres:
         image: public.ecr.aws/docker/library/postgres:16
@@ -436,8 +450,6 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - name: Install jq
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq jq
       - name: Lite dbt (duckdb) e2e (#573)
         run: bash test/e2e/lite-dbt.sh
 
@@ -452,6 +464,7 @@ jobs:
   ui-smoke:
     name: UI smoke (headless SPA crash check)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       PYTHONPATH: parser
     steps:
@@ -505,6 +518,7 @@ jobs:
   operator-e2e:
     name: E2E operators (k3d pod-per-task)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     services:
       postgres:
         image: public.ecr.aws/docker/library/postgres:16
@@ -564,14 +578,13 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - name: Install k3d + kubectl + jq + migrate
+      - name: Install k3d + kubectl + migrate
         if: steps.gate.outputs.run == 'true'
         run: |
           set -euo pipefail
           curl -fsSL https://raw.githubusercontent.com/k3d-io/k3d/v5.7.4/install.sh | TAG=v5.7.4 bash
           curl -fsSLO "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
           sudo install -m 0755 kubectl /usr/local/bin/kubectl
-          sudo apt-get update -qq && sudo apt-get install -y -qq jq
           go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
       - name: Apply migrations
         if: steps.gate.outputs.run == 'true'
@@ -596,6 +609,7 @@ jobs:
   split-e2e:
     name: E2E split (k3d two-process api/scheduler)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     services:
       postgres:
         image: public.ecr.aws/docker/library/postgres:16
@@ -651,14 +665,13 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - name: Install k3d + kubectl + jq + migrate
+      - name: Install k3d + kubectl + migrate
         if: steps.gate.outputs.run == 'true'
         run: |
           set -euo pipefail
           curl -fsSL https://raw.githubusercontent.com/k3d-io/k3d/v5.7.4/install.sh | TAG=v5.7.4 bash
           curl -fsSLO "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
           sudo install -m 0755 kubectl /usr/local/bin/kubectl
-          sudo apt-get update -qq && sudo apt-get install -y -qq jq
           go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
       - name: Apply migrations
         if: steps.gate.outputs.run == 'true'
@@ -680,6 +693,7 @@ jobs:
   e2e-dbt:
     name: E2E dbt (k3d pod-per-model)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     services:
       postgres:
         image: public.ecr.aws/docker/library/postgres:16
@@ -735,14 +749,13 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - name: Install k3d + kubectl + jq + migrate + dbt
+      - name: Install k3d + kubectl + migrate + dbt
         if: steps.gate.outputs.run == 'true'
         run: |
           set -euo pipefail
           curl -fsSL https://raw.githubusercontent.com/k3d-io/k3d/v5.7.4/install.sh | TAG=v5.7.4 bash
           curl -fsSLO "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
           sudo install -m 0755 kubectl /usr/local/bin/kubectl
-          sudo apt-get update -qq && sudo apt-get install -y -qq jq
           go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
           pip install --quiet dbt-core dbt-postgres
       - name: Apply migrations
@@ -770,6 +783,7 @@ jobs:
   dbt-adapter-contracts:
     name: dbt adapter contracts (${{ matrix.adapter }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -796,6 +810,7 @@ jobs:
   deploy-e2e:
     name: E2E deploy (k3d + registry)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     services:
       postgres:
         image: public.ecr.aws/docker/library/postgres:16
@@ -852,14 +867,13 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - name: Install k3d + kubectl + jq + migrate
+      - name: Install k3d + kubectl + migrate
         if: steps.gate.outputs.run == 'true'
         run: |
           set -euo pipefail
           curl -fsSL https://raw.githubusercontent.com/k3d-io/k3d/v5.7.4/install.sh | TAG=v5.7.4 bash
           curl -fsSLO "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
           sudo install -m 0755 kubectl /usr/local/bin/kubectl
-          sudo apt-get update -qq && sudo apt-get install -y -qq jq
           go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
       - name: Apply migrations
         if: steps.gate.outputs.run == 'true'
@@ -879,6 +893,7 @@ jobs:
   tdd-check:
     name: TDD discipline (commit pattern check)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -903,6 +918,7 @@ jobs:
   build:
     name: Build binaries
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [lint, test]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -934,6 +950,7 @@ jobs:
   openapi-lint:
     name: OpenAPI spec lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -960,6 +977,7 @@ jobs:
   examples-dockerfile-drift:
     name: Examples Dockerfile drift (#318)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Check Dockerfiles are in sync with leoflow.yaml
@@ -976,6 +994,7 @@ jobs:
   dependabot-dirs:
     name: Dependabot directories resolve
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install PyYAML
@@ -993,6 +1012,7 @@ jobs:
   python-parser:
     name: Python parser tests (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -1023,6 +1043,7 @@ jobs:
   python-runtime:
     name: Python runtime tests
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: runtime/python

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -47,7 +48,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with: { python-version: "3.12" }
       # Imaging libs for the Material social-cards plugin.
-      - run: sudo apt-get update && sudo apt-get install -y libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
+      - run: sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update && sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
       - run: pip install "mkdocs-material[imaging]" "mkdocstrings[python]"
       # Python docstrings (the task runtime) for the Python API page.
       - run: pip install -e ./runtime/python
@@ -82,6 +83,7 @@ jobs:
     # exist to gate the build; the published site is updated by main.
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       pages: write      # Publish the built site to GitHub Pages.
       id-token: write   # OIDC token for the Pages deployment.

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -46,6 +46,7 @@ jobs:
   lint:
     name: helm lint + template-checks + kubeconform
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
@@ -125,6 +126,7 @@ jobs:
   kind-e2e:
     name: kind install + upgrade smoke
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: lint
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/pro-netpol-rwx.yaml
+++ b/.github/workflows/pro-netpol-rwx.yaml
@@ -23,6 +23,7 @@ jobs:
   netpol-rwx:
     name: kind + Calico (netpol enforced) + NFS RWX
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 

--- a/.github/workflows/prune-prealpha.yaml
+++ b/.github/workflows/prune-prealpha.yaml
@@ -39,6 +39,7 @@ jobs:
   prune:
     name: Prune stale pre-alpha releases
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write   # Delete pre-alpha releases and their tags.
     steps:

--- a/.github/workflows/publish-devto.yml
+++ b/.github/workflows/publish-devto.yml
@@ -32,6 +32,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write # the publish step commits the returned article id back to the repo
     # Skip entirely if the token secret is not configured, so forks/CI stay green.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,7 @@ jobs:
   release:
     name: Build, sign, publish
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write   # GoReleaser creates the GitHub release.
       packages: write   # Push the leoflow-server image to GHCR.
@@ -79,6 +80,7 @@ jobs:
     name: Build + push leoflow-migrate image
     needs: release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -157,6 +159,7 @@ jobs:
     name: Build + push leoflow-runtime base (py${{ matrix.python }})
     needs: release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -235,6 +238,7 @@ jobs:
     name: Install smoke (${{ matrix.image }})
     needs: release
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container: ${{ matrix.image }}
     defaults:
       run:
@@ -243,8 +247,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { image: "debian:12", prep: "apt-get update -qq && apt-get install -y -qq curl ca-certificates tar" }
-          - { image: "ubuntu:24.04", prep: "apt-get update -qq && apt-get install -y -qq curl ca-certificates tar" }
+          - { image: "debian:12", prep: "apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update -qq && apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y -qq curl ca-certificates tar" }
+          - { image: "ubuntu:24.04", prep: "apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update -qq && apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y -qq curl ca-certificates tar" }
           - { image: "fedora:41", prep: "dnf install -y -q tar curl --allowerasing" }
           - { image: "quay.io/rockylinux/rockylinux:9", prep: "dnf install -y -q tar curl --allowerasing" }
           - { image: "opensuse/leap:15", prep: "zypper --no-gpg-checks -n in -y curl tar gzip" }
@@ -285,6 +289,7 @@ jobs:
     name: Lite cold-start (boot + /readyz, docker PG)
     needs: release
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Install Leoflow via the published install.sh
         env:
@@ -337,20 +342,21 @@ jobs:
     name: Upgrade smoke (previous → ${{ github.ref_name }})
     needs: release
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container: ubuntu:24.04
     steps:
       - name: Install prerequisites
         run: |
-          apt-get update -qq
-          apt-get install -y -qq curl ca-certificates tar git
+          apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update -qq
+          apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y -qq curl ca-certificates tar git
           # gh CLI for release listing
           mkdir -p /etc/apt/keyrings
           chmod 755 /etc/apt/keyrings
           out=$(mktemp) && curl -sL https://cli.github.com/packages/githubcli-archive-keyring.gpg > "$out" && cat "$out" > /etc/apt/keyrings/githubcli-archive-keyring.gpg
           chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
           echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
-          apt-get update -qq
-          apt-get install -y -qq gh
+          apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update -qq
+          apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y -qq gh
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Run upgrade smoke
         env:
@@ -370,6 +376,7 @@ jobs:
     needs: [release, install-smoke, lite-cold-start-smoke, upgrade-smoke, migrate-image, runtime-image]
     if: always() && needs.release.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write   # Edit the published release back to a draft on failure.
     steps:

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -13,6 +13,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       security-events: write
       id-token: write

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -23,6 +23,7 @@ jobs:
   govulncheck:
     name: govulncheck
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -42,6 +43,7 @@ jobs:
   codeql:
     name: CodeQL
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -69,6 +71,7 @@ jobs:
   trivy:
     name: Trivy (image scan)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -103,6 +106,7 @@ jobs:
   gitleaks:
     name: gitleaks (secret scan)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:


### PR DESCRIPTION
## Problem
CI jobs hang ~6 hours and get canceled. Root cause: (1) **no job had `timeout-minutes`**, so a stuck step ran to GitHub's 6-hour default; (2) `apt-get` had no retry/timeout, so a flaky apt mirror hung the step indefinitely; (3) steps `apt-get install jq`, but jq is preinstalled on ubuntu-latest — a needless `apt-get update` that was exactly where it hung. ("It wasn't like this before" = the apt mirror got flaky recently and the workflows had no guardrail.)

## Fix (3 layers, 9 workflows)
1. **`timeout-minutes` on all 46 jobs** — 30 (heavy k3d/E2E/image builds), 20 (test/integration/codeql), 15 (everything else). A hang now fails in minutes, not 6h.
2. **Hardened every `apt-get`** with `-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30` (kept `-y -qq`) — a stalled mirror retries then fails fast.
3. **Removed the redundant `jq` installs** (standalone step + from the combined "Install k3d + …" steps); jq ships on the runner.

## Validation
`actionlint` clean on all 9 workflows; YAML parse OK; **no job `name:` changed** (required-check identifiers intact); composes with the #633 docs/tooling gate (all 26 gate refs intact). This PR's own CI runs with the fix applied, so it can't 6h-hang either.
