### PR TITLE
feat(warm): warm worker self-lifecycle — caps + drain + idle-TTL + attempt watchdog (ADR 0058 N1d-d)

### DIFF
--- a/cmd/leoflow-agent/main.go
+++ b/cmd/leoflow-agent/main.go
@@ -10,7 +10,9 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/neochaotic/leoflow/internal/agent"
 	"github.com/neochaotic/leoflow/internal/version"
@@ -50,6 +52,24 @@ func bootstrapToken() (token string, exchange bool, err error) {
 		}
 	}
 	return os.Getenv("LEOFLOW_AGENT_TOKEN"), false, nil
+}
+
+// envInt reads a non-negative integer env var, returning 0 when unset or
+// unparseable. The warm-worker caps treat 0 as "no bound", so a missing or
+// malformed value disables that cap rather than failing startup.
+func envInt(key string) int {
+	n, err := strconv.Atoi(os.Getenv(key))
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
+
+// envSeconds reads an integer-seconds env var into a Duration, returning 0 (=
+// "no bound") when unset or unparseable, matching envInt's fail-open-to-disabled
+// convention for the warm-worker lifecycle caps (ADR 0058 N1d-d).
+func envSeconds(key string) time.Duration {
+	return time.Duration(envInt(key)) * time.Second
 }
 
 func run() int {
@@ -235,6 +255,13 @@ func runWarm(ctx context.Context, streamClient agentv1.AgentServiceClient, addr,
 		ScratchDir:         scratchDir,
 		TerminationLogPath: os.Getenv("LEOFLOW_TERMINATION_LOG_PATH"),
 		HeartbeatInterval:  agent.DefaultHeartbeatInterval,
+		// Self-lifecycle caps, injected by BuildWarmPod from the operator's
+		// execution.* config (ADR 0058 N1d-d). Zero (unset/invalid) disables that
+		// bound in WarmRunner, so an off-cluster run is unbounded exactly as before.
+		MaxAttempts:     envInt("LEOFLOW_MAX_ATTEMPTS_PER_WORKER"),
+		MaxLifetime:     envSeconds("LEOFLOW_MAX_WORKER_LIFETIME_SECONDS"),
+		IdleTTL:         envSeconds("LEOFLOW_WORKER_IDLE_TTL_SECONDS"),
+		AttemptWatchdog: envSeconds("LEOFLOW_ATTEMPT_WATCHDOG_SECONDS"),
 	}
 	if rerr := w.Run(ctx, dagVersionID); rerr != nil {
 		slog.Error("warm worker failed", "error", rerr)

--- a/cmd/leoflow-agent/warm_caps_env_test.go
+++ b/cmd/leoflow-agent/warm_caps_env_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// TestEnvInt locks the fail-open-to-disabled convention for the warm-worker caps:
+// a valid non-negative integer parses; unset, empty, non-numeric, or negative all
+// yield 0 (= "no bound"), so a missing or malformed cap disables that bound rather
+// than crashing the agent (ADR 0058 N1d-d).
+func TestEnvInt(t *testing.T) {
+	cases := []struct {
+		name, val string
+		set       bool
+		want      int
+	}{
+		{name: "valid", val: "50", set: true, want: 50},
+		{name: "zero", val: "0", set: true, want: 0},
+		{name: "unset", set: false, want: 0},
+		{name: "empty", val: "", set: true, want: 0},
+		{name: "non-numeric", val: "abc", set: true, want: 0},
+		{name: "negative", val: "-5", set: true, want: 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			const key = "LEOFLOW_TEST_CAP"
+			if tc.set {
+				t.Setenv(key, tc.val)
+			}
+			if got := envInt(key); got != tc.want {
+				t.Errorf("envInt(%q=%q set=%v) = %d, want %d", key, tc.val, tc.set, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEnvSeconds locks that an integer-seconds env var becomes the matching
+// Duration, and that a missing/invalid value is 0 (= "no bound").
+func TestEnvSeconds(t *testing.T) {
+	const key = "LEOFLOW_TEST_CAP_SECONDS"
+	t.Run("valid", func(t *testing.T) {
+		t.Setenv(key, "3600")
+		if got := envSeconds(key); got != time.Hour {
+			t.Errorf("envSeconds(3600) = %v, want 1h", got)
+		}
+	})
+	t.Run("unset-is-zero", func(t *testing.T) {
+		if got := envSeconds("LEOFLOW_TEST_CAP_UNSET"); got != 0 {
+			t.Errorf("envSeconds(unset) = %v, want 0", got)
+		}
+	})
+}

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -1027,6 +1027,14 @@ func warmPodSpecFunc(cfg *config.ServerConfig, authn *auth.JWTAuthenticator, con
 			AgentTLSCAConfigMap: cfg.Executor.AgentTLSCAConfigMap,
 			BootstrapToken:      token,
 			PodSecurity:         defaults.PodSecurity,
+			// Self-lifecycle caps (ADR 0058 D9/D10/D6/H3). The attempt watchdog is
+			// anchored to the credential ceiling: an attempt can never validly outlive
+			// its per-attempt credential, so max_attempt_credential_lifetime is the
+			// natural hard upper bound and needs no separate operator knob.
+			MaxAttemptsPerWorker:     cfg.Execution.MaxAttemptsPerWorker,
+			MaxWorkerLifetimeSeconds: int64(cfg.Execution.MaxWorkerLifetime.Seconds()),
+			WorkerIdleTTLSeconds:     int64(cfg.Execution.WorkerIdleTTL.Seconds()),
+			AttemptWatchdogSeconds:   int64(cfg.Auth.MaxAttemptCredentialLifetime.Seconds()),
 		}, nil
 	}
 }

--- a/cmd/leoflow-server/warm_caps_wiring_test.go
+++ b/cmd/leoflow-server/warm_caps_wiring_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/config"
+	"github.com/neochaotic/leoflow/internal/executor"
+)
+
+// TestWarmPodSpecFuncCarriesSelfLifecycleCaps locks the wiring (ADR 0058
+// D9/D10/D6/H3): warmPodSpecFunc copies the operator's execution.* caps onto the
+// warm-pod spec, and anchors the per-attempt watchdog to
+// auth.max_attempt_credential_lifetime — an attempt can never validly outlive its
+// credential ceiling, so that is the hard upper bound with no separate knob.
+func TestWarmPodSpecFuncCarriesSelfLifecycleCaps(t *testing.T) {
+	cfg := &config.ServerConfig{}
+	cfg.Execution.MaxAttemptsPerWorker = 50
+	cfg.Execution.MaxWorkerLifetime = time.Hour
+	cfg.Execution.WorkerIdleTTL = 5 * time.Minute
+	cfg.Auth.MaxAttemptCredentialLifetime = 24 * time.Hour
+
+	authn := auth.NewJWTAuthenticator(nil, "secret", time.Hour)
+	spec, err := warmPodSpecFunc(cfg, authn, "cp:9000")(executor.WarmTarget{DagVersionID: "dv-1", Image: "reg/dag:v1"})
+	if err != nil {
+		t.Fatalf("warmPodSpecFunc: %v", err)
+	}
+
+	if spec.MaxAttemptsPerWorker != 50 {
+		t.Errorf("MaxAttemptsPerWorker = %d, want 50", spec.MaxAttemptsPerWorker)
+	}
+	if spec.MaxWorkerLifetimeSeconds != 3600 {
+		t.Errorf("MaxWorkerLifetimeSeconds = %d, want 3600", spec.MaxWorkerLifetimeSeconds)
+	}
+	if spec.WorkerIdleTTLSeconds != 300 {
+		t.Errorf("WorkerIdleTTLSeconds = %d, want 300", spec.WorkerIdleTTLSeconds)
+	}
+	// The watchdog is the credential ceiling (24h), NOT a bespoke knob.
+	if spec.AttemptWatchdogSeconds != 86400 {
+		t.Errorf("AttemptWatchdogSeconds = %d, want 86400 (= max_attempt_credential_lifetime)", spec.AttemptWatchdogSeconds)
+	}
+}

--- a/internal/agent/warm.go
+++ b/internal/agent/warm.go
@@ -67,6 +67,23 @@ type WarmRunner struct {
 	// fields and are threaded into every per-attempt Runner.
 	TerminationLogPath string
 	HeartbeatInterval  time.Duration
+
+	// Self-lifecycle bounds (ADR 0058 D9/D10/D6/H3), populated from the warm-pod env
+	// in main.go. A warm worker that exits is replaced by the reconciler
+	// (RestartPolicy:Never + busy-aware create), so bounding its own life is how a
+	// pool stays fresh and scales down. Each bound is disabled when zero/unset — a
+	// defensive default; the operator config values are non-zero.
+	//
+	//   - MaxAttempts: drain after this many completed attempts (D9/D10).
+	//   - MaxLifetime: drain once the worker is this old (D9/D10).
+	//   - IdleTTL: idle-recycle after this long awaiting the next assignment (D6).
+	//   - AttemptWatchdog: hard per-attempt ceiling, INDEPENDENT of the task's
+	//     execution_timeout, so a task that declares no timeout and then wedges is
+	//     still killed and the slot freed (H3).
+	MaxAttempts     int
+	MaxLifetime     time.Duration
+	IdleTTL         time.Duration
+	AttemptWatchdog time.Duration
 }
 
 // Run registers the worker once, opens the assignment stream, and serves
@@ -97,13 +114,24 @@ func (w *WarmRunner) Run(ctx context.Context, dagVersionID string) error {
 		return fmt.Errorf("sending worker register: %w", serr)
 	}
 
+	// D9/D10 accounting: bound the worker by attempts served and wall-clock age.
+	// Both are checked only BETWEEN attempts (after SlotFree), so a recycle is always
+	// graceful — it never interrupts an in-flight attempt.
+	workerStart := time.Now()
+	attemptsServed := 0
+
 	for {
-		assignment, rerr := stream.Recv()
+		assignment, rerr := w.recvAssignment(ctx, stream)
 		if rerr != nil {
-			// A closed / drained stream (EOF), or a parent shutdown (SIGTERM,
-			// which gRPC surfaces on the stream as codes.Canceled), both mean
-			// "stop serving" — exit cleanly. Anything else is a real transport
+			// D6 idle-recycle: no assignment arrived within IdleTTL, so recycle this
+			// worker for freshness / scale-down. A closed / drained stream (EOF), or a
+			// parent shutdown (SIGTERM, surfaced on the stream as codes.Canceled), also
+			// mean "stop serving" — all exit cleanly. Anything else is a real transport
 			// failure worth surfacing.
+			if errors.Is(rerr, errIdleRecycle) {
+				slog.Info("warm worker idle-recycle: no assignment within idle TTL", "idle_ttl", w.IdleTTL)
+				return nil
+			}
 			if errors.Is(rerr, io.EOF) || status.Code(rerr) == codes.Canceled {
 				return nil
 			}
@@ -117,6 +145,58 @@ func (w *WarmRunner) Run(ctx context.Context, dagVersionID string) error {
 			}
 			return serr
 		}
+
+		// D9/D10 graceful drain: the attempt above is DONE and its SlotFree is sent, so
+		// stopping here awaits no more work and lets the process exit — the reconciler
+		// then replaces the pod (RestartPolicy:Never). Checked here, never mid-attempt.
+		attemptsServed++
+		if w.MaxAttempts > 0 && attemptsServed >= w.MaxAttempts {
+			slog.Info("warm worker draining: max attempts reached",
+				"attempts_served", attemptsServed, "max_attempts", w.MaxAttempts)
+			return nil
+		}
+		if w.MaxLifetime > 0 && time.Since(workerStart) >= w.MaxLifetime {
+			slog.Info("warm worker draining: max lifetime reached",
+				"age", time.Since(workerStart), "max_lifetime", w.MaxLifetime)
+			return nil
+		}
+	}
+}
+
+// errIdleRecycle is the sentinel recvAssignment returns when no assignment arrives
+// within IdleTTL, so Run can distinguish a D6 idle-recycle (clean exit) from a real
+// stream error.
+var errIdleRecycle = errors.New("warm worker idle-recycle")
+
+// recvAssignment receives the next assignment, enforcing the D6 idle-TTL. With a
+// non-positive IdleTTL it is a plain blocking Recv (the timeout disabled). Otherwise
+// it runs Recv in a goroutine feeding a buffered channel and races it against the
+// idle timer and ctx: if the timer wins it returns errIdleRecycle, and the Recv
+// goroutine does NOT leak — the channel is buffered (size 1) so the goroutine's send
+// never blocks even with no reader, and the blocked Recv unblocks with an error once
+// Run returns and the stream closes.
+func (w *WarmRunner) recvAssignment(ctx context.Context, stream agentv1.AgentService_AwaitAssignmentClient) (*agentv1.WorkAssignment, error) {
+	if w.IdleTTL <= 0 {
+		return stream.Recv()
+	}
+	type recvResult struct {
+		a   *agentv1.WorkAssignment
+		err error
+	}
+	recvCh := make(chan recvResult, 1) // buffered so the goroutine can always send and exit
+	go func() {
+		a, err := stream.Recv()
+		recvCh <- recvResult{a, err}
+	}()
+	timer := time.NewTimer(w.IdleTTL)
+	defer timer.Stop()
+	select {
+	case r := <-recvCh:
+		return r.a, r.err
+	case <-timer.C:
+		return nil, errIdleRecycle
+	case <-ctx.Done():
+		return nil, ctx.Err()
 	}
 }
 
@@ -160,12 +240,19 @@ func (w *WarmRunner) serveAssignment(ctx context.Context, stream agentv1.AgentSe
 	sink := w.openSink(ctx)
 	r := w.attemptRunner(sink)
 
-	// A wedged child is bounded by the task's execution_timeout (honored inside
-	// execute via a deadline context), so a normal long task cannot hang the worker
-	// forever. A hard per-attempt watchdog INDEPENDENT of execution_timeout — to
-	// bound a task that declares no timeout and then wedges — is ADR 0058 H3;
-	// TODO(N1d): add that watchdog here so a no-timeout wedge cannot pin the slot.
-	if aerr := r.runOneAttempt(ctx); aerr != nil {
+	// H3 per-attempt watchdog: a hard ceiling on this attempt, INDEPENDENT of the
+	// task's execution_timeout (which runOneAttempt still honors inside). A task that
+	// declares no execution_timeout and then wedges is killed here — the child exec
+	// runs on attemptCtx, so the deadline cancel kills it; the attempt then fails and
+	// is reported, SlotFree fires below, and the worker keeps serving. A non-positive
+	// watchdog disables the extra ceiling (fall back to just execution_timeout).
+	attemptCtx := ctx
+	if w.AttemptWatchdog > 0 {
+		var cancel context.CancelFunc
+		attemptCtx, cancel = context.WithTimeout(ctx, w.AttemptWatchdog)
+		defer cancel()
+	}
+	if aerr := r.runOneAttempt(attemptCtx); aerr != nil {
 		// A failed attempt is a normal, already-reported outcome. Keep serving.
 		slog.Warn("warm attempt finished with an error",
 			"assignment", a.GetAssignmentId(), "error", aerr)

--- a/internal/agent/warm_test.go
+++ b/internal/agent/warm_test.go
@@ -2,14 +2,18 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 // fakeAssignmentStream is a hand-rolled grpc.BidiStreamingClient double for the
@@ -233,6 +237,251 @@ func TestWarmWorkerRegisterCarriesPodName(t *testing.T) {
 	}
 	if reg.GetPodName() != "leoflow-warm-dv-abc-x7k2" {
 		t.Errorf("WorkerRegister.pod_name = %q, want leoflow-warm-dv-abc-x7k2", reg.GetPodName())
+	}
+}
+
+// warmSpecs returns n identical minimal specs (bash true, no execution_timeout) so
+// a warmFake can hand one out per served attempt without index-out-of-range.
+func warmSpecs(n int) []*agentv1.TaskSpec {
+	out := make([]*agentv1.TaskSpec, n)
+	for i := range out {
+		out[i] = &agentv1.TaskSpec{Operator: "bash", Entrypoint: "true"}
+	}
+	return out
+}
+
+// TestWarmWorkerDrainsAtMaxAttempts is D9/D10 (ADR 0058): a warm worker serves at
+// most MaxAttempts attempts, then DRAINS — Run returns nil (the process exits and
+// the reconciler replaces the pod). The stream offers more work than the cap, so
+// the only reason exactly two attempts run is the cap, and the drain is graceful
+// (checked after SlotFree, never mid-attempt).
+func TestWarmWorkerDrainsAtMaxAttempts(t *testing.T) {
+	scratch := filepath.Join(t.TempDir(), "scratch")
+	stream := &fakeAssignmentStream{
+		ctx: context.Background(),
+		assignments: []*agentv1.WorkAssignment{
+			{AssignmentId: "asg-1", AttemptToken: "tok-1"},
+			{AssignmentId: "asg-2", AttemptToken: "tok-2"},
+			{AssignmentId: "asg-3", AttemptToken: "tok-3"},
+		},
+	}
+	tokens := NewTokenSource("bootstrap")
+	client := &warmFake{fakeClient: &fakeClient{}, stream: stream, tokens: tokens, specs: warmSpecs(3)}
+	cmd := &scratchProbeCmd{scratchDir: scratch}
+
+	w := &WarmRunner{
+		StreamClient: client, WorkClient: client, AttemptTokens: tokens,
+		Cmd: cmd, Hostname: "warm-pod-1", Version: "test", ScratchDir: scratch,
+		MaxAttempts: 2,
+	}
+	if err := w.Run(context.Background(), "dagver-1"); err != nil {
+		t.Fatalf("WarmRunner.Run: %v", err)
+	}
+	if cmd.runs != 2 {
+		t.Fatalf("attempts run = %d, want exactly 2 (drained at MaxAttempts)", cmd.runs)
+	}
+	// The worker Recv'd only two assignments — it drained rather than pulling asg-3.
+	if stream.idx != 2 {
+		t.Errorf("assignments received = %d, want 2 (drain must stop awaiting new work)", stream.idx)
+	}
+}
+
+// TestWarmWorkerDrainsAtMaxLifetime is D9's wall-clock cap: with a 1ns lifetime the
+// after-SlotFree check trips on the very first attempt, so the worker serves one and
+// drains. Deterministic — any elapsed time since workerStart exceeds 1ns.
+func TestWarmWorkerDrainsAtMaxLifetime(t *testing.T) {
+	scratch := filepath.Join(t.TempDir(), "scratch")
+	stream := &fakeAssignmentStream{
+		ctx: context.Background(),
+		assignments: []*agentv1.WorkAssignment{
+			{AssignmentId: "asg-1", AttemptToken: "tok-1"},
+			{AssignmentId: "asg-2", AttemptToken: "tok-2"},
+		},
+	}
+	tokens := NewTokenSource("bootstrap")
+	client := &warmFake{fakeClient: &fakeClient{}, stream: stream, tokens: tokens, specs: warmSpecs(2)}
+	cmd := &scratchProbeCmd{scratchDir: scratch}
+
+	w := &WarmRunner{
+		StreamClient: client, WorkClient: client, AttemptTokens: tokens,
+		Cmd: cmd, Hostname: "warm-pod-1", Version: "test", ScratchDir: scratch,
+		MaxLifetime: time.Nanosecond,
+	}
+	if err := w.Run(context.Background(), "dagver-1"); err != nil {
+		t.Fatalf("WarmRunner.Run: %v", err)
+	}
+	if cmd.runs != 1 {
+		t.Fatalf("attempts run = %d, want exactly 1 (drained at MaxLifetime)", cmd.runs)
+	}
+	if stream.idx != 1 {
+		t.Errorf("assignments received = %d, want 1 (lifetime drain stops awaiting new work)", stream.idx)
+	}
+}
+
+// idleStream serves one assignment, then BLOCKS in Recv until its context is
+// canceled — modeling a real gRPC stream whose Recv only returns when the stream
+// closes. The idle-TTL path in Run must recycle the worker BEFORE this returns; the
+// blocked Recv goroutine then unblocks on the parent cancel and closes recvExited,
+// letting the test prove no goroutine is leaked.
+type idleStream struct {
+	ctx        context.Context
+	first      *agentv1.WorkAssignment
+	served     bool
+	sent       []*agentv1.WorkerMessage
+	recvExited chan struct{}
+}
+
+func (s *idleStream) Send(m *agentv1.WorkerMessage) error { s.sent = append(s.sent, m); return nil }
+
+func (s *idleStream) Recv() (*agentv1.WorkAssignment, error) {
+	if !s.served {
+		s.served = true
+		return s.first, nil
+	}
+	<-s.ctx.Done()
+	close(s.recvExited)
+	return nil, status.Error(codes.Canceled, "stream closed")
+}
+
+func (s *idleStream) Header() (metadata.MD, error) { return metadata.MD{}, nil }
+func (s *idleStream) Trailer() metadata.MD         { return nil }
+func (s *idleStream) CloseSend() error             { return nil }
+func (s *idleStream) Context() context.Context     { return s.ctx }
+func (s *idleStream) SendMsg(any) error            { return nil }
+func (s *idleStream) RecvMsg(any) error            { return nil }
+
+// idleFake overrides AwaitAssignment to hand back the blocking idleStream.
+type idleFake struct {
+	*fakeClient
+	stream *idleStream
+}
+
+func (c *idleFake) AwaitAssignment(context.Context, ...grpc.CallOption) (grpc.BidiStreamingClient[agentv1.WorkerMessage, agentv1.WorkAssignment], error) {
+	return c.stream, nil
+}
+
+// TestWarmWorkerIdleRecycle is D6: while awaiting the next assignment, a worker that
+// sees no work within IdleTTL recycles itself (Run returns nil) for freshness /
+// scale-down. The recv goroutine must not leak — once the stream closes on teardown
+// its blocked Recv returns and the goroutine exits.
+func TestWarmWorkerIdleRecycle(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	scratch := filepath.Join(t.TempDir(), "scratch")
+	stream := &idleStream{
+		ctx:        ctx,
+		first:      &agentv1.WorkAssignment{AssignmentId: "asg-1", AttemptToken: "tok-1"},
+		recvExited: make(chan struct{}),
+	}
+	tokens := NewTokenSource("bootstrap")
+	client := &idleFake{fakeClient: &fakeClient{spec: &agentv1.TaskSpec{Operator: "bash", Entrypoint: "true"}}}
+	client.stream = stream
+
+	w := &WarmRunner{
+		StreamClient: client, WorkClient: client, AttemptTokens: tokens,
+		Cmd: &scratchProbeCmd{scratchDir: scratch}, Hostname: "warm-pod-1", Version: "test",
+		ScratchDir: scratch,
+		IdleTTL:    20 * time.Millisecond,
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx, "dagver-1") }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("WarmRunner.Run returned %v, want nil (idle recycle)", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not idle-recycle within 2s")
+	}
+
+	// No goroutine leak: after Run returns, tear down the stream (parent cancel) and
+	// prove the blocked Recv goroutine unblocks and exits.
+	cancel()
+	select {
+	case <-stream.recvExited:
+	case <-time.After(2 * time.Second):
+		t.Fatal("recv goroutine leaked: blocked Recv never returned after stream close")
+	}
+}
+
+// wedgeThenOKCmd wedges its first invocation until the ctx is canceled (recording
+// the cancel cause), then succeeds on every later invocation — modeling a task with
+// no execution_timeout that hangs, followed by a well-behaved one.
+type wedgeThenOKCmd struct {
+	runs         int
+	wedgedCtxErr error
+}
+
+func (c *wedgeThenOKCmd) Run(ctx context.Context, _, _ []string, _, _ io.Writer) (int, error) {
+	c.runs++
+	if c.runs == 1 {
+		<-ctx.Done()
+		c.wedgedCtxErr = ctx.Err()
+		return 137, ctx.Err()
+	}
+	return 0, nil
+}
+
+// TestWarmWorkerWatchdogKillsWedgedAttempt is H3: an always-on per-attempt watchdog,
+// INDEPENDENT of the task's execution_timeout (0 here), hard-bounds a wedged attempt.
+// The first attempt hangs and is killed at the watchdog — reported FAILED, SlotFree
+// still sent — and the worker keeps serving, running the second attempt to SUCCESS.
+func TestWarmWorkerWatchdogKillsWedgedAttempt(t *testing.T) {
+	scratch := filepath.Join(t.TempDir(), "scratch")
+	stream := &fakeAssignmentStream{
+		ctx: context.Background(),
+		assignments: []*agentv1.WorkAssignment{
+			{AssignmentId: "asg-1", AttemptToken: "tok-1"},
+			{AssignmentId: "asg-2", AttemptToken: "tok-2"},
+		},
+	}
+	tokens := NewTokenSource("bootstrap")
+	// execution_timeout=0 on both specs: the ONLY ceiling is the watchdog.
+	client := &warmFake{fakeClient: &fakeClient{}, stream: stream, tokens: tokens, specs: warmSpecs(2)}
+	cmd := &wedgeThenOKCmd{}
+
+	w := &WarmRunner{
+		StreamClient: client, WorkClient: client, AttemptTokens: tokens,
+		Cmd: cmd, Hostname: "warm-pod-1", Version: "test", ScratchDir: scratch,
+		AttemptWatchdog: 20 * time.Millisecond,
+	}
+	if err := w.Run(context.Background(), "dagver-1"); err != nil {
+		t.Fatalf("WarmRunner.Run: %v (a wedged attempt must not be loop-fatal)", err)
+	}
+
+	if cmd.runs != 2 {
+		t.Fatalf("attempts run = %d, want 2 (worker keeps serving after the watchdog kill)", cmd.runs)
+	}
+	// The wedge was cut by the watchdog deadline, not by execution_timeout (which was
+	// 0) — proving the watchdog is an independent ceiling.
+	if !errors.Is(cmd.wedgedCtxErr, context.DeadlineExceeded) {
+		t.Errorf("wedged attempt ctx err = %v, want context.DeadlineExceeded (watchdog)", cmd.wedgedCtxErr)
+	}
+	// Attempt 1 RUNNING→FAILED (killed), attempt 2 RUNNING→SUCCESS.
+	wantStates := []agentv1.TaskState{
+		agentv1.TaskState_TASK_STATE_RUNNING, agentv1.TaskState_TASK_STATE_FAILED,
+		agentv1.TaskState_TASK_STATE_RUNNING, agentv1.TaskState_TASK_STATE_SUCCESS,
+	}
+	if len(client.states) != len(wantStates) {
+		t.Fatalf("reported states = %v, want %v", client.states, wantStates)
+	}
+	for i, s := range wantStates {
+		if client.states[i] != s {
+			t.Fatalf("reported states = %v, want %v", client.states, wantStates)
+		}
+	}
+	// SlotFree still fires for BOTH attempts (register + 2×[ack, slotfree] = 5).
+	slotFrees := 0
+	for _, m := range stream.sent {
+		if m.GetSlotFree() != nil {
+			slotFrees++
+		}
+	}
+	if slotFrees != 2 {
+		t.Errorf("SlotFree count = %d, want 2 (slot must free even after a watchdog kill)", slotFrees)
 	}
 }
 

--- a/internal/executor/warmpod.go
+++ b/internal/executor/warmpod.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -50,6 +51,23 @@ type WarmPodSpec struct {
 	AgentTokenExpirationSeconds int64
 	AgentTokenSecretName        string
 	AgentTokenSecretKey         string
+
+	// Self-lifecycle caps the warm agent enforces on ITSELF (ADR 0058 D9/D10/D6/H3),
+	// carried in-band as env so a worker can drain, idle-recycle, and hard-bound a
+	// wedged attempt without any control-plane round trip. Each is zero when the
+	// operator disables that bound; the agent treats zero/unset as "no bound".
+	//
+	//   - MaxAttemptsPerWorker: drain after this many completed attempts (D9/D10).
+	//   - MaxWorkerLifetimeSeconds: drain past this wall-clock age (D9/D10).
+	//   - WorkerIdleTTLSeconds: idle-recycle after this long awaiting work (D6).
+	//   - AttemptWatchdogSeconds: hard per-attempt ceiling, independent of the task's
+	//     execution_timeout, so a no-timeout wedge cannot pin the slot (H3). main.go
+	//     sets it to auth.max_attempt_credential_lifetime — an attempt can never
+	//     validly outlive its credential ceiling.
+	MaxAttemptsPerWorker     int
+	MaxWorkerLifetimeSeconds int64
+	WorkerIdleTTLSeconds     int64
+	AttemptWatchdogSeconds   int64
 
 	// PodSecurity carries the same container/pod hardening choices as a task pod.
 	PodSecurity PodSecurity
@@ -144,7 +162,7 @@ func (spec WarmPodSpec) agentToken() agentToken {
 // selectors, and — when a CA is configured — the TLS env. It deliberately omits
 // every task-specific var.
 func warmPodEnv(spec WarmPodSpec) []corev1.EnvVar {
-	env := make([]corev1.EnvVar, 0, 6)
+	env := make([]corev1.EnvVar, 0, 12)
 	env = append(env, corev1.EnvVar{Name: "LEOFLOW_CONTROL_PLANE_ADDR", Value: spec.ControlPlaneAddr})
 	tok := spec.agentToken()
 	env = append(env, tok.env()...)
@@ -156,6 +174,11 @@ func warmPodEnv(spec WarmPodSpec) []corev1.EnvVar {
 	// match the attempt against the live warm-pod set. The pod name is not known at
 	// build time (it carries a random suffix), so it must come from the downward
 	// API's metadata.name rather than a literal value.
+	// Warm-mode selectors + the pod's own name via the downward API, then the
+	// self-lifecycle caps (ADR 0058 D9/D10/D6/H3): the worker reads these and bounds
+	// its own life — draining after N attempts or a lifetime, idle-recycling, and
+	// hard-killing a wedged attempt. The caps are emitted verbatim (zero means "no
+	// bound" to the agent), so the contract is explicit on every warm pod.
 	env = append(env,
 		corev1.EnvVar{Name: "LEOFLOW_WARM_WORKER", Value: "1"},
 		corev1.EnvVar{Name: "LEOFLOW_DAG_VERSION_ID", Value: spec.DagVersionID},
@@ -165,6 +188,10 @@ func warmPodEnv(spec WarmPodSpec) []corev1.EnvVar {
 				FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
 			},
 		},
+		corev1.EnvVar{Name: "LEOFLOW_MAX_ATTEMPTS_PER_WORKER", Value: strconv.Itoa(spec.MaxAttemptsPerWorker)},
+		corev1.EnvVar{Name: "LEOFLOW_MAX_WORKER_LIFETIME_SECONDS", Value: strconv.FormatInt(spec.MaxWorkerLifetimeSeconds, 10)},
+		corev1.EnvVar{Name: "LEOFLOW_WORKER_IDLE_TTL_SECONDS", Value: strconv.FormatInt(spec.WorkerIdleTTLSeconds, 10)},
+		corev1.EnvVar{Name: "LEOFLOW_ATTEMPT_WATCHDOG_SECONDS", Value: strconv.FormatInt(spec.AttemptWatchdogSeconds, 10)},
 	)
 	if spec.AgentTLSCAConfigMap != "" {
 		env = append(env,

--- a/internal/executor/warmpod_test.go
+++ b/internal/executor/warmpod_test.go
@@ -117,6 +117,31 @@ func TestBuildWarmPodWarmEnvAndLabels(t *testing.T) {
 	}
 }
 
+// TestBuildWarmPodCarriesSelfLifecycleCaps locks the four self-lifecycle caps the
+// warm agent enforces on itself (ADR 0058 D9/D10/D6/H3): the attempt count cap, the
+// wall-clock lifetime cap (seconds), the idle-TTL (seconds), and the per-attempt
+// watchdog (seconds). BuildWarmPod injects them as env so the worker can drain,
+// idle-recycle, and hard-bound a wedged attempt without any control-plane round trip.
+func TestBuildWarmPodCarriesSelfLifecycleCaps(t *testing.T) {
+	spec := baseWarmSpec()
+	spec.MaxAttemptsPerWorker = 50
+	spec.MaxWorkerLifetimeSeconds = 3600
+	spec.WorkerIdleTTLSeconds = 300
+	spec.AttemptWatchdogSeconds = 86400
+
+	env := warmEnvMap(BuildWarmPod(spec))
+	for _, tc := range []struct{ key, want string }{
+		{"LEOFLOW_MAX_ATTEMPTS_PER_WORKER", "50"},
+		{"LEOFLOW_MAX_WORKER_LIFETIME_SECONDS", "3600"},
+		{"LEOFLOW_WORKER_IDLE_TTL_SECONDS", "300"},
+		{"LEOFLOW_ATTEMPT_WATCHDOG_SECONDS", "86400"},
+	} {
+		if env[tc.key] != tc.want {
+			t.Errorf("%s = %q, want %q", tc.key, env[tc.key], tc.want)
+		}
+	}
+}
+
 // TestBuildWarmPodEnvVarTransport locks the default (env-var) bootstrap-token
 // transport: the minted worker JWT rides as the plaintext LEOFLOW_AGENT_TOKEN,
 // exactly how a task pod carries its token on the env-var path.


### PR DESCRIPTION
**N1d-d of the warm-pool track (ADR 0058)** — the warm worker's own lifecycle: **D9** attempt/lifetime caps, **D10** graceful drain, **D6** idle-TTL recycle, and the **H3** per-attempt watchdog. Closes the last reliability gap (a wedged task with no `execution_timeout` pinning a slot forever). Warm mode only; dedicated/single-shot and warm-off unchanged. A worker that exits is replaced by the busy-aware reconciler (N1d-b).

## What
- **Caps to the pod:** `BuildWarmPod` injects `LEOFLOW_MAX_ATTEMPTS_PER_WORKER`, `LEOFLOW_MAX_WORKER_LIFETIME_SECONDS`, `LEOFLOW_WORKER_IDLE_TTL_SECONDS` (from `execution.*`) and `LEOFLOW_ATTEMPT_WATCHDOG_SECONDS` anchored to `auth.max_attempt_credential_lifetime` (an attempt can't validly outlive its credential → natural hard ceiling, no new knob). `runWarm` reads them into `WarmRunner` via `envInt`/`envSeconds` (0 = no bound; fail-open-to-disabled).
- **D9 + D10 drain:** `WarmRunner` tracks `attemptsServed` + `workerStart`; **only after a SlotFree** (between attempts, never mid-attempt) it exits when `attempts ≥ MaxAttempts` or `age ≥ MaxLifetime` — graceful recycle.
- **D6 idle-TTL:** `recvAssignment` selects `Recv` (in a goroutine, buffered-1 channel → no leak) against an `IdleTTL` timer and `ctx.Done`; timer wins → idle recycle. **`-race` clean.**
- **H3 watchdog:** `serveAssignment` wraps the attempt ctx with `WithTimeout(AttemptWatchdog)`, an always-on ceiling **independent of** the task's `execution_timeout` (still honored inside) → a no-timeout wedge is killed at the watchdog, reported failed, SlotFree fires, worker keeps serving.

## Tests (RED-first)
max-attempts drain (serves exactly N of N+1 → exits); max-lifetime drain; idle-recycle (**RED: plain blocking Recv never returned**); **watchdog kills a wedged attempt (RED: hit the 120s test timeout without it)** and is `DeadlineExceeded` independent of `execution_timeout=0`; `BuildWarmPod` cap env; `envInt`/`envSeconds` parse (fail-open). `go vet ./...` **and** `-tags integration` clean · build + `-tags integration` green · **`go test -race` clean** · `golangci-lint` 0.

**All reliability review findings + the failover/lifecycle story are now closed in tested code.** Remaining pre-enable: M4 aggregate per-tenant cap (security), D11 GC-anchor (cleanup), the bootstrap worker-scoped exchange (security), and the cold-start harness + real-cluster e2e (validation). Enable = operator's enforce-flip decision.