### PR TITLE
fix(config): relax warm-pool boot guard — drop worker-lifetime ordering check (ADR 0058 D10 review)

### DIFF
--- a/internal/config/execution_test.go
+++ b/internal/config/execution_test.go
@@ -61,14 +61,16 @@ func TestExecutionEnvBinds(t *testing.T) {
 }
 
 // validWarmConfig returns a ServerConfig that passes the warm-pool boot gate: warm
-// pools on, token-exchange transport, liveness enforce, a worker lifetime >= the
-// attempt-credential ceiling, and sane caps.
+// pools on, token-exchange transport, liveness enforce, and sane caps. It uses the
+// SHIPPED defaults for the two durations (1h worker lifetime, 24h credential
+// ceiling) — worker lifetime is deliberately shorter than the ceiling, which the
+// relaxed gate allows (recycle drains, it does not hard-kill; ADR 0058 D10 review).
 func validWarmConfig() *ServerConfig {
 	c := &ServerConfig{}
 	c.Auth.JWT.Secret = "set"
 	c.Auth.AgentTokenTransport = AgentTokenTransportExchange
 	c.Auth.SecretLivenessMode = SecretLivenessEnforce
-	c.Auth.MaxAttemptCredentialLifetime = 30 * time.Minute
+	c.Auth.MaxAttemptCredentialLifetime = 24 * time.Hour
 	c.Execution.WarmPoolsEnabled = true
 	c.Execution.MaxAttemptsPerWorker = 50
 	c.Execution.MaxWorkerLifetime = time.Hour
@@ -98,7 +100,8 @@ func TestValidateExecutionWarmPoolsOffIgnoresCoupling(t *testing.T) {
 }
 
 // TestValidateExecutionWarmPoolsOnSucceeds locks the happy path: warm pools on with
-// the security prerequisites and a compatible lifetime ordering boots.
+// the security prerequisites boots — using the shipped defaults, where the worker
+// lifetime (1h) is shorter than the credential ceiling (24h), which is now allowed.
 func TestValidateExecutionWarmPoolsOnSucceeds(t *testing.T) {
 	if err := validWarmConfig().Validate(); err != nil {
 		t.Errorf("Validate() = %v for a valid warm-pool config, want nil", err)
@@ -134,19 +137,19 @@ func TestValidateExecutionWarmPoolsRequiresLivenessEnforce(t *testing.T) {
 	}
 }
 
-// TestValidateExecutionWorkerLifetimeOrdering locks the D9 guard: a worker lifetime
-// shorter than the attempt-credential ceiling fails boot closed, because a worker
-// could be force-recycled mid-attempt by token lapse.
-func TestValidateExecutionWorkerLifetimeOrdering(t *testing.T) {
+// TestValidateExecutionAllowsShortWorkerLifetime locks the RELAXED gate (ADR 0058
+// D10 review): a worker lifetime far shorter than the attempt-credential ceiling is
+// valid, because recycle is a graceful DRAIN, not a hard mid-attempt kill — the
+// worker finishes its in-flight attempt (on its own renewed credential) before
+// recycling. The old max_worker_lifetime >= credential-ceiling ordering guard was
+// removed: it defended a force-recycle that drain forbids and blocked a naive
+// enable under the shipped defaults (1h vs 24h).
+func TestValidateExecutionAllowsShortWorkerLifetime(t *testing.T) {
 	c := validWarmConfig()
 	c.Auth.MaxAttemptCredentialLifetime = 24 * time.Hour
-	c.Execution.MaxWorkerLifetime = 10 * time.Minute
-	err := c.Validate()
-	if err == nil {
-		t.Fatal("Validate() = nil for worker lifetime < credential lifetime, want error")
-	}
-	if !strings.Contains(err.Error(), "max_worker_lifetime") {
-		t.Errorf("error = %q, want it to name execution.max_worker_lifetime", err.Error())
+	c.Execution.MaxWorkerLifetime = 10 * time.Minute // << ceiling, previously rejected
+	if err := c.Validate(); err != nil {
+		t.Errorf("Validate() = %v for worker lifetime < credential ceiling, want nil (recycle drains, ADR 0058 D10)", err)
 	}
 }
 

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -737,11 +737,21 @@ func (c *ServerConfig) validateSecretPolicies() error {
 //	    attempts; without token-exchange transport and liveness enforcement a
 //	    superseded attempt's token would still resolve secrets. So warm pools
 //	    require auth.agent_token_transport=exchange AND auth.secret_liveness_mode=
-//	    enforce (ADR 0058 D2/HIGH-1).
-//	(b) D9 ordering — max_worker_lifetime must be >= the attempt-credential ceiling,
-//	    else a worker could be force-recycled mid-attempt by its token lapsing.
-//	(c) sanity — a zero/negative attempts cap, worker lifetime, or idle TTL would
+//	    enforce (ADR 0058 D2/HIGH-1). This half stays fail-closed: there is no safe
+//	    degraded mode — the degraded mode IS the vulnerability.
+//	(b) sanity — a zero/negative attempts cap, worker lifetime, or idle TTL would
 //	    recycle instantly or never; each must be positive.
+//
+// There is deliberately NO max_worker_lifetime >= max_attempt_credential_lifetime
+// ordering guard. That invariant was dropped (ADR 0058 D10 review): recycle is a
+// graceful DRAIN, not a hard mid-attempt kill, so a worker lifetime shorter than
+// the credential ceiling is harmless — the worker finishes its in-flight attempt
+// (on its own renewed credential) before recycling. The guard defended a
+// force-recycle that drain forbids, and with the shipped defaults (1h worker vs
+// 24h ceiling) it also blocked a naive enable and pushed operators toward less-safe
+// config. The real "credential lapses mid-attempt" bound is per-ATTEMPT
+// (execution_timeout / the warm-worker watchdog <= the ceiling), enforced on the
+// execution path, not here.
 func (c *ServerConfig) validateExecution() error {
 	if !c.Execution.WarmPoolsEnabled {
 		return nil
@@ -758,10 +768,6 @@ func (c *ServerConfig) validateExecution() error {
 	}
 	if c.Execution.WorkerIdleTTL <= 0 {
 		return fmt.Errorf("execution.worker_idle_ttl must be > 0 when execution.warm_pools_enabled (got %v): a non-positive TTL would recycle an idle warm worker instantly (ADR 0058 D6)", c.Execution.WorkerIdleTTL)
-	}
-	if c.Execution.MaxWorkerLifetime < c.Auth.MaxAttemptCredentialLifetime {
-		return fmt.Errorf("execution.max_worker_lifetime (%v) must be >= auth.max_attempt_credential_lifetime (%v) when execution.warm_pools_enabled: a shorter worker lifetime could force-recycle a worker mid-attempt when its credential outlives the pod (ADR 0058 D9)",
-			c.Execution.MaxWorkerLifetime, c.Auth.MaxAttemptCredentialLifetime)
 	}
 	return nil
 }


### PR DESCRIPTION
Specialist follow-up to N1a (#671), secure-but-not-blocking / reliability lens.

## What
Removes the `max_worker_lifetime >= max_attempt_credential_lifetime` boot guard. **Keeps** the HIGH-1 security coupling (`warm_pools_enabled` requires `transport=exchange` AND `liveness=enforce`) fail-closed, and the positive-value sanity caps.

## Why the ordering guard was wrong
- **It defended a force-recycle that D10 forbids.** Recycle is a graceful **drain**, not a hard mid-attempt kill — a worker past its lifetime finishes its in-flight attempt (on its own renewed credential) before recycling. So a worker lifetime shorter than the credential ceiling is harmless.
- **It was self-defeating.** With shipped defaults (1h worker vs 24h ceiling), a naive `warm_pools_enabled=true` failed at boot, and the only ways past it made things worse: worker lifetime → 24h (defeats the D9 leak/stale-image bound) or credential ceiling → 1h (risks biting long tasks). A guard that pushes operators toward less-safe config is a bad guard — exactly the "needlessly blocking" failure mode.

The real *credential-lapses-mid-attempt* bound is **per-attempt** (`execution_timeout` / the warm-worker watchdog ≤ the ceiling), enforced on the execution path (N1d), not in config validation.

## Security unchanged
The enforce-coupling half stays fail-closed — there is no safe degraded mode for it; the degraded mode *is* the vulnerability (a warm pod under `liveness=observe` delivering the vault to a superseded attempt). Only the operationally-obstructive, semantically-wrong half is dropped.

## Test
`TestValidateExecutionWorkerLifetimeOrdering` (asserted the error) is inverted to `TestValidateExecutionAllowsShortWorkerLifetime` (asserts a 10m worker vs 24h ceiling validates OK). The happy-path helper now uses the shipped defaults (1h vs 24h) to lock that the naive enable boots. `go build` + `internal/config` tests green · `golangci-lint` 0 issues.