### PR TITLE
fix(warm): reconciler skips terminal pods (H1) + join per-attempt heartbeat (M3)

### DIFF
--- a/internal/agent/auth.go
+++ b/internal/agent/auth.go
@@ -5,6 +5,14 @@ import (
 	"sync"
 )
 
+// tokenSetter is the swap side of the bearer credential the heartbeat loop uses
+// to adopt a renewed token. *TokenSource satisfies it; Runner.Token is typed as
+// this narrow interface so a test can inject a recorder that observes when the
+// heartbeat's Set runs (proving the goroutine is joined before the next attempt).
+type tokenSetter interface {
+	Set(token string)
+}
+
 // TokenSource holds the agent's current bearer token behind a lock so the
 // heartbeat loop can atomically swap it (token renewal, ADR 0055 Fix #4) while
 // the gRPC per-RPC credential reads it on every outbound call. Reads and swaps

--- a/internal/agent/heartbeat_join_test.go
+++ b/internal/agent/heartbeat_join_test.go
@@ -1,0 +1,134 @@
+package agent
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+	"google.golang.org/grpc"
+)
+
+// gatedTokenSetter records every Token.Set call; each Set signals setCalled and
+// then blocks on setGate. That lets a test freeze a heartbeat mid-Set and observe
+// whether runOneAttempt waits for the heartbeat goroutine (the join) before it
+// returns. It satisfies the tokenSetter seam that Runner.Token is typed to.
+type gatedTokenSetter struct {
+	setCalled chan string
+	setGate   chan struct{}
+	mu        sync.Mutex
+	values    []string
+}
+
+func (g *gatedTokenSetter) Set(token string) {
+	g.mu.Lock()
+	g.values = append(g.values, token)
+	g.mu.Unlock()
+	g.setCalled <- token
+	<-g.setGate
+}
+
+func (g *gatedTokenSetter) count() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return len(g.values)
+}
+
+// gatedHeartbeatClient embeds the standard fake client and overrides Heartbeat:
+// the FIRST beat returns a renewed token (so applyHeartbeatResponse calls
+// Token.Set exactly once), and every later beat blocks until ctx cancel and then
+// returns promptly — so the loop issues no further Set.
+type gatedHeartbeatClient struct {
+	*fakeClient
+	mu    sync.Mutex
+	calls int
+}
+
+func (g *gatedHeartbeatClient) Heartbeat(ctx context.Context, _ *agentv1.HeartbeatRequest, _ ...grpc.CallOption) (*agentv1.HeartbeatResponse, error) {
+	g.mu.Lock()
+	g.calls++
+	first := g.calls == 1
+	g.mu.Unlock()
+	if first {
+		return &agentv1.HeartbeatResponse{RenewedToken: "hb-renewed"}, nil
+	}
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// blockingCmd blocks in Run until release is closed, guaranteeing the heartbeat
+// fires (and its Set is in-flight) while the attempt is still running.
+type blockingCmd struct {
+	release chan struct{}
+}
+
+func (c *blockingCmd) Run(_ context.Context, _, _ []string, _, _ io.Writer) (int, error) {
+	<-c.release
+	return 0, nil
+}
+
+// TestRunOneAttemptJoinsHeartbeat is the M3 regression: the per-attempt heartbeat
+// goroutine must be JOINED before runOneAttempt returns, so its last Token.Set
+// (adopting a renewed bearer) completes before the warm loop swaps to the next
+// attempt's token on the SHARED AttemptTokens. The test freezes a heartbeat
+// inside Token.Set and proves runOneAttempt blocks until that Set finishes — with
+// the join it does; without it (bare `go r.heartbeat` + `defer cancel()`)
+// runOneAttempt returns while the Set is still in-flight, which is the bug: a
+// lingering heartbeat clobbers the next attempt's token.
+func TestRunOneAttemptJoinsHeartbeat(t *testing.T) {
+	setter := &gatedTokenSetter{setCalled: make(chan string, 1), setGate: make(chan struct{})}
+	client := &gatedHeartbeatClient{fakeClient: &fakeClient{
+		spec: &agentv1.TaskSpec{Operator: "python", Entrypoint: "dag:f"},
+	}}
+	cmd := &blockingCmd{release: make(chan struct{})}
+	r := &Runner{
+		Client:            client,
+		Cmd:               cmd,
+		Sink:              &recordingSink{},
+		Hostname:          "pod-1",
+		Version:           "test",
+		Token:             setter,
+		HeartbeatInterval: time.Millisecond,
+	}
+
+	done := make(chan struct{})
+	go func() { _ = r.runOneAttempt(context.Background()); close(done) }()
+
+	// A heartbeat Set is now in-flight, frozen on setGate.
+	select {
+	case v := <-setter.setCalled:
+		if v != "hb-renewed" {
+			t.Fatalf("Token.Set(%q), want the renewed token hb-renewed", v)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("heartbeat never called Token.Set — cannot exercise the join")
+	}
+
+	// Let the user command finish so execute() reaches its deferred join.
+	close(cmd.release)
+
+	// With the join, runOneAttempt must still be blocked at hbWG.Wait(): the
+	// heartbeat goroutine is frozen inside Set and has not returned. Without the
+	// join it would already have returned.
+	select {
+	case <-done:
+		t.Fatal("runOneAttempt returned while a heartbeat Set was still in-flight: the heartbeat goroutine is not joined (M3 bug)")
+	case <-time.After(200 * time.Millisecond):
+		// Expected: blocked on the join.
+	}
+
+	// Release the frozen Set; the heartbeat can finish its cycle, observe the
+	// cancel, and exit — unblocking the join so the attempt returns.
+	close(setter.setGate)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runOneAttempt did not return after the heartbeat Set completed")
+	}
+
+	if n := setter.count(); n != 1 {
+		t.Errorf("Token.Set called %d times, want exactly 1", n)
+	}
+}

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/neochaotic/leoflow/internal/taskoutcome"
@@ -75,11 +76,13 @@ type Runner struct {
 	// HeartbeatInterval is how often to ping the control plane while the task
 	// runs; zero disables heartbeats.
 	HeartbeatInterval time.Duration
-	// Token, when set, is the swappable bearer the gRPC per-RPC credential reads.
+	// Token, when set, is the swappable bearer backing the gRPC per-RPC credential.
 	// On a heartbeat carrying a renewed_token the loop atomically swaps it here so
 	// every subsequent RPC uses the new credential (ADR 0055 Fix #4). Nil disables
-	// bearer swapping (a heartbeat's renewed_token is then ignored).
-	Token *TokenSource
+	// bearer swapping (a heartbeat's renewed_token is then ignored). Typed as the
+	// narrow tokenSetter seam (satisfied by *TokenSource) so the heartbeat's Set
+	// can be observed in tests; production always wires a *TokenSource.
+	Token tokenSetter
 	// BeforeReport, if set, is invoked with the terminal state AFTER the durable
 	// outcome record is written and BEFORE the report is delivered. It is a
 	// fault-injection seam for the durable-outcome E2E (ADR 0052) — the agent
@@ -387,10 +390,21 @@ func (r *Runner) execute(ctx context.Context, argv, env []string, timeout time.D
 	stderr := &logWriter{sink: r.Sink, stream: "stderr", level: agentv1.LogLevel_LOG_LEVEL_ERROR}
 
 	runCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	// Join the heartbeat goroutine before this attempt returns. Its last
+	// Token.Set (adopting a renewed bearer) must complete before the caller
+	// swaps to the next attempt's token — in warm mode r.Token is the SHARED
+	// AttemptTokens and attempts are sequential, so a lingering heartbeat
+	// finishing a Set after attempt N+1 adopted its token would make N+1 run
+	// under N's superseded credential. cancel() signals the loop to stop, THEN
+	// Wait() blocks for its in-flight cycle to finish; the order matters (a
+	// single deferred func, not two defers). Single-shot is unaffected — the
+	// process exits after Run either way; the join just adds a bounded wait.
+	var hbWG sync.WaitGroup
 	if r.HeartbeatInterval > 0 {
-		go r.heartbeat(runCtx, cancel)
+		hbWG.Add(1)
+		go func() { defer hbWG.Done(); r.heartbeat(runCtx, cancel) }()
 	}
+	defer func() { cancel(); hbWG.Wait() }()
 
 	// `execution_timeout_seconds` enforcement (#194): wrap the runCtx in a
 	// deadline so a wedged user process is interrupted at the boundary the user

--- a/internal/executor/warmpool.go
+++ b/internal/executor/warmpool.go
@@ -27,9 +27,16 @@ type WarmTargetSource interface {
 
 // WarmPodInfo identifies one existing warm-worker pod and the dag_version it
 // serves (read from its labels). The reconciler counts these per version.
+//
+// Terminal marks a warm pod that has reached a terminal phase (Succeeded or
+// Failed). Warm pods are RestartPolicy:Never and the agent has no reconnect, so
+// a crashed/drained/finished worker lingers as a terminal pod that can never
+// serve again. The reconciler must NOT count terminal pods toward the target
+// (or a dead worker never gets replaced) and always reaps them.
 type WarmPodInfo struct {
 	Name         string
 	DagVersionID string
+	Terminal     bool
 }
 
 // WarmPodClient is the cluster side of warm-pool reconciliation: list the warm
@@ -127,11 +134,26 @@ func (r *WarmPoolReconciler) reconcileVersion(ctx context.Context, t WarmTarget,
 		}
 	}()
 
+	// Reap every terminal warm pod first and keep only the live ones. Warm pods
+	// are RestartPolicy:Never with no agent reconnect, so a Succeeded/Failed pod
+	// is a dead worker: it can never serve again, must not count toward the
+	// target (or a crashed/drained worker would never be replaced and the pool
+	// would silently die), and must not leak. This runs regardless of target, so
+	// the drain path (inactive version, target 0) reaps terminal pods too.
+	live := make([]WarmPodInfo, 0, len(have))
+	for _, p := range have {
+		if p.Terminal {
+			r.deleteWarmPod(ctx, t, p, "deleting terminal warm worker")
+			continue
+		}
+		live = append(live, p)
+	}
+
 	switch {
-	case len(have) < t.EffectiveMinIdle:
+	case len(live) < t.EffectiveMinIdle:
 		// Under target: create the shortfall. Each create is isolated so one
 		// apiserver rejection does not stop the rest of this version's workers.
-		for i := 0; i < t.EffectiveMinIdle-len(have); i++ {
+		for i := 0; i < t.EffectiveMinIdle-len(live); i++ {
 			if err := r.pods.CreateWarmPod(ctx, t); err != nil {
 				r.logger.ErrorContext(ctx, "creating warm worker",
 					"dag_version", t.DagVersionID, "image", t.Image, "error", err)
@@ -140,20 +162,26 @@ func (r *WarmPoolReconciler) reconcileVersion(ctx context.Context, t WarmTarget,
 			}
 			r.record("warm_pool_pod_created")
 		}
-	case len(have) > t.EffectiveMinIdle:
+	case len(live) > t.EffectiveMinIdle:
 		// Over target (or the version is no longer active, target 0): delete the
-		// excess. Deleting the tail is arbitrary but stable — every worker of a
-		// version is interchangeable.
-		for _, p := range have[t.EffectiveMinIdle:] {
-			if err := r.pods.DeleteWarmPod(ctx, p.Name); err != nil {
-				r.logger.ErrorContext(ctx, "deleting excess warm worker",
-					"dag_version", t.DagVersionID, "pod", p.Name, "error", err)
-				r.record("warm_pool_delete_error")
-				continue
-			}
-			r.record("warm_pool_pod_deleted")
+		// excess live workers. Deleting the tail is arbitrary but stable — every
+		// worker of a version is interchangeable.
+		for _, p := range live[t.EffectiveMinIdle:] {
+			r.deleteWarmPod(ctx, t, p, "deleting excess warm worker")
 		}
 	}
+}
+
+// deleteWarmPod deletes one warm worker by name, logging/metering a failure
+// without aborting the sweep. msg names why (terminal cleanup vs excess).
+func (r *WarmPoolReconciler) deleteWarmPod(ctx context.Context, t WarmTarget, p WarmPodInfo, msg string) {
+	if err := r.pods.DeleteWarmPod(ctx, p.Name); err != nil {
+		r.logger.ErrorContext(ctx, msg,
+			"dag_version", t.DagVersionID, "pod", p.Name, "error", err)
+		r.record("warm_pool_delete_error")
+		return
+	}
+	r.record("warm_pool_pod_deleted")
 }
 
 func (r *WarmPoolReconciler) record(decision string) {

--- a/internal/executor/warmpool_k8s.go
+++ b/internal/executor/warmpool_k8s.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -48,7 +49,15 @@ func (k *KubernetesWarmPods) ListWarmPods(ctx context.Context) ([]WarmPodInfo, e
 	out := make([]WarmPodInfo, 0, len(list.Items))
 	for i := range list.Items {
 		p := &list.Items[i]
-		out = append(out, WarmPodInfo{Name: p.Name, DagVersionID: p.Labels[warmDagVersionLabelKey]})
+		// Warm pods are RestartPolicy:Never; a Succeeded/Failed pod is a dead
+		// worker that can never serve again. Flag it so the reconciler neither
+		// counts it toward the target nor leaves it to leak.
+		terminal := p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed
+		out = append(out, WarmPodInfo{
+			Name:         p.Name,
+			DagVersionID: p.Labels[warmDagVersionLabelKey],
+			Terminal:     terminal,
+		})
 	}
 	return out, nil
 }

--- a/internal/executor/warmpool_k8s_test.go
+++ b/internal/executor/warmpool_k8s_test.go
@@ -36,6 +36,41 @@ func TestKubernetesWarmPodsListSelectsWarmOnly(t *testing.T) {
 	}
 }
 
+// TestKubernetesWarmPodsListFlagsTerminal proves ListWarmPods marks Succeeded
+// and Failed warm pods Terminal (dead RestartPolicy:Never workers) while a
+// Running/Pending pod stays live, so the reconciler can replace and reap them.
+func TestKubernetesWarmPodsListFlagsTerminal(t *testing.T) {
+	warm := func(name string, phase corev1.PodPhase) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name, Namespace: "leoflow",
+				Labels: map[string]string{warmWorkerLabelKey: warmWorkerLabelVal, warmDagVersionLabelKey: "dv1"},
+			},
+			Status: corev1.PodStatus{Phase: phase},
+		}
+	}
+	cs := fake.NewSimpleClientset(
+		warm("running", corev1.PodRunning),
+		warm("succeeded", corev1.PodSucceeded),
+		warm("failed", corev1.PodFailed),
+	)
+	k := NewKubernetesWarmPods(cs, "leoflow", nil)
+	got, err := k.ListWarmPods(context.Background())
+	if err != nil {
+		t.Fatalf("ListWarmPods: %v", err)
+	}
+	terminal := map[string]bool{}
+	for _, p := range got {
+		terminal[p.Name] = p.Terminal
+	}
+	if terminal["running"] {
+		t.Errorf("running pod flagged Terminal, want live")
+	}
+	if !terminal["succeeded"] || !terminal["failed"] {
+		t.Errorf("Succeeded/Failed pods not flagged Terminal: %+v", got)
+	}
+}
+
 // TestKubernetesWarmPodsCreateBuildsAndCreates proves CreateWarmPod runs the
 // injected spec builder, builds a warm pod, and Creates it in the namespace.
 func TestKubernetesWarmPodsCreateBuildsAndCreates(t *testing.T) {

--- a/internal/executor/warmpool_test.go
+++ b/internal/executor/warmpool_test.go
@@ -60,6 +60,17 @@ func warmPods(dagVersionID string, names ...string) []WarmPodInfo {
 	return out
 }
 
+// warmTerminalPods builds warm pods that have reached a terminal phase (a
+// crashed/drained/finished RestartPolicy:Never worker). The reconciler must not
+// count these toward the target and must always reap them.
+func warmTerminalPods(dagVersionID string, names ...string) []WarmPodInfo {
+	out := make([]WarmPodInfo, 0, len(names))
+	for _, n := range names {
+		out = append(out, WarmPodInfo{Name: n, DagVersionID: dagVersionID, Terminal: true})
+	}
+	return out
+}
+
 func reconcileWarm(t *testing.T, targets *fakeWarmTargets, pods *fakeWarmPods) {
 	t.Helper()
 	r := NewWarmPoolReconciler(targets, pods, nil, nil)
@@ -140,6 +151,68 @@ func TestWarmPoolReconcileTargetZeroCreatesNothing(t *testing.T) {
 	}
 	if len(pods.deleted) != 2 {
 		t.Errorf("deleted %v, want both pods drained for a zero target", pods.deleted)
+	}
+}
+
+// TestWarmPoolReconcileReplacesTerminalPods is the H1 regression: a fleet of 2
+// TERMINAL pods (crashed/drained workers) for a target of 2 must NOT read as
+// satisfied. The reconciler must CREATE 2 replacements (terminal pods do not
+// count toward the target) AND reap the 2 terminal pods (they can never serve
+// again). Before the fix this created 0 and deleted 0 — the pool silently died.
+func TestWarmPoolReconcileReplacesTerminalPods(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", Image: "img", EffectiveMinIdle: 2}}}
+	pods := &fakeWarmPods{existing: warmTerminalPods("dv1", "dead1", "dead2")}
+	reconcileWarm(t, targets, pods)
+	if len(pods.created) != 2 {
+		t.Errorf("created %d pods, want 2 (terminal pods must not count toward the target)", len(pods.created))
+	}
+	if len(pods.deleted) != 2 {
+		t.Errorf("deleted %v, want the 2 terminal pods reaped", pods.deleted)
+	}
+	gotDeleted := map[string]bool{}
+	for _, n := range pods.deleted {
+		gotDeleted[n] = true
+	}
+	if !gotDeleted["dead1"] || !gotDeleted["dead2"] {
+		t.Errorf("deleted %v, want both dead1 and dead2 reaped", pods.deleted)
+	}
+}
+
+// TestWarmPoolReconcileTerminalPlusLive: target 2 with 1 live + 1 terminal =>
+// create 1 (only the live pod counts), reap the terminal one, keep the live one.
+func TestWarmPoolReconcileTerminalPlusLive(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", Image: "img", EffectiveMinIdle: 2}}}
+	pods := &fakeWarmPods{existing: append(warmPods("dv1", "live1"), warmTerminalPods("dv1", "dead1")...)}
+	reconcileWarm(t, targets, pods)
+	if len(pods.created) != 1 {
+		t.Errorf("created %d pods, want 1 (1 live + 1 terminal, only live counts)", len(pods.created))
+	}
+	if len(pods.deleted) != 1 || pods.deleted[0] != "dead1" {
+		t.Errorf("deleted %v, want [dead1] (terminal reaped, live kept)", pods.deleted)
+	}
+}
+
+// TestWarmPoolReconcileDrainsTerminalOnInactiveVersion: an inactive version
+// (target 0) with a live + a terminal pod must drain BOTH.
+func TestWarmPoolReconcileDrainsTerminalOnInactiveVersion(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", EffectiveMinIdle: 1}}}
+	pods := &fakeWarmPods{existing: append(
+		warmPods("dv1", "keep"),
+		append(warmPods("gone", "orphan-live"), warmTerminalPods("gone", "orphan-dead")...)...,
+	)}
+	reconcileWarm(t, targets, pods)
+	gotDeleted := map[string]bool{}
+	for _, n := range pods.deleted {
+		gotDeleted[n] = true
+	}
+	if !gotDeleted["orphan-live"] || !gotDeleted["orphan-dead"] {
+		t.Errorf("deleted %v, want both orphan-live and orphan-dead drained", pods.deleted)
+	}
+	if gotDeleted["keep"] {
+		t.Errorf("deleted %v, must not drain the active version's live pod", pods.deleted)
+	}
+	if len(pods.created) != 0 {
+		t.Errorf("created %v, want none (dv1 already at target)", pods.created)
 	}
 }
 


### PR DESCRIPTION
Two reliability fixes from the warm-pool **critical review** (data-structures/resilience pass), each with a regression test that **fails before the fix**. Both in already-merged warm-pool code; still behind `execution.warm_pools_enabled` (off) — no exposure, but both would strand/degrade if enabled.

## H1 — reconciler counted terminal pods as live → pool silently dies
A warm worker is `RestartPolicy:Never` with no agent reconnect, so a crashed/drained/finished worker lingers as a `Succeeded`/`Failed` pod. `ListWarmPods` had no phase filter and the reconciler counted it as present → `have==target` → **never created a replacement**. Any control-plane restart terminated every warm agent → all pods terminal → pool permanently "satisfied" but empty.
**Fix:** `WarmPodInfo.Terminal` (from pod phase); `reconcileVersion` reaps every terminal pod unconditionally (no leak; drain path included) and drives create/delete-excess off the **live** count only. Regression: target=2 with 2 terminal + 0 live → **creates 2 + deletes 2** (was: creates 0).

## M3 — unjoined heartbeat goroutine clobbers the next attempt's token
The per-attempt heartbeat goroutine was started but never joined. In warm mode `r.Token` is the **shared** `AttemptTokens`, swapped per attempt; a lingering heartbeat finishing `Token.Set` after attempt N+1 adopted its token made N+1 run under N's superseded credential (refutes the "sequential ⇒ race-free" claim — it ignored the async heartbeat writer).
**Fix:** `execute()` joins the heartbeat — `WaitGroup` + a single deferred func doing `cancel()` **then** `Wait()` — so the in-flight `Set` finishes before the attempt returns. `Runner.Token` retyped to a minimal `tokenSetter` interface for test injection (only production use is `.Set()`; `*TokenSource` satisfies it) — no behavior change. Regression (`TestRunOneAttemptJoinsHeartbeat`, gated-Set seam): while a heartbeat `Set` is in-flight, `runOneAttempt` has **not** returned (was: returned early). Single-shot unchanged; **`-race` clean**.

## Verification
`go vet ./...` **and** `-tags integration` both clean · build + `-tags integration` green · `go test` executor+agent green · `go test -race ./internal/agent/...` clean · `golangci-lint` 0 issues · no proto change.

Remaining review findings (H2/H3/H4/M1/M2/M4) are the expanded scope of **N1d-a** (durable attempt→worker binding + reaper fan-out) — next.