### PR TITLE
feat(warm): busy-aware reconciler — min_idle is idle workers, never delete busy (ADR 0058 N1d-b)

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -938,12 +938,14 @@ func startReconciler(ctx context.Context, cs kubernetes.Interface, namespace str
 }
 
 // startWarmPoolReconciler runs the leader-gated warm-pool reconciler (ADR 0058
-// N1b2b): each tick it reconciles the number of warm workers per active
-// dag_version to that version's effective min_idle. Like the pod reconciler it
-// mutates cluster state, so it runs on the leader alone via the gated ticker. It
-// is only called when warm pools are enabled.
-func startWarmPoolReconciler(ctx context.Context, targets executor.WarmTargetSource, pods executor.WarmPodClient, leading func() bool, rec executor.DecisionRecorder, logger *slog.Logger) {
-	rc := executor.NewWarmPoolReconciler(targets, pods, logger, rec)
+// N1b2b + N1d-b, model A2): each tick it keeps EffectiveMinIdle IDLE warm workers
+// ready per active dag_version, growing the pool past min_idle under load up to
+// MaxPoolSize and deleting only idle/terminal workers (never a busy one). It reads
+// the busy set (busy) once per tick to classify workers. Like the pod reconciler
+// it mutates cluster state, so it runs on the leader alone via the gated ticker.
+// It is only called when warm pools are enabled.
+func startWarmPoolReconciler(ctx context.Context, targets executor.WarmTargetSource, pods executor.WarmPodClient, busy executor.BusyWarmWorkerSource, leading func() bool, rec executor.DecisionRecorder, logger *slog.Logger) {
+	rc := executor.NewWarmPoolReconciler(targets, pods, busy, logger, rec)
 	startGatedTicker(ctx, "warm-pool-reconcile", reconcileInterval, leading, logger, func() {
 		if err := rc.Reconcile(ctx); err != nil {
 			logger.Error("warm pool reconcile", "error", err)
@@ -1341,7 +1343,10 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 	// stays byte-for-byte today's dedicated pod-per-task.
 	if cfg.Execution.WarmPoolsEnabled {
 		store.SetWarmExecution(cfg.Execution)
-		startWarmPoolReconciler(ctx, store, warmPods, sched.IsLeading, metrics, logger)
+		// The busy set (running attempts durably bound to a warm worker) makes the
+		// reconciler busy-aware (ADR 0058 N1d-b): it scales the IDLE buffer and never
+		// deletes a worker with an in-flight attempt. store implements it.
+		startWarmPoolReconciler(ctx, store, warmPods, store, sched.IsLeading, metrics, logger)
 		logger.Warn("warm pool reconciler enabled (ADR 0058 N1b2b); maintaining min_idle warm workers per active dag_version", "namespace", cfg.Executor.TaskNamespace)
 	}
 	logger.Info("pod dispatch enabled", "namespace", cfg.Executor.TaskNamespace, "agent_control_plane_addr", controlAddr)

--- a/internal/executor/warmpool.go
+++ b/internal/executor/warmpool.go
@@ -6,13 +6,28 @@ import (
 )
 
 // WarmTarget is one active dag_version the warm-pool reconciler keeps warm workers
-// ready for, and how many (already resolved through the clamp/fallback/flag gate —
-// see config.ExecutionSection.EffectiveMinIdle). Image is the DAG's image the warm
-// worker runs the agent from.
+// ready for (model A2, ADR 0058 N1d-b). Image is the DAG's image the warm worker
+// runs the agent from.
+//
+// EffectiveMinIdle is the number of IDLE workers to keep ready for this version —
+// the warm buffer, already resolved through the clamp/fallback/flag gate (see
+// config.ExecutionSection.EffectiveMinIdle). It is NOT a total pool size: busy
+// workers do not count against it, so under load the pool grows past min_idle to
+// keep the idle buffer available.
+//
+// MaxPoolSize is the TOTAL ceiling of live workers (idle + busy) the version may
+// hold at once (config.ExecutionSection.MaxPoolSize). The reconciler never creates
+// past it, so the pool breathes between EffectiveMinIdle-idle + busy and this cap.
+// The N1a boot validation guarantees max_pool_size >= 1 when warm pools are on and
+// EffectiveMinIdle is clamped to it upstream, so MaxPoolSize >= EffectiveMinIdle in
+// practice; the reconciler still handles MaxPoolSize < EffectiveMinIdle defensively
+// by taking the effective ceiling as max(EffectiveMinIdle, MaxPoolSize) — the idle
+// buffer must always be creatable.
 type WarmTarget struct {
 	DagVersionID     string
 	Image            string
 	EffectiveMinIdle int
+	MaxPoolSize      int
 }
 
 // WarmTargetSource yields the currently active dag_versions and their effective
@@ -23,6 +38,20 @@ type WarmTarget struct {
 // cycle — storage already imports executor).
 type WarmTargetSource interface {
 	ActiveWarmTargets(ctx context.Context) ([]WarmTarget, error)
+}
+
+// BusyWarmWorkerSource yields the set of warm-worker pod names currently serving a
+// `running` attempt (ADR 0058 N1d-b): a warm worker is BUSY iff some `running`
+// task_instance is durably bound to it (warm_worker_id = the pod's own name — the
+// binding landed in N1d-a1/a2). Returned as a set keyed by pod name so the
+// reconciler classifies each live pod in O(1).
+//
+// Implemented on the storage side and defined HERE so the reconciler depends on a
+// narrow capability rather than importing storage. With warm pools off no TI is
+// ever bound, so the set is always empty and every worker classifies as idle —
+// byte-for-byte today's dedicated pod-per-task behavior.
+type BusyWarmWorkerSource interface {
+	ListBusyWarmWorkerPods(ctx context.Context) (map[string]bool, error)
 }
 
 // WarmPodInfo identifies one existing warm-worker pod and the dag_version it
@@ -51,38 +80,55 @@ type WarmPodClient interface {
 	DeleteWarmPod(ctx context.Context, name string) error
 }
 
-// WarmPoolReconciler maintains the target number of warm workers per active
-// dag_version (ADR 0058 N1b2b, model A2). Each tick it reads the active targets
-// and the existing warm fleet, then for each version CREATEs missing workers up to
-// the target and DELETEs excess — and drains any version that is no longer active
-// (target 0). It is leader-gated (run on a gated ticker, like the pod reconciler)
-// so at replicaCount>1 only the leader mutates the fleet.
+// WarmPoolReconciler maintains the IDLE warm-worker buffer per active dag_version
+// (ADR 0058 N1b2b + N1d-b, model A2). Each tick it reads the active targets, the
+// existing warm fleet, and the busy set (pods serving a running attempt), then per
+// version partitions the live pods into BUSY and IDLE and:
+//   - CREATEs enough workers to restore EffectiveMinIdle IDLE workers, capped by
+//     MaxPoolSize (the total ceiling) — so the pool grows past min_idle under load
+//     and never exceeds the cap;
+//   - DELETEs only EXCESS IDLE workers (idle over the target), never a busy one, so
+//     a scale-down or a drain never kills an in-flight attempt (review M1);
+//   - reaps terminal pods unconditionally (H1);
+//   - drains a no-longer-active version (target 0) down to its idle workers +
+//     terminal pods, LEAVING busy workers to finish (they are deleted a later tick
+//     once idle).
 //
-// Idempotent (it reconciles to a count, so re-running converges), panic-safe and
-// per-version isolated (one bad dag_version never blocks the others), and O(active
-// versions) per tick. It is only constructed and started when warm pools are
-// enabled; with them off the reconciler never runs, so every warm pool stays empty
-// and dispatch is byte-for-byte today's dedicated pod-per-task.
+// It is leader-gated (run on a gated ticker, like the pod reconciler) so at
+// replicaCount>1 only the leader mutates the fleet. Idempotent (it reconciles to
+// the idle target, so re-running converges), panic-safe and per-version isolated
+// (one bad dag_version never blocks the others), and O(active versions) per tick.
+// It is only constructed and started when warm pools are enabled; with them off
+// the reconciler never runs, every warm pool stays empty, and dispatch is
+// byte-for-byte today's dedicated pod-per-task.
 //
-// Deferred to N1d (NOT this brick): the idle-TTL freshness recycle (D6), the D9
-// worker lifetime / attempts-per-worker caps, and the D7 failover reaper fan-out +
-// H2 durable binding. The GC-anchor ConfigMap (D11) is also N1d; a bare warm pod
-// deleted here is fine until then.
+// The busy set is a hard safety input: without it every worker looks idle and a
+// busy worker could be deleted, so a nil busy source or a busy-list error aborts
+// the tick with zero mutations (do-no-harm).
+//
+// Deferred beyond this brick: the idle-TTL freshness recycle (D6), the D9 worker
+// lifetime / attempts-per-worker caps, and the GC-anchor ConfigMap (D11); a bare
+// warm pod deleted here is fine until then.
 type WarmPoolReconciler struct {
 	targets WarmTargetSource
 	pods    WarmPodClient
+	busy    BusyWarmWorkerSource
 	logger  *slog.Logger
 	rec     DecisionRecorder
 }
 
-// NewWarmPoolReconciler builds a reconciler over the given target source and pod
-// client. logger and rec (metrics) are optional — a nil logger falls back to the
-// default and a nil rec skips metering.
-func NewWarmPoolReconciler(targets WarmTargetSource, pods WarmPodClient, logger *slog.Logger, rec DecisionRecorder) *WarmPoolReconciler {
+// NewWarmPoolReconciler builds a reconciler over the given target source, pod
+// client, and busy-worker source. busy is REQUIRED: it classifies each live pod as
+// busy or idle so scale-down never kills an in-flight attempt (ADR 0058 N1d-b M1);
+// without it every worker would look idle and a busy worker could be deleted, so a
+// nil busy source (or a busy-list error at tick time) makes the tick do nothing —
+// do-no-harm. logger and rec (metrics) are optional — a nil logger falls back to
+// the default and a nil rec skips metering.
+func NewWarmPoolReconciler(targets WarmTargetSource, pods WarmPodClient, busy BusyWarmWorkerSource, logger *slog.Logger, rec DecisionRecorder) *WarmPoolReconciler {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &WarmPoolReconciler{targets: targets, pods: pods, logger: logger, rec: rec}
+	return &WarmPoolReconciler{targets: targets, pods: pods, busy: busy, logger: logger, rec: rec}
 }
 
 // Reconcile brings the warm fleet in line with the active targets for one tick. It
@@ -100,6 +146,24 @@ func (r *WarmPoolReconciler) Reconcile(ctx context.Context) error {
 		return err
 	}
 
+	// Read the busy set ONCE per tick. This is the safety input: it tells the
+	// reconciler which live workers are serving a running attempt so scale-down and
+	// drain delete only IDLE workers (ADR 0058 N1d-b M1). Without it every worker
+	// looks idle and a busy worker could be deleted mid-attempt, so a nil source or
+	// a store error here ABORTS the tick with zero creates/deletes (do-no-harm):
+	// log, meter, and return so the ticker retries next tick on a good view.
+	if r.busy == nil {
+		r.logger.ErrorContext(ctx, "warm-pool reconcile skipped: no busy-worker source wired; cannot classify workers, taking no action")
+		r.record("warm_pool_busy_source_missing")
+		return nil
+	}
+	busy, err := r.busy.ListBusyWarmWorkerPods(ctx)
+	if err != nil {
+		r.logger.ErrorContext(ctx, "warm-pool reconcile aborted: listing busy warm workers failed; taking no action this tick to avoid deleting a busy worker", "error", err)
+		r.record("warm_pool_busy_list_error")
+		return nil
+	}
+
 	// Group the existing fleet by the dag_version each worker serves.
 	byVersion := make(map[string][]WarmPodInfo, len(existing))
 	for _, p := range existing {
@@ -111,21 +175,28 @@ func (r *WarmPoolReconciler) Reconcile(ctx context.Context) error {
 	active := make(map[string]bool, len(targets))
 	for _, t := range targets {
 		active[t.DagVersionID] = true
-		r.reconcileVersion(ctx, t, byVersion[t.DagVersionID])
+		r.reconcileVersion(ctx, t, byVersion[t.DagVersionID], busy)
 	}
 	for dagVersionID, have := range byVersion {
 		if active[dagVersionID] {
 			continue
 		}
-		r.reconcileVersion(ctx, WarmTarget{DagVersionID: dagVersionID, EffectiveMinIdle: 0}, have)
+		r.reconcileVersion(ctx, WarmTarget{DagVersionID: dagVersionID, EffectiveMinIdle: 0}, have, busy)
 	}
 	return nil
 }
 
-// reconcileVersion brings one dag_version's warm-worker count to its target,
-// isolated behind a recover so a panic in one version's create/delete path never
-// takes down the whole sweep.
-func (r *WarmPoolReconciler) reconcileVersion(ctx context.Context, t WarmTarget, have []WarmPodInfo) {
+// reconcileVersion brings one dag_version's IDLE warm-worker buffer to its target
+// under model A2 (ADR 0058 N1d-b), isolated behind a recover so a panic in one
+// version's create/delete path never takes down the whole sweep. busy is the
+// tick's live busy set (pod names serving a running attempt).
+//
+// The unit here is IDLE workers, not total workers: EffectiveMinIdle is how many
+// idle workers to keep ready and MaxPoolSize is the total ceiling. So the pool
+// grows past min_idle under load (busy workers do not consume the idle buffer) and
+// never exceeds the ceiling, and scale-down/drain deletes only IDLE workers so an
+// in-flight attempt is never killed (M1).
+func (r *WarmPoolReconciler) reconcileVersion(ctx context.Context, t WarmTarget, have []WarmPodInfo, busy map[string]bool) {
 	defer func() {
 		if p := recover(); p != nil {
 			r.logger.ErrorContext(ctx, "warm-pool reconcile panicked for a dag_version; other versions unaffected",
@@ -139,21 +210,46 @@ func (r *WarmPoolReconciler) reconcileVersion(ctx context.Context, t WarmTarget,
 	// is a dead worker: it can never serve again, must not count toward the
 	// target (or a crashed/drained worker would never be replaced and the pool
 	// would silently die), and must not leak. This runs regardless of target, so
-	// the drain path (inactive version, target 0) reaps terminal pods too.
-	live := make([]WarmPodInfo, 0, len(have))
+	// the drain path (inactive version, target 0) reaps terminal pods too. Then
+	// partition the live pods into BUSY (currently serving a running attempt) and
+	// IDLE (the rest) — the reconciler only ever creates toward, or deletes from,
+	// the IDLE set; busy workers are never touched (M1).
+	idle := make([]WarmPodInfo, 0, len(have))
+	busyCount := 0
 	for _, p := range have {
 		if p.Terminal {
 			r.deleteWarmPod(ctx, t, p, "deleting terminal warm worker")
 			continue
 		}
-		live = append(live, p)
+		if busy[p.Name] {
+			busyCount++
+			continue
+		}
+		idle = append(idle, p)
+	}
+	live := busyCount + len(idle)
+
+	// Effective ceiling: the idle buffer must always be creatable, so never let the
+	// ceiling fall below the idle target even if an operator (or a stale target)
+	// hands us MaxPoolSize < EffectiveMinIdle. In practice MaxPoolSize >=
+	// EffectiveMinIdle already (boot validation + upstream clamp), so this is a
+	// defensive floor, not a normal path.
+	maxPool := t.MaxPoolSize
+	if maxPool < t.EffectiveMinIdle {
+		maxPool = t.EffectiveMinIdle
 	}
 
 	switch {
-	case len(live) < t.EffectiveMinIdle:
-		// Under target: create the shortfall. Each create is isolated so one
-		// apiserver rejection does not stop the rest of this version's workers.
-		for i := 0; i < t.EffectiveMinIdle-len(live); i++ {
+	case len(idle) < t.EffectiveMinIdle && live < maxPool:
+		// Idle buffer is short AND the pool is below its total ceiling: create
+		// enough to restore the buffer, but never past the ceiling. create =
+		// min(idle shortfall, headroom to the ceiling). Each create is isolated so
+		// one apiserver rejection does not stop the rest of this version's workers.
+		create := t.EffectiveMinIdle - len(idle)
+		if headroom := maxPool - live; headroom < create {
+			create = headroom
+		}
+		for i := 0; i < create; i++ {
 			if err := r.pods.CreateWarmPod(ctx, t); err != nil {
 				r.logger.ErrorContext(ctx, "creating warm worker",
 					"dag_version", t.DagVersionID, "image", t.Image, "error", err)
@@ -162,12 +258,15 @@ func (r *WarmPoolReconciler) reconcileVersion(ctx context.Context, t WarmTarget,
 			}
 			r.record("warm_pool_pod_created")
 		}
-	case len(live) > t.EffectiveMinIdle:
-		// Over target (or the version is no longer active, target 0): delete the
-		// excess live workers. Deleting the tail is arbitrary but stable — every
-		// worker of a version is interchangeable.
-		for _, p := range live[t.EffectiveMinIdle:] {
-			r.deleteWarmPod(ctx, t, p, "deleting excess warm worker")
+	case len(idle) > t.EffectiveMinIdle:
+		// Too many idle workers (over target, or the version is no longer active so
+		// the idle target is 0): delete the excess IDLE workers only. Busy workers
+		// are excluded from `idle` entirely, so a scale-down or a drain can never
+		// kill an in-flight attempt (M1) — a busy worker is deleted only on a later
+		// tick, once it has gone idle. Deleting the tail is arbitrary but stable:
+		// every idle worker of a version is interchangeable.
+		for _, p := range idle[t.EffectiveMinIdle:] {
+			r.deleteWarmPod(ctx, t, p, "deleting excess idle warm worker")
 		}
 	}
 }

--- a/internal/executor/warmpool_test.go
+++ b/internal/executor/warmpool_test.go
@@ -52,6 +52,27 @@ func (f *fakeWarmPods) DeleteWarmPod(_ context.Context, name string) error {
 	return nil
 }
 
+// fakeBusyWorkers is a canned BusyWarmWorkerSource: the set of warm-worker pod
+// names currently serving a running attempt. err simulates the busy-list failing
+// (do-no-harm abort).
+type fakeBusyWorkers struct {
+	busy map[string]bool
+	err  error
+}
+
+func (f *fakeBusyWorkers) ListBusyWarmWorkerPods(context.Context) (map[string]bool, error) {
+	return f.busy, f.err
+}
+
+// busySet builds a busy source from a list of busy pod names.
+func busySet(names ...string) *fakeBusyWorkers {
+	b := map[string]bool{}
+	for _, n := range names {
+		b[n] = true
+	}
+	return &fakeBusyWorkers{busy: b}
+}
+
 func warmPods(dagVersionID string, names ...string) []WarmPodInfo {
 	out := make([]WarmPodInfo, 0, len(names))
 	for _, n := range names {
@@ -71,9 +92,17 @@ func warmTerminalPods(dagVersionID string, names ...string) []WarmPodInfo {
 	return out
 }
 
+// reconcileWarm runs a tick with NO busy workers (every live pod is idle) — the
+// classic case the pre-N1d-b tests exercise.
 func reconcileWarm(t *testing.T, targets *fakeWarmTargets, pods *fakeWarmPods) {
 	t.Helper()
-	r := NewWarmPoolReconciler(targets, pods, nil, nil)
+	reconcileWarmBusy(t, targets, pods, &fakeBusyWorkers{})
+}
+
+// reconcileWarmBusy runs a tick against a specific busy set.
+func reconcileWarmBusy(t *testing.T, targets *fakeWarmTargets, pods *fakeWarmPods, busy *fakeBusyWorkers) {
+	t.Helper()
+	r := NewWarmPoolReconciler(targets, pods, busy, nil, nil)
 	if err := r.Reconcile(context.Background()); err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
@@ -264,7 +293,7 @@ func TestWarmPoolReconcileCreateErrorIsolatedPerPod(t *testing.T) {
 func TestWarmPoolReconcileListErrorReturned(t *testing.T) {
 	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", EffectiveMinIdle: 1}}}
 	pods := &fakeWarmPods{listErr: errors.New("watch broke")}
-	r := NewWarmPoolReconciler(targets, pods, nil, nil)
+	r := NewWarmPoolReconciler(targets, pods, &fakeBusyWorkers{}, nil, nil)
 	if err := r.Reconcile(context.Background()); err == nil {
 		t.Fatal("Reconcile = nil on list error, want the error surfaced")
 	}
@@ -277,8 +306,166 @@ func TestWarmPoolReconcileListErrorReturned(t *testing.T) {
 func TestWarmPoolReconcileTargetsErrorReturned(t *testing.T) {
 	targets := &fakeWarmTargets{err: errors.New("db down")}
 	pods := &fakeWarmPods{}
-	r := NewWarmPoolReconciler(targets, pods, nil, nil)
+	r := NewWarmPoolReconciler(targets, pods, &fakeBusyWorkers{}, nil, nil)
 	if err := r.Reconcile(context.Background()); err == nil {
 		t.Fatal("Reconcile = nil on targets error, want the error surfaced")
+	}
+}
+
+// ---- ADR 0058 N1d-b: busy-aware reconcile (model A2). EffectiveMinIdle is the
+// number of IDLE workers to keep ready; MaxPoolSize is the total ceiling. Busy
+// workers (serving a running attempt) never count against the idle target and are
+// never deleted. ----
+
+// deletedSet turns the reconciler's deleted list into a set for membership asserts.
+func deletedSet(pods *fakeWarmPods) map[string]bool {
+	s := map[string]bool{}
+	for _, n := range pods.deleted {
+		s[n] = true
+	}
+	return s
+}
+
+// TestWarmPoolReconcileCreatesIdleBufferUnderLoad is the M2 create-idle-buffer
+// case: EffectiveMinIdle=2, MaxPoolSize=8, and all 3 live workers are BUSY (0
+// idle). Model A2 keeps 2 IDLE workers ready, so busy workers must NOT satisfy the
+// idle target: the reconciler CREATES 2 (restoring the idle buffer) and deletes 0.
+// The pre-N1d-b logic counted total workers against the target (3 > 2) and deleted
+// a busy worker — the M1/M2 bug this fix closes.
+func TestWarmPoolReconcileCreatesIdleBufferUnderLoad(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", Image: "img", EffectiveMinIdle: 2, MaxPoolSize: 8}}}
+	pods := &fakeWarmPods{existing: warmPods("dv1", "b1", "b2", "b3")}
+	reconcileWarmBusy(t, targets, pods, busySet("b1", "b2", "b3"))
+	if len(pods.created) != 2 {
+		t.Errorf("created %d, want 2 (busy workers do not count toward the idle buffer)", len(pods.created))
+	}
+	if len(pods.deleted) != 0 {
+		t.Errorf("deleted %v, want none (all 3 live workers are busy)", pods.deleted)
+	}
+}
+
+// TestWarmPoolReconcileRespectsMaxPoolSize is the M2 respect-ceiling case:
+// EffectiveMinIdle=2, MaxPoolSize=8, 8 live workers all BUSY (0 idle). The idle
+// buffer is short but the pool is at its total ceiling, so the reconciler creates
+// 0 (never exceeding MaxPoolSize) and deletes 0.
+func TestWarmPoolReconcileRespectsMaxPoolSize(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", Image: "img", EffectiveMinIdle: 2, MaxPoolSize: 8}}}
+	pods := &fakeWarmPods{existing: warmPods("dv1", "b1", "b2", "b3", "b4", "b5", "b6", "b7", "b8")}
+	reconcileWarmBusy(t, targets, pods, busySet("b1", "b2", "b3", "b4", "b5", "b6", "b7", "b8"))
+	if len(pods.created) != 0 {
+		t.Errorf("created %d, want 0 (pool is at MaxPoolSize=8)", len(pods.created))
+	}
+	if len(pods.deleted) != 0 {
+		t.Errorf("deleted %v, want none", pods.deleted)
+	}
+}
+
+// TestWarmPoolReconcileIdleSteadyState: EffectiveMinIdle=2 with exactly 2 idle + 3
+// busy workers is at steady state — the idle buffer is satisfied and no idle is in
+// excess, so nothing is created or deleted.
+func TestWarmPoolReconcileIdleSteadyState(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", EffectiveMinIdle: 2, MaxPoolSize: 8}}}
+	pods := &fakeWarmPods{existing: warmPods("dv1", "i1", "i2", "b1", "b2", "b3")}
+	reconcileWarmBusy(t, targets, pods, busySet("b1", "b2", "b3"))
+	if len(pods.created) != 0 || len(pods.deleted) != 0 {
+		t.Errorf("created %v deleted %v, want no changes (2 idle + 3 busy is steady state)", pods.created, pods.deleted)
+	}
+}
+
+// TestWarmPoolReconcileDeletesExcessIdleOnly: EffectiveMinIdle=2 with 5 idle + 1
+// busy. There are 3 idle workers over target, so the reconciler deletes exactly 3
+// IDLE workers, keeping the busy worker and 2 idle.
+func TestWarmPoolReconcileDeletesExcessIdleOnly(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", EffectiveMinIdle: 2, MaxPoolSize: 8}}}
+	pods := &fakeWarmPods{existing: warmPods("dv1", "i1", "i2", "i3", "i4", "i5", "b1")}
+	reconcileWarmBusy(t, targets, pods, busySet("b1"))
+	if len(pods.created) != 0 {
+		t.Errorf("created %v, want none", pods.created)
+	}
+	if len(pods.deleted) != 3 {
+		t.Fatalf("deleted %v, want exactly 3 idle workers", pods.deleted)
+	}
+	if deletedSet(pods)["b1"] {
+		t.Errorf("deleted %v, must NOT delete the busy worker b1", pods.deleted)
+	}
+}
+
+// TestWarmPoolReconcileNeverDeletesBusy is the M1 case: a scale-down where every
+// candidate is BUSY. EffectiveMinIdle=0 (drain-like) with 3 busy workers and 0
+// idle — there is nothing idle to delete, so the reconciler deletes 0. A busy
+// worker's in-flight attempt is never killed; it is reaped on a later tick once it
+// goes idle.
+func TestWarmPoolReconcileNeverDeletesBusy(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", EffectiveMinIdle: 0, MaxPoolSize: 8}}}
+	pods := &fakeWarmPods{existing: warmPods("dv1", "b1", "b2", "b3")}
+	reconcileWarmBusy(t, targets, pods, busySet("b1", "b2", "b3"))
+	if len(pods.deleted) != 0 {
+		t.Errorf("deleted %v, want none (every candidate is busy; M1: never delete a busy worker)", pods.deleted)
+	}
+	if len(pods.created) != 0 {
+		t.Errorf("created %v, want none", pods.created)
+	}
+}
+
+// TestWarmPoolReconcileDrainLeavesBusy is the drain case: an inactive version
+// (target 0, MaxPoolSize 0) holding 2 idle + 1 busy + 1 terminal. The reconciler
+// drains the 2 idle and reaps the 1 terminal, but LEAVES the busy worker to finish
+// its attempt — deleting it would kill live work (M1). It is deleted next tick
+// once idle.
+func TestWarmPoolReconcileDrainLeavesBusy(t *testing.T) {
+	// dv1 is active (keeps its own pod); "gone" is inactive (not in targets).
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", EffectiveMinIdle: 1, MaxPoolSize: 8}}}
+	pods := &fakeWarmPods{existing: append(
+		warmPods("dv1", "keep"),
+		append(warmPods("gone", "idle1", "idle2", "busy1"), warmTerminalPods("gone", "dead1")...)...,
+	)}
+	reconcileWarmBusy(t, targets, pods, busySet("busy1"))
+	del := deletedSet(pods)
+	if !del["idle1"] || !del["idle2"] {
+		t.Errorf("deleted %v, want both idle workers drained", pods.deleted)
+	}
+	if !del["dead1"] {
+		t.Errorf("deleted %v, want the terminal pod reaped", pods.deleted)
+	}
+	if del["busy1"] {
+		t.Errorf("deleted %v, must LEAVE the busy worker to finish its attempt (M1)", pods.deleted)
+	}
+	if del["keep"] {
+		t.Errorf("deleted %v, must not touch the active version's pod", pods.deleted)
+	}
+	if len(pods.deleted) != 3 {
+		t.Errorf("deleted %v, want exactly 3 (2 idle + 1 terminal)", pods.deleted)
+	}
+}
+
+// TestWarmPoolReconcileBusyListErrorAborts is the do-no-harm case: the busy-worker
+// source erroring means the reconciler cannot tell busy from idle, so the tick
+// takes NO action — zero creates, zero deletes — rather than risk deleting a busy
+// worker. Reconcile returns nil (logged + metered, not surfaced as a ticker error)
+// so it simply retries next tick on a good view.
+func TestWarmPoolReconcileBusyListErrorAborts(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", EffectiveMinIdle: 2, MaxPoolSize: 8}}}
+	pods := &fakeWarmPods{existing: warmPods("dv1", "p1", "p2", "p3")}
+	busy := &fakeBusyWorkers{err: errors.New("db down")}
+	r := NewWarmPoolReconciler(targets, pods, busy, nil, nil)
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile = %v, want nil (busy-list error is do-no-harm, not surfaced)", err)
+	}
+	if len(pods.created) != 0 || len(pods.deleted) != 0 {
+		t.Errorf("created %v deleted %v, want NO action when the busy set is unavailable", pods.created, pods.deleted)
+	}
+}
+
+// TestWarmPoolReconcileNoBusySourceAborts: a nil busy source (wiring regression)
+// is do-no-harm too — no classification means no action.
+func TestWarmPoolReconcileNoBusySourceAborts(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", EffectiveMinIdle: 2, MaxPoolSize: 8}}}
+	pods := &fakeWarmPods{existing: warmPods("dv1", "p1", "p2", "p3")}
+	r := NewWarmPoolReconciler(targets, pods, nil, nil, nil)
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile = %v, want nil (nil busy source is do-no-harm)", err)
+	}
+	if len(pods.created) != 0 || len(pods.deleted) != 0 {
+		t.Errorf("created %v deleted %v, want NO action without a busy source", pods.created, pods.deleted)
 	}
 }

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -170,6 +170,16 @@ type Querier interface {
 	// outage; the rest are picked up on the next tick.
 	ListAgentLostCandidates(ctx context.Context) ([]ListAgentLostCandidatesRow, error)
 	ListAuditLogs(ctx context.Context, arg ListAuditLogsParams) ([]ListAuditLogsRow, error)
+	// Lists the DISTINCT warm-worker pod names currently serving a `running` attempt
+	// (ADR 0058 N1d-b): a warm worker is BUSY iff some `running` task_instance is
+	// durably bound to it (warm_worker_id = the pod's own name — the binding landed
+	// in N1d-a1/a2). The busy-aware warm-pool reconciler reads this once per tick to
+	// classify each live warm pod as busy (serving an attempt) or idle, so
+	// scale-down and drain delete only IDLE workers and never kill an in-flight
+	// attempt (review findings M1/M2). With warm pools off no TI is ever bound, so
+	// this is always empty and every worker classifies as idle — byte-for-byte
+	// today's dedicated pod-per-task behavior.
+	ListBusyWarmWorkerPods(ctx context.Context) ([]*string, error)
 	// All of a tenant's connections WITH the encrypted password, for delivering
 	// credentials to task pods (ADR 0021). Never use this for UI/API responses,
 	// which must mask the password.

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -762,6 +762,21 @@ WHERE ti.state = 'running'
 ORDER BY ti.started_at NULLS LAST
 LIMIT 100;
 
+-- name: ListBusyWarmWorkerPods :many
+-- Lists the DISTINCT warm-worker pod names currently serving a `running` attempt
+-- (ADR 0058 N1d-b): a warm worker is BUSY iff some `running` task_instance is
+-- durably bound to it (warm_worker_id = the pod's own name — the binding landed
+-- in N1d-a1/a2). The busy-aware warm-pool reconciler reads this once per tick to
+-- classify each live warm pod as busy (serving an attempt) or idle, so
+-- scale-down and drain delete only IDLE workers and never kill an in-flight
+-- attempt (review findings M1/M2). With warm pools off no TI is ever bound, so
+-- this is always empty and every worker classifies as idle — byte-for-byte
+-- today's dedicated pod-per-task behavior.
+SELECT DISTINCT ti.warm_worker_id AS warm_worker_id
+FROM task_instances ti
+WHERE ti.state = 'running'
+  AND ti.warm_worker_id IS NOT NULL;
+
 -- name: ListAgentLostCandidates :many
 -- Lists running TIs that have heartbeated at least once and whose latest
 -- heartbeat is non-null, alongside enough identity to log + observe.

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -742,6 +742,42 @@ func (q *Queries) ListAgentLostCandidates(ctx context.Context) ([]ListAgentLostC
 	return items, nil
 }
 
+const listBusyWarmWorkerPods = `-- name: ListBusyWarmWorkerPods :many
+SELECT DISTINCT ti.warm_worker_id AS warm_worker_id
+FROM task_instances ti
+WHERE ti.state = 'running'
+  AND ti.warm_worker_id IS NOT NULL
+`
+
+// Lists the DISTINCT warm-worker pod names currently serving a `running` attempt
+// (ADR 0058 N1d-b): a warm worker is BUSY iff some `running` task_instance is
+// durably bound to it (warm_worker_id = the pod's own name — the binding landed
+// in N1d-a1/a2). The busy-aware warm-pool reconciler reads this once per tick to
+// classify each live warm pod as busy (serving an attempt) or idle, so
+// scale-down and drain delete only IDLE workers and never kill an in-flight
+// attempt (review findings M1/M2). With warm pools off no TI is ever bound, so
+// this is always empty and every worker classifies as idle — byte-for-byte
+// today's dedicated pod-per-task behavior.
+func (q *Queries) ListBusyWarmWorkerPods(ctx context.Context) ([]*string, error) {
+	rows, err := q.db.Query(ctx, listBusyWarmWorkerPods)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*string{}
+	for rows.Next() {
+		var warm_worker_id *string
+		if err := rows.Scan(&warm_worker_id); err != nil {
+			return nil, err
+		}
+		items = append(items, warm_worker_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listDagRunsByDag = `-- name: ListDagRunsByDag :many
 SELECT id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note, alerted_at, alert_attempts, next_alert_attempt_at FROM dag_runs
 WHERE dag_id = $1

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -201,6 +201,10 @@ func warmTargets(versions []activeWarmVersion, exec config.ExecutionSection) []e
 			DagVersionID:     v.dagVersionID,
 			Image:            v.image,
 			EffectiveMinIdle: exec.EffectiveMinIdle(v.dagMinIdle),
+			// MaxPoolSize is the operator's total ceiling of warm workers per
+			// dag_version (model A2, ADR 0058 N1d-b). The reconciler grows the pool
+			// past min_idle under load up to this cap and never beyond it.
+			MaxPoolSize: exec.MaxPoolSize,
 		})
 	}
 	return out
@@ -563,6 +567,7 @@ func applyDefaultRetries(spec *domain.DAGSpec) {
 
 var _ scheduler.Store = (*SchedulerStore)(nil)
 var _ executor.WarmTargetSource = (*SchedulerStore)(nil)
+var _ executor.BusyWarmWorkerSource = (*SchedulerStore)(nil)
 
 // RecordStagingVolume records a per-run staging volume as active, keyed by PVC
 // name (idempotent — called per task as the PVC is ensured). ADR 0022.
@@ -766,6 +771,29 @@ func (s *SchedulerStore) ListWarmBoundRunningTIs(ctx context.Context) ([]executo
 		})
 	}
 	return out, nil
+}
+
+// ListBusyWarmWorkerPods returns the set of warm-worker pod names currently
+// serving a `running` attempt (ADR 0058 N1d-b): a warm worker is BUSY iff some
+// `running` task_instance is durably bound to it (warm_worker_id = the pod's own
+// name). The busy-aware warm-pool reconciler reads this once per tick to classify
+// each live warm pod as busy or idle, so scale-down/drain deletes only IDLE
+// workers and never kills an in-flight attempt (review findings M1/M2). With warm
+// pools off no TI is ever bound, so the set is always empty and every worker
+// classifies as idle — byte-for-byte today. Implements
+// executor.BusyWarmWorkerSource without the executor importing storage.
+func (s *SchedulerStore) ListBusyWarmWorkerPods(ctx context.Context) (map[string]bool, error) {
+	rows, err := s.q.ListBusyWarmWorkerPods(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("listing busy warm-worker pods: %w", err)
+	}
+	busy := make(map[string]bool, len(rows))
+	for _, name := range rows {
+		if name != nil {
+			busy[*name] = true
+		}
+	}
+	return busy, nil
 }
 
 // MarkTaskDispatchLost transitions one TI to `failed` with the dispatch_lost

--- a/internal/storage/warm_targets_test.go
+++ b/internal/storage/warm_targets_test.go
@@ -34,6 +34,13 @@ func TestWarmTargets(t *testing.T) {
 			t.Errorf("target %s carries no image", tgt.DagVersionID)
 		}
 	}
+	// MaxPoolSize (the operator's total ceiling) is threaded onto every target so
+	// the busy-aware reconciler can cap pool growth under load (ADR 0058 N1d-b).
+	for _, tgt := range got {
+		if tgt.MaxPoolSize != 8 {
+			t.Errorf("target %s MaxPoolSize = %d, want 8 (operator's execution.max_pool_size)", tgt.DagVersionID, tgt.MaxPoolSize)
+		}
+	}
 }
 
 // TestWarmTargetsWarmPoolsOff locks that with warm pools off every effective


### PR DESCRIPTION
**N1d-b of the warm-pool track (ADR 0058)** — fixes review findings **M1** (scale-down/drain deleted busy workers, killing in-flight attempts) and **M2** (reconciler counted total, not idle → no idle buffer under load, `max_pool_size` dead config). Behind `execution.warm_pools_enabled` (off ⇒ busy set empty ⇒ reconciler not started ⇒ byte-for-byte today).

## Semantics (model A2)
`EffectiveMinIdle` = idle workers to keep **ready**; `MaxPoolSize` = **total** ceiling. Per version, after reaping terminal pods (H1 preserved), live pods split into BUSY (a running `task_instance` has that pod in `warm_worker_id`) and IDLE:
- **create** when `len(idle) < EffectiveMinIdle && live < MaxPoolSize`: `min(EffectiveMinIdle − len(idle), MaxPoolSize − live)`
- **delete** when `len(idle) > EffectiveMinIdle`: `len(idle) − EffectiveMinIdle`, **only from the idle slice**
- **busy workers are never in the delete set** → never deleted (M1), on scale-down or drain; recycled only on a later tick once idle.

So `min_idle=0` (default / no warmth) keeps no idle → dedicated; `min_idle=3` keeps 3 ready and the pool grows with load up to `max_pool_size`.

## Busy source + do-no-harm
`ListBusyWarmWorkerPods` (distinct `warm_worker_id` among running TIs), fetched **once per tick**. A nil source or a list error **aborts the tick with zero mutations** — without the busy set every worker looks idle, so acting would risk deleting a busy one. `MaxPoolSize` threaded onto `WarmTarget` from `execution.max_pool_size`.

## Tests (RED-first — old total-count logic produced genuine RED, e.g. `deleted [b3], created 0` for create-idle-buffer)
M1 never-delete-busy (scale-down + drain), M2 create-idle-buffer (3 busy + min_idle 2 → **create 2**), M2 respect-max (8 busy at cap → create 0), idle steady-state, delete-excess-idle-only, drain-leaves-busy, busy-list-error-aborts, no-busy-source-aborts; H1 terminal-reaping still holds. `go vet ./...` **and** `-tags integration` clean · sqlc idempotent · build + `-tags integration` green · `golangci-lint` 0.

Remaining pre-enable: N1d-c (reclaim wiring H2/H4 + M4 cap + idle-TTL + D9 caps + watchdog + GC-anchor), bootstrap worker-scoped exchange (security), harness + real-cluster e2e.