### PR TITLE
feat(api): /api/v2/users surface — GET list + create aligned to plural roles

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -63,8 +63,8 @@ paths:
       summary: Create a user
       description: |
         Admin-only. Creates a control-plane account with the given email and
-        password and grants at most one role. The password is write-only and is
-        never returned. Requires the admin:tenant permission.
+        password and grants the requested roles. The password is write-only and
+        is never returned. Requires the write:user permission.
       operationId: createUser
       tags: [Users]
       requestBody:
@@ -513,20 +513,21 @@ components:
           description: >-
             Plaintext password (write-only; never returned). Must be at least 8
             characters — the server rejects anything shorter with 400.
-        role:
-          type: string
+        roles:
+          type: array
+          items: { type: string }
           description: >-
-            Name of an existing role to grant (e.g. "admin"). Omit to grant no
-            role — the most restrictive default; the user then holds no
-            permissions until an admin grants one.
+            Names of existing roles to grant; omit or empty to grant none.
 
     User:
       type: object
-      required: [id, email]
+      required: [id, email, roles, is_active, created_at]
       properties:
         id: { type: string }
         email: { type: string }
-        role: { type: string }
+        roles:
+          type: array
+          items: { type: string }
         is_active: { type: boolean }
         created_at: { type: string, format: date-time }
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -40,6 +40,25 @@ paths:
           $ref: "#/components/responses/Unauthorized"
 
   /api/v2/users:
+    get:
+      summary: List users
+      description: |
+        Lists the tenant's control-plane accounts, newest first. Each entry
+        carries the full set of roles the user holds; the password and its hash
+        are write-only and never returned. Requires the read:user permission.
+      operationId: listUsers
+      tags: [Users]
+      parameters:
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+      responses:
+        "200":
+          description: A page of users
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/UserCollection" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
     post:
       summary: Create a user
       description: |
@@ -510,6 +529,30 @@ components:
         role: { type: string }
         is_active: { type: boolean }
         created_at: { type: string, format: date-time }
+
+    UserListItem:
+      type: object
+      required: [id, email, roles, is_active, created_at]
+      description: >-
+        One account in the user list. Leoflow accounts are email-keyed and carry
+        a set of RBAC roles, so this diverges from the Airflow FAB users API
+        (username-keyed with first_name/last_name).
+      properties:
+        id: { type: string }
+        email: { type: string }
+        roles:
+          type: array
+          items: { type: string }
+        is_active: { type: boolean }
+        created_at: { type: string, format: date-time }
+
+    UserCollection:
+      type: object
+      properties:
+        users:
+          type: array
+          items: { $ref: "#/components/schemas/UserListItem" }
+        total_entries: { type: integer }
 
     DAG:
       type: object

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -63,8 +63,8 @@ paths:
       summary: Create a user
       description: |
         Admin-only. Creates a control-plane account with the given email and
-        password and grants at most one role. The password is write-only and is
-        never returned. Requires the admin:tenant permission.
+        password and grants the requested roles. The password is write-only and
+        is never returned. Requires the write:user permission.
       operationId: createUser
       tags: [Users]
       requestBody:
@@ -513,20 +513,21 @@ components:
           description: >-
             Plaintext password (write-only; never returned). Must be at least 8
             characters — the server rejects anything shorter with 400.
-        role:
-          type: string
+        roles:
+          type: array
+          items: { type: string }
           description: >-
-            Name of an existing role to grant (e.g. "admin"). Omit to grant no
-            role — the most restrictive default; the user then holds no
-            permissions until an admin grants one.
+            Names of existing roles to grant; omit or empty to grant none.
 
     User:
       type: object
-      required: [id, email]
+      required: [id, email, roles, is_active, created_at]
       properties:
         id: { type: string }
         email: { type: string }
-        role: { type: string }
+        roles:
+          type: array
+          items: { type: string }
         is_active: { type: boolean }
         created_at: { type: string, format: date-time }
 

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -40,6 +40,25 @@ paths:
           $ref: "#/components/responses/Unauthorized"
 
   /api/v2/users:
+    get:
+      summary: List users
+      description: |
+        Lists the tenant's control-plane accounts, newest first. Each entry
+        carries the full set of roles the user holds; the password and its hash
+        are write-only and never returned. Requires the read:user permission.
+      operationId: listUsers
+      tags: [Users]
+      parameters:
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+      responses:
+        "200":
+          description: A page of users
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/UserCollection" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
     post:
       summary: Create a user
       description: |
@@ -510,6 +529,30 @@ components:
         role: { type: string }
         is_active: { type: boolean }
         created_at: { type: string, format: date-time }
+
+    UserListItem:
+      type: object
+      required: [id, email, roles, is_active, created_at]
+      description: >-
+        One account in the user list. Leoflow accounts are email-keyed and carry
+        a set of RBAC roles, so this diverges from the Airflow FAB users API
+        (username-keyed with first_name/last_name).
+      properties:
+        id: { type: string }
+        email: { type: string }
+        roles:
+          type: array
+          items: { type: string }
+        is_active: { type: boolean }
+        created_at: { type: string, format: date-time }
+
+    UserCollection:
+      type: object
+      properties:
+        users:
+          type: array
+          items: { $ref: "#/components/schemas/UserListItem" }
+        total_entries: { type: integer }
 
     DAG:
       type: object

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -37,38 +37,44 @@ func normalizeEmail(email string) string {
 // scheme) and returns the created user without any secret. A duplicate email
 // must surface as domain.ErrConflict and an unknown role as domain.ErrValidation.
 type UserStore interface {
-	CreateUser(ctx context.Context, tenant, email, password, role string) (domain.User, error)
+	CreateUser(ctx context.Context, tenant, email, password string, roles []string) (domain.User, error)
 	ListUsers(ctx context.Context, tenant string, limit, offset int) ([]domain.User, int, error)
 }
 
 // UserAuditWriter records account-creation events for the Audit Log. It is a
 // separate, narrow interface (not the task-shaped AuditWriter) so account
-// management writes a "user" resource entry with the acting admin as owner.
+// management writes a "user" resource entry with the acting admin as owner. The
+// granted roles are passed as a single joined string so the record captures the
+// full set.
 type UserAuditWriter interface {
-	RecordUserCreatedAudit(ctx context.Context, tenant, actorUserID, createdUserID, email, role string) error
+	RecordUserCreatedAudit(ctx context.Context, tenant, actorUserID, createdUserID, email, roles string) error
 }
 
 // createUserBody is the POST /api/v2/users payload. Password is write-only.
 type createUserBody struct {
-	Email    string `json:"email"`
-	Password string `json:"password"`
-	Role     string `json:"role"`
+	Email    string   `json:"email"`
+	Password string   `json:"password"`
+	Roles    []string `json:"roles"`
 }
 
 // userDTO is the create-user response. It never includes the password or hash.
 type userDTO struct {
-	ID        string `json:"id"`
-	Email     string `json:"email"`
-	Role      string `json:"role"`
-	IsActive  bool   `json:"is_active"`
-	CreatedAt string `json:"created_at"`
+	ID        string   `json:"id"`
+	Email     string   `json:"email"`
+	Roles     []string `json:"roles"`
+	IsActive  bool     `json:"is_active"`
+	CreatedAt string   `json:"created_at"`
 }
 
 func toUserDTO(u domain.User) userDTO {
+	roles := u.Roles
+	if roles == nil {
+		roles = []string{}
+	}
 	return userDTO{
 		ID:        u.ID,
 		Email:     u.Email,
-		Role:      u.Role,
+		Roles:     roles,
 		IsActive:  u.IsActive,
 		CreatedAt: u.CreatedAt.UTC().Format(time.RFC3339),
 	}
@@ -146,7 +152,7 @@ func createUserHandler(store UserStore, audit UserAuditWriter) gin.HandlerFunc {
 				fmt.Sprintf("password must be at least %d characters", minPasswordLength))
 			return
 		}
-		user, err := store.CreateUser(c.Request.Context(), tenantOf(c), email, body.Password, body.Role)
+		user, err := store.CreateUser(c.Request.Context(), tenantOf(c), email, body.Password, body.Roles)
 		if err != nil {
 			handleUserWriteError(c, err)
 			return
@@ -167,7 +173,7 @@ func recordUserCreatedAudit(c *gin.Context, audit UserAuditWriter, u domain.User
 	if actor, ok := UserFromContext(c); ok {
 		actorID = actor.ID
 	}
-	if err := audit.RecordUserCreatedAudit(c.Request.Context(), tenantOf(c), actorID, u.ID, u.Email, u.Role); err != nil {
+	if err := audit.RecordUserCreatedAudit(c.Request.Context(), tenantOf(c), actorID, u.ID, u.Email, strings.Join(u.Roles, ",")); err != nil {
 		slog.Warn("recording user-created audit", "user", u.ID, "error", err)
 	}
 }
@@ -184,7 +190,7 @@ func handleUserWriteError(c *gin.Context, err error) {
 }
 
 // registerUsers mounts the admin user-management surface. The list is gated with
-// read:user and the create with admin:tenant (both admin-only in practice — the
+// read:user and the create with write:user (both admin-only in practice — the
 // admin role short-circuits every permission check). With no store wired the
 // list still renders an empty collection (matching the other Admin resources, so
 // the page never 404s), while the create route is left unregistered.
@@ -194,5 +200,5 @@ func registerUsers(r gin.IRouter, store UserStore, audit UserAuditWriter) {
 		return
 	}
 	r.GET("/api/v2/users", RequirePermission("read", "user"), listUsersHandler(store))
-	r.POST("/api/v2/users", RequirePermission("admin", "tenant"), createUserHandler(store, audit))
+	r.POST("/api/v2/users", RequirePermission("write", "user"), createUserHandler(store, audit))
 }

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -38,6 +38,7 @@ func normalizeEmail(email string) string {
 // must surface as domain.ErrConflict and an unknown role as domain.ErrValidation.
 type UserStore interface {
 	CreateUser(ctx context.Context, tenant, email, password, role string) (domain.User, error)
+	ListUsers(ctx context.Context, tenant string, limit, offset int) ([]domain.User, int, error)
 }
 
 // UserAuditWriter records account-creation events for the Audit Log. It is a

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -74,6 +74,57 @@ func toUserDTO(u domain.User) userDTO {
 	}
 }
 
+// userListItemDTO is one row of the user list. Unlike the Airflow FAB users API
+// (which is username-keyed with first_name/last_name columns Leoflow does not
+// have), Leoflow accounts are email-keyed and carry a set of RBAC roles, so the
+// list is expressed in that native shape rather than the Airflow one. The
+// password and its hash are write-only and never appear here.
+type userListItemDTO struct {
+	ID        string   `json:"id"`
+	Email     string   `json:"email"`
+	Roles     []string `json:"roles"`
+	IsActive  bool     `json:"is_active"`
+	CreatedAt string   `json:"created_at"`
+}
+
+// userCollectionDTO is the paged list response: the page of users plus the
+// unpaged total, matching the {items, total_entries} shape of the other
+// /api/v2 collections.
+type userCollectionDTO struct {
+	Users        []userListItemDTO `json:"users"`
+	TotalEntries int               `json:"total_entries"`
+}
+
+func toUserListItemDTO(u domain.User) userListItemDTO {
+	roles := u.Roles
+	if roles == nil {
+		roles = []string{}
+	}
+	return userListItemDTO{
+		ID:        u.ID,
+		Email:     u.Email,
+		Roles:     roles,
+		IsActive:  u.IsActive,
+		CreatedAt: u.CreatedAt.UTC().Format(time.RFC3339),
+	}
+}
+
+func listUsersHandler(store UserStore) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		limit, offset := pagination(c)
+		users, total, err := store.ListUsers(c.Request.Context(), tenantOf(c), limit, offset)
+		if err != nil {
+			handleRepoError(c, err)
+			return
+		}
+		out := userCollectionDTO{Users: make([]userListItemDTO, 0, len(users)), TotalEntries: total}
+		for _, u := range users {
+			out.Users = append(out.Users, toUserListItemDTO(u))
+		}
+		c.JSON(http.StatusOK, out)
+	}
+}
+
 func createUserHandler(store UserStore, audit UserAuditWriter) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var body createUserBody
@@ -132,13 +183,16 @@ func handleUserWriteError(c *gin.Context, err error) {
 	handleRepoError(c, err)
 }
 
-// registerUsers mounts the admin create-user route when a store is wired. It is
-// gated with the admin:tenant permission, matching how other privileged /api/v2
-// mutations are gated (RequirePermission), so only administrators may create
-// users. With no store it is left unregistered (unknown route -> 404).
+// registerUsers mounts the admin user-management surface. The list is gated with
+// read:user and the create with admin:tenant (both admin-only in practice — the
+// admin role short-circuits every permission check). With no store wired the
+// list still renders an empty collection (matching the other Admin resources, so
+// the page never 404s), while the create route is left unregistered.
 func registerUsers(r gin.IRouter, store UserStore, audit UserAuditWriter) {
 	if store == nil {
+		r.GET("/api/v2/users", apiEmptyCollection("users"))
 		return
 	}
+	r.GET("/api/v2/users", RequirePermission("read", "user"), listUsersHandler(store))
 	r.POST("/api/v2/users", RequirePermission("admin", "tenant"), createUserHandler(store, audit))
 }

--- a/internal/api/users_test.go
+++ b/internal/api/users_test.go
@@ -25,6 +25,9 @@ type fakeUserStore struct {
 	gotEmail, gotPassword, gotRole string
 	enforceUnique                  bool
 	seen                           map[string]bool
+	users                          []domain.User
+	listErr                        error
+	listCalled                     bool
 }
 
 func (f *fakeUserStore) CreateUser(_ context.Context, _, email, password, role string) (domain.User, error) {
@@ -43,6 +46,23 @@ func (f *fakeUserStore) CreateUser(_ context.Context, _, email, password, role s
 		f.seen[email] = true
 	}
 	return f.created, nil
+}
+
+func (f *fakeUserStore) ListUsers(_ context.Context, _ string, limit, offset int) ([]domain.User, int, error) {
+	f.listCalled = true
+	if f.listErr != nil {
+		return nil, 0, f.listErr
+	}
+	total := len(f.users)
+	lo := offset
+	if lo > total {
+		lo = total
+	}
+	hi := lo + limit
+	if hi > total {
+		hi = total
+	}
+	return f.users[lo:hi], total, nil
 }
 
 // fakeUserAudit records the audit entries the handler writes on success.
@@ -228,5 +248,60 @@ func TestCreateUserWithoutStoreNotRegistered(t *testing.T) {
 		`{"email":"a@example.com","password":"pw-12345678"}`)
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("nil store = %d, want 404", rec.Code)
+	}
+}
+
+func TestListUsersReturnsCollectionWithoutSecret(t *testing.T) {
+	store := &fakeUserStore{users: []domain.User{{
+		ID: "u-1", Email: "alice@example.com", Roles: []string{"admin"}, IsActive: true,
+		CreatedAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+	}}}
+	rec := authGet(userServer(store, adminUser()), http.MethodGet, "/api/v2/users", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list = %d (%s)", rec.Code, rec.Body.String())
+	}
+	// The list must never expose a password or hash column.
+	if strings.Contains(rec.Body.String(), "password") || strings.Contains(rec.Body.String(), "hash") {
+		t.Errorf("list leaked a secret: %s", rec.Body.String())
+	}
+	var col userCollectionDTO
+	if err := json.Unmarshal(rec.Body.Bytes(), &col); err != nil {
+		t.Fatal(err)
+	}
+	if col.TotalEntries != 1 || len(col.Users) != 1 {
+		t.Fatalf("unexpected collection: %+v", col)
+	}
+	u := col.Users[0]
+	if u.ID != "u-1" || u.Email != "alice@example.com" || !u.IsActive ||
+		len(u.Roles) != 1 || u.Roles[0] != "admin" || u.CreatedAt != "2026-01-02T03:04:05Z" {
+		t.Errorf("unexpected user item: %+v", u)
+	}
+}
+
+func TestListUsersRequiresPermission(t *testing.T) {
+	// A non-admin principal without read:user is forbidden and must not reach
+	// the store.
+	viewer := &auth.User{ID: "v-1", TenantID: "default", Roles: []string{"viewer"}}
+	store := &fakeUserStore{}
+	rec := authGet(userServer(store, viewer), http.MethodGet, "/api/v2/users", "")
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("non-admin list = %d, want 403", rec.Code)
+	}
+	if store.listCalled {
+		t.Error("store must not be reached when the caller lacks permission")
+	}
+}
+
+func TestListUsersEmptyStubWithoutStore(t *testing.T) {
+	// With no user store wired, the list still renders an empty collection (200)
+	// rather than 404, matching the other Admin resources.
+	rec := authGet(userServer(nil, adminUser()), http.MethodGet, "/api/v2/users", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("nil store list = %d", rec.Code)
+	}
+	var col map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &col)
+	if col["total_entries"].(float64) != 0 {
+		t.Errorf("nil store should yield empty collection, got %v", col)
 	}
 }

--- a/internal/api/users_test.go
+++ b/internal/api/users_test.go
@@ -19,20 +19,21 @@ import (
 // that the plaintext password is delegated to the store (which hashes it) and
 // never echoed back in the response.
 type fakeUserStore struct {
-	created                        domain.User
-	err                            error
-	called                         bool
-	gotEmail, gotPassword, gotRole string
-	enforceUnique                  bool
-	seen                           map[string]bool
-	users                          []domain.User
-	listErr                        error
-	listCalled                     bool
+	created               domain.User
+	err                   error
+	called                bool
+	gotEmail, gotPassword string
+	gotRoles              []string
+	enforceUnique         bool
+	seen                  map[string]bool
+	users                 []domain.User
+	listErr               error
+	listCalled            bool
 }
 
-func (f *fakeUserStore) CreateUser(_ context.Context, _, email, password, role string) (domain.User, error) {
+func (f *fakeUserStore) CreateUser(_ context.Context, _, email, password string, roles []string) (domain.User, error) {
 	f.called = true
-	f.gotEmail, f.gotPassword, f.gotRole = email, password, role
+	f.gotEmail, f.gotPassword, f.gotRoles = email, password, roles
 	if f.err != nil {
 		return domain.User{}, f.err
 	}
@@ -71,10 +72,10 @@ type fakeUserAudit struct {
 	err     error
 }
 
-type userAuditEntry struct{ tenant, actorID, createdID, email, role string }
+type userAuditEntry struct{ tenant, actorID, createdID, email, roles string }
 
-func (f *fakeUserAudit) RecordUserCreatedAudit(_ context.Context, tenant, actorUserID, createdUserID, email, role string) error {
-	f.entries = append(f.entries, userAuditEntry{tenant, actorUserID, createdUserID, email, role})
+func (f *fakeUserAudit) RecordUserCreatedAudit(_ context.Context, tenant, actorUserID, createdUserID, email, roles string) error {
+	f.entries = append(f.entries, userAuditEntry{tenant, actorUserID, createdUserID, email, roles})
 	return f.err
 }
 
@@ -99,12 +100,12 @@ func adminUser() *auth.User {
 
 func TestCreateUserReturnsCreatedUserWithoutSecret(t *testing.T) {
 	store := &fakeUserStore{created: domain.User{
-		ID: "u-1", Email: "alice@example.com", Role: "admin", IsActive: true,
+		ID: "u-1", Email: "alice@example.com", Roles: []string{"admin"}, IsActive: true,
 		CreatedAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
 	}}
 	srv := userServer(store, adminUser())
 
-	body := `{"email":"alice@example.com","password":"s3cret-pass","role":"admin"}`
+	body := `{"email":"alice@example.com","password":"s3cret-pass","roles":["admin"]}`
 	rec := authGet(srv, http.MethodPost, "/api/v2/users", body)
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("create = %d (%s)", rec.Code, rec.Body.String())
@@ -114,16 +115,23 @@ func TestCreateUserReturnsCreatedUserWithoutSecret(t *testing.T) {
 	if store.gotPassword != "s3cret-pass" {
 		t.Errorf("store should receive the plaintext password, got %q", store.gotPassword)
 	}
+	if len(store.gotRoles) != 1 || store.gotRoles[0] != "admin" {
+		t.Errorf("store should receive the requested roles, got %v", store.gotRoles)
+	}
 	if strings.Contains(rec.Body.String(), "s3cret-pass") ||
 		strings.Contains(rec.Body.String(), "password") ||
 		strings.Contains(rec.Body.String(), "hash") {
 		t.Errorf("response leaked a secret: %s", rec.Body.String())
 	}
+	if !strings.Contains(rec.Body.String(), `"roles":["admin"]`) {
+		t.Errorf("response missing roles: %s", rec.Body.String())
+	}
 	var dto userDTO
 	if err := json.Unmarshal(rec.Body.Bytes(), &dto); err != nil {
 		t.Fatal(err)
 	}
-	if dto.ID != "u-1" || dto.Email != "alice@example.com" || dto.Role != "admin" || !dto.IsActive {
+	if dto.ID != "u-1" || dto.Email != "alice@example.com" ||
+		len(dto.Roles) != 1 || dto.Roles[0] != "admin" || !dto.IsActive {
 		t.Errorf("unexpected user dto: %+v", dto)
 	}
 	if dto.CreatedAt != "2026-01-02T03:04:05Z" {
@@ -143,14 +151,15 @@ func TestCreateUserDuplicateEmailConflict(t *testing.T) {
 func TestCreateUserUnknownRoleIsBadRequest(t *testing.T) {
 	store := &fakeUserStore{err: domain.ErrValidation}
 	rec := authGet(userServer(store, adminUser()), http.MethodPost, "/api/v2/users",
-		`{"email":"bob@example.com","password":"pw-12345678","role":"wizard"}`)
+		`{"email":"bob@example.com","password":"pw-12345678","roles":["wizard"]}`)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("unknown role = %d, want 400", rec.Code)
 	}
 }
 
 func TestCreateUserRequiresAdmin(t *testing.T) {
-	// A non-admin principal (no admin role, no admin permission) is forbidden.
+	// A non-admin principal (no write:user permission, no admin short-circuit) is
+	// forbidden by the write:user gate on POST.
 	viewer := &auth.User{ID: "v-1", TenantID: "default", Roles: []string{"viewer"}}
 	store := &fakeUserStore{}
 	rec := authGet(userServer(store, viewer), http.MethodPost, "/api/v2/users",
@@ -184,10 +193,10 @@ func TestCreateUserValidatesRequiredFields(t *testing.T) {
 }
 
 func TestCreateUserWritesAuditOnSuccess(t *testing.T) {
-	store := &fakeUserStore{created: domain.User{ID: "u-7", Email: "alice@example.com", Role: "admin", IsActive: true}}
+	store := &fakeUserStore{created: domain.User{ID: "u-7", Email: "alice@example.com", Roles: []string{"admin"}, IsActive: true}}
 	audit := &fakeUserAudit{}
 	rec := authGet(userServerAudit(store, audit, adminUser()), http.MethodPost, "/api/v2/users",
-		`{"email":"alice@example.com","password":"pw-12345678","role":"admin"}`)
+		`{"email":"alice@example.com","password":"pw-12345678","roles":["admin"]}`)
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("create = %d (%s)", rec.Code, rec.Body.String())
 	}
@@ -195,7 +204,7 @@ func TestCreateUserWritesAuditOnSuccess(t *testing.T) {
 		t.Fatalf("audit entries = %d, want exactly 1", len(audit.entries))
 	}
 	e := audit.entries[0]
-	if e.actorID != "admin-1" || e.createdID != "u-7" || e.email != "alice@example.com" || e.role != "admin" || e.tenant != "default" {
+	if e.actorID != "admin-1" || e.createdID != "u-7" || e.email != "alice@example.com" || e.roles != "admin" || e.tenant != "default" {
 		t.Errorf("unexpected audit entry: %+v", e)
 	}
 }

--- a/internal/cli/token.go
+++ b/internal/cli/token.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -31,7 +32,8 @@ func newAuthCommand() *cobra.Command {
 // existing admin's bearer token, resolved with the same precedence as `deploy`:
 // --token, then LEOFLOW_TOKEN, then the session saved by `auth login`.
 func newCreateUserCommand() *cobra.Command {
-	var serverURL, token, email, password, role string
+	var serverURL, token, email, password string
+	var roles []string
 	cmd := &cobra.Command{
 		Use:   "create-user",
 		Short: "Create a user on the control plane (admin only).",
@@ -44,12 +46,12 @@ func newCreateUserCommand() *cobra.Command {
 			if email == "" || password == "" {
 				return fmt.Errorf("--email and --password are required")
 			}
-			created, err := createUser(cmdContext(cmd), resolvedServer, resolvedToken, email, password, role)
+			created, err := createUser(cmdContext(cmd), resolvedServer, resolvedToken, email, password, roles)
 			if err != nil {
 				return err
 			}
-			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Created user %s (id %s, role %s)\n",
-				created.Email, created.Id, roleOrNone(created.Role))
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Created user %s (id %s, roles %s)\n",
+				created.Email, created.Id, rolesOrNone(created.Roles))
 			return err
 		},
 	}
@@ -57,21 +59,21 @@ func newCreateUserCommand() *cobra.Command {
 	cmd.Flags().StringVar(&token, "token", os.Getenv("LEOFLOW_TOKEN"), "admin JWT bearer token (default: config token)")
 	cmd.Flags().StringVar(&email, "email", "", "email of the user to create")
 	cmd.Flags().StringVar(&password, "password", os.Getenv("LEOFLOW_PASSWORD"), "password for the new user")
-	cmd.Flags().StringVar(&role, "role", "", "existing role to grant (e.g. admin); empty grants none")
+	cmd.Flags().StringArrayVar(&roles, "role", nil, "existing role to grant (repeatable); empty grants none")
 	return cmd
 }
 
 // createUser posts to /api/v2/users through the shared typed client, carrying the
 // admin bearer, and returns the created user. It mirrors requestToken's use of
 // the generated client (ADR 0050 D8) rather than hand-rolling HTTP.
-func createUser(ctx context.Context, serverURL, token, email, password, role string) (apiclient.User, error) {
+func createUser(ctx context.Context, serverURL, token, email, password string, roles []string) (apiclient.User, error) {
 	c, err := apiclient.New(serverURL, token)
 	if err != nil {
 		return apiclient.User{}, err
 	}
 	body := apiclient.CreateUserRequest{Email: email, Password: &password}
-	if role != "" {
-		body.Role = &role
+	if len(roles) > 0 {
+		body.Roles = &roles
 	}
 	resp, err := c.CreateUserWithResponse(ctx, body)
 	if err != nil {
@@ -86,13 +88,13 @@ func createUser(ctx context.Context, serverURL, token, email, password, role str
 	return *resp.JSON201, nil
 }
 
-// roleOrNone renders an optional role for CLI output, showing "(none)" when the
-// user was created without one.
-func roleOrNone(role *string) string {
-	if role == nil || *role == "" {
+// rolesOrNone renders the granted roles for CLI output, showing "(none)" when the
+// user was created without any.
+func rolesOrNone(roles []string) string {
+	if len(roles) == 0 {
 		return "(none)"
 	}
-	return *role
+	return strings.Join(roles, ",")
 }
 
 func newCreateTokenCommand() *cobra.Command {

--- a/internal/cli/token_test.go
+++ b/internal/cli/token_test.go
@@ -45,22 +45,25 @@ func TestCreateUserSendsRoleAndReturnsUser(t *testing.T) {
 		gotBody = string(b)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_, _ = io.WriteString(w, `{"id":"u-9","email":"alice@example.com","role":"admin","is_active":true}`)
+		_, _ = io.WriteString(w, `{"id":"u-9","email":"alice@example.com","roles":["admin"],"is_active":true}`)
 	}))
 	defer srv.Close()
 
-	user, err := createUser(context.Background(), srv.URL, "admin-jwt", "alice@example.com", "pw-12345678", "admin")
+	user, err := createUser(context.Background(), srv.URL, "admin-jwt", "alice@example.com", "pw-12345678", []string{"admin"})
 	if err != nil {
 		t.Fatalf("createUser: %v", err)
 	}
 	if user.Id != "u-9" || user.Email != "alice@example.com" {
 		t.Errorf("unexpected user: %+v", user)
 	}
+	if len(user.Roles) != 1 || user.Roles[0] != "admin" {
+		t.Errorf("unexpected roles: %v", user.Roles)
+	}
 	if gotAuth != "Bearer admin-jwt" {
 		t.Errorf("Authorization = %q, want the admin bearer", gotAuth)
 	}
-	if !strings.Contains(gotBody, `"role":"admin"`) {
-		t.Errorf("request body missing role: %s", gotBody)
+	if !strings.Contains(gotBody, `"roles":["admin"]`) {
+		t.Errorf("request body missing roles: %s", gotBody)
 	}
 }
 
@@ -71,7 +74,7 @@ func TestCreateUserRejectsBadStatus(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if _, err := createUser(context.Background(), srv.URL, "t", "dupe@example.com", "pw-12345678", ""); err == nil {
+	if _, err := createUser(context.Background(), srv.URL, "t", "dupe@example.com", "pw-12345678", nil); err == nil {
 		t.Error("expected error on 409")
 	}
 }

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -2,14 +2,18 @@ package domain
 
 import "time"
 
-// User is a control-plane account as returned by the admin create-user API. It
-// never carries the password or its hash — those are write-only. Role is the
+// User is a control-plane account as returned by the admin user-management API.
+// It never carries the password or its hash — those are write-only. Role is the
 // single role granted at creation ("" when none was assigned); the RBAC model
-// supports multiple roles per user, but create-user grants at most one.
+// supports multiple roles per user, but create-user grants at most one. Roles is
+// the full set of roles a user holds, populated by the list path (which
+// aggregates every role grant); the create path leaves it nil and reports the
+// one role it granted through Role.
 type User struct {
 	ID        string
 	Email     string
 	Role      string
+	Roles     []string
 	IsActive  bool
 	CreatedAt time.Time
 }

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -3,16 +3,13 @@ package domain
 import "time"
 
 // User is a control-plane account as returned by the admin user-management API.
-// It never carries the password or its hash — those are write-only. Role is the
-// single role granted at creation ("" when none was assigned); the RBAC model
-// supports multiple roles per user, but create-user grants at most one. Roles is
-// the full set of roles a user holds, populated by the list path (which
-// aggregates every role grant); the create path leaves it nil and reports the
-// one role it granted through Role.
+// It never carries the password or its hash — those are write-only. Roles is the
+// full set of role names the user holds: the list path aggregates every role
+// grant, and the create path echoes back the roles it granted (empty when none
+// were requested).
 type User struct {
 	ID        string
 	Email     string
-	Role      string
 	Roles     []string
 	IsActive  bool
 	CreatedAt time.Time

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -165,6 +165,10 @@ type Querier interface {
 	// get them via the JOIN.
 	ListTaskInstanceAttempts(ctx context.Context, arg ListTaskInstanceAttemptsParams) ([]ListTaskInstanceAttemptsRow, error)
 	ListTaskInstancesByRun(ctx context.Context, dagRunID pgtype.UUID) ([]TaskInstance, error)
+	// One row per user in the tenant, newest first, with every granted role name
+	// aggregated into a text array (empty when the user holds none). Paged by the
+	// caller. Never selects password_hash — the list must not expose secrets.
+	ListUsers(ctx context.Context, arg ListUsersParams) ([]ListUsersRow, error)
 	ListVariables(ctx context.Context, arg ListVariablesParams) ([]ListVariablesRow, error)
 	ListXComEntries(ctx context.Context, arg ListXComEntriesParams) ([]ListXComEntriesRow, error)
 	// Stamp a run's on-failure alert as DELIVERED. Called only after a successful

--- a/internal/storage/queries/users.sql
+++ b/internal/storage/queries/users.sql
@@ -23,6 +23,20 @@ SET password_hash = $3
 WHERE email = $2
   AND tenant_id = (SELECT id FROM tenants WHERE name = $1);
 
+-- name: ListUsers :many
+-- One row per user in the tenant, newest first, with every granted role name
+-- aggregated into a text array (empty when the user holds none). Paged by the
+-- caller. Never selects password_hash — the list must not expose secrets.
+SELECT u.id, u.email, u.is_active, u.created_at,
+    COALESCE(array_remove(array_agg(r.name), NULL), '{}')::text[] AS roles
+FROM users u
+LEFT JOIN user_roles ur ON ur.user_id = u.id
+LEFT JOIN roles r ON r.id = ur.role_id
+WHERE u.tenant_id = $1
+GROUP BY u.id, u.email, u.is_active, u.created_at
+ORDER BY u.created_at DESC, u.id DESC
+LIMIT $2 OFFSET $3;
+
 -- name: GetUserRoles :many
 SELECT r.name
 FROM user_roles ur

--- a/internal/storage/queries/users.sql.go
+++ b/internal/storage/queries/users.sql.go
@@ -169,6 +169,61 @@ func (q *Queries) InsertUser(ctx context.Context, arg InsertUserParams) (InsertU
 	return i, err
 }
 
+const listUsers = `-- name: ListUsers :many
+SELECT u.id, u.email, u.is_active, u.created_at,
+    COALESCE(array_remove(array_agg(r.name), NULL), '{}')::text[] AS roles
+FROM users u
+LEFT JOIN user_roles ur ON ur.user_id = u.id
+LEFT JOIN roles r ON r.id = ur.role_id
+WHERE u.tenant_id = $1
+GROUP BY u.id, u.email, u.is_active, u.created_at
+ORDER BY u.created_at DESC, u.id DESC
+LIMIT $2 OFFSET $3
+`
+
+type ListUsersParams struct {
+	TenantID pgtype.UUID `json:"tenant_id"`
+	Limit    int32       `json:"limit"`
+	Offset   int32       `json:"offset"`
+}
+
+type ListUsersRow struct {
+	ID        pgtype.UUID        `json:"id"`
+	Email     string             `json:"email"`
+	IsActive  bool               `json:"is_active"`
+	CreatedAt pgtype.Timestamptz `json:"created_at"`
+	Roles     []string           `json:"roles"`
+}
+
+// One row per user in the tenant, newest first, with every granted role name
+// aggregated into a text array (empty when the user holds none). Paged by the
+// caller. Never selects password_hash — the list must not expose secrets.
+func (q *Queries) ListUsers(ctx context.Context, arg ListUsersParams) ([]ListUsersRow, error) {
+	rows, err := q.db.Query(ctx, listUsers, arg.TenantID, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListUsersRow{}
+	for rows.Next() {
+		var i ListUsersRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Email,
+			&i.IsActive,
+			&i.CreatedAt,
+			&i.Roles,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const updateUserPassword = `-- name: UpdateUserPassword :execrows
 UPDATE users
 SET password_hash = $3

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -731,6 +731,36 @@ func (r *Repository) CreateUser(ctx context.Context, tenant, email, password, ro
 	}, nil
 }
 
+// ListUsers returns a page of the tenant's accounts, newest first, each with the
+// full set of role names it holds. It never reads or returns password_hash — the
+// list must not expose secrets. The second result is the unpaged total, so the
+// caller can render total_entries independent of the page size.
+func (r *Repository) ListUsers(ctx context.Context, tenant string, limit, offset int) ([]domain.User, int, error) {
+	tid, err := r.tenantID(ctx, tenant)
+	if err != nil {
+		return nil, 0, err
+	}
+	rows, err := r.q.ListUsers(ctx, queries.ListUsersParams{TenantID: tid, Limit: toInt32(limit), Offset: toInt32(offset)})
+	if err != nil {
+		return nil, 0, fmt.Errorf("listing users: %w", err)
+	}
+	total, err := r.q.CountUsers(ctx, tid)
+	if err != nil {
+		return nil, 0, fmt.Errorf("counting users: %w", err)
+	}
+	out := make([]domain.User, 0, len(rows))
+	for _, u := range rows {
+		out = append(out, domain.User{
+			ID:        uuidToString(u.ID),
+			Email:     u.Email,
+			Roles:     u.Roles,
+			IsActive:  u.IsActive,
+			CreatedAt: timeVal(u.CreatedAt),
+		})
+	}
+	return out, int(total), nil
+}
+
 // SetUserPassword sets a user's bcrypt hash by email, returning whether a user
 // was updated (false when no such user exists). Used by `leoflow lite
 // reset-password`.

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -445,9 +445,10 @@ func (r *Repository) RecordTaskActionAudit(ctx context.Context, tenant, userID, 
 }
 
 // RecordUserCreatedAudit logs an account creation with the acting admin as the
-// owner and the new account's email and role in metadata, scoped to the "user"
-// resource so account-management actions are visible in the Audit Log.
-func (r *Repository) RecordUserCreatedAudit(ctx context.Context, tenant, actorUserID, createdUserID, email, role string) error {
+// owner and the new account's email and granted roles in metadata, scoped to the
+// "user" resource so account-management actions are visible in the Audit Log. The
+// roles arrive as a single comma-joined string (empty when none were granted).
+func (r *Repository) RecordUserCreatedAudit(ctx context.Context, tenant, actorUserID, createdUserID, email, roles string) error {
 	tid, err := r.tenantID(ctx, tenant)
 	if err != nil {
 		return err
@@ -457,8 +458,8 @@ func (r *Repository) RecordUserCreatedAudit(ctx context.Context, tenant, actorUs
 		uid = u
 	}
 	fields := map[string]any{"email": email}
-	if role != "" {
-		fields["role"] = role
+	if roles != "" {
+		fields["roles"] = roles
 	}
 	meta, err := json.Marshal(fields)
 	if err != nil {
@@ -667,36 +668,37 @@ func (r *Repository) BootstrapAdmin(ctx context.Context, tenant, email, password
 	return r.BootstrapAdminHash(ctx, tenant, email, hash)
 }
 
-// CreateUser provisions a new account in the tenant and grants it at most one
-// role, returning the created user (never its password or hash). It reuses the
-// same bcrypt hashing as the bootstrap admin path (auth.HashPassword) and the
+// CreateUser provisions a new account in the tenant and grants it the given set
+// of roles, returning the created user (never its password or hash). It reuses
+// the same bcrypt hashing as the bootstrap admin path (auth.HashPassword) and the
 // same email uniqueness guarantee, so a duplicate email surfaces as
-// domain.ErrConflict (the API maps it to 409). The role is resolved BEFORE the
-// insert so an unknown role fails cleanly as domain.ErrValidation without
-// leaving an orphaned account; an empty role grants none — the most restrictive
-// default, leaving the user with no permissions until an admin grants a role.
+// domain.ErrConflict (the API maps it to 409). Every role is resolved BEFORE the
+// insert so an unknown role fails cleanly as domain.ErrValidation without leaving
+// an orphaned account; an empty set grants none — the most restrictive default,
+// leaving the user with no permissions until an admin grants a role.
 //
-// The insert and the role grant run in a single transaction, so a failure in the
-// grant rolls the user insert back. Without that atomicity a failed grant would
-// leave a role-less account that the (tenant_id, email) UNIQUE makes impossible
-// to recreate — every retry would 409 forever with no recovery path.
+// The insert and the role grants run in a single transaction, so a failure in
+// any grant rolls the user insert back. Without that atomicity a failed grant
+// would leave an account the (tenant_id, email) UNIQUE makes impossible to
+// recreate — every retry would 409 forever with no recovery path.
 //
 // This backs `leoflow auth create-user` (ADR 0008) and is purely additive: it
 // does not touch the bootstrap/reconcile path.
-func (r *Repository) CreateUser(ctx context.Context, tenant, email, password, role string) (domain.User, error) {
+func (r *Repository) CreateUser(ctx context.Context, tenant, email, password string, roles []string) (domain.User, error) {
 	tid, err := r.tenantID(ctx, tenant)
 	if err != nil {
 		return domain.User{}, err
 	}
-	var roleID pgtype.UUID
-	if role != "" {
-		roleID, err = r.q.GetRoleByName(ctx, queries.GetRoleByNameParams{TenantID: tid, Name: role})
-		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+	roleIDs := make([]pgtype.UUID, 0, len(roles))
+	for _, role := range roles {
+		roleID, rerr := r.q.GetRoleByName(ctx, queries.GetRoleByNameParams{TenantID: tid, Name: role})
+		if rerr != nil {
+			if errors.Is(rerr, pgx.ErrNoRows) {
 				return domain.User{}, fmt.Errorf("unknown role %q: %w", role, domain.ErrValidation)
 			}
-			return domain.User{}, fmt.Errorf("looking up role: %w", err)
+			return domain.User{}, fmt.Errorf("looking up role: %w", rerr)
 		}
+		roleIDs = append(roleIDs, roleID)
 	}
 	hash, err := auth.HashPassword(password)
 	if err != nil {
@@ -714,7 +716,7 @@ func (r *Repository) CreateUser(ctx context.Context, tenant, email, password, ro
 	if err != nil {
 		return domain.User{}, mapConflict(err)
 	}
-	if role != "" {
+	for _, roleID := range roleIDs {
 		if aerr := qtx.AssignUserRole(ctx, queries.AssignUserRoleParams{UserID: row.ID, RoleID: roleID}); aerr != nil {
 			return domain.User{}, fmt.Errorf("assigning role: %w", aerr)
 		}
@@ -725,7 +727,7 @@ func (r *Repository) CreateUser(ctx context.Context, tenant, email, password, ro
 	return domain.User{
 		ID:        uuidToString(row.ID),
 		Email:     row.Email,
-		Role:      role,
+		Roles:     roles,
 		IsActive:  row.IsActive,
 		CreatedAt: timeVal(row.CreatedAt),
 	}, nil

--- a/internal/storage/users_integration_test.go
+++ b/internal/storage/users_integration_test.go
@@ -66,3 +66,66 @@ func TestCreateUserUnknownRoleIntegration(t *testing.T) {
 		t.Errorf("create after rejected role: %v", err)
 	}
 }
+
+// TestListUsersIntegration proves the list surfaces a just-created account with
+// its granted role aggregated, reports a total that counts it, and never exposes
+// a password or hash (there is no such field to expose on the returned type).
+func TestListUsersIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	email := fmt.Sprintf("listed_%d@example.com", time.Now().UnixNano())
+	if _, err := repo.CreateUser(ctx, "default", email, "pw-12345678", "admin"); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	users, total, err := repo.ListUsers(ctx, "default", 100, 0)
+	if err != nil {
+		t.Fatalf("ListUsers: %v", err)
+	}
+	if total < 1 {
+		t.Fatalf("total = %d, want at least the created user", total)
+	}
+	var found *domain.User
+	for i := range users {
+		if users[i].Email == email {
+			found = &users[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("created user %q not in list", email)
+	}
+	if found.ID == "" || !found.IsActive {
+		t.Errorf("unexpected listed user: %+v", *found)
+	}
+	if len(found.Roles) != 1 || found.Roles[0] != "admin" {
+		t.Errorf("roles = %v, want [admin]", found.Roles)
+	}
+}
+
+// TestListUsersRoleAggregationIntegration proves a user with more than one role
+// comes back with every role name, and one with none comes back with an empty
+// (non-nil) set rather than a null.
+func TestListUsersRoleAggregationIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	email := fmt.Sprintf("noroles_%d@example.com", time.Now().UnixNano())
+	if _, err := repo.CreateUser(ctx, "default", email, "pw-12345678", ""); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	users, _, err := repo.ListUsers(ctx, "default", 100, 0)
+	if err != nil {
+		t.Fatalf("ListUsers: %v", err)
+	}
+	for i := range users {
+		if users[i].Email == email {
+			if users[i].Roles == nil {
+				t.Errorf("a role-less user must list an empty (non-nil) role set")
+			}
+			if len(users[i].Roles) != 0 {
+				t.Errorf("roles = %v, want empty", users[i].Roles)
+			}
+			return
+		}
+	}
+	t.Fatalf("role-less user %q not in list", email)
+}

--- a/internal/storage/users_integration_test.go
+++ b/internal/storage/users_integration_test.go
@@ -3,13 +3,17 @@
 package storage_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/config"
 	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/storage"
 )
 
 // TestCreateUserIntegration exercises the admin create-user query end to end:
@@ -20,11 +24,11 @@ func TestCreateUserIntegration(t *testing.T) {
 	email := fmt.Sprintf("newuser_%d@example.com", time.Now().UnixNano())
 	const password = "create-user-secret-1"
 
-	got, err := repo.CreateUser(ctx, "default", email, password, "admin")
+	got, err := repo.CreateUser(ctx, "default", email, password, []string{"admin"})
 	if err != nil {
 		t.Fatalf("CreateUser: %v", err)
 	}
-	if got.ID == "" || got.Email != email || got.Role != "admin" || !got.IsActive {
+	if got.ID == "" || got.Email != email || len(got.Roles) != 1 || got.Roles[0] != "admin" || !got.IsActive {
 		t.Fatalf("unexpected created user: %+v", got)
 	}
 
@@ -42,10 +46,10 @@ func TestCreateUserDuplicateEmailIntegration(t *testing.T) {
 	repo, _, ctx := openRepo(t)
 	email := fmt.Sprintf("dupe_%d@example.com", time.Now().UnixNano())
 
-	if _, err := repo.CreateUser(ctx, "default", email, "pw-first-1234", "admin"); err != nil {
+	if _, err := repo.CreateUser(ctx, "default", email, "pw-first-1234", []string{"admin"}); err != nil {
 		t.Fatalf("first create: %v", err)
 	}
-	if _, err := repo.CreateUser(ctx, "default", email, "pw-second-1234", "admin"); !errors.Is(err, domain.ErrConflict) {
+	if _, err := repo.CreateUser(ctx, "default", email, "pw-second-1234", []string{"admin"}); !errors.Is(err, domain.ErrConflict) {
 		t.Errorf("duplicate create err = %v, want ErrConflict", err)
 	}
 }
@@ -57,12 +61,12 @@ func TestCreateUserUnknownRoleIntegration(t *testing.T) {
 	repo, _, ctx := openRepo(t)
 	email := fmt.Sprintf("norole_%d@example.com", time.Now().UnixNano())
 
-	if _, err := repo.CreateUser(ctx, "default", email, "pw-12345678", "wizard"); !errors.Is(err, domain.ErrValidation) {
+	if _, err := repo.CreateUser(ctx, "default", email, "pw-12345678", []string{"wizard"}); !errors.Is(err, domain.ErrValidation) {
 		t.Fatalf("unknown role err = %v, want ErrValidation", err)
 	}
-	// No account was created, so a subsequent create with a valid (empty) role
-	// succeeds rather than colliding.
-	if _, err := repo.CreateUser(ctx, "default", email, "pw-12345678", ""); err != nil {
+	// No account was created, so a subsequent create with no roles succeeds rather
+	// than colliding.
+	if _, err := repo.CreateUser(ctx, "default", email, "pw-12345678", nil); err != nil {
 		t.Errorf("create after rejected role: %v", err)
 	}
 }
@@ -73,7 +77,7 @@ func TestCreateUserUnknownRoleIntegration(t *testing.T) {
 func TestListUsersIntegration(t *testing.T) {
 	repo, _, ctx := openRepo(t)
 	email := fmt.Sprintf("listed_%d@example.com", time.Now().UnixNano())
-	if _, err := repo.CreateUser(ctx, "default", email, "pw-12345678", "admin"); err != nil {
+	if _, err := repo.CreateUser(ctx, "default", email, "pw-12345678", []string{"admin"}); err != nil {
 		t.Fatalf("CreateUser: %v", err)
 	}
 
@@ -102,13 +106,70 @@ func TestListUsersIntegration(t *testing.T) {
 	}
 }
 
+// TestCreateUserAssignsMultipleRolesIntegration proves the create path grants
+// every role in the slice, and the list reflects all of them. It seeds a second
+// grantable role in the default tenant (removed on cleanup; its user_roles rows
+// cascade) so the account can hold more than one.
+func TestCreateUserAssignsMultipleRolesIntegration(t *testing.T) {
+	url := os.Getenv("DATABASE_URL")
+	if url == "" {
+		t.Skip("DATABASE_URL must point at a migrated database for integration tests")
+	}
+	ctx := context.Background()
+	pg, err := storage.NewPostgres(ctx, config.DatabaseSection{URL: url})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pg.Close)
+	repo := storage.NewRepository(pg)
+
+	const extraRole = "editor"
+	if _, err := pg.Pool.Exec(ctx,
+		`INSERT INTO roles (tenant_id, name, description, is_system)
+		 SELECT id, $1, 'grantable test role', false FROM tenants WHERE name = 'default'
+		 ON CONFLICT (tenant_id, name) DO NOTHING`, extraRole); err != nil {
+		t.Fatalf("seeding role: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pg.Pool.Exec(context.Background(),
+			`DELETE FROM roles WHERE name = $1 AND tenant_id = (SELECT id FROM tenants WHERE name = 'default')`, extraRole)
+	})
+
+	email := fmt.Sprintf("multirole_%d@example.com", time.Now().UnixNano())
+	if _, err := repo.CreateUser(ctx, "default", email, "pw-12345678", []string{"admin", extraRole}); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	users, _, err := repo.ListUsers(ctx, "default", 1000, 0)
+	if err != nil {
+		t.Fatalf("ListUsers: %v", err)
+	}
+	var found *domain.User
+	for i := range users {
+		if users[i].Email == email {
+			found = &users[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("created user %q not in list", email)
+	}
+	got := map[string]bool{}
+	for _, r := range found.Roles {
+		got[r] = true
+	}
+	if len(found.Roles) != 2 || !got["admin"] || !got[extraRole] {
+		t.Errorf("roles = %v, want both admin and %s", found.Roles, extraRole)
+	}
+}
+
 // TestListUsersRoleAggregationIntegration proves a user with more than one role
 // comes back with every role name, and one with none comes back with an empty
 // (non-nil) set rather than a null.
 func TestListUsersRoleAggregationIntegration(t *testing.T) {
 	repo, _, ctx := openRepo(t)
 	email := fmt.Sprintf("noroles_%d@example.com", time.Now().UnixNano())
-	if _, err := repo.CreateUser(ctx, "default", email, "pw-12345678", ""); err != nil {
+	if _, err := repo.CreateUser(ctx, "default", email, "pw-12345678", nil); err != nil {
 		t.Fatalf("CreateUser: %v", err)
 	}
 

--- a/internal/storage/users_test.go
+++ b/internal/storage/users_test.go
@@ -86,7 +86,7 @@ func TestCreateUserRollsBackWhenRoleAssignFails(t *testing.T) {
 	fc := &fakeConn{}
 	repo := &Repository{q: queries.New(fc), pool: fakeBeginner{tx: fc}}
 
-	_, err := repo.CreateUser(context.Background(), "default", "alice@example.com", "pw-12345678", "admin")
+	_, err := repo.CreateUser(context.Background(), "default", "alice@example.com", "pw-12345678", []string{"admin"})
 	if err == nil {
 		t.Fatal("expected an error when the role assignment fails")
 	}

--- a/migrations/024_user_permissions.down.sql
+++ b/migrations/024_user_permissions.down.sql
@@ -1,0 +1,6 @@
+DELETE FROM role_permissions
+WHERE permission_id IN (
+    SELECT id FROM permissions WHERE resource = 'user' AND action IN ('read', 'write')
+);
+
+DELETE FROM permissions WHERE resource = 'user' AND action IN ('read', 'write');

--- a/migrations/024_user_permissions.up.sql
+++ b/migrations/024_user_permissions.up.sql
@@ -1,0 +1,17 @@
+-- RBAC vocabulary for the user-management surface: read and write on the "user"
+-- resource, so listing and creating accounts is expressed in the same
+-- permission grammar as every other resource rather than relying solely on the
+-- admin-role short-circuit. Permissions are system-wide (UNIQUE (action,
+-- resource)); the grants are added to every tenant's built-in admin role.
+INSERT INTO permissions (action, resource, description) VALUES
+    ('read',  'user', 'List control-plane user accounts'),
+    ('write', 'user', 'Create and manage control-plane user accounts')
+ON CONFLICT (action, resource) DO NOTHING;
+
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r CROSS JOIN permissions p
+WHERE r.name = 'admin'
+  AND p.resource = 'user'
+  AND p.action IN ('read', 'write')
+ON CONFLICT DO NOTHING;

--- a/pkg/client/client.gen.go
+++ b/pkg/client/client.gen.go
@@ -153,8 +153,8 @@ type CreateUserRequest struct {
 	// Password Plaintext password (write-only; never returned). Must be at least 8 characters — the server rejects anything shorter with 400.
 	Password *string `json:"password,omitempty"`
 
-	// Role Name of an existing role to grant (e.g. "admin"). Omit to grant no role — the most restrictive default; the user then holds no permissions until an admin grants one.
-	Role *string `json:"role,omitempty"`
+	// Roles Names of existing roles to grant; omit or empty to grant none.
+	Roles *[]string `json:"roles,omitempty"`
 }
 
 // DAG defines model for DAG.
@@ -321,11 +321,11 @@ type TokenResponse struct {
 
 // User defines model for User.
 type User struct {
-	CreatedAt *time.Time `json:"created_at,omitempty"`
-	Email     string     `json:"email"`
-	Id        string     `json:"id"`
-	IsActive  *bool      `json:"is_active,omitempty"`
-	Role      *string    `json:"role,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	Email     string    `json:"email"`
+	Id        string    `json:"id"`
+	IsActive  bool      `json:"is_active"`
+	Roles     []string  `json:"roles"`
 }
 
 // UserCollection defines model for UserCollection.
@@ -613,8 +613,8 @@ type ClientInterface interface {
 	// CreateUserWithBody Create a user
 	//
 	// Admin-only. Creates a control-plane account with the given email and
-	// password and grants at most one role. The password is write-only and is
-	// never returned. Requires the admin:tenant permission.
+	// password and grants the requested roles. The password is write-only and
+	// is never returned. Requires the write:user permission.
 	//
 	// Takes any type of body and a specified content type.
 	//
@@ -624,8 +624,8 @@ type ClientInterface interface {
 	// CreateUser Create a user
 	//
 	// Admin-only. Creates a control-plane account with the given email and
-	// password and grants at most one role. The password is write-only and is
-	// never returned. Requires the admin:tenant permission.
+	// password and grants the requested roles. The password is write-only and
+	// is never returned. Requires the write:user permission.
 	//
 	// Takes a body of the `application/json` content type.
 	//
@@ -986,8 +986,8 @@ func (c *Client) ListUsers(ctx context.Context, params *ListUsersParams, reqEdit
 // CreateUserWithBody Create a user
 //
 // Admin-only. Creates a control-plane account with the given email and
-// password and grants at most one role. The password is write-only and is
-// never returned. Requires the admin:tenant permission.
+// password and grants the requested roles. The password is write-only and
+// is never returned. Requires the write:user permission.
 //
 // Takes any type of body and a specified content type.
 //
@@ -1007,8 +1007,8 @@ func (c *Client) CreateUserWithBody(ctx context.Context, contentType string, bod
 // CreateUser Create a user
 //
 // Admin-only. Creates a control-plane account with the given email and
-// password and grants at most one role. The password is write-only and is
-// never returned. Requires the admin:tenant permission.
+// password and grants the requested roles. The password is write-only and
+// is never returned. Requires the write:user permission.
 //
 // Takes a body of the `application/json` content type.
 //
@@ -2336,8 +2336,8 @@ type ClientWithResponsesInterface interface {
 	// CreateUserWithBodyWithResponse Create a user
 	//
 	// Admin-only. Creates a control-plane account with the given email and
-	// password and grants at most one role. The password is write-only and is
-	// never returned. Requires the admin:tenant permission.
+	// password and grants the requested roles. The password is write-only and
+	// is never returned. Requires the write:user permission.
 	//
 	// Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
 	//
@@ -2347,8 +2347,8 @@ type ClientWithResponsesInterface interface {
 	// CreateUserWithResponse Create a user
 	//
 	// Admin-only. Creates a control-plane account with the given email and
-	// password and grants at most one role. The password is write-only and is
-	// never returned. Requires the admin:tenant permission.
+	// password and grants the requested roles. The password is write-only and
+	// is never returned. Requires the write:user permission.
 	//
 	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
 	//
@@ -3664,8 +3664,8 @@ func (c *ClientWithResponses) ListUsersWithResponse(ctx context.Context, params 
 // CreateUserWithBodyWithResponse Create a user
 //
 // Admin-only. Creates a control-plane account with the given email and
-// password and grants at most one role. The password is write-only and is
-// never returned. Requires the admin:tenant permission.
+// password and grants the requested roles. The password is write-only and
+// is never returned. Requires the write:user permission.
 //
 // Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
 //
@@ -3681,8 +3681,8 @@ func (c *ClientWithResponses) CreateUserWithBodyWithResponse(ctx context.Context
 // CreateUserWithResponse Create a user
 //
 // Admin-only. Creates a control-plane account with the given email and
-// password and grants at most one role. The password is write-only and is
-// never returned. Requires the admin:tenant permission.
+// password and grants the requested roles. The password is write-only and
+// is never returned. Requires the write:user permission.
 //
 // Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
 //

--- a/pkg/client/client.gen.go
+++ b/pkg/client/client.gen.go
@@ -328,6 +328,21 @@ type User struct {
 	Role      *string    `json:"role,omitempty"`
 }
 
+// UserCollection defines model for UserCollection.
+type UserCollection struct {
+	TotalEntries *int            `json:"total_entries,omitempty"`
+	Users        *[]UserListItem `json:"users,omitempty"`
+}
+
+// UserListItem One account in the user list. Leoflow accounts are email-keyed and carry a set of RBAC roles, so this diverges from the Airflow FAB users API (username-keyed with first_name/last_name).
+type UserListItem struct {
+	CreatedAt time.Time `json:"created_at"`
+	Email     string    `json:"email"`
+	Id        string    `json:"id"`
+	IsActive  bool      `json:"is_active"`
+	Roles     []string  `json:"roles"`
+}
+
 // VersionInfo defines model for VersionInfo.
 type VersionInfo struct {
 	GitVersion *string `json:"git_version,omitempty"`
@@ -383,6 +398,12 @@ type ListDagRunsParams struct {
 
 // ListDagRunsParamsState defines parameters for ListDagRuns.
 type ListDagRunsParamsState string
+
+// ListUsersParams defines parameters for ListUsers.
+type ListUsersParams struct {
+	Limit  *Limit  `form:"limit,omitempty" json:"limit,omitempty"`
+	Offset *Offset `form:"offset,omitempty" json:"offset,omitempty"`
+}
 
 // UpdateDagJSONRequestBody defines body for UpdateDag for application/json ContentType.
 type UpdateDagJSONRequestBody = DAGUpdate
@@ -579,6 +600,15 @@ type ClientInterface interface {
 	//
 	// Corresponds with GET /api/v2/monitor/health (the `GetMonitorHealth` operationId).
 	GetMonitorHealth(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListUsers List users
+	//
+	// Lists the tenant's control-plane accounts, newest first. Each entry
+	// carries the full set of roles the user holds; the password and its hash
+	// are write-only and never returned. Requires the read:user permission.
+	//
+	// Corresponds with GET /api/v2/users (the `ListUsers` operationId).
+	ListUsers(ctx context.Context, params *ListUsersParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// CreateUserWithBody Create a user
 	//
@@ -924,6 +954,25 @@ func (c *Client) GetMonitorExecutor(ctx context.Context, reqEditors ...RequestEd
 // Corresponds with GET /api/v2/monitor/health (the `GetMonitorHealth` operationId).
 func (c *Client) GetMonitorHealth(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetMonitorHealthRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// ListUsers List users
+//
+// Lists the tenant's control-plane accounts, newest first. Each entry
+// carries the full set of roles the user holds; the password and its hash
+// are write-only and never returned. Requires the read:user permission.
+//
+// Corresponds with GET /api/v2/users (the `ListUsers` operationId).
+func (c *Client) ListUsers(ctx context.Context, params *ListUsersParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListUsersRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -1814,6 +1863,72 @@ func NewGetMonitorHealthRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewListUsersRequest constructs an http.Request for the ListUsers method
+func NewListUsersRequest(server string, params *ListUsersParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v2/users")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "limit", *params.Limit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Offset != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "offset", *params.Offset, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewCreateUserRequest calls the generic CreateUser builder with application/json body
 func NewCreateUserRequest(server string, body CreateUserJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -2206,6 +2321,17 @@ type ClientWithResponsesInterface interface {
 	//
 	// Corresponds with GET /api/v2/monitor/health (the `GetMonitorHealth` operationId).
 	GetMonitorHealthWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetMonitorHealthResponse, error)
+
+	// ListUsersWithResponse List users
+	//
+	// Lists the tenant's control-plane accounts, newest first. Each entry
+	// carries the full set of roles the user holds; the password and its hash
+	// are write-only and never returned. Requires the read:user permission.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with GET /api/v2/users (the `ListUsers` operationId).
+	ListUsersWithResponse(ctx context.Context, params *ListUsersParams, reqEditors ...RequestEditorFn) (*ListUsersResponse, error)
 
 	// CreateUserWithBodyWithResponse Create a user
 	//
@@ -2956,6 +3082,54 @@ func (r GetMonitorHealthResponse) ContentType() string {
 	return ""
 }
 
+type ListUsersResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *UserCollection
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *Unauthorized
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r ListUsersResponse) GetJSON200() *UserCollection {
+	return r.JSON200
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r ListUsersResponse) GetJSON401() *Unauthorized {
+	return r.JSON401
+}
+
+// GetBody returns the raw response body bytes
+func (r ListUsersResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r ListUsersResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListUsersResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListUsersResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type CreateUserResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -3468,6 +3642,23 @@ func (c *ClientWithResponses) GetMonitorHealthWithResponse(ctx context.Context, 
 		return nil, err
 	}
 	return ParseGetMonitorHealthResponse(rsp)
+}
+
+// ListUsersWithResponse List users
+//
+// Lists the tenant's control-plane accounts, newest first. Each entry
+// carries the full set of roles the user holds; the password and its hash
+// are write-only and never returned. Requires the read:user permission.
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with GET /api/v2/users (the `ListUsers` operationId).
+func (c *ClientWithResponses) ListUsersWithResponse(ctx context.Context, params *ListUsersParams, reqEditors ...RequestEditorFn) (*ListUsersResponse, error) {
+	rsp, err := c.ListUsers(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListUsersResponse(rsp)
 }
 
 // CreateUserWithBodyWithResponse Create a user
@@ -4017,6 +4208,39 @@ func ParseGetMonitorHealthResponse(rsp *http.Response) (*GetMonitorHealthRespons
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListUsersResponse parses an HTTP response from a ListUsersWithResponse call
+func ParseListUsersResponse(rsp *http.Response) (*ListUsersResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListUsersResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest UserCollection
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
 
 	}
 


### PR DESCRIPTION
## PR-5 — `/api/v2/users` user-management surface (list + consistent create)

Closes #648. Lane: Identity/Auth (shared-cluster release #623). Unblocks PR-7 (admin CLI) and PR-9 (OIDC).

Two things, both on the **unreleased** users surface (create shipped to main via #627 *after* v0.3.0, so aligning it now is not a breaking change to any released contract):

### 1. New `GET /api/v2/users` (the genuinely-missing half)
- `RequirePermission("read","user")` → `200 {"users":[{id,email,roles,is_active,created_at}], "total_entries":N}`, paged.
- Never returns `password_hash` (the `ListUsers` SQL does not select it; the DTO has no password field).
- `ListUsers` sqlc query aggregates granted role names via `array_agg`/`array_remove`.

### 2. Create endpoint aligned to the list's contract (resolves the shape mismatch)
The `POST` that shipped in #627 used a singular `role` + gate `admin:tenant`; that was inconsistent with the new list. Since it is unreleased, it's evolved in-place to match:
- Body `role` → **`roles []string`** (plural); repo assigns each role in the one pgx transaction (unknown role → 400, empty → no roles).
- Gate `admin:tenant` → **`write:user`** (functionally identical — admin short-circuits — but on the same `user` resource vocabulary as the GET).
- Response returns `roles` plural + `is_active`.
- `leoflow auth create-user` CLI: `--role` is now repeatable (`--role a --role b`).

### RBAC vocabulary
`migration 024` seeds `read:user` + `write:user` and grants them to the admin role (idempotent, reversible).

### Airflow divergence (documented on the DTOs)
Leoflow accounts are email-keyed with a set of RBAC roles; this deliberately diverges from Airflow's username-keyed FAB users API.

### Contained — Lite unaffected
No change to Lite's config-hash-reconciled single-admin boot. Nil `Users` store serves the `apiEmptyCollection("users")` stub. Ships in both editions; admin-gating is the security boundary.

### Verification
`go build`/`go vet` (incl. `-tags integration`)/`gofmt` clean · `golangci-lint run ./...` **0** · api (13) + cli token + storage tests green · OpenAPI two copies byte-identical (`TestEmbeddedOpenAPIMatchesDocs`) · `make pkg-client-check` clean · sqlc no-diff · integration tests compile under the tag (need a DB to run — will be exercised in CI).

Strict TDD (test-first commits), no AI attribution. **Held for the Wave-3 closing specialist review** before merge.