### PR TITLE
feat(secrets): scope-by-policy + task-liveness gate (observe/permissive defaults — no denial)

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -338,7 +338,7 @@ func startSchedulerSide(ctx context.Context, cfg *config.ServerConfig, pg *stora
 	if !servesScheduler {
 		return nil, false, func() {}, nil
 	}
-	grpcSrv, gerr := startAgentGRPC(ctx, cfg.Server.GRPCAddr, authn, execStore, repo, xcomSvc, logSink, logTailer, allowInsecureSecrets, cfg.Server.GRPCTLSCert, cfg.Server.GRPCTLSKey, logger)
+	grpcSrv, gerr := startAgentGRPC(ctx, cfg.Server.GRPCAddr, authn, execStore, repo, xcomSvc, logSink, logTailer, allowInsecureSecrets, cfg.Auth.SecretScoping, cfg.Auth.SecretLivenessMode, cfg.Server.GRPCTLSCert, cfg.Server.GRPCTLSKey, logger)
 	if gerr != nil {
 		return nil, false, nil, gerr
 	}
@@ -510,7 +510,7 @@ func serveHTTP(ctx context.Context, logger *slog.Logger, servesAPI bool, apiSrv,
 // shutdown. TLS is enabled when tlsCert/tlsKey are set (issue #58); otherwise the
 // channel is plaintext (dev). The per-task bearer token in metadata authenticates
 // each call regardless.
-func startAgentGRPC(ctx context.Context, addr string, authn *auth.JWTAuthenticator, store *storage.ExecutionStore, secretsStore agentrpc.SecretsStore, xcomSvc agentrpc.XComService, logSink agentrpc.LogSink, logTailer agentrpc.LogPublisher, allowInsecureSecrets bool, tlsCert, tlsKey string, logger *slog.Logger) (*grpc.Server, error) {
+func startAgentGRPC(ctx context.Context, addr string, authn *auth.JWTAuthenticator, store *storage.ExecutionStore, secretsStore agentrpc.SecretsStore, xcomSvc agentrpc.XComService, logSink agentrpc.LogSink, logTailer agentrpc.LogPublisher, allowInsecureSecrets bool, secretScoping, secretLivenessMode, tlsCert, tlsKey string, logger *slog.Logger) (*grpc.Server, error) {
 	var lc net.ListenConfig
 	lis, err := lc.Listen(ctx, "tcp", addr)
 	if err != nil {
@@ -520,12 +520,25 @@ func startAgentGRPC(ctx context.Context, addr string, authn *auth.JWTAuthenticat
 	agentSrv.SetLogSink(logSink)
 	agentSrv.SetLogPublisher(logTailer)
 	agentSrv.SetSecrets(secretsStore, allowInsecureSecrets)
+	// Scope-by-declaration policy (ADR 0055 D9). Default permissive: the whole
+	// tenant vault, warning on a narrow declaration but never denying.
+	agentSrv.SetSecretScoping(secretScoping)
+	// Bind secret delivery to task-instance liveness (ADR 0055 E2). The
+	// ExecutionStore is the read-only liveness predicate; the mode defaults to
+	// observe (log a would-have-denied, still deliver). Secret-path only.
+	agentSrv.SetLivenessGate(store, secretLivenessMode)
 	// The secrets store is the Repository, which also records the warn-phase
 	// secret-scope audit event (ADR 0045, ADR 0055); wire it as the auditor so a
 	// narrowly-declared task's full-vault delivery is surfaced. Optional: without
 	// it the WARN log still fires.
 	if auditor, ok := secretsStore.(agentrpc.SecretScopeAuditor); ok {
 		agentSrv.SetSecretScopeAuditor(auditor)
+	}
+	// The Repository also records the secret-path liveness would-have-denied /
+	// denial audit event (ADR 0055 E2); wire it so the observe phase is
+	// observable. Optional: without it the WARN log still fires.
+	if auditor, ok := secretsStore.(agentrpc.SecretLivenessAuditor); ok {
+		agentSrv.SetSecretLivenessAuditor(auditor)
 	}
 
 	// Recover panics in any agent RPC handler so a single malformed request from a

--- a/docs/adr/0055-secret-scoping-and-token-liveness.md
+++ b/docs/adr/0055-secret-scoping-and-token-liveness.md
@@ -248,10 +248,17 @@ implementation.
     (a finished task's token resolving the whole vault for its TTL, from anywhere)
     is real even for a single-tenant deployment.
   - **Scope-by-declaration (Fix #1) is an operator-set policy `secret_scoping:
-    enforce | permissive | off`.** `enforce` = declare-or-receive-nothing (default
-    for multi-tenant); `permissive` = no declaration ⇒ the whole tenant vault
-    (today's behavior), scoping applies only where a DAG declared (opt-in
-    least-privilege — default for single-tenant / Lite); `off` = no scoping. The
+    enforce | permissive | off`.** `permissive` (the initial default everywhere)
+    is the **warn phase**: every task still receives the whole tenant vault
+    (today's behavior), and a task whose non-empty declaration is a strict subset
+    of that vault gets a warn + audit event (E1b) — delivery is NOT subset under
+    permissive. This is deliberate: declarations are populated from static analysis
+    and may be incomplete, so the warn phase surfaces gaps WITHOUT breaking a task
+    that under-declared. `enforce` is the least-privilege flip: a task receives ONLY
+    its declared subset (empty declaration ⇒ nothing); it is the operator's
+    deliberate go-live after the warn phase proves declarations complete (the
+    per-edition enforce default — multi-tenant Pro — is that flip, not the initial
+    ship). `off` = no scoping at all. The
     policy is operator-scoped, NEVER author-settable (a DAG author cannot downgrade
     their own task's scoping — the same confused-deputy bar as the token TTL). The
     declaration mechanism exists for every deployment regardless of policy; only the

--- a/internal/agentrpc/secrets.go
+++ b/internal/agentrpc/secrets.go
@@ -31,7 +31,7 @@ type SecretsStore interface {
 // Secret scoping policy (ADR 0055 D9), operator-set, NEVER author-settable.
 const (
 	// ScopingPermissive delivers the whole tenant vault when a DAG declares
-	// nothing (today's behaviour) and warns — but still delivers the whole vault —
+	// nothing (today's behavior) and warns — but still delivers the whole vault —
 	// when a DAG declares a narrower set. Subsetting is reserved for enforce, so no
 	// already-declaring pipeline loses access. It is the default for this shipment.
 	ScopingPermissive = "permissive"
@@ -58,7 +58,7 @@ type SecretScopeAuditor interface {
 const (
 	// LivenessObserve logs a structured warn + records a would-have-denied audit
 	// event when the caller's TI is not live, but STILL delivers. It is the
-	// default: no behaviour change, the observe half of the warn→enforce arc.
+	// default: no behavior change, the observe half of the warn→enforce arc.
 	LivenessObserve = "observe"
 	// LivenessEnforce denies with codes.PermissionDenied when the caller's TI is
 	// not live. It is the operator's later flip, after an observe period.
@@ -98,7 +98,7 @@ func (s *Server) SetSecretScopeAuditor(a SecretScopeAuditor) { s.secretAudit = a
 
 // SetLivenessGate attaches the read-only task-instance liveness predicate the
 // secret path consults, in the given mode ("observe" | "enforce", ADR 0055 E2).
-// An unrecognised mode falls back to observe — the safe, non-denying default.
+// An unrecognized mode falls back to observe — the safe, non-denying default.
 // A nil checker leaves the gate off (delivery unchanged), so the gate is opt-in.
 func (s *Server) SetLivenessGate(checker TaskLivenessChecker, mode string) {
 	s.liveness = checker
@@ -115,7 +115,7 @@ func (s *Server) SetLivenessGate(checker TaskLivenessChecker, mode string) {
 func (s *Server) SetSecretLivenessAuditor(a SecretLivenessAuditor) { s.livenessAudit = a }
 
 // SetSecretScoping sets the operator scope-by-declaration policy (ADR 0055 D9):
-// "enforce" | "permissive" | "off". An unrecognised value falls back to
+// "enforce" | "permissive" | "off". An unrecognized value falls back to
 // permissive — the safe, non-denying default — so a misconfiguration never
 // silently denies. The policy is operator-scoped, never author-settable.
 func (s *Server) SetSecretScoping(policy string) { s.scoping = policy }
@@ -156,7 +156,7 @@ func (s *Server) guardSecretChannel(ctx context.Context) error {
 //
 // It returns a PermissionDenied error ONLY in enforce mode on a POSITIVE
 // not-live result. In observe mode a not-live result logs + audits a
-// would-have-denied and returns nil (delivery proceeds — no behaviour change).
+// would-have-denied and returns nil (delivery proceeds — no behavior change).
 //
 // Transient-error rule (both modes): an inconclusive liveness read (a nil
 // checker, or a DB error) NEVER denies and NEVER warns-as-not-live — an errored

--- a/internal/agentrpc/secrets.go
+++ b/internal/agentrpc/secrets.go
@@ -15,10 +15,32 @@ import (
 // SecretsStore returns a tenant's Variables and Connections for delivery to a
 // task pod (ADR 0021). Connection URIs carry decrypted credentials, so this is
 // only ever served over the authenticated agent channel — never to the UI/API.
+//
+// The unscoped methods return the whole tenant vault (permissive / off). The
+// scoped methods return ONLY the named subset, filtered IN THE QUERY (ADR 0055
+// D1: never post-filter the decrypted whole vault in the handler); they back
+// secret_scoping: enforce, where a task receives only what it declared. An empty
+// name set returns nothing — enforce's load-bearing [] case.
 type SecretsStore interface {
 	SecretVariables(ctx context.Context, tenant string) (map[string]string, error)
 	SecretConnectionURIs(ctx context.Context, tenant string) (map[string]string, error)
+	SecretVariablesScoped(ctx context.Context, tenant string, names []string) (map[string]string, error)
+	SecretConnectionURIsScoped(ctx context.Context, tenant string, names []string) (map[string]string, error)
 }
+
+// Secret scoping policy (ADR 0055 D9), operator-set, NEVER author-settable.
+const (
+	// ScopingPermissive delivers the whole tenant vault when a DAG declares
+	// nothing (today's behaviour) and warns — but still delivers the whole vault —
+	// when a DAG declares a narrower set. Subsetting is reserved for enforce, so no
+	// already-declaring pipeline loses access. It is the default for this shipment.
+	ScopingPermissive = "permissive"
+	// ScopingEnforce delivers ONLY the declared subset (empty declaration →
+	// nothing), resolved server-side and filtered in the query.
+	ScopingEnforce = "enforce"
+	// ScopingOff disables scoping entirely: the whole tenant vault, no warn.
+	ScopingOff = "off"
+)
 
 // SecretScopeAuditor records a structured audit event when a task receives the
 // full tenant secret set despite declaring only a subset of it — the visibility
@@ -91,6 +113,23 @@ func (s *Server) SetLivenessGate(checker TaskLivenessChecker, mode string) {
 // (optional). Without it, a would-have-denied / denial still produces the WARN
 // log but no audit row.
 func (s *Server) SetSecretLivenessAuditor(a SecretLivenessAuditor) { s.livenessAudit = a }
+
+// SetSecretScoping sets the operator scope-by-declaration policy (ADR 0055 D9):
+// "enforce" | "permissive" | "off". An unrecognised value falls back to
+// permissive — the safe, non-denying default — so a misconfiguration never
+// silently denies. The policy is operator-scoped, never author-settable.
+func (s *Server) SetSecretScoping(policy string) { s.scoping = policy }
+
+// scopingPolicy normalises the configured policy to one of the three known
+// values, defaulting (and failing safe on an unknown value) to permissive.
+func (s *Server) scopingPolicy() string {
+	switch s.scoping {
+	case ScopingEnforce, ScopingOff:
+		return s.scoping
+	default:
+		return ScopingPermissive
+	}
+}
 
 // guardSecretChannel refuses to serve secrets when the store is unconfigured or
 // the transport is not TLS (unless explicitly allowed for dev). This is the
@@ -179,11 +218,25 @@ func (s *Server) GetVariables(ctx context.Context, _ *agentv1.GetVariablesReques
 	if lerr := s.checkLiveness(ctx, id, "variables"); lerr != nil {
 		return nil, lerr
 	}
+	if s.scopingPolicy() == ScopingEnforce {
+		declared, derr := s.declaredNames(ctx, id, "variables")
+		if derr != nil {
+			return nil, derr
+		}
+		vars, verr := s.secrets.SecretVariablesScoped(ctx, id.TenantID, declared)
+		if verr != nil {
+			return nil, status.Errorf(codes.Internal, "fetching variables: %v", verr)
+		}
+		return &agentv1.GetVariablesResponse{Variables: vars}, nil
+	}
 	vars, err := s.secrets.SecretVariables(ctx, id.TenantID)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "fetching variables: %v", err)
 	}
-	s.warnIfNarrowerScope(ctx, id, "variables", vars)
+	// permissive warns on a narrow declaration; off disables the warn entirely.
+	if s.scopingPolicy() == ScopingPermissive {
+		s.warnIfNarrowerScope(ctx, id, "variables", vars)
+	}
 	return &agentv1.GetVariablesResponse{Variables: vars}, nil
 }
 
@@ -200,12 +253,43 @@ func (s *Server) GetConnections(ctx context.Context, _ *agentv1.GetConnectionsRe
 	if lerr := s.checkLiveness(ctx, id, "connections"); lerr != nil {
 		return nil, lerr
 	}
+	if s.scopingPolicy() == ScopingEnforce {
+		declared, derr := s.declaredNames(ctx, id, "connections")
+		if derr != nil {
+			return nil, derr
+		}
+		uris, uerr := s.secrets.SecretConnectionURIsScoped(ctx, id.TenantID, declared)
+		if uerr != nil {
+			return nil, status.Errorf(codes.Internal, "fetching connections: %v", uerr)
+		}
+		return &agentv1.GetConnectionsResponse{ConnectionUris: uris}, nil
+	}
 	uris, err := s.secrets.SecretConnectionURIs(ctx, id.TenantID)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "fetching connections: %v", err)
 	}
-	s.warnIfNarrowerScope(ctx, id, "connections", uris)
+	// permissive warns on a narrow declaration; off disables the warn entirely.
+	if s.scopingPolicy() == ScopingPermissive {
+		s.warnIfNarrowerScope(ctx, id, "connections", uris)
+	}
 	return &agentv1.GetConnectionsResponse{ConnectionUris: uris}, nil
+}
+
+// declaredNames resolves the caller's declared secret set for enforce mode from
+// its task spec (E1a threaded it onto the agent-facing spec). kind is
+// "variables" or "connections". A spec-load failure fails the RPC closed
+// (Internal): under enforce we must never fall back to the whole vault when the
+// declared set cannot be determined. The scoping is resolved server-side from
+// the token identity, never from anything the agent claims.
+func (s *Server) declaredNames(ctx context.Context, id *auth.AgentIdentity, kind string) ([]string, error) {
+	spec, err := s.store.TaskSpec(ctx, *id)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "loading task spec for scope enforcement: %v", err)
+	}
+	if kind == "connections" {
+		return spec.DeclaredConnections, nil
+	}
+	return spec.DeclaredVariables, nil
 }
 
 // warnIfNarrowerScope emits a structured WARN log and a best-effort audit event

--- a/internal/agentrpc/secrets.go
+++ b/internal/agentrpc/secrets.go
@@ -30,6 +30,38 @@ type SecretScopeAuditor interface {
 	RecordSecretScopeWarning(ctx context.Context, tenant, dagID, runID, taskID, kind string, declared, total int) error
 }
 
+// Secret-path liveness gate modes (ADR 0055 E2). The gate consults the
+// read-only task-instance liveness predicate before serving secrets so a token
+// whose task instance is no longer live stops resolving them.
+const (
+	// LivenessObserve logs a structured warn + records a would-have-denied audit
+	// event when the caller's TI is not live, but STILL delivers. It is the
+	// default: no behaviour change, the observe half of the warn→enforce arc.
+	LivenessObserve = "observe"
+	// LivenessEnforce denies with codes.PermissionDenied when the caller's TI is
+	// not live. It is the operator's later flip, after an observe period.
+	LivenessEnforce = "enforce"
+)
+
+// TaskLivenessChecker reports whether a task-instance attempt is still live —
+// present and in an active (non-terminal) state for the given (run, task, try).
+// It is the read-only revocation signal the secret path consults (ADR 0055 D3):
+// a terminal, superseded, or reaped attempt is not live, so its token stops
+// resolving secrets. The predicate derives ONLY from (run, task, try) + active
+// state — never run recency — so a clear-and-rerun of an old run stays live.
+type TaskLivenessChecker interface {
+	IsTaskInstanceLive(ctx context.Context, runID, taskID string, tryNumber int) (bool, error)
+}
+
+// SecretLivenessAuditor records a structured audit event when the secret-path
+// liveness gate fires: a would-have-denied in observe mode, or a denial in
+// enforce mode (ADR 0055). It carries identity + kind + mode only, never secret
+// names or values. Optional and best-effort: a nil auditor or a write error only
+// skips the row; it never changes the gate's decision.
+type SecretLivenessAuditor interface {
+	RecordSecretLivenessDenial(ctx context.Context, tenant, dagID, runID, taskID string, tryNumber int, kind, mode string) error
+}
+
 // SetSecrets attaches the secrets store. allowInsecure permits serving secrets
 // over a non-TLS channel — for local/dev only; production must use TLS (the
 // handlers fail closed otherwise). See ADR 0021 / issue #58.
@@ -41,6 +73,24 @@ func (s *Server) SetSecrets(store SecretsStore, allowInsecure bool) {
 // (optional). Without it, a narrowing declaration still produces the WARN log
 // but no audit row.
 func (s *Server) SetSecretScopeAuditor(a SecretScopeAuditor) { s.secretAudit = a }
+
+// SetLivenessGate attaches the read-only task-instance liveness predicate the
+// secret path consults, in the given mode ("observe" | "enforce", ADR 0055 E2).
+// An unrecognised mode falls back to observe — the safe, non-denying default.
+// A nil checker leaves the gate off (delivery unchanged), so the gate is opt-in.
+func (s *Server) SetLivenessGate(checker TaskLivenessChecker, mode string) {
+	s.liveness = checker
+	if mode == LivenessEnforce {
+		s.livenessMode = LivenessEnforce
+	} else {
+		s.livenessMode = LivenessObserve
+	}
+}
+
+// SetSecretLivenessAuditor attaches the sink for secret-path liveness events
+// (optional). Without it, a would-have-denied / denial still produces the WARN
+// log but no audit row.
+func (s *Server) SetSecretLivenessAuditor(a SecretLivenessAuditor) { s.livenessAudit = a }
 
 // guardSecretChannel refuses to serve secrets when the store is unconfigured or
 // the transport is not TLS (unless explicitly allowed for dev). This is the
@@ -59,6 +109,63 @@ func (s *Server) guardSecretChannel(ctx context.Context) error {
 		"refusing to send secrets over an insecure channel; enable gRPC TLS (see issue #58)")
 }
 
+// checkLiveness consults the read-only task-instance liveness predicate on the
+// secret path (ADR 0055 D2/D3, E2). It is called ONLY by GetVariables and
+// GetConnections — never by the shared identify(), because Heartbeat/ReportState
+// are designed to run for a superseded TI so they can return the terminate
+// signal, and gating them on liveness would break it.
+//
+// It returns a PermissionDenied error ONLY in enforce mode on a POSITIVE
+// not-live result. In observe mode a not-live result logs + audits a
+// would-have-denied and returns nil (delivery proceeds — no behaviour change).
+//
+// Transient-error rule (both modes): an inconclusive liveness read (a nil
+// checker, or a DB error) NEVER denies and NEVER warns-as-not-live — an errored
+// check cannot conclude the TI is dead, and the short token TTL bounds a real
+// blip. Failing closed on a transient read would break a live pipeline.
+func (s *Server) checkLiveness(ctx context.Context, id *auth.AgentIdentity, kind string) error {
+	if s.liveness == nil {
+		return nil // gate not configured — delivery unchanged
+	}
+	live, err := s.liveness.IsTaskInstanceLive(ctx, id.RunID, id.TaskID, id.TryNumber)
+	if err != nil {
+		// Inconclusive: cannot conclude not-live. Never deny, never warn-as-not-live.
+		slog.Warn("secret-path liveness check inconclusive; delivering (transient error, token TTL bounds exposure)",
+			"ti", id.TaskInstanceID, "run", id.RunID, "task", id.TaskID, "try", id.TryNumber, "kind", kind, "error", err)
+		return nil
+	}
+	if live {
+		return nil
+	}
+	// Positive not-live result: the TI is terminal, superseded, or reaped.
+	if s.livenessMode == LivenessEnforce {
+		slog.Warn("denying secrets: task instance is not live (secret_liveness_mode: enforce)",
+			"ti", id.TaskInstanceID, "tenant", id.TenantID, "dag", id.DagID, "run", id.RunID,
+			"task", id.TaskID, "try", id.TryNumber, "kind", kind)
+		s.recordLiveness(ctx, id, kind, LivenessEnforce)
+		return status.Error(codes.PermissionDenied, "task instance is no longer live")
+	}
+	// Observe mode: would-have-denied, but deliver.
+	slog.Warn("would-have-denied secrets: task instance is not live (secret_liveness_mode: observe; delivering)",
+		"ti", id.TaskInstanceID, "tenant", id.TenantID, "dag", id.DagID, "run", id.RunID,
+		"task", id.TaskID, "try", id.TryNumber, "kind", kind)
+	s.recordLiveness(ctx, id, kind, LivenessObserve)
+	return nil
+}
+
+// recordLiveness writes the best-effort secret-path liveness audit event. A nil
+// auditor or a write error only skips the row; it never changes the gate's
+// decision.
+func (s *Server) recordLiveness(ctx context.Context, id *auth.AgentIdentity, kind, mode string) {
+	if s.livenessAudit == nil {
+		return
+	}
+	if aerr := s.livenessAudit.RecordSecretLivenessDenial(ctx, id.TenantID, id.DagID, id.RunID, id.TaskID, id.TryNumber, kind, mode); aerr != nil {
+		slog.Warn("recording secret-path liveness audit event",
+			"ti", id.TaskInstanceID, "kind", kind, "mode", mode, "error", aerr)
+	}
+}
+
 // GetVariables returns the calling task's tenant Variables for the agent to
 // export as AIRFLOW_VAR_<KEY>.
 func (s *Server) GetVariables(ctx context.Context, _ *agentv1.GetVariablesRequest) (*agentv1.GetVariablesResponse, error) {
@@ -68,6 +175,9 @@ func (s *Server) GetVariables(ctx context.Context, _ *agentv1.GetVariablesReques
 	}
 	if gerr := s.guardSecretChannel(ctx); gerr != nil {
 		return nil, gerr
+	}
+	if lerr := s.checkLiveness(ctx, id, "variables"); lerr != nil {
+		return nil, lerr
 	}
 	vars, err := s.secrets.SecretVariables(ctx, id.TenantID)
 	if err != nil {
@@ -86,6 +196,9 @@ func (s *Server) GetConnections(ctx context.Context, _ *agentv1.GetConnectionsRe
 	}
 	if gerr := s.guardSecretChannel(ctx); gerr != nil {
 		return nil, gerr
+	}
+	if lerr := s.checkLiveness(ctx, id, "connections"); lerr != nil {
+		return nil, lerr
 	}
 	uris, err := s.secrets.SecretConnectionURIs(ctx, id.TenantID)
 	if err != nil {

--- a/internal/agentrpc/secrets_liveness_test.go
+++ b/internal/agentrpc/secrets_liveness_test.go
@@ -1,0 +1,204 @@
+package agentrpc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+)
+
+// fakeLiveness is a scripted liveness predicate: it returns (live, err) and
+// records how many times it was consulted so a test can prove the gate ran (or
+// did not) on a given path.
+type fakeLiveness struct {
+	live  bool
+	err   error
+	calls int
+}
+
+func (f *fakeLiveness) IsTaskInstanceLive(_ context.Context, _, _ string, _ int) (bool, error) {
+	f.calls++
+	return f.live, f.err
+}
+
+// livenessEvent captures one RecordSecretLivenessDenial call — identity + kind +
+// mode, never secret names or values.
+type livenessEvent struct {
+	tenant, dagID, runID, taskID, kind, mode string
+	tryNumber                                int
+}
+
+type fakeLivenessAuditor struct {
+	events []livenessEvent
+}
+
+func (f *fakeLivenessAuditor) RecordSecretLivenessDenial(_ context.Context, tenant, dagID, runID, taskID string, tryNumber int, kind, mode string) error {
+	f.events = append(f.events, livenessEvent{tenant, dagID, runID, taskID, kind, mode, tryNumber})
+	return nil
+}
+
+// TestSecretLivenessObserveDeliversWhenNotLive is the observe-mode contract and
+// the strongest guard against a pipeline-breaking bug: a NOT-live TI does NOT
+// deny in observe mode — the secrets are still delivered — and the
+// would-have-denied is recorded on the audit surface. Observe mode must never
+// change behaviour.
+func TestSecretLivenessObserveDeliversWhenNotLive(t *testing.T) {
+	srv, a := newServer(&fakeStore{})
+	sec := &fakeSecrets{vars: map[string]string{"FOO": "bar"}, conns: map[string]string{"pg": "postgres://u:p@h/db"}}
+	audit := &fakeLivenessAuditor{}
+	srv.SetSecrets(sec, true)
+	srv.SetLivenessGate(&fakeLiveness{live: false}, LivenessObserve)
+	srv.SetSecretLivenessAuditor(audit)
+	ctx := ctxWithToken(t, a)
+
+	vresp, err := srv.GetVariables(ctx, &agentv1.GetVariablesRequest{})
+	if err != nil {
+		t.Fatalf("observe mode must not deny a not-live TI: %v", err)
+	}
+	if vresp.Variables["FOO"] != "bar" {
+		t.Errorf("observe mode must still deliver: got %v", vresp.Variables)
+	}
+	if _, err := srv.GetConnections(ctx, &agentv1.GetConnectionsRequest{}); err != nil {
+		t.Fatalf("observe mode must not deny connections: %v", err)
+	}
+	if len(audit.events) != 2 {
+		t.Fatalf("recorded %d liveness events, want 2 (one per kind): %+v", len(audit.events), audit.events)
+	}
+	for _, e := range audit.events {
+		if e.mode != "observe" {
+			t.Errorf("observe-mode event mode = %q, want observe", e.mode)
+		}
+		if e.tenant != "acme" || e.runID != "run-1" || e.taskID != "extract" {
+			t.Errorf("liveness event identity = %+v, want tenant=acme run=run-1 task=extract", e)
+		}
+	}
+}
+
+// TestSecretLivenessEnforceDeniesWhenNotLive is the security side: in enforce
+// mode a positive not-live result denies with PermissionDenied and records the
+// denial.
+func TestSecretLivenessEnforceDeniesWhenNotLive(t *testing.T) {
+	srv, a := newServer(&fakeStore{})
+	sec := &fakeSecrets{vars: map[string]string{"FOO": "bar"}, conns: map[string]string{"pg": "postgres://u:p@h/db"}}
+	audit := &fakeLivenessAuditor{}
+	srv.SetSecrets(sec, true)
+	srv.SetLivenessGate(&fakeLiveness{live: false}, LivenessEnforce)
+	srv.SetSecretLivenessAuditor(audit)
+	ctx := ctxWithToken(t, a)
+
+	if _, err := srv.GetVariables(ctx, &agentv1.GetVariablesRequest{}); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("enforce mode + not-live GetVariables = %v, want PermissionDenied", err)
+	}
+	if _, err := srv.GetConnections(ctx, &agentv1.GetConnectionsRequest{}); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("enforce mode + not-live GetConnections = %v, want PermissionDenied", err)
+	}
+	if len(audit.events) != 2 {
+		t.Fatalf("recorded %d liveness events, want 2: %+v", len(audit.events), audit.events)
+	}
+	for _, e := range audit.events {
+		if e.mode != "enforce" {
+			t.Errorf("enforce-mode event mode = %q, want enforce", e.mode)
+		}
+	}
+}
+
+// TestSecretLivenessLiveAlwaysResolves is the availability invariant on both
+// modes: a LIVE TI always resolves, never a false-deny.
+func TestSecretLivenessLiveAlwaysResolves(t *testing.T) {
+	for _, mode := range []string{LivenessObserve, LivenessEnforce} {
+		t.Run(mode, func(t *testing.T) {
+			srv, a := newServer(&fakeStore{})
+			sec := &fakeSecrets{vars: map[string]string{"FOO": "bar"}}
+			audit := &fakeLivenessAuditor{}
+			srv.SetSecrets(sec, true)
+			srv.SetLivenessGate(&fakeLiveness{live: true}, mode)
+			srv.SetSecretLivenessAuditor(audit)
+
+			vresp, err := srv.GetVariables(ctxWithToken(t, a), &agentv1.GetVariablesRequest{})
+			if err != nil {
+				t.Fatalf("%s mode + live TI must resolve: %v", mode, err)
+			}
+			if vresp.Variables["FOO"] != "bar" {
+				t.Errorf("live TI must deliver: got %v", vresp.Variables)
+			}
+			if len(audit.events) != 0 {
+				t.Errorf("a live TI must record no liveness event: %+v", audit.events)
+			}
+		})
+	}
+}
+
+// TestSecretLivenessTransientErrorDoesNotDeny is the transient-error rule: an
+// inconclusive liveness read (a DB blip) must NOT deny and must NOT warn-as-not-
+// live, in EITHER mode. Denying on an errored check would break a live pipeline
+// on a transient blip; the short token TTL already bounds a real one.
+func TestSecretLivenessTransientErrorDoesNotDeny(t *testing.T) {
+	for _, mode := range []string{LivenessObserve, LivenessEnforce} {
+		t.Run(mode, func(t *testing.T) {
+			srv, a := newServer(&fakeStore{})
+			sec := &fakeSecrets{vars: map[string]string{"FOO": "bar"}}
+			audit := &fakeLivenessAuditor{}
+			srv.SetSecrets(sec, true)
+			srv.SetLivenessGate(&fakeLiveness{err: errors.New("db blip")}, mode)
+			srv.SetSecretLivenessAuditor(audit)
+
+			vresp, err := srv.GetVariables(ctxWithToken(t, a), &agentv1.GetVariablesRequest{})
+			if err != nil {
+				t.Fatalf("%s mode: an inconclusive liveness read must not deny: %v", mode, err)
+			}
+			if vresp.Variables["FOO"] != "bar" {
+				t.Errorf("%s mode: must still deliver on an inconclusive read: got %v", mode, vresp.Variables)
+			}
+			if len(audit.events) != 0 {
+				t.Errorf("an inconclusive read must not record a not-live event: %+v", audit.events)
+			}
+		})
+	}
+}
+
+// TestSecretLivenessNoCheckerDelivers proves the gate is opt-in: with no
+// liveness checker configured (the pre-E2 wiring), delivery is unchanged.
+func TestSecretLivenessNoCheckerDelivers(t *testing.T) {
+	srv, a := newServer(&fakeStore{})
+	sec := &fakeSecrets{vars: map[string]string{"FOO": "bar"}}
+	srv.SetSecrets(sec, true) // no SetLivenessGate
+
+	vresp, err := srv.GetVariables(ctxWithToken(t, a), &agentv1.GetVariablesRequest{})
+	if err != nil {
+		t.Fatalf("no checker configured must deliver: %v", err)
+	}
+	if vresp.Variables["FOO"] != "bar" {
+		t.Errorf("no checker must deliver the full set: got %v", vresp.Variables)
+	}
+}
+
+// TestSecretLivenessGateIsSecretPathOnly locks D2: the liveness gate wraps the
+// secret RPCs only, never the shared identify(). Heartbeat and ReportState are
+// designed to run for a superseded TI so they can return the terminate signal;
+// gating them on liveness would break that. Even with a not-live checker in
+// enforce mode, Heartbeat and Register must not consult it and must not be
+// denied by it.
+func TestSecretLivenessGateIsSecretPathOnly(t *testing.T) {
+	live := &fakeLiveness{live: false}
+	srv, a := newServer(&fakeStore{})
+	srv.SetSecrets(&fakeSecrets{}, true)
+	srv.SetLivenessGate(live, LivenessEnforce)
+	ctx := ctxWithToken(t, a)
+
+	if _, err := srv.Heartbeat(ctx, &agentv1.HeartbeatRequest{}); err != nil {
+		t.Fatalf("Heartbeat must never be gated on liveness: %v", err)
+	}
+	if _, err := srv.Register(ctx, &agentv1.RegisterRequest{}); err != nil {
+		t.Fatalf("Register must never be gated on liveness: %v", err)
+	}
+	if _, err := srv.ReportState(ctx, &agentv1.ReportStateRequest{State: agentv1.TaskState_TASK_STATE_RUNNING}); err != nil {
+		t.Fatalf("ReportState must never be gated on liveness: %v", err)
+	}
+	if live.calls != 0 {
+		t.Errorf("liveness checker consulted %d times on non-secret paths, want 0", live.calls)
+	}
+}

--- a/internal/agentrpc/secrets_liveness_test.go
+++ b/internal/agentrpc/secrets_liveness_test.go
@@ -45,7 +45,7 @@ func (f *fakeLivenessAuditor) RecordSecretLivenessDenial(_ context.Context, tena
 // the strongest guard against a pipeline-breaking bug: a NOT-live TI does NOT
 // deny in observe mode — the secrets are still delivered — and the
 // would-have-denied is recorded on the audit surface. Observe mode must never
-// change behaviour.
+// change behavior.
 func TestSecretLivenessObserveDeliversWhenNotLive(t *testing.T) {
 	srv, a := newServer(&fakeStore{})
 	sec := &fakeSecrets{vars: map[string]string{"FOO": "bar"}, conns: map[string]string{"pg": "postgres://u:p@h/db"}}

--- a/internal/agentrpc/secrets_scoping_test.go
+++ b/internal/agentrpc/secrets_scoping_test.go
@@ -160,7 +160,7 @@ func TestSecretScopingOffWholeVaultNoWarn(t *testing.T) {
 }
 
 // TestSecretScopingUnknownFallsBackToPermissive proves the setter fails safe: an
-// unrecognised policy value is treated as permissive (whole vault), never as a
+// unrecognized policy value is treated as permissive (whole vault), never as a
 // silent enforce that would deny.
 func TestSecretScopingUnknownFallsBackToPermissive(t *testing.T) {
 	store := &fakeStore{spec: TaskSpec{DeclaredVariables: []string{"FOO"}}}

--- a/internal/agentrpc/secrets_scoping_test.go
+++ b/internal/agentrpc/secrets_scoping_test.go
@@ -1,0 +1,179 @@
+package agentrpc
+
+import (
+	"testing"
+
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+)
+
+// TestSecretScopingDefaultIsPermissiveWholeVault is the SAFE-default contract: a
+// server with no scoping policy set behaves EXACTLY as before this shipment —
+// the whole tenant vault is delivered and the scoped path is never taken. This
+// is the guarantee that a fresh deploy denies nothing and no task loses access.
+func TestSecretScopingDefaultIsPermissiveWholeVault(t *testing.T) {
+	store := &fakeStore{spec: TaskSpec{DeclaredVariables: []string{"FOO"}}}
+	srv, a := newServer(store)
+	sec := &fakeSecrets{vars: map[string]string{"FOO": "bar", "BAR": "baz"}}
+	srv.SetSecrets(sec, true) // no SetSecretScoping — default permissive
+
+	vresp, err := srv.GetVariables(ctxWithToken(t, a), &agentv1.GetVariablesRequest{})
+	if err != nil {
+		t.Fatalf("GetVariables: %v", err)
+	}
+	if len(vresp.Variables) != 2 {
+		t.Errorf("default permissive must deliver the whole vault: got %v", vresp.Variables)
+	}
+	if sec.scopedVar {
+		t.Errorf("default permissive must not take the scoped path")
+	}
+}
+
+// TestSecretScopingPermissiveDeclaredStillWholeVault pins the chosen permissive
+// interpretation: even when a DAG declares a narrow set, permissive delivers the
+// WHOLE vault (and warns) — it never subsets. Subsetting is reserved for
+// enforce, so no already-declaring pipeline loses access on merge.
+func TestSecretScopingPermissiveDeclaredStillWholeVault(t *testing.T) {
+	store := &fakeStore{spec: TaskSpec{DeclaredVariables: []string{"FOO"}}}
+	srv, a := newServer(store)
+	sec := &fakeSecrets{vars: map[string]string{"FOO": "bar", "BAR": "baz"}}
+	audit := &fakeScopeAuditor{}
+	srv.SetSecrets(sec, true)
+	srv.SetSecretScopeAuditor(audit)
+	srv.SetSecretScoping(ScopingPermissive)
+
+	vresp, err := srv.GetVariables(ctxWithToken(t, a), &agentv1.GetVariablesRequest{})
+	if err != nil {
+		t.Fatalf("GetVariables: %v", err)
+	}
+	if len(vresp.Variables) != 2 {
+		t.Errorf("permissive must deliver the whole vault despite a narrow declaration: got %v", vresp.Variables)
+	}
+	if sec.scopedVar {
+		t.Errorf("permissive must not take the scoped path")
+	}
+	// The narrowing is still surfaced by the E1b warn.
+	if len(audit.events) != 1 || audit.events[0].kind != "variables" {
+		t.Errorf("permissive must warn on the narrow declaration: %+v", audit.events)
+	}
+}
+
+// TestSecretScopingEnforceReturnsOnlyDeclared is the enforce contract: a task
+// receives ONLY its declared subset, resolved server-side and filtered in the
+// query (the scoped path), not the whole vault.
+func TestSecretScopingEnforceReturnsOnlyDeclared(t *testing.T) {
+	store := &fakeStore{spec: TaskSpec{
+		DeclaredVariables:   []string{"FOO"},
+		DeclaredConnections: []string{"pg"},
+	}}
+	srv, a := newServer(store)
+	sec := &fakeSecrets{
+		vars:  map[string]string{"FOO": "bar", "BAR": "baz"},
+		conns: map[string]string{"pg": "postgres://u:p@h/db", "redis": "redis://h:6379"},
+	}
+	audit := &fakeScopeAuditor{}
+	srv.SetSecrets(sec, true)
+	srv.SetSecretScopeAuditor(audit)
+	srv.SetSecretScoping(ScopingEnforce)
+	ctx := ctxWithToken(t, a)
+
+	vresp, err := srv.GetVariables(ctx, &agentv1.GetVariablesRequest{})
+	if err != nil {
+		t.Fatalf("GetVariables: %v", err)
+	}
+	if len(vresp.Variables) != 1 || vresp.Variables["FOO"] != "bar" {
+		t.Errorf("enforce must deliver only the declared subset {FOO}: got %v", vresp.Variables)
+	}
+	if !sec.scopedVar {
+		t.Errorf("enforce must take the scoped (in-query) path")
+	}
+	cresp, err := srv.GetConnections(ctx, &agentv1.GetConnectionsRequest{})
+	if err != nil {
+		t.Fatalf("GetConnections: %v", err)
+	}
+	if len(cresp.ConnectionUris) != 1 || cresp.ConnectionUris["pg"] == "" {
+		t.Errorf("enforce must deliver only the declared subset {pg}: got %v", cresp.ConnectionUris)
+	}
+	if !sec.scopedConn {
+		t.Errorf("enforce must take the scoped (in-query) path for connections")
+	}
+	// No E1b warn under enforce: it delivered only-declared, not the whole vault.
+	if len(audit.events) != 0 {
+		t.Errorf("enforce must not emit a full-vault scope warning: %+v", audit.events)
+	}
+}
+
+// TestSecretScopingEnforceEmptyDeclarationReturnsNone is the load-bearing []
+// case: under enforce a task that declared nothing receives NOTHING — not the
+// whole vault.
+func TestSecretScopingEnforceEmptyDeclarationReturnsNone(t *testing.T) {
+	store := &fakeStore{spec: TaskSpec{}} // no declaration
+	srv, a := newServer(store)
+	sec := &fakeSecrets{
+		vars:  map[string]string{"FOO": "bar"},
+		conns: map[string]string{"pg": "postgres://u:p@h/db"},
+	}
+	srv.SetSecrets(sec, true)
+	srv.SetSecretScoping(ScopingEnforce)
+	ctx := ctxWithToken(t, a)
+
+	vresp, err := srv.GetVariables(ctx, &agentv1.GetVariablesRequest{})
+	if err != nil {
+		t.Fatalf("GetVariables: %v", err)
+	}
+	if len(vresp.Variables) != 0 {
+		t.Errorf("enforce + empty declaration must deliver NO variables: got %v", vresp.Variables)
+	}
+	cresp, err := srv.GetConnections(ctx, &agentv1.GetConnectionsRequest{})
+	if err != nil {
+		t.Fatalf("GetConnections: %v", err)
+	}
+	if len(cresp.ConnectionUris) != 0 {
+		t.Errorf("enforce + empty declaration must deliver NO connections: got %v", cresp.ConnectionUris)
+	}
+}
+
+// TestSecretScopingOffWholeVaultNoWarn is the off contract: scoping disabled
+// delivers the whole vault and emits no scope warning even for a narrow
+// declaration — the operator explicitly turned scoping off.
+func TestSecretScopingOffWholeVaultNoWarn(t *testing.T) {
+	store := &fakeStore{spec: TaskSpec{DeclaredVariables: []string{"FOO"}}}
+	srv, a := newServer(store)
+	sec := &fakeSecrets{vars: map[string]string{"FOO": "bar", "BAR": "baz"}}
+	audit := &fakeScopeAuditor{}
+	srv.SetSecrets(sec, true)
+	srv.SetSecretScopeAuditor(audit)
+	srv.SetSecretScoping(ScopingOff)
+
+	vresp, err := srv.GetVariables(ctxWithToken(t, a), &agentv1.GetVariablesRequest{})
+	if err != nil {
+		t.Fatalf("GetVariables: %v", err)
+	}
+	if len(vresp.Variables) != 2 {
+		t.Errorf("off must deliver the whole vault: got %v", vresp.Variables)
+	}
+	if sec.scopedVar {
+		t.Errorf("off must not take the scoped path")
+	}
+	if len(audit.events) != 0 {
+		t.Errorf("off must not emit a scope warning: %+v", audit.events)
+	}
+}
+
+// TestSecretScopingUnknownFallsBackToPermissive proves the setter fails safe: an
+// unrecognised policy value is treated as permissive (whole vault), never as a
+// silent enforce that would deny.
+func TestSecretScopingUnknownFallsBackToPermissive(t *testing.T) {
+	store := &fakeStore{spec: TaskSpec{DeclaredVariables: []string{"FOO"}}}
+	srv, a := newServer(store)
+	sec := &fakeSecrets{vars: map[string]string{"FOO": "bar", "BAR": "baz"}}
+	srv.SetSecrets(sec, true)
+	srv.SetSecretScoping("bogus")
+
+	vresp, err := srv.GetVariables(ctxWithToken(t, a), &agentv1.GetVariablesRequest{})
+	if err != nil {
+		t.Fatalf("GetVariables: %v", err)
+	}
+	if len(vresp.Variables) != 2 || sec.scopedVar {
+		t.Errorf("an unknown scoping policy must fall back to permissive whole-vault: got %v scoped=%v", vresp.Variables, sec.scopedVar)
+	}
+}

--- a/internal/agentrpc/secrets_test.go
+++ b/internal/agentrpc/secrets_test.go
@@ -11,9 +11,12 @@ import (
 )
 
 type fakeSecrets struct {
-	vars     map[string]string
-	conns    map[string]string
-	gotVarTn string
+	vars        map[string]string
+	conns       map[string]string
+	gotVarTn    string
+	gotVarNames []string // the declared set the scoped variables path received
+	scopedVar   bool     // whether the scoped variables path was taken
+	scopedConn  bool     // whether the scoped connections path was taken
 }
 
 func (f *fakeSecrets) SecretVariables(_ context.Context, tenant string) (map[string]string, error) {
@@ -22,6 +25,29 @@ func (f *fakeSecrets) SecretVariables(_ context.Context, tenant string) (map[str
 }
 func (f *fakeSecrets) SecretConnectionURIs(_ context.Context, _ string) (map[string]string, error) {
 	return f.conns, nil
+}
+func (f *fakeSecrets) SecretVariablesScoped(_ context.Context, tenant string, names []string) (map[string]string, error) {
+	f.gotVarTn = tenant
+	f.gotVarNames = names
+	f.scopedVar = true
+	return fakeSubset(f.vars, names), nil
+}
+func (f *fakeSecrets) SecretConnectionURIsScoped(_ context.Context, _ string, names []string) (map[string]string, error) {
+	f.scopedConn = true
+	return fakeSubset(f.conns, names), nil
+}
+
+// fakeSubset mirrors the real store's scoped query: it returns only the named
+// subset of the tenant set (an empty name set returns nothing), so handler-level
+// scoping is exercised exactly as the SQL would filter it.
+func fakeSubset(all map[string]string, names []string) map[string]string {
+	out := map[string]string{}
+	for _, n := range names {
+		if v, ok := all[n]; ok {
+			out[n] = v
+		}
+	}
+	return out
 }
 
 func TestGetVariablesAndConnections(t *testing.T) {

--- a/internal/agentrpc/server.go
+++ b/internal/agentrpc/server.go
@@ -135,6 +135,10 @@ type Server struct {
 	tail                 LogPublisher
 	secrets              SecretsStore
 	secretAudit          SecretScopeAuditor
+	liveness             TaskLivenessChecker
+	livenessMode         string
+	livenessAudit        SecretLivenessAuditor
+	scoping              string
 	allowInsecureSecrets bool
 	now                  func() time.Time
 }

--- a/internal/agentrpc/tls_test.go
+++ b/internal/agentrpc/tls_test.go
@@ -72,6 +72,12 @@ func (fakeSecretsTLS) SecretVariables(context.Context, string) (map[string]strin
 func (fakeSecretsTLS) SecretConnectionURIs(context.Context, string) (map[string]string, error) {
 	return map[string]string{}, nil
 }
+func (fakeSecretsTLS) SecretVariablesScoped(context.Context, string, []string) (map[string]string, error) {
+	return map[string]string{"FOO": "bar"}, nil
+}
+func (fakeSecretsTLS) SecretConnectionURIsScoped(context.Context, string, []string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
 
 type tlsFakeStore struct{}
 

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -283,6 +283,19 @@ type AuthSection struct {
 	// consumes budget. Lite raises this well above the production default because
 	// it is a local single-user tool where lockouts are pure friction.
 	LoginRateLimitPerMinute int `mapstructure:"login_rate_limit_per_minute"`
+	// SecretScoping is the operator scope-by-declaration policy (ADR 0055 D9):
+	// "permissive" | "enforce" | "off". permissive (the default) delivers the
+	// whole tenant vault when a DAG declares nothing and warns — but still
+	// delivers the whole vault — when a DAG declares a narrower set; enforce
+	// delivers only the declared subset (empty declaration → nothing); off
+	// disables scoping. It is operator-scoped, NEVER author-settable. Empty = the
+	// permissive default.
+	SecretScoping string `mapstructure:"secret_scoping"`
+	// SecretLivenessMode gates secret delivery on task-instance liveness (ADR 0055
+	// E2): "observe" | "enforce". observe (the default) logs + audits a
+	// would-have-denied when the caller's TI is not live but still delivers;
+	// enforce denies with PermissionDenied. Empty = the observe default.
+	SecretLivenessMode string `mapstructure:"secret_liveness_mode"`
 }
 
 // JWTSection configures JWT issuance and validation.
@@ -417,6 +430,12 @@ var serverDefaults = map[string]any{
 	"auth.jwt.secret":                  "",
 	"auth.jwt.token_ttl_seconds":       3600,
 	"auth.login_rate_limit_per_minute": 5,
+	// Secret scope-by-declaration and token-liveness policies (ADR 0055). Both
+	// ship SAFE by default: permissive delivers the whole tenant vault (today's
+	// behaviour) and observe logs a would-have-denied without denying. The go-live
+	// flips (enforce) are separate operator decisions after an observe period.
+	"auth.secret_scoping":       "permissive",
+	"auth.secret_liveness_mode": "observe",
 	// OIDC leaves. Every leaf is registered so viper's AutomaticEnv binds the
 	// scalar LEOFLOW_AUTH_OIDC_* env vars (notably the client secret). The map and
 	// slice leaves are config-file / Helm-values driven — viper does not split a
@@ -525,6 +544,23 @@ const (
 	AuthProviderOIDC = "oidc"
 )
 
+// Secret policy allowlists (ADR 0055). auth.secret_scoping and
+// auth.secret_liveness_mode are validated against these; an unknown value fails
+// boot closed. Empty is valid — serverDefaults sets the safe default for each.
+const (
+	// SecretScopingPermissive delivers the whole tenant vault (today's behaviour),
+	// scoping only where a DAG declared; the default.
+	SecretScopingPermissive = "permissive"
+	// SecretScopingEnforce delivers only the declared subset.
+	SecretScopingEnforce = "enforce"
+	// SecretScopingOff disables scope-by-declaration entirely.
+	SecretScopingOff = "off"
+	// SecretLivenessObserve logs a would-have-denied without denying; the default.
+	SecretLivenessObserve = "observe"
+	// SecretLivenessEnforce denies secret delivery when the caller's TI is not live.
+	SecretLivenessEnforce = "enforce"
+)
+
 // Validate reports configuration errors that must abort startup.
 func (c *ServerConfig) Validate() error {
 	if err := c.validateRole(); err != nil {
@@ -534,6 +570,9 @@ func (c *ServerConfig) Validate() error {
 		return err
 	}
 	if err := c.validateLogs(); err != nil {
+		return err
+	}
+	if err := c.validateSecretPolicies(); err != nil {
 		return err
 	}
 	// Both providers mint the app's own HS256 _token (oidc mints it after the IdP
@@ -580,6 +619,26 @@ func (c *ServerConfig) validateLogs() error {
 	default:
 		return fmt.Errorf(`unknown logs.backend %q (want "disk", "s3" or "gcs")`, c.Logs.Backend)
 	}
+}
+
+// validateSecretPolicies rejects an unknown auth.secret_scoping or
+// auth.secret_liveness_mode, failing closed at boot rather than letting main.go
+// wire an unrecognised policy (ADR 0055). Empty is valid: serverDefaults sets
+// the safe default (permissive / observe) for each.
+func (c *ServerConfig) validateSecretPolicies() error {
+	switch c.Auth.SecretScoping {
+	case "", SecretScopingPermissive, SecretScopingEnforce, SecretScopingOff:
+	default:
+		return fmt.Errorf("invalid auth.secret_scoping %q: must be %q, %q or %q",
+			c.Auth.SecretScoping, SecretScopingPermissive, SecretScopingEnforce, SecretScopingOff)
+	}
+	switch c.Auth.SecretLivenessMode {
+	case "", SecretLivenessObserve, SecretLivenessEnforce:
+	default:
+		return fmt.Errorf("invalid auth.secret_liveness_mode %q: must be %q or %q",
+			c.Auth.SecretLivenessMode, SecretLivenessObserve, SecretLivenessEnforce)
+	}
+	return nil
 }
 
 // validateProvider rejects an unknown auth.provider, failing closed at boot

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -432,7 +432,7 @@ var serverDefaults = map[string]any{
 	"auth.login_rate_limit_per_minute": 5,
 	// Secret scope-by-declaration and token-liveness policies (ADR 0055). Both
 	// ship SAFE by default: permissive delivers the whole tenant vault (today's
-	// behaviour) and observe logs a would-have-denied without denying. The go-live
+	// behavior) and observe logs a would-have-denied without denying. The go-live
 	// flips (enforce) are separate operator decisions after an observe period.
 	"auth.secret_scoping":       "permissive",
 	"auth.secret_liveness_mode": "observe",
@@ -548,7 +548,7 @@ const (
 // auth.secret_liveness_mode are validated against these; an unknown value fails
 // boot closed. Empty is valid — serverDefaults sets the safe default for each.
 const (
-	// SecretScopingPermissive delivers the whole tenant vault (today's behaviour),
+	// SecretScopingPermissive delivers the whole tenant vault (today's behavior),
 	// scoping only where a DAG declared; the default.
 	SecretScopingPermissive = "permissive"
 	// SecretScopingEnforce delivers only the declared subset.
@@ -623,7 +623,7 @@ func (c *ServerConfig) validateLogs() error {
 
 // validateSecretPolicies rejects an unknown auth.secret_scoping or
 // auth.secret_liveness_mode, failing closed at boot rather than letting main.go
-// wire an unrecognised policy (ADR 0055). Empty is valid: serverDefaults sets
+// wire an unrecognized policy (ADR 0055). Empty is valid: serverDefaults sets
 // the safe default (permissive / observe) for each.
 func (c *ServerConfig) validateSecretPolicies() error {
 	switch c.Auth.SecretScoping {

--- a/internal/config/server_test.go
+++ b/internal/config/server_test.go
@@ -165,6 +165,72 @@ func TestServerConfigValidateProviderAllowlist(t *testing.T) {
 	}
 }
 
+// TestServerConfigSecretPolicyDefaults locks the SAFE defaults (ADR 0055): a
+// fresh config binds secret_scoping=permissive and secret_liveness_mode=observe,
+// so a default deploy denies nothing.
+func TestServerConfigSecretPolicyDefaults(t *testing.T) {
+	c, err := LoadServer("", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Auth.SecretScoping != "permissive" {
+		t.Errorf("SecretScoping default = %q, want permissive", c.Auth.SecretScoping)
+	}
+	if c.Auth.SecretLivenessMode != "observe" {
+		t.Errorf("SecretLivenessMode default = %q, want observe", c.Auth.SecretLivenessMode)
+	}
+}
+
+// TestServerConfigSecretPolicyEnvBinding proves the two keys bind from their
+// LEOFLOW_* env vars (they are registered in serverDefaults so AutomaticEnv sees
+// them).
+func TestServerConfigSecretPolicyEnvBinding(t *testing.T) {
+	t.Setenv("LEOFLOW_AUTH_SECRET_SCOPING", "enforce")
+	t.Setenv("LEOFLOW_AUTH_SECRET_LIVENESS_MODE", "enforce")
+	c, err := LoadServer("", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Auth.SecretScoping != "enforce" {
+		t.Errorf("SecretScoping = %q, want enforce (from env)", c.Auth.SecretScoping)
+	}
+	if c.Auth.SecretLivenessMode != "enforce" {
+		t.Errorf("SecretLivenessMode = %q, want enforce (from env)", c.Auth.SecretLivenessMode)
+	}
+}
+
+// TestServerConfigValidateSecretPolicies locks the enum allowlist: valid values
+// (and empty = default) pass; an unknown value fails closed at boot.
+func TestServerConfigValidateSecretPolicies(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		scoping  string
+		liveness string
+		wantErr  bool
+	}{
+		{"empty defaults", "", "", false},
+		{"permissive+observe", "permissive", "observe", false},
+		{"enforce+enforce", "enforce", "enforce", false},
+		{"off+observe", "off", "observe", false},
+		{"bad scoping", "loose", "observe", true},
+		{"bad liveness", "permissive", "loud", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &ServerConfig{}
+			c.Auth.JWT.Secret = "set"
+			c.Auth.SecretScoping = tc.scoping
+			c.Auth.SecretLivenessMode = tc.liveness
+			err := c.Validate()
+			if tc.wantErr && err == nil {
+				t.Errorf("scoping=%q liveness=%q: Validate() = nil, want error", tc.scoping, tc.liveness)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("scoping=%q liveness=%q: Validate() = %v, want nil", tc.scoping, tc.liveness, err)
+			}
+		})
+	}
+}
+
 // validOIDCConfig returns a ServerConfig that passes the OIDC boot gate: Pro
 // edition, a JWT secret (oidc still mints the app's own _token), and the three
 // required oidc fields with an https issuer.

--- a/internal/storage/agent_store.go
+++ b/internal/storage/agent_store.go
@@ -221,6 +221,29 @@ func (s *ExecutionStore) RecordHeartbeat(ctx context.Context, id auth.AgentIdent
 	return nil
 }
 
+// IsTaskInstanceLive reports whether the attempt (runID, taskID, tryNumber) is
+// still live — present and in an active (non-terminal) state — derived from the
+// same predicate RecordHeartbeat writes on, but as a pure read with no
+// side-effect (ADR 0055). It is the read-only revocation signal the secret path
+// consults: a terminal, superseded (try_number moved on), or reaped attempt is
+// not live, so its token stops resolving secrets even while the signature holds.
+//
+// It derives ONLY from (run, task, try) + active state, exactly as the heartbeat
+// predicate does. It must never gain a run-recency / logical_date clause: a
+// recency term would deny a legitimate clear-and-rerun of an old run, binding
+// credential lifetime to the run's age rather than to the attempt.
+func (s *ExecutionStore) IsTaskInstanceLive(ctx context.Context, runID, taskID string, tryNumber int) (bool, error) {
+	rid, err := parseUUID(runID)
+	if err != nil {
+		return false, err
+	}
+	return s.q.IsTaskInstanceLive(ctx, queries.IsTaskInstanceLiveParams{
+		DagRunID:  rid,
+		TaskID:    taskID,
+		TryNumber: toInt32(tryNumber),
+	})
+}
+
 // FailTask marks a task instance failed by its ID, guarded by the attempt
 // (try_number) and the active states so it never clobbers a different attempt or a
 // terminal row. It implements part of executor.OutcomeReporter for the pod

--- a/internal/storage/queries/connections.sql
+++ b/internal/storage/queries/connections.sql
@@ -17,6 +17,18 @@ FROM connections
 WHERE tenant_id = $1
 ORDER BY conn_id;
 
+-- name: ListConnectionSecretsScoped :many
+-- The tenant's connections WITH the encrypted password, restricted to the given
+-- conn_ids and filtered in the query (ADR 0055 D1: scope in the SQL, never
+-- post-filter the decrypted whole vault). Never use this for UI/API responses,
+-- which must mask the password. Used under secret_scoping: enforce so a task
+-- receives only the connections it declared. An empty conn_id set never reaches
+-- here — the handler returns nothing without a query.
+SELECT conn_id, conn_type, host, conn_schema, login, password, port, extra
+FROM connections
+WHERE tenant_id = $1 AND conn_id = ANY(sqlc.arg(conn_ids)::text[])
+ORDER BY conn_id;
+
 -- name: GetConnection :one
 SELECT conn_id, conn_type, host, conn_schema, login, password, port, extra, description
 FROM connections

--- a/internal/storage/queries/connections.sql.go
+++ b/internal/storage/queries/connections.sql.go
@@ -162,6 +162,64 @@ func (q *Queries) ListConnectionSecrets(ctx context.Context, tenantID pgtype.UUI
 	return items, nil
 }
 
+const listConnectionSecretsScoped = `-- name: ListConnectionSecretsScoped :many
+SELECT conn_id, conn_type, host, conn_schema, login, password, port, extra
+FROM connections
+WHERE tenant_id = $1 AND conn_id = ANY($2::text[])
+ORDER BY conn_id
+`
+
+type ListConnectionSecretsScopedParams struct {
+	TenantID pgtype.UUID `json:"tenant_id"`
+	ConnIds  []string    `json:"conn_ids"`
+}
+
+type ListConnectionSecretsScopedRow struct {
+	ConnID     string  `json:"conn_id"`
+	ConnType   string  `json:"conn_type"`
+	Host       *string `json:"host"`
+	ConnSchema *string `json:"conn_schema"`
+	Login      *string `json:"login"`
+	Password   *string `json:"password"`
+	Port       *int32  `json:"port"`
+	Extra      *string `json:"extra"`
+}
+
+// The tenant's connections WITH the encrypted password, restricted to the given
+// conn_ids and filtered in the query (ADR 0055 D1: scope in the SQL, never
+// post-filter the decrypted whole vault). Never use this for UI/API responses,
+// which must mask the password. Used under secret_scoping: enforce so a task
+// receives only the connections it declared. An empty conn_id set never reaches
+// here — the handler returns nothing without a query.
+func (q *Queries) ListConnectionSecretsScoped(ctx context.Context, arg ListConnectionSecretsScopedParams) ([]ListConnectionSecretsScopedRow, error) {
+	rows, err := q.db.Query(ctx, listConnectionSecretsScoped, arg.TenantID, arg.ConnIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListConnectionSecretsScopedRow{}
+	for rows.Next() {
+		var i ListConnectionSecretsScopedRow
+		if err := rows.Scan(
+			&i.ConnID,
+			&i.ConnType,
+			&i.Host,
+			&i.ConnSchema,
+			&i.Login,
+			&i.Password,
+			&i.Port,
+			&i.Extra,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listConnections = `-- name: ListConnections :many
 SELECT conn_id, conn_type, host, conn_schema, login, port, extra, description
 FROM connections

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -161,6 +161,13 @@ type Querier interface {
 	// credentials to task pods (ADR 0021). Never use this for UI/API responses,
 	// which must mask the password.
 	ListConnectionSecrets(ctx context.Context, tenantID pgtype.UUID) ([]ListConnectionSecretsRow, error)
+	// The tenant's connections WITH the encrypted password, restricted to the given
+	// conn_ids and filtered in the query (ADR 0055 D1: scope in the SQL, never
+	// post-filter the decrypted whole vault). Never use this for UI/API responses,
+	// which must mask the password. Used under secret_scoping: enforce so a task
+	// receives only the connections it declared. An empty conn_id set never reaches
+	// here — the handler returns nothing without a query.
+	ListConnectionSecretsScoped(ctx context.Context, arg ListConnectionSecretsScopedParams) ([]ListConnectionSecretsScopedRow, error)
 	ListConnections(ctx context.Context, arg ListConnectionsParams) ([]ListConnectionsRow, error)
 	ListDagRunsByDag(ctx context.Context, arg ListDagRunsByDagParams) ([]DagRun, error)
 	ListDagVersions(ctx context.Context, arg ListDagVersionsParams) ([]ListDagVersionsRow, error)
@@ -214,6 +221,12 @@ type Querier interface {
 	// caller. Never selects password_hash — the list must not expose secrets.
 	ListUsers(ctx context.Context, arg ListUsersParams) ([]ListUsersRow, error)
 	ListVariables(ctx context.Context, arg ListVariablesParams) ([]ListVariablesRow, error)
+	// The tenant's variables restricted to the given keys, filtered in the query
+	// (ADR 0055 D1: scope in the SQL, never post-filter the decrypted whole vault in
+	// the handler). Used under secret_scoping: enforce so a task receives only the
+	// Variables it declared. An empty key set never reaches here — the handler
+	// returns nothing without a query.
+	ListVariablesScoped(ctx context.Context, arg ListVariablesScopedParams) ([]ListVariablesScopedRow, error)
 	ListXComEntries(ctx context.Context, arg ListXComEntriesParams) ([]ListXComEntriesRow, error)
 	// Stamp a run's on-failure alert as DELIVERED. Called only after a successful
 	// send, which is the whole point of the split: alerted_at now answers "did the

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -130,6 +130,20 @@ type Querier interface {
 	// Mirrors the bootstrap CreateUser insert (tenant_id, email, password_hash) but
 	// returns the columns the admin create-user API echoes back to the caller.
 	InsertUser(ctx context.Context, arg InsertUserParams) (InsertUserRow, error)
+	// Reports whether the attempt (dag_run_id, task_id, try_number) is still live:
+	// present and in an active (non-terminal) state. This is exactly the predicate
+	// RecordTaskHeartbeat stamps on — the same (dag_run_id, task_id, try_number)
+	// tuple and the same state IN ('queued', 'running') guard — but as a pure READ
+	// with no write. It is the read-only revocation signal the secret path consults
+	// (ADR 0055): a terminal or superseded attempt (try_number moved on) is not
+	// live, so a token that carries it stops resolving secrets, even while its
+	// signature is still valid.
+	//
+	// It MUST derive ONLY from (run, task, try) + active state. It must NEVER gain a
+	// "run is not current / archived / logical_date in the past" clause: a recency
+	// term would deny a legitimate clear-and-rerun of an old run — credential
+	// lifetime binds to the attempt, never to the run's age or logical date.
+	IsTaskInstanceLive(ctx context.Context, arg IsTaskInstanceLiveParams) (bool, error)
 	LatestRunsForDags(ctx context.Context, arg LatestRunsForDagsParams) ([]LatestRunsForDagsRow, error)
 	ListActiveDagRuns(ctx context.Context) ([]DagRun, error)
 	// run_id is the dag_run's UUID (StagingClaimName uses it), so join on dag_runs.id,

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -691,6 +691,28 @@ WHERE dag_run_id = $1
   AND try_number = $3
   AND state IN ('queued', 'running');
 
+-- name: IsTaskInstanceLive :one
+-- Reports whether the attempt (dag_run_id, task_id, try_number) is still live:
+-- present and in an active (non-terminal) state. This is exactly the predicate
+-- RecordTaskHeartbeat stamps on — the same (dag_run_id, task_id, try_number)
+-- tuple and the same state IN ('queued', 'running') guard — but as a pure READ
+-- with no write. It is the read-only revocation signal the secret path consults
+-- (ADR 0055): a terminal or superseded attempt (try_number moved on) is not
+-- live, so a token that carries it stops resolving secrets, even while its
+-- signature is still valid.
+--
+-- It MUST derive ONLY from (run, task, try) + active state. It must NEVER gain a
+-- "run is not current / archived / logical_date in the past" clause: a recency
+-- term would deny a legitimate clear-and-rerun of an old run — credential
+-- lifetime binds to the attempt, never to the run's age or logical date.
+SELECT EXISTS (
+    SELECT 1 FROM task_instances
+    WHERE dag_run_id = $1
+      AND task_id = $2
+      AND try_number = $3
+      AND state IN ('queued', 'running')
+);
+
 -- name: ListAgentLostCandidates :many
 -- Lists running TIs that have heartbeated at least once and whose latest
 -- heartbeat is non-null, alongside enough identity to log + observe.

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -499,6 +499,42 @@ func (q *Queries) GetDagVersionByID(ctx context.Context, id pgtype.UUID) (DagVer
 	return i, err
 }
 
+const isTaskInstanceLive = `-- name: IsTaskInstanceLive :one
+SELECT EXISTS (
+    SELECT 1 FROM task_instances
+    WHERE dag_run_id = $1
+      AND task_id = $2
+      AND try_number = $3
+      AND state IN ('queued', 'running')
+)
+`
+
+type IsTaskInstanceLiveParams struct {
+	DagRunID  pgtype.UUID `json:"dag_run_id"`
+	TaskID    string      `json:"task_id"`
+	TryNumber int32       `json:"try_number"`
+}
+
+// Reports whether the attempt (dag_run_id, task_id, try_number) is still live:
+// present and in an active (non-terminal) state. This is exactly the predicate
+// RecordTaskHeartbeat stamps on — the same (dag_run_id, task_id, try_number)
+// tuple and the same state IN ('queued', 'running') guard — but as a pure READ
+// with no write. It is the read-only revocation signal the secret path consults
+// (ADR 0055): a terminal or superseded attempt (try_number moved on) is not
+// live, so a token that carries it stops resolving secrets, even while its
+// signature is still valid.
+//
+// It MUST derive ONLY from (run, task, try) + active state. It must NEVER gain a
+// "run is not current / archived / logical_date in the past" clause: a recency
+// term would deny a legitimate clear-and-rerun of an old run — credential
+// lifetime binds to the attempt, never to the run's age or logical date.
+func (q *Queries) IsTaskInstanceLive(ctx context.Context, arg IsTaskInstanceLiveParams) (bool, error) {
+	row := q.db.QueryRow(ctx, isTaskInstanceLive, arg.DagRunID, arg.TaskID, arg.TryNumber)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const latestRunsForDags = `-- name: LatestRunsForDags :many
 SELECT d.dag_id AS dag_id_text,
        r.run_id, r.logical_date, r.state, r.trigger, r.queued_at, r.started_at, r.ended_at

--- a/internal/storage/queries/variables.sql
+++ b/internal/storage/queries/variables.sql
@@ -5,6 +5,17 @@ WHERE tenant_id = $1
 ORDER BY key
 LIMIT $2 OFFSET $3;
 
+-- name: ListVariablesScoped :many
+-- The tenant's variables restricted to the given keys, filtered in the query
+-- (ADR 0055 D1: scope in the SQL, never post-filter the decrypted whole vault in
+-- the handler). Used under secret_scoping: enforce so a task receives only the
+-- Variables it declared. An empty key set never reaches here — the handler
+-- returns nothing without a query.
+SELECT key, value, description
+FROM variables
+WHERE tenant_id = $1 AND key = ANY(sqlc.arg(keys)::text[])
+ORDER BY key;
+
 -- name: CountVariables :one
 SELECT count(*) FROM variables WHERE tenant_id = $1;
 

--- a/internal/storage/queries/variables.sql.go
+++ b/internal/storage/queries/variables.sql.go
@@ -136,6 +136,49 @@ func (q *Queries) ListVariables(ctx context.Context, arg ListVariablesParams) ([
 	return items, nil
 }
 
+const listVariablesScoped = `-- name: ListVariablesScoped :many
+SELECT key, value, description
+FROM variables
+WHERE tenant_id = $1 AND key = ANY($2::text[])
+ORDER BY key
+`
+
+type ListVariablesScopedParams struct {
+	TenantID pgtype.UUID `json:"tenant_id"`
+	Keys     []string    `json:"keys"`
+}
+
+type ListVariablesScopedRow struct {
+	Key         string  `json:"key"`
+	Value       string  `json:"value"`
+	Description *string `json:"description"`
+}
+
+// The tenant's variables restricted to the given keys, filtered in the query
+// (ADR 0055 D1: scope in the SQL, never post-filter the decrypted whole vault in
+// the handler). Used under secret_scoping: enforce so a task receives only the
+// Variables it declared. An empty key set never reaches here — the handler
+// returns nothing without a query.
+func (q *Queries) ListVariablesScoped(ctx context.Context, arg ListVariablesScopedParams) ([]ListVariablesScopedRow, error) {
+	rows, err := q.db.Query(ctx, listVariablesScoped, arg.TenantID, arg.Keys)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListVariablesScopedRow{}
+	for rows.Next() {
+		var i ListVariablesScopedRow
+		if err := rows.Scan(&i.Key, &i.Value, &i.Description); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const upsertVariable = `-- name: UpsertVariable :exec
 INSERT INTO variables (tenant_id, key, value, description)
 VALUES ($1, $2, $3, $4)

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -737,6 +737,40 @@ func (r *Repository) RecordSecretScopeWarning(ctx context.Context, tenant, dagID
 	return nil
 }
 
+// RecordSecretLivenessDenial records that the secret-path liveness gate fired
+// for a task instance whose attempt is no longer live (ADR 0055): a
+// would-have-denied in observe mode, or a denial in enforce mode. It is scoped
+// to the DAG resource so the event surfaces on the DAG's Audit Log tab, with the
+// kind ("variables" or "connections"), the run, task, attempt, and the gate mode
+// in metadata. It records identity + kind + mode only — never secret names or
+// values.
+func (r *Repository) RecordSecretLivenessDenial(ctx context.Context, tenant, dagID, runID, taskID string, tryNumber int, kind, mode string) error {
+	tid, err := r.tenantID(ctx, tenant)
+	if err != nil {
+		return err
+	}
+	meta, err := json.Marshal(map[string]any{
+		"kind": kind, "run_id": runID, "task_id": taskID,
+		"try_number": tryNumber, "mode": mode,
+	})
+	if err != nil {
+		return fmt.Errorf("encoding audit metadata: %w", err)
+	}
+	// Distinct actions per mode so an operator can tell an observe-phase
+	// would-have-denied from an enforce-phase denial at a glance.
+	action := "secret.liveness_would_deny"
+	if mode == "enforce" {
+		action = "secret.liveness_denied"
+	}
+	if err := r.q.CreateAuditLog(ctx, queries.CreateAuditLogParams{
+		TenantID: tid, Action: action,
+		ResourceType: strPtr("dag"), ResourceID: strPtr(dagID), Metadata: meta,
+	}); err != nil {
+		return fmt.Errorf("writing secret-path liveness audit: %w", err)
+	}
+	return nil
+}
+
 // SetTaskInstanceState sets a task instance's state directly, backing the UI's
 // "mark success"/"mark failed" actions. It does not run the task.
 func (r *Repository) SetTaskInstanceState(ctx context.Context, tenant, dagID, runID, taskID, state string) error {

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -1387,6 +1387,73 @@ func (r *Repository) SecretConnectionURIs(ctx context.Context, tenantID string) 
 	return out, nil
 }
 
+// SecretVariablesScoped returns only the named subset of the tenant's variables,
+// filtered in the query (ADR 0055 D1: scope in the SQL, never post-filter the
+// decrypted whole vault in the handler). It backs secret_scoping: enforce, where
+// a task receives only the Variables it declared. An empty name set returns
+// nothing without a query — enforce's load-bearing [] case. tenantID is the
+// tenant UUID carried by the agent token.
+func (r *Repository) SecretVariablesScoped(ctx context.Context, tenantID string, names []string) (map[string]string, error) {
+	if len(names) == 0 {
+		return map[string]string{}, nil
+	}
+	tid, err := parseUUID(tenantID)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := r.q.ListVariablesScoped(ctx, queries.ListVariablesScopedParams{TenantID: tid, Keys: names})
+	if err != nil {
+		return nil, fmt.Errorf("listing scoped variables: %w", err)
+	}
+	out := make(map[string]string, len(rows))
+	for _, v := range rows {
+		out[v.Key] = v.Value
+	}
+	return out, nil
+}
+
+// SecretConnectionURIsScoped returns only the named subset of the tenant's
+// connections as Airflow URIs (password decrypted), filtered in the query
+// (ADR 0055 D1). It backs secret_scoping: enforce. An empty name set returns
+// nothing without a query. Never expose these in UI/API responses. It shares the
+// per-connection decrypt-and-skip-on-failure semantics of SecretConnectionURIs:
+// one undecryptable connection is skipped with a warning, never blinding the
+// rest of the declared set.
+func (r *Repository) SecretConnectionURIsScoped(ctx context.Context, tenantID string, names []string) (map[string]string, error) {
+	if len(names) == 0 {
+		return map[string]string{}, nil
+	}
+	tid, err := parseUUID(tenantID)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := r.q.ListConnectionSecretsScoped(ctx, queries.ListConnectionSecretsScopedParams{TenantID: tid, ConnIds: names})
+	if err != nil {
+		return nil, fmt.Errorf("listing scoped connection secrets: %w", err)
+	}
+	out := make(map[string]string, len(rows))
+	for _, row := range rows {
+		pass, derr := r.decryptExtra(row.Password)
+		if derr != nil {
+			slog.Warn("skipping connection: password decrypt failed (key rotated or wrong LEOFLOW_SECRET_KEY?)",
+				"conn_id", row.ConnID, "error", derr)
+			continue
+		}
+		extra, eerr := r.decryptExtra(row.Extra)
+		if eerr != nil {
+			slog.Warn("skipping connection: extra decrypt failed (key rotated or wrong LEOFLOW_SECRET_KEY?)",
+				"conn_id", row.ConnID, "error", eerr)
+			continue
+		}
+		out[row.ConnID] = airflowConnURI(domain.Connection{
+			ConnID: row.ConnID, ConnType: row.ConnType, Host: strOrEmpty(row.Host),
+			Schema: strOrEmpty(row.ConnSchema), Login: strOrEmpty(row.Login),
+			Password: pass, Port: int32PtrToInt(row.Port), Extra: extra,
+		})
+	}
+	return out, nil
+}
+
 // AlertEndpoint resolves an alert channel connection (#424) to its endpoint for a
 // tenant UUID: the decrypted password is the channel URL (the full webhook URL,
 // kept encrypted at rest), and an optional `headers` object in the connection's

--- a/internal/storage/secret_enforcement_integration_test.go
+++ b/internal/storage/secret_enforcement_integration_test.go
@@ -161,15 +161,18 @@ func TestSecretRoundTripPermissiveNoDeclarationWholeVault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetVariables: %v", err)
 	}
-	if len(vresp.GetVariables()) != 2 {
-		t.Errorf("permissive + no declaration must deliver the whole vault {V_DECLARED,V_OTHER}: got %v", vresp.GetVariables())
+	// The shared 'default' tenant may carry variables seeded by sibling tests, so
+	// assert the UNDECLARED seeded var is delivered (proving permissive does not
+	// subset) rather than an exact vault size.
+	if vars := vresp.GetVariables(); vars["V_DECLARED"] != "d" || vars["V_OTHER"] != "o" {
+		t.Errorf("permissive + no declaration must deliver both V_DECLARED and V_OTHER (not subset): got %v", vars)
 	}
 	cresp, err := client.GetConnections(ctx, &agentv1.GetConnectionsRequest{})
 	if err != nil {
 		t.Fatalf("GetConnections: %v", err)
 	}
-	if len(cresp.GetConnectionUris()) != 2 {
-		t.Errorf("permissive + no declaration must deliver both connections: got %v", cresp.GetConnectionUris())
+	if conns := cresp.GetConnectionUris(); conns["c_declared"] == "" || conns["c_other"] == "" {
+		t.Errorf("permissive + no declaration must deliver both connections (not subset): got %v", conns)
 	}
 }
 

--- a/internal/storage/secret_enforcement_integration_test.go
+++ b/internal/storage/secret_enforcement_integration_test.go
@@ -1,0 +1,283 @@
+//go:build integration
+
+// Package storage_test — the end-to-end liveness + scoping round-trip.
+//
+// This wires the REAL agent gRPC server (agentrpc.Server) over a REAL gRPC
+// channel, backed by the REAL ExecutionStore (task-spec + liveness predicate)
+// and the REAL Repository (secret delivery + audit), against a REAL Postgres.
+// It exercises the whole GetVariables/GetConnections path — identify →
+// liveness gate → scope-by-policy → scoped/whole query — that no fake-store unit
+// test can prove, because the scoping filter and the liveness predicate both
+// live in SQL.
+//
+// Every case asserts the two-sided invariant: a LIVE attempt always resolves
+// (the availability guard against a pipeline-breaking false-deny) and, where the
+// policy denies, a not-live / undeclared request is refused (the security
+// guard).
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/neochaotic/leoflow/internal/agent"
+	"github.com/neochaotic/leoflow/internal/agentrpc"
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/secrets"
+	"github.com/neochaotic/leoflow/internal/storage"
+	"github.com/neochaotic/leoflow/internal/xcom"
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+)
+
+// noXCom is a no-op XComService for the secret round-trip.
+type noXCom struct{}
+
+func (noXCom) Push(context.Context, xcom.Key, []byte, string, map[string]any) error { return nil }
+func (noXCom) Fetch(context.Context, xcom.Key) (xcom.Entry, error) {
+	return xcom.Entry{}, xcom.ErrNotFound
+}
+
+// dialSecretServer stands up the real agent gRPC server backed by exec + repo in
+// the given scoping + liveness policy, dials it over a plaintext channel, and
+// returns a client bound to the identity's agent token. The channel is insecure
+// (allowInsecure=true) since this is a loopback test; the token authenticates.
+func dialSecretServer(t *testing.T, exec *storage.ExecutionStore, repo *storage.Repository, id auth.AgentIdentity, scoping, livenessMode string) agentv1.AgentServiceClient {
+	t.Helper()
+	authn := auth.NewJWTAuthenticator(nil, "test-secret", time.Hour)
+	srv := agentrpc.NewServer(authn, exec, noXCom{})
+	srv.SetSecrets(repo, true) // allow the insecure loopback channel
+	srv.SetSecretScoping(scoping)
+	srv.SetLivenessGate(exec, livenessMode)
+	srv.SetSecretScopeAuditor(repo)
+	srv.SetSecretLivenessAuditor(repo)
+
+	gs := grpc.NewServer()
+	agentv1.RegisterAgentServiceServer(gs, srv)
+	var lc net.ListenConfig
+	lis, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = gs.Serve(lis) }()
+	t.Cleanup(gs.Stop)
+
+	token, err := authn.IssueAgentToken(id, time.Hour)
+	if err != nil {
+		t.Fatalf("IssueAgentToken: %v", err)
+	}
+	client, conn, err := agent.Dial(lis.Addr().String(), token, true, "")
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return client
+}
+
+// seedDeclaringRun seeds a tenant with two variables (V_DECLARED, V_OTHER) and
+// two connections (c_declared, c_other), then registers a DAG whose "declares"
+// task declares only the "_declared" secrets and whose "bare" task declares
+// nothing, and brings both task instances to running. It returns the tenant UUID
+// and the run UUID. The variables/connections are seeded BEFORE registration
+// because E1a rejects a DAG that declares an unknown name.
+func seedDeclaringRun(t *testing.T, repo *storage.Repository, sched *storage.SchedulerStore, ctx context.Context, dagID string) (tenantUUID, runUUID string) {
+	t.Helper()
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i) + 7
+	}
+	cipher, err := secrets.NewAESGCM(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo.SetCipher(cipher)
+
+	for _, v := range []domain.Variable{{Key: "V_DECLARED", Value: "d"}, {Key: "V_OTHER", Value: "o"}} {
+		if err := repo.SetVariable(ctx, "default", v); err != nil {
+			t.Fatalf("SetVariable %s: %v", v.Key, err)
+		}
+	}
+	for _, c := range []domain.Connection{
+		{ConnID: "c_declared", ConnType: "http", Host: "declared.example"},
+		{ConnID: "c_other", ConnType: "http", Host: "other.example"},
+	} {
+		if err := repo.SetConnection(ctx, "default", c); err != nil {
+			t.Fatalf("SetConnection %s: %v", c.ConnID, err)
+		}
+	}
+
+	tasks := []domain.TaskSpec{
+		{TaskID: "declares", Type: domain.TaskTypePython, Variables: []string{"V_DECLARED"}, Connections: []string{"c_declared"}},
+		{TaskID: "bare", Type: domain.TaskTypePython},
+	}
+	registerSpec(t, repo, ctx, dagID, tasks)
+	if _, err := repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+		RunID: "r1", State: domain.DagRunStateRunning, RunType: "manual", LogicalDate: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateDagRun: %v", err)
+	}
+	runUUID = resolveRunUUID(t, sched, ctx, dagID)
+	if err := sched.MaterializeTasks(ctx, runUUID, tasks); err != nil {
+		t.Fatalf("MaterializeTasks: %v", err)
+	}
+	for _, taskID := range []string{"declares", "bare"} {
+		for _, st := range []domain.TaskState{domain.TaskStateQueued, domain.TaskStateRunning} {
+			if err := sched.ApplyTransition(ctx, runUUID, taskID, st); err != nil {
+				t.Fatalf("ApplyTransition %s->%s: %v", taskID, st, err)
+			}
+		}
+	}
+	tenantUUID, err = repo.TenantUUID(ctx, "default")
+	if err != nil {
+		t.Fatalf("TenantUUID: %v", err)
+	}
+	return tenantUUID, runUUID
+}
+
+func identityFor(tenantUUID, dagID, runUUID, taskID string) auth.AgentIdentity {
+	return auth.AgentIdentity{
+		TaskInstanceID: taskID + "-ti", TenantID: tenantUUID, DagID: dagID,
+		RunID: runUUID, TaskID: taskID, TryNumber: 1,
+	}
+}
+
+// TestSecretRoundTripPermissiveNoDeclarationWholeVault: the SAFE default — a task
+// that declares nothing receives the WHOLE tenant vault, exactly as before this
+// shipment. This is the unchanged-behaviour guarantee.
+func TestSecretRoundTripPermissiveNoDeclarationWholeVault(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("secjrt_perm_bare_%d", time.Now().UnixNano())
+	tenantUUID, runUUID := seedDeclaringRun(t, repo, sched, ctx, dagID)
+
+	client := dialSecretServer(t, exec, repo, identityFor(tenantUUID, dagID, runUUID, "bare"), "permissive", "observe")
+	vresp, err := client.GetVariables(ctx, &agentv1.GetVariablesRequest{})
+	if err != nil {
+		t.Fatalf("GetVariables: %v", err)
+	}
+	if len(vresp.GetVariables()) != 2 {
+		t.Errorf("permissive + no declaration must deliver the whole vault {V_DECLARED,V_OTHER}: got %v", vresp.GetVariables())
+	}
+	cresp, err := client.GetConnections(ctx, &agentv1.GetConnectionsRequest{})
+	if err != nil {
+		t.Fatalf("GetConnections: %v", err)
+	}
+	if len(cresp.GetConnectionUris()) != 2 {
+		t.Errorf("permissive + no declaration must deliver both connections: got %v", cresp.GetConnectionUris())
+	}
+}
+
+// TestSecretRoundTripEnforceReturnsOnlyDeclared: under enforce the declaring task
+// receives ONLY its declared subset, filtered in the query — and the bare task
+// receives NOTHING (the load-bearing [] case).
+func TestSecretRoundTripEnforceReturnsOnlyDeclared(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("secjrt_enforce_%d", time.Now().UnixNano())
+	tenantUUID, runUUID := seedDeclaringRun(t, repo, sched, ctx, dagID)
+
+	// Declaring task: only V_DECLARED / c_declared.
+	dc := dialSecretServer(t, exec, repo, identityFor(tenantUUID, dagID, runUUID, "declares"), "enforce", "observe")
+	vresp, err := dc.GetVariables(ctx, &agentv1.GetVariablesRequest{})
+	if err != nil {
+		t.Fatalf("GetVariables: %v", err)
+	}
+	if len(vresp.GetVariables()) != 1 || vresp.GetVariables()["V_DECLARED"] != "d" {
+		t.Errorf("enforce must deliver only {V_DECLARED}: got %v", vresp.GetVariables())
+	}
+	cresp, err := dc.GetConnections(ctx, &agentv1.GetConnectionsRequest{})
+	if err != nil {
+		t.Fatalf("GetConnections: %v", err)
+	}
+	if len(cresp.GetConnectionUris()) != 1 || cresp.GetConnectionUris()["c_declared"] == "" {
+		t.Errorf("enforce must deliver only {c_declared}: got %v", cresp.GetConnectionUris())
+	}
+
+	// Bare task: nothing.
+	bc := dialSecretServer(t, exec, repo, identityFor(tenantUUID, dagID, runUUID, "bare"), "enforce", "observe")
+	bvresp, err := bc.GetVariables(ctx, &agentv1.GetVariablesRequest{})
+	if err != nil {
+		t.Fatalf("GetVariables (bare): %v", err)
+	}
+	if len(bvresp.GetVariables()) != 0 {
+		t.Errorf("enforce + empty declaration must deliver NO variables: got %v", bvresp.GetVariables())
+	}
+}
+
+// TestSecretRoundTripObserveDoesNotDenyNotLive: the observe-mode rollout proof —
+// a NOT-live TI (settled terminal) still receives its secrets under observe. A
+// bug that denied here would break every legitimate pipeline, so this is the
+// load-bearing availability assertion.
+func TestSecretRoundTripObserveDoesNotDenyNotLive(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("secjrt_observe_%d", time.Now().UnixNano())
+	tenantUUID, runUUID := seedDeclaringRun(t, repo, sched, ctx, dagID)
+
+	// Settle the declaring task terminal — its token is now NOT live.
+	if err := sched.ApplyTransition(ctx, runUUID, "declares", domain.TaskStateSuccess); err != nil {
+		t.Fatalf("ApplyTransition to success: %v", err)
+	}
+	if live, err := exec.IsTaskInstanceLive(ctx, runUUID, "declares", 1); err != nil || live {
+		t.Fatalf("precondition: declares must be not-live, got live=%v err=%v", live, err)
+	}
+
+	client := dialSecretServer(t, exec, repo, identityFor(tenantUUID, dagID, runUUID, "declares"), "permissive", "observe")
+	vresp, err := client.GetVariables(ctx, &agentv1.GetVariablesRequest{})
+	if err != nil {
+		t.Fatalf("observe mode must NOT deny a not-live TI: %v", err)
+	}
+	if len(vresp.GetVariables()) == 0 {
+		t.Errorf("observe mode must still deliver to a not-live TI: got %v", vresp.GetVariables())
+	}
+}
+
+// TestSecretRoundTripEnforceDeniesNotLive: with the liveness gate in enforce
+// mode, a not-live TI is denied with PermissionDenied — the security side.
+func TestSecretRoundTripEnforceDeniesNotLive(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("secjrt_liveenf_%d", time.Now().UnixNano())
+	tenantUUID, runUUID := seedDeclaringRun(t, repo, sched, ctx, dagID)
+
+	if err := sched.ApplyTransition(ctx, runUUID, "bare", domain.TaskStateFailed); err != nil {
+		t.Fatalf("ApplyTransition to failed: %v", err)
+	}
+
+	client := dialSecretServer(t, exec, repo, identityFor(tenantUUID, dagID, runUUID, "bare"), "permissive", "enforce")
+	if _, err := client.GetVariables(ctx, &agentv1.GetVariablesRequest{}); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("enforce liveness + not-live TI = %v, want PermissionDenied", err)
+	}
+
+	// The still-live "declares" task in the same run is never denied — the
+	// availability side, proving enforce does not over-deny a live sibling.
+	live := dialSecretServer(t, exec, repo, identityFor(tenantUUID, dagID, runUUID, "declares"), "permissive", "enforce")
+	if _, err := live.GetVariables(ctx, &agentv1.GetVariablesRequest{}); err != nil {
+		t.Fatalf("enforce liveness must never deny a LIVE TI: %v", err)
+	}
+}
+
+// TestSecretRoundTripTransientLivenessErrorDoesNotDeny: an inconclusive liveness
+// read must not deny, even in enforce mode. A malformed run id makes the store's
+// liveness read error (it cannot conclude not-live); the gate must treat that as
+// inconclusive and deliver, never break a pipeline on a transient read.
+func TestSecretRoundTripTransientLivenessErrorDoesNotDeny(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("secjrt_transient_%d", time.Now().UnixNano())
+	tenantUUID, _ := seedDeclaringRun(t, repo, sched, ctx, dagID)
+
+	// A run id that is not a UUID makes IsTaskInstanceLive error rather than
+	// return a definitive not-live — the "DB blip" shape.
+	id := identityFor(tenantUUID, dagID, "not-a-uuid", "bare")
+	client := dialSecretServer(t, exec, repo, id, "off", "enforce")
+	vresp, err := client.GetVariables(ctx, &agentv1.GetVariablesRequest{})
+	if err != nil {
+		t.Fatalf("an inconclusive liveness read must NOT deny (enforce): %v", err)
+	}
+	if len(vresp.GetVariables()) == 0 {
+		t.Errorf("an inconclusive liveness read must still deliver: got %v", vresp.GetVariables())
+	}
+}

--- a/internal/storage/task_liveness_integration_test.go
+++ b/internal/storage/task_liveness_integration_test.go
@@ -1,0 +1,168 @@
+//go:build integration
+
+// Package storage_test — the read-only task-instance liveness predicate.
+//
+// IsTaskInstanceLive answers whether the attempt (dag_run_id, task_id,
+// try_number) is still in an active (non-terminal) state. It is the same
+// predicate RecordTaskHeartbeat stamps on, minus the write: a pure read the
+// secret path consults so a token whose task instance has finished, failed, been
+// superseded by a retry, or been reaped stops resolving secrets (ADR 0055).
+//
+// A fake-store unit test cannot prove this: the predicate lives in the SELECT's
+// WHERE clause, so only real Postgres shows that an active row reads live and a
+// terminal / superseded one does not. Every case asserts BOTH sides — a live
+// attempt reads live (the availability guard against a false-deny that would
+// break a legitimate pipeline) and a dead attempt reads not-live (the security
+// guard) — per the mandatory two-sided discipline.
+package storage_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// TestIsTaskInstanceLiveRunningAttemptIsLive: the ordinary path — a running,
+// matching attempt reads live, so a live task's token always resolves secrets
+// (the availability invariant that guards every pipeline).
+func TestIsTaskInstanceLiveRunningAttemptIsLive(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("live_running_%d", time.Now().UnixNano())
+	runUUID := seedRunningTask(t, repo, sched, ctx, dagID, "load")
+
+	live, err := exec.IsTaskInstanceLive(ctx, runUUID, "load", 1)
+	if err != nil {
+		t.Fatalf("IsTaskInstanceLive on a running attempt: %v", err)
+	}
+	if !live {
+		t.Fatalf("running attempt reads not-live; a live task's token must always resolve secrets")
+	}
+	// The unknown-attempt companion: a try that never existed is not live.
+	if other, err := exec.IsTaskInstanceLive(ctx, runUUID, "load", 2); err != nil || other {
+		t.Fatalf("unknown attempt 2 reads live=%v err=%v, want live=false", other, err)
+	}
+}
+
+// TestIsTaskInstanceLiveTerminalIsNotLive: once the row is settled terminal
+// (success or failed), the attempt is not live, so the token stops resolving.
+func TestIsTaskInstanceLiveTerminalIsNotLive(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		state domain.TaskState
+	}{
+		{"success", domain.TaskStateSuccess},
+		{"failed", domain.TaskStateFailed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, sched, exec, ctx := openExec(t)
+			dagID := fmt.Sprintf("live_terminal_%s_%d", tc.name, time.Now().UnixNano())
+			runUUID := seedRunningTask(t, repo, sched, ctx, dagID, "load")
+
+			// Live before the transition (two-sided: prove availability first).
+			if live, err := exec.IsTaskInstanceLive(ctx, runUUID, "load", 1); err != nil || !live {
+				t.Fatalf("pre-terminal live=%v err=%v, want live=true", live, err)
+			}
+			if err := sched.ApplyTransition(ctx, runUUID, "load", tc.state); err != nil {
+				t.Fatalf("ApplyTransition to %s: %v", tc.state, err)
+			}
+			if live, err := exec.IsTaskInstanceLive(ctx, runUUID, "load", 1); err != nil || live {
+				t.Fatalf("terminal (%s) attempt reads live=%v err=%v, want live=false", tc.state, live, err)
+			}
+		})
+	}
+}
+
+// TestIsTaskInstanceLiveSupersededByRetry: after a retry bumps try_number, the
+// old attempt is not live and the new attempt is live — the token follows the
+// work, so a zombie previous-attempt pod stops resolving the instant the retry
+// supersedes it, while the new attempt resolves normally.
+func TestIsTaskInstanceLiveSupersededByRetry(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("live_superseded_%d", time.Now().UnixNano())
+	runUUID := seedRunningTask(t, repo, sched, ctx, dagID, "load")
+
+	// Real retry rail: failed -> up_for_retry -> ResetForRetry (bumps try to 2)
+	// -> queued -> running.
+	if err := sched.ApplyTransition(ctx, runUUID, "load", domain.TaskStateFailed); err != nil {
+		t.Fatalf("ApplyTransition to failed: %v", err)
+	}
+	if err := sched.ApplyTransition(ctx, runUUID, "load", domain.TaskStateUpForRetry); err != nil {
+		t.Fatalf("ApplyTransition to up_for_retry: %v", err)
+	}
+	if applied, err := sched.ResetForRetry(ctx, runUUID, "load"); err != nil || !applied {
+		t.Fatalf("ResetForRetry applied=%v err=%v, want applied=true", applied, err)
+	}
+	for _, st := range []domain.TaskState{domain.TaskStateQueued, domain.TaskStateRunning} {
+		if err := sched.ApplyTransition(ctx, runUUID, "load", st); err != nil {
+			t.Fatalf("ApplyTransition to %s: %v", st, err)
+		}
+	}
+
+	// Old attempt (try 1) is superseded — not live.
+	if live, err := exec.IsTaskInstanceLive(ctx, runUUID, "load", 1); err != nil || live {
+		t.Fatalf("superseded attempt 1 reads live=%v err=%v, want live=false", live, err)
+	}
+	// New attempt (try 2) is live.
+	if live, err := exec.IsTaskInstanceLive(ctx, runUUID, "load", 2); err != nil || !live {
+		t.Fatalf("current attempt 2 reads live=%v err=%v, want live=true", live, err)
+	}
+}
+
+// TestIsTaskInstanceLiveClearedOldRunReruns is the D3 hazard, pinned: clearing
+// and rerunning an arbitrarily OLD run mints a live new attempt. The predicate
+// carries no run-recency / logical_date term, so an old logical date never
+// spuriously denies the rerun — the exact unacceptable case the ADR warns
+// against. Availability side: the reran attempt reads live. Security side: the
+// cleared (superseded) old attempt reads not-live.
+func TestIsTaskInstanceLiveClearedOldRunReruns(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("live_cleared_old_%d", time.Now().UnixNano())
+
+	// A run with a logical date a year in the past — the "old run" the hazard is
+	// about. Seed it running, fail it, then clear-and-rerun.
+	tasks := []domain.TaskSpec{{TaskID: "load", Type: domain.TaskTypePython}}
+	registerSpec(t, repo, ctx, dagID, tasks)
+	if _, err := repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+		RunID: "r1", State: domain.DagRunStateRunning, RunType: "manual",
+		LogicalDate: time.Now().UTC().AddDate(-1, 0, 0),
+	}); err != nil {
+		t.Fatalf("CreateDagRun: %v", err)
+	}
+	runUUID := resolveRunUUID(t, sched, ctx, dagID)
+	if err := sched.MaterializeTasks(ctx, runUUID, tasks); err != nil {
+		t.Fatalf("MaterializeTasks: %v", err)
+	}
+	for _, st := range []domain.TaskState{domain.TaskStateQueued, domain.TaskStateRunning, domain.TaskStateFailed} {
+		if err := sched.ApplyTransition(ctx, runUUID, "load", st); err != nil {
+			t.Fatalf("ApplyTransition to %s: %v", st, err)
+		}
+	}
+
+	// Clear the failed task: archives try 1 and bumps the live row to try 2 in
+	// state none. The clear rebinds the run to the current version, exactly the
+	// UI's clear-and-rerun.
+	if _, err := repo.ClearTaskInstances(ctx, "default", dagID, "r1", []string{"load"}, true, true); err != nil {
+		t.Fatalf("ClearTaskInstances: %v", err)
+	}
+	// none is not an active state — not live yet.
+	if live, err := exec.IsTaskInstanceLive(ctx, runUUID, "load", 2); err != nil || live {
+		t.Fatalf("cleared-but-not-yet-dispatched attempt 2 reads live=%v err=%v, want live=false", live, err)
+	}
+	// Re-dispatch the rerun to running.
+	for _, st := range []domain.TaskState{domain.TaskStateQueued, domain.TaskStateRunning} {
+		if err := sched.ApplyTransition(ctx, runUUID, "load", st); err != nil {
+			t.Fatalf("ApplyTransition to %s: %v", st, err)
+		}
+	}
+
+	// The rerun of a year-old run is live — no recency denial (the hazard).
+	if live, err := exec.IsTaskInstanceLive(ctx, runUUID, "load", 2); err != nil || !live {
+		t.Fatalf("rerun of an old run reads live=%v err=%v, want live=true (a recency clause would wrongly deny this)", live, err)
+	}
+	// The cleared old attempt (try 1) is not live.
+	if live, err := exec.IsTaskInstanceLive(ctx, runUUID, "load", 1); err != nil || live {
+		t.Fatalf("cleared old attempt 1 reads live=%v err=%v, want live=false", live, err)
+	}
+}


### PR DESCRIPTION
Lane E enforcement shipment (#662) — E2a + E2b + E1c in one PR (they ship together per ADR 0055). **Ships in SAFE mode: nothing denies by default.** Heavy specialist review = **SAFE TO MERGE, 0 HIGH** (`spec/lane-e-enforcement-review.md`). Go-live flips are separate operator decisions.

### E2a — read-only liveness predicate
`IsTaskInstanceLive(run,task,try)` = the proven `RecordTaskHeartbeat` predicate `(run,task,try)+state IN(queued,running)` as a pure READ. **No recency/logical_date clause** (D3 hazard) — a clear-and-rerun of a year-old run reads live (integration-pinned).

### E2b — secret-path liveness gate (default `observe`)
In `GetVariables`/`GetConnections` only (never shared `identify()` — Heartbeat/ReportState still deliver `should_terminate`). `observe` (default) = log+audit "would-have-denied", still deliver; `enforce` = deny not-live. **Transient/inconclusive read NEVER denies** (a DB blip can't break a live pipeline); observe NEVER denies.

### E1c — scope-by-policy (default `permissive`)
`permissive` (default) = warn phase: whole vault delivered, warn when a non-empty declaration ⊊ vault (E1b preserved) — delivery NOT subset. `enforce` = least-privilege: only the declared subset (empty→none), scoped **in the SQL** (`= ANY(...)`, never post-filter the decrypted vault). `off` = no scoping. Declared set resolved from token identity, never author-claimed. Operator-scoped.

### Config / safe defaults
`auth.secret_scoping` (permissive default) + `auth.secret_liveness_mode` (observe default), enum-validated fail-closed at boot + handler-side fallbacks. **Fresh deploy = v0.2.0 behavior exactly** (whole vault, no denial); strictly ≥ today's safety.

### Review outcome
0 HIGH. 1 MEDIUM (ADR D9 wording vs the safe permissive-is-warn choice) — **resolved by updating D9 in this PR**. LOWs tracked: bounded TOCTOU (safe direction), enforce case-sensitive exact-match (runbook note for #659), residual 24h token TTL until E2d (ADR-tracked).

### Verification
`go build`/`go vet`(+`-tags integration`)/`gofmt` clean · `golangci-lint run ./...` **0** · full unit suite exit 0 · integration matrix compile-verified (runs in CI). Strict TDD, no AI attribution. Held only for CI green (specialist review done).