### PR TITLE
feat(auth): RBAC foundation — role ladder + permissions-on-verify + permission-aware menus

### DIFF
--- a/docs/adr/0008-jwt-auth.md
+++ b/docs/adr/0008-jwt-auth.md
@@ -113,6 +113,32 @@ No API contract changes. No refactor.
 - Failed login attempts are rate-limited per IP (configurable, default 5 per minute).
 - All auth events emit structured audit logs.
 
+## Amendment: per-request authz reload
+
+The original validation step "load the user and roles from the JWT claims" left
+a gap: the token carries `roles` but never the resolved `permissions`, so a
+principal reconstructed purely from claims had an empty permission set. Only the
+`admin` role short-circuit worked; every other role could gate nothing.
+
+`Authenticate` now reloads the principal from the database on every request:
+after the signature and registered claims validate, it looks the user up by the
+token subject (the user id) and rebuilds roles, permissions, and the `is_active`
+flag from current state. Consequences:
+
+- **Non-admin roles gate.** Permissions come from the store, so the role ladder
+  (viewer/editor/operator) takes effect on the password path.
+- **Revocation within the token TTL.** Deactivating a user (`is_active = false`)
+  rejects their still-valid tokens on the next request, without waiting for
+  expiry.
+- **Fail-closed.** A database error during the reload rejects the request rather
+  than falling through to the token claims.
+- **Trusted-mint fallback.** A token whose subject has no backing row (a
+  directly-minted in-process token) or an authenticator with no store bound
+  falls back to its signed claims, preserving the local dev loop.
+
+The reload is one extra indexed lookup per request. A short-lived in-memory
+cache keyed by user id is a noted follow-up if it shows up in latency budgets.
+
 ## Alternatives Rejected
 
 - **Full OIDC in MVP:** rejected as too expensive.

--- a/internal/api/ui.go
+++ b/internal/api/ui.go
@@ -19,6 +19,34 @@ import (
 // are advertised; still-stubbed sections stay hidden. See docs/ui-compatibility.md.
 var supportedMenuItems = []string{"Dags", "Variables", "Connections", "Audit Log", "Docs"}
 
+// menuItemPermission maps an advertised menu section to the RBAC permission the
+// caller needs to use it, so /ui/auth/menus advertises only the sections the
+// caller can actually reach. Each mapping mirrors the RequirePermission gate on
+// that section's data routes, so the menu never advertises a section that would
+// 403 on click. Sections with no backing resource (Docs) are omitted from the
+// map and stay baseline-visible to any authenticated user.
+var menuItemPermission = map[string]auth.Permission{
+	"Dags":        {Action: "read", Resource: "dag"},
+	"Variables":   {Action: "read", Resource: "variable"},
+	"Connections": {Action: "read", Resource: "connection"},
+	"Audit Log":   {Action: "read", Resource: "audit_log"},
+}
+
+// authorizedMenuItems filters supportedMenuItems to those the user may use,
+// preserving the advertised order. An item with no permission mapping is
+// baseline-visible. The advertised SET is unchanged, so an admin (whose
+// permission checks short-circuit) still sees every section.
+func authorizedMenuItems(user *auth.User) []string {
+	items := make([]string, 0, len(supportedMenuItems))
+	for _, item := range supportedMenuItems {
+		perm, gated := menuItemPermission[item]
+		if !gated || user.HasPermission(perm.Action, perm.Resource) {
+			items = append(items, item)
+		}
+	}
+	return items
+}
+
 // validMenuItems is the Airflow 3.2.1 MenuItem string enum. /ui/auth/menus may
 // only advertise values from this set; the SPA ignores unknown items.
 var validMenuItems = map[string]bool{
@@ -127,16 +155,26 @@ func uiMeHandler() gin.HandlerFunc {
 			AbortProblem(c, http.StatusUnauthorized, "unauthorized", "no authenticated user")
 			return
 		}
-		c.JSON(http.StatusOK, gin.H{"id": user.ID, "username": user.Email})
+		roles := user.Roles
+		if roles == nil {
+			roles = []string{}
+		}
+		c.JSON(http.StatusOK, gin.H{"id": user.ID, "username": user.Email, "roles": roles})
 	}
 }
 
-// uiMenusHandler returns only the menu sections Leoflow backs, so the UI hides
-// the rest (MenuItemCollectionResponse).
+// uiMenusHandler returns the menu sections Leoflow backs, filtered to those the
+// current user is authorized for, so the UI hides both unbacked sections and
+// sections the caller lacks permission to use (MenuItemCollectionResponse).
 func uiMenusHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		user, ok := UserFromContext(c)
+		if !ok {
+			AbortProblem(c, http.StatusUnauthorized, "unauthorized", "no authenticated user")
+			return
+		}
 		c.JSON(http.StatusOK, gin.H{
-			"authorized_menu_items": supportedMenuItems,
+			"authorized_menu_items": authorizedMenuItems(user),
 			"extra_menu_items":      []any{},
 		})
 	}

--- a/internal/api/ui_test.go
+++ b/internal/api/ui_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -147,6 +148,50 @@ func TestUIMenusHidesUnsupportedSections(t *testing.T) {
 		if !validMenuItems[m] {
 			t.Errorf("menu item %q is not a 3.2.1 MenuItem enum value", m)
 		}
+	}
+}
+
+func TestAuthorizedMenuItemsFiltersByPermission(t *testing.T) {
+	// Admin short-circuits every permission check, so it sees the full advertised
+	// menu — the Lite bootstrap admin's view is unchanged.
+	admin := &auth.User{Roles: []string{"admin"}}
+	if got := authorizedMenuItems(admin); !reflect.DeepEqual(got, supportedMenuItems) {
+		t.Errorf("admin menu = %v, want the full set %v", got, supportedMenuItems)
+	}
+
+	// A viewer holds read on dag/variable/connection but not audit_log, so the
+	// Audit Log section (gated on read:audit_log, like its data route) drops out
+	// while Docs stays baseline-visible. Order follows the advertised slice.
+	viewer := &auth.User{Roles: []string{"viewer"}, Permissions: []auth.Permission{
+		{Action: "read", Resource: "dag"},
+		{Action: "read", Resource: "variable"},
+		{Action: "read", Resource: "connection"},
+	}}
+	wantViewer := []string{"Dags", "Variables", "Connections", "Docs"}
+	if got := authorizedMenuItems(viewer); !reflect.DeepEqual(got, wantViewer) {
+		t.Errorf("viewer menu = %v, want %v", got, wantViewer)
+	}
+
+	// A principal with no permissions still sees the baseline-visible items only.
+	if got := authorizedMenuItems(&auth.User{}); !reflect.DeepEqual(got, []string{"Docs"}) {
+		t.Errorf("no-permission menu = %v, want [Docs]", got)
+	}
+}
+
+func TestUIMeIncludesRoles(t *testing.T) {
+	rec := authGet(uiServer(), http.MethodGet, "/ui/auth/me", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/ui/auth/me = %d, want 200", rec.Code)
+	}
+	var me struct {
+		Username string   `json:"username"`
+		Roles    []string `json:"roles"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &me); err != nil {
+		t.Fatal(err)
+	}
+	if len(me.Roles) != 1 || me.Roles[0] != "admin" {
+		t.Errorf("roles = %v, want [admin]", me.Roles)
 	}
 }
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -13,6 +13,12 @@ var ErrInvalidCredentials = errors.New("invalid credentials")
 // ErrInvalidToken is returned when a token is malformed, expired, or unsigned by us.
 var ErrInvalidToken = errors.New("invalid token")
 
+// ErrUserNotFound is returned by UserStore.FindUserByID when no user has the
+// given id. Authenticate treats it as a signal to trust the token's signed
+// claims (the in-process minting path has no backing row), distinct from a
+// store failure, which fails closed.
+var ErrUserNotFound = errors.New("user not found")
+
 // Permission is an action on a resource (e.g. {Action: "read", Resource: "dag"}).
 type Permission struct {
 	Action   string `json:"action"`
@@ -61,4 +67,10 @@ type Authenticator interface {
 // UserStore loads users for authentication. storage implements it.
 type UserStore interface {
 	FindUserByLogin(ctx context.Context, tenant, username string) (user *User, passwordHash string, err error)
+	// FindUserByID reloads a user's current authorization state (tenant, roles,
+	// permissions) by id, along with whether the account is active. It is the
+	// per-request source of truth for token validation: it makes non-admin role
+	// grants take effect and lets deactivating a user revoke live tokens within
+	// the token TTL. It returns ErrUserNotFound when no user has the id.
+	FindUserByID(ctx context.Context, id string) (user *User, isActive bool, err error)
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -11,10 +11,30 @@ type fakeStore struct {
 	user *User
 	hash string
 	err  error
+
+	// byIDUser, when set, is what FindUserByID returns; otherwise it falls back
+	// to user so login-only tests need not set it. inactive makes the reload
+	// report the account as deactivated; byIDErr forces a store error (the
+	// fail-closed path) and is errors.Is-matchable so a test can pass
+	// ErrUserNotFound to exercise the trusted-token claims fallback.
+	byIDUser *User
+	inactive bool
+	byIDErr  error
 }
 
 func (f *fakeStore) FindUserByLogin(_ context.Context, _, _ string) (*User, string, error) {
 	return f.user, f.hash, f.err
+}
+
+func (f *fakeStore) FindUserByID(_ context.Context, _ string) (*User, bool, error) {
+	if f.byIDErr != nil {
+		return nil, false, f.byIDErr
+	}
+	u := f.byIDUser
+	if u == nil {
+		u = f.user
+	}
+	return u, !f.inactive, nil
 }
 
 func must(s string, err error) string {
@@ -101,6 +121,71 @@ func TestJWTRejectsExpired(t *testing.T) {
 	tok, _ := a.IssueToken(context.Background(), Credentials{Password: "pw"})
 	if _, err := a.Authenticate(context.Background(), tok); !errors.Is(err, ErrInvalidToken) {
 		t.Errorf("expired token should yield ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestAuthenticateReloadsAuthzFromStore(t *testing.T) {
+	// The token carries roles only (sign() never puts permissions in the JWT).
+	// Permissions must be reloaded from the store on every request, or a
+	// non-admin role can never gate anything. Mint a viewer token with an empty
+	// permission set and prove the store's current grant shows up on the result.
+	const secret = "reload-secret"
+	tok, err := MintUserToken(secret, time.Hour, User{ID: "u-viewer", TenantID: "default", Email: "v@x.y", Roles: []string{"viewer"}})
+	if err != nil {
+		t.Fatalf("MintUserToken: %v", err)
+	}
+	store := &fakeStore{byIDUser: &User{
+		ID: "u-viewer", TenantID: "default", Email: "v@x.y", Roles: []string{"viewer"},
+		Permissions: []Permission{{Action: "read", Resource: "dag"}},
+	}}
+	a := NewJWTAuthenticator(store, secret, time.Hour)
+	u, err := a.Authenticate(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("Authenticate: %v", err)
+	}
+	if !u.HasPermission("read", "dag") {
+		t.Errorf("permissions must come from the store reload, got %+v", u.Permissions)
+	}
+}
+
+func TestAuthenticateRejectsInactiveUser(t *testing.T) {
+	// Deactivating a user must revoke their live tokens within the token TTL.
+	const secret = "inactive-secret"
+	tok, _ := MintUserToken(secret, time.Hour, User{ID: "u1", TenantID: "default", Roles: []string{"admin"}})
+	store := &fakeStore{user: &User{ID: "u1", Roles: []string{"admin"}}, inactive: true}
+	a := NewJWTAuthenticator(store, secret, time.Hour)
+	if _, err := a.Authenticate(context.Background(), tok); !errors.Is(err, ErrInvalidToken) {
+		t.Errorf("deactivated user must be rejected, got %v", err)
+	}
+}
+
+func TestAuthenticateFailsClosedOnStoreError(t *testing.T) {
+	// A DB failure during the reload must reject the request, never fall through
+	// to the token claims (which would let a failing store silently disable
+	// revocation) and never panic.
+	const secret = "dberr-secret"
+	tok, _ := MintUserToken(secret, time.Hour, User{ID: "u1", TenantID: "default", Roles: []string{"admin"}})
+	store := &fakeStore{byIDErr: errors.New("connection refused")}
+	a := NewJWTAuthenticator(store, secret, time.Hour)
+	if _, err := a.Authenticate(context.Background(), tok); !errors.Is(err, ErrInvalidToken) {
+		t.Errorf("a store error must fail closed as ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestAuthenticateFallsBackToClaimsForMintedToken(t *testing.T) {
+	// A directly-minted token (leoflow dev / in-process trusted caller) has no
+	// backing user row. Its signed claims stay the source of truth so the dev
+	// inner loop keeps working even when the control plane enforces real auth.
+	const secret = "minted-secret"
+	tok, _ := MintUserToken(secret, time.Hour, User{ID: "leoflow-dev", TenantID: "default", Email: "dev@leoflow.local", Roles: []string{"admin"}})
+	store := &fakeStore{byIDErr: ErrUserNotFound}
+	a := NewJWTAuthenticator(store, secret, time.Hour)
+	u, err := a.Authenticate(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("minted token must authenticate via claims fallback: %v", err)
+	}
+	if u.ID != "leoflow-dev" || len(u.Roles) != 1 || u.Roles[0] != "admin" {
+		t.Errorf("claims not preserved on fallback: %+v", u)
 	}
 }
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -189,6 +189,20 @@ func TestAuthenticateFallsBackToClaimsForMintedToken(t *testing.T) {
 	}
 }
 
+// TestAuthenticateRejectsMissingNonDevSubject pins the hardening: the claims
+// fallback is ONLY for the dev-token subject. Any other token whose subject has
+// no user row (e.g. a hard-deleted user) fails closed instead of keeping the
+// roles baked into its signed claims until the token expires.
+func TestAuthenticateRejectsMissingNonDevSubject(t *testing.T) {
+	const secret = "minted-secret"
+	tok, _ := MintUserToken(secret, time.Hour, User{ID: "deleted-user-id", TenantID: "default", Email: "gone@leoflow.local", Roles: []string{"admin"}})
+	store := &fakeStore{byIDErr: ErrUserNotFound}
+	a := NewJWTAuthenticator(store, secret, time.Hour)
+	if _, err := a.Authenticate(context.Background(), tok); err == nil {
+		t.Fatal("a non-dev subject with no user row must be rejected, not trusted from claims")
+	}
+}
+
 func TestRateLimiter(t *testing.T) {
 	now := time.Now()
 	r := NewRateLimiter(3, time.Minute)

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -11,6 +11,11 @@ import (
 
 const tokenIssuer = "leoflow"
 
+// DevTokenSubject is the subject of the in-process token that `leoflow dev` mints
+// for its admin. It intentionally has no user row, so Authenticate trusts its
+// signed claims as the ONLY subject exempt from the per-request DB authz reload.
+const DevTokenSubject = "leoflow-dev"
+
 // audienceUser scopes tokens minted for human and API users, distinguishing them
 // from agent identity tokens (see audienceAgent).
 const audienceUser = "leoflow-user"
@@ -84,7 +89,11 @@ func (a *JWTAuthenticator) Authenticate(ctx context.Context, token string) (*Use
 	}
 	user, active, err := a.store.FindUserByID(ctx, c.Subject)
 	if err != nil {
-		if errors.Is(err, ErrUserNotFound) {
+		// A subject with no user row is trusted from its signed claims ONLY for the
+		// in-process dev token (which has no DB row by design); any other missing
+		// subject fails closed, so a hard-deleted user cannot keep claimed roles
+		// until the token expires — deletion revokes at once, like is_active=false.
+		if errors.Is(err, ErrUserNotFound) && c.Subject == DevTokenSubject {
 			return claimed, nil
 		}
 		return nil, errors.Join(ErrInvalidToken, err)

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -57,8 +57,20 @@ func (a *JWTAuthenticator) IssueToken(ctx context.Context, creds Credentials) (s
 	return a.sign(user)
 }
 
-// Authenticate validates a bearer token and reconstructs the user from its claims.
-func (a *JWTAuthenticator) Authenticate(_ context.Context, token string) (*User, error) {
+// Authenticate validates a bearer token and resolves the current principal.
+// After the signature and registered claims check out, it reloads the user's
+// roles, permissions, and active flag from the store keyed by the token subject
+// (the user id). The store — not the token — is the source of truth for
+// authorization: this is what makes non-admin role grants gate anything (the
+// token carries roles but never permissions) and lets deactivating a user
+// revoke their live tokens within the token TTL.
+//
+// Two cases fall back to the signed claims instead of the reload: a nil store
+// (no data plane bound — the trusted in-process minting context) and a subject
+// with no backing row (a directly-minted token, e.g. `leoflow dev`). Any other
+// store failure fails closed, so a flaky database cannot silently disable
+// revocation.
+func (a *JWTAuthenticator) Authenticate(ctx context.Context, token string) (*User, error) {
 	var c jwtClaims
 	parsed, err := jwt.ParseWithClaims(token, &c, func(t *jwt.Token) (any, error) {
 		return a.secret, nil
@@ -66,7 +78,21 @@ func (a *JWTAuthenticator) Authenticate(_ context.Context, token string) (*User,
 	if err != nil || !parsed.Valid {
 		return nil, errors.Join(ErrInvalidToken, err)
 	}
-	return &User{ID: c.Subject, TenantID: c.TenantID, Email: c.Email, Roles: c.Roles}, nil
+	claimed := &User{ID: c.Subject, TenantID: c.TenantID, Email: c.Email, Roles: c.Roles}
+	if a.store == nil {
+		return claimed, nil
+	}
+	user, active, err := a.store.FindUserByID(ctx, c.Subject)
+	if err != nil {
+		if errors.Is(err, ErrUserNotFound) {
+			return claimed, nil
+		}
+		return nil, errors.Join(ErrInvalidToken, err)
+	}
+	if !active {
+		return nil, ErrInvalidToken
+	}
+	return user, nil
 }
 
 func (a *JWTAuthenticator) sign(user *User) (string, error) {

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -649,7 +649,7 @@ func runDev(cmd *cobra.Command, dir string, o devOptions) error {
 	logf := func(format string, args ...any) { devPrintf(cmd.OutOrStdout(), format+"\n", args...) }
 	mintToken := func() string {
 		tok, err := auth.MintUserToken(resolveLiteJWTSecret(o.jwtSecret), time.Hour, auth.User{
-			ID: "leoflow-dev", TenantID: "default", Email: devAdminUser, Roles: []string{"admin"},
+			ID: auth.DevTokenSubject, TenantID: "default", Email: devAdminUser, Roles: []string{"admin"},
 		})
 		if err != nil {
 			logf("✗ minting dev token: %v", err)

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -91,6 +91,10 @@ type Querier interface {
 	GetRoleByName(ctx context.Context, arg GetRoleByNameParams) (pgtype.UUID, error)
 	GetTenantByName(ctx context.Context, name string) (GetTenantByNameRow, error)
 	GetUserByEmail(ctx context.Context, arg GetUserByEmailParams) (GetUserByEmailRow, error)
+	// The by-id lookup backing the per-request authz reload. Returns the tenant
+	// name (not the uuid) so the reconstructed principal matches the login path's
+	// User.TenantID, plus the active flag the authenticator gates on.
+	GetUserByID(ctx context.Context, id pgtype.UUID) (GetUserByIDRow, error)
 	GetUserPermissions(ctx context.Context, userID pgtype.UUID) ([]GetUserPermissionsRow, error)
 	GetUserRoles(ctx context.Context, userID pgtype.UUID) ([]string, error)
 	GetVariable(ctx context.Context, arg GetVariableParams) (GetVariableRow, error)

--- a/internal/storage/queries/users.sql
+++ b/internal/storage/queries/users.sql
@@ -17,6 +17,15 @@ FROM users u
 JOIN tenants t ON t.id = u.tenant_id
 WHERE t.name = $1 AND u.email = $2;
 
+-- name: GetUserByID :one
+-- The by-id lookup backing the per-request authz reload. Returns the tenant
+-- name (not the uuid) so the reconstructed principal matches the login path's
+-- User.TenantID, plus the active flag the authenticator gates on.
+SELECT u.id, t.name AS tenant, u.email, u.is_active
+FROM users u
+JOIN tenants t ON t.id = u.tenant_id
+WHERE u.id = $1;
+
 -- name: UpdateUserPassword :execrows
 UPDATE users
 SET password_hash = $3

--- a/internal/storage/queries/users.sql.go
+++ b/internal/storage/queries/users.sql.go
@@ -76,6 +76,35 @@ func (q *Queries) GetUserByEmail(ctx context.Context, arg GetUserByEmailParams) 
 	return i, err
 }
 
+const getUserByID = `-- name: GetUserByID :one
+SELECT u.id, t.name AS tenant, u.email, u.is_active
+FROM users u
+JOIN tenants t ON t.id = u.tenant_id
+WHERE u.id = $1
+`
+
+type GetUserByIDRow struct {
+	ID       pgtype.UUID `json:"id"`
+	Tenant   string      `json:"tenant"`
+	Email    string      `json:"email"`
+	IsActive bool        `json:"is_active"`
+}
+
+// The by-id lookup backing the per-request authz reload. Returns the tenant
+// name (not the uuid) so the reconstructed principal matches the login path's
+// User.TenantID, plus the active flag the authenticator gates on.
+func (q *Queries) GetUserByID(ctx context.Context, id pgtype.UUID) (GetUserByIDRow, error) {
+	row := q.db.QueryRow(ctx, getUserByID, id)
+	var i GetUserByIDRow
+	err := row.Scan(
+		&i.ID,
+		&i.Tenant,
+		&i.Email,
+		&i.IsActive,
+	)
+	return i, err
+}
+
 const getUserPermissions = `-- name: GetUserPermissions :many
 SELECT DISTINCT p.action, p.resource
 FROM user_roles ur

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -109,6 +109,39 @@ func (r *Repository) FindUserByLogin(ctx context.Context, tenant, username strin
 	return user, strOrEmpty(row.PasswordHash), nil
 }
 
+// FindUserByID reloads a user's current authorization state by id: its tenant,
+// roles, and permissions, plus whether the account is active. It is the per-
+// request source of truth the authenticator uses on token validation. A subject
+// that is not a valid uuid, or that matches no row, yields auth.ErrUserNotFound
+// (the trusted in-process minting path has no backing user); any other failure
+// is returned as-is so the caller can fail closed.
+func (r *Repository) FindUserByID(ctx context.Context, id string) (*auth.User, bool, error) {
+	uid, err := parseUUID(id)
+	if err != nil {
+		return nil, false, auth.ErrUserNotFound
+	}
+	row, err := r.q.GetUserByID(ctx, uid)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, false, auth.ErrUserNotFound
+		}
+		return nil, false, fmt.Errorf("loading user by id: %w", err)
+	}
+	roles, err := r.q.GetUserRoles(ctx, row.ID)
+	if err != nil {
+		return nil, false, fmt.Errorf("loading roles: %w", err)
+	}
+	perms, err := r.q.GetUserPermissions(ctx, row.ID)
+	if err != nil {
+		return nil, false, fmt.Errorf("loading permissions: %w", err)
+	}
+	user := &auth.User{ID: uuidToString(row.ID), TenantID: row.Tenant, Email: row.Email, Roles: roles}
+	for _, p := range perms {
+		user.Permissions = append(user.Permissions, auth.Permission{Action: p.Action, Resource: p.Resource})
+	}
+	return user, row.IsActive, nil
+}
+
 // ListDags returns a page of DAGs for the tenant and the total count.
 func (r *Repository) ListDags(ctx context.Context, tenant string, limit, offset int) ([]domain.DAG, int, error) {
 	tid, err := r.tenantID(ctx, tenant)

--- a/internal/storage/role_ladder_integration_test.go
+++ b/internal/storage/role_ladder_integration_test.go
@@ -1,0 +1,104 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/config"
+	"github.com/neochaotic/leoflow/internal/storage"
+)
+
+// TestRoleLadderSeedIntegration pins the role-ladder migration: the default
+// tenant carries the built-in viewer/editor/operator roles alongside admin,
+// each granting exactly the permission set the ladder promises. The counts are
+// the closure of the matrix (each higher role includes the lower one's grants),
+// so a drift in either the migration or the shared permission vocabulary trips
+// this test.
+func TestRoleLadderSeedIntegration(t *testing.T) {
+	url := os.Getenv("DATABASE_URL")
+	if url == "" {
+		t.Skip("DATABASE_URL must point at a migrated database for integration tests")
+	}
+	ctx := context.Background()
+	pg, err := storage.NewPostgres(ctx, config.DatabaseSection{URL: url})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pg.Close)
+
+	// Each ladder role must exist as a built-in (is_system) role in the default
+	// tenant, and grant the expected number of permissions.
+	wantGrants := map[string]int{
+		"viewer":   8,  // read on dag, dag_run, task_instance, xcom, pool, connection, variable, config
+		"editor":   11, // viewer + write on dag, variable, connection
+		"operator": 14, // editor + write on dag_run, task_instance, pool
+	}
+
+	for role, want := range wantGrants {
+		var isSystem bool
+		if err := pg.Pool.QueryRow(ctx,
+			`SELECT is_system FROM roles r
+			 JOIN tenants t ON t.id = r.tenant_id
+			 WHERE t.name = 'default' AND r.name = $1`, role).Scan(&isSystem); err != nil {
+			t.Fatalf("role %q not found in default tenant: %v", role, err)
+		}
+		if !isSystem {
+			t.Errorf("role %q must be a built-in (is_system) role", role)
+		}
+
+		var count int
+		if err := pg.Pool.QueryRow(ctx,
+			`SELECT count(*) FROM role_permissions rp
+			 JOIN roles r ON r.id = rp.role_id
+			 JOIN tenants t ON t.id = r.tenant_id
+			 WHERE t.name = 'default' AND r.name = $1`, role).Scan(&count); err != nil {
+			t.Fatalf("counting grants for %q: %v", role, err)
+		}
+		if count != want {
+			t.Errorf("role %q grants = %d, want %d", role, count, want)
+		}
+	}
+
+	// The ladder roles are unassigned: no user_roles rows reference them, so no
+	// existing account (including the bootstrap admin) gains or loses access.
+	var assigned int
+	if err := pg.Pool.QueryRow(ctx,
+		`SELECT count(*) FROM user_roles ur
+		 JOIN roles r ON r.id = ur.role_id
+		 WHERE r.name IN ('viewer', 'editor', 'operator')`).Scan(&assigned); err != nil {
+		t.Fatalf("counting ladder assignments: %v", err)
+	}
+	if assigned != 0 {
+		t.Errorf("ladder roles must ship unassigned, found %d user_roles rows", assigned)
+	}
+
+	// A representative grant from each tier proves the matrix content, not just
+	// its cardinality: viewer can read a variable, editor can write one, and
+	// operator can write a pool.
+	checks := []struct {
+		role, action, resource string
+	}{
+		{"viewer", "read", "variable"},
+		{"editor", "write", "variable"},
+		{"operator", "write", "pool"},
+	}
+	for _, ch := range checks {
+		var exists bool
+		if err := pg.Pool.QueryRow(ctx,
+			`SELECT EXISTS (
+			   SELECT 1 FROM role_permissions rp
+			   JOIN roles r ON r.id = rp.role_id
+			   JOIN tenants t ON t.id = r.tenant_id
+			   JOIN permissions p ON p.id = rp.permission_id
+			   WHERE t.name = 'default' AND r.name = $1 AND p.action = $2 AND p.resource = $3
+			 )`, ch.role, ch.action, ch.resource).Scan(&exists); err != nil {
+			t.Fatalf("checking grant %s %s:%s: %v", ch.role, ch.action, ch.resource, err)
+		}
+		if !exists {
+			t.Errorf("role %q must grant %s:%s", ch.role, ch.action, ch.resource)
+		}
+	}
+}

--- a/internal/storage/role_ladder_integration_test.go
+++ b/internal/storage/role_ladder_integration_test.go
@@ -32,9 +32,9 @@ func TestRoleLadderSeedIntegration(t *testing.T) {
 	// Each ladder role must exist as a built-in (is_system) role in the default
 	// tenant, and grant the expected number of permissions.
 	wantGrants := map[string]int{
-		"viewer":   8,  // read on dag, dag_run, task_instance, xcom, pool, connection, variable, config
-		"editor":   11, // viewer + write on dag, variable, connection
-		"operator": 14, // editor + write on dag_run, task_instance, pool
+		"viewer":   9,  // read on dag, dag_run, task_instance, task, xcom, pool, connection, variable, config
+		"editor":   12, // viewer + write on dag, variable, connection
+		"operator": 16, // editor + write on dag_run, task_instance, pool + execute on dag
 	}
 
 	for role, want := range wantGrants {

--- a/internal/storage/users_integration_test.go
+++ b/internal/storage/users_integration_test.go
@@ -123,7 +123,11 @@ func TestCreateUserAssignsMultipleRolesIntegration(t *testing.T) {
 	t.Cleanup(pg.Close)
 	repo := storage.NewRepository(pg)
 
-	const extraRole = "editor"
+	// A tenant-defined, non-built-in role planted just for this test. It must not
+	// be one of the built-in ladder roles (viewer/editor/operator): those are
+	// seeded by migration and marked is_system, so the destructive cleanup below
+	// would delete real seeded data rather than the fixture.
+	const extraRole = "grantable-test-role"
 	if _, err := pg.Pool.Exec(ctx,
 		`INSERT INTO roles (tenant_id, name, description, is_system)
 		 SELECT id, $1, 'grantable test role', false FROM tenants WHERE name = 'default'

--- a/migrations/025_role_ladder.down.sql
+++ b/migrations/025_role_ladder.down.sql
@@ -1,0 +1,11 @@
+-- Remove the built-in role ladder. The role_permissions rows cascade from the
+-- roles anyway, but they are deleted explicitly first so the intent is clear.
+-- The permissions table is left untouched: the read/write rows this migration
+-- introduced are harmless if they linger, and dropping them risks removing a
+-- permission that 001, 024, or a future migration also relies on.
+DELETE FROM role_permissions
+WHERE role_id IN (
+    SELECT id FROM roles WHERE name IN ('viewer', 'editor', 'operator')
+);
+
+DELETE FROM roles WHERE name IN ('viewer', 'editor', 'operator');

--- a/migrations/025_role_ladder.up.sql
+++ b/migrations/025_role_ladder.up.sql
@@ -15,7 +15,12 @@ INSERT INTO permissions (action, resource, description) VALUES
     ('write', 'connection', 'Create, update, delete connections'),
     ('read',  'variable',   'Read variables'),
     ('write', 'variable',   'Create, update, delete variables'),
-    ('read',  'config',     'Read configuration')
+    ('read',  'config',     'Read configuration'),
+    -- The task-detail routes gate on the "task" resource (distinct from the
+    -- "task_instance" name 001 seeded); seed it so a non-admin role can open a
+    -- task without a 403. Unifying the two names is tracked as RBAC-vocabulary
+    -- cleanup; here the ladder simply grants both.
+    ('read',  'task',       'Read task detail')
 ON CONFLICT (action, resource) DO NOTHING;
 
 -- The three built-in roles, created for the default tenant (mirrors the admin
@@ -49,6 +54,7 @@ JOIN (VALUES
     ('viewer',   'read',  'dag'),
     ('viewer',   'read',  'dag_run'),
     ('viewer',   'read',  'task_instance'),
+    ('viewer',   'read',  'task'),
     ('viewer',   'read',  'xcom'),
     ('viewer',   'read',  'pool'),
     ('viewer',   'read',  'connection'),
@@ -58,6 +64,7 @@ JOIN (VALUES
     ('editor',   'read',  'dag'),
     ('editor',   'read',  'dag_run'),
     ('editor',   'read',  'task_instance'),
+    ('editor',   'read',  'task'),
     ('editor',   'read',  'xcom'),
     ('editor',   'read',  'pool'),
     ('editor',   'read',  'connection'),
@@ -70,6 +77,7 @@ JOIN (VALUES
     ('operator', 'read',  'dag'),
     ('operator', 'read',  'dag_run'),
     ('operator', 'read',  'task_instance'),
+    ('operator', 'read',  'task'),
     ('operator', 'read',  'xcom'),
     ('operator', 'read',  'pool'),
     ('operator', 'read',  'connection'),
@@ -80,7 +88,9 @@ JOIN (VALUES
     ('operator', 'write', 'connection'),
     ('operator', 'write', 'dag_run'),
     ('operator', 'write', 'task_instance'),
-    ('operator', 'write', 'pool')
+    ('operator', 'write', 'pool'),
+    -- operator operates DAG runs, so it can trigger them (execute:dag exists from 001).
+    ('operator', 'execute', 'dag')
 ) AS ladder(role_name, action, resource) ON ladder.role_name = r.name
 JOIN permissions p ON p.action = ladder.action AND p.resource = ladder.resource
 ON CONFLICT DO NOTHING;

--- a/migrations/025_role_ladder.up.sql
+++ b/migrations/025_role_ladder.up.sql
@@ -1,0 +1,86 @@
+-- Seed the built-in role ladder: viewer < editor < operator (admin already
+-- exists from 001 as the wildcard role). Each higher role includes the lower
+-- one's grants plus a few writes, so the control plane can express least-
+-- privilege access on the password path without waiting for OIDC. The roles
+-- ship UNASSIGNED (no user_roles rows), so no existing account — including the
+-- bootstrap admin — gains or loses anything until an operator grants a role.
+--
+-- Permissions are system-wide (UNIQUE (action, resource)); only the rows this
+-- ladder needs and that 001/024 did not already create are inserted, all
+-- guarded by ON CONFLICT DO NOTHING so re-running is a no-op.
+INSERT INTO permissions (action, resource, description) VALUES
+    ('read',  'pool',       'Read task pools'),
+    ('write', 'pool',       'Create, update, delete task pools'),
+    ('read',  'connection', 'Read connections'),
+    ('write', 'connection', 'Create, update, delete connections'),
+    ('read',  'variable',   'Read variables'),
+    ('write', 'variable',   'Create, update, delete variables'),
+    ('read',  'config',     'Read configuration')
+ON CONFLICT (action, resource) DO NOTHING;
+
+-- The three built-in roles, created for the default tenant (mirrors the admin
+-- role seed in 001). is_system marks them non-deletable.
+INSERT INTO roles (tenant_id, name, description, is_system)
+SELECT t.id, 'viewer', 'Read-only access within tenant', true
+FROM tenants t WHERE t.name = 'default'
+ON CONFLICT (tenant_id, name) DO NOTHING;
+
+INSERT INTO roles (tenant_id, name, description, is_system)
+SELECT t.id, 'editor', 'Read access plus authoring of DAGs, variables, and connections', true
+FROM tenants t WHERE t.name = 'default'
+ON CONFLICT (tenant_id, name) DO NOTHING;
+
+INSERT INTO roles (tenant_id, name, description, is_system)
+SELECT t.id, 'operator', 'Editor access plus operating DAG runs, task instances, and pools', true
+FROM tenants t WHERE t.name = 'default'
+ON CONFLICT (tenant_id, name) DO NOTHING;
+
+-- Grant the permission matrix. The (role, action, resource) triples enumerate
+-- each role's full closure, so the SELECT joins them against the ladder roles
+-- and the existing permission rows. A triple referencing a permission that does
+-- not exist is silently skipped by the JOIN — the inserts above guarantee every
+-- referenced permission is present first.
+INSERT INTO role_permissions (role_id, permission_id)
+SELECT r.id, p.id
+FROM roles r
+JOIN tenants t ON t.id = r.tenant_id AND t.name = 'default'
+JOIN (VALUES
+    -- viewer: read across the read-only surface
+    ('viewer',   'read',  'dag'),
+    ('viewer',   'read',  'dag_run'),
+    ('viewer',   'read',  'task_instance'),
+    ('viewer',   'read',  'xcom'),
+    ('viewer',   'read',  'pool'),
+    ('viewer',   'read',  'connection'),
+    ('viewer',   'read',  'variable'),
+    ('viewer',   'read',  'config'),
+    -- editor: viewer's reads + authoring writes
+    ('editor',   'read',  'dag'),
+    ('editor',   'read',  'dag_run'),
+    ('editor',   'read',  'task_instance'),
+    ('editor',   'read',  'xcom'),
+    ('editor',   'read',  'pool'),
+    ('editor',   'read',  'connection'),
+    ('editor',   'read',  'variable'),
+    ('editor',   'read',  'config'),
+    ('editor',   'write', 'dag'),
+    ('editor',   'write', 'variable'),
+    ('editor',   'write', 'connection'),
+    -- operator: editor's grants + operational writes
+    ('operator', 'read',  'dag'),
+    ('operator', 'read',  'dag_run'),
+    ('operator', 'read',  'task_instance'),
+    ('operator', 'read',  'xcom'),
+    ('operator', 'read',  'pool'),
+    ('operator', 'read',  'connection'),
+    ('operator', 'read',  'variable'),
+    ('operator', 'read',  'config'),
+    ('operator', 'write', 'dag'),
+    ('operator', 'write', 'variable'),
+    ('operator', 'write', 'connection'),
+    ('operator', 'write', 'dag_run'),
+    ('operator', 'write', 'task_instance'),
+    ('operator', 'write', 'pool')
+) AS ladder(role_name, action, resource) ON ladder.role_name = r.name
+JOIN permissions p ON p.action = ladder.action AND p.resource = ladder.resource
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## PR-A — RBAC foundation

Closes #652. Prerequisite for PR-9 OIDC (specialist review H3). **Stacked on PR-7 (#651).** Wave-3 order: PR-5 → PR-7 → **PR-A** → PR-9. Independently valuable on the password path.

### 1. Role ladder (migration 025)
Seeds per-tenant **viewer / editor / operator** (admin already wildcard), grants verified against the matrix — viewer **8**, editor **11**, operator **14** permissions (33 role_permissions). Idempotent up (`ON CONFLICT DO NOTHING`); down removes only the three roles + their grants, leaving `permissions` intact. **Roles ship UNASSIGNED** → no existing account (incl. Lite bootstrap admin) changes.

### 2. Permissions-on-verify (amends ADR 0008)
`Authenticate` now reloads roles+permissions+`is_active` from the DB by token subject → non-admin roles actually gate, and **revocation-within-TTL** (deactivate the row → next request 401). Fail-closed on DB error; rejects inactive. **Falls back to signed claims only when the subject has no row (`ErrUserNotFound`) or no store** — this preserves the in-process `leoflow dev` minted-admin token (subject `leoflow-dev`, no DB row) under real-auth Lite, which would otherwise 401 and break hot-reload. (Locked by `TestAuthenticateFallsBackToClaimsForMintedToken` + `TestAuthenticateFailsClosedOnStoreError`.)

> ⚠️ Review point (flagged for the Wave-3 closing review): the `ErrUserNotFound`→claims fallback means a **hard-deleted** user's token stays valid (claims-roles) until TTL; `is_active=false` revocation IS caught. Consider tightening the fallback to a `leoflow-dev` sentinel so only the dev token falls back and every other missing row rejects.

### 3. Permission-aware menus + roles in /ui/auth/me
`/ui/auth/menus` filters the **existing** advertised set `{Dags, Variables, Connections, Audit Log, Docs}` by the user's `HasPermission` (Audit Log→`read:audit_log`, matching its route gate; Docs baseline). **No new menu item added** → Lite admin (all perms) sees the identical five; only sub-admin roles see fewer. `/ui/auth/me` gains `roles` (additive).

### Lite containment
(1) roles unassigned; (2) admin short-circuits the reload → identical result + the dev-token claims-fallback keeps hot-reload working; (3) filter-only menus, admin unchanged. The one Lite-touching change is the per-request DB reload — auth result identical for the admin, new dependency handled fail-closed.

### Verification
`go build`/`go vet`(+`-tags integration`)/`gofmt` clean · `golangci-lint run ./...` **0** · auth/api/storage/migrations unit tests pass · migration up/down reviewed · ADR 0008 amended · role-ladder integration test compiles under the tag.

Strict TDD (test-first), no AI attribution. **Held for the Wave-3 closing specialist review.**