### PR TITLE
feat(auth): OIDC/SSO with fail-closed tenant pinning (ADR 0057)

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -189,16 +189,9 @@ func run() error {
 	// The API side (HTTP + embedded UI) is built only in the api/"all" role. The
 	// scheduler role serves no API, so none of the UI/handler machinery is even
 	// constructed — apiSrv stays nil and serveHTTP omits it.
-	var apiSrv *http.Server
-	if servesAPI {
-		// Under provider: oidc, discover the IdP and build the login flow now, so a
-		// misconfigured issuer fails boot closed rather than at first login. The JWT
-		// authenticator built above stays the request-path verifier in both modes.
-		oidcFlow, ferr := buildOIDCFlow(ctx, cfg, tel.Logger)
-		if ferr != nil {
-			return ferr
-		}
-		apiSrv = buildAPIServer(cfg, tel, authn, pg, repo, xcomReader, logSink, logTailer, checks, executorInfo, schedulerHealth, oidcFlow)
+	apiSrv, aerr := startAPISide(ctx, cfg, tel, authn, pg, repo, xcomReader, logSink, logTailer, checks, executorInfo, schedulerHealth, servesAPI)
+	if aerr != nil {
+		return aerr
 	}
 
 	// The metrics listener also serves /healthz + /readyz in every role so a
@@ -378,15 +371,33 @@ func startSchedulerSide(ctx context.Context, cfg *config.ServerConfig, pg *stora
 // role (ADR 0049). It is called only when the role serves the API, so the UI
 // shell, editor FS, rate limiter, and full route set are never constructed in a
 // scheduler-only process.
-// buildOIDCFlow discovers the IdP and builds the Authorization Code + PKCE login
-// flow when provider is "oidc"; it returns nil in JWT mode (the default), where
-// the OIDC routes are never registered. The client secret comes from the
-// environment (LEOFLOW_AUTH_OIDC_CLIENT_SECRET, bound by viper); it is never
-// logged. Discovery failure is a boot failure — fail closed.
-func buildOIDCFlow(ctx context.Context, cfg *config.ServerConfig, logger *slog.Logger) (*oidc.Flow, error) {
-	if cfg.Auth.Provider != config.AuthProviderOIDC {
-		return nil, nil
+// startAPISide builds the HTTP API + embedded UI server, or nothing in a
+// scheduler-only role (ADR 0049). It is factored out of run() so the OIDC-flow
+// build and its error handling do not inflate run()'s complexity. Under
+// provider: oidc it discovers the IdP and builds the login flow now, so a
+// misconfigured issuer fails boot closed rather than at first login.
+func startAPISide(ctx context.Context, cfg *config.ServerConfig, tel *observability.Telemetry, authn *auth.JWTAuthenticator, pg *storage.Postgres, repo *storage.Repository, xcomReader *storage.XComReader, logSink logs.Sink, logTailer logs.Tailer, checks map[string]api.HealthChecker, executorInfo api.ExecutorInfo, schedulerHealth api.Heartbeater, servesAPI bool) (*http.Server, error) {
+	if !servesAPI {
+		return nil, nil //nolint:nilnil // scheduler-only role serves no API; that is not an error
 	}
+	var oidcFlow *oidc.Flow
+	if cfg.Auth.Provider == config.AuthProviderOIDC {
+		flow, err := discoverOIDCFlow(ctx, cfg, tel.Logger)
+		if err != nil {
+			return nil, err
+		}
+		oidcFlow = flow
+	}
+	//nolint:contextcheck // buildAPIServer wires per-request handlers; each request carries its own context
+	return buildAPIServer(cfg, tel, authn, pg, repo, xcomReader, logSink, logTailer, checks, executorInfo, schedulerHealth, oidcFlow), nil
+}
+
+// discoverOIDCFlow discovers the IdP and builds the Authorization Code + PKCE
+// login flow. It is only called under provider: oidc (so it always returns a
+// flow or an error, never nil,nil). The client secret comes from the environment
+// (LEOFLOW_AUTH_OIDC_CLIENT_SECRET, bound by viper); it is never logged.
+// Discovery failure is a boot failure — fail closed.
+func discoverOIDCFlow(ctx context.Context, cfg *config.ServerConfig, logger *slog.Logger) (*oidc.Flow, error) {
 	flow, err := oidc.NewFlow(ctx, cfg.Auth.OIDC, cfg.Auth.JWT.Secret)
 	if err != nil {
 		return nil, fmt.Errorf("oidc setup: %w", err)

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/neochaotic/leoflow/internal/failurealert"
 	"github.com/neochaotic/leoflow/internal/logs"
 	"github.com/neochaotic/leoflow/internal/observability"
+	"github.com/neochaotic/leoflow/internal/oidc"
 	"github.com/neochaotic/leoflow/internal/scheduler"
 	"github.com/neochaotic/leoflow/internal/secrets"
 	"github.com/neochaotic/leoflow/internal/storage"
@@ -190,7 +191,14 @@ func run() error {
 	// constructed — apiSrv stays nil and serveHTTP omits it.
 	var apiSrv *http.Server
 	if servesAPI {
-		apiSrv = buildAPIServer(cfg, tel, authn, pg, repo, xcomReader, logSink, logTailer, checks, executorInfo, schedulerHealth)
+		// Under provider: oidc, discover the IdP and build the login flow now, so a
+		// misconfigured issuer fails boot closed rather than at first login. The JWT
+		// authenticator built above stays the request-path verifier in both modes.
+		oidcFlow, ferr := buildOIDCFlow(ctx, cfg, tel.Logger)
+		if ferr != nil {
+			return ferr
+		}
+		apiSrv = buildAPIServer(cfg, tel, authn, pg, repo, xcomReader, logSink, logTailer, checks, executorInfo, schedulerHealth, oidcFlow)
 	}
 
 	// The metrics listener also serves /healthz + /readyz in every role so a
@@ -370,7 +378,27 @@ func startSchedulerSide(ctx context.Context, cfg *config.ServerConfig, pg *stora
 // role (ADR 0049). It is called only when the role serves the API, so the UI
 // shell, editor FS, rate limiter, and full route set are never constructed in a
 // scheduler-only process.
-func buildAPIServer(cfg *config.ServerConfig, tel *observability.Telemetry, authn *auth.JWTAuthenticator, pg *storage.Postgres, repo *storage.Repository, xcomReader *storage.XComReader, logSink logs.Sink, logTailer logs.Tailer, checks map[string]api.HealthChecker, executorInfo api.ExecutorInfo, schedulerHealth api.Heartbeater) *http.Server {
+// buildOIDCFlow discovers the IdP and builds the Authorization Code + PKCE login
+// flow when provider is "oidc"; it returns nil in JWT mode (the default), where
+// the OIDC routes are never registered. The client secret comes from the
+// environment (LEOFLOW_AUTH_OIDC_CLIENT_SECRET, bound by viper); it is never
+// logged. Discovery failure is a boot failure — fail closed.
+func buildOIDCFlow(ctx context.Context, cfg *config.ServerConfig, logger *slog.Logger) (*oidc.Flow, error) {
+	if cfg.Auth.Provider != config.AuthProviderOIDC {
+		return nil, nil
+	}
+	flow, err := oidc.NewFlow(ctx, cfg.Auth.OIDC, cfg.Auth.JWT.Secret)
+	if err != nil {
+		return nil, fmt.Errorf("oidc setup: %w", err)
+	}
+	logger.Info("oidc login enabled",
+		"issuer", cfg.Auth.OIDC.Issuer,
+		"jit_provisioning", cfg.Auth.OIDC.JITProvisioning,
+		"break_glass_accounts", len(cfg.Auth.OIDC.BreakGlassEmails))
+	return flow, nil
+}
+
+func buildAPIServer(cfg *config.ServerConfig, tel *observability.Telemetry, authn *auth.JWTAuthenticator, pg *storage.Postgres, repo *storage.Repository, xcomReader *storage.XComReader, logSink logs.Sink, logTailer logs.Tailer, checks map[string]api.HealthChecker, executorInfo api.ExecutorInfo, schedulerHealth api.Heartbeater, oidcFlow *oidc.Flow) *http.Server {
 	if cfg.Auth.DevNoAuth {
 		tel.Logger.Warn("AUTHENTICATION DISABLED (auth.dev_no_auth): every request is treated as admin. Dev only — NEVER use in production")
 	}
@@ -426,6 +454,14 @@ func buildAPIServer(cfg *config.ServerConfig, tel *observability.Telemetry, auth
 		Workspace:       editorFS,
 		MonacoDir:       cfg.UI.MonacoDir,
 		ExamplesFS:      leoflow.ExampleDAGs(),
+
+		// OIDC/SSO login flow (nil in JWT mode → routes not registered). The repo
+		// resolves/JIT-provisions identities and records auth-event audit.
+		OIDCFlow:     oidcFlow,
+		OIDCSettings: cfg.Auth.OIDC,
+		OIDCUsers:    repo,
+		AuthAudit:    repo,
+		JWTSecret:    cfg.Auth.JWT.Secret,
 	})
 	return &http.Server{Addr: cfg.Server.HTTPAddr, Handler: handler, ReadHeaderTimeout: 10 * time.Second}
 }

--- a/cmd/leoflow-server/oidc_wiring_test.go
+++ b/cmd/leoflow-server/oidc_wiring_test.go
@@ -9,26 +9,10 @@ import (
 	"github.com/neochaotic/leoflow/internal/config"
 )
 
-// TestBuildOIDCFlowNilInJWTMode locks that the default (provider: jwt) never
-// attempts IdP discovery and returns a nil flow, so the OIDC routes stay
-// unregistered and boot does no network I/O for auth.
-func TestBuildOIDCFlowNilInJWTMode(t *testing.T) {
-	cfg := &config.ServerConfig{}
-	cfg.Auth.Provider = config.AuthProviderJWT
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-
-	flow, err := buildOIDCFlow(context.Background(), cfg, logger)
-	if err != nil {
-		t.Fatalf("buildOIDCFlow(jwt) = %v, want nil error", err)
-	}
-	if flow != nil {
-		t.Error("buildOIDCFlow(jwt) returned a non-nil flow; jwt mode must not build one")
-	}
-}
-
-// TestBuildOIDCFlowDiscoveryFailureIsBootError locks that an unreachable issuer
-// fails boot closed rather than deferring the failure to first login.
-func TestBuildOIDCFlowDiscoveryFailureIsBootError(t *testing.T) {
+// TestDiscoverOIDCFlowDiscoveryFailureIsBootError locks that an unreachable
+// issuer fails boot closed rather than deferring the failure to first login —
+// the fail-closed posture the OIDC flow depends on.
+func TestDiscoverOIDCFlowDiscoveryFailureIsBootError(t *testing.T) {
 	cfg := &config.ServerConfig{}
 	cfg.Auth.Provider = config.AuthProviderOIDC
 	cfg.Auth.JWT.Secret = "secret"
@@ -38,7 +22,7 @@ func TestBuildOIDCFlowDiscoveryFailureIsBootError(t *testing.T) {
 	cfg.Auth.OIDC.RedirectURL = "https://app.example/api/v2/auth/oidc/callback"
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	if _, err := buildOIDCFlow(context.Background(), cfg, logger); err == nil {
-		t.Error("buildOIDCFlow with an unreachable issuer = nil error, want a boot failure")
+	if _, err := discoverOIDCFlow(context.Background(), cfg, logger); err == nil {
+		t.Error("discoverOIDCFlow with an unreachable issuer = nil error, want a boot failure")
 	}
 }

--- a/cmd/leoflow-server/oidc_wiring_test.go
+++ b/cmd/leoflow-server/oidc_wiring_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/config"
+)
+
+// TestBuildOIDCFlowNilInJWTMode locks that the default (provider: jwt) never
+// attempts IdP discovery and returns a nil flow, so the OIDC routes stay
+// unregistered and boot does no network I/O for auth.
+func TestBuildOIDCFlowNilInJWTMode(t *testing.T) {
+	cfg := &config.ServerConfig{}
+	cfg.Auth.Provider = config.AuthProviderJWT
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	flow, err := buildOIDCFlow(context.Background(), cfg, logger)
+	if err != nil {
+		t.Fatalf("buildOIDCFlow(jwt) = %v, want nil error", err)
+	}
+	if flow != nil {
+		t.Error("buildOIDCFlow(jwt) returned a non-nil flow; jwt mode must not build one")
+	}
+}
+
+// TestBuildOIDCFlowDiscoveryFailureIsBootError locks that an unreachable issuer
+// fails boot closed rather than deferring the failure to first login.
+func TestBuildOIDCFlowDiscoveryFailureIsBootError(t *testing.T) {
+	cfg := &config.ServerConfig{}
+	cfg.Auth.Provider = config.AuthProviderOIDC
+	cfg.Auth.JWT.Secret = "secret"
+	// A syntactically valid but unreachable issuer: discovery must fail.
+	cfg.Auth.OIDC.Issuer = "https://127.0.0.1:1/does-not-exist"
+	cfg.Auth.OIDC.ClientID = "client"
+	cfg.Auth.OIDC.RedirectURL = "https://app.example/api/v2/auth/oidc/callback"
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	if _, err := buildOIDCFlow(context.Background(), cfg, logger); err == nil {
+		t.Error("buildOIDCFlow with an unreachable issuer = nil error, want a boot failure")
+	}
+}

--- a/docs/adr/0057-oidc-sso.md
+++ b/docs/adr/0057-oidc-sso.md
@@ -58,9 +58,12 @@ password) with the roles from D5. When OFF and no row matches, the login is
 rejected (403) — never auto-created.
 
 **D5. Group→role mapping = explicit config map to existing DB role names,
-default-DENY.** `auth.oidc.role_mappings: {<idp_group_value>: <leoflow_role>}`. An
-unmapped group grants no role. The mapped role names go into the minted token's
-roles; the per-request reload turns DB roles into permissions.
+default-DENY, IdP-authoritative.** `auth.oidc.role_mappings: {<idp_group_value>:
+<leoflow_role>}`. An unmapped group grants no role. On every login the mapped set
+is written to the DB `user_roles` as the user's EXACTLY-current roles (see the
+reconciliation consequence below) and also carried in the minted token; the
+per-request reload then turns those DB roles into permissions. The identity
+provider therefore stays authoritative for an OIDC user's roles.
 
 **D5a. `default_role` (opt-in UX softener).** `auth.oidc.default_role` softens
 default-deny **without weakening the secure default**: when an authenticated
@@ -139,10 +142,17 @@ the security event still lands, with the attempted values in the metadata.
 - Session length is bounded by the JWT TTL; full logout propagation is deferred
   with the rest of ADR 0055. The per-request `is_active` reload gives
   revocation-within-TTL.
-- For a returning (pre-provisioned) user the minted token carries the IdP-mapped
-  roles (D5); the per-request reload against the DB remains the authority for
-  live permissions, so an admin-managed DB grant is never silently overwritten by
-  a login.
+- The identity provider is authoritative for an OIDC user's roles. On every
+  successful login — for both JIT-created and returning users — the user's DB
+  `user_roles` are reconciled to EXACTLY the group→role-mapped set (D5), falling
+  back to `[default_role]` when the mapping is empty and one is set, or to no
+  roles otherwise. The per-request reload then reads that freshly-written set, so
+  an IdP demotion or deprovisioning takes effect on the next login. The
+  consequence is that a manual DB role grant for an OIDC user is overwritten by
+  the next login: OIDC users' roles are managed through IdP group membership, not
+  through admin DB grants. A role name (mapped or `default_role`) that does not
+  exist in the tenant fails the login closed and is audited, rather than silently
+  granting nothing.
 
 ## Security review — folded in
 

--- a/docs/adr/0057-oidc-sso.md
+++ b/docs/adr/0057-oidc-sso.md
@@ -1,0 +1,156 @@
+# ADR 0057: OIDC/SSO authentication with fail-closed tenant pinning
+
+**Status:** Proposed
+**Date:** 2026-08-19
+**Relates:** ADR 0008 (JWT auth — the `Authenticator` seam OIDC plugs into; the `_token` this flow mints and the per-request reload that governs live permissions), ADR 0035 (keyless-first — the verify path uses the issuer's public JWKS, no secret), ADR 0055 (token liveness/revocation — bounds the OIDC session lifetime), ADR 0014 (supply chain — the new `go-oidc` dependency), ADR 0049 (edition gating precedent), ADR 0018 (embedded login UI the `_token` cookie drives)
+
+## Context
+
+Leoflow authenticates with HS256 JWTs (`internal/auth/jwt.go`): a
+username/password `POST /auth/token` mints a token carrying
+`{tenant_id, email, roles}`, and the middleware accepts it as a bearer or the
+`_token` cookie. The `Authenticator` interface was documented from the start as
+keeping OIDC/LDAP pluggable, and the `users` table already carries
+`oidc_subject`/`oidc_provider` (unique) with a nullable `password_hash` — the
+schema anticipated SSO, but no code used those columns and `auth.provider: oidc`
+booted closed as unimplemented.
+
+The enterprise pivot needs SSO against Entra ID / Google Cloud Identity / Okta,
+with **fail-closed** mapping of external identities to Leoflow tenants and roles.
+OIDC is a **login flow**, not a new request-path authenticator: the callback
+verifies the IdP's ID token and mints Leoflow's own `_token`, so the middleware,
+`/ui/auth/*`, and the API are unchanged. The per-request reload from ADR 0008's
+prerequisite work (roles/permissions/`is_active` reloaded on every verify)
+remains the authority for live permissions and gives revocation-within-TTL.
+
+An identity/zero-trust specialist review of the design flagged five HIGH issues;
+all five are folded into the decisions below (H1→D6, H2→D8, H3→relies on the
+role-ladder prerequisite, H4→D10, H5→the audit decision).
+
+## Decisions
+
+**D1. Flow = Authorization Code + PKCE.** Endpoints `GET /api/v2/auth/oidc/login`
+and `GET /api/v2/auth/oidc/callback`, registered under the existing public
+`/api/v2/auth/` prefix. The `state`, `nonce`, and PKCE `code_verifier` are carried
+in a short-lived, signed, `HttpOnly; Secure; SameSite=Lax` cookie (stateless — no
+new session store). The cookie is signed with a key **derived** from the app's
+HS256 secret, distinct from the session-token key, so a state cookie can never
+cross-verify as a session token. Implicit flow is rejected.
+
+**D2. Session = the `_token` JWT cookie.** On success the callback mints
+Leoflow's own `_token` via `MintUserToken` and sets it **server-side**
+`HttpOnly; Secure; SameSite=Lax` (hardened vs the credential login page's
+client-JS cookie). The OIDC session length equals the JWT TTL; mid-session
+revocation is the per-request `is_active` reload (revocation-within-TTL). The
+post-login redirect reuses `sanitizeNext` (open-redirect safe).
+
+**D3. Identity match = `(oidc_provider, oidc_subject)`, email only as a verified
+link key.** `FindUserByOIDCSubject` resolves a returning user by the immutable
+pair (loading roles + permissions + `is_active`, mirroring the credential path).
+`oidc_provider` is the pinned **issuer URL** — stable and unambiguous per
+deployment. `email` is trusted only when `email_verified == true` (absent ⇒
+false).
+
+**D4. JIT provisioning = OFF by default (`auth.oidc.jit_provisioning: false`).**
+Default requires a pre-existing user row (no accidental over-privilege). When ON,
+a first OIDC login creates a `users` row (email + oidc_subject/provider, NULL
+password) with the roles from D5. When OFF and no row matches, the login is
+rejected (403) — never auto-created.
+
+**D5. Group→role mapping = explicit config map to existing DB role names,
+default-DENY.** `auth.oidc.role_mappings: {<idp_group_value>: <leoflow_role>}`. An
+unmapped group grants no role. The mapped role names go into the minted token's
+roles; the per-request reload turns DB roles into permissions.
+
+**D5a. `default_role` (opt-in UX softener).** `auth.oidc.default_role` softens
+default-deny **without weakening the secure default**: when an authenticated
+user resolves to zero mapped roles and `default_role` is set, they are granted
+that single fallback role (operators are advised to use a read-only role such as
+`viewer`). Empty (the default) keeps strict deny — an unmapped user gets no role.
+The role must exist for the resolved tenant; an unknown `default_role` fails the
+login closed (audited), on both the pre-provisioned and the JIT paths.
+
+**D6. Tenant pin = issuer-locked + IdP claim (`tid`/`hd`), fail-closed. NOT
+email-domain (H1).** (a) the config pins the org's single-tenant **issuer URL**
+and every ID token whose `iss` differs is rejected; (b) the tenant is resolved
+from an IdP-issued claim — Entra `tid`, Google Workspace `hd` — via
+`auth.oidc.tenant_claims: {<value>: <tenant_name>}`; (c) `email_verified == true`
+is required before any email is trusted; (d) an absent/unmapped claim or an
+issuer mismatch is a **403 that never falls back to `default`**. Email domain is
+never the pin (spoofable under Entra `/common` or "any Google account").
+
+**D6a. `allowed_email_domains` (login-level allowlist, layered on the pin — NOT
+the pin).** `auth.oidc.allowed_email_domains` gates **every** OIDC login
+(pre-provisioned and JIT). It runs **only after** the issuer pin, the `tid`/`hd`
+pin, and `email_verified == true` have passed, so the email domain is trustworthy
+at that point. Empty imposes no restriction (the `tid`/`hd` pin is the sole
+boundary). Non-empty admits a login only when the verified email's domain is in
+the list; every other login is 403 (audited). It is configured at install time
+(env `LEOFLOW_AUTH_OIDC_ALLOWED_EMAIL_DOMAINS` / Helm value). It does **not**
+substitute for `tid`/`hd` — H1 stays closed.
+
+**D7. `provider: jwt` stays default; `oidc` is opt-in AND Pro-gated.**
+`validateProvider` allows `provider: oidc` only when `ui.edition == "pro"` AND
+the required config is present (issuer, client_id, redirect_url, https issuer);
+otherwise boot fails closed with an actionable message. The JWT secret stays
+required because the callback mints the app's own `_token`.
+
+**D8. Break-glass = designated local admin(s) only (H2).** When
+`provider: oidc`, the credential path `POST /auth/token` accepts ONLY the emails
+in `auth.oidc.break_glass_emails`; every other password login is rejected. Each
+break-glass attempt (allowed, denied, bad-credentials) is audited. Default posture
+is effectively SSO-only. `dev_no_auth` stays loopback-only. In JWT mode the
+credential path is ungated and unchanged.
+
+**D9. Verify path is keyless (ADR 0035-aligned).** ID-token verification uses the
+IdP's public OIDC discovery + JWKS — no secret. The `client_secret` is used only
+for the code exchange, injected via `LEOFLOW_AUTH_OIDC_CLIENT_SECRET` (env, never
+persisted, never logged). All `auth.oidc.*` keys are registered in
+`serverDefaults` so viper binds the scalar `LEOFLOW_AUTH_OIDC_*` env vars; the
+map/slice leaves (role_mappings, tenant_claims, allowed_email_domains,
+break_glass_emails) are config-file / Helm-values driven.
+
+**D10. Dependency = `github.com/coreos/go-oidc/v3` (+ `golang.org/x/oauth2`,
+promoted to direct).** go-oidc verifies the signature (against the discovered
+JWKS), the audience, and the issuer, and its `NewProvider` pins the issuer at
+discovery. It does **not** verify nonce, azp, the callback state/CSRF binding, or
+clock skew — these are enforced explicitly in Leoflow code (H4): `state` bound to
+and compared against the signed cookie; RFC 9207 `iss` response param checked
+where present; `aud == client_id`; `azp == client_id` when present; `nonce`
+against the state cookie (constant-time); and `exp`/`iat`/`nbf` with a small
+configurable clock skew (default 60s), which is why go-oidc's leeway-less expiry
+check is disabled and this package is the single time authority.
+
+**Audit (H5).** Every auth event is recorded to the existing audit sink
+(`RecordAuthEvent`, alongside `RecordUserCreatedAudit`): login success/failure,
+tenant-pin rejection, JIT provisioning, break-glass (allowed/denied), each with
+actor/email/tenant/outcome and a non-secret reason. Tokens and the client secret
+are never recorded. Audit is best-effort — a sink error never changes a security
+outcome (a 403 stays a 403, a success stays a success). Events that never
+resolved a tenant (a tenant-pin rejection) fall back to the `default` tenant so
+the security event still lands, with the attempted values in the metadata.
+
+## Consequences
+
+- New public redirect endpoints; one new direct dependency; `x/oauth2` promoted
+  to direct.
+- The self-asserted tenant is closed off for OIDC logins (the JWT/password path
+  is unchanged). Email-domain is a secondary, opt-in allowlist, never the pin.
+- Session length is bounded by the JWT TTL; full logout propagation is deferred
+  with the rest of ADR 0055. The per-request `is_active` reload gives
+  revocation-within-TTL.
+- For a returning (pre-provisioned) user the minted token carries the IdP-mapped
+  roles (D5); the per-request reload against the DB remains the authority for
+  live permissions, so an admin-managed DB grant is never silently overwritten by
+  a login.
+
+## Security review — folded in
+
+H1 → D6 (issuer-lock + `tid`/`hd`, never email-domain as the pin; D6a adds the
+domain allowlist strictly on top). H2 → D8 (break-glass scoped to an explicit
+allowlist, audited). H3 → the role model relies on the seeded role ladder and the
+per-request permission reload already in place. H4 → D10 (explicit
+nonce/azp/state/skew/iss checks, not assumed from the library). H5 → the audit
+decision. Verification order is fixed and fail-closed at every step:
+signature/audience/issuer → nonce → azp → clock skew → subject → email_verified →
+tenant pin → email-domain allowlist.

--- a/docs/adrs.md
+++ b/docs/adrs.md
@@ -58,4 +58,6 @@ The *why* behind Leoflow's design. ADRs are immutable once accepted.
 - [ADR 0053: Admission + placement — one scheduler-side layer for task concurrency and pod assignment](adr/0053-admission-and-placement.md)
 - [ADR 0054: Coexistence in a shared, multi-team Kubernetes cluster](adr/0054-shared-cluster-coexistence.md)
 - [ADR 0055: Secret scoping and token liveness — scope by declaration, exchange the token, bind it to task liveness](adr/0055-secret-scoping-and-token-liveness.md)
+- [ADR 0056: Task-log object sink — native dual-SDK (S3 + GCS), keyless-first](adr/0056-task-log-object-sink.md)
+- [ADR 0057: OIDC/SSO authentication with fail-closed tenant pinning](adr/0057-oidc-sso.md)
 <!-- END ADR INDEX -->

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.37
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.36
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.2
+	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/gin-gonic/gin v1.12.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang-migrate/migrate/v4 v4.19.1
@@ -30,6 +31,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0
 	go.yaml.in/yaml/v3 v3.0.5
 	golang.org/x/crypto v0.54.0
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/term v0.45.0
 	google.golang.org/api v0.287.1
 	google.golang.org/grpc v1.82.1
@@ -150,7 +152,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	golang.org/x/arch v0.22.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
-	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,8 @@ github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
+github.com/coreos/go-oidc/v3 v3.20.0 h1:EtE0WIBHk03N+DqGkY4+UONzzZHk7amKt6IyNd7OsZE=
+github.com/coreos/go-oidc/v3 v3.20.0/go.mod h1:DYCf24+ncYi+XkIH97GY1+dqoRlbaSI26KVTCI9SrY4=
 github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -10,6 +10,34 @@ import (
 	"github.com/neochaotic/leoflow/internal/auth"
 )
 
+// breakGlass gates the credential path when the provider is OIDC (D8): only the
+// designated local admin email(s) may log in with a password; every other
+// password login is rejected, and each attempt is audited (H5). It is nil in
+// JWT mode, where the credential path is ungated and unchanged.
+type breakGlass struct {
+	emails map[string]bool
+	audit  AuthAuditWriter
+}
+
+// newBreakGlass builds the gate from the allowlist. It returns nil for an empty
+// allowlist so the caller keeps the ungated behavior (JWT mode, or an OIDC
+// deployment that configured no break-glass account).
+func newBreakGlass(emails []string, audit AuthAuditWriter) *breakGlass {
+	if len(emails) == 0 {
+		return nil
+	}
+	set := make(map[string]bool, len(emails))
+	for _, e := range emails {
+		set[strings.ToLower(strings.TrimSpace(e))] = true
+	}
+	return &breakGlass{emails: set, audit: audit}
+}
+
+// allows reports whether the email may use the credential path.
+func (b *breakGlass) allows(email string) bool {
+	return b.emails[strings.ToLower(strings.TrimSpace(email))]
+}
+
 type tokenRequest struct {
 	Username string `json:"username" binding:"required"`
 	Password string `json:"password" binding:"required"`
@@ -23,7 +51,10 @@ type tokenResponse struct {
 }
 
 // authTokenHandler issues a JWT for valid credentials, rate-limited per client IP.
-func authTokenHandler(authn auth.Authenticator, limiter *auth.RateLimiter, ttlSeconds int) gin.HandlerFunc {
+// When bg is non-nil (OIDC mode, D8) only the break-glass allowlist may use the
+// credential path; every other password login is rejected and audited, so
+// enabling SSO does not silently leave a full password bypass open.
+func authTokenHandler(authn auth.Authenticator, limiter *auth.RateLimiter, ttlSeconds int, bg *breakGlass) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Peek the limiter up front but DON'T count this attempt yet: only failed
 		// logins consume the budget (recorded below). This is what keeps a user who
@@ -43,23 +74,49 @@ func authTokenHandler(authn auth.Authenticator, limiter *auth.RateLimiter, ttlSe
 		if tenant == "" {
 			tenant = "default"
 		}
+		username := strings.TrimSpace(req.Username)
+		// Break-glass gate (D8): under OIDC, reject any password login that is not
+		// on the designated local-admin allowlist, before touching the credential
+		// store. Audited either way.
+		if bg != nil && !bg.allows(username) {
+			recordBreakGlass(c, bg, tenant, username, "denied")
+			limiter.Allow(c.ClientIP())
+			AbortProblem(c, http.StatusUnauthorized, "unauthorized", "invalid credentials")
+			return
+		}
 		// Trim the username/tenant (emails carry no meaningful surrounding space and
 		// autofill/paste often add one), but NEVER the password — trailing/leading
 		// spaces are valid password characters, and silently trimming them is unsafe.
 		token, err := authn.IssueToken(c.Request.Context(), auth.Credentials{
 			Tenant:   tenant,
-			Username: strings.TrimSpace(req.Username),
+			Username: username,
 			Password: req.Password,
 		})
 		if err != nil {
 			if errors.Is(err, auth.ErrInvalidCredentials) {
 				limiter.Allow(c.ClientIP()) // count the failure toward the lockout budget
+				if bg != nil {
+					recordBreakGlass(c, bg, tenant, username, "bad_credentials")
+				}
 				AbortProblem(c, http.StatusUnauthorized, "unauthorized", "invalid credentials")
 				return
 			}
 			AbortProblem(c, http.StatusInternalServerError, "internal error", "could not issue token")
 			return
 		}
+		if bg != nil {
+			recordBreakGlass(c, bg, tenant, username, "success")
+		}
 		c.JSON(http.StatusOK, tokenResponse{AccessToken: token, TokenType: "bearer", ExpiresIn: ttlSeconds})
 	}
+}
+
+// recordBreakGlass audits a break-glass credential-path attempt (H5),
+// best-effort so a flaky audit sink never changes the login outcome.
+func recordBreakGlass(c *gin.Context, bg *breakGlass, tenant, email, outcome string) {
+	if bg == nil || bg.audit == nil {
+		return
+	}
+	//nolint:errcheck // best-effort audit; a sink error must never fail the login
+	_ = bg.audit.RecordAuthEvent(c.Request.Context(), tenant, "", auditBreakGlass, email, outcome, nil)
 }

--- a/internal/api/oidc_breakglass_test.go
+++ b/internal/api/oidc_breakglass_test.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/config"
+)
+
+// emailPassAuthn issues a token only for one specific email+password, so the
+// break-glass tests can distinguish an allowlisted success from a rejection.
+type emailPassAuthn struct{ email, pass string }
+
+func (a emailPassAuthn) IssueToken(_ context.Context, c auth.Credentials) (string, error) {
+	if c.Username == a.email && c.Password == a.pass {
+		return "session-token", nil
+	}
+	return "", auth.ErrInvalidCredentials
+}
+
+func (a emailPassAuthn) Authenticate(context.Context, string) (*auth.User, error) {
+	return &auth.User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}, nil
+}
+
+// breakGlassServer builds a server in OIDC break-glass mode: the credential path
+// admits only the given allowlisted email (with the given password).
+func breakGlassServer(allow []string, authn auth.Authenticator, audit AuthAuditWriter) *gin.Engine {
+	return NewServer(Dependencies{
+		Logger:        discardLogger(),
+		Authenticator: authn,
+		RateLimiter:   auth.NewRateLimiter(50, time.Minute),
+		HealthChecks:  map[string]HealthChecker{},
+		CORSOrigins:   []string{"*"},
+		TokenTTLSecs:  3600,
+		AuthAudit:     audit,
+		OIDCSettings:  config.OIDCSection{BreakGlassEmails: allow},
+	})
+}
+
+func TestBreakGlassAllowsOnlyAllowlistedEmail(t *testing.T) {
+	authn := emailPassAuthn{email: "admin@corp.example", pass: "right"}
+	audit := &fakeAuthAudit{}
+	srv := breakGlassServer([]string{"admin@corp.example"}, authn, audit)
+
+	t.Run("allowlisted email + right password → 200, audited success", func(t *testing.T) {
+		rec := do(srv, http.MethodPost, "/auth/token", `{"username":"admin@corp.example","password":"right"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("break-glass login = %d, want 200", rec.Code)
+		}
+		if !audit.has(auditBreakGlass, "success") {
+			t.Error("break-glass success was not audited")
+		}
+	})
+
+	t.Run("non-allowlisted email → 401, audited denied", func(t *testing.T) {
+		rec := do(srv, http.MethodPost, "/auth/token", `{"username":"someone@corp.example","password":"right"}`)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("non-break-glass login = %d, want 401", rec.Code)
+		}
+		if !audit.has(auditBreakGlass, "denied") {
+			t.Error("break-glass denial was not audited")
+		}
+	})
+
+	t.Run("allowlisted email + wrong password → 401, audited", func(t *testing.T) {
+		rec := do(srv, http.MethodPost, "/auth/token", `{"username":"admin@corp.example","password":"wrong"}`)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("wrong password = %d, want 401", rec.Code)
+		}
+		if !audit.has(auditBreakGlass, "bad_credentials") {
+			t.Error("break-glass bad-credential attempt was not audited")
+		}
+	})
+}
+
+// TestJWTModeCredentialPathUngated locks that with no OIDC configured (the
+// default), /auth/token is exactly as before: any credential the authenticator
+// accepts works, with no break-glass gating and no auth-event audit.
+func TestJWTModeCredentialPathUngated(t *testing.T) {
+	audit := &fakeAuthAudit{}
+	// No BreakGlassEmails, no OIDCFlow → bg is nil, path ungated.
+	srv := NewServer(Dependencies{
+		Logger:        discardLogger(),
+		Authenticator: credAuthn{}, // issues for password "right", any username
+		RateLimiter:   auth.NewRateLimiter(50, time.Minute),
+		HealthChecks:  map[string]HealthChecker{},
+		CORSOrigins:   []string{"*"},
+		TokenTTLSecs:  3600,
+		AuthAudit:     audit,
+	})
+
+	rec := do(srv, http.MethodPost, "/auth/token", `{"username":"anyone@corp.example","password":"right"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("jwt-mode login = %d, want 200 (ungated)", rec.Code)
+	}
+	if len(audit.events) != 0 {
+		t.Errorf("jwt mode must not emit auth-event audit; got %d events", len(audit.events))
+	}
+}
+
+// TestJWTModeOIDCRoutesAbsent locks that the OIDC endpoints are not registered
+// unless a flow was discovered at boot (provider: jwt is the default).
+func TestJWTModeOIDCRoutesAbsent(t *testing.T) {
+	srv := testServer(&fakeAuthn{})
+	for _, path := range []string{"/api/v2/auth/oidc/login", "/api/v2/auth/oidc/callback"} {
+		rec := do(srv, http.MethodGet, path, "")
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("%s in jwt mode = %d, want 404 (route absent)", path, rec.Code)
+		}
+	}
+}

--- a/internal/api/oidc_flow_test.go
+++ b/internal/api/oidc_flow_test.go
@@ -1,0 +1,758 @@
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/config"
+	"github.com/neochaotic/leoflow/internal/oidc"
+)
+
+// ─────────────────────────── fake IdP ───────────────────────────
+
+// fakeIdP is an in-process OpenID Provider: it serves discovery + JWKS + a token
+// endpoint, and signs ID tokens with an in-test RSA key. The token endpoint
+// verifies the PKCE code_verifier against the challenge staged for the code, so
+// the tests exercise a real PKCE round-trip.
+type fakeIdP struct {
+	srv    *httptest.Server
+	key    *rsa.PrivateKey
+	kid    string
+	issuer string
+
+	mu     sync.Mutex
+	staged map[string]stagedCode
+}
+
+type stagedCode struct {
+	challenge string
+	idToken   string
+}
+
+func newFakeIdP(t *testing.T) *fakeIdP {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa keygen: %v", err)
+	}
+	f := &fakeIdP{key: key, kid: "test-key-1", staged: map[string]stagedCode{}}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", f.handleDiscovery)
+	mux.HandleFunc("/jwks", f.handleJWKS)
+	mux.HandleFunc("/token", f.handleToken)
+	f.srv = httptest.NewServer(mux)
+	f.issuer = f.srv.URL
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+func (f *fakeIdP) handleDiscovery(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, map[string]any{
+		"issuer":                                f.issuer,
+		"authorization_endpoint":                f.issuer + "/authorize",
+		"token_endpoint":                        f.issuer + "/token",
+		"jwks_uri":                              f.issuer + "/jwks",
+		"response_types_supported":              []string{"code"},
+		"subject_types_supported":               []string{"public"},
+		"id_token_signing_alg_values_supported": []string{"RS256"},
+	})
+}
+
+func (f *fakeIdP) handleJWKS(w http.ResponseWriter, _ *http.Request) {
+	pub := f.key.PublicKey
+	writeJSON(w, map[string]any{"keys": []map[string]any{{
+		"kty": "RSA",
+		"use": "sig",
+		"alg": "RS256",
+		"kid": f.kid,
+		"n":   base64.RawURLEncoding.EncodeToString(pub.N.Bytes()),
+		"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes()),
+	}}})
+}
+
+func (f *fakeIdP) handleToken(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "bad form", http.StatusBadRequest)
+		return
+	}
+	code := r.PostForm.Get("code")
+	verifier := r.PostForm.Get("code_verifier")
+	f.mu.Lock()
+	st, ok := f.staged[code]
+	f.mu.Unlock()
+	if !ok {
+		http.Error(w, "unknown code", http.StatusBadRequest)
+		return
+	}
+	// Prove PKCE: the presented verifier must hash to the staged challenge.
+	sum := sha256.Sum256([]byte(verifier))
+	if base64.RawURLEncoding.EncodeToString(sum[:]) != st.challenge {
+		http.Error(w, "pkce mismatch", http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, map[string]any{
+		"access_token": "fake-access-token",
+		"token_type":   "Bearer",
+		"expires_in":   3600,
+		"id_token":     st.idToken,
+	})
+}
+
+func (f *fakeIdP) signIDToken(claims jwt.MapClaims) string {
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = f.kid
+	s, err := tok.SignedString(f.key)
+	if err != nil {
+		panic(err)
+	}
+	return s
+}
+
+func (f *fakeIdP) stage(code, challenge, idToken string) {
+	f.mu.Lock()
+	f.staged[code] = stagedCode{challenge: challenge, idToken: idToken}
+	f.mu.Unlock()
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// ─────────────────────────── fakes ───────────────────────────
+
+type fakeOIDCStore struct {
+	users     map[string]*auth.User // provider|subject → user
+	active    map[string]bool
+	roles     map[string]bool
+	created   []createdOIDC
+	createErr error
+}
+
+type createdOIDC struct {
+	tenant, email, provider, subject string
+	roles                            []string
+}
+
+func newFakeOIDCStore() *fakeOIDCStore {
+	return &fakeOIDCStore{
+		users:  map[string]*auth.User{},
+		active: map[string]bool{},
+		roles:  map[string]bool{"viewer": true, "editor": true, "operator": true, "admin": true},
+	}
+}
+
+func key(provider, subject string) string { return provider + "|" + subject }
+
+func (s *fakeOIDCStore) seed(provider, subject string, u *auth.User, active bool) {
+	s.users[key(provider, subject)] = u
+	s.active[key(provider, subject)] = active
+}
+
+func (s *fakeOIDCStore) FindUserByOIDCSubject(_ context.Context, provider, subject string) (*auth.User, bool, error) {
+	u, ok := s.users[key(provider, subject)]
+	if !ok {
+		return nil, false, auth.ErrUserNotFound
+	}
+	return u, s.active[key(provider, subject)], nil
+}
+
+func (s *fakeOIDCStore) CreateOIDCUser(_ context.Context, tenant, email, provider, subject string, roles []string) (*auth.User, error) {
+	if s.createErr != nil {
+		return nil, s.createErr
+	}
+	s.created = append(s.created, createdOIDC{tenant, email, provider, subject, roles})
+	u := &auth.User{ID: "jit-" + subject, TenantID: tenant, Email: email, Roles: roles}
+	s.seed(provider, subject, u, true)
+	return u, nil
+}
+
+func (s *fakeOIDCStore) RoleExists(_ context.Context, _ string, role string) (bool, error) {
+	return s.roles[role], nil
+}
+
+type fakeAuthAudit struct {
+	mu     sync.Mutex
+	events []authEvent
+}
+
+type authEvent struct {
+	tenant, userID, action, email, outcome string
+	extra                                  map[string]string
+}
+
+func (a *fakeAuthAudit) RecordAuthEvent(_ context.Context, tenant, userID, action, email, outcome string, extra map[string]string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.events = append(a.events, authEvent{tenant, userID, action, email, outcome, extra})
+	return nil
+}
+
+func (a *fakeAuthAudit) has(action, outcome string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, e := range a.events {
+		if e.action == action && e.outcome == outcome {
+			return true
+		}
+	}
+	return false
+}
+
+// ─────────────────────────── harness ───────────────────────────
+
+const testHS256Secret = "oidc-flow-test-secret"
+
+func baseOIDCConfig(f *fakeIdP) config.OIDCSection {
+	return config.OIDCSection{
+		Issuer:           f.issuer,
+		ClientID:         "client-abc",
+		ClientSecret:     "client-secret",
+		RedirectURL:      "https://app.example/api/v2/auth/oidc/callback",
+		Scopes:           []string{"openid", "email", "profile", "groups"},
+		GroupsClaim:      "groups",
+		RoleMappings:     map[string]string{"data-eng": "editor"},
+		TenantClaim:      "tid",
+		TenantClaims:     map[string]string{"tenant-guid": "default"},
+		ClockSkewSeconds: 60,
+	}
+}
+
+func oidcServer(t *testing.T, f *fakeIdP, cfg config.OIDCSection, store OIDCUserStore, audit AuthAuditWriter, authn auth.Authenticator) *gin.Engine {
+	t.Helper()
+	flow, err := oidc.NewFlow(context.Background(), cfg, testHS256Secret)
+	if err != nil {
+		t.Fatalf("NewFlow: %v", err)
+	}
+	if authn == nil {
+		authn = &fakeAuthn{}
+	}
+	return NewServer(Dependencies{
+		Logger:        discardLogger(),
+		Authenticator: authn,
+		RateLimiter:   auth.NewRateLimiter(50, time.Minute),
+		HealthChecks:  map[string]HealthChecker{},
+		CORSOrigins:   []string{"*"},
+		TokenTTLSecs:  3600,
+		OIDCFlow:      flow,
+		OIDCSettings:  cfg,
+		OIDCUsers:     store,
+		AuthAudit:     audit,
+		JWTSecret:     testHS256Secret,
+	})
+}
+
+type loginState struct {
+	state, nonce, challenge string
+	cookie                  *http.Cookie
+}
+
+func startLogin(t *testing.T, srv *gin.Engine) loginState {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/auth/oidc/login?next=/dags", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("login = %d, want 302", rec.Code)
+	}
+	loc, err := url.Parse(rec.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse Location: %v", err)
+	}
+	q := loc.Query()
+	if q.Get("code_challenge_method") != "S256" {
+		t.Errorf("code_challenge_method = %q, want S256 (PKCE)", q.Get("code_challenge_method"))
+	}
+	var cookie *http.Cookie
+	for _, ck := range rec.Result().Cookies() {
+		if ck.Name == oidcStateCookie {
+			cookie = ck
+		}
+	}
+	if cookie == nil {
+		t.Fatal("login did not set the state cookie")
+	}
+	if !cookie.HttpOnly {
+		t.Error("state cookie is not HttpOnly")
+	}
+	return loginState{state: q.Get("state"), nonce: q.Get("nonce"), challenge: q.Get("code_challenge"), cookie: cookie}
+}
+
+func baseClaims(cfg config.OIDCSection, nonce string) jwt.MapClaims {
+	now := time.Now()
+	return jwt.MapClaims{
+		"iss":            cfg.Issuer,
+		"aud":            cfg.ClientID,
+		"sub":            "subject-123",
+		"exp":            now.Add(time.Hour).Unix(),
+		"iat":            now.Unix(),
+		"nonce":          nonce,
+		"email":          "alice@corp.example",
+		"email_verified": true,
+		"tid":            "tenant-guid",
+		"groups":         []string{"data-eng"},
+	}
+}
+
+// completeCallback stages the given raw ID token for a fresh code and invokes the
+// callback with the login state's state + cookie.
+func completeCallback(srv *gin.Engine, f *fakeIdP, st loginState, idToken string) *httptest.ResponseRecorder {
+	code := "code-" + st.state[:12]
+	f.stage(code, st.challenge, idToken)
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/auth/oidc/callback?code="+code+"&state="+url.QueryEscape(st.state), nil)
+	req.AddCookie(st.cookie)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	return rec
+}
+
+// driveCallback runs the full login→callback, minting claims from baseClaims with
+// the login nonce and an optional mutation.
+func driveCallback(t *testing.T, srv *gin.Engine, f *fakeIdP, cfg config.OIDCSection, mutate func(jwt.MapClaims)) *httptest.ResponseRecorder {
+	t.Helper()
+	st := startLogin(t, srv)
+	claims := baseClaims(cfg, st.nonce)
+	if mutate != nil {
+		mutate(claims)
+	}
+	return completeCallback(srv, f, st, f.signIDToken(claims))
+}
+
+func sessionCookie(rec *httptest.ResponseRecorder) *http.Cookie {
+	for _, ck := range rec.Result().Cookies() {
+		if ck.Name == authTokenCookie && ck.Value != "" {
+			return ck
+		}
+	}
+	return nil
+}
+
+func tokenRoles(t *testing.T, token string) []string {
+	t.Helper()
+	var claims jwt.MapClaims
+	if _, err := jwt.ParseWithClaims(token, &claims, func(*jwt.Token) (any, error) {
+		return []byte(testHS256Secret), nil
+	}); err != nil {
+		t.Fatalf("parse minted token: %v", err)
+	}
+	raw, _ := claims["roles"].([]any)
+	roles := make([]string, 0, len(raw))
+	for _, r := range raw {
+		if s, ok := r.(string); ok {
+			roles = append(roles, s)
+		}
+	}
+	return roles
+}
+
+// ─────────────────────────── happy path ───────────────────────────
+
+func TestOIDCHappyPathResolvesUserAndMintsSession(t *testing.T) {
+	f := newFakeIdP(t)
+	cfg := baseOIDCConfig(f)
+	store := newFakeOIDCStore()
+	// Pre-provisioned user, resolved by the immutable (issuer, subject) pair.
+	store.seed(cfg.Issuer, "subject-123", &auth.User{ID: "user-1", TenantID: "default", Email: "alice@corp.example", Roles: []string{"editor"}}, true)
+	audit := &fakeAuthAudit{}
+	srv := oidcServer(t, f, cfg, store, audit, nil)
+
+	rec := driveCallback(t, srv, f, cfg, nil)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("callback = %d, want 302", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/dags" {
+		t.Errorf("redirect = %q, want /dags (sanitized next)", loc)
+	}
+	ck := sessionCookie(rec)
+	if ck == nil {
+		t.Fatal("callback did not set the _token session cookie")
+	}
+	if !ck.HttpOnly || !ck.Secure {
+		t.Errorf("session cookie must be HttpOnly+Secure; got HttpOnly=%v Secure=%v", ck.HttpOnly, ck.Secure)
+	}
+	// D5: the minted token carries the group-mapped role.
+	if roles := tokenRoles(t, ck.Value); len(roles) != 1 || roles[0] != "editor" {
+		t.Errorf("token roles = %v, want [editor] (mapped from group data-eng)", roles)
+	}
+	if !audit.has(auditOIDCLoginSuccess, "success") {
+		t.Error("login success was not audited")
+	}
+}
+
+// ─────────────────────────── H1: tenant pin ───────────────────────────
+
+func TestOIDCTenantPinFailsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(jwt.MapClaims)
+	}{
+		{"issuer mismatch", func(c jwt.MapClaims) { c["iss"] = "https://evil.example" }},
+		{"tid not in tenant_claims", func(c jwt.MapClaims) { c["tid"] = "some-other-tenant" }},
+		{"tid absent", func(c jwt.MapClaims) { delete(c, "tid") }},
+		{"email_verified false", func(c jwt.MapClaims) { c["email_verified"] = false }},
+		{"email_verified absent", func(c jwt.MapClaims) { delete(c, "email_verified") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeIdP(t)
+			cfg := baseOIDCConfig(f)
+			store := newFakeOIDCStore()
+			store.seed(cfg.Issuer, "subject-123", &auth.User{ID: "user-1", TenantID: "default"}, true)
+			audit := &fakeAuthAudit{}
+			srv := oidcServer(t, f, cfg, store, audit, nil)
+
+			rec := driveCallback(t, srv, f, cfg, tc.mutate)
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("%s = %d, want 403 (fail closed)", tc.name, rec.Code)
+			}
+			if sessionCookie(rec) != nil {
+				t.Error("a rejected login must NOT mint a session cookie")
+			}
+			// Never a fallback to the default tenant/identity.
+			if len(store.created) != 0 {
+				t.Error("a rejected login must NOT provision a user")
+			}
+		})
+	}
+}
+
+func TestOIDCTenantPinRejectionIsAudited(t *testing.T) {
+	f := newFakeIdP(t)
+	cfg := baseOIDCConfig(f)
+	audit := &fakeAuthAudit{}
+	srv := oidcServer(t, f, cfg, newFakeOIDCStore(), audit, nil)
+
+	driveCallback(t, srv, f, cfg, func(c jwt.MapClaims) { c["tid"] = "rogue-tenant" })
+
+	if !audit.has(auditOIDCTenantReject, "denied") {
+		t.Error("tenant-pin rejection was not audited as a tenant-pin rejection")
+	}
+}
+
+// ─────────────────────────── H4: token verification ───────────────────────────
+
+func TestOIDCTokenVerificationFailsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(jwt.MapClaims)
+	}{
+		{"wrong audience", func(c jwt.MapClaims) { c["aud"] = "some-other-client" }},
+		{"wrong nonce", func(c jwt.MapClaims) { c["nonce"] = "not-the-cookie-nonce" }},
+		{"absent nonce", func(c jwt.MapClaims) { delete(c, "nonce") }},
+		{"expired beyond skew", func(c jwt.MapClaims) { c["exp"] = time.Now().Add(-5 * time.Minute).Unix() }},
+		{"azp mismatch", func(c jwt.MapClaims) { c["azp"] = "some-other-client" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeIdP(t)
+			cfg := baseOIDCConfig(f)
+			store := newFakeOIDCStore()
+			store.seed(cfg.Issuer, "subject-123", &auth.User{ID: "user-1", TenantID: "default"}, true)
+			srv := oidcServer(t, f, cfg, store, &fakeAuthAudit{}, nil)
+
+			rec := driveCallback(t, srv, f, cfg, tc.mutate)
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("%s = %d, want 403", tc.name, rec.Code)
+			}
+			if sessionCookie(rec) != nil {
+				t.Errorf("%s: a rejected token must NOT mint a session", tc.name)
+			}
+		})
+	}
+}
+
+func TestOIDCTamperedSignatureRejected(t *testing.T) {
+	f := newFakeIdP(t)
+	cfg := baseOIDCConfig(f)
+	store := newFakeOIDCStore()
+	store.seed(cfg.Issuer, "subject-123", &auth.User{ID: "user-1", TenantID: "default"}, true)
+	srv := oidcServer(t, f, cfg, store, &fakeAuthAudit{}, nil)
+
+	st := startLogin(t, srv)
+	idToken := f.signIDToken(baseClaims(cfg, st.nonce))
+	// Corrupt the signature segment.
+	parts := strings.Split(idToken, ".")
+	sig := []byte(parts[2])
+	if sig[0] == 'A' {
+		sig[0] = 'B'
+	} else {
+		sig[0] = 'A'
+	}
+	parts[2] = string(sig)
+	rec := completeCallback(srv, f, st, strings.Join(parts, "."))
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("tampered signature = %d, want 403", rec.Code)
+	}
+	if sessionCookie(rec) != nil {
+		t.Error("a tampered token must NOT mint a session")
+	}
+}
+
+func TestOIDCWithinSkewAccepted(t *testing.T) {
+	f := newFakeIdP(t)
+	cfg := baseOIDCConfig(f)
+	store := newFakeOIDCStore()
+	store.seed(cfg.Issuer, "subject-123", &auth.User{ID: "user-1", TenantID: "default", Roles: []string{"editor"}}, true)
+	srv := oidcServer(t, f, cfg, store, &fakeAuthAudit{}, nil)
+
+	// Expired 30s ago, inside the 60s skew → still accepted.
+	rec := driveCallback(t, srv, f, cfg, func(c jwt.MapClaims) {
+		c["exp"] = time.Now().Add(-30 * time.Second).Unix()
+	})
+	if rec.Code != http.StatusFound {
+		t.Fatalf("within-skew token = %d, want 302 (accepted)", rec.Code)
+	}
+}
+
+// ─────────────────────────── state / CSRF ───────────────────────────
+
+func TestOIDCCallbackRejectsMissingStateCookie(t *testing.T) {
+	f := newFakeIdP(t)
+	cfg := baseOIDCConfig(f)
+	srv := oidcServer(t, f, cfg, newFakeOIDCStore(), &fakeAuthAudit{}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/auth/oidc/callback?code=x&state=y", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("missing state cookie = %d, want 403", rec.Code)
+	}
+}
+
+func TestOIDCCallbackRejectsStateMismatch(t *testing.T) {
+	f := newFakeIdP(t)
+	cfg := baseOIDCConfig(f)
+	srv := oidcServer(t, f, cfg, newFakeOIDCStore(), &fakeAuthAudit{}, nil)
+
+	st := startLogin(t, srv)
+	// Present a different state query param than the one sealed in the cookie.
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/auth/oidc/callback?code=x&state=forged-state", nil)
+	req.AddCookie(st.cookie)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("state mismatch = %d, want 403", rec.Code)
+	}
+}
+
+func TestOIDCCallbackRejectsIssParamMismatch(t *testing.T) {
+	f := newFakeIdP(t)
+	cfg := baseOIDCConfig(f)
+	srv := oidcServer(t, f, cfg, newFakeOIDCStore(), &fakeAuthAudit{}, nil)
+
+	st := startLogin(t, srv)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v2/auth/oidc/callback?code=x&state="+url.QueryEscape(st.state)+"&iss=https://evil.example", nil)
+	req.AddCookie(st.cookie)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("RFC 9207 iss mismatch = %d, want 403", rec.Code)
+	}
+}
+
+// ─────────────────────────── D4: JIT provisioning ───────────────────────────
+
+func TestOIDCJITOffRejectsUnknownSubject(t *testing.T) {
+	f := newFakeIdP(t)
+	cfg := baseOIDCConfig(f) // JITProvisioning defaults off
+	store := newFakeOIDCStore()
+	audit := &fakeAuthAudit{}
+	srv := oidcServer(t, f, cfg, store, audit, nil)
+
+	rec := driveCallback(t, srv, f, cfg, nil)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("JIT-off unknown subject = %d, want 403", rec.Code)
+	}
+	if len(store.created) != 0 {
+		t.Error("JIT off must not create a user")
+	}
+}
+
+func TestOIDCJITOnCreatesUserWithMappedRoles(t *testing.T) {
+	f := newFakeIdP(t)
+	cfg := baseOIDCConfig(f)
+	cfg.JITProvisioning = true
+	store := newFakeOIDCStore()
+	audit := &fakeAuthAudit{}
+	srv := oidcServer(t, f, cfg, store, audit, nil)
+
+	rec := driveCallback(t, srv, f, cfg, nil)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("JIT-on = %d, want 302", rec.Code)
+	}
+	if len(store.created) != 1 {
+		t.Fatalf("JIT on created %d users, want 1", len(store.created))
+	}
+	got := store.created[0]
+	if got.email != "alice@corp.example" || got.tenant != "default" || got.subject != "subject-123" {
+		t.Errorf("created = %+v, unexpected", got)
+	}
+	if len(got.roles) != 1 || got.roles[0] != "editor" {
+		t.Errorf("created roles = %v, want [editor]", got.roles)
+	}
+	if !audit.has(auditOIDCJITProvision, "success") {
+		t.Error("JIT provisioning was not audited")
+	}
+}
+
+// ─────────────────────────── D5 + default_role ───────────────────────────
+
+func TestOIDCUnmappedGroupGrantsNoRole(t *testing.T) {
+	f := newFakeIdP(t)
+	cfg := baseOIDCConfig(f)
+	cfg.JITProvisioning = true
+	store := newFakeOIDCStore()
+	srv := oidcServer(t, f, cfg, store, &fakeAuthAudit{}, nil)
+
+	rec := driveCallback(t, srv, f, cfg, func(c jwt.MapClaims) { c["groups"] = []string{"unmapped-group"} })
+	if rec.Code != http.StatusFound {
+		t.Fatalf("unmapped-group login = %d, want 302", rec.Code)
+	}
+	if len(store.created) != 1 || len(store.created[0].roles) != 0 {
+		t.Errorf("unmapped group should grant no role (default-deny); created = %+v", store.created)
+	}
+}
+
+func TestOIDCDefaultRoleFallback(t *testing.T) {
+	f := newFakeIdP(t)
+	cfg := baseOIDCConfig(f)
+	cfg.JITProvisioning = true
+	cfg.DefaultRole = "viewer"
+	store := newFakeOIDCStore()
+	srv := oidcServer(t, f, cfg, store, &fakeAuthAudit{}, nil)
+
+	rec := driveCallback(t, srv, f, cfg, func(c jwt.MapClaims) { c["groups"] = []string{"unmapped-group"} })
+	if rec.Code != http.StatusFound {
+		t.Fatalf("default_role login = %d, want 302", rec.Code)
+	}
+	if len(store.created) != 1 || len(store.created[0].roles) != 1 || store.created[0].roles[0] != "viewer" {
+		t.Errorf("unmapped + default_role=viewer should grant [viewer]; created = %+v", store.created)
+	}
+}
+
+func TestOIDCDefaultRoleEmptyKeepsDeny(t *testing.T) {
+	f := newFakeIdP(t)
+	cfg := baseOIDCConfig(f)
+	cfg.JITProvisioning = true
+	cfg.DefaultRole = "" // secure default
+	store := newFakeOIDCStore()
+	srv := oidcServer(t, f, cfg, store, &fakeAuthAudit{}, nil)
+
+	rec := driveCallback(t, srv, f, cfg, func(c jwt.MapClaims) { c["groups"] = []string{"unmapped-group"} })
+	if rec.Code != http.StatusFound || len(store.created) != 1 || len(store.created[0].roles) != 0 {
+		t.Errorf("empty default_role must keep default-deny; code=%d created=%+v", rec.Code, store.created)
+	}
+}
+
+func TestOIDCDefaultRoleNonexistentRejected(t *testing.T) {
+	f := newFakeIdP(t)
+	cfg := baseOIDCConfig(f)
+	cfg.JITProvisioning = true
+	cfg.DefaultRole = "wizard" // not a real role
+	store := newFakeOIDCStore()
+	audit := &fakeAuthAudit{}
+	srv := oidcServer(t, f, cfg, store, audit, nil)
+
+	rec := driveCallback(t, srv, f, cfg, func(c jwt.MapClaims) { c["groups"] = []string{"unmapped-group"} })
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("nonexistent default_role = %d, want 403 (fail closed)", rec.Code)
+	}
+	if len(store.created) != 0 {
+		t.Error("a login with an unknown default_role must not create a user")
+	}
+	if !audit.has(auditOIDCLoginFailure, "denied") {
+		t.Error("the rejection was not audited")
+	}
+}
+
+// ─────────────────────────── allowed_email_domains ───────────────────────────
+
+func TestOIDCEmailDomainAllowlist(t *testing.T) {
+	seededUser := func(cfg config.OIDCSection) *fakeOIDCStore {
+		s := newFakeOIDCStore()
+		s.seed(cfg.Issuer, "subject-123", &auth.User{ID: "user-1", TenantID: "default", Roles: []string{"editor"}}, true)
+		return s
+	}
+
+	t.Run("domain in allowlist, pre-existing user → ok", func(t *testing.T) {
+		f := newFakeIdP(t)
+		cfg := baseOIDCConfig(f)
+		cfg.AllowedEmailDomains = []string{"corp.example"}
+		srv := oidcServer(t, f, cfg, seededUser(cfg), &fakeAuthAudit{}, nil)
+		if rec := driveCallback(t, srv, f, cfg, nil); rec.Code != http.StatusFound {
+			t.Fatalf("in-allowlist login = %d, want 302", rec.Code)
+		}
+	})
+
+	t.Run("domain NOT in allowlist, pre-existing user → 403", func(t *testing.T) {
+		f := newFakeIdP(t)
+		cfg := baseOIDCConfig(f)
+		cfg.AllowedEmailDomains = []string{"trusted.example"}
+		store := seededUser(cfg)
+		srv := oidcServer(t, f, cfg, store, &fakeAuthAudit{}, nil)
+		rec := driveCallback(t, srv, f, cfg, nil) // email alice@corp.example
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("out-of-allowlist pre-existing user = %d, want 403", rec.Code)
+		}
+		if sessionCookie(rec) != nil {
+			t.Error("out-of-allowlist login must not mint a session")
+		}
+	})
+
+	t.Run("domain NOT in allowlist, JIT-on → 403, no row", func(t *testing.T) {
+		f := newFakeIdP(t)
+		cfg := baseOIDCConfig(f)
+		cfg.JITProvisioning = true
+		cfg.AllowedEmailDomains = []string{"trusted.example"}
+		store := newFakeOIDCStore()
+		srv := oidcServer(t, f, cfg, store, &fakeAuthAudit{}, nil)
+		rec := driveCallback(t, srv, f, cfg, nil)
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("out-of-allowlist JIT = %d, want 403", rec.Code)
+		}
+		if len(store.created) != 0 {
+			t.Error("out-of-allowlist login must not provision a user")
+		}
+	})
+
+	t.Run("empty allowlist → no domain restriction", func(t *testing.T) {
+		f := newFakeIdP(t)
+		cfg := baseOIDCConfig(f) // AllowedEmailDomains empty
+		srv := oidcServer(t, f, cfg, seededUser(cfg), &fakeAuthAudit{}, nil)
+		if rec := driveCallback(t, srv, f, cfg, nil); rec.Code != http.StatusFound {
+			t.Fatalf("empty allowlist login = %d, want 302", rec.Code)
+		}
+	})
+
+	t.Run("unverified email is rejected before the domain check", func(t *testing.T) {
+		f := newFakeIdP(t)
+		cfg := baseOIDCConfig(f)
+		cfg.AllowedEmailDomains = []string{"corp.example"} // domain WOULD pass
+		srv := oidcServer(t, f, cfg, seededUser(cfg), &fakeAuthAudit{}, nil)
+		rec := driveCallback(t, srv, f, cfg, func(c jwt.MapClaims) { c["email_verified"] = false })
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("unverified email = %d, want 403 (fails at email_verified, before the domain check)", rec.Code)
+		}
+	})
+}

--- a/internal/api/oidc_flow_test.go
+++ b/internal/api/oidc_flow_test.go
@@ -138,16 +138,23 @@ func writeJSON(w http.ResponseWriter, v any) {
 // ─────────────────────────── fakes ───────────────────────────
 
 type fakeOIDCStore struct {
-	users     map[string]*auth.User // provider|subject → user
-	active    map[string]bool
-	roles     map[string]bool
-	created   []createdOIDC
-	createErr error
+	users        map[string]*auth.User // provider|subject → user
+	active       map[string]bool
+	roles        map[string]bool
+	created      []createdOIDC
+	createErr    error
+	reconciled   []reconcileCall
+	reconcileErr error
 }
 
 type createdOIDC struct {
 	tenant, email, provider, subject string
 	roles                            []string
+}
+
+type reconcileCall struct {
+	userID string
+	roles  []string
 }
 
 func newFakeOIDCStore() *fakeOIDCStore {
@@ -185,6 +192,33 @@ func (s *fakeOIDCStore) CreateOIDCUser(_ context.Context, tenant, email, provide
 
 func (s *fakeOIDCStore) RoleExists(_ context.Context, _ string, role string) (bool, error) {
 	return s.roles[role], nil
+}
+
+func (s *fakeOIDCStore) ReconcileUserRoles(_ context.Context, userID string, roleNames []string) error {
+	if s.reconcileErr != nil {
+		return s.reconcileErr
+	}
+	s.reconciled = append(s.reconciled, reconcileCall{userID: userID, roles: append([]string(nil), roleNames...)})
+	// Reflect the reconciled set onto the resolvable user so a later
+	// FindUserByOIDCSubject (the per-request reload analogue) observes it.
+	for k, u := range s.users {
+		if u.ID == userID {
+			u.Roles = append([]string(nil), roleNames...)
+			s.users[k] = u
+		}
+	}
+	return nil
+}
+
+// lastReconcile returns the roles from the most recent reconcile for userID, and
+// whether any reconcile happened for it.
+func (s *fakeOIDCStore) lastReconcile(userID string) ([]string, bool) {
+	for i := len(s.reconciled) - 1; i >= 0; i-- {
+		if s.reconciled[i].userID == userID {
+			return s.reconciled[i].roles, true
+		}
+	}
+	return nil, false
 }
 
 type fakeAuthAudit struct {

--- a/internal/api/oidc_flow_test.go
+++ b/internal/api/oidc_flow_test.go
@@ -200,7 +200,7 @@ func (s *fakeOIDCStore) ReconcileUserRoles(_ context.Context, userID string, rol
 	}
 	s.reconciled = append(s.reconciled, reconcileCall{userID: userID, roles: append([]string(nil), roleNames...)})
 	// Reflect the reconciled set onto the resolvable user so a later
-	// FindUserByOIDCSubject (the per-request reload analogue) observes it.
+	// FindUserByOIDCSubject (standing in for the per-request reload) observes it.
 	for k, u := range s.users {
 		if u.ID == userID {
 			u.Roles = append([]string(nil), roleNames...)

--- a/internal/api/oidc_flow_test.go
+++ b/internal/api/oidc_flow_test.go
@@ -26,11 +26,11 @@ import (
 
 // ─────────────────────────── fake IdP ───────────────────────────
 
-// fakeIdP is an in-process OpenID Provider: it serves discovery + JWKS + a token
+// fakeIDP is an in-process OpenID Provider: it serves discovery + JWKS + a token
 // endpoint, and signs ID tokens with an in-test RSA key. The token endpoint
 // verifies the PKCE code_verifier against the challenge staged for the code, so
 // the tests exercise a real PKCE round-trip.
-type fakeIdP struct {
+type fakeIDP struct {
 	srv    *httptest.Server
 	key    *rsa.PrivateKey
 	kid    string
@@ -45,13 +45,13 @@ type stagedCode struct {
 	idToken   string
 }
 
-func newFakeIdP(t *testing.T) *fakeIdP {
+func newFakeIDP(t *testing.T) *fakeIDP {
 	t.Helper()
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		t.Fatalf("rsa keygen: %v", err)
 	}
-	f := &fakeIdP{key: key, kid: "test-key-1", staged: map[string]stagedCode{}}
+	f := &fakeIDP{key: key, kid: "test-key-1", staged: map[string]stagedCode{}}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/.well-known/openid-configuration", f.handleDiscovery)
 	mux.HandleFunc("/jwks", f.handleJWKS)
@@ -62,7 +62,7 @@ func newFakeIdP(t *testing.T) *fakeIdP {
 	return f
 }
 
-func (f *fakeIdP) handleDiscovery(w http.ResponseWriter, _ *http.Request) {
+func (f *fakeIDP) handleDiscovery(w http.ResponseWriter, _ *http.Request) {
 	writeJSON(w, map[string]any{
 		"issuer":                                f.issuer,
 		"authorization_endpoint":                f.issuer + "/authorize",
@@ -74,7 +74,7 @@ func (f *fakeIdP) handleDiscovery(w http.ResponseWriter, _ *http.Request) {
 	})
 }
 
-func (f *fakeIdP) handleJWKS(w http.ResponseWriter, _ *http.Request) {
+func (f *fakeIDP) handleJWKS(w http.ResponseWriter, _ *http.Request) {
 	pub := f.key.PublicKey
 	writeJSON(w, map[string]any{"keys": []map[string]any{{
 		"kty": "RSA",
@@ -86,7 +86,7 @@ func (f *fakeIdP) handleJWKS(w http.ResponseWriter, _ *http.Request) {
 	}}})
 }
 
-func (f *fakeIdP) handleToken(w http.ResponseWriter, r *http.Request) {
+func (f *fakeIDP) handleToken(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, "bad form", http.StatusBadRequest)
 		return
@@ -114,7 +114,7 @@ func (f *fakeIdP) handleToken(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (f *fakeIdP) signIDToken(claims jwt.MapClaims) string {
+func (f *fakeIDP) signIDToken(claims jwt.MapClaims) string {
 	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 	tok.Header["kid"] = f.kid
 	s, err := tok.SignedString(f.key)
@@ -124,7 +124,7 @@ func (f *fakeIdP) signIDToken(claims jwt.MapClaims) string {
 	return s
 }
 
-func (f *fakeIdP) stage(code, challenge, idToken string) {
+func (f *fakeIDP) stage(code, challenge, idToken string) {
 	f.mu.Lock()
 	f.staged[code] = stagedCode{challenge: challenge, idToken: idToken}
 	f.mu.Unlock()
@@ -219,7 +219,7 @@ func (a *fakeAuthAudit) has(action, outcome string) bool {
 
 const testHS256Secret = "oidc-flow-test-secret"
 
-func baseOIDCConfig(f *fakeIdP) config.OIDCSection {
+func baseOIDCConfig(f *fakeIDP) config.OIDCSection {
 	return config.OIDCSection{
 		Issuer:           f.issuer,
 		ClientID:         "client-abc",
@@ -234,7 +234,7 @@ func baseOIDCConfig(f *fakeIdP) config.OIDCSection {
 	}
 }
 
-func oidcServer(t *testing.T, f *fakeIdP, cfg config.OIDCSection, store OIDCUserStore, audit AuthAuditWriter, authn auth.Authenticator) *gin.Engine {
+func oidcServer(t *testing.T, f *fakeIDP, cfg config.OIDCSection, store OIDCUserStore, audit AuthAuditWriter, authn auth.Authenticator) *gin.Engine {
 	t.Helper()
 	flow, err := oidc.NewFlow(context.Background(), cfg, testHS256Secret)
 	if err != nil {
@@ -265,7 +265,7 @@ type loginState struct {
 
 func startLogin(t *testing.T, srv *gin.Engine) loginState {
 	t.Helper()
-	req := httptest.NewRequest(http.MethodGet, "/api/v2/auth/oidc/login?next=/dags", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v2/auth/oidc/login?next=/dags", http.NoBody)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 	if rec.Code != http.StatusFound {
@@ -312,10 +312,10 @@ func baseClaims(cfg config.OIDCSection, nonce string) jwt.MapClaims {
 
 // completeCallback stages the given raw ID token for a fresh code and invokes the
 // callback with the login state's state + cookie.
-func completeCallback(srv *gin.Engine, f *fakeIdP, st loginState, idToken string) *httptest.ResponseRecorder {
+func completeCallback(srv *gin.Engine, f *fakeIDP, st loginState, idToken string) *httptest.ResponseRecorder {
 	code := "code-" + st.state[:12]
 	f.stage(code, st.challenge, idToken)
-	req := httptest.NewRequest(http.MethodGet, "/api/v2/auth/oidc/callback?code="+code+"&state="+url.QueryEscape(st.state), nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v2/auth/oidc/callback?code="+code+"&state="+url.QueryEscape(st.state), http.NoBody)
 	req.AddCookie(st.cookie)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -324,7 +324,7 @@ func completeCallback(srv *gin.Engine, f *fakeIdP, st loginState, idToken string
 
 // driveCallback runs the full login→callback, minting claims from baseClaims with
 // the login nonce and an optional mutation.
-func driveCallback(t *testing.T, srv *gin.Engine, f *fakeIdP, cfg config.OIDCSection, mutate func(jwt.MapClaims)) *httptest.ResponseRecorder {
+func driveCallback(t *testing.T, srv *gin.Engine, f *fakeIDP, cfg config.OIDCSection, mutate func(jwt.MapClaims)) *httptest.ResponseRecorder {
 	t.Helper()
 	st := startLogin(t, srv)
 	claims := baseClaims(cfg, st.nonce)
@@ -364,7 +364,7 @@ func tokenRoles(t *testing.T, token string) []string {
 // ─────────────────────────── happy path ───────────────────────────
 
 func TestOIDCHappyPathResolvesUserAndMintsSession(t *testing.T) {
-	f := newFakeIdP(t)
+	f := newFakeIDP(t)
 	cfg := baseOIDCConfig(f)
 	store := newFakeOIDCStore()
 	// Pre-provisioned user, resolved by the immutable (issuer, subject) pair.
@@ -410,7 +410,7 @@ func TestOIDCTenantPinFailsClosed(t *testing.T) {
 		{"email_verified absent", func(c jwt.MapClaims) { delete(c, "email_verified") }},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			f := newFakeIdP(t)
+			f := newFakeIDP(t)
 			cfg := baseOIDCConfig(f)
 			store := newFakeOIDCStore()
 			store.seed(cfg.Issuer, "subject-123", &auth.User{ID: "user-1", TenantID: "default"}, true)
@@ -434,7 +434,7 @@ func TestOIDCTenantPinFailsClosed(t *testing.T) {
 }
 
 func TestOIDCTenantPinRejectionIsAudited(t *testing.T) {
-	f := newFakeIdP(t)
+	f := newFakeIDP(t)
 	cfg := baseOIDCConfig(f)
 	audit := &fakeAuthAudit{}
 	srv := oidcServer(t, f, cfg, newFakeOIDCStore(), audit, nil)
@@ -460,7 +460,7 @@ func TestOIDCTokenVerificationFailsClosed(t *testing.T) {
 		{"azp mismatch", func(c jwt.MapClaims) { c["azp"] = "some-other-client" }},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			f := newFakeIdP(t)
+			f := newFakeIDP(t)
 			cfg := baseOIDCConfig(f)
 			store := newFakeOIDCStore()
 			store.seed(cfg.Issuer, "subject-123", &auth.User{ID: "user-1", TenantID: "default"}, true)
@@ -479,7 +479,7 @@ func TestOIDCTokenVerificationFailsClosed(t *testing.T) {
 }
 
 func TestOIDCTamperedSignatureRejected(t *testing.T) {
-	f := newFakeIdP(t)
+	f := newFakeIDP(t)
 	cfg := baseOIDCConfig(f)
 	store := newFakeOIDCStore()
 	store.seed(cfg.Issuer, "subject-123", &auth.User{ID: "user-1", TenantID: "default"}, true)
@@ -507,7 +507,7 @@ func TestOIDCTamperedSignatureRejected(t *testing.T) {
 }
 
 func TestOIDCWithinSkewAccepted(t *testing.T) {
-	f := newFakeIdP(t)
+	f := newFakeIDP(t)
 	cfg := baseOIDCConfig(f)
 	store := newFakeOIDCStore()
 	store.seed(cfg.Issuer, "subject-123", &auth.User{ID: "user-1", TenantID: "default", Roles: []string{"editor"}}, true)
@@ -525,11 +525,11 @@ func TestOIDCWithinSkewAccepted(t *testing.T) {
 // ─────────────────────────── state / CSRF ───────────────────────────
 
 func TestOIDCCallbackRejectsMissingStateCookie(t *testing.T) {
-	f := newFakeIdP(t)
+	f := newFakeIDP(t)
 	cfg := baseOIDCConfig(f)
 	srv := oidcServer(t, f, cfg, newFakeOIDCStore(), &fakeAuthAudit{}, nil)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v2/auth/oidc/callback?code=x&state=y", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v2/auth/oidc/callback?code=x&state=y", http.NoBody)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 	if rec.Code != http.StatusForbidden {
@@ -538,13 +538,13 @@ func TestOIDCCallbackRejectsMissingStateCookie(t *testing.T) {
 }
 
 func TestOIDCCallbackRejectsStateMismatch(t *testing.T) {
-	f := newFakeIdP(t)
+	f := newFakeIDP(t)
 	cfg := baseOIDCConfig(f)
 	srv := oidcServer(t, f, cfg, newFakeOIDCStore(), &fakeAuthAudit{}, nil)
 
 	st := startLogin(t, srv)
 	// Present a different state query param than the one sealed in the cookie.
-	req := httptest.NewRequest(http.MethodGet, "/api/v2/auth/oidc/callback?code=x&state=forged-state", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v2/auth/oidc/callback?code=x&state=forged-state", http.NoBody)
 	req.AddCookie(st.cookie)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -554,13 +554,13 @@ func TestOIDCCallbackRejectsStateMismatch(t *testing.T) {
 }
 
 func TestOIDCCallbackRejectsIssParamMismatch(t *testing.T) {
-	f := newFakeIdP(t)
+	f := newFakeIDP(t)
 	cfg := baseOIDCConfig(f)
 	srv := oidcServer(t, f, cfg, newFakeOIDCStore(), &fakeAuthAudit{}, nil)
 
 	st := startLogin(t, srv)
-	req := httptest.NewRequest(http.MethodGet,
-		"/api/v2/auth/oidc/callback?code=x&state="+url.QueryEscape(st.state)+"&iss=https://evil.example", nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+		"/api/v2/auth/oidc/callback?code=x&state="+url.QueryEscape(st.state)+"&iss=https://evil.example", http.NoBody)
 	req.AddCookie(st.cookie)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
@@ -572,7 +572,7 @@ func TestOIDCCallbackRejectsIssParamMismatch(t *testing.T) {
 // ─────────────────────────── D4: JIT provisioning ───────────────────────────
 
 func TestOIDCJITOffRejectsUnknownSubject(t *testing.T) {
-	f := newFakeIdP(t)
+	f := newFakeIDP(t)
 	cfg := baseOIDCConfig(f) // JITProvisioning defaults off
 	store := newFakeOIDCStore()
 	audit := &fakeAuthAudit{}
@@ -589,7 +589,7 @@ func TestOIDCJITOffRejectsUnknownSubject(t *testing.T) {
 }
 
 func TestOIDCJITOnCreatesUserWithMappedRoles(t *testing.T) {
-	f := newFakeIdP(t)
+	f := newFakeIDP(t)
 	cfg := baseOIDCConfig(f)
 	cfg.JITProvisioning = true
 	store := newFakeOIDCStore()
@@ -619,7 +619,7 @@ func TestOIDCJITOnCreatesUserWithMappedRoles(t *testing.T) {
 // ─────────────────────────── D5 + default_role ───────────────────────────
 
 func TestOIDCUnmappedGroupGrantsNoRole(t *testing.T) {
-	f := newFakeIdP(t)
+	f := newFakeIDP(t)
 	cfg := baseOIDCConfig(f)
 	cfg.JITProvisioning = true
 	store := newFakeOIDCStore()
@@ -635,7 +635,7 @@ func TestOIDCUnmappedGroupGrantsNoRole(t *testing.T) {
 }
 
 func TestOIDCDefaultRoleFallback(t *testing.T) {
-	f := newFakeIdP(t)
+	f := newFakeIDP(t)
 	cfg := baseOIDCConfig(f)
 	cfg.JITProvisioning = true
 	cfg.DefaultRole = "viewer"
@@ -652,7 +652,7 @@ func TestOIDCDefaultRoleFallback(t *testing.T) {
 }
 
 func TestOIDCDefaultRoleEmptyKeepsDeny(t *testing.T) {
-	f := newFakeIdP(t)
+	f := newFakeIDP(t)
 	cfg := baseOIDCConfig(f)
 	cfg.JITProvisioning = true
 	cfg.DefaultRole = "" // secure default
@@ -666,7 +666,7 @@ func TestOIDCDefaultRoleEmptyKeepsDeny(t *testing.T) {
 }
 
 func TestOIDCDefaultRoleNonexistentRejected(t *testing.T) {
-	f := newFakeIdP(t)
+	f := newFakeIDP(t)
 	cfg := baseOIDCConfig(f)
 	cfg.JITProvisioning = true
 	cfg.DefaultRole = "wizard" // not a real role
@@ -696,7 +696,7 @@ func TestOIDCEmailDomainAllowlist(t *testing.T) {
 	}
 
 	t.Run("domain in allowlist, pre-existing user → ok", func(t *testing.T) {
-		f := newFakeIdP(t)
+		f := newFakeIDP(t)
 		cfg := baseOIDCConfig(f)
 		cfg.AllowedEmailDomains = []string{"corp.example"}
 		srv := oidcServer(t, f, cfg, seededUser(cfg), &fakeAuthAudit{}, nil)
@@ -706,7 +706,7 @@ func TestOIDCEmailDomainAllowlist(t *testing.T) {
 	})
 
 	t.Run("domain NOT in allowlist, pre-existing user → 403", func(t *testing.T) {
-		f := newFakeIdP(t)
+		f := newFakeIDP(t)
 		cfg := baseOIDCConfig(f)
 		cfg.AllowedEmailDomains = []string{"trusted.example"}
 		store := seededUser(cfg)
@@ -721,7 +721,7 @@ func TestOIDCEmailDomainAllowlist(t *testing.T) {
 	})
 
 	t.Run("domain NOT in allowlist, JIT-on → 403, no row", func(t *testing.T) {
-		f := newFakeIdP(t)
+		f := newFakeIDP(t)
 		cfg := baseOIDCConfig(f)
 		cfg.JITProvisioning = true
 		cfg.AllowedEmailDomains = []string{"trusted.example"}
@@ -737,7 +737,7 @@ func TestOIDCEmailDomainAllowlist(t *testing.T) {
 	})
 
 	t.Run("empty allowlist → no domain restriction", func(t *testing.T) {
-		f := newFakeIdP(t)
+		f := newFakeIDP(t)
 		cfg := baseOIDCConfig(f) // AllowedEmailDomains empty
 		srv := oidcServer(t, f, cfg, seededUser(cfg), &fakeAuthAudit{}, nil)
 		if rec := driveCallback(t, srv, f, cfg, nil); rec.Code != http.StatusFound {
@@ -746,7 +746,7 @@ func TestOIDCEmailDomainAllowlist(t *testing.T) {
 	})
 
 	t.Run("unverified email is rejected before the domain check", func(t *testing.T) {
-		f := newFakeIdP(t)
+		f := newFakeIDP(t)
 		cfg := baseOIDCConfig(f)
 		cfg.AllowedEmailDomains = []string{"corp.example"} // domain WOULD pass
 		srv := oidcServer(t, f, cfg, seededUser(cfg), &fakeAuthAudit{}, nil)

--- a/internal/api/oidc_handler.go
+++ b/internal/api/oidc_handler.go
@@ -44,6 +44,10 @@ type OIDCUserStore interface {
 	// RoleExists reports whether a role name exists for the tenant, used to fail
 	// closed on a misconfigured default_role or role mapping.
 	RoleExists(ctx context.Context, tenant, role string) (bool, error)
+	// ReconcileUserRoles sets the user's DB roles to EXACTLY roleNames (the IdP is
+	// authoritative). It fails closed on a name that is not a role in the tenant,
+	// leaving the prior grants intact.
+	ReconcileUserRoles(ctx context.Context, userID string, roleNames []string) error
 }
 
 // AuthAuditWriter records authentication events to the audit sink (H5). It is
@@ -165,7 +169,7 @@ func oidcCallbackHandler(deps oidcDeps) gin.HandlerFunc {
 		}
 		setSessionCookie(c, token, deps.tokenTTL)
 		deps.record(c, auditOIDCLoginSuccess, identity.Tenant, user.ID, identity.Email, "success",
-			map[string]string{"subject": identity.Subject})
+			map[string]string{"subject": identity.Subject, "roles": strings.Join(user.Roles, ",")})
 		c.Redirect(http.StatusFound, sanitizeNext(payload.Next))
 	}
 }
@@ -212,22 +216,36 @@ func (d oidcDeps) resolveUser(c *gin.Context, id *oidc.VerifiedIdentity) (*auth.
 	}
 
 	user, active, err := d.users.FindUserByOIDCSubject(ctx, id.Provider, id.Subject)
+	var resolved *auth.User
 	switch {
 	case err == nil:
 		if !active {
 			d.deny(c, auditOIDCLoginFailure, id.Tenant, user.ID, id.Email, "inactive")
 			return nil, errRejected
 		}
-		// Returning user: token carries the IdP-mapped roles (D5); per-request
-		// reload (PR-A) remains the authority for live permissions.
-		return &auth.User{ID: user.ID, TenantID: id.Tenant, Email: id.Email, Roles: loginRoles}, nil
+		resolved = &auth.User{ID: user.ID, TenantID: id.Tenant, Email: id.Email, Roles: loginRoles}
 	case errors.Is(err, auth.ErrUserNotFound):
-		return d.jitProvision(c, id, loginRoles)
+		resolved, err = d.jitProvision(c, id, loginRoles)
+		if err != nil {
+			return nil, err // jitProvision already audited + wrote the 403
+		}
 	default:
 		d.logger.Error("oidc: resolving user", "error", err)
 		d.deny(c, auditOIDCLoginFailure, id.Tenant, "", id.Email, "user_lookup_failed")
 		return nil, errRejected
 	}
+
+	// IdP-authoritative role reconciliation (D5): set the DB roles to EXACTLY the
+	// group-mapped set for BOTH new and returning users, so the per-request authz
+	// reload reflects the IdP's current groups — an IdP demotion or deprovisioning
+	// takes effect on the next login instead of stale DB grants winning. A failure
+	// here rejects the login rather than minting a token the DB does not back.
+	if rerr := d.users.ReconcileUserRoles(ctx, resolved.ID, loginRoles); rerr != nil {
+		d.logger.Error("oidc: reconciling roles", "error", rerr)
+		d.deny(c, auditOIDCLoginFailure, id.Tenant, resolved.ID, id.Email, "role_reconcile_failed")
+		return nil, errRejected
+	}
+	return resolved, nil
 }
 
 // jitProvision handles the no-matching-row case per D4: reject when JIT is off,

--- a/internal/api/oidc_handler.go
+++ b/internal/api/oidc_handler.go
@@ -259,7 +259,7 @@ func (d oidcDeps) jitProvision(c *gin.Context, id *oidc.VerifiedIdentity, loginR
 	return &auth.User{ID: created.ID, TenantID: id.Tenant, Email: id.Email, Roles: loginRoles}, nil
 }
 
-// errRejected is a sentinel signalling that a helper already wrote the 403 and
+// errRejected is a sentinel signaling that a helper already wrote the 403 and
 // audited; the caller must simply stop.
 var errRejected = errors.New("oidc: request already rejected")
 

--- a/internal/api/oidc_handler.go
+++ b/internal/api/oidc_handler.go
@@ -1,0 +1,321 @@
+package api
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/config"
+	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/oidc"
+)
+
+// oidcStateCookie carries the signed state/nonce/PKCE-verifier between the login
+// redirect and the callback. Scoped to the auth path and short-lived.
+const oidcStateCookie = "_oidc_state"
+
+// Auth audit actions (H5).
+const (
+	auditOIDCLoginSuccess = "oidc.login.success"
+	auditOIDCLoginFailure = "oidc.login.failure"
+	auditOIDCTenantReject = "oidc.tenant_pin_rejected"
+	auditOIDCJITProvision = "oidc.jit_provision"
+	auditBreakGlass       = "auth.break_glass"
+)
+
+// OIDCUserStore resolves and just-in-time-provisions OIDC identities. storage
+// implements it. The interface lives with its consumer (the callback handler).
+type OIDCUserStore interface {
+	// FindUserByOIDCSubject resolves a returning identity by its (provider,
+	// subject) pair, returning the user, whether it is active, and
+	// auth.ErrUserNotFound when no row matches.
+	FindUserByOIDCSubject(ctx context.Context, provider, subject string) (*auth.User, bool, error)
+	// CreateOIDCUser JIT-provisions an OIDC-only user with the given roles.
+	CreateOIDCUser(ctx context.Context, tenant, email, provider, subject string, roles []string) (*auth.User, error)
+	// RoleExists reports whether a role name exists for the tenant, used to fail
+	// closed on a misconfigured default_role or role mapping.
+	RoleExists(ctx context.Context, tenant, role string) (bool, error)
+}
+
+// AuthAuditWriter records authentication events to the audit sink (H5). It is
+// best-effort: a write error never changes the auth outcome.
+type AuthAuditWriter interface {
+	RecordAuthEvent(ctx context.Context, tenant, actorUserID, action, email, outcome string, extra map[string]string) error
+}
+
+// oidcDeps bundles what the callback handler needs beyond the flow itself.
+type oidcDeps struct {
+	flow      *oidc.Flow
+	users     OIDCUserStore
+	audit     AuthAuditWriter
+	cfg       config.OIDCSection
+	jwtSecret string
+	tokenTTL  time.Duration
+	logger    *slog.Logger
+}
+
+// randomURLToken returns a cryptographically random, URL-safe token used for the
+// CSRF state and the ID-token nonce.
+func randomURLToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// setSessionCookie sets the app's _token session cookie server-side, hardened
+// HttpOnly; Secure; SameSite=Lax (D2). Unlike the client-JS cookie the login
+// page sets, this one is never readable by scripts.
+func setSessionCookie(c *gin.Context, token string, ttl time.Duration) {
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie(authTokenCookie, token, int(ttl.Seconds()), "/", "", true, true)
+}
+
+// oidcLoginHandler implements GET /api/v2/auth/oidc/login: it starts the
+// Authorization Code + PKCE flow. It generates the CSRF state, the nonce, and
+// the PKCE verifier, seals them (plus the sanitized post-login target) in a
+// signed HttpOnly state cookie, and redirects the browser to the IdP.
+func oidcLoginHandler(flow *oidc.Flow, logger *slog.Logger) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		state, serr := randomURLToken()
+		nonce, nerr := randomURLToken()
+		if serr != nil || nerr != nil {
+			AbortProblem(c, http.StatusInternalServerError, "internal error", "could not start login")
+			return
+		}
+		verifier := oidc.GenerateCodeVerifier()
+		next := sanitizeNext(c.Query("next"))
+		cookie, err := flow.Codec().Encode(oidc.StatePayload{
+			State: state, Nonce: nonce, Verifier: verifier, Next: next,
+		}, oidc.StateCookieTTL)
+		if err != nil {
+			logger.Error("oidc: encoding state cookie", "error", err)
+			AbortProblem(c, http.StatusInternalServerError, "internal error", "could not start login")
+			return
+		}
+		c.SetSameSite(http.SameSiteLaxMode)
+		c.SetCookie(oidcStateCookie, cookie, int(oidc.StateCookieTTL.Seconds()), "/api/v2/auth/", "", true, true)
+		c.Redirect(http.StatusFound, flow.AuthCodeURL(state, nonce, verifier))
+	}
+}
+
+// oidcCallbackHandler implements GET /api/v2/auth/oidc/callback: it validates the
+// CSRF state, exchanges the code (PKCE + client secret), verifies the ID token
+// (issuer pin, audience, nonce, azp, clock skew, email_verified, tenant pin,
+// email-domain allowlist), resolves or JIT-provisions the user, mints the app's
+// _token session cookie, and redirects. Every terminal path is audited; a
+// verification failure is a 403 that never falls back to a default identity.
+func oidcCallbackHandler(deps oidcDeps) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		payload, ok := deps.readState(c)
+		if !ok {
+			return
+		}
+		// CSRF: the state query param must match the signed cookie.
+		if subtle.ConstantTimeCompare([]byte(c.Query("state")), []byte(payload.State)) != 1 {
+			deps.deny(c, auditOIDCLoginFailure, "", "", "", "state_mismatch")
+			return
+		}
+		// RFC 9207 issuer response param, when the IdP provides it, must be the
+		// pinned issuer (H4/H1).
+		if iss := c.Query("iss"); iss != "" && iss != deps.cfg.Issuer {
+			deps.deny(c, auditOIDCLoginFailure, "", "", "", "iss_param_mismatch")
+			return
+		}
+		// The IdP may redirect back with an error instead of a code.
+		if e := c.Query("error"); e != "" {
+			deps.deny(c, auditOIDCLoginFailure, "", "", "", "idp_error:"+e)
+			return
+		}
+		code := c.Query("code")
+		if code == "" {
+			deps.deny(c, auditOIDCLoginFailure, "", "", "", "missing_code")
+			return
+		}
+		rawIDToken, err := deps.flow.Exchange(c.Request.Context(), code, payload.Verifier)
+		if err != nil {
+			deps.logger.Warn("oidc: code exchange failed", "error", err)
+			deps.deny(c, auditOIDCLoginFailure, "", "", "", "exchange_failed")
+			return
+		}
+		identity, err := deps.flow.Verifier().Verify(c.Request.Context(), rawIDToken, payload.Nonce)
+		if err != nil {
+			deps.rejectVerify(c, err)
+			return
+		}
+		user, err := deps.resolveUser(c, identity)
+		if err != nil {
+			return // resolveUser already audited + wrote the 403
+		}
+		token, terr := auth.MintUserToken(deps.jwtSecret, deps.tokenTTL, *user)
+		if terr != nil {
+			deps.logger.Error("oidc: minting session token", "error", terr)
+			AbortProblem(c, http.StatusInternalServerError, "internal error", "could not mint session")
+			return
+		}
+		setSessionCookie(c, token, deps.tokenTTL)
+		deps.record(c, auditOIDCLoginSuccess, identity.Tenant, user.ID, identity.Email, "success",
+			map[string]string{"subject": identity.Subject})
+		c.Redirect(http.StatusFound, sanitizeNext(payload.Next))
+	}
+}
+
+// readState reads and verifies the signed state cookie. A missing or invalid
+// cookie is a 403 (CSRF/replay), audited.
+func (d oidcDeps) readState(c *gin.Context) (oidc.StatePayload, bool) {
+	cookie, err := c.Request.Cookie(oidcStateCookie)
+	if err != nil || cookie.Value == "" {
+		d.deny(c, auditOIDCLoginFailure, "", "", "", "missing_state")
+		return oidc.StatePayload{}, false
+	}
+	payload, err := d.flow.Codec().Decode(cookie.Value)
+	if err != nil {
+		d.deny(c, auditOIDCLoginFailure, "", "", "", "invalid_state")
+		return oidc.StatePayload{}, false
+	}
+	// The state cookie is single-use for this attempt; clear it regardless of
+	// outcome so it cannot be replayed.
+	c.SetCookie(oidcStateCookie, "", -1, "/api/v2/auth/", "", true, true)
+	return payload, true
+}
+
+// resolveUser turns a verified identity into a Leoflow user, applying the
+// group→role mapping (with the default_role fallback), the JIT policy, and
+// fail-closed role validation. On any rejection it audits and writes the 403,
+// returning errRejected so the caller stops.
+func (d oidcDeps) resolveUser(c *gin.Context, id *oidc.VerifiedIdentity) (*auth.User, error) {
+	ctx := c.Request.Context()
+	loginRoles := oidc.ApplyDefaultRole(oidc.MapRoles(id.Groups, d.cfg.RoleMappings), d.cfg.DefaultRole)
+	// Fail closed on a role name (mapped or default_role) that does not exist for
+	// the tenant, rather than minting a token referencing an unknown role.
+	for _, role := range loginRoles {
+		exists, err := d.users.RoleExists(ctx, id.Tenant, role)
+		if err != nil {
+			d.logger.Error("oidc: checking role", "error", err)
+			d.deny(c, auditOIDCLoginFailure, id.Tenant, "", id.Email, "role_check_failed")
+			return nil, errRejected
+		}
+		if !exists {
+			d.deny(c, auditOIDCLoginFailure, id.Tenant, "", id.Email, "unknown_role:"+role)
+			return nil, errRejected
+		}
+	}
+
+	user, active, err := d.users.FindUserByOIDCSubject(ctx, id.Provider, id.Subject)
+	switch {
+	case err == nil:
+		if !active {
+			d.deny(c, auditOIDCLoginFailure, id.Tenant, user.ID, id.Email, "inactive")
+			return nil, errRejected
+		}
+		// Returning user: token carries the IdP-mapped roles (D5); per-request
+		// reload (PR-A) remains the authority for live permissions.
+		return &auth.User{ID: user.ID, TenantID: id.Tenant, Email: id.Email, Roles: loginRoles}, nil
+	case errors.Is(err, auth.ErrUserNotFound):
+		return d.jitProvision(c, id, loginRoles)
+	default:
+		d.logger.Error("oidc: resolving user", "error", err)
+		d.deny(c, auditOIDCLoginFailure, id.Tenant, "", id.Email, "user_lookup_failed")
+		return nil, errRejected
+	}
+}
+
+// jitProvision handles the no-matching-row case per D4: reject when JIT is off,
+// create the user with the mapped roles when it is on.
+func (d oidcDeps) jitProvision(c *gin.Context, id *oidc.VerifiedIdentity, loginRoles []string) (*auth.User, error) {
+	ctx := c.Request.Context()
+	if !d.cfg.JITProvisioning {
+		d.deny(c, auditOIDCLoginFailure, id.Tenant, "", id.Email, "no_user_jit_off")
+		return nil, errRejected
+	}
+	created, err := d.users.CreateOIDCUser(ctx, id.Tenant, id.Email, id.Provider, id.Subject, loginRoles)
+	if err != nil {
+		if errors.Is(err, domain.ErrValidation) {
+			d.deny(c, auditOIDCLoginFailure, id.Tenant, "", id.Email, "unknown_role")
+			return nil, errRejected
+		}
+		// A concurrent login may have provisioned the same identity first.
+		if errors.Is(err, domain.ErrConflict) {
+			if u, active, ferr := d.users.FindUserByOIDCSubject(ctx, id.Provider, id.Subject); ferr == nil && active {
+				return &auth.User{ID: u.ID, TenantID: id.Tenant, Email: id.Email, Roles: loginRoles}, nil
+			}
+		}
+		d.logger.Error("oidc: jit provisioning", "error", err)
+		d.deny(c, auditOIDCLoginFailure, id.Tenant, "", id.Email, "jit_failed")
+		return nil, errRejected
+	}
+	d.recordCtx(ctx, auditOIDCJITProvision, id.Tenant, created.ID, id.Email, "success",
+		map[string]string{"subject": id.Subject, "roles": strings.Join(loginRoles, ",")})
+	return &auth.User{ID: created.ID, TenantID: id.Tenant, Email: id.Email, Roles: loginRoles}, nil
+}
+
+// errRejected is a sentinel signalling that a helper already wrote the 403 and
+// audited; the caller must simply stop.
+var errRejected = errors.New("oidc: request already rejected")
+
+// rejectVerify maps a verification error to a 403, choosing the audit action so
+// tenant-pin rejections are distinguishable from other verification failures.
+func (d oidcDeps) rejectVerify(c *gin.Context, err error) {
+	action := auditOIDCLoginFailure
+	if errors.Is(err, oidc.ErrTenantNotAllowed) || errors.Is(err, oidc.ErrEmailNotVerified) || errors.Is(err, oidc.ErrEmailDomainNotAllowed) {
+		action = auditOIDCTenantReject
+	}
+	d.deny(c, action, "", "", "", verifyReason(err))
+}
+
+// verifyReason returns a stable, non-secret audit reason for a verification
+// error.
+func verifyReason(err error) string {
+	switch {
+	case errors.Is(err, oidc.ErrIssuerMismatch):
+		return "issuer_mismatch"
+	case errors.Is(err, oidc.ErrNonceMismatch):
+		return "nonce_mismatch"
+	case errors.Is(err, oidc.ErrAzpMismatch):
+		return "azp_mismatch"
+	case errors.Is(err, oidc.ErrTokenExpired):
+		return "token_expired"
+	case errors.Is(err, oidc.ErrEmailNotVerified):
+		return "email_not_verified"
+	case errors.Is(err, oidc.ErrTenantNotAllowed):
+		return "tenant_not_allowed"
+	case errors.Is(err, oidc.ErrEmailDomainNotAllowed):
+		return "email_domain_not_allowed"
+	default:
+		return "token_invalid"
+	}
+}
+
+// deny audits a failed login (outcome "denied", with a non-secret reason) and
+// writes the 403. Every fail-closed path funnels through here so a rejection is
+// always both recorded and answered — never a silent fall-through.
+func (d oidcDeps) deny(c *gin.Context, action, tenant, userID, email, reason string) {
+	d.recordCtx(c.Request.Context(), action, tenant, userID, email, "denied", map[string]string{"reason": reason})
+	AbortProblem(c, http.StatusForbidden, "forbidden", "single sign-on was rejected")
+}
+
+// record audits an event using the request context.
+func (d oidcDeps) record(c *gin.Context, action, tenant, userID, email, outcome string, extra map[string]string) {
+	d.recordCtx(c.Request.Context(), action, tenant, userID, email, outcome, extra)
+}
+
+// recordCtx writes one audit event, best-effort: a sink error is logged and
+// dropped so it never changes the auth outcome.
+func (d oidcDeps) recordCtx(ctx context.Context, action, tenant, userID, email, outcome string, extra map[string]string) {
+	if d.audit == nil {
+		return
+	}
+	if err := d.audit.RecordAuthEvent(ctx, tenant, userID, action, email, outcome, extra); err != nil {
+		d.logger.Error("oidc: recording audit event", "action", action, "error", err)
+	}
+}

--- a/internal/api/oidc_reconcile_test.go
+++ b/internal/api/oidc_reconcile_test.go
@@ -1,0 +1,141 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+)
+
+// TestOIDCReturningUserReconcilesToMappedRoles proves the IdP is authoritative
+// for a returning user: a user previously granted [operator] whose IdP groups now
+// map to [viewer] has the DB roles reconciled to exactly [viewer] on login, and
+// the minted token carries the same set. The demotion therefore takes effect for
+// the per-request authz reload, not just the token.
+func TestOIDCReturningUserReconcilesToMappedRoles(t *testing.T) {
+	f := newFakeIDP(t)
+	cfg := baseOIDCConfig(f)
+	cfg.RoleMappings = map[string]string{"data-eng": "viewer"} // group now maps to viewer
+	store := newFakeOIDCStore()
+	store.seed(cfg.Issuer, "subject-123", &auth.User{ID: "user-1", TenantID: "default", Email: "alice@corp.example", Roles: []string{"operator"}}, true)
+	srv := oidcServer(t, f, cfg, store, &fakeAuthAudit{}, nil)
+
+	rec := driveCallback(t, srv, f, cfg, nil) // groups: [data-eng]
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("callback = %d, want 302", rec.Code)
+	}
+	roles, ok := store.lastReconcile("user-1")
+	if !ok {
+		t.Fatal("returning user was not reconciled")
+	}
+	if len(roles) != 1 || roles[0] != "viewer" {
+		t.Errorf("reconciled roles = %v, want [viewer] (IdP-authoritative demotion)", roles)
+	}
+	if ck := sessionCookie(rec); ck == nil {
+		t.Fatal("no session cookie")
+	} else if tr := tokenRoles(t, ck.Value); len(tr) != 1 || tr[0] != "viewer" {
+		t.Errorf("token roles = %v, want [viewer]", tr)
+	}
+}
+
+// TestOIDCReturningUserEmptyMappingWithDefaultRole proves a returning user whose
+// groups map to no role is reconciled to [default_role] when one is set.
+func TestOIDCReturningUserEmptyMappingWithDefaultRole(t *testing.T) {
+	f := newFakeIDP(t)
+	cfg := baseOIDCConfig(f)
+	cfg.DefaultRole = "viewer"
+	store := newFakeOIDCStore()
+	store.seed(cfg.Issuer, "subject-123", &auth.User{ID: "user-1", TenantID: "default", Email: "alice@corp.example", Roles: []string{"operator"}}, true)
+	srv := oidcServer(t, f, cfg, store, &fakeAuthAudit{}, nil)
+
+	rec := driveCallback(t, srv, f, cfg, func(c jwt.MapClaims) { c["groups"] = []string{"unmapped-group"} })
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("callback = %d, want 302", rec.Code)
+	}
+	roles, ok := store.lastReconcile("user-1")
+	if !ok || len(roles) != 1 || roles[0] != "viewer" {
+		t.Errorf("reconciled roles = %v (found=%v), want [viewer] via default_role", roles, ok)
+	}
+}
+
+// TestOIDCReturningUserEmptyMappingNoDefaultRole proves a returning user whose
+// groups map to no role and with no default_role is reconciled to the empty set
+// (default-deny) — a prior grant is stripped.
+func TestOIDCReturningUserEmptyMappingNoDefaultRole(t *testing.T) {
+	f := newFakeIDP(t)
+	cfg := baseOIDCConfig(f)
+	cfg.DefaultRole = ""
+	store := newFakeOIDCStore()
+	store.seed(cfg.Issuer, "subject-123", &auth.User{ID: "user-1", TenantID: "default", Email: "alice@corp.example", Roles: []string{"operator"}}, true)
+	srv := oidcServer(t, f, cfg, store, &fakeAuthAudit{}, nil)
+
+	rec := driveCallback(t, srv, f, cfg, func(c jwt.MapClaims) { c["groups"] = []string{"unmapped-group"} })
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("callback = %d, want 302", rec.Code)
+	}
+	roles, ok := store.lastReconcile("user-1")
+	if !ok {
+		t.Fatal("returning user was not reconciled")
+	}
+	if len(roles) != 0 {
+		t.Errorf("reconciled roles = %v, want [] (default-deny)", roles)
+	}
+}
+
+// TestOIDCJITUserAlsoReconciles proves reconciliation runs for the JIT path too,
+// with the same mapped set the account was created with — so both paths converge
+// on identical DB state.
+func TestOIDCJITUserAlsoReconciles(t *testing.T) {
+	f := newFakeIDP(t)
+	cfg := baseOIDCConfig(f)
+	cfg.JITProvisioning = true
+	store := newFakeOIDCStore()
+	srv := oidcServer(t, f, cfg, store, &fakeAuthAudit{}, nil)
+
+	rec := driveCallback(t, srv, f, cfg, nil) // groups [data-eng] → editor
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("callback = %d, want 302", rec.Code)
+	}
+	if len(store.created) != 1 {
+		t.Fatalf("JIT created %d users, want 1", len(store.created))
+	}
+	roles, ok := store.lastReconcile("jit-subject-123")
+	if !ok {
+		t.Fatal("JIT-created user was not reconciled")
+	}
+	if len(roles) != 1 || roles[0] != "editor" {
+		t.Errorf("reconciled roles = %v, want [editor]", roles)
+	}
+}
+
+// TestOIDCReconcileFailureFailsClosed proves a reconcile error rejects the login:
+// no session cookie is minted and the failure is audited, so a role write that
+// cannot be applied never yields a token whose roles the DB does not back.
+func TestOIDCReconcileFailureFailsClosed(t *testing.T) {
+	f := newFakeIDP(t)
+	cfg := baseOIDCConfig(f)
+	store := newFakeOIDCStore()
+	store.seed(cfg.Issuer, "subject-123", &auth.User{ID: "user-1", TenantID: "default", Email: "alice@corp.example", Roles: []string{"editor"}}, true)
+	store.reconcileErr = errors.New("db unavailable")
+	audit := &fakeAuthAudit{}
+	srv := oidcServer(t, f, cfg, store, audit, nil)
+
+	rec := driveCallback(t, srv, f, cfg, nil)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("reconcile failure = %d, want 403 (fail closed)", rec.Code)
+	}
+	if sessionCookie(rec) != nil {
+		t.Error("a failed reconcile must NOT mint a session cookie")
+	}
+	if !audit.has(auditOIDCLoginFailure, "denied") {
+		t.Error("the reconcile failure was not audited")
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -5,11 +5,15 @@ import (
 	"log/slog"
 	"net/http"
 
+	"time"
+
 	"github.com/gin-gonic/gin"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/config"
+	"github.com/neochaotic/leoflow/internal/oidc"
 )
 
 // UIServer serves the embedded single-page app: static assets and an
@@ -99,6 +103,23 @@ type Dependencies struct {
 
 	// UI serves the embedded SPA. When nil the server is API-only.
 	UI UIServer
+
+	// OIDC wiring (registered only when OIDCFlow is non-nil — provider: oidc).
+	// The JWT authenticator above stays the request-path verifier in both modes.
+	//
+	// OIDCFlow is the discovered Authorization Code + PKCE flow; nil in JWT mode,
+	// in which case the /api/v2/auth/oidc/* routes are not registered.
+	OIDCFlow *oidc.Flow
+	// OIDCSettings carries the role mappings, JIT policy, default_role, and
+	// break-glass allowlist the login flow and the credential gate read.
+	OIDCSettings config.OIDCSection
+	// OIDCUsers resolves and JIT-provisions OIDC identities (the storage repo).
+	OIDCUsers OIDCUserStore
+	// AuthAudit records authentication events (login, tenant-pin rejection, JIT,
+	// break-glass, logout) to the audit sink.
+	AuthAudit AuthAuditWriter
+	// JWTSecret is the HS256 secret the OIDC callback mints the app's _token with.
+	JWTSecret string
 }
 
 // NewServer builds the gin engine with the full middleware chain, health and
@@ -141,10 +162,28 @@ func NewServer(deps Dependencies) *gin.Engine {
 	// public API/UI surface. deps.Registry is retained for that listener's wiring.
 	registerDocs(r)
 
-	r.POST("/auth/token", authTokenHandler(deps.Authenticator, deps.RateLimiter, deps.TokenTTLSecs))
+	// Under OIDC the credential path is break-glass-only (D8): pass the allowlist
+	// so every non-allowlisted password login is rejected and audited. In JWT mode
+	// the allowlist is empty, newBreakGlass returns nil, and the path is unchanged.
+	bg := newBreakGlass(deps.OIDCSettings.BreakGlassEmails, deps.AuthAudit)
+	r.POST("/auth/token", authTokenHandler(deps.Authenticator, deps.RateLimiter, deps.TokenTTLSecs, bg))
 	// The Airflow UI redirects unauthenticated users to GET /api/v2/auth/login.
 	r.GET("/api/v2/auth/login", loginPageHandler())
 	r.GET("/api/v2/auth/logout", logoutHandler())
+	// OIDC/SSO login flow (D1): registered only when a provider was discovered at
+	// boot. Both routes sit under the public /api/v2/auth/ prefix.
+	if deps.OIDCFlow != nil {
+		r.GET("/api/v2/auth/oidc/login", oidcLoginHandler(deps.OIDCFlow, deps.Logger))
+		r.GET("/api/v2/auth/oidc/callback", oidcCallbackHandler(oidcDeps{
+			flow:      deps.OIDCFlow,
+			users:     deps.OIDCUsers,
+			audit:     deps.AuthAudit,
+			cfg:       deps.OIDCSettings,
+			jwtSecret: deps.JWTSecret,
+			tokenTTL:  time.Duration(deps.TokenTTLSecs) * time.Second,
+			logger:    deps.Logger,
+		}))
+	}
 	r.GET("/api/v2/monitor/health", monitorHealthHandler(deps.HealthChecks, deps.SchedulerHealth))
 	r.GET("/api/v2/monitor/executor", monitorExecutorHandler(deps.ExecutorInfo))
 

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -335,6 +335,15 @@ type OIDCSection struct {
 	// TenantClaims maps a TenantClaim value to a Leoflow tenant name. A value not
 	// present here is rejected (403) — the login never falls back to "default".
 	TenantClaims map[string]string `mapstructure:"tenant_claims"`
+	// AllowedEmailDomains is an install-time, login-level allowlist layered on TOP
+	// of the tid/hd tenant pin — it is NOT the pin itself (that stays issuer +
+	// tid/hd + email_verified per D6). The check runs only AFTER the pin and
+	// email_verified==true have passed, so the email domain is trustworthy at that
+	// point. Empty (the default) imposes no domain restriction — the tid/hd pin is
+	// the sole boundary. Non-empty admits a login (pre-provisioned OR JIT) only
+	// when the verified email's domain is in the list; every other login is
+	// rejected 403. It gates EVERY OIDC login, not just auto-provisioning.
+	AllowedEmailDomains []string `mapstructure:"allowed_email_domains"`
 	// BreakGlassEmails is the allowlist of local password logins permitted while
 	// provider is "oidc"; every other password login is rejected (SSO-only).
 	BreakGlassEmails []string `mapstructure:"break_glass_emails"`
@@ -412,21 +421,22 @@ var serverDefaults = map[string]any{
 	// slice leaves are config-file / Helm-values driven — viper does not split a
 	// single env var into a map or list — but they must appear here so Unmarshal
 	// resolves them from the file.
-	"auth.oidc.issuer":             "",
-	"auth.oidc.client_id":          "",
-	"auth.oidc.client_secret":      "",
-	"auth.oidc.redirect_url":       "",
-	"auth.oidc.scopes":             []string{"openid", "email", "profile"},
-	"auth.oidc.groups_claim":       "groups",
-	"auth.oidc.role_mappings":      map[string]string{},
-	"auth.oidc.default_role":       "",
-	"auth.oidc.tenant_claim":       "",
-	"auth.oidc.tenant_claims":      map[string]string{},
-	"auth.oidc.break_glass_emails": []string{},
-	"auth.oidc.jit_provisioning":   false,
-	"auth.oidc.clock_skew_seconds": 60,
-	"scheduler.loop_interval_ms":       1000,
-	"scheduler.enabled":                true,
+	"auth.oidc.issuer":                "",
+	"auth.oidc.client_id":             "",
+	"auth.oidc.client_secret":         "",
+	"auth.oidc.redirect_url":          "",
+	"auth.oidc.scopes":                []string{"openid", "email", "profile"},
+	"auth.oidc.groups_claim":          "groups",
+	"auth.oidc.role_mappings":         map[string]string{},
+	"auth.oidc.default_role":          "",
+	"auth.oidc.tenant_claim":          "",
+	"auth.oidc.tenant_claims":         map[string]string{},
+	"auth.oidc.allowed_email_domains": []string{},
+	"auth.oidc.break_glass_emails":    []string{},
+	"auth.oidc.jit_provisioning":      false,
+	"auth.oidc.clock_skew_seconds":    60,
+	"scheduler.loop_interval_ms":      1000,
+	"scheduler.enabled":               true,
 	// Default: synchronous dispatch (BufferSize=0). Safe and zero-overhead for
 	// Lite. Pro deployments should set buffer_size>=1 + workers>=1 in their
 	// values.yaml so K8s API latency does not stretch the tick (#127, ADR 0031).

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -626,10 +626,7 @@ func (c *ServerConfig) validateOIDC() error {
 	if !strings.HasPrefix(c.Auth.OIDC.Issuer, "https://") {
 		return fmt.Errorf("auth.oidc.issuer must be an https:// URL (got %q)", c.Auth.OIDC.Issuer)
 	}
-	if err := validateRedirectURL(c.Auth.OIDC.RedirectURL); err != nil {
-		return err
-	}
-	return nil
+	return validateRedirectURL(c.Auth.OIDC.RedirectURL)
 }
 
 // validateRedirectURL requires the OIDC callback URL to use https so the

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/url"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -625,7 +626,43 @@ func (c *ServerConfig) validateOIDC() error {
 	if !strings.HasPrefix(c.Auth.OIDC.Issuer, "https://") {
 		return fmt.Errorf("auth.oidc.issuer must be an https:// URL (got %q)", c.Auth.OIDC.Issuer)
 	}
+	if err := validateRedirectURL(c.Auth.OIDC.RedirectURL); err != nil {
+		return err
+	}
 	return nil
+}
+
+// validateRedirectURL requires the OIDC callback URL to use https so the
+// authorization code is never returned over plaintext, with an http exception
+// for loopback hosts (localhost, 127.0.0.1, [::1]) to keep local dev workable.
+func validateRedirectURL(raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("auth.oidc.redirect_url must be a valid URL (got %q): %w", raw, err)
+	}
+	switch u.Scheme {
+	case "https":
+		return nil
+	case "http":
+		if isLoopbackHost(u.Hostname()) {
+			return nil
+		}
+		return fmt.Errorf("auth.oidc.redirect_url must be an https:// URL (got %q); http:// is only allowed for loopback hosts (localhost, 127.0.0.1, [::1])", raw)
+	default:
+		return fmt.Errorf("auth.oidc.redirect_url must be an https:// URL (got %q)", raw)
+	}
+}
+
+// isLoopbackHost reports whether host is a loopback name or address. url.Hostname
+// strips the brackets from an IPv6 literal, so [::1] arrives as "::1".
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 // validateRole rejects an unknown server.role (ADR 0049). Empty is valid (defaults

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -268,6 +268,10 @@ type RedisSection struct {
 type AuthSection struct {
 	Provider string     `mapstructure:"provider"`
 	JWT      JWTSection `mapstructure:"jwt"`
+	// OIDC configures the OIDC/SSO login flow. It is read only when Provider is
+	// "oidc" (Pro-gated); the JWT authenticator remains the request-path verifier
+	// in both modes.
+	OIDC OIDCSection `mapstructure:"oidc"`
 	// DevNoAuth disables authentication entirely, treating every request as an
 	// admin. It exists ONLY for `leoflow dev` (local, unsandboxed). It is false by
 	// default and the server logs a prominent warning when it is on. NEVER set
@@ -284,6 +288,64 @@ type AuthSection struct {
 type JWTSection struct {
 	Secret          string `mapstructure:"secret"`
 	TokenTTLSeconds int    `mapstructure:"token_ttl_seconds"`
+}
+
+// OIDCSection configures the OIDC/SSO login flow (Authorization Code + PKCE).
+// It is read only when auth.provider is "oidc", which is Pro-gated and fails
+// boot closed unless Issuer, ClientID, and RedirectURL are all set.
+//
+// Verification is keyless: the ID token is validated against the issuer's
+// public JWKS discovered from Issuer, so no secret is stored for the verify
+// path. ClientSecret is used solely for the authorization-code exchange and is
+// injected via LEOFLOW_AUTH_OIDC_CLIENT_SECRET (env, never persisted, never
+// logged) — the same posture as the JWT secret.
+type OIDCSection struct {
+	// Issuer is the org's single-tenant issuer URL (https). It is pinned: any ID
+	// token whose iss claim differs is rejected (fail-closed tenant pin).
+	Issuer string `mapstructure:"issuer"`
+	// ClientID is the registered application (client) id; it is the expected
+	// audience of every ID token.
+	ClientID string `mapstructure:"client_id"`
+	// ClientSecret is used only for the code exchange. Set via
+	// LEOFLOW_AUTH_OIDC_CLIENT_SECRET; never persist it in a config file.
+	ClientSecret string `mapstructure:"client_secret"`
+	// RedirectURL is this server's callback URL registered with the IdP
+	// (…/api/v2/auth/oidc/callback).
+	RedirectURL string `mapstructure:"redirect_url"`
+	// Scopes are the OAuth scopes requested; defaults to openid, email, profile.
+	// Add the IdP's groups scope here when group→role mapping is used.
+	Scopes []string `mapstructure:"scopes"`
+	// GroupsClaim is the ID-token claim carrying the user's IdP groups (default
+	// "groups"). Its values drive RoleMappings.
+	GroupsClaim string `mapstructure:"groups_claim"`
+	// RoleMappings maps an IdP group value to an existing Leoflow role name.
+	// Default-DENY: a group with no mapping grants no role. Configure via the
+	// config file / Helm values (maps do not bind from a single env var).
+	RoleMappings map[string]string `mapstructure:"role_mappings"`
+	// DefaultRole softens the default-deny WITHOUT weakening the secure default:
+	// when an authenticated user resolves to zero mapped roles and DefaultRole is
+	// set, they are granted this single role (operators are advised to use a
+	// read-only role such as "viewer"). Empty (the default) keeps strict
+	// default-deny — an unmapped user gets no role. It must name an existing DB
+	// role for the resolved tenant; an unknown role fails the login closed.
+	DefaultRole string `mapstructure:"default_role"`
+	// TenantClaim selects which IdP claim identifies the tenant: "tid" (Entra) or
+	// "hd" (Google Workspace).
+	TenantClaim string `mapstructure:"tenant_claim"`
+	// TenantClaims maps a TenantClaim value to a Leoflow tenant name. A value not
+	// present here is rejected (403) — the login never falls back to "default".
+	TenantClaims map[string]string `mapstructure:"tenant_claims"`
+	// BreakGlassEmails is the allowlist of local password logins permitted while
+	// provider is "oidc"; every other password login is rejected (SSO-only).
+	BreakGlassEmails []string `mapstructure:"break_glass_emails"`
+	// JITProvisioning creates a user row on first OIDC login when no matching one
+	// exists. OFF by default (a pre-provisioned user is required); when ON, the new
+	// row is granted the roles from RoleMappings.
+	JITProvisioning bool `mapstructure:"jit_provisioning"`
+	// ClockSkewSeconds is the tolerance applied to the ID token's exp/iat/nbf
+	// checks to absorb small clock differences between the IdP and this server.
+	// Defaults to 60.
+	ClockSkewSeconds int `mapstructure:"clock_skew_seconds"`
 }
 
 // SchedulerSection configures the scheduler loop.
@@ -345,6 +407,24 @@ var serverDefaults = map[string]any{
 	"auth.jwt.secret":                  "",
 	"auth.jwt.token_ttl_seconds":       3600,
 	"auth.login_rate_limit_per_minute": 5,
+	// OIDC leaves. Every leaf is registered so viper's AutomaticEnv binds the
+	// scalar LEOFLOW_AUTH_OIDC_* env vars (notably the client secret). The map and
+	// slice leaves are config-file / Helm-values driven — viper does not split a
+	// single env var into a map or list — but they must appear here so Unmarshal
+	// resolves them from the file.
+	"auth.oidc.issuer":             "",
+	"auth.oidc.client_id":          "",
+	"auth.oidc.client_secret":      "",
+	"auth.oidc.redirect_url":       "",
+	"auth.oidc.scopes":             []string{"openid", "email", "profile"},
+	"auth.oidc.groups_claim":       "groups",
+	"auth.oidc.role_mappings":      map[string]string{},
+	"auth.oidc.default_role":       "",
+	"auth.oidc.tenant_claim":       "",
+	"auth.oidc.tenant_claims":      map[string]string{},
+	"auth.oidc.break_glass_emails": []string{},
+	"auth.oidc.jit_provisioning":   false,
+	"auth.oidc.clock_skew_seconds": 60,
 	"scheduler.loop_interval_ms":       1000,
 	"scheduler.enabled":                true,
 	// Default: synchronous dispatch (BufferSize=0). Safe and zero-overhead for
@@ -423,15 +503,14 @@ func LoadServer(configFile string, flags *pflag.FlagSet) (*ServerConfig, error) 
 	return &c, nil
 }
 
-// Auth providers (auth.provider allowlist). "jwt" is the only implemented
-// authenticator; "oidc" is a recognized-but-unimplemented value that is
-// rejected at boot rather than silently falling back to JWT.
+// Auth providers (auth.provider allowlist). "jwt" is the default credential
+// authenticator; "oidc" adds the SSO login flow on top of it (the JWT
+// authenticator stays the request-path verifier in both modes).
 const (
-	// AuthProviderJWT is the only auth.provider main.go can build an
-	// Authenticator for today.
+	// AuthProviderJWT is the default: username/password issues an HS256 token.
 	AuthProviderJWT = "jwt"
-	// AuthProviderOIDC is a declared future provider with no implementation;
-	// selecting it is a boot failure, not a silent JWT fallback.
+	// AuthProviderOIDC enables the OIDC/SSO login flow. It is Pro-gated and
+	// requires the auth.oidc.* configuration; boot fails closed otherwise.
 	AuthProviderOIDC = "oidc"
 )
 
@@ -446,7 +525,9 @@ func (c *ServerConfig) Validate() error {
 	if err := c.validateLogs(); err != nil {
 		return err
 	}
-	if c.Auth.Provider == AuthProviderJWT && c.Auth.JWT.Secret == "" {
+	// Both providers mint the app's own HS256 _token (oidc mints it after the IdP
+	// verify), so the JWT secret is required for either.
+	if (c.Auth.Provider == AuthProviderJWT || c.Auth.Provider == AuthProviderOIDC) && c.Auth.JWT.Secret == "" {
 		return errors.New("auth.jwt.secret is required (set LEOFLOW_AUTH_JWT_SECRET)")
 	}
 	// auth.dev_no_auth disables authentication entirely; permit it only when the
@@ -490,22 +571,51 @@ func (c *ServerConfig) validateLogs() error {
 	}
 }
 
-// validateProvider rejects an unknown or unimplemented auth.provider, failing
-// closed at boot instead of letting main.go build a JWTAuthenticator regardless
-// of what was configured. Empty is valid: serverDefaults sets auth.provider to
-// "jwt", so an unset provider in an existing config keeps defaulting to JWT and
-// is unaffected. "oidc" is recognized but has no implementation, so it is
-// rejected with an actionable hint rather than a silent JWT fallback.
+// validateProvider rejects an unknown auth.provider, failing closed at boot
+// instead of letting main.go build an authenticator regardless of what was
+// configured. Empty is valid: serverDefaults sets auth.provider to "jwt", so an
+// unset provider in an existing config keeps defaulting to JWT and is
+// unaffected. "oidc" is valid only when its Pro-gated prerequisites are met
+// (validateOIDC); anything else is a loud boot failure.
 func (c *ServerConfig) validateProvider() error {
 	switch c.Auth.Provider {
 	case "", AuthProviderJWT:
 		return nil
 	case AuthProviderOIDC:
-		return errors.New("auth.provider: oidc is declared but not yet implemented; set provider: jwt")
+		return c.validateOIDC()
 	default:
-		return fmt.Errorf("invalid auth.provider %q: must be %q (or empty = %q)",
-			c.Auth.Provider, AuthProviderJWT, AuthProviderJWT)
+		return fmt.Errorf("invalid auth.provider %q: must be %q or %q (or empty = %q)",
+			c.Auth.Provider, AuthProviderJWT, AuthProviderOIDC, AuthProviderJWT)
 	}
+}
+
+// validateOIDC enforces the fail-closed prerequisites for auth.provider: oidc
+// (D7): the Pro edition, and the three fields the login flow cannot run without
+// (issuer, client_id, redirect_url). The issuer must be https so discovery and
+// JWKS are fetched over TLS (keyless verify, ADR 0035). A misconfigured OIDC
+// deployment fails boot with an actionable message rather than starting a login
+// flow that cannot complete.
+func (c *ServerConfig) validateOIDC() error {
+	if c.UI.Edition != "pro" {
+		return errors.New("auth.provider: oidc requires the Pro edition (set ui.edition: pro)")
+	}
+	var missing []string
+	if c.Auth.OIDC.Issuer == "" {
+		missing = append(missing, "auth.oidc.issuer")
+	}
+	if c.Auth.OIDC.ClientID == "" {
+		missing = append(missing, "auth.oidc.client_id")
+	}
+	if c.Auth.OIDC.RedirectURL == "" {
+		missing = append(missing, "auth.oidc.redirect_url")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("auth.provider: oidc requires %s to be set", strings.Join(missing, ", "))
+	}
+	if !strings.HasPrefix(c.Auth.OIDC.Issuer, "https://") {
+		return fmt.Errorf("auth.oidc.issuer must be an https:// URL (got %q)", c.Auth.OIDC.Issuer)
+	}
+	return nil
 }
 
 // validateRole rejects an unknown server.role (ADR 0049). Empty is valid (defaults

--- a/internal/config/server_test.go
+++ b/internal/config/server_test.go
@@ -237,6 +237,42 @@ func TestServerConfigValidateOIDCRequiresHTTPSIssuer(t *testing.T) {
 	}
 }
 
+// TestServerConfigValidateOIDCRedirectURLScheme locks that the callback URL the
+// browser is redirected to (and where the IdP posts the code back) is https,
+// except for loopback hosts which may use http for local dev. A plaintext
+// redirect to a non-loopback host would expose the code in transit, so it fails
+// boot closed.
+func TestServerConfigValidateOIDCRedirectURLScheme(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{"https non-loopback ok", "https://app.example.com/api/v2/auth/oidc/callback", false},
+		{"http localhost ok", "http://localhost:8080/api/v2/auth/oidc/callback", false},
+		{"http 127.0.0.1 ok", "http://127.0.0.1:8080/api/v2/auth/oidc/callback", false},
+		{"http ipv6 loopback ok", "http://[::1]:8080/api/v2/auth/oidc/callback", false},
+		{"https localhost ok", "https://localhost:8080/api/v2/auth/oidc/callback", false},
+		{"http non-loopback rejected", "http://app.example.com/api/v2/auth/oidc/callback", true},
+		{"non-url rejected", "not-a-url", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := validOIDCConfig()
+			c.Auth.OIDC.RedirectURL = tc.url
+			err := c.Validate()
+			if tc.wantErr && err == nil {
+				t.Fatalf("Validate() = nil for redirect_url %q, want error", tc.url)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("Validate() = %v for redirect_url %q, want nil", err, tc.url)
+			}
+			if tc.wantErr && err != nil && !strings.Contains(err.Error(), "auth.oidc.redirect_url") {
+				t.Errorf("error = %q, want it to name auth.oidc.redirect_url", err.Error())
+			}
+		})
+	}
+}
+
 // TestServerConfigValidateOIDCRequiresJWTSecret locks that oidc still needs the
 // JWT secret, because the callback mints the app's own HS256 _token.
 func TestServerConfigValidateOIDCRequiresJWTSecret(t *testing.T) {

--- a/internal/config/server_test.go
+++ b/internal/config/server_test.go
@@ -147,7 +147,7 @@ func TestServerConfigValidateProviderAllowlist(t *testing.T) {
 		{"unset defaults to jwt", "", "set", false},
 		{"jwt with secret", "jwt", "set", false},
 		{"jwt without secret", "jwt", "", true},
-		{"oidc known but unimplemented", "oidc", "set", true},
+		{"oidc without pro edition or fields", "oidc", "set", true},
 		{"garbage unknown provider", "garbage", "set", true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -165,19 +165,85 @@ func TestServerConfigValidateProviderAllowlist(t *testing.T) {
 	}
 }
 
-// TestServerConfigValidateOIDCMessage locks the actionable hint for the known
-// but unimplemented oidc provider, so an operator is told to switch to jwt
-// rather than left guessing why boot failed.
-func TestServerConfigValidateOIDCMessage(t *testing.T) {
+// validOIDCConfig returns a ServerConfig that passes the OIDC boot gate: Pro
+// edition, a JWT secret (oidc still mints the app's own _token), and the three
+// required oidc fields with an https issuer.
+func validOIDCConfig() *ServerConfig {
 	c := &ServerConfig{}
 	c.Auth.Provider = "oidc"
 	c.Auth.JWT.Secret = "set"
+	c.UI.Edition = "pro"
+	c.Auth.OIDC.Issuer = "https://idp.example.com"
+	c.Auth.OIDC.ClientID = "client-123"
+	c.Auth.OIDC.RedirectURL = "https://app.example.com/api/v2/auth/oidc/callback"
+	return c
+}
+
+// TestServerConfigValidateOIDCPassesWhenComplete locks that a fully-configured,
+// Pro-edition OIDC deployment boots.
+func TestServerConfigValidateOIDCPassesWhenComplete(t *testing.T) {
+	if err := validOIDCConfig().Validate(); err != nil {
+		t.Errorf("Validate() = %v for a complete Pro OIDC config, want nil", err)
+	}
+}
+
+// TestServerConfigValidateOIDCRequiresPro locks D7: provider oidc without the
+// Pro edition fails boot closed.
+func TestServerConfigValidateOIDCRequiresPro(t *testing.T) {
+	c := validOIDCConfig()
+	c.UI.Edition = ""
 	err := c.Validate()
 	if err == nil {
-		t.Fatal("Validate() = nil for oidc provider, want error")
+		t.Fatal("Validate() = nil for oidc without Pro edition, want error")
 	}
-	if !strings.Contains(err.Error(), "not yet implemented") {
-		t.Errorf("oidc error = %q, want it to mention it is not yet implemented", err.Error())
+	if !strings.Contains(err.Error(), "Pro edition") {
+		t.Errorf("error = %q, want it to mention the Pro edition", err.Error())
+	}
+}
+
+// TestServerConfigValidateOIDCRequiresFields locks D7: each missing required
+// oidc field fails boot closed and names the offending key.
+func TestServerConfigValidateOIDCRequiresFields(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mut  func(*ServerConfig)
+		want string
+	}{
+		{"missing issuer", func(c *ServerConfig) { c.Auth.OIDC.Issuer = "" }, "auth.oidc.issuer"},
+		{"missing client_id", func(c *ServerConfig) { c.Auth.OIDC.ClientID = "" }, "auth.oidc.client_id"},
+		{"missing redirect_url", func(c *ServerConfig) { c.Auth.OIDC.RedirectURL = "" }, "auth.oidc.redirect_url"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := validOIDCConfig()
+			tc.mut(c)
+			err := c.Validate()
+			if err == nil {
+				t.Fatalf("Validate() = nil with %s, want error", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want it to name %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// TestServerConfigValidateOIDCRequiresHTTPSIssuer locks that a non-https issuer
+// is rejected: discovery and JWKS must be fetched over TLS (keyless verify).
+func TestServerConfigValidateOIDCRequiresHTTPSIssuer(t *testing.T) {
+	c := validOIDCConfig()
+	c.Auth.OIDC.Issuer = "http://idp.example.com"
+	if err := c.Validate(); err == nil {
+		t.Error("Validate() = nil for an http:// issuer, want error")
+	}
+}
+
+// TestServerConfigValidateOIDCRequiresJWTSecret locks that oidc still needs the
+// JWT secret, because the callback mints the app's own HS256 _token.
+func TestServerConfigValidateOIDCRequiresJWTSecret(t *testing.T) {
+	c := validOIDCConfig()
+	c.Auth.JWT.Secret = ""
+	if err := c.Validate(); err == nil {
+		t.Error("Validate() = nil for oidc without a JWT secret, want error")
 	}
 }
 

--- a/internal/oidc/flow.go
+++ b/internal/oidc/flow.go
@@ -1,0 +1,90 @@
+package oidc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	gooidc "github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
+
+	"github.com/neochaotic/leoflow/internal/config"
+)
+
+// StateCookieTTL bounds how long a login may sit at the IdP before the callback
+// must arrive. Short enough to limit the replay window on the signed state
+// cookie, long enough for a human to complete an MFA prompt.
+const StateCookieTTL = 10 * time.Minute
+
+// ErrNoIDToken is returned when the token endpoint's response carries no
+// id_token — a misbehaving or misconfigured IdP. The login fails closed rather
+// than proceeding without an identity to verify.
+var ErrNoIDToken = errors.New("oidc: token response has no id_token")
+
+// Flow drives the Authorization Code + PKCE login: it builds the authorization
+// redirect, exchanges the code for tokens (using the client secret and the PKCE
+// verifier), and exposes the keyless ID-token Verifier. Discovery runs once at
+// construction and pins the issuer.
+type Flow struct {
+	oauth    *oauth2.Config
+	verifier *Verifier
+	codec    *StateCodec
+	cfg      config.OIDCSection
+}
+
+// NewFlow discovers the issuer, pins it, and assembles the OAuth2 client and the
+// ID-token verifier. hs256Secret is the app secret the state cookie is signed
+// with (a derived key). It returns an error if discovery fails, so a
+// misconfigured issuer is a boot failure rather than a per-login surprise.
+func NewFlow(ctx context.Context, cfg config.OIDCSection, hs256Secret string) (*Flow, error) {
+	provider, err := gooidc.NewProvider(ctx, cfg.Issuer)
+	if err != nil {
+		return nil, fmt.Errorf("oidc discovery for %q: %w", cfg.Issuer, err)
+	}
+	return &Flow{
+		oauth: &oauth2.Config{
+			ClientID:     cfg.ClientID,
+			ClientSecret: cfg.ClientSecret,
+			Endpoint:     provider.Endpoint(),
+			RedirectURL:  cfg.RedirectURL,
+			Scopes:       cfg.Scopes,
+		},
+		verifier: newVerifierWithProvider(provider, cfg),
+		codec:    NewStateCodec(hs256Secret),
+		cfg:      cfg,
+	}, nil
+}
+
+// Codec returns the state-cookie codec so the caller can encode the cookie on
+// login and decode it on callback.
+func (f *Flow) Codec() *StateCodec { return f.codec }
+
+// Verifier returns the ID-token verifier.
+func (f *Flow) Verifier() *Verifier { return f.verifier }
+
+// AuthCodeURL builds the authorization redirect for the given CSRF state, ID
+// token nonce, and PKCE verifier. The verifier is sent as an S256 challenge
+// (never in the clear); the nonce is echoed back in the ID token and checked on
+// callback.
+func (f *Flow) AuthCodeURL(state, nonce, verifier string) string {
+	return f.oauth.AuthCodeURL(state,
+		gooidc.Nonce(nonce),
+		oauth2.S256ChallengeOption(verifier),
+	)
+}
+
+// Exchange trades the authorization code for tokens (proving possession of the
+// PKCE verifier and the client secret) and returns the raw ID token for
+// verification. A response without an id_token fails closed.
+func (f *Flow) Exchange(ctx context.Context, code, verifier string) (string, error) {
+	tok, err := f.oauth.Exchange(ctx, code, oauth2.VerifierOption(verifier))
+	if err != nil {
+		return "", fmt.Errorf("oidc: code exchange: %w", err)
+	}
+	raw, ok := tok.Extra("id_token").(string)
+	if !ok || raw == "" {
+		return "", ErrNoIDToken
+	}
+	return raw, nil
+}

--- a/internal/oidc/flow.go
+++ b/internal/oidc/flow.go
@@ -56,6 +56,10 @@ func NewFlow(ctx context.Context, cfg config.OIDCSection, hs256Secret string) (*
 	}, nil
 }
 
+// GenerateCodeVerifier returns a fresh PKCE code verifier (high-entropy,
+// URL-safe). The caller stores it in the state cookie and passes it to Exchange.
+func GenerateCodeVerifier() string { return oauth2.GenerateVerifier() }
+
 // Codec returns the state-cookie codec so the caller can encode the cookie on
 // login and decode it on callback.
 func (f *Flow) Codec() *StateCodec { return f.codec }

--- a/internal/oidc/flow_test.go
+++ b/internal/oidc/flow_test.go
@@ -1,0 +1,169 @@
+package oidc
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/config"
+)
+
+const testFlowSecret = "oidc-flow-test-secret"
+
+func newTestFlow(t *testing.T, cfg config.OIDCSection) *Flow {
+	t.Helper()
+	flow, err := NewFlow(context.Background(), cfg, testFlowSecret)
+	if err != nil {
+		t.Fatalf("NewFlow: %v", err)
+	}
+	return flow
+}
+
+func TestNewFlowDiscoveryFailureIsFatal(t *testing.T) {
+	cfg := config.OIDCSection{Issuer: "http://127.0.0.1:1/does-not-exist", ClientID: "c"}
+	if _, err := NewFlow(context.Background(), cfg, testFlowSecret); err == nil {
+		t.Fatal("NewFlow with an unreachable issuer = nil error, want a discovery failure")
+	}
+}
+
+func TestGenerateCodeVerifier(t *testing.T) {
+	a := GenerateCodeVerifier()
+	b := GenerateCodeVerifier()
+	if a == "" || b == "" {
+		t.Fatal("GenerateCodeVerifier returned an empty verifier")
+	}
+	if a == b {
+		t.Error("two GenerateCodeVerifier calls returned identical values (not high-entropy)")
+	}
+}
+
+func TestFlowCodecRoundTrip(t *testing.T) {
+	f := newFakeIDP(t)
+	flow := newTestFlow(t, baseOIDCConfig(f))
+
+	codec := flow.Codec()
+	if codec == nil {
+		t.Fatal("Codec() = nil")
+	}
+	in := StatePayload{State: "st-123", Nonce: "nonce-abc", Verifier: "vfy-xyz", Next: "/dags"}
+	tok, err := codec.Encode(in, time.Minute)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	got, err := codec.Decode(tok)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got != in {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+
+	if _, err := codec.Decode("not-a-jwt-at-all"); !errors.Is(err, ErrInvalidState) {
+		t.Errorf("Decode(garbage) err = %v, want ErrInvalidState", err)
+	}
+}
+
+func TestFlowVerifierIsWired(t *testing.T) {
+	f := newFakeIDP(t)
+	flow := newTestFlow(t, baseOIDCConfig(f))
+	if flow.Verifier() == nil {
+		t.Fatal("Verifier() = nil, want the flow's ID-token verifier")
+	}
+}
+
+func TestAuthCodeURL(t *testing.T) {
+	f := newFakeIDP(t)
+	cfg := baseOIDCConfig(f)
+	flow := newTestFlow(t, cfg)
+
+	verifier := GenerateCodeVerifier()
+	raw := flow.AuthCodeURL("state-123", "nonce-456", verifier)
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse AuthCodeURL: %v", err)
+	}
+	q := u.Query()
+
+	if got := q.Get("state"); got != "state-123" {
+		t.Errorf("state = %q, want state-123", got)
+	}
+	if got := q.Get("nonce"); got != "nonce-456" {
+		t.Errorf("nonce = %q, want nonce-456", got)
+	}
+	if got := q.Get("client_id"); got != cfg.ClientID {
+		t.Errorf("client_id = %q, want %q", got, cfg.ClientID)
+	}
+	if got := q.Get("redirect_uri"); got != cfg.RedirectURL {
+		t.Errorf("redirect_uri = %q, want %q", got, cfg.RedirectURL)
+	}
+	if got := q.Get("scope"); got != "openid email profile groups" {
+		t.Errorf("scope = %q, want the configured scopes", got)
+	}
+	if got := q.Get("code_challenge_method"); got != "S256" {
+		t.Errorf("code_challenge_method = %q, want S256 (PKCE)", got)
+	}
+	// The PKCE challenge must be the S256 hash of the verifier, never the verifier
+	// itself in the clear.
+	sum := sha256.Sum256([]byte(verifier))
+	wantChallenge := base64.RawURLEncoding.EncodeToString(sum[:])
+	if got := q.Get("code_challenge"); got != wantChallenge {
+		t.Errorf("code_challenge = %q, want S256(verifier) = %q", got, wantChallenge)
+	}
+	if got := q.Get("code_challenge"); got == verifier {
+		t.Error("code_challenge equals the raw verifier — PKCE must send the S256 challenge, not the verifier")
+	}
+}
+
+func TestExchange(t *testing.T) {
+	t.Run("returns the raw id_token", func(t *testing.T) {
+		f := newFakeIDP(t)
+		cfg := baseOIDCConfig(f)
+		idToken := f.signIDToken(t, baseClaims(cfg, testNonce))
+		f.tokenResp = map[string]any{
+			"access_token": "fake-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+			"id_token":     idToken,
+		}
+		flow := newTestFlow(t, cfg)
+
+		raw, err := flow.Exchange(context.Background(), "auth-code", GenerateCodeVerifier())
+		if err != nil {
+			t.Fatalf("Exchange = %v, want success", err)
+		}
+		if raw != idToken {
+			t.Errorf("Exchange returned a different id_token than the token endpoint sent")
+		}
+	})
+
+	t.Run("no id_token fails closed", func(t *testing.T) {
+		f := newFakeIDP(t)
+		cfg := baseOIDCConfig(f)
+		f.tokenResp = map[string]any{
+			"access_token": "fake-access-token",
+			"token_type":   "Bearer",
+			"expires_in":   3600,
+			// no id_token
+		}
+		flow := newTestFlow(t, cfg)
+
+		if _, err := flow.Exchange(context.Background(), "auth-code", GenerateCodeVerifier()); !errors.Is(err, ErrNoIDToken) {
+			t.Fatalf("Exchange(no id_token) = %v, want ErrNoIDToken", err)
+		}
+	})
+
+	t.Run("token endpoint error surfaces", func(t *testing.T) {
+		f := newFakeIDP(t)
+		cfg := baseOIDCConfig(f)
+		// tokenResp left nil → /token returns 400, so the exchange fails.
+		flow := newTestFlow(t, cfg)
+
+		if _, err := flow.Exchange(context.Background(), "auth-code", GenerateCodeVerifier()); err == nil {
+			t.Fatal("Exchange against a failing token endpoint = nil, want an error")
+		}
+	})
+}

--- a/internal/oidc/roles.go
+++ b/internal/oidc/roles.go
@@ -1,0 +1,33 @@
+package oidc
+
+// MapRoles translates the user's IdP group values into Leoflow role names using
+// the configured mapping. It is DEFAULT-DENY: a group with no entry in the map
+// contributes no role. The result is de-duplicated and preserves first-seen
+// order, so a token's role list is stable regardless of group ordering.
+func MapRoles(groups []string, mappings map[string]string) []string {
+	if len(mappings) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool)
+	var roles []string
+	for _, g := range groups {
+		role, ok := mappings[g]
+		if !ok || seen[role] {
+			continue
+		}
+		seen[role] = true
+		roles = append(roles, role)
+	}
+	return roles
+}
+
+// ApplyDefaultRole softens the default-deny without weakening it: when the
+// mapped set is empty and a default role is configured, the user is granted that
+// single fallback role. An empty defaultRole leaves the deny in place (the
+// secure default) and a non-empty mapped set is never overridden.
+func ApplyDefaultRole(roles []string, defaultRole string) []string {
+	if len(roles) == 0 && defaultRole != "" {
+		return []string{defaultRole}
+	}
+	return roles
+}

--- a/internal/oidc/roles_test.go
+++ b/internal/oidc/roles_test.go
@@ -1,0 +1,54 @@
+package oidc
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMapRolesDefaultDeny(t *testing.T) {
+	mappings := map[string]string{"platform-admins": "admin", "data-eng": "editor"}
+	for _, tc := range []struct {
+		name   string
+		groups []string
+		want   []string
+	}{
+		{"mapped groups map to roles", []string{"data-eng"}, []string{"editor"}},
+		{"unmapped group grants nothing", []string{"random-group"}, nil},
+		{"mix keeps only mapped", []string{"random-group", "platform-admins"}, []string{"admin"}},
+		{"no groups grants nothing", nil, nil},
+		{"duplicate role de-duplicated", []string{"data-eng", "data-eng"}, []string{"editor"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MapRoles(tc.groups, mappings)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("MapRoles(%v) = %v, want %v", tc.groups, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMapRolesEmptyMappingGrantsNothing(t *testing.T) {
+	if got := MapRoles([]string{"anything"}, nil); got != nil {
+		t.Errorf("MapRoles with no mapping = %v, want nil (default-deny)", got)
+	}
+}
+
+func TestApplyDefaultRole(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		roles       []string
+		defaultRole string
+		want        []string
+	}{
+		{"empty + default set → fallback", nil, "viewer", []string{"viewer"}},
+		{"empty + no default → still empty (secure default)", nil, "", nil},
+		{"non-empty is never overridden", []string{"editor"}, "viewer", []string{"editor"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ApplyDefaultRole(tc.roles, tc.defaultRole)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ApplyDefaultRole(%v, %q) = %v, want %v", tc.roles, tc.defaultRole, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/oidc/state.go
+++ b/internal/oidc/state.go
@@ -1,0 +1,100 @@
+// Package oidc implements the OIDC/SSO login flow: the Authorization Code +
+// PKCE redirect, keyless ID-token verification against the issuer's public
+// JWKS, fail-closed tenant pinning, and group→role mapping. It ends by handing
+// the caller a verified identity; minting the app's own session token is the
+// caller's job (the JWT authenticator stays the request-path verifier).
+package oidc
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// stateIssuer marks the short-lived state cookie so it can never be confused
+// with the app's own session token (which uses a different issuer and a
+// different key).
+const stateIssuer = "leoflow-oidc-state"
+
+// ErrInvalidState is returned when the state cookie is missing, malformed,
+// expired, or not signed by us — every case is a failed CSRF/replay check.
+var ErrInvalidState = errors.New("invalid oidc state")
+
+// StatePayload is the login-flow state carried statelessly in a signed,
+// HttpOnly cookie between the login redirect and the callback: the CSRF
+// `state`, the ID-token `nonce`, the PKCE `code_verifier`, and the sanitized
+// post-login redirect target. No server-side session store is needed.
+type StatePayload struct {
+	State    string
+	Nonce    string
+	Verifier string
+	Next     string
+}
+
+// StateCodec signs and verifies the state cookie with a key derived from the
+// app's HS256 secret. Deriving a distinct key (rather than reusing the secret
+// directly) keeps a state cookie from ever validating as a session token and
+// vice versa.
+type StateCodec struct {
+	key []byte
+}
+
+// NewStateCodec builds a StateCodec from the app's HS256 secret, deriving a
+// dedicated signing key so state cookies and session tokens never cross-verify.
+func NewStateCodec(hs256Secret string) *StateCodec {
+	sum := sha256.Sum256([]byte(hs256Secret + "|" + stateIssuer))
+	return &StateCodec{key: sum[:]}
+}
+
+// stateClaims is the signed cookie payload.
+type stateClaims struct {
+	Nonce    string `json:"nonce"`
+	Verifier string `json:"vfy"`
+	Next     string `json:"next"`
+	jwt.RegisteredClaims
+}
+
+// Encode signs the payload into a compact token valid for ttl. The CSRF `state`
+// travels as the JWT ID (jti), so verifying the callback's state query param is
+// a direct comparison against the signed cookie.
+func (c *StateCodec) Encode(p StatePayload, ttl time.Duration) (string, error) {
+	now := time.Now()
+	claims := stateClaims{
+		Nonce:    p.Nonce,
+		Verifier: p.Verifier,
+		Next:     p.Next,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        p.State,
+			Issuer:    stateIssuer,
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
+		},
+	}
+	signed, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(c.key)
+	if err != nil {
+		return "", fmt.Errorf("signing oidc state: %w", err)
+	}
+	return signed, nil
+}
+
+// Decode verifies the cookie's signature and expiry and returns its payload.
+// Any failure — bad signature, wrong issuer, expired, malformed — is
+// ErrInvalidState, so the callback fails closed on a tampered or stale cookie.
+func (c *StateCodec) Decode(token string) (StatePayload, error) {
+	var claims stateClaims
+	parsed, err := jwt.ParseWithClaims(token, &claims, func(t *jwt.Token) (any, error) {
+		return c.key, nil
+	}, jwt.WithIssuer(stateIssuer), jwt.WithValidMethods([]string{"HS256"}))
+	if err != nil || !parsed.Valid {
+		return StatePayload{}, ErrInvalidState
+	}
+	return StatePayload{
+		State:    claims.ID,
+		Nonce:    claims.Nonce,
+		Verifier: claims.Verifier,
+		Next:     claims.Next,
+	}, nil
+}

--- a/internal/oidc/state_test.go
+++ b/internal/oidc/state_test.go
@@ -1,6 +1,7 @@
 package oidc
 
 import (
+	"errors"
 	"testing"
 	"time"
 )
@@ -36,7 +37,7 @@ func TestStateCodecRejectsTamper(t *testing.T) {
 	} else {
 		b[mid] = 'a'
 	}
-	if _, err := c.Decode(string(b)); err != ErrInvalidState {
+	if _, err := c.Decode(string(b)); !errors.Is(err, ErrInvalidState) {
 		t.Errorf("Decode(tampered) err = %v, want ErrInvalidState", err)
 	}
 }
@@ -48,7 +49,7 @@ func TestStateCodecRejectsWrongKey(t *testing.T) {
 	}
 	// A codec derived from a different app secret must not validate the cookie —
 	// this is what stops a state cookie and a session token from cross-verifying.
-	if _, err := NewStateCodec("secret-two").Decode(tok); err != ErrInvalidState {
+	if _, err := NewStateCodec("secret-two").Decode(tok); !errors.Is(err, ErrInvalidState) {
 		t.Errorf("Decode(wrong key) err = %v, want ErrInvalidState", err)
 	}
 }
@@ -59,7 +60,7 @@ func TestStateCodecRejectsExpired(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := c.Decode(tok); err != ErrInvalidState {
+	if _, err := c.Decode(tok); !errors.Is(err, ErrInvalidState) {
 		t.Errorf("Decode(expired) err = %v, want ErrInvalidState", err)
 	}
 }

--- a/internal/oidc/state_test.go
+++ b/internal/oidc/state_test.go
@@ -1,0 +1,65 @@
+package oidc
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStateCodecRoundTrip(t *testing.T) {
+	c := NewStateCodec("app-secret")
+	in := StatePayload{State: "st-123", Nonce: "nonce-abc", Verifier: "vfy-xyz", Next: "/dags"}
+	tok, err := c.Encode(in, time.Minute)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	got, err := c.Decode(tok)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if got != in {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+}
+
+func TestStateCodecRejectsTamper(t *testing.T) {
+	c := NewStateCodec("app-secret")
+	tok, err := c.Encode(StatePayload{State: "st", Nonce: "n", Verifier: "v"}, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Corrupt a byte in the middle of the token (the payload segment) so the
+	// signed content no longer matches the signature.
+	b := []byte(tok)
+	mid := len(b) / 2
+	if b[mid] == 'a' {
+		b[mid] = 'b'
+	} else {
+		b[mid] = 'a'
+	}
+	if _, err := c.Decode(string(b)); err != ErrInvalidState {
+		t.Errorf("Decode(tampered) err = %v, want ErrInvalidState", err)
+	}
+}
+
+func TestStateCodecRejectsWrongKey(t *testing.T) {
+	tok, err := NewStateCodec("secret-one").Encode(StatePayload{State: "st"}, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A codec derived from a different app secret must not validate the cookie —
+	// this is what stops a state cookie and a session token from cross-verifying.
+	if _, err := NewStateCodec("secret-two").Decode(tok); err != ErrInvalidState {
+		t.Errorf("Decode(wrong key) err = %v, want ErrInvalidState", err)
+	}
+}
+
+func TestStateCodecRejectsExpired(t *testing.T) {
+	c := NewStateCodec("app-secret")
+	tok, err := c.Encode(StatePayload{State: "st"}, -time.Second) // already expired
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Decode(tok); err != ErrInvalidState {
+		t.Errorf("Decode(expired) err = %v, want ErrInvalidState", err)
+	}
+}

--- a/internal/oidc/verify.go
+++ b/internal/oidc/verify.go
@@ -1,0 +1,275 @@
+package oidc
+
+import (
+	"context"
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	gooidc "github.com/coreos/go-oidc/v3/oidc"
+
+	"github.com/neochaotic/leoflow/internal/config"
+)
+
+// Verification failures. Each is a fail-closed rejection the caller maps to a
+// 403 and audits by reason; none of them ever falls back to a default tenant or
+// a trusted default identity.
+var (
+	// ErrIssuerMismatch is returned when the ID token's iss differs from the
+	// pinned issuer (H1a).
+	ErrIssuerMismatch = errors.New("oidc: issuer mismatch")
+	// ErrNonceMismatch is returned when the ID token's nonce does not match the
+	// value bound in the state cookie (H4 — replay/CSRF on the token).
+	ErrNonceMismatch = errors.New("oidc: nonce mismatch")
+	// ErrAzpMismatch is returned when the authorized-party (azp) claim is present
+	// and is not this client (H4).
+	ErrAzpMismatch = errors.New("oidc: azp mismatch")
+	// ErrTokenExpired is returned when exp/iat/nbf fall outside the allowed clock
+	// skew (H4).
+	ErrTokenExpired = errors.New("oidc: token outside validity window")
+	// ErrEmailNotVerified is returned when email_verified is not true; an absent
+	// claim is treated as false (D6c).
+	ErrEmailNotVerified = errors.New("oidc: email not verified")
+	// ErrTenantNotAllowed is returned when the tenant claim (tid/hd) is absent or
+	// not present in the tenant_claims map (D6b/d) — never a fallback to default.
+	ErrTenantNotAllowed = errors.New("oidc: tenant claim not allowed")
+	// ErrEmailDomainNotAllowed is returned when a non-empty allowed_email_domains
+	// list does not include the verified email's domain (login-level allowlist).
+	ErrEmailDomainNotAllowed = errors.New("oidc: email domain not allowed")
+	// ErrNoSubject is returned when the ID token carries no subject — there is no
+	// stable identity to key on.
+	ErrNoSubject = errors.New("oidc: token has no subject")
+)
+
+// VerifiedIdentity is the result of a fully-checked ID token: a trustworthy
+// identity the caller may resolve to a Leoflow user and mint a session for. It
+// is only ever returned after every H1/H4 check and the tenant pin have passed.
+type VerifiedIdentity struct {
+	// Provider is the stable provider key stored on the user row (the pinned
+	// issuer URL), half of the (provider, subject) link key.
+	Provider string
+	// Subject is the immutable IdP subject, the other half of the link key.
+	Subject string
+	// Email is the user's email; it is only trusted because EmailVerified is true.
+	Email string
+	// EmailVerified is always true on a returned identity (a false/absent claim
+	// fails verification).
+	EmailVerified bool
+	// Tenant is the resolved Leoflow tenant name (from the tid/hd pin).
+	Tenant string
+	// Groups are the raw IdP group values, for group→role mapping.
+	Groups []string
+}
+
+// Verifier verifies ID tokens keylessly against the issuer's public JWKS and
+// enforces the fail-closed identity gate (issuer pin, audience, nonce, azp,
+// clock skew, email_verified, tenant pin, email-domain allowlist). It wraps
+// go-oidc but does NOT rely on it for nonce, azp, or clock skew, which go-oidc
+// does not check — those are enforced here explicitly (H4).
+type Verifier struct {
+	cfg      config.OIDCSection
+	verifier *gooidc.IDTokenVerifier
+	now      func() time.Time
+}
+
+// NewVerifier discovers the issuer's OIDC metadata (which pins the issuer: the
+// discovery document's issuer must equal cfg.Issuer) and builds an ID-token
+// verifier that checks the signature against the published JWKS and the
+// audience against the client id. Expiry is deferred to this package's
+// skew-aware check, so the verifier is configured to skip go-oidc's own
+// expiry check.
+func NewVerifier(ctx context.Context, cfg config.OIDCSection) (*Verifier, error) {
+	provider, err := gooidc.NewProvider(ctx, cfg.Issuer)
+	if err != nil {
+		return nil, fmt.Errorf("oidc discovery for %q: %w", cfg.Issuer, err)
+	}
+	return newVerifierWithProvider(provider, cfg), nil
+}
+
+// newVerifierWithProvider builds the verifier from an already-discovered
+// provider; split out so a test can supply a provider pointed at a local IdP.
+func newVerifierWithProvider(provider *gooidc.Provider, cfg config.OIDCSection) *Verifier {
+	return &Verifier{
+		cfg: cfg,
+		verifier: provider.Verifier(&gooidc.Config{
+			ClientID: cfg.ClientID,
+			// This package enforces exp/iat/nbf with a configurable skew, so it is
+			// the single time authority; go-oidc's own (leeway-less) expiry check is
+			// disabled to avoid rejecting a token that is valid within the skew.
+			SkipExpiryCheck: true,
+		}),
+		now: time.Now,
+	}
+}
+
+// idClaims are the security-relevant claims pulled from the ID token in addition
+// to the fields go-oidc exposes on its *IDToken. Groups and the tenant claim are
+// read separately because their claim names are configurable.
+type idClaims struct {
+	Azp           string `json:"azp"`
+	NotBefore     int64  `json:"nbf"`
+	Email         string `json:"email"`
+	EmailVerified bool   `json:"email_verified"`
+}
+
+// Verify performs the full fail-closed check on a raw ID token and returns the
+// resulting identity. expectedNonce is the value bound in the state cookie. The
+// order matters: signature/audience/issuer (go-oidc) → nonce → azp → clock skew
+// → subject → email_verified → tenant pin → email-domain allowlist. The domain
+// allowlist is deliberately last (and only reached once email_verified is true)
+// so a spoofable domain can never substitute for the tid/hd pin.
+func (v *Verifier) Verify(ctx context.Context, rawIDToken, expectedNonce string) (*VerifiedIdentity, error) {
+	idToken, err := v.verifier.Verify(ctx, rawIDToken)
+	if err != nil {
+		// Covers a tampered/invalid signature, a wrong audience, and an issuer that
+		// does not match the pinned discovery issuer.
+		if strings.Contains(err.Error(), "issuer") {
+			return nil, ErrIssuerMismatch
+		}
+		return nil, fmt.Errorf("oidc: token verification failed: %w", err)
+	}
+	// Explicit issuer pin (H1a), independent of go-oidc's own check.
+	if idToken.Issuer != v.cfg.Issuer {
+		return nil, ErrIssuerMismatch
+	}
+	// Nonce binding (H4): constant-time compare against the state cookie.
+	if expectedNonce == "" || subtle.ConstantTimeCompare([]byte(idToken.Nonce), []byte(expectedNonce)) != 1 {
+		return nil, ErrNonceMismatch
+	}
+
+	var claims idClaims
+	if cerr := idToken.Claims(&claims); cerr != nil {
+		return nil, fmt.Errorf("oidc: decoding claims: %w", cerr)
+	}
+	// azp, when present, must be this client (H4).
+	if claims.Azp != "" && claims.Azp != v.cfg.ClientID {
+		return nil, ErrAzpMismatch
+	}
+	// Clock-skew-aware exp/iat/nbf (H4).
+	if err := v.checkTimes(idToken, claims.NotBefore); err != nil {
+		return nil, err
+	}
+	if idToken.Subject == "" {
+		return nil, ErrNoSubject
+	}
+	// email_verified must be explicitly true (absent → false, D6c).
+	if !claims.EmailVerified {
+		return nil, ErrEmailNotVerified
+	}
+	// Tenant pin (D6b/d): resolve from the configured tid/hd claim; absent or
+	// unmapped is a hard reject, never a default fallback.
+	tenant, err := v.resolveTenant(idToken)
+	if err != nil {
+		return nil, err
+	}
+	// Login-level email-domain allowlist, layered on top of the pin. Only reached
+	// after email_verified, so the domain is trustworthy here.
+	if err := v.checkEmailDomain(claims.Email); err != nil {
+		return nil, err
+	}
+
+	groups, err := extractGroups(idToken, v.cfg.GroupsClaim)
+	if err != nil {
+		return nil, err
+	}
+	return &VerifiedIdentity{
+		Provider:      v.cfg.Issuer,
+		Subject:       idToken.Subject,
+		Email:         claims.Email,
+		EmailVerified: true,
+		Tenant:        tenant,
+		Groups:        groups,
+	}, nil
+}
+
+// checkTimes enforces exp/iat/nbf within the configured clock skew.
+func (v *Verifier) checkTimes(idToken *gooidc.IDToken, nbfUnix int64) error {
+	skew := time.Duration(v.cfg.ClockSkewSeconds) * time.Second
+	now := v.now()
+	if !idToken.Expiry.IsZero() && now.After(idToken.Expiry.Add(skew)) {
+		return ErrTokenExpired
+	}
+	if !idToken.IssuedAt.IsZero() && idToken.IssuedAt.After(now.Add(skew)) {
+		return ErrTokenExpired
+	}
+	if nbfUnix != 0 {
+		nbf := time.Unix(nbfUnix, 0)
+		if now.Before(nbf.Add(-skew)) {
+			return ErrTokenExpired
+		}
+	}
+	return nil
+}
+
+// resolveTenant maps the configured tid/hd claim value to a Leoflow tenant,
+// failing closed when the claim is absent or unmapped.
+func (v *Verifier) resolveTenant(idToken *gooidc.IDToken) (string, error) {
+	if v.cfg.TenantClaim == "" {
+		return "", ErrTenantNotAllowed
+	}
+	var raw map[string]any
+	if err := idToken.Claims(&raw); err != nil {
+		return "", fmt.Errorf("oidc: decoding tenant claim: %w", err)
+	}
+	val, _ := raw[v.cfg.TenantClaim].(string)
+	if val == "" {
+		return "", ErrTenantNotAllowed
+	}
+	tenant, ok := v.cfg.TenantClaims[val]
+	if !ok || tenant == "" {
+		return "", ErrTenantNotAllowed
+	}
+	return tenant, nil
+}
+
+// checkEmailDomain enforces the optional login-level domain allowlist. An empty
+// list imposes no restriction (the tid/hd pin is the sole boundary).
+func (v *Verifier) checkEmailDomain(email string) error {
+	if len(v.cfg.AllowedEmailDomains) == 0 {
+		return nil
+	}
+	at := strings.LastIndex(email, "@")
+	if at < 0 {
+		return ErrEmailDomainNotAllowed
+	}
+	domain := strings.ToLower(email[at+1:])
+	for _, allowed := range v.cfg.AllowedEmailDomains {
+		if strings.ToLower(strings.TrimSpace(allowed)) == domain {
+			return nil
+		}
+	}
+	return ErrEmailDomainNotAllowed
+}
+
+// extractGroups reads the configured groups claim as a list of strings,
+// tolerating both a JSON array and a single string value.
+func extractGroups(idToken *gooidc.IDToken, claimName string) ([]string, error) {
+	if claimName == "" {
+		return nil, nil
+	}
+	var raw map[string]any
+	if err := idToken.Claims(&raw); err != nil {
+		return nil, fmt.Errorf("oidc: decoding groups claim: %w", err)
+	}
+	switch v := raw[claimName].(type) {
+	case nil:
+		return nil, nil
+	case string:
+		if v == "" {
+			return nil, nil
+		}
+		return []string{v}, nil
+	case []any:
+		groups := make([]string, 0, len(v))
+		for _, g := range v {
+			if s, ok := g.(string); ok && s != "" {
+				groups = append(groups, s)
+			}
+		}
+		return groups, nil
+	default:
+		return nil, nil
+	}
+}

--- a/internal/oidc/verify.go
+++ b/internal/oidc/verify.go
@@ -124,8 +124,9 @@ func (v *Verifier) Verify(ctx context.Context, rawIDToken, expectedNonce string)
 	idToken, err := v.verifier.Verify(ctx, rawIDToken)
 	if err != nil {
 		// Covers a tampered/invalid signature, a wrong audience, and an issuer that
-		// does not match the pinned discovery issuer.
-		if strings.Contains(err.Error(), "issuer") {
+		// does not match the pinned discovery issuer (go-oidc phrases the last as
+		// "issued by a different provider").
+		if strings.Contains(err.Error(), "different provider") || strings.Contains(err.Error(), "issuer") {
 			return nil, ErrIssuerMismatch
 		}
 		return nil, fmt.Errorf("oidc: token verification failed: %w", err)
@@ -134,29 +135,14 @@ func (v *Verifier) Verify(ctx context.Context, rawIDToken, expectedNonce string)
 	if idToken.Issuer != v.cfg.Issuer {
 		return nil, ErrIssuerMismatch
 	}
-	// Nonce binding (H4): constant-time compare against the state cookie.
-	if expectedNonce == "" || subtle.ConstantTimeCompare([]byte(idToken.Nonce), []byte(expectedNonce)) != 1 {
-		return nil, ErrNonceMismatch
-	}
-
 	var claims idClaims
 	if cerr := idToken.Claims(&claims); cerr != nil {
 		return nil, fmt.Errorf("oidc: decoding claims: %w", cerr)
 	}
-	// azp, when present, must be this client (H4).
-	if claims.Azp != "" && claims.Azp != v.cfg.ClientID {
-		return nil, ErrAzpMismatch
-	}
-	// Clock-skew-aware exp/iat/nbf (H4).
-	if err := v.checkTimes(idToken, claims.NotBefore); err != nil {
-		return nil, err
-	}
-	if idToken.Subject == "" {
-		return nil, ErrNoSubject
-	}
-	// email_verified must be explicitly true (absent → false, D6c).
-	if !claims.EmailVerified {
-		return nil, ErrEmailNotVerified
+	// The explicit H4 checks go-oidc does not perform (nonce, azp, clock skew),
+	// plus subject presence and email_verified.
+	if berr := v.checkBindings(idToken, claims, expectedNonce); berr != nil {
+		return nil, berr
 	}
 	// Tenant pin (D6b/d): resolve from the configured tid/hd claim; absent or
 	// unmapped is a hard reject, never a default fallback.
@@ -166,8 +152,8 @@ func (v *Verifier) Verify(ctx context.Context, rawIDToken, expectedNonce string)
 	}
 	// Login-level email-domain allowlist, layered on top of the pin. Only reached
 	// after email_verified, so the domain is trustworthy here.
-	if err := v.checkEmailDomain(claims.Email); err != nil {
-		return nil, err
+	if derr := v.checkEmailDomain(claims.Email); derr != nil {
+		return nil, derr
 	}
 
 	groups, err := extractGroups(idToken, v.cfg.GroupsClaim)
@@ -182,6 +168,32 @@ func (v *Verifier) Verify(ctx context.Context, rawIDToken, expectedNonce string)
 		Tenant:        tenant,
 		Groups:        groups,
 	}, nil
+}
+
+// checkBindings performs the fail-closed checks go-oidc does not: the nonce
+// binding to the state cookie, azp when present, the clock-skew-aware validity
+// window, subject presence, and email_verified.
+func (v *Verifier) checkBindings(idToken *gooidc.IDToken, claims idClaims, expectedNonce string) error {
+	// Nonce binding (H4): constant-time compare against the state cookie.
+	if expectedNonce == "" || subtle.ConstantTimeCompare([]byte(idToken.Nonce), []byte(expectedNonce)) != 1 {
+		return ErrNonceMismatch
+	}
+	// azp, when present, must be this client (H4).
+	if claims.Azp != "" && claims.Azp != v.cfg.ClientID {
+		return ErrAzpMismatch
+	}
+	// Clock-skew-aware exp/iat/nbf (H4).
+	if terr := v.checkTimes(idToken, claims.NotBefore); terr != nil {
+		return terr
+	}
+	if idToken.Subject == "" {
+		return ErrNoSubject
+	}
+	// email_verified must be explicitly true (absent → false, D6c).
+	if !claims.EmailVerified {
+		return ErrEmailNotVerified
+	}
+	return nil
 }
 
 // checkTimes enforces exp/iat/nbf within the configured clock skew.
@@ -213,8 +225,8 @@ func (v *Verifier) resolveTenant(idToken *gooidc.IDToken) (string, error) {
 	if err := idToken.Claims(&raw); err != nil {
 		return "", fmt.Errorf("oidc: decoding tenant claim: %w", err)
 	}
-	val, _ := raw[v.cfg.TenantClaim].(string)
-	if val == "" {
+	val, ok := raw[v.cfg.TenantClaim].(string)
+	if !ok || val == "" {
 		return "", ErrTenantNotAllowed
 	}
 	tenant, ok := v.cfg.TenantClaims[val]

--- a/internal/oidc/verify_test.go
+++ b/internal/oidc/verify_test.go
@@ -1,0 +1,522 @@
+package oidc
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/neochaotic/leoflow/internal/config"
+)
+
+// ─────────────────────────── fake IdP ───────────────────────────
+
+// fakeIDP is an in-process OpenID Provider: it serves discovery + JWKS and signs
+// ID tokens with an in-test RSA key. It is the minimal harness needed to drive
+// the verifier against a real signature and a real discovery document, ported
+// down from the api-layer OIDC flow tests so internal/oidc exercises verify.go
+// and flow.go directly.
+type fakeIDP struct {
+	srv    *httptest.Server
+	key    *rsa.PrivateKey
+	kid    string
+	issuer string
+
+	// tokenResp, when set, is the JSON body the /token endpoint returns; it lets a
+	// flow test drive Exchange against a controlled response.
+	tokenResp map[string]any
+}
+
+func newFakeIDP(t *testing.T) *fakeIDP {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa keygen: %v", err)
+	}
+	f := &fakeIDP{key: key, kid: "test-key-1"}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", f.handleDiscovery)
+	mux.HandleFunc("/jwks", f.handleJWKS)
+	mux.HandleFunc("/token", f.handleToken)
+	f.srv = httptest.NewServer(mux)
+	f.issuer = f.srv.URL
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+func (f *fakeIDP) handleToken(w http.ResponseWriter, _ *http.Request) {
+	if f.tokenResp == nil {
+		http.Error(w, "no token response staged", http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, f.tokenResp)
+}
+
+func (f *fakeIDP) handleDiscovery(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, map[string]any{
+		"issuer":                                f.issuer,
+		"authorization_endpoint":                f.issuer + "/authorize",
+		"token_endpoint":                        f.issuer + "/token",
+		"jwks_uri":                              f.issuer + "/jwks",
+		"response_types_supported":              []string{"code"},
+		"subject_types_supported":               []string{"public"},
+		"id_token_signing_alg_values_supported": []string{"RS256"},
+	})
+}
+
+func (f *fakeIDP) handleJWKS(w http.ResponseWriter, _ *http.Request) {
+	pub := f.key.PublicKey
+	writeJSON(w, map[string]any{"keys": []map[string]any{{
+		"kty": "RSA",
+		"use": "sig",
+		"alg": "RS256",
+		"kid": f.kid,
+		"n":   base64.RawURLEncoding.EncodeToString(pub.N.Bytes()),
+		"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes()),
+	}}})
+}
+
+// signIDToken signs claims with the IdP's published key under its published kid.
+func (f *fakeIDP) signIDToken(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+	return signWith(t, claims, f.key, f.kid)
+}
+
+// signWith signs claims with an arbitrary key/kid, so a test can mint a token
+// that does not match the JWKS.
+func signWith(t *testing.T, claims jwt.MapClaims, key *rsa.PrivateKey, kid string) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tok.Header["kid"] = kid
+	s, err := tok.SignedString(key)
+	if err != nil {
+		t.Fatalf("sign id token: %v", err)
+	}
+	return s
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// ─────────────────────────── harness ───────────────────────────
+
+const testNonce = "nonce-xyz"
+
+func baseOIDCConfig(f *fakeIDP) config.OIDCSection {
+	return config.OIDCSection{
+		Issuer:           f.issuer,
+		ClientID:         "client-abc",
+		ClientSecret:     "client-secret",
+		RedirectURL:      "https://app.example/api/v2/auth/oidc/callback",
+		Scopes:           []string{"openid", "email", "profile", "groups"},
+		GroupsClaim:      "groups",
+		TenantClaim:      "tid",
+		TenantClaims:     map[string]string{"tenant-guid": "default"},
+		ClockSkewSeconds: 60,
+	}
+}
+
+func baseClaims(cfg config.OIDCSection, nonce string) jwt.MapClaims {
+	now := time.Now()
+	return jwt.MapClaims{
+		"iss":            cfg.Issuer,
+		"aud":            cfg.ClientID,
+		"sub":            "subject-123",
+		"exp":            now.Add(time.Hour).Unix(),
+		"iat":            now.Unix(),
+		"nonce":          nonce,
+		"email":          "alice@corp.example",
+		"email_verified": true,
+		"tid":            "tenant-guid",
+		"groups":         []string{"data-eng"},
+	}
+}
+
+// newTestVerifier discovers the fake IdP and builds a verifier, exercising the
+// real NewVerifier → newVerifierWithProvider construction path.
+func newTestVerifier(t *testing.T, cfg config.OIDCSection) *Verifier {
+	t.Helper()
+	v, err := NewVerifier(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("NewVerifier: %v", err)
+	}
+	return v
+}
+
+// ─────────────────────────── happy path ───────────────────────────
+
+func TestVerifyHappyPath(t *testing.T) {
+	f := newFakeIDP(t)
+	cfg := baseOIDCConfig(f)
+	v := newTestVerifier(t, cfg)
+
+	id, err := v.Verify(context.Background(), f.signIDToken(t, baseClaims(cfg, testNonce)), testNonce)
+	if err != nil {
+		t.Fatalf("Verify(valid token) = %v, want success", err)
+	}
+	if id.Provider != cfg.Issuer {
+		t.Errorf("Provider = %q, want %q", id.Provider, cfg.Issuer)
+	}
+	if id.Subject != "subject-123" {
+		t.Errorf("Subject = %q, want subject-123", id.Subject)
+	}
+	if id.Email != "alice@corp.example" {
+		t.Errorf("Email = %q, want alice@corp.example", id.Email)
+	}
+	if !id.EmailVerified {
+		t.Error("EmailVerified = false, want true on a returned identity")
+	}
+	if id.Tenant != "default" {
+		t.Errorf("Tenant = %q, want default (mapped from tid tenant-guid)", id.Tenant)
+	}
+	if len(id.Groups) != 1 || id.Groups[0] != "data-eng" {
+		t.Errorf("Groups = %v, want [data-eng]", id.Groups)
+	}
+}
+
+// ─────────────────────────── H1a: issuer pin ───────────────────────────
+
+func TestVerifyIssuerMismatch(t *testing.T) {
+	f := newFakeIDP(t)
+	cfg := baseOIDCConfig(f)
+	v := newTestVerifier(t, cfg)
+
+	claims := baseClaims(cfg, testNonce)
+	claims["iss"] = "https://evil.example"
+	_, err := v.Verify(context.Background(), f.signIDToken(t, claims), testNonce)
+	if !errors.Is(err, ErrIssuerMismatch) {
+		t.Fatalf("Verify(iss mismatch) = %v, want ErrIssuerMismatch", err)
+	}
+}
+
+// ─────────────────────────── H4: nonce binding ───────────────────────────
+
+func TestVerifyNonceMismatch(t *testing.T) {
+	f := newFakeIDP(t)
+	cfg := baseOIDCConfig(f)
+	v := newTestVerifier(t, cfg)
+
+	t.Run("nonce differs from expected", func(t *testing.T) {
+		claims := baseClaims(cfg, "some-other-nonce")
+		if _, err := v.Verify(context.Background(), f.signIDToken(t, claims), testNonce); !errors.Is(err, ErrNonceMismatch) {
+			t.Fatalf("Verify(nonce mismatch) = %v, want ErrNonceMismatch", err)
+		}
+	})
+
+	t.Run("empty expected nonce is rejected", func(t *testing.T) {
+		claims := baseClaims(cfg, testNonce)
+		if _, err := v.Verify(context.Background(), f.signIDToken(t, claims), ""); !errors.Is(err, ErrNonceMismatch) {
+			t.Fatalf("Verify(empty expected nonce) = %v, want ErrNonceMismatch", err)
+		}
+	})
+}
+
+// ─────────────────────────── H4: azp ───────────────────────────
+
+func TestVerifyAzpMismatch(t *testing.T) {
+	f := newFakeIDP(t)
+	cfg := baseOIDCConfig(f)
+	v := newTestVerifier(t, cfg)
+
+	t.Run("azp present and not this client", func(t *testing.T) {
+		claims := baseClaims(cfg, testNonce)
+		claims["azp"] = "some-other-client"
+		if _, err := v.Verify(context.Background(), f.signIDToken(t, claims), testNonce); !errors.Is(err, ErrAzpMismatch) {
+			t.Fatalf("Verify(azp mismatch) = %v, want ErrAzpMismatch", err)
+		}
+	})
+
+	t.Run("azp present and equal to client id is accepted", func(t *testing.T) {
+		claims := baseClaims(cfg, testNonce)
+		claims["azp"] = cfg.ClientID
+		if _, err := v.Verify(context.Background(), f.signIDToken(t, claims), testNonce); err != nil {
+			t.Fatalf("Verify(azp == client_id) = %v, want success", err)
+		}
+	})
+}
+
+// ─────────────────────────── H4: clock skew ───────────────────────────
+
+func TestVerifyClockSkew(t *testing.T) {
+	f := newFakeIDP(t)
+	cfg := baseOIDCConfig(f) // 60s skew
+
+	t.Run("expired beyond skew", func(t *testing.T) {
+		v := newTestVerifier(t, cfg)
+		claims := baseClaims(cfg, testNonce)
+		claims["exp"] = time.Now().Add(-5 * time.Minute).Unix()
+		if _, err := v.Verify(context.Background(), f.signIDToken(t, claims), testNonce); !errors.Is(err, ErrTokenExpired) {
+			t.Fatalf("Verify(expired) = %v, want ErrTokenExpired", err)
+		}
+	})
+
+	t.Run("within skew boundary is accepted", func(t *testing.T) {
+		v := newTestVerifier(t, cfg)
+		claims := baseClaims(cfg, testNonce)
+		// Expired 30s ago, inside the 60s skew → still valid.
+		claims["exp"] = time.Now().Add(-30 * time.Second).Unix()
+		if _, err := v.Verify(context.Background(), f.signIDToken(t, claims), testNonce); err != nil {
+			t.Fatalf("Verify(within skew) = %v, want success", err)
+		}
+	})
+
+	t.Run("iat too far in the future", func(t *testing.T) {
+		v := newTestVerifier(t, cfg)
+		claims := baseClaims(cfg, testNonce)
+		claims["iat"] = time.Now().Add(5 * time.Minute).Unix()
+		if _, err := v.Verify(context.Background(), f.signIDToken(t, claims), testNonce); !errors.Is(err, ErrTokenExpired) {
+			t.Fatalf("Verify(future iat) = %v, want ErrTokenExpired", err)
+		}
+	})
+
+	t.Run("nbf in the future beyond skew", func(t *testing.T) {
+		v := newTestVerifier(t, cfg)
+		claims := baseClaims(cfg, testNonce)
+		claims["nbf"] = time.Now().Add(5 * time.Minute).Unix()
+		if _, err := v.Verify(context.Background(), f.signIDToken(t, claims), testNonce); !errors.Is(err, ErrTokenExpired) {
+			t.Fatalf("Verify(future nbf) = %v, want ErrTokenExpired", err)
+		}
+	})
+
+	t.Run("nbf within skew is accepted", func(t *testing.T) {
+		v := newTestVerifier(t, cfg)
+		claims := baseClaims(cfg, testNonce)
+		// Not-before is 30s ahead, inside the 60s skew → accepted.
+		claims["nbf"] = time.Now().Add(30 * time.Second).Unix()
+		if _, err := v.Verify(context.Background(), f.signIDToken(t, claims), testNonce); err != nil {
+			t.Fatalf("Verify(nbf within skew) = %v, want success", err)
+		}
+	})
+}
+
+// ─────────────────────────── subject presence ───────────────────────────
+
+func TestVerifyNoSubject(t *testing.T) {
+	f := newFakeIDP(t)
+	cfg := baseOIDCConfig(f)
+	v := newTestVerifier(t, cfg)
+
+	claims := baseClaims(cfg, testNonce)
+	claims["sub"] = ""
+	if _, err := v.Verify(context.Background(), f.signIDToken(t, claims), testNonce); !errors.Is(err, ErrNoSubject) {
+		t.Fatalf("Verify(empty sub) = %v, want ErrNoSubject", err)
+	}
+}
+
+// ─────────────────────────── D6c: email_verified ───────────────────────────
+
+func TestVerifyEmailNotVerified(t *testing.T) {
+	f := newFakeIDP(t)
+	cfg := baseOIDCConfig(f)
+	v := newTestVerifier(t, cfg)
+
+	t.Run("email_verified false", func(t *testing.T) {
+		claims := baseClaims(cfg, testNonce)
+		claims["email_verified"] = false
+		if _, err := v.Verify(context.Background(), f.signIDToken(t, claims), testNonce); !errors.Is(err, ErrEmailNotVerified) {
+			t.Fatalf("Verify(email_verified=false) = %v, want ErrEmailNotVerified", err)
+		}
+	})
+
+	t.Run("email_verified absent (treated as false)", func(t *testing.T) {
+		claims := baseClaims(cfg, testNonce)
+		delete(claims, "email_verified")
+		if _, err := v.Verify(context.Background(), f.signIDToken(t, claims), testNonce); !errors.Is(err, ErrEmailNotVerified) {
+			t.Fatalf("Verify(email_verified absent) = %v, want ErrEmailNotVerified", err)
+		}
+	})
+}
+
+// ─────────────────────────── D6b/d: tenant pin ───────────────────────────
+
+func TestVerifyTenantNotAllowed(t *testing.T) {
+	f := newFakeIDP(t)
+
+	t.Run("TenantClaim unset", func(t *testing.T) {
+		cfg := baseOIDCConfig(f)
+		cfg.TenantClaim = ""
+		v := newTestVerifier(t, cfg)
+		if _, err := v.Verify(context.Background(), f.signIDToken(t, baseClaims(cfg, testNonce)), testNonce); !errors.Is(err, ErrTenantNotAllowed) {
+			t.Fatalf("Verify(TenantClaim unset) = %v, want ErrTenantNotAllowed", err)
+		}
+	})
+
+	t.Run("tid claim absent", func(t *testing.T) {
+		cfg := baseOIDCConfig(f)
+		v := newTestVerifier(t, cfg)
+		claims := baseClaims(cfg, testNonce)
+		delete(claims, "tid")
+		if _, err := v.Verify(context.Background(), f.signIDToken(t, claims), testNonce); !errors.Is(err, ErrTenantNotAllowed) {
+			t.Fatalf("Verify(tid absent) = %v, want ErrTenantNotAllowed", err)
+		}
+	})
+
+	t.Run("tid value not in TenantClaims map", func(t *testing.T) {
+		cfg := baseOIDCConfig(f)
+		v := newTestVerifier(t, cfg)
+		claims := baseClaims(cfg, testNonce)
+		claims["tid"] = "unmapped-tenant"
+		if _, err := v.Verify(context.Background(), f.signIDToken(t, claims), testNonce); !errors.Is(err, ErrTenantNotAllowed) {
+			t.Fatalf("Verify(tid unmapped) = %v, want ErrTenantNotAllowed", err)
+		}
+	})
+}
+
+// ─────────────────────────── email-domain allowlist ───────────────────────────
+
+func TestVerifyEmailDomainAllowlist(t *testing.T) {
+	f := newFakeIDP(t)
+
+	t.Run("domain in allowlist is accepted", func(t *testing.T) {
+		cfg := baseOIDCConfig(f)
+		cfg.AllowedEmailDomains = []string{"corp.example"}
+		v := newTestVerifier(t, cfg)
+		if _, err := v.Verify(context.Background(), f.signIDToken(t, baseClaims(cfg, testNonce)), testNonce); err != nil {
+			t.Fatalf("Verify(domain in allowlist) = %v, want success", err)
+		}
+	})
+
+	t.Run("domain not in allowlist is rejected", func(t *testing.T) {
+		cfg := baseOIDCConfig(f)
+		cfg.AllowedEmailDomains = []string{"trusted.example"}
+		v := newTestVerifier(t, cfg)
+		if _, err := v.Verify(context.Background(), f.signIDToken(t, baseClaims(cfg, testNonce)), testNonce); !errors.Is(err, ErrEmailDomainNotAllowed) {
+			t.Fatalf("Verify(domain not in allowlist) = %v, want ErrEmailDomainNotAllowed", err)
+		}
+	})
+
+	t.Run("empty allowlist imposes no restriction", func(t *testing.T) {
+		cfg := baseOIDCConfig(f) // AllowedEmailDomains empty
+		v := newTestVerifier(t, cfg)
+		if _, err := v.Verify(context.Background(), f.signIDToken(t, baseClaims(cfg, testNonce)), testNonce); err != nil {
+			t.Fatalf("Verify(empty allowlist) = %v, want success", err)
+		}
+	})
+
+	t.Run("unverified email fails before the domain check", func(t *testing.T) {
+		cfg := baseOIDCConfig(f)
+		cfg.AllowedEmailDomains = []string{"corp.example"} // domain WOULD pass
+		v := newTestVerifier(t, cfg)
+		claims := baseClaims(cfg, testNonce)
+		claims["email_verified"] = false
+		// The domain would be allowed, so a domain error here would prove the
+		// order is wrong; email_verified must be the failing check.
+		if _, err := v.Verify(context.Background(), f.signIDToken(t, claims), testNonce); !errors.Is(err, ErrEmailNotVerified) {
+			t.Fatalf("Verify(unverified) = %v, want ErrEmailNotVerified (before domain check)", err)
+		}
+	})
+}
+
+// ─────────────────────────── signature ───────────────────────────
+
+func TestVerifyRejectsForeignSignature(t *testing.T) {
+	f := newFakeIDP(t)
+	cfg := baseOIDCConfig(f)
+	v := newTestVerifier(t, cfg)
+
+	// Sign with a key that is NOT in the JWKS, under the published kid so go-oidc
+	// selects the real key and the signature fails to verify.
+	foreign, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa keygen: %v", err)
+	}
+	raw := signWith(t, baseClaims(cfg, testNonce), foreign, f.kid)
+	if _, verr := v.Verify(context.Background(), raw, testNonce); verr == nil {
+		t.Fatal("Verify(foreign signature) = nil, want a verification error")
+	}
+}
+
+// ─────────────────────────── extractGroups ───────────────────────────
+
+func TestVerifyExtractGroups(t *testing.T) {
+	f := newFakeIDP(t)
+
+	verifyGroups := func(t *testing.T, cfg config.OIDCSection, groupsVal any, present bool) []string {
+		t.Helper()
+		v := newTestVerifier(t, cfg)
+		claims := baseClaims(cfg, testNonce)
+		if present {
+			claims["groups"] = groupsVal
+		} else {
+			delete(claims, "groups")
+		}
+		// When the configured claim name differs, stage it explicitly.
+		if cfg.GroupsClaim != "groups" && cfg.GroupsClaim != "" && present {
+			delete(claims, "groups")
+			claims[cfg.GroupsClaim] = groupsVal
+		}
+		id, err := v.Verify(context.Background(), f.signIDToken(t, claims), testNonce)
+		if err != nil {
+			t.Fatalf("Verify = %v, want success", err)
+		}
+		return id.Groups
+	}
+
+	t.Run("array claim", func(t *testing.T) {
+		got := verifyGroups(t, baseOIDCConfig(f), []string{"a", "b"}, true)
+		if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+			t.Errorf("groups = %v, want [a b]", got)
+		}
+	})
+
+	t.Run("single string claim", func(t *testing.T) {
+		got := verifyGroups(t, baseOIDCConfig(f), "solo", true)
+		if len(got) != 1 || got[0] != "solo" {
+			t.Errorf("groups = %v, want [solo]", got)
+		}
+	})
+
+	t.Run("absent claim yields nil", func(t *testing.T) {
+		if got := verifyGroups(t, baseOIDCConfig(f), nil, false); got != nil {
+			t.Errorf("groups = %v, want nil", got)
+		}
+	})
+
+	t.Run("non-string entries are skipped", func(t *testing.T) {
+		got := verifyGroups(t, baseOIDCConfig(f), []any{"a", 123, "", "b"}, true)
+		if len(got) != 2 || got[0] != "a" || got[1] != "b" {
+			t.Errorf("groups = %v, want [a b] (non-string and empty skipped)", got)
+		}
+	})
+
+	t.Run("empty single string yields nil", func(t *testing.T) {
+		if got := verifyGroups(t, baseOIDCConfig(f), "", true); got != nil {
+			t.Errorf("groups = %v, want nil (empty string)", got)
+		}
+	})
+
+	t.Run("non-array non-string claim yields nil", func(t *testing.T) {
+		if got := verifyGroups(t, baseOIDCConfig(f), 42, true); got != nil {
+			t.Errorf("groups = %v, want nil (numeric claim ignored)", got)
+		}
+	})
+
+	t.Run("configurable claim name", func(t *testing.T) {
+		cfg := baseOIDCConfig(f)
+		cfg.GroupsClaim = "roles"
+		got := verifyGroups(t, cfg, []string{"x"}, true)
+		if len(got) != 1 || got[0] != "x" {
+			t.Errorf("groups = %v, want [x] (read from custom claim 'roles')", got)
+		}
+	})
+
+	t.Run("empty claim name yields nil", func(t *testing.T) {
+		cfg := baseOIDCConfig(f)
+		cfg.GroupsClaim = ""
+		got := verifyGroups(t, cfg, []string{"ignored"}, true)
+		if got != nil {
+			t.Errorf("groups = %v, want nil (groups_claim unset)", got)
+		}
+	})
+}

--- a/internal/storage/oidc_users_integration_test.go
+++ b/internal/storage/oidc_users_integration_test.go
@@ -1,0 +1,104 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// TestCreateAndFindOIDCUserIntegration exercises the OIDC provisioning and
+// resolution queries end to end: a JIT-created OIDC-only user (no password) is
+// linked by (provider, subject), granted the requested role, and resolved back
+// by that immutable pair with its roles and permissions loaded and active=true.
+func TestCreateAndFindOIDCUserIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	email := fmt.Sprintf("oidc_%d@example.com", time.Now().UnixNano())
+	subject := fmt.Sprintf("sub-%d", time.Now().UnixNano())
+
+	created, err := repo.CreateOIDCUser(ctx, "default", email, "azure", subject, []string{"viewer"})
+	if err != nil {
+		t.Fatalf("CreateOIDCUser: %v", err)
+	}
+	if created.ID == "" || created.Email != email || len(created.Roles) != 1 || created.Roles[0] != "viewer" {
+		t.Fatalf("unexpected created oidc user: %+v", created)
+	}
+
+	got, active, err := repo.FindUserByOIDCSubject(ctx, "azure", subject)
+	if err != nil {
+		t.Fatalf("FindUserByOIDCSubject: %v", err)
+	}
+	if !active {
+		t.Error("resolved oidc user is not active")
+	}
+	if got.ID != created.ID || got.Email != email || got.TenantID != "default" {
+		t.Errorf("resolved user = %+v, want id=%s email=%s tenant=default", got, created.ID, email)
+	}
+	if len(got.Roles) != 1 || got.Roles[0] != "viewer" {
+		t.Errorf("roles = %v, want [viewer]", got.Roles)
+	}
+	// viewer carries the read:dag permission (PR-A ladder), proving perms load.
+	if !got.HasPermission("read", "dag") {
+		t.Errorf("resolved viewer lacks read:dag; perms = %v", got.Permissions)
+	}
+}
+
+// TestFindOIDCUserNotFoundIntegration proves an unknown (provider, subject)
+// pair yields auth.ErrUserNotFound — the signal the login flow uses to consider
+// JIT provisioning rather than a hard failure.
+func TestFindOIDCUserNotFoundIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	if _, _, err := repo.FindUserByOIDCSubject(ctx, "azure", "nobody-here"); !errors.Is(err, auth.ErrUserNotFound) {
+		t.Errorf("err = %v, want auth.ErrUserNotFound", err)
+	}
+}
+
+// TestCreateOIDCUserUnknownRoleIntegration proves an unknown role (e.g. a
+// misconfigured default_role or role_mapping) fails closed as ErrValidation and
+// leaves no orphaned account — the pair can be provisioned cleanly afterwards.
+func TestCreateOIDCUserUnknownRoleIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	email := fmt.Sprintf("oidcbad_%d@example.com", time.Now().UnixNano())
+	subject := fmt.Sprintf("subbad-%d", time.Now().UnixNano())
+
+	if _, err := repo.CreateOIDCUser(ctx, "default", email, "azure", subject, []string{"wizard"}); !errors.Is(err, domain.ErrValidation) {
+		t.Fatalf("unknown role err = %v, want ErrValidation", err)
+	}
+	// No account was created, so a subsequent clean provision succeeds.
+	if _, err := repo.CreateOIDCUser(ctx, "default", email, "azure", subject, nil); err != nil {
+		t.Errorf("create after rejected role: %v", err)
+	}
+}
+
+// TestCreateOIDCUserDuplicateSubjectIntegration proves a second provision of the
+// same (provider, subject) surfaces as domain.ErrConflict (the unique
+// constraint), so a concurrent double-login cannot create two identities.
+func TestCreateOIDCUserDuplicateSubjectIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	subject := fmt.Sprintf("subdup-%d", time.Now().UnixNano())
+
+	if _, err := repo.CreateOIDCUser(ctx, "default", fmt.Sprintf("a_%d@example.com", time.Now().UnixNano()), "azure", subject, nil); err != nil {
+		t.Fatalf("first provision: %v", err)
+	}
+	if _, err := repo.CreateOIDCUser(ctx, "default", fmt.Sprintf("b_%d@example.com", time.Now().UnixNano()), "azure", subject, nil); !errors.Is(err, domain.ErrConflict) {
+		t.Errorf("duplicate subject err = %v, want ErrConflict", err)
+	}
+}
+
+// TestRoleExistsIntegration proves the role existence check the OIDC login path
+// uses to fail closed on a misconfigured default_role: a seeded role is found, a
+// nonexistent one is not, and neither is an error.
+func TestRoleExistsIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	if ok, err := repo.RoleExists(ctx, "default", "viewer"); err != nil || !ok {
+		t.Errorf("RoleExists(viewer) = %v, %v; want true, nil", ok, err)
+	}
+	if ok, err := repo.RoleExists(ctx, "default", "wizard"); err != nil || ok {
+		t.Errorf("RoleExists(wizard) = %v, %v; want false, nil", ok, err)
+	}
+}

--- a/internal/storage/oidc_users_integration_test.go
+++ b/internal/storage/oidc_users_integration_test.go
@@ -90,6 +90,117 @@ func TestCreateOIDCUserDuplicateSubjectIntegration(t *testing.T) {
 	}
 }
 
+// TestReconcileUserRolesDemotionIntegration proves the IdP-authoritative
+// reconcile: an OIDC user first granted [operator] whose IdP groups later map to
+// [viewer] ends with EXACTLY [viewer] in the DB, losing operator's extra
+// permissions. Because the resolve path (FindUserByOIDCSubject) reads the same
+// user_roles rows the per-request authz reload reads, the demotion takes effect
+// on the next request.
+func TestReconcileUserRolesDemotionIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	email := fmt.Sprintf("oidc_demote_%d@example.com", time.Now().UnixNano())
+	subject := fmt.Sprintf("subdemote-%d", time.Now().UnixNano())
+
+	created, err := repo.CreateOIDCUser(ctx, "default", email, "azure", subject, []string{"operator"})
+	if err != nil {
+		t.Fatalf("CreateOIDCUser: %v", err)
+	}
+
+	if err := repo.ReconcileUserRoles(ctx, created.ID, []string{"viewer"}); err != nil {
+		t.Fatalf("ReconcileUserRoles([viewer]): %v", err)
+	}
+
+	got, active, err := repo.FindUserByOIDCSubject(ctx, "azure", subject)
+	if err != nil || !active {
+		t.Fatalf("FindUserByOIDCSubject: user=%v active=%v err=%v", got, active, err)
+	}
+	if len(got.Roles) != 1 || got.Roles[0] != "viewer" {
+		t.Errorf("roles after demotion = %v, want [viewer]", got.Roles)
+	}
+	if !got.HasPermission("read", "dag") {
+		t.Error("demoted viewer lost read:dag")
+	}
+	if got.HasPermission("write", "dag_run") {
+		t.Error("demoted user still holds operator's write:dag_run — demotion did not take effect")
+	}
+}
+
+// TestReconcileUserRolesEmptyIntegration proves reconciling to the empty set
+// clears all grants (default-deny), the shape produced when a login maps to no
+// role and no default_role is configured.
+func TestReconcileUserRolesEmptyIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	email := fmt.Sprintf("oidc_empty_%d@example.com", time.Now().UnixNano())
+	subject := fmt.Sprintf("subempty-%d", time.Now().UnixNano())
+
+	created, err := repo.CreateOIDCUser(ctx, "default", email, "azure", subject, []string{"viewer"})
+	if err != nil {
+		t.Fatalf("CreateOIDCUser: %v", err)
+	}
+	if err := repo.ReconcileUserRoles(ctx, created.ID, nil); err != nil {
+		t.Fatalf("ReconcileUserRoles(nil): %v", err)
+	}
+	got, _, err := repo.FindUserByOIDCSubject(ctx, "azure", subject)
+	if err != nil {
+		t.Fatalf("FindUserByOIDCSubject: %v", err)
+	}
+	if len(got.Roles) != 0 {
+		t.Errorf("roles after empty reconcile = %v, want none", got.Roles)
+	}
+}
+
+// TestReconcileUserRolesIdempotentIntegration proves re-login with the same
+// groups yields the same rows: reconciling to [viewer] twice leaves exactly one
+// grant (no duplicate rows, no error).
+func TestReconcileUserRolesIdempotentIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	email := fmt.Sprintf("oidc_idem_%d@example.com", time.Now().UnixNano())
+	subject := fmt.Sprintf("subidem-%d", time.Now().UnixNano())
+
+	created, err := repo.CreateOIDCUser(ctx, "default", email, "azure", subject, nil)
+	if err != nil {
+		t.Fatalf("CreateOIDCUser: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		if err := repo.ReconcileUserRoles(ctx, created.ID, []string{"viewer"}); err != nil {
+			t.Fatalf("ReconcileUserRoles pass %d: %v", i, err)
+		}
+	}
+	got, _, err := repo.FindUserByOIDCSubject(ctx, "azure", subject)
+	if err != nil {
+		t.Fatalf("FindUserByOIDCSubject: %v", err)
+	}
+	if len(got.Roles) != 1 || got.Roles[0] != "viewer" {
+		t.Errorf("roles after idempotent reconcile = %v, want [viewer]", got.Roles)
+	}
+}
+
+// TestReconcileUserRolesUnknownRoleFailsClosedIntegration proves an unknown role
+// name fails closed as ErrValidation and leaves the prior grants intact — the
+// login path turns this into a rejected, audited login rather than silently
+// wiping the user's roles.
+func TestReconcileUserRolesUnknownRoleFailsClosedIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	email := fmt.Sprintf("oidc_unknown_%d@example.com", time.Now().UnixNano())
+	subject := fmt.Sprintf("subunknown-%d", time.Now().UnixNano())
+
+	created, err := repo.CreateOIDCUser(ctx, "default", email, "azure", subject, []string{"operator"})
+	if err != nil {
+		t.Fatalf("CreateOIDCUser: %v", err)
+	}
+	if err := repo.ReconcileUserRoles(ctx, created.ID, []string{"wizard"}); !errors.Is(err, domain.ErrValidation) {
+		t.Fatalf("ReconcileUserRoles([wizard]) = %v, want ErrValidation", err)
+	}
+	// The failed reconcile must not have wiped the existing grant.
+	got, _, err := repo.FindUserByOIDCSubject(ctx, "azure", subject)
+	if err != nil {
+		t.Fatalf("FindUserByOIDCSubject: %v", err)
+	}
+	if len(got.Roles) != 1 || got.Roles[0] != "operator" {
+		t.Errorf("roles after failed reconcile = %v, want unchanged [operator]", got.Roles)
+	}
+}
+
 // TestRoleExistsIntegration proves the role existence check the OIDC login path
 // uses to fail closed on a misconfigured default_role: a seeded role is found, a
 // nonexistent one is not, and neither is an error.

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -66,6 +66,9 @@ type Querier interface {
 	// The implicit default pool is never deletable (Airflow parity): the guard is in
 	// the query so a direct call cannot orphan the fallback pool the gate resolves to.
 	DeletePool(ctx context.Context, arg DeletePoolParams) (int64, error)
+	// Remove every role grant for a user: the delete half of the IdP-authoritative
+	// reconcile that sets the grants to exactly the group-mapped set on each login.
+	DeleteUserRoles(ctx context.Context, userID pgtype.UUID) error
 	DeleteVariable(ctx context.Context, arg DeleteVariableParams) (int64, error)
 	// The dispatch-attempt budget is spent (ADR 0031 Amendment A): fail the task with
 	// a dispatch_failed reason so the run can finalize instead of looping forever.
@@ -89,6 +92,11 @@ type Querier interface {
 	GetDefaultTenant(ctx context.Context) (GetDefaultTenantRow, error)
 	GetPool(ctx context.Context, arg GetPoolParams) (GetPoolRow, error)
 	GetRoleByName(ctx context.Context, arg GetRoleByNameParams) (pgtype.UUID, error)
+	// Resolve a role name to its id within the user's OWN tenant, so an OIDC login
+	// can reconcile the user's grants to the group-mapped set without the caller
+	// passing the tenant separately. A name that is not a role in that tenant yields
+	// no row, which the reconcile turns into a fail-closed error.
+	GetRoleIDForUserTenant(ctx context.Context, arg GetRoleIDForUserTenantParams) (pgtype.UUID, error)
 	GetTenantByName(ctx context.Context, name string) (GetTenantByNameRow, error)
 	GetUserByEmail(ctx context.Context, arg GetUserByEmailParams) (GetUserByEmailRow, error)
 	// The by-id lookup backing the per-request authz reload. Returns the tenant

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -95,12 +95,22 @@ type Querier interface {
 	// name (not the uuid) so the reconstructed principal matches the login path's
 	// User.TenantID, plus the active flag the authenticator gates on.
 	GetUserByID(ctx context.Context, id pgtype.UUID) (GetUserByIDRow, error)
+	// Resolve an OIDC identity to a Leoflow user by its immutable (provider,
+	// subject) pair (the trusted link key). Returns the tenant name (not the uuid)
+	// so the reconstructed principal matches the login path's User.TenantID, plus
+	// the active flag the login gates on. Never selects password_hash.
+	GetUserByOIDCSubject(ctx context.Context, arg GetUserByOIDCSubjectParams) (GetUserByOIDCSubjectRow, error)
 	GetUserPermissions(ctx context.Context, userID pgtype.UUID) ([]GetUserPermissionsRow, error)
 	GetUserRoles(ctx context.Context, userID pgtype.UUID) ([]string, error)
 	GetVariable(ctx context.Context, arg GetVariableParams) (GetVariableRow, error)
 	GetXComByNames(ctx context.Context, arg GetXComByNamesParams) (GetXComByNamesRow, error)
 	GetXComEntry(ctx context.Context, arg GetXComEntryParams) (GetXComEntryRow, error)
 	InsertDagVersion(ctx context.Context, arg InsertDagVersionParams) (DagVersion, error)
+	// Just-in-time provisioning insert for a first OIDC login: an OIDC-only user
+	// (NULL password) linked by (oidc_provider, oidc_subject). The unique
+	// (oidc_provider, oidc_subject) constraint makes a concurrent double-provision
+	// surface as a conflict rather than a duplicate identity.
+	InsertOIDCUser(ctx context.Context, arg InsertOIDCUserParams) (InsertOIDCUserRow, error)
 	// Mirrors the bootstrap CreateUser insert (tenant_id, email, password_hash) but
 	// returns the columns the admin create-user API echoes back to the caller.
 	InsertUser(ctx context.Context, arg InsertUserParams) (InsertUserRow, error)

--- a/internal/storage/queries/users.sql
+++ b/internal/storage/queries/users.sql
@@ -17,6 +17,25 @@ FROM users u
 JOIN tenants t ON t.id = u.tenant_id
 WHERE t.name = $1 AND u.email = $2;
 
+-- name: GetUserByOIDCSubject :one
+-- Resolve an OIDC identity to a Leoflow user by its immutable (provider,
+-- subject) pair (the trusted link key). Returns the tenant name (not the uuid)
+-- so the reconstructed principal matches the login path's User.TenantID, plus
+-- the active flag the login gates on. Never selects password_hash.
+SELECT u.id, t.name AS tenant, u.email, u.is_active
+FROM users u
+JOIN tenants t ON t.id = u.tenant_id
+WHERE u.oidc_provider = $1 AND u.oidc_subject = $2;
+
+-- name: InsertOIDCUser :one
+-- Just-in-time provisioning insert for a first OIDC login: an OIDC-only user
+-- (NULL password) linked by (oidc_provider, oidc_subject). The unique
+-- (oidc_provider, oidc_subject) constraint makes a concurrent double-provision
+-- surface as a conflict rather than a duplicate identity.
+INSERT INTO users (tenant_id, email, oidc_provider, oidc_subject)
+VALUES ($1, $2, $3, $4)
+RETURNING id, email, is_active, created_at;
+
 -- name: GetUserByID :one
 -- The by-id lookup backing the per-request authz reload. Returns the tenant
 -- name (not the uuid) so the reconstructed principal matches the login path's

--- a/internal/storage/queries/users.sql
+++ b/internal/storage/queries/users.sql
@@ -71,6 +71,21 @@ FROM user_roles ur
 JOIN roles r ON r.id = ur.role_id
 WHERE ur.user_id = $1;
 
+-- name: GetRoleIDForUserTenant :one
+-- Resolve a role name to its id within the user's OWN tenant, so an OIDC login
+-- can reconcile the user's grants to the group-mapped set without the caller
+-- passing the tenant separately. A name that is not a role in that tenant yields
+-- no row, which the reconcile turns into a fail-closed error.
+SELECT r.id
+FROM roles r
+JOIN users u ON u.tenant_id = r.tenant_id
+WHERE u.id = $1 AND r.name = $2;
+
+-- name: DeleteUserRoles :exec
+-- Remove every role grant for a user: the delete half of the IdP-authoritative
+-- reconcile that sets the grants to exactly the group-mapped set on each login.
+DELETE FROM user_roles WHERE user_id = $1;
+
 -- name: GetUserPermissions :many
 SELECT DISTINCT p.action, p.resource
 FROM user_roles ur

--- a/internal/storage/queries/users.sql.go
+++ b/internal/storage/queries/users.sql.go
@@ -105,6 +105,41 @@ func (q *Queries) GetUserByID(ctx context.Context, id pgtype.UUID) (GetUserByIDR
 	return i, err
 }
 
+const getUserByOIDCSubject = `-- name: GetUserByOIDCSubject :one
+SELECT u.id, t.name AS tenant, u.email, u.is_active
+FROM users u
+JOIN tenants t ON t.id = u.tenant_id
+WHERE u.oidc_provider = $1 AND u.oidc_subject = $2
+`
+
+type GetUserByOIDCSubjectParams struct {
+	OidcProvider *string `json:"oidc_provider"`
+	OidcSubject  *string `json:"oidc_subject"`
+}
+
+type GetUserByOIDCSubjectRow struct {
+	ID       pgtype.UUID `json:"id"`
+	Tenant   string      `json:"tenant"`
+	Email    string      `json:"email"`
+	IsActive bool        `json:"is_active"`
+}
+
+// Resolve an OIDC identity to a Leoflow user by its immutable (provider,
+// subject) pair (the trusted link key). Returns the tenant name (not the uuid)
+// so the reconstructed principal matches the login path's User.TenantID, plus
+// the active flag the login gates on. Never selects password_hash.
+func (q *Queries) GetUserByOIDCSubject(ctx context.Context, arg GetUserByOIDCSubjectParams) (GetUserByOIDCSubjectRow, error) {
+	row := q.db.QueryRow(ctx, getUserByOIDCSubject, arg.OidcProvider, arg.OidcSubject)
+	var i GetUserByOIDCSubjectRow
+	err := row.Scan(
+		&i.ID,
+		&i.Tenant,
+		&i.Email,
+		&i.IsActive,
+	)
+	return i, err
+}
+
 const getUserPermissions = `-- name: GetUserPermissions :many
 SELECT DISTINCT p.action, p.resource
 FROM user_roles ur
@@ -163,6 +198,47 @@ func (q *Queries) GetUserRoles(ctx context.Context, userID pgtype.UUID) ([]strin
 		return nil, err
 	}
 	return items, nil
+}
+
+const insertOIDCUser = `-- name: InsertOIDCUser :one
+INSERT INTO users (tenant_id, email, oidc_provider, oidc_subject)
+VALUES ($1, $2, $3, $4)
+RETURNING id, email, is_active, created_at
+`
+
+type InsertOIDCUserParams struct {
+	TenantID     pgtype.UUID `json:"tenant_id"`
+	Email        string      `json:"email"`
+	OidcProvider *string     `json:"oidc_provider"`
+	OidcSubject  *string     `json:"oidc_subject"`
+}
+
+type InsertOIDCUserRow struct {
+	ID        pgtype.UUID        `json:"id"`
+	Email     string             `json:"email"`
+	IsActive  bool               `json:"is_active"`
+	CreatedAt pgtype.Timestamptz `json:"created_at"`
+}
+
+// Just-in-time provisioning insert for a first OIDC login: an OIDC-only user
+// (NULL password) linked by (oidc_provider, oidc_subject). The unique
+// (oidc_provider, oidc_subject) constraint makes a concurrent double-provision
+// surface as a conflict rather than a duplicate identity.
+func (q *Queries) InsertOIDCUser(ctx context.Context, arg InsertOIDCUserParams) (InsertOIDCUserRow, error) {
+	row := q.db.QueryRow(ctx, insertOIDCUser,
+		arg.TenantID,
+		arg.Email,
+		arg.OidcProvider,
+		arg.OidcSubject,
+	)
+	var i InsertOIDCUserRow
+	err := row.Scan(
+		&i.ID,
+		&i.Email,
+		&i.IsActive,
+		&i.CreatedAt,
+	)
+	return i, err
 }
 
 const insertUser = `-- name: InsertUser :one

--- a/internal/storage/queries/users.sql.go
+++ b/internal/storage/queries/users.sql.go
@@ -11,6 +11,17 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const deleteUserRoles = `-- name: DeleteUserRoles :exec
+DELETE FROM user_roles WHERE user_id = $1
+`
+
+// Remove every role grant for a user: the delete half of the IdP-authoritative
+// reconcile that sets the grants to exactly the group-mapped set on each login.
+func (q *Queries) DeleteUserRoles(ctx context.Context, userID pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, deleteUserRoles, userID)
+	return err
+}
+
 const getDefaultTenant = `-- name: GetDefaultTenant :one
 SELECT id, name FROM tenants WHERE name = 'default'
 `
@@ -25,6 +36,29 @@ func (q *Queries) GetDefaultTenant(ctx context.Context) (GetDefaultTenantRow, er
 	var i GetDefaultTenantRow
 	err := row.Scan(&i.ID, &i.Name)
 	return i, err
+}
+
+const getRoleIDForUserTenant = `-- name: GetRoleIDForUserTenant :one
+SELECT r.id
+FROM roles r
+JOIN users u ON u.tenant_id = r.tenant_id
+WHERE u.id = $1 AND r.name = $2
+`
+
+type GetRoleIDForUserTenantParams struct {
+	ID   pgtype.UUID `json:"id"`
+	Name string      `json:"name"`
+}
+
+// Resolve a role name to its id within the user's OWN tenant, so an OIDC login
+// can reconcile the user's grants to the group-mapped set without the caller
+// passing the tenant separately. A name that is not a role in that tenant yields
+// no row, which the reconcile turns into a fail-closed error.
+func (q *Queries) GetRoleIDForUserTenant(ctx context.Context, arg GetRoleIDForUserTenantParams) (pgtype.UUID, error) {
+	row := q.db.QueryRow(ctx, getRoleIDForUserTenant, arg.ID, arg.Name)
+	var id pgtype.UUID
+	err := row.Scan(&id)
+	return id, err
 }
 
 const getTenantByName = `-- name: GetTenantByName :one

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -142,6 +142,103 @@ func (r *Repository) FindUserByID(ctx context.Context, id string) (*auth.User, b
 	return user, row.IsActive, nil
 }
 
+// FindUserByOIDCSubject resolves an OIDC identity to a Leoflow user by its
+// immutable (provider, subject) pair — the trusted link key for a returning SSO
+// login. Like FindUserByID it loads the current tenant, roles, and permissions
+// plus the active flag, so the caller reconstructs the same principal the
+// credential path would. A pair matching no row yields auth.ErrUserNotFound (the
+// signal to consider just-in-time provisioning); any other failure is returned
+// as-is so the caller can fail closed.
+func (r *Repository) FindUserByOIDCSubject(ctx context.Context, provider, subject string) (*auth.User, bool, error) {
+	row, err := r.q.GetUserByOIDCSubject(ctx, queries.GetUserByOIDCSubjectParams{
+		OidcProvider: strPtr(provider), OidcSubject: strPtr(subject),
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, false, auth.ErrUserNotFound
+		}
+		return nil, false, fmt.Errorf("loading user by oidc subject: %w", err)
+	}
+	roles, err := r.q.GetUserRoles(ctx, row.ID)
+	if err != nil {
+		return nil, false, fmt.Errorf("loading roles: %w", err)
+	}
+	perms, err := r.q.GetUserPermissions(ctx, row.ID)
+	if err != nil {
+		return nil, false, fmt.Errorf("loading permissions: %w", err)
+	}
+	user := &auth.User{ID: uuidToString(row.ID), TenantID: row.Tenant, Email: row.Email, Roles: roles}
+	for _, p := range perms {
+		user.Permissions = append(user.Permissions, auth.Permission{Action: p.Action, Resource: p.Resource})
+	}
+	return user, row.IsActive, nil
+}
+
+// CreateOIDCUser just-in-time provisions an OIDC-only account (NULL password),
+// linked by (oidc_provider, oidc_subject), and grants it the given roles. It
+// mirrors CreateUser's atomicity: every role is resolved BEFORE the insert so an
+// unknown role fails cleanly as domain.ErrValidation without leaving an orphaned
+// account, and the insert plus the grants run in one transaction so a failed
+// grant rolls the account back. An empty role set grants none (default-deny).
+// A concurrent double-provision surfaces as domain.ErrConflict via the unique
+// (oidc_provider, oidc_subject) constraint. The returned user carries the
+// granted role names so the caller can mint a token without a reload.
+func (r *Repository) CreateOIDCUser(ctx context.Context, tenant, email, provider, subject string, roles []string) (*auth.User, error) {
+	tid, err := r.tenantID(ctx, tenant)
+	if err != nil {
+		return nil, err
+	}
+	roleIDs := make([]pgtype.UUID, 0, len(roles))
+	for _, role := range roles {
+		roleID, rerr := r.q.GetRoleByName(ctx, queries.GetRoleByNameParams{TenantID: tid, Name: role})
+		if rerr != nil {
+			if errors.Is(rerr, pgx.ErrNoRows) {
+				return nil, fmt.Errorf("unknown role %q: %w", role, domain.ErrValidation)
+			}
+			return nil, fmt.Errorf("looking up role: %w", rerr)
+		}
+		roleIDs = append(roleIDs, roleID)
+	}
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("beginning create-oidc-user tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }() //nolint:errcheck // best-effort; the commit path returns the meaningful error
+	qtx := r.q.WithTx(tx)
+	row, err := qtx.InsertOIDCUser(ctx, queries.InsertOIDCUserParams{
+		TenantID: tid, Email: email, OidcProvider: strPtr(provider), OidcSubject: strPtr(subject),
+	})
+	if err != nil {
+		return nil, mapConflict(err)
+	}
+	for _, roleID := range roleIDs {
+		if aerr := qtx.AssignUserRole(ctx, queries.AssignUserRoleParams{UserID: row.ID, RoleID: roleID}); aerr != nil {
+			return nil, fmt.Errorf("assigning role: %w", aerr)
+		}
+	}
+	if cerr := tx.Commit(ctx); cerr != nil {
+		return nil, fmt.Errorf("committing create-oidc-user tx: %w", cerr)
+	}
+	return &auth.User{ID: uuidToString(row.ID), TenantID: tenant, Email: row.Email, Roles: roles}, nil
+}
+
+// RoleExists reports whether a role name exists for the tenant. The OIDC login
+// path uses it to fail closed on a misconfigured default_role before minting a
+// token for a returning user (the JIT path validates roles inside CreateOIDCUser).
+func (r *Repository) RoleExists(ctx context.Context, tenant, role string) (bool, error) {
+	tid, err := r.tenantID(ctx, tenant)
+	if err != nil {
+		return false, err
+	}
+	if _, err := r.q.GetRoleByName(ctx, queries.GetRoleByNameParams{TenantID: tid, Name: role}); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf("looking up role: %w", err)
+	}
+	return true, nil
+}
+
 // ListDags returns a page of DAGs for the tenant and the total count.
 func (r *Repository) ListDags(ctx context.Context, tenant string, limit, offset int) ([]domain.DAG, int, error) {
 	tid, err := r.tenantID(ctx, tenant)
@@ -503,6 +600,61 @@ func (r *Repository) RecordUserCreatedAudit(ctx context.Context, tenant, actorUs
 		ResourceType: strPtr("user"), ResourceID: strPtr(createdUserID), Metadata: meta,
 	}); err != nil {
 		return fmt.Errorf("writing user-created audit: %w", err)
+	}
+	return nil
+}
+
+// RecordAuthEvent records an authentication event to the audit log (H5): OIDC
+// login success/failure, tenant-pin rejection, JIT provisioning, break-glass
+// login, and logout. It NEVER records tokens or the client secret — only the
+// actor's email, the resolved tenant (best-effort), the outcome, and small
+// non-secret detail fields (e.g. the rejection reason, the attempted tenant
+// claim). It is best-effort: the caller logs and continues on error so a flaky
+// audit sink never turns a security decision (a 403 rejection, a successful
+// login) into a 5xx.
+//
+// The event is scoped to the resolved tenant when known; events that never
+// resolved a tenant (a login failure, a tenant-pin rejection) fall back to the
+// "default" tenant so the row still lands, with the attempted values in the
+// metadata. resourceID carries the email so account-scoped auth activity is
+// filterable alongside user.create.
+func (r *Repository) RecordAuthEvent(ctx context.Context, tenant, actorUserID, action, email, outcome string, extra map[string]string) error {
+	if tenant == "" {
+		tenant = "default"
+	}
+	tid, err := r.tenantID(ctx, tenant)
+	if err != nil {
+		// The resolved tenant may not exist (an attacker-supplied claim); fall back
+		// to default so the security event is never silently dropped.
+		tid, err = r.tenantID(ctx, "default")
+		if err != nil {
+			return fmt.Errorf("resolving audit tenant: %w", err)
+		}
+	}
+	var uid pgtype.UUID
+	if u, perr := parseUUID(actorUserID); perr == nil {
+		uid = u
+	}
+	fields := map[string]any{"outcome": outcome}
+	if email != "" {
+		fields["email"] = email
+	}
+	for k, v := range extra {
+		fields[k] = v
+	}
+	meta, err := json.Marshal(fields)
+	if err != nil {
+		return fmt.Errorf("encoding audit metadata: %w", err)
+	}
+	var resourceID *string
+	if email != "" {
+		resourceID = strPtr(email)
+	}
+	if err := r.q.CreateAuditLog(ctx, queries.CreateAuditLogParams{
+		TenantID: tid, UserID: uid, Action: action,
+		ResourceType: strPtr("auth"), ResourceID: resourceID, Metadata: meta,
+	}); err != nil {
+		return fmt.Errorf("writing auth-event audit: %w", err)
 	}
 	return nil
 }

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -239,6 +239,56 @@ func (r *Repository) RoleExists(ctx context.Context, tenant, role string) (bool,
 	return true, nil
 }
 
+// ReconcileUserRoles makes the user's granted roles exactly roleNames, atomically:
+// it is how the identity provider stays authoritative over an OIDC user's roles.
+// On each OIDC login the caller passes the group-mapped role set, and this sets
+// the DB user_roles to precisely that set, so a demotion or deprovisioning at the
+// IdP takes effect on the next login and the per-request authz reload sees it.
+//
+// Every name is resolved to a role id in the user's OWN tenant BEFORE any write,
+// so a name that is not a role in that tenant fails closed as domain.ErrValidation
+// with the prior grants untouched — the login path turns that into a rejected,
+// audited login rather than silently wiping the user's roles. The delete and the
+// inserts run in one transaction, making the operation idempotent (reconciling
+// the same set yields the same rows) and an empty roleNames a full clear
+// (default-deny).
+func (r *Repository) ReconcileUserRoles(ctx context.Context, userID string, roleNames []string) error {
+	uid, err := parseUUID(userID)
+	if err != nil {
+		return err
+	}
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("beginning reconcile-user-roles tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }() //nolint:errcheck // best-effort; the commit path returns the meaningful error
+	qtx := r.q.WithTx(tx)
+	// Resolve every role id first so an unknown name aborts before any mutation.
+	roleIDs := make([]pgtype.UUID, 0, len(roleNames))
+	for _, name := range roleNames {
+		roleID, rerr := qtx.GetRoleIDForUserTenant(ctx, queries.GetRoleIDForUserTenantParams{ID: uid, Name: name})
+		if rerr != nil {
+			if errors.Is(rerr, pgx.ErrNoRows) {
+				return fmt.Errorf("unknown role %q: %w", name, domain.ErrValidation)
+			}
+			return fmt.Errorf("looking up role: %w", rerr)
+		}
+		roleIDs = append(roleIDs, roleID)
+	}
+	if derr := qtx.DeleteUserRoles(ctx, uid); derr != nil {
+		return fmt.Errorf("clearing user roles: %w", derr)
+	}
+	for _, roleID := range roleIDs {
+		if aerr := qtx.AssignUserRole(ctx, queries.AssignUserRoleParams{UserID: uid, RoleID: roleID}); aerr != nil {
+			return fmt.Errorf("assigning role: %w", aerr)
+		}
+	}
+	if cerr := tx.Commit(ctx); cerr != nil {
+		return fmt.Errorf("committing reconcile-user-roles tx: %w", cerr)
+	}
+	return nil
+}
+
 // ListDags returns a page of DAGs for the tenant and the total count.
 func (r *Repository) ListDags(ctx context.Context, tenant string, limit, offset int) ([]domain.DAG, int, error) {
 	tid, err := r.tenantID(ctx, tenant)

--- a/internal/storage/role_ladder_integration_test.go
+++ b/internal/storage/role_ladder_integration_test.go
@@ -62,18 +62,13 @@ func TestRoleLadderSeedIntegration(t *testing.T) {
 		}
 	}
 
-	// The ladder roles are unassigned: no user_roles rows reference them, so no
-	// existing account (including the bootstrap admin) gains or loses access.
-	var assigned int
-	if err := pg.Pool.QueryRow(ctx,
-		`SELECT count(*) FROM user_roles ur
-		 JOIN roles r ON r.id = ur.role_id
-		 WHERE r.name IN ('viewer', 'editor', 'operator')`).Scan(&assigned); err != nil {
-		t.Fatalf("counting ladder assignments: %v", err)
-	}
-	if assigned != 0 {
-		t.Errorf("ladder roles must ship unassigned, found %d user_roles rows", assigned)
-	}
+	// The migration ships the roles unassigned — it only writes `roles` and
+	// `role_permissions`, never `user_roles` — so no pre-existing account gains
+	// access on upgrade. That is a property of the migration SQL (verified by
+	// inspection and the permission-count assertions above), not a global runtime
+	// invariant: application code (OIDC login reconciliation, admin role grants)
+	// legitimately assigns these roles to users, so a shared-DB count of ladder
+	// user_roles is NOT zero once other tests have run and must not be asserted.
 
 	// A representative grant from each tier proves the matrix content, not just
 	// its cardinality: viewer can read a variable, editor can write one, and


### PR DESCRIPTION
## PR-9 — OIDC/SSO (final Identity/Auth item)

Closes #653. Design: **ADR 0057** (in this PR). **Stacked on PR-A (#654) → PR-7 → PR-5.** Specialist-reviewed; all 5 HIGH baked in; the 4 maintainer decisions + both addenda (`default_role`, `allowed_email_domains`) implemented.

### What it does
Authorization Code + PKCE login (`/api/v2/auth/oidc/login` + `/callback`) → keyless ID-token verification (public discovery + JWKS) → fail-closed tenant pin → user resolve/JIT → group→role map → mints the existing `_token` JWT (rest of the app unchanged; PR-A's per-request reload stays authoritative for live permissions).

### Security core (fail-closed) — with proofs
- **Tenant pin (H1):** issuer-locked + `tid`(Entra)/`hd`(Google) → `tenant_claims` map + `email_verified==true`; absent/unmapped/mismatch → **403, never falls back to `default`**. `TestOIDCTenantPinFailsClosed` (+ audited).
- **Verification (H4):** nonce (constant-time), `azp`, clock-skew-aware `exp`/`iat`/`nbf` (this package is the single time authority; go-oidc's expiry check disabled), tampered-sig, wrong-aud → all 403. `TestOIDCTokenVerificationFailsClosed`.
- **Break-glass (H2):** under `provider: oidc`, `POST /auth/token` accepts ONLY `break_glass_emails`; all others rejected + audited. `TestBreakGlassAllowsOnlyAllowlistedEmail`.
- **Order:** sig/aud/issuer → nonce → azp → skew → subject → email_verified → tenant pin → **email-domain allowlist LAST** (so a spoofable domain can never substitute for the pin).

### Locked decisions
JIT off-by-default (opt-in); `default_role` opt-in fallback for authenticated-but-unmapped (empty=deny, validated via `RoleExists`); `allowed_email_domains` login-level allowlist (install-time, post-pin, post-email_verified; empty=pin is the boundary, non-empty=only those domains log in — pre-existing users included); provider Pro-gated; keyless verify, `client_secret` env-only (never persisted/logged); **audit via the real Postgres `audit_log`** (not JSONL — that was a PowerLab detail) for login success/failure/tenant-pin-reject/JIT/break-glass.

### `provider: jwt` (default) unchanged — proven
`TestJWTModeOIDCRoutesAbsent` (OIDC routes 404 when no flow built) + `TestJWTModeCredentialPathUngated` (`/auth/token` ungated, no auth audit). No IdP discovery in JWT mode.

### Dependency
`github.com/coreos/go-oidc/v3` added; `golang.org/x/oauth2` promoted to direct. `go mod tidy` clean, `govulncheck ./internal/oidc/...` clean.

### Verification
build/vet(+`-tags integration`)/gofmt clean · `golangci-lint run ./...` **0** · oidc/config/api/storage/cmd tests pass · integration tests self-skip without a DB · ADR 0057 authored.

Strict TDD (test-first pairs). No AI attribution. **Held for the Wave-3 closing specialist review** (a review nit noted: issuer-mismatch error-string matching is redundant with an explicit check — audit-reason only, rejection guaranteed).