### PR TITLE
feat(config): warm-pool operator knobs + fail-closed boot guard (ADR 0058 N1a)

### DIFF
--- a/internal/config/execution_test.go
+++ b/internal/config/execution_test.go
@@ -1,0 +1,182 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestExecutionDefaults locks the byte-for-byte no-op defaults (ADR 0058 N1a): a
+// fresh config keeps warm pools OFF and carries the D6/D9 caps at their documented
+// values, so a default deploy behaves exactly like today's pod-per-task.
+func TestExecutionDefaults(t *testing.T) {
+	c, err := LoadServer("", nil)
+	if err != nil {
+		t.Fatalf("LoadServer: %v", err)
+	}
+	if c.Execution.WarmPoolsEnabled {
+		t.Errorf("execution.warm_pools_enabled default = true, want false")
+	}
+	if got := c.Execution.MaxAttemptsPerWorker; got != 50 {
+		t.Errorf("execution.max_attempts_per_worker default = %d, want 50", got)
+	}
+	if got := c.Execution.MaxWorkerLifetime; got != time.Hour {
+		t.Errorf("execution.max_worker_lifetime default = %v, want 1h", got)
+	}
+	if got := c.Execution.MinIdleWorkers; got != 0 {
+		t.Errorf("execution.min_idle_workers default = %d, want 0", got)
+	}
+	if got := c.Execution.WorkerIdleTTL; got != 5*time.Minute {
+		t.Errorf("execution.worker_idle_ttl default = %v, want 5m", got)
+	}
+}
+
+// TestExecutionEnvBinds proves each execution key binds from its LEOFLOW_* env var
+// (they are registered in serverDefaults so AutomaticEnv sees them).
+func TestExecutionEnvBinds(t *testing.T) {
+	t.Setenv("LEOFLOW_EXECUTION_WARM_POOLS_ENABLED", "true")
+	t.Setenv("LEOFLOW_EXECUTION_MAX_ATTEMPTS_PER_WORKER", "10")
+	t.Setenv("LEOFLOW_EXECUTION_MAX_WORKER_LIFETIME", "2h")
+	t.Setenv("LEOFLOW_EXECUTION_MIN_IDLE_WORKERS", "3")
+	t.Setenv("LEOFLOW_EXECUTION_WORKER_IDLE_TTL", "90s")
+	c, err := LoadServer("", nil)
+	if err != nil {
+		t.Fatalf("LoadServer: %v", err)
+	}
+	if !c.Execution.WarmPoolsEnabled {
+		t.Errorf("execution.warm_pools_enabled = false, want true (from env)")
+	}
+	if got := c.Execution.MaxAttemptsPerWorker; got != 10 {
+		t.Errorf("execution.max_attempts_per_worker = %d, want 10 (from env)", got)
+	}
+	if got := c.Execution.MaxWorkerLifetime; got != 2*time.Hour {
+		t.Errorf("execution.max_worker_lifetime = %v, want 2h (from env)", got)
+	}
+	if got := c.Execution.MinIdleWorkers; got != 3 {
+		t.Errorf("execution.min_idle_workers = %d, want 3 (from env)", got)
+	}
+	if got := c.Execution.WorkerIdleTTL; got != 90*time.Second {
+		t.Errorf("execution.worker_idle_ttl = %v, want 90s (from env)", got)
+	}
+}
+
+// validWarmConfig returns a ServerConfig that passes the warm-pool boot gate: warm
+// pools on, token-exchange transport, liveness enforce, a worker lifetime >= the
+// attempt-credential ceiling, and sane caps.
+func validWarmConfig() *ServerConfig {
+	c := &ServerConfig{}
+	c.Auth.JWT.Secret = "set"
+	c.Auth.AgentTokenTransport = AgentTokenTransportExchange
+	c.Auth.SecretLivenessMode = SecretLivenessEnforce
+	c.Auth.MaxAttemptCredentialLifetime = 30 * time.Minute
+	c.Execution.WarmPoolsEnabled = true
+	c.Execution.MaxAttemptsPerWorker = 50
+	c.Execution.MaxWorkerLifetime = time.Hour
+	c.Execution.WorkerIdleTTL = 5 * time.Minute
+	return c
+}
+
+// TestValidateExecutionWarmPoolsOffIgnoresCoupling locks that when warm pools are
+// OFF (the default), Validate() succeeds regardless of transport/liveness/caps: an
+// operator who never turns warm pools on is completely unaffected.
+func TestValidateExecutionWarmPoolsOffIgnoresCoupling(t *testing.T) {
+	c := &ServerConfig{}
+	c.Auth.JWT.Secret = "set"
+	// Defaults: warm pools off, envvar transport, observe liveness, zero caps.
+	if err := c.Validate(); err != nil {
+		t.Errorf("Validate() = %v with warm pools off, want nil", err)
+	}
+	// Even with zero caps and the insecure transport/liveness, off = no coupling.
+	c.Auth.AgentTokenTransport = AgentTokenTransportEnvVar
+	c.Auth.SecretLivenessMode = SecretLivenessObserve
+	c.Execution.MaxAttemptsPerWorker = 0
+	c.Execution.MaxWorkerLifetime = 0
+	c.Execution.WorkerIdleTTL = 0
+	if err := c.Validate(); err != nil {
+		t.Errorf("Validate() = %v with warm pools off and zero caps, want nil", err)
+	}
+}
+
+// TestValidateExecutionWarmPoolsOnSucceeds locks the happy path: warm pools on with
+// the security prerequisites and a compatible lifetime ordering boots.
+func TestValidateExecutionWarmPoolsOnSucceeds(t *testing.T) {
+	if err := validWarmConfig().Validate(); err != nil {
+		t.Errorf("Validate() = %v for a valid warm-pool config, want nil", err)
+	}
+}
+
+// TestValidateExecutionWarmPoolsRequiresTransportExchange locks HIGH #1: warm pools
+// on with the default envvar transport fails boot closed and names the required
+// setting.
+func TestValidateExecutionWarmPoolsRequiresTransportExchange(t *testing.T) {
+	c := validWarmConfig()
+	c.Auth.AgentTokenTransport = AgentTokenTransportEnvVar
+	err := c.Validate()
+	if err == nil {
+		t.Fatal("Validate() = nil for warm pools on with envvar transport, want error")
+	}
+	if !strings.Contains(err.Error(), "agent_token_transport") {
+		t.Errorf("error = %q, want it to name auth.agent_token_transport", err.Error())
+	}
+}
+
+// TestValidateExecutionWarmPoolsRequiresLivenessEnforce locks HIGH #1: warm pools on
+// with the default observe liveness fails boot closed and names the required setting.
+func TestValidateExecutionWarmPoolsRequiresLivenessEnforce(t *testing.T) {
+	c := validWarmConfig()
+	c.Auth.SecretLivenessMode = SecretLivenessObserve
+	err := c.Validate()
+	if err == nil {
+		t.Fatal("Validate() = nil for warm pools on with observe liveness, want error")
+	}
+	if !strings.Contains(err.Error(), "secret_liveness_mode") {
+		t.Errorf("error = %q, want it to name auth.secret_liveness_mode", err.Error())
+	}
+}
+
+// TestValidateExecutionWorkerLifetimeOrdering locks the D9 guard: a worker lifetime
+// shorter than the attempt-credential ceiling fails boot closed, because a worker
+// could be force-recycled mid-attempt by token lapse.
+func TestValidateExecutionWorkerLifetimeOrdering(t *testing.T) {
+	c := validWarmConfig()
+	c.Auth.MaxAttemptCredentialLifetime = 24 * time.Hour
+	c.Execution.MaxWorkerLifetime = 10 * time.Minute
+	err := c.Validate()
+	if err == nil {
+		t.Fatal("Validate() = nil for worker lifetime < credential lifetime, want error")
+	}
+	if !strings.Contains(err.Error(), "max_worker_lifetime") {
+		t.Errorf("error = %q, want it to name execution.max_worker_lifetime", err.Error())
+	}
+}
+
+// TestValidateExecutionSanityCaps locks the D9 sanity caps (only enforced when warm
+// pools are on): a zero/negative attempts cap, worker lifetime, or idle TTL fails
+// boot closed rather than recycling instantly or never.
+func TestValidateExecutionSanityCaps(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mut  func(*ServerConfig)
+		want string
+	}{
+		{"zero attempts", func(c *ServerConfig) { c.Execution.MaxAttemptsPerWorker = 0 }, "max_attempts_per_worker"},
+		{"negative attempts", func(c *ServerConfig) { c.Execution.MaxAttemptsPerWorker = -1 }, "max_attempts_per_worker"},
+		{"zero worker lifetime", func(c *ServerConfig) {
+			c.Auth.MaxAttemptCredentialLifetime = 0
+			c.Execution.MaxWorkerLifetime = 0
+		}, "max_worker_lifetime"},
+		{"zero idle ttl", func(c *ServerConfig) { c.Execution.WorkerIdleTTL = 0 }, "worker_idle_ttl"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := validWarmConfig()
+			tc.mut(c)
+			err := c.Validate()
+			if err == nil {
+				t.Fatalf("Validate() = nil with %s, want error", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want it to name %q", err.Error(), tc.want)
+			}
+		})
+	}
+}

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -21,6 +21,7 @@ type ServerConfig struct {
 	Auth          AuthSection          `mapstructure:"auth"`
 	Scheduler     SchedulerSection     `mapstructure:"scheduler"`
 	Executor      ExecutorSection      `mapstructure:"executor"`
+	Execution     ExecutionSection     `mapstructure:"execution"`
 	Logs          LogsSection          `mapstructure:"logs"`
 	Observability ObservabilitySection `mapstructure:"observability"`
 	UI            UISection            `mapstructure:"ui"`
@@ -152,6 +153,37 @@ type PlatformDefaultsSection struct {
 	// breaks ordinary Python tasks (pip cache, /tmp, matplotlib config); turn it
 	// on for a fleet of tasks known not to write outside their volumes.
 	ReadOnlyTaskRootFilesystem bool `mapstructure:"read_only_task_root_filesystem"`
+}
+
+// ExecutionSection configures warm worker pools — Pro-gated N:1 pod reuse
+// (ADR 0058). Every field is operator-set (never DAG-author-set), consistent
+// with the secret-scoping stance: whether a pod may be reused across attempts is
+// an operator's security decision, not a DAG author's. All fields default to a
+// byte-for-byte no-op — warm pools OFF means dedicated pod-per-task, today's
+// behavior — and are read for runtime behavior only in a later brick; N1a
+// introduces the knobs plus the fail-closed boot guard (validateExecution).
+type ExecutionSection struct {
+	// WarmPoolsEnabled turns on N:1 pod reuse (ADR 0058). Default false = a
+	// dedicated pod per task attempt, today's behavior byte-for-byte. Turning it on
+	// is gated at boot on the security prerequisites (token-exchange transport +
+	// liveness enforcement) because a warm pod reuses one credential across attempts.
+	WarmPoolsEnabled bool `mapstructure:"warm_pools_enabled"`
+	// MaxAttemptsPerWorker caps how many attempts a warm worker serves before it is
+	// drained and recycled (ADR 0058 D9). Bounds credential-leak and stale-image
+	// exposure by forcing a fresh pod periodically. Default 50.
+	MaxAttemptsPerWorker int `mapstructure:"max_attempts_per_worker"`
+	// MaxWorkerLifetime is the wall-clock cap on a warm worker before it is drained
+	// and recycled (ADR 0058 D9), independent of the attempt count. Default 1h. When
+	// warm pools are on it MUST be >= auth.max_attempt_credential_lifetime, so a
+	// worker is never force-recycled mid-attempt by its token lapsing.
+	MaxWorkerLifetime time.Duration `mapstructure:"max_worker_lifetime"`
+	// MinIdleWorkers is the number of warm workers kept ready per DAG version
+	// (ADR 0058 D6). Default 0 = scale-to-zero, preserving the ADR 0002 zero-idle
+	// floor; an operator opts into warmth by raising it.
+	MinIdleWorkers int `mapstructure:"min_idle_workers"`
+	// WorkerIdleTTL is how long an idle warm worker is kept before it is recycled
+	// (ADR 0058 D6). Default 5m.
+	WorkerIdleTTL time.Duration `mapstructure:"worker_idle_ttl"`
 }
 
 // UISection configures the embedded Airflow UI.
@@ -503,24 +535,34 @@ var serverDefaults = map[string]any{
 	"executor.defaults.staging_access_mode":            "ReadWriteMany",
 	"executor.defaults.run_tasks_as_non_root":          true,
 	"executor.defaults.read_only_task_root_filesystem": false,
-	"logs.dir":                    "/var/log/leoflow",
-	"logs.backend":                "disk",
-	"logs.sink.bucket":            "",
-	"logs.sink.prefix":            "",
-	"logs.sink.region":            "",
-	"logs.sink.endpoint":          "",
-	"logs.sink.force_path_style":  false,
-	"logs.sink.access_key_id":     "",
-	"logs.sink.secret_access_key": "",
-	"logs.sink.credentials_file":  "",
-	"observability.otel.enabled":  true,
-	"observability.otel.endpoint": "localhost:4317",
-	"observability.log_level":     "info",
-	"observability.log_format":    "json",
-	"ui.instance_name":            "Leoflow",
-	"ui.edition":                  "",
-	"ui.workspace":                "",
-	"ui.monaco_dir":               "",
+	// Warm worker pools (ADR 0058). Ships a byte-for-byte no-op: warm pools OFF =
+	// dedicated pod-per-task, today's behavior. The D6/D9 caps carry their
+	// documented values so an operator who flips warm_pools_enabled on inherits sane
+	// bounds. Durations are written as strings and parsed by viper's decode hook,
+	// matching auth.max_attempt_credential_lifetime.
+	"execution.warm_pools_enabled":      false,
+	"execution.max_attempts_per_worker": 50,
+	"execution.max_worker_lifetime":     "1h",
+	"execution.min_idle_workers":        0,
+	"execution.worker_idle_ttl":         "5m",
+	"logs.dir":                          "/var/log/leoflow",
+	"logs.backend":                      "disk",
+	"logs.sink.bucket":                  "",
+	"logs.sink.prefix":                  "",
+	"logs.sink.region":                  "",
+	"logs.sink.endpoint":                "",
+	"logs.sink.force_path_style":        false,
+	"logs.sink.access_key_id":           "",
+	"logs.sink.secret_access_key":       "",
+	"logs.sink.credentials_file":        "",
+	"observability.otel.enabled":        true,
+	"observability.otel.endpoint":       "localhost:4317",
+	"observability.log_level":           "info",
+	"observability.log_format":          "json",
+	"ui.instance_name":                  "Leoflow",
+	"ui.edition":                        "",
+	"ui.workspace":                      "",
+	"ui.monaco_dir":                     "",
 	// Must appear here even though the zero value is meaningful (the handler
 	// falls back to api.DefaultUIAutoRefreshIntervalSeconds when ≤ 0): viper's
 	// AutomaticEnv only binds env vars for keys it has seen via SetDefault or
@@ -611,6 +653,9 @@ func (c *ServerConfig) Validate() error {
 	if err := c.validateSecretPolicies(); err != nil {
 		return err
 	}
+	if err := c.validateExecution(); err != nil {
+		return err
+	}
 	// Both providers mint the app's own HS256 _token (oidc mints it after the IdP
 	// verify), so the JWT secret is required for either.
 	if (c.Auth.Provider == AuthProviderJWT || c.Auth.Provider == AuthProviderOIDC) && c.Auth.JWT.Secret == "" {
@@ -679,6 +724,44 @@ func (c *ServerConfig) validateSecretPolicies() error {
 	default:
 		return fmt.Errorf("invalid auth.agent_token_transport %q: must be %q or %q",
 			c.Auth.AgentTokenTransport, AgentTokenTransportEnvVar, AgentTokenTransportExchange)
+	}
+	return nil
+}
+
+// validateExecution enforces the warm-pool boot gate (ADR 0058 N1a), fail-closed.
+// The whole block is gated on WarmPoolsEnabled: with warm pools OFF (the default)
+// none of these fields is validated, so an operator who never turns warm pools on
+// is unaffected. With warm pools ON it rejects, rather than silently correcting:
+//
+//	(a) HIGH #1 — the security coupling. A warm pod reuses one credential across
+//	    attempts; without token-exchange transport and liveness enforcement a
+//	    superseded attempt's token would still resolve secrets. So warm pools
+//	    require auth.agent_token_transport=exchange AND auth.secret_liveness_mode=
+//	    enforce (ADR 0058 D2/HIGH-1).
+//	(b) D9 ordering — max_worker_lifetime must be >= the attempt-credential ceiling,
+//	    else a worker could be force-recycled mid-attempt by its token lapsing.
+//	(c) sanity — a zero/negative attempts cap, worker lifetime, or idle TTL would
+//	    recycle instantly or never; each must be positive.
+func (c *ServerConfig) validateExecution() error {
+	if !c.Execution.WarmPoolsEnabled {
+		return nil
+	}
+	if c.Auth.AgentTokenTransport != AgentTokenTransportExchange || c.Auth.SecretLivenessMode != SecretLivenessEnforce {
+		return fmt.Errorf("execution.warm_pools_enabled requires auth.agent_token_transport=%q and auth.secret_liveness_mode=%q (a warm pod reuses one credential across attempts; without token-exchange + liveness enforcement a superseded attempt's token would still resolve secrets — ADR 0058 D2/HIGH-1)",
+			AgentTokenTransportExchange, SecretLivenessEnforce)
+	}
+	if c.Execution.MaxAttemptsPerWorker < 1 {
+		return fmt.Errorf("execution.max_attempts_per_worker must be >= 1 when execution.warm_pools_enabled (got %d): a zero cap would recycle a warm worker instantly (ADR 0058 D9)", c.Execution.MaxAttemptsPerWorker)
+	}
+	if c.Execution.MaxWorkerLifetime <= 0 {
+		return fmt.Errorf("execution.max_worker_lifetime must be > 0 when execution.warm_pools_enabled (got %v): a non-positive lifetime would recycle a warm worker instantly (ADR 0058 D9)", c.Execution.MaxWorkerLifetime)
+	}
+	if c.Execution.WorkerIdleTTL <= 0 {
+		return fmt.Errorf("execution.worker_idle_ttl must be > 0 when execution.warm_pools_enabled (got %v): a non-positive TTL would recycle an idle warm worker instantly (ADR 0058 D6)", c.Execution.WorkerIdleTTL)
+	}
+	if c.Execution.MaxWorkerLifetime < c.Auth.MaxAttemptCredentialLifetime {
+		return fmt.Errorf("execution.max_worker_lifetime (%v) must be >= auth.max_attempt_credential_lifetime (%v) when execution.warm_pools_enabled: a shorter worker lifetime could force-recycle a worker mid-attempt when its credential outlives the pod (ADR 0058 D9)",
+			c.Execution.MaxWorkerLifetime, c.Auth.MaxAttemptCredentialLifetime)
 	}
 	return nil
 }


### PR DESCRIPTION
**N1a of the warm-pool track (ADR 0058).** First brick: the `execution.*` config surface + the fail-closed boot guard. **No warm-pool behavior** — every knob defaults to a no-op and nothing outside `internal/config` reads them. This lands the ADR 0058 **HIGH-1** security coupling as code *before* any warm machinery exists (security floor first).

## `execution` section (operator-set, never DAG-author-set)
| knob | default | ref |
|---|---|---|
| `warm_pools_enabled` | **false** (dedicated pod-per-task = today) | D8 |
| `max_attempts_per_worker` | 50 | D9 |
| `max_worker_lifetime` | 1h | D9 |
| `min_idle_workers` | 0 (scale-to-zero) | D6 |
| `worker_idle_ttl` | 5m | D6 |

## `validateExecution` — fail-closed, gated on `warm_pools_enabled`
- **HIGH-1 coupling:** warm pools ON require `auth.agent_token_transport=exchange` **AND** `auth.secret_liveness_mode=enforce`, else a warm pod's reused credential would resolve secrets for a *superseded* attempt (D2). Unset counts as not-enforce → the default (`envvar`/`observe`) **fails closed**.
- **D9 ordering:** `max_worker_lifetime ≥ auth.max_attempt_credential_lifetime`, or a worker could be force-recycled mid-attempt by token lapse.
- **sanity:** `max_attempts_per_worker ≥ 1`, `max_worker_lifetime > 0`, `worker_idle_ttl > 0`.

## Reviewer note (intended, not a bug)
With defaults, worker lifetime (1h) < credential ceiling (24h), so a config that only flips `warm_pools_enabled=true` **fails the D9 guard at boot by design** — the operator must consciously reconcile the two durations (lower the credential ceiling for typical tasks, or raise the worker lifetime) to enable warm pools. This is the fail-closed gate doing its job.

## Tests / verification
Table-driven `validateExecution` tests (RED→green): warm-off ignores the coupling even with insecure transport/liveness + zero caps; warm-on happy path; each missing requirement errors by name; ordering; zero/negative caps. `go build ./...` + `-tags integration` green · `internal/config` tests green · `golangci-lint` **0 issues** · grep confirms no runtime wiring outside config.