### PR TITLE
feat(warm): failover reaper + double-run guard over the durable binding (ADR 0058 N1d-a2)

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -942,8 +942,7 @@ func startReconciler(ctx context.Context, cs kubernetes.Interface, namespace str
 // dag_version to that version's effective min_idle. Like the pod reconciler it
 // mutates cluster state, so it runs on the leader alone via the gated ticker. It
 // is only called when warm pools are enabled.
-func startWarmPoolReconciler(ctx context.Context, cfg *config.ServerConfig, cs kubernetes.Interface, targets executor.WarmTargetSource, authn *auth.JWTAuthenticator, controlAddr string, leading func() bool, rec executor.DecisionRecorder, logger *slog.Logger) {
-	pods := executor.NewKubernetesWarmPods(cs, cfg.Executor.TaskNamespace, warmPodSpecFunc(cfg, authn, controlAddr))
+func startWarmPoolReconciler(ctx context.Context, targets executor.WarmTargetSource, pods executor.WarmPodClient, leading func() bool, rec executor.DecisionRecorder, logger *slog.Logger) {
 	rc := executor.NewWarmPoolReconciler(targets, pods, logger, rec)
 	startGatedTicker(ctx, "warm-pool-reconcile", reconcileInterval, leading, logger, func() {
 		if err := rc.Reconcile(ctx); err != nil {
@@ -1316,11 +1315,23 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 		snapshotter = podInformer
 		cache = podInformer
 	}
+	// Warm failover seam (ADR 0058 N1d-a2): one warm-pod client, built ONLY when
+	// warm pools are enabled, is shared as the live-warm-pod lister for the reaper
+	// (the warm-worker-lost recovery + the dispatch-lost H3 defer) AND as the
+	// reconciler's create/delete/list client. With the flag off it stays a nil
+	// interface, so both warm reaper paths are inert and no warm pod is ever
+	// created — dispatch is byte-for-byte today's dedicated pod-per-task.
+	var warmLister executor.WarmPodLister
+	var warmPods *executor.KubernetesWarmPods
+	if cfg.Execution.WarmPoolsEnabled {
+		warmPods = executor.NewKubernetesWarmPods(cs, cfg.Executor.TaskNamespace, warmPodSpecFunc(cfg, authn, controlAddr))
+		warmLister = warmPods
+	}
 	// The execution reaper (#120/#128/#202/#527) fails stuck runs and TIs; it
 	// tears down a reaped task's pod and gates the dispatch-lost decision on real
 	// pod liveness (#474, #461), so it is wired only on the pod path. Lite/
 	// subprocess leaves the scheduler's reaper unset and does no reaping.
-	reaper := executor.NewReaper(store, podExec, cache, metrics, logger, executor.DefaultReaperConfig(), sched.SteppingDown)
+	reaper := executor.NewReaper(store, podExec, cache, warmLister, metrics, logger, executor.DefaultReaperConfig(), sched.SteppingDown)
 	sched.SetExecutionReaper(reaper)
 	startReconciler(ctx, cs, cfg.Executor.TaskNamespace, execStore, sched.IsLeading, logger, snapshotter)
 	startStagingGC(ctx, cs, cfg.Executor.TaskNamespace, store, sched.IsLeading, logger)
@@ -1330,7 +1341,7 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 	// stays byte-for-byte today's dedicated pod-per-task.
 	if cfg.Execution.WarmPoolsEnabled {
 		store.SetWarmExecution(cfg.Execution)
-		startWarmPoolReconciler(ctx, cfg, cs, store, authn, controlAddr, sched.IsLeading, metrics, logger)
+		startWarmPoolReconciler(ctx, store, warmPods, sched.IsLeading, metrics, logger)
 		logger.Warn("warm pool reconciler enabled (ADR 0058 N1b2b); maintaining min_idle warm workers per active dag_version", "namespace", cfg.Executor.TaskNamespace)
 	}
 	logger.Info("pod dispatch enabled", "namespace", cfg.Executor.TaskNamespace, "agent_control_plane_addr", controlAddr)

--- a/internal/executor/reaper.go
+++ b/internal/executor/reaper.go
@@ -24,6 +24,7 @@ type ReaperStore interface {
 	HeartbeatReapStore
 	DispatchLostReapStore
 	PodLostReapStore
+	WarmWorkerLostReapStore
 }
 
 // Default reaper thresholds. These carry over verbatim from the values the
@@ -72,25 +73,33 @@ func DefaultReaperConfig() ReaperConfig {
 // per leader tick, so the scheduler depends on a single capability rather than
 // wiring each reaper itself.
 type Reaper struct {
-	orphan       *orphanReaper
-	agentLost    *agentLostReaper
-	dispatchLost *dispatchLostReaper
-	podLost      *podLostReaper
-	logger       *slog.Logger
-	rec          DecisionRecorder
+	orphan         *orphanReaper
+	agentLost      *agentLostReaper
+	dispatchLost   *dispatchLostReaper
+	podLost        *podLostReaper
+	warmWorkerLost *warmWorkerLostReaper
+	logger         *slog.Logger
+	rec            DecisionRecorder
 	// inStepDown reports whether the scheduler is in a graceful leader step-down,
 	// so an expected context-cancel fanout of the run-context logs at WARN, not
 	// ERROR (#311). Nil is tolerated (treated as "not stepping down").
 	inStepDown func() bool
 }
 
-// NewReaper constructs the four reapers and wires their pod-teardown / liveness
+// NewReaper constructs the reapers and wires their pod-teardown / liveness
 // capability (pods) and, for the two K8s-aware reapers, the presence cache. The
 // wiring mirrors exactly what the scheduler used to do inline: every reaper gets
 // pods; only the dispatch-lost and pod-lost reapers get the cache. Nil pods
 // (Lite/subprocess) keeps every reaper DB-only and makes the pod-lost reaper a
 // no-op, byte-for-byte as before.
-func NewReaper(store ReaperStore, pods PodManager, cache PodPresenceCache, rec DecisionRecorder, logger *slog.Logger, cfg ReaperConfig, inStepDown func() bool) *Reaper {
+//
+// warmPods is the live warm-pod seam (ADR 0058 N1d-a2), threaded to the two warm
+// consumers exactly the way pods/cache are threaded: the warm-worker-lost reaper
+// (which recovers a dead worker's attempts) and the dispatch-lost reaper's H3
+// defer. Nil (warm pools off / not wired) makes the warm reaper a no-op and the
+// dispatch-lost warm defer inert — with the flag off no TI ever carries a
+// warm_worker_id either, so both warm paths are doubly inert, byte-for-byte today.
+func NewReaper(store ReaperStore, pods PodManager, cache PodPresenceCache, warmPods WarmPodLister, rec DecisionRecorder, logger *slog.Logger, cfg ReaperConfig, inStepDown func() bool) *Reaper {
 	orphan := newOrphanReaper(store, logger, cfg.OrphanThreshold, rec)
 	orphan.pods = pods
 
@@ -100,19 +109,24 @@ func NewReaper(store ReaperStore, pods PodManager, cache PodPresenceCache, rec D
 	dispatchLost := newDispatchLostReaper(store, logger, cfg.DispatchLostThreshold, rec)
 	dispatchLost.pods = pods
 	dispatchLost.cache = cache
+	dispatchLost.warmPods = warmPods
 
 	podLost := newPodLostReaper(store, logger, cfg.PodLostGrace, rec)
 	podLost.pods = pods
 	podLost.cache = cache
 
+	warmWorkerLost := newWarmWorkerLostReaper(store, logger, rec)
+	warmWorkerLost.warmPods = warmPods
+
 	return &Reaper{
-		orphan:       orphan,
-		agentLost:    agentLost,
-		dispatchLost: dispatchLost,
-		podLost:      podLost,
-		logger:       logger,
-		rec:          rec,
-		inStepDown:   inStepDown,
+		orphan:         orphan,
+		agentLost:      agentLost,
+		dispatchLost:   dispatchLost,
+		podLost:        podLost,
+		warmWorkerLost: warmWorkerLost,
+		logger:         logger,
+		rec:            rec,
+		inStepDown:     inStepDown,
 	}
 }
 
@@ -144,6 +158,10 @@ func (r *Reaper) ReapOnce(ctx context.Context) error {
 	if err := r.podLost.run(ctx); err != nil {
 		r.logError("pod-lost reaper", err)
 		r.record("pod_lost_list_error")
+	}
+	if err := r.warmWorkerLost.run(ctx); err != nil {
+		r.logError("warm-worker-lost reaper", err)
+		r.record("warm_worker_lost_list_error")
 	}
 	return nil
 }

--- a/internal/executor/reaper_test.go
+++ b/internal/executor/reaper_test.go
@@ -45,6 +45,7 @@ type fakeReaperStore struct {
 	queuedMarked []string
 	runningCands []PodLostCandidate
 	podMarked    []string
+	warmBound    []WarmBoundTI
 }
 
 func (f *fakeReaperStore) ListReapCandidates(context.Context) ([]ReapCandidate, error) {
@@ -75,6 +76,9 @@ func (f *fakeReaperStore) MarkTaskPodLost(_ context.Context, tiID string) (bool,
 	f.podMarked = append(f.podMarked, tiID)
 	return true, nil
 }
+func (f *fakeReaperStore) ListWarmBoundRunningTIs(context.Context) ([]WarmBoundTI, error) {
+	return f.warmBound, nil
+}
 
 // TestReaperReapOnceDrivesReapers is the aggregate-seam contract, the executor
 // side of what used to be TestStepReapsOrphanRunsOnLeader /
@@ -90,7 +94,7 @@ func TestReaperReapOnceDrivesReapers(t *testing.T) {
 		queuedCands: []StaleQueuedCandidate{{TaskInstanceID: "stuck-ti", QueuedAt: past}},
 	}
 	rec := &capturingRecorder{}
-	r := NewReaper(store, nil, nil, rec, reapTestLogger(), DefaultReaperConfig(), nil)
+	r := NewReaper(store, nil, nil, nil, rec, reapTestLogger(), DefaultReaperConfig(), nil)
 
 	if err := r.ReapOnce(context.Background()); err != nil {
 		t.Fatalf("ReapOnce: %v", err)
@@ -116,7 +120,7 @@ func TestReaperThreadsPresenceCacheToDispatchLost(t *testing.T) {
 	}
 	pods := &fakePodManager{active: map[string]bool{}}
 	cache := &fakePresenceCache{active: map[string]bool{"run-a/work": true}}
-	r := NewReaper(store, pods, cache, nil, reapTestLogger(), DefaultReaperConfig(), nil)
+	r := NewReaper(store, pods, cache, nil, nil, reapTestLogger(), DefaultReaperConfig(), nil)
 
 	if err := r.ReapOnce(context.Background()); err != nil {
 		t.Fatalf("ReapOnce: %v", err)

--- a/internal/executor/stale_queued_reap.go
+++ b/internal/executor/stale_queued_reap.go
@@ -24,6 +24,14 @@ type StaleQueuedCandidate struct {
 	// delete after the mark targets exactly that attempt's pod (#474).
 	TryNumber int
 	QueuedAt  time.Time
+	// WarmWorkerID is the warm pod durably bound to this attempt (ADR 0058
+	// N1d-a2), or "" for a dedicated task or a warm attempt not yet acked. When
+	// set AND the worker is in the live warm-pod set, the dispatch-lost reaper
+	// DEFERS: the warm worker holds this attempt and is merely slow to transition
+	// queued->running, so failing it would double-run the task (review finding
+	// H3). A warm attempt has no task pod, so the existing TaskPodActive gate
+	// cannot protect it — this warm check is what does.
+	WarmWorkerID string
 }
 
 // IsDispatchLost reports whether a queued TI has been waiting long enough to
@@ -73,6 +81,15 @@ type dispatchLostReaper struct {
 	// TaskPodActive read, so cache lag can only delay a reap, never cause a
 	// false-positive one (#461, the queued path). Nil keeps the live path.
 	cache PodPresenceCache
+	// warmPods is the live warm-pod seam (ADR 0058 N1d-a2), consulted ONLY to
+	// DEFER a reap of a warm-bound queued TI: a warm attempt has no task pod, so
+	// TaskPodActive cannot tell a slow queued->running transition from a lost
+	// dispatch. Before failing a candidate whose WarmWorkerID is set, the reaper
+	// checks whether that worker is still live; if so it defers (the worker holds
+	// the attempt — failing it would double-run, review finding H3). Nil (warm
+	// off / not wired) yields an empty live set, so the warm check never defers
+	// and the dedicated pod-liveness path is byte-for-byte unchanged.
+	warmPods WarmPodLister
 }
 
 func newDispatchLostReaper(store DispatchLostReapStore, logger *slog.Logger, threshold time.Duration, rec DecisionRecorder) *dispatchLostReaper {
@@ -93,9 +110,25 @@ func (r *dispatchLostReaper) run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// Live warm-pod set for the H3 defer, read ONCE per tick (Θ(pools)). A nil
+	// lister (warm off / not wired) yields an empty set, so the warm defer below
+	// never triggers and the dedicated path is unchanged.
+	liveWarm := liveWarmPodNames(ctx, r.warmPods, r.logger)
 	now := time.Now().UTC()
 	for _, c := range candidates {
 		if !IsDispatchLost(c, r.threshold, now) {
+			continue
+		}
+		// Warm-liveness gate (ADR 0058 N1d-a2, review finding H3): a warm attempt
+		// can sit in `queued` past the threshold while its serving warm worker is
+		// alive and merely slow to transition queued->running. A warm attempt has
+		// no task pod, so the TaskPodActive gate below cannot protect it; failing
+		// it would double-run the task once the live worker does transition it.
+		// If this candidate is bound to a warm worker that is still live, DEFER.
+		if c.WarmWorkerID != "" && liveWarm[c.WarmWorkerID] {
+			r.logger.Info("dispatch-lost: warm worker live; deferring",
+				"ti", c.TaskInstanceID, "run", c.DagRunID, "task", c.TaskID, "worker", c.WarmWorkerID)
+			r.record("dispatch_lost_warm_deferred")
 			continue
 		}
 		// K8s-aware liveness gate (#461): a TI can sit in `queued` past the

--- a/internal/executor/stale_queued_reap_test.go
+++ b/internal/executor/stale_queued_reap_test.go
@@ -113,3 +113,79 @@ func TestReapDispatchLost_PerTIErrorIsolated(t *testing.T) {
 		t.Errorf("run err = %v, want nil (per-TI errors isolated)", err)
 	}
 }
+
+// TestReapDispatchLost_H3_WarmLiveDefers is the double-run regression (ADR 0058
+// N1d-a2, review finding H3). A warm attempt can sit in `queued` past the
+// dispatch threshold while its serving warm worker is alive and merely slow to
+// transition queued->running. A warm attempt has NO task pod, so the existing
+// TaskPodActive gate cannot protect it — the pure time threshold would fail it,
+// and once the live worker DOES transition the attempt, the task runs twice.
+//
+// The fix: if the candidate's WarmWorkerID is in the live warm-pod set, DEFER.
+// This test pins that. Remove the defer (the pre-fix behavior) and the reaper
+// marks the TI dispatch-lost → the double-run.
+func TestReapDispatchLost_H3_WarmLiveDefers(t *testing.T) {
+	now := time.Now().UTC()
+	store := &fakeStaleQueuedStore{candidates: []StaleQueuedCandidate{
+		{TaskInstanceID: "warm-slow", DagRunID: "run-1", TaskID: "load", QueuedAt: now.Add(-10 * time.Minute), WarmWorkerID: "pod-live"},
+	}}
+	lister := &fakeWarmLister{pods: []WarmPodInfo{{Name: "pod-live", Terminal: false}}}
+	rec := &capturingRecorder{}
+	r := newDispatchLostReaper(store, reapTestLogger(), 3*time.Minute, rec)
+	r.warmPods = lister
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.failed) != 0 {
+		t.Fatalf("a warm attempt whose worker is LIVE must be deferred, not failed — the double-run bug; got %v", store.failed)
+	}
+	if got := rec.count("dispatch_lost_warm_deferred"); got != 1 {
+		t.Errorf("dispatch_lost_warm_deferred meter = %d, want 1", got)
+	}
+}
+
+// TestReapDispatchLost_H3_WarmGoneReaped: the other side of the guard — a warm
+// attempt whose bound worker is NOT in the live set (the worker really died)
+// still gets reaped. The defer protects only LIVE workers; it must not turn the
+// reaper into a no-op for genuinely lost warm dispatches.
+func TestReapDispatchLost_H3_WarmGoneReaped(t *testing.T) {
+	now := time.Now().UTC()
+	store := &fakeStaleQueuedStore{candidates: []StaleQueuedCandidate{
+		{TaskInstanceID: "warm-gone", DagRunID: "run-1", TaskID: "load", QueuedAt: now.Add(-10 * time.Minute), WarmWorkerID: "pod-dead"},
+	}}
+	lister := &fakeWarmLister{pods: []WarmPodInfo{{Name: "pod-other", Terminal: false}}}
+	r := newDispatchLostReaper(store, reapTestLogger(), 3*time.Minute, nil)
+	r.warmPods = lister
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.failed) != 1 || store.failed[0] != "warm-gone" {
+		t.Fatalf("a warm attempt whose worker is GONE must still be reaped, got %v", store.failed)
+	}
+}
+
+// TestReapDispatchLost_H3_DedicatedUnchanged: an attempt with empty WarmWorkerID
+// (a dedicated, non-warm task) is untouched by the warm defer — it flows through
+// the existing pod-liveness path. With no pods wired it falls back to the pure
+// time threshold and is reaped, exactly as before N1d-a2. This proves warm-off /
+// dedicated behavior is byte-for-byte unchanged.
+func TestReapDispatchLost_H3_DedicatedUnchanged(t *testing.T) {
+	now := time.Now().UTC()
+	store := &fakeStaleQueuedStore{candidates: []StaleQueuedCandidate{
+		{TaskInstanceID: "dedicated", DagRunID: "run-1", TaskID: "load", QueuedAt: now.Add(-10 * time.Minute), WarmWorkerID: ""},
+	}}
+	// A live warm fleet is present, but this candidate is not warm-bound, so the
+	// warm defer must not fire regardless.
+	lister := &fakeWarmLister{pods: []WarmPodInfo{{Name: "pod-live"}}}
+	r := newDispatchLostReaper(store, reapTestLogger(), 3*time.Minute, nil)
+	r.warmPods = lister
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.failed) != 1 || store.failed[0] != "dedicated" {
+		t.Fatalf("a dedicated (unbound) TI must be reaped by the existing path, got %v", store.failed)
+	}
+}

--- a/internal/executor/warm_worker_lost_reap.go
+++ b/internal/executor/warm_worker_lost_reap.go
@@ -1,0 +1,182 @@
+package executor
+
+import (
+	"context"
+	"log/slog"
+	"runtime/debug"
+)
+
+// WarmPodLister is the narrow read-only seam onto the live warm fleet the
+// failover paths need: just the warm-pod LIST, no create/delete. Both the
+// warm-worker-lost reaper and the dispatch-lost reaper's H3 defer depend on this
+// capability rather than the full WarmPodClient, so a unit test fakes only the
+// LIST. KubernetesWarmPods (via WarmPodClient) already satisfies it — production
+// reuses that one type, it is not duplicated.
+type WarmPodLister interface {
+	ListWarmPods(ctx context.Context) ([]WarmPodInfo, error)
+}
+
+// liveWarmPodNames returns the set of LIVE (non-terminal) warm-pod names, read
+// once per tick. A nil lister (warm pools off, or not wired) yields an empty
+// set, which makes every warm consumer inert: the failover reaper marks nothing
+// and the dispatch-lost warm defer never triggers. A LIST error is logged and
+// also yields an empty set — "do no harm" for the reaper reads as "cannot prove
+// a worker dead, so mark nothing this tick"; the dispatch-lost path likewise
+// falls through to its existing pod-liveness gate. Terminal warm pods (a crashed
+// worker that can never serve again) are excluded, so an attempt still bound to a
+// terminal pod is correctly treated as lost. Θ(pools).
+func liveWarmPodNames(ctx context.Context, lister WarmPodLister, logger *slog.Logger) map[string]bool {
+	if lister == nil {
+		return map[string]bool{}
+	}
+	pods, err := lister.ListWarmPods(ctx)
+	if err != nil {
+		if logger != nil {
+			logger.Warn("warm failover: listing warm pods failed; treating live set as empty this tick", "error", err)
+		}
+		return map[string]bool{}
+	}
+	live := make(map[string]bool, len(pods))
+	for _, p := range pods {
+		if p.Terminal {
+			continue
+		}
+		live[p.Name] = true
+	}
+	return live
+}
+
+// WarmBoundTI is one `running` task instance durably bound to a warm worker
+// (ADR 0058 N1d-a2): WarmWorkerID is the warm pod that acked and is serving this
+// attempt. The failover reaper matches WarmWorkerID against the live warm-pod set
+// to find attempts a dead warm pod held.
+type WarmBoundTI struct {
+	TaskInstanceID string
+	DagRunID       string
+	TaskID         string
+	TryNumber      int
+	WarmWorkerID   string
+}
+
+// WarmWorkerLostReapStore is the slice of the store the warm-worker-lost reaper
+// needs: list the warm-bound running TIs, and reuse the pod-lost mark to route a
+// lost attempt to infra (bumps infra_attempts, NOT try_number). The full
+// scheduler store satisfies it; a unit test fakes just this surface.
+type WarmWorkerLostReapStore interface {
+	ListWarmBoundRunningTIs(ctx context.Context) ([]WarmBoundTI, error)
+	// MarkTaskPodLost is reused verbatim from the pod-lost reaper: a warm worker
+	// vanishing is the same infra failure as a task pod vanishing, so it routes
+	// through the same infra path with the same idempotency guard (WHERE
+	// state='running'). applied=false means a late settle raced the mark — a
+	// benign skip, never a false reap.
+	MarkTaskPodLost(ctx context.Context, taskInstanceID string) (bool, error)
+}
+
+// warmWorkerLostReaper recovers a dead warm worker's in-flight attempts (ADR 0058
+// N1d-a2, the D7 failover). A warm worker serves MANY attempts per pod, so when a
+// warm pod dies mid-attempt every attempt it was serving is stranded `running`
+// with no backing pod — invisible to the pod-lost reaper (a warm attempt has no
+// per-task pod) and, until its heartbeat lapses, to the agent-lost reaper. This
+// reaper closes that gap: it lists the durably-bound running attempts, reads the
+// live warm-pod set once per tick, and for every attempt whose worker is no
+// longer live it routes the attempt to infra via MarkTaskPodLost.
+//
+// Fan-out: a dead worker holding N attempts gets all N marked in the tick,
+// because every bound TI names the same (now-absent) worker. The set lookup is
+// O(1) per TI, so the reaper is Θ(bound TIs + pools) overall.
+//
+// Warm-off inertness: with warm pools disabled the lister is nil (empty live
+// set) AND no TI ever carries a warm_worker_id (ListWarmBoundRunningTIs returns
+// empty), so the reaper is a double no-op — byte-for-byte today. Resilience
+// mirrors the sibling reapers: panic-safe, per-TI isolated, metered.
+type warmWorkerLostReaper struct {
+	store    WarmWorkerLostReapStore
+	logger   *slog.Logger
+	recorder DecisionRecorder
+	// warmPods is the live warm-pod seam. Nil (warm off / not wired) makes run a
+	// no-op via the empty live set.
+	warmPods WarmPodLister
+}
+
+func newWarmWorkerLostReaper(store WarmWorkerLostReapStore, logger *slog.Logger, rec DecisionRecorder) *warmWorkerLostReaper {
+	return &warmWorkerLostReaper{store: store, logger: logger, recorder: rec}
+}
+
+// run lists the warm-bound running TIs and marks pod_lost every one whose
+// serving warm worker is no longer live. Per-TI mark failures are isolated; a
+// panic anywhere is recovered so the scheduler tick stays alive.
+func (r *warmWorkerLostReaper) run(ctx context.Context) error {
+	defer func() {
+		if rec := recover(); rec != nil {
+			r.logger.Error("warm-worker-lost reaper panic recovered", "panic", rec, "stack", string(debug.Stack()))
+			r.record("warm_worker_lost_panic")
+		}
+	}()
+	// Warm off / not wired: no lister means no warm fleet to consult, so nothing
+	// can be proven dead. Skip before touching the store.
+	if r.warmPods == nil {
+		return nil
+	}
+	bound, err := r.store.ListWarmBoundRunningTIs(ctx)
+	if err != nil {
+		return err
+	}
+	if len(bound) == 0 {
+		// No warm attempts in flight — nothing to recover.
+		return nil
+	}
+	// Live warm-pod set, read ONCE per tick (Θ(pools)); the per-TI membership
+	// check is then O(1), grouping the fan-out by worker implicitly.
+	//
+	// A LIST error is NOT an empty fleet: on this authoritative kill path,
+	// treating "cannot list" as "everything is dead" would reap every live warm
+	// attempt on a transient apiserver blip. So a LIST error aborts the tick with
+	// no marks ("do no harm", ADR 0031) — the attempts are picked up next tick
+	// once the fleet is readable again. (The dispatch-lost H3 defer differs: an
+	// empty set there merely skips an extra defer, never causing a kill, so it
+	// tolerates the empty-on-error fallback.)
+	pods, perr := r.warmPods.ListWarmPods(ctx)
+	if perr != nil {
+		r.logger.Warn("warm-worker-lost: listing warm pods failed; deferring all this tick", "error", perr)
+		r.record("warm_worker_lost_list_pods_error")
+		return nil
+	}
+	live := make(map[string]bool, len(pods))
+	for _, p := range pods {
+		if p.Terminal {
+			// A terminal warm pod can never serve again; it is not live, so an
+			// attempt still bound to it is correctly reaped below.
+			continue
+		}
+		live[p.Name] = true
+	}
+	for _, ti := range bound {
+		if live[ti.WarmWorkerID] {
+			// The serving warm worker is still alive; the attempt is healthy.
+			continue
+		}
+		applied, ferr := r.store.MarkTaskPodLost(ctx, ti.TaskInstanceID)
+		if ferr != nil {
+			r.logger.Error("marking warm-worker-lost task pod-lost",
+				"ti", ti.TaskInstanceID, "run", ti.DagRunID, "task", ti.TaskID, "worker", ti.WarmWorkerID, "error", ferr)
+			r.record("warm_worker_lost_error")
+			continue
+		}
+		if !applied {
+			// A late terminal report settled the TI between our list and our write
+			// (WHERE state='running' matched 0 rows) — a benign race, not a reap.
+			r.record("warm_worker_lost_noop")
+			continue
+		}
+		r.logger.Warn("warm worker gone; failing its in-flight attempt as pod_lost",
+			"ti", ti.TaskInstanceID, "run", ti.DagRunID, "task", ti.TaskID, "worker", ti.WarmWorkerID)
+		r.record("warm_worker_lost")
+	}
+	return nil
+}
+
+func (r *warmWorkerLostReaper) record(decision string) {
+	if r.recorder != nil {
+		r.recorder.RecordSchedulerDecision(decision)
+	}
+}

--- a/internal/executor/warm_worker_lost_reap_test.go
+++ b/internal/executor/warm_worker_lost_reap_test.go
@@ -1,0 +1,236 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// fakeWarmLister serves a canned warm fleet and can inject a LIST error. It
+// satisfies WarmPodLister (the read-only slice of the warm-pod client).
+type fakeWarmLister struct {
+	pods    []WarmPodInfo
+	listErr error
+}
+
+func (f *fakeWarmLister) ListWarmPods(context.Context) ([]WarmPodInfo, error) {
+	return f.pods, f.listErr
+}
+
+// fakeWarmBoundStore serves warm-bound running TIs and records pod_lost marks,
+// satisfying WarmWorkerLostReapStore.
+type fakeWarmBoundStore struct {
+	bound    []WarmBoundTI
+	listErr  error
+	marked   []string
+	markErr  error
+	markNoop bool // MarkTaskPodLost reports 0 rows (a late settle raced)
+}
+
+func (f *fakeWarmBoundStore) ListWarmBoundRunningTIs(context.Context) ([]WarmBoundTI, error) {
+	return f.bound, f.listErr
+}
+
+func (f *fakeWarmBoundStore) MarkTaskPodLost(_ context.Context, id string) (bool, error) {
+	if f.markErr != nil {
+		return false, f.markErr
+	}
+	if f.markNoop {
+		return false, nil
+	}
+	f.marked = append(f.marked, id)
+	return true, nil
+}
+
+func newWarmReaper(store WarmWorkerLostReapStore, lister WarmPodLister) *warmWorkerLostReaper {
+	r := newWarmWorkerLostReaper(store, reapTestLogger(), nil)
+	r.warmPods = lister
+	return r
+}
+
+// TestWarmWorkerLostReaper_OnlyDeadWorkersReaped: an attempt bound to a worker
+// NOT in the live set is failed as pod_lost; an attempt bound to a live worker
+// is left alone. This is the failover contract — a warm pod dies mid-attempt and
+// its in-flight work is recovered, while healthy workers keep serving.
+func TestWarmWorkerLostReaper_OnlyDeadWorkersReaped(t *testing.T) {
+	store := &fakeWarmBoundStore{bound: []WarmBoundTI{
+		{TaskInstanceID: "ti-dead", DagRunID: "run-1", TaskID: "load", TryNumber: 1, WarmWorkerID: "pod-dead"},
+		{TaskInstanceID: "ti-live", DagRunID: "run-2", TaskID: "xform", TryNumber: 1, WarmWorkerID: "pod-live"},
+	}}
+	lister := &fakeWarmLister{pods: []WarmPodInfo{
+		{Name: "pod-live", Terminal: false},
+	}}
+	rec := &capturingRecorder{}
+	r := newWarmWorkerLostReaper(store, reapTestLogger(), rec)
+	r.warmPods = lister
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.marked) != 1 || store.marked[0] != "ti-dead" {
+		t.Fatalf("only the dead worker's attempt must be reaped, got %v", store.marked)
+	}
+	if got := rec.count("warm_worker_lost"); got != 1 {
+		t.Errorf("warm_worker_lost meter = %d, want 1", got)
+	}
+}
+
+// TestWarmWorkerLostReaper_FanOut: a single dead worker serving THREE attempts
+// gets all three marked in one tick. This is the whole point of warm pools — one
+// pod serves many attempts — so a worker's death must fan out to every attempt
+// it held, not just one.
+func TestWarmWorkerLostReaper_FanOut(t *testing.T) {
+	store := &fakeWarmBoundStore{bound: []WarmBoundTI{
+		{TaskInstanceID: "a", DagRunID: "run-1", TaskID: "t1", TryNumber: 1, WarmWorkerID: "pod-dead"},
+		{TaskInstanceID: "b", DagRunID: "run-1", TaskID: "t2", TryNumber: 1, WarmWorkerID: "pod-dead"},
+		{TaskInstanceID: "c", DagRunID: "run-2", TaskID: "t3", TryNumber: 1, WarmWorkerID: "pod-dead"},
+	}}
+	lister := &fakeWarmLister{pods: []WarmPodInfo{}} // pod-dead is gone from the fleet
+	r := newWarmReaper(store, lister)
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.marked) != 3 {
+		t.Fatalf("a dead worker's 3 attempts must all be marked (fan-out), got %v", store.marked)
+	}
+}
+
+// TestWarmWorkerLostReaper_TerminalWorkerIsDead: a bound attempt whose worker
+// exists in the fleet BUT is terminal (Succeeded/Failed — can never serve again)
+// is reaped, exactly as if the pod were gone. A terminal warm pod is not live.
+func TestWarmWorkerLostReaper_TerminalWorkerIsDead(t *testing.T) {
+	store := &fakeWarmBoundStore{bound: []WarmBoundTI{
+		{TaskInstanceID: "ti-term", DagRunID: "run-1", TaskID: "load", TryNumber: 1, WarmWorkerID: "pod-term"},
+	}}
+	lister := &fakeWarmLister{pods: []WarmPodInfo{
+		{Name: "pod-term", Terminal: true},
+	}}
+	r := newWarmReaper(store, lister)
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.marked) != 1 || store.marked[0] != "ti-term" {
+		t.Fatalf("a terminal worker must be treated as dead, got %v", store.marked)
+	}
+}
+
+// TestWarmWorkerLostReaper_NilListerNoOp: with no lister (warm pools off / not
+// wired) the reaper never touches the store — inert.
+func TestWarmWorkerLostReaper_NilListerNoOp(t *testing.T) {
+	store := &fakeWarmBoundStore{bound: []WarmBoundTI{
+		{TaskInstanceID: "ti", DagRunID: "run-1", TaskID: "load", TryNumber: 1, WarmWorkerID: "pod-dead"},
+	}}
+	r := newWarmWorkerLostReaper(store, reapTestLogger(), nil) // r.warmPods stays nil
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.marked) != 0 {
+		t.Fatalf("nil lister must reap nothing, got %v", store.marked)
+	}
+}
+
+// TestWarmWorkerLostReaper_EmptyBoundNoOp: with a live lister but no warm-bound
+// attempts in flight, the reaper marks nothing.
+func TestWarmWorkerLostReaper_EmptyBoundNoOp(t *testing.T) {
+	store := &fakeWarmBoundStore{bound: nil}
+	lister := &fakeWarmLister{pods: []WarmPodInfo{{Name: "pod-live"}}}
+	r := newWarmReaper(store, lister)
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.marked) != 0 {
+		t.Fatalf("no bound attempts must reap nothing, got %v", store.marked)
+	}
+}
+
+// TestWarmWorkerLostReaper_ListPodsErrorMarksNothing: if the warm-pod LIST fails,
+// the live set is empty for this tick, so "do no harm" — nothing is proven dead,
+// nothing is marked. (A blind mark-all on a transient apiserver blip would kill
+// every live warm attempt.)
+func TestWarmWorkerLostReaper_ListPodsErrorMarksNothing(t *testing.T) {
+	store := &fakeWarmBoundStore{bound: []WarmBoundTI{
+		{TaskInstanceID: "ti", DagRunID: "run-1", TaskID: "load", TryNumber: 1, WarmWorkerID: "pod-x"},
+	}}
+	lister := &fakeWarmLister{listErr: errors.New("apiserver unavailable")}
+	r := newWarmReaper(store, lister)
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.marked) != 0 {
+		t.Fatalf("a warm-pod LIST error must reap nothing this tick, got %v", store.marked)
+	}
+}
+
+// TestWarmWorkerLostReaper_ListBoundErrorSurfaces: a store list error is returned
+// so ReapOnce can log it; nothing is reaped.
+func TestWarmWorkerLostReaper_ListBoundErrorSurfaces(t *testing.T) {
+	store := &fakeWarmBoundStore{listErr: errors.New("db down")}
+	lister := &fakeWarmLister{pods: []WarmPodInfo{}}
+	r := newWarmReaper(store, lister)
+	if err := r.run(context.Background()); err == nil {
+		t.Fatal("expected the store list error to surface")
+	}
+	if len(store.marked) != 0 {
+		t.Fatalf("nothing should be reaped on a list error, got %v", store.marked)
+	}
+}
+
+// TestWarmWorkerLostReaper_NoopMarkIsBenign: a MarkTaskPodLost returning
+// applied=false (a late terminal report settled the row between the list and the
+// write) is a benign skip — metered as a no-op, not a false reap.
+func TestWarmWorkerLostReaper_NoopMarkIsBenign(t *testing.T) {
+	store := &fakeWarmBoundStore{
+		bound:    []WarmBoundTI{{TaskInstanceID: "raced", DagRunID: "run-1", TaskID: "load", TryNumber: 1, WarmWorkerID: "pod-dead"}},
+		markNoop: true,
+	}
+	lister := &fakeWarmLister{pods: []WarmPodInfo{}}
+	rec := &capturingRecorder{}
+	r := newWarmWorkerLostReaper(store, reapTestLogger(), rec)
+	r.warmPods = lister
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := rec.count("warm_worker_lost_noop"); got != 1 {
+		t.Errorf("warm_worker_lost_noop meter = %d, want 1", got)
+	}
+	if got := rec.count("warm_worker_lost"); got != 0 {
+		t.Errorf("a no-op mark must not meter a real reap, got %d", got)
+	}
+}
+
+// TestWarmWorkerLostReaper_PerTIErrorIsolated: a mark failure on one attempt does
+// not stall the others (same isolation as the sibling reapers). The reaper never
+// returns a per-TI error.
+func TestWarmWorkerLostReaper_PerTIErrorIsolated(t *testing.T) {
+	store := &fakeWarmBoundStore{
+		bound: []WarmBoundTI{
+			{TaskInstanceID: "a", DagRunID: "run-1", TaskID: "t1", TryNumber: 1, WarmWorkerID: "pod-dead"},
+			{TaskInstanceID: "b", DagRunID: "run-1", TaskID: "t2", TryNumber: 1, WarmWorkerID: "pod-dead"},
+		},
+		markErr: errors.New("write failed"),
+	}
+	lister := &fakeWarmLister{pods: []WarmPodInfo{}}
+	r := newWarmReaper(store, lister)
+	if err := r.run(context.Background()); err != nil {
+		t.Errorf("run err = %v, want nil (per-TI errors isolated)", err)
+	}
+}
+
+// panickyWarmStore panics on the list to prove the reaper's recover keeps the
+// scheduler tick alive.
+type panickyWarmStore struct{}
+
+func (panickyWarmStore) ListWarmBoundRunningTIs(context.Context) ([]WarmBoundTI, error) {
+	panic("boom")
+}
+func (panickyWarmStore) MarkTaskPodLost(context.Context, string) (bool, error) { return true, nil }
+
+// TestWarmWorkerLostReaper_PanicRecovered: a panic anywhere in run is recovered,
+// mirroring the sibling reapers, so one bad tick never crashes the scheduler.
+func TestWarmWorkerLostReaper_PanicRecovered(t *testing.T) {
+	r := newWarmReaper(panickyWarmStore{}, &fakeWarmLister{pods: []WarmPodInfo{}})
+	// Must not panic out of run.
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run returned err after recovered panic: %v", err)
+	}
+}

--- a/internal/storage/chaos_integration_test.go
+++ b/internal/storage/chaos_integration_test.go
@@ -69,7 +69,7 @@ func TestChaosMidTickCrashRecoveryIntegration(t *testing.T) {
 	// enough for a fast test but well above the ~ms in-process Step() latency.
 	// AgentLostThreshold is a minute — irrelevant here, kept high so it can't fire
 	// on unrelated rows; PodLostGrace is a no-op with nil pods.
-	s.SetExecutionReaper(executor.NewReaper(sched, nil, nil, nil, logger, executor.ReaperConfig{
+	s.SetExecutionReaper(executor.NewReaper(sched, nil, nil, nil, nil, logger, executor.ReaperConfig{
 		OrphanThreshold:       400 * time.Millisecond,
 		AgentLostThreshold:    time.Minute,
 		DispatchLostThreshold: 200 * time.Millisecond,

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -220,6 +220,12 @@ type Querier interface {
 	// candidate so the SQL stays simple and the decision is purely in Go. The
 	// LIMIT bounds a tick's reap work after a long outage; the rest are picked
 	// up next tick (backstop, not sprint).
+	// warm_worker_id rides along (ADR 0058 N1d-a2, review finding H3): a queued warm
+	// attempt whose serving warm worker is still alive is just slow to transition
+	// queued->running, so the dispatch-lost reaper must DEFER it rather than fail it
+	// (the double-run bug). It is NULL for a dedicated attempt and for a warm attempt
+	// not yet acked, in which case the reaper falls back to its existing pod-liveness
+	// gate unchanged.
 	ListStaleQueuedTaskInstances(ctx context.Context) ([]ListStaleQueuedTaskInstancesRow, error)
 	// Returns every attempt for (run, task), oldest first. UNIONs the current
 	// task_instances row with all archived task_instance_history rows so the UI's
@@ -240,6 +246,17 @@ type Querier interface {
 	// Variables it declared. An empty key set never reaches here — the handler
 	// returns nothing without a query.
 	ListVariablesScoped(ctx context.Context, arg ListVariablesScopedParams) ([]ListVariablesScopedRow, error)
+	// Lists every `running` TI that is durably bound to a warm worker (ADR 0058
+	// N1d-a2): warm_worker_id names the warm pod that acked and is serving this
+	// attempt. The failover reaper matches that name against the live warm-pod set;
+	// a bound TI whose worker is no longer live has lost its serving pod and is
+	// routed to infra via MarkTaskPodLost (fan-out: every attempt a dead worker
+	// held is marked). Only `running` rows carry a live attempt, and the
+	// IS NOT NULL filter keeps dedicated (non-warm) tasks out of this reaper
+	// entirely — with warm pools off no TI is ever bound, so this returns empty and
+	// the reaper is inert. The LIMIT bounds a single tick's work after a large
+	// outage; the rest are picked up next tick.
+	ListWarmBoundRunningTIs(ctx context.Context) ([]ListWarmBoundRunningTIsRow, error)
 	ListXComEntries(ctx context.Context, arg ListXComEntriesParams) ([]ListXComEntriesRow, error)
 	// Stamp a run's on-failure alert as DELIVERED. Called only after a successful
 	// send, which is the whole point of the split: alerted_at now answers "did the

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -31,12 +31,19 @@ WHERE dag_id = $1 AND state IN ('queued', 'running');
 -- candidate so the SQL stays simple and the decision is purely in Go. The
 -- LIMIT bounds a tick's reap work after a long outage; the rest are picked
 -- up next tick (backstop, not sprint).
+-- warm_worker_id rides along (ADR 0058 N1d-a2, review finding H3): a queued warm
+-- attempt whose serving warm worker is still alive is just slow to transition
+-- queued->running, so the dispatch-lost reaper must DEFER it rather than fail it
+-- (the double-run bug). It is NULL for a dedicated attempt and for a warm attempt
+-- not yet acked, in which case the reaper falls back to its existing pod-liveness
+-- gate unchanged.
 SELECT ti.id AS task_instance_id,
        ti.dag_run_id,
        d.dag_id AS dag_id_text,
        ti.task_id,
        ti.try_number,
-       ti.queued_at
+       ti.queued_at,
+       ti.warm_worker_id
 FROM task_instances ti
 JOIN dag_runs dr ON dr.id = ti.dag_run_id
 JOIN dags d ON d.id = dr.dag_id
@@ -732,6 +739,28 @@ WHERE dag_run_id = $1
   AND task_id = $2
   AND try_number = $3
   AND state IN ('queued', 'running');
+
+-- name: ListWarmBoundRunningTIs :many
+-- Lists every `running` TI that is durably bound to a warm worker (ADR 0058
+-- N1d-a2): warm_worker_id names the warm pod that acked and is serving this
+-- attempt. The failover reaper matches that name against the live warm-pod set;
+-- a bound TI whose worker is no longer live has lost its serving pod and is
+-- routed to infra via MarkTaskPodLost (fan-out: every attempt a dead worker
+-- held is marked). Only `running` rows carry a live attempt, and the
+-- IS NOT NULL filter keeps dedicated (non-warm) tasks out of this reaper
+-- entirely — with warm pools off no TI is ever bound, so this returns empty and
+-- the reaper is inert. The LIMIT bounds a single tick's work after a large
+-- outage; the rest are picked up next tick.
+SELECT ti.id AS task_instance_id,
+       ti.dag_run_id AS dag_run_id,
+       ti.task_id AS task_id,
+       ti.try_number AS try_number,
+       ti.warm_worker_id AS warm_worker_id
+FROM task_instances ti
+WHERE ti.state = 'running'
+  AND ti.warm_worker_id IS NOT NULL
+ORDER BY ti.started_at NULLS LAST
+LIMIT 100;
 
 -- name: ListAgentLostCandidates :many
 -- Lists running TIs that have heartbeated at least once and whose latest

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -968,7 +968,8 @@ SELECT ti.id AS task_instance_id,
        d.dag_id AS dag_id_text,
        ti.task_id,
        ti.try_number,
-       ti.queued_at
+       ti.queued_at,
+       ti.warm_worker_id
 FROM task_instances ti
 JOIN dag_runs dr ON dr.id = ti.dag_run_id
 JOIN dags d ON d.id = dr.dag_id
@@ -984,6 +985,7 @@ type ListStaleQueuedTaskInstancesRow struct {
 	TaskID         string             `json:"task_id"`
 	TryNumber      int32              `json:"try_number"`
 	QueuedAt       pgtype.Timestamptz `json:"queued_at"`
+	WarmWorkerID   *string            `json:"warm_worker_id"`
 }
 
 // Lists every TI currently in `queued` alongside its queued_at timestamp for
@@ -991,6 +993,12 @@ type ListStaleQueuedTaskInstancesRow struct {
 // candidate so the SQL stays simple and the decision is purely in Go. The
 // LIMIT bounds a tick's reap work after a long outage; the rest are picked
 // up next tick (backstop, not sprint).
+// warm_worker_id rides along (ADR 0058 N1d-a2, review finding H3): a queued warm
+// attempt whose serving warm worker is still alive is just slow to transition
+// queued->running, so the dispatch-lost reaper must DEFER it rather than fail it
+// (the double-run bug). It is NULL for a dedicated attempt and for a warm attempt
+// not yet acked, in which case the reaper falls back to its existing pod-liveness
+// gate unchanged.
 func (q *Queries) ListStaleQueuedTaskInstances(ctx context.Context) ([]ListStaleQueuedTaskInstancesRow, error) {
 	rows, err := q.db.Query(ctx, listStaleQueuedTaskInstances)
 	if err != nil {
@@ -1007,6 +1015,7 @@ func (q *Queries) ListStaleQueuedTaskInstances(ctx context.Context) ([]ListStale
 			&i.TaskID,
 			&i.TryNumber,
 			&i.QueuedAt,
+			&i.WarmWorkerID,
 		); err != nil {
 			return nil, err
 		}
@@ -1178,6 +1187,63 @@ func (q *Queries) ListTaskInstancesByRun(ctx context.Context, dagRunID pgtype.UU
 			&i.NextDispatchAt,
 			&i.LastFailureKind,
 			&i.InfraAttempts,
+			&i.WarmWorkerID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listWarmBoundRunningTIs = `-- name: ListWarmBoundRunningTIs :many
+SELECT ti.id AS task_instance_id,
+       ti.dag_run_id AS dag_run_id,
+       ti.task_id AS task_id,
+       ti.try_number AS try_number,
+       ti.warm_worker_id AS warm_worker_id
+FROM task_instances ti
+WHERE ti.state = 'running'
+  AND ti.warm_worker_id IS NOT NULL
+ORDER BY ti.started_at NULLS LAST
+LIMIT 100
+`
+
+type ListWarmBoundRunningTIsRow struct {
+	TaskInstanceID pgtype.UUID `json:"task_instance_id"`
+	DagRunID       pgtype.UUID `json:"dag_run_id"`
+	TaskID         string      `json:"task_id"`
+	TryNumber      int32       `json:"try_number"`
+	WarmWorkerID   *string     `json:"warm_worker_id"`
+}
+
+// Lists every `running` TI that is durably bound to a warm worker (ADR 0058
+// N1d-a2): warm_worker_id names the warm pod that acked and is serving this
+// attempt. The failover reaper matches that name against the live warm-pod set;
+// a bound TI whose worker is no longer live has lost its serving pod and is
+// routed to infra via MarkTaskPodLost (fan-out: every attempt a dead worker
+// held is marked). Only `running` rows carry a live attempt, and the
+// IS NOT NULL filter keeps dedicated (non-warm) tasks out of this reaper
+// entirely — with warm pools off no TI is ever bound, so this returns empty and
+// the reaper is inert. The LIMIT bounds a single tick's work after a large
+// outage; the rest are picked up next tick.
+func (q *Queries) ListWarmBoundRunningTIs(ctx context.Context) ([]ListWarmBoundRunningTIsRow, error) {
+	rows, err := q.db.Query(ctx, listWarmBoundRunningTIs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListWarmBoundRunningTIsRow{}
+	for rows.Next() {
+		var i ListWarmBoundRunningTIsRow
+		if err := rows.Scan(
+			&i.TaskInstanceID,
+			&i.DagRunID,
+			&i.TaskID,
+			&i.TryNumber,
 			&i.WarmWorkerID,
 		); err != nil {
 			return nil, err

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -740,6 +740,29 @@ func (s *SchedulerStore) ListStaleQueuedCandidates(ctx context.Context) ([]execu
 			TaskID:         r.TaskID,
 			TryNumber:      int(r.TryNumber),
 			QueuedAt:       qed,
+			WarmWorkerID:   strOrEmpty(r.WarmWorkerID),
+		})
+	}
+	return out, nil
+}
+
+// ListWarmBoundRunningTIs returns every `running` TI durably bound to a warm
+// worker (warm_worker_id IS NOT NULL), for the warm-worker-lost reaper (ADR 0058
+// N1d-a2). With warm pools off no TI is ever bound, so this is always empty and
+// the reaper is inert.
+func (s *SchedulerStore) ListWarmBoundRunningTIs(ctx context.Context) ([]executor.WarmBoundTI, error) {
+	rows, err := s.q.ListWarmBoundRunningTIs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing warm-bound running TIs: %w", err)
+	}
+	out := make([]executor.WarmBoundTI, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, executor.WarmBoundTI{
+			TaskInstanceID: uuidToString(r.TaskInstanceID),
+			DagRunID:       uuidToString(r.DagRunID),
+			TaskID:         r.TaskID,
+			TryNumber:      int(r.TryNumber),
+			WarmWorkerID:   strOrEmpty(r.WarmWorkerID),
 		})
 	}
 	return out, nil

--- a/internal/storage/warm_failover_integration_test.go
+++ b/internal/storage/warm_failover_integration_test.go
@@ -1,0 +1,180 @@
+//go:build integration
+
+// Package storage_test — the read-side of the warm failover reaper (ADR 0058
+// N1d-a2).
+//
+// Two store reads back the failover reaper and the H3 double-run guard, and both
+// depend on SQL predicates a fake-store unit test cannot prove:
+//
+//   - ListWarmBoundRunningTIs must return exactly the `running` TIs with a
+//     non-null warm_worker_id — never a terminal bound TI (its worker no longer
+//     matters) and never an unbound running TI (a dedicated task).
+//   - ListStaleQueuedCandidates must now CARRY warm_worker_id, so the
+//     dispatch-lost reaper's H3 defer can see which queued attempt a live warm
+//     worker holds.
+//
+// The shared-DB harness means these rows live alongside whatever else the suite
+// seeded, so each test seeds its own uniquely-named DAG and asserts only on rows
+// it owns.
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/executor"
+	"github.com/neochaotic/leoflow/internal/storage"
+)
+
+// seedQueuedWarmTask brings a fresh DAG up to a single task instance in `queued`
+// (the state the dispatch-lost reaper reads), binds it to warmPod, and returns
+// the run UUID. Binding is legal in `queued` (the BindWarmAttempt guard allows
+// queued/running), which is exactly the H3 case: a warm attempt still queued.
+func seedQueuedWarmTask(t *testing.T, repo *storage.Repository, sched *storage.SchedulerStore, exec *storage.ExecutionStore, ctx context.Context, dagID, taskID, warmPod string) string {
+	t.Helper()
+	tasks := []domain.TaskSpec{{TaskID: taskID, Type: domain.TaskTypePython}}
+	registerSpec(t, repo, ctx, dagID, tasks)
+	if _, err := repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+		RunID: "r1", State: domain.DagRunStateRunning, RunType: "manual",
+		LogicalDate: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateDagRun: %v", err)
+	}
+	runUUID := resolveRunUUID(t, sched, ctx, dagID)
+	if err := sched.MaterializeTasks(ctx, runUUID, tasks); err != nil {
+		t.Fatalf("MaterializeTasks: %v", err)
+	}
+	if err := sched.ApplyTransition(ctx, runUUID, taskID, domain.TaskStateQueued); err != nil {
+		t.Fatalf("ApplyTransition to queued: %v", err)
+	}
+	if err := exec.BindWarmAttempt(ctx, runUUID, taskID, 1, warmPod); err != nil {
+		t.Fatalf("BindWarmAttempt on a queued TI: %v", err)
+	}
+	return runUUID
+}
+
+// TestListWarmBoundRunningTIsIntegration: only `running` TIs with a non-null
+// warm_worker_id come back. Seed three rows this test owns — a running bound TI,
+// a terminal bound TI, and an unbound running TI — and assert only the first is
+// returned.
+func TestListWarmBoundRunningTIsIntegration(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	stamp := time.Now().UnixNano()
+
+	// (1) running + bound — the one that must come back.
+	liveDag := fmt.Sprintf("warm_bound_live_%d", stamp)
+	liveRun := seedRunningTask(t, repo, sched, ctx, liveDag, "load")
+	wantPod := fmt.Sprintf("leoflow-warm-live-%d", stamp)
+	if err := exec.BindWarmAttempt(ctx, liveRun, "load", 1, wantPod); err != nil {
+		t.Fatalf("BindWarmAttempt (live): %v", err)
+	}
+
+	// (2) bound-then-terminal — must NOT come back (state moved off `running`,
+	// even though warm_worker_id is still set).
+	termDag := fmt.Sprintf("warm_bound_term_%d", stamp)
+	termRun := seedRunningTask(t, repo, sched, ctx, termDag, "load")
+	if err := exec.BindWarmAttempt(ctx, termRun, "load", 1, fmt.Sprintf("leoflow-warm-term-%d", stamp)); err != nil {
+		t.Fatalf("BindWarmAttempt (terminal): %v", err)
+	}
+	if err := sched.ApplyTransition(ctx, termRun, "load", domain.TaskStateFailed); err != nil {
+		t.Fatalf("ApplyTransition to failed: %v", err)
+	}
+
+	// (3) running + UNbound (a dedicated task) — must NOT come back.
+	dedDag := fmt.Sprintf("warm_unbound_run_%d", stamp)
+	dedRun := seedRunningTask(t, repo, sched, ctx, dedDag, "load")
+
+	got, err := sched.ListWarmBoundRunningTIs(ctx)
+	if err != nil {
+		t.Fatalf("ListWarmBoundRunningTIs: %v", err)
+	}
+
+	// Assert ONLY on the rows this test owns (shared DB), keyed by DagRunID.
+	var mine *executor.WarmBoundTI
+	for i := range got {
+		switch got[i].DagRunID {
+		case liveRun:
+			mine = &got[i]
+		case termRun:
+			t.Errorf("a terminal bound TI must not be listed: %+v", got[i])
+		case dedRun:
+			t.Errorf("an unbound running TI must not be listed: %+v", got[i])
+		}
+	}
+	if mine == nil {
+		t.Fatalf("the running bound TI (run %s, worker %s) must be listed", liveRun, wantPod)
+	}
+	if mine.WarmWorkerID != wantPod {
+		t.Errorf("WarmWorkerID = %q, want %q", mine.WarmWorkerID, wantPod)
+	}
+	if mine.TaskID != "load" || mine.TryNumber != 1 {
+		t.Errorf("identity = (task %q, try %d), want (load, 1)", mine.TaskID, mine.TryNumber)
+	}
+}
+
+// TestListStaleQueuedCarriesWarmWorkerIDIntegration: a queued warm attempt shows
+// up in ListStaleQueuedCandidates carrying its warm_worker_id, and a queued
+// dedicated attempt carries "" — the exact input the H3 defer keys on.
+func TestListStaleQueuedCarriesWarmWorkerIDIntegration(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	stamp := time.Now().UnixNano()
+
+	warmDag := fmt.Sprintf("stale_warm_%d", stamp)
+	warmPod := fmt.Sprintf("leoflow-warm-stale-%d", stamp)
+	warmRun := seedQueuedWarmTask(t, repo, sched, exec, ctx, warmDag, "load", warmPod)
+
+	dedDag := fmt.Sprintf("stale_dedicated_%d", stamp)
+	dedRun := seedQueuedTaskNoBind(t, repo, sched, ctx, dedDag, "load")
+
+	got, err := sched.ListStaleQueuedCandidates(ctx)
+	if err != nil {
+		t.Fatalf("ListStaleQueuedCandidates: %v", err)
+	}
+
+	var warmSeen, dedSeen bool
+	for _, c := range got {
+		if c.DagRunID == warmRun {
+			warmSeen = true
+			if c.WarmWorkerID != warmPod {
+				t.Errorf("queued warm candidate WarmWorkerID = %q, want %q", c.WarmWorkerID, warmPod)
+			}
+		}
+		if c.DagRunID == dedRun {
+			dedSeen = true
+			if c.WarmWorkerID != "" {
+				t.Errorf("queued dedicated candidate WarmWorkerID = %q, want \"\" (NULL)", c.WarmWorkerID)
+			}
+		}
+	}
+	if !warmSeen {
+		t.Fatalf("the queued warm attempt (run %s) must appear among stale-queued candidates", warmRun)
+	}
+	if !dedSeen {
+		t.Fatalf("the queued dedicated attempt (run %s) must appear among stale-queued candidates", dedRun)
+	}
+}
+
+// seedQueuedTaskNoBind brings a fresh DAG up to a single task instance in
+// `queued` with NO warm binding (a dedicated task), returning the run UUID.
+func seedQueuedTaskNoBind(t *testing.T, repo *storage.Repository, sched *storage.SchedulerStore, ctx context.Context, dagID, taskID string) string {
+	t.Helper()
+	tasks := []domain.TaskSpec{{TaskID: taskID, Type: domain.TaskTypePython}}
+	registerSpec(t, repo, ctx, dagID, tasks)
+	if _, err := repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+		RunID: "r1", State: domain.DagRunStateRunning, RunType: "manual",
+		LogicalDate: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("CreateDagRun: %v", err)
+	}
+	runUUID := resolveRunUUID(t, sched, ctx, dagID)
+	if err := sched.MaterializeTasks(ctx, runUUID, tasks); err != nil {
+		t.Fatalf("MaterializeTasks: %v", err)
+	}
+	if err := sched.ApplyTransition(ctx, runUUID, taskID, domain.TaskStateQueued); err != nil {
+		t.Fatalf("ApplyTransition to queued: %v", err)
+	}
+	return runUUID
+}


### PR DESCRIPTION
**N1d-a2 of the warm-pool track (ADR 0058)** — consumes the durable `warm_worker_id` binding (N1d-a1) to **close the failover story** ("a warm pod dies mid-attempt, and its tasks?") and **kill the double-run** (review finding H3). Behind `execution.warm_pools_enabled` (off ⇒ no TI is warm-bound and the lister is nil ⇒ both paths inert ⇒ byte-for-byte today).

## warm-worker-lost reaper (new)
Lists running warm-bound TIs, reads the live warm-pod set **once** per tick, and for each attempt whose serving worker is gone (absent from the live set, or its pod went terminal) marks it `pod_lost` → **infra budget** (`infra_attempts`, not `try_number`). **Fan-out** is implicit: a dead worker holding N attempts gets all N re-placed in one tick. `Θ(bound TIs + pools)`. Panic-safe; per-TI errors isolated; `applied=false` (late settle) is a benign skip.
**Do-no-harm asymmetry:** on this authoritative KILL path a warm-pod LIST error is **not** an empty fleet (that would reap every live warm attempt on a transient apiserver blip) — a LIST error aborts the tick with zero marks and retries next tick.

## H3 double-run guard (dispatch-lost reaper)
A warm attempt has no task pod, so the existing `TaskPodActive` defer never protects it — the pure time threshold would fail a live-but-slow warm attempt (queued→running not yet reported) and infra-replace it **while the warm worker is still running it** = a second execution. Now: before failing a candidate, if its `WarmWorkerID` is set **and** its worker is in the live warm-pod set → **defer** (mirrors the #461 pod-liveness defer). The H3 defer tolerates empty-on-error (an empty set only skips a defer, never causes a kill).

## Wiring
`NewReaper` gains a `WarmPodLister`, set on the new reaper + the dispatch-lost reaper; `ReapOnce` runs the warm reaper after pod-lost. `main.go` builds one `KubernetesWarmPods` client **only when warm pools are enabled**, shared as reaper lister + reconciler client. Flag off ⇒ nil lister ⇒ inert.

## Tests
RED-first. warm reaper: dead-worker attempts marked (3-on-one-worker → 3; live untouched; terminal reaped; **LIST error → zero marks**; nil/empty → no-op; panic isolation). **H3 regression:** a stale queued attempt whose worker is LIVE is **deferred, not failed** (RED without the defer = the double-run); gone worker still reaped; dedicated unchanged. Integration (real Postgres): `ListWarmBoundRunningTIs` + `ListStaleQueued` carries `warm_worker_id`. `go vet ./...` **and** `-tags integration` clean · sqlc idempotent · build + `-tags integration` green · `golangci-lint` 0.

Remaining: N1d-b (reconciler busy-aware M1/M2 + reclaim wiring H2/H4), N1d-c (M4 cap + idle-TTL + D9 caps + watchdog + GC-anchor), bootstrap worker-scoped exchange (security), harness + real-cluster e2e — all pre-enable.