### PR TITLE
refactor(exec): re-home the reapers behind the execution seam (ADR 0051 Phase 3 / warm-pool P1)

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -1190,21 +1190,26 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 	dispatcher.SetPlatformDefaults(platformDefaults(cfg.Executor.Defaults))
 	disp, closer := wrapBuffered(dispatcher, store, logger, metrics, cfg.Scheduler.Dispatch) //nolint:contextcheck // buffered worker deliberately detaches from caller ctx
 	sched.SetDispatcher(disp)
-	// Let the reapers tear down a reaped task's pod and gate the dispatch-lost
-	// decision on real pod liveness (#474, #461). Only wired on the pod path;
-	// Lite/subprocess leaves it nil and the reapers stay DB-only.
-	sched.SetPodManager(podExec)
 	// Shared informer read-path (PR-10): one long-lived watch replaces the
 	// reapers' per-running-TI LIST storm and the reconciler's 30s LIST. Consulted
 	// only to DEFER a reap; the live TaskPodActive kill path is unchanged (#461).
-	// A typed-nil pointer would defeat the reconciler's nil check, so the
-	// snapshotter interface is only populated when the informer actually built.
+	// A typed-nil pointer would defeat the reconciler's / reaper's nil check, so
+	// the interfaces are only populated when the informer actually built.
 	podInformer := buildPodInformer(ctx, cfg, cs, logger)
-	var snapshotter executor.PodSnapshotter
+	var (
+		snapshotter executor.PodSnapshotter
+		cache       executor.PodPresenceCache
+	)
 	if podInformer != nil {
-		sched.SetPodPresenceCache(podInformer)
 		snapshotter = podInformer
+		cache = podInformer
 	}
+	// The execution reaper (#120/#128/#202/#527) fails stuck runs and TIs; it
+	// tears down a reaped task's pod and gates the dispatch-lost decision on real
+	// pod liveness (#474, #461), so it is wired only on the pod path. Lite/
+	// subprocess leaves the scheduler's reaper unset and does no reaping.
+	reaper := executor.NewReaper(store, podExec, cache, metrics, logger, executor.DefaultReaperConfig(), sched.SteppingDown)
+	sched.SetExecutionReaper(reaper)
 	startReconciler(ctx, cs, cfg.Executor.TaskNamespace, execStore, sched.IsLeading, logger, snapshotter)
 	startStagingGC(ctx, cs, cfg.Executor.TaskNamespace, store, sched.IsLeading, logger)
 	logger.Info("pod dispatch enabled", "namespace", cfg.Executor.TaskNamespace, "agent_control_plane_addr", controlAddr)

--- a/internal/executor/heartbeat_reap.go
+++ b/internal/executor/heartbeat_reap.go
@@ -1,4 +1,4 @@
-package scheduler
+package executor
 
 import (
 	"context"
@@ -64,14 +64,14 @@ type agentLostReaper struct {
 	store     HeartbeatReapStore
 	logger    *slog.Logger
 	threshold time.Duration
-	recorder  Recorder
+	recorder  DecisionRecorder
 	// pods tears down the reaped TI's pod after the DB transition (#474). A
 	// silent agent may be a network-partitioned but still-running container;
 	// deleting the pod is what actually stops the abandoned work. Nil in Lite.
 	pods PodManager
 }
 
-func newAgentLostReaper(store HeartbeatReapStore, logger *slog.Logger, threshold time.Duration, rec Recorder) *agentLostReaper {
+func newAgentLostReaper(store HeartbeatReapStore, logger *slog.Logger, threshold time.Duration, rec DecisionRecorder) *agentLostReaper {
 	return &agentLostReaper{store: store, logger: logger, threshold: threshold, recorder: rec}
 }
 

--- a/internal/executor/heartbeat_reap_test.go
+++ b/internal/executor/heartbeat_reap_test.go
@@ -1,4 +1,4 @@
-package scheduler
+package executor
 
 import (
 	"context"

--- a/internal/executor/pod_cache_reap_test.go
+++ b/internal/executor/pod_cache_reap_test.go
@@ -1,4 +1,4 @@
-package scheduler
+package executor
 
 import (
 	"context"
@@ -199,26 +199,6 @@ func TestDispatchLostReaper_CacheAbsentAndLiveAbsent_Reaps(t *testing.T) {
 	}
 	if len(pods.deletedTasks) != 1 || pods.deletedTasks[0] != (deletedTask{"run-a", "work", 4}) {
 		t.Fatalf("teardown must be pinned to (run-a,work,try 4), got %v", pods.deletedTasks)
-	}
-}
-
-// TestStepThreadsPresenceCacheToReapers is the wiring check: a presence cache set
-// via SetPodPresenceCache must reach the dispatch-lost reaper through
-// Step → reapOrphansIfLeader. A stale queued TI whose pod the cache shows as
-// active is deferred, so a leader tick does NOT fail it — proving the cache is
-// threaded, not dropped on the floor.
-func TestStepThreadsPresenceCacheToReapers(t *testing.T) {
-	store := newFakeStore()
-	store.staleQueuedCands = []StaleQueuedCandidate{
-		{TaskInstanceID: "slow", DagRunID: "run-a", TaskID: "work", QueuedAt: time.Now().UTC().Add(-10 * time.Minute)},
-	}
-	s := newScheduler(store)
-	s.SetPodPresenceCache(&fakePresenceCache{active: map[string]bool{"run-a/work": true}})
-	if err := s.Step(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	if len(store.dispatchLostMarked) != 0 {
-		t.Errorf("a cache-active queued TI must be deferred through Step, got %v", store.dispatchLostMarked)
 	}
 }
 

--- a/internal/executor/pod_lost_reap.go
+++ b/internal/executor/pod_lost_reap.go
@@ -1,4 +1,4 @@
-package scheduler
+package executor
 
 import (
 	"context"
@@ -67,7 +67,7 @@ type podLostReaper struct {
 	store    PodLostReapStore
 	logger   *slog.Logger
 	grace    time.Duration
-	recorder Recorder
+	recorder DecisionRecorder
 	// pods is required for this reaper to do anything; nil (Lite) makes run a
 	// no-op. See the type doc.
 	pods PodManager
@@ -79,7 +79,7 @@ type podLostReaper struct {
 	cache PodPresenceCache
 }
 
-func newPodLostReaper(store PodLostReapStore, logger *slog.Logger, grace time.Duration, rec Recorder) *podLostReaper {
+func newPodLostReaper(store PodLostReapStore, logger *slog.Logger, grace time.Duration, rec DecisionRecorder) *podLostReaper {
 	return &podLostReaper{store: store, logger: logger, grace: grace, recorder: rec}
 }
 

--- a/internal/executor/pod_lost_reap_test.go
+++ b/internal/executor/pod_lost_reap_test.go
@@ -1,4 +1,4 @@
-package scheduler
+package executor
 
 import (
 	"context"

--- a/internal/executor/pod_manager.go
+++ b/internal/executor/pod_manager.go
@@ -1,4 +1,4 @@
-package scheduler
+package executor
 
 import "context"
 

--- a/internal/executor/reap.go
+++ b/internal/executor/reap.go
@@ -1,4 +1,4 @@
-package scheduler
+package executor
 
 import (
 	"context"
@@ -53,13 +53,13 @@ type orphanReaper struct {
 	store     ReapStore
 	logger    *slog.Logger
 	threshold time.Duration
-	recorder  Recorder
+	recorder  DecisionRecorder
 	// pods tears down the reaped run's pods after the DB transition (#474).
 	// Nil in Lite (no pods); the delete is skipped.
 	pods PodManager
 }
 
-func newOrphanReaper(store ReapStore, logger *slog.Logger, threshold time.Duration, rec Recorder) *orphanReaper {
+func newOrphanReaper(store ReapStore, logger *slog.Logger, threshold time.Duration, rec DecisionRecorder) *orphanReaper {
 	return &orphanReaper{store: store, logger: logger, threshold: threshold, recorder: rec}
 }
 

--- a/internal/executor/reap_pod_teardown_test.go
+++ b/internal/executor/reap_pod_teardown_test.go
@@ -1,4 +1,4 @@
-package scheduler
+package executor
 
 import (
 	"context"

--- a/internal/executor/reap_test.go
+++ b/internal/executor/reap_test.go
@@ -1,4 +1,4 @@
-package scheduler
+package executor
 
 import (
 	"context"

--- a/internal/executor/reaper.go
+++ b/internal/executor/reaper.go
@@ -1,0 +1,169 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+)
+
+// DecisionRecorder records the reaper's per-tick decision metrics. It is the
+// narrow slice of the scheduler's metrics sink the reapers need — only the one
+// counter — so the executor depends on a capability, not on the observability
+// package. A nil DecisionRecorder is tolerated (tests need not stub it).
+type DecisionRecorder interface {
+	RecordSchedulerDecision(decisionType string)
+}
+
+// ReaperStore is the full store surface the four reapers need, composed from
+// each reaper's own slice. The metadatabase-backed SchedulerStore satisfies all
+// four, so production wires through one type; a unit test fakes just the slice
+// its reaper touches.
+type ReaperStore interface {
+	ReapStore
+	HeartbeatReapStore
+	DispatchLostReapStore
+	PodLostReapStore
+}
+
+// Default reaper thresholds. These carry over verbatim from the values the
+// scheduler used to own; they are the floor a stuck run/TI/pod must sit idle
+// before a backstop reaps it.
+//
+//   - orphan (5m):        a running dag run may stay quiet this long before the
+//     run reaper declares it orphaned — well above any healthy tick or hand-off.
+//   - agent-lost (90s):   6x the default 15s agent heartbeat interval, tolerating
+//     a handful of missed pings before failing the TI as agent_lost.
+//   - dispatch-lost (3m): well above healthy dispatch latency on Lite or Pro, so
+//     a live dispatch is never reaped but a stuck queued TI is caught quickly.
+//   - pod-lost (60s):     a floor against a transient "pod not listed yet" blip
+//     right after the running transition; the reap still needs a no-live-pod read.
+const (
+	defaultOrphanThreshold       = 5 * time.Minute
+	defaultAgentLostThreshold    = 90 * time.Second
+	defaultDispatchLostThreshold = 3 * time.Minute
+	defaultPodLostGrace          = 60 * time.Second
+)
+
+// ReaperConfig holds the four idle thresholds the reapers apply. Zero values are
+// legal but reap aggressively; callers pass DefaultReaperConfig unless a test or
+// load harness deliberately overrides them.
+type ReaperConfig struct {
+	OrphanThreshold       time.Duration
+	AgentLostThreshold    time.Duration
+	DispatchLostThreshold time.Duration
+	PodLostGrace          time.Duration
+}
+
+// DefaultReaperConfig returns the production thresholds — the exact values the
+// scheduler configured before the reapers moved here.
+func DefaultReaperConfig() ReaperConfig {
+	return ReaperConfig{
+		OrphanThreshold:       defaultOrphanThreshold,
+		AgentLostThreshold:    defaultAgentLostThreshold,
+		DispatchLostThreshold: defaultDispatchLostThreshold,
+		PodLostGrace:          defaultPodLostGrace,
+	}
+}
+
+// Reaper is the execution-side backstop that fails stuck runs and task instances
+// the scheduler dispatched but that then went dark. It bundles the four
+// independent reapers behind one ReapOnce entrypoint the scheduler drives once
+// per leader tick, so the scheduler depends on a single capability rather than
+// wiring each reaper itself.
+type Reaper struct {
+	orphan       *orphanReaper
+	agentLost    *agentLostReaper
+	dispatchLost *dispatchLostReaper
+	podLost      *podLostReaper
+	logger       *slog.Logger
+	rec          DecisionRecorder
+	// inStepDown reports whether the scheduler is in a graceful leader step-down,
+	// so an expected context-cancel fanout of the run-context logs at WARN, not
+	// ERROR (#311). Nil is tolerated (treated as "not stepping down").
+	inStepDown func() bool
+}
+
+// NewReaper constructs the four reapers and wires their pod-teardown / liveness
+// capability (pods) and, for the two K8s-aware reapers, the presence cache. The
+// wiring mirrors exactly what the scheduler used to do inline: every reaper gets
+// pods; only the dispatch-lost and pod-lost reapers get the cache. Nil pods
+// (Lite/subprocess) keeps every reaper DB-only and makes the pod-lost reaper a
+// no-op, byte-for-byte as before.
+func NewReaper(store ReaperStore, pods PodManager, cache PodPresenceCache, rec DecisionRecorder, logger *slog.Logger, cfg ReaperConfig, inStepDown func() bool) *Reaper {
+	orphan := newOrphanReaper(store, logger, cfg.OrphanThreshold, rec)
+	orphan.pods = pods
+
+	agentLost := newAgentLostReaper(store, logger, cfg.AgentLostThreshold, rec)
+	agentLost.pods = pods
+
+	dispatchLost := newDispatchLostReaper(store, logger, cfg.DispatchLostThreshold, rec)
+	dispatchLost.pods = pods
+	dispatchLost.cache = cache
+
+	podLost := newPodLostReaper(store, logger, cfg.PodLostGrace, rec)
+	podLost.pods = pods
+	podLost.cache = cache
+
+	return &Reaper{
+		orphan:       orphan,
+		agentLost:    agentLost,
+		dispatchLost: dispatchLost,
+		podLost:      podLost,
+		logger:       logger,
+		rec:          rec,
+		inStepDown:   inStepDown,
+	}
+}
+
+// ReapOnce runs the four reapers once, in the same order the scheduler drove
+// them: orphan-run, then agent-lost, then dispatch-lost, then pod-lost. The
+// dispatch-lost reaper runs AFTER the orphan-run reaper so a clean
+// stuck-queued -> failed -> orphan-run-failed chain can complete in a single
+// tick once the thresholds elapse.
+//
+// Each reaper's infra-level list error is logged and metered but never returned:
+// the reapers are independent backstops, so one's failure must not block the
+// others, and a list error must not stall the scheduler tick. Per-candidate
+// failures are already isolated inside each reaper's run. ReapOnce therefore
+// always returns nil today; the error return is kept for the seam so a future
+// hard-failure mode need not change the scheduler.
+func (r *Reaper) ReapOnce(ctx context.Context) error {
+	if err := r.orphan.run(ctx); err != nil {
+		r.logError("orphan reaper", err)
+		r.record("orphan_list_error")
+	}
+	if err := r.agentLost.run(ctx); err != nil {
+		r.logError("agent-lost reaper", err)
+		r.record("agent_lost_list_error")
+	}
+	if err := r.dispatchLost.run(ctx); err != nil {
+		r.logError("dispatch-lost reaper", err)
+		r.record("dispatch_lost_list_error")
+	}
+	if err := r.podLost.run(ctx); err != nil {
+		r.logError("pod-lost reaper", err)
+		r.record("pod_lost_list_error")
+	}
+	return nil
+}
+
+// logError mirrors the scheduler's logSchedulerError: downgrade a reaper's error
+// to WARN only when it wraps context.Canceled AND the scheduler is currently in a
+// graceful leader step-down (the run-context is canceled as the leader releases
+// the advisory lock, and every in-flight reaper returns "context canceled"
+// milliseconds later — a non-event, #311). Any other error, or a cancel outside a
+// known step-down, stays ERROR: the tripwire that catches an unexpected cancel.
+func (r *Reaper) logError(msg string, err error) {
+	if r.inStepDown != nil && r.inStepDown() && errors.Is(err, context.Canceled) {
+		r.logger.Warn(msg+" canceled (leader step-down in progress)", "error", err, "expected", true)
+		return
+	}
+	r.logger.Error(msg, "error", err)
+}
+
+func (r *Reaper) record(decision string) {
+	if r.rec != nil {
+		r.rec.RecordSchedulerDecision(decision)
+	}
+}

--- a/internal/executor/reaper_test.go
+++ b/internal/executor/reaper_test.go
@@ -1,0 +1,130 @@
+package executor
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// capturingRecorder records every scheduler decision the reapers meter, so a
+// test can assert on the decision counters. It satisfies DecisionRecorder.
+// Concurrency-safe to match the production recorder.
+type capturingRecorder struct {
+	mu        sync.Mutex
+	decisions []string
+}
+
+func (r *capturingRecorder) RecordSchedulerDecision(d string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.decisions = append(r.decisions, d)
+}
+
+func (r *capturingRecorder) count(decision string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	n := 0
+	for _, d := range r.decisions {
+		if d == decision {
+			n++
+		}
+	}
+	return n
+}
+
+// fakeReaperStore satisfies the full ReaperStore (all four reap interfaces), so
+// a test can drive NewReaper + ReapOnce end-to-end and assert which candidates
+// each reaper marked. Empty candidate slices make a reaper a no-op.
+type fakeReaperStore struct {
+	orphanCands  []ReapCandidate
+	reapedRuns   []string
+	agentCands   []AgentLostCandidate
+	agentMarked  []string
+	queuedCands  []StaleQueuedCandidate
+	queuedMarked []string
+	runningCands []PodLostCandidate
+	podMarked    []string
+}
+
+func (f *fakeReaperStore) ListReapCandidates(context.Context) ([]ReapCandidate, error) {
+	return f.orphanCands, nil
+}
+func (f *fakeReaperStore) ReapRun(_ context.Context, runID string) error {
+	f.reapedRuns = append(f.reapedRuns, runID)
+	return nil
+}
+func (f *fakeReaperStore) ListAgentLostCandidates(context.Context) ([]AgentLostCandidate, error) {
+	return f.agentCands, nil
+}
+func (f *fakeReaperStore) MarkTaskAgentLost(_ context.Context, tiID string) (bool, error) {
+	f.agentMarked = append(f.agentMarked, tiID)
+	return true, nil
+}
+func (f *fakeReaperStore) ListStaleQueuedCandidates(context.Context) ([]StaleQueuedCandidate, error) {
+	return f.queuedCands, nil
+}
+func (f *fakeReaperStore) MarkTaskDispatchLost(_ context.Context, tiID string) error {
+	f.queuedMarked = append(f.queuedMarked, tiID)
+	return nil
+}
+func (f *fakeReaperStore) ListRunningTasks(context.Context) ([]PodLostCandidate, error) {
+	return f.runningCands, nil
+}
+func (f *fakeReaperStore) MarkTaskPodLost(_ context.Context, tiID string) (bool, error) {
+	f.podMarked = append(f.podMarked, tiID)
+	return true, nil
+}
+
+// TestReaperReapOnceDrivesReapers is the aggregate-seam contract, the executor
+// side of what used to be TestStepReapsOrphanRunsOnLeader /
+// TestStepRunsDispatchLostReaperOnLeader in the scheduler package: NewReaper
+// wires the four reapers and ReapOnce runs them, so a stale orphan run and a
+// stale queued TI are both reaped in one call. Nil pods (Lite) exercises the
+// DB-only path — the orphan reaper still reaps and the dispatch-lost reaper
+// falls back to its pure time threshold.
+func TestReaperReapOnceDrivesReapers(t *testing.T) {
+	past := time.Now().UTC().Add(-1 * time.Hour)
+	store := &fakeReaperStore{
+		orphanCands: []ReapCandidate{{RunID: "stuck-run", DagID: "etl", LastActivity: past}},
+		queuedCands: []StaleQueuedCandidate{{TaskInstanceID: "stuck-ti", QueuedAt: past}},
+	}
+	rec := &capturingRecorder{}
+	r := NewReaper(store, nil, nil, rec, reapTestLogger(), DefaultReaperConfig(), nil)
+
+	if err := r.ReapOnce(context.Background()); err != nil {
+		t.Fatalf("ReapOnce: %v", err)
+	}
+	if len(store.reapedRuns) != 1 || store.reapedRuns[0] != "stuck-run" {
+		t.Errorf("orphan reaper must reap stuck-run, got %v", store.reapedRuns)
+	}
+	if len(store.queuedMarked) != 1 || store.queuedMarked[0] != "stuck-ti" {
+		t.Errorf("dispatch-lost reaper must fail stuck-ti, got %v", store.queuedMarked)
+	}
+}
+
+// TestReaperThreadsPresenceCacheToDispatchLost is the wiring check re-homed from
+// the scheduler's TestStepThreadsPresenceCacheToReapers: a presence cache passed
+// to NewReaper must reach the dispatch-lost reaper. A stale queued TI whose pod
+// the cache shows as active is deferred, so ReapOnce does NOT fail it — proving
+// the cache is threaded, not dropped on the floor.
+func TestReaperThreadsPresenceCacheToDispatchLost(t *testing.T) {
+	store := &fakeReaperStore{
+		queuedCands: []StaleQueuedCandidate{
+			{TaskInstanceID: "slow", DagRunID: "run-a", TaskID: "work", QueuedAt: time.Now().UTC().Add(-10 * time.Minute)},
+		},
+	}
+	pods := &fakePodManager{active: map[string]bool{}}
+	cache := &fakePresenceCache{active: map[string]bool{"run-a/work": true}}
+	r := NewReaper(store, pods, cache, nil, reapTestLogger(), DefaultReaperConfig(), nil)
+
+	if err := r.ReapOnce(context.Background()); err != nil {
+		t.Fatalf("ReapOnce: %v", err)
+	}
+	if len(store.queuedMarked) != 0 {
+		t.Errorf("a cache-active queued TI must be deferred through ReapOnce, got %v", store.queuedMarked)
+	}
+	if pods.activeCalls != 0 {
+		t.Errorf("a cache-active defer must skip the live LIST, got %d live calls", pods.activeCalls)
+	}
+}

--- a/internal/executor/stale_queued_reap.go
+++ b/internal/executor/stale_queued_reap.go
@@ -1,4 +1,4 @@
-package scheduler
+package executor
 
 import (
 	"context"
@@ -60,7 +60,7 @@ type dispatchLostReaper struct {
 	store     DispatchLostReapStore
 	logger    *slog.Logger
 	threshold time.Duration
-	recorder  Recorder
+	recorder  DecisionRecorder
 	// pods makes the reaper K8s-aware (#461): before failing a past-threshold
 	// queued TI, it checks whether the TI's pod is actually live (Pending/
 	// Running) — a slow image pull on a cold node means the dispatch DID land,
@@ -75,7 +75,7 @@ type dispatchLostReaper struct {
 	cache PodPresenceCache
 }
 
-func newDispatchLostReaper(store DispatchLostReapStore, logger *slog.Logger, threshold time.Duration, rec Recorder) *dispatchLostReaper {
+func newDispatchLostReaper(store DispatchLostReapStore, logger *slog.Logger, threshold time.Duration, rec DecisionRecorder) *dispatchLostReaper {
 	return &dispatchLostReaper{store: store, logger: logger, threshold: threshold, recorder: rec}
 }
 

--- a/internal/executor/stale_queued_reap_test.go
+++ b/internal/executor/stale_queued_reap_test.go
@@ -1,4 +1,4 @@
-package scheduler
+package executor
 
 import (
 	"context"
@@ -111,40 +111,5 @@ func TestReapDispatchLost_PerTIErrorIsolated(t *testing.T) {
 	r := newDispatchLostReaper(store, reapTestLogger(), 3*time.Minute, nil)
 	if err := r.run(context.Background()); err != nil {
 		t.Errorf("run err = %v, want nil (per-TI errors isolated)", err)
-	}
-}
-
-// TestStepRunsDispatchLostReaperOnLeader is the end-to-end wiring check:
-// Step → reapOrphansIfLeader → newDispatchLostReaper.run. A leader that ticks
-// with a stale queued candidate must fail it; a follower never reaps.
-func TestStepRunsDispatchLostReaperOnLeader(t *testing.T) {
-	store := newFakeStore()
-	store.staleQueuedCands = []StaleQueuedCandidate{
-		{TaskInstanceID: "stuck-ti", QueuedAt: time.Now().UTC().Add(-10 * time.Minute)},
-	}
-	s := newScheduler(store)
-	s.SetLeading(true)
-	if err := s.Step(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	if len(store.dispatchLostMarked) != 1 || store.dispatchLostMarked[0] != "stuck-ti" {
-		t.Errorf("leader Step should reap stuck-ti, got %v", store.dispatchLostMarked)
-	}
-}
-
-// TestStepSkipsDispatchLostReaperOnFollower mirrors TestStepDoesNotReapOnFollower:
-// reaping writes state and must be single-writer across the fleet.
-func TestStepSkipsDispatchLostReaperOnFollower(t *testing.T) {
-	store := newFakeStore()
-	store.staleQueuedCands = []StaleQueuedCandidate{
-		{TaskInstanceID: "stuck-ti", QueuedAt: time.Now().UTC().Add(-10 * time.Minute)},
-	}
-	s := newScheduler(store)
-	s.SetLeading(false) // newScheduler defaults to leader; opt out for follower-mode test.
-	if err := s.Step(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	if len(store.dispatchLostMarked) != 0 {
-		t.Errorf("follower must not reap, got %v", store.dispatchLostMarked)
 	}
 }

--- a/internal/scheduler/reaper_seam_test.go
+++ b/internal/scheduler/reaper_seam_test.go
@@ -1,0 +1,78 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// spyExecutionReaper records how many times the scheduler drove it, so the seam
+// tests can assert the leader-gating contract without depending on the executor
+// package. The reaper's own marking behavior is covered by the executor-package
+// reaper tests; here we only prove the scheduler invokes it at the right time.
+type spyExecutionReaper struct {
+	calls int
+}
+
+func (s *spyExecutionReaper) ReapOnce(context.Context) error {
+	s.calls++
+	return nil
+}
+
+// TestStepDrivesExecutionReaperOnLeader is the leader half of the reap-gate
+// contract (#120/#208), re-expressed at the new seam: a leader tick drives the
+// execution reaper exactly once. It replaces the pre-refactor
+// TestStepReapsOrphanRunsOnLeader / TestStepRunsDispatchLostReaperOnLeader,
+// whose end-to-end marking behavior now lives in the executor package.
+func TestStepDrivesExecutionReaperOnLeader(t *testing.T) {
+	s := newScheduler(newFakeStore())
+	s.SetLeading(true)
+	reaper := &spyExecutionReaper{}
+	s.SetExecutionReaper(reaper)
+
+	if err := s.Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if reaper.calls != 1 {
+		t.Errorf("a leader tick must drive the execution reaper once, got %d", reaper.calls)
+	}
+}
+
+// TestStepDrivesExecutionReaperEvenIfCreateDueRunsFails preserves the backstop
+// guard from the pre-refactor TestStepReapsEvenIfCreateDueRunsFails: the reaper
+// runs even when the rest of the tick is degraded (a DB hiccup on
+// createScheduledRun), because a sick DB hiding orphans exactly when you want to
+// see them would be a silent failure mode.
+func TestStepDrivesExecutionReaperEvenIfCreateDueRunsFails(t *testing.T) {
+	store := newFakeStore()
+	last := time.Now().UTC().Add(-2 * time.Hour)
+	store.scheduled = []ScheduledDAG{{DagID: "etl", Schedule: "@hourly", LastLogical: &last}}
+	store.createErr = true
+	s := newScheduler(store)
+	s.SetLeading(true)
+	reaper := &spyExecutionReaper{}
+	s.SetExecutionReaper(reaper)
+
+	_ = s.Step(context.Background())
+	if reaper.calls != 1 {
+		t.Errorf("the reaper must run even when createScheduledRun fails, got %d calls", reaper.calls)
+	}
+}
+
+// TestStepSkipsExecutionReaperOnFollower is the follower half: reaping writes
+// state and must be single-writer across the fleet, so a follower tick never
+// drives the reaper. Replaces the pre-refactor TestStepDoesNotReapOnFollower /
+// TestStepSkipsDispatchLostReaperOnFollower.
+func TestStepSkipsExecutionReaperOnFollower(t *testing.T) {
+	s := newScheduler(newFakeStore())
+	s.SetLeading(false) // newScheduler defaults to leader; opt out for follower-mode test.
+	reaper := &spyExecutionReaper{}
+	s.SetExecutionReaper(reaper)
+
+	if err := s.Step(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if reaper.calls != 0 {
+		t.Errorf("a follower must not drive the execution reaper, got %d calls", reaper.calls)
+	}
+}

--- a/internal/scheduler/resilience_test.go
+++ b/internal/scheduler/resilience_test.go
@@ -123,23 +123,6 @@ func (f *flakyStore) MarkRunAlertDelivered(context.Context, string, int) error {
 
 func (f *flakyStore) SetTaskNote(context.Context, string, string, string) error { return nil }
 
-func (f *flakyStore) ListReapCandidates(context.Context) ([]ReapCandidate, error) {
-	return nil, nil
-}
-func (f *flakyStore) ReapRun(context.Context, string) error { return nil }
-func (f *flakyStore) ListAgentLostCandidates(context.Context) ([]AgentLostCandidate, error) {
-	return nil, nil
-}
-func (f *flakyStore) MarkTaskAgentLost(context.Context, string) (bool, error) { return true, nil }
-func (f *flakyStore) ListStaleQueuedCandidates(context.Context) ([]StaleQueuedCandidate, error) {
-	return nil, nil
-}
-func (f *flakyStore) MarkTaskDispatchLost(context.Context, string) error { return nil }
-func (f *flakyStore) ListRunningTasks(context.Context) ([]PodLostCandidate, error) {
-	return nil, nil
-}
-func (f *flakyStore) MarkTaskPodLost(context.Context, string) (bool, error) { return true, nil }
-
 func (f *flakyStore) snapshotMaterialized() []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -213,25 +213,6 @@ type Store interface {
 	// SetTaskNote attaches operational context to a task instance (shown in the
 	// UI), e.g. why it is queued but not running.
 	SetTaskNote(ctx context.Context, runID, taskID, note string) error
-	// ReapStore methods drive the orphan reaper (#120): they list running runs
-	// that have gone quiet and fail them so the dashboard counter is correct.
-	ReapStore
-	// HeartbeatReapStore methods drive the TI heartbeat reaper (#128): they
-	// list `running` task instances whose agent has gone silent and fail them
-	// as `agent_lost` so the dashboard counter recovers from agent-side crashes.
-	HeartbeatReapStore
-	// DispatchLostReapStore methods drive the dispatch-lost reaper (#202):
-	// they list `queued` task instances whose dispatch has been pending past
-	// the threshold and fail them as `dispatch_lost`. This unblocks the
-	// orphan-run reaper for runs stuck by a mid-tick scheduler crash, which
-	// would otherwise keep stuck queued TIs out of the candidate set forever
-	// (the orphan reaper's "no active TI" safety guard).
-	DispatchLostReapStore
-	// PodLostReapStore methods drive the pod-lost reaper (#527): they list
-	// `running` task instances and fail as `pod_lost` any whose backing pod has
-	// vanished past a grace period, closing the window where a pod killed before
-	// its first heartbeat sat `running` until the 5-minute orphan reaper.
-	PodLostReapStore
 }
 
 // Recorder records scheduler metrics. observability.Metrics implements it.
@@ -269,40 +250,11 @@ type Dispatcher interface {
 // ADR 0031).
 const maxCatchupSlotsPerTick = 100
 
-// defaultOrphanThreshold is how long a running dag run may stay quiet before
-// the reaper declares it orphaned. Five minutes is well above any healthy tick
-// or task hand-off latency, so a live run is never reaped, but short enough
-// that a real orphan is reaped before the operator looks at the dashboard.
-const defaultOrphanThreshold = 5 * time.Minute
-
 // defaultAlertConcurrency caps concurrent on-failure alert dispatches (#424) so a
 // mass failure can't spawn an unbounded burst of alert goroutines/POSTs. Each
 // dispatch is short (bounded by the notifier's HTTP timeout), so a small pool
 // absorbs normal bursts; beyond it, extra alerts are dropped best-effort.
 const defaultAlertConcurrency = 8
-
-// defaultAgentLostThreshold is how long a running TI may go without an agent
-// heartbeat before the TI reaper declares the agent lost. 90 s is 6x the
-// default agent heartbeat interval (15 s, see cmd/leoflow-agent/main.go),
-// tolerating a handful of missed pings before failing the task.
-const defaultAgentLostThreshold = 90 * time.Second
-
-// defaultDispatchLostThreshold is how long a TI may stay `queued` before the
-// dispatch-lost reaper declares it dispatch-lost. 3 minutes is well above
-// any healthy dispatch latency on Lite (sub-millisecond passthrough) or Pro
-// (bounded pool, low single-digit seconds even under load), so a live
-// dispatch is never reaped, but short enough that a stuck queued TI from a
-// mid-tick scheduler crash is reaped before the operator notices (#202).
-const defaultDispatchLostThreshold = 3 * time.Minute
-
-// defaultPodLostGrace is how long a TI may be `running` before the pod-lost
-// reaper checks whether its pod still exists (#527). It only matters as a floor
-// against a transient "pod not listed yet" blip right after the running
-// transition — the actual reap needs TaskPodActive to report NO live pod, so a
-// slow-starting (Pending) pod is deferred regardless. 60 s catches a pod that
-// vanished in its first seconds ~5x faster than the 5-minute orphan reaper,
-// while staying well clear of any real pod lifecycle timing. Kubernetes-only.
-const defaultPodLostGrace = 60 * time.Second
 
 // Scheduler advances dag runs by applying the planning rules each tick.
 type Scheduler struct {
@@ -317,24 +269,16 @@ type Scheduler struct {
 	// failure must not spawn an unbounded burst of alert goroutines/POSTs. A
 	// buffered channel used as a counting semaphore; a saturated slot drops the
 	// alert (best-effort) rather than blocking the tick.
-	alertSem              chan struct{}
-	orphanThreshold       time.Duration
-	agentLostThreshold    time.Duration
-	dispatchLostThreshold time.Duration
-	podLostGrace          time.Duration
-	// podManager lets the reapers tear down a reaped task's pod and gate the
-	// dispatch-lost decision on pod liveness (#474, #461). Nil in Lite; the
-	// reapers guard the nil and fall back to DB-only behavior.
-	podManager PodManager
-	// podPresenceCache is an optional informer-backed read cache (PR-10) the
-	// pod-lost and dispatch-lost reapers consult to DEFER a reap without an
-	// apiserver LIST. Trusted only in the safe (presence) direction; a miss falls
-	// through to podManager's live read (#461). Nil in Lite and before the
-	// informer is wired — every candidate then uses the live path.
-	podPresenceCache PodPresenceCache
-	lastTick         atomic.Int64 // unix-nano of the last loop iteration; 0 = not yet ticked
-	leading          atomic.Bool  // true only while this instance holds leadership and ticks
-	steppingDown     atomic.Bool  // true only during a leader step-down — the campaign loop sets it before canceling the run-context so the expected cancel-fanout logs at WARN, not ERROR (#311 tripwire preserved when it's false)
+	alertSem chan struct{}
+	// executionReaper is the execution-side backstop that fails stuck runs and
+	// task instances (the four reapers, #120/#128/#202/#527). It lives in the
+	// executor package because reaping tears down pods and gates on pod liveness;
+	// the scheduler only drives it once per leader tick through this seam. Nil
+	// leaves the tick with no reaping (e.g. a load harness that opts out).
+	executionReaper ExecutionReaper
+	lastTick        atomic.Int64 // unix-nano of the last loop iteration; 0 = not yet ticked
+	leading         atomic.Bool  // true only while this instance holds leadership and ticks
+	steppingDown    atomic.Bool  // true only during a leader step-down — the campaign loop sets it before canceling the run-context so the expected cancel-fanout logs at WARN, not ERROR (#311 tripwire preserved when it's false)
 	// warnedSchedules dedupes the "unparseable schedule" warning per DAG (keyed by
 	// the offending expression) so a bad cron logs once, not every tick. Accessed
 	// only from the single-threaded tick (createDueRuns), so it needs no lock.
@@ -351,53 +295,30 @@ type Scheduler struct {
 // NewScheduler builds a Scheduler over the given store, ticking every interval.
 func NewScheduler(store Store, logger *slog.Logger, interval time.Duration) *Scheduler {
 	return &Scheduler{
-		store:                 store,
-		logger:                logger,
-		interval:              interval,
-		stepTimeout:           defaultStepTimeout(interval),
-		orphanThreshold:       defaultOrphanThreshold,
-		agentLostThreshold:    defaultAgentLostThreshold,
-		dispatchLostThreshold: defaultDispatchLostThreshold,
-		podLostGrace:          defaultPodLostGrace,
-		warnedSchedules:       map[string]string{},
-		alertSem:              make(chan struct{}, defaultAlertConcurrency),
+		store:           store,
+		logger:          logger,
+		interval:        interval,
+		stepTimeout:     defaultStepTimeout(interval),
+		warnedSchedules: map[string]string{},
+		alertSem:        make(chan struct{}, defaultAlertConcurrency),
 	}
 }
 
-// SetOrphanThreshold overrides the stall-detection window the reaper uses to
-// declare a running dag run orphaned (optional; mainly for tests). The default
-// is defaultOrphanThreshold.
-func (s *Scheduler) SetOrphanThreshold(d time.Duration) { s.orphanThreshold = d }
+// ExecutionReaper is the execution-side backstop the scheduler drives once per
+// leader tick to fail stuck runs and task instances. It is the seam between the
+// scheduler (which owns the leader gate and the tick) and the executor package
+// (which owns pod teardown and pod-liveness). executor.Reaper satisfies it.
+type ExecutionReaper interface {
+	// ReapOnce runs every reaper once. Implementations isolate per-reaper and
+	// per-candidate failures internally and log/meter list errors, so the
+	// scheduler ignores the return today; the error is kept for the seam.
+	ReapOnce(ctx context.Context) error
+}
 
-// SetAgentLostThreshold overrides the silence window the TI heartbeat reaper
-// uses to declare a task's agent lost (optional; mainly for tests). The default
-// is defaultAgentLostThreshold.
-func (s *Scheduler) SetAgentLostThreshold(d time.Duration) { s.agentLostThreshold = d }
-
-// SetDispatchLostThreshold overrides the wait window the dispatch-lost reaper
-// uses to declare a queued task's dispatch lost (optional; mainly for tests).
-// The default is defaultDispatchLostThreshold.
-func (s *Scheduler) SetDispatchLostThreshold(d time.Duration) { s.dispatchLostThreshold = d }
-
-// SetPodLostGrace overrides how long a TI may be `running` before the pod-lost
-// reaper checks pod liveness (optional; mainly for tests). The default is
-// defaultPodLostGrace.
-func (s *Scheduler) SetPodLostGrace(d time.Duration) { s.podLostGrace = d }
-
-// SetPodManager wires the pod-teardown / liveness capability the reapers use to
-// stop a reaped task's pod and to defer the dispatch-lost decision when a
-// queued TI's pod is actually live (#474, #461). Left unset in Lite/subprocess,
-// where the reapers stay DB-only. Called from main once the K8s client exists.
-func (s *Scheduler) SetPodManager(pm PodManager) { s.podManager = pm }
-
-// SetPodPresenceCache wires the informer-backed presence cache the pod-lost and
-// dispatch-lost reapers use to defer a reap without a live apiserver LIST (PR-10).
-// It is consulted only in the safe direction: a cached Pending/Running pod defers;
-// a miss falls through to the live TaskPodActive read, so cache lag can never
-// cause a false-positive reap (#461). Left unset in Lite/subprocess and until the
-// informer is constructed, where the reapers stay on the live path. Called from
-// main on the Pro (scheduler/all) K8s path only.
-func (s *Scheduler) SetPodPresenceCache(c PodPresenceCache) { s.podPresenceCache = c }
+// SetExecutionReaper wires the execution-side reaper the scheduler drives on the
+// leader tick. Left unset (e.g. a load harness, or a Lite path that opts out of
+// reaping), the tick simply reaps nothing.
+func (s *Scheduler) SetExecutionReaper(r ExecutionReaper) { s.executionReaper = r }
 
 // defaultStepTimeout bounds how long one scheduling tick may run before it is
 // canceled so the loop can recover, rather than hang forever on a stuck query.
@@ -463,8 +384,9 @@ func (s *Scheduler) RecordReacquireSince(stepDownAt time.Time) {
 }
 
 // SteppingDown exposes the current step-down state for tests and callers that
-// want to classify an error themselves (the four scheduler.go log sites call
-// logSchedulerError with this value).
+// want to classify an error themselves: the scheduler's own log sites pass it to
+// logSchedulerError, and the execution reaper receives it (as the inStepDown
+// callback) so an expected step-down cancel logs at WARN, not ERROR (#311).
 func (s *Scheduler) SteppingDown() bool { return s.steppingDown.Load() }
 
 // SetRecorder attaches a metrics recorder (optional).
@@ -626,51 +548,25 @@ func (s *Scheduler) Step(ctx context.Context) error {
 	return createErr
 }
 
-// reapOrphansIfLeader runs both reapers (run-level orphans + TI-level
-// agent-lost) exactly once per tick, only on the leader: reaping writes state
-// and we want one writer at a time across the fleet. A list error is logged
-// (not returned) because it should not stall the rest of the loop — the
-// reapers are backstops, not on the critical path. The two reapers are
-// independent: a failure in one does not prevent the other from running.
+// reapOrphansIfLeader drives the execution-side reaper exactly once per tick,
+// only on the leader: reaping writes state and we want one writer at a time
+// across the fleet. The reaper (executor.Reaper) isolates per-reaper and
+// per-candidate failures internally and logs/meters its own list errors, so the
+// tick neither returns nor stalls on a reap error — the reapers are backstops,
+// not on the critical path. Nil executionReaper (a harness that opts out, or a
+// role that does no reaping) makes this a no-op.
 func (s *Scheduler) reapOrphansIfLeader(ctx context.Context) {
 	if !s.leading.Load() {
 		return
 	}
-	runReaper := newOrphanReaper(s.store, s.logger, s.orphanThreshold, s.recorder)
-	runReaper.pods = s.podManager
-	if err := runReaper.run(ctx); err != nil {
-		logSchedulerError(s.logger, "orphan reaper", err, s.steppingDown.Load())
-		s.record("orphan_list_error")
+	if s.executionReaper == nil {
+		return
 	}
-	tiReaper := newAgentLostReaper(s.store, s.logger, s.agentLostThreshold, s.recorder)
-	tiReaper.pods = s.podManager
-	if err := tiReaper.run(ctx); err != nil {
-		logSchedulerError(s.logger, "agent-lost reaper", err, s.steppingDown.Load())
-		s.record("agent_lost_list_error")
-	}
-	// The dispatch-lost reaper (#202) catches TIs left in `queued` after a
-	// scheduler crash mid-tick: the orphan-run reaper's "no active TI" guard
-	// would otherwise keep the stuck run alive forever. Running it AFTER the
-	// orphan-run reaper means a clean stuck-queued → failed → orphan-run-failed
-	// chain takes two ticks; running here in the same tick gives a one-tick
-	// chain once the threshold elapses.
-	dispatchReaper := newDispatchLostReaper(s.store, s.logger, s.dispatchLostThreshold, s.recorder)
-	dispatchReaper.pods = s.podManager
-	dispatchReaper.cache = s.podPresenceCache
-	if err := dispatchReaper.run(ctx); err != nil {
-		logSchedulerError(s.logger, "dispatch-lost reaper", err, s.steppingDown.Load())
-		s.record("dispatch_lost_list_error")
-	}
-
-	// Pod-lost reaper (#527): fails a running TI whose pod vanished before any
-	// other reaper could catch it. Kubernetes-only — nil podManager (Lite) makes
-	// it a no-op, so a live subprocess task is never reaped.
-	podLostReaper := newPodLostReaper(s.store, s.logger, s.podLostGrace, s.recorder)
-	podLostReaper.pods = s.podManager
-	podLostReaper.cache = s.podPresenceCache
-	if err := podLostReaper.run(ctx); err != nil {
-		logSchedulerError(s.logger, "pod-lost reaper", err, s.steppingDown.Load())
-		s.record("pod_lost_list_error")
+	// ReapOnce isolates and logs its own per-reaper failures and returns nil
+	// today; the guarded log keeps the scheduler honest if the seam ever grows a
+	// hard-failure return, matching how the tick logs (never returns) reap errors.
+	if err := s.executionReaper.ReapOnce(ctx); err != nil {
+		logSchedulerError(s.logger, "execution reaper", err, s.steppingDown.Load())
 	}
 }
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -30,13 +30,7 @@ type fakeStore struct {
 	scheduled            []ScheduledDAG
 	createdRuns          []string
 	notes                map[string]string
-	reapCands            []ReapCandidate
-	reaped               []string
 	createErr            bool
-	agentLostCands       []AgentLostCandidate
-	agentLostMarked      []string
-	staleQueuedCands     []StaleQueuedCandidate
-	dispatchLostMarked   []string
 	dispatchFailures     []transition
 	dispatchBackpressure []transition
 	dispatchExhausted    []string
@@ -194,30 +188,6 @@ func (f *fakeStore) SetTaskNote(_ context.Context, _, taskID, note string) error
 	f.notes[taskID] = note
 	return nil
 }
-func (f *fakeStore) ListReapCandidates(context.Context) ([]ReapCandidate, error) {
-	return f.reapCands, nil
-}
-func (f *fakeStore) ReapRun(_ context.Context, runID string) error {
-	f.reaped = append(f.reaped, runID)
-	return nil
-}
-func (f *fakeStore) ListAgentLostCandidates(context.Context) ([]AgentLostCandidate, error) {
-	return f.agentLostCands, nil
-}
-func (f *fakeStore) MarkTaskAgentLost(_ context.Context, tiID string) (bool, error) {
-	f.agentLostMarked = append(f.agentLostMarked, tiID)
-	return true, nil
-}
-func (f *fakeStore) ListStaleQueuedCandidates(context.Context) ([]StaleQueuedCandidate, error) {
-	return f.staleQueuedCands, nil
-}
-func (f *fakeStore) MarkTaskDispatchLost(_ context.Context, tiID string) error {
-	f.dispatchLostMarked = append(f.dispatchLostMarked, tiID)
-	return nil
-}
-func (f *fakeStore) ListRunningTasks(context.Context) ([]PodLostCandidate, error) { return nil, nil }
-func (f *fakeStore) MarkTaskPodLost(context.Context, string) (bool, error)        { return true, nil }
-
 func newScheduler(store Store) *Scheduler {
 	s := NewScheduler(store, slog.New(slog.NewTextHandler(io.Discard, nil)), time.Millisecond)
 	// Default tests to leader so the writer-path assertions (which is most of
@@ -473,66 +443,6 @@ func TestStepFinalizesCompletedRun(t *testing.T) {
 	}
 }
 
-// TestStepReapsOrphanRunsOnLeader covers the #120 fix end-to-end at the
-// scheduler layer: a leader tick must reap any candidate older than the orphan
-// threshold (default 5 min), turning a stuck `running` dag run into `failed` so
-// the dashboard's "Dags em Execução" gauge drops back to zero. Fresh candidates
-// stay untouched.
-func TestStepReapsOrphanRunsOnLeader(t *testing.T) {
-	store := newFakeStore()
-	now := time.Now().UTC()
-	store.reapCands = []ReapCandidate{
-		{RunID: "stuck", DagID: "etl", LastActivity: now.Add(-1 * time.Hour)},
-		{RunID: "fresh", DagID: "etl", LastActivity: now.Add(-30 * time.Second)},
-	}
-	s := newScheduler(store)
-	s.SetLeading(true)
-	if err := s.Step(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	if len(store.reaped) != 1 || store.reaped[0] != "stuck" {
-		t.Errorf("reaped = %v, want [stuck]", store.reaped)
-	}
-}
-
-// TestStepReapsEvenIfCreateDueRunsFails covers an important resilience guard:
-// the reaper is a backstop, so it must run even when the rest of the tick is
-// degraded (a DB hiccup on createScheduledRun, for example). The reverse — a
-// sick DB hiding orphans precisely when you want to see them — would be a
-// silent failure mode the dashboard counter would never recover from.
-func TestStepReapsEvenIfCreateDueRunsFails(t *testing.T) {
-	store := newFakeStore()
-	store.reapCands = []ReapCandidate{
-		{RunID: "stuck", LastActivity: time.Now().UTC().Add(-1 * time.Hour)},
-	}
-	last := time.Now().UTC().Add(-2 * time.Hour)
-	store.scheduled = []ScheduledDAG{{DagID: "etl", Schedule: "@hourly", LastLogical: &last}}
-	store.createErr = true
-	s := newScheduler(store)
-	s.SetLeading(true)
-	_ = s.Step(context.Background())
-	if len(store.reaped) != 1 || store.reaped[0] != "stuck" {
-		t.Errorf("reaper must run even when createScheduledRun fails; reaped = %v", store.reaped)
-	}
-}
-
-// TestStepDoesNotReapOnFollower: a follower (or an instance that lost the
-// lock) must not write — reaping is a state-changing operation reserved for the
-// leader. The followers tick to keep their heartbeat path warm but skip the
-// reaper.
-func TestStepDoesNotReapOnFollower(t *testing.T) {
-	store := newFakeStore()
-	store.reapCands = []ReapCandidate{{RunID: "stuck", LastActivity: time.Now().UTC().Add(-1 * time.Hour)}}
-	s := newScheduler(store)
-	s.SetLeading(false) // newScheduler defaults to leader; this test wants follower.
-	if err := s.Step(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	if len(store.reaped) != 0 {
-		t.Errorf("follower must not reap; got %v", store.reaped)
-	}
-}
-
 // TestStepFollowerSkipsAllWrites: a follower (no leadership lock) MUST NOT read
 // or write scheduler state. Today only the reaper is gated; ActiveRuns and
 // createDueRuns also run on every follower, violating the single-writer
@@ -545,9 +455,10 @@ func TestStepFollowerSkipsAllWrites(t *testing.T) {
 		Tries:  map[string]int{"a": 1, "b": 1}, MaxTries: map[string]int{"a": 3, "b": 3},
 	})
 	store.scheduled = []ScheduledDAG{{DagID: "etl", Schedule: "@hourly"}}
-	store.reapCands = []ReapCandidate{{RunID: "stuck", LastActivity: time.Now().UTC().Add(-1 * time.Hour)}}
 	s := newScheduler(store)
 	s.SetLeading(false) // newScheduler defaults to leader; opt out for this follower-mode test.
+	reaper := &spyExecutionReaper{}
+	s.SetExecutionReaper(reaper)
 
 	if err := s.Step(context.Background()); err != nil {
 		t.Fatalf("Step on follower must not return infra-level error: %v", err)
@@ -561,8 +472,8 @@ func TestStepFollowerSkipsAllWrites(t *testing.T) {
 	if len(store.createdRuns) != 0 {
 		t.Errorf("follower must not create scheduled runs; got %v", store.createdRuns)
 	}
-	if len(store.reaped) != 0 {
-		t.Errorf("follower must not reap; got %v", store.reaped)
+	if reaper.calls != 0 {
+		t.Errorf("follower must not drive the execution reaper; got %d calls", reaper.calls)
 	}
 	// Heartbeat MUST still fire — the leadership check sits AFTER lastTick.Store
 	// so the orchestrator can prove the instance is alive without granting it

--- a/internal/storage/chaos_integration_test.go
+++ b/internal/storage/chaos_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/executor"
 	"github.com/neochaotic/leoflow/internal/scheduler"
 )
 
@@ -26,9 +27,9 @@ import (
 //     run up and fails it with `orphaned`.
 //
 // Wall-clock dogfood would wait 3 min + 5 min for the production thresholds;
-// here we shrink them to a couple hundred ms via SetDispatchLostThreshold /
-// SetOrphanThreshold so the test stays fast. We are validating the contract
-// SHAPE, not the production tuning.
+// here we shrink them to a couple hundred ms in the ReaperConfig wired to the
+// scheduler's execution-reaper seam so the test stays fast. We are validating
+// the contract SHAPE, not the production tuning.
 //
 // Skips when DATABASE_URL is absent (no PG available).
 func TestChaosMidTickCrashRecoveryIntegration(t *testing.T) {
@@ -60,11 +61,20 @@ func TestChaosMidTickCrashRecoveryIntegration(t *testing.T) {
 	//    while still well above the per-tick wall-clock latency the in-
 	//    process Step() takes (~ms). The leader flag is the gate the
 	//    reapers check before writing — must be on for any of this to run.
-	s := scheduler.NewScheduler(sched, slog.New(slog.NewTextHandler(io.Discard, nil)), time.Millisecond)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	s := scheduler.NewScheduler(sched, logger, time.Millisecond)
 	s.SetLeading(true)
-	s.SetDispatchLostThreshold(200 * time.Millisecond)
-	s.SetOrphanThreshold(400 * time.Millisecond)
-	s.SetAgentLostThreshold(time.Minute) // irrelevant here, default keeps it from firing on unrelated rows
+	// The reapers now live behind the execution-reaper seam. Wire one over the
+	// same store (Lite path: nil pods/cache/recorder) with thresholds tight
+	// enough for a fast test but well above the ~ms in-process Step() latency.
+	// AgentLostThreshold is a minute — irrelevant here, kept high so it can't fire
+	// on unrelated rows; PodLostGrace is a no-op with nil pods.
+	s.SetExecutionReaper(executor.NewReaper(sched, nil, nil, nil, logger, executor.ReaperConfig{
+		OrphanThreshold:       400 * time.Millisecond,
+		AgentLostThreshold:    time.Minute,
+		DispatchLostThreshold: 200 * time.Millisecond,
+		PodLostGrace:          time.Minute,
+	}, s.SteppingDown))
 
 	// 3. Wait past the dispatch-lost threshold, then tick. The reaper must
 	//    flip our queued TI to failed/dispatch_lost.

--- a/internal/storage/heartbeat_reap_integration_test.go
+++ b/internal/storage/heartbeat_reap_integration_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/neochaotic/leoflow/internal/auth"
 	"github.com/neochaotic/leoflow/internal/config"
 	"github.com/neochaotic/leoflow/internal/domain"
-	"github.com/neochaotic/leoflow/internal/scheduler"
+	"github.com/neochaotic/leoflow/internal/executor"
 	"github.com/neochaotic/leoflow/internal/storage"
 )
 
@@ -154,7 +154,7 @@ func TestMarkTaskAgentLostIntegration(t *testing.T) {
 
 // findAgentLostCandidate returns the candidate matching the run uuid (a
 // single-TI test set), or nil.
-func findAgentLostCandidate(cands []scheduler.AgentLostCandidate, runUUID string) *scheduler.AgentLostCandidate {
+func findAgentLostCandidate(cands []executor.AgentLostCandidate, runUUID string) *executor.AgentLostCandidate {
 	for i := range cands {
 		if cands[i].DagRunID == runUUID {
 			return &cands[i]

--- a/internal/storage/lima_bugs_integration_test.go
+++ b/internal/storage/lima_bugs_integration_test.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/neochaotic/leoflow/internal/domain"
-	"github.com/neochaotic/leoflow/internal/scheduler"
+	"github.com/neochaotic/leoflow/internal/executor"
 	"github.com/neochaotic/leoflow/internal/storage"
 )
 
@@ -124,8 +124,8 @@ func TestLimaBug1_ClearResetsQueuedAtIntegration(t *testing.T) {
 	// re-mark the TI. (The threshold check IsDispatchLost(now - queued_at)
 	// is in Go — we exercise it here with a generous threshold so the
 	// freshly-re-queued TI is well under it.)
-	cand := scheduler.StaleQueuedCandidate{QueuedAt: newQueuedAt}
-	if scheduler.IsDispatchLost(cand, 60*time.Second, time.Now()) {
+	cand := executor.StaleQueuedCandidate{QueuedAt: newQueuedAt}
+	if executor.IsDispatchLost(cand, 60*time.Second, time.Now()) {
 		t.Fatalf("Bug 1: freshly re-queued TI was flagged dispatch_lost — " +
 			"the reaper sees the stale timestamp from before the clear")
 	}

--- a/internal/storage/pod_lost_reap_integration_test.go
+++ b/internal/storage/pod_lost_reap_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/neochaotic/leoflow/internal/domain"
-	"github.com/neochaotic/leoflow/internal/scheduler"
+	"github.com/neochaotic/leoflow/internal/executor"
 )
 
 // TestListRunningTasksIntegration is the query contract for the pod-lost reaper
@@ -111,7 +111,7 @@ func TestMarkTaskPodLostIntegration(t *testing.T) {
 }
 
 // findPodLostCandidate returns the candidate matching (run uuid, task id), or nil.
-func findPodLostCandidate(cands []scheduler.PodLostCandidate, runUUID, taskID string) *scheduler.PodLostCandidate {
+func findPodLostCandidate(cands []executor.PodLostCandidate, runUUID, taskID string) *executor.PodLostCandidate {
 	for i := range cands {
 		if cands[i].DagRunID == runUUID && cands[i].TaskID == taskID {
 			return &cands[i]

--- a/internal/storage/reap_integration_test.go
+++ b/internal/storage/reap_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/executor"
 	"github.com/neochaotic/leoflow/internal/scheduler"
 	"github.com/neochaotic/leoflow/internal/storage"
 )
@@ -203,7 +204,7 @@ func resolveRunUUID(t *testing.T, sched *storage.SchedulerStore, ctx context.Con
 }
 
 // findCandidate returns the candidate matching runUUID or nil.
-func findCandidate(cands []scheduler.ReapCandidate, runUUID string) *scheduler.ReapCandidate {
+func findCandidate(cands []executor.ReapCandidate, runUUID string) *executor.ReapCandidate {
 	for i := range cands {
 		if cands[i].RunID == runUUID {
 			return &cands[i]

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/executor"
 	"github.com/neochaotic/leoflow/internal/scheduler"
 	"github.com/neochaotic/leoflow/internal/storage/queries"
 )
@@ -519,18 +520,18 @@ func (s *SchedulerStore) MarkStagingDeleted(ctx context.Context, pvcName, reason
 // the timestamp of its most recent activity, for the scheduler's orphan reaper.
 // The query (sqlc.runs.ListOrphanCandidates) is the authority on how to compute
 // the timestamp; the reaper only decides whether each one is past its threshold.
-func (s *SchedulerStore) ListReapCandidates(ctx context.Context) ([]scheduler.ReapCandidate, error) {
+func (s *SchedulerStore) ListReapCandidates(ctx context.Context) ([]executor.ReapCandidate, error) {
 	rows, err := s.q.ListOrphanCandidates(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("listing orphan candidates: %w", err)
 	}
-	out := make([]scheduler.ReapCandidate, 0, len(rows))
+	out := make([]executor.ReapCandidate, 0, len(rows))
 	for _, r := range rows {
 		var last time.Time
 		if r.LastActivity.Valid {
 			last = r.LastActivity.Time.UTC()
 		}
-		out = append(out, scheduler.ReapCandidate{
+		out = append(out, executor.ReapCandidate{
 			RunID:        uuidToString(r.ID),
 			DagID:        r.DagIDText,
 			LastActivity: last,
@@ -585,18 +586,18 @@ func (s *SchedulerStore) ReapRun(ctx context.Context, runID string) error {
 // ListAgentLostCandidates returns every `running` TI with a non-null
 // last_heartbeat_at, for the scheduler's TI heartbeat reaper (#128). The
 // reaper applies the threshold per row so the SQL stays simple.
-func (s *SchedulerStore) ListAgentLostCandidates(ctx context.Context) ([]scheduler.AgentLostCandidate, error) {
+func (s *SchedulerStore) ListAgentLostCandidates(ctx context.Context) ([]executor.AgentLostCandidate, error) {
 	rows, err := s.q.ListAgentLostCandidates(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("listing agent-lost candidates: %w", err)
 	}
-	out := make([]scheduler.AgentLostCandidate, 0, len(rows))
+	out := make([]executor.AgentLostCandidate, 0, len(rows))
 	for _, r := range rows {
 		var last time.Time
 		if r.LastHeartbeatAt.Valid {
 			last = r.LastHeartbeatAt.Time.UTC()
 		}
-		out = append(out, scheduler.AgentLostCandidate{
+		out = append(out, executor.AgentLostCandidate{
 			TaskInstanceID: uuidToString(r.TaskInstanceID),
 			DagRunID:       uuidToString(r.DagRunID),
 			DagID:          r.DagIDText,
@@ -645,18 +646,18 @@ func (s *SchedulerStore) MarkTaskAgentLost(ctx context.Context, taskInstanceID s
 // ListStaleQueuedCandidates returns every `queued` TI with its queued_at, for
 // the dispatch-lost reaper (#202). The reaper applies the threshold per row
 // so the SQL stays simple.
-func (s *SchedulerStore) ListStaleQueuedCandidates(ctx context.Context) ([]scheduler.StaleQueuedCandidate, error) {
+func (s *SchedulerStore) ListStaleQueuedCandidates(ctx context.Context) ([]executor.StaleQueuedCandidate, error) {
 	rows, err := s.q.ListStaleQueuedTaskInstances(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("listing stale-queued candidates: %w", err)
 	}
-	out := make([]scheduler.StaleQueuedCandidate, 0, len(rows))
+	out := make([]executor.StaleQueuedCandidate, 0, len(rows))
 	for _, r := range rows {
 		var qed time.Time
 		if r.QueuedAt.Valid {
 			qed = r.QueuedAt.Time.UTC()
 		}
-		out = append(out, scheduler.StaleQueuedCandidate{
+		out = append(out, executor.StaleQueuedCandidate{
 			TaskInstanceID: uuidToString(r.TaskInstanceID),
 			DagRunID:       uuidToString(r.DagRunID),
 			DagID:          r.DagIDText,
@@ -685,18 +686,18 @@ func (s *SchedulerStore) MarkTaskDispatchLost(ctx context.Context, taskInstanceI
 // ListRunningTasks returns every `running` TI with the timestamp it entered
 // running, for the pod-lost reaper (#527). The reaper applies the grace period
 // and the pod-liveness check per row, so the SQL stays simple.
-func (s *SchedulerStore) ListRunningTasks(ctx context.Context) ([]scheduler.PodLostCandidate, error) {
+func (s *SchedulerStore) ListRunningTasks(ctx context.Context) ([]executor.PodLostCandidate, error) {
 	rows, err := s.q.ListRunningTasks(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("listing running tasks: %w", err)
 	}
-	out := make([]scheduler.PodLostCandidate, 0, len(rows))
+	out := make([]executor.PodLostCandidate, 0, len(rows))
 	for _, r := range rows {
 		var since time.Time
 		if r.StartedAt.Valid {
 			since = r.StartedAt.Time.UTC()
 		}
-		out = append(out, scheduler.PodLostCandidate{
+		out = append(out, executor.PodLostCandidate{
 			TaskInstanceID: uuidToString(r.TaskInstanceID),
 			DagRunID:       uuidToString(r.DagRunID),
 			DagID:          r.DagIDText,

--- a/test/load/scheduler_ceiling/main.go
+++ b/test/load/scheduler_ceiling/main.go
@@ -47,10 +47,6 @@ import (
 	"github.com/neochaotic/leoflow/internal/storage"
 )
 
-// neverReap is a threshold long enough that none of Step's reapers touch our
-// synthetic runs during a measurement window, so the active set stays fixed at N.
-const neverReap = 1000 * time.Hour
-
 func main() {
 	if err := run(); err != nil {
 		fmt.Fprintf(os.Stderr, "scheduler_ceiling: %v\n", err)
@@ -97,11 +93,9 @@ func run() error {
 	sched := scheduler.NewScheduler(store, logger, time.Second)
 	sched.SetRecorder(metrics) // captures step-downs; scraped per N below
 	sched.SetLeading(true)     // Step is a no-op for a follower
-	// Keep every reaper off our synthetic runs for the run of the experiment.
-	sched.SetOrphanThreshold(neverReap)
-	sched.SetAgentLostThreshold(neverReap)
-	sched.SetDispatchLostThreshold(neverReap)
-	sched.SetPodLostGrace(neverReap)
+	// No execution reaper is wired, so no reaper ever touches our synthetic runs
+	// and the active set stays fixed at N for the measurement window (reaping now
+	// lives behind the scheduler's ExecutionReaper seam, off by default).
 	// No dispatcher is wired: a `running` task is never re-dispatched, so the
 	// scheduler advances state only and launches nothing.
 


### PR DESCRIPTION
**P1 of the warm-pool track (ADR 0058).** Pure refactor, zero behavior change — the safe precursor before `ExecutionOutcome` (P2) and warm reuse (PR-N1).

## What
Moves the four backstop reapers (orphan-run, agent-lost, dispatch-lost, pod-lost) + the `PodManager`/`PodPresenceCache` capabilities + the candidate projections from `internal/scheduler` into `internal/executor`, behind a new `ExecutionReaper` seam the scheduler drives once per leader tick. Mirrors the reconciler, which already lives on the execution side behind narrow interfaces.

## Why
ADR 0051 Phase 3: a warm *worker* has a lifecycle (spawn/idle/recycle/lose) distinct from an *attempt* lifecycle. That machine belongs on the execution side, where PR-N1's N:1 reaper fan-out (per-pod liveness, ADR 0058 D7) will land.

## No behavior change
- `executor.Reaper.ReapOnce` runs the four in the **same order**, logs+meters each list error with the **identical decision strings**, isolates per-reaper failures, returns nil.
- `logError` reproduces `logSchedulerError` exactly (WARN a `context.Canceled` only during graceful leader step-down, else ERROR).
- Nil `PodManager` (Lite) keeps every reaper DB-only and pod-lost a no-op, byte-for-byte.

## Seam
- scheduler: `ExecutionReaper` interface + `SetExecutionReaper`; inline reaper block → leader-gated `ReapOnce`; `Store` drops the four reap-store embeds; `podManager`/`cache`/threshold fields removed.
- executor: `NewReaper`/`ReaperConfig`/`DefaultReaperConfig` + narrow `DecisionRecorder`.
- storage: repoints the four candidate types scheduler→executor (acyclic — executor imports neither scheduler nor storage).

## Tests
Moved reaper unit tests keep assertions **verbatim**. Step-driven wiring tests re-expressed at the seam: leader-gating (leader drives once, follower never, runs even if `createDueRuns` fails) stays in scheduler via a spy reaper; end-to-end marking + presence-cache threading move to executor with real assertions.

## Verification (local)
`go build ./...` + `go build -tags integration ./...` green · unit tests (executor/scheduler/storage) green · `golangci-lint` **0 issues** on touched packages. Storage integration tests compile (`-tags integration`) with unchanged assertions; they run against real Postgres in CI.

22 files changed, +126 / −380.