### PR TITLE
feat(agentrpc): warm-worker assignment transport + H1 ack/lease (ADR 0058 N1b1)

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -18,6 +18,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -345,7 +346,7 @@ func startSchedulerSide(ctx context.Context, cfg *config.ServerConfig, pg *stora
 	if !servesScheduler {
 		return nil, false, func() {}, nil
 	}
-	grpcSrv, gerr := startAgentGRPC(ctx, cfg.Server.GRPCAddr, authn, execStore, repo, xcomSvc, logSink, logTailer, allowInsecureSecrets, cfg.Auth.SecretScoping, cfg.Auth.SecretLivenessMode, cfg.Auth.MaxAttemptCredentialLifetime, buildTokenExchange(cfg, logger), cfg.Server.GRPCTLSCert, cfg.Server.GRPCTLSKey, logger)
+	grpcSrv, gerr := startAgentGRPC(ctx, cfg.Server.GRPCAddr, authn, execStore, repo, xcomSvc, logSink, logTailer, allowInsecureSecrets, cfg.Auth.SecretScoping, cfg.Auth.SecretLivenessMode, cfg.Auth.MaxAttemptCredentialLifetime, buildTokenExchange(cfg, logger), cfg.Server.GRPCTLSCert, cfg.Server.GRPCTLSKey, cfg.Execution.WarmPoolsEnabled, logger)
 	if gerr != nil {
 		return nil, false, nil, gerr
 	}
@@ -517,7 +518,7 @@ func serveHTTP(ctx context.Context, logger *slog.Logger, servesAPI bool, apiSrv,
 // shutdown. TLS is enabled when tlsCert/tlsKey are set (issue #58); otherwise the
 // channel is plaintext (dev). The per-task bearer token in metadata authenticates
 // each call regardless.
-func startAgentGRPC(ctx context.Context, addr string, authn *auth.JWTAuthenticator, store *storage.ExecutionStore, secretsStore agentrpc.SecretsStore, xcomSvc agentrpc.XComService, logSink agentrpc.LogSink, logTailer agentrpc.LogPublisher, allowInsecureSecrets bool, secretScoping, secretLivenessMode string, maxAttemptLifetime time.Duration, exchange *tokenExchange, tlsCert, tlsKey string, logger *slog.Logger) (*grpc.Server, error) {
+func startAgentGRPC(ctx context.Context, addr string, authn *auth.JWTAuthenticator, store *storage.ExecutionStore, secretsStore agentrpc.SecretsStore, xcomSvc agentrpc.XComService, logSink agentrpc.LogSink, logTailer agentrpc.LogPublisher, allowInsecureSecrets bool, secretScoping, secretLivenessMode string, maxAttemptLifetime time.Duration, exchange *tokenExchange, tlsCert, tlsKey string, warmPoolsEnabled bool, logger *slog.Logger) (*grpc.Server, error) {
 	var lc net.ListenConfig
 	lis, err := lc.Listen(ctx, "tcp", addr)
 	if err != nil {
@@ -559,12 +560,37 @@ func startAgentGRPC(ctx context.Context, addr string, authn *auth.JWTAuthenticat
 	if auditor, ok := secretsStore.(agentrpc.SecretLivenessAuditor); ok {
 		agentSrv.SetSecretLivenessAuditor(auditor)
 	}
+	// Warm worker assignment transport (ADR 0058 N1b). Wired only when the operator
+	// enabled warm pools (which the boot guard already gated on the token-exchange +
+	// liveness prerequisites). Off by default => AwaitAssignment stays inert
+	// (FailedPrecondition) and no running path changes. N1b1 wires the transport
+	// only; there is no placement caller yet, so no assignment is ever handed out
+	// and the reclaim observer never fires — a debug log is enough for now.
+	if warmPoolsEnabled {
+		agentSrv.EnableWarmPools(func(ev agentrpc.ReclaimEvent) {
+			logger.Debug("warm worker assignment reclaimed", "assignment", ev.AssignmentID, "dag_version", ev.DagVersionID, "reason", ev.Reason)
+		})
+		logger.Warn("warm worker pools enabled (ADR 0058); assignment transport is live but no placement caller exists yet (N1b1)")
+	}
 
 	// Recover panics in any agent RPC handler so a single malformed request from a
 	// worker pod cannot crash the control plane (it returns Internal instead).
 	opts := []grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(agentrpc.RecoveryUnaryInterceptor(logger)),
 		grpc.ChainStreamInterceptor(agentrpc.RecoveryStreamInterceptor(logger)),
+		// Tolerate a warm worker's keepalive pings on an otherwise idle assignment
+		// stream so gRPC does not GOAWAY it as abusive (ADR 0058 N1b). This only
+		// RELAXES the server's default client-ping enforcement (5m, streams-only),
+		// so it cannot change StreamLogs behavior — an active StreamLogs already
+		// satisfies both the old and new policy. Server-initiated keepalive
+		// (ServerParameters: MaxConnectionIdle / Time pings) is deliberately NOT
+		// added here: it would start pinging existing idle StreamLogs connections,
+		// a behavior change with no benefit until a real warm worker connects.
+		// Deferred to N1b1-place as a documented TODO.
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             10 * time.Second,
+			PermitWithoutStream: true,
+		}),
 	}
 	secure := tlsCert != "" && tlsKey != ""
 	if secure {

--- a/internal/agent/runner_test.go
+++ b/internal/agent/runner_test.go
@@ -65,6 +65,13 @@ func (f *fakeClient) GetTaskSpec(context.Context, *agentv1.GetTaskSpecRequest, .
 	return f.spec, nil
 }
 
+// AwaitAssignment satisfies the AgentServiceClient interface (warm-worker
+// transport, ADR 0058 N1b). No single-shot agent test drives it; the embedding
+// fakes (exchangeClient, registerErrClient, secretsErrClient) inherit this stub.
+func (f *fakeClient) AwaitAssignment(context.Context, ...grpc.CallOption) (grpc.BidiStreamingClient[agentv1.WorkerMessage, agentv1.WorkAssignment], error) {
+	return nil, status.Error(codes.Unimplemented, "AwaitAssignment not used in this test")
+}
+
 func (f *fakeClient) FetchXCom(_ context.Context, in *agentv1.FetchXComRequest, _ ...grpc.CallOption) (*agentv1.FetchXComResponse, error) {
 	if resp, ok := f.xcom[in.GetUpstreamTaskId()]; ok {
 		return resp, nil

--- a/internal/agentrpc/await_assignment.go
+++ b/internal/agentrpc/await_assignment.go
@@ -1,0 +1,130 @@
+package agentrpc
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// SetWarmPools wires a prebuilt warm-worker assignment registry (ADR 0058 N1b).
+// A nil registry (the default) leaves AwaitAssignment inert — it returns
+// FailedPrecondition — so with execution.warm_pools_enabled off the transport is
+// completely dormant and no running path changes. Used by tests to inject a
+// registry with a deterministic lease; callers wire it via EnableWarmPools.
+func (s *Server) SetWarmPools(reg *workerRegistry) { s.warmPools = reg }
+
+// EnableWarmPools turns on the warm-worker assignment transport with a
+// production registry (ADR 0058 N1b). onReclaim (may be nil) observes reclaim
+// events for the future placement layer to consume. Call only when
+// execution.warm_pools_enabled is set — the default leaves the handler inert.
+func (s *Server) EnableWarmPools(onReclaim func(ReclaimEvent)) {
+	s.SetWarmPools(newWorkerRegistry(onReclaim))
+}
+
+// AwaitAssignment is the warm-worker assignment transport (ADR 0058 N1b): a
+// long-lived bidi stream over which the control plane pushes per-attempt
+// WorkAssignments down and the worker sends its registration, acks, and
+// slot-free signals up.
+//
+// Inert-when-off: if warm pools are not wired the handler refuses immediately
+// with FailedPrecondition — the flag-gated dormant state.
+//
+// Identity: the registry key is the worker's AUTHENTICATED identity from the
+// stream's bearer token (via identify), NOT the dag_version_id in the register
+// payload — a worker cannot claim an arbitrary identity through the message. The
+// payload's dag_version_id only names which pool the worker serves and must be
+// non-empty.
+//
+// After registration two flows run concurrently: the receive loop drains
+// WorkerMessages (acks feed the H1 lease machine, slot-free frees the worker)
+// while the main select pumps assignments from the worker's outbound channel
+// down the stream. The handler exits — deregistering the worker (defer) — on
+// context cancellation, a stream Send error, or the receive loop ending (clean
+// EOF or a transport error).
+func (s *Server) AwaitAssignment(stream agentv1.AgentService_AwaitAssignmentServer) error {
+	if s.warmPools == nil {
+		return status.Error(codes.FailedPrecondition, "warm pools disabled")
+	}
+	ctx := stream.Context()
+	id, err := s.identify(ctx)
+	if err != nil {
+		return err
+	}
+	worker, err := s.registerFromStream(stream, id.TaskInstanceID)
+	if err != nil {
+		return err
+	}
+	defer s.warmPools.Deregister(worker)
+
+	// Receive loop: acks and slot-free signals feed the registry. It ends on EOF
+	// (clean close) or any transport error, reported once on recvErr.
+	recvErr := make(chan error, 1)
+	go s.pumpWorkerMessages(stream, id.TaskInstanceID, recvErr)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return status.FromContextError(ctx.Err()).Err()
+		case rerr := <-recvErr:
+			if errors.Is(rerr, io.EOF) {
+				return nil
+			}
+			return status.Errorf(codes.Internal, "receiving worker message: %v", rerr)
+		case a := <-worker.send:
+			if serr := stream.Send(a); serr != nil {
+				return serr
+			}
+		}
+	}
+}
+
+// registerFromStream reads and validates the mandatory first WorkerMessage (a
+// WorkerRegister) and registers the worker under its authenticated identity. The
+// dag_version_id in the payload names the pool and must be non-empty; the
+// identity is NOT taken from the payload. The bearer token is never logged.
+func (s *Server) registerFromStream(stream agentv1.AgentService_AwaitAssignmentServer, identity string) (*registeredWorker, error) {
+	first, err := stream.Recv()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, status.Error(codes.FailedPrecondition, "stream closed before worker registration")
+		}
+		return nil, status.Errorf(codes.Internal, "receiving worker registration: %v", err)
+	}
+	reg := first.GetRegister()
+	if reg == nil {
+		return nil, status.Error(codes.FailedPrecondition, "first worker message must be a register")
+	}
+	dagVersion := reg.GetDagVersionId()
+	if dagVersion == "" {
+		return nil, status.Error(codes.InvalidArgument, "worker register missing dag_version_id")
+	}
+	send := make(chan *agentv1.WorkAssignment, 1)
+	worker := s.warmPools.Register(identity, dagVersion, send)
+	slog.Info("warm worker registered", "identity", identity, "dag_version", dagVersion)
+	return worker, nil
+}
+
+// pumpWorkerMessages drains WorkerMessages off the stream into the registry
+// until the stream ends, then reports the terminating error once on recvErr.
+func (s *Server) pumpWorkerMessages(stream agentv1.AgentService_AwaitAssignmentServer, identity string, recvErr chan<- error) {
+	for {
+		msg, rerr := stream.Recv()
+		if rerr != nil {
+			recvErr <- rerr
+			return
+		}
+		switch m := msg.Msg.(type) {
+		case *agentv1.WorkerMessage_Ack:
+			s.warmPools.Ack(m.Ack.GetAssignmentId(), m.Ack.GetStarted())
+		case *agentv1.WorkerMessage_SlotFree:
+			s.warmPools.MarkFree(identity)
+		case *agentv1.WorkerMessage_Register:
+			// A re-registration on an established stream is redundant; the worker is
+			// already keyed by its authenticated identity. Ignore.
+		}
+	}
+}

--- a/internal/agentrpc/await_assignment_test.go
+++ b/internal/agentrpc/await_assignment_test.go
@@ -1,0 +1,265 @@
+package agentrpc
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ─── test doubles ───────────────────────────────────────────────────────────
+
+// fakeAwaitStream is an in-memory bidi AwaitAssignment server stream. The test
+// pushes WorkerMessages (and terminal errors) onto recv; assignments the handler
+// Sends land on sent.
+type fakeAwaitStream struct {
+	grpc.ServerStream
+	ctx  context.Context
+	recv chan recvItem
+	sent chan *agentv1.WorkAssignment
+}
+
+type recvItem struct {
+	m   *agentv1.WorkerMessage
+	err error
+}
+
+func newFakeAwaitStream(ctx context.Context) *fakeAwaitStream {
+	return &fakeAwaitStream{
+		ctx:  ctx,
+		recv: make(chan recvItem, 16),
+		sent: make(chan *agentv1.WorkAssignment, 16),
+	}
+}
+
+func (s *fakeAwaitStream) Context() context.Context { return s.ctx }
+
+func (s *fakeAwaitStream) Recv() (*agentv1.WorkerMessage, error) {
+	it := <-s.recv
+	return it.m, it.err
+}
+
+func (s *fakeAwaitStream) Send(a *agentv1.WorkAssignment) error {
+	s.sent <- a
+	return nil
+}
+
+func (s *fakeAwaitStream) pushMsg(m *agentv1.WorkerMessage) { s.recv <- recvItem{m: m} }
+func (s *fakeAwaitStream) pushErr(err error)                { s.recv <- recvItem{err: err} }
+
+func regMsg(dagVersion string) *agentv1.WorkerMessage {
+	return &agentv1.WorkerMessage{Msg: &agentv1.WorkerMessage_Register{
+		Register: &agentv1.WorkerRegister{DagVersionId: dagVersion},
+	}}
+}
+
+func ackMsg(assignmentID string, started bool) *agentv1.WorkerMessage {
+	return &agentv1.WorkerMessage{Msg: &agentv1.WorkerMessage_Ack{
+		Ack: &agentv1.AssignmentAck{AssignmentId: assignmentID, Started: started},
+	}}
+}
+
+// newWarmServer builds a Server with warm pools ENABLED (a registry wired) plus
+// the JWT authenticator whose token ctxWithToken mints (identity "ti-1").
+func newWarmServer(t *testing.T, onReclaim func(ReclaimEvent)) (*Server, *auth.JWTAuthenticator, *workerRegistry) {
+	t.Helper()
+	srv, a := newServer(&fakeStore{})
+	reg := newWorkerRegistry(onReclaim)
+	srv.SetWarmPools(reg)
+	return srv, a, reg
+}
+
+// awaitEventually polls cond until true or the deadline, failing the test otherwise.
+func awaitEventually(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("condition not met within deadline")
+}
+
+// ─── (a) inert when warm pools off ──────────────────────────────────────────
+
+func TestAwaitAssignmentInertWhenWarmPoolsOff(t *testing.T) {
+	srv, a := newServer(&fakeStore{}) // no SetWarmPools => off
+	stream := newFakeAwaitStream(ctxWithToken(t, a))
+	err := srv.AwaitAssignment(stream)
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("warm pools off: got %v, want FailedPrecondition", err)
+	}
+}
+
+// ─── (b) non-register first message ─────────────────────────────────────────
+
+func TestAwaitAssignmentRequiresRegisterFirst(t *testing.T) {
+	srv, a, _ := newWarmServer(t, nil)
+	stream := newFakeAwaitStream(ctxWithToken(t, a))
+	stream.pushMsg(ackMsg("as-1", true)) // first message is an ack, not a register
+	err := srv.AwaitAssignment(stream)
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("non-register first message: got %v, want FailedPrecondition", err)
+	}
+}
+
+// ─── (c) register => present in registry ────────────────────────────────────
+
+func TestAwaitAssignmentRegistersWorker(t *testing.T) {
+	srv, a, reg := newWarmServer(t, nil)
+	stream := newFakeAwaitStream(ctxWithToken(t, a))
+	stream.pushMsg(regMsg("dagver-1"))
+	go func() { _ = srv.AwaitAssignment(stream) }()
+
+	awaitEventually(t, func() bool { return reg.registered("ti-1") })
+	if got := reg.dagVersionOf("ti-1"); got != "dagver-1" {
+		t.Fatalf("registered dag version = %q, want dagver-1", got)
+	}
+	stream.pushErr(io.EOF) // clean shutdown
+}
+
+// ─── (d) Assign pushes a WorkAssignment the stream receives ─────────────────
+
+func TestAwaitAssignmentDeliversAssignment(t *testing.T) {
+	srv, a, reg := newWarmServer(t, nil)
+	stream := newFakeAwaitStream(ctxWithToken(t, a))
+	stream.pushMsg(regMsg("dagver-1"))
+	go func() { _ = srv.AwaitAssignment(stream) }()
+	awaitEventually(t, func() bool { return reg.registered("ti-1") })
+
+	if reg.Assign("other-version", &agentv1.WorkAssignment{AssignmentId: "x"}) {
+		t.Fatal("Assign to a dag version with no free worker should return false")
+	}
+	if !reg.Assign("dagver-1", &agentv1.WorkAssignment{AssignmentId: "as-1", TaskId: "extract", LeaseSeconds: 30}) {
+		t.Fatal("Assign to a free worker's dag version should return true")
+	}
+	select {
+	case got := <-stream.sent:
+		if got.GetAssignmentId() != "as-1" || got.GetTaskId() != "extract" {
+			t.Fatalf("delivered assignment = %+v, want as-1/extract", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no assignment delivered to the stream")
+	}
+	stream.pushErr(io.EOF)
+}
+
+// ─── (e) ack started=true within lease => busy, no reclaim ──────────────────
+
+func TestAckStartedWithinLeaseMarksBusyNoReclaim(t *testing.T) {
+	reclaims := make(chan ReclaimEvent, 4)
+	reg := newWorkerRegistry(func(ev ReclaimEvent) { reclaims <- ev })
+	reg.leaseFor = func(*agentv1.WorkAssignment) time.Duration { return time.Hour } // long lease
+
+	send := make(chan *agentv1.WorkAssignment, 1)
+	reg.Register("w1", "v1", send)
+	if !reg.Assign("v1", &agentv1.WorkAssignment{AssignmentId: "as-1"}) {
+		t.Fatal("Assign should succeed")
+	}
+	<-send // drain the delivered assignment
+	reg.Ack("as-1", true)
+
+	if !reg.busy("w1") {
+		t.Fatal("worker should be marked busy after ack started=true")
+	}
+	select {
+	case ev := <-reclaims:
+		t.Fatalf("unexpected reclaim after ack started=true: %+v", ev)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// ─── (f) lease expiry with no ack => reclaim ────────────────────────────────
+
+func TestLeaseExpiryReclaims(t *testing.T) {
+	reclaims := make(chan ReclaimEvent, 4)
+	reg := newWorkerRegistry(func(ev ReclaimEvent) { reclaims <- ev })
+	reg.leaseFor = func(*agentv1.WorkAssignment) time.Duration { return 5 * time.Millisecond }
+
+	send := make(chan *agentv1.WorkAssignment, 1)
+	reg.Register("w1", "v1", send)
+	reg.Assign("v1", &agentv1.WorkAssignment{AssignmentId: "as-1", DagVersionId: "v1"})
+	<-send
+
+	select {
+	case ev := <-reclaims:
+		if ev.AssignmentID != "as-1" || ev.Reason != ReclaimLeaseExpired {
+			t.Fatalf("reclaim = %+v, want as-1/ReclaimLeaseExpired", ev)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected a reclaim event on lease expiry")
+	}
+}
+
+// ─── (g) ack started=false => reclaim ───────────────────────────────────────
+
+func TestAckRefusedReclaims(t *testing.T) {
+	reclaims := make(chan ReclaimEvent, 4)
+	reg := newWorkerRegistry(func(ev ReclaimEvent) { reclaims <- ev })
+	reg.leaseFor = func(*agentv1.WorkAssignment) time.Duration { return time.Hour }
+
+	send := make(chan *agentv1.WorkAssignment, 1)
+	reg.Register("w1", "v1", send)
+	reg.Assign("v1", &agentv1.WorkAssignment{AssignmentId: "as-1", DagVersionId: "v1"})
+	<-send
+	reg.Ack("as-1", false)
+
+	select {
+	case ev := <-reclaims:
+		if ev.AssignmentID != "as-1" || ev.Reason != ReclaimRefused {
+			t.Fatalf("reclaim = %+v, want as-1/ReclaimRefused", ev)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected a reclaim event on ack started=false")
+	}
+	if reg.busy("w1") {
+		t.Fatal("a worker that refused an assignment must not be marked busy")
+	}
+}
+
+// ─── (h) stream close => deregistered ───────────────────────────────────────
+
+func TestAwaitAssignmentDeregistersOnStreamClose(t *testing.T) {
+	srv, a, reg := newWarmServer(t, nil)
+	stream := newFakeAwaitStream(ctxWithToken(t, a))
+	stream.pushMsg(regMsg("dagver-1"))
+	done := make(chan error, 1)
+	go func() { done <- srv.AwaitAssignment(stream) }()
+
+	awaitEventually(t, func() bool { return reg.registered("ti-1") })
+	stream.pushErr(io.EOF)
+
+	if err := <-done; err != nil {
+		t.Fatalf("clean stream close should return nil, got %v", err)
+	}
+	awaitEventually(t, func() bool { return !reg.registered("ti-1") })
+}
+
+// ─── (i) reconnect same identity => single entry ────────────────────────────
+
+func TestAwaitAssignmentReconnectSameIdentitySingleEntry(t *testing.T) {
+	srv, a, reg := newWarmServer(t, nil)
+
+	s1 := newFakeAwaitStream(ctxWithToken(t, a))
+	s1.pushMsg(regMsg("v1"))
+	go func() { _ = srv.AwaitAssignment(s1) }()
+	awaitEventually(t, func() bool { return reg.dagVersionOf("ti-1") == "v1" })
+
+	// A reconnect with the SAME authenticated identity but a new registration.
+	s2 := newFakeAwaitStream(ctxWithToken(t, a))
+	s2.pushMsg(regMsg("v2"))
+	go func() { _ = srv.AwaitAssignment(s2) }()
+	awaitEventually(t, func() bool { return reg.dagVersionOf("ti-1") == "v2" })
+
+	if reg.size() != 1 {
+		t.Fatalf("reconnect same identity: registry size = %d, want 1", reg.size())
+	}
+}

--- a/internal/agentrpc/server.go
+++ b/internal/agentrpc/server.go
@@ -161,6 +161,10 @@ type Server struct {
 	exchangeTTL           time.Duration
 	allowInsecureExchange bool
 	now                   func() time.Time
+	// Warm worker assignment transport (ADR 0058 N1b). nil by default, so
+	// AwaitAssignment is inert (returns FailedPrecondition) unless the operator
+	// enabled warm pools and the server wired a registry via SetWarmPools.
+	warmPools *workerRegistry
 }
 
 // NewServer builds an AgentService server backed by the given authenticator,

--- a/internal/agentrpc/worker_registry.go
+++ b/internal/agentrpc/worker_registry.go
@@ -1,0 +1,286 @@
+package agentrpc
+
+import (
+	"sync"
+	"time"
+
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+)
+
+// ReclaimReason names why an assignment was reclaimed (ADR 0058 N1b, H1).
+type ReclaimReason int
+
+const (
+	// ReclaimLeaseExpired means the worker did not ack the assignment as started
+	// before its lease elapsed.
+	ReclaimLeaseExpired ReclaimReason = iota
+	// ReclaimRefused means the worker acked with started=false (it cannot or will
+	// not run it).
+	ReclaimRefused
+	// ReclaimWorkerGone means the worker's stream ended while it held an unacked
+	// assignment (a disconnected worker can never ack it).
+	ReclaimWorkerGone
+)
+
+// ReclaimEvent is emitted when a handed-out assignment must be re-placed. The
+// future placement layer (N1b1-place) consumes it to re-dispatch the attempt on
+// the infra budget. It deliberately carries no attempt_token.
+type ReclaimEvent struct {
+	AssignmentID string
+	DagVersionID string
+	Reason       ReclaimReason
+}
+
+// registeredWorker is one warm worker's registry entry. send is the handler's
+// outbound assignment channel; the handler owns Send()ing what lands on it.
+type registeredWorker struct {
+	identity   string
+	dagVersion string
+	send       chan *agentv1.WorkAssignment
+	// busy is set once the worker acks an assignment as started; it is cleared
+	// when the worker signals SlotFree.
+	busy bool
+}
+
+// leaseState tracks one in-flight assignment awaiting an ack.
+type leaseState struct {
+	worker     *registeredWorker
+	dagVersion string
+	timer      *time.Timer
+}
+
+// workerRegistry is the concurrency-safe home of the warm-worker fleet and the
+// H1 ack/lease machine (ADR 0058 N1b).
+//
+// Data structures and complexity:
+//   - workers: identity -> entry. Register/Deregister/MarkFree are O(1).
+//   - free:    dag_version -> (identity -> entry). Assign grabs one free worker
+//     of a dag_version in O(1) (a single map-range that breaks on the first
+//     element), then removes it in O(1).
+//   - leases:  assignment_id -> in-flight lease. Ack and lease-expiry are O(1).
+type workerRegistry struct {
+	mu      sync.Mutex
+	workers map[string]*registeredWorker
+	free    map[string]map[string]*registeredWorker
+	leases  map[string]*leaseState
+
+	onReclaim func(ReclaimEvent)
+	// leaseFor computes an assignment's ack deadline. Injectable so tests drive
+	// reclaim deterministically with a tiny lease.
+	leaseFor func(*agentv1.WorkAssignment) time.Duration
+}
+
+// newWorkerRegistry builds a registry whose reclaim events are delivered to
+// onReclaim (may be nil).
+func newWorkerRegistry(onReclaim func(ReclaimEvent)) *workerRegistry {
+	return &workerRegistry{
+		workers:   map[string]*registeredWorker{},
+		free:      map[string]map[string]*registeredWorker{},
+		leases:    map[string]*leaseState{},
+		onReclaim: onReclaim,
+		leaseFor: func(a *agentv1.WorkAssignment) time.Duration {
+			return time.Duration(a.GetLeaseSeconds()) * time.Second
+		},
+	}
+}
+
+// Register records a warm worker under its authenticated identity, ready to take
+// work for dagVersion. Idempotent: a reconnect with the same identity replaces
+// the prior entry (never adds a second), and the fresh entry starts free. It
+// returns the entry so the caller can Deregister exactly the entry it created.
+func (r *workerRegistry) Register(identity, dagVersion string, send chan *agentv1.WorkAssignment) *registeredWorker {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if old, ok := r.workers[identity]; ok {
+		// Drop the superseded entry from the free set; any lease still bound to it
+		// keeps its own timer and reclaims independently.
+		r.removeFreeLocked(old)
+	}
+	w := &registeredWorker{identity: identity, dagVersion: dagVersion, send: send}
+	r.workers[identity] = w
+	r.addFreeLocked(w)
+	return w
+}
+
+// Deregister removes a worker's entry, but only if the registry still points at
+// exactly this entry — a reconnect under the same identity installs a new entry,
+// and the stale stream's later Deregister must not evict the live one. Any
+// in-flight leases the worker still held are reclaimed: a gone worker can never
+// ack them.
+func (r *workerRegistry) Deregister(w *registeredWorker) {
+	if w == nil {
+		return
+	}
+	r.mu.Lock()
+	if r.workers[w.identity] != w {
+		r.mu.Unlock()
+		return
+	}
+	delete(r.workers, w.identity)
+	r.removeFreeLocked(w)
+	var reclaims []ReclaimEvent
+	for aid, ls := range r.leases {
+		if ls.worker == w {
+			ls.timer.Stop()
+			delete(r.leases, aid)
+			reclaims = append(reclaims, ReclaimEvent{AssignmentID: aid, DagVersionID: ls.dagVersion, Reason: ReclaimWorkerGone})
+		}
+	}
+	r.mu.Unlock()
+	for _, ev := range reclaims {
+		r.emitReclaim(ev)
+	}
+}
+
+// Assign hands a WorkAssignment to some free worker of dagVersion by pushing it
+// onto that worker's outbound channel and starting its lease. It returns false
+// when no free worker of that dag_version exists (nothing was handed out and no
+// lease was started).
+func (r *workerRegistry) Assign(dagVersion string, a *agentv1.WorkAssignment) bool {
+	r.mu.Lock()
+	w := r.takeFreeLocked(dagVersion)
+	if w == nil {
+		r.mu.Unlock()
+		return false
+	}
+	// The worker was just removed from the free set, so nothing else races for
+	// its channel; a non-blocking send cannot lose the assignment unless the
+	// channel is already occupied (a caller Assigned twice without an ack). In
+	// that case put it back and refuse.
+	select {
+	case w.send <- a:
+	default:
+		r.addFreeLocked(w)
+		r.mu.Unlock()
+		return false
+	}
+	aid := a.GetAssignmentId()
+	ls := &leaseState{worker: w, dagVersion: dagVersion}
+	ls.timer = time.AfterFunc(r.leaseFor(a), func() { r.onLeaseExpire(aid) })
+	r.leases[aid] = ls
+	r.mu.Unlock()
+	return true
+}
+
+// Ack settles the lease for assignmentID. started=true marks the worker busy and
+// cancels the lease (no reclaim). started=false reclaims the assignment. An ack
+// for an unknown assignment (already expired or already settled) is ignored.
+func (r *workerRegistry) Ack(assignmentID string, started bool) {
+	r.mu.Lock()
+	ls, ok := r.leases[assignmentID]
+	if !ok {
+		r.mu.Unlock()
+		return
+	}
+	delete(r.leases, assignmentID)
+	ls.timer.Stop()
+	if started {
+		ls.worker.busy = true
+		r.mu.Unlock()
+		return
+	}
+	dagVersion := ls.dagVersion
+	r.mu.Unlock()
+	r.emitReclaim(ReclaimEvent{AssignmentID: assignmentID, DagVersionID: dagVersion, Reason: ReclaimRefused})
+}
+
+// MarkFree records a worker's SlotFree signal: it clears busy and returns the
+// worker to the free set so it can take new work. Unknown identities are ignored.
+func (r *workerRegistry) MarkFree(identity string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	w, ok := r.workers[identity]
+	if !ok {
+		return
+	}
+	w.busy = false
+	r.addFreeLocked(w)
+}
+
+// onLeaseExpire reclaims an assignment whose lease elapsed with no ack. If the
+// lease was already settled (acked or the worker deregistered), it is a no-op.
+func (r *workerRegistry) onLeaseExpire(assignmentID string) {
+	r.mu.Lock()
+	ls, ok := r.leases[assignmentID]
+	if !ok {
+		r.mu.Unlock()
+		return
+	}
+	delete(r.leases, assignmentID)
+	dagVersion := ls.dagVersion
+	r.mu.Unlock()
+	r.emitReclaim(ReclaimEvent{AssignmentID: assignmentID, DagVersionID: dagVersion, Reason: ReclaimLeaseExpired})
+}
+
+// emitReclaim delivers a reclaim event to the observer, always OUTSIDE the lock
+// so the observer may re-enter the registry without deadlocking.
+func (r *workerRegistry) emitReclaim(ev ReclaimEvent) {
+	if r.onReclaim != nil {
+		r.onReclaim(ev)
+	}
+}
+
+// ── free-set helpers (all require r.mu held) ────────────────────────────────
+
+func (r *workerRegistry) addFreeLocked(w *registeredWorker) {
+	set := r.free[w.dagVersion]
+	if set == nil {
+		set = map[string]*registeredWorker{}
+		r.free[w.dagVersion] = set
+	}
+	set[w.identity] = w
+}
+
+func (r *workerRegistry) removeFreeLocked(w *registeredWorker) {
+	set := r.free[w.dagVersion]
+	if set == nil {
+		return
+	}
+	delete(set, w.identity)
+	if len(set) == 0 {
+		delete(r.free, w.dagVersion)
+	}
+}
+
+func (r *workerRegistry) takeFreeLocked(dagVersion string) *registeredWorker {
+	set := r.free[dagVersion]
+	for id, w := range set {
+		delete(set, id)
+		if len(set) == 0 {
+			delete(r.free, dagVersion)
+		}
+		return w
+	}
+	return nil
+}
+
+// ── test/introspection helpers ──────────────────────────────────────────────
+
+func (r *workerRegistry) registered(identity string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	_, ok := r.workers[identity]
+	return ok
+}
+
+func (r *workerRegistry) size() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.workers)
+}
+
+func (r *workerRegistry) busy(identity string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	w, ok := r.workers[identity]
+	return ok && w.busy
+}
+
+func (r *workerRegistry) dagVersionOf(identity string) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if w, ok := r.workers[identity]; ok {
+		return w.dagVersion
+	}
+	return ""
+}

--- a/proto/agent.proto
+++ b/proto/agent.proto
@@ -54,6 +54,14 @@ service AgentService {
     // Agent fetches the tenant's Connections (as Airflow connection URIs) to
     // export as AIRFLOW_CONN_* env vars.
     rpc GetConnections (GetConnectionsRequest) returns (GetConnectionsResponse);
+
+    // A warm worker awaits per-attempt assignments over a long-lived bidi stream
+    // (ADR 0058 N1b). Down: the control plane pushes WorkAssignments. Up: the
+    // worker sends its initial WorkerRegister, per-assignment AssignmentAcks, and
+    // SlotFree signals. Gated on execution.warm_pools_enabled — the handler
+    // returns FailedPrecondition when warm pools are off, so the transport is
+    // inert by default.
+    rpc AwaitAssignment (stream WorkerMessage) returns (stream WorkAssignment);
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -217,6 +225,51 @@ message HeartbeatRequest {
     google.protobuf.Timestamp sent_at = 1;
     map<string, double> custom_metrics = 2;       // optional task-reported metrics
 }
+
+// WorkAssignment is one unit of per-attempt work the control plane hands to a
+// warm worker over AwaitAssignment (ADR 0058 N1b). The control plane mints the
+// attempt_token and generates assignment_id; the worker replies with an
+// AssignmentAck referencing assignment_id.
+message WorkAssignment {
+    string assignment_id = 1;   // control-plane-generated correlation id for this hand-off
+    string attempt_token = 2;   // per-attempt agent JWT the worker adopts for this attempt; NEVER logged
+    string dag_run_id = 3;
+    string task_id = 4;
+    int32 try_number = 5;
+    string dag_version_id = 6;  // the pool identity this assignment belongs to
+    int64 lease_seconds = 7;    // ack deadline: unacked within it => the attempt is reclaimed
+}
+
+// WorkerMessage is everything a warm worker sends UP the AwaitAssignment stream:
+// its one initial registration, then per-assignment acks and slot-free signals.
+message WorkerMessage {
+    oneof msg {
+        WorkerRegister register = 1;
+        AssignmentAck ack = 2;
+        SlotFree slot_free = 3;
+    }
+}
+
+// WorkerRegister is the mandatory first WorkerMessage. dag_version_id names which
+// pool the worker serves. The worker's IDENTITY (registry key) is taken from its
+// authenticated pod/bootstrap credential on the stream context, NOT from this
+// payload — a worker must not be able to claim an arbitrary identity here.
+message WorkerRegister {
+    string dag_version_id = 1;
+}
+
+// AssignmentAck answers a WorkAssignment. started=true means the worker began the
+// attempt (the control plane marks it active and cancels the lease). started=false
+// means the worker refuses or cannot start it (the control plane reclaims it).
+message AssignmentAck {
+    string assignment_id = 1;
+    bool started = 2;
+}
+
+// SlotFree signals that the worker freed an execution slot. Reserved for the
+// placement layer (N1b1-place); the transport carries it now and the registry
+// records it.
+message SlotFree {}
 
 message HeartbeatResponse {
     bool should_terminate = 1;

--- a/proto/agent/v1/agent.pb.go
+++ b/proto/agent/v1/agent.pb.go
@@ -1356,6 +1356,344 @@ func (x *HeartbeatRequest) GetCustomMetrics() map[string]float64 {
 	return nil
 }
 
+// WorkAssignment is one unit of per-attempt work the control plane hands to a
+// warm worker over AwaitAssignment (ADR 0058 N1b). The control plane mints the
+// attempt_token and generates assignment_id; the worker replies with an
+// AssignmentAck referencing assignment_id.
+type WorkAssignment struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	AssignmentId  string                 `protobuf:"bytes,1,opt,name=assignment_id,json=assignmentId,proto3" json:"assignment_id,omitempty"` // control-plane-generated correlation id for this hand-off
+	AttemptToken  string                 `protobuf:"bytes,2,opt,name=attempt_token,json=attemptToken,proto3" json:"attempt_token,omitempty"` // per-attempt agent JWT the worker adopts for this attempt; NEVER logged
+	DagRunId      string                 `protobuf:"bytes,3,opt,name=dag_run_id,json=dagRunId,proto3" json:"dag_run_id,omitempty"`
+	TaskId        string                 `protobuf:"bytes,4,opt,name=task_id,json=taskId,proto3" json:"task_id,omitempty"`
+	TryNumber     int32                  `protobuf:"varint,5,opt,name=try_number,json=tryNumber,proto3" json:"try_number,omitempty"`
+	DagVersionId  string                 `protobuf:"bytes,6,opt,name=dag_version_id,json=dagVersionId,proto3" json:"dag_version_id,omitempty"` // the pool identity this assignment belongs to
+	LeaseSeconds  int64                  `protobuf:"varint,7,opt,name=lease_seconds,json=leaseSeconds,proto3" json:"lease_seconds,omitempty"`  // ack deadline: unacked within it => the attempt is reclaimed
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkAssignment) Reset() {
+	*x = WorkAssignment{}
+	mi := &file_agent_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkAssignment) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkAssignment) ProtoMessage() {}
+
+func (x *WorkAssignment) ProtoReflect() protoreflect.Message {
+	mi := &file_agent_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkAssignment.ProtoReflect.Descriptor instead.
+func (*WorkAssignment) Descriptor() ([]byte, []int) {
+	return file_agent_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *WorkAssignment) GetAssignmentId() string {
+	if x != nil {
+		return x.AssignmentId
+	}
+	return ""
+}
+
+func (x *WorkAssignment) GetAttemptToken() string {
+	if x != nil {
+		return x.AttemptToken
+	}
+	return ""
+}
+
+func (x *WorkAssignment) GetDagRunId() string {
+	if x != nil {
+		return x.DagRunId
+	}
+	return ""
+}
+
+func (x *WorkAssignment) GetTaskId() string {
+	if x != nil {
+		return x.TaskId
+	}
+	return ""
+}
+
+func (x *WorkAssignment) GetTryNumber() int32 {
+	if x != nil {
+		return x.TryNumber
+	}
+	return 0
+}
+
+func (x *WorkAssignment) GetDagVersionId() string {
+	if x != nil {
+		return x.DagVersionId
+	}
+	return ""
+}
+
+func (x *WorkAssignment) GetLeaseSeconds() int64 {
+	if x != nil {
+		return x.LeaseSeconds
+	}
+	return 0
+}
+
+// WorkerMessage is everything a warm worker sends UP the AwaitAssignment stream:
+// its one initial registration, then per-assignment acks and slot-free signals.
+type WorkerMessage struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Msg:
+	//
+	//	*WorkerMessage_Register
+	//	*WorkerMessage_Ack
+	//	*WorkerMessage_SlotFree
+	Msg           isWorkerMessage_Msg `protobuf_oneof:"msg"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkerMessage) Reset() {
+	*x = WorkerMessage{}
+	mi := &file_agent_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerMessage) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerMessage) ProtoMessage() {}
+
+func (x *WorkerMessage) ProtoReflect() protoreflect.Message {
+	mi := &file_agent_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerMessage.ProtoReflect.Descriptor instead.
+func (*WorkerMessage) Descriptor() ([]byte, []int) {
+	return file_agent_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *WorkerMessage) GetMsg() isWorkerMessage_Msg {
+	if x != nil {
+		return x.Msg
+	}
+	return nil
+}
+
+func (x *WorkerMessage) GetRegister() *WorkerRegister {
+	if x != nil {
+		if x, ok := x.Msg.(*WorkerMessage_Register); ok {
+			return x.Register
+		}
+	}
+	return nil
+}
+
+func (x *WorkerMessage) GetAck() *AssignmentAck {
+	if x != nil {
+		if x, ok := x.Msg.(*WorkerMessage_Ack); ok {
+			return x.Ack
+		}
+	}
+	return nil
+}
+
+func (x *WorkerMessage) GetSlotFree() *SlotFree {
+	if x != nil {
+		if x, ok := x.Msg.(*WorkerMessage_SlotFree); ok {
+			return x.SlotFree
+		}
+	}
+	return nil
+}
+
+type isWorkerMessage_Msg interface {
+	isWorkerMessage_Msg()
+}
+
+type WorkerMessage_Register struct {
+	Register *WorkerRegister `protobuf:"bytes,1,opt,name=register,proto3,oneof"`
+}
+
+type WorkerMessage_Ack struct {
+	Ack *AssignmentAck `protobuf:"bytes,2,opt,name=ack,proto3,oneof"`
+}
+
+type WorkerMessage_SlotFree struct {
+	SlotFree *SlotFree `protobuf:"bytes,3,opt,name=slot_free,json=slotFree,proto3,oneof"`
+}
+
+func (*WorkerMessage_Register) isWorkerMessage_Msg() {}
+
+func (*WorkerMessage_Ack) isWorkerMessage_Msg() {}
+
+func (*WorkerMessage_SlotFree) isWorkerMessage_Msg() {}
+
+// WorkerRegister is the mandatory first WorkerMessage. dag_version_id names which
+// pool the worker serves. The worker's IDENTITY (registry key) is taken from its
+// authenticated pod/bootstrap credential on the stream context, NOT from this
+// payload — a worker must not be able to claim an arbitrary identity here.
+type WorkerRegister struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	DagVersionId  string                 `protobuf:"bytes,1,opt,name=dag_version_id,json=dagVersionId,proto3" json:"dag_version_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *WorkerRegister) Reset() {
+	*x = WorkerRegister{}
+	mi := &file_agent_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *WorkerRegister) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*WorkerRegister) ProtoMessage() {}
+
+func (x *WorkerRegister) ProtoReflect() protoreflect.Message {
+	mi := &file_agent_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use WorkerRegister.ProtoReflect.Descriptor instead.
+func (*WorkerRegister) Descriptor() ([]byte, []int) {
+	return file_agent_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *WorkerRegister) GetDagVersionId() string {
+	if x != nil {
+		return x.DagVersionId
+	}
+	return ""
+}
+
+// AssignmentAck answers a WorkAssignment. started=true means the worker began the
+// attempt (the control plane marks it active and cancels the lease). started=false
+// means the worker refuses or cannot start it (the control plane reclaims it).
+type AssignmentAck struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	AssignmentId  string                 `protobuf:"bytes,1,opt,name=assignment_id,json=assignmentId,proto3" json:"assignment_id,omitempty"`
+	Started       bool                   `protobuf:"varint,2,opt,name=started,proto3" json:"started,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AssignmentAck) Reset() {
+	*x = AssignmentAck{}
+	mi := &file_agent_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AssignmentAck) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AssignmentAck) ProtoMessage() {}
+
+func (x *AssignmentAck) ProtoReflect() protoreflect.Message {
+	mi := &file_agent_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AssignmentAck.ProtoReflect.Descriptor instead.
+func (*AssignmentAck) Descriptor() ([]byte, []int) {
+	return file_agent_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *AssignmentAck) GetAssignmentId() string {
+	if x != nil {
+		return x.AssignmentId
+	}
+	return ""
+}
+
+func (x *AssignmentAck) GetStarted() bool {
+	if x != nil {
+		return x.Started
+	}
+	return false
+}
+
+// SlotFree signals that the worker freed an execution slot. Reserved for the
+// placement layer (N1b1-place); the transport carries it now and the registry
+// records it.
+type SlotFree struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SlotFree) Reset() {
+	*x = SlotFree{}
+	mi := &file_agent_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SlotFree) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SlotFree) ProtoMessage() {}
+
+func (x *SlotFree) ProtoReflect() protoreflect.Message {
+	mi := &file_agent_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SlotFree.ProtoReflect.Descriptor instead.
+func (*SlotFree) Descriptor() ([]byte, []int) {
+	return file_agent_proto_rawDescGZIP(), []int{24}
+}
+
 type HeartbeatResponse struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	ShouldTerminate bool                   `protobuf:"varint,1,opt,name=should_terminate,json=shouldTerminate,proto3" json:"should_terminate,omitempty"`
@@ -1373,7 +1711,7 @@ type HeartbeatResponse struct {
 
 func (x *HeartbeatResponse) Reset() {
 	*x = HeartbeatResponse{}
-	mi := &file_agent_proto_msgTypes[20]
+	mi := &file_agent_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1385,7 +1723,7 @@ func (x *HeartbeatResponse) String() string {
 func (*HeartbeatResponse) ProtoMessage() {}
 
 func (x *HeartbeatResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_agent_proto_msgTypes[20]
+	mi := &file_agent_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1398,7 +1736,7 @@ func (x *HeartbeatResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeartbeatResponse.ProtoReflect.Descriptor instead.
 func (*HeartbeatResponse) Descriptor() ([]byte, []int) {
-	return file_agent_proto_rawDescGZIP(), []int{20}
+	return file_agent_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *HeartbeatResponse) GetShouldTerminate() bool {
@@ -1538,7 +1876,29 @@ const file_agent_proto_rawDesc = "" +
 	"\x0ecustom_metrics\x18\x02 \x03(\v25.leoflow.agent.v1.HeartbeatRequest.CustomMetricsEntryR\rcustomMetrics\x1a@\n" +
 	"\x12CustomMetricsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\x01R\x05value:\x028\x01\"\xa0\x01\n" +
+	"\x05value\x18\x02 \x01(\x01R\x05value:\x028\x01\"\xfb\x01\n" +
+	"\x0eWorkAssignment\x12#\n" +
+	"\rassignment_id\x18\x01 \x01(\tR\fassignmentId\x12#\n" +
+	"\rattempt_token\x18\x02 \x01(\tR\fattemptToken\x12\x1c\n" +
+	"\n" +
+	"dag_run_id\x18\x03 \x01(\tR\bdagRunId\x12\x17\n" +
+	"\atask_id\x18\x04 \x01(\tR\x06taskId\x12\x1d\n" +
+	"\n" +
+	"try_number\x18\x05 \x01(\x05R\ttryNumber\x12$\n" +
+	"\x0edag_version_id\x18\x06 \x01(\tR\fdagVersionId\x12#\n" +
+	"\rlease_seconds\x18\a \x01(\x03R\fleaseSeconds\"\xc6\x01\n" +
+	"\rWorkerMessage\x12>\n" +
+	"\bregister\x18\x01 \x01(\v2 .leoflow.agent.v1.WorkerRegisterH\x00R\bregister\x123\n" +
+	"\x03ack\x18\x02 \x01(\v2\x1f.leoflow.agent.v1.AssignmentAckH\x00R\x03ack\x129\n" +
+	"\tslot_free\x18\x03 \x01(\v2\x1a.leoflow.agent.v1.SlotFreeH\x00R\bslotFreeB\x05\n" +
+	"\x03msg\"6\n" +
+	"\x0eWorkerRegister\x12$\n" +
+	"\x0edag_version_id\x18\x01 \x01(\tR\fdagVersionId\"N\n" +
+	"\rAssignmentAck\x12#\n" +
+	"\rassignment_id\x18\x01 \x01(\tR\fassignmentId\x12\x18\n" +
+	"\astarted\x18\x02 \x01(\bR\astarted\"\n" +
+	"\n" +
+	"\bSlotFree\"\xa0\x01\n" +
 	"\x11HeartbeatResponse\x12)\n" +
 	"\x10should_terminate\x18\x01 \x01(\bR\x0fshouldTerminate\x12;\n" +
 	"\vserver_time\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
@@ -1556,7 +1916,7 @@ const file_agent_proto_rawDesc = "" +
 	"\x12TASK_STATE_SUCCESS\x10\x02\x12\x15\n" +
 	"\x11TASK_STATE_FAILED\x10\x03\x12\x16\n" +
 	"\x12TASK_STATE_SKIPPED\x10\x04\x12 \n" +
-	"\x1cTASK_STATE_UP_FOR_RESCHEDULE\x10\x052\xfa\x06\n" +
+	"\x1cTASK_STATE_UP_FOR_RESCHEDULE\x10\x052\xd4\a\n" +
 	"\fAgentService\x12`\n" +
 	"\rExchangeToken\x12&.leoflow.agent.v1.ExchangeTokenRequest\x1a'.leoflow.agent.v1.ExchangeTokenResponse\x12Q\n" +
 	"\bRegister\x12!.leoflow.agent.v1.RegisterRequest\x1a\".leoflow.agent.v1.RegisterResponse\x12O\n" +
@@ -1568,7 +1928,8 @@ const file_agent_proto_rawDesc = "" +
 	"\vReportState\x12$.leoflow.agent.v1.ReportStateRequest\x1a%.leoflow.agent.v1.ReportStateResponse\x12T\n" +
 	"\tHeartbeat\x12\".leoflow.agent.v1.HeartbeatRequest\x1a#.leoflow.agent.v1.HeartbeatResponse\x12]\n" +
 	"\fGetVariables\x12%.leoflow.agent.v1.GetVariablesRequest\x1a&.leoflow.agent.v1.GetVariablesResponse\x12c\n" +
-	"\x0eGetConnections\x12'.leoflow.agent.v1.GetConnectionsRequest\x1a(.leoflow.agent.v1.GetConnectionsResponseB6Z4github.com/neochaotic/leoflow/proto/agent/v1;agentv1b\x06proto3"
+	"\x0eGetConnections\x12'.leoflow.agent.v1.GetConnectionsRequest\x1a(.leoflow.agent.v1.GetConnectionsResponse\x12X\n" +
+	"\x0fAwaitAssignment\x12\x1f.leoflow.agent.v1.WorkerMessage\x1a .leoflow.agent.v1.WorkAssignment(\x010\x01B6Z4github.com/neochaotic/leoflow/proto/agent/v1;agentv1b\x06proto3"
 
 var (
 	file_agent_proto_rawDescOnce sync.Once
@@ -1583,7 +1944,7 @@ func file_agent_proto_rawDescGZIP() []byte {
 }
 
 var file_agent_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
+var file_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
 var file_agent_proto_goTypes = []any{
 	(LogLevel)(0),                  // 0: leoflow.agent.v1.LogLevel
 	(TaskState)(0),                 // 1: leoflow.agent.v1.TaskState
@@ -1607,59 +1968,69 @@ var file_agent_proto_goTypes = []any{
 	(*ReportStateRequest)(nil),     // 19: leoflow.agent.v1.ReportStateRequest
 	(*ReportStateResponse)(nil),    // 20: leoflow.agent.v1.ReportStateResponse
 	(*HeartbeatRequest)(nil),       // 21: leoflow.agent.v1.HeartbeatRequest
-	(*HeartbeatResponse)(nil),      // 22: leoflow.agent.v1.HeartbeatResponse
-	nil,                            // 23: leoflow.agent.v1.GetVariablesResponse.VariablesEntry
-	nil,                            // 24: leoflow.agent.v1.GetConnectionsResponse.ConnectionUrisEntry
-	nil,                            // 25: leoflow.agent.v1.RegisterRequest.EnvironmentEntry
-	nil,                            // 26: leoflow.agent.v1.TaskSpec.EnvironmentEntry
-	nil,                            // 27: leoflow.agent.v1.TaskSpec.XcomInputMappingEntry
-	nil,                            // 28: leoflow.agent.v1.HeartbeatRequest.CustomMetricsEntry
-	(*timestamppb.Timestamp)(nil),  // 29: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),        // 30: google.protobuf.Struct
+	(*WorkAssignment)(nil),         // 22: leoflow.agent.v1.WorkAssignment
+	(*WorkerMessage)(nil),          // 23: leoflow.agent.v1.WorkerMessage
+	(*WorkerRegister)(nil),         // 24: leoflow.agent.v1.WorkerRegister
+	(*AssignmentAck)(nil),          // 25: leoflow.agent.v1.AssignmentAck
+	(*SlotFree)(nil),               // 26: leoflow.agent.v1.SlotFree
+	(*HeartbeatResponse)(nil),      // 27: leoflow.agent.v1.HeartbeatResponse
+	nil,                            // 28: leoflow.agent.v1.GetVariablesResponse.VariablesEntry
+	nil,                            // 29: leoflow.agent.v1.GetConnectionsResponse.ConnectionUrisEntry
+	nil,                            // 30: leoflow.agent.v1.RegisterRequest.EnvironmentEntry
+	nil,                            // 31: leoflow.agent.v1.TaskSpec.EnvironmentEntry
+	nil,                            // 32: leoflow.agent.v1.TaskSpec.XcomInputMappingEntry
+	nil,                            // 33: leoflow.agent.v1.HeartbeatRequest.CustomMetricsEntry
+	(*timestamppb.Timestamp)(nil),  // 34: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),        // 35: google.protobuf.Struct
 }
 var file_agent_proto_depIdxs = []int32{
-	23, // 0: leoflow.agent.v1.GetVariablesResponse.variables:type_name -> leoflow.agent.v1.GetVariablesResponse.VariablesEntry
-	24, // 1: leoflow.agent.v1.GetConnectionsResponse.connection_uris:type_name -> leoflow.agent.v1.GetConnectionsResponse.ConnectionUrisEntry
-	25, // 2: leoflow.agent.v1.RegisterRequest.environment:type_name -> leoflow.agent.v1.RegisterRequest.EnvironmentEntry
-	29, // 3: leoflow.agent.v1.RegisterResponse.server_time:type_name -> google.protobuf.Timestamp
-	26, // 4: leoflow.agent.v1.TaskSpec.environment:type_name -> leoflow.agent.v1.TaskSpec.EnvironmentEntry
-	27, // 5: leoflow.agent.v1.TaskSpec.xcom_input_mapping:type_name -> leoflow.agent.v1.TaskSpec.XcomInputMappingEntry
-	30, // 6: leoflow.agent.v1.TaskSpec.extra:type_name -> google.protobuf.Struct
-	29, // 7: leoflow.agent.v1.FetchXComResponse.created_at:type_name -> google.protobuf.Timestamp
-	29, // 8: leoflow.agent.v1.LogLine.time:type_name -> google.protobuf.Timestamp
+	28, // 0: leoflow.agent.v1.GetVariablesResponse.variables:type_name -> leoflow.agent.v1.GetVariablesResponse.VariablesEntry
+	29, // 1: leoflow.agent.v1.GetConnectionsResponse.connection_uris:type_name -> leoflow.agent.v1.GetConnectionsResponse.ConnectionUrisEntry
+	30, // 2: leoflow.agent.v1.RegisterRequest.environment:type_name -> leoflow.agent.v1.RegisterRequest.EnvironmentEntry
+	34, // 3: leoflow.agent.v1.RegisterResponse.server_time:type_name -> google.protobuf.Timestamp
+	31, // 4: leoflow.agent.v1.TaskSpec.environment:type_name -> leoflow.agent.v1.TaskSpec.EnvironmentEntry
+	32, // 5: leoflow.agent.v1.TaskSpec.xcom_input_mapping:type_name -> leoflow.agent.v1.TaskSpec.XcomInputMappingEntry
+	35, // 6: leoflow.agent.v1.TaskSpec.extra:type_name -> google.protobuf.Struct
+	34, // 7: leoflow.agent.v1.FetchXComResponse.created_at:type_name -> google.protobuf.Timestamp
+	34, // 8: leoflow.agent.v1.LogLine.time:type_name -> google.protobuf.Timestamp
 	0,  // 9: leoflow.agent.v1.LogLine.level:type_name -> leoflow.agent.v1.LogLevel
 	1,  // 10: leoflow.agent.v1.ReportStateRequest.state:type_name -> leoflow.agent.v1.TaskState
-	29, // 11: leoflow.agent.v1.ReportStateRequest.occurred_at:type_name -> google.protobuf.Timestamp
-	29, // 12: leoflow.agent.v1.ReportStateRequest.reschedule_at:type_name -> google.protobuf.Timestamp
-	29, // 13: leoflow.agent.v1.HeartbeatRequest.sent_at:type_name -> google.protobuf.Timestamp
-	28, // 14: leoflow.agent.v1.HeartbeatRequest.custom_metrics:type_name -> leoflow.agent.v1.HeartbeatRequest.CustomMetricsEntry
-	29, // 15: leoflow.agent.v1.HeartbeatResponse.server_time:type_name -> google.protobuf.Timestamp
-	12, // 16: leoflow.agent.v1.TaskSpec.XcomInputMappingEntry.value:type_name -> leoflow.agent.v1.XComUpstreams
-	6,  // 17: leoflow.agent.v1.AgentService.ExchangeToken:input_type -> leoflow.agent.v1.ExchangeTokenRequest
-	8,  // 18: leoflow.agent.v1.AgentService.Register:input_type -> leoflow.agent.v1.RegisterRequest
-	10, // 19: leoflow.agent.v1.AgentService.GetTaskSpec:input_type -> leoflow.agent.v1.GetTaskSpecRequest
-	13, // 20: leoflow.agent.v1.AgentService.FetchXCom:input_type -> leoflow.agent.v1.FetchXComRequest
-	15, // 21: leoflow.agent.v1.AgentService.PushXCom:input_type -> leoflow.agent.v1.PushXComRequest
-	17, // 22: leoflow.agent.v1.AgentService.StreamLogs:input_type -> leoflow.agent.v1.LogLine
-	19, // 23: leoflow.agent.v1.AgentService.ReportState:input_type -> leoflow.agent.v1.ReportStateRequest
-	21, // 24: leoflow.agent.v1.AgentService.Heartbeat:input_type -> leoflow.agent.v1.HeartbeatRequest
-	2,  // 25: leoflow.agent.v1.AgentService.GetVariables:input_type -> leoflow.agent.v1.GetVariablesRequest
-	4,  // 26: leoflow.agent.v1.AgentService.GetConnections:input_type -> leoflow.agent.v1.GetConnectionsRequest
-	7,  // 27: leoflow.agent.v1.AgentService.ExchangeToken:output_type -> leoflow.agent.v1.ExchangeTokenResponse
-	9,  // 28: leoflow.agent.v1.AgentService.Register:output_type -> leoflow.agent.v1.RegisterResponse
-	11, // 29: leoflow.agent.v1.AgentService.GetTaskSpec:output_type -> leoflow.agent.v1.TaskSpec
-	14, // 30: leoflow.agent.v1.AgentService.FetchXCom:output_type -> leoflow.agent.v1.FetchXComResponse
-	16, // 31: leoflow.agent.v1.AgentService.PushXCom:output_type -> leoflow.agent.v1.PushXComResponse
-	18, // 32: leoflow.agent.v1.AgentService.StreamLogs:output_type -> leoflow.agent.v1.LogAck
-	20, // 33: leoflow.agent.v1.AgentService.ReportState:output_type -> leoflow.agent.v1.ReportStateResponse
-	22, // 34: leoflow.agent.v1.AgentService.Heartbeat:output_type -> leoflow.agent.v1.HeartbeatResponse
-	3,  // 35: leoflow.agent.v1.AgentService.GetVariables:output_type -> leoflow.agent.v1.GetVariablesResponse
-	5,  // 36: leoflow.agent.v1.AgentService.GetConnections:output_type -> leoflow.agent.v1.GetConnectionsResponse
-	27, // [27:37] is the sub-list for method output_type
-	17, // [17:27] is the sub-list for method input_type
-	17, // [17:17] is the sub-list for extension type_name
-	17, // [17:17] is the sub-list for extension extendee
-	0,  // [0:17] is the sub-list for field type_name
+	34, // 11: leoflow.agent.v1.ReportStateRequest.occurred_at:type_name -> google.protobuf.Timestamp
+	34, // 12: leoflow.agent.v1.ReportStateRequest.reschedule_at:type_name -> google.protobuf.Timestamp
+	34, // 13: leoflow.agent.v1.HeartbeatRequest.sent_at:type_name -> google.protobuf.Timestamp
+	33, // 14: leoflow.agent.v1.HeartbeatRequest.custom_metrics:type_name -> leoflow.agent.v1.HeartbeatRequest.CustomMetricsEntry
+	24, // 15: leoflow.agent.v1.WorkerMessage.register:type_name -> leoflow.agent.v1.WorkerRegister
+	25, // 16: leoflow.agent.v1.WorkerMessage.ack:type_name -> leoflow.agent.v1.AssignmentAck
+	26, // 17: leoflow.agent.v1.WorkerMessage.slot_free:type_name -> leoflow.agent.v1.SlotFree
+	34, // 18: leoflow.agent.v1.HeartbeatResponse.server_time:type_name -> google.protobuf.Timestamp
+	12, // 19: leoflow.agent.v1.TaskSpec.XcomInputMappingEntry.value:type_name -> leoflow.agent.v1.XComUpstreams
+	6,  // 20: leoflow.agent.v1.AgentService.ExchangeToken:input_type -> leoflow.agent.v1.ExchangeTokenRequest
+	8,  // 21: leoflow.agent.v1.AgentService.Register:input_type -> leoflow.agent.v1.RegisterRequest
+	10, // 22: leoflow.agent.v1.AgentService.GetTaskSpec:input_type -> leoflow.agent.v1.GetTaskSpecRequest
+	13, // 23: leoflow.agent.v1.AgentService.FetchXCom:input_type -> leoflow.agent.v1.FetchXComRequest
+	15, // 24: leoflow.agent.v1.AgentService.PushXCom:input_type -> leoflow.agent.v1.PushXComRequest
+	17, // 25: leoflow.agent.v1.AgentService.StreamLogs:input_type -> leoflow.agent.v1.LogLine
+	19, // 26: leoflow.agent.v1.AgentService.ReportState:input_type -> leoflow.agent.v1.ReportStateRequest
+	21, // 27: leoflow.agent.v1.AgentService.Heartbeat:input_type -> leoflow.agent.v1.HeartbeatRequest
+	2,  // 28: leoflow.agent.v1.AgentService.GetVariables:input_type -> leoflow.agent.v1.GetVariablesRequest
+	4,  // 29: leoflow.agent.v1.AgentService.GetConnections:input_type -> leoflow.agent.v1.GetConnectionsRequest
+	23, // 30: leoflow.agent.v1.AgentService.AwaitAssignment:input_type -> leoflow.agent.v1.WorkerMessage
+	7,  // 31: leoflow.agent.v1.AgentService.ExchangeToken:output_type -> leoflow.agent.v1.ExchangeTokenResponse
+	9,  // 32: leoflow.agent.v1.AgentService.Register:output_type -> leoflow.agent.v1.RegisterResponse
+	11, // 33: leoflow.agent.v1.AgentService.GetTaskSpec:output_type -> leoflow.agent.v1.TaskSpec
+	14, // 34: leoflow.agent.v1.AgentService.FetchXCom:output_type -> leoflow.agent.v1.FetchXComResponse
+	16, // 35: leoflow.agent.v1.AgentService.PushXCom:output_type -> leoflow.agent.v1.PushXComResponse
+	18, // 36: leoflow.agent.v1.AgentService.StreamLogs:output_type -> leoflow.agent.v1.LogAck
+	20, // 37: leoflow.agent.v1.AgentService.ReportState:output_type -> leoflow.agent.v1.ReportStateResponse
+	27, // 38: leoflow.agent.v1.AgentService.Heartbeat:output_type -> leoflow.agent.v1.HeartbeatResponse
+	3,  // 39: leoflow.agent.v1.AgentService.GetVariables:output_type -> leoflow.agent.v1.GetVariablesResponse
+	5,  // 40: leoflow.agent.v1.AgentService.GetConnections:output_type -> leoflow.agent.v1.GetConnectionsResponse
+	22, // 41: leoflow.agent.v1.AgentService.AwaitAssignment:output_type -> leoflow.agent.v1.WorkAssignment
+	31, // [31:42] is the sub-list for method output_type
+	20, // [20:31] is the sub-list for method input_type
+	20, // [20:20] is the sub-list for extension type_name
+	20, // [20:20] is the sub-list for extension extendee
+	0,  // [0:20] is the sub-list for field type_name
 }
 
 func init() { file_agent_proto_init() }
@@ -1667,13 +2038,18 @@ func file_agent_proto_init() {
 	if File_agent_proto != nil {
 		return
 	}
+	file_agent_proto_msgTypes[21].OneofWrappers = []any{
+		(*WorkerMessage_Register)(nil),
+		(*WorkerMessage_Ack)(nil),
+		(*WorkerMessage_SlotFree)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_agent_proto_rawDesc), len(file_agent_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   27,
+			NumMessages:   32,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/agent/v1/agent_grpc.pb.go
+++ b/proto/agent/v1/agent_grpc.pb.go
@@ -23,16 +23,17 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	AgentService_ExchangeToken_FullMethodName  = "/leoflow.agent.v1.AgentService/ExchangeToken"
-	AgentService_Register_FullMethodName       = "/leoflow.agent.v1.AgentService/Register"
-	AgentService_GetTaskSpec_FullMethodName    = "/leoflow.agent.v1.AgentService/GetTaskSpec"
-	AgentService_FetchXCom_FullMethodName      = "/leoflow.agent.v1.AgentService/FetchXCom"
-	AgentService_PushXCom_FullMethodName       = "/leoflow.agent.v1.AgentService/PushXCom"
-	AgentService_StreamLogs_FullMethodName     = "/leoflow.agent.v1.AgentService/StreamLogs"
-	AgentService_ReportState_FullMethodName    = "/leoflow.agent.v1.AgentService/ReportState"
-	AgentService_Heartbeat_FullMethodName      = "/leoflow.agent.v1.AgentService/Heartbeat"
-	AgentService_GetVariables_FullMethodName   = "/leoflow.agent.v1.AgentService/GetVariables"
-	AgentService_GetConnections_FullMethodName = "/leoflow.agent.v1.AgentService/GetConnections"
+	AgentService_ExchangeToken_FullMethodName   = "/leoflow.agent.v1.AgentService/ExchangeToken"
+	AgentService_Register_FullMethodName        = "/leoflow.agent.v1.AgentService/Register"
+	AgentService_GetTaskSpec_FullMethodName     = "/leoflow.agent.v1.AgentService/GetTaskSpec"
+	AgentService_FetchXCom_FullMethodName       = "/leoflow.agent.v1.AgentService/FetchXCom"
+	AgentService_PushXCom_FullMethodName        = "/leoflow.agent.v1.AgentService/PushXCom"
+	AgentService_StreamLogs_FullMethodName      = "/leoflow.agent.v1.AgentService/StreamLogs"
+	AgentService_ReportState_FullMethodName     = "/leoflow.agent.v1.AgentService/ReportState"
+	AgentService_Heartbeat_FullMethodName       = "/leoflow.agent.v1.AgentService/Heartbeat"
+	AgentService_GetVariables_FullMethodName    = "/leoflow.agent.v1.AgentService/GetVariables"
+	AgentService_GetConnections_FullMethodName  = "/leoflow.agent.v1.AgentService/GetConnections"
+	AgentService_AwaitAssignment_FullMethodName = "/leoflow.agent.v1.AgentService/AwaitAssignment"
 )
 
 // AgentServiceClient is the client API for AgentService service.
@@ -73,6 +74,13 @@ type AgentServiceClient interface {
 	// Agent fetches the tenant's Connections (as Airflow connection URIs) to
 	// export as AIRFLOW_CONN_* env vars.
 	GetConnections(ctx context.Context, in *GetConnectionsRequest, opts ...grpc.CallOption) (*GetConnectionsResponse, error)
+	// A warm worker awaits per-attempt assignments over a long-lived bidi stream
+	// (ADR 0058 N1b). Down: the control plane pushes WorkAssignments. Up: the
+	// worker sends its initial WorkerRegister, per-assignment AssignmentAcks, and
+	// SlotFree signals. Gated on execution.warm_pools_enabled — the handler
+	// returns FailedPrecondition when warm pools are off, so the transport is
+	// inert by default.
+	AwaitAssignment(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[WorkerMessage, WorkAssignment], error)
 }
 
 type agentServiceClient struct {
@@ -186,6 +194,19 @@ func (c *agentServiceClient) GetConnections(ctx context.Context, in *GetConnecti
 	return out, nil
 }
 
+func (c *agentServiceClient) AwaitAssignment(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[WorkerMessage, WorkAssignment], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &AgentService_ServiceDesc.Streams[1], AgentService_AwaitAssignment_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[WorkerMessage, WorkAssignment]{ClientStream: stream}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type AgentService_AwaitAssignmentClient = grpc.BidiStreamingClient[WorkerMessage, WorkAssignment]
+
 // AgentServiceServer is the server API for AgentService service.
 // All implementations must embed UnimplementedAgentServiceServer
 // for forward compatibility.
@@ -224,6 +245,13 @@ type AgentServiceServer interface {
 	// Agent fetches the tenant's Connections (as Airflow connection URIs) to
 	// export as AIRFLOW_CONN_* env vars.
 	GetConnections(context.Context, *GetConnectionsRequest) (*GetConnectionsResponse, error)
+	// A warm worker awaits per-attempt assignments over a long-lived bidi stream
+	// (ADR 0058 N1b). Down: the control plane pushes WorkAssignments. Up: the
+	// worker sends its initial WorkerRegister, per-assignment AssignmentAcks, and
+	// SlotFree signals. Gated on execution.warm_pools_enabled — the handler
+	// returns FailedPrecondition when warm pools are off, so the transport is
+	// inert by default.
+	AwaitAssignment(grpc.BidiStreamingServer[WorkerMessage, WorkAssignment]) error
 	mustEmbedUnimplementedAgentServiceServer()
 }
 
@@ -263,6 +291,9 @@ func (UnimplementedAgentServiceServer) GetVariables(context.Context, *GetVariabl
 }
 func (UnimplementedAgentServiceServer) GetConnections(context.Context, *GetConnectionsRequest) (*GetConnectionsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetConnections not implemented")
+}
+func (UnimplementedAgentServiceServer) AwaitAssignment(grpc.BidiStreamingServer[WorkerMessage, WorkAssignment]) error {
+	return status.Error(codes.Unimplemented, "method AwaitAssignment not implemented")
 }
 func (UnimplementedAgentServiceServer) mustEmbedUnimplementedAgentServiceServer() {}
 func (UnimplementedAgentServiceServer) testEmbeddedByValue()                      {}
@@ -454,6 +485,13 @@ func _AgentService_GetConnections_Handler(srv interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _AgentService_AwaitAssignment_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(AgentServiceServer).AwaitAssignment(&grpc.GenericServerStream[WorkerMessage, WorkAssignment]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type AgentService_AwaitAssignmentServer = grpc.BidiStreamingServer[WorkerMessage, WorkAssignment]
+
 // AgentService_ServiceDesc is the grpc.ServiceDesc for AgentService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -502,6 +540,12 @@ var AgentService_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "StreamLogs",
 			Handler:       _AgentService_StreamLogs_Handler,
+			ServerStreams: true,
+			ClientStreams: true,
+		},
+		{
+			StreamName:    "AwaitAssignment",
+			Handler:       _AgentService_AwaitAssignment_Handler,
 			ServerStreams: true,
 			ClientStreams: true,
 		},


### PR DESCRIPTION
**N1b1 of the warm-pool track (ADR 0058 + the decided N1b protocol).** The warm-worker **assignment transport** — the bidi gRPC stream that hands per-attempt work to a long-lived warm worker — plus the worker registry and the **H1 ack/lease reclaim** machine. **Transport only:** no placement caller, no agent change; the scheduler still dispatches dedicated pods, the runner stays single-shot.

## Inert when off (zero behavior change)
Gated behind `execution.warm_pools_enabled` (default off). With the flag off, `warmPools` is nil → `AwaitAssignment` returns `FailedPrecondition` → completely dormant. `EnableWarmPools` is called only inside `if warmPoolsEnabled` in `startAgentGRPC`.

## Protocol (`proto/agent.proto`)
`rpc AwaitAssignment (stream WorkerMessage) returns (stream WorkAssignment)`. Down: `WorkAssignment{assignment_id, attempt_token, dag_run_id, task_id, try_number, dag_version_id, lease_seconds}`. Up: `WorkerMessage` oneof `{WorkerRegister(dag_version_id), AssignmentAck(assignment_id, started), SlotFree}`.

## Reliability contract (the decided N1b robustness scope)
- **Identity from auth, not payload:** the registry key is the worker's authenticated identity from the stream bearer token (same `identify()` path `Heartbeat`/`ReportState` use); the payload `dag_version_id` only names the pool and must be non-empty.
- **H1 ack/lease:** an assignment starts a lease; `ack{started:true}` cancels it + marks busy; **lease expiry**, `ack{started:false}`, or **the worker disconnecting with an unacked lease** each emit a `ReclaimEvent` (`LeaseExpired`/`Refused`/`WorkerGone`) for the placement layer to re-place on the infra budget. Lease duration is injectable → deterministic tests, no sleeps. Reclaim fires outside the lock.
- **Reconnect-safe:** `Register` replaces (never a 2nd entry); `Deregister` evicts only if the registry still points at that entry (a stale stream can't evict a live reconnect). Buffered cap-1 outbound channel decouples `Assign` from the Send loop; buffered `recvErr` → no goroutine leak.
- **O(1)** registry ops (free set = `dag_version → identity → worker`).
- **Keepalive:** `EnforcementPolicy` relaxed (MinTime 10s, PermitWithoutStream) so idle streams aren't killed as abusive — only relaxes the prior streams-only policy, so `StreamLogs` is unaffected. Server-initiated `ServerParameters` deferred to N1b1-place (TODO in `main.go`).

## Known N1b2 follow-ups (not N1b1 bugs — transport is inert + fake-identity tested)
1. Worker identity is keyed on `TaskInstanceID` as a **placeholder**; a warm worker's bootstrap token must carry a stable pod/worker id and key on that.
2. A still-connected worker that misses/refuses a lease is left out of rotation until idle-recycle; the agent protocol must define how it re-signals availability (SlotFree / re-register).

## Tests / verification
9 TDD cases (RED-first) via an in-memory fake bidi stream (inert-off, register-required, register present, assign delivered, ack-in-lease no-reclaim+busy, lease-expiry reclaim, ack-refused reclaim, stream-close deregister, reconnect single-entry). `go test -race` clean · `go build ./...` + `-tags integration` green · `golangci-lint` 0 issues · proto regenerated in sync · agent runner untouched.