### PR TITLE
feat(auth): short per-attempt agent-token TTL, renewed on heartbeat (ADR 0055 Fix #4)

### DIFF
--- a/cmd/leoflow-agent/main.go
+++ b/cmd/leoflow-agent/main.go
@@ -11,7 +11,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
-	"time"
 
 	"github.com/neochaotic/leoflow/internal/agent"
 	"github.com/neochaotic/leoflow/internal/version"
@@ -55,7 +54,7 @@ func run() int {
 	allowInsecure := os.Getenv("LEOFLOW_AGENT_INSECURE") != "false"
 	caFile := os.Getenv("LEOFLOW_AGENT_TLS_CA") // PEM CA to verify the server cert (TLS)
 
-	client, conn, err := agent.Dial(addr, token, allowInsecure, caFile)
+	client, conn, tokens, err := agent.Dial(addr, token, allowInsecure, caFile)
 	if err != nil {
 		slog.Error("connecting to control plane", "error", err)
 		return 1
@@ -104,7 +103,10 @@ func run() int {
 		// The durable outcome record's destination (the container termination
 		// message), set by the executor's podEnv; empty outside a pod (ADR 0052).
 		TerminationLogPath: os.Getenv("LEOFLOW_TERMINATION_LOG_PATH"),
-		HeartbeatInterval:  15 * time.Second,
+		HeartbeatInterval:  agent.DefaultHeartbeatInterval,
+		// The heartbeat loop swaps a renewed bearer into this source (ADR 0055
+		// Fix #4); the per-RPC credential reads it on every subsequent call.
+		Token: tokens,
 	}
 	// Fault-injection seam for the durable-outcome chaos E2E (ADR 0052): when a DAG
 	// sets LEOFLOW_CHAOS_DIE_BEFORE_REPORT to a task state, the agent writes the

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	leoflow "github.com/neochaotic/leoflow"
+	"github.com/neochaotic/leoflow/internal/agent"
 	"github.com/neochaotic/leoflow/internal/agentrpc"
 	"github.com/neochaotic/leoflow/internal/alerts"
 	"github.com/neochaotic/leoflow/internal/api"
@@ -313,8 +314,13 @@ func bootstrapAdmin(ctx context.Context, repo *storage.Repository, logger *slog.
 	return nil
 }
 
-// agentTokenTTL is how long a dispatched task's agent identity token stays valid.
-const agentTokenTTL = 24 * time.Hour
+// attemptTokenTTL is the short per-attempt agent-token lifetime minted at
+// dispatch (ADR 0055 Fix #4), derived from the heartbeat interval so a live task
+// refreshes its credential on every beat (see agentrpc.Server.Heartbeat) while a
+// stolen or finished token lapses in minutes. It replaces the former flat 24h
+// TTL at the dispatch site; the total renewed lifetime is separately capped by
+// auth.max_attempt_credential_lifetime.
+var attemptTokenTTL = agent.AttemptTokenTTL(agent.DefaultHeartbeatInterval)
 
 // loginRateLimit returns the per-minute failed-login cap with a safe floor: a
 // missing or nonsensical (<=0) config value falls back to the conservative
@@ -338,7 +344,7 @@ func startSchedulerSide(ctx context.Context, cfg *config.ServerConfig, pg *stora
 	if !servesScheduler {
 		return nil, false, func() {}, nil
 	}
-	grpcSrv, gerr := startAgentGRPC(ctx, cfg.Server.GRPCAddr, authn, execStore, repo, xcomSvc, logSink, logTailer, allowInsecureSecrets, cfg.Auth.SecretScoping, cfg.Auth.SecretLivenessMode, cfg.Server.GRPCTLSCert, cfg.Server.GRPCTLSKey, logger)
+	grpcSrv, gerr := startAgentGRPC(ctx, cfg.Server.GRPCAddr, authn, execStore, repo, xcomSvc, logSink, logTailer, allowInsecureSecrets, cfg.Auth.SecretScoping, cfg.Auth.SecretLivenessMode, cfg.Auth.MaxAttemptCredentialLifetime, cfg.Server.GRPCTLSCert, cfg.Server.GRPCTLSKey, logger)
 	if gerr != nil {
 		return nil, false, nil, gerr
 	}
@@ -510,7 +516,7 @@ func serveHTTP(ctx context.Context, logger *slog.Logger, servesAPI bool, apiSrv,
 // shutdown. TLS is enabled when tlsCert/tlsKey are set (issue #58); otherwise the
 // channel is plaintext (dev). The per-task bearer token in metadata authenticates
 // each call regardless.
-func startAgentGRPC(ctx context.Context, addr string, authn *auth.JWTAuthenticator, store *storage.ExecutionStore, secretsStore agentrpc.SecretsStore, xcomSvc agentrpc.XComService, logSink agentrpc.LogSink, logTailer agentrpc.LogPublisher, allowInsecureSecrets bool, secretScoping, secretLivenessMode, tlsCert, tlsKey string, logger *slog.Logger) (*grpc.Server, error) {
+func startAgentGRPC(ctx context.Context, addr string, authn *auth.JWTAuthenticator, store *storage.ExecutionStore, secretsStore agentrpc.SecretsStore, xcomSvc agentrpc.XComService, logSink agentrpc.LogSink, logTailer agentrpc.LogPublisher, allowInsecureSecrets bool, secretScoping, secretLivenessMode string, maxAttemptLifetime time.Duration, tlsCert, tlsKey string, logger *slog.Logger) (*grpc.Server, error) {
 	var lc net.ListenConfig
 	lis, err := lc.Listen(ctx, "tcp", addr)
 	if err != nil {
@@ -520,6 +526,11 @@ func startAgentGRPC(ctx context.Context, addr string, authn *auth.JWTAuthenticat
 	agentSrv.SetLogSink(logSink)
 	agentSrv.SetLogPublisher(logTailer)
 	agentSrv.SetSecrets(secretsStore, allowInsecureSecrets)
+	// Refresh a live attempt's bearer on every heartbeat (ADR 0055 Fix #4) with the
+	// same short per-attempt TTL used at dispatch, so a long task keeps a working
+	// credential while a stolen/finished token lapses in minutes. The renewal total
+	// is capped by auth.max_attempt_credential_lifetime.
+	agentSrv.SetTokenRenewal(authn, attemptTokenTTL, maxAttemptLifetime)
 	// Scope-by-declaration policy (ADR 0055 D9). Default permissive: the whole
 	// tenant vault, warning on a narrow declaration but never denying.
 	agentSrv.SetSecretScoping(secretScoping)
@@ -1109,7 +1120,7 @@ func resolveAgentControlAddr(cfg *config.ServerConfig) string {
 func setupSubprocessDispatch(cfg *config.ServerConfig, sched *scheduler.Scheduler, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, logger *slog.Logger, sink dispatch.FailureSink, metrics *observability.Metrics) (bool, io.Closer) {
 	subExec := executor.NewSubprocessExecutor(cfg.Executor.AgentPath, logger)
 	subExec.SetWorkDir(cfg.Executor.SubprocessWorkDir)
-	dispatcher := dispatch.NewDispatcher(subExec, execStore, authn, resolveAgentControlAddr(cfg), agentTokenTTL)
+	dispatcher := dispatch.NewDispatcher(subExec, execStore, authn, resolveAgentControlAddr(cfg), attemptTokenTTL)
 	dispatcher.SetPlatformDefaults(platformDefaults(cfg.Executor.Defaults))
 	disp, closer := wrapBuffered(dispatcher, sink, logger, metrics, cfg.Scheduler.Dispatch)
 	sched.SetDispatcher(disp)
@@ -1129,7 +1140,7 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 	controlAddr := resolveAgentControlAddr(cfg)
 	podExec := executor.NewKubernetesExecutor(cs, cfg.Executor.TaskNamespace)
 	podExec.SetStagingStore(store) // record per-run staging volumes in the metadatabase (ADR 0022)
-	dispatcher := dispatch.NewDispatcher(podExec, execStore, authn, controlAddr, agentTokenTTL)
+	dispatcher := dispatch.NewDispatcher(podExec, execStore, authn, controlAddr, attemptTokenTTL)
 	dispatcher.SetAgentTLSCAConfigMap(cfg.Executor.AgentTLSCAConfigMap)
 	dispatcher.SetTaskSecret(cfg.Executor.TaskSecretName, cfg.Executor.TaskSecretMountPath)
 	dispatcher.SetPlatformDefaults(platformDefaults(cfg.Executor.Defaults))

--- a/internal/agent/auth.go
+++ b/internal/agent/auth.go
@@ -1,17 +1,56 @@
 package agent
 
-import "context"
+import (
+	"context"
+	"sync"
+)
 
-// tokenAuth is a gRPC per-RPC credential that attaches the agent's bearer token
-// to every call so the control plane can identify the task instance.
+// TokenSource holds the agent's current bearer token behind a lock so the
+// heartbeat loop can atomically swap it (token renewal, ADR 0055 Fix #4) while
+// the gRPC per-RPC credential reads it on every outbound call. Reads and swaps
+// may race across goroutines, so both go through the mutex.
+type TokenSource struct {
+	mu    sync.RWMutex
+	token string
+}
+
+// NewTokenSource seeds a TokenSource with the dispatch token.
+func NewTokenSource(token string) *TokenSource {
+	return &TokenSource{token: token}
+}
+
+// Token returns the current bearer.
+func (s *TokenSource) Token() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.token
+}
+
+// Set atomically swaps the bearer used by subsequent RPCs. An empty token is
+// ignored so a "no renewal this beat" response never blanks a working
+// credential.
+func (s *TokenSource) Set(token string) {
+	if token == "" {
+		return
+	}
+	s.mu.Lock()
+	s.token = token
+	s.mu.Unlock()
+}
+
+// tokenAuth is a gRPC per-RPC credential that attaches the agent's current
+// bearer token to every call so the control plane can identify the task
+// instance. It reads the live token from the shared TokenSource on each call, so
+// a renewal swap takes effect on the very next RPC.
 type tokenAuth struct {
-	token  string
+	source *TokenSource
 	secure bool
 }
 
-// GetRequestMetadata returns the authorization header carrying the bearer token.
+// GetRequestMetadata returns the authorization header carrying the current
+// bearer token.
 func (t tokenAuth) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
-	return map[string]string{"authorization": "Bearer " + t.token}, nil
+	return map[string]string{"authorization": "Bearer " + t.source.Token()}, nil
 }
 
 // RequireTransportSecurity reports whether the credential may only travel over a

--- a/internal/agent/auth_test.go
+++ b/internal/agent/auth_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestTokenAuthAttachesBearer(t *testing.T) {
-	creds := tokenAuth{token: "abc123", secure: true}
+	creds := tokenAuth{source: NewTokenSource("abc123"), secure: true}
 	md, err := creds.GetRequestMetadata(context.Background())
 	if err != nil {
 		t.Fatalf("GetRequestMetadata: %v", err)
@@ -20,7 +20,7 @@ func TestTokenAuthAttachesBearer(t *testing.T) {
 }
 
 func TestTokenAuthInsecureForLocalDev(t *testing.T) {
-	creds := tokenAuth{token: "x", secure: false}
+	creds := tokenAuth{source: NewTokenSource("x"), secure: false}
 	if creds.RequireTransportSecurity() {
 		t.Error("insecure credentials must not require transport security")
 	}

--- a/internal/agent/dial.go
+++ b/internal/agent/dial.go
@@ -35,12 +35,16 @@ func caPool(path string) (*x509.CertPool, error) {
 // without TLS) the transport is unencrypted; otherwise TLS 1.2+ is required. When
 // caFile is set, the server certificate is verified against that CA (a
 // self-signed / cluster CA); otherwise the system roots are used.
-func Dial(addr, token string, allowInsecure bool, caFile string) (agentv1.AgentServiceClient, *grpc.ClientConn, error) {
+//
+// It also returns the *TokenSource backing the per-RPC credential: the heartbeat
+// loop swaps a renewed token into it (ADR 0055 Fix #4) and the interceptor picks
+// the new bearer up on the next call.
+func Dial(addr, token string, allowInsecure bool, caFile string) (agentv1.AgentServiceClient, *grpc.ClientConn, *TokenSource, error) {
 	if addr == "" {
-		return nil, nil, errors.New("control plane address is required")
+		return nil, nil, nil, errors.New("control plane address is required")
 	}
 	if token == "" {
-		return nil, nil, errors.New("agent token is required")
+		return nil, nil, nil, errors.New("agent token is required")
 	}
 
 	transport := insecure.NewCredentials()
@@ -49,21 +53,22 @@ func Dial(addr, token string, allowInsecure bool, caFile string) (agentv1.AgentS
 		if caFile != "" {
 			pool, cerr := caPool(caFile)
 			if cerr != nil {
-				return nil, nil, cerr
+				return nil, nil, nil, cerr
 			}
 			tlsCfg.RootCAs = pool
 		}
 		transport = credentials.NewTLS(tlsCfg)
 	}
 
+	tokens := NewTokenSource(token)
 	conn, err := grpc.NewClient(addr,
 		grpc.WithTransportCredentials(transport),
-		grpc.WithPerRPCCredentials(tokenAuth{token: token, secure: !allowInsecure}),
+		grpc.WithPerRPCCredentials(tokenAuth{source: tokens, secure: !allowInsecure}),
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("dialing control plane at %q: %w", addr, err)
+		return nil, nil, nil, fmt.Errorf("dialing control plane at %q: %w", addr, err)
 	}
-	return agentv1.NewAgentServiceClient(conn), conn, nil
+	return agentv1.NewAgentServiceClient(conn), conn, tokens, nil
 }
 
 // grpcLogSink adapts the StreamLogs bidirectional stream to the LogSink

--- a/internal/agent/dial_extra_test.go
+++ b/internal/agent/dial_extra_test.go
@@ -68,7 +68,7 @@ func TestCAPoolAcceptsValidCert(t *testing.T) {
 // TestDialPropagatesBadCAFile: the secure path with a broken CA file must fail
 // to dial rather than silently fall back to no verification.
 func TestDialPropagatesBadCAFile(t *testing.T) {
-	if _, _, err := Dial("localhost:50051", "token", false, filepath.Join(t.TempDir(), "absent.pem")); err == nil {
+	if _, _, _, err := Dial("localhost:50051", "token", false, filepath.Join(t.TempDir(), "absent.pem")); err == nil {
 		t.Error("Dial with an unreadable CA file should error")
 	}
 }

--- a/internal/agent/dial_test.go
+++ b/internal/agent/dial_test.go
@@ -3,22 +3,25 @@ package agent
 import "testing"
 
 func TestDialRequiresAddressAndToken(t *testing.T) {
-	if _, _, err := Dial("", "token", true, ""); err == nil {
+	if _, _, _, err := Dial("", "token", true, ""); err == nil {
 		t.Error("missing address should error")
 	}
-	if _, _, err := Dial("localhost:50051", "", true, ""); err == nil {
+	if _, _, _, err := Dial("localhost:50051", "", true, ""); err == nil {
 		t.Error("missing token should error")
 	}
 }
 
 func TestDialBuildsClient(t *testing.T) {
 	for _, insecure := range []bool{true, false} {
-		client, conn, err := Dial("localhost:50051", "token", insecure, "")
+		client, conn, tokens, err := Dial("localhost:50051", "token", insecure, "")
 		if err != nil {
 			t.Fatalf("Dial(insecure=%v): %v", insecure, err)
 		}
-		if client == nil || conn == nil {
-			t.Fatalf("Dial(insecure=%v) returned nil client/conn", insecure)
+		if client == nil || conn == nil || tokens == nil {
+			t.Fatalf("Dial(insecure=%v) returned nil client/conn/tokens", insecure)
+		}
+		if tokens.Token() != "token" {
+			t.Errorf("Dial seeded token = %q, want %q", tokens.Token(), "token")
 		}
 		if cerr := conn.Close(); cerr != nil {
 			t.Errorf("closing conn: %v", cerr)

--- a/internal/agent/heartbeat_roundtrip_test.go
+++ b/internal/agent/heartbeat_roundtrip_test.go
@@ -1,0 +1,150 @@
+package agent
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/neochaotic/leoflow/internal/agentrpc"
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/domain"
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+	"google.golang.org/grpc"
+)
+
+// stubStore is a minimal agentrpc.Store: heartbeats are always live (nil), the
+// rest are unused by this heartbeat-only round-trip.
+type stubStore struct{}
+
+func (stubStore) TaskSpec(context.Context, auth.AgentIdentity) (agentrpc.TaskSpec, error) {
+	return agentrpc.TaskSpec{}, nil
+}
+func (stubStore) ReportState(context.Context, auth.AgentIdentity, domain.TaskState, int, string) error {
+	return nil
+}
+func (stubStore) Reschedule(context.Context, auth.AgentIdentity, time.Time) error { return nil }
+func (stubStore) RecordHeartbeat(context.Context, auth.AgentIdentity) error       { return nil }
+
+// recordingAuth wraps a real authenticator and records every raw bearer the
+// server was asked to verify, so a test can prove which token the agent sent on
+// each call.
+type recordingAuth struct {
+	inner *auth.JWTAuthenticator
+	mu    sync.Mutex
+	seen  []string
+}
+
+func (r *recordingAuth) AuthenticateAgent(token string) (*auth.AgentIdentity, error) {
+	r.mu.Lock()
+	r.seen = append(r.seen, token)
+	r.mu.Unlock()
+	return r.inner.AuthenticateAgent(token)
+}
+
+func (r *recordingAuth) tokens() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.seen...)
+}
+
+func ttlOf(t *testing.T, token string) time.Duration {
+	t.Helper()
+	var c jwt.MapClaims
+	if _, err := jwt.ParseWithClaims(token, &c, func(*jwt.Token) (any, error) {
+		return []byte("secret"), nil
+	}, jwt.WithValidMethods([]string{"HS256"})); err != nil {
+		t.Fatalf("parsing token: %v", err)
+	}
+	iat, _ := c.GetIssuedAt()
+	exp, _ := c.GetExpirationTime()
+	if iat == nil || exp == nil {
+		t.Fatal("token missing iat/exp")
+	}
+	return exp.Time.Sub(iat.Time)
+}
+
+// TestHeartbeatRenewalRoundTrip drives real gRPC across two heartbeats: the
+// control plane renews the bearer on each live beat, the agent swaps it into its
+// TokenSource, and the interceptor sends the renewed token on the next call. The
+// dispatch token uses a different TTL from the renewal so the token the server
+// receives on beat #2 is provably the renewed one, not the original.
+func TestHeartbeatRenewalRoundTrip(t *testing.T) {
+	authn := auth.NewJWTAuthenticator(nil, "secret", time.Hour)
+	rec := &recordingAuth{inner: authn}
+	srv := agentrpc.NewServer(rec, stubStore{}, nil)
+	const (
+		dispatchTTL = 5 * time.Minute
+		renewalTTL  = 10 * time.Minute
+	)
+	srv.SetTokenRenewal(authn, renewalTTL, 24*time.Hour)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	gsrv := grpc.NewServer()
+	agentv1.RegisterAgentServiceServer(gsrv, srv)
+	go func() { _ = gsrv.Serve(lis) }()
+	defer gsrv.Stop()
+
+	id := auth.AgentIdentity{TaskInstanceID: "ti-1", TenantID: "acme", DagID: "etl", RunID: "run-1", TaskID: "extract", TryNumber: 1}
+	dispatched, err := authn.IssueAgentToken(id, dispatchTTL)
+	if err != nil {
+		t.Fatalf("IssueAgentToken: %v", err)
+	}
+	client, conn, tokens, err := Dial(lis.Addr().String(), dispatched, true, "")
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	r := &Runner{Token: tokens}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Beat 1: carries the dispatch bearer; the reply renews it.
+	resp1, err := client.Heartbeat(ctx, &agentv1.HeartbeatRequest{})
+	if err != nil {
+		t.Fatalf("Heartbeat #1: %v", err)
+	}
+	if resp1.GetRenewedToken() == "" {
+		t.Fatal("beat #1 must return a renewed token")
+	}
+	r.applyHeartbeatResponse(resp1)
+
+	// Beat 2: must now carry the renewed bearer.
+	resp2, err := client.Heartbeat(ctx, &agentv1.HeartbeatRequest{})
+	if err != nil {
+		t.Fatalf("Heartbeat #2: %v", err)
+	}
+	if resp2.GetRenewedToken() == "" {
+		t.Fatal("beat #2 must return a renewed token")
+	}
+	r.applyHeartbeatResponse(resp2)
+
+	seen := rec.tokens()
+	if len(seen) < 2 {
+		t.Fatalf("server saw %d tokens, want >= 2", len(seen))
+	}
+	// Beat #1 carried the dispatch token (5m TTL); beat #2 carried the renewed one
+	// (10m TTL) — proof the agent swapped to the new bearer.
+	if got := ttlOf(t, seen[0]); got != dispatchTTL {
+		t.Errorf("beat #1 bearer TTL = %v, want the dispatch TTL %v", got, dispatchTTL)
+	}
+	if got := ttlOf(t, seen[1]); got != renewalTTL {
+		t.Errorf("beat #2 bearer TTL = %v, want the renewal TTL %v (agent did not swap)", got, renewalTTL)
+	}
+	// Every token the server accepted still resolves the same identity.
+	for i, tok := range seen {
+		gotID, aerr := authn.AuthenticateAgent(tok)
+		if aerr != nil {
+			t.Fatalf("token %d must authenticate: %v", i, aerr)
+		}
+		if gotID.TaskInstanceID != "ti-1" || gotID.TryNumber != 1 {
+			t.Errorf("token %d identity = %+v, want ti-1/try-1", i, *gotID)
+		}
+	}
+}

--- a/internal/agent/heartbeat_roundtrip_test.go
+++ b/internal/agent/heartbeat_roundtrip_test.go
@@ -63,7 +63,7 @@ func ttlOf(t *testing.T, token string) time.Duration {
 	if iat == nil || exp == nil {
 		t.Fatal("token missing iat/exp")
 	}
-	return exp.Time.Sub(iat.Time)
+	return exp.Sub(iat.Time)
 }
 
 // TestHeartbeatRenewalRoundTrip drives real gRPC across two heartbeats: the
@@ -81,7 +81,8 @@ func TestHeartbeatRenewalRoundTrip(t *testing.T) {
 	)
 	srv.SetTokenRenewal(authn, renewalTTL, 24*time.Hour)
 
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	var lc net.ListenConfig
+	lis, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -75,6 +75,11 @@ type Runner struct {
 	// HeartbeatInterval is how often to ping the control plane while the task
 	// runs; zero disables heartbeats.
 	HeartbeatInterval time.Duration
+	// Token, when set, is the swappable bearer the gRPC per-RPC credential reads.
+	// On a heartbeat carrying a renewed_token the loop atomically swaps it here so
+	// every subsequent RPC uses the new credential (ADR 0055 Fix #4). Nil disables
+	// bearer swapping (a heartbeat's renewed_token is then ignored).
+	Token *TokenSource
 	// BeforeReport, if set, is invoked with the terminal state AFTER the durable
 	// outcome record is written and BEFORE the report is delivered. It is a
 	// fault-injection seam for the durable-outcome E2E (ADR 0052) — the agent
@@ -577,13 +582,26 @@ func (r *Runner) heartbeat(ctx context.Context, cancel context.CancelFunc) {
 				slog.Warn("heartbeat failed", "error", err)
 				continue
 			}
-			if resp.GetShouldTerminate() {
+			if r.applyHeartbeatResponse(resp) {
 				slog.Warn("control plane requested task termination")
 				cancel()
 				return
 			}
 		}
 	}
+}
+
+// applyHeartbeatResponse handles a heartbeat reply: it swaps in a renewed bearer
+// (ADR 0055 Fix #4) and reports whether the control plane asked the task to
+// terminate. The swap happens before the terminate check, but the two are
+// mutually exclusive on the wire — the server sends a renewed token only on the
+// live branch and should_terminate only on the superseded branch. The token is
+// never logged.
+func (r *Runner) applyHeartbeatResponse(resp *agentv1.HeartbeatResponse) (terminate bool) {
+	if r.Token != nil {
+		r.Token.Set(resp.GetRenewedToken()) // no-op on empty (keep current bearer)
+	}
+	return resp.GetShouldTerminate()
 }
 
 func (r *Runner) report(ctx context.Context, state agentv1.TaskState, exitCode int32, msg string) error {

--- a/internal/agent/token_renewal_test.go
+++ b/internal/agent/token_renewal_test.go
@@ -1,0 +1,112 @@
+package agent
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+)
+
+// TestTokenSourceSwap: the credential reads the live token, and a concurrent
+// swap is observed by subsequent reads. Empty swaps never blank a working token.
+func TestTokenSourceSwap(t *testing.T) {
+	src := NewTokenSource("initial")
+	cred := tokenAuth{source: src}
+
+	md, err := cred.GetRequestMetadata(t.Context())
+	if err != nil {
+		t.Fatalf("GetRequestMetadata: %v", err)
+	}
+	if got := md["authorization"]; got != "Bearer initial" {
+		t.Errorf("authorization = %q, want %q", got, "Bearer initial")
+	}
+
+	src.Set("renewed")
+	md, _ = cred.GetRequestMetadata(t.Context())
+	if got := md["authorization"]; got != "Bearer renewed" {
+		t.Errorf("after swap authorization = %q, want %q", got, "Bearer renewed")
+	}
+
+	src.Set("") // no-op: keep the current bearer
+	if got := src.Token(); got != "renewed" {
+		t.Errorf("empty swap changed the token to %q, want %q", got, "renewed")
+	}
+}
+
+// TestTokenSourceConcurrent exercises the lock under -race: concurrent readers
+// and a writer must not data-race.
+func TestTokenSourceConcurrent(t *testing.T) {
+	src := NewTokenSource("t0")
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); _ = src.Token() }()
+	}
+	wg.Add(1)
+	go func() { defer wg.Done(); src.Set("t1") }()
+	wg.Wait()
+}
+
+// TestApplyHeartbeatResponseSwapsBearer: a heartbeat carrying a renewed token
+// swaps the agent's bearer for subsequent RPCs; an empty one is left untouched;
+// and should_terminate is surfaced.
+func TestApplyHeartbeatResponseSwapsBearer(t *testing.T) {
+	src := NewTokenSource("old")
+	r := &Runner{Token: src}
+
+	if term := r.applyHeartbeatResponse(&agentv1.HeartbeatResponse{RenewedToken: "new"}); term {
+		t.Error("a live heartbeat must not signal terminate")
+	}
+	if got := src.Token(); got != "new" {
+		t.Errorf("bearer after renewal = %q, want %q", got, "new")
+	}
+
+	// No renewed token: keep the current bearer.
+	if term := r.applyHeartbeatResponse(&agentv1.HeartbeatResponse{}); term {
+		t.Error("empty heartbeat must not signal terminate")
+	}
+	if got := src.Token(); got != "new" {
+		t.Errorf("bearer after empty heartbeat = %q, want %q (unchanged)", got, "new")
+	}
+
+	// Superseded: terminate, and by construction no renewed token on that branch.
+	if term := r.applyHeartbeatResponse(&agentv1.HeartbeatResponse{ShouldTerminate: true}); !term {
+		t.Error("superseded heartbeat must signal terminate")
+	}
+}
+
+// TestApplyHeartbeatResponseNilToken: with no TokenSource wired, a renewed token
+// is ignored rather than panicking.
+func TestApplyHeartbeatResponseNilToken(t *testing.T) {
+	r := &Runner{}
+	if term := r.applyHeartbeatResponse(&agentv1.HeartbeatResponse{RenewedToken: "x"}); term {
+		t.Error("unexpected terminate")
+	}
+}
+
+// TestAttemptTokenTTL: the derived per-attempt TTL always exceeds a single
+// heartbeat interval (so one missed beat survives), honors the floor for small
+// intervals, and scales past the floor for large ones.
+func TestAttemptTokenTTL(t *testing.T) {
+	// Production interval (15s): floor dominates and gives dozens of beats of
+	// tolerance.
+	if ttl := AttemptTokenTTL(DefaultHeartbeatInterval); ttl != attemptTokenTTLFloor {
+		t.Errorf("AttemptTokenTTL(15s) = %v, want the floor %v", ttl, attemptTokenTTLFloor)
+	}
+	// The floor exceeds the interval × missed-beat tolerance: several consecutive
+	// missed beats still leave the credential valid.
+	if attemptTokenTTLFloor <= DefaultHeartbeatInterval*attemptTokenTTLBeats {
+		t.Errorf("floor %v must exceed interval×beats %v", attemptTokenTTLFloor, DefaultHeartbeatInterval*attemptTokenTTLBeats)
+	}
+	// A single missed beat is always survivable at any interval.
+	for _, iv := range []time.Duration{time.Second, 15 * time.Second, time.Minute, 10 * time.Minute} {
+		if got := AttemptTokenTTL(iv); got <= iv {
+			t.Errorf("AttemptTokenTTL(%v) = %v, must exceed one interval", iv, got)
+		}
+	}
+	// A large interval scales past the floor: max(floor, beats×interval).
+	if ttl := AttemptTokenTTL(time.Hour); ttl != attemptTokenTTLBeats*time.Hour {
+		t.Errorf("AttemptTokenTTL(1h) = %v, want %v", ttl, attemptTokenTTLBeats*time.Hour)
+	}
+}

--- a/internal/agent/ttl.go
+++ b/internal/agent/ttl.go
@@ -1,0 +1,34 @@
+package agent
+
+import "time"
+
+// DefaultHeartbeatInterval is how often the in-pod agent pings the control plane
+// while a task runs. Token renewal rides this signal (ADR 0055 Fix #4): every
+// live heartbeat refreshes the bearer, so the per-attempt token TTL is derived
+// from this interval rather than set to a flat day.
+const DefaultHeartbeatInterval = 15 * time.Second
+
+// attemptTokenTTLFloor is the minimum per-attempt token lifetime. It must
+// comfortably exceed the heartbeat interval so a single missed beat (a slow tick,
+// a brief partition) does not lapse a live task's credential before the next
+// beat renews it, while still bounding a stolen or finished token to minutes
+// rather than a day. Verified against the ADR's ~10 min projected-token floor.
+const attemptTokenTTLFloor = 10 * time.Minute
+
+// attemptTokenTTLBeats is the missed-beat tolerance: the token stays valid for
+// this many heartbeat intervals even before the floor applies, so several
+// consecutive missed beats are survivable.
+const attemptTokenTTLBeats = 4
+
+// AttemptTokenTTL derives the short per-attempt agent-token TTL from the
+// heartbeat interval: max(floor, beats × interval). The result always exceeds a
+// single interval, so one missed beat never lapses a live credential, while the
+// floor keeps the TTL short enough to bound an exfiltrated token. A non-positive
+// interval (heartbeats disabled) yields the floor.
+func AttemptTokenTTL(interval time.Duration) time.Duration {
+	ttl := attemptTokenTTLFloor
+	if scaled := time.Duration(attemptTokenTTLBeats) * interval; scaled > ttl {
+		ttl = scaled
+	}
+	return ttl
+}

--- a/internal/agentrpc/heartbeat_renewal_test.go
+++ b/internal/agentrpc/heartbeat_renewal_test.go
@@ -1,0 +1,148 @@
+package agentrpc
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+)
+
+// errTransient is a non-stale store error: the "DB blip" case that must neither
+// terminate nor renew.
+var errTransient = errors.New("db transient blip")
+
+// ttlOfToken decodes the short-TTL window (exp - iat) of a signed agent token,
+// verifying it against the test authenticator's secret. The agentrpc test lives
+// outside the auth package, so it reads the registered claims via MapClaims
+// rather than the (unexported) agentClaims type.
+func ttlOfToken(t *testing.T, token string) time.Duration {
+	t.Helper()
+	var c jwt.MapClaims
+	if _, err := jwt.ParseWithClaims(token, &c, func(*jwt.Token) (any, error) {
+		return []byte("secret"), nil
+	}, jwt.WithValidMethods([]string{"HS256"})); err != nil {
+		t.Fatalf("parsing renewed token: %v", err)
+	}
+	iat, err := c.GetIssuedAt()
+	if err != nil || iat == nil {
+		t.Fatalf("renewed token has no iat: %v", err)
+	}
+	exp, err := c.GetExpirationTime()
+	if err != nil || exp == nil {
+		t.Fatalf("renewed token has no exp: %v", err)
+	}
+	return exp.Time.Sub(iat.Time)
+}
+
+// TestHeartbeatRenewsTokenOnLiveAttempt is the live side of the two-sided
+// renewal contract: when RecordHeartbeat applies (the attempt is live), the
+// response carries a freshly minted task-scoped token with exp = now+shortTTL,
+// it authenticates to the SAME identity, and it never signals terminate.
+func TestHeartbeatRenewsTokenOnLiveAttempt(t *testing.T) {
+	store := &fakeStore{}
+	srv, authn := newServer(store)
+	const shortTTL = 10 * time.Minute
+	srv.SetTokenRenewal(authn, shortTTL, 24*time.Hour)
+
+	resp, err := srv.Heartbeat(ctxWithToken(t, authn), &agentv1.HeartbeatRequest{})
+	if err != nil {
+		t.Fatalf("Heartbeat: %v", err)
+	}
+	if resp.GetShouldTerminate() {
+		t.Fatal("live heartbeat must not signal terminate")
+	}
+	renewed := resp.GetRenewedToken()
+	if renewed == "" {
+		t.Fatal("live heartbeat must carry a renewed token")
+	}
+	// The renewed bearer verifies unchanged and still identifies the same TI.
+	got, err := authn.AuthenticateAgent(renewed)
+	if err != nil {
+		t.Fatalf("renewed token must authenticate: %v", err)
+	}
+	if got.TaskInstanceID != "ti-1" || got.RunID != "run-1" || got.TaskID != "extract" || got.TryNumber != 1 {
+		t.Errorf("renewed identity = %+v, want the testIdentity", *got)
+	}
+	// exp = now + shortTTL exactly (never accumulated onto the old exp).
+	if ttl := ttlOfToken(t, renewed); ttl != shortTTL {
+		t.Errorf("renewed exp-iat = %v, want %v", ttl, shortTTL)
+	}
+}
+
+// TestHeartbeatSupersededReturnsTerminateNoToken is the dead side: a superseded
+// attempt (ErrStaleReport) is told to terminate and is NEVER handed a renewed
+// token — the two outcomes are mutually exclusive, so a finished/superseded
+// attempt's credential lapses rather than being refreshed.
+func TestHeartbeatSupersededReturnsTerminateNoToken(t *testing.T) {
+	store := &fakeStore{heartbeatErr: ErrStaleReport}
+	srv, authn := newServer(store)
+	srv.SetTokenRenewal(authn, 10*time.Minute, 24*time.Hour)
+
+	resp, err := srv.Heartbeat(ctxWithToken(t, authn), &agentv1.HeartbeatRequest{})
+	if err != nil {
+		t.Fatalf("stale heartbeat must not be an RPC error: %v", err)
+	}
+	if !resp.GetShouldTerminate() {
+		t.Error("superseded heartbeat: should_terminate = false, want true")
+	}
+	if resp.GetRenewedToken() != "" {
+		t.Error("superseded heartbeat must NOT carry a renewed token (never both)")
+	}
+}
+
+// TestHeartbeatTransientErrorDoesNotRenew: a genuine (non-stale) store error
+// leaves liveness unproven, so the heartbeat neither terminates nor renews — a
+// DB blip must not re-credential (nor kill) a task.
+func TestHeartbeatTransientErrorDoesNotRenew(t *testing.T) {
+	store := &fakeStore{heartbeatErr: errTransient}
+	srv, authn := newServer(store)
+	srv.SetTokenRenewal(authn, 10*time.Minute, 24*time.Hour)
+
+	resp, err := srv.Heartbeat(ctxWithToken(t, authn), &agentv1.HeartbeatRequest{})
+	if err != nil {
+		t.Fatalf("transient heartbeat error must not surface as RPC error: %v", err)
+	}
+	if resp.GetShouldTerminate() {
+		t.Error("transient DB error must not signal terminate")
+	}
+	if resp.GetRenewedToken() != "" {
+		t.Error("transient DB error must not renew (liveness unproven)")
+	}
+}
+
+// TestHeartbeatCeilingStopsRenewal: once an attempt has been alive past
+// max_attempt_credential_lifetime since first dispatch, a live heartbeat still
+// succeeds but stops handing out renewed tokens, so a runaway attempt's
+// credential lapses. Modeled here with a sub-tick ceiling that the dispatch
+// origin has already exceeded.
+func TestHeartbeatCeilingStopsRenewal(t *testing.T) {
+	store := &fakeStore{}
+	srv, authn := newServer(store)
+	srv.SetTokenRenewal(authn, 10*time.Minute, time.Nanosecond)
+
+	resp, err := srv.Heartbeat(ctxWithToken(t, authn), &agentv1.HeartbeatRequest{})
+	if err != nil {
+		t.Fatalf("Heartbeat: %v", err)
+	}
+	if resp.GetShouldTerminate() {
+		t.Error("a live attempt past the ceiling must not be told to terminate; its token simply lapses")
+	}
+	if resp.GetRenewedToken() != "" {
+		t.Error("past the max-attempt-lifetime ceiling the heartbeat must not renew")
+	}
+}
+
+// TestHeartbeatNoRenewerLeavesTokenEmpty: with renewal unconfigured the handler
+// behaves exactly as before — a live heartbeat carries no renewed token.
+func TestHeartbeatNoRenewerLeavesTokenEmpty(t *testing.T) {
+	srv, authn := newServer(&fakeStore{})
+	resp, err := srv.Heartbeat(ctxWithToken(t, authn), &agentv1.HeartbeatRequest{})
+	if err != nil {
+		t.Fatalf("Heartbeat: %v", err)
+	}
+	if resp.GetRenewedToken() != "" {
+		t.Error("no renewer configured: renewed token must be empty")
+	}
+}

--- a/internal/agentrpc/heartbeat_renewal_test.go
+++ b/internal/agentrpc/heartbeat_renewal_test.go
@@ -33,7 +33,7 @@ func ttlOfToken(t *testing.T, token string) time.Duration {
 	if err != nil || exp == nil {
 		t.Fatalf("renewed token has no exp: %v", err)
 	}
-	return exp.Time.Sub(iat.Time)
+	return exp.Sub(iat.Time)
 }
 
 // TestHeartbeatRenewsTokenOnLiveAttempt is the live side of the two-sided

--- a/internal/agentrpc/server.go
+++ b/internal/agentrpc/server.go
@@ -86,6 +86,15 @@ type Authenticator interface {
 	AuthenticateAgent(token string) (*auth.AgentIdentity, error)
 }
 
+// AgentTokenRenewer re-mints a live attempt's agent token with a fresh short
+// TTL, preserving the identity and the attempt's first-dispatch origin. It is
+// consulted only on a liveness-proven heartbeat (ADR 0055 Fix #4). ok is false
+// when the attempt has outlived its max-lifetime ceiling — the signal to let the
+// credential lapse rather than refresh it. Implemented by *auth.JWTAuthenticator.
+type AgentTokenRenewer interface {
+	RenewAgentToken(token string, ttl, maxLifetime time.Duration) (string, bool, error)
+}
+
 // ErrStaleReport is returned by Store.ReportState when the report did not apply
 // because the task instance had already moved on — a reaper settled it, or a
 // retry advanced past the attempt the reporting agent was dispatched for. It is
@@ -140,6 +149,9 @@ type Server struct {
 	livenessAudit        SecretLivenessAuditor
 	scoping              string
 	allowInsecureSecrets bool
+	renewer              AgentTokenRenewer
+	renewalTTL           time.Duration
+	maxAttemptLifetime   time.Duration
 	now                  func() time.Time
 }
 
@@ -147,6 +159,17 @@ type Server struct {
 // store, and XCom service.
 func NewServer(authn Authenticator, store Store, xcomSvc XComService) *Server {
 	return &Server{auth: authn, store: store, xcom: xcomSvc, now: time.Now}
+}
+
+// SetTokenRenewal wires per-attempt token renewal (ADR 0055 Fix #4): on a
+// liveness-proven heartbeat the server re-mints the caller's bearer with a fresh
+// renewalTTL and returns it on HeartbeatResponse.renewed_token, so a long task
+// keeps a working credential while the short TTL bounds a stolen/finished one.
+// maxAttemptLifetime is the hard ceiling on an attempt's total credential age
+// since dispatch (0 disables it). A nil renewer or non-positive renewalTTL
+// leaves renewal off — the heartbeat returns no token (unchanged behavior).
+func (s *Server) SetTokenRenewal(renewer AgentTokenRenewer, renewalTTL, maxAttemptLifetime time.Duration) {
+	s.renewer, s.renewalTTL, s.maxAttemptLifetime = renewer, renewalTTL, maxAttemptLifetime
 }
 
 // SetLogSink attaches the log sink that StreamLogs writes to. Without it,
@@ -264,6 +287,9 @@ func (s *Server) Heartbeat(ctx context.Context, _ *agentv1.HeartbeatRequest) (*a
 		// (the same "moved on" predicate the state report is guarded by, #467).
 		// Signal terminate so a reaped-but-alive pod stops itself (#474). The live,
 		// matching attempt stamps a row (no error), so it never gets the signal.
+		// Deliberately NO renewed token here: a superseded attempt's credential must
+		// lapse, never be refreshed — renewal happens ONLY on the liveness-proven
+		// (nil) branch below.
 		if errors.Is(hbErr, ErrStaleReport) {
 			slog.Warn("stale heartbeat from a superseded attempt; signaling terminate",
 				"ti", id.TaskInstanceID, "run", id.RunID, "task", id.TaskID, "try", id.TryNumber)
@@ -271,11 +297,49 @@ func (s *Server) Heartbeat(ctx context.Context, _ *agentv1.HeartbeatRequest) (*a
 		}
 		// A genuine (non-stale) store error is logged but does not fail the RPC or
 		// signal terminate — failing would risk the agent killing a live task on a
-		// transient DB blip. The scheduler's heartbeat reaper is the backstop.
+		// transient DB blip. The scheduler's heartbeat reaper is the backstop. It
+		// also does NOT renew: liveness is not proven, so the credential is not
+		// refreshed on a blip.
 		slog.Warn("recording heartbeat",
 			"ti", id.TaskInstanceID, "run", id.RunID, "task", id.TaskID, "error", hbErr)
+		return &agentv1.HeartbeatResponse{ServerTime: timestamppb.New(s.now())}, nil
 	}
-	return &agentv1.HeartbeatResponse{ServerTime: timestamppb.New(s.now())}, nil
+	// Liveness proven (RecordHeartbeat applied for this exact attempt): refresh the
+	// bearer so a long-running task keeps a working credential while the short
+	// per-attempt TTL bounds a stolen or finished one (ADR 0055 Fix #4).
+	resp := &agentv1.HeartbeatResponse{ServerTime: timestamppb.New(s.now())}
+	s.renewToken(ctx, id, resp)
+	return resp, nil
+}
+
+// renewToken re-mints the caller's agent token onto resp.RenewedToken when a
+// renewer is configured and the attempt has not outlived its lifetime ceiling.
+// It runs ONLY on the liveness-proven heartbeat branch. Best-effort: a renewer
+// error or a past-ceiling result leaves the response without a renewed token
+// (the agent keeps its current bearer) and never fails the heartbeat. The token
+// is never logged.
+func (s *Server) renewToken(ctx context.Context, id *auth.AgentIdentity, resp *agentv1.HeartbeatResponse) {
+	if s.renewer == nil || s.renewalTTL <= 0 {
+		return
+	}
+	token, ok := bearerFromContext(ctx)
+	if !ok || token == "" {
+		return
+	}
+	renewed, ok, err := s.renewer.RenewAgentToken(token, s.renewalTTL, s.maxAttemptLifetime)
+	if err != nil {
+		slog.Warn("renewing agent token on heartbeat; agent keeps its current bearer",
+			"ti", id.TaskInstanceID, "run", id.RunID, "task", id.TaskID, "try", id.TryNumber, "error", err)
+		return
+	}
+	if !ok {
+		// Past max_attempt_credential_lifetime: let the credential lapse rather than
+		// keep a runaway attempt alive.
+		slog.Warn("not renewing agent token: attempt past max_attempt_credential_lifetime",
+			"ti", id.TaskInstanceID, "run", id.RunID, "task", id.TaskID, "try", id.TryNumber)
+		return
+	}
+	resp.RenewedToken = renewed
 }
 
 // PushXCom stores a value the task produced, keyed by the caller's identity.
@@ -460,20 +524,31 @@ func toXComUpstreamsMap(in map[string][]string) map[string]*agentv1.XComUpstream
 
 // identify extracts and verifies the agent token from the request metadata.
 func (s *Server) identify(ctx context.Context) (*auth.AgentIdentity, error) {
-	md, ok := metadata.FromIncomingContext(ctx)
+	token, ok := bearerFromContext(ctx)
 	if !ok {
-		return nil, status.Error(codes.Unauthenticated, "missing request metadata")
-	}
-	values := md.Get("authorization")
-	if len(values) == 0 {
 		return nil, status.Error(codes.Unauthenticated, "missing authorization token")
 	}
-	token := strings.TrimPrefix(values[0], "Bearer ")
 	id, err := s.auth.AuthenticateAgent(token)
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, "invalid agent token")
 	}
 	return id, nil
+}
+
+// bearerFromContext pulls the raw bearer token (Bearer prefix stripped) from the
+// incoming gRPC metadata. ok is false when no metadata or no authorization
+// header is present. It is the shared extraction used by both identify (to
+// authenticate) and renewToken (to re-mint the same token).
+func bearerFromContext(ctx context.Context) (string, bool) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return "", false
+	}
+	values := md.Get("authorization")
+	if len(values) == 0 {
+		return "", false
+	}
+	return strings.TrimPrefix(values[0], "Bearer "), true
 }
 
 // mapState translates a protobuf task state into the domain vocabulary.

--- a/internal/agentrpc/streamlogs_transport_test.go
+++ b/internal/agentrpc/streamlogs_transport_test.go
@@ -67,7 +67,7 @@ func TestStreamLogsOverRealTransport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("IssueAgentToken: %v", err)
 	}
-	client, conn, err := agent.Dial(lis.Addr().String(), token, true, "")
+	client, conn, _, err := agent.Dial(lis.Addr().String(), token, true, "")
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}

--- a/internal/agentrpc/tls_test.go
+++ b/internal/agentrpc/tls_test.go
@@ -127,7 +127,7 @@ func TestSecretsOverTLSWithoutInsecureFlag(t *testing.T) {
 		t.Fatal(err)
 	}
 	// allowInsecure=false + the cert as the CA → verified TLS.
-	client, conn, err := agent.Dial(lis.Addr().String(), token, false, certPath)
+	client, conn, _, err := agent.Dial(lis.Addr().String(), token, false, certPath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/auth/agent_token.go
+++ b/internal/auth/agent_token.go
@@ -30,19 +30,36 @@ type agentClaims struct {
 	RunID     string `json:"run_id"`
 	TaskID    string `json:"task_id"`
 	TryNumber int    `json:"try_number"`
+	// OriginIssuedAt records when this attempt's credential was FIRST minted (at
+	// dispatch). Unlike iat, it is preserved verbatim across heartbeat renewals so
+	// the control plane can bound an attempt's total credential lifetime no matter
+	// how many times its token is re-minted (ADR 0055 Fix #4). Absent on tokens
+	// minted before this field existed; renewal then falls back to iat.
+	OriginIssuedAt *jwt.NumericDate `json:"oiat,omitempty"`
 	jwt.RegisteredClaims
 }
 
 // IssueAgentToken mints a signed token that identifies a single task instance,
 // valid for the given TTL. The control plane passes it to the worker pod.
+//
+// The token's origin (oiat) is set to the mint time — this is a fresh dispatch.
+// Renewal (RenewAgentToken) preserves that origin instead of resetting it.
 func (a *JWTAuthenticator) IssueAgentToken(id AgentIdentity, ttl time.Duration) (string, error) {
-	now := time.Now()
+	return a.mintAgentToken(id, ttl, a.clock())
+}
+
+// mintAgentToken signs an agent token whose iat/exp are anchored at now and whose
+// preserved dispatch-origin is `origin`. Dispatch passes now as the origin; a
+// renewal passes the incoming token's origin so it never advances.
+func (a *JWTAuthenticator) mintAgentToken(id AgentIdentity, ttl time.Duration, origin time.Time) (string, error) {
+	now := a.clock()
 	c := agentClaims{
-		TenantID:  id.TenantID,
-		DagID:     id.DagID,
-		RunID:     id.RunID,
-		TaskID:    id.TaskID,
-		TryNumber: id.TryNumber,
+		TenantID:       id.TenantID,
+		DagID:          id.DagID,
+		RunID:          id.RunID,
+		TaskID:         id.TaskID,
+		TryNumber:      id.TryNumber,
+		OriginIssuedAt: jwt.NewNumericDate(origin),
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject:   id.TaskInstanceID,
 			Issuer:    tokenIssuer,
@@ -58,13 +75,64 @@ func (a *JWTAuthenticator) IssueAgentToken(id AgentIdentity, ttl time.Duration) 
 	return signed, nil
 }
 
+// RenewAgentToken validates an in-flight agent bearer token and re-mints it for
+// the SAME task instance with a fresh short TTL, refreshing the live window
+// without ever changing what AuthenticateAgent verifies (signature, issuer,
+// leoflow-agent audience, HS256). It is the heartbeat-driven half of the
+// short-TTL-plus-renewal design (ADR 0055 Fix #4): the short TTL bounds a
+// stolen or finished token, while renewal keeps a genuinely live task's
+// credential working.
+//
+// The attempt's original dispatch time is preserved across every renewal (the
+// oiat claim). maxLifetime is a hard ceiling on that total age: once the attempt
+// has been alive longer than maxLifetime since first dispatch, renewal is
+// refused (ok=false, empty token) so a runaway attempt's credential lapses
+// instead of being kept alive forever. A non-positive maxLifetime disables the
+// ceiling. exp is always now+ttl — never accumulated onto the previous exp.
+//
+// An invalid incoming token (bad signature, wrong audience, expired) returns an
+// error and is never re-minted.
+func (a *JWTAuthenticator) RenewAgentToken(token string, ttl, maxLifetime time.Duration) (string, bool, error) {
+	var c agentClaims
+	parsed, err := jwt.ParseWithClaims(token, &c, func(*jwt.Token) (any, error) {
+		return a.secret, nil
+	}, jwt.WithIssuer(tokenIssuer), jwt.WithAudience(audienceAgent), jwt.WithValidMethods([]string{"HS256"}), jwt.WithTimeFunc(a.clock))
+	if err != nil || !parsed.Valid {
+		return "", false, errors.Join(ErrInvalidToken, err)
+	}
+	// Preserve the attempt's first-dispatch origin across renewals; fall back to
+	// iat for a token minted before the origin claim existed.
+	origin := time.Time{}
+	if c.OriginIssuedAt != nil {
+		origin = c.OriginIssuedAt.Time
+	} else if c.IssuedAt != nil {
+		origin = c.IssuedAt.Time
+	}
+	if maxLifetime > 0 && !origin.IsZero() && a.clock().Sub(origin) > maxLifetime {
+		return "", false, nil // past the ceiling: let the credential lapse
+	}
+	id := AgentIdentity{
+		TaskInstanceID: c.Subject,
+		TenantID:       c.TenantID,
+		DagID:          c.DagID,
+		RunID:          c.RunID,
+		TaskID:         c.TaskID,
+		TryNumber:      c.TryNumber,
+	}
+	renewed, err := a.mintAgentToken(id, ttl, origin)
+	if err != nil {
+		return "", false, err
+	}
+	return renewed, true, nil
+}
+
 // AuthenticateAgent validates an agent bearer token and returns the task
 // instance it identifies.
 func (a *JWTAuthenticator) AuthenticateAgent(token string) (*AgentIdentity, error) {
 	var c agentClaims
 	parsed, err := jwt.ParseWithClaims(token, &c, func(*jwt.Token) (any, error) {
 		return a.secret, nil
-	}, jwt.WithIssuer(tokenIssuer), jwt.WithAudience(audienceAgent), jwt.WithValidMethods([]string{"HS256"}))
+	}, jwt.WithIssuer(tokenIssuer), jwt.WithAudience(audienceAgent), jwt.WithValidMethods([]string{"HS256"}), jwt.WithTimeFunc(a.clock))
 	if err != nil || !parsed.Valid {
 		return nil, errors.Join(ErrInvalidToken, err)
 	}

--- a/internal/auth/agent_token.go
+++ b/internal/auth/agent_token.go
@@ -92,7 +92,7 @@ func (a *JWTAuthenticator) mintAgentToken(id AgentIdentity, ttl time.Duration, o
 //
 // An invalid incoming token (bad signature, wrong audience, expired) returns an
 // error and is never re-minted.
-func (a *JWTAuthenticator) RenewAgentToken(token string, ttl, maxLifetime time.Duration) (string, bool, error) {
+func (a *JWTAuthenticator) RenewAgentToken(token string, ttl, maxLifetime time.Duration) (renewed string, ok bool, err error) {
 	var c agentClaims
 	parsed, err := jwt.ParseWithClaims(token, &c, func(*jwt.Token) (any, error) {
 		return a.secret, nil
@@ -119,7 +119,7 @@ func (a *JWTAuthenticator) RenewAgentToken(token string, ttl, maxLifetime time.D
 		TaskID:         c.TaskID,
 		TryNumber:      c.TryNumber,
 	}
-	renewed, err := a.mintAgentToken(id, ttl, origin)
+	renewed, err = a.mintAgentToken(id, ttl, origin)
 	if err != nil {
 		return "", false, err
 	}

--- a/internal/auth/agent_token_renewal_test.go
+++ b/internal/auth/agent_token_renewal_test.go
@@ -134,6 +134,42 @@ func TestRenewAgentTokenNoCeiling(t *testing.T) {
 	}
 }
 
+// TestIssueAgentTokenFreshOriginPerDispatch: dispatch mints a fresh credential
+// dated from the dispatch instant, never from the run's age. A retry or
+// clear-and-rerun of an arbitrarily old task instance is a new dispatch, so its
+// token's origin and exp are anchored at the new dispatch — age-independent (D4).
+func TestIssueAgentTokenFreshOriginPerDispatch(t *testing.T) {
+	a := NewJWTAuthenticator(nil, "secret", time.Hour)
+
+	// First attempt dispatched at t0.
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return t0 }
+	try1, err := a.IssueAgentToken(agentIdentity(), 10*time.Minute)
+	if err != nil {
+		t.Fatalf("IssueAgentToken try1: %v", err)
+	}
+	if origin := originOf(t, a, try1); !origin.Equal(t0) {
+		t.Errorf("try1 origin = %v, want the dispatch time %v", origin, t0)
+	}
+
+	// A clear-and-rerun 1000h later is a NEW dispatch: its origin is the new
+	// dispatch instant, not t0, and its short TTL is fresh — the credential is not
+	// aged by the original run's recency.
+	t2 := t0.Add(1000 * time.Hour)
+	a.now = func() time.Time { return t2 }
+	try2, err := a.IssueAgentToken(agentIdentity(), 10*time.Minute)
+	if err != nil {
+		t.Fatalf("IssueAgentToken try2: %v", err)
+	}
+	if origin := originOf(t, a, try2); !origin.Equal(t2) {
+		t.Errorf("clear-and-rerun origin = %v, want the new dispatch time %v (age-independent)", origin, t2)
+	}
+	iat, exp := iatExpOf(t, a, try2)
+	if !iat.Equal(t2) || exp.Sub(iat) != 10*time.Minute {
+		t.Errorf("clear-and-rerun iat/exp = %v/%v, want iat=%v exp-iat=10m", iat, exp, t2)
+	}
+}
+
 // TestRenewAgentTokenRejectsInvalidToken: renewal validates the incoming token
 // exactly as AuthenticateAgent does; a tampered/foreign token is refused with an
 // error, never silently re-minted.

--- a/internal/auth/agent_token_renewal_test.go
+++ b/internal/auth/agent_token_renewal_test.go
@@ -1,0 +1,150 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// originOf decodes the preserved dispatch-origin claim (oiat) from a signed agent
+// token, so a test can assert renewal never advances it.
+func originOf(t *testing.T, a *JWTAuthenticator, token string) time.Time {
+	t.Helper()
+	var c agentClaims
+	if _, err := jwt.ParseWithClaims(token, &c, func(*jwt.Token) (any, error) {
+		return a.secret, nil
+	}, jwt.WithIssuer(tokenIssuer), jwt.WithAudience(audienceAgent), jwt.WithValidMethods([]string{"HS256"}), jwt.WithTimeFunc(a.clock)); err != nil {
+		t.Fatalf("parsing renewed token: %v", err)
+	}
+	if c.OriginIssuedAt == nil {
+		t.Fatalf("renewed token carries no origin (oiat) claim")
+	}
+	return c.OriginIssuedAt.Time
+}
+
+func iatExpOf(t *testing.T, a *JWTAuthenticator, token string) (iat, exp time.Time) {
+	t.Helper()
+	var c agentClaims
+	if _, err := jwt.ParseWithClaims(token, &c, func(*jwt.Token) (any, error) {
+		return a.secret, nil
+	}, jwt.WithIssuer(tokenIssuer), jwt.WithAudience(audienceAgent), jwt.WithValidMethods([]string{"HS256"}), jwt.WithTimeFunc(a.clock)); err != nil {
+		t.Fatalf("parsing token: %v", err)
+	}
+	return c.IssuedAt.Time, c.ExpiresAt.Time
+}
+
+// TestRenewAgentTokenShortTTLAndPreservedOrigin: a renewal for a live attempt
+// re-mints the SAME identity with a fresh short TTL (exp = now + ttl, never
+// accumulating) while preserving the original dispatch time so the attempt's
+// total credential lifetime can be bounded across renewals.
+func TestRenewAgentTokenShortTTLAndPreservedOrigin(t *testing.T) {
+	a := NewJWTAuthenticator(nil, "secret", time.Hour)
+	t0 := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return t0 }
+
+	// Dispatch mints the initial per-attempt token; its origin is t0.
+	dispatched, err := a.IssueAgentToken(agentIdentity(), 10*time.Minute)
+	if err != nil {
+		t.Fatalf("IssueAgentToken: %v", err)
+	}
+	if origin := originOf(t, a, dispatched); !origin.Equal(t0) {
+		t.Fatalf("dispatch origin = %v, want %v", origin, t0)
+	}
+
+	// Five minutes later, the attempt heartbeats and renews.
+	t1 := t0.Add(5 * time.Minute)
+	a.now = func() time.Time { return t1 }
+	renewed, ok, err := a.RenewAgentToken(dispatched, 10*time.Minute, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("RenewAgentToken: %v", err)
+	}
+	if !ok {
+		t.Fatal("renewal within the ceiling must succeed (ok=false)")
+	}
+
+	// The renewed token verifies unchanged (signature/issuer/audience/method) and
+	// carries the same identity.
+	got, err := a.AuthenticateAgent(renewed)
+	if err != nil {
+		t.Fatalf("AuthenticateAgent(renewed): %v", err)
+	}
+	if *got != agentIdentity() {
+		t.Errorf("renewed identity = %+v, want %+v", *got, agentIdentity())
+	}
+
+	// exp = now + ttl exactly (never accumulated onto the previous exp).
+	iat, exp := iatExpOf(t, a, renewed)
+	if !iat.Equal(t1) {
+		t.Errorf("renewed iat = %v, want %v (the renewal instant)", iat, t1)
+	}
+	if exp.Sub(iat) != 10*time.Minute {
+		t.Errorf("renewed exp-iat = %v, want %v (fresh short TTL, no accumulation)", exp.Sub(iat), 10*time.Minute)
+	}
+
+	// The origin is preserved across the renewal — it still points at dispatch.
+	if origin := originOf(t, a, renewed); !origin.Equal(t0) {
+		t.Errorf("renewed origin = %v, want the dispatch time %v (must not advance)", origin, t0)
+	}
+}
+
+// TestRenewAgentTokenCeilingStopsRenewal: once an attempt has been alive past the
+// max-lifetime ceiling since first dispatch, renewal is refused (ok=false, no
+// token) so a runaway attempt's credential lapses rather than living forever.
+func TestRenewAgentTokenCeilingStopsRenewal(t *testing.T) {
+	a := NewJWTAuthenticator(nil, "secret", time.Hour)
+	t0 := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+
+	// Simulate a token that has been renewed for 25h: it is freshly minted (so
+	// still valid) but its preserved origin still points at the original dispatch
+	// at t0. This is exactly the shape RenewAgentToken re-mints on every beat.
+	a.now = func() time.Time { return t0.Add(25 * time.Hour) }
+	aged, err := a.mintAgentToken(agentIdentity(), 10*time.Minute, t0)
+	if err != nil {
+		t.Fatalf("mintAgentToken: %v", err)
+	}
+	renewed, ok, err := a.RenewAgentToken(aged, 10*time.Minute, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("RenewAgentToken must not error past the ceiling: %v", err)
+	}
+	if ok {
+		t.Error("renewal past the max-lifetime ceiling must be refused (ok=true)")
+	}
+	if renewed != "" {
+		t.Error("renewal past the ceiling must not mint a token")
+	}
+}
+
+// TestRenewAgentTokenNoCeiling: a non-positive ceiling disables the bound —
+// renewal always succeeds regardless of age.
+func TestRenewAgentTokenNoCeiling(t *testing.T) {
+	a := NewJWTAuthenticator(nil, "secret", time.Hour)
+	t0 := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return t0.Add(1000 * time.Hour) }
+	aged, err := a.mintAgentToken(agentIdentity(), 10*time.Minute, t0)
+	if err != nil {
+		t.Fatalf("mintAgentToken: %v", err)
+	}
+	_, ok, err := a.RenewAgentToken(aged, 10*time.Minute, 0)
+	if err != nil {
+		t.Fatalf("RenewAgentToken: %v", err)
+	}
+	if !ok {
+		t.Error("a non-positive ceiling must never refuse renewal")
+	}
+}
+
+// TestRenewAgentTokenRejectsInvalidToken: renewal validates the incoming token
+// exactly as AuthenticateAgent does; a tampered/foreign token is refused with an
+// error, never silently re-minted.
+func TestRenewAgentTokenRejectsInvalidToken(t *testing.T) {
+	a := NewJWTAuthenticator(nil, "secret", time.Hour)
+	other := NewJWTAuthenticator(nil, "different-secret", time.Hour)
+	foreign, err := other.IssueAgentToken(agentIdentity(), 10*time.Minute)
+	if err != nil {
+		t.Fatalf("IssueAgentToken: %v", err)
+	}
+	if _, ok, err := a.RenewAgentToken(foreign, 10*time.Minute, 24*time.Hour); err == nil || ok {
+		t.Errorf("renewing a foreign-signed token must fail; got ok=%v err=%v", ok, err)
+	}
+}

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -33,12 +33,26 @@ type JWTAuthenticator struct {
 	store  UserStore
 	secret []byte
 	ttl    time.Duration
+	// now is the clock used when stamping agent-token iat/exp/origin. It defaults
+	// to time.Now and is overridden only in tests, so renewal exp/ceiling math is
+	// deterministic.
+	now func() time.Time
 }
 
 // NewJWTAuthenticator builds a JWTAuthenticator with the given user store,
 // HS256 secret, and token lifetime.
 func NewJWTAuthenticator(store UserStore, secret string, ttl time.Duration) *JWTAuthenticator {
-	return &JWTAuthenticator{store: store, secret: []byte(secret), ttl: ttl}
+	return &JWTAuthenticator{store: store, secret: []byte(secret), ttl: ttl, now: time.Now}
+}
+
+// clock returns the authenticator's time source, tolerating a zero value on an
+// authenticator built as a struct literal (e.g. MintUserToken) rather than via
+// the constructor.
+func (a *JWTAuthenticator) clock() time.Time {
+	if a.now != nil {
+		return a.now()
+	}
+	return time.Now()
 }
 
 // MintUserToken signs a user JWT directly, without checking credentials against

--- a/internal/config/max_attempt_lifetime_test.go
+++ b/internal/config/max_attempt_lifetime_test.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+// TestMaxAttemptCredentialLifetimeDefault: the ceiling defaults generous (24h)
+// so per-attempt token renewal never regresses a normal long task.
+func TestMaxAttemptCredentialLifetimeDefault(t *testing.T) {
+	c, err := LoadServer("", nil)
+	if err != nil {
+		t.Fatalf("LoadServer: %v", err)
+	}
+	if got := c.Auth.MaxAttemptCredentialLifetime; got != 24*time.Hour {
+		t.Errorf("auth.max_attempt_credential_lifetime default = %v, want 24h", got)
+	}
+}
+
+// TestMaxAttemptCredentialLifetimeEnvBinds: the operator can shorten the ceiling
+// via LEOFLOW_AUTH_MAX_ATTEMPT_CREDENTIAL_LIFETIME as a duration string.
+func TestMaxAttemptCredentialLifetimeEnvBinds(t *testing.T) {
+	t.Setenv("LEOFLOW_AUTH_MAX_ATTEMPT_CREDENTIAL_LIFETIME", "90m")
+	c, err := LoadServer("", nil)
+	if err != nil {
+		t.Fatalf("LoadServer: %v", err)
+	}
+	if got := c.Auth.MaxAttemptCredentialLifetime; got != 90*time.Minute {
+		t.Errorf("auth.max_attempt_credential_lifetime = %v, want 90m", got)
+	}
+}

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -296,6 +297,15 @@ type AuthSection struct {
 	// would-have-denied when the caller's TI is not live but still delivers;
 	// enforce denies with PermissionDenied. Empty = the observe default.
 	SecretLivenessMode string `mapstructure:"secret_liveness_mode"`
+	// MaxAttemptCredentialLifetime is the hard ceiling on how long a single task
+	// attempt's agent credential may be kept alive by heartbeat renewal (ADR 0055
+	// Fix #4). Past this age since first dispatch, the control plane stops renewing
+	// the token on heartbeat and lets it lapse, bounding a runaway attempt. The
+	// short per-attempt TTL still bounds a stolen/finished token independently;
+	// this only caps the total renewed lifetime. Generous by default (24h) so no
+	// normal task regresses. Bind via LEOFLOW_AUTH_MAX_ATTEMPT_CREDENTIAL_LIFETIME
+	// as a duration (e.g. "24h", "90m"); a non-positive value disables the ceiling.
+	MaxAttemptCredentialLifetime time.Duration `mapstructure:"max_attempt_credential_lifetime"`
 }
 
 // JWTSection configures JWT issuance and validation.
@@ -436,6 +446,10 @@ var serverDefaults = map[string]any{
 	// flips (enforce) are separate operator decisions after an observe period.
 	"auth.secret_scoping":       "permissive",
 	"auth.secret_liveness_mode": "observe",
+	// Hard ceiling on an attempt's total renewed credential lifetime (ADR 0055
+	// Fix #4). Generous by default so nothing regresses; the short per-attempt TTL
+	// is what bounds a stolen token. Parsed as a duration by viper's decode hook.
+	"auth.max_attempt_credential_lifetime": "24h",
 	// OIDC leaves. Every leaf is registered so viper's AutomaticEnv binds the
 	// scalar LEOFLOW_AUTH_OIDC_* env vars (notably the client secret). The map and
 	// slice leaves are config-file / Helm-values driven — viper does not split a

--- a/internal/storage/secret_enforcement_integration_test.go
+++ b/internal/storage/secret_enforcement_integration_test.go
@@ -73,7 +73,7 @@ func dialSecretServer(t *testing.T, exec *storage.ExecutionStore, repo *storage.
 	if err != nil {
 		t.Fatalf("IssueAgentToken: %v", err)
 	}
-	client, conn, err := agent.Dial(lis.Addr().String(), token, true, "")
+	client, conn, _, err := agent.Dial(lis.Addr().String(), token, true, "")
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}

--- a/proto/agent.proto
+++ b/proto/agent.proto
@@ -199,4 +199,11 @@ message HeartbeatRequest {
 message HeartbeatResponse {
     bool should_terminate = 1;
     google.protobuf.Timestamp server_time = 2;
+    // A freshly minted, task-scoped agent token the control plane issues when the
+    // heartbeat proves the attempt is still live (ADR 0055 Fix #4). When non-empty
+    // the agent atomically swaps its bearer to this value, so a long task keeps a
+    // working credential while the short per-attempt TTL bounds a stolen/finished
+    // one. Empty means "keep the current token" (no renewal this beat, or the
+    // attempt is superseded/past its lifetime ceiling). Never logged.
+    string renewed_token = 3;
 }

--- a/proto/agent/v1/agent.pb.go
+++ b/proto/agent/v1/agent.pb.go
@@ -1273,8 +1273,15 @@ type HeartbeatResponse struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	ShouldTerminate bool                   `protobuf:"varint,1,opt,name=should_terminate,json=shouldTerminate,proto3" json:"should_terminate,omitempty"`
 	ServerTime      *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=server_time,json=serverTime,proto3" json:"server_time,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// A freshly minted, task-scoped agent token the control plane issues when the
+	// heartbeat proves the attempt is still live (ADR 0055 Fix #4). When non-empty
+	// the agent atomically swaps its bearer to this value, so a long task keeps a
+	// working credential while the short per-attempt TTL bounds a stolen/finished
+	// one. Empty means "keep the current token" (no renewal this beat, or the
+	// attempt is superseded/past its lifetime ceiling). Never logged.
+	RenewedToken  string `protobuf:"bytes,3,opt,name=renewed_token,json=renewedToken,proto3" json:"renewed_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *HeartbeatResponse) Reset() {
@@ -1319,6 +1326,13 @@ func (x *HeartbeatResponse) GetServerTime() *timestamppb.Timestamp {
 		return x.ServerTime
 	}
 	return nil
+}
+
+func (x *HeartbeatResponse) GetRenewedToken() string {
+	if x != nil {
+		return x.RenewedToken
+	}
+	return ""
 }
 
 var File_agent_proto protoreflect.FileDescriptor
@@ -1433,11 +1447,12 @@ const file_agent_proto_rawDesc = "" +
 	"\x0ecustom_metrics\x18\x02 \x03(\v25.leoflow.agent.v1.HeartbeatRequest.CustomMetricsEntryR\rcustomMetrics\x1a@\n" +
 	"\x12CustomMetricsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\x01R\x05value:\x028\x01\"{\n" +
+	"\x05value\x18\x02 \x01(\x01R\x05value:\x028\x01\"\xa0\x01\n" +
 	"\x11HeartbeatResponse\x12)\n" +
 	"\x10should_terminate\x18\x01 \x01(\bR\x0fshouldTerminate\x12;\n" +
 	"\vserver_time\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
-	"serverTime*w\n" +
+	"serverTime\x12#\n" +
+	"\rrenewed_token\x18\x03 \x01(\tR\frenewedToken*w\n" +
 	"\bLogLevel\x12\x19\n" +
 	"\x15LOG_LEVEL_UNSPECIFIED\x10\x00\x12\x13\n" +
 	"\x0fLOG_LEVEL_DEBUG\x10\x01\x12\x12\n" +


### PR DESCRIPTION
Lane E, Fix #4 (ADR 0055 D4). Closes #664. Retires the flat 24h agent-token TTL: a short per-attempt token that renews on the liveness heartbeat — a long task keeps a live credential, a stolen/finished one expires in minutes.

- **Short TTL** = `max(~10min floor, 4 × HeartbeatInterval)`, derived (not author/duration-estimated); used at dispatch AND as the renewal TTL.
- **Renew on heartbeat:** on the `RecordHeartbeat==nil` branch (liveness proof), re-mint the same identity's token, fresh short TTL, returned in the new `HeartbeatResponse.renewed_token`; the agent swaps the bearer thread-safely (verified under `-race` + a real gRPC round-trip). Renewal happens ONLY on that branch.
- **Superseded/terminal heartbeat → `ShouldTerminate` + NO token** (never both). Transient DB error → neither terminate nor renew.
- **Operator ceiling** `auth.max_attempt_credential_lifetime` (default 24h) via a preserved `oiat` origin claim — a runaway attempt lapses past the ceiling. `exp = now+shortTTL` each beat, never accumulated.
- **Retry / clear-and-rerun = fresh dispatch token** (age-independent — origin/exp anchored at the new dispatch, not the run's age). Long task keeps working.
- `AuthenticateAgent` verification unchanged; proto regenerated in-sync (`buf generate` no diff).

### Verification
`go build`/`go vet`(+`-tags integration`)/`gofmt`/`buf`/`go mod tidy` clean · `golangci-lint run ./...` **0** · auth/agentrpc/agent/config/dispatch unit tests pass under `-race` · two-sided token tests (live renews, superseded lapses, ceiling stops, missed-beat tolerance, real round-trip) · integration compile-verified. Strict TDD, no AI attribution.

Focused review done (renewal-only-on-liveness + no-token-on-superseded spot-checked). Safe: renewal only shortens the live window.