### PR TITLE
feat(agent): projected-SA token exchange transport (ADR 0055 Fix #3, flag-gated off)

### DIFF
--- a/cmd/leoflow-agent/main.go
+++ b/cmd/leoflow-agent/main.go
@@ -33,6 +33,25 @@ Flags:
 
 func main() { os.Exit(run()) }
 
+// bootstrapToken resolves the agent's initial bearer and whether a token exchange
+// is required (ADR 0055 Fix #3). Under the exchange transport it reads the
+// projected ServiceAccount token from LEOFLOW_AGENT_TOKEN_PATH (the bootstrap
+// credential to exchange); otherwise it returns LEOFLOW_AGENT_TOKEN unchanged
+// (the env-var default). exchange is true only when both the transport marker and
+// the token path are set.
+func bootstrapToken() (token string, exchange bool, err error) {
+	if os.Getenv("LEOFLOW_AGENT_TOKEN_TRANSPORT") == "exchange" {
+		if path := os.Getenv("LEOFLOW_AGENT_TOKEN_PATH"); path != "" {
+			projected, rerr := agent.ReadTokenFile(path)
+			if rerr != nil {
+				return "", true, rerr
+			}
+			return projected, true, nil
+		}
+	}
+	return os.Getenv("LEOFLOW_AGENT_TOKEN"), false, nil
+}
+
 func run() int {
 	// Answer `--version`/`--help` before connecting, so an operator can query a
 	// deployed agent without a reachable control plane (#593). Without this,
@@ -58,16 +77,10 @@ func run() int {
 	// which the agent exchanges once for a task-scoped JWT after dialing. The
 	// default env-var transport leaves the path unset and uses LEOFLOW_AGENT_TOKEN
 	// directly (byte-identical to before).
-	exchange := os.Getenv("LEOFLOW_AGENT_TOKEN_TRANSPORT") == "exchange"
-	tokenPath := os.Getenv("LEOFLOW_AGENT_TOKEN_PATH")
-	token := os.Getenv("LEOFLOW_AGENT_TOKEN")
-	if exchange && tokenPath != "" {
-		projected, rerr := agent.ReadTokenFile(tokenPath)
-		if rerr != nil {
-			slog.Error("reading projected bootstrap token", "error", rerr)
-			return 1
-		}
-		token = projected
+	token, exchange, berr := bootstrapToken()
+	if berr != nil {
+		slog.Error("reading projected bootstrap token", "error", berr)
+		return 1
 	}
 
 	client, conn, tokens, err := agent.Dial(addr, token, allowInsecure, caFile)
@@ -87,7 +100,7 @@ func run() int {
 	// Exchange the projected bootstrap token for the task-scoped JWT before any
 	// other RPC, then swap it into the shared TokenSource so every subsequent call
 	// authenticates as the task instance. Fails startup if the exchange is refused.
-	if exchange && tokenPath != "" {
+	if exchange {
 		if xerr := agent.ExchangeToken(ctx, client, tokens); xerr != nil {
 			slog.Error("exchanging bootstrap token for a task-scoped credential", "error", xerr)
 			return 1

--- a/cmd/leoflow-agent/main.go
+++ b/cmd/leoflow-agent/main.go
@@ -50,9 +50,25 @@ func run() int {
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, nil)))
 
 	addr := os.Getenv("LEOFLOW_CONTROL_PLANE_ADDR")
-	token := os.Getenv("LEOFLOW_AGENT_TOKEN")
 	allowInsecure := os.Getenv("LEOFLOW_AGENT_INSECURE") != "false"
 	caFile := os.Getenv("LEOFLOW_AGENT_TLS_CA") // PEM CA to verify the server cert (TLS)
+
+	// Bootstrap credential: under the exchange transport (ADR 0055 Fix #3) the
+	// control plane projects a ServiceAccount token at LEOFLOW_AGENT_TOKEN_PATH,
+	// which the agent exchanges once for a task-scoped JWT after dialing. The
+	// default env-var transport leaves the path unset and uses LEOFLOW_AGENT_TOKEN
+	// directly (byte-identical to before).
+	exchange := os.Getenv("LEOFLOW_AGENT_TOKEN_TRANSPORT") == "exchange"
+	tokenPath := os.Getenv("LEOFLOW_AGENT_TOKEN_PATH")
+	token := os.Getenv("LEOFLOW_AGENT_TOKEN")
+	if exchange && tokenPath != "" {
+		projected, rerr := agent.ReadTokenFile(tokenPath)
+		if rerr != nil {
+			slog.Error("reading projected bootstrap token", "error", rerr)
+			return 1
+		}
+		token = projected
+	}
 
 	client, conn, tokens, err := agent.Dial(addr, token, allowInsecure, caFile)
 	if err != nil {
@@ -67,6 +83,16 @@ func run() int {
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
+
+	// Exchange the projected bootstrap token for the task-scoped JWT before any
+	// other RPC, then swap it into the shared TokenSource so every subsequent call
+	// authenticates as the task instance. Fails startup if the exchange is refused.
+	if exchange && tokenPath != "" {
+		if xerr := agent.ExchangeToken(ctx, client, tokens); xerr != nil {
+			slog.Error("exchanging bootstrap token for a task-scoped credential", "error", xerr)
+			return 1
+		}
+	}
 
 	sink, err := agent.OpenLogSink(ctx, client)
 	if err != nil {

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/neochaotic/leoflow/internal/domain"
 	"github.com/neochaotic/leoflow/internal/executor"
 	"github.com/neochaotic/leoflow/internal/failurealert"
+	"github.com/neochaotic/leoflow/internal/kubeexchange"
 	"github.com/neochaotic/leoflow/internal/logs"
 	"github.com/neochaotic/leoflow/internal/observability"
 	"github.com/neochaotic/leoflow/internal/oidc"
@@ -344,7 +345,7 @@ func startSchedulerSide(ctx context.Context, cfg *config.ServerConfig, pg *stora
 	if !servesScheduler {
 		return nil, false, func() {}, nil
 	}
-	grpcSrv, gerr := startAgentGRPC(ctx, cfg.Server.GRPCAddr, authn, execStore, repo, xcomSvc, logSink, logTailer, allowInsecureSecrets, cfg.Auth.SecretScoping, cfg.Auth.SecretLivenessMode, cfg.Auth.MaxAttemptCredentialLifetime, cfg.Server.GRPCTLSCert, cfg.Server.GRPCTLSKey, logger)
+	grpcSrv, gerr := startAgentGRPC(ctx, cfg.Server.GRPCAddr, authn, execStore, repo, xcomSvc, logSink, logTailer, allowInsecureSecrets, cfg.Auth.SecretScoping, cfg.Auth.SecretLivenessMode, cfg.Auth.MaxAttemptCredentialLifetime, buildTokenExchange(cfg, logger), cfg.Server.GRPCTLSCert, cfg.Server.GRPCTLSKey, logger)
 	if gerr != nil {
 		return nil, false, nil, gerr
 	}
@@ -516,7 +517,7 @@ func serveHTTP(ctx context.Context, logger *slog.Logger, servesAPI bool, apiSrv,
 // shutdown. TLS is enabled when tlsCert/tlsKey are set (issue #58); otherwise the
 // channel is plaintext (dev). The per-task bearer token in metadata authenticates
 // each call regardless.
-func startAgentGRPC(ctx context.Context, addr string, authn *auth.JWTAuthenticator, store *storage.ExecutionStore, secretsStore agentrpc.SecretsStore, xcomSvc agentrpc.XComService, logSink agentrpc.LogSink, logTailer agentrpc.LogPublisher, allowInsecureSecrets bool, secretScoping, secretLivenessMode string, maxAttemptLifetime time.Duration, tlsCert, tlsKey string, logger *slog.Logger) (*grpc.Server, error) {
+func startAgentGRPC(ctx context.Context, addr string, authn *auth.JWTAuthenticator, store *storage.ExecutionStore, secretsStore agentrpc.SecretsStore, xcomSvc agentrpc.XComService, logSink agentrpc.LogSink, logTailer agentrpc.LogPublisher, allowInsecureSecrets bool, secretScoping, secretLivenessMode string, maxAttemptLifetime time.Duration, exchange *tokenExchange, tlsCert, tlsKey string, logger *slog.Logger) (*grpc.Server, error) {
 	var lc net.ListenConfig
 	lis, err := lc.Listen(ctx, "tcp", addr)
 	if err != nil {
@@ -538,6 +539,13 @@ func startAgentGRPC(ctx context.Context, addr string, authn *auth.JWTAuthenticat
 	// ExecutionStore is the read-only liveness predicate; the mode defaults to
 	// observe (log a would-have-denied, still deliver). Secret-path only.
 	agentSrv.SetLivenessGate(store, secretLivenessMode)
+	// Projected-SA-token exchange (ADR 0055 Fix #3). Wired only when the operator
+	// selected the exchange transport on a Kubernetes executor; nil (the default)
+	// leaves ExchangeToken Unimplemented, so the env-var transport is unchanged.
+	if exchange != nil {
+		agentSrv.SetTokenExchange(exchange.reviewer, exchange.resolver, authn, attemptTokenTTL, allowInsecureSecrets)
+		logger.Warn("agent token exchange enabled (projected SA token → TokenReview → task-scoped JWT); real-cluster e2e owed before flipping this on in production")
+	}
 	// The secrets store is the Repository, which also records the warn-phase
 	// secret-scope audit event (ADR 0045, ADR 0055); wire it as the auditor so a
 	// narrowly-declared task's full-vault delivery is surfaced. Optional: without
@@ -575,6 +583,36 @@ func startAgentGRPC(ctx context.Context, addr string, authn *auth.JWTAuthenticat
 	}()
 	logger.Info("agent grpc server started", "grpc_addr", addr, "tls", secure)
 	return srv, nil
+}
+
+// tokenExchange bundles the Kubernetes-backed dependencies of the agent
+// token-exchange transport (ADR 0055 Fix #3): the TokenReview client and the
+// pod→task-instance resolver. nil means the exchange is not wired (the default
+// env-var transport), in which case ExchangeToken reports Unimplemented.
+type tokenExchange struct {
+	reviewer agentrpc.TokenReviewer
+	resolver agentrpc.PodTaskResolver
+}
+
+// buildTokenExchange constructs the exchange dependencies when the operator
+// selected the exchange transport on a Kubernetes executor; it returns nil
+// otherwise (env-var default, or the subprocess executor, which has no pod/SA/
+// TokenReview). A Kubernetes client that cannot be built leaves the exchange
+// unwired with a warning — matching pod dispatch's warn-and-disable posture —
+// rather than failing boot, since the transport flip is a deliberate opt-in.
+func buildTokenExchange(cfg *config.ServerConfig, logger *slog.Logger) *tokenExchange {
+	if cfg.Auth.AgentTokenTransport != config.AgentTokenTransportExchange || cfg.Executor.Type != "kubernetes" {
+		return nil
+	}
+	cs, err := buildK8sClient()
+	if err != nil {
+		logger.Warn("agent token exchange selected but no Kubernetes client is available; exchange disabled (agents on the exchange transport will fail to start)", "error", err)
+		return nil
+	}
+	return &tokenExchange{
+		reviewer: kubeexchange.NewTokenReviewer(cs, executor.DefaultAgentTokenAudience),
+		resolver: kubeexchange.NewPodResolver(cs, cfg.Executor.TaskNamespace),
+	}
 }
 
 // buildPodExecutor constructs a Kubernetes executor from the in-cluster config
@@ -1143,6 +1181,12 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 	dispatcher := dispatch.NewDispatcher(podExec, execStore, authn, controlAddr, attemptTokenTTL)
 	dispatcher.SetAgentTLSCAConfigMap(cfg.Executor.AgentTLSCAConfigMap)
 	dispatcher.SetTaskSecret(cfg.Executor.TaskSecretName, cfg.Executor.TaskSecretMountPath)
+	// Agent-token transport (ADR 0055 Fix #3). Under the exchange transport the
+	// executor projects a ServiceAccount token instead of the plaintext one; the
+	// default (envvar) leaves the pod spec unchanged. The audience is the shared
+	// const the control-plane TokenReviewer validates against; expiration floors in
+	// BuildPod.
+	dispatcher.SetAgentTokenTransport(cfg.Auth.AgentTokenTransport, executor.DefaultAgentTokenAudience, 0)
 	dispatcher.SetPlatformDefaults(platformDefaults(cfg.Executor.Defaults))
 	disp, closer := wrapBuffered(dispatcher, store, logger, metrics, cfg.Scheduler.Dispatch) //nolint:contextcheck // buffered worker deliberately detaches from caller ctx
 	sched.SetDispatcher(disp)

--- a/docs/adr/0055-secret-scoping-and-token-liveness.md
+++ b/docs/adr/0055-secret-scoping-and-token-liveness.md
@@ -434,9 +434,30 @@ landed, #476), not by this ADR.
 
 ## Verify at implementation
 
-- Exact `TokenReview` bound-token `extra` keys
-  (`authentication.kubernetes.io/pod-name`, `authentication.kubernetes.io/pod-uid`)
-  for the target apiserver version, used to resolve pod → task-instance.
-- Projected-token minimum-TTL floor (~10 min) versus the shortest expected
-  attempt, so a very short task's bootstrap token has not already expired at
-  `Register`.
+The transport-exchange transport (Fix #3) ships **flag-gated, default off**
+(`auth.agent_token_transport: envvar | exchange`, default `envvar`). The env-var
+path is byte-identical to before; the exchange path is Pro/Kubernetes-executor
+only, behind the executor interface, and the subprocess (Lite) path is untouched.
+The `TokenReview` call cannot be validated without a real apiserver, so the flip
+to `exchange` in production is a later operator decision (the same posture as the
+scope-enforce and liveness-enforce flips), gated on the owed e2e below.
+
+- **D7 bound-token `extra` keys — pinned.** The resolver keys on
+  `authentication.kubernetes.io/pod-name` (with
+  `authentication.kubernetes.io/pod-uid` as a stale-pod guard) from the
+  `TokenReview` status, then reads the exact (unsanitized) task-instance identity
+  the executor stamped on the pod as the `leoflow.io/agent-identity` annotation —
+  pod labels are sanitized and lossy, so the annotation is the single-sourced
+  contract both sides share. The `TokenReview` client and the pod resolver are
+  injected as interfaces and unit-tested with mocks / a fake clientset; the exact
+  extra-key availability is apiserver-version-dependent and is confirmed only by
+  the owed real-cluster e2e.
+- **Projected-token minimum-TTL floor** is enforced at ~10 min (600s) in the pod
+  builder, floored above any shorter requested value, so a very short task's
+  bootstrap token has not already expired at exchange time.
+- **OWED — real-cluster e2e before the `exchange` flip.** Exercise, against a real
+  apiserver: a projected SA token minted for the control-plane audience →
+  `TokenReview` authenticates it → the bound-token extra keys resolve the pod →
+  the pod's identity annotation resolves the attempt → the minted task-scoped JWT
+  authenticates the steady-state RPCs, and a wrong-audience / expired projected
+  token is rejected. Until this runs, `exchange` must not be the default.

--- a/internal/agent/exchange.go
+++ b/internal/agent/exchange.go
@@ -1,0 +1,48 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+)
+
+// ExchangeToken performs the one-time bootstrap token exchange (ADR 0055 Fix #3):
+// it calls the control plane's ExchangeToken RPC carrying the current bootstrap
+// bearer (the projected ServiceAccount token) and swaps the returned task-scoped
+// agent JWT into tokens, so every subsequent RPC authenticates as the task
+// instance. It runs ONLY under the exchange transport, before any other RPC; the
+// default env-var transport never calls it.
+//
+// It fails the startup on any error: the agent must never proceed with a
+// bootstrap credential the control plane rejected, nor with an empty token.
+func ExchangeToken(ctx context.Context, client agentv1.AgentServiceClient, tokens *TokenSource) error {
+	resp, err := client.ExchangeToken(ctx, &agentv1.ExchangeTokenRequest{})
+	if err != nil {
+		return fmt.Errorf("exchanging bootstrap token: %w", err)
+	}
+	minted := resp.GetAgentToken()
+	if minted == "" {
+		return errors.New("token exchange returned an empty agent token")
+	}
+	tokens.Set(minted)
+	return nil
+}
+
+// ReadTokenFile reads a projected token from path and trims surrounding
+// whitespace (the kubelet writes the token without a trailing newline, but trim
+// defensively so the bearer matches exactly what the apiserver signed).
+func ReadTokenFile(path string) (string, error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // G304: token path is set by the control plane on the pod spec.
+	if err != nil {
+		return "", fmt.Errorf("reading projected token %q: %w", path, err)
+	}
+	token := strings.TrimSpace(string(raw))
+	if token == "" {
+		return "", fmt.Errorf("projected token file %q is empty", path)
+	}
+	return token, nil
+}

--- a/internal/agent/exchange_test.go
+++ b/internal/agent/exchange_test.go
@@ -1,0 +1,96 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"google.golang.org/grpc"
+
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+)
+
+// exchangeClient overrides ExchangeToken to return a configured token or error;
+// all other RPCs fall back to fakeClient.
+type exchangeClient struct {
+	*fakeClient
+	token string
+	err   error
+	calls int
+}
+
+func (c *exchangeClient) ExchangeToken(context.Context, *agentv1.ExchangeTokenRequest, ...grpc.CallOption) (*agentv1.ExchangeTokenResponse, error) {
+	c.calls++
+	if c.err != nil {
+		return nil, c.err
+	}
+	return &agentv1.ExchangeTokenResponse{AgentToken: c.token}, nil
+}
+
+// TestExchangeTokenSwapsBearer: the agent exchanges its bootstrap (projected)
+// token for the returned task-scoped JWT and swaps it into the shared
+// TokenSource, so every subsequent RPC authenticates as the task instance.
+func TestExchangeTokenSwapsBearer(t *testing.T) {
+	tokens := NewTokenSource("projected-bootstrap")
+	client := &exchangeClient{fakeClient: &fakeClient{}, token: "task-scoped-jwt"}
+
+	if err := ExchangeToken(context.Background(), client, tokens); err != nil {
+		t.Fatalf("ExchangeToken: %v", err)
+	}
+	if got := tokens.Token(); got != "task-scoped-jwt" {
+		t.Errorf("bearer after exchange = %q, want the task-scoped JWT", got)
+	}
+	if client.calls != 1 {
+		t.Errorf("ExchangeToken called %d times, want exactly once", client.calls)
+	}
+}
+
+// TestExchangeTokenSurfacesError: an exchange failure aborts startup — the agent
+// must never proceed with a bootstrap credential the control plane rejected.
+func TestExchangeTokenSurfacesError(t *testing.T) {
+	tokens := NewTokenSource("projected-bootstrap")
+	client := &exchangeClient{fakeClient: &fakeClient{}, err: errors.New("projected token is not valid")}
+
+	if err := ExchangeToken(context.Background(), client, tokens); err == nil {
+		t.Error("a rejected exchange must return an error")
+	}
+	if got := tokens.Token(); got != "projected-bootstrap" {
+		t.Errorf("bearer must be unchanged after a failed exchange, got %q", got)
+	}
+}
+
+// TestExchangeTokenRejectsEmpty: an empty returned token is a protocol fault, not
+// a working credential — fail rather than silently keep the bootstrap token.
+func TestExchangeTokenRejectsEmpty(t *testing.T) {
+	tokens := NewTokenSource("projected-bootstrap")
+	client := &exchangeClient{fakeClient: &fakeClient{}, token: ""}
+	if err := ExchangeToken(context.Background(), client, tokens); err == nil {
+		t.Error("an empty exchanged token must return an error")
+	}
+}
+
+// TestReadTokenFileTrims: the projected token file is read and trailing
+// whitespace/newlines trimmed so the bearer matches what the apiserver signed.
+func TestReadTokenFileTrims(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token")
+	if err := os.WriteFile(path, []byte("the-projected-token\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadTokenFile(path)
+	if err != nil {
+		t.Fatalf("ReadTokenFile: %v", err)
+	}
+	if got != "the-projected-token" {
+		t.Errorf("ReadTokenFile = %q, want trimmed token", got)
+	}
+}
+
+// TestReadTokenFileMissing: a missing file is an error (the exchange cannot run).
+func TestReadTokenFileMissing(t *testing.T) {
+	if _, err := ReadTokenFile(filepath.Join(t.TempDir(), "absent")); err == nil {
+		t.Error("ReadTokenFile on a missing path must error")
+	}
+}

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -49,6 +49,10 @@ func (f *fakeClient) GetConnections(context.Context, *agentv1.GetConnectionsRequ
 	return &agentv1.GetConnectionsResponse{ConnectionUris: f.conns}, nil
 }
 
+func (f *fakeClient) ExchangeToken(context.Context, *agentv1.ExchangeTokenRequest, ...grpc.CallOption) (*agentv1.ExchangeTokenResponse, error) {
+	return &agentv1.ExchangeTokenResponse{AgentToken: "exchanged"}, nil
+}
+
 func (f *fakeClient) Register(context.Context, *agentv1.RegisterRequest, ...grpc.CallOption) (*agentv1.RegisterResponse, error) {
 	f.registered = true
 	return &agentv1.RegisterResponse{SessionId: "s1"}, nil

--- a/internal/agentrpc/exchange.go
+++ b/internal/agentrpc/exchange.go
@@ -1,0 +1,128 @@
+package agentrpc
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+)
+
+// ReviewedPod is the pod a validated projected ServiceAccount token identifies.
+// The concrete TokenReviewer fills it from the Kubernetes TokenReview response —
+// the bound-token status carries the pod name/uid the token was issued for. The
+// field names the control plane resolves a task instance from are
+// apiserver-version-dependent (ADR 0055 D7): the primary key is PodName in the
+// task namespace; PodUID guards against a name-reused stale pod.
+type ReviewedPod struct {
+	Namespace      string
+	PodName        string
+	PodUID         string
+	ServiceAccount string
+}
+
+// TokenReviewer validates a projected ServiceAccount token against the control
+// plane's audience via the Kubernetes TokenReview API and returns the pod it was
+// issued for. It is the ONE apiserver call in the exchange, made once per pod at
+// bootstrap (never on the secret hot path). It is an interface so it is MOCKED in
+// unit tests — the concrete client needs a real apiserver and is exercised only
+// by the owed real-cluster e2e. An error (bad signature, expired, wrong audience,
+// or authenticated=false) means the token is not a valid bootstrap credential.
+type TokenReviewer interface {
+	ReviewProjectedToken(ctx context.Context, token string) (ReviewedPod, error)
+}
+
+// PodTaskResolver maps a reviewed pod to the task-instance identity it runs, so
+// the minted JWT is scoped to the attempt (the identity Fix #1 filters on and
+// Fix #2 liveness-checks). It is an interface so it is mocked in unit tests. The
+// concrete resolver reads the identity the control plane itself stamped on the
+// pod object at dispatch, keyed on the apiserver-validated pod reference.
+type PodTaskResolver interface {
+	ResolveTaskInstance(ctx context.Context, pod ReviewedPod) (auth.AgentIdentity, error)
+}
+
+// AgentTokenMinter issues a task-scoped agent JWT for a resolved identity. It is
+// satisfied by *auth.JWTAuthenticator (IssueAgentToken) — the same minter used at
+// dispatch and heartbeat renewal, so the exchanged token is indistinguishable
+// from a dispatched one on every downstream path.
+type AgentTokenMinter interface {
+	IssueAgentToken(id auth.AgentIdentity, ttl time.Duration) (string, error)
+}
+
+// SetTokenExchange wires the projected-SA-token exchange (ADR 0055 Fix #3): the
+// TokenReview client, the pod→task-instance resolver, the JWT minter, and the TTL
+// of the minted task-scoped token. allowInsecure permits running the exchange
+// over a non-TLS channel (dev only); production must use TLS (ExchangeToken fails
+// closed otherwise, like the secret path). A nil reviewer leaves the exchange OFF
+// — ExchangeToken then reports Unimplemented — which is the default (env-var)
+// transport, so a deployment that does not opt in is byte-identical to today.
+func (s *Server) SetTokenExchange(reviewer TokenReviewer, resolver PodTaskResolver, minter AgentTokenMinter, ttl time.Duration, allowInsecure bool) {
+	s.reviewer = reviewer
+	s.podResolver = resolver
+	s.tokenMinter = minter
+	s.exchangeTTL = ttl
+	s.allowInsecureExchange = allowInsecure
+}
+
+// ExchangeToken validates the agent's projected ServiceAccount token (bootstrap
+// bearer), resolves the pod to its task instance, and returns a freshly minted
+// task-scoped agent JWT (ADR 0055 Fix #3). It is called ONCE at agent startup
+// under the exchange transport; the default env-var transport never calls it.
+//
+// It fails closed at every step: Unimplemented when the exchange is not wired,
+// PermissionDenied on an insecure channel, Unauthenticated on a missing or
+// rejected projected token, and Internal when the reviewed pod cannot be resolved
+// to an attempt (never mint an unscoped or misattributed token). The minted token
+// and the presented projected token are never logged.
+func (s *Server) ExchangeToken(ctx context.Context, _ *agentv1.ExchangeTokenRequest) (*agentv1.ExchangeTokenResponse, error) {
+	if s.reviewer == nil || s.podResolver == nil || s.tokenMinter == nil {
+		return nil, status.Error(codes.Unimplemented, "token exchange is not enabled")
+	}
+	if gerr := s.guardExchangeChannel(ctx); gerr != nil {
+		return nil, gerr
+	}
+	token, ok := bearerFromContext(ctx)
+	if !ok || token == "" {
+		return nil, status.Error(codes.Unauthenticated, "missing projected token")
+	}
+	pod, err := s.reviewer.ReviewProjectedToken(ctx, token)
+	if err != nil {
+		// A rejected projected token is not a server fault: the credential is
+		// invalid, expired, or carries the wrong audience. Surface Unauthenticated
+		// without echoing the token or the review detail to the agent.
+		slog.Warn("rejecting agent token exchange: projected token review failed", "error", err)
+		return nil, status.Error(codes.Unauthenticated, "projected token is not valid")
+	}
+	id, err := s.podResolver.ResolveTaskInstance(ctx, pod)
+	if err != nil {
+		slog.Warn("agent token exchange: cannot resolve reviewed pod to a task instance",
+			"namespace", pod.Namespace, "pod", pod.PodName, "pod_uid", pod.PodUID, "error", err)
+		return nil, status.Errorf(codes.Internal, "resolving pod to task instance: %v", err)
+	}
+	minted, err := s.tokenMinter.IssueAgentToken(id, s.exchangeTTL)
+	if err != nil {
+		slog.Warn("agent token exchange: minting task-scoped token failed",
+			"ti", id.TaskInstanceID, "run", id.RunID, "task", id.TaskID, "try", id.TryNumber, "error", err)
+		return nil, status.Errorf(codes.Internal, "minting task-scoped token: %v", err)
+	}
+	slog.Info("exchanged projected token for a task-scoped agent JWT",
+		"ti", id.TaskInstanceID, "tenant", id.TenantID, "dag", id.DagID,
+		"run", id.RunID, "task", id.TaskID, "try", id.TryNumber, "namespace", pod.Namespace, "pod", pod.PodName)
+	return &agentv1.ExchangeTokenResponse{AgentToken: minted}, nil
+}
+
+// guardExchangeChannel refuses to run the exchange over a plaintext channel
+// unless explicitly allowed for dev — the exchange returns a bearer credential,
+// so it must not transit an insecure transport by default. Mirrors the secret
+// channel guard.
+func (s *Server) guardExchangeChannel(ctx context.Context) error {
+	if s.allowInsecureExchange || channelIsSecure(ctx) {
+		return nil
+	}
+	return status.Error(codes.PermissionDenied,
+		"refusing to exchange a token over an insecure channel; enable gRPC TLS (see issue #58)")
+}

--- a/internal/agentrpc/exchange.go
+++ b/internal/agentrpc/exchange.go
@@ -124,5 +124,5 @@ func (s *Server) guardExchangeChannel(ctx context.Context) error {
 		return nil
 	}
 	return status.Error(codes.PermissionDenied,
-		"refusing to exchange a token over an insecure channel; enable gRPC TLS (see issue #58)")
+		"refusing to exchange a token over an insecure channel; enable gRPC TLS")
 }

--- a/internal/agentrpc/exchange_test.go
+++ b/internal/agentrpc/exchange_test.go
@@ -1,0 +1,159 @@
+package agentrpc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// fakeReviewer is a mockable stand-in for the Kubernetes TokenReview client, so
+// the exchange handler is unit-tested without a real apiserver.
+type fakeReviewer struct {
+	pod   ReviewedPod
+	err   error
+	calls int
+	seen  string // the token last presented for review
+}
+
+func (r *fakeReviewer) ReviewProjectedToken(_ context.Context, token string) (ReviewedPod, error) {
+	r.calls++
+	r.seen = token
+	if r.err != nil {
+		return ReviewedPod{}, r.err
+	}
+	return r.pod, nil
+}
+
+// fakeResolver maps a reviewed pod to the task-instance identity it runs.
+type fakeResolver struct {
+	id   auth.AgentIdentity
+	err  error
+	seen ReviewedPod
+}
+
+func (r *fakeResolver) ResolveTaskInstance(_ context.Context, pod ReviewedPod) (auth.AgentIdentity, error) {
+	r.seen = pod
+	if r.err != nil {
+		return auth.AgentIdentity{}, r.err
+	}
+	return r.id, nil
+}
+
+// ctxWithBootstrap carries an opaque projected SA token as the bearer (it is NOT
+// a leoflow JWT — the exchange validates it via the reviewer, not the signer).
+func ctxWithBootstrap(token string) context.Context {
+	md := metadata.Pairs("authorization", "Bearer "+token)
+	return metadata.NewIncomingContext(context.Background(), md)
+}
+
+func reviewedPod() ReviewedPod {
+	return ReviewedPod{Namespace: "leoflow", PodName: "leoflow-etl-extract-1-abcd", PodUID: "uid-1", ServiceAccount: "system:serviceaccount:leoflow:task"}
+}
+
+// TestExchangeTokenMintsScopedJWT: a valid projected token is reviewed, resolved
+// to its task instance, and exchanged for a task-scoped agent JWT that
+// AuthenticateAgent verifies back to the SAME identity.
+func TestExchangeTokenMintsScopedJWT(t *testing.T) {
+	srv, a := newServer(&fakeStore{})
+	rev := &fakeReviewer{pod: reviewedPod()}
+	res := &fakeResolver{id: testIdentity()}
+	srv.SetTokenExchange(rev, res, a, time.Hour, true)
+
+	resp, err := srv.ExchangeToken(ctxWithBootstrap("projected-sa-token"), &agentv1.ExchangeTokenRequest{})
+	if err != nil {
+		t.Fatalf("ExchangeToken: %v", err)
+	}
+	if resp.GetAgentToken() == "" {
+		t.Fatal("ExchangeToken returned an empty agent token")
+	}
+	if rev.seen != "projected-sa-token" {
+		t.Errorf("reviewer saw token %q, want the presented projected token", rev.seen)
+	}
+	if res.seen != rev.pod {
+		t.Errorf("resolver saw pod %+v, want the reviewed pod %+v", res.seen, rev.pod)
+	}
+	// The minted JWT must verify back to the resolved task instance.
+	id, verr := a.AuthenticateAgent(resp.GetAgentToken())
+	if verr != nil {
+		t.Fatalf("minted token does not verify: %v", verr)
+	}
+	if *id != testIdentity() {
+		t.Errorf("minted identity = %+v, want %+v", *id, testIdentity())
+	}
+}
+
+// TestExchangeTokenRejectsInvalidProjectedToken: the reviewer rejecting the token
+// (bad signature, expired, or WRONG AUDIENCE — all surfaced by the concrete
+// TokenReview client) fails the exchange Unauthenticated. No JWT is minted.
+func TestExchangeTokenRejectsInvalidProjectedToken(t *testing.T) {
+	srv, a := newServer(&fakeStore{})
+	rev := &fakeReviewer{err: errors.New("token review: not authenticated (wrong audience or expired)")}
+	res := &fakeResolver{id: testIdentity()}
+	srv.SetTokenExchange(rev, res, a, time.Hour, true)
+
+	if _, err := srv.ExchangeToken(ctxWithBootstrap("bad-token"), &agentv1.ExchangeTokenRequest{}); status.Code(err) != codes.Unauthenticated {
+		t.Errorf("invalid projected token: code = %v, want Unauthenticated", status.Code(err))
+	}
+	if res.seen != (ReviewedPod{}) {
+		t.Error("resolver must not be consulted when review fails")
+	}
+}
+
+// TestExchangeTokenResolverFailureFailsClosed: a pod that reviews but cannot be
+// resolved to a task instance fails the exchange (Internal) — it must never mint
+// an unscoped or misattributed token.
+func TestExchangeTokenResolverFailureFailsClosed(t *testing.T) {
+	srv, a := newServer(&fakeStore{})
+	rev := &fakeReviewer{pod: reviewedPod()}
+	res := &fakeResolver{err: errors.New("no task instance for pod")}
+	srv.SetTokenExchange(rev, res, a, time.Hour, true)
+
+	if _, err := srv.ExchangeToken(ctxWithBootstrap("projected-sa-token"), &agentv1.ExchangeTokenRequest{}); status.Code(err) != codes.Internal {
+		t.Errorf("resolver failure: code = %v, want Internal", status.Code(err))
+	}
+}
+
+// TestExchangeTokenUnconfiguredIsUnimplemented: the default (env-var) transport
+// never wires the exchanger, so a stray ExchangeToken call is Unimplemented — no
+// panic, no TokenReview.
+func TestExchangeTokenUnconfiguredIsUnimplemented(t *testing.T) {
+	srv, _ := newServer(&fakeStore{})
+	if _, err := srv.ExchangeToken(ctxWithBootstrap("whatever"), &agentv1.ExchangeTokenRequest{}); status.Code(err) != codes.Unimplemented {
+		t.Errorf("unconfigured exchange: code = %v, want Unimplemented", status.Code(err))
+	}
+}
+
+// TestExchangeTokenRejectsMissingBearer: no authorization metadata → Unauthenticated.
+func TestExchangeTokenRejectsMissingBearer(t *testing.T) {
+	srv, a := newServer(&fakeStore{})
+	srv.SetTokenExchange(&fakeReviewer{pod: reviewedPod()}, &fakeResolver{id: testIdentity()}, a, time.Hour, true)
+	if _, err := srv.ExchangeToken(context.Background(), &agentv1.ExchangeTokenRequest{}); status.Code(err) != codes.Unauthenticated {
+		t.Errorf("missing bearer: code = %v, want Unauthenticated", status.Code(err))
+	}
+}
+
+// TestNormalRPCsNeverInvokeTokenReview: even with the exchanger configured, the
+// steady-state path (identify() on a real agent JWT) authenticates by signature
+// and NEVER calls the apiserver TokenReview — the exchange is a one-time
+// bootstrap, not a per-RPC capability (ADR 0055: the secret hot path is
+// apiserver-free).
+func TestNormalRPCsNeverInvokeTokenReview(t *testing.T) {
+	store := &fakeStore{spec: TaskSpec{Operator: "python", Entrypoint: "dag:x"}}
+	srv, a := newServer(store)
+	rev := &fakeReviewer{pod: reviewedPod()}
+	srv.SetTokenExchange(rev, &fakeResolver{id: testIdentity()}, a, time.Hour, true)
+
+	if _, err := srv.GetTaskSpec(ctxWithToken(t, a), &agentv1.GetTaskSpecRequest{}); err != nil {
+		t.Fatalf("GetTaskSpec: %v", err)
+	}
+	if rev.calls != 0 {
+		t.Errorf("TokenReview was called %d times on the steady-state path, want 0", rev.calls)
+	}
+}

--- a/internal/agentrpc/secrets.go
+++ b/internal/agentrpc/secrets.go
@@ -138,14 +138,20 @@ func (s *Server) guardSecretChannel(ctx context.Context) error {
 	if s.secrets == nil {
 		return status.Error(codes.Unavailable, "secrets delivery is not configured")
 	}
-	if s.allowInsecureSecrets {
+	if s.allowInsecureSecrets || channelIsSecure(ctx) {
 		return nil
-	}
-	if p, ok := peer.FromContext(ctx); ok && p.AuthInfo != nil {
-		return nil // TLS (AuthInfo present) — secure
 	}
 	return status.Error(codes.PermissionDenied,
 		"refusing to send secrets over an insecure channel; enable gRPC TLS (see issue #58)")
+}
+
+// channelIsSecure reports whether the incoming gRPC call arrived over a secure
+// (TLS) transport — the peer carries AuthInfo only when the channel is
+// encrypted. It is the shared secure-transport check used by both the secret and
+// the token-exchange channel guards.
+func channelIsSecure(ctx context.Context) bool {
+	p, ok := peer.FromContext(ctx)
+	return ok && p.AuthInfo != nil
 }
 
 // checkLiveness consults the read-only task-instance liveness predicate on the

--- a/internal/agentrpc/server.go
+++ b/internal/agentrpc/server.go
@@ -152,7 +152,15 @@ type Server struct {
 	renewer              AgentTokenRenewer
 	renewalTTL           time.Duration
 	maxAttemptLifetime   time.Duration
-	now                  func() time.Time
+	// Projected-SA-token exchange (ADR 0055 Fix #3). All nil/zero by default, so a
+	// deployment that does not opt into the exchange transport is byte-identical to
+	// today (env-var token); ExchangeToken then reports Unimplemented.
+	reviewer              TokenReviewer
+	podResolver           PodTaskResolver
+	tokenMinter           AgentTokenMinter
+	exchangeTTL           time.Duration
+	allowInsecureExchange bool
+	now                   func() time.Time
 }
 
 // NewServer builds an AgentService server backed by the given authenticator,

--- a/internal/config/agent_token_transport_test.go
+++ b/internal/config/agent_token_transport_test.go
@@ -1,0 +1,58 @@
+package config
+
+import "testing"
+
+// TestAgentTokenTransportDefault: a fresh config binds
+// auth.agent_token_transport=envvar, so a default deploy keeps the plaintext
+// agent-token env var — the exchange transport is strictly opt-in.
+func TestAgentTokenTransportDefault(t *testing.T) {
+	c, err := LoadServer("", nil)
+	if err != nil {
+		t.Fatalf("LoadServer: %v", err)
+	}
+	if got := c.Auth.AgentTokenTransport; got != AgentTokenTransportEnvVar {
+		t.Errorf("auth.agent_token_transport default = %q, want %q", got, AgentTokenTransportEnvVar)
+	}
+}
+
+// TestAgentTokenTransportEnvBinds proves the key binds from
+// LEOFLOW_AUTH_AGENT_TOKEN_TRANSPORT (registered in serverDefaults so
+// AutomaticEnv sees it).
+func TestAgentTokenTransportEnvBinds(t *testing.T) {
+	t.Setenv("LEOFLOW_AUTH_AGENT_TOKEN_TRANSPORT", "exchange")
+	c, err := LoadServer("", nil)
+	if err != nil {
+		t.Fatalf("LoadServer: %v", err)
+	}
+	if got := c.Auth.AgentTokenTransport; got != AgentTokenTransportExchange {
+		t.Errorf("auth.agent_token_transport = %q, want %q (from env)", got, AgentTokenTransportExchange)
+	}
+}
+
+// TestValidateAgentTokenTransport locks the enum allowlist: valid values (and
+// empty = the envvar default) pass; an unknown value fails closed at boot.
+func TestValidateAgentTokenTransport(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		transport string
+		wantErr   bool
+	}{
+		{"empty defaults", "", false},
+		{"envvar", AgentTokenTransportEnvVar, false},
+		{"exchange", AgentTokenTransportExchange, false},
+		{"unknown", "magic", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &ServerConfig{}
+			c.Auth.JWT.Secret = "set"
+			c.Auth.AgentTokenTransport = tc.transport
+			err := c.Validate()
+			if tc.wantErr && err == nil {
+				t.Errorf("transport=%q: Validate() = nil, want error", tc.transport)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("transport=%q: Validate() = %v, want nil", tc.transport, err)
+			}
+		})
+	}
+}

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -306,6 +306,16 @@ type AuthSection struct {
 	// normal task regresses. Bind via LEOFLOW_AUTH_MAX_ATTEMPT_CREDENTIAL_LIFETIME
 	// as a duration (e.g. "24h", "90m"); a non-positive value disables the ceiling.
 	MaxAttemptCredentialLifetime time.Duration `mapstructure:"max_attempt_credential_lifetime"`
+	// AgentTokenTransport selects how the in-pod agent obtains its control-plane
+	// bearer credential (ADR 0055 Fix #3): "envvar" (the default) sets the token as
+	// a plaintext LEOFLOW_AGENT_TOKEN env var on the pod spec — today's behavior,
+	// byte-identical; "exchange" mounts a projected ServiceAccount token that the
+	// agent exchanges once (via a control-plane TokenReview) for the task-scoped
+	// JWT, so no bearer sits in plaintext on the Pod object. The exchange path is
+	// Pro/Kubernetes-executor-only (the subprocess executor has no pod/SA/TokenReview
+	// and ignores this). It is operator-scoped, NEVER author-settable. Empty = the
+	// envvar default. Bind via LEOFLOW_AUTH_AGENT_TOKEN_TRANSPORT.
+	AgentTokenTransport string `mapstructure:"agent_token_transport"`
 }
 
 // JWTSection configures JWT issuance and validation.
@@ -446,6 +456,11 @@ var serverDefaults = map[string]any{
 	// flips (enforce) are separate operator decisions after an observe period.
 	"auth.secret_scoping":       "permissive",
 	"auth.secret_liveness_mode": "observe",
+	// Agent-token transport (ADR 0055 Fix #3). Ships SAFE by default: envvar keeps
+	// the plaintext LEOFLOW_AGENT_TOKEN env var (today's behavior, byte-identical).
+	// The projected-SA-token exchange is opt-in ("exchange") and Pro/K8s-only; the
+	// flip to it is a separate operator decision after real-cluster e2e.
+	"auth.agent_token_transport": "envvar",
 	// Hard ceiling on an attempt's total renewed credential lifetime (ADR 0055
 	// Fix #4). Generous by default so nothing regresses; the short per-attempt TTL
 	// is what bounds a stolen token. Parsed as a duration by viper's decode hook.
@@ -573,6 +588,13 @@ const (
 	SecretLivenessObserve = "observe"
 	// SecretLivenessEnforce denies secret delivery when the caller's TI is not live.
 	SecretLivenessEnforce = "enforce"
+	// AgentTokenTransportEnvVar sets the agent token as a plaintext env var on the
+	// pod spec (today's behavior); the default.
+	AgentTokenTransportEnvVar = "envvar"
+	// AgentTokenTransportExchange mounts a projected ServiceAccount token the agent
+	// exchanges (via TokenReview) for a task-scoped JWT, so no bearer sits in
+	// plaintext on the Pod object (ADR 0055 Fix #3). Pro/Kubernetes-executor-only.
+	AgentTokenTransportExchange = "exchange"
 )
 
 // Validate reports configuration errors that must abort startup.
@@ -651,6 +673,12 @@ func (c *ServerConfig) validateSecretPolicies() error {
 	default:
 		return fmt.Errorf("invalid auth.secret_liveness_mode %q: must be %q or %q",
 			c.Auth.SecretLivenessMode, SecretLivenessObserve, SecretLivenessEnforce)
+	}
+	switch c.Auth.AgentTokenTransport {
+	case "", AgentTokenTransportEnvVar, AgentTokenTransportExchange:
+	default:
+		return fmt.Errorf("invalid auth.agent_token_transport %q: must be %q or %q",
+			c.Auth.AgentTokenTransport, AgentTokenTransportEnvVar, AgentTokenTransportExchange)
 	}
 	return nil
 }

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -75,6 +75,13 @@ type Dispatcher struct {
 	taskSecret     string
 	taskSecretPath string
 	defaults       PlatformDefaults
+	// Agent-token transport (ADR 0055 Fix #3). Empty tokenTransport = the env-var
+	// default (plaintext token env var), so a deployment that does not opt in is
+	// byte-identical to today. "exchange" threads the projected-token config onto
+	// the request; the audience/expiration are read only under exchange.
+	tokenTransport         string
+	tokenAudience          string
+	tokenExpirationSeconds int64
 }
 
 // NewDispatcher builds a Dispatcher that launches tasks via exec, resolves their
@@ -100,6 +107,16 @@ func (d *Dispatcher) SetTaskSecret(name, mountPath string) {
 // SetPlatformDefaults configures the per-cluster task defaults applied at
 // dispatch to fill gaps the DAG artifact left empty (ADR 0023, layer L0).
 func (d *Dispatcher) SetPlatformDefaults(p PlatformDefaults) { d.defaults = p }
+
+// SetAgentTokenTransport selects how the agent's bearer credential reaches the
+// task pod (ADR 0055 Fix #3). transport is "" / "envvar" (the plaintext env-var
+// default) or "exchange" (project a ServiceAccount token the agent exchanges for
+// a task-scoped JWT). audience and expirationSeconds configure the projected
+// token and are read only under the exchange transport. Ignored by the
+// subprocess (Lite) executor, which has no pod.
+func (d *Dispatcher) SetAgentTokenTransport(transport, audience string, expirationSeconds int64) {
+	d.tokenTransport, d.tokenAudience, d.tokenExpirationSeconds = transport, audience, expirationSeconds
+}
 
 // Dispatch resolves the task, mints its agent token, and executes it.
 func (d *Dispatcher) Dispatch(ctx context.Context, runID, dagID string, task domain.TaskSpec) error {
@@ -163,6 +180,13 @@ func (d *Dispatcher) Dispatch(ctx context.Context, runID, dagID string, task dom
 	req.AgentTLSCAConfigMap = d.tlsCAConfigMap
 	req.TaskSecretName = d.taskSecret
 	req.TaskSecretMountPath = d.taskSecretPath
+	// Agent-token transport (ADR 0055 Fix #3). Under the exchange transport the
+	// executor projects a ServiceAccount token instead of placing the plaintext
+	// token on the pod; the token is still minted above (the env-var path needs it,
+	// and it is harmless under exchange).
+	req.AgentTokenTransport = d.tokenTransport
+	req.AgentTokenAudience = d.tokenAudience
+	req.AgentTokenExpirationSeconds = d.tokenExpirationSeconds
 	return d.exec.Execute(ctx, req)
 }
 

--- a/internal/dispatch/dispatch_transport_test.go
+++ b/internal/dispatch/dispatch_transport_test.go
@@ -3,8 +3,6 @@ package dispatch
 import (
 	"context"
 	"testing"
-
-	"github.com/neochaotic/leoflow/internal/executor"
 )
 
 // TestDispatchDefaultTransportIsEnvVar: with no transport configured the request
@@ -15,9 +13,6 @@ func TestDispatchDefaultTransportIsEnvVar(t *testing.T) {
 	d := newDispatcher(&fakeResolver{resolved: Resolved{TaskInstanceID: "ti-1"}}, &fakeIssuer{token: "t"}, exec)
 	if err := d.Dispatch(context.Background(), "run", "etl", pythonTask()); err != nil {
 		t.Fatalf("Dispatch: %v", err)
-	}
-	if exec.req.AgentTokenTransport != "" && exec.req.AgentTokenTransport != executor.DefaultAgentTokenAudience {
-		// only assert it is not "exchange"
 	}
 	if exec.req.AgentTokenTransport == "exchange" {
 		t.Errorf("default transport must not be exchange, got %q", exec.req.AgentTokenTransport)

--- a/internal/dispatch/dispatch_transport_test.go
+++ b/internal/dispatch/dispatch_transport_test.go
@@ -1,0 +1,48 @@
+package dispatch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/executor"
+)
+
+// TestDispatchDefaultTransportIsEnvVar: with no transport configured the request
+// carries the env-var transport (empty), so BuildPod keeps today's plaintext
+// token env var — the safe default.
+func TestDispatchDefaultTransportIsEnvVar(t *testing.T) {
+	exec := &fakeExecutor{}
+	d := newDispatcher(&fakeResolver{resolved: Resolved{TaskInstanceID: "ti-1"}}, &fakeIssuer{token: "t"}, exec)
+	if err := d.Dispatch(context.Background(), "run", "etl", pythonTask()); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if exec.req.AgentTokenTransport != "" && exec.req.AgentTokenTransport != executor.DefaultAgentTokenAudience {
+		// only assert it is not "exchange"
+	}
+	if exec.req.AgentTokenTransport == "exchange" {
+		t.Errorf("default transport must not be exchange, got %q", exec.req.AgentTokenTransport)
+	}
+}
+
+// TestDispatchExchangeTransportThreaded: when the operator selects the exchange
+// transport, the dispatcher threads it (plus the projected-token audience) onto
+// the request so the K8s executor projects a token instead of the plaintext one.
+func TestDispatchExchangeTransportThreaded(t *testing.T) {
+	exec := &fakeExecutor{}
+	d := newDispatcher(&fakeResolver{resolved: Resolved{TaskInstanceID: "ti-1"}}, &fakeIssuer{token: "t"}, exec)
+	d.SetAgentTokenTransport("exchange", "leoflow-control-plane", 900)
+	if err := d.Dispatch(context.Background(), "run", "etl", pythonTask()); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if exec.req.AgentTokenTransport != "exchange" {
+		t.Errorf("AgentTokenTransport = %q, want exchange", exec.req.AgentTokenTransport)
+	}
+	if exec.req.AgentTokenAudience != "leoflow-control-plane" || exec.req.AgentTokenExpirationSeconds != 900 {
+		t.Errorf("projected-token config not threaded: aud=%q exp=%d", exec.req.AgentTokenAudience, exec.req.AgentTokenExpirationSeconds)
+	}
+	// The plaintext token is still minted (needed by the env-var path and harmless
+	// under exchange); the executor decides whether to place it on the pod.
+	if exec.req.AgentToken == "" {
+		t.Error("a token should still be minted at dispatch")
+	}
+}

--- a/internal/executor/agent_token_transport_test.go
+++ b/internal/executor/agent_token_transport_test.go
@@ -1,0 +1,180 @@
+package executor
+
+import (
+	"encoding/json"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// podEnvMap flattens a container's plain-valued env vars into a lookup.
+func podEnvMap(c corev1.Container) map[string]string {
+	env := map[string]string{}
+	for _, e := range c.Env {
+		env[e.Name] = e.Value
+	}
+	return env
+}
+
+// envVar returns the named EnvVar (by reference) or nil.
+func envVar(c corev1.Container, name string) *corev1.EnvVar {
+	for i := range c.Env {
+		if c.Env[i].Name == name {
+			return &c.Env[i]
+		}
+	}
+	return nil
+}
+
+// TestBuildPodEnvVarTransportUnchanged: the default (and empty) transport sets
+// the plaintext LEOFLOW_AGENT_TOKEN env var exactly as today — no projected
+// volume, no token-path/transport env vars, no identity annotation. This is the
+// safe default: a deploy that does not opt in is byte-identical to before.
+func TestBuildPodEnvVarTransportUnchanged(t *testing.T) {
+	for _, transport := range []string{"", "envvar"} {
+		req := sampleReq()
+		req.AgentTokenTransport = transport
+		pod := BuildPod(req)
+		c := pod.Spec.Containers[0]
+		env := podEnvMap(c)
+
+		if env["LEOFLOW_AGENT_TOKEN"] != "tok" {
+			t.Errorf("transport %q: LEOFLOW_AGENT_TOKEN = %q, want plaintext %q", transport, env["LEOFLOW_AGENT_TOKEN"], "tok")
+		}
+		if _, ok := env["LEOFLOW_AGENT_TOKEN_PATH"]; ok {
+			t.Errorf("transport %q: LEOFLOW_AGENT_TOKEN_PATH must not be set on the env-var path", transport)
+		}
+		if _, ok := env["LEOFLOW_AGENT_TOKEN_TRANSPORT"]; ok {
+			t.Errorf("transport %q: LEOFLOW_AGENT_TOKEN_TRANSPORT must not be set on the env-var path", transport)
+		}
+		for _, v := range pod.Spec.Volumes {
+			if v.Name == agentTokenVolumeName {
+				t.Errorf("transport %q: projected token volume must not be mounted on the env-var path", transport)
+			}
+		}
+		if _, ok := pod.Annotations[agentIdentityAnnotation]; ok {
+			t.Errorf("transport %q: identity annotation must not be set on the env-var path", transport)
+		}
+	}
+}
+
+// TestBuildPodExchangeTransportProjectsToken: under exchange the plaintext token
+// is GONE from the pod object — replaced by a projected ServiceAccount token
+// volume (bound to the control-plane audience, short-lived) the agent reads from
+// a file and exchanges. The identity annotation lets the control plane resolve
+// pod → task instance after TokenReview.
+func TestBuildPodExchangeTransportProjectsToken(t *testing.T) {
+	req := sampleReq()
+	req.AgentTokenTransport = "exchange"
+	req.AgentTokenAudience = "leoflow-control-plane"
+	req.AgentTokenExpirationSeconds = 900
+	pod := BuildPod(req)
+	c := pod.Spec.Containers[0]
+	env := podEnvMap(c)
+
+	// The invariant: NO bearer credential as a plaintext field on the Pod object.
+	if _, ok := env["LEOFLOW_AGENT_TOKEN"]; ok {
+		t.Error("exchange: plaintext LEOFLOW_AGENT_TOKEN must NOT be present on the pod spec")
+	}
+	if env["LEOFLOW_AGENT_TOKEN_TRANSPORT"] != "exchange" {
+		t.Errorf("exchange: LEOFLOW_AGENT_TOKEN_TRANSPORT = %q, want exchange", env["LEOFLOW_AGENT_TOKEN_TRANSPORT"])
+	}
+	if env["LEOFLOW_AGENT_TOKEN_PATH"] != agentTokenMountDir+"/"+agentTokenFile {
+		t.Errorf("exchange: LEOFLOW_AGENT_TOKEN_PATH = %q, want %q", env["LEOFLOW_AGENT_TOKEN_PATH"], agentTokenMountDir+"/"+agentTokenFile)
+	}
+
+	// The projected volume must exist, source the pod's SA token for the given
+	// audience, and be mounted read-only.
+	var vol *corev1.Volume
+	for i := range pod.Spec.Volumes {
+		if pod.Spec.Volumes[i].Name == agentTokenVolumeName {
+			vol = &pod.Spec.Volumes[i]
+		}
+	}
+	if vol == nil || vol.Projected == nil || len(vol.Projected.Sources) != 1 || vol.Projected.Sources[0].ServiceAccountToken == nil {
+		t.Fatalf("exchange: projected SA token volume not mounted: %+v", pod.Spec.Volumes)
+	}
+	sat := vol.Projected.Sources[0].ServiceAccountToken
+	if sat.Audience != "leoflow-control-plane" {
+		t.Errorf("projected token audience = %q, want leoflow-control-plane", sat.Audience)
+	}
+	if sat.ExpirationSeconds == nil || *sat.ExpirationSeconds != 900 {
+		t.Errorf("projected token expiration = %v, want 900", sat.ExpirationSeconds)
+	}
+	if sat.Path != agentTokenFile {
+		t.Errorf("projected token path = %q, want %q", sat.Path, agentTokenFile)
+	}
+	var mounted bool
+	for _, m := range c.VolumeMounts {
+		if m.Name == agentTokenVolumeName {
+			mounted = true
+			if !m.ReadOnly || m.MountPath != agentTokenMountDir {
+				t.Errorf("projected token mount = %+v, want readonly at %q", m, agentTokenMountDir)
+			}
+		}
+	}
+	if !mounted {
+		t.Error("exchange: projected token volume is not mounted into the task container")
+	}
+
+	// The identity annotation must round-trip the exact (unsanitized) identity the
+	// resolver needs — pod labels are sanitized and lossy, so the resolver reads this.
+	raw, ok := pod.Annotations[agentIdentityAnnotation]
+	if !ok {
+		t.Fatal("exchange: identity annotation not set")
+	}
+	var got podIdentity
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("identity annotation is not valid JSON: %v", err)
+	}
+	want := podIdentity{TaskInstanceID: "ti-1", TenantID: "default", DagID: "etl", RunID: "r1", TaskID: "extract", TryNumber: 1}
+	if got != want {
+		t.Errorf("identity annotation = %+v, want %+v", got, want)
+	}
+}
+
+// TestBuildPodExchangeExpirationFloor: an unset or too-small expiration is
+// floored to the minimum so a very short task's bootstrap token has not already
+// expired at Register (ADR 0055 "Verify at implementation").
+func TestBuildPodExchangeExpirationFloor(t *testing.T) {
+	for _, secs := range []int64{0, 60} {
+		req := sampleReq()
+		req.AgentTokenTransport = "exchange"
+		req.AgentTokenExpirationSeconds = secs
+		pod := BuildPod(req)
+		for _, v := range pod.Spec.Volumes {
+			if v.Name == agentTokenVolumeName {
+				exp := v.Projected.Sources[0].ServiceAccountToken.ExpirationSeconds
+				if exp == nil || *exp != minProjectedTokenExpirationSeconds {
+					t.Errorf("expiration %d floored to %v, want %d", secs, exp, minProjectedTokenExpirationSeconds)
+				}
+			}
+		}
+	}
+}
+
+// TestBuildPodExchangeSecretKeyRefFallback: for a cluster that cannot project an
+// SA token, the SecretKeyRef fallback sources LEOFLOW_AGENT_TOKEN from a
+// Kubernetes Secret (ValueFrom, not a plaintext Value) and mounts no projected
+// volume — still keeping the credential off the plaintext pod spec.
+func TestBuildPodExchangeSecretKeyRefFallback(t *testing.T) {
+	req := sampleReq()
+	req.AgentTokenTransport = "exchange"
+	req.AgentTokenSecretName = "leoflow-agent-token-ti-1"
+	req.AgentTokenSecretKey = "token"
+	pod := BuildPod(req)
+	c := pod.Spec.Containers[0]
+
+	ev := envVar(c, "LEOFLOW_AGENT_TOKEN")
+	if ev == nil || ev.Value != "" || ev.ValueFrom == nil || ev.ValueFrom.SecretKeyRef == nil {
+		t.Fatalf("fallback: LEOFLOW_AGENT_TOKEN must be a SecretKeyRef with no plaintext value, got %+v", ev)
+	}
+	if ev.ValueFrom.SecretKeyRef.Name != "leoflow-agent-token-ti-1" || ev.ValueFrom.SecretKeyRef.Key != "token" {
+		t.Errorf("fallback SecretKeyRef = %+v", ev.ValueFrom.SecretKeyRef)
+	}
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == agentTokenVolumeName {
+			t.Error("fallback: projected token volume must not be mounted when SecretKeyRef fallback is used")
+		}
+	}
+}

--- a/internal/executor/agent_token_transport_test.go
+++ b/internal/executor/agent_token_transport_test.go
@@ -52,7 +52,7 @@ func TestBuildPodEnvVarTransportUnchanged(t *testing.T) {
 				t.Errorf("transport %q: projected token volume must not be mounted on the env-var path", transport)
 			}
 		}
-		if _, ok := pod.Annotations[agentIdentityAnnotation]; ok {
+		if _, ok := pod.Annotations[AgentIdentityAnnotation]; ok {
 			t.Errorf("transport %q: identity annotation must not be set on the env-var path", transport)
 		}
 	}
@@ -119,15 +119,15 @@ func TestBuildPodExchangeTransportProjectsToken(t *testing.T) {
 
 	// The identity annotation must round-trip the exact (unsanitized) identity the
 	// resolver needs — pod labels are sanitized and lossy, so the resolver reads this.
-	raw, ok := pod.Annotations[agentIdentityAnnotation]
+	raw, ok := pod.Annotations[AgentIdentityAnnotation]
 	if !ok {
 		t.Fatal("exchange: identity annotation not set")
 	}
-	var got podIdentity
+	var got PodIdentity
 	if err := json.Unmarshal([]byte(raw), &got); err != nil {
 		t.Fatalf("identity annotation is not valid JSON: %v", err)
 	}
-	want := podIdentity{TaskInstanceID: "ti-1", TenantID: "default", DagID: "etl", RunID: "r1", TaskID: "extract", TryNumber: 1}
+	want := PodIdentity{TaskInstanceID: "ti-1", TenantID: "default", DagID: "etl", RunID: "r1", TaskID: "extract", TryNumber: 1}
 	if got != want {
 		t.Errorf("identity annotation = %+v, want %+v", got, want)
 	}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -67,6 +67,28 @@ type Request struct {
 	ControlPlaneAddr string
 	AgentToken       string
 
+	// AgentTokenTransport selects how the agent's bearer credential reaches the
+	// pod (ADR 0055 Fix #3): "" / "envvar" (the default) sets AgentToken as a
+	// plaintext LEOFLOW_AGENT_TOKEN env var — today's behavior, byte-identical;
+	// "exchange" keeps the plaintext token OFF the pod object and instead projects
+	// a ServiceAccount token the agent exchanges for a task-scoped JWT. Ignored by
+	// the subprocess executor (Lite has no pod/SA).
+	AgentTokenTransport string
+	// AgentTokenAudience is the audience of the projected ServiceAccount token
+	// under the exchange transport (the control plane's audience). Empty falls back
+	// to the default control-plane audience.
+	AgentTokenAudience string
+	// AgentTokenExpirationSeconds is the projected token's expiration under the
+	// exchange transport. Floored to a safe minimum so a very short task's
+	// bootstrap token has not already expired at exchange time.
+	AgentTokenExpirationSeconds int64
+	// AgentTokenSecretName / AgentTokenSecretKey select the SecretKeyRef fallback
+	// for the exchange transport (a cluster that cannot project an SA token): when
+	// AgentTokenSecretName is set, LEOFLOW_AGENT_TOKEN is sourced from that Secret
+	// via SecretKeyRef rather than projected — still off the plaintext pod spec.
+	AgentTokenSecretName string
+	AgentTokenSecretKey  string
+
 	// StagingClaim, when set, is the name of the per-DAG-run RWX PVC mounted at
 	// /staging in the task pod for large intermediate data shared across the run
 	// (ADR 0022). Empty means no staging volume. StagingSize/StagingStorageClass

--- a/internal/executor/kubernetes.go
+++ b/internal/executor/kubernetes.go
@@ -131,7 +131,118 @@ func BuildPod(req Request) *corev1.Pod {
 	mountStagingVolume(pod, req)
 	mountAgentTLSCA(pod, req)
 	mountTaskSecret(pod, req)
+	mountAgentToken(pod, req)
 	return pod
+}
+
+// Agent-token transport (ADR 0055 Fix #3). The env-var transport keeps the
+// plaintext token on the pod spec (today's behavior); the exchange transport
+// keeps it OFF and projects a ServiceAccount token instead.
+const (
+	agentTransportEnvVar   = "envvar"
+	agentTransportExchange = "exchange"
+	// agentTokenVolumeName / agentTokenMountDir / agentTokenFile place the
+	// projected ServiceAccount token the agent exchanges for a task-scoped JWT.
+	agentTokenVolumeName = "leoflow-agent-token"
+	agentTokenMountDir   = "/var/run/leoflow"
+	agentTokenFile       = "token"
+	// defaultAgentTokenAudience is the projected token's audience when the request
+	// does not set one — the control plane validates it against this on exchange.
+	defaultAgentTokenAudience = "leoflow-control-plane"
+	// minProjectedTokenExpirationSeconds floors the projected token's lifetime so a
+	// very short task's bootstrap credential is not already expired at exchange time
+	// (ADR 0055 "Verify at implementation": ~10 min floor). It is also the default.
+	minProjectedTokenExpirationSeconds int64 = 600
+	// agentIdentityAnnotation carries the exact (unsanitized) task-instance identity
+	// the control plane resolves a reviewed pod to on exchange. Pod labels are
+	// sanitized and lossy, so the resolver reads this instead. Written only under
+	// the exchange transport, so the env-var default pod spec is unchanged.
+	agentIdentityAnnotation = "leoflow.io/agent-identity"
+)
+
+// podIdentity is the JSON payload of agentIdentityAnnotation: the full
+// task-instance identity the control plane mints the exchanged JWT for.
+type podIdentity struct {
+	TaskInstanceID string `json:"ti"`
+	TenantID       string `json:"tenant"`
+	DagID          string `json:"dag"`
+	RunID          string `json:"run"`
+	TaskID         string `json:"task"`
+	TryNumber      int    `json:"try"`
+}
+
+// usesTokenExchange reports whether this request opted into the projected-token
+// exchange transport. Empty / "envvar" is the default (plaintext env var).
+func usesTokenExchange(req Request) bool { return req.AgentTokenTransport == agentTransportExchange }
+
+// agentTokenEnv returns the env var(s) carrying (or pointing at) the agent's
+// bearer credential, per the selected transport:
+//   - env-var (default): a plaintext LEOFLOW_AGENT_TOKEN — today's behavior.
+//   - exchange + SecretKeyRef fallback: LEOFLOW_AGENT_TOKEN sourced from a Secret.
+//   - exchange (projected, primary): NO token env var at all — the agent reads the
+//     projected token from LEOFLOW_AGENT_TOKEN_PATH and exchanges it. The path and
+//     transport marker are added by podEnv.
+func agentTokenEnv(req Request) []corev1.EnvVar {
+	if !usesTokenExchange(req) {
+		return []corev1.EnvVar{{Name: "LEOFLOW_AGENT_TOKEN", Value: req.AgentToken}}
+	}
+	if req.AgentTokenSecretName != "" {
+		key := req.AgentTokenSecretKey
+		if key == "" {
+			key = agentTokenFile
+		}
+		return []corev1.EnvVar{{
+			Name: "LEOFLOW_AGENT_TOKEN",
+			ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: req.AgentTokenSecretName},
+				Key:                  key,
+			}},
+		}}
+	}
+	return nil // projected primary path: no token env var, only the path (podEnv).
+}
+
+// mountAgentToken projects the ServiceAccount token the agent exchanges (ADR 0055
+// Fix #3), and stamps the identity annotation the control plane resolves the pod
+// to on exchange. It is a no-op for the env-var default and for the SecretKeyRef
+// fallback (neither projects a token), keeping those pod specs unchanged.
+func mountAgentToken(pod *corev1.Pod, req Request) {
+	if !usesTokenExchange(req) || req.AgentTokenSecretName != "" {
+		return
+	}
+	audience := req.AgentTokenAudience
+	if audience == "" {
+		audience = defaultAgentTokenAudience
+	}
+	exp := req.AgentTokenExpirationSeconds
+	if exp < minProjectedTokenExpirationSeconds {
+		exp = minProjectedTokenExpirationSeconds
+	}
+	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+		Name: agentTokenVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			Projected: &corev1.ProjectedVolumeSource{
+				Sources: []corev1.VolumeProjection{{
+					ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+						Audience:          audience,
+						ExpirationSeconds: ptr(exp),
+						Path:              agentTokenFile,
+					},
+				}},
+			},
+		},
+	})
+	c := &pod.Spec.Containers[0]
+	c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{
+		Name: agentTokenVolumeName, MountPath: agentTokenMountDir, ReadOnly: true,
+	})
+	id := podIdentity{
+		TaskInstanceID: req.TaskInstanceID, TenantID: req.TenantID, DagID: req.DagID,
+		RunID: req.RunID, TaskID: req.TaskID, TryNumber: req.TryNumber,
+	}
+	if raw, err := json.Marshal(id); err == nil {
+		pod.Annotations[agentIdentityAnnotation] = string(raw)
+	}
 }
 
 // taskSecretVolumeName is the pod volume name for the operator-supplied task
@@ -210,16 +321,28 @@ func mountStagingVolume(pod *corev1.Pod, req Request) {
 }
 
 func podEnv(req Request) []corev1.EnvVar {
-	env := make([]corev1.EnvVar, 0, 3+len(req.Env))
+	env := make([]corev1.EnvVar, 0, 4+len(req.Env))
+	env = append(env, corev1.EnvVar{Name: "LEOFLOW_CONTROL_PLANE_ADDR", Value: req.ControlPlaneAddr})
+	// The bearer credential: a plaintext env var (env-var default), a SecretKeyRef
+	// (exchange fallback), or nothing on the pod object (exchange projected path).
+	env = append(env, agentTokenEnv(req)...)
 	env = append(env,
-		corev1.EnvVar{Name: "LEOFLOW_CONTROL_PLANE_ADDR", Value: req.ControlPlaneAddr},
-		corev1.EnvVar{Name: "LEOFLOW_AGENT_TOKEN", Value: req.AgentToken},
 		corev1.EnvVar{Name: "LEOFLOW_TASK_INSTANCE_ID", Value: req.TaskInstanceID},
 		// Tell the pod agent where to write its durable outcome record; it matches
 		// the container's TerminationMessagePath. Only the pod path sets this, so
 		// Lite (subprocess, no pod) leaves the agent's record writing disabled.
 		corev1.EnvVar{Name: "LEOFLOW_TERMINATION_LOG_PATH", Value: terminationMessagePath},
 	)
+	// Under the exchange transport's projected path, tell the agent to read its
+	// bootstrap token from the mounted file and exchange it for a task-scoped JWT.
+	// The SecretKeyRef fallback and the env-var default leave these unset (the
+	// token is already in LEOFLOW_AGENT_TOKEN), so those pod specs are unchanged.
+	if usesTokenExchange(req) && req.AgentTokenSecretName == "" {
+		env = append(env,
+			corev1.EnvVar{Name: "LEOFLOW_AGENT_TOKEN_TRANSPORT", Value: agentTransportExchange},
+			corev1.EnvVar{Name: "LEOFLOW_AGENT_TOKEN_PATH", Value: agentTokenMountDir + "/" + agentTokenFile},
+		)
+	}
 	if req.StagingClaim != "" {
 		env = append(env, corev1.EnvVar{Name: "LEOFLOW_STAGING_DIR", Value: stagingMountPath})
 	}

--- a/internal/executor/kubernetes.go
+++ b/internal/executor/kubernetes.go
@@ -139,36 +139,49 @@ func BuildPod(req Request) *corev1.Pod {
 // plaintext token on the pod spec (today's behavior); the exchange transport
 // keeps it OFF and projects a ServiceAccount token instead.
 const (
-	agentTransportEnvVar   = "envvar"
 	agentTransportExchange = "exchange"
 	// agentTokenVolumeName / agentTokenMountDir / agentTokenFile place the
 	// projected ServiceAccount token the agent exchanges for a task-scoped JWT.
 	agentTokenVolumeName = "leoflow-agent-token"
 	agentTokenMountDir   = "/var/run/leoflow"
 	agentTokenFile       = "token"
-	// defaultAgentTokenAudience is the projected token's audience when the request
-	// does not set one — the control plane validates it against this on exchange.
-	defaultAgentTokenAudience = "leoflow-control-plane"
+	// DefaultAgentTokenAudience is the projected token's audience when the request
+	// does not set one — the control plane's TokenReviewer validates the projected
+	// token against this exact audience on exchange, so both sides share the const.
+	DefaultAgentTokenAudience = "leoflow-control-plane"
 	// minProjectedTokenExpirationSeconds floors the projected token's lifetime so a
 	// very short task's bootstrap credential is not already expired at exchange time
 	// (ADR 0055 "Verify at implementation": ~10 min floor). It is also the default.
 	minProjectedTokenExpirationSeconds int64 = 600
-	// agentIdentityAnnotation carries the exact (unsanitized) task-instance identity
+	// AgentIdentityAnnotation carries the exact (unsanitized) task-instance identity
 	// the control plane resolves a reviewed pod to on exchange. Pod labels are
 	// sanitized and lossy, so the resolver reads this instead. Written only under
-	// the exchange transport, so the env-var default pod spec is unchanged.
-	agentIdentityAnnotation = "leoflow.io/agent-identity"
+	// the exchange transport, so the env-var default pod spec is unchanged. It is
+	// exported so the pod → task-instance resolver reads the SAME contract that
+	// wrote it (single-sourced, no drift).
+	AgentIdentityAnnotation = "leoflow.io/agent-identity"
 )
 
-// podIdentity is the JSON payload of agentIdentityAnnotation: the full
+// PodIdentity is the JSON payload of AgentIdentityAnnotation: the full
 // task-instance identity the control plane mints the exchanged JWT for.
-type podIdentity struct {
+type PodIdentity struct {
 	TaskInstanceID string `json:"ti"`
 	TenantID       string `json:"tenant"`
 	DagID          string `json:"dag"`
 	RunID          string `json:"run"`
 	TaskID         string `json:"task"`
 	TryNumber      int    `json:"try"`
+}
+
+// ParseAgentIdentity decodes the AgentIdentityAnnotation payload. It is the read
+// side of the identity contract mountAgentToken writes, used by the pod →
+// task-instance resolver on the exchange path.
+func ParseAgentIdentity(raw string) (PodIdentity, error) {
+	var id PodIdentity
+	if err := json.Unmarshal([]byte(raw), &id); err != nil {
+		return PodIdentity{}, fmt.Errorf("decoding agent-identity annotation: %w", err)
+	}
+	return id, nil
 }
 
 // usesTokenExchange reports whether this request opted into the projected-token
@@ -212,7 +225,7 @@ func mountAgentToken(pod *corev1.Pod, req Request) {
 	}
 	audience := req.AgentTokenAudience
 	if audience == "" {
-		audience = defaultAgentTokenAudience
+		audience = DefaultAgentTokenAudience
 	}
 	exp := req.AgentTokenExpirationSeconds
 	if exp < minProjectedTokenExpirationSeconds {
@@ -236,12 +249,12 @@ func mountAgentToken(pod *corev1.Pod, req Request) {
 	c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{
 		Name: agentTokenVolumeName, MountPath: agentTokenMountDir, ReadOnly: true,
 	})
-	id := podIdentity{
+	id := PodIdentity{
 		TaskInstanceID: req.TaskInstanceID, TenantID: req.TenantID, DagID: req.DagID,
 		RunID: req.RunID, TaskID: req.TaskID, TryNumber: req.TryNumber,
 	}
 	if raw, err := json.Marshal(id); err == nil {
-		pod.Annotations[agentIdentityAnnotation] = string(raw)
+		pod.Annotations[AgentIdentityAnnotation] = string(raw)
 	}
 }
 

--- a/internal/kubeexchange/kubeexchange.go
+++ b/internal/kubeexchange/kubeexchange.go
@@ -1,0 +1,163 @@
+// Package kubeexchange implements the Kubernetes-backed half of the agent
+// token-exchange transport (ADR 0055 Fix #3): validating a pod's projected
+// ServiceAccount token via the apiserver TokenReview API, and resolving the
+// reviewed pod to the task-instance identity the control plane stamped on it.
+// Both satisfy the mockable interfaces in internal/agentrpc, so the exchange
+// handler is unit-tested without a cluster; this concrete code is the Pro/K8s
+// implementation the owed real-cluster e2e exercises.
+package kubeexchange
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	authv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/neochaotic/leoflow/internal/agentrpc"
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/executor"
+)
+
+// boundTokenPodNameKey / boundTokenPodUIDKey are the apiserver "extra" keys a
+// bound (pod-scoped) ServiceAccount token carries in the TokenReview response
+// (Kubernetes 1.22+ for BoundServiceAccountTokenVolume). ADR 0055 D7 pins these
+// as the resolution keys; they are validated end-to-end by the owed real-cluster
+// e2e against the target apiserver version.
+const (
+	boundTokenPodNameKey = "authentication.kubernetes.io/pod-name"
+	boundTokenPodUIDKey  = "authentication.kubernetes.io/pod-uid"
+)
+
+// TokenReviewer validates a projected SA token against a fixed audience via the
+// apiserver TokenReview API. It implements agentrpc.TokenReviewer.
+type TokenReviewer struct {
+	client   kubernetes.Interface
+	audience string
+}
+
+var _ agentrpc.TokenReviewer = (*TokenReviewer)(nil)
+
+// NewTokenReviewer builds a reviewer that asks the apiserver to validate tokens
+// for the given control-plane audience. A token not valid for that audience is
+// rejected by the apiserver (authenticated=false), so audience separation is
+// enforced server-side, not by string comparison here.
+func NewTokenReviewer(client kubernetes.Interface, audience string) *TokenReviewer {
+	return &TokenReviewer{client: client, audience: audience}
+}
+
+// ReviewProjectedToken submits the token to the apiserver's TokenReview API,
+// scoped to the control-plane audience, and returns the pod it was bound to. This
+// is the single apiserver call in the exchange, made once per pod at bootstrap.
+func (r *TokenReviewer) ReviewProjectedToken(ctx context.Context, token string) (agentrpc.ReviewedPod, error) {
+	review := &authv1.TokenReview{
+		Spec: authv1.TokenReviewSpec{Token: token, Audiences: []string{r.audience}},
+	}
+	out, err := r.client.AuthenticationV1().TokenReviews().Create(ctx, review, metav1.CreateOptions{})
+	if err != nil {
+		return agentrpc.ReviewedPod{}, fmt.Errorf("submitting token review: %w", err)
+	}
+	return reviewedPodFromStatus(out.Status)
+}
+
+// reviewedPodFromStatus extracts the pod reference from an authenticated bound
+// token's review status. It is the pure parsing core (unit-tested): an
+// unauthenticated review, or an authenticated-but-not-pod-bound token, is an
+// error — never a resolvable caller.
+func reviewedPodFromStatus(st authv1.TokenReviewStatus) (agentrpc.ReviewedPod, error) {
+	if !st.Authenticated {
+		if st.Error != "" {
+			return agentrpc.ReviewedPod{}, fmt.Errorf("token review: not authenticated: %s", st.Error)
+		}
+		return agentrpc.ReviewedPod{}, errors.New("token review: not authenticated")
+	}
+	podName := firstExtra(st.User.Extra, boundTokenPodNameKey)
+	if podName == "" {
+		return agentrpc.ReviewedPod{}, errors.New("token review: token is not pod-bound (no pod-name in bound-token extra)")
+	}
+	return agentrpc.ReviewedPod{
+		Namespace:      namespaceFromSAUsername(st.User.Username),
+		PodName:        podName,
+		PodUID:         firstExtra(st.User.Extra, boundTokenPodUIDKey),
+		ServiceAccount: st.User.Username,
+	}, nil
+}
+
+// firstExtra returns the first value of a TokenReview "extra" key, or "".
+func firstExtra(extra map[string]authv1.ExtraValue, key string) string {
+	if vals, ok := extra[key]; ok && len(vals) > 0 {
+		return vals[0]
+	}
+	return ""
+}
+
+// namespaceFromSAUsername pulls the namespace out of a ServiceAccount username of
+// the form "system:serviceaccount:<namespace>:<name>". Returns "" if it does not
+// match, letting the resolver fall back to its configured task namespace.
+func namespaceFromSAUsername(username string) string {
+	const prefix = "system:serviceaccount:"
+	if !strings.HasPrefix(username, prefix) {
+		return ""
+	}
+	parts := strings.Split(strings.TrimPrefix(username, prefix), ":")
+	if len(parts) != 2 {
+		return ""
+	}
+	return parts[0]
+}
+
+// PodResolver maps a reviewed pod to the task-instance identity the control plane
+// stamped on it at dispatch. It implements agentrpc.PodTaskResolver.
+type PodResolver struct {
+	client    kubernetes.Interface
+	namespace string
+}
+
+var _ agentrpc.PodTaskResolver = (*PodResolver)(nil)
+
+// NewPodResolver builds a resolver that reads pods from the task namespace
+// (falling back to it when the reviewed pod carries no namespace).
+func NewPodResolver(client kubernetes.Interface, namespace string) *PodResolver {
+	return &PodResolver{client: client, namespace: namespace}
+}
+
+// ResolveTaskInstance fetches the reviewed pod and reads the identity annotation
+// the executor wrote (the shared executor.AgentIdentityAnnotation contract), so
+// the minted JWT is scoped to the true attempt rather than a lossy label read. A
+// UID mismatch (a name reused by a newer pod) or a missing annotation fails
+// closed.
+func (r *PodResolver) ResolveTaskInstance(ctx context.Context, pod agentrpc.ReviewedPod) (auth.AgentIdentity, error) {
+	ns := pod.Namespace
+	if ns == "" {
+		ns = r.namespace
+	}
+	got, err := r.client.CoreV1().Pods(ns).Get(ctx, pod.PodName, metav1.GetOptions{})
+	if err != nil {
+		return auth.AgentIdentity{}, fmt.Errorf("getting pod %s/%s: %w", ns, pod.PodName, err)
+	}
+	if pod.PodUID != "" && string(got.UID) != pod.PodUID {
+		return auth.AgentIdentity{}, fmt.Errorf("pod %s/%s uid mismatch: reviewed %q, current %q (stale pod)", ns, pod.PodName, pod.PodUID, got.UID)
+	}
+	raw, ok := got.Annotations[executor.AgentIdentityAnnotation]
+	if !ok || raw == "" {
+		return auth.AgentIdentity{}, fmt.Errorf("pod %s/%s has no %s annotation", ns, pod.PodName, executor.AgentIdentityAnnotation)
+	}
+	id, err := executor.ParseAgentIdentity(raw)
+	if err != nil {
+		return auth.AgentIdentity{}, err
+	}
+	if id.TaskInstanceID == "" {
+		return auth.AgentIdentity{}, fmt.Errorf("pod %s/%s identity annotation carries no task instance id", ns, pod.PodName)
+	}
+	return auth.AgentIdentity{
+		TaskInstanceID: id.TaskInstanceID,
+		TenantID:       id.TenantID,
+		DagID:          id.DagID,
+		RunID:          id.RunID,
+		TaskID:         id.TaskID,
+		TryNumber:      id.TryNumber,
+	}, nil
+}

--- a/internal/kubeexchange/kubeexchange_test.go
+++ b/internal/kubeexchange/kubeexchange_test.go
@@ -1,0 +1,108 @@
+package kubeexchange
+
+import (
+	"context"
+	"testing"
+
+	authv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/neochaotic/leoflow/internal/agentrpc"
+	"github.com/neochaotic/leoflow/internal/executor"
+)
+
+// TestReviewedPodFromStatus parses the bound-token TokenReview status into a
+// ReviewedPod: an authenticated review yields the pod name/uid from the apiserver
+// "extra" keys and the namespace from the ServiceAccount username (ADR 0055 D7).
+func TestReviewedPodFromStatus(t *testing.T) {
+	st := authv1.TokenReviewStatus{
+		Authenticated: true,
+		User: authv1.UserInfo{
+			Username: "system:serviceaccount:leoflow:task",
+			Extra: map[string]authv1.ExtraValue{
+				boundTokenPodNameKey: {"leoflow-etl-extract-1-abcd"},
+				boundTokenPodUIDKey:  {"uid-123"},
+			},
+		},
+	}
+	pod, err := reviewedPodFromStatus(st)
+	if err != nil {
+		t.Fatalf("reviewedPodFromStatus: %v", err)
+	}
+	if pod.PodName != "leoflow-etl-extract-1-abcd" || pod.PodUID != "uid-123" {
+		t.Errorf("pod name/uid = %q/%q", pod.PodName, pod.PodUID)
+	}
+	if pod.Namespace != "leoflow" {
+		t.Errorf("namespace = %q, want leoflow (from SA username)", pod.Namespace)
+	}
+}
+
+// TestReviewedPodFromStatusRejectsUnauthenticated: authenticated=false (a bad,
+// expired, or wrong-audience token — the apiserver sets this) is an error, never
+// a ReviewedPod.
+func TestReviewedPodFromStatusRejectsUnauthenticated(t *testing.T) {
+	if _, err := reviewedPodFromStatus(authv1.TokenReviewStatus{Authenticated: false, Error: "bad audience"}); err == nil {
+		t.Error("an unauthenticated review must be an error")
+	}
+}
+
+// TestReviewedPodFromStatusRejectsMissingPod: an authenticated token that is not
+// pod-bound (no pod-name extra) cannot resolve to a task instance — reject rather
+// than mint a token for an ambiguous caller.
+func TestReviewedPodFromStatusRejectsMissingPod(t *testing.T) {
+	st := authv1.TokenReviewStatus{Authenticated: true, User: authv1.UserInfo{Username: "system:serviceaccount:leoflow:task"}}
+	if _, err := reviewedPodFromStatus(st); err == nil {
+		t.Error("a non-pod-bound token must be an error")
+	}
+}
+
+// TestPodResolverReadsIdentityAnnotation: the resolver reads the exact identity
+// the executor stamped on the pod (via the shared AgentIdentityAnnotation
+// contract), so scoping/liveness key on the true attempt — not lossy labels.
+func TestPodResolverReadsIdentityAnnotation(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "leoflow-etl-extract-1-abcd",
+		Namespace: "leoflow",
+		UID:       "uid-123",
+		Annotations: map[string]string{
+			executor.AgentIdentityAnnotation: `{"ti":"ti-1","tenant":"acme","dag":"ETL","run":"run-1","task":"Extract","try":2}`,
+		},
+	}}
+	cs := fake.NewClientset(pod)
+	r := NewPodResolver(cs, "leoflow")
+
+	id, err := r.ResolveTaskInstance(context.Background(), agentrpc.ReviewedPod{Namespace: "leoflow", PodName: "leoflow-etl-extract-1-abcd", PodUID: "uid-123"})
+	if err != nil {
+		t.Fatalf("ResolveTaskInstance: %v", err)
+	}
+	if id.TaskInstanceID != "ti-1" || id.TenantID != "acme" || id.DagID != "ETL" || id.TaskID != "Extract" || id.TryNumber != 2 {
+		t.Errorf("resolved identity = %+v", id)
+	}
+}
+
+// TestPodResolverRejectsStaleUID: a name reused by a different pod (UID mismatch)
+// must not resolve — the reviewed token was issued for a different pod object.
+func TestPodResolverRejectsStaleUID(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "leoflow-etl-extract-1-abcd", Namespace: "leoflow", UID: "current-uid",
+		Annotations: map[string]string{executor.AgentIdentityAnnotation: `{"ti":"ti-1"}`},
+	}}
+	cs := fake.NewClientset(pod)
+	r := NewPodResolver(cs, "leoflow")
+	if _, err := r.ResolveTaskInstance(context.Background(), agentrpc.ReviewedPod{PodName: "leoflow-etl-extract-1-abcd", PodUID: "stale-uid"}); err == nil {
+		t.Error("a UID mismatch must be an error")
+	}
+}
+
+// TestPodResolverRejectsMissingAnnotation: a pod without the identity annotation
+// (e.g. an env-var-transport pod) cannot be resolved via the exchange path.
+func TestPodResolverRejectsMissingAnnotation(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "leoflow", UID: "u"}}
+	cs := fake.NewClientset(pod)
+	r := NewPodResolver(cs, "leoflow")
+	if _, err := r.ResolveTaskInstance(context.Background(), agentrpc.ReviewedPod{PodName: "p", PodUID: "u"}); err == nil {
+		t.Error("a pod without the identity annotation must be an error")
+	}
+}

--- a/proto/agent.proto
+++ b/proto/agent.proto
@@ -15,6 +15,15 @@ import "google/protobuf/struct.proto";
 // Service
 // ─────────────────────────────────────────────────────────────────────────
 service AgentService {
+    // Agent exchanges its bootstrap credential for a task-scoped agent JWT
+    // (ADR 0055 Fix #3). Called once at startup ONLY when the pod was given a
+    // projected ServiceAccount token instead of a plaintext token: the agent
+    // presents that projected token in metadata, the Control Plane validates it
+    // with a Kubernetes TokenReview, resolves the pod to its task instance, and
+    // returns the task-scoped JWT the agent uses as its bearer thereafter. The
+    // default (env-var) transport never calls this.
+    rpc ExchangeToken (ExchangeTokenRequest) returns (ExchangeTokenResponse);
+
     // Agent registers with the Control Plane on container startup.
     // The JWT in metadata identifies the task instance.
     rpc Register (RegisterRequest) returns (RegisterResponse);
@@ -65,6 +74,19 @@ message GetConnectionsRequest {}
 message GetConnectionsResponse {
     // conn_id -> Airflow connection URI, exported as AIRFLOW_CONN_<CONN_ID>.
     map<string, string> connection_uris = 1;
+}
+
+// ExchangeTokenRequest is empty; the agent presents its projected ServiceAccount
+// token as the bootstrap bearer in the authorization metadata. The Control Plane
+// derives everything it needs (the pod, hence the task instance) from that token
+// via a Kubernetes TokenReview.
+message ExchangeTokenRequest {}
+
+message ExchangeTokenResponse {
+    // A freshly minted, task-scoped agent JWT — the same identity scoped and
+    // liveness-checked on the secret path. The agent swaps its bearer to this
+    // value for every subsequent RPC. Never logged.
+    string agent_token = 1;
 }
 
 message RegisterRequest {

--- a/proto/agent/v1/agent.pb.go
+++ b/proto/agent/v1/agent.pb.go
@@ -307,6 +307,93 @@ func (x *GetConnectionsResponse) GetConnectionUris() map[string]string {
 	return nil
 }
 
+// ExchangeTokenRequest is empty; the agent presents its projected ServiceAccount
+// token as the bootstrap bearer in the authorization metadata. The Control Plane
+// derives everything it needs (the pod, hence the task instance) from that token
+// via a Kubernetes TokenReview.
+type ExchangeTokenRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExchangeTokenRequest) Reset() {
+	*x = ExchangeTokenRequest{}
+	mi := &file_agent_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExchangeTokenRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExchangeTokenRequest) ProtoMessage() {}
+
+func (x *ExchangeTokenRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_agent_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExchangeTokenRequest.ProtoReflect.Descriptor instead.
+func (*ExchangeTokenRequest) Descriptor() ([]byte, []int) {
+	return file_agent_proto_rawDescGZIP(), []int{4}
+}
+
+type ExchangeTokenResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A freshly minted, task-scoped agent JWT — the same identity scoped and
+	// liveness-checked on the secret path. The agent swaps its bearer to this
+	// value for every subsequent RPC. Never logged.
+	AgentToken    string `protobuf:"bytes,1,opt,name=agent_token,json=agentToken,proto3" json:"agent_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExchangeTokenResponse) Reset() {
+	*x = ExchangeTokenResponse{}
+	mi := &file_agent_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExchangeTokenResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExchangeTokenResponse) ProtoMessage() {}
+
+func (x *ExchangeTokenResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_agent_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExchangeTokenResponse.ProtoReflect.Descriptor instead.
+func (*ExchangeTokenResponse) Descriptor() ([]byte, []int) {
+	return file_agent_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *ExchangeTokenResponse) GetAgentToken() string {
+	if x != nil {
+		return x.AgentToken
+	}
+	return ""
+}
+
 type RegisterRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	AgentVersion  string                 `protobuf:"bytes,1,opt,name=agent_version,json=agentVersion,proto3" json:"agent_version,omitempty"`
@@ -318,7 +405,7 @@ type RegisterRequest struct {
 
 func (x *RegisterRequest) Reset() {
 	*x = RegisterRequest{}
-	mi := &file_agent_proto_msgTypes[4]
+	mi := &file_agent_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -330,7 +417,7 @@ func (x *RegisterRequest) String() string {
 func (*RegisterRequest) ProtoMessage() {}
 
 func (x *RegisterRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agent_proto_msgTypes[4]
+	mi := &file_agent_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -343,7 +430,7 @@ func (x *RegisterRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RegisterRequest.ProtoReflect.Descriptor instead.
 func (*RegisterRequest) Descriptor() ([]byte, []int) {
-	return file_agent_proto_rawDescGZIP(), []int{4}
+	return file_agent_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *RegisterRequest) GetAgentVersion() string {
@@ -379,7 +466,7 @@ type RegisterResponse struct {
 
 func (x *RegisterResponse) Reset() {
 	*x = RegisterResponse{}
-	mi := &file_agent_proto_msgTypes[5]
+	mi := &file_agent_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -391,7 +478,7 @@ func (x *RegisterResponse) String() string {
 func (*RegisterResponse) ProtoMessage() {}
 
 func (x *RegisterResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agent_proto_msgTypes[5]
+	mi := &file_agent_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -404,7 +491,7 @@ func (x *RegisterResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RegisterResponse.ProtoReflect.Descriptor instead.
 func (*RegisterResponse) Descriptor() ([]byte, []int) {
-	return file_agent_proto_rawDescGZIP(), []int{5}
+	return file_agent_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *RegisterResponse) GetSessionId() string {
@@ -429,7 +516,7 @@ type GetTaskSpecRequest struct {
 
 func (x *GetTaskSpecRequest) Reset() {
 	*x = GetTaskSpecRequest{}
-	mi := &file_agent_proto_msgTypes[6]
+	mi := &file_agent_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -441,7 +528,7 @@ func (x *GetTaskSpecRequest) String() string {
 func (*GetTaskSpecRequest) ProtoMessage() {}
 
 func (x *GetTaskSpecRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agent_proto_msgTypes[6]
+	mi := &file_agent_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -454,7 +541,7 @@ func (x *GetTaskSpecRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetTaskSpecRequest.ProtoReflect.Descriptor instead.
 func (*GetTaskSpecRequest) Descriptor() ([]byte, []int) {
-	return file_agent_proto_rawDescGZIP(), []int{6}
+	return file_agent_proto_rawDescGZIP(), []int{8}
 }
 
 type TaskSpec struct {
@@ -488,7 +575,7 @@ type TaskSpec struct {
 
 func (x *TaskSpec) Reset() {
 	*x = TaskSpec{}
-	mi := &file_agent_proto_msgTypes[7]
+	mi := &file_agent_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -500,7 +587,7 @@ func (x *TaskSpec) String() string {
 func (*TaskSpec) ProtoMessage() {}
 
 func (x *TaskSpec) ProtoReflect() protoreflect.Message {
-	mi := &file_agent_proto_msgTypes[7]
+	mi := &file_agent_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -513,7 +600,7 @@ func (x *TaskSpec) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TaskSpec.ProtoReflect.Descriptor instead.
 func (*TaskSpec) Descriptor() ([]byte, []int) {
-	return file_agent_proto_rawDescGZIP(), []int{7}
+	return file_agent_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *TaskSpec) GetTenantId() string {
@@ -691,7 +778,7 @@ type XComUpstreams struct {
 
 func (x *XComUpstreams) Reset() {
 	*x = XComUpstreams{}
-	mi := &file_agent_proto_msgTypes[8]
+	mi := &file_agent_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -703,7 +790,7 @@ func (x *XComUpstreams) String() string {
 func (*XComUpstreams) ProtoMessage() {}
 
 func (x *XComUpstreams) ProtoReflect() protoreflect.Message {
-	mi := &file_agent_proto_msgTypes[8]
+	mi := &file_agent_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -716,7 +803,7 @@ func (x *XComUpstreams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use XComUpstreams.ProtoReflect.Descriptor instead.
 func (*XComUpstreams) Descriptor() ([]byte, []int) {
-	return file_agent_proto_rawDescGZIP(), []int{8}
+	return file_agent_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *XComUpstreams) GetTaskIds() []string {
@@ -736,7 +823,7 @@ type FetchXComRequest struct {
 
 func (x *FetchXComRequest) Reset() {
 	*x = FetchXComRequest{}
-	mi := &file_agent_proto_msgTypes[9]
+	mi := &file_agent_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -748,7 +835,7 @@ func (x *FetchXComRequest) String() string {
 func (*FetchXComRequest) ProtoMessage() {}
 
 func (x *FetchXComRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agent_proto_msgTypes[9]
+	mi := &file_agent_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -761,7 +848,7 @@ func (x *FetchXComRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FetchXComRequest.ProtoReflect.Descriptor instead.
 func (*FetchXComRequest) Descriptor() ([]byte, []int) {
-	return file_agent_proto_rawDescGZIP(), []int{9}
+	return file_agent_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *FetchXComRequest) GetUpstreamTaskId() string {
@@ -790,7 +877,7 @@ type FetchXComResponse struct {
 
 func (x *FetchXComResponse) Reset() {
 	*x = FetchXComResponse{}
-	mi := &file_agent_proto_msgTypes[10]
+	mi := &file_agent_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -802,7 +889,7 @@ func (x *FetchXComResponse) String() string {
 func (*FetchXComResponse) ProtoMessage() {}
 
 func (x *FetchXComResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agent_proto_msgTypes[10]
+	mi := &file_agent_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -815,7 +902,7 @@ func (x *FetchXComResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FetchXComResponse.ProtoReflect.Descriptor instead.
 func (*FetchXComResponse) Descriptor() ([]byte, []int) {
-	return file_agent_proto_rawDescGZIP(), []int{10}
+	return file_agent_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *FetchXComResponse) GetValue() []byte {
@@ -857,7 +944,7 @@ type PushXComRequest struct {
 
 func (x *PushXComRequest) Reset() {
 	*x = PushXComRequest{}
-	mi := &file_agent_proto_msgTypes[11]
+	mi := &file_agent_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -869,7 +956,7 @@ func (x *PushXComRequest) String() string {
 func (*PushXComRequest) ProtoMessage() {}
 
 func (x *PushXComRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agent_proto_msgTypes[11]
+	mi := &file_agent_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -882,7 +969,7 @@ func (x *PushXComRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PushXComRequest.ProtoReflect.Descriptor instead.
 func (*PushXComRequest) Descriptor() ([]byte, []int) {
-	return file_agent_proto_rawDescGZIP(), []int{11}
+	return file_agent_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *PushXComRequest) GetKey() string {
@@ -917,7 +1004,7 @@ type PushXComResponse struct {
 
 func (x *PushXComResponse) Reset() {
 	*x = PushXComResponse{}
-	mi := &file_agent_proto_msgTypes[12]
+	mi := &file_agent_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -929,7 +1016,7 @@ func (x *PushXComResponse) String() string {
 func (*PushXComResponse) ProtoMessage() {}
 
 func (x *PushXComResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agent_proto_msgTypes[12]
+	mi := &file_agent_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -942,7 +1029,7 @@ func (x *PushXComResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PushXComResponse.ProtoReflect.Descriptor instead.
 func (*PushXComResponse) Descriptor() ([]byte, []int) {
-	return file_agent_proto_rawDescGZIP(), []int{12}
+	return file_agent_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *PushXComResponse) GetAccepted() bool {
@@ -979,7 +1066,7 @@ type LogLine struct {
 
 func (x *LogLine) Reset() {
 	*x = LogLine{}
-	mi := &file_agent_proto_msgTypes[13]
+	mi := &file_agent_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -991,7 +1078,7 @@ func (x *LogLine) String() string {
 func (*LogLine) ProtoMessage() {}
 
 func (x *LogLine) ProtoReflect() protoreflect.Message {
-	mi := &file_agent_proto_msgTypes[13]
+	mi := &file_agent_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1004,7 +1091,7 @@ func (x *LogLine) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogLine.ProtoReflect.Descriptor instead.
 func (*LogLine) Descriptor() ([]byte, []int) {
-	return file_agent_proto_rawDescGZIP(), []int{13}
+	return file_agent_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *LogLine) GetTime() *timestamppb.Timestamp {
@@ -1051,7 +1138,7 @@ type LogAck struct {
 
 func (x *LogAck) Reset() {
 	*x = LogAck{}
-	mi := &file_agent_proto_msgTypes[14]
+	mi := &file_agent_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1063,7 +1150,7 @@ func (x *LogAck) String() string {
 func (*LogAck) ProtoMessage() {}
 
 func (x *LogAck) ProtoReflect() protoreflect.Message {
-	mi := &file_agent_proto_msgTypes[14]
+	mi := &file_agent_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1076,7 +1163,7 @@ func (x *LogAck) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LogAck.ProtoReflect.Descriptor instead.
 func (*LogAck) Descriptor() ([]byte, []int) {
-	return file_agent_proto_rawDescGZIP(), []int{14}
+	return file_agent_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *LogAck) GetAcknowledgedThroughLine() int64 {
@@ -1101,7 +1188,7 @@ type ReportStateRequest struct {
 
 func (x *ReportStateRequest) Reset() {
 	*x = ReportStateRequest{}
-	mi := &file_agent_proto_msgTypes[15]
+	mi := &file_agent_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1113,7 +1200,7 @@ func (x *ReportStateRequest) String() string {
 func (*ReportStateRequest) ProtoMessage() {}
 
 func (x *ReportStateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agent_proto_msgTypes[15]
+	mi := &file_agent_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1126,7 +1213,7 @@ func (x *ReportStateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReportStateRequest.ProtoReflect.Descriptor instead.
 func (*ReportStateRequest) Descriptor() ([]byte, []int) {
-	return file_agent_proto_rawDescGZIP(), []int{15}
+	return file_agent_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ReportStateRequest) GetState() TaskState {
@@ -1175,7 +1262,7 @@ type ReportStateResponse struct {
 
 func (x *ReportStateResponse) Reset() {
 	*x = ReportStateResponse{}
-	mi := &file_agent_proto_msgTypes[16]
+	mi := &file_agent_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1187,7 +1274,7 @@ func (x *ReportStateResponse) String() string {
 func (*ReportStateResponse) ProtoMessage() {}
 
 func (x *ReportStateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agent_proto_msgTypes[16]
+	mi := &file_agent_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1200,7 +1287,7 @@ func (x *ReportStateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReportStateResponse.ProtoReflect.Descriptor instead.
 func (*ReportStateResponse) Descriptor() ([]byte, []int) {
-	return file_agent_proto_rawDescGZIP(), []int{16}
+	return file_agent_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ReportStateResponse) GetAcknowledged() bool {
@@ -1227,7 +1314,7 @@ type HeartbeatRequest struct {
 
 func (x *HeartbeatRequest) Reset() {
 	*x = HeartbeatRequest{}
-	mi := &file_agent_proto_msgTypes[17]
+	mi := &file_agent_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1239,7 +1326,7 @@ func (x *HeartbeatRequest) String() string {
 func (*HeartbeatRequest) ProtoMessage() {}
 
 func (x *HeartbeatRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_agent_proto_msgTypes[17]
+	mi := &file_agent_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1252,7 +1339,7 @@ func (x *HeartbeatRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeartbeatRequest.ProtoReflect.Descriptor instead.
 func (*HeartbeatRequest) Descriptor() ([]byte, []int) {
-	return file_agent_proto_rawDescGZIP(), []int{17}
+	return file_agent_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *HeartbeatRequest) GetSentAt() *timestamppb.Timestamp {
@@ -1286,7 +1373,7 @@ type HeartbeatResponse struct {
 
 func (x *HeartbeatResponse) Reset() {
 	*x = HeartbeatResponse{}
-	mi := &file_agent_proto_msgTypes[18]
+	mi := &file_agent_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1298,7 +1385,7 @@ func (x *HeartbeatResponse) String() string {
 func (*HeartbeatResponse) ProtoMessage() {}
 
 func (x *HeartbeatResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agent_proto_msgTypes[18]
+	mi := &file_agent_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1311,7 +1398,7 @@ func (x *HeartbeatResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeartbeatResponse.ProtoReflect.Descriptor instead.
 func (*HeartbeatResponse) Descriptor() ([]byte, []int) {
-	return file_agent_proto_rawDescGZIP(), []int{18}
+	return file_agent_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *HeartbeatResponse) GetShouldTerminate() bool {
@@ -1351,7 +1438,11 @@ const file_agent_proto_rawDesc = "" +
 	"\x0fconnection_uris\x18\x01 \x03(\v2<.leoflow.agent.v1.GetConnectionsResponse.ConnectionUrisEntryR\x0econnectionUris\x1aA\n" +
 	"\x13ConnectionUrisEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xe8\x01\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x16\n" +
+	"\x14ExchangeTokenRequest\"8\n" +
+	"\x15ExchangeTokenResponse\x12\x1f\n" +
+	"\vagent_token\x18\x01 \x01(\tR\n" +
+	"agentToken\"\xe8\x01\n" +
 	"\x0fRegisterRequest\x12#\n" +
 	"\ragent_version\x18\x01 \x01(\tR\fagentVersion\x12\x1a\n" +
 	"\bhostname\x18\x02 \x01(\tR\bhostname\x12T\n" +
@@ -1465,8 +1556,9 @@ const file_agent_proto_rawDesc = "" +
 	"\x12TASK_STATE_SUCCESS\x10\x02\x12\x15\n" +
 	"\x11TASK_STATE_FAILED\x10\x03\x12\x16\n" +
 	"\x12TASK_STATE_SKIPPED\x10\x04\x12 \n" +
-	"\x1cTASK_STATE_UP_FOR_RESCHEDULE\x10\x052\x98\x06\n" +
-	"\fAgentService\x12Q\n" +
+	"\x1cTASK_STATE_UP_FOR_RESCHEDULE\x10\x052\xfa\x06\n" +
+	"\fAgentService\x12`\n" +
+	"\rExchangeToken\x12&.leoflow.agent.v1.ExchangeTokenRequest\x1a'.leoflow.agent.v1.ExchangeTokenResponse\x12Q\n" +
 	"\bRegister\x12!.leoflow.agent.v1.RegisterRequest\x1a\".leoflow.agent.v1.RegisterResponse\x12O\n" +
 	"\vGetTaskSpec\x12$.leoflow.agent.v1.GetTaskSpecRequest\x1a\x1a.leoflow.agent.v1.TaskSpec\x12T\n" +
 	"\tFetchXCom\x12\".leoflow.agent.v1.FetchXComRequest\x1a#.leoflow.agent.v1.FetchXComResponse\x12Q\n" +
@@ -1491,7 +1583,7 @@ func file_agent_proto_rawDescGZIP() []byte {
 }
 
 var file_agent_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
+var file_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
 var file_agent_proto_goTypes = []any{
 	(LogLevel)(0),                  // 0: leoflow.agent.v1.LogLevel
 	(TaskState)(0),                 // 1: leoflow.agent.v1.TaskState
@@ -1499,68 +1591,72 @@ var file_agent_proto_goTypes = []any{
 	(*GetVariablesResponse)(nil),   // 3: leoflow.agent.v1.GetVariablesResponse
 	(*GetConnectionsRequest)(nil),  // 4: leoflow.agent.v1.GetConnectionsRequest
 	(*GetConnectionsResponse)(nil), // 5: leoflow.agent.v1.GetConnectionsResponse
-	(*RegisterRequest)(nil),        // 6: leoflow.agent.v1.RegisterRequest
-	(*RegisterResponse)(nil),       // 7: leoflow.agent.v1.RegisterResponse
-	(*GetTaskSpecRequest)(nil),     // 8: leoflow.agent.v1.GetTaskSpecRequest
-	(*TaskSpec)(nil),               // 9: leoflow.agent.v1.TaskSpec
-	(*XComUpstreams)(nil),          // 10: leoflow.agent.v1.XComUpstreams
-	(*FetchXComRequest)(nil),       // 11: leoflow.agent.v1.FetchXComRequest
-	(*FetchXComResponse)(nil),      // 12: leoflow.agent.v1.FetchXComResponse
-	(*PushXComRequest)(nil),        // 13: leoflow.agent.v1.PushXComRequest
-	(*PushXComResponse)(nil),       // 14: leoflow.agent.v1.PushXComResponse
-	(*LogLine)(nil),                // 15: leoflow.agent.v1.LogLine
-	(*LogAck)(nil),                 // 16: leoflow.agent.v1.LogAck
-	(*ReportStateRequest)(nil),     // 17: leoflow.agent.v1.ReportStateRequest
-	(*ReportStateResponse)(nil),    // 18: leoflow.agent.v1.ReportStateResponse
-	(*HeartbeatRequest)(nil),       // 19: leoflow.agent.v1.HeartbeatRequest
-	(*HeartbeatResponse)(nil),      // 20: leoflow.agent.v1.HeartbeatResponse
-	nil,                            // 21: leoflow.agent.v1.GetVariablesResponse.VariablesEntry
-	nil,                            // 22: leoflow.agent.v1.GetConnectionsResponse.ConnectionUrisEntry
-	nil,                            // 23: leoflow.agent.v1.RegisterRequest.EnvironmentEntry
-	nil,                            // 24: leoflow.agent.v1.TaskSpec.EnvironmentEntry
-	nil,                            // 25: leoflow.agent.v1.TaskSpec.XcomInputMappingEntry
-	nil,                            // 26: leoflow.agent.v1.HeartbeatRequest.CustomMetricsEntry
-	(*timestamppb.Timestamp)(nil),  // 27: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),        // 28: google.protobuf.Struct
+	(*ExchangeTokenRequest)(nil),   // 6: leoflow.agent.v1.ExchangeTokenRequest
+	(*ExchangeTokenResponse)(nil),  // 7: leoflow.agent.v1.ExchangeTokenResponse
+	(*RegisterRequest)(nil),        // 8: leoflow.agent.v1.RegisterRequest
+	(*RegisterResponse)(nil),       // 9: leoflow.agent.v1.RegisterResponse
+	(*GetTaskSpecRequest)(nil),     // 10: leoflow.agent.v1.GetTaskSpecRequest
+	(*TaskSpec)(nil),               // 11: leoflow.agent.v1.TaskSpec
+	(*XComUpstreams)(nil),          // 12: leoflow.agent.v1.XComUpstreams
+	(*FetchXComRequest)(nil),       // 13: leoflow.agent.v1.FetchXComRequest
+	(*FetchXComResponse)(nil),      // 14: leoflow.agent.v1.FetchXComResponse
+	(*PushXComRequest)(nil),        // 15: leoflow.agent.v1.PushXComRequest
+	(*PushXComResponse)(nil),       // 16: leoflow.agent.v1.PushXComResponse
+	(*LogLine)(nil),                // 17: leoflow.agent.v1.LogLine
+	(*LogAck)(nil),                 // 18: leoflow.agent.v1.LogAck
+	(*ReportStateRequest)(nil),     // 19: leoflow.agent.v1.ReportStateRequest
+	(*ReportStateResponse)(nil),    // 20: leoflow.agent.v1.ReportStateResponse
+	(*HeartbeatRequest)(nil),       // 21: leoflow.agent.v1.HeartbeatRequest
+	(*HeartbeatResponse)(nil),      // 22: leoflow.agent.v1.HeartbeatResponse
+	nil,                            // 23: leoflow.agent.v1.GetVariablesResponse.VariablesEntry
+	nil,                            // 24: leoflow.agent.v1.GetConnectionsResponse.ConnectionUrisEntry
+	nil,                            // 25: leoflow.agent.v1.RegisterRequest.EnvironmentEntry
+	nil,                            // 26: leoflow.agent.v1.TaskSpec.EnvironmentEntry
+	nil,                            // 27: leoflow.agent.v1.TaskSpec.XcomInputMappingEntry
+	nil,                            // 28: leoflow.agent.v1.HeartbeatRequest.CustomMetricsEntry
+	(*timestamppb.Timestamp)(nil),  // 29: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),        // 30: google.protobuf.Struct
 }
 var file_agent_proto_depIdxs = []int32{
-	21, // 0: leoflow.agent.v1.GetVariablesResponse.variables:type_name -> leoflow.agent.v1.GetVariablesResponse.VariablesEntry
-	22, // 1: leoflow.agent.v1.GetConnectionsResponse.connection_uris:type_name -> leoflow.agent.v1.GetConnectionsResponse.ConnectionUrisEntry
-	23, // 2: leoflow.agent.v1.RegisterRequest.environment:type_name -> leoflow.agent.v1.RegisterRequest.EnvironmentEntry
-	27, // 3: leoflow.agent.v1.RegisterResponse.server_time:type_name -> google.protobuf.Timestamp
-	24, // 4: leoflow.agent.v1.TaskSpec.environment:type_name -> leoflow.agent.v1.TaskSpec.EnvironmentEntry
-	25, // 5: leoflow.agent.v1.TaskSpec.xcom_input_mapping:type_name -> leoflow.agent.v1.TaskSpec.XcomInputMappingEntry
-	28, // 6: leoflow.agent.v1.TaskSpec.extra:type_name -> google.protobuf.Struct
-	27, // 7: leoflow.agent.v1.FetchXComResponse.created_at:type_name -> google.protobuf.Timestamp
-	27, // 8: leoflow.agent.v1.LogLine.time:type_name -> google.protobuf.Timestamp
+	23, // 0: leoflow.agent.v1.GetVariablesResponse.variables:type_name -> leoflow.agent.v1.GetVariablesResponse.VariablesEntry
+	24, // 1: leoflow.agent.v1.GetConnectionsResponse.connection_uris:type_name -> leoflow.agent.v1.GetConnectionsResponse.ConnectionUrisEntry
+	25, // 2: leoflow.agent.v1.RegisterRequest.environment:type_name -> leoflow.agent.v1.RegisterRequest.EnvironmentEntry
+	29, // 3: leoflow.agent.v1.RegisterResponse.server_time:type_name -> google.protobuf.Timestamp
+	26, // 4: leoflow.agent.v1.TaskSpec.environment:type_name -> leoflow.agent.v1.TaskSpec.EnvironmentEntry
+	27, // 5: leoflow.agent.v1.TaskSpec.xcom_input_mapping:type_name -> leoflow.agent.v1.TaskSpec.XcomInputMappingEntry
+	30, // 6: leoflow.agent.v1.TaskSpec.extra:type_name -> google.protobuf.Struct
+	29, // 7: leoflow.agent.v1.FetchXComResponse.created_at:type_name -> google.protobuf.Timestamp
+	29, // 8: leoflow.agent.v1.LogLine.time:type_name -> google.protobuf.Timestamp
 	0,  // 9: leoflow.agent.v1.LogLine.level:type_name -> leoflow.agent.v1.LogLevel
 	1,  // 10: leoflow.agent.v1.ReportStateRequest.state:type_name -> leoflow.agent.v1.TaskState
-	27, // 11: leoflow.agent.v1.ReportStateRequest.occurred_at:type_name -> google.protobuf.Timestamp
-	27, // 12: leoflow.agent.v1.ReportStateRequest.reschedule_at:type_name -> google.protobuf.Timestamp
-	27, // 13: leoflow.agent.v1.HeartbeatRequest.sent_at:type_name -> google.protobuf.Timestamp
-	26, // 14: leoflow.agent.v1.HeartbeatRequest.custom_metrics:type_name -> leoflow.agent.v1.HeartbeatRequest.CustomMetricsEntry
-	27, // 15: leoflow.agent.v1.HeartbeatResponse.server_time:type_name -> google.protobuf.Timestamp
-	10, // 16: leoflow.agent.v1.TaskSpec.XcomInputMappingEntry.value:type_name -> leoflow.agent.v1.XComUpstreams
-	6,  // 17: leoflow.agent.v1.AgentService.Register:input_type -> leoflow.agent.v1.RegisterRequest
-	8,  // 18: leoflow.agent.v1.AgentService.GetTaskSpec:input_type -> leoflow.agent.v1.GetTaskSpecRequest
-	11, // 19: leoflow.agent.v1.AgentService.FetchXCom:input_type -> leoflow.agent.v1.FetchXComRequest
-	13, // 20: leoflow.agent.v1.AgentService.PushXCom:input_type -> leoflow.agent.v1.PushXComRequest
-	15, // 21: leoflow.agent.v1.AgentService.StreamLogs:input_type -> leoflow.agent.v1.LogLine
-	17, // 22: leoflow.agent.v1.AgentService.ReportState:input_type -> leoflow.agent.v1.ReportStateRequest
-	19, // 23: leoflow.agent.v1.AgentService.Heartbeat:input_type -> leoflow.agent.v1.HeartbeatRequest
-	2,  // 24: leoflow.agent.v1.AgentService.GetVariables:input_type -> leoflow.agent.v1.GetVariablesRequest
-	4,  // 25: leoflow.agent.v1.AgentService.GetConnections:input_type -> leoflow.agent.v1.GetConnectionsRequest
-	7,  // 26: leoflow.agent.v1.AgentService.Register:output_type -> leoflow.agent.v1.RegisterResponse
-	9,  // 27: leoflow.agent.v1.AgentService.GetTaskSpec:output_type -> leoflow.agent.v1.TaskSpec
-	12, // 28: leoflow.agent.v1.AgentService.FetchXCom:output_type -> leoflow.agent.v1.FetchXComResponse
-	14, // 29: leoflow.agent.v1.AgentService.PushXCom:output_type -> leoflow.agent.v1.PushXComResponse
-	16, // 30: leoflow.agent.v1.AgentService.StreamLogs:output_type -> leoflow.agent.v1.LogAck
-	18, // 31: leoflow.agent.v1.AgentService.ReportState:output_type -> leoflow.agent.v1.ReportStateResponse
-	20, // 32: leoflow.agent.v1.AgentService.Heartbeat:output_type -> leoflow.agent.v1.HeartbeatResponse
-	3,  // 33: leoflow.agent.v1.AgentService.GetVariables:output_type -> leoflow.agent.v1.GetVariablesResponse
-	5,  // 34: leoflow.agent.v1.AgentService.GetConnections:output_type -> leoflow.agent.v1.GetConnectionsResponse
-	26, // [26:35] is the sub-list for method output_type
-	17, // [17:26] is the sub-list for method input_type
+	29, // 11: leoflow.agent.v1.ReportStateRequest.occurred_at:type_name -> google.protobuf.Timestamp
+	29, // 12: leoflow.agent.v1.ReportStateRequest.reschedule_at:type_name -> google.protobuf.Timestamp
+	29, // 13: leoflow.agent.v1.HeartbeatRequest.sent_at:type_name -> google.protobuf.Timestamp
+	28, // 14: leoflow.agent.v1.HeartbeatRequest.custom_metrics:type_name -> leoflow.agent.v1.HeartbeatRequest.CustomMetricsEntry
+	29, // 15: leoflow.agent.v1.HeartbeatResponse.server_time:type_name -> google.protobuf.Timestamp
+	12, // 16: leoflow.agent.v1.TaskSpec.XcomInputMappingEntry.value:type_name -> leoflow.agent.v1.XComUpstreams
+	6,  // 17: leoflow.agent.v1.AgentService.ExchangeToken:input_type -> leoflow.agent.v1.ExchangeTokenRequest
+	8,  // 18: leoflow.agent.v1.AgentService.Register:input_type -> leoflow.agent.v1.RegisterRequest
+	10, // 19: leoflow.agent.v1.AgentService.GetTaskSpec:input_type -> leoflow.agent.v1.GetTaskSpecRequest
+	13, // 20: leoflow.agent.v1.AgentService.FetchXCom:input_type -> leoflow.agent.v1.FetchXComRequest
+	15, // 21: leoflow.agent.v1.AgentService.PushXCom:input_type -> leoflow.agent.v1.PushXComRequest
+	17, // 22: leoflow.agent.v1.AgentService.StreamLogs:input_type -> leoflow.agent.v1.LogLine
+	19, // 23: leoflow.agent.v1.AgentService.ReportState:input_type -> leoflow.agent.v1.ReportStateRequest
+	21, // 24: leoflow.agent.v1.AgentService.Heartbeat:input_type -> leoflow.agent.v1.HeartbeatRequest
+	2,  // 25: leoflow.agent.v1.AgentService.GetVariables:input_type -> leoflow.agent.v1.GetVariablesRequest
+	4,  // 26: leoflow.agent.v1.AgentService.GetConnections:input_type -> leoflow.agent.v1.GetConnectionsRequest
+	7,  // 27: leoflow.agent.v1.AgentService.ExchangeToken:output_type -> leoflow.agent.v1.ExchangeTokenResponse
+	9,  // 28: leoflow.agent.v1.AgentService.Register:output_type -> leoflow.agent.v1.RegisterResponse
+	11, // 29: leoflow.agent.v1.AgentService.GetTaskSpec:output_type -> leoflow.agent.v1.TaskSpec
+	14, // 30: leoflow.agent.v1.AgentService.FetchXCom:output_type -> leoflow.agent.v1.FetchXComResponse
+	16, // 31: leoflow.agent.v1.AgentService.PushXCom:output_type -> leoflow.agent.v1.PushXComResponse
+	18, // 32: leoflow.agent.v1.AgentService.StreamLogs:output_type -> leoflow.agent.v1.LogAck
+	20, // 33: leoflow.agent.v1.AgentService.ReportState:output_type -> leoflow.agent.v1.ReportStateResponse
+	22, // 34: leoflow.agent.v1.AgentService.Heartbeat:output_type -> leoflow.agent.v1.HeartbeatResponse
+	3,  // 35: leoflow.agent.v1.AgentService.GetVariables:output_type -> leoflow.agent.v1.GetVariablesResponse
+	5,  // 36: leoflow.agent.v1.AgentService.GetConnections:output_type -> leoflow.agent.v1.GetConnectionsResponse
+	27, // [27:37] is the sub-list for method output_type
+	17, // [17:27] is the sub-list for method input_type
 	17, // [17:17] is the sub-list for extension type_name
 	17, // [17:17] is the sub-list for extension extendee
 	0,  // [0:17] is the sub-list for field type_name
@@ -1577,7 +1673,7 @@ func file_agent_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_agent_proto_rawDesc), len(file_agent_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   25,
+			NumMessages:   27,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/agent/v1/agent_grpc.pb.go
+++ b/proto/agent/v1/agent_grpc.pb.go
@@ -23,6 +23,7 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
+	AgentService_ExchangeToken_FullMethodName  = "/leoflow.agent.v1.AgentService/ExchangeToken"
 	AgentService_Register_FullMethodName       = "/leoflow.agent.v1.AgentService/Register"
 	AgentService_GetTaskSpec_FullMethodName    = "/leoflow.agent.v1.AgentService/GetTaskSpec"
 	AgentService_FetchXCom_FullMethodName      = "/leoflow.agent.v1.AgentService/FetchXCom"
@@ -42,6 +43,14 @@ const (
 // Service
 // ─────────────────────────────────────────────────────────────────────────
 type AgentServiceClient interface {
+	// Agent exchanges its bootstrap credential for a task-scoped agent JWT
+	// (ADR 0055 Fix #3). Called once at startup ONLY when the pod was given a
+	// projected ServiceAccount token instead of a plaintext token: the agent
+	// presents that projected token in metadata, the Control Plane validates it
+	// with a Kubernetes TokenReview, resolves the pod to its task instance, and
+	// returns the task-scoped JWT the agent uses as its bearer thereafter. The
+	// default (env-var) transport never calls this.
+	ExchangeToken(ctx context.Context, in *ExchangeTokenRequest, opts ...grpc.CallOption) (*ExchangeTokenResponse, error)
 	// Agent registers with the Control Plane on container startup.
 	// The JWT in metadata identifies the task instance.
 	Register(ctx context.Context, in *RegisterRequest, opts ...grpc.CallOption) (*RegisterResponse, error)
@@ -72,6 +81,16 @@ type agentServiceClient struct {
 
 func NewAgentServiceClient(cc grpc.ClientConnInterface) AgentServiceClient {
 	return &agentServiceClient{cc}
+}
+
+func (c *agentServiceClient) ExchangeToken(ctx context.Context, in *ExchangeTokenRequest, opts ...grpc.CallOption) (*ExchangeTokenResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ExchangeTokenResponse)
+	err := c.cc.Invoke(ctx, AgentService_ExchangeToken_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (c *agentServiceClient) Register(ctx context.Context, in *RegisterRequest, opts ...grpc.CallOption) (*RegisterResponse, error) {
@@ -175,6 +194,14 @@ func (c *agentServiceClient) GetConnections(ctx context.Context, in *GetConnecti
 // Service
 // ─────────────────────────────────────────────────────────────────────────
 type AgentServiceServer interface {
+	// Agent exchanges its bootstrap credential for a task-scoped agent JWT
+	// (ADR 0055 Fix #3). Called once at startup ONLY when the pod was given a
+	// projected ServiceAccount token instead of a plaintext token: the agent
+	// presents that projected token in metadata, the Control Plane validates it
+	// with a Kubernetes TokenReview, resolves the pod to its task instance, and
+	// returns the task-scoped JWT the agent uses as its bearer thereafter. The
+	// default (env-var) transport never calls this.
+	ExchangeToken(context.Context, *ExchangeTokenRequest) (*ExchangeTokenResponse, error)
 	// Agent registers with the Control Plane on container startup.
 	// The JWT in metadata identifies the task instance.
 	Register(context.Context, *RegisterRequest) (*RegisterResponse, error)
@@ -207,6 +234,9 @@ type AgentServiceServer interface {
 // pointer dereference when methods are called.
 type UnimplementedAgentServiceServer struct{}
 
+func (UnimplementedAgentServiceServer) ExchangeToken(context.Context, *ExchangeTokenRequest) (*ExchangeTokenResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ExchangeToken not implemented")
+}
 func (UnimplementedAgentServiceServer) Register(context.Context, *RegisterRequest) (*RegisterResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Register not implemented")
 }
@@ -253,6 +283,24 @@ func RegisterAgentServiceServer(s grpc.ServiceRegistrar, srv AgentServiceServer)
 		t.testEmbeddedByValue()
 	}
 	s.RegisterService(&AgentService_ServiceDesc, srv)
+}
+
+func _AgentService_ExchangeToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ExchangeTokenRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AgentServiceServer).ExchangeToken(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AgentService_ExchangeToken_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AgentServiceServer).ExchangeToken(ctx, req.(*ExchangeTokenRequest))
+	}
+	return interceptor(ctx, in, info, handler)
 }
 
 func _AgentService_Register_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
@@ -413,6 +461,10 @@ var AgentService_ServiceDesc = grpc.ServiceDesc{
 	ServiceName: "leoflow.agent.v1.AgentService",
 	HandlerType: (*AgentServiceServer)(nil),
 	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "ExchangeToken",
+			Handler:    _AgentService_ExchangeToken_Handler,
+		},
 		{
 			MethodName: "Register",
 			Handler:    _AgentService_Register_Handler,


### PR DESCRIPTION
Lane E, Fix #3 — the FINAL Lane E piece. Closes #666. Replaces the plaintext agent-token env var on the pod spec (readable via \`kubectl get pod -o yaml\`) with a token EXCHANGE: projected SA token → TokenReview → task-scoped JWT. **Ships flag-gated, DEFAULT = current env-var behavior — nothing changes on merge.**

- **Config** \`auth.agent_token_transport: envvar | exchange\`, **default envvar** (enum-validated fail-closed). envvar = today's pod spec byte-identical (locked by \`TestBuildPodEnvVarTransportUnchanged\`).
- **exchange** (opt-in): BuildPod projects an SA token volume (control-plane audience, ~10min floor), drops the plaintext token; the agent exchanges it ONCE via a new \`ExchangeToken\` RPC → control plane TokenReviews the pod, resolves pod→TI (D7 keys: pod-name/pod-uid + identity annotation, UID-guarded), mints the task-scoped JWT into the E2d TokenSource.
- **Design call:** exchange is a dedicated \`ExchangeToken\` RPC, not folded into Register (avoids a double TokenReview + keeps Register/default byte-identical; honors "exchange exactly once"). Noted in the ADR.
- **Lite untouched** (subprocess.go 0 diff); exchange is Pro/K8s-executor + flag only. Missing K8s client → warns-and-disables (matches pod-dispatch posture).

### Verification
`go build`/`go vet`(+`-tags integration`)/`gofmt`/`buf`/`go mod tidy` clean · `golangci-lint run ./...` **0** · config/executor/agentrpc/agent/dispatch/kubeexchange/auth unit tests pass (TokenReview mocked + fake clientset). **Real-cluster e2e is OWED before the exchange flip** (TokenReview needs a live apiserver) — documented in the ADR. Strict TDD, no AI attribution.

Focused review done. Flip to \`exchange\` is a later operator decision after real-cluster validation (like the enforce flips).