### PR TITLE
feat(secrets): warn when a narrowly-declared task receives the full vault + declare example DAGs

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -520,6 +520,13 @@ func startAgentGRPC(ctx context.Context, addr string, authn *auth.JWTAuthenticat
 	agentSrv.SetLogSink(logSink)
 	agentSrv.SetLogPublisher(logTailer)
 	agentSrv.SetSecrets(secretsStore, allowInsecureSecrets)
+	// The secrets store is the Repository, which also records the warn-phase
+	// secret-scope audit event (ADR 0045, ADR 0055); wire it as the auditor so a
+	// narrowly-declared task's full-vault delivery is surfaced. Optional: without
+	// it the WARN log still fires.
+	if auditor, ok := secretsStore.(agentrpc.SecretScopeAuditor); ok {
+		agentSrv.SetSecretScopeAuditor(auditor)
+	}
 
 	// Recover panics in any agent RPC handler so a single malformed request from a
 	// worker pod cannot crash the control plane (it returns Internal instead).

--- a/examples/gcp_gcs_load/leoflow.yaml
+++ b/examples/gcp_gcs_load/leoflow.yaml
@@ -10,6 +10,15 @@ dependencies:
   - google-cloud-storage==2.18.2
   - google-cloud-secret-manager==2.20.2
 
+# The managed Connection and Variable this DAG reads (ADR 0045, ADR 0055):
+# the google_cloud_default Connection for credentials and the GCS_BUCKET
+# Variable for the target bucket. Declaring them keeps the DAG valid once
+# secret delivery is scoped to the declared set.
+connections:
+  - google_cloud_default
+variables:
+  - GCS_BUCKET
+
 # Keyless on Pro/GKE: run the task pod as a Kubernetes ServiceAccount bound to a
 # GCP service account via Workload Identity, so credentials come from the
 # metadata server (no key). Create/annotate the KSA per the README, or drop this

--- a/examples/http_load/leoflow.yaml
+++ b/examples/http_load/leoflow.yaml
@@ -6,3 +6,7 @@ tags:
   - example
 python_version: "3.11"
 dependencies: []
+# The managed Connection this DAG reads (ADR 0045, ADR 0055). Declaring it keeps
+# the DAG valid once secret delivery is scoped to the declared set.
+connections:
+  - http_target

--- a/examples/mssql_load/leoflow.yaml
+++ b/examples/mssql_load/leoflow.yaml
@@ -7,3 +7,7 @@ tags:
 python_version: "3.11"
 dependencies:
   - pymssql==2.3.2
+# The managed Connection this DAG reads (ADR 0045, ADR 0055). Declaring it keeps
+# the DAG valid once secret delivery is scoped to the declared set.
+connections:
+  - mssql_target

--- a/examples/mysql_load/leoflow.yaml
+++ b/examples/mysql_load/leoflow.yaml
@@ -7,3 +7,7 @@ tags:
 python_version: "3.11"
 dependencies:
   - PyMySQL==1.1.1
+# The managed Connection this DAG reads (ADR 0045, ADR 0055). Declaring it keeps
+# the DAG valid once secret delivery is scoped to the declared set.
+connections:
+  - my_db

--- a/examples/postgres_hook_load/leoflow.yaml
+++ b/examples/postgres_hook_load/leoflow.yaml
@@ -11,3 +11,9 @@ python_version: "3.11"
 # dependencies: and uses psycopg2 directly. ADR 0038.
 connectors:
   - postgres
+# The managed Connection this DAG reads via PostgresHook(postgres_conn_id=...)
+# (ADR 0045, ADR 0055) — distinct from connectors: above, which is the pip
+# provider package (ADR 0038). Declaring it keeps the DAG valid once secret
+# delivery is scoped to the declared set.
+connections:
+  - pg_target

--- a/examples/postgres_load/leoflow.yaml
+++ b/examples/postgres_load/leoflow.yaml
@@ -7,3 +7,7 @@ tags:
 python_version: "3.11"
 dependencies:
   - psycopg2-binary==2.9.10
+# The managed Connection this DAG reads (ADR 0045, ADR 0055). Declaring it keeps
+# the DAG valid once secret delivery is scoped to the declared set.
+connections:
+  - pg_target

--- a/examples/redis_load/leoflow.yaml
+++ b/examples/redis_load/leoflow.yaml
@@ -7,3 +7,7 @@ tags:
 python_version: "3.11"
 dependencies:
   - redis==5.2.1
+# The managed Connection this DAG reads (ADR 0045, ADR 0055). Declaring it keeps
+# the DAG valid once secret delivery is scoped to the declared set.
+connections:
+  - redis_target

--- a/examples/sqlite_load/leoflow.yaml
+++ b/examples/sqlite_load/leoflow.yaml
@@ -7,3 +7,7 @@ tags:
 python_version: "3.11"
 # sqlite3 is part of the Python stdlib — no third-party dependency needed.
 dependencies: []
+# The managed Connection this DAG reads (ADR 0045, ADR 0055). Declaring it keeps
+# the DAG valid once secret delivery is scoped to the declared set.
+connections:
+  - sqlite_target

--- a/internal/agentrpc/secrets.go
+++ b/internal/agentrpc/secrets.go
@@ -2,11 +2,13 @@ package agentrpc
 
 import (
 	"context"
+	"log/slog"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 
+	"github.com/neochaotic/leoflow/internal/auth"
 	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
 )
 
@@ -18,12 +20,27 @@ type SecretsStore interface {
 	SecretConnectionURIs(ctx context.Context, tenant string) (map[string]string, error)
 }
 
+// SecretScopeAuditor records a structured audit event when a task receives the
+// full tenant secret set despite declaring only a subset of it — the visibility
+// half of the warn-before-enforce arc (ADR 0045 §Settled #3, ADR 0055). It
+// carries counts only, never secret names or values. It is optional and
+// best-effort: a nil auditor or a write error only skips the audit row; it never
+// changes what is delivered.
+type SecretScopeAuditor interface {
+	RecordSecretScopeWarning(ctx context.Context, tenant, dagID, runID, taskID, kind string, declared, total int) error
+}
+
 // SetSecrets attaches the secrets store. allowInsecure permits serving secrets
 // over a non-TLS channel — for local/dev only; production must use TLS (the
 // handlers fail closed otherwise). See ADR 0021 / issue #58.
 func (s *Server) SetSecrets(store SecretsStore, allowInsecure bool) {
 	s.secrets, s.allowInsecureSecrets = store, allowInsecure
 }
+
+// SetSecretScopeAuditor attaches the sink for secret-scope warning events
+// (optional). Without it, a narrowing declaration still produces the WARN log
+// but no audit row.
+func (s *Server) SetSecretScopeAuditor(a SecretScopeAuditor) { s.secretAudit = a }
 
 // guardSecretChannel refuses to serve secrets when the store is unconfigured or
 // the transport is not TLS (unless explicitly allowed for dev). This is the
@@ -56,6 +73,7 @@ func (s *Server) GetVariables(ctx context.Context, _ *agentv1.GetVariablesReques
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "fetching variables: %v", err)
 	}
+	s.warnIfNarrowerScope(ctx, id, "variables", vars)
 	return &agentv1.GetVariablesResponse{Variables: vars}, nil
 }
 
@@ -73,5 +91,66 @@ func (s *Server) GetConnections(ctx context.Context, _ *agentv1.GetConnectionsRe
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "fetching connections: %v", err)
 	}
+	s.warnIfNarrowerScope(ctx, id, "connections", uris)
 	return &agentv1.GetConnectionsResponse{ConnectionUris: uris}, nil
+}
+
+// warnIfNarrowerScope emits a structured WARN log and a best-effort audit event
+// when the calling task declared a non-empty secret set that is a strict subset
+// of the full tenant set it is about to receive (ADR 0045 §Settled #3, ADR 0055).
+// It never changes what is delivered — delivery stays fetch-all in the warn phase
+// — and it records counts only, never secret names or values. kind is
+// "variables" or "connections". A task that declared nothing is the permissive
+// default and is not warned.
+func (s *Server) warnIfNarrowerScope(ctx context.Context, id *auth.AgentIdentity, kind string, delivered map[string]string) {
+	// The declared set lives on the task spec (ADR 0045). Loading it is only for
+	// the warning; a load failure must never affect delivery, which already
+	// succeeded, so log and return without warning.
+	spec, err := s.store.TaskSpec(ctx, *id)
+	if err != nil {
+		slog.Warn("loading task spec for secret-scope warning; skipping warn",
+			"ti", id.TaskInstanceID, "kind", kind, "error", err)
+		return
+	}
+	declared := spec.DeclaredVariables
+	if kind == "connections" {
+		declared = spec.DeclaredConnections
+	}
+	declaredCount, deliveredCount, warn := scopeGap(declared, delivered)
+	if !warn {
+		return
+	}
+	slog.Warn("task received the full secret vault but declared a narrower set; under secret_scoping: enforce it would receive only its declared set",
+		"ti", id.TaskInstanceID, "tenant", id.TenantID, "dag", id.DagID, "run", id.RunID,
+		"task", id.TaskID, "kind", kind, "declared", declaredCount, "delivered", deliveredCount)
+	if s.secretAudit == nil {
+		return
+	}
+	if aerr := s.secretAudit.RecordSecretScopeWarning(ctx, id.TenantID, id.DagID, id.RunID, id.TaskID, kind, declaredCount, deliveredCount); aerr != nil {
+		slog.Warn("recording secret-scope warning audit event",
+			"ti", id.TaskInstanceID, "kind", kind, "error", aerr)
+	}
+}
+
+// scopeGap compares a task's declared secret names against the full tenant set it
+// is about to receive. It returns the count of declared names that are actually
+// delivered, the delivered total, and whether that declaration is a strict subset
+// (non-empty and covering fewer than all delivered secrets) — the condition the
+// warn phase records. E1a rejects declaring a name that does not exist, so a
+// declared name is expected to be delivered; a name that is not is simply not
+// counted, keeping the comparison robust.
+func scopeGap(declared []string, delivered map[string]string) (declaredCount, deliveredCount int, strictSubset bool) {
+	deliveredCount = len(delivered)
+	if len(declared) == 0 {
+		return 0, deliveredCount, false
+	}
+	seen := make(map[string]struct{}, len(declared))
+	for _, name := range declared {
+		if _, ok := delivered[name]; ok {
+			seen[name] = struct{}{}
+		}
+	}
+	declaredCount = len(seen)
+	strictSubset = declaredCount > 0 && declaredCount < deliveredCount
+	return declaredCount, deliveredCount, strictSubset
 }

--- a/internal/agentrpc/secrets_test.go
+++ b/internal/agentrpc/secrets_test.go
@@ -72,3 +72,151 @@ func TestSecretsRejectMissingToken(t *testing.T) {
 		t.Errorf("missing token = %v, want Unauthenticated", err)
 	}
 }
+
+// scopeWarnEvent captures one RecordSecretScopeWarning call so a test can assert
+// what the warn phase recorded — counts only, never secret names or values.
+type scopeWarnEvent struct {
+	tenant, dagID, runID, taskID, kind string
+	declared, total                    int
+}
+
+type fakeScopeAuditor struct {
+	events []scopeWarnEvent
+	err    error
+}
+
+func (f *fakeScopeAuditor) RecordSecretScopeWarning(_ context.Context, tenant, dagID, runID, taskID, kind string, declared, total int) error {
+	f.events = append(f.events, scopeWarnEvent{tenant, dagID, runID, taskID, kind, declared, total})
+	return f.err
+}
+
+// TestSecretsWarnOnNarrowDeclaration is the core of the warn phase: a task that
+// declared a strict subset of the tenant vault STILL receives the full set
+// (delivery is unchanged), and the narrowing is recorded as a scope-warning
+// audit event carrying counts only.
+func TestSecretsWarnOnNarrowDeclaration(t *testing.T) {
+	store := &fakeStore{spec: TaskSpec{
+		DeclaredVariables:   []string{"FOO"},
+		DeclaredConnections: []string{"pg"},
+	}}
+	srv, a := newServer(store)
+	sec := &fakeSecrets{
+		vars:  map[string]string{"FOO": "bar", "BAR": "baz"},
+		conns: map[string]string{"pg": "postgres://u:p@h:5432/db", "redis": "redis://h:6379"},
+	}
+	audit := &fakeScopeAuditor{}
+	srv.SetSecrets(sec, true)
+	srv.SetSecretScopeAuditor(audit)
+	ctx := ctxWithToken(t, a)
+
+	vresp, err := srv.GetVariables(ctx, &agentv1.GetVariablesRequest{})
+	if err != nil {
+		t.Fatalf("GetVariables: %v", err)
+	}
+	// Delivery unchanged: the full tenant set is still returned despite the narrow
+	// declaration.
+	if len(vresp.Variables) != 2 || vresp.Variables["FOO"] != "bar" || vresp.Variables["BAR"] != "baz" {
+		t.Errorf("variables = %v, want the full set {FOO,BAR}", vresp.Variables)
+	}
+	cresp, err := srv.GetConnections(ctx, &agentv1.GetConnectionsRequest{})
+	if err != nil {
+		t.Fatalf("GetConnections: %v", err)
+	}
+	if len(cresp.ConnectionUris) != 2 {
+		t.Errorf("connections = %v, want the full set {pg,redis}", cresp.ConnectionUris)
+	}
+
+	if len(audit.events) != 2 {
+		t.Fatalf("recorded %d scope-warning events, want 2 (one per kind): %+v", len(audit.events), audit.events)
+	}
+	byKind := map[string]scopeWarnEvent{}
+	for _, e := range audit.events {
+		byKind[e.kind] = e
+	}
+	v, ok := byKind["variables"]
+	if !ok {
+		t.Fatalf("no variables scope-warning event: %+v", audit.events)
+	}
+	if v.declared != 1 || v.total != 2 {
+		t.Errorf("variables event declared/total = %d/%d, want 1/2", v.declared, v.total)
+	}
+	if v.tenant != "acme" || v.dagID != "etl" || v.runID != "run-1" || v.taskID != "extract" {
+		t.Errorf("variables event identity = %+v, want tenant=acme dag=etl run=run-1 task=extract", v)
+	}
+	c, ok := byKind["connections"]
+	if !ok {
+		t.Fatalf("no connections scope-warning event: %+v", audit.events)
+	}
+	if c.declared != 1 || c.total != 2 {
+		t.Errorf("connections event declared/total = %d/%d, want 1/2", c.declared, c.total)
+	}
+}
+
+// TestSecretsNoWarnOnEmptyDeclaration is the permissive default: a task that
+// declared nothing triggers no warn and receives the full set, exactly as before
+// the warn phase existed.
+func TestSecretsNoWarnOnEmptyDeclaration(t *testing.T) {
+	store := &fakeStore{spec: TaskSpec{}} // no declaration
+	srv, a := newServer(store)
+	sec := &fakeSecrets{
+		vars:  map[string]string{"FOO": "bar", "BAR": "baz"},
+		conns: map[string]string{"pg": "postgres://u:p@h:5432/db"},
+	}
+	audit := &fakeScopeAuditor{}
+	srv.SetSecrets(sec, true)
+	srv.SetSecretScopeAuditor(audit)
+	ctx := ctxWithToken(t, a)
+
+	vresp, err := srv.GetVariables(ctx, &agentv1.GetVariablesRequest{})
+	if err != nil {
+		t.Fatalf("GetVariables: %v", err)
+	}
+	if len(vresp.Variables) != 2 {
+		t.Errorf("variables = %v, want the full set", vresp.Variables)
+	}
+	if _, err := srv.GetConnections(ctx, &agentv1.GetConnectionsRequest{}); err != nil {
+		t.Fatalf("GetConnections: %v", err)
+	}
+	if len(audit.events) != 0 {
+		t.Errorf("recorded %d scope-warning events for an undeclared task, want 0: %+v", len(audit.events), audit.events)
+	}
+}
+
+// TestSecretsNoWarnWhenDeclarationCoversFullSet guards the strict-subset rule: a
+// task that declared every delivered secret is not narrowing anything, so no warn
+// fires even though it has a non-empty declaration.
+func TestSecretsNoWarnWhenDeclarationCoversFullSet(t *testing.T) {
+	store := &fakeStore{spec: TaskSpec{
+		DeclaredVariables: []string{"FOO", "BAR"},
+	}}
+	srv, a := newServer(store)
+	sec := &fakeSecrets{vars: map[string]string{"FOO": "bar", "BAR": "baz"}}
+	audit := &fakeScopeAuditor{}
+	srv.SetSecrets(sec, true)
+	srv.SetSecretScopeAuditor(audit)
+
+	if _, err := srv.GetVariables(ctxWithToken(t, a), &agentv1.GetVariablesRequest{}); err != nil {
+		t.Fatalf("GetVariables: %v", err)
+	}
+	if len(audit.events) != 0 {
+		t.Errorf("recorded %d events for a full-coverage declaration, want 0: %+v", len(audit.events), audit.events)
+	}
+}
+
+// TestSecretsWarnWithoutAuditorStillDelivers proves the WARN log path is
+// independent of the audit sink: with no auditor configured, a narrowly-declared
+// task still receives the full set and the handler does not panic.
+func TestSecretsWarnWithoutAuditorStillDelivers(t *testing.T) {
+	store := &fakeStore{spec: TaskSpec{DeclaredVariables: []string{"FOO"}}}
+	srv, a := newServer(store)
+	sec := &fakeSecrets{vars: map[string]string{"FOO": "bar", "BAR": "baz"}}
+	srv.SetSecrets(sec, true) // no SetSecretScopeAuditor
+
+	vresp, err := srv.GetVariables(ctxWithToken(t, a), &agentv1.GetVariablesRequest{})
+	if err != nil {
+		t.Fatalf("GetVariables: %v", err)
+	}
+	if len(vresp.Variables) != 2 {
+		t.Errorf("variables = %v, want the full set", vresp.Variables)
+	}
+}

--- a/internal/agentrpc/server.go
+++ b/internal/agentrpc/server.go
@@ -134,6 +134,7 @@ type Server struct {
 	logs                 LogSink
 	tail                 LogPublisher
 	secrets              SecretsStore
+	secretAudit          SecretScopeAuditor
 	allowInsecureSecrets bool
 	now                  func() time.Time
 }

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -710,6 +710,33 @@ func (r *Repository) RecordAuthEvent(ctx context.Context, tenant, actorUserID, a
 	return nil
 }
 
+// RecordSecretScopeWarning records that a task received the full tenant secret
+// set while it declared only a narrower subset (ADR 0045, ADR 0055): under
+// secret_scoping: enforce it would receive only its declared set. It is scoped to
+// the DAG resource so the event surfaces on the DAG's Audit Log tab, with the
+// kind ("variables" or "connections"), the run and task, and the declared/total
+// counts in metadata. It records counts only — never secret names or values.
+func (r *Repository) RecordSecretScopeWarning(ctx context.Context, tenant, dagID, runID, taskID, kind string, declared, total int) error {
+	tid, err := r.tenantID(ctx, tenant)
+	if err != nil {
+		return err
+	}
+	meta, err := json.Marshal(map[string]any{
+		"kind": kind, "run_id": runID, "task_id": taskID,
+		"declared": declared, "total": total,
+	})
+	if err != nil {
+		return fmt.Errorf("encoding audit metadata: %w", err)
+	}
+	if err := r.q.CreateAuditLog(ctx, queries.CreateAuditLogParams{
+		TenantID: tid, Action: "secret.scope_warning",
+		ResourceType: strPtr("dag"), ResourceID: strPtr(dagID), Metadata: meta,
+	}); err != nil {
+		return fmt.Errorf("writing secret-scope warning audit: %w", err)
+	}
+	return nil
+}
+
 // SetTaskInstanceState sets a task instance's state directly, backing the UI's
 // "mark success"/"mark failed" actions. It does not run the task.
 func (r *Repository) SetTaskInstanceState(ctx context.Context, tenant, dagID, runID, taskID, state string) error {

--- a/internal/storage/ui_queries_integration_test.go
+++ b/internal/storage/ui_queries_integration_test.go
@@ -4,6 +4,7 @@ package storage_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -470,10 +471,27 @@ func TestRecordSecretScopeWarningIntegration(t *testing.T) {
 	if found.ResourceType != "dag" || found.ResourceID != dagID {
 		t.Errorf("resource = %s/%s, want dag/%s", found.ResourceType, found.ResourceID, dagID)
 	}
-	for _, want := range []string{`"kind":"connections"`, `"declared":1`, `"total":3`, `"run_id":"run-1"`, `"task_id":"t"`} {
-		if !strings.Contains(found.Extra, want) {
-			t.Errorf("metadata %q missing %q", found.Extra, want)
-		}
+	// Parse the metadata JSON and compare fields — jsonb normalizes spacing, so a
+	// substring match on `"kind":"connections"` is brittle (the stored form is
+	// `"kind": "connections"`). Numbers decode to float64.
+	var meta map[string]any
+	if err := json.Unmarshal([]byte(found.Extra), &meta); err != nil {
+		t.Fatalf("metadata is not valid JSON: %v (%q)", err, found.Extra)
+	}
+	if meta["kind"] != "connections" {
+		t.Errorf("kind = %v, want connections", meta["kind"])
+	}
+	if meta["run_id"] != "run-1" {
+		t.Errorf("run_id = %v, want run-1", meta["run_id"])
+	}
+	if meta["task_id"] != "t" {
+		t.Errorf("task_id = %v, want t", meta["task_id"])
+	}
+	if meta["declared"] != float64(1) {
+		t.Errorf("declared = %v, want 1", meta["declared"])
+	}
+	if meta["total"] != float64(3) {
+		t.Errorf("total = %v, want 3", meta["total"])
 	}
 }
 

--- a/internal/storage/ui_queries_integration_test.go
+++ b/internal/storage/ui_queries_integration_test.go
@@ -440,6 +440,43 @@ func TestListAuditLogsIntegration(t *testing.T) {
 	}
 }
 
+// TestRecordSecretScopeWarningIntegration checks the warn-phase audit event
+// (ADR 0045, ADR 0055): a task that received the full vault while declaring a
+// narrower set records a secret.scope_warning row against the DAG, carrying the
+// kind and the declared/total counts in metadata — and no secret names.
+func TestRecordSecretScopeWarningIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	dagID := fmt.Sprintf("uiq_scopewarn_%d", time.Now().UnixNano())
+	registerSpec(t, repo, ctx, dagID, []domain.TaskSpec{{TaskID: "t", Type: domain.TaskTypePython}})
+
+	if err := repo.RecordSecretScopeWarning(ctx, "default", dagID, "run-1", "t", "connections", 1, 3); err != nil {
+		t.Fatalf("RecordSecretScopeWarning: %v", err)
+	}
+
+	entries, _, err := repo.ListAuditLogs(ctx, "default", dagID, 50, 0)
+	if err != nil {
+		t.Fatalf("ListAuditLogs: %v", err)
+	}
+	var found *domain.AuditLogEntry
+	for i := range entries {
+		if entries[i].Action == "secret.scope_warning" {
+			found = &entries[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("secret.scope_warning entry not found for %s: %+v", dagID, entries)
+	}
+	if found.ResourceType != "dag" || found.ResourceID != dagID {
+		t.Errorf("resource = %s/%s, want dag/%s", found.ResourceType, found.ResourceID, dagID)
+	}
+	for _, want := range []string{`"kind":"connections"`, `"declared":1`, `"total":3`, `"run_id":"run-1"`, `"task_id":"t"`} {
+		if !strings.Contains(found.Extra, want) {
+			t.Errorf("metadata %q missing %q", found.Extra, want)
+		}
+	}
+}
+
 // TestListDagsFilteredIntegration guards the DAG list filters: by latest-run
 // state and by paused flag, with correct totals.
 func TestListDagsFilteredIntegration(t *testing.T) {

--- a/parser/tests/golden/postgres_load.json
+++ b/parser/tests/golden/postgres_load.json
@@ -1,4 +1,7 @@
 {
+  "connections": [
+    "pg_target"
+  ],
   "dag_id": "postgres_load",
   "dag_version": "v1",
   "owner": "examples",


### PR DESCRIPTION
PR-E1b — the warn step of Lane E's declaration shipment (stacked on E1a #660, now in main). **Delivery unchanged (still fetch-all)** — this is pure observability toward the future enforce (E1c).

- **Server-side WARN + audit** (`internal/agentrpc/secrets.go`): when a task's declared set (from E1a, on the task spec) is a non-empty STRICT SUBSET of the full vault being delivered, emit a structured warn + a `secret.scope_warning` audit event (Postgres audit_log, scoped to the DAG so it shows on the Audit Log tab). Counts only — never secret names/values. Fires only on a non-empty strict subset; empty declaration → no warn.
- **Delivery untouched:** `SecretVariables`/`SecretConnectionURIs` unchanged — still return the whole tenant set.
- **Example DAGs declared:** all 8 secret-using load examples got `connections:` (+ `gcp_gcs_load` `variables:`), so they stay green when E1c flips to enforce; `postgres_load` golden regenerated.

### Verification
`go build`/`go vet`(+`-tags integration`)/`gofmt` clean · `golangci-lint run ./...` 0 · agentrpc/storage/domain Go tests + parser pytest green · audit test is `//go:build integration` (CI-run). Strict TDD, no AI attribution.

Second half of the declaration shipment; the enforcement shipment (E1c+E2a+E2b) is the next, heavily-reviewed one.