### PR TITLE
feat(cli): leoflow admin users list

### DIFF
--- a/internal/cli/admin.go
+++ b/internal/cli/admin.go
@@ -32,6 +32,7 @@ func newAdminCommand() *cobra.Command {
 		newAdminDagsCommand(),
 		newAdminDrainCommand(),
 		newAdminRunsCommand(),
+		newAdminUsersCommand(),
 	)
 	return cmd
 }

--- a/internal/cli/admin_users.go
+++ b/internal/cli/admin_users.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
+)
+
+// newAdminUsersCommand groups the account-inspection operator commands. Like
+// the rest of the admin tree it operates a deployed control plane over the
+// typed /api/v2 client rather than the local authoring project.
+func newAdminUsersCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "users",
+		Short: "Inspect accounts on the running control plane.",
+	}
+	cmd.AddCommand(newAdminUsersListCommand())
+	return cmd
+}
+
+// newAdminUsersListCommand builds `leoflow admin users list`: a single page of
+// the account list, bounded by --limit/--offset — the "who has access?" query.
+// A Lite control plane returns an empty collection, which lists as no users
+// rather than an error.
+func newAdminUsersListCommand() *cobra.Command {
+	var f adminFlags
+	var limit, offset int
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List accounts (email, roles, active, age), bounded by --limit/--offset.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			c, _, err := adminClient(cmd, f)
+			if err != nil {
+				return err
+			}
+			users, err := collectUsers(cmdContext(cmd), c, limit, offset)
+			if err != nil {
+				return err
+			}
+			return renderUsers(cmd.OutOrStdout(), users)
+		},
+	}
+	addAdminFlags(cmd, &f)
+	cmd.Flags().IntVar(&limit, "limit", 100, "maximum number of accounts to return")
+	cmd.Flags().IntVar(&offset, "offset", 0, "number of accounts to skip before returning results")
+	return cmd
+}
+
+// collectUsers fetches a single page of the account list honoring the caller's
+// limit/offset, and returns the decoded accounts.
+func collectUsers(ctx context.Context, c *apiclient.ClientWithResponses, limit, offset int) ([]apiclient.UserListItem, error) {
+	lim, off := limit, offset
+	resp, err := c.ListUsersWithResponse(ctx, &apiclient.ListUsersParams{Limit: &lim, Offset: &off})
+	if err != nil {
+		return nil, fmt.Errorf("listing users: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+		return nil, fmt.Errorf("server returned %d: %s", resp.StatusCode(), string(resp.Body))
+	}
+	if resp.JSON200.Users == nil {
+		return []apiclient.UserListItem{}, nil
+	}
+	return *resp.JSON200.Users, nil
+}
+
+// renderUsers prints the accounts as an aligned table, or a friendly note when
+// there are none.
+func renderUsers(w io.Writer, users []apiclient.UserListItem) error {
+	if len(users) == 0 {
+		return writeLine(w, "No users found.")
+	}
+	lines := make([]string, 0, len(users)+1)
+	lines = append(lines, fmt.Sprintf("%-30s %-24s %-24s %-6s %s", "EMAIL", "ID", "ROLES", "ACTIVE", "AGE"))
+	for _, u := range users {
+		created := u.CreatedAt
+		lines = append(lines, fmt.Sprintf("%-30s %-24s %-24s %-6s %s",
+			u.Email, u.Id, strings.Join(u.Roles, ","), strconv.FormatBool(u.IsActive), ageString(&created)))
+	}
+	return writeLine(w, strings.Join(lines, "\n"))
+}

--- a/internal/cli/admin_users_test.go
+++ b/internal/cli/admin_users_test.go
@@ -1,0 +1,122 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
+)
+
+// usersServer serves a fixed two-user collection at /api/v2/users so the
+// listing and rendering can be exercised end-to-end.
+func usersServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	created := time.Now().Add(-48 * time.Hour)
+	users := []apiclient.UserListItem{
+		{Id: "u-1", Email: "alice@example.com", Roles: []string{"admin", "operator"}, IsActive: true, CreatedAt: created},
+		{Id: "u-2", Email: "bob@example.com", Roles: []string{"viewer"}, IsActive: false, CreatedAt: created},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/users", func(w http.ResponseWriter, _ *http.Request) {
+		total := len(users)
+		writeJSON(t, w, apiclient.UserCollection{Users: &users, TotalEntries: &total})
+	})
+	return httptest.NewServer(mux)
+}
+
+// TestAdminUsersList drives the command end-to-end against a fake control
+// plane and asserts the seeded accounts (and their roles) reach stdout.
+func TestAdminUsersList(t *testing.T) {
+	srv := usersServer(t)
+	defer srv.Close()
+
+	out, _, err := run(t, "admin", "users", "list", "--server", srv.URL, "--token", "x")
+	if err != nil {
+		t.Fatalf("admin users list: %v", err)
+	}
+	for _, want := range []string{"alice@example.com", "bob@example.com", "admin,operator", "viewer"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output = %q, want it to include %q", out, want)
+		}
+	}
+}
+
+// TestCollectUsers pins the client-facing collection helper: it honors the
+// limit/offset it is handed and returns the decoded accounts.
+func TestCollectUsers(t *testing.T) {
+	srv := usersServer(t)
+	defer srv.Close()
+
+	users, err := collectUsers(context.Background(), newTestClient(t, srv.URL), 100, 0)
+	if err != nil {
+		t.Fatalf("collectUsers: %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("collectUsers returned %d users, want 2", len(users))
+	}
+	if users[0].Email != "alice@example.com" {
+		t.Errorf("first user email = %q, want alice@example.com", users[0].Email)
+	}
+}
+
+// TestRenderUsers pins the table shape and the comma-joined roles column
+// without a server in the loop.
+func TestRenderUsers(t *testing.T) {
+	users := []apiclient.UserListItem{
+		{Id: "u-1", Email: "alice@example.com", Roles: []string{"admin", "operator"}, IsActive: true, CreatedAt: time.Now()},
+	}
+	var buf bytes.Buffer
+	if err := renderUsers(&buf, users); err != nil {
+		t.Fatalf("renderUsers: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"EMAIL", "ID", "ROLES", "ACTIVE", "AGE", "alice@example.com", "admin,operator", "true"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rendered table = %q, want it to include %q", out, want)
+		}
+	}
+}
+
+// TestRenderUsersEmpty covers the empty control plane (e.g. a Lite install):
+// an empty collection is a friendly note, never an error.
+func TestRenderUsersEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := renderUsers(&buf, nil); err != nil {
+		t.Fatalf("renderUsers(empty): %v", err)
+	}
+	if !strings.Contains(buf.String(), "No users found.") {
+		t.Errorf("empty render = %q, want a friendly no-users note", buf.String())
+	}
+}
+
+// TestAdminUsersRegistered pins that the `users` subcommand is wired under the
+// admin tree, with its own `list` child.
+func TestAdminUsersRegistered(t *testing.T) {
+	admin := newAdminCommand()
+	var users *cobra.Command
+	for _, c := range admin.Commands() {
+		if c.Name() == "users" {
+			users = c
+			break
+		}
+	}
+	if users == nil {
+		t.Fatal("admin command is missing the `users` subcommand")
+	}
+	found := false
+	for _, c := range users.Commands() {
+		if c.Name() == "list" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("admin users is missing the `list` subcommand")
+	}
+}


### PR DESCRIPTION
## PR-7 — `leoflow admin users list`

Closes #650. Identity/Auth lane (#623). **Stacked on PR-5 (#649)** — uses its `ListUsersWithResponse` client method. Base is set to the PR-5 branch for a clean stacked diff; will be rebased onto main after PR-5 merges.

The `admin` operator CLI (health/dags/drain/runs) already ships on main over the typed `pkg/client`. This completes it for the users surface PR-5 added:

- **`leoflow admin users list [--limit --offset]`** → `ListUsersWithResponse` → aligned table `EMAIL / ID / ROLES / ACTIVE / AGE` (roles comma-joined, AGE via the existing `ageString` helper). Reuses `addAdminFlags`/`adminClient` for token resolution. Grouped under `admin users` so a future `admin users create` can absorb `auth create-user`.
- An empty collection (the Lite / non-populated case) renders a friendly note, not an error.

### Files
- `internal/cli/admin_users.go` — command + pure `collectUsers` + `renderUsers`.
- `internal/cli/admin_users_test.go` — `TestAdminUsersList` (e2e via httptest), `TestCollectUsers`, `TestRenderUsers`, `TestRenderUsersEmpty`, `TestAdminUsersRegistered`.
- `internal/cli/admin.go` — register `newAdminUsersCommand()`.

### Verification
`go build`/`go vet`/`gofmt` clean · `golangci-lint run ./...` **0** · 5 new tests pass · registered under `admin`. Strict TDD (test-first), no AI attribution.

### Out of scope (follow-up)
`admin pools` — pools are Pro gin handlers not yet in the OpenAPI spec / typed client (PR-8 shipped UI handlers only); building it over pkg/client needs pools added to the spec + client regen first.

**Held for the Wave-3 closing specialist review** before merge.