### PR TITLE
feat(warm): reclaim wiring — unstrand worker + reason-gated fast re-placement (ADR 0058 N1d-c)

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -335,6 +335,49 @@ func loginRateLimit(cfg *config.ServerConfig) int {
 	return 5
 }
 
+// redispatchStore is the seam the warm reclaim observer uses to re-place an
+// attempt (ADR 0058 N1d-c, H2). *storage.ExecutionStore satisfies it; a fake
+// records the calls in tests.
+type redispatchStore interface {
+	RequeueForRedispatch(ctx context.Context, runID, taskID string, tryNumber int) error
+}
+
+// reclaimShouldRequeue reports whether a reclaimed warm assignment may be
+// immediately re-placed for fast recovery (ADR 0058 N1d-c, H2). ONLY the reasons
+// where the worker demonstrably will NOT run the attempt qualify, so re-placing
+// cannot double-run:
+//   - ReclaimWorkerGone: the worker's stream ended holding an unacked lease; a
+//     disconnected worker can never run it.
+//   - ReclaimRefused: the worker acked started=false — it explicitly declined.
+//
+// ReclaimLeaseExpired is deliberately NOT re-placed: a lease-expired worker may
+// be alive-but-slow and, by agent order, will still ack-then-run the attempt, so
+// fast-re-placing it could double-run. That case is recovered double-run-free by
+// the 3-minute dispatch-lost reaper + the H3 warm-defer already merged.
+func reclaimShouldRequeue(reason agentrpc.ReclaimReason) bool {
+	switch reason {
+	case agentrpc.ReclaimWorkerGone, agentrpc.ReclaimRefused:
+		return true
+	default: // ReclaimLeaseExpired and any future reason: recover via the reaper.
+		return false
+	}
+}
+
+// handleReclaim is the warm reclaim observer wired into the registry (ADR 0058
+// N1d-c, H2). It logs every reclaim, then re-places the attempt only for the
+// double-run-safe reasons (reclaimShouldRequeue). Re-placement is best-effort:
+// an error is logged, never fatal, so a transient DB blip cannot crash the
+// registry's emit path.
+func handleReclaim(ctx context.Context, store redispatchStore, logger *slog.Logger, ev agentrpc.ReclaimEvent) {
+	logger.Debug("warm worker assignment reclaimed", "assignment", ev.AssignmentID, "dag_version", ev.DagVersionID, "reason", ev.Reason)
+	if !reclaimShouldRequeue(ev.Reason) {
+		return
+	}
+	if err := store.RequeueForRedispatch(ctx, ev.RunID, ev.TaskID, ev.TryNumber); err != nil {
+		logger.Error("warm reclaim re-placement failed", "run", ev.RunID, "task", ev.TaskID, "try", ev.TryNumber, "err", err)
+	}
+}
+
 // startSchedulerSide starts the scheduler-role components (ADR 0049): the agent
 // gRPC endpoint, the XCom/log janitors, and — when cfg.Scheduler.Enabled — the
 // scheduler loop + dispatch pool. It returns the scheduler's health handle (nil
@@ -352,12 +395,13 @@ func startSchedulerSide(ctx context.Context, cfg *config.ServerConfig, pg *stora
 	// register/ack on it via SetWarmPools) and the dispatcher's placer (Assign).
 	// nil when warm pools are off => the handler stays inert (FailedPrecondition)
 	// and the dispatcher's placer stays nil, so every path is byte-for-byte
-	// today's dedicated pod-per-task. The reclaim-observer debug log is kept; a
-	// reclaimed attempt is re-placed by the buffered dispatch path on the next tick.
+	// today's dedicated pod-per-task; nothing reclaims and RequeueForRedispatch is
+	// never called. The reclaim observer (ADR 0058 N1d-c, H2) re-places reclaimed
+	// attempts through execStore for the double-run-safe reasons only.
 	var warmReg *agentrpc.WorkerRegistry
 	if cfg.Execution.WarmPoolsEnabled {
 		warmReg = agentrpc.NewWorkerRegistry(func(ev agentrpc.ReclaimEvent) {
-			logger.Debug("warm worker assignment reclaimed", "assignment", ev.AssignmentID, "dag_version", ev.DagVersionID, "reason", ev.Reason)
+			handleReclaim(ctx, execStore, logger, ev)
 		})
 		logger.Warn("warm worker pools enabled (ADR 0058 N1b1-place); admitted tasks place on a free warm worker of their dag_version, else dispatch dedicated")
 	}

--- a/cmd/leoflow-server/reclaim_wiring_test.go
+++ b/cmd/leoflow-server/reclaim_wiring_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/agentrpc"
+)
+
+// fakeRedispatchStore records RequeueForRedispatch calls so the reason-gating
+// decision (ADR 0058 N1d-c, H2) can be asserted without a database.
+type fakeRedispatchStore struct {
+	mu    sync.Mutex
+	calls []redispatchCall
+	err   error
+}
+
+type redispatchCall struct {
+	runID     string
+	taskID    string
+	tryNumber int
+}
+
+func (f *fakeRedispatchStore) RequeueForRedispatch(_ context.Context, runID, taskID string, tryNumber int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, redispatchCall{runID, taskID, tryNumber})
+	return f.err
+}
+
+func (f *fakeRedispatchStore) recorded() []redispatchCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]redispatchCall(nil), f.calls...)
+}
+
+func discardLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// TestReclaimShouldRequeueGating pins the pure decision: only the reasons where
+// the worker demonstrably will NOT run the attempt (WorkerGone, Refused) may be
+// fast-re-placed; LeaseExpired must not, because a slow-but-alive worker will
+// still ack-then-run and re-placing it could double-run.
+func TestReclaimShouldRequeueGating(t *testing.T) {
+	cases := []struct {
+		reason agentrpc.ReclaimReason
+		want   bool
+	}{
+		{agentrpc.ReclaimWorkerGone, true},
+		{agentrpc.ReclaimRefused, true},
+		{agentrpc.ReclaimLeaseExpired, false},
+	}
+	for _, c := range cases {
+		if got := reclaimShouldRequeue(c.reason); got != c.want {
+			t.Errorf("reclaimShouldRequeue(%v) = %v, want %v", c.reason, got, c.want)
+		}
+	}
+}
+
+// TestHandleReclaimReplacesOnlyDoubleRunSafeReasons drives handleReclaim end to
+// end against the fake store: WorkerGone and Refused re-place the exact attempt;
+// LeaseExpired does not call the store at all.
+func TestHandleReclaimReplacesOnlyDoubleRunSafeReasons(t *testing.T) {
+	t.Run("WorkerGone requeues", func(t *testing.T) {
+		store := &fakeRedispatchStore{}
+		handleReclaim(context.Background(), store, discardLogger(), agentrpc.ReclaimEvent{
+			Reason: agentrpc.ReclaimWorkerGone, RunID: "run-1", TaskID: "extract", TryNumber: 2,
+		})
+		got := store.recorded()
+		if len(got) != 1 {
+			t.Fatalf("WorkerGone: RequeueForRedispatch calls = %d, want 1", len(got))
+		}
+		if got[0] != (redispatchCall{"run-1", "extract", 2}) {
+			t.Fatalf("WorkerGone: requeued %+v, want run-1/extract/2", got[0])
+		}
+	})
+
+	t.Run("Refused requeues", func(t *testing.T) {
+		store := &fakeRedispatchStore{}
+		handleReclaim(context.Background(), store, discardLogger(), agentrpc.ReclaimEvent{
+			Reason: agentrpc.ReclaimRefused, RunID: "run-2", TaskID: "load", TryNumber: 1,
+		})
+		if got := store.recorded(); len(got) != 1 || got[0] != (redispatchCall{"run-2", "load", 1}) {
+			t.Fatalf("Refused: requeued %+v, want exactly run-2/load/1", got)
+		}
+	})
+
+	t.Run("LeaseExpired does NOT requeue", func(t *testing.T) {
+		store := &fakeRedispatchStore{}
+		handleReclaim(context.Background(), store, discardLogger(), agentrpc.ReclaimEvent{
+			Reason: agentrpc.ReclaimLeaseExpired, RunID: "run-3", TaskID: "transform", TryNumber: 5,
+		})
+		if got := store.recorded(); len(got) != 0 {
+			t.Fatalf("LeaseExpired: RequeueForRedispatch calls = %d, want 0 (recovered by the reaper, not fast-re-placed)", len(got))
+		}
+	})
+}
+
+// TestHandleReclaimBestEffortOnStoreError: a store error is swallowed (logged),
+// never propagated — the registry's emit path must not crash on a DB blip.
+func TestHandleReclaimBestEffortOnStoreError(t *testing.T) {
+	store := &fakeRedispatchStore{err: context.DeadlineExceeded}
+	// Must not panic; there is no error to return, so the assertion is simply
+	// that the call completes and the store was still attempted.
+	handleReclaim(context.Background(), store, discardLogger(), agentrpc.ReclaimEvent{
+		Reason: agentrpc.ReclaimWorkerGone, RunID: "run-9", TaskID: "x", TryNumber: 1,
+	})
+	if len(store.recorded()) != 1 {
+		t.Fatal("expected the re-placement to be attempted even though it errored")
+	}
+}

--- a/internal/agentrpc/await_assignment_test.go
+++ b/internal/agentrpc/await_assignment_test.go
@@ -244,6 +244,106 @@ func TestAckRefusedReclaims(t *testing.T) {
 	}
 }
 
+// ─── (f2) lease expiry returns the worker to the free set (H4) ──────────────
+
+// TestLeaseExpiryReturnsWorkerToFree: a missed ack is a transient slow-start,
+// not a wedge, so onLeaseExpire must return the worker to the free set rather
+// than strand it holding a pool slot forever (ADR 0058 N1d-c, H4). Proven
+// behaviourally: after the lease expires, a fresh Assign for the same
+// dag_version hands the worker out again.
+func TestLeaseExpiryReturnsWorkerToFree(t *testing.T) {
+	reclaims := make(chan ReclaimEvent, 4)
+	reg := NewWorkerRegistry(func(ev ReclaimEvent) { reclaims <- ev })
+	reg.leaseFor = func(*agentv1.WorkAssignment) time.Duration { return 5 * time.Millisecond }
+
+	send := make(chan *agentv1.WorkAssignment, 2)
+	reg.Register("w1", "v1", "pod-1", send)
+	if !reg.Assign("v1", &agentv1.WorkAssignment{AssignmentId: "as-1", DagVersionId: "v1"}) {
+		t.Fatal("first Assign should succeed")
+	}
+	<-send
+
+	// Wait for the reclaim so the lease has certainly expired and the worker
+	// has been returned to free under the lock.
+	select {
+	case ev := <-reclaims:
+		if ev.Reason != ReclaimLeaseExpired {
+			t.Fatalf("reclaim reason = %v, want ReclaimLeaseExpired", ev.Reason)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected a reclaim on lease expiry")
+	}
+	if reg.busy("w1") {
+		t.Fatal("a worker that never acked must not be busy")
+	}
+
+	// The worker is reusable: a subsequent Assign for the same dag_version hands
+	// it out again (it would return false if the worker were stranded).
+	awaitEventually(t, func() bool {
+		return reg.Assign("v1", &agentv1.WorkAssignment{AssignmentId: "as-2", DagVersionId: "v1"})
+	})
+	select {
+	case got := <-send:
+		if got.GetAssignmentId() != "as-2" {
+			t.Fatalf("re-Assigned assignment = %q, want as-2", got.GetAssignmentId())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected the re-Assigned assignment on the worker's channel")
+	}
+}
+
+// ─── (f3) reclaim events carry the attempt identity ─────────────────────────
+
+// TestReclaimEventCarriesAttemptIdentity: every emit site populates the
+// reclaimed attempt's (run, task, try) from the leaseState, so the observer can
+// re-place the exact attempt (ADR 0058 N1d-c). Proven on the lease-expiry site.
+func TestReclaimEventCarriesAttemptIdentity(t *testing.T) {
+	reclaims := make(chan ReclaimEvent, 4)
+	reg := NewWorkerRegistry(func(ev ReclaimEvent) { reclaims <- ev })
+	reg.leaseFor = func(*agentv1.WorkAssignment) time.Duration { return 5 * time.Millisecond }
+
+	send := make(chan *agentv1.WorkAssignment, 1)
+	reg.Register("w1", "v1", "pod-1", send)
+	reg.Assign("v1", &agentv1.WorkAssignment{
+		AssignmentId: "as-1", DagVersionId: "v1", DagRunId: "run-7", TaskId: "extract", TryNumber: 4,
+	})
+	<-send
+
+	select {
+	case ev := <-reclaims:
+		if ev.RunID != "run-7" || ev.TaskID != "extract" || ev.TryNumber != 4 {
+			t.Fatalf("reclaim identity = %s/%s/%d, want run-7/extract/4", ev.RunID, ev.TaskID, ev.TryNumber)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected a reclaim carrying the attempt identity")
+	}
+}
+
+// TestReclaimRefusedCarriesAttemptIdentity: the refused-ack emit site also
+// carries the attempt identity.
+func TestReclaimRefusedCarriesAttemptIdentity(t *testing.T) {
+	reclaims := make(chan ReclaimEvent, 4)
+	reg := NewWorkerRegistry(func(ev ReclaimEvent) { reclaims <- ev })
+	reg.leaseFor = func(*agentv1.WorkAssignment) time.Duration { return time.Hour }
+
+	send := make(chan *agentv1.WorkAssignment, 1)
+	reg.Register("w1", "v1", "pod-1", send)
+	reg.Assign("v1", &agentv1.WorkAssignment{
+		AssignmentId: "as-1", DagVersionId: "v1", DagRunId: "run-7", TaskId: "load", TryNumber: 2,
+	})
+	<-send
+	reg.Ack("as-1", false)
+
+	select {
+	case ev := <-reclaims:
+		if ev.Reason != ReclaimRefused || ev.RunID != "run-7" || ev.TaskID != "load" || ev.TryNumber != 2 {
+			t.Fatalf("refused reclaim = %v %s/%s/%d, want Refused run-7/load/2", ev.Reason, ev.RunID, ev.TaskID, ev.TryNumber)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected a refused reclaim carrying the attempt identity")
+	}
+}
+
 // ─── (h) stream close => deregistered ───────────────────────────────────────
 
 func TestAwaitAssignmentDeregistersOnStreamClose(t *testing.T) {

--- a/internal/agentrpc/worker_registry.go
+++ b/internal/agentrpc/worker_registry.go
@@ -23,12 +23,18 @@ const (
 )
 
 // ReclaimEvent is emitted when a handed-out assignment must be re-placed. The
-// future placement layer (N1b1-place) consumes it to re-dispatch the attempt on
-// the infra budget. It deliberately carries no attempt_token.
+// placement layer consumes it to re-dispatch the attempt on the infra budget. It
+// carries the attempt identity (RunID, TaskID, TryNumber) — populated from the
+// leaseState at every emit site — so the observer can re-place the exact attempt
+// (ADR 0058 N1d-c, H2) without re-deriving it. It deliberately carries no
+// attempt_token.
 type ReclaimEvent struct {
 	AssignmentID string
 	DagVersionID string
 	Reason       ReclaimReason
+	RunID        string
+	TaskID       string
+	TryNumber    int
 }
 
 // WarmBinding is the durable binding an ack (started=true) establishes: the warm
@@ -146,7 +152,14 @@ func (r *WorkerRegistry) Deregister(w *registeredWorker) {
 		if ls.worker == w {
 			ls.timer.Stop()
 			delete(r.leases, aid)
-			reclaims = append(reclaims, ReclaimEvent{AssignmentID: aid, DagVersionID: ls.dagVersion, Reason: ReclaimWorkerGone})
+			reclaims = append(reclaims, ReclaimEvent{
+				AssignmentID: aid,
+				DagVersionID: ls.dagVersion,
+				Reason:       ReclaimWorkerGone,
+				RunID:        ls.runID,
+				TaskID:       ls.taskID,
+				TryNumber:    ls.tryNumber,
+			})
 		}
 	}
 	r.mu.Unlock()
@@ -217,9 +230,16 @@ func (r *WorkerRegistry) Ack(assignmentID string, started bool) (*WarmBinding, b
 		r.mu.Unlock()
 		return binding, true
 	}
-	dagVersion := ls.dagVersion
+	ev := ReclaimEvent{
+		AssignmentID: assignmentID,
+		DagVersionID: ls.dagVersion,
+		Reason:       ReclaimRefused,
+		RunID:        ls.runID,
+		TaskID:       ls.taskID,
+		TryNumber:    ls.tryNumber,
+	}
 	r.mu.Unlock()
-	r.emitReclaim(ReclaimEvent{AssignmentID: assignmentID, DagVersionID: dagVersion, Reason: ReclaimRefused})
+	r.emitReclaim(ev)
 	return nil, false
 }
 
@@ -238,6 +258,14 @@ func (r *WorkerRegistry) MarkFree(identity string) {
 
 // onLeaseExpire reclaims an assignment whose lease elapsed with no ack. If the
 // lease was already settled (acked or the worker deregistered), it is a no-op.
+//
+// H4 (ADR 0058 N1d-c): a missed ack is usually a transient slow-start, not a
+// wedge, so the worker is returned to the free set rather than stranded holding
+// a pool slot forever — but only if the registry still points at exactly this
+// entry (a reconnect under the same identity installs a fresh entry we must not
+// disturb) and it is not busy serving another acked attempt. A genuine wedge is
+// bounded later by the D9 lifetime/attempt caps (out of scope here). Done under
+// the lock, consistent with the other free-set mutations.
 func (r *WorkerRegistry) onLeaseExpire(assignmentID string) {
 	r.mu.Lock()
 	ls, ok := r.leases[assignmentID]
@@ -246,9 +274,19 @@ func (r *WorkerRegistry) onLeaseExpire(assignmentID string) {
 		return
 	}
 	delete(r.leases, assignmentID)
-	dagVersion := ls.dagVersion
+	if w := ls.worker; r.workers[w.identity] == w && !w.busy {
+		r.addFreeLocked(w)
+	}
+	ev := ReclaimEvent{
+		AssignmentID: assignmentID,
+		DagVersionID: ls.dagVersion,
+		Reason:       ReclaimLeaseExpired,
+		RunID:        ls.runID,
+		TaskID:       ls.taskID,
+		TryNumber:    ls.tryNumber,
+	}
 	r.mu.Unlock()
-	r.emitReclaim(ReclaimEvent{AssignmentID: assignmentID, DagVersionID: dagVersion, Reason: ReclaimLeaseExpired})
+	r.emitReclaim(ev)
 }
 
 // emitReclaim delivers a reclaim event to the observer, always OUTSIDE the lock

--- a/internal/storage/agent_store.go
+++ b/internal/storage/agent_store.go
@@ -320,6 +320,29 @@ func (s *ExecutionStore) RescheduleTask(ctx context.Context, taskInstanceID stri
 	})
 }
 
+// RequeueForRedispatch re-places a reclaimed warm assignment (ADR 0058 N1d-c,
+// H2): an attempt that a warm worker was handed but demonstrably will not run
+// (its stream ended holding an unacked lease, or it acked started=false) sits
+// `queued` having never run. This moves it back to `scheduled` so the planner
+// re-admits and re-dispatches it, rather than leaving it stuck until the
+// 3-minute dispatch-lost reaper. Guarded to state='queued' and bounded to the
+// exact attempt (runID, taskID, tryNumber): zero rows is the guard working (the
+// TI is running or settled, or the attempt moved on), a benign no-op, not an
+// error. It bumps neither try_number nor infra_attempts — the attempt never ran,
+// this is a re-offer of the same attempt.
+func (s *ExecutionStore) RequeueForRedispatch(ctx context.Context, runID, taskID string, tryNumber int) error {
+	rid, err := parseUUID(runID)
+	if err != nil {
+		return err
+	}
+	_, err = s.q.RequeueForRedispatch(ctx, queries.RequeueForRedispatchParams{
+		DagRunID:  rid,
+		TaskID:    taskID,
+		TryNumber: toInt32(tryNumber),
+	})
+	return err
+}
+
 // ResolveTask returns the dispatcher's execution context for a run's task.
 func (s *ExecutionStore) ResolveTask(ctx context.Context, runID, taskID string) (dispatch.Resolved, error) {
 	task, spec, ver, _, err := s.resolve(ctx, runID, taskID)

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -390,6 +390,21 @@ type Querier interface {
 	// trading a rare silent corruption for a frequent one. The settled states
 	// (success/failed/skipped/upstream_failed) are what this guard is for.
 	ReportTaskResult(ctx context.Context, arg ReportTaskResultParams) (int64, error)
+	// Re-place a reclaimed warm assignment (ADR 0058 N1d-c, H2): a warm worker was
+	// handed this attempt but demonstrably will NOT run it (its stream ended holding
+	// an unacked lease, or it acked started=false), so the attempt sits `queued`
+	// having never run. Move it back to `scheduled` so the planner re-admits it and
+	// re-dispatches (the planner plans scheduled->queued; it never re-plans a TI
+	// that is already `queued`, which is why a no-op reclaim left it stuck until the
+	// 3-minute dispatch-lost reaper).
+	//
+	// Guarded to state='queued' — bounded by (dag_run_id, task_id, try_number) to the
+	// exact attempt the assignment named — so it never disturbs a running or settled
+	// TI: zero rows is the guard working, a benign no-op, never an error. It does NOT
+	// bump try_number or infra_attempts: the attempt never ran, this is a re-offer of
+	// the SAME attempt, and the existing dispatch_attempts/backoff on the re-dispatch
+	// bounds a reclaim loop.
+	RequeueForRedispatch(ctx context.Context, arg RequeueForRedispatchParams) (int64, error)
 	// A reschedule-mode sensor (mode='reschedule') poked not-ready: park the active TI
 	// in up_for_reschedule with its next-poke time ($3) so the scheduler re-dispatches
 	// it once reschedule_at passes (#380), without consuming retry budget. Guarded to

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -895,6 +895,25 @@ UPDATE task_instances
 SET next_dispatch_at = $3
 WHERE dag_run_id = $1 AND task_id = $2 AND state = 'scheduled';
 
+-- name: RequeueForRedispatch :execrows
+-- Re-place a reclaimed warm assignment (ADR 0058 N1d-c, H2): a warm worker was
+-- handed this attempt but demonstrably will NOT run it (its stream ended holding
+-- an unacked lease, or it acked started=false), so the attempt sits `queued`
+-- having never run. Move it back to `scheduled` so the planner re-admits it and
+-- re-dispatches (the planner plans scheduled->queued; it never re-plans a TI
+-- that is already `queued`, which is why a no-op reclaim left it stuck until the
+-- 3-minute dispatch-lost reaper).
+--
+-- Guarded to state='queued' — bounded by (dag_run_id, task_id, try_number) to the
+-- exact attempt the assignment named — so it never disturbs a running or settled
+-- TI: zero rows is the guard working, a benign no-op, never an error. It does NOT
+-- bump try_number or infra_attempts: the attempt never ran, this is a re-offer of
+-- the SAME attempt, and the existing dispatch_attempts/backoff on the re-dispatch
+-- bounds a reclaim loop.
+UPDATE task_instances
+SET state = 'scheduled'
+WHERE dag_run_id = $1 AND task_id = $2 AND try_number = $3 AND state = 'queued';
+
 -- name: FailDispatchExhausted :exec
 -- The dispatch-attempt budget is spent (ADR 0031 Amendment A): fail the task with
 -- a dispatch_failed reason so the run can finalize instead of looping forever.

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -1623,6 +1623,40 @@ func (q *Queries) ReportTaskResult(ctx context.Context, arg ReportTaskResultPara
 	return result.RowsAffected(), nil
 }
 
+const requeueForRedispatch = `-- name: RequeueForRedispatch :execrows
+UPDATE task_instances
+SET state = 'scheduled'
+WHERE dag_run_id = $1 AND task_id = $2 AND try_number = $3 AND state = 'queued'
+`
+
+type RequeueForRedispatchParams struct {
+	DagRunID  pgtype.UUID `json:"dag_run_id"`
+	TaskID    string      `json:"task_id"`
+	TryNumber int32       `json:"try_number"`
+}
+
+// Re-place a reclaimed warm assignment (ADR 0058 N1d-c, H2): a warm worker was
+// handed this attempt but demonstrably will NOT run it (its stream ended holding
+// an unacked lease, or it acked started=false), so the attempt sits `queued`
+// having never run. Move it back to `scheduled` so the planner re-admits it and
+// re-dispatches (the planner plans scheduled->queued; it never re-plans a TI
+// that is already `queued`, which is why a no-op reclaim left it stuck until the
+// 3-minute dispatch-lost reaper).
+//
+// Guarded to state='queued' — bounded by (dag_run_id, task_id, try_number) to the
+// exact attempt the assignment named — so it never disturbs a running or settled
+// TI: zero rows is the guard working, a benign no-op, never an error. It does NOT
+// bump try_number or infra_attempts: the attempt never ran, this is a re-offer of
+// the SAME attempt, and the existing dispatch_attempts/backoff on the re-dispatch
+// bounds a reclaim loop.
+func (q *Queries) RequeueForRedispatch(ctx context.Context, arg RequeueForRedispatchParams) (int64, error) {
+	result, err := q.db.Exec(ctx, requeueForRedispatch, arg.DagRunID, arg.TaskID, arg.TryNumber)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const rescheduleTaskInstance = `-- name: RescheduleTaskInstance :exec
 UPDATE task_instances
 SET state = 'up_for_reschedule'::task_state,

--- a/internal/storage/warm_reclaim_requeue_integration_test.go
+++ b/internal/storage/warm_reclaim_requeue_integration_test.go
@@ -1,0 +1,75 @@
+//go:build integration
+
+// Package storage_test — the state guard on the warm reclaim re-placement
+// (ADR 0058 N1d-c, H2).
+//
+// RequeueForRedispatch moves a reclaimed (queued, never-ran) attempt back to
+// 'scheduled' so the planner re-admits and re-dispatches it. The guard lives in
+// the UPDATE's WHERE clause (state='queued', bounded to the exact attempt), so a
+// fake-store unit test cannot prove it: only real Postgres shows that a running
+// or a terminal attempt is left untouched (0 rows, benign). Three cases lock the
+// contract — a queued attempt is re-placed, a running one is a no-op, a terminal
+// one is a no-op — so fast re-placement can never disturb a live or settled TI.
+package storage_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// TestRequeueForRedispatchMovesQueuedToScheduled: the ordinary path — a queued
+// attempt a warm worker was handed but never ran is moved back to scheduled.
+func TestRequeueForRedispatchMovesQueuedToScheduled(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("warm_requeue_queued_%d", time.Now().UnixNano())
+	runUUID := seedQueuedTaskNoBind(t, repo, sched, ctx, dagID, "load")
+
+	if err := exec.RequeueForRedispatch(ctx, runUUID, "load", 1); err != nil {
+		t.Fatalf("RequeueForRedispatch on a queued TI = %v, want nil", err)
+	}
+
+	if st := taskInstanceState(t, sched, ctx, runUUID, "load"); st != domain.TaskStateScheduled {
+		t.Fatalf("TI 'load' = %q, want scheduled — a reclaimed queued attempt must be re-admitted for re-dispatch", st)
+	}
+}
+
+// TestRequeueForRedispatchNoOpOnRunningTI: a running attempt is live — the
+// guarded UPDATE matches zero rows and the TI stays running, so a stray reclaim
+// can never yank a running attempt out from under itself.
+func TestRequeueForRedispatchNoOpOnRunningTI(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("warm_requeue_running_%d", time.Now().UnixNano())
+	runUUID := seedRunningTask(t, repo, sched, ctx, dagID, "load")
+
+	if err := exec.RequeueForRedispatch(ctx, runUUID, "load", 1); err != nil {
+		t.Fatalf("RequeueForRedispatch on a running TI = %v, want nil (a guarded no-op is not an error)", err)
+	}
+
+	if st := taskInstanceState(t, sched, ctx, runUUID, "load"); st != domain.TaskStateRunning {
+		t.Fatalf("TI 'load' = %q, want running — a running attempt must never be disturbed", st)
+	}
+}
+
+// TestRequeueForRedispatchNoOpOnTerminalTI: a settled attempt is terminal — the
+// guarded UPDATE matches zero rows and the TI stays failed, so a late reclaim
+// never resurrects an abandoned attempt.
+func TestRequeueForRedispatchNoOpOnTerminalTI(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("warm_requeue_terminal_%d", time.Now().UnixNano())
+	runUUID := seedRunningTask(t, repo, sched, ctx, dagID, "load")
+
+	if err := sched.ApplyTransition(ctx, runUUID, "load", domain.TaskStateFailed); err != nil {
+		t.Fatalf("ApplyTransition to failed: %v", err)
+	}
+
+	if err := exec.RequeueForRedispatch(ctx, runUUID, "load", 1); err != nil {
+		t.Fatalf("RequeueForRedispatch on a terminal TI = %v, want nil (a guarded no-op is not an error)", err)
+	}
+
+	if st := taskInstanceState(t, sched, ctx, runUUID, "load"); st != domain.TaskStateFailed {
+		t.Fatalf("TI 'load' = %q, want failed — a settled attempt must never be resurrected", st)
+	}
+}


### PR DESCRIPTION
**N1d-c of the warm-pool track (ADR 0058)** — fixes review findings **H4** (lease-expiry stranded a live worker out of rotation) and **H2** (reclaim event was a no-op). Behind `execution.warm_pools_enabled` (off ⇒ nothing reclaims ⇒ byte-for-byte today).

## H4 — unstrand
`onLeaseExpire` deleted the lease but never returned the worker to the free set → a live-but-slow worker permanently consumed a pool slot. Now it returns the worker to free under the lock, **guarded** (only if the registry still points at that entry — not reconnect-superseded — and it is not busy).

## H2 — fast re-placement, reason-gated for double-run safety
The reclaim was a no-op, so a reclaimed attempt sat `queued` until the 3-min dispatch-lost reaper. Now `onReclaim` re-places it — but **only for `ReclaimWorkerGone` and `ReclaimRefused`** (the worker demonstrably won't run it). A `ReclaimLeaseExpired` worker may be **alive-but-slow** and (agent order is ack-then-run) will still run the attempt → fast-re-placing could **double-run**, so it is deliberately left to the 3-min reaper + the merged **H3** warm-defer (double-run-free). `reclaimShouldRequeue` encodes the gate with the reasoning; re-placement is best-effort.

`ReclaimEvent` gained the attempt identity `(RunID, TaskID, TryNumber)`, populated at all three emit sites. Store `RequeueForRedispatch`: `UPDATE ... SET state='scheduled' WHERE (run,task,try) AND state='queued'` — moves a reclaimed (queued, never-ran) attempt back to `scheduled` so the planner re-admits it (it never re-plans a `queued` TI, which is why the no-op left it stuck). No `try_number`/`infra_attempts` bump (a re-offer, not a retry); existing dispatch backoff bounds a reclaim loop.

## Tests (RED-first)
gating (WorkerGone/Refused requeue, **LeaseExpired does NOT** — RED when forced all-true); H4 lease-expiry returns worker to free (RED when the line removed); ReclaimEvent carries identity per emit site; store integration `RequeueForRedispatch` moves `queued→scheduled`, **guarded no-op on running + terminal** (RED when the state guard dropped). `go vet ./...` **and** `-tags integration` clean · sqlc idempotent · build + `-tags integration` green · `golangci-lint` 0.

**All reliability review findings H1–H4, M1–M3 are now addressed in tested code.** Remaining pre-enable: M4 aggregate cap, idle-TTL (D6) + lifetime/attempt caps (D9) + per-attempt watchdog (H3), GC-anchor (D11); the bootstrap worker-scoped exchange (security); harness + real-cluster e2e.