### PR TITLE
fix(oidc): reject exp-less tokens + guard role-ladder migration invariant

### DIFF
--- a/internal/oidc/verify.go
+++ b/internal/oidc/verify.go
@@ -29,6 +29,10 @@ var (
 	// ErrTokenExpired is returned when exp/iat/nbf fall outside the allowed clock
 	// skew (H4).
 	ErrTokenExpired = errors.New("oidc: token outside validity window")
+	// ErrMissingExpiry is returned when the ID token carries no exp claim; with
+	// go-oidc's own expiry check disabled, an absent exp must fail closed rather
+	// than grant an unbounded session.
+	ErrMissingExpiry = errors.New("oidc: token has no expiry")
 	// ErrEmailNotVerified is returned when email_verified is not true; an absent
 	// claim is treated as false (D6c).
 	ErrEmailNotVerified = errors.New("oidc: email not verified")
@@ -200,7 +204,13 @@ func (v *Verifier) checkBindings(idToken *gooidc.IDToken, claims idClaims, expec
 func (v *Verifier) checkTimes(idToken *gooidc.IDToken, nbfUnix int64) error {
 	skew := time.Duration(v.cfg.ClockSkewSeconds) * time.Second
 	now := v.now()
-	if !idToken.Expiry.IsZero() && now.After(idToken.Expiry.Add(skew)) {
+	// A token with no exp has no validity window. Because go-oidc runs with
+	// SkipExpiryCheck (this package is the time authority), a missing exp would
+	// otherwise sail through unbounded — fail closed instead.
+	if idToken.Expiry.IsZero() {
+		return ErrMissingExpiry
+	}
+	if now.After(idToken.Expiry.Add(skew)) {
 		return ErrTokenExpired
 	}
 	if !idToken.IssuedAt.IsZero() && idToken.IssuedAt.After(now.Add(skew)) {

--- a/internal/oidc/verify_test.go
+++ b/internal/oidc/verify_test.go
@@ -261,6 +261,15 @@ func TestVerifyClockSkew(t *testing.T) {
 		}
 	})
 
+	t.Run("missing exp is rejected", func(t *testing.T) {
+		v := newTestVerifier(t, cfg)
+		claims := baseClaims(cfg, testNonce)
+		delete(claims, "exp") // a token with no expiry has no validity window
+		if _, err := v.Verify(context.Background(), f.signIDToken(t, claims), testNonce); !errors.Is(err, ErrMissingExpiry) {
+			t.Fatalf("Verify(no exp) = %v, want ErrMissingExpiry", err)
+		}
+	})
+
 	t.Run("within skew boundary is accepted", func(t *testing.T) {
 		v := newTestVerifier(t, cfg)
 		claims := baseClaims(cfg, testNonce)

--- a/internal/storage/role_ladder_migration_test.go
+++ b/internal/storage/role_ladder_migration_test.go
@@ -1,0 +1,37 @@
+package storage_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestRoleLadderMigrationDoesNotAssignRoles guards the upgrade-safety invariant
+// that the role-ladder migration ships its roles UNASSIGNED: it may only seed
+// permissions, roles, and role_permissions — never user_roles — so no
+// pre-existing account (the bootstrap admin above all) silently gains access on
+// upgrade. This is a property of the migration SQL, asserted statically because
+// a shared integration DB cannot: application code (OIDC login reconciliation,
+// admin grants) legitimately writes user_roles at runtime. If a future edit adds
+// an `INSERT INTO user_roles` to this migration, this test fails.
+func TestRoleLadderMigrationDoesNotAssignRoles(t *testing.T) {
+	const path = "../../migrations/025_role_ladder.up.sql"
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	// Strip `--` line comments before checking, so a comment that merely mentions
+	// user_roles (e.g. "ships UNASSIGNED, no user_roles rows") is not a false
+	// positive — only executable SQL touching the table must fail the guard.
+	var code strings.Builder
+	for _, line := range strings.Split(string(raw), "\n") {
+		if i := strings.Index(line, "--"); i >= 0 {
+			line = line[:i]
+		}
+		code.WriteString(strings.ToLower(line))
+		code.WriteByte('\n')
+	}
+	if strings.Contains(code.String(), "user_roles") {
+		t.Errorf("%s must not touch user_roles — the ladder ships unassigned so upgrades grant no pre-existing account access", path)
+	}
+}


### PR DESCRIPTION
Post-merge review follow-ups (spec/wave-3-postmerge-review.md — the review verdict was SOLID; these are the two LOW items).

### F2 — reject ID tokens with no `exp` (fail closed)
`internal/oidc/verify.go` runs go-oidc with `SkipExpiryCheck` and is the time authority, but `checkTimes` only enforced `exp` when present → a signed token with no `exp` had no validity window. Now fails closed with `ErrMissingExpiry`. Narrow (only the trusted IdP signs ID tokens), but the verify core must never grant an unbounded session. Test: `Verify(no exp)` → `ErrMissingExpiry`.

### F1 — guard the role-ladder migration invariant
The merge removed a fragile global `user_roles`-count assertion (it broke once OIDC reconcile/JIT tests legitimately assigned ladder roles in the shared DB). That left the real invariant — *migration 025 never writes `user_roles`, so no pre-existing account gains access on upgrade* — unguarded. New static test asserts (comment-stripped) that `025_role_ladder.up.sql` touches only permissions/roles/role_permissions, never `user_roles`. Robust: no DB, immune to shared-DB pollution.

### Verification
`go build` ✅ · `internal/oidc` + `internal/storage` tests ✅ · `golangci-lint run` **0** · no production behavior change beyond the exp-less rejection. Strict TDD, no AI attribution.