### PR TITLE
feat(agent): warm-worker mode — serve many attempts per pod, fork-per-attempt (ADR 0058 N1b2a)

### DIFF
--- a/cmd/leoflow-agent/main.go
+++ b/cmd/leoflow-agent/main.go
@@ -97,6 +97,15 @@ func run() int {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
+	// Warm-worker mode (ADR 0058): a long-lived process that registers once with
+	// the bootstrap token and serves MANY attempts over the AwaitAssignment stream,
+	// each in a fresh forked child. Selected by env; the bootstrap credential comes
+	// from the same path as single-shot. Anything else falls through to the
+	// byte-identical single-shot path below.
+	if os.Getenv("LEOFLOW_WARM_WORKER") == "1" {
+		return runWarm(ctx, client, addr, token, allowInsecure, caFile)
+	}
+
 	// Exchange the projected bootstrap token for the task-scoped JWT before any
 	// other RPC, then swap it into the shared TokenSource so every subsequent call
 	// authenticates as the task instance. Fails startup if the exchange is refused.
@@ -162,6 +171,69 @@ func run() int {
 	}
 	if rerr := runner.Run(ctx); rerr != nil {
 		slog.Error("task failed", "error", rerr)
+		return 1
+	}
+	return 0
+}
+
+// runWarm serves the warm-worker loop (ADR 0058). streamClient carries the
+// worker's bootstrap identity (Register + AwaitAssignment). A SECOND dial gives
+// the WorkClient its own connection bound to an attempt-scoped TokenSource, which
+// the loop swaps to each assignment's attempt_token — so the per-attempt work RPCs
+// authenticate as the attempt while the stream keeps the bootstrap identity it was
+// opened with. The work dial is seeded with the bootstrap token only to satisfy
+// Dial's non-empty check; no work RPC fires before the first attempt_token swap.
+func runWarm(ctx context.Context, streamClient agentv1.AgentServiceClient, addr, seedToken string, allowInsecure bool, caFile string) int {
+	dagVersionID := os.Getenv("LEOFLOW_DAG_VERSION_ID")
+	if dagVersionID == "" {
+		slog.Error("warm worker requires LEOFLOW_DAG_VERSION_ID")
+		return 1
+	}
+
+	workClient, workConn, attemptTokens, err := agent.Dial(addr, seedToken, allowInsecure, caFile)
+	if err != nil {
+		slog.Error("dialing control plane for per-attempt work", "error", err)
+		return 1
+	}
+	defer func() {
+		if cerr := workConn.Close(); cerr != nil {
+			slog.Warn("closing work connection", "error", cerr)
+		}
+	}()
+
+	hostname, herr := os.Hostname()
+	if herr != nil {
+		hostname = "unknown"
+	}
+
+	// The agent-owned scratch root, wiped and recreated before every attempt
+	// (D4 isolation). Removed on exit.
+	scratchDir, err := os.MkdirTemp("", "leoflow-warm-")
+	if err != nil {
+		slog.Error("preparing warm scratch dir", "error", err)
+		return 1
+	}
+	defer func() { _ = os.RemoveAll(scratchDir) }() //nolint:errcheck // best-effort cleanup on exit
+
+	w := &agent.WarmRunner{
+		StreamClient:  streamClient,
+		WorkClient:    workClient,
+		AttemptTokens: attemptTokens,
+		// A fresh per-attempt log sink on the work client, so each attempt's logs
+		// ship under its own attempt_token.
+		NewSink: func(ctx context.Context) (agent.LogSink, error) {
+			return agent.OpenLogSink(ctx, workClient)
+		},
+		Cmd:                agent.NewExecRunner(),
+		Hostname:           hostname,
+		Version:            version.Get().Version,
+		Env:                os.Environ(),
+		ScratchDir:         scratchDir,
+		TerminationLogPath: os.Getenv("LEOFLOW_TERMINATION_LOG_PATH"),
+		HeartbeatInterval:  agent.DefaultHeartbeatInterval,
+	}
+	if rerr := w.Run(ctx, dagVersionID); rerr != nil {
+		slog.Error("warm worker failed", "error", rerr)
 		return 1
 	}
 	return 0

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -100,11 +100,23 @@ func (r *Runner) after(d time.Duration) <-chan time.Time {
 	return time.After(d)
 }
 
-// Run executes the task lifecycle and returns an error if the task failed.
+// Run executes the task lifecycle and returns an error if the task failed. In
+// single-shot mode the agent registers once and serves exactly one attempt, so
+// Run is register followed by runOneAttempt. The warm worker (warm.go) reuses
+// runOneAttempt directly, registering separately and driving many attempts.
 func (r *Runner) Run(ctx context.Context) error {
 	if err := r.register(ctx); err != nil {
 		return err
 	}
+	return r.runOneAttempt(ctx)
+}
+
+// runOneAttempt fetches the task spec, builds the command and its environment, and
+// runs the user process to its terminal ReportState. It is the whole per-attempt
+// body: a single-shot agent calls it once (via Run); a warm worker calls it once
+// per WorkAssignment, each time in a fresh forked child with a freshly-built env.
+// It does NOT register — registration is a per-worker concern the caller owns.
+func (r *Runner) runOneAttempt(ctx context.Context) error {
 	spec, err := r.Client.GetTaskSpec(ctx, &agentv1.GetTaskSpecRequest{})
 	if err != nil {
 		return fmt.Errorf("fetching task spec: %w", err)

--- a/internal/agent/warm.go
+++ b/internal/agent/warm.go
@@ -1,0 +1,227 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// WarmRunner is the client side of the warm-worker transport (ADR 0058 D4): a
+// long-lived process that registers once, opens the AwaitAssignment bidi stream,
+// and serves MANY task attempts — one at a time — each in a fresh forked child.
+//
+// Two identities are kept deliberately separate:
+//
+//   - StreamClient carries the worker's BOOTSTRAP identity. Register and the
+//     AwaitAssignment control stream run on it and never adopt an attempt token,
+//     so the pod's membership in the pool is stable for the worker's whole life.
+//   - WorkClient carries each attempt's PER-ATTEMPT identity. Its per-RPC
+//     credential reads AttemptTokens, which the loop swaps to the assignment's
+//     attempt_token before running. Because attempts are strictly sequential, no
+//     two attempts' RPCs are ever in flight at once, so the swap is race-free; and
+//     because the swap only touches AttemptTokens (a different TokenSource / dial
+//     from the stream), it never disturbs the already-open bootstrap stream, whose
+//     authorization header was sent once at stream open.
+//
+// In production StreamClient and WorkClient are two dials of the same control
+// plane (see cmd/leoflow-agent), one bound to the bootstrap TokenSource and one to
+// AttemptTokens. They may be the same client only in tests that don't exercise the
+// credential.
+type WarmRunner struct {
+	StreamClient  agentv1.AgentServiceClient
+	WorkClient    agentv1.AgentServiceClient
+	AttemptTokens *TokenSource
+
+	// NewSink opens a fresh per-attempt log sink on the WorkClient, so each
+	// attempt's logs are shipped under its own attempt_token. Nil (or a returned
+	// error) falls back to NoopLogSink — logs are best-effort, never fatal.
+	NewSink func(ctx context.Context) (LogSink, error)
+
+	Cmd      CommandRunner
+	Hostname string
+	Version  string
+	Env      []string // base process environment (typically os.Environ())
+
+	// ScratchDir is the agent-owned per-attempt scratch root. It is wiped and
+	// recreated before every attempt (D4 isolation) and holds the return-value,
+	// extra-links, xcom-pushes, and reschedule files the runtime writes.
+	ScratchDir string
+
+	// TerminationLogPath and HeartbeatInterval mirror the single-shot Runner's
+	// fields and are threaded into every per-attempt Runner.
+	TerminationLogPath string
+	HeartbeatInterval  time.Duration
+}
+
+// Run registers the worker once, opens the assignment stream, and serves
+// assignments until the stream ends (server close / drain) or ctx is canceled —
+// returning nil in both those cases. It returns a non-nil error only on a
+// registration failure, a stream transport failure, or a failure to guarantee a
+// clean scratch (isolation is fail-closed). A failed TASK is a normal outcome and
+// never ends the loop.
+func (w *WarmRunner) Run(ctx context.Context, dagVersionID string) error {
+	if _, err := w.StreamClient.Register(ctx, &agentv1.RegisterRequest{
+		AgentVersion: w.Version,
+		Hostname:     w.Hostname,
+	}); err != nil {
+		return fmt.Errorf("registering warm worker: %w", err)
+	}
+
+	stream, err := w.StreamClient.AwaitAssignment(ctx)
+	if err != nil {
+		return fmt.Errorf("opening assignment stream: %w", err)
+	}
+	// The mandatory first WorkerMessage names which pool (dag_version) this worker
+	// serves, so the control plane only dispatches matching assignments to it.
+	if serr := stream.Send(&agentv1.WorkerMessage{
+		Msg: &agentv1.WorkerMessage_Register{
+			Register: &agentv1.WorkerRegister{DagVersionId: dagVersionID},
+		},
+	}); serr != nil {
+		return fmt.Errorf("sending worker register: %w", serr)
+	}
+
+	for {
+		assignment, rerr := stream.Recv()
+		if rerr != nil {
+			// A closed / drained stream (EOF), or a parent shutdown (SIGTERM,
+			// which gRPC surfaces on the stream as codes.Canceled), both mean
+			// "stop serving" — exit cleanly. Anything else is a real transport
+			// failure worth surfacing.
+			if errors.Is(rerr, io.EOF) || status.Code(rerr) == codes.Canceled {
+				return nil
+			}
+			return fmt.Errorf("receiving assignment: %w", rerr)
+		}
+		if serr := w.serveAssignment(ctx, stream, assignment); serr != nil {
+			// A stream / isolation failure is loop-fatal, EXCEPT a canceled stream
+			// (parent shutdown mid-attempt) — that is a clean shutdown, not an error.
+			if status.Code(serr) == codes.Canceled {
+				return nil
+			}
+			return serr
+		}
+	}
+}
+
+// serveAssignment claims, runs, and completes a single assignment, then signals
+// availability for the next. The returned error is loop-fatal (a stream or
+// isolation failure); a failed task is NOT such an error — runOneAttempt already
+// reported the terminal FAILED state, so it is logged and the worker keeps serving.
+func (w *WarmRunner) serveAssignment(ctx context.Context, stream agentv1.AgentService_AwaitAssignmentClient, a *agentv1.WorkAssignment) error {
+	// D4 isolation, part 1: a fresh, empty agent scratch before the attempt runs.
+	// This is fail-closed — if we cannot guarantee a clean scratch we tear the
+	// worker down rather than risk one attempt observing another's writable state.
+	// Done BEFORE the ack on purpose: a scratch failure here means we never ack, so
+	// the assignment is reclaimed by lease expiry (the N1b1 path already built),
+	// rather than being acked-as-started and then stranded on the worker teardown
+	// (which would need the N1d reaper to recover). resetScratch is a fast
+	// rm+mkdir, so the pre-ack window stays sub-millisecond — no lease-expiry race.
+	if err := w.resetScratch(); err != nil {
+		return fmt.Errorf("resetting scratch for assignment %q: %w", a.GetAssignmentId(), err)
+	}
+
+	// Claim the lease now that we have committed to running: the control plane
+	// holds the attempt for us until this ack and reclaims it if we do not ack
+	// within lease_seconds. Sent after the scratch reset so "started" is truthful.
+	if err := stream.Send(&agentv1.WorkerMessage{
+		Msg: &agentv1.WorkerMessage_Ack{
+			Ack: &agentv1.AssignmentAck{AssignmentId: a.GetAssignmentId(), Started: true},
+		},
+	}); err != nil {
+		return fmt.Errorf("acking assignment %q: %w", a.GetAssignmentId(), err)
+	}
+
+	// Adopt this attempt's own credential for every per-attempt unary RPC. Only
+	// AttemptTokens (WorkClient's source) is touched; the bootstrap stream is
+	// unaffected. The attempt's identity (run/task/try) is resolved by GetTaskSpec
+	// from this token, exactly as a dedicated pod resolves it today.
+	w.AttemptTokens.Set(a.GetAttemptToken())
+
+	// D4 isolation, part 2 (fresh env) is inherent: attemptRunner builds a new
+	// Runner whose buildEnv runs from scratch each attempt, so no attempt inherits
+	// another attempt's secrets, XCom, or run-context env.
+	sink := w.openSink(ctx)
+	r := w.attemptRunner(sink)
+
+	// A wedged child is bounded by the task's execution_timeout (honored inside
+	// execute via a deadline context), so a normal long task cannot hang the worker
+	// forever. A hard per-attempt watchdog INDEPENDENT of execution_timeout — to
+	// bound a task that declares no timeout and then wedges — is ADR 0058 H3;
+	// TODO(N1d): add that watchdog here so a no-timeout wedge cannot pin the slot.
+	if aerr := r.runOneAttempt(ctx); aerr != nil {
+		// A failed attempt is a normal, already-reported outcome. Keep serving.
+		slog.Warn("warm attempt finished with an error",
+			"assignment", a.GetAssignmentId(), "error", aerr)
+	}
+
+	// Signal availability so the control plane may dispatch the next assignment.
+	if err := stream.Send(&agentv1.WorkerMessage{
+		Msg: &agentv1.WorkerMessage_SlotFree{SlotFree: &agentv1.SlotFree{}},
+	}); err != nil {
+		return fmt.Errorf("signaling slot free after assignment %q: %w", a.GetAssignmentId(), err)
+	}
+	return nil
+}
+
+// resetScratch removes and recreates the agent's per-attempt scratch dir. This is
+// the D4 filesystem scrub: it deletes everything the previous attempt (or its user
+// process) wrote UNDER the agent's own scratch — the return-value, extra-links,
+// xcom-pushes, and reschedule files, plus anything else the runtime staged there —
+// so no attempt observes another attempt's writable fs state. It deletes ONLY the
+// agent-owned scratch; paths outside it (the task image, mounts, the pod's own
+// /tmp) are left untouched.
+func (w *WarmRunner) resetScratch() error {
+	if err := os.RemoveAll(w.ScratchDir); err != nil {
+		return fmt.Errorf("removing scratch %q: %w", w.ScratchDir, err)
+	}
+	if err := os.MkdirAll(w.ScratchDir, 0o700); err != nil {
+		return fmt.Errorf("recreating scratch %q: %w", w.ScratchDir, err)
+	}
+	return nil
+}
+
+// openSink opens a fresh per-attempt log sink, falling back to NoopLogSink when no
+// factory is configured or the stream cannot be opened (logs are best-effort).
+func (w *WarmRunner) openSink(ctx context.Context) LogSink {
+	if w.NewSink == nil {
+		return NoopLogSink{}
+	}
+	sink, err := w.NewSink(ctx)
+	if err != nil {
+		slog.Warn("opening per-attempt log sink; logs will not ship this attempt", "error", err)
+		return NoopLogSink{}
+	}
+	return sink
+}
+
+// attemptRunner builds the single-shot Runner that executes one attempt. Its
+// per-task output paths live under the agent-owned scratch (wiped between
+// attempts), and its Client is the WorkClient bound to AttemptTokens so every
+// per-attempt RPC carries the attempt_token.
+func (w *WarmRunner) attemptRunner(sink LogSink) *Runner {
+	return &Runner{
+		Client:             w.WorkClient,
+		Cmd:                w.Cmd,
+		Sink:               sink,
+		Hostname:           w.Hostname,
+		Version:            w.Version,
+		Env:                w.Env,
+		ReturnPath:         filepath.Join(w.ScratchDir, "return_value.json"),
+		LinksPath:          filepath.Join(w.ScratchDir, "extra_links.json"),
+		PushesPath:         filepath.Join(w.ScratchDir, "xcom_pushes.json"),
+		ReschedulePath:     filepath.Join(w.ScratchDir, "reschedule.txt"),
+		TerminationLogPath: w.TerminationLogPath,
+		HeartbeatInterval:  w.HeartbeatInterval,
+		Token:              w.AttemptTokens,
+	}
+}

--- a/internal/agent/warm_test.go
+++ b/internal/agent/warm_test.go
@@ -1,0 +1,221 @@
+package agent
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// fakeAssignmentStream is a hand-rolled grpc.BidiStreamingClient double for the
+// AwaitAssignment stream. It yields the queued assignments in order (then io.EOF,
+// so the warm loop exits cleanly) and records every WorkerMessage the worker sends
+// up the stream, so a test can assert the ack / slot-free protocol.
+type fakeAssignmentStream struct {
+	ctx         context.Context
+	assignments []*agentv1.WorkAssignment
+	idx         int
+	sent        []*agentv1.WorkerMessage
+	recvErr     error // returned once assignments are exhausted; io.EOF when nil
+}
+
+func (s *fakeAssignmentStream) Send(m *agentv1.WorkerMessage) error {
+	s.sent = append(s.sent, m)
+	return nil
+}
+
+func (s *fakeAssignmentStream) Recv() (*agentv1.WorkAssignment, error) {
+	if s.idx >= len(s.assignments) {
+		if s.recvErr != nil {
+			return nil, s.recvErr
+		}
+		return nil, io.EOF
+	}
+	a := s.assignments[s.idx]
+	s.idx++
+	return a, nil
+}
+
+func (s *fakeAssignmentStream) Header() (metadata.MD, error) { return metadata.MD{}, nil }
+func (s *fakeAssignmentStream) Trailer() metadata.MD         { return nil }
+func (s *fakeAssignmentStream) CloseSend() error             { return nil }
+func (s *fakeAssignmentStream) Context() context.Context     { return s.ctx }
+func (s *fakeAssignmentStream) SendMsg(any) error            { return nil }
+func (s *fakeAssignmentStream) RecvMsg(any) error            { return nil }
+
+// warmFake is the control-plane double for the warm-worker tests. It embeds the
+// single-shot fakeClient (reusing its Register / ReportState / secrets stubs) and
+// overrides AwaitAssignment (to hand back the scripted stream) and GetTaskSpec (to
+// return a distinct spec per attempt and record which bearer token was live when
+// the per-attempt RPC ran — proving the worker adopts each attempt_token).
+type warmFake struct {
+	*fakeClient
+	stream      *fakeAssignmentStream
+	tokens      *TokenSource
+	specs       []*agentv1.TaskSpec
+	specIdx     int
+	tokenAtSpec []string
+}
+
+func (c *warmFake) AwaitAssignment(context.Context, ...grpc.CallOption) (grpc.BidiStreamingClient[agentv1.WorkerMessage, agentv1.WorkAssignment], error) {
+	return c.stream, nil
+}
+
+func (c *warmFake) GetTaskSpec(context.Context, *agentv1.GetTaskSpecRequest, ...grpc.CallOption) (*agentv1.TaskSpec, error) {
+	if c.tokens != nil {
+		c.tokenAtSpec = append(c.tokenAtSpec, c.tokens.Token())
+	}
+	s := c.specs[c.specIdx]
+	c.specIdx++
+	return s, nil
+}
+
+// scratchProbeCmd is a CommandRunner double that, on each invocation, records
+// whether a marker file already exists in the agent scratch dir, then writes it.
+// Between warm attempts the worker must scrub the scratch (D4 isolation); if it
+// does, attempt 2 sees the marker ABSENT even though attempt 1 wrote it.
+type scratchProbeCmd struct {
+	scratchDir string
+	runs       int
+	sawMarker  []bool
+}
+
+func (c *scratchProbeCmd) Run(_ context.Context, _, _ []string, _, _ io.Writer) (int, error) {
+	marker := filepath.Join(c.scratchDir, "attempt-marker")
+	_, statErr := os.Stat(marker)
+	c.sawMarker = append(c.sawMarker, statErr == nil)
+	_ = os.WriteFile(marker, []byte("written by an earlier attempt"), 0o600)
+	c.runs++
+	return 0, nil
+}
+
+// TestWarmWorkerServesTwoAttempts is the warm-mode contract: register once, open
+// the assignment stream, and serve each assignment in a fresh forked child —
+// acking before running, reporting the outcome, scrubbing scratch, and signaling
+// SlotFree after each. The D4 scrub is proven by the marker file being absent when
+// the second attempt starts.
+func TestWarmWorkerServesTwoAttempts(t *testing.T) {
+	scratch := filepath.Join(t.TempDir(), "scratch")
+	stream := &fakeAssignmentStream{
+		ctx: context.Background(),
+		assignments: []*agentv1.WorkAssignment{
+			{AssignmentId: "asg-1", AttemptToken: "tok-1", DagRunId: "run-a", TaskId: "t-a", TryNumber: 1},
+			{AssignmentId: "asg-2", AttemptToken: "tok-2", DagRunId: "run-b", TaskId: "t-b", TryNumber: 2},
+		},
+	}
+	tokens := NewTokenSource("bootstrap")
+	client := &warmFake{
+		fakeClient: &fakeClient{},
+		stream:     stream,
+		tokens:     tokens,
+		specs: []*agentv1.TaskSpec{
+			{Operator: "bash", Entrypoint: "true", RunId: "run-a", TaskId: "t-a", TryNumber: 1},
+			{Operator: "bash", Entrypoint: "true", RunId: "run-b", TaskId: "t-b", TryNumber: 2},
+		},
+	}
+	cmd := &scratchProbeCmd{scratchDir: scratch}
+
+	w := &WarmRunner{
+		StreamClient:  client,
+		WorkClient:    client,
+		AttemptTokens: tokens,
+		Cmd:           cmd,
+		Hostname:      "warm-pod-1",
+		Version:       "test",
+		Env:           []string{"PATH=/usr/bin"},
+		ScratchDir:    scratch,
+	}
+
+	if err := w.Run(context.Background(), "dagver-1"); err != nil {
+		t.Fatalf("WarmRunner.Run: %v", err)
+	}
+
+	// Registered exactly once with the bootstrap identity.
+	if !client.registered {
+		t.Error("warm worker must register on startup")
+	}
+
+	// Both attempts ran as child execs.
+	if cmd.runs != 2 {
+		t.Fatalf("child execs = %d, want 2 (one per assignment)", cmd.runs)
+	}
+
+	// D4 isolation: attempt 1 wrote a marker into scratch; attempt 2 must NOT see
+	// it — the worker scrubbed the shared scratch between attempts.
+	if len(cmd.sawMarker) != 2 || cmd.sawMarker[0] || cmd.sawMarker[1] {
+		t.Errorf("scratch scrub failed: sawMarker=%v, want [false false]", cmd.sawMarker)
+	}
+
+	// Each attempt ran under its own attempt_token (adopted before GetTaskSpec).
+	wantTokens := []string{"tok-1", "tok-2"}
+	if len(client.tokenAtSpec) != 2 || client.tokenAtSpec[0] != wantTokens[0] || client.tokenAtSpec[1] != wantTokens[1] {
+		t.Errorf("token live at GetTaskSpec = %v, want %v", client.tokenAtSpec, wantTokens)
+	}
+
+	// Both attempts reported RUNNING then SUCCESS.
+	wantStates := []agentv1.TaskState{
+		agentv1.TaskState_TASK_STATE_RUNNING, agentv1.TaskState_TASK_STATE_SUCCESS,
+		agentv1.TaskState_TASK_STATE_RUNNING, agentv1.TaskState_TASK_STATE_SUCCESS,
+	}
+	if len(client.states) != len(wantStates) {
+		t.Fatalf("reported states = %v, want %v", client.states, wantStates)
+	}
+	for i, s := range wantStates {
+		if client.states[i] != s {
+			t.Fatalf("reported states = %v, want %v", client.states, wantStates)
+		}
+	}
+
+	// Up-stream protocol: WorkerRegister first, then Ack(started)+SlotFree per
+	// assignment, in that order.
+	if len(stream.sent) != 5 {
+		t.Fatalf("worker sent %d messages, want 5 (register + 2×[ack,slotfree]); got %+v", len(stream.sent), stream.sent)
+	}
+	if reg := stream.sent[0].GetRegister(); reg == nil || reg.GetDagVersionId() != "dagver-1" {
+		t.Errorf("first message must be WorkerRegister(dagver-1), got %+v", stream.sent[0])
+	}
+	assertAck := func(idx int, wantID string) {
+		ack := stream.sent[idx].GetAck()
+		if ack == nil {
+			t.Fatalf("message %d must be an AssignmentAck, got %+v", idx, stream.sent[idx])
+		}
+		if !ack.GetStarted() {
+			t.Errorf("ack %d must have started=true", idx)
+		}
+		if ack.GetAssignmentId() != wantID {
+			t.Errorf("ack %d assignment_id = %q, want %q", idx, ack.GetAssignmentId(), wantID)
+		}
+	}
+	assertAck(1, "asg-1")
+	if stream.sent[2].GetSlotFree() == nil {
+		t.Errorf("message 2 must be SlotFree, got %+v", stream.sent[2])
+	}
+	assertAck(3, "asg-2")
+	if stream.sent[4].GetSlotFree() == nil {
+		t.Errorf("message 4 must be SlotFree, got %+v", stream.sent[4])
+	}
+}
+
+// TestRunnerRunIsRegisterThenOneAttempt locks the single-shot refactor: Run must
+// still be exactly "register, then run one attempt" — one GetTaskSpec, one
+// RUNNING→SUCCESS pair — with no warm-loop behavior leaking in.
+func TestRunnerRunIsRegisterThenOneAttempt(t *testing.T) {
+	client := &fakeClient{spec: &agentv1.TaskSpec{Operator: "bash", Entrypoint: "true"}}
+	r := newRunner(client, &fakeCmd{}, &recordingSink{})
+
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !client.registered {
+		t.Error("Run must register")
+	}
+	wantStates := []agentv1.TaskState{agentv1.TaskState_TASK_STATE_RUNNING, agentv1.TaskState_TASK_STATE_SUCCESS}
+	if len(client.states) != 2 || client.states[0] != wantStates[0] || client.states[1] != wantStates[1] {
+		t.Errorf("states = %v, want exactly one attempt (running then success)", client.states)
+	}
+}


### PR DESCRIPTION
**N1b2a of the warm-pool track (ADR 0058 D4).** The agent's **warm-worker mode**: a long-lived process that registers once, opens the `AwaitAssignment` stream, and serves **many attempts per pod** — one at a time, each in a fresh forked child. This is the piece that makes a pod actually accept reuse. Single-shot mode untouched; warm mode is a new env-selected branch (`LEOFLOW_WARM_WORKER=1` + `LEOFLOW_DAG_VERSION_ID`). No proto/scheduler/executor change. Dormant until N1b2b creates a warm pod (and only when `execution.warm_pools_enabled`).

## Design
- **Runner refactor (pure extract-method):** `Run = register + runOneAttempt`; the per-task body moved verbatim into `runOneAttempt`. Single-shot behavior identical (locked by a test).
- **Two identities, kept separate:** `StreamClient` carries the **bootstrap** token (Register + control stream, never swapped → stable pool membership for the pod's life); `WorkClient` carries the **per-attempt** token via `AttemptTokens`, swapped to each assignment's `attempt_token` before running. Attempts are strictly sequential → the swap is race-free and never disturbs the open bootstrap stream. Every per-attempt unary RPC carries the attempt_token, never the bootstrap token.
- **Per assignment:** reset scratch (fail-closed) → **ack started** → adopt attempt token → run one attempt in a fresh child → **SlotFree**. The ack is sent *after* the scratch reset, so a scratch failure is reclaimed by **lease expiry** (the N1b1 path, already built) instead of being acked-then-stranded (which would need the N1d reaper). resetScratch is a fast rm+mkdir → sub-ms pre-ack window.
- **D4 isolation:** fresh forked child + rebuilt env per attempt + scrubbed agent scratch (only the agent's own scratch — never the image/mounts/pod `/tmp`). Encoded invariant: *no attempt observes another attempt's secrets, env, or writable scratch state.* Fail-closed.
- **Clean exit** on stream EOF / drain / SIGTERM (`codes.Canceled → nil`). A FAILED task is a normal already-reported outcome — logged, worker keeps serving.

## Deferred
`execution_timeout` bounds a normal long task; a hard per-attempt watchdog independent of it (a no-timeout wedge) is `TODO(N1d)` (ADR 0058 H3).

## Tests / verification
RED-first `TestWarmWorkerServesTwoAttempts`: fake `AwaitAssignment` stream, two assignments → registered once; both ran as child execs; RUNNING→SUCCESS each; up-stream order `WorkerRegister → Ack(started) → SlotFree`; attempt_token live at each GetTaskSpec (`[tok-1, tok-2]`); **D4 check** — a scratch marker from attempt 1 is ABSENT at attempt 2. Single-shot lock: `TestRunnerRunIsRegisterThenOneAttempt`. `go vet ./...` **and** `-tags integration` both clean, `go build` + `-tags integration` green, `golangci-lint` 0 issues.