### PR TITLE
feat(executor): warm-pod provisioning + min_idle reconciler, model A2 (ADR 0058 N1b2b)

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
@@ -936,6 +937,65 @@ func startReconciler(ctx context.Context, cs kubernetes.Interface, namespace str
 	})
 }
 
+// startWarmPoolReconciler runs the leader-gated warm-pool reconciler (ADR 0058
+// N1b2b): each tick it reconciles the number of warm workers per active
+// dag_version to that version's effective min_idle. Like the pod reconciler it
+// mutates cluster state, so it runs on the leader alone via the gated ticker. It
+// is only called when warm pools are enabled.
+func startWarmPoolReconciler(ctx context.Context, cfg *config.ServerConfig, cs kubernetes.Interface, targets executor.WarmTargetSource, authn *auth.JWTAuthenticator, controlAddr string, leading func() bool, rec executor.DecisionRecorder, logger *slog.Logger) {
+	pods := executor.NewKubernetesWarmPods(cs, cfg.Executor.TaskNamespace, warmPodSpecFunc(cfg, authn, controlAddr))
+	rc := executor.NewWarmPoolReconciler(targets, pods, logger, rec)
+	startGatedTicker(ctx, "warm-pool-reconcile", reconcileInterval, leading, logger, func() {
+		if err := rc.Reconcile(ctx); err != nil {
+			logger.Error("warm pool reconcile", "error", err)
+		}
+	})
+}
+
+// warmPodSpecFunc returns the per-target warm-pod spec builder the warm-pod client
+// calls on each create. It mints a fresh, UNIQUE bootstrap credential per pod
+// (each worker registers as a distinct member of its dag_version pool) and stamps
+// the connection + hardening fields.
+//
+// The bootstrap token rides the ENV-VAR transport deliberately, regardless of
+// auth.agent_token_transport: it authorizes ONLY Register + AwaitAssignment and
+// resolves no secrets, so it needs neither the projected-token exchange nor the
+// liveness enforcement that guard the per-attempt credential. The warm agent
+// registers with it directly (it does not exchange a bootstrap token), so env-var
+// is the transport that actually works against the warm loop. The per-attempt
+// token — the one that resolves secrets — arrives in-band over AwaitAssignment and
+// is exchange/liveness-gated upstream (N1b1/N1b2a); the durable identity binding
+// (H2) is deferred to N1d.
+func warmPodSpecFunc(cfg *config.ServerConfig, authn *auth.JWTAuthenticator, controlAddr string) executor.WarmPodSpecFunc {
+	defaults := platformDefaults(cfg.Executor.Defaults)
+	return func(t executor.WarmTarget) (executor.WarmPodSpec, error) {
+		token, err := authn.IssueAgentToken(auth.AgentIdentity{
+			TaskInstanceID: "warm-" + t.DagVersionID + "-" + uuid.NewString(),
+		}, warmBootstrapTokenTTL(cfg))
+		if err != nil {
+			return executor.WarmPodSpec{}, fmt.Errorf("minting warm bootstrap token: %w", err)
+		}
+		return executor.WarmPodSpec{
+			DagVersionID:        t.DagVersionID,
+			Image:               t.Image,
+			ControlPlaneAddr:    controlAddr,
+			AgentTLSCAConfigMap: cfg.Executor.AgentTLSCAConfigMap,
+			BootstrapToken:      token,
+			PodSecurity:         defaults.PodSecurity,
+		}, nil
+	}
+}
+
+// warmBootstrapTokenTTL sizes the bootstrap credential to outlive the worker's
+// whole life (the stream bearer is validated once at open), anchored to the worker
+// lifetime cap so it cannot lapse while the worker is still valid.
+func warmBootstrapTokenTTL(cfg *config.ServerConfig) time.Duration {
+	if cfg.Execution.MaxWorkerLifetime > 0 {
+		return cfg.Execution.MaxWorkerLifetime + time.Hour
+	}
+	return 2 * time.Hour
+}
+
 // stagingGCInterval is how often the per-run staging-volume GC sweeps; stagingTTL
 // is how long a FAILED run's volume is kept after its terminal time before the
 // PVC is deleted (ADR 0022 — long enough for a clear+re-run to re-attach the
@@ -1264,6 +1324,15 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 	sched.SetExecutionReaper(reaper)
 	startReconciler(ctx, cs, cfg.Executor.TaskNamespace, execStore, sched.IsLeading, logger, snapshotter)
 	startStagingGC(ctx, cs, cfg.Executor.TaskNamespace, store, sched.IsLeading, logger)
+	// Warm-pool reconciler (ADR 0058 N1b2b, model A2): keeps min_idle warm workers
+	// ready per active dag_version. Started ONLY when warm pools are enabled — with
+	// them off it is never constructed, so no warm pod is ever created and dispatch
+	// stays byte-for-byte today's dedicated pod-per-task.
+	if cfg.Execution.WarmPoolsEnabled {
+		store.SetWarmExecution(cfg.Execution)
+		startWarmPoolReconciler(ctx, cfg, cs, store, authn, controlAddr, sched.IsLeading, metrics, logger)
+		logger.Warn("warm pool reconciler enabled (ADR 0058 N1b2b); maintaining min_idle warm workers per active dag_version", "namespace", cfg.Executor.TaskNamespace)
+	}
 	logger.Info("pod dispatch enabled", "namespace", cfg.Executor.TaskNamespace, "agent_control_plane_addr", controlAddr)
 	return true, closer
 }

--- a/docs/api/dag-schema.json
+++ b/docs/api/dag-schema.json
@@ -75,6 +75,11 @@
       "type": "integer",
       "minimum": 1
     },
+    "min_idle_workers": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Warm workers the author wants kept ready for this DAG version so its tasks skip cold-pod startup (ADR 0058, warm pools). Operator-capped at execution.max_pool_size and inert unless the operator enabled warm pools; 0 (default) means no warmth."
+    },
     "catchup": {
       "type": "boolean",
       "default": false

--- a/internal/config/execution_effective_test.go
+++ b/internal/config/execution_effective_test.go
@@ -1,0 +1,46 @@
+package config
+
+import "testing"
+
+// TestEffectiveMinIdle locks the model-A2 effective-warm-target formula (ADR 0058
+// N1b2b): the per-DAG author-declared min_idle is clamped to [0, max_pool_size]
+// with a fall back to the operator's execution.min_idle_workers when the DAG sets
+// none, and the whole thing is gated by warm_pools_enabled (off => always 0).
+func TestEffectiveMinIdle(t *testing.T) {
+	cases := []struct {
+		name       string
+		enabled    bool
+		minIdle    int // execution.min_idle_workers (operator fallback)
+		maxPool    int // execution.max_pool_size (operator cap)
+		dagMinIdle int // the DAG author's declared min_idle_workers
+		want       int
+	}{
+		// Gate: warm pools off => never warm, whatever the DAG or operator asked.
+		{"off ignores dag", false, 5, 8, 4, 0},
+		{"off ignores operator floor", false, 3, 8, 0, 0},
+		// DAG author declares a target within the cap => used verbatim.
+		{"dag within cap", true, 0, 8, 2, 2},
+		{"dag equal cap", true, 0, 8, 8, 8},
+		// Author over-asks => clamped to the operator's max_pool_size.
+		{"dag over cap clamped", true, 0, 8, 20, 8},
+		// Author declares none (0) => fall back to the operator floor, then clamp.
+		{"fallback to operator floor", true, 3, 8, 0, 3},
+		{"fallback clamped by cap", true, 20, 8, 0, 8},
+		{"fallback zero stays zero", true, 0, 8, 0, 0},
+		// A negative (nonsensical) author value floors at 0, never a fallback.
+		{"negative dag floors at zero", true, 5, 8, -1, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			e := ExecutionSection{
+				WarmPoolsEnabled: c.enabled,
+				MinIdleWorkers:   c.minIdle,
+				MaxPoolSize:      c.maxPool,
+			}
+			if got := e.EffectiveMinIdle(c.dagMinIdle); got != c.want {
+				t.Errorf("EffectiveMinIdle(%d) = %d, want %d (enabled=%v floor=%d cap=%d)",
+					c.dagMinIdle, got, c.want, c.enabled, c.minIdle, c.maxPool)
+			}
+		})
+	}
+}

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -193,6 +193,36 @@ type ExecutionSection struct {
 	MaxPoolSize int `mapstructure:"max_pool_size"`
 }
 
+// EffectiveMinIdle resolves the warm-worker target for one dag_version under
+// model A2 (ADR 0058 N1b2b): the DAG author declares desired warmth per DAG
+// (dagMinIdle), the operator caps and floors it.
+//
+//   - Warm pools OFF => always 0. This is what makes a default deploy a
+//     byte-for-byte no-op: with warmth gated off no warm pod is ever targeted, so
+//     the reconciler (when it runs at all) reconciles every pool to zero.
+//   - The DAG author's value wins when set (> 0); when the DAG declares none (0)
+//     it falls back to the operator's execution.min_idle_workers floor.
+//   - The resolved value is clamped to [0, max_pool_size] so an author can never
+//     provision more warmth than the operator's per-version cap allows, and a
+//     nonsensical negative never underflows.
+func (e ExecutionSection) EffectiveMinIdle(dagMinIdle int) int {
+	if !e.WarmPoolsEnabled {
+		return 0
+	}
+	target := dagMinIdle
+	if target == 0 {
+		// The author declared no warmth; inherit the operator's floor.
+		target = e.MinIdleWorkers
+	}
+	if target < 0 {
+		target = 0
+	}
+	if e.MaxPoolSize > 0 && target > e.MaxPoolSize {
+		target = e.MaxPoolSize
+	}
+	return target
+}
+
 // UISection configures the embedded Airflow UI.
 type UISection struct {
 	// InstanceName is shown in the UI navbar (Airflow's instance_name). Empty

--- a/internal/domain/dag.go
+++ b/internal/domain/dag.go
@@ -76,7 +76,18 @@ type DAGSpec struct {
 	// default) means unlimited: a DAG that never sets it, and all of Lite, plans
 	// exactly as before. The scheduler enforces it in PlanRun's scheduled→queued
 	// admission gate.
-	MaxActiveTasks int          `json:"max_active_tasks,omitempty"`
+	MaxActiveTasks int `json:"max_active_tasks,omitempty"`
+	// MinIdleWorkers is the number of warm workers the DAG AUTHOR wants kept ready
+	// for this DAG version so its tasks skip cold-pod startup (ADR 0058 N1b2b,
+	// warm pools model A2). It mirrors MaxActiveTasks as a per-DAG author-declared
+	// spec field: zero (the default) means no warmth, and a DAG that never sets it
+	// — and all of Lite — behaves exactly as before. It is only a REQUEST: the
+	// operator caps it at execution.max_pool_size, floors an unset value at
+	// execution.min_idle_workers, and the whole thing is inert unless the operator
+	// enabled execution.warm_pools_enabled (see config.ExecutionSection.
+	// EffectiveMinIdle). Whether a pod may be reused across attempts stays the
+	// operator's security decision; this field only tunes how many.
+	MinIdleWorkers int          `json:"min_idle_workers,omitempty"`
 	Catchup        bool         `json:"catchup,omitempty"`
 	DefaultArgs    *DefaultArgs `json:"default_args,omitempty"`
 	// Staging, when enabled, requests an ephemeral RWX volume shared by the run's

--- a/internal/domain/min_idle_workers_test.go
+++ b/internal/domain/min_idle_workers_test.go
@@ -1,0 +1,39 @@
+package domain
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestDAGSpecMinIdleWorkers locks the per-DAG author-declared warm-worker target
+// (ADR 0058 N1b2b, model A2): it round-trips through JSON under the
+// min_idle_workers key and is omitted when unset (0), mirroring max_active_tasks
+// so a DAG that declares no warmth serializes exactly as before.
+func TestDAGSpecMinIdleWorkers(t *testing.T) {
+	in := DAGSpec{DagID: "d", MinIdleWorkers: 3}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"min_idle_workers":3`) {
+		t.Errorf("marshaled spec = %s, want it to carry min_idle_workers:3", b)
+	}
+	var out DAGSpec
+	if uerr := json.Unmarshal(b, &out); uerr != nil {
+		t.Fatalf("unmarshal: %v", uerr)
+	}
+	if out.MinIdleWorkers != 3 {
+		t.Errorf("round-tripped MinIdleWorkers = %d, want 3", out.MinIdleWorkers)
+	}
+
+	// Unset (0) is omitted: a DAG that declares no warmth is byte-identical to a
+	// pre-N1b2b artifact.
+	zero, err := json.Marshal(DAGSpec{DagID: "d"})
+	if err != nil {
+		t.Fatalf("marshal zero: %v", err)
+	}
+	if strings.Contains(string(zero), "min_idle_workers") {
+		t.Errorf("marshaled zero spec = %s, want min_idle_workers omitted", zero)
+	}
+}

--- a/internal/domain/schemas/dag-schema.json
+++ b/internal/domain/schemas/dag-schema.json
@@ -75,6 +75,11 @@
       "type": "integer",
       "minimum": 1
     },
+    "min_idle_workers": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Warm workers the author wants kept ready for this DAG version so its tasks skip cold-pod startup (ADR 0058, warm pools). Operator-capped at execution.max_pool_size and inert unless the operator enabled warm pools; 0 (default) means no warmth."
+    },
     "catchup": {
       "type": "boolean",
       "default": false

--- a/internal/executor/kubernetes.go
+++ b/internal/executor/kubernetes.go
@@ -138,7 +138,7 @@ func BuildPod(req Request) *corev1.Pod {
 	mountStagingVolume(pod, req)
 	mountAgentTLSCA(pod, req)
 	mountTaskSecret(pod, req)
-	mountAgentToken(pod, req)
+	mountAgentToken(pod, agentTokenOf(req))
 	return pod
 }
 
@@ -191,50 +191,101 @@ func ParseAgentIdentity(raw string) (PodIdentity, error) {
 	return id, nil
 }
 
-// usesTokenExchange reports whether this request opted into the projected-token
-// exchange transport. Empty / "envvar" is the default (plaintext env var).
-func usesTokenExchange(req Request) bool { return req.AgentTokenTransport == agentTransportExchange }
+// agentToken is the transport-independent description of how an agent's bootstrap
+// bearer credential reaches a pod, shared by the task-pod (BuildPod) and warm-pod
+// (BuildWarmPod) builders so the token transport is wired one way for both. A task
+// pod fills identity so the exchange resolver can map the projected token back to
+// its task instance; a warm worker leaves identity nil (it registers under its
+// bearer's own identity, not a task instance), so no identity annotation is
+// stamped for it.
+type agentToken struct {
+	transport         string
+	token             string
+	secretName        string
+	secretKey         string
+	audience          string
+	expirationSeconds int64
+	identity          *PodIdentity
+}
 
-// agentTokenEnv returns the env var(s) carrying (or pointing at) the agent's
-// bearer credential, per the selected transport:
+// agentTokenOf projects a Request's token fields into the shared carrier, stamping
+// the task-instance identity so the exchange path is byte-identical to before.
+func agentTokenOf(req Request) agentToken {
+	return agentToken{
+		transport:         req.AgentTokenTransport,
+		token:             req.AgentToken,
+		secretName:        req.AgentTokenSecretName,
+		secretKey:         req.AgentTokenSecretKey,
+		audience:          req.AgentTokenAudience,
+		expirationSeconds: req.AgentTokenExpirationSeconds,
+		identity: &PodIdentity{
+			TaskInstanceID: req.TaskInstanceID, TenantID: req.TenantID, DagID: req.DagID,
+			RunID: req.RunID, TaskID: req.TaskID, TryNumber: req.TryNumber,
+		},
+	}
+}
+
+// usesExchange reports whether the token opted into the projected-token exchange
+// transport. Empty / "envvar" is the default (plaintext env var).
+func (t agentToken) usesExchange() bool { return t.transport == agentTransportExchange }
+
+// env returns the env var(s) carrying (or pointing at) the agent's bearer
+// credential, per the selected transport:
 //   - env-var (default): a plaintext LEOFLOW_AGENT_TOKEN — today's behavior.
 //   - exchange + SecretKeyRef fallback: LEOFLOW_AGENT_TOKEN sourced from a Secret.
 //   - exchange (projected, primary): NO token env var at all — the agent reads the
 //     projected token from LEOFLOW_AGENT_TOKEN_PATH and exchanges it. The path and
-//     transport marker are added by podEnv.
-func agentTokenEnv(req Request) []corev1.EnvVar {
-	if !usesTokenExchange(req) {
-		return []corev1.EnvVar{{Name: "LEOFLOW_AGENT_TOKEN", Value: req.AgentToken}}
+//     transport marker are added by pathEnv.
+func (t agentToken) env() []corev1.EnvVar {
+	if !t.usesExchange() {
+		return []corev1.EnvVar{{Name: "LEOFLOW_AGENT_TOKEN", Value: t.token}}
 	}
-	if req.AgentTokenSecretName != "" {
-		key := req.AgentTokenSecretKey
+	if t.secretName != "" {
+		key := t.secretKey
 		if key == "" {
 			key = agentTokenFile
 		}
 		return []corev1.EnvVar{{
 			Name: "LEOFLOW_AGENT_TOKEN",
 			ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{Name: req.AgentTokenSecretName},
+				LocalObjectReference: corev1.LocalObjectReference{Name: t.secretName},
 				Key:                  key,
 			}},
 		}}
 	}
-	return nil // projected primary path: no token env var, only the path (podEnv).
+	return nil // projected primary path: no token env var, only the path (pathEnv).
+}
+
+// pathEnv returns the transport marker + token-file path the agent reads under the
+// projected exchange path, or nil for the env-var default and the SecretKeyRef
+// fallback (whose token is already in LEOFLOW_AGENT_TOKEN), keeping those pod specs
+// unchanged.
+func (t agentToken) pathEnv() []corev1.EnvVar {
+	if !t.usesExchange() || t.secretName != "" {
+		return nil
+	}
+	return []corev1.EnvVar{
+		{Name: "LEOFLOW_AGENT_TOKEN_TRANSPORT", Value: agentTransportExchange},
+		{Name: "LEOFLOW_AGENT_TOKEN_PATH", Value: agentTokenMountDir + "/" + agentTokenFile},
+	}
 }
 
 // mountAgentToken projects the ServiceAccount token the agent exchanges (ADR 0055
-// Fix #3), and stamps the identity annotation the control plane resolves the pod
-// to on exchange. It is a no-op for the env-var default and for the SecretKeyRef
-// fallback (neither projects a token), keeping those pod specs unchanged.
-func mountAgentToken(pod *corev1.Pod, req Request) {
-	if !usesTokenExchange(req) || req.AgentTokenSecretName != "" {
+// Fix #3), and — for a task pod — stamps the identity annotation the control plane
+// resolves the pod to on exchange. It is a no-op for the env-var default and for
+// the SecretKeyRef fallback (neither projects a token), keeping those pod specs
+// unchanged. A warm worker (identity nil) projects the token but stamps no
+// task-instance identity: it authenticates its stream under its bootstrap bearer
+// and serves any task of its dag_version, so a task identity would be wrong.
+func mountAgentToken(pod *corev1.Pod, t agentToken) {
+	if !t.usesExchange() || t.secretName != "" {
 		return
 	}
-	audience := req.AgentTokenAudience
+	audience := t.audience
 	if audience == "" {
 		audience = DefaultAgentTokenAudience
 	}
-	exp := req.AgentTokenExpirationSeconds
+	exp := t.expirationSeconds
 	if exp < minProjectedTokenExpirationSeconds {
 		exp = minProjectedTokenExpirationSeconds
 	}
@@ -256,11 +307,10 @@ func mountAgentToken(pod *corev1.Pod, req Request) {
 	c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{
 		Name: agentTokenVolumeName, MountPath: agentTokenMountDir, ReadOnly: true,
 	})
-	id := PodIdentity{
-		TaskInstanceID: req.TaskInstanceID, TenantID: req.TenantID, DagID: req.DagID,
-		RunID: req.RunID, TaskID: req.TaskID, TryNumber: req.TryNumber,
+	if t.identity == nil {
+		return
 	}
-	if raw, err := json.Marshal(id); err == nil {
+	if raw, err := json.Marshal(*t.identity); err == nil {
 		pod.Annotations[AgentIdentityAnnotation] = string(raw)
 	}
 }
@@ -343,9 +393,10 @@ func mountStagingVolume(pod *corev1.Pod, req Request) {
 func podEnv(req Request) []corev1.EnvVar {
 	env := make([]corev1.EnvVar, 0, 4+len(req.Env))
 	env = append(env, corev1.EnvVar{Name: "LEOFLOW_CONTROL_PLANE_ADDR", Value: req.ControlPlaneAddr})
+	tok := agentTokenOf(req)
 	// The bearer credential: a plaintext env var (env-var default), a SecretKeyRef
 	// (exchange fallback), or nothing on the pod object (exchange projected path).
-	env = append(env, agentTokenEnv(req)...)
+	env = append(env, tok.env()...)
 	env = append(env,
 		corev1.EnvVar{Name: "LEOFLOW_TASK_INSTANCE_ID", Value: req.TaskInstanceID},
 		// Tell the pod agent where to write its durable outcome record; it matches
@@ -357,12 +408,7 @@ func podEnv(req Request) []corev1.EnvVar {
 	// bootstrap token from the mounted file and exchange it for a task-scoped JWT.
 	// The SecretKeyRef fallback and the env-var default leave these unset (the
 	// token is already in LEOFLOW_AGENT_TOKEN), so those pod specs are unchanged.
-	if usesTokenExchange(req) && req.AgentTokenSecretName == "" {
-		env = append(env,
-			corev1.EnvVar{Name: "LEOFLOW_AGENT_TOKEN_TRANSPORT", Value: agentTransportExchange},
-			corev1.EnvVar{Name: "LEOFLOW_AGENT_TOKEN_PATH", Value: agentTokenMountDir + "/" + agentTokenFile},
-		)
-	}
+	env = append(env, tok.pathEnv()...)
 	if req.StagingClaim != "" {
 		env = append(env, corev1.EnvVar{Name: "LEOFLOW_STAGING_DIR", Value: stagingMountPath})
 	}

--- a/internal/executor/warmpod.go
+++ b/internal/executor/warmpod.go
@@ -1,0 +1,197 @@
+package executor
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Warm-worker pod labels (ADR 0058 N1b2b). The warm-pool reconciler lists and
+// counts warm pods per dag_version by selecting on these, so they are the stable
+// contract between BuildWarmPod (writes them) and the reconciler (reads them).
+const (
+	// warmWorkerLabelKey marks a pod as a warm worker; its value is always "true".
+	// It is the selector the reconciler lists the warm fleet by.
+	warmWorkerLabelKey = "leoflow.io/warm-worker"
+	warmWorkerLabelVal = "true"
+	// warmDagVersionLabelKey names the dag_version pool a warm worker serves, so
+	// the reconciler can group and reconcile counts per version.
+	warmDagVersionLabelKey = "leoflow.io/dag-version-id"
+)
+
+// WarmPodSpec is everything BuildWarmPod needs to build one long-lived warm-worker
+// pod: which dag_version pool it serves, the image (the DAG's image — a warm
+// worker runs the agent in warm mode and forks a child per attempt), the
+// control-plane connection, and how its BOOTSTRAP credential reaches it (the same
+// transport a task pod uses). It carries NO task instance: the per-attempt token
+// and task identity arrive in-band over AwaitAssignment, never on this spec.
+type WarmPodSpec struct {
+	DagVersionID    string
+	Image           string
+	ImagePullPolicy string
+	Namespace       string
+
+	// ControlPlaneAddr / AgentTLSCAConfigMap mirror the task-pod connection knobs:
+	// where the agent dials and (when set) the CA ConfigMap it verifies the server
+	// cert against. Reused verbatim so a warm worker connects exactly as a task pod.
+	ControlPlaneAddr    string
+	AgentTLSCAConfigMap string
+
+	// Bootstrap-credential transport (ADR 0055 Fix #3), mirroring Request's token
+	// fields: BootstrapToken rides plaintext on the env-var default; the exchange
+	// transport keeps it off the pod and projects a ServiceAccount token instead.
+	// The credential authorizes only Register + AwaitAssignment (no secret access —
+	// secrets resolve per-attempt against the in-band attempt token), so a warm
+	// worker never stamps a task-instance identity annotation.
+	BootstrapToken              string
+	AgentTokenTransport         string
+	AgentTokenAudience          string
+	AgentTokenExpirationSeconds int64
+	AgentTokenSecretName        string
+	AgentTokenSecretKey         string
+
+	// PodSecurity carries the same container/pod hardening choices as a task pod.
+	PodSecurity PodSecurity
+
+	// Labels / Annotations are operator-declared metadata overlaid onto the pod;
+	// Leoflow's own warm-worker labels always win a collision (see mergeMetadata).
+	Labels      map[string]string
+	Annotations map[string]string
+}
+
+// BuildWarmPod constructs the pod spec for one warm worker. It reuses BuildPod's
+// machinery — the token transport, the CA mount, the control-plane env, and the
+// security contexts — but for a LONG-LIVED worker bound to a dag_version rather
+// than a single task attempt. The differences from a task pod are deliberate:
+//
+//   - Env: LEOFLOW_WARM_WORKER=1 + LEOFLOW_DAG_VERSION_ID select the agent's warm
+//     loop, and there is NO task env (no task-instance id, no per-attempt token, no
+//     durable-outcome path) — a warm worker has no task until an attempt is pushed
+//     to it in-band.
+//   - Labels: a stable warm-worker label set (warmWorkerLabelKey +
+//     warmDagVersionLabelKey) so the reconciler can list, count, and reap warm
+//     pods per version. None of the task identity labels are set.
+//   - RestartPolicy Never: a warm worker that exits (drain, idle recycle, or a
+//     crash) is REPLACED by the reconciler with a fresh pod that re-registers
+//     cleanly, rather than restarted in place with stale in-container state. This
+//     is the clean model for the reconciler-owned lifecycle; the D9 lifetime/
+//     attempt caps and the idle-TTL recycle that drive drains are deferred to N1d.
+//
+// It is pure (modulo the random name suffix) and unit-tested independently of any
+// cluster. It bakes NO task token in; the GC-anchor ConfigMap (D11) is deferred to
+// N1d — a bare warm pod deleted by the reconciler is fine for now.
+func BuildWarmPod(spec WarmPodSpec) *corev1.Pod {
+	pullPolicy := corev1.PullIfNotPresent
+	if spec.ImagePullPolicy != "" {
+		pullPolicy = corev1.PullPolicy(spec.ImagePullPolicy)
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: warmPodName(spec.DagVersionID),
+			Labels: map[string]string{
+				warmWorkerLabelKey:     warmWorkerLabelVal,
+				warmDagVersionLabelKey: sanitizeLabel(spec.DagVersionID),
+			},
+			Annotations: map[string]string{},
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy:   corev1.RestartPolicyNever,
+			SecurityContext: buildPodSecurityContext(spec.PodSecurity),
+			// The warm agent authenticates to the control plane with its bootstrap
+			// token over gRPC and never calls the Kubernetes API, so a mounted
+			// ServiceAccount token is a credential handed to code for no reason.
+			AutomountServiceAccountToken: ptr(false),
+			Containers: []corev1.Container{{
+				Name:            warmContainerName,
+				Image:           spec.Image,
+				ImagePullPolicy: pullPolicy,
+				Env:             warmPodEnv(spec),
+				SecurityContext: buildSecurityContext(spec.PodSecurity),
+			}},
+		},
+	}
+	mergeMetadata(pod.Labels, spec.Labels)
+	mergeMetadata(pod.Annotations, spec.Annotations)
+	mountWarmAgentTLSCA(pod, spec)
+	// Bootstrap-credential transport, shared with the task pod. identity is nil: a
+	// warm worker registers under its bearer's own identity, so no task-instance
+	// identity annotation is stamped even under the exchange transport.
+	mountAgentToken(pod, spec.agentToken())
+	return pod
+}
+
+// warmContainerName is the warm worker's single container.
+const warmContainerName = "warm-worker"
+
+// agentToken projects a WarmPodSpec's token fields into the shared transport
+// carrier. identity is left nil so mountAgentToken projects the token (under
+// exchange) without stamping a task-instance identity annotation.
+func (spec WarmPodSpec) agentToken() agentToken {
+	return agentToken{
+		transport:         spec.AgentTokenTransport,
+		token:             spec.BootstrapToken,
+		secretName:        spec.AgentTokenSecretName,
+		secretKey:         spec.AgentTokenSecretKey,
+		audience:          spec.AgentTokenAudience,
+		expirationSeconds: spec.AgentTokenExpirationSeconds,
+		identity:          nil,
+	}
+}
+
+// warmPodEnv builds the warm worker's container env: the control-plane address,
+// the bootstrap-token transport env (reused from the task path), the warm-mode
+// selectors, and — when a CA is configured — the TLS env. It deliberately omits
+// every task-specific var.
+func warmPodEnv(spec WarmPodSpec) []corev1.EnvVar {
+	env := make([]corev1.EnvVar, 0, 6)
+	env = append(env, corev1.EnvVar{Name: "LEOFLOW_CONTROL_PLANE_ADDR", Value: spec.ControlPlaneAddr})
+	tok := spec.agentToken()
+	env = append(env, tok.env()...)
+	env = append(env, tok.pathEnv()...)
+	// Select the agent's warm-worker loop for this dag_version pool.
+	env = append(env,
+		corev1.EnvVar{Name: "LEOFLOW_WARM_WORKER", Value: "1"},
+		corev1.EnvVar{Name: "LEOFLOW_DAG_VERSION_ID", Value: spec.DagVersionID},
+	)
+	if spec.AgentTLSCAConfigMap != "" {
+		env = append(env,
+			corev1.EnvVar{Name: "LEOFLOW_AGENT_INSECURE", Value: "false"},
+			corev1.EnvVar{Name: "LEOFLOW_AGENT_TLS_CA", Value: agentCADir + "/" + agentCAFile},
+		)
+	}
+	return env
+}
+
+// mountWarmAgentTLSCA mounts the CA ConfigMap (when configured) into the warm pod
+// so the agent can verify the control plane's TLS cert, mirroring the task pod's
+// mountAgentTLSCA (the matching env is set in warmPodEnv).
+func mountWarmAgentTLSCA(pod *corev1.Pod, spec WarmPodSpec) {
+	if spec.AgentTLSCAConfigMap == "" {
+		return
+	}
+	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+		Name: agentCAVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: spec.AgentTLSCAConfigMap},
+			},
+		},
+	})
+	c := &pod.Spec.Containers[0]
+	c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{Name: agentCAVolumeName, MountPath: agentCADir, ReadOnly: true})
+}
+
+// warmPodName builds a DNS-safe, collision-resistant name for a warm pod:
+// leoflow-warm-<dag-version>-<rand>, truncated to the 63-char label limit like
+// podName. The random suffix lets the reconciler create many workers for one
+// version without name clashes.
+func warmPodName(dagVersionID string) string {
+	suffix := randSuffix()
+	base := "leoflow-warm-" + sanitizeLabel(dagVersionID)
+	maxBase := 63 - len(suffix) - 1
+	if len(base) > maxBase {
+		base = strings.TrimRight(base[:maxBase], "-")
+	}
+	return base + "-" + suffix
+}

--- a/internal/executor/warmpod_test.go
+++ b/internal/executor/warmpod_test.go
@@ -1,0 +1,160 @@
+package executor
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// warmEnvMap projects the warm pod's single container env into a name->value map,
+// for value assertions. Env vars sourced from elsewhere (SecretKeyRef) have an
+// empty value here.
+func warmEnvMap(pod *corev1.Pod) map[string]string {
+	m := map[string]string{}
+	for _, e := range pod.Spec.Containers[0].Env {
+		m[e.Name] = e.Value
+	}
+	return m
+}
+
+// baseWarmSpec is a minimal env-var-transport warm spec used across the cases.
+func baseWarmSpec() WarmPodSpec {
+	return WarmPodSpec{
+		DagVersionID:     "dv-abc",
+		Image:            "reg.example/dag:v3",
+		Namespace:        "leoflow",
+		ControlPlaneAddr: "cp:9000",
+		BootstrapToken:   "boot-tok",
+	}
+}
+
+// TestBuildWarmPodWarmEnvAndLabels locks the warm-worker pod shape (ADR 0058
+// N1b2b): the agent is told to run in warm mode for a dag_version, the pod is
+// labeled so the reconciler can list/count it, and it carries NO task-specific
+// env (a warm worker has no task instance until an attempt arrives in-band).
+func TestBuildWarmPodWarmEnvAndLabels(t *testing.T) {
+	pod := BuildWarmPod(baseWarmSpec())
+
+	env := warmEnvMap(pod)
+	if env["LEOFLOW_WARM_WORKER"] != "1" {
+		t.Errorf("LEOFLOW_WARM_WORKER = %q, want 1", env["LEOFLOW_WARM_WORKER"])
+	}
+	if env["LEOFLOW_DAG_VERSION_ID"] != "dv-abc" {
+		t.Errorf("LEOFLOW_DAG_VERSION_ID = %q, want dv-abc", env["LEOFLOW_DAG_VERSION_ID"])
+	}
+	if env["LEOFLOW_CONTROL_PLANE_ADDR"] != "cp:9000" {
+		t.Errorf("LEOFLOW_CONTROL_PLANE_ADDR = %q, want cp:9000", env["LEOFLOW_CONTROL_PLANE_ADDR"])
+	}
+
+	// No task-specific env: the warm worker has no task instance, try number, or
+	// per-attempt outcome path — those arrive in-band per attempt (AwaitAssignment).
+	for _, k := range []string{"LEOFLOW_TASK_INSTANCE_ID", "LEOFLOW_TERMINATION_LOG_PATH"} {
+		if _, ok := env[k]; ok {
+			t.Errorf("warm pod must not carry task env %s (got %q)", k, env[k])
+		}
+	}
+
+	// Image and warm-worker labels the reconciler selects on.
+	if got := pod.Spec.Containers[0].Image; got != "reg.example/dag:v3" {
+		t.Errorf("image = %q, want reg.example/dag:v3", got)
+	}
+	if pod.Labels[warmWorkerLabelKey] != "true" {
+		t.Errorf("label %s = %q, want true", warmWorkerLabelKey, pod.Labels[warmWorkerLabelKey])
+	}
+	if pod.Labels[warmDagVersionLabelKey] != "dv-abc" {
+		t.Errorf("label %s = %q, want dv-abc", warmDagVersionLabelKey, pod.Labels[warmDagVersionLabelKey])
+	}
+	// No per-task identity labels leak onto a warm pod.
+	for _, k := range []string{"leoflow.io/task-id", "leoflow.io/run-id", "leoflow.io/try-number"} {
+		if _, ok := pod.Labels[k]; ok {
+			t.Errorf("warm pod must not carry task label %s", k)
+		}
+	}
+
+	// A warm worker that exits on drain must be REPLACED by the reconciler, not
+	// restarted in place (a fresh pod re-registers cleanly); RestartPolicy Never.
+	if pod.Spec.RestartPolicy != corev1.RestartPolicyNever {
+		t.Errorf("RestartPolicy = %q, want Never", pod.Spec.RestartPolicy)
+	}
+	// The agent authenticates over gRPC and never calls the Kubernetes API.
+	if pod.Spec.AutomountServiceAccountToken == nil || *pod.Spec.AutomountServiceAccountToken {
+		t.Error("AutomountServiceAccountToken must be explicitly false")
+	}
+}
+
+// TestBuildWarmPodEnvVarTransport locks the default (env-var) bootstrap-token
+// transport: the minted worker JWT rides as the plaintext LEOFLOW_AGENT_TOKEN,
+// exactly how a task pod carries its token on the env-var path.
+func TestBuildWarmPodEnvVarTransport(t *testing.T) {
+	pod := BuildWarmPod(baseWarmSpec())
+	env := warmEnvMap(pod)
+	if env["LEOFLOW_AGENT_TOKEN"] != "boot-tok" {
+		t.Errorf("LEOFLOW_AGENT_TOKEN = %q, want boot-tok", env["LEOFLOW_AGENT_TOKEN"])
+	}
+	if _, ok := env["LEOFLOW_AGENT_TOKEN_PATH"]; ok {
+		t.Error("env-var transport must not set LEOFLOW_AGENT_TOKEN_PATH")
+	}
+	if _, ok := pod.Annotations[AgentIdentityAnnotation]; ok {
+		t.Error("env-var transport must not stamp the exchange identity annotation")
+	}
+}
+
+// TestBuildWarmPodExchangeTransport locks the exchange bootstrap transport reuse:
+// the plaintext token is kept OFF the pod, a ServiceAccount token is projected and
+// pointed at by LEOFLOW_AGENT_TOKEN_PATH, and — crucially — NO task-instance
+// identity annotation is stamped (a warm worker registers under its bearer's
+// identity, not a task instance).
+func TestBuildWarmPodExchangeTransport(t *testing.T) {
+	spec := baseWarmSpec()
+	spec.AgentTokenTransport = agentTransportExchange
+	pod := BuildWarmPod(spec)
+
+	env := warmEnvMap(pod)
+	if _, ok := env["LEOFLOW_AGENT_TOKEN"]; ok {
+		t.Error("exchange: plaintext LEOFLOW_AGENT_TOKEN must not be on the warm pod")
+	}
+	if env["LEOFLOW_AGENT_TOKEN_TRANSPORT"] != agentTransportExchange {
+		t.Errorf("LEOFLOW_AGENT_TOKEN_TRANSPORT = %q, want exchange", env["LEOFLOW_AGENT_TOKEN_TRANSPORT"])
+	}
+	if env["LEOFLOW_AGENT_TOKEN_PATH"] != agentTokenMountDir+"/"+agentTokenFile {
+		t.Errorf("LEOFLOW_AGENT_TOKEN_PATH = %q, want %q", env["LEOFLOW_AGENT_TOKEN_PATH"], agentTokenMountDir+"/"+agentTokenFile)
+	}
+	if _, ok := pod.Annotations[AgentIdentityAnnotation]; ok {
+		t.Error("exchange: a warm worker must NOT carry the task-instance identity annotation")
+	}
+	// The projected token volume is mounted.
+	var found bool
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == agentTokenVolumeName {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("exchange: projected agent-token volume must be mounted")
+	}
+}
+
+// TestBuildWarmPodMountsCA locks CA-mount reuse: when a CA ConfigMap is set the
+// warm pod mounts it and selects TLS via the same env the task pod uses.
+func TestBuildWarmPodMountsCA(t *testing.T) {
+	spec := baseWarmSpec()
+	spec.AgentTLSCAConfigMap = "leoflow-ca"
+	pod := BuildWarmPod(spec)
+
+	env := warmEnvMap(pod)
+	if env["LEOFLOW_AGENT_INSECURE"] != "false" {
+		t.Errorf("LEOFLOW_AGENT_INSECURE = %q, want false", env["LEOFLOW_AGENT_INSECURE"])
+	}
+	if env["LEOFLOW_AGENT_TLS_CA"] != agentCADir+"/"+agentCAFile {
+		t.Errorf("LEOFLOW_AGENT_TLS_CA = %q, want %q", env["LEOFLOW_AGENT_TLS_CA"], agentCADir+"/"+agentCAFile)
+	}
+	var found bool
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == agentCAVolumeName {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("CA ConfigMap volume must be mounted")
+	}
+}

--- a/internal/executor/warmpool.go
+++ b/internal/executor/warmpool.go
@@ -1,0 +1,163 @@
+package executor
+
+import (
+	"context"
+	"log/slog"
+)
+
+// WarmTarget is one active dag_version the warm-pool reconciler keeps warm workers
+// ready for, and how many (already resolved through the clamp/fallback/flag gate —
+// see config.ExecutionSection.EffectiveMinIdle). Image is the DAG's image the warm
+// worker runs the agent from.
+type WarmTarget struct {
+	DagVersionID     string
+	Image            string
+	EffectiveMinIdle int
+}
+
+// WarmTargetSource yields the currently active dag_versions and their effective
+// warm target. It is implemented on the storage/scheduler side (it reads active
+// runs and their cached specs and applies the operator's clamp/fallback), and is
+// defined HERE so the executor's reconciler depends on a narrow capability rather
+// than importing the scheduler or storage package (which would be a dependency
+// cycle — storage already imports executor).
+type WarmTargetSource interface {
+	ActiveWarmTargets(ctx context.Context) ([]WarmTarget, error)
+}
+
+// WarmPodInfo identifies one existing warm-worker pod and the dag_version it
+// serves (read from its labels). The reconciler counts these per version.
+type WarmPodInfo struct {
+	Name         string
+	DagVersionID string
+}
+
+// WarmPodClient is the cluster side of warm-pool reconciliation: list the warm
+// fleet, create a new warm worker for a target (which mints the bootstrap token,
+// builds the pod via BuildWarmPod, and Creates it — the auth/config-aware half,
+// wired in main.go), and delete one by name. Kept as a narrow seam so the
+// reconciler is unit-tested with a fake and the executor imports neither auth nor
+// config. KubernetesWarmPods is the production implementation.
+type WarmPodClient interface {
+	ListWarmPods(ctx context.Context) ([]WarmPodInfo, error)
+	CreateWarmPod(ctx context.Context, t WarmTarget) error
+	DeleteWarmPod(ctx context.Context, name string) error
+}
+
+// WarmPoolReconciler maintains the target number of warm workers per active
+// dag_version (ADR 0058 N1b2b, model A2). Each tick it reads the active targets
+// and the existing warm fleet, then for each version CREATEs missing workers up to
+// the target and DELETEs excess — and drains any version that is no longer active
+// (target 0). It is leader-gated (run on a gated ticker, like the pod reconciler)
+// so at replicaCount>1 only the leader mutates the fleet.
+//
+// Idempotent (it reconciles to a count, so re-running converges), panic-safe and
+// per-version isolated (one bad dag_version never blocks the others), and O(active
+// versions) per tick. It is only constructed and started when warm pools are
+// enabled; with them off the reconciler never runs, so every warm pool stays empty
+// and dispatch is byte-for-byte today's dedicated pod-per-task.
+//
+// Deferred to N1d (NOT this brick): the idle-TTL freshness recycle (D6), the D9
+// worker lifetime / attempts-per-worker caps, and the D7 failover reaper fan-out +
+// H2 durable binding. The GC-anchor ConfigMap (D11) is also N1d; a bare warm pod
+// deleted here is fine until then.
+type WarmPoolReconciler struct {
+	targets WarmTargetSource
+	pods    WarmPodClient
+	logger  *slog.Logger
+	rec     DecisionRecorder
+}
+
+// NewWarmPoolReconciler builds a reconciler over the given target source and pod
+// client. logger and rec (metrics) are optional — a nil logger falls back to the
+// default and a nil rec skips metering.
+func NewWarmPoolReconciler(targets WarmTargetSource, pods WarmPodClient, logger *slog.Logger, rec DecisionRecorder) *WarmPoolReconciler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &WarmPoolReconciler{targets: targets, pods: pods, logger: logger, rec: rec}
+}
+
+// Reconcile brings the warm fleet in line with the active targets for one tick. It
+// returns an error only when it could not read the world (the target source or the
+// pod list failed) so the ticker logs it and retries next tick without acting on a
+// bad view; per-version and per-pod failures are logged/metered and isolated, and
+// never abort the sweep.
+func (r *WarmPoolReconciler) Reconcile(ctx context.Context) error {
+	targets, err := r.targets.ActiveWarmTargets(ctx)
+	if err != nil {
+		return err
+	}
+	existing, err := r.pods.ListWarmPods(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Group the existing fleet by the dag_version each worker serves.
+	byVersion := make(map[string][]WarmPodInfo, len(existing))
+	for _, p := range existing {
+		byVersion[p.DagVersionID] = append(byVersion[p.DagVersionID], p)
+	}
+
+	// Reconcile every active version to its target, then drain any version that is
+	// present in the fleet but no longer active (its target is implicitly 0).
+	active := make(map[string]bool, len(targets))
+	for _, t := range targets {
+		active[t.DagVersionID] = true
+		r.reconcileVersion(ctx, t, byVersion[t.DagVersionID])
+	}
+	for dagVersionID, have := range byVersion {
+		if active[dagVersionID] {
+			continue
+		}
+		r.reconcileVersion(ctx, WarmTarget{DagVersionID: dagVersionID, EffectiveMinIdle: 0}, have)
+	}
+	return nil
+}
+
+// reconcileVersion brings one dag_version's warm-worker count to its target,
+// isolated behind a recover so a panic in one version's create/delete path never
+// takes down the whole sweep.
+func (r *WarmPoolReconciler) reconcileVersion(ctx context.Context, t WarmTarget, have []WarmPodInfo) {
+	defer func() {
+		if p := recover(); p != nil {
+			r.logger.ErrorContext(ctx, "warm-pool reconcile panicked for a dag_version; other versions unaffected",
+				"dag_version", t.DagVersionID, "panic", p)
+			r.record("warm_pool_version_panic")
+		}
+	}()
+
+	switch {
+	case len(have) < t.EffectiveMinIdle:
+		// Under target: create the shortfall. Each create is isolated so one
+		// apiserver rejection does not stop the rest of this version's workers.
+		for i := 0; i < t.EffectiveMinIdle-len(have); i++ {
+			if err := r.pods.CreateWarmPod(ctx, t); err != nil {
+				r.logger.ErrorContext(ctx, "creating warm worker",
+					"dag_version", t.DagVersionID, "image", t.Image, "error", err)
+				r.record("warm_pool_create_error")
+				continue
+			}
+			r.record("warm_pool_pod_created")
+		}
+	case len(have) > t.EffectiveMinIdle:
+		// Over target (or the version is no longer active, target 0): delete the
+		// excess. Deleting the tail is arbitrary but stable — every worker of a
+		// version is interchangeable.
+		for _, p := range have[t.EffectiveMinIdle:] {
+			if err := r.pods.DeleteWarmPod(ctx, p.Name); err != nil {
+				r.logger.ErrorContext(ctx, "deleting excess warm worker",
+					"dag_version", t.DagVersionID, "pod", p.Name, "error", err)
+				r.record("warm_pool_delete_error")
+				continue
+			}
+			r.record("warm_pool_pod_deleted")
+		}
+	}
+}
+
+func (r *WarmPoolReconciler) record(decision string) {
+	if r.rec != nil {
+		r.rec.RecordSchedulerDecision(decision)
+	}
+}

--- a/internal/executor/warmpool_k8s.go
+++ b/internal/executor/warmpool_k8s.go
@@ -1,0 +1,81 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// WarmPodSpecFunc mints the per-pod bootstrap credential and fills the transport /
+// connection / security fields for a warm worker of the target, returning a spec
+// ready for BuildWarmPod. It is the auth- and config-aware half of warm-pod
+// creation, injected from main.go so the executor package imports neither auth nor
+// config. It is called once per warm worker the reconciler needs to create.
+type WarmPodSpecFunc func(t WarmTarget) (WarmPodSpec, error)
+
+// KubernetesWarmPods is the production WarmPodClient: it lists warm pods by the
+// warm-worker label, builds new ones via the injected spec func + BuildWarmPod,
+// and deletes them, all in one namespace. It owns the label selector so the
+// executor's warm-worker label contract stays private to this package.
+type KubernetesWarmPods struct {
+	clientset kubernetes.Interface
+	namespace string
+	newSpec   WarmPodSpecFunc
+}
+
+// NewKubernetesWarmPods builds the cluster-backed warm-pod client. newSpec is the
+// auth/config-aware builder invoked per create; List and Delete do not need it.
+func NewKubernetesWarmPods(cs kubernetes.Interface, namespace string, newSpec WarmPodSpecFunc) *KubernetesWarmPods {
+	if namespace == "" {
+		namespace = "default"
+	}
+	return &KubernetesWarmPods{clientset: cs, namespace: namespace, newSpec: newSpec}
+}
+
+// warmPodSelector selects exactly the warm-worker pods (excludes ordinary task
+// pods), the label BuildWarmPod stamps.
+const warmPodSelector = warmWorkerLabelKey + "=" + warmWorkerLabelVal
+
+// ListWarmPods returns every warm-worker pod in the namespace, tagged with the
+// dag_version it serves (from its label).
+func (k *KubernetesWarmPods) ListWarmPods(ctx context.Context) ([]WarmPodInfo, error) {
+	list, err := k.clientset.CoreV1().Pods(k.namespace).List(ctx, metav1.ListOptions{LabelSelector: warmPodSelector})
+	if err != nil {
+		return nil, fmt.Errorf("listing warm pods: %w", err)
+	}
+	out := make([]WarmPodInfo, 0, len(list.Items))
+	for i := range list.Items {
+		p := &list.Items[i]
+		out = append(out, WarmPodInfo{Name: p.Name, DagVersionID: p.Labels[warmDagVersionLabelKey]})
+	}
+	return out, nil
+}
+
+// CreateWarmPod mints the target's warm-pod spec, builds the pod, and creates it.
+func (k *KubernetesWarmPods) CreateWarmPod(ctx context.Context, t WarmTarget) error {
+	if k.newSpec == nil {
+		return fmt.Errorf("warm pod creation requires a spec builder")
+	}
+	spec, err := k.newSpec(t)
+	if err != nil {
+		return fmt.Errorf("building warm pod spec for dag_version %s: %w", t.DagVersionID, err)
+	}
+	spec.Namespace = k.namespace
+	pod := BuildWarmPod(spec)
+	if _, err := k.clientset.CoreV1().Pods(k.namespace).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("creating warm pod for dag_version %s: %w", t.DagVersionID, err)
+	}
+	return nil
+}
+
+// DeleteWarmPod removes one warm worker by name.
+func (k *KubernetesWarmPods) DeleteWarmPod(ctx context.Context, name string) error {
+	if err := k.clientset.CoreV1().Pods(k.namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+		return fmt.Errorf("deleting warm pod %s: %w", name, err)
+	}
+	return nil
+}
+
+var _ WarmPodClient = (*KubernetesWarmPods)(nil)

--- a/internal/executor/warmpool_k8s_test.go
+++ b/internal/executor/warmpool_k8s_test.go
@@ -1,0 +1,81 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// TestKubernetesWarmPodsListSelectsWarmOnly proves the cluster-backed client lists
+// ONLY warm-worker pods (by label) and reads the dag_version each serves, so a
+// namespace full of ordinary task pods does not confuse the reconciler's counts.
+func TestKubernetesWarmPodsListSelectsWarmOnly(t *testing.T) {
+	cs := fake.NewSimpleClientset(
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name: "warm-1", Namespace: "leoflow",
+			Labels: map[string]string{warmWorkerLabelKey: warmWorkerLabelVal, warmDagVersionLabelKey: "dv1"},
+		}},
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name: "task-1", Namespace: "leoflow",
+			Labels: map[string]string{"leoflow.io/run-id": "r1"},
+		}},
+	)
+	k := NewKubernetesWarmPods(cs, "leoflow", nil)
+	got, err := k.ListWarmPods(context.Background())
+	if err != nil {
+		t.Fatalf("ListWarmPods: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("listed %d warm pods, want 1 (task pods must be excluded): %+v", len(got), got)
+	}
+	if got[0].Name != "warm-1" || got[0].DagVersionID != "dv1" {
+		t.Errorf("listed %+v, want {warm-1 dv1}", got[0])
+	}
+}
+
+// TestKubernetesWarmPodsCreateBuildsAndCreates proves CreateWarmPod runs the
+// injected spec builder, builds a warm pod, and Creates it in the namespace.
+func TestKubernetesWarmPodsCreateBuildsAndCreates(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	newSpec := func(t WarmTarget) (WarmPodSpec, error) {
+		return WarmPodSpec{DagVersionID: t.DagVersionID, Image: t.Image, BootstrapToken: "tok"}, nil
+	}
+	k := NewKubernetesWarmPods(cs, "leoflow", newSpec)
+	if err := k.CreateWarmPod(context.Background(), WarmTarget{DagVersionID: "dv1", Image: "img", EffectiveMinIdle: 1}); err != nil {
+		t.Fatalf("CreateWarmPod: %v", err)
+	}
+	pods, err := cs.CoreV1().Pods("leoflow").List(context.Background(), metav1.ListOptions{
+		LabelSelector: warmWorkerLabelKey + "=" + warmWorkerLabelVal,
+	})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(pods.Items) != 1 {
+		t.Fatalf("created %d warm pods, want 1", len(pods.Items))
+	}
+	if got := pods.Items[0].Spec.Containers[0].Image; got != "img" {
+		t.Errorf("created pod image = %q, want img", got)
+	}
+}
+
+// TestKubernetesWarmPodsDelete proves DeleteWarmPod removes the named pod.
+func TestKubernetesWarmPodsDelete(t *testing.T) {
+	cs := fake.NewSimpleClientset(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "warm-1", Namespace: "leoflow",
+		Labels: map[string]string{warmWorkerLabelKey: warmWorkerLabelVal, warmDagVersionLabelKey: "dv1"},
+	}})
+	k := NewKubernetesWarmPods(cs, "leoflow", nil)
+	if err := k.DeleteWarmPod(context.Background(), "warm-1"); err != nil {
+		t.Fatalf("DeleteWarmPod: %v", err)
+	}
+	got, err := k.ListWarmPods(context.Background())
+	if err != nil {
+		t.Fatalf("ListWarmPods: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("after delete listed %d, want 0", len(got))
+	}
+}

--- a/internal/executor/warmpool_test.go
+++ b/internal/executor/warmpool_test.go
@@ -1,0 +1,211 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// fakeWarmTargets is a canned WarmTargetSource.
+type fakeWarmTargets struct {
+	targets []WarmTarget
+	err     error
+}
+
+func (f *fakeWarmTargets) ActiveWarmTargets(context.Context) ([]WarmTarget, error) {
+	return f.targets, f.err
+}
+
+// fakeWarmPods records the reconciler's create/delete calls against a canned
+// existing-pod set, so a test can assert exactly what the reconciler did.
+type fakeWarmPods struct {
+	existing  []WarmPodInfo
+	created   []WarmTarget
+	deleted   []string
+	listErr   error
+	createErr map[string]error // per dag_version create error (nil = ok)
+	panicOn   string           // dag_version whose create panics (isolation test)
+}
+
+func (f *fakeWarmPods) ListWarmPods(context.Context) ([]WarmPodInfo, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.existing, nil
+}
+
+func (f *fakeWarmPods) CreateWarmPod(_ context.Context, t WarmTarget) error {
+	if f.panicOn != "" && t.DagVersionID == f.panicOn {
+		panic("boom creating " + t.DagVersionID)
+	}
+	if f.createErr != nil {
+		if err := f.createErr[t.DagVersionID]; err != nil {
+			return err
+		}
+	}
+	f.created = append(f.created, t)
+	return nil
+}
+
+func (f *fakeWarmPods) DeleteWarmPod(_ context.Context, name string) error {
+	f.deleted = append(f.deleted, name)
+	return nil
+}
+
+func warmPods(dagVersionID string, names ...string) []WarmPodInfo {
+	out := make([]WarmPodInfo, 0, len(names))
+	for _, n := range names {
+		out = append(out, WarmPodInfo{Name: n, DagVersionID: dagVersionID})
+	}
+	return out
+}
+
+func reconcileWarm(t *testing.T, targets *fakeWarmTargets, pods *fakeWarmPods) {
+	t.Helper()
+	r := NewWarmPoolReconciler(targets, pods, nil, nil)
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+}
+
+// TestWarmPoolReconcileCreatesMissing: target 2, zero existing => create 2.
+func TestWarmPoolReconcileCreatesMissing(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", Image: "img", EffectiveMinIdle: 2}}}
+	pods := &fakeWarmPods{}
+	reconcileWarm(t, targets, pods)
+	if len(pods.created) != 2 {
+		t.Errorf("created %d pods, want 2", len(pods.created))
+	}
+	for _, c := range pods.created {
+		if c.DagVersionID != "dv1" || c.Image != "img" {
+			t.Errorf("created %+v, want dv1/img", c)
+		}
+	}
+	if len(pods.deleted) != 0 {
+		t.Errorf("deleted %v, want none", pods.deleted)
+	}
+}
+
+// TestWarmPoolReconcileAtTargetNoop: target 2, 2 existing => create 0, delete 0.
+func TestWarmPoolReconcileAtTargetNoop(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", EffectiveMinIdle: 2}}}
+	pods := &fakeWarmPods{existing: warmPods("dv1", "p1", "p2")}
+	reconcileWarm(t, targets, pods)
+	if len(pods.created) != 0 || len(pods.deleted) != 0 {
+		t.Errorf("created %v deleted %v, want no changes", pods.created, pods.deleted)
+	}
+}
+
+// TestWarmPoolReconcileDeletesExcess: target 2, 3 existing => delete 1.
+func TestWarmPoolReconcileDeletesExcess(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", EffectiveMinIdle: 2}}}
+	pods := &fakeWarmPods{existing: warmPods("dv1", "p1", "p2", "p3")}
+	reconcileWarm(t, targets, pods)
+	if len(pods.created) != 0 {
+		t.Errorf("created %v, want none", pods.created)
+	}
+	if len(pods.deleted) != 1 {
+		t.Fatalf("deleted %v, want exactly 1", pods.deleted)
+	}
+}
+
+// TestWarmPoolReconcileDeletesInactiveVersion: a version no longer active (not in
+// targets) with 1 existing pod => the pod is deleted (target 0).
+func TestWarmPoolReconcileDeletesInactiveVersion(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", EffectiveMinIdle: 1}}}
+	pods := &fakeWarmPods{existing: append(warmPods("dv1", "p1"), warmPods("gone", "orphan")...)}
+	reconcileWarm(t, targets, pods)
+	if len(pods.deleted) != 1 || pods.deleted[0] != "orphan" {
+		t.Errorf("deleted %v, want [orphan] (the inactive version's pod)", pods.deleted)
+	}
+	// dv1 was already at its target of 1, so no create.
+	if len(pods.created) != 0 {
+		t.Errorf("created %v, want none", pods.created)
+	}
+}
+
+// TestWarmPoolReconcileTargetZeroCreatesNothing: warm pools off / effective target
+// 0 (the reconciler receives no targets, or a target of 0) creates nothing and,
+// for a 0-target with existing pods, drains them.
+func TestWarmPoolReconcileTargetZeroCreatesNothing(t *testing.T) {
+	// No active targets at all: nothing to create, nothing existing to delete.
+	reconcileWarm(t, &fakeWarmTargets{}, &fakeWarmPods{})
+
+	// Explicit zero target with existing pods => drained to zero, never created.
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", EffectiveMinIdle: 0}}}
+	pods := &fakeWarmPods{existing: warmPods("dv1", "p1", "p2")}
+	reconcileWarm(t, targets, pods)
+	if len(pods.created) != 0 {
+		t.Errorf("created %v, want none for a zero target", pods.created)
+	}
+	if len(pods.deleted) != 2 {
+		t.Errorf("deleted %v, want both pods drained for a zero target", pods.deleted)
+	}
+}
+
+// TestWarmPoolReconcilePerVersionIsolation: a version whose create panics must not
+// block a healthy version's reconcile (panic-safe, per-version isolated).
+func TestWarmPoolReconcilePerVersionIsolation(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{
+		{DagVersionID: "bad", EffectiveMinIdle: 1},
+		{DagVersionID: "good", EffectiveMinIdle: 2},
+	}}
+	pods := &fakeWarmPods{panicOn: "bad"}
+	// Must not panic out of Reconcile.
+	reconcileWarm(t, targets, pods)
+	// The healthy version was still fully reconciled.
+	var good int
+	for _, c := range pods.created {
+		if c.DagVersionID == "good" {
+			good++
+		}
+	}
+	if good != 2 {
+		t.Errorf("healthy version got %d creates, want 2 (bad version must not block it)", good)
+	}
+}
+
+// TestWarmPoolReconcileCreateErrorIsolatedPerPod: a create error is logged and the
+// version keeps going; it does not abort the whole reconcile.
+func TestWarmPoolReconcileCreateErrorIsolatedPerPod(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{
+		{DagVersionID: "err", EffectiveMinIdle: 2},
+		{DagVersionID: "ok", EffectiveMinIdle: 1},
+	}}
+	pods := &fakeWarmPods{createErr: map[string]error{"err": errors.New("apiserver 500")}}
+	reconcileWarm(t, targets, pods)
+	// The healthy version still created its pod despite the other's error.
+	var ok int
+	for _, c := range pods.created {
+		if c.DagVersionID == "ok" {
+			ok++
+		}
+	}
+	if ok != 1 {
+		t.Errorf("ok version got %d creates, want 1", ok)
+	}
+}
+
+// TestWarmPoolReconcileListErrorReturned: a list failure is surfaced so the ticker
+// logs it and retries next tick (nothing is created off a bad view of the world).
+func TestWarmPoolReconcileListErrorReturned(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", EffectiveMinIdle: 1}}}
+	pods := &fakeWarmPods{listErr: errors.New("watch broke")}
+	r := NewWarmPoolReconciler(targets, pods, nil, nil)
+	if err := r.Reconcile(context.Background()); err == nil {
+		t.Fatal("Reconcile = nil on list error, want the error surfaced")
+	}
+	if len(pods.created) != 0 {
+		t.Errorf("created %v off a failed list, want none", pods.created)
+	}
+}
+
+// TestWarmPoolReconcileTargetsErrorReturned: a targets-source failure is surfaced.
+func TestWarmPoolReconcileTargetsErrorReturned(t *testing.T) {
+	targets := &fakeWarmTargets{err: errors.New("db down")}
+	pods := &fakeWarmPods{}
+	r := NewWarmPoolReconciler(targets, pods, nil, nil)
+	if err := r.Reconcile(context.Background()); err == nil {
+		t.Fatal("Reconcile = nil on targets error, want the error surfaced")
+	}
+}

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/neochaotic/leoflow/internal/config"
 	"github.com/neochaotic/leoflow/internal/domain"
 	"github.com/neochaotic/leoflow/internal/executor"
 	"github.com/neochaotic/leoflow/internal/scheduler"
@@ -20,6 +21,10 @@ type SchedulerStore struct {
 	q     *queries.Queries
 	pool  poolBeginner
 	specs *specCache
+	// warmExec is the operator's warm-pool config, consulted by ActiveWarmTargets
+	// to resolve each active dag_version's effective warm target (ADR 0058 N1b2b).
+	// Zero value = warm pools off, so ActiveWarmTargets reports every target as 0.
+	warmExec config.ExecutionSection
 }
 
 // poolBeginner is the slice of pgxpool.Pool the store uses to start the orphan
@@ -162,6 +167,75 @@ func (s *SchedulerStore) ActiveRuns(ctx context.Context) ([]scheduler.RunState, 
 		})
 	}
 	return out, nil
+}
+
+// SetWarmExecution records the operator's warm-pool config so ActiveWarmTargets
+// can resolve each active dag_version's effective warm target. main.go calls it
+// only when warm pools are enabled; left unset, warm pools read as off (every
+// target 0).
+func (s *SchedulerStore) SetWarmExecution(exec config.ExecutionSection) { s.warmExec = exec }
+
+// activeWarmVersion is one active dag_version's warm-relevant spec fields — the
+// pure input to warmTargets, extracted so the projection is unit-testable without
+// a database.
+type activeWarmVersion struct {
+	dagVersionID string
+	image        string
+	dagMinIdle   int
+}
+
+// warmTargets dedupes the active versions (many runs share one immutable
+// dag_version) and resolves each to its effective warm target through the
+// operator's clamp/fallback/flag gate (config.ExecutionSection.EffectiveMinIdle).
+// The result is the executor.WarmTargetSource contract: one entry per distinct
+// active dag_version.
+func warmTargets(versions []activeWarmVersion, exec config.ExecutionSection) []executor.WarmTarget {
+	seen := make(map[string]bool, len(versions))
+	out := make([]executor.WarmTarget, 0, len(versions))
+	for _, v := range versions {
+		if seen[v.dagVersionID] {
+			continue
+		}
+		seen[v.dagVersionID] = true
+		out = append(out, executor.WarmTarget{
+			DagVersionID:     v.dagVersionID,
+			Image:            v.image,
+			EffectiveMinIdle: exec.EffectiveMinIdle(v.dagMinIdle),
+		})
+	}
+	return out
+}
+
+// ActiveWarmTargets returns one warm target per distinct active dag_version with
+// its effective warm-worker count (ADR 0058 N1b2b), the read side of a warm-pool
+// reconcile tick. It reuses the same active-runs + cached-spec path as ActiveRuns:
+// the spec is immutable per dag_version_id, so N active runs sharing a version
+// decode it once and the effective target is derived from the DAG author's
+// min_idle_workers under the operator's clamp/fallback. It implements
+// executor.WarmTargetSource without the executor importing storage.
+func (s *SchedulerStore) ActiveWarmTargets(ctx context.Context) ([]executor.WarmTarget, error) {
+	runs, err := s.q.ListActiveDagRuns(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing active runs: %w", err)
+	}
+	versions := make([]activeWarmVersion, 0, len(runs))
+	seen := make(map[pgtype.UUID]bool, len(runs))
+	for _, run := range runs {
+		if seen[run.DagVersionID] {
+			continue
+		}
+		seen[run.DagVersionID] = true
+		_, spec, err := s.specs.get(ctx, s.q, run.DagVersionID)
+		if err != nil {
+			return nil, err
+		}
+		versions = append(versions, activeWarmVersion{
+			dagVersionID: uuidToString(run.DagVersionID),
+			image:        spec.Image,
+			dagMinIdle:   spec.MinIdleWorkers,
+		})
+	}
+	return warmTargets(versions, s.warmExec), nil
 }
 
 // MaterializeTasks creates a none-state task instance for each task in the run,
@@ -488,6 +562,7 @@ func applyDefaultRetries(spec *domain.DAGSpec) {
 }
 
 var _ scheduler.Store = (*SchedulerStore)(nil)
+var _ executor.WarmTargetSource = (*SchedulerStore)(nil)
 
 // RecordStagingVolume records a per-run staging volume as active, keyed by PVC
 // name (idempotent — called per task as the PVC is ensured). ADR 0022.

--- a/internal/storage/warm_targets_integration_test.go
+++ b/internal/storage/warm_targets_integration_test.go
@@ -1,0 +1,86 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/config"
+	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/storage"
+)
+
+// registerWarmSpec registers a one-task DAG version carrying an author-declared
+// min_idle_workers and a distinct image, so ActiveWarmTargets has a real
+// dag_version to project.
+func registerWarmSpec(t *testing.T, repo *storage.Repository, ctx context.Context, dagID, image string, minIdle int) {
+	t.Helper()
+	spec := domain.DAGSpec{
+		SchemaVersion:  "1.0",
+		DagID:          dagID,
+		DagVersion:     "v1",
+		Image:          image,
+		MinIdleWorkers: minIdle,
+		Tasks:          []domain.TaskSpec{{TaskID: "a", Type: domain.TaskTypePython}},
+	}
+	hash, err := spec.CanonicalHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created, rerr := repo.RegisterDagVersion(ctx, "default", spec, hash); rerr != nil || !created {
+		t.Fatalf("register %s: created=%v err=%v", dagID, created, rerr)
+	}
+}
+
+// TestActiveWarmTargetsIntegration exercises the real DB seam: an active dag_version
+// with an author-declared min_idle_workers surfaces as one warm target whose
+// effective count is resolved through the operator's clamp (min_idle 20, cap 8 => 8).
+func TestActiveWarmTargetsIntegration(t *testing.T) {
+	repo, sched, ctx := openRepo(t)
+	sched.SetWarmExecution(config.ExecutionSection{WarmPoolsEnabled: true, MinIdleWorkers: 1, MaxPoolSize: 8})
+
+	dagID := fmt.Sprintf("warm_tgt_%d", time.Now().UnixNano())
+	image := fmt.Sprintf("warm-img-%d:v1", time.Now().UnixNano())
+	registerWarmSpec(t, repo, ctx, dagID, image, 20) // author over-asks -> clamped to cap 8
+	if _, err := repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+		RunID: "r1", State: domain.DagRunStateQueued, RunType: "manual", LogicalDate: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("create run: %v", err)
+	}
+
+	targets, err := sched.ActiveWarmTargets(ctx)
+	if err != nil {
+		t.Fatalf("ActiveWarmTargets: %v", err)
+	}
+	var found bool
+	for _, tgt := range targets {
+		if tgt.Image != image {
+			continue // another test's active DAG in the shared database
+		}
+		found = true
+		if tgt.EffectiveMinIdle != 8 {
+			t.Errorf("effective min_idle = %d, want 8 (author 20 clamped to cap 8)", tgt.EffectiveMinIdle)
+		}
+		if tgt.DagVersionID == "" {
+			t.Error("warm target carries no dag_version_id")
+		}
+	}
+	if !found {
+		t.Fatalf("no warm target for image %s in %+v", image, targets)
+	}
+
+	// With warm pools off the same active version reports a zero target (the gate).
+	sched.SetWarmExecution(config.ExecutionSection{WarmPoolsEnabled: false, MinIdleWorkers: 5, MaxPoolSize: 8})
+	offTargets, err := sched.ActiveWarmTargets(ctx)
+	if err != nil {
+		t.Fatalf("ActiveWarmTargets (off): %v", err)
+	}
+	for _, tgt := range offTargets {
+		if tgt.Image == image && tgt.EffectiveMinIdle != 0 {
+			t.Errorf("warm pools off: effective min_idle = %d, want 0", tgt.EffectiveMinIdle)
+		}
+	}
+}

--- a/internal/storage/warm_targets_test.go
+++ b/internal/storage/warm_targets_test.go
@@ -1,0 +1,48 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/config"
+)
+
+// TestWarmTargets locks the pure active-version -> warm-target projection (ADR
+// 0058 N1b2b): distinct active dag_versions each resolve to their effective warm
+// target via the operator's clamp/fallback/flag gate, and duplicates (many active
+// runs of one version) collapse to a single target.
+func TestWarmTargets(t *testing.T) {
+	exec := config.ExecutionSection{WarmPoolsEnabled: true, MinIdleWorkers: 1, MaxPoolSize: 8}
+	versions := []activeWarmVersion{
+		{dagVersionID: "dv1", image: "img1", dagMinIdle: 2},  // author 2 -> 2
+		{dagVersionID: "dv1", image: "img1", dagMinIdle: 2},  // dup of dv1, collapses
+		{dagVersionID: "dv2", image: "img2", dagMinIdle: 0},  // unset -> operator floor 1
+		{dagVersionID: "dv3", image: "img3", dagMinIdle: 20}, // over cap -> clamped 8
+	}
+	got := warmTargets(versions, exec)
+	if len(got) != 3 {
+		t.Fatalf("warmTargets returned %d entries, want 3 distinct versions: %+v", len(got), got)
+	}
+	want := map[string]int{"dv1": 2, "dv2": 1, "dv3": 8}
+	for _, tgt := range got {
+		if w, ok := want[tgt.DagVersionID]; !ok || tgt.EffectiveMinIdle != w {
+			t.Errorf("target %s = %d, want %d", tgt.DagVersionID, tgt.EffectiveMinIdle, w)
+		}
+	}
+	// Image is threaded through so the reconciler can build the warm pod.
+	for _, tgt := range got {
+		if tgt.Image == "" {
+			t.Errorf("target %s carries no image", tgt.DagVersionID)
+		}
+	}
+}
+
+// TestWarmTargetsWarmPoolsOff locks that with warm pools off every effective
+// target is 0, so the reconciler (were it even running) would keep every pool
+// empty.
+func TestWarmTargetsWarmPoolsOff(t *testing.T) {
+	exec := config.ExecutionSection{WarmPoolsEnabled: false, MinIdleWorkers: 5, MaxPoolSize: 8}
+	got := warmTargets([]activeWarmVersion{{dagVersionID: "dv1", image: "i", dagMinIdle: 4}}, exec)
+	if len(got) != 1 || got[0].EffectiveMinIdle != 0 {
+		t.Errorf("warmTargets with pools off = %+v, want single dv1 with target 0", got)
+	}
+}


### PR DESCRIPTION
**N1b2b of the warm-pool track (ADR 0058, model A2).** Provisions warm-worker pods and maintains the target count per active DAG version. Behind `execution.warm_pools_enabled` (default off → reconciler never constructed → no warm pods → byte-for-byte today's dedicated pod-per-task).

## Pieces
- **Per-DAG min_idle (A2, operator-capped):** `DAGSpec.MinIdleWorkers` (author-declared, mirrors `MaxActiveTasks`). `EffectiveMinIdle` = 0 when warm off; else dagMinIdle (or operator `MinIdleWorkers` default when unset), floored at 0, **clamped to `MaxPoolSize`** (asks 20, cap 8 → 8). Author declares, operator bounds.
- **`BuildWarmPod`:** reuses BuildPod's transport/CA/control-plane/security machinery (extracted into a shared carrier — BuildPod stays byte-identical). Long-lived worker: `LEOFLOW_WARM_WORKER=1` + `LEOFLOW_DAG_VERSION_ID`, **no task env**, warm-worker labels, `RestartPolicy Never` (reconciler replaces exited workers), no task token baked in.
- **`WarmPoolReconciler`:** reconcile each active version to `EffectiveMinIdle` (create/delete), drain inactive versions. Idempotent, per-version `recover()`-isolated, leader-gated ticker. Seams (`WarmTargetSource`, `WarmPodClient`) live in executor → no scheduler/storage import.

## 🔒 Security follow-up — REQUIRED before any warm-pool enable (tracked)
The wiring passes the **bootstrap credential on the env-var transport** regardless of `auth.agent_token_transport`, because the warm agent (N1b2a `runWarm`) registers with its bearer directly and does not yet exchange a projected SA token. `BuildWarmPod` itself is transport-agnostic (supports exchange). A plaintext bootstrap token on the warm pod spec is a **shared-cluster exposure** (a pod-spec reader could register a rogue worker and receive pushed per-attempt tokens). **Making `runWarm` exchange its bootstrap credential is a required pre-enable fix** (small — reuses the single-shot agent's existing exchange path). Off by default, so nothing ships exposed now.

## Deferred to N1d
idle-TTL recycle (D6), lifetime/attempts caps (D9), reaper fan-out + H2 (D7), GC-anchor ConfigMap (D11).

## Tests / verification
RED-first: `EffectiveMinIdle` (clamp/fallback/gate/floor), `MinIdleWorkers` omitempty, `BuildWarmPod` (warm env / no task env / labels / both transports / RestartPolicy), `WarmPoolReconciler` (create / noop / delete-excess / drain-inactive / zero-target / clamp / panic-isolation / per-pod-error / list-error-surfaced), fake-clientset `KubernetesWarmPods`, `storage.warmTargets`. `go vet ./...` **and** `-tags integration` both clean, build + `-tags integration` green, `golangci-lint` 0, no proto change.