### PR TITLE
feat(warm): durable attempt→worker binding, persisted on ack (ADR 0058 N1d-a1)

### DIFF
--- a/cmd/leoflow-agent/main.go
+++ b/cmd/leoflow-agent/main.go
@@ -224,10 +224,14 @@ func runWarm(ctx context.Context, streamClient agentv1.AgentServiceClient, addr,
 		NewSink: func(ctx context.Context) (agent.LogSink, error) {
 			return agent.OpenLogSink(ctx, workClient)
 		},
-		Cmd:                agent.NewExecRunner(),
-		Hostname:           hostname,
-		Version:            version.Get().Version,
-		Env:                os.Environ(),
+		Cmd:      agent.NewExecRunner(),
+		Hostname: hostname,
+		Version:  version.Get().Version,
+		Env:      os.Environ(),
+		// The pod's own name, injected by BuildWarmPod via the downward API. Sent
+		// up in WorkerRegister so the control plane binds a started attempt to it
+		// as the durable warm_worker_id (ADR 0058 N1d-a1). Empty off-cluster.
+		PodName:            os.Getenv("LEOFLOW_POD_NAME"),
 		ScratchDir:         scratchDir,
 		TerminationLogPath: os.Getenv("LEOFLOW_TERMINATION_LOG_PATH"),
 		HeartbeatInterval:  agent.DefaultHeartbeatInterval,

--- a/internal/agent/heartbeat_roundtrip_test.go
+++ b/internal/agent/heartbeat_roundtrip_test.go
@@ -27,6 +27,9 @@ func (stubStore) ReportState(context.Context, auth.AgentIdentity, domain.TaskSta
 }
 func (stubStore) Reschedule(context.Context, auth.AgentIdentity, time.Time) error { return nil }
 func (stubStore) RecordHeartbeat(context.Context, auth.AgentIdentity) error       { return nil }
+func (stubStore) BindWarmAttempt(context.Context, string, string, int, string) error {
+	return nil
+}
 
 // recordingAuth wraps a real authenticator and records every raw bearer the
 // server was asked to verify, so a test can prove which token the agent sent on

--- a/internal/agent/warm.go
+++ b/internal/agent/warm.go
@@ -51,6 +51,13 @@ type WarmRunner struct {
 	Version  string
 	Env      []string // base process environment (typically os.Environ())
 
+	// PodName is the worker's OWN Kubernetes pod name, read from LEOFLOW_POD_NAME
+	// (injected via the downward API) in main.go. It is sent up in WorkerRegister
+	// so the control plane can bind a started attempt to it as the durable
+	// warm_worker_id (ADR 0058 N1d-a1). Empty outside Kubernetes (e.g. tests); the
+	// binding then simply degrades to per-pod liveness for this worker.
+	PodName string
+
 	// ScratchDir is the agent-owned per-attempt scratch root. It is wiped and
 	// recreated before every attempt (D4 isolation) and holds the return-value,
 	// extra-links, xcom-pushes, and reschedule files the runtime writes.
@@ -84,7 +91,7 @@ func (w *WarmRunner) Run(ctx context.Context, dagVersionID string) error {
 	// serves, so the control plane only dispatches matching assignments to it.
 	if serr := stream.Send(&agentv1.WorkerMessage{
 		Msg: &agentv1.WorkerMessage_Register{
-			Register: &agentv1.WorkerRegister{DagVersionId: dagVersionID},
+			Register: &agentv1.WorkerRegister{DagVersionId: dagVersionID, PodName: w.PodName},
 		},
 	}); serr != nil {
 		return fmt.Errorf("sending worker register: %w", serr)

--- a/internal/agent/warm_test.go
+++ b/internal/agent/warm_test.go
@@ -201,6 +201,41 @@ func TestWarmWorkerServesTwoAttempts(t *testing.T) {
 	}
 }
 
+// TestWarmWorkerRegisterCarriesPodName locks the durable-binding key on the wire
+// (ADR 0058 N1d-a1): the worker's own pod name (from LEOFLOW_POD_NAME, threaded
+// in as WarmRunner.PodName) rides in WorkerRegister.pod_name so the control plane
+// can bind a started attempt to it. No assignments follow, so Run registers and
+// exits on the stream's EOF.
+func TestWarmWorkerRegisterCarriesPodName(t *testing.T) {
+	stream := &fakeAssignmentStream{ctx: context.Background()} // empty => immediate io.EOF
+	client := &warmFake{fakeClient: &fakeClient{}, stream: stream, tokens: NewTokenSource("bootstrap")}
+
+	w := &WarmRunner{
+		StreamClient:  client,
+		WorkClient:    client,
+		AttemptTokens: NewTokenSource("bootstrap"),
+		Cmd:           &scratchProbeCmd{scratchDir: filepath.Join(t.TempDir(), "scratch")},
+		Hostname:      "warm-pod-1",
+		Version:       "test",
+		PodName:       "leoflow-warm-dv-abc-x7k2",
+		ScratchDir:    filepath.Join(t.TempDir(), "scratch"),
+	}
+
+	if err := w.Run(context.Background(), "dagver-1"); err != nil {
+		t.Fatalf("WarmRunner.Run: %v", err)
+	}
+	if len(stream.sent) == 0 {
+		t.Fatal("worker sent no messages; expected a WorkerRegister")
+	}
+	reg := stream.sent[0].GetRegister()
+	if reg == nil {
+		t.Fatalf("first message must be a WorkerRegister, got %+v", stream.sent[0])
+	}
+	if reg.GetPodName() != "leoflow-warm-dv-abc-x7k2" {
+		t.Errorf("WorkerRegister.pod_name = %q, want leoflow-warm-dv-abc-x7k2", reg.GetPodName())
+	}
+}
+
 // TestRunnerRunIsRegisterThenOneAttempt locks the single-shot refactor: Run must
 // still be exactly "register, then run one attempt" — one GetTaskSpec, one
 // RUNNING→SUCCESS pair — with no warm-loop behavior leaking in.

--- a/internal/agentrpc/await_assignment.go
+++ b/internal/agentrpc/await_assignment.go
@@ -1,6 +1,7 @@
 package agentrpc
 
 import (
+	"context"
 	"errors"
 	"io"
 	"log/slog"
@@ -102,9 +103,14 @@ func (s *Server) registerFromStream(stream agentv1.AgentService_AwaitAssignmentS
 	if dagVersion == "" {
 		return nil, status.Error(codes.InvalidArgument, "worker register missing dag_version_id")
 	}
+	// pod_name is the worker's own downward-API pod name, the durable key a started
+	// attempt is bound to (ADR 0058 N1d-a1). It is a locator, not a credential — the
+	// identity above still governs authorization — so an empty value only means the
+	// binding degrades to per-pod liveness for this worker, never a refusal.
+	podName := reg.GetPodName()
 	send := make(chan *agentv1.WorkAssignment, 1)
-	worker := s.warmPools.Register(identity, dagVersion, send)
-	slog.Info("warm worker registered", "identity", identity, "dag_version", dagVersion)
+	worker := s.warmPools.Register(identity, dagVersion, podName, send)
+	slog.Info("warm worker registered", "identity", identity, "dag_version", dagVersion, "pod_name", podName)
 	return worker, nil
 }
 
@@ -119,12 +125,28 @@ func (s *Server) pumpWorkerMessages(stream agentv1.AgentService_AwaitAssignmentS
 		}
 		switch m := msg.Msg.(type) {
 		case *agentv1.WorkerMessage_Ack:
-			s.warmPools.Ack(m.Ack.GetAssignmentId(), m.Ack.GetStarted())
+			if binding, ok := s.warmPools.Ack(m.Ack.GetAssignmentId(), m.Ack.GetStarted()); ok {
+				s.bindWarmAttempt(stream.Context(), binding)
+			}
 		case *agentv1.WorkerMessage_SlotFree:
 			s.warmPools.MarkFree(identity)
 		case *agentv1.WorkerMessage_Register:
 			// A re-registration on an established stream is redundant; the worker is
 			// already keyed by its authenticated identity. Ignore.
 		}
+	}
+}
+
+// bindWarmAttempt persists the durable warm-attempt binding a started ack
+// established (ADR 0058 N1d-a1): warm_worker_id on the running TI names the warm
+// pod now serving the attempt, so a later failover reaper can recover which
+// attempts a dead warm pod held. It is BEST-EFFORT — a persist failure is logged
+// and swallowed, never fatal to the live stream: a DB blip must not tear down a
+// worker that is already running the attempt. The reaper degrades gracefully to
+// per-pod liveness for an attempt whose binding did not land.
+func (s *Server) bindWarmAttempt(ctx context.Context, b *WarmBinding) {
+	if err := s.store.BindWarmAttempt(ctx, b.RunID, b.TaskID, b.TryNumber, b.PodName); err != nil {
+		slog.Warn("persisting warm attempt binding (best-effort; worker keeps serving)",
+			"run", b.RunID, "task", b.TaskID, "try", b.TryNumber, "pod_name", b.PodName, "error", err)
 	}
 }

--- a/internal/agentrpc/await_assignment_test.go
+++ b/internal/agentrpc/await_assignment_test.go
@@ -59,6 +59,12 @@ func regMsg(dagVersion string) *agentv1.WorkerMessage {
 	}}
 }
 
+func regMsgPod(dagVersion, podName string) *agentv1.WorkerMessage {
+	return &agentv1.WorkerMessage{Msg: &agentv1.WorkerMessage_Register{
+		Register: &agentv1.WorkerRegister{DagVersionId: dagVersion, PodName: podName},
+	}}
+}
+
 func ackMsg(assignmentID string, started bool) *agentv1.WorkerMessage {
 	return &agentv1.WorkerMessage{Msg: &agentv1.WorkerMessage_Ack{
 		Ack: &agentv1.AssignmentAck{AssignmentId: assignmentID, Started: started},
@@ -160,13 +166,23 @@ func TestAckStartedWithinLeaseMarksBusyNoReclaim(t *testing.T) {
 	reg.leaseFor = func(*agentv1.WorkAssignment) time.Duration { return time.Hour } // long lease
 
 	send := make(chan *agentv1.WorkAssignment, 1)
-	reg.Register("w1", "v1", send)
-	if !reg.Assign("v1", &agentv1.WorkAssignment{AssignmentId: "as-1"}) {
+	reg.Register("w1", "v1", "pod-1", send)
+	// The assignment carries the attempt identity (run/task/try); the lease must
+	// carry it through so a started ack can return it as the binding to persist.
+	if !reg.Assign("v1", &agentv1.WorkAssignment{
+		AssignmentId: "as-1", DagRunId: "run-1", TaskId: "extract", TryNumber: 2,
+	}) {
 		t.Fatal("Assign should succeed")
 	}
 	<-send // drain the delivered assignment
-	reg.Ack("as-1", true)
+	binding, ok := reg.Ack("as-1", true)
 
+	if !ok || binding == nil {
+		t.Fatalf("Ack(started=true) = (%+v, %v), want a non-nil binding + ok=true", binding, ok)
+	}
+	if binding.RunID != "run-1" || binding.TaskID != "extract" || binding.TryNumber != 2 || binding.PodName != "pod-1" {
+		t.Fatalf("binding = %+v, want run-1/extract/2/pod-1 (the attempt identity + the worker's pod name)", binding)
+	}
 	if !reg.busy("w1") {
 		t.Fatal("worker should be marked busy after ack started=true")
 	}
@@ -185,7 +201,7 @@ func TestLeaseExpiryReclaims(t *testing.T) {
 	reg.leaseFor = func(*agentv1.WorkAssignment) time.Duration { return 5 * time.Millisecond }
 
 	send := make(chan *agentv1.WorkAssignment, 1)
-	reg.Register("w1", "v1", send)
+	reg.Register("w1", "v1", "pod-1", send)
 	reg.Assign("v1", &agentv1.WorkAssignment{AssignmentId: "as-1", DagVersionId: "v1"})
 	<-send
 
@@ -207,11 +223,14 @@ func TestAckRefusedReclaims(t *testing.T) {
 	reg.leaseFor = func(*agentv1.WorkAssignment) time.Duration { return time.Hour }
 
 	send := make(chan *agentv1.WorkAssignment, 1)
-	reg.Register("w1", "v1", send)
+	reg.Register("w1", "v1", "pod-1", send)
 	reg.Assign("v1", &agentv1.WorkAssignment{AssignmentId: "as-1", DagVersionId: "v1"})
 	<-send
-	reg.Ack("as-1", false)
+	binding, ok := reg.Ack("as-1", false)
 
+	if ok || binding != nil {
+		t.Fatalf("Ack(started=false) = (%+v, %v), want (nil, false) — a refusal binds nothing", binding, ok)
+	}
 	select {
 	case ev := <-reclaims:
 		if ev.AssignmentID != "as-1" || ev.Reason != ReclaimRefused {
@@ -262,4 +281,74 @@ func TestAwaitAssignmentReconnectSameIdentitySingleEntry(t *testing.T) {
 	if reg.size() != 1 {
 		t.Fatalf("reconnect same identity: registry size = %d, want 1", reg.size())
 	}
+}
+
+// ─── (j) started ack => handler persists the durable binding ────────────────
+
+// TestAwaitAssignmentPersistsBindingOnStartedAck is the handler seam: when a
+// worker acks an assignment as started, pumpWorkerMessages must call the store's
+// BindWarmAttempt with the assignment's (run, task, try) and the worker's pod
+// name (from WorkerRegister.pod_name), so the binding is durable for the reaper.
+func TestAwaitAssignmentPersistsBindingOnStartedAck(t *testing.T) {
+	store := &fakeStore{}
+	srv, a := newServer(store)
+	reg := NewWorkerRegistry(nil)
+	reg.leaseFor = func(*agentv1.WorkAssignment) time.Duration { return time.Hour } // no reclaim mid-test
+	srv.SetWarmPools(reg)
+
+	stream := newFakeAwaitStream(ctxWithToken(t, a))
+	stream.pushMsg(regMsgPod("dagver-1", "warm-pod-7"))
+	go func() { _ = srv.AwaitAssignment(stream) }()
+	awaitEventually(t, func() bool { return reg.registered("ti-1") })
+
+	if !reg.Assign("dagver-1", &agentv1.WorkAssignment{
+		AssignmentId: "as-9", DagRunId: "run-42", TaskId: "load", TryNumber: 3, LeaseSeconds: 3600,
+	}) {
+		t.Fatal("Assign should succeed against the registered worker")
+	}
+	<-stream.sent // handler delivered the assignment down the stream
+
+	stream.pushMsg(ackMsg("as-9", true))
+
+	awaitEventually(t, func() bool { return len(store.warmBindingCalls()) == 1 })
+	got := store.warmBindingCalls()[0]
+	if got.runID != "run-42" || got.taskID != "load" || got.tryNumber != 3 || got.workerPod != "warm-pod-7" {
+		t.Fatalf("BindWarmAttempt call = %+v, want run-42/load/3/warm-pod-7", got)
+	}
+	stream.pushErr(io.EOF)
+}
+
+// TestAwaitAssignmentDoesNotPersistOnRefusedAck: a started=false ack reclaims
+// and binds nothing — the store's BindWarmAttempt must not be called.
+func TestAwaitAssignmentDoesNotPersistOnRefusedAck(t *testing.T) {
+	store := &fakeStore{}
+	srv, a := newServer(store)
+	reclaims := make(chan ReclaimEvent, 1)
+	reg := NewWorkerRegistry(func(ev ReclaimEvent) { reclaims <- ev })
+	reg.leaseFor = func(*agentv1.WorkAssignment) time.Duration { return time.Hour }
+	srv.SetWarmPools(reg)
+
+	stream := newFakeAwaitStream(ctxWithToken(t, a))
+	stream.pushMsg(regMsgPod("dagver-1", "warm-pod-7"))
+	go func() { _ = srv.AwaitAssignment(stream) }()
+	awaitEventually(t, func() bool { return reg.registered("ti-1") })
+
+	if !reg.Assign("dagver-1", &agentv1.WorkAssignment{
+		AssignmentId: "as-9", DagRunId: "run-42", TaskId: "load", TryNumber: 3, LeaseSeconds: 3600,
+	}) {
+		t.Fatal("Assign should succeed")
+	}
+	<-stream.sent
+	stream.pushMsg(ackMsg("as-9", false))
+
+	// The refusal is observed as a reclaim; no binding is persisted.
+	select {
+	case <-reclaims:
+	case <-time.After(time.Second):
+		t.Fatal("expected a reclaim on refused ack")
+	}
+	if n := len(store.warmBindingCalls()); n != 0 {
+		t.Fatalf("BindWarmAttempt calls = %d, want 0 on a refused ack", n)
+	}
+	stream.pushErr(io.EOF)
 }

--- a/internal/agentrpc/server.go
+++ b/internal/agentrpc/server.go
@@ -116,6 +116,13 @@ type Store interface {
 	// scheduler's heartbeat reaper (#128) can tell live tasks from agent-lost
 	// ones. The state guard inside the SQL skips already-terminal rows.
 	RecordHeartbeat(ctx context.Context, id auth.AgentIdentity) error
+	// BindWarmAttempt records the durable warm-attempt binding (ADR 0058 N1d-a1):
+	// the warm worker pod (workerPod) that acked this attempt (runID, taskID,
+	// tryNumber) as started. The write is guarded on active state, so a settled
+	// attempt is never bound (a benign no-op, not an error). Called only on a warm
+	// ack — with warm pools off no assignment is ever acked, so it is never called
+	// and warm_worker_id stays NULL.
+	BindWarmAttempt(ctx context.Context, runID, taskID string, tryNumber int, workerPod string) error
 }
 
 // XComService stores and retrieves XCom values for the agent.

--- a/internal/agentrpc/server_test.go
+++ b/internal/agentrpc/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"sync"
 	"testing"
 	"time"
 
@@ -29,6 +30,18 @@ type fakeStore struct {
 	rescheduleErr error
 	heartbeats    []auth.AgentIdentity
 	heartbeatErr  error
+	// warm bindings are recorded from the AwaitAssignment pump goroutine while the
+	// test asserts from its own goroutine, so this slice needs its own lock.
+	warmMu       sync.Mutex
+	warmBindings []warmBindingCall
+	bindWarmErr  error
+}
+
+type warmBindingCall struct {
+	runID     string
+	taskID    string
+	tryNumber int
+	workerPod string
 }
 
 type reportedState struct {
@@ -60,6 +73,21 @@ func (s *fakeStore) Reschedule(_ context.Context, id auth.AgentIdentity, at time
 func (s *fakeStore) RecordHeartbeat(_ context.Context, id auth.AgentIdentity) error {
 	s.heartbeats = append(s.heartbeats, id)
 	return s.heartbeatErr
+}
+
+func (s *fakeStore) BindWarmAttempt(_ context.Context, runID, taskID string, tryNumber int, workerPod string) error {
+	s.warmMu.Lock()
+	s.warmBindings = append(s.warmBindings, warmBindingCall{runID, taskID, tryNumber, workerPod})
+	s.warmMu.Unlock()
+	return s.bindWarmErr
+}
+
+// warmBindingCalls returns a snapshot of the recorded BindWarmAttempt calls,
+// taken under the lock so a polling assertion never races the pump goroutine.
+func (s *fakeStore) warmBindingCalls() []warmBindingCall {
+	s.warmMu.Lock()
+	defer s.warmMu.Unlock()
+	return append([]warmBindingCall(nil), s.warmBindings...)
 }
 
 func testIdentity() auth.AgentIdentity {

--- a/internal/agentrpc/tls_test.go
+++ b/internal/agentrpc/tls_test.go
@@ -89,6 +89,9 @@ func (tlsFakeStore) ReportState(context.Context, auth.AgentIdentity, domain.Task
 }
 func (tlsFakeStore) Reschedule(context.Context, auth.AgentIdentity, time.Time) error { return nil }
 func (tlsFakeStore) RecordHeartbeat(context.Context, auth.AgentIdentity) error       { return nil }
+func (tlsFakeStore) BindWarmAttempt(context.Context, string, string, int, string) error {
+	return nil
+}
 
 type tlsNoXCom struct{}
 

--- a/internal/agentrpc/worker_registry.go
+++ b/internal/agentrpc/worker_registry.go
@@ -31,21 +31,43 @@ type ReclaimEvent struct {
 	Reason       ReclaimReason
 }
 
+// WarmBinding is the durable binding an ack (started=true) establishes: the warm
+// worker pod (PodName) now serving a specific attempt (RunID, TaskID, TryNumber).
+// The handler persists it (BindWarmAttempt) so a later failover reaper can match
+// bound attempts against the live warm-pod set (ADR 0058 N1d-a1). PodName is the
+// worker's own downward-API pod name it sent in WorkerRegister — the reaper's join
+// key against ListWarmPods — NOT the registry's authenticated identity.
+type WarmBinding struct {
+	RunID     string
+	TaskID    string
+	TryNumber int
+	PodName   string
+}
+
 // registeredWorker is one warm worker's registry entry. send is the handler's
 // outbound assignment channel; the handler owns Send()ing what lands on it.
 type registeredWorker struct {
 	identity   string
 	dagVersion string
-	send       chan *agentv1.WorkAssignment
+	// podName is the worker's OWN Kubernetes pod name (WorkerRegister.pod_name,
+	// sourced from the downward API). It is the durable key a started attempt is
+	// bound to; distinct from identity, which is the authenticated stream credential.
+	podName string
+	send    chan *agentv1.WorkAssignment
 	// busy is set once the worker acks an assignment as started; it is cleared
 	// when the worker signals SlotFree.
 	busy bool
 }
 
-// leaseState tracks one in-flight assignment awaiting an ack.
+// leaseState tracks one in-flight assignment awaiting an ack. It carries the
+// assignment's attempt identity (runID, taskID, tryNumber) so a started ack can
+// return the WarmBinding to persist without the handler re-deriving it.
 type leaseState struct {
 	worker     *registeredWorker
 	dagVersion string
+	runID      string
+	taskID     string
+	tryNumber  int
 	timer      *time.Timer
 }
 
@@ -85,10 +107,11 @@ func NewWorkerRegistry(onReclaim func(ReclaimEvent)) *WorkerRegistry {
 }
 
 // Register records a warm worker under its authenticated identity, ready to take
-// work for dagVersion. Idempotent: a reconnect with the same identity replaces
+// work for dagVersion. podName is the worker's own pod name, carried so a started
+// ack can bind the attempt to it. Idempotent: a reconnect with the same identity replaces
 // the prior entry (never adds a second), and the fresh entry starts free. It
 // returns the entry so the caller can Deregister exactly the entry it created.
-func (r *WorkerRegistry) Register(identity, dagVersion string, send chan *agentv1.WorkAssignment) *registeredWorker {
+func (r *WorkerRegistry) Register(identity, dagVersion, podName string, send chan *agentv1.WorkAssignment) *registeredWorker {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if old, ok := r.workers[identity]; ok {
@@ -96,7 +119,7 @@ func (r *WorkerRegistry) Register(identity, dagVersion string, send chan *agentv
 		// keeps its own timer and reclaims independently.
 		r.removeFreeLocked(old)
 	}
-	w := &registeredWorker{identity: identity, dagVersion: dagVersion, send: send}
+	w := &registeredWorker{identity: identity, dagVersion: dagVersion, podName: podName, send: send}
 	r.workers[identity] = w
 	r.addFreeLocked(w)
 	return w
@@ -155,33 +178,49 @@ func (r *WorkerRegistry) Assign(dagVersion string, a *agentv1.WorkAssignment) bo
 		return false
 	}
 	aid := a.GetAssignmentId()
-	ls := &leaseState{worker: w, dagVersion: dagVersion}
+	ls := &leaseState{
+		worker:     w,
+		dagVersion: dagVersion,
+		runID:      a.GetDagRunId(),
+		taskID:     a.GetTaskId(),
+		tryNumber:  int(a.GetTryNumber()),
+	}
 	ls.timer = time.AfterFunc(r.leaseFor(a), func() { r.onLeaseExpire(aid) })
 	r.leases[aid] = ls
 	r.mu.Unlock()
 	return true
 }
 
-// Ack settles the lease for assignmentID. started=true marks the worker busy and
-// cancels the lease (no reclaim). started=false reclaims the assignment. An ack
-// for an unknown assignment (already expired or already settled) is ignored.
-func (r *WorkerRegistry) Ack(assignmentID string, started bool) {
+// Ack settles the lease for assignmentID. started=true marks the worker busy,
+// cancels the lease (no reclaim), and returns the WarmBinding to persist — the
+// acked attempt's (run, task, try) plus the worker's pod name — with ok=true.
+// started=false reclaims the assignment and returns ok=false. An ack for an
+// unknown assignment (already expired or already settled) also returns ok=false.
+// Only ok=true carries a non-nil binding the handler should persist.
+func (r *WorkerRegistry) Ack(assignmentID string, started bool) (*WarmBinding, bool) {
 	r.mu.Lock()
 	ls, ok := r.leases[assignmentID]
 	if !ok {
 		r.mu.Unlock()
-		return
+		return nil, false
 	}
 	delete(r.leases, assignmentID)
 	ls.timer.Stop()
 	if started {
 		ls.worker.busy = true
+		binding := &WarmBinding{
+			RunID:     ls.runID,
+			TaskID:    ls.taskID,
+			TryNumber: ls.tryNumber,
+			PodName:   ls.worker.podName,
+		}
 		r.mu.Unlock()
-		return
+		return binding, true
 	}
 	dagVersion := ls.dagVersion
 	r.mu.Unlock()
 	r.emitReclaim(ReclaimEvent{AssignmentID: assignmentID, DagVersionID: dagVersion, Reason: ReclaimRefused})
+	return nil, false
 }
 
 // MarkFree records a worker's SlotFree signal: it clears busy and returns the

--- a/internal/executor/warmpod.go
+++ b/internal/executor/warmpod.go
@@ -149,10 +149,22 @@ func warmPodEnv(spec WarmPodSpec) []corev1.EnvVar {
 	tok := spec.agentToken()
 	env = append(env, tok.env()...)
 	env = append(env, tok.pathEnv()...)
-	// Select the agent's warm-worker loop for this dag_version pool.
+	// Select the agent's warm-worker loop for this dag_version pool, and inject the
+	// worker's OWN pod name via the Kubernetes downward API (ADR 0058 N1d-a1). The
+	// agent forwards LEOFLOW_POD_NAME in WorkerRegister.pod_name; the control plane
+	// binds a started attempt to it (warm_worker_id) so a later failover reaper can
+	// match the attempt against the live warm-pod set. The pod name is not known at
+	// build time (it carries a random suffix), so it must come from the downward
+	// API's metadata.name rather than a literal value.
 	env = append(env,
 		corev1.EnvVar{Name: "LEOFLOW_WARM_WORKER", Value: "1"},
 		corev1.EnvVar{Name: "LEOFLOW_DAG_VERSION_ID", Value: spec.DagVersionID},
+		corev1.EnvVar{
+			Name: "LEOFLOW_POD_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+			},
+		},
 	)
 	if spec.AgentTLSCAConfigMap != "" {
 		env = append(env,

--- a/internal/executor/warmpod_test.go
+++ b/internal/executor/warmpod_test.go
@@ -17,6 +17,41 @@ func warmEnvMap(pod *corev1.Pod) map[string]string {
 	return m
 }
 
+// warmEnvVar returns the full EnvVar named name from the warm pod's container, so
+// a test can inspect ValueFrom (downward-API sources carry no literal Value).
+func warmEnvVar(pod *corev1.Pod, name string) (corev1.EnvVar, bool) {
+	for _, e := range pod.Spec.Containers[0].Env {
+		if e.Name == name {
+			return e, true
+		}
+	}
+	return corev1.EnvVar{}, false
+}
+
+// TestBuildWarmPodInjectsPodNameViaDownwardAPI locks the durable-binding key
+// plumbing (ADR 0058 N1d-a1): the worker learns its OWN pod name through the
+// Kubernetes downward API as LEOFLOW_POD_NAME (fieldRef metadata.name), since the
+// name — carrying a random suffix — is unknown at build time. The agent forwards
+// it in WorkerRegister.pod_name so the control plane can bind a started attempt
+// to it as warm_worker_id.
+func TestBuildWarmPodInjectsPodNameViaDownwardAPI(t *testing.T) {
+	pod := BuildWarmPod(baseWarmSpec())
+
+	ev, ok := warmEnvVar(pod, "LEOFLOW_POD_NAME")
+	if !ok {
+		t.Fatal("warm pod must carry LEOFLOW_POD_NAME env for the durable binding key")
+	}
+	if ev.Value != "" {
+		t.Errorf("LEOFLOW_POD_NAME must be sourced from the downward API, not a literal value (got %q)", ev.Value)
+	}
+	if ev.ValueFrom == nil || ev.ValueFrom.FieldRef == nil {
+		t.Fatalf("LEOFLOW_POD_NAME must use valueFrom.fieldRef, got %+v", ev.ValueFrom)
+	}
+	if got := ev.ValueFrom.FieldRef.FieldPath; got != "metadata.name" {
+		t.Errorf("LEOFLOW_POD_NAME fieldRef.fieldPath = %q, want metadata.name", got)
+	}
+}
+
 // baseWarmSpec is a minimal env-var-transport warm spec used across the cases.
 func baseWarmSpec() WarmPodSpec {
 	return WarmPodSpec{

--- a/internal/storage/agent_store.go
+++ b/internal/storage/agent_store.go
@@ -221,6 +221,36 @@ func (s *ExecutionStore) RecordHeartbeat(ctx context.Context, id auth.AgentIdent
 	return nil
 }
 
+// BindWarmAttempt records the durable warm-attempt binding (ADR 0058 N1d-a1): the
+// warm worker pod (workerPod, its own downward-API pod name) that acked this
+// attempt as started, stamped onto warm_worker_id so a later failover reaper can
+// tell which running attempts a dead warm pod held. The UPDATE is guarded on
+// state IN ('queued', 'running'), so a settled attempt is never bound — an ack
+// that races a reaper settling the row is a benign no-op (zero rows), not an
+// error. It is written ONLY on a warm ack; a dedicated-pod attempt (and every
+// attempt while warm pools are off) leaves warm_worker_id NULL.
+//
+// N1d-a2 deferral: warm_worker_id is intentionally NOT cleared when the attempt
+// settles. The consuming reaper filters on state, so a lingering value on a
+// terminal TI is harmless; a settle-time clear is left to that increment.
+func (s *ExecutionStore) BindWarmAttempt(ctx context.Context, runID, taskID string, tryNumber int, workerPod string) error {
+	rid, err := parseUUID(runID)
+	if err != nil {
+		return err
+	}
+	pod := workerPod
+	_, err = s.q.BindWarmAttempt(ctx, queries.BindWarmAttemptParams{
+		DagRunID:     rid,
+		TaskID:       taskID,
+		TryNumber:    toInt32(tryNumber),
+		WarmWorkerID: &pod,
+	})
+	// Zero rows is the guard working, not a failure: the attempt already moved on
+	// (terminal or superseded), so there is nothing to bind. Only a real DB error
+	// propagates; the caller (best-effort) logs it and keeps the worker serving.
+	return err
+}
+
 // IsTaskInstanceLive reports whether the attempt (runID, taskID, tryNumber) is
 // still live — present and in an active (non-terminal) state — derived from the
 // same predicate RecordHeartbeat writes on, but as a pure read with no

--- a/internal/storage/queries/models.go
+++ b/internal/storage/queries/models.go
@@ -350,6 +350,7 @@ type TaskInstance struct {
 	NextDispatchAt    pgtype.Timestamptz `json:"next_dispatch_at"`
 	LastFailureKind   *string            `json:"last_failure_kind"`
 	InfraAttempts     int32              `json:"infra_attempts"`
+	WarmWorkerID      *string            `json:"warm_worker_id"`
 }
 
 type TaskInstanceHistory struct {

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -13,6 +13,19 @@ import (
 type Querier interface {
 	AddFavorite(ctx context.Context, arg AddFavoriteParams) error
 	AssignUserRole(ctx context.Context, arg AssignUserRoleParams) error
+	// Records the durable warm-attempt binding (ADR 0058 N1d-a1): the warm worker
+	// pod ($4, its own downward-API pod name) that acked THIS attempt (dag_run_id,
+	// task_id, try_number) as started. A later failover reaper matches warm_worker_id
+	// against the live warm-pod set to find attempts a dead warm pod held.
+	//
+	// Guarded on state IN ('queued', 'running') — the same active predicate the
+	// heartbeat and liveness queries use — so a settled attempt is never bound: an
+	// ack that races a reaper settling the row must not stamp a worker onto a
+	// terminal TI. Bounded by (dag_run_id, task_id, try_number) to match exactly the
+	// attempt the assignment named. Returns the affected row count; zero means the
+	// attempt already moved on (terminal or superseded), and the caller treats that
+	// as a benign no-op, never an error.
+	BindWarmAttempt(ctx context.Context, arg BindWarmAttemptParams) (int64, error)
 	// Atomically claim one on-failure ATTEMPT for a run, returning the row iff this
 	// call won it. Replaces the old claim-then-send (#431), which set alerted_at
 	// before the send and so lost the page whenever the send failed.

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -713,6 +713,26 @@ SELECT EXISTS (
       AND state IN ('queued', 'running')
 );
 
+-- name: BindWarmAttempt :execrows
+-- Records the durable warm-attempt binding (ADR 0058 N1d-a1): the warm worker
+-- pod ($4, its own downward-API pod name) that acked THIS attempt (dag_run_id,
+-- task_id, try_number) as started. A later failover reaper matches warm_worker_id
+-- against the live warm-pod set to find attempts a dead warm pod held.
+--
+-- Guarded on state IN ('queued', 'running') — the same active predicate the
+-- heartbeat and liveness queries use — so a settled attempt is never bound: an
+-- ack that races a reaper settling the row must not stamp a worker onto a
+-- terminal TI. Bounded by (dag_run_id, task_id, try_number) to match exactly the
+-- attempt the assignment named. Returns the affected row count; zero means the
+-- attempt already moved on (terminal or superseded), and the caller treats that
+-- as a benign no-op, never an error.
+UPDATE task_instances
+SET warm_worker_id = $4
+WHERE dag_run_id = $1
+  AND task_id = $2
+  AND try_number = $3
+  AND state IN ('queued', 'running');
+
 -- name: ListAgentLostCandidates :many
 -- Lists running TIs that have heartbeated at least once and whose latest
 -- heartbeat is non-null, alongside enough identity to log + observe.

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -11,6 +11,47 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const bindWarmAttempt = `-- name: BindWarmAttempt :execrows
+UPDATE task_instances
+SET warm_worker_id = $4
+WHERE dag_run_id = $1
+  AND task_id = $2
+  AND try_number = $3
+  AND state IN ('queued', 'running')
+`
+
+type BindWarmAttemptParams struct {
+	DagRunID     pgtype.UUID `json:"dag_run_id"`
+	TaskID       string      `json:"task_id"`
+	TryNumber    int32       `json:"try_number"`
+	WarmWorkerID *string     `json:"warm_worker_id"`
+}
+
+// Records the durable warm-attempt binding (ADR 0058 N1d-a1): the warm worker
+// pod ($4, its own downward-API pod name) that acked THIS attempt (dag_run_id,
+// task_id, try_number) as started. A later failover reaper matches warm_worker_id
+// against the live warm-pod set to find attempts a dead warm pod held.
+//
+// Guarded on state IN ('queued', 'running') — the same active predicate the
+// heartbeat and liveness queries use — so a settled attempt is never bound: an
+// ack that races a reaper settling the row must not stamp a worker onto a
+// terminal TI. Bounded by (dag_run_id, task_id, try_number) to match exactly the
+// attempt the assignment named. Returns the affected row count; zero means the
+// attempt already moved on (terminal or superseded), and the caller treats that
+// as a benign no-op, never an error.
+func (q *Queries) BindWarmAttempt(ctx context.Context, arg BindWarmAttemptParams) (int64, error) {
+	result, err := q.db.Exec(ctx, bindWarmAttempt,
+		arg.DagRunID,
+		arg.TaskID,
+		arg.TryNumber,
+		arg.WarmWorkerID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const claimAlertAttempt = `-- name: ClaimAlertAttempt :one
 UPDATE dag_runs
 SET alert_attempts = alert_attempts + 1,
@@ -276,7 +317,7 @@ func (q *Queries) CreateScheduledRunByDagID(ctx context.Context, arg CreateSched
 const createTaskInstance = `-- name: CreateTaskInstance :one
 INSERT INTO task_instances (tenant_id, dag_run_id, task_id, operator, max_tries, state, pool, try_number)
 VALUES ($1, $2, $3, $4, $5, $6, $7, 1)
-RETURNING id, tenant_id, dag_run_id, task_id, map_index, try_number, max_tries, state, pool, operator, queued_at, started_at, ended_at, duration_seconds, pod_name, node_name, exit_code, error_message, log_url, hostname, note, scheduled_at, last_heartbeat_at, reschedule_at, first_reschedule_at, dispatch_attempts, next_dispatch_at, last_failure_kind, infra_attempts
+RETURNING id, tenant_id, dag_run_id, task_id, map_index, try_number, max_tries, state, pool, operator, queued_at, started_at, ended_at, duration_seconds, pod_name, node_name, exit_code, error_message, log_url, hostname, note, scheduled_at, last_heartbeat_at, reschedule_at, first_reschedule_at, dispatch_attempts, next_dispatch_at, last_failure_kind, infra_attempts, warm_worker_id
 `
 
 type CreateTaskInstanceParams struct {
@@ -333,6 +374,7 @@ func (q *Queries) CreateTaskInstance(ctx context.Context, arg CreateTaskInstance
 		&i.NextDispatchAt,
 		&i.LastFailureKind,
 		&i.InfraAttempts,
+		&i.WarmWorkerID,
 	)
 	return i, err
 }
@@ -1092,7 +1134,7 @@ func (q *Queries) ListTaskInstanceAttempts(ctx context.Context, arg ListTaskInst
 }
 
 const listTaskInstancesByRun = `-- name: ListTaskInstancesByRun :many
-SELECT id, tenant_id, dag_run_id, task_id, map_index, try_number, max_tries, state, pool, operator, queued_at, started_at, ended_at, duration_seconds, pod_name, node_name, exit_code, error_message, log_url, hostname, note, scheduled_at, last_heartbeat_at, reschedule_at, first_reschedule_at, dispatch_attempts, next_dispatch_at, last_failure_kind, infra_attempts FROM task_instances
+SELECT id, tenant_id, dag_run_id, task_id, map_index, try_number, max_tries, state, pool, operator, queued_at, started_at, ended_at, duration_seconds, pod_name, node_name, exit_code, error_message, log_url, hostname, note, scheduled_at, last_heartbeat_at, reschedule_at, first_reschedule_at, dispatch_attempts, next_dispatch_at, last_failure_kind, infra_attempts, warm_worker_id FROM task_instances
 WHERE dag_run_id = $1
 ORDER BY task_id
 `
@@ -1136,6 +1178,7 @@ func (q *Queries) ListTaskInstancesByRun(ctx context.Context, dagRunID pgtype.UU
 			&i.NextDispatchAt,
 			&i.LastFailureKind,
 			&i.InfraAttempts,
+			&i.WarmWorkerID,
 		); err != nil {
 			return nil, err
 		}
@@ -2011,7 +2054,7 @@ const updateTaskInstanceState = `-- name: UpdateTaskInstanceState :one
 UPDATE task_instances
 SET state = $2, started_at = $3, ended_at = $4
 WHERE id = $1
-RETURNING id, tenant_id, dag_run_id, task_id, map_index, try_number, max_tries, state, pool, operator, queued_at, started_at, ended_at, duration_seconds, pod_name, node_name, exit_code, error_message, log_url, hostname, note, scheduled_at, last_heartbeat_at, reschedule_at, first_reschedule_at, dispatch_attempts, next_dispatch_at, last_failure_kind, infra_attempts
+RETURNING id, tenant_id, dag_run_id, task_id, map_index, try_number, max_tries, state, pool, operator, queued_at, started_at, ended_at, duration_seconds, pod_name, node_name, exit_code, error_message, log_url, hostname, note, scheduled_at, last_heartbeat_at, reschedule_at, first_reschedule_at, dispatch_attempts, next_dispatch_at, last_failure_kind, infra_attempts, warm_worker_id
 `
 
 type UpdateTaskInstanceStateParams struct {
@@ -2059,6 +2102,7 @@ func (q *Queries) UpdateTaskInstanceState(ctx context.Context, arg UpdateTaskIns
 		&i.NextDispatchAt,
 		&i.LastFailureKind,
 		&i.InfraAttempts,
+		&i.WarmWorkerID,
 	)
 	return i, err
 }

--- a/internal/storage/warm_binding_integration_test.go
+++ b/internal/storage/warm_binding_integration_test.go
@@ -1,0 +1,100 @@
+//go:build integration
+
+// Package storage_test — the write-side guard on the durable warm-attempt
+// binding (ADR 0058 N1d-a1).
+//
+// BindWarmAttempt stamps warm_worker_id — the warm pod now serving an attempt —
+// but ONLY while the (dag_run_id, task_id, try_number) tuple is still active
+// (queued/running). The guard lives in the UPDATE's WHERE clause, so a fake-store
+// unit test cannot prove it: only real Postgres shows that a settled attempt is
+// never bound. Two cases lock the contract — a live attempt is bound, a terminal
+// attempt is a no-op — so a later failover reaper never matches a stale pod name
+// onto an attempt that already moved on.
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/config"
+	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/storage"
+)
+
+// openExecPG mirrors openExec but also hands back the *Postgres so a test can read
+// warm_worker_id directly — no query exposes it, and reading it is the whole point.
+func openExecPG(t *testing.T) (*storage.Postgres, *storage.Repository, *storage.SchedulerStore, *storage.ExecutionStore, context.Context) {
+	t.Helper()
+	url := os.Getenv("DATABASE_URL")
+	if url == "" {
+		t.Skip("DATABASE_URL must point at a migrated database for integration tests")
+	}
+	ctx := context.Background()
+	pg, err := storage.NewPostgres(ctx, config.DatabaseSection{URL: url})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pg.Close)
+	return pg, storage.NewRepository(pg), storage.NewSchedulerStore(pg), storage.NewExecutionStore(pg), ctx
+}
+
+// warmWorkerID reads the warm_worker_id column for one attempt directly. A nil
+// return means the column is SQL NULL (never bound).
+func warmWorkerID(t *testing.T, pg *storage.Postgres, ctx context.Context, runUUID, taskID string, try int) *string {
+	t.Helper()
+	var got *string
+	err := pg.Pool.QueryRow(ctx,
+		`SELECT warm_worker_id FROM task_instances
+		 WHERE dag_run_id = $1::uuid AND task_id = $2 AND try_number = $3`,
+		runUUID, taskID, try).Scan(&got)
+	if err != nil {
+		t.Fatalf("reading warm_worker_id: %v", err)
+	}
+	return got
+}
+
+// TestBindWarmAttemptStampsRunningTI: the ordinary path — a running attempt is
+// bound to the warm pod that acked it, so warm_worker_id holds that pod name.
+func TestBindWarmAttemptStampsRunningTI(t *testing.T) {
+	pg, repo, sched, exec, ctx := openExecPG(t)
+	dagID := fmt.Sprintf("warm_bind_live_%d", time.Now().UnixNano())
+	runUUID := seedRunningTask(t, repo, sched, ctx, dagID, "load")
+
+	// Seed our own worker-pod name so the assertion is on a value this test owns,
+	// never on whatever another test may have left in a shared table.
+	wantPod := fmt.Sprintf("leoflow-warm-%d", time.Now().UnixNano())
+	if err := exec.BindWarmAttempt(ctx, runUUID, "load", 1, wantPod); err != nil {
+		t.Fatalf("BindWarmAttempt on a running TI = %v, want nil", err)
+	}
+
+	got := warmWorkerID(t, pg, ctx, runUUID, "load", 1)
+	if got == nil || *got != wantPod {
+		t.Fatalf("warm_worker_id = %v, want %q (a running attempt must be bound)", got, wantPod)
+	}
+}
+
+// TestBindWarmAttemptNoOpOnTerminalTI: once the attempt has settled terminal, the
+// guarded UPDATE matches zero rows — the pod name must NOT be stamped onto a
+// settled attempt (a benign no-op, not an error), so warm_worker_id stays NULL.
+func TestBindWarmAttemptNoOpOnTerminalTI(t *testing.T) {
+	pg, repo, sched, exec, ctx := openExecPG(t)
+	dagID := fmt.Sprintf("warm_bind_terminal_%d", time.Now().UnixNano())
+	runUUID := seedRunningTask(t, repo, sched, ctx, dagID, "load")
+
+	// A reaper settles the attempt terminal before the (late) ack lands.
+	if err := sched.ApplyTransition(ctx, runUUID, "load", domain.TaskStateFailed); err != nil {
+		t.Fatalf("ApplyTransition to failed: %v", err)
+	}
+
+	wantPod := fmt.Sprintf("leoflow-warm-%d", time.Now().UnixNano())
+	if err := exec.BindWarmAttempt(ctx, runUUID, "load", 1, wantPod); err != nil {
+		t.Fatalf("BindWarmAttempt on a terminal TI = %v, want nil (a guarded no-op is not an error)", err)
+	}
+
+	if got := warmWorkerID(t, pg, ctx, runUUID, "load", 1); got != nil {
+		t.Fatalf("warm_worker_id = %q, want NULL — a settled attempt must never be bound", *got)
+	}
+}

--- a/migrations/026_task_instance_warm_worker.down.sql
+++ b/migrations/026_task_instance_warm_worker.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE task_instances
+    DROP COLUMN IF EXISTS warm_worker_id;

--- a/migrations/026_task_instance_warm_worker.up.sql
+++ b/migrations/026_task_instance_warm_worker.up.sql
@@ -1,0 +1,15 @@
+-- Durable warm-attempt binding (ADR 0058 N1d-a1). When a warm worker acks an
+-- assignment as started, the control plane records WHICH warm pod is serving the
+-- attempt in warm_worker_id — the pod's own name, delivered to the worker via the
+-- downward API and sent up in WorkerRegister.pod_name. The binding is durable so a
+-- later failover reaper (N1d-a2) and the stale-queued reaper can tell, even after a
+-- leader failover, which running attempts a now-dead warm pod held, by matching
+-- warm_worker_id against the live warm-pod set ListWarmPods returns.
+--
+-- Nullable and written ONLY on a warm ack: a dedicated-pod attempt (the default,
+-- and every attempt while execution.warm_pools_enabled is off) never sets it, so
+-- the column stays NULL and today's behavior is byte-for-byte unchanged. It is
+-- distinct from pod_name (the dedicated task pod that ran an attempt): this names
+-- the long-lived warm WORKER pod, which serves many attempts across its life.
+ALTER TABLE task_instances
+    ADD COLUMN IF NOT EXISTS warm_worker_id TEXT;

--- a/proto/agent.proto
+++ b/proto/agent.proto
@@ -256,6 +256,14 @@ message WorkerMessage {
 // payload — a worker must not be able to claim an arbitrary identity here.
 message WorkerRegister {
     string dag_version_id = 1;
+    // pod_name is the worker's OWN Kubernetes pod name, delivered to the
+    // container via the downward API (LEOFLOW_POD_NAME). It is the durable key
+    // the control plane binds a started attempt to (warm_worker_id on the running
+    // TI) so a later reaper can match bound attempts against the live warm-pod set
+    // ListWarmPods returns, even after a leader failover. Unlike an identity, it
+    // is a locator, not a credential: the worker's authenticated identity still
+    // comes from its bearer token on the stream context, never from this field.
+    string pod_name = 2;
 }
 
 // AssignmentAck answers a WorkAssignment. started=true means the worker began the

--- a/proto/agent/v1/agent.pb.go
+++ b/proto/agent/v1/agent.pb.go
@@ -1557,8 +1557,16 @@ func (*WorkerMessage_SlotFree) isWorkerMessage_Msg() {}
 // authenticated pod/bootstrap credential on the stream context, NOT from this
 // payload — a worker must not be able to claim an arbitrary identity here.
 type WorkerRegister struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	DagVersionId  string                 `protobuf:"bytes,1,opt,name=dag_version_id,json=dagVersionId,proto3" json:"dag_version_id,omitempty"`
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	DagVersionId string                 `protobuf:"bytes,1,opt,name=dag_version_id,json=dagVersionId,proto3" json:"dag_version_id,omitempty"`
+	// pod_name is the worker's OWN Kubernetes pod name, delivered to the
+	// container via the downward API (LEOFLOW_POD_NAME). It is the durable key
+	// the control plane binds a started attempt to (warm_worker_id on the running
+	// TI) so a later reaper can match bound attempts against the live warm-pod set
+	// ListWarmPods returns, even after a leader failover. Unlike an identity, it
+	// is a locator, not a credential: the worker's authenticated identity still
+	// comes from its bearer token on the stream context, never from this field.
+	PodName       string `protobuf:"bytes,2,opt,name=pod_name,json=podName,proto3" json:"pod_name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1596,6 +1604,13 @@ func (*WorkerRegister) Descriptor() ([]byte, []int) {
 func (x *WorkerRegister) GetDagVersionId() string {
 	if x != nil {
 		return x.DagVersionId
+	}
+	return ""
+}
+
+func (x *WorkerRegister) GetPodName() string {
+	if x != nil {
+		return x.PodName
 	}
 	return ""
 }
@@ -1891,9 +1906,10 @@ const file_agent_proto_rawDesc = "" +
 	"\bregister\x18\x01 \x01(\v2 .leoflow.agent.v1.WorkerRegisterH\x00R\bregister\x123\n" +
 	"\x03ack\x18\x02 \x01(\v2\x1f.leoflow.agent.v1.AssignmentAckH\x00R\x03ack\x129\n" +
 	"\tslot_free\x18\x03 \x01(\v2\x1a.leoflow.agent.v1.SlotFreeH\x00R\bslotFreeB\x05\n" +
-	"\x03msg\"6\n" +
+	"\x03msg\"Q\n" +
 	"\x0eWorkerRegister\x12$\n" +
-	"\x0edag_version_id\x18\x01 \x01(\tR\fdagVersionId\"N\n" +
+	"\x0edag_version_id\x18\x01 \x01(\tR\fdagVersionId\x12\x19\n" +
+	"\bpod_name\x18\x02 \x01(\tR\apodName\"N\n" +
 	"\rAssignmentAck\x12#\n" +
 	"\rassignment_id\x18\x01 \x01(\tR\fassignmentId\x12\x18\n" +
 	"\astarted\x18\x02 \x01(\bR\astarted\"\n" +


### PR DESCRIPTION
**N1d-a1 of the warm-pool track (ADR 0058)** — the durable attempt→worker binding, the foundation for the failover reaper (**N1d-a2**, next). Records durably WHICH warm pod is serving a running attempt, so a reaper can tell — **even after a leader failover** — which attempts a now-dead warm pod held (by matching against the live warm-pod set `ListWarmPods` returns). This brick only persists the binding; the reaper consuming it is N1d-a2. Behind `execution.warm_pools_enabled` (off ⇒ column stays NULL ⇒ byte-for-byte today; dedicated pods never touch it).

## What
- **Migration 026:** nullable `task_instances.warm_worker_id` (distinct from `pod_name` — this names the long-lived warm WORKER pod that serves many attempts).
- **Binding key = the warm pod's own name**, via the downward API: `BuildWarmPod` injects `LEOFLOW_POD_NAME` (`fieldRef metadata.name`); the warm agent sends it up in `WorkerRegister.pod_name` (new proto field).
- **Registry:** lease carries `(run,task,try)`; worker carries its pod name (from the register message; identity is still the bearer, not a payload field). `Ack(started=true)` → `WarmBinding{run,task,try,podName}`; refusal/unknown → `(nil,false)` + reclaim.
- **Handler:** persists on a started ack via the existing `agentrpc.Store` seam (`BindWarmAttempt`) — **best-effort** (DB error logged, never propagated → a blip can't tear down a live worker).
- **Store `BindWarmAttempt`:** `UPDATE ... WHERE (run,task,try) AND state IN ('queued','running')` — a settled attempt (ack racing a reaper settle) is **never** bound.

## Deferred to N1d-a2
The reaper fan-out (dead warm pod → its in-flight attempts re-placed on the infra budget, no double-run), the stale-queued-reaper H3 defer, and `ClearWarmAttempt`-on-settle. The reaper filters on state, so an unclear binding on a terminal TI is harmless meanwhile.

## Notes
- No metrics counter on the persist error: `agentrpc` has no metrics seam yet; `slog.Warn` matches every other best-effort failure in the handler.

## Verification
`go vet ./...` **and** `-tags integration` both clean · proto + sqlc regen idempotent · build + `-tags integration` green · unit tests (agentrpc/executor/agent) green · integration (real Postgres, migration 026): `BindWarmAttempt` stamps a running TI, guarded no-op on terminal · `golangci-lint` 0.