### PR TITLE
feat(secrets): declared-secret schema + accept ADR 0055 (no delivery change)

### DIFF
--- a/docs/adr/0055-secret-scoping-and-token-liveness.md
+++ b/docs/adr/0055-secret-scoping-and-token-liveness.md
@@ -187,7 +187,7 @@ each narrows a different dimension (what a token can fetch, when it works, who c
 read it, how long it lives) — and Fix #1 is not independently shippable, because
 the token must identify the task for the scope filter to bind (Fix #3).
 
-## Resolved decisions (D1–D8)
+## Resolved decisions (D1–D9)
 
 The design above (Fixes #1–#4, the rejection, and the hard ordering) stands. The
 mechanical questions it left open are resolved as follows; these bind the
@@ -241,6 +241,23 @@ implementation.
   the task spec (per-task narrowing), serialized into `dag.json`, schema-validated,
   and threaded through the agent-facing task spec so scoping can key on them. The
   dead `secretKeyRef`-shaped secret struct is deleted rather than reused.
+- **D9 — scope enforcement is an operator policy (edition-defaulted); token
+  liveness is always on.** The two halves are gated differently by their cost:
+  - **Token liveness + short renewed TTL (Fix #2/#4) is ALWAYS on, no toggle** — it
+    adds no user friction (the agent renews automatically) and the hole it closes
+    (a finished task's token resolving the whole vault for its TTL, from anywhere)
+    is real even for a single-tenant deployment.
+  - **Scope-by-declaration (Fix #1) is an operator-set policy `secret_scoping:
+    enforce | permissive | off`.** `enforce` = declare-or-receive-nothing (default
+    for multi-tenant); `permissive` = no declaration ⇒ the whole tenant vault
+    (today's behavior), scoping applies only where a DAG declared (opt-in
+    least-privilege — default for single-tenant / Lite); `off` = no scoping. The
+    policy is operator-scoped, NEVER author-settable (a DAG author cannot downgrade
+    their own task's scoping — the same confused-deputy bar as the token TTL). The
+    declaration mechanism exists for every deployment regardless of policy; only the
+    obligation varies. `off`/`permissive` is a conscious operator choice with a
+    per-edition default, not a silent global security-off — even single-tenant, the
+    scope reduces blast radius (a compromised task leaks only what it declared).
 
 ### Invariants the implementation must hold
 
@@ -259,6 +276,32 @@ implementation.
   clause: a recency term would deny a legitimate clear-and-rerun of an old run with a
   spurious secret-denied, the exact unacceptable case. The safe design is already in
   the tree; the only risk is "improving" the predicate with a recency term.
+
+### Token liveness/renewal (E2) — mandatory test discipline
+
+A bug here breaks every legitimate pipeline (a false-deny drops a live task's secret
+access), so the token work ships with this discipline:
+
+- **Two-sided invariants on every test.** Assert both availability — a live attempt's
+  token ALWAYS resolves and ALWAYS renews on heartbeat, never a false-deny — and
+  security — a terminal/superseded/expired token NEVER resolves. The availability side
+  is what guards pipelines.
+- **State-machine matrix + deterministic clock.** Token validity is a function of TI
+  state, attempt number, and time; enumerate every transition (running→success/failed,
+  running→superseded-by-retry, cleared-old→rerun, reschedule defer→return). Use an
+  injectable clock, never wall-clock; the TTL floor must exceed the heartbeat interval
+  times the missed-beat tolerance so a slow heartbeat never drops a live task.
+- **Real integration, not just fakes.** Exercise the full dispatch → mint →
+  heartbeat-renew → finish → token-dies loop against a real datastore and a real RPC
+  round-trip, plus retry and clear-old-rerun end-to-end.
+- **Transient-error calibration.** Deny only on a POSITIVE not-live result; an
+  inconclusive liveness read (a datastore blip) must NOT kill a live task — the short
+  TTL already covers a brief blip and the agent retries the heartbeat. Failing closed
+  on a transient read would break legitimate pipelines.
+- **Observe-mode rollout.** Ship the liveness gate in observe mode first (log
+  would-have-denied, do not deny), watch real traffic for false-denies, then flip to
+  enforce — the same warn→enforce arc as scope enforcement, and the strongest guard
+  against a latent pipeline-breaking bug.
 
 ## Ordering (hard — this gates the warm-worker roadmap)
 

--- a/docs/adr/0055-secret-scoping-and-token-liveness.md
+++ b/docs/adr/0055-secret-scoping-and-token-liveness.md
@@ -1,7 +1,8 @@
 # ADR 0055: Secret scoping and token liveness — scope by declaration, exchange the token, bind it to task liveness
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-08-17
+**Accepted:** 2026-08-19
 **Relates:** ADR 0045 (secrets reach a task because it declared it — this ADR is the code that ships its open half), ADR 0021 (exposing variables/connections to pods — the MVP that shipped fetch-all), ADR 0008 (JWT auth — the token this ADR binds to liveness), ADR 0052 (durable task outcome — the same liveness signal, on a different path), ADR 0053 (admission + placement — the warm-worker roadmap this ADR gates), ADR 0054 (shared-cluster coexistence — the namespace split that shrinks, but does not close, B1)
 **Issues:** #59 (scope to declared secrets), #388 (declaration in `leoflow.yaml` → storage), #486 (Lite fixed encryption key — bounded here, not fixed), #507 (token liveness / revocation)
 
@@ -185,6 +186,79 @@ a captured token dangerous. None of the four is a reason to defer the others —
 each narrows a different dimension (what a token can fetch, when it works, who can
 read it, how long it lives) — and Fix #1 is not independently shippable, because
 the token must identify the task for the scope filter to bind (Fix #3).
+
+## Resolved decisions (D1–D8)
+
+The design above (Fixes #1–#4, the rejection, and the hard ordering) stands. The
+mechanical questions it left open are resolved as follows; these bind the
+implementation.
+
+- **D1 — scope in the query, not the handler.** The secret RPCs pass the resolved
+  task identity to the store, which resolves the declared set and returns only it
+  in one scoped query. Post-filtering in the handler is barred: it decrypts the
+  whole vault into control-plane memory before discarding it, which is the exposure
+  scoping exists to remove. This replaces the current fetch-all `SecretVariables`/
+  `SecretConnectionURIs(tenant)`.
+- **D2 — liveness gate wraps the secret RPCs only, never the shared `identify()`.**
+  `Heartbeat`/`ReportState` are designed to run for a stale or superseded task
+  instance so they can return the terminate signal; gating the shared identity path
+  on liveness would break that signal. Only `GetVariables`/`GetConnections` consult
+  liveness.
+- **D3 — revocation v1 derives from terminal task-instance state, no new table.** A
+  read-only `IsTaskInstanceLive(run, task, try)` predicate — the same terminal-state
+  / attempt-superseded signal the heartbeat path already computes, minus the write —
+  is the revocation mechanism. A finished, failed, or superseded task instance is
+  not live, so its token stops resolving secrets. An explicit revoked-token set is
+  deferred until there is a need to kill a token before its task instance reaches a
+  terminal state.
+- **D4 — short per-attempt token TTL, renewed on liveness, no author knob.** Once
+  the secret path consults liveness, a finished attempt's token is dead the instant
+  its task instance is terminal, regardless of the clock; the TTL then only bounds a
+  token exfiltrated from a still-live task. So the lever for long tasks is not a
+  bigger clock but tying credential lifetime to the liveness signal: the per-attempt
+  token is short-lived (a derived internal value, not author- or duration-set) and
+  re-minted on each successful heartbeat, returned in the heartbeat response for the
+  agent to swap in. The stale/superseded branch returns the terminate signal and no
+  token, so renewal can never outrun liveness. The only operator control is a global
+  ceiling on attempt-credential lifetime as a runaway-task backstop; an author-set
+  TTL is barred as a confused-deputy self-authorization of the exfil window.
+- **D5 — record undeclared runtime use on the existing audit surface**, not a new
+  table. The warn phase instruments the runtime resolution path; a task reading an
+  undeclared name is an audit event, already queryable, fitting the two-release
+  warn→enforce arc.
+- **D6 — reject at both compile and registration.** The compiler warns on an
+  obviously-unknown declared name; the server rejects at DAG registration when a
+  declared `variables`/`connections` name does not exist for the tenant, via an
+  existence check against the variables/connections tables. An empty declaration is
+  always valid.
+- **D7 — bound-token `extra` keys resolved at implementation.** The exact
+  apiserver keys used to resolve pod → task instance for the `TokenReview` exchange
+  are apiserver-version-dependent and are pinned when the transport-exchange work
+  lands, not here. This is the one genuinely environment-dependent item and does not
+  block the scoping or liveness core.
+- **D8 — the declaration rides the existing `dag_version` spec blob, no new
+  table.** `variables`/`connections` string lists live on the DAG spec (per-DAG) and
+  the task spec (per-task narrowing), serialized into `dag.json`, schema-validated,
+  and threaded through the agent-facing task spec so scoping can key on them. The
+  dead `secretKeyRef`-shaped secret struct is deleted rather than reused.
+
+### Invariants the implementation must hold
+
+- **Retry and clear-and-rerun are a new attempt.** Both bump the attempt number and
+  dispatch now, minting a fresh per-attempt credential dated from the new dispatch
+  and renewed on its own heartbeats; the superseded attempt's token goes non-live
+  via the `(run, task, try)` + active-state predicate, so a zombie previous-attempt
+  pod stops resolving secrets the instant the retry supersedes it. An expired token
+  is never terminal for the task — the next attempt gets a new credential.
+- **Age-independence.** Clearing and rerunning an arbitrarily old task instance
+  mints a fresh credential and succeeds; credential lifetime binds to the new
+  attempt, never to the original run's age, logical date, or recency.
+- **D3 implementation hazard.** `IsTaskInstanceLive` must derive only from
+  `(run, task, try)` plus active-state, exactly as the heartbeat predicate does. It
+  must never gain a "run is not current / archived / logical date in the past"
+  clause: a recency term would deny a legitimate clear-and-rerun of an old run with a
+  spurious secret-denied, the exact unacceptable case. The safe design is already in
+  the tree; the only risk is "improving" the predicate with a recency term.
 
 ## Ordering (hard — this gates the warm-worker roadmap)
 

--- a/docs/api/dag-schema.json
+++ b/docs/api/dag-schema.json
@@ -130,6 +130,18 @@
       },
       "additionalProperties": false
     },
+    "variables": {
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true,
+      "description": "Airflow Variable names this DAG declares (ADR 0045, ADR 0055). A task receives a Variable only if declared; tasks may narrow further. Absent (empty) declares none."
+    },
+    "connections": {
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true,
+      "description": "Managed connection ids this DAG declares (ADR 0045, ADR 0055). A task receives a connection only if declared; tasks may narrow further. Distinct from connectors: (pip provider packages, ADR 0038). Absent (empty) declares none."
+    },
     "tasks": {
       "type": "array",
       "minItems": 1,
@@ -230,31 +242,17 @@
           },
           "description": "Environment variables for the worker pod / process."
         },
-        "secrets": {
+        "variables": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "source"
-            ],
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "source": {
-                "type": "string",
-                "enum": [
-                  "env",
-                  "vault",
-                  "k8s_secret"
-                ]
-              },
-              "reference": {
-                "type": "string"
-              }
-            }
-          }
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "description": "Airflow Variable names this task declares, narrowing the DAG-level declaration (ADR 0045, ADR 0055). Absent inherits the DAG's declaration."
+        },
+        "connections": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "description": "Managed connection ids this task declares, narrowing the DAG-level declaration (ADR 0045, ADR 0055). Absent inherits the DAG's declaration."
         },
         "resources": {
           "type": "object",

--- a/docs/api/leoflow-yaml-schema.json
+++ b/docs/api/leoflow-yaml-schema.json
@@ -42,6 +42,18 @@
       "items": { "type": "string" },
       "description": "Short connector names (e.g. 'postgres', 'http') expanded at compile to their apache-airflow-providers-* packages. Sugar over dependencies; advanced users can pin via dependencies instead."
     },
+    "connections": {
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true,
+      "description": "Managed connection ids this DAG declares (ADR 0045, ADR 0055). A task receives a connection only if declared; per-task narrowing is available under tasks. Distinct from connectors: (pip provider packages, ADR 0038). Absent (empty) declares none."
+    },
+    "variables": {
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true,
+      "description": "Airflow Variable names this DAG declares (ADR 0045, ADR 0055). A task receives a Variable only if declared; per-task narrowing is available under tasks. Absent (empty) declares none."
+    },
     "system_packages": {
       "type": "array",
       "items": { "type": "string" },
@@ -199,6 +211,18 @@
             "type": "object",
             "additionalProperties": { "type": "string" },
             "description": "Environment variables merged over the task's compiled env."
+          },
+          "connections": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "description": "Managed connection ids this task declares, narrowing the DAG-level declaration (ADR 0045, ADR 0055)."
+          },
+          "variables": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "description": "Airflow Variable names this task declares, narrowing the DAG-level declaration (ADR 0045, ADR 0055)."
           },
           "resources": {
             "type": "object",

--- a/internal/agentrpc/server.go
+++ b/internal/agentrpc/server.go
@@ -71,6 +71,14 @@ type TaskSpec struct {
 	// (#424). The agent stamps LEOFLOW_ON_FAILURE_CALLBACK=1 so the runtime runs it
 	// in-process on the task's final failure.
 	OnFailureCallback bool
+	// DeclaredVariables and DeclaredConnections are the secret names this task
+	// declared (ADR 0045, ADR 0055): the task's own set when it narrows, otherwise
+	// the DAG's. They are carried on the resolved spec so a later increment can
+	// scope secret delivery server-side to the declared set. Today this is data
+	// only: the secret RPCs still return the whole tenant vault, so a declaration
+	// changes nothing about what the agent receives.
+	DeclaredVariables   []string
+	DeclaredConnections []string
 }
 
 // Authenticator verifies an agent bearer token into a task instance identity.

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -702,6 +702,15 @@ func applyTaskOverride(task *domain.TaskSpec, o *domain.TaskConfig) {
 	if o.Execution != nil {
 		task.Execution = o.Execution
 	}
+	// Per-task declared secret sets narrow the DAG-level declaration (ADR 0045,
+	// ADR 0055). A set list replaces (does not merge with) the compiled value,
+	// matching the override semantics of the other scalar/struct fields above.
+	if len(o.Connections) > 0 {
+		task.Connections = o.Connections
+	}
+	if len(o.Variables) > 0 {
+		task.Variables = o.Variables
+	}
 	if len(o.Env) > 0 {
 		if task.Env == nil {
 			task.Env = make(map[string]string, len(o.Env))

--- a/internal/cli/compile_overlay_test.go
+++ b/internal/cli/compile_overlay_test.go
@@ -97,6 +97,43 @@ func TestOverlayProjectAppliesTaskOverrides(t *testing.T) {
 	}
 }
 
+// The overlay carries the leoflow.yaml per-task declared secret sets
+// (connections/variables) onto the compiled task, narrowing the DAG-level
+// declaration (ADR 0045, ADR 0055). A set list replaces the compiled value.
+func TestOverlayProjectAppliesDeclaredSecretNarrowing(t *testing.T) {
+	path := writeDagJSON(t)
+	cfg := &domain.LeoflowConfig{
+		DagID: "proj",
+		Tasks: map[string]*domain.TaskConfig{
+			"transform": {
+				Connections: []string{"warehouse"},
+				Variables:   []string{"greeting"},
+			},
+		},
+	}
+	if err := overlayProject(path, cfg); err != nil {
+		t.Fatalf("overlayProject: %v", err)
+	}
+	got := readSpec(t, path)
+
+	transform, ok := taskByID(got, "transform")
+	if !ok {
+		t.Fatal("transform task missing after overlay")
+	}
+	if len(transform.Connections) != 1 || transform.Connections[0] != "warehouse" {
+		t.Errorf("transform connections = %v, want [warehouse]", transform.Connections)
+	}
+	if len(transform.Variables) != 1 || transform.Variables[0] != "greeting" {
+		t.Errorf("transform variables = %v, want [greeting]", transform.Variables)
+	}
+
+	// The untouched task declares nothing (no narrowing leaked onto it).
+	extract, _ := taskByID(got, "extract")
+	if len(extract.Connections) != 0 || len(extract.Variables) != 0 {
+		t.Errorf("extract gained a declaration from overlay: %+v", extract)
+	}
+}
+
 func TestOverlayProjectUnknownTaskIDErrors(t *testing.T) {
 	path := writeDagJSON(t)
 	cfg := &domain.LeoflowConfig{

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -11,15 +11,21 @@ import (
 // leoflow.yaml. It mirrors docs/api/leoflow-yaml-schema.json and is consumed
 // by `leoflow compile` to build an image and emit a DAGSpec.
 type LeoflowConfig struct {
-	SchemaVersion  string          `json:"schema_version,omitempty" yaml:"schema_version,omitempty"`
-	DagID          string          `json:"dag_id" yaml:"dag_id"`
-	Description    string          `json:"description,omitempty" yaml:"description,omitempty"`
-	Owner          string          `json:"owner,omitempty" yaml:"owner,omitempty"`
-	Tags           []string        `json:"tags,omitempty" yaml:"tags,omitempty"`
-	PythonVersion  string          `json:"python_version,omitempty" yaml:"python_version,omitempty"`
-	BaseImage      string          `json:"base_image,omitempty" yaml:"base_image,omitempty"`
-	Dependencies   []string        `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
-	Connectors     []string        `json:"connectors,omitempty" yaml:"connectors,omitempty"`
+	SchemaVersion string   `json:"schema_version,omitempty" yaml:"schema_version,omitempty"`
+	DagID         string   `json:"dag_id" yaml:"dag_id"`
+	Description   string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Owner         string   `json:"owner,omitempty" yaml:"owner,omitempty"`
+	Tags          []string `json:"tags,omitempty" yaml:"tags,omitempty"`
+	PythonVersion string   `json:"python_version,omitempty" yaml:"python_version,omitempty"`
+	BaseImage     string   `json:"base_image,omitempty" yaml:"base_image,omitempty"`
+	Dependencies  []string `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
+	Connectors    []string `json:"connectors,omitempty" yaml:"connectors,omitempty"`
+	// Connections and Variables are the per-DAG declared secret sets (ADR 0045,
+	// ADR 0055). Carried verbatim to the parser, which emits them into dag.json.
+	// Distinct from Connectors (pip provider packages, ADR 0038) — a different key
+	// one letter away. Empty declares nothing.
+	Connections    []string        `json:"connections,omitempty" yaml:"connections,omitempty"`
+	Variables      []string        `json:"variables,omitempty" yaml:"variables,omitempty"`
 	SystemPackages []string        `json:"system_packages,omitempty" yaml:"system_packages,omitempty"`
 	DagSource      string          `json:"dag_source,omitempty" yaml:"dag_source,omitempty"`
 	IncludePaths   []string        `json:"include_paths,omitempty" yaml:"include_paths,omitempty"`
@@ -107,8 +113,13 @@ type TaskConfig struct {
 	RetryDelaySeconds       *int              `json:"retry_delay_seconds,omitempty" yaml:"retry_delay_seconds,omitempty"`
 	ExecutionTimeoutSeconds *int              `json:"execution_timeout_seconds,omitempty" yaml:"execution_timeout_seconds,omitempty"`
 	Env                     map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
-	Resources               *Resources        `json:"resources,omitempty" yaml:"resources,omitempty"`
-	Execution               *Execution        `json:"execution,omitempty" yaml:"execution,omitempty"`
+	// Connections and Variables narrow the DAG-level declared secret set to this
+	// task (ADR 0045 §Settled #1, ADR 0055). Empty means the task inherits the
+	// DAG-level declaration.
+	Connections []string   `json:"connections,omitempty" yaml:"connections,omitempty"`
+	Variables   []string   `json:"variables,omitempty" yaml:"variables,omitempty"`
+	Resources   *Resources `json:"resources,omitempty" yaml:"resources,omitempty"`
+	Execution   *Execution `json:"execution,omitempty" yaml:"execution,omitempty"`
 }
 
 // BuildConfig controls how the container image is built from the project.

--- a/internal/domain/dag.go
+++ b/internal/domain/dag.go
@@ -86,7 +86,15 @@ type DAGSpec struct {
 	// at compile time so the scheduler fires it from the artifact without re-reading
 	// the project config. nil means no alerting.
 	Alerts *AlertsConfig `json:"alerts,omitempty"`
-	Tasks  []TaskSpec    `json:"tasks"`
+	// Variables and Connections are the secret names this DAG declares (ADR 0045,
+	// ADR 0055). A task receives a variable or connection only if the DAG declared
+	// it; TaskSpec may narrow the set further per task. Absent (empty) is always
+	// valid and means the DAG declares nothing — the additive, back-compatible
+	// default. These carry the declaration only; secret delivery still ships the
+	// whole tenant vault until enforcement lands on a later increment.
+	Variables   []string   `json:"variables,omitempty"`
+	Connections []string   `json:"connections,omitempty"`
+	Tasks       []TaskSpec `json:"tasks"`
 	// Source is the original dag.py text, captured at compile time so the UI's
 	// Code tab can show the Python a human wrote (not the compiled spec). It is
 	// part of the artifact: changing it produces a new version.
@@ -120,18 +128,22 @@ type TaskSpec struct {
 	// (the default) means the implicit default_pool, so every task is always in a
 	// well-defined pool. The pool gate is Pro-only; Lite ignores this field, so a
 	// DAG that sets it plans identically on Lite.
-	Pool                    string              `json:"pool,omitempty"`
-	Retries                 *int                `json:"retries,omitempty"`
-	RetryDelaySeconds       *int                `json:"retry_delay_seconds,omitempty"`
-	ExecutionTimeoutSeconds *int                `json:"execution_timeout_seconds,omitempty"`
-	ExecutionMode           ExecutionMode       `json:"execution_mode,omitempty"`
-	Entrypoint              string              `json:"entrypoint,omitempty"`
-	Env                     map[string]string   `json:"env,omitempty"`
-	Secrets                 []Secret            `json:"secrets,omitempty"`
-	Resources               *Resources          `json:"resources,omitempty"`
-	Execution               *Execution          `json:"execution,omitempty"`
-	XComInput               map[string][]string `json:"xcom_input,omitempty"`
-	XComSchema              map[string]any      `json:"xcom_schema,omitempty"`
+	Pool                    string            `json:"pool,omitempty"`
+	Retries                 *int              `json:"retries,omitempty"`
+	RetryDelaySeconds       *int              `json:"retry_delay_seconds,omitempty"`
+	ExecutionTimeoutSeconds *int              `json:"execution_timeout_seconds,omitempty"`
+	ExecutionMode           ExecutionMode     `json:"execution_mode,omitempty"`
+	Entrypoint              string            `json:"entrypoint,omitempty"`
+	Env                     map[string]string `json:"env,omitempty"`
+	// Variables and Connections narrow the DAG's declared secret set to this task
+	// (ADR 0045 §Settled #1, ADR 0055). Absent (empty) means the task inherits the
+	// DAG-level declaration. Carries the declaration only; delivery is unchanged.
+	Variables   []string            `json:"variables,omitempty"`
+	Connections []string            `json:"connections,omitempty"`
+	Resources   *Resources          `json:"resources,omitempty"`
+	Execution   *Execution          `json:"execution,omitempty"`
+	XComInput   map[string][]string `json:"xcom_input,omitempty"`
+	XComSchema  map[string]any      `json:"xcom_schema,omitempty"`
 	// CallArgs carries TaskFlow literal call arguments captured at compile time
 	// (#115). The agent serializes the whole map as a single env var
 	// LEOFLOW_CALL_ARGS_JSON; the runtime decodes and delivers each value to
@@ -153,13 +165,6 @@ type TaskSpec struct {
 	// runtime re-imports dag.py and runs it in the task process on failure. The
 	// flag lets the agent/UI know a callback will run without importing user code.
 	OnFailureCallback bool `json:"on_failure_callback,omitempty"`
-}
-
-// Secret references a credential injected into the worker at run time.
-type Secret struct {
-	Name      string `json:"name"`
-	Source    string `json:"source"`
-	Reference string `json:"reference,omitempty"`
 }
 
 // Resources holds Kubernetes-style resource requests and limits for a task.

--- a/internal/domain/declared_secrets_test.go
+++ b/internal/domain/declared_secrets_test.go
@@ -1,0 +1,89 @@
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The declared secret set (ADR 0055 / ADR 0045) rides the DAG spec: per-DAG on
+// DAGSpec and, for narrowing, per-task on TaskSpec. It serializes under the
+// Airflow-native keys `variables` / `connections`, and is additive — absent
+// declarations round-trip as empty, so a DAG that declares nothing is unchanged.
+
+func TestDAGSpecDeclaredSecretsRoundTrip(t *testing.T) {
+	spec := validDAGSpec()
+	spec.Variables = []string{"greeting"}
+	spec.Connections = []string{"warehouse"}
+	spec.Tasks[0].Variables = []string{"greeting"}
+	spec.Tasks[0].Connections = []string{"warehouse"}
+
+	data, err := json.Marshal(spec)
+	if err != nil {
+		t.Fatalf("Marshal() = %v", err)
+	}
+	// The keys must be the Airflow-native words, not connectors (ADR 0038).
+	var raw map[string]any
+	if uerr := json.Unmarshal(data, &raw); uerr != nil {
+		t.Fatalf("Unmarshal to map = %v", uerr)
+	}
+	if _, ok := raw["variables"]; !ok {
+		t.Errorf("marshaled DAGSpec missing %q key: %s", "variables", data)
+	}
+	if _, ok := raw["connections"]; !ok {
+		t.Errorf("marshaled DAGSpec missing %q key: %s", "connections", data)
+	}
+
+	var got DAGSpec
+	if uerr := json.Unmarshal(data, &got); uerr != nil {
+		t.Fatalf("Unmarshal = %v", uerr)
+	}
+	if len(got.Variables) != 1 || got.Variables[0] != "greeting" {
+		t.Errorf("DAGSpec.Variables = %v, want [greeting]", got.Variables)
+	}
+	if len(got.Connections) != 1 || got.Connections[0] != "warehouse" {
+		t.Errorf("DAGSpec.Connections = %v, want [warehouse]", got.Connections)
+	}
+	if len(got.Tasks[0].Variables) != 1 || got.Tasks[0].Variables[0] != "greeting" {
+		t.Errorf("TaskSpec.Variables = %v, want [greeting]", got.Tasks[0].Variables)
+	}
+	if len(got.Tasks[0].Connections) != 1 || got.Tasks[0].Connections[0] != "warehouse" {
+		t.Errorf("TaskSpec.Connections = %v, want [warehouse]", got.Tasks[0].Connections)
+	}
+}
+
+// A declaration is optional: an absent one marshals to no key (omitempty) and a
+// spec declaring nothing still validates. This is the Lite/back-compat safety —
+// every existing DAG declares nothing, so none changes shape.
+func TestDAGSpecDeclaredSecretsAbsentIsEmpty(t *testing.T) {
+	spec := validDAGSpec()
+	data, err := json.Marshal(spec)
+	if err != nil {
+		t.Fatalf("Marshal() = %v", err)
+	}
+	var raw map[string]any
+	if uerr := json.Unmarshal(data, &raw); uerr != nil {
+		t.Fatalf("Unmarshal to map = %v", uerr)
+	}
+	if _, ok := raw["variables"]; ok {
+		t.Errorf("absent declaration should omit %q key: %s", "variables", data)
+	}
+	if _, ok := raw["connections"]; ok {
+		t.Errorf("absent declaration should omit %q key: %s", "connections", data)
+	}
+	if verr := spec.Validate(); verr != nil {
+		t.Fatalf("Validate() with no declaration = %v, want nil", verr)
+	}
+}
+
+// A spec declaring variables/connections at both DAG and task level passes
+// schema validation (the schema grew the two array fields at both scopes).
+func TestDAGSpecValidateAcceptsDeclaredSecrets(t *testing.T) {
+	spec := validDAGSpec()
+	spec.Variables = []string{"greeting"}
+	spec.Connections = []string{"warehouse"}
+	spec.Tasks[0].Variables = []string{"greeting"}
+	spec.Tasks[0].Connections = []string{"warehouse"}
+	if err := spec.Validate(); err != nil {
+		t.Fatalf("Validate() with declarations = %v, want nil", err)
+	}
+}

--- a/internal/domain/declared_secrets_test.go
+++ b/internal/domain/declared_secrets_test.go
@@ -75,6 +75,21 @@ func TestDAGSpecDeclaredSecretsAbsentIsEmpty(t *testing.T) {
 	}
 }
 
+// leoflow.yaml may declare variables/connections per-DAG and per-task; the
+// author-facing config validates against the leoflow.yaml schema (the source
+// keys the compiler carries into dag.json).
+func TestLeoflowConfigValidateAcceptsDeclaredSecrets(t *testing.T) {
+	cfg := validLeoflowConfig()
+	cfg.Connections = []string{"warehouse"}
+	cfg.Variables = []string{"greeting"}
+	cfg.Tasks = map[string]*TaskConfig{
+		"extract": {Connections: []string{"warehouse"}, Variables: []string{"greeting"}},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() with declarations = %v, want nil", err)
+	}
+}
+
 // A spec declaring variables/connections at both DAG and task level passes
 // schema validation (the schema grew the two array fields at both scopes).
 func TestDAGSpecValidateAcceptsDeclaredSecrets(t *testing.T) {

--- a/internal/domain/schemas/dag-schema.json
+++ b/internal/domain/schemas/dag-schema.json
@@ -130,6 +130,18 @@
       },
       "additionalProperties": false
     },
+    "variables": {
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true,
+      "description": "Airflow Variable names this DAG declares (ADR 0045, ADR 0055). A task receives a Variable only if declared; tasks may narrow further. Absent (empty) declares none."
+    },
+    "connections": {
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true,
+      "description": "Managed connection ids this DAG declares (ADR 0045, ADR 0055). A task receives a connection only if declared; tasks may narrow further. Distinct from connectors: (pip provider packages, ADR 0038). Absent (empty) declares none."
+    },
     "tasks": {
       "type": "array",
       "minItems": 1,
@@ -230,31 +242,17 @@
           },
           "description": "Environment variables for the worker pod / process."
         },
-        "secrets": {
+        "variables": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "required": [
-              "name",
-              "source"
-            ],
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "source": {
-                "type": "string",
-                "enum": [
-                  "env",
-                  "vault",
-                  "k8s_secret"
-                ]
-              },
-              "reference": {
-                "type": "string"
-              }
-            }
-          }
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "description": "Airflow Variable names this task declares, narrowing the DAG-level declaration (ADR 0045, ADR 0055). Absent inherits the DAG's declaration."
+        },
+        "connections": {
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true,
+          "description": "Managed connection ids this task declares, narrowing the DAG-level declaration (ADR 0045, ADR 0055). Absent inherits the DAG's declaration."
         },
         "resources": {
           "type": "object",

--- a/internal/domain/schemas/leoflow-yaml-schema.json
+++ b/internal/domain/schemas/leoflow-yaml-schema.json
@@ -42,6 +42,18 @@
       "items": { "type": "string" },
       "description": "Short connector names (e.g. 'postgres', 'http') expanded at compile to their apache-airflow-providers-* packages. Sugar over dependencies; advanced users can pin via dependencies instead."
     },
+    "connections": {
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true,
+      "description": "Managed connection ids this DAG declares (ADR 0045, ADR 0055). A task receives a connection only if declared; per-task narrowing is available under tasks. Distinct from connectors: (pip provider packages, ADR 0038). Absent (empty) declares none."
+    },
+    "variables": {
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true,
+      "description": "Airflow Variable names this DAG declares (ADR 0045, ADR 0055). A task receives a Variable only if declared; per-task narrowing is available under tasks. Absent (empty) declares none."
+    },
     "system_packages": {
       "type": "array",
       "items": { "type": "string" },
@@ -199,6 +211,18 @@
             "type": "object",
             "additionalProperties": { "type": "string" },
             "description": "Environment variables merged over the task's compiled env."
+          },
+          "connections": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "description": "Managed connection ids this task declares, narrowing the DAG-level declaration (ADR 0045, ADR 0055)."
+          },
+          "variables": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "description": "Airflow Variable names this task declares, narrowing the DAG-level declaration (ADR 0045, ADR 0055)."
           },
           "resources": {
             "type": "object",

--- a/internal/storage/agent_store.go
+++ b/internal/storage/agent_store.go
@@ -111,7 +111,30 @@ func (s *ExecutionStore) TaskSpec(ctx context.Context, id auth.AgentIdentity) (a
 		FirstRescheduleAt: firstRescheduleAt,
 		MaxTries:          maxTries(task),
 		OnFailureCallback: task.OnFailureCallback,
+		// Carry the declared secret set (ADR 0045, ADR 0055) so a later increment
+		// can scope delivery. Data only here — no secret is filtered by it yet.
+		DeclaredVariables:   declaredVariables(task, spec),
+		DeclaredConnections: declaredConnections(task, spec),
 	}, nil
+}
+
+// declaredVariables and declaredConnections resolve the effective declared
+// secret names for a task: the task's own declaration when it narrows the
+// DAG-level set, otherwise the DAG-level declaration it inherits (ADR 0045
+// §Settled #1). These carry the declared set onto the agent-facing spec; they
+// do not filter what secrets are delivered — enforcement lands separately.
+func declaredVariables(task domain.TaskSpec, spec domain.DAGSpec) []string {
+	if len(task.Variables) > 0 {
+		return task.Variables
+	}
+	return spec.Variables
+}
+
+func declaredConnections(task domain.TaskSpec, spec domain.DAGSpec) []string {
+	if len(task.Connections) > 0 {
+		return task.Connections
+	}
+	return spec.Connections
 }
 
 // maxTries is a task's total attempt budget: retries + 1 (a task with no retries

--- a/internal/storage/declared_secrets_test.go
+++ b/internal/storage/declared_secrets_test.go
@@ -1,0 +1,66 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// The agent-facing task spec carries the declared secret set (ADR 0045, ADR
+// 0055) so a later increment can scope delivery to it. Resolution is
+// inheritance: a task that narrows uses its own declaration, otherwise it
+// inherits the DAG-level declaration. This carries data only — nothing here
+// filters what secrets the agent receives.
+func TestDeclaredSecretResolution(t *testing.T) {
+	cases := []struct {
+		name     string
+		task     domain.TaskSpec
+		spec     domain.DAGSpec
+		wantVars []string
+		wantConn []string
+	}{
+		{
+			name:     "inherits dag level when task declares nothing",
+			task:     domain.TaskSpec{},
+			spec:     domain.DAGSpec{Variables: []string{"greeting"}, Connections: []string{"warehouse"}},
+			wantVars: []string{"greeting"},
+			wantConn: []string{"warehouse"},
+		},
+		{
+			name:     "task narrows the dag declaration",
+			task:     domain.TaskSpec{Variables: []string{"greeting"}, Connections: []string{"warehouse"}},
+			spec:     domain.DAGSpec{Variables: []string{"greeting", "farewell"}, Connections: []string{"warehouse", "lake"}},
+			wantVars: []string{"greeting"},
+			wantConn: []string{"warehouse"},
+		},
+		{
+			name:     "empty when neither declares",
+			task:     domain.TaskSpec{},
+			spec:     domain.DAGSpec{},
+			wantVars: nil,
+			wantConn: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := declaredVariables(tc.task, tc.spec); !equalStrings(got, tc.wantVars) {
+				t.Errorf("declaredVariables = %v, want %v", got, tc.wantVars)
+			}
+			if got := declaredConnections(tc.task, tc.spec); !equalStrings(got, tc.wantConn) {
+				t.Errorf("declaredConnections = %v, want %v", got, tc.wantConn)
+			}
+		})
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/storage/declared_secrets_test.go
+++ b/internal/storage/declared_secrets_test.go
@@ -53,6 +53,46 @@ func TestDeclaredSecretResolution(t *testing.T) {
 	}
 }
 
+// declaredSecretNames gathers the DAG-level declaration and every task's
+// narrowing declaration into one deduplicated, order-preserving set — the input
+// to the registration existence check (ADR 0055 D6).
+func TestDeclaredSecretNamesCollectsAndDedupes(t *testing.T) {
+	spec := domain.DAGSpec{
+		Variables: []string{"greeting", "farewell"},
+		Tasks: []domain.TaskSpec{
+			{TaskID: "a", Variables: []string{"greeting", "extra"}},
+			{TaskID: "b", Variables: []string{"only_b"}},
+		},
+	}
+	got := declaredSecretNames(spec.Variables, spec.Tasks, func(t domain.TaskSpec) []string { return t.Variables })
+	want := []string{"greeting", "farewell", "extra", "only_b"}
+	if !equalStrings(got, want) {
+		t.Errorf("declaredSecretNames = %v, want %v (deduped, first-occurrence order)", got, want)
+	}
+}
+
+func TestDeclaredSecretNamesEmpty(t *testing.T) {
+	got := declaredSecretNames(nil, []domain.TaskSpec{{TaskID: "a"}}, func(t domain.TaskSpec) []string { return t.Variables })
+	if len(got) != 0 {
+		t.Errorf("declaredSecretNames with no declarations = %v, want empty", got)
+	}
+}
+
+// missingNames returns the declared names absent from the existing set, in
+// declaration order — these are what the registration check reports.
+func TestMissingNames(t *testing.T) {
+	declared := []string{"greeting", "nope", "warehouse", "gone"}
+	existing := []string{"greeting", "warehouse"}
+	got := missingNames(declared, existing)
+	want := []string{"nope", "gone"}
+	if !equalStrings(got, want) {
+		t.Errorf("missingNames = %v, want %v", got, want)
+	}
+	if len(missingNames([]string{"a", "b"}, []string{"a", "b"})) != 0 {
+		t.Error("missingNames should be empty when all declared names exist")
+	}
+}
+
 func equalStrings(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/internal/storage/queries/connections.sql
+++ b/internal/storage/queries/connections.sql
@@ -22,6 +22,13 @@ SELECT conn_id, conn_type, host, conn_schema, login, password, port, extra, desc
 FROM connections
 WHERE tenant_id = $1 AND conn_id = $2;
 
+-- name: ExistingConnectionIDs :many
+-- The subset of the given conn_ids that exist for the tenant. Used to reject a
+-- DAG that declares an unknown connection at registration (ADR 0055 D6); a name
+-- absent from the result does not exist.
+SELECT conn_id FROM connections
+WHERE tenant_id = $1 AND conn_id = ANY(sqlc.arg(conn_ids)::text[]);
+
 -- name: UpsertConnection :exec
 INSERT INTO connections (tenant_id, conn_id, conn_type, host, conn_schema, login, password, port, extra, description)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)

--- a/internal/storage/queries/connections.sql.go
+++ b/internal/storage/queries/connections.sql.go
@@ -39,6 +39,39 @@ func (q *Queries) DeleteConnection(ctx context.Context, arg DeleteConnectionPara
 	return result.RowsAffected(), nil
 }
 
+const existingConnectionIDs = `-- name: ExistingConnectionIDs :many
+SELECT conn_id FROM connections
+WHERE tenant_id = $1 AND conn_id = ANY($2::text[])
+`
+
+type ExistingConnectionIDsParams struct {
+	TenantID pgtype.UUID `json:"tenant_id"`
+	ConnIds  []string    `json:"conn_ids"`
+}
+
+// The subset of the given conn_ids that exist for the tenant. Used to reject a
+// DAG that declares an unknown connection at registration (ADR 0055 D6); a name
+// absent from the result does not exist.
+func (q *Queries) ExistingConnectionIDs(ctx context.Context, arg ExistingConnectionIDsParams) ([]string, error) {
+	rows, err := q.db.Query(ctx, existingConnectionIDs, arg.TenantID, arg.ConnIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var conn_id string
+		if err := rows.Scan(&conn_id); err != nil {
+			return nil, err
+		}
+		items = append(items, conn_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getConnection = `-- name: GetConnection :one
 SELECT conn_id, conn_type, host, conn_schema, login, password, port, extra, description
 FROM connections

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -70,6 +70,14 @@ type Querier interface {
 	// reconcile that sets the grants to exactly the group-mapped set on each login.
 	DeleteUserRoles(ctx context.Context, userID pgtype.UUID) error
 	DeleteVariable(ctx context.Context, arg DeleteVariableParams) (int64, error)
+	// The subset of the given conn_ids that exist for the tenant. Used to reject a
+	// DAG that declares an unknown connection at registration (ADR 0055 D6); a name
+	// absent from the result does not exist.
+	ExistingConnectionIDs(ctx context.Context, arg ExistingConnectionIDsParams) ([]string, error)
+	// The subset of the given keys that exist for the tenant. Used to reject a DAG
+	// that declares an unknown Variable at registration (ADR 0055 D6); a name absent
+	// from the result does not exist.
+	ExistingVariableKeys(ctx context.Context, arg ExistingVariableKeysParams) ([]string, error)
 	// The dispatch-attempt budget is spent (ADR 0031 Amendment A): fail the task with
 	// a dispatch_failed reason so the run can finalize instead of looping forever.
 	// error_message carries the underlying cause. Guarded to 'scheduled' for the same

--- a/internal/storage/queries/variables.sql
+++ b/internal/storage/queries/variables.sql
@@ -13,6 +13,13 @@ SELECT key, value, description
 FROM variables
 WHERE tenant_id = $1 AND key = $2;
 
+-- name: ExistingVariableKeys :many
+-- The subset of the given keys that exist for the tenant. Used to reject a DAG
+-- that declares an unknown Variable at registration (ADR 0055 D6); a name absent
+-- from the result does not exist.
+SELECT key FROM variables
+WHERE tenant_id = $1 AND key = ANY(sqlc.arg(keys)::text[]);
+
 -- name: UpsertVariable :exec
 INSERT INTO variables (tenant_id, key, value, description)
 VALUES ($1, $2, $3, $4)

--- a/internal/storage/queries/variables.sql.go
+++ b/internal/storage/queries/variables.sql.go
@@ -39,6 +39,39 @@ func (q *Queries) DeleteVariable(ctx context.Context, arg DeleteVariableParams) 
 	return result.RowsAffected(), nil
 }
 
+const existingVariableKeys = `-- name: ExistingVariableKeys :many
+SELECT key FROM variables
+WHERE tenant_id = $1 AND key = ANY($2::text[])
+`
+
+type ExistingVariableKeysParams struct {
+	TenantID pgtype.UUID `json:"tenant_id"`
+	Keys     []string    `json:"keys"`
+}
+
+// The subset of the given keys that exist for the tenant. Used to reject a DAG
+// that declares an unknown Variable at registration (ADR 0055 D6); a name absent
+// from the result does not exist.
+func (q *Queries) ExistingVariableKeys(ctx context.Context, arg ExistingVariableKeysParams) ([]string, error) {
+	rows, err := q.db.Query(ctx, existingVariableKeys, arg.TenantID, arg.Keys)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var key string
+		if err := rows.Scan(&key); err != nil {
+			return nil, err
+		}
+		items = append(items, key)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getVariable = `-- name: GetVariable :one
 SELECT key, value, description
 FROM variables

--- a/internal/storage/register_declared_secrets_integration_test.go
+++ b/internal/storage/register_declared_secrets_integration_test.go
@@ -10,7 +10,23 @@ import (
 	"time"
 
 	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/secrets"
 )
+
+// withTestCipher configures a deterministic AES-GCM cipher on the repo so
+// connection seeding (which encrypts at rest, ADR 0019) works in the test.
+func withTestCipher(t *testing.T, repo interface{ SetCipher(secrets.Cipher) }) {
+	t.Helper()
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	c, err := secrets.NewAESGCM(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo.SetCipher(c)
+}
 
 // registerDeclaring registers a DAG that declares the given variable/connection
 // names and returns the RegisterDagVersion error (nil on success).
@@ -36,6 +52,7 @@ func registerDeclaring(t *testing.T, repo interface {
 // tenant is rejected at registration (ADR 0055 D6). The error names the offender.
 func TestRegisterRejectsUnknownDeclaredNamesIntegration(t *testing.T) {
 	repo, _, ctx := openRepo(t)
+	withTestCipher(t, repo)
 	suffix := time.Now().UnixNano()
 
 	// Seed one real variable and one real connection.
@@ -72,6 +89,7 @@ func TestRegisterRejectsUnknownDeclaredNamesIntegration(t *testing.T) {
 // declares anything, so none is rejected.
 func TestRegisterAcceptsValidAndEmptyDeclarationsIntegration(t *testing.T) {
 	repo, _, ctx := openRepo(t)
+	withTestCipher(t, repo)
 	suffix := time.Now().UnixNano()
 
 	if err := repo.SetVariable(ctx, "default", domain.Variable{Key: "greeting", Value: "hi"}); err != nil {
@@ -93,6 +111,7 @@ func TestRegisterAcceptsValidAndEmptyDeclarationsIntegration(t *testing.T) {
 // only at the task level is rejected too (ADR 0055 D6).
 func TestRegisterRejectsUnknownTaskLevelDeclarationIntegration(t *testing.T) {
 	repo, _, ctx := openRepo(t)
+	withTestCipher(t, repo)
 	suffix := time.Now().UnixNano()
 
 	spec := domain.DAGSpec{

--- a/internal/storage/register_declared_secrets_integration_test.go
+++ b/internal/storage/register_declared_secrets_integration_test.go
@@ -1,0 +1,117 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// registerDeclaring registers a DAG that declares the given variable/connection
+// names and returns the RegisterDagVersion error (nil on success).
+func registerDeclaring(t *testing.T, repo interface {
+	RegisterDagVersion(context.Context, string, domain.DAGSpec, string) (bool, error)
+}, ctx context.Context, dagID string, vars, conns []string) error {
+	t.Helper()
+	spec := domain.DAGSpec{
+		SchemaVersion: "1.0", DagID: dagID, DagVersion: "v1", Image: "img:v1",
+		Variables:   vars,
+		Connections: conns,
+		Tasks:       []domain.TaskSpec{{TaskID: "t", Type: domain.TaskTypePython}},
+	}
+	hash, err := spec.CanonicalHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, rerr := repo.RegisterDagVersion(ctx, "default", spec, hash)
+	return rerr
+}
+
+// A DAG that declares a variable or connection name that does not exist for the
+// tenant is rejected at registration (ADR 0055 D6). The error names the offender.
+func TestRegisterRejectsUnknownDeclaredNamesIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	suffix := time.Now().UnixNano()
+
+	// Seed one real variable and one real connection.
+	if err := repo.SetVariable(ctx, "default", domain.Variable{Key: "greeting", Value: "hi"}); err != nil {
+		t.Fatalf("seed variable: %v", err)
+	}
+	if err := repo.SetConnection(ctx, "default", domain.Connection{ConnID: "warehouse", ConnType: "postgres", Host: "db"}); err != nil {
+		t.Fatalf("seed connection: %v", err)
+	}
+
+	t.Run("unknown variable", func(t *testing.T) {
+		err := registerDeclaring(t, repo, ctx, fmt.Sprintf("dec_uv_%d", suffix), []string{"greeting", "nope_var"}, nil)
+		if err == nil {
+			t.Fatal("expected registration to fail for an unknown declared variable")
+		}
+		if !strings.Contains(err.Error(), "nope_var") {
+			t.Errorf("error %q should name the unknown variable 'nope_var'", err.Error())
+		}
+	})
+
+	t.Run("unknown connection", func(t *testing.T) {
+		err := registerDeclaring(t, repo, ctx, fmt.Sprintf("dec_uc_%d", suffix), nil, []string{"warehouse", "nope_conn"})
+		if err == nil {
+			t.Fatal("expected registration to fail for an unknown declared connection")
+		}
+		if !strings.Contains(err.Error(), "nope_conn") {
+			t.Errorf("error %q should name the unknown connection 'nope_conn'", err.Error())
+		}
+	})
+}
+
+// A valid declaration (all names exist) and an empty declaration both register
+// cleanly. The empty case is the Lite/back-compat safety: no existing DAG
+// declares anything, so none is rejected.
+func TestRegisterAcceptsValidAndEmptyDeclarationsIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	suffix := time.Now().UnixNano()
+
+	if err := repo.SetVariable(ctx, "default", domain.Variable{Key: "greeting", Value: "hi"}); err != nil {
+		t.Fatalf("seed variable: %v", err)
+	}
+	if err := repo.SetConnection(ctx, "default", domain.Connection{ConnID: "warehouse", ConnType: "postgres", Host: "db"}); err != nil {
+		t.Fatalf("seed connection: %v", err)
+	}
+
+	if err := registerDeclaring(t, repo, ctx, fmt.Sprintf("dec_ok_%d", suffix), []string{"greeting"}, []string{"warehouse"}); err != nil {
+		t.Fatalf("valid declaration should register: %v", err)
+	}
+	if err := registerDeclaring(t, repo, ctx, fmt.Sprintf("dec_empty_%d", suffix), nil, nil); err != nil {
+		t.Fatalf("empty declaration should register: %v", err)
+	}
+}
+
+// Per-task narrowing declarations are also checked: an unknown name declared
+// only at the task level is rejected too (ADR 0055 D6).
+func TestRegisterRejectsUnknownTaskLevelDeclarationIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	suffix := time.Now().UnixNano()
+
+	spec := domain.DAGSpec{
+		SchemaVersion: "1.0", DagID: fmt.Sprintf("dec_task_%d", suffix), DagVersion: "v1", Image: "img:v1",
+		Tasks: []domain.TaskSpec{{
+			TaskID:    "t",
+			Type:      domain.TaskTypePython,
+			Variables: []string{"task_only_unknown"},
+		}},
+	}
+	hash, err := spec.CanonicalHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, rerr := repo.RegisterDagVersion(ctx, "default", spec, hash)
+	if rerr == nil {
+		t.Fatal("expected registration to fail for an unknown task-level declared variable")
+	}
+	if !strings.Contains(rerr.Error(), "task_only_unknown") {
+		t.Errorf("error %q should name the unknown variable", rerr.Error())
+	}
+}

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -839,6 +840,13 @@ func (r *Repository) RegisterDagVersion(ctx context.Context, tenant string, spec
 	if err != nil {
 		return false, err
 	}
+	// A DAG may not declare a variable/connection that does not exist for the
+	// tenant (ADR 0055 D6). Checked before any write so a bad declaration fails
+	// fast with no partial state. An empty declaration is always valid, so no
+	// pre-declaration DAG is ever rejected.
+	if verr := r.validateDeclaredSecrets(ctx, tid, spec); verr != nil {
+		return false, verr
+	}
 	maxRuns := spec.MaxActiveRuns
 	if maxRuns == 0 {
 		maxRuns = defaultMaxActiveRuns
@@ -890,6 +898,82 @@ func (r *Repository) RegisterDagVersion(ctx context.Context, tenant string, spec
 		return false, fmt.Errorf("writing audit log: %w", err)
 	}
 	return true, nil
+}
+
+// validateDeclaredSecrets rejects a spec that declares a variable or connection
+// name that does not exist for the tenant (ADR 0055 D6). It gathers every
+// declared name — DAG-level and per-task narrowing — and confirms each with one
+// existence query per kind. A name renamed in the UI but not in the DAG surfaces
+// here at registration rather than silently at run time; the error names both
+// the DAG and the offending names so the author knows which side to fix.
+//
+// An empty declaration is always valid. Because declaration is new, no existing
+// DAG declares anything, so this never rejects a pre-declaration DAG — the
+// Lite/back-compat safety.
+func (r *Repository) validateDeclaredSecrets(ctx context.Context, tid pgtype.UUID, spec domain.DAGSpec) error {
+	varNames := declaredSecretNames(spec.Variables, spec.Tasks, func(t domain.TaskSpec) []string { return t.Variables })
+	if len(varNames) > 0 {
+		existing, err := r.q.ExistingVariableKeys(ctx, queries.ExistingVariableKeysParams{TenantID: tid, Keys: varNames})
+		if err != nil {
+			return fmt.Errorf("checking declared variables: %w", err)
+		}
+		if missing := missingNames(varNames, existing); len(missing) > 0 {
+			return fmt.Errorf(
+				"dag %q declares unknown variable(s) %s; define them (leoflow variables set) or remove them from the DAG's variables: declaration: %w",
+				spec.DagID, strings.Join(missing, ", "), domain.ErrValidation)
+		}
+	}
+	connNames := declaredSecretNames(spec.Connections, spec.Tasks, func(t domain.TaskSpec) []string { return t.Connections })
+	if len(connNames) > 0 {
+		existing, err := r.q.ExistingConnectionIDs(ctx, queries.ExistingConnectionIDsParams{TenantID: tid, ConnIds: connNames})
+		if err != nil {
+			return fmt.Errorf("checking declared connections: %w", err)
+		}
+		if missing := missingNames(connNames, existing); len(missing) > 0 {
+			return fmt.Errorf(
+				"dag %q declares unknown connection(s) %s; define them (leoflow connections set) or remove them from the DAG's connections: declaration: %w",
+				spec.DagID, strings.Join(missing, ", "), domain.ErrValidation)
+		}
+	}
+	return nil
+}
+
+// declaredSecretNames collects the deduplicated set of declared names across the
+// DAG-level declaration and every task's narrowing declaration, preserving first
+// occurrence order so error messages are stable.
+func declaredSecretNames(dagLevel []string, tasks []domain.TaskSpec, taskLevel func(domain.TaskSpec) []string) []string {
+	seen := make(map[string]struct{})
+	out := make([]string, 0, len(dagLevel))
+	add := func(names []string) {
+		for _, n := range names {
+			if _, ok := seen[n]; ok {
+				continue
+			}
+			seen[n] = struct{}{}
+			out = append(out, n)
+		}
+	}
+	add(dagLevel)
+	for _, t := range tasks {
+		add(taskLevel(t))
+	}
+	return out
+}
+
+// missingNames returns the declared names absent from the existing set, in
+// declaration order.
+func missingNames(declared, existing []string) []string {
+	have := make(map[string]struct{}, len(existing))
+	for _, e := range existing {
+		have[e] = struct{}{}
+	}
+	var missing []string
+	for _, d := range declared {
+		if _, ok := have[d]; !ok {
+			missing = append(missing, d)
+		}
+	}
+	return missing
 }
 
 // BootstrapAdmin creates a default admin user with the given password when the

--- a/parser/leoflow_parser/compiler.py
+++ b/parser/leoflow_parser/compiler.py
@@ -56,6 +56,17 @@ def compile_dag(
     tags = config.get("tags") or sorted(getattr(dag, "tags", []) or [])
     if tags:
         spec["tags"] = list(tags)
+    # Declared secret sets (ADR 0045, ADR 0055): the per-DAG variables/connections
+    # a task may receive. Airflow-native keys, distinct from connectors: (pip
+    # provider packages, ADR 0038) which is a build concern the parser never emits.
+    # Absent or empty declares nothing — omit the key so the compiled shape of a
+    # DAG that declares nothing is unchanged (additive/back-compatible).
+    connections = config.get("connections")
+    if connections:
+        spec["connections"] = list(connections)
+    variables = config.get("variables")
+    if variables:
+        spec["variables"] = list(variables)
     default_args = _default_args(config)
     if default_args:
         spec["default_args"] = default_args

--- a/parser/tests/test_declared_secrets.py
+++ b/parser/tests/test_declared_secrets.py
@@ -17,7 +17,6 @@ sys.path.insert(0, os.path.dirname(HERE))
 
 from leoflow_parser.compiler import compile_dag  # noqa: E402  (sys.path set above)
 
-
 _TRIVIAL_DAG = """
     from airflow.sdk import DAG
     from airflow.providers.standard.operators.python import PythonOperator

--- a/parser/tests/test_declared_secrets.py
+++ b/parser/tests/test_declared_secrets.py
@@ -1,0 +1,102 @@
+"""The compiler carries declared variables/connections from leoflow.yaml into
+the compiled dag.json (ADR 0045, ADR 0055).
+
+These are the Airflow-native words. They are distinct from ``connectors:`` (pip
+provider packages, ADR 0038) one letter away — declaring connections must never
+touch connectors, and vice versa.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import textwrap
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+
+from leoflow_parser.compiler import compile_dag  # noqa: E402  (sys.path set above)
+
+
+_TRIVIAL_DAG = """
+    from airflow.sdk import DAG
+    from airflow.providers.standard.operators.python import PythonOperator
+
+    def _f():
+        return None
+
+    with DAG(dag_id="declared_demo") as dag:
+        t = PythonOperator(task_id="t", python_callable=_f)
+"""
+
+
+def _write_dag(tmp_path):
+    src = tmp_path / "dag.py"
+    src.write_text(textwrap.dedent(_TRIVIAL_DAG))
+    return src
+
+
+def test_declared_connections_and_variables_land_in_dag_json(tmp_path, monkeypatch):
+    src = _write_dag(tmp_path)
+    cfg = {
+        "schema_version": "1.0",
+        "dag_id": "declared_demo",
+        "connections": ["warehouse", "webhook"],
+        "variables": ["greeting"],
+    }
+    monkeypatch.setenv("LEOFLOW_PROJECT_CONFIG_JSON", json.dumps(cfg))
+
+    spec = compile_dag(str(src), "/nonexistent/leoflow.yaml", "img:v1")
+
+    assert spec["connections"] == ["warehouse", "webhook"]
+    assert spec["variables"] == ["greeting"]
+
+
+def test_absent_declarations_are_omitted(tmp_path, monkeypatch):
+    src = _write_dag(tmp_path)
+    cfg = {"schema_version": "1.0", "dag_id": "declared_demo"}
+    monkeypatch.setenv("LEOFLOW_PROJECT_CONFIG_JSON", json.dumps(cfg))
+
+    spec = compile_dag(str(src), "/nonexistent/leoflow.yaml", "img:v1")
+
+    # Absent declarations are additive/optional: no key at all (empty = declares
+    # nothing), so an existing DAG's compiled shape is unchanged.
+    assert "connections" not in spec
+    assert "variables" not in spec
+
+
+def test_empty_declaration_lists_are_omitted(tmp_path, monkeypatch):
+    src = _write_dag(tmp_path)
+    cfg = {
+        "schema_version": "1.0",
+        "dag_id": "declared_demo",
+        "connections": [],
+        "variables": [],
+    }
+    monkeypatch.setenv("LEOFLOW_PROJECT_CONFIG_JSON", json.dumps(cfg))
+
+    spec = compile_dag(str(src), "/nonexistent/leoflow.yaml", "img:v1")
+
+    assert "connections" not in spec
+    assert "variables" not in spec
+
+
+def test_connectors_is_untouched_by_connections(tmp_path, monkeypatch):
+    """connections: (managed connection ids) and connectors: (pip provider
+    packages, ADR 0038) are different keys. Declaring connections must not leak
+    into the compiled spec as anything connector-shaped, and connectors: is a
+    build-time concern the parser never emits into dag.json."""
+    src = _write_dag(tmp_path)
+    cfg = {
+        "schema_version": "1.0",
+        "dag_id": "declared_demo",
+        "connections": ["warehouse"],
+        "connectors": ["postgres"],
+    }
+    monkeypatch.setenv("LEOFLOW_PROJECT_CONFIG_JSON", json.dumps(cfg))
+
+    spec = compile_dag(str(src), "/nonexistent/leoflow.yaml", "img:v1")
+
+    assert spec["connections"] == ["warehouse"]
+    # connectors is a build/dependency concern; it never appears in dag.json.
+    assert "connectors" not in spec


### PR DESCRIPTION
PR-E1a — first step of Lane E (the secret-scoping security chain, #623). Closes half of #59/#388. **No change to secret delivery** — that is E1c; this PR persists the declaration, rejects unknown declared names at registration, deletes dead code, and accepts ADR 0055.

### What it does
- **Schema:** `variables []string` / `connections []string` on `domain.DAGSpec` (per-DAG) + `TaskSpec` (per-task narrowing), `omitempty`; both `dag-schema.json` copies in sync (drift test passes). Same on `LeoflowConfig`/`TaskConfig` + `leoflow-yaml-schema.json` so the declaration flows leoflow.yaml → dag.json.
- **Python compiler** reads per-DAG `connections:`/`variables:` into `dag.json`; `connectors:` (ADR 0038) untouched; per-task narrowing via the existing Go overlay.
- **Dead code deleted:** `domain.Secret` + `TaskSpec.Secrets` (unused secretKeyRef shape, ADR 0045 §Settled #1).
- **ExecutionStore.TaskSpec** carries the resolved declared set (data-only) so E1c can scope on it.
- **Registration rejection (D6):** a declared var/conn name unknown to the tenant fails `RegisterDagVersion` (existence check, checked before any write); empty declaration always valid → no existing DAG rejected.
- **ADR 0055 → Accepted**, folding D1–**D9** (incl. the scope-enforcement policy `secret_scoping: enforce|permissive|off` edition-defaulted; token liveness always-on) + the retry/clear + age-independence invariants + the D3 no-recency-clause hazard + the E2 token-liveness test discipline.

### Contained — delivery untouched, Lite unaffected
`internal/agentrpc/secrets.go` = **zero diff**; `repository.go` `SecretVariables`/`SecretConnectionURIs` unchanged. Secret delivery still returns the whole vault (enforcement is E1c). Schema + registration-validation only → Lite behavior identical; empty declaration always valid.

### Verification
`go build`/`go vet`(+`-tags integration`)/`gofmt` clean · `golangci-lint run ./...` **0** · domain/storage/agentrpc Go tests + parser pytest (80) green · schema pairs byte-identical · `gen-adr-index --check` passes · registration-rejection integration tests written (`//go:build integration`, run in CI). Strict TDD (test-first), no AI attribution.

Held for the Lane-E closing specialist review before the enforcement PRs merge.