### PR TITLE
fix(warm): leader-gate the assignment stream + agent reconnect-to-leader (ADR 0058 Hole B)

### DIFF
--- a/cmd/leoflow-agent/main.go
+++ b/cmd/leoflow-agent/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -255,6 +256,18 @@ func runWarm(ctx context.Context, streamClient agentv1.AgentServiceClient, addr,
 		ScratchDir:         scratchDir,
 		TerminationLogPath: os.Getenv("LEOFLOW_TERMINATION_LOG_PATH"),
 		HeartbeatInterval:  agent.DefaultHeartbeatInterval,
+		// Warm-pool Hole B: on a not-leader rejection, re-dial the STREAM connection
+		// so a fresh Service backend can reach the scheduler leader (a single gRPC
+		// connection sticks to one backend). Re-dials with the bootstrap token, like
+		// the initial stream dial; the work connection is untouched. The returned conn
+		// is closed by WarmRunner on the next reconnect / exit.
+		Redial: func() (agentv1.AgentServiceClient, io.Closer, error) {
+			c, conn, _, derr := agent.Dial(addr, seedToken, allowInsecure, caFile)
+			if derr != nil {
+				return nil, nil, derr
+			}
+			return c, conn, nil
+		},
 		// Self-lifecycle caps, injected by BuildWarmPod from the operator's
 		// execution.* config (ADR 0058 N1d-d). Zero (unset/invalid) disables that
 		// bound in WarmRunner, so an off-cluster run is unbounded exactly as before.

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -405,7 +405,7 @@ func startSchedulerSide(ctx context.Context, cfg *config.ServerConfig, pg *stora
 		})
 		logger.Warn("warm worker pools enabled (ADR 0058 N1b1-place); admitted tasks place on a free warm worker of their dag_version, else dispatch dedicated")
 	}
-	grpcSrv, gerr := startAgentGRPC(ctx, cfg.Server.GRPCAddr, authn, execStore, repo, xcomSvc, logSink, logTailer, allowInsecureSecrets, cfg.Auth.SecretScoping, cfg.Auth.SecretLivenessMode, cfg.Auth.MaxAttemptCredentialLifetime, buildTokenExchange(cfg, logger), cfg.Server.GRPCTLSCert, cfg.Server.GRPCTLSKey, warmReg, logger)
+	grpcSrv, agentSrv, gerr := startAgentGRPC(ctx, cfg.Server.GRPCAddr, authn, execStore, repo, xcomSvc, logSink, logTailer, allowInsecureSecrets, cfg.Auth.SecretScoping, cfg.Auth.SecretLivenessMode, cfg.Auth.MaxAttemptCredentialLifetime, buildTokenExchange(cfg, logger), cfg.Server.GRPCTLSCert, cfg.Server.GRPCTLSKey, warmReg, logger)
 	if gerr != nil {
 		return nil, false, nil, gerr
 	}
@@ -419,6 +419,15 @@ func startSchedulerSide(ctx context.Context, cfg *config.ServerConfig, pg *stora
 		if serr != nil {
 			grpcSrv.GracefulStop()
 			return nil, false, nil, serr
+		}
+		// Warm-pool Hole B: gate the assignment stream to the scheduler LEADER. This
+		// replica gates on ITS OWN leadership (sched.IsLeading), so behind one Service
+		// exactly the leader — whose leader-only placer consults the SAME in-memory
+		// registry workers register into here — serves AwaitAssignment; a follower
+		// refuses so the worker reconnects toward the leader. Only with warm pools on;
+		// off, the handler already refuses before the gate and nothing changes.
+		if cfg.Execution.WarmPoolsEnabled {
+			agentSrv.SetLeaderCheck(sched.IsLeading)
 		}
 		// On shutdown, drain the buffered dispatch pool (if any) so in-flight
 		// dispatches settle (success or failed via the sink) instead of leaking
@@ -577,13 +586,13 @@ func serveHTTP(ctx context.Context, logger *slog.Logger, servesAPI bool, apiSrv,
 // shutdown. TLS is enabled when tlsCert/tlsKey are set (issue #58); otherwise the
 // channel is plaintext (dev). The per-task bearer token in metadata authenticates
 // each call regardless.
-func startAgentGRPC(ctx context.Context, addr string, authn *auth.JWTAuthenticator, store *storage.ExecutionStore, secretsStore agentrpc.SecretsStore, xcomSvc agentrpc.XComService, logSink agentrpc.LogSink, logTailer agentrpc.LogPublisher, allowInsecureSecrets bool, secretScoping, secretLivenessMode string, maxAttemptLifetime time.Duration, exchange *tokenExchange, tlsCert, tlsKey string, warmPools *agentrpc.WorkerRegistry, logger *slog.Logger) (*grpc.Server, error) {
+func startAgentGRPC(ctx context.Context, addr string, authn *auth.JWTAuthenticator, store *storage.ExecutionStore, secretsStore agentrpc.SecretsStore, xcomSvc agentrpc.XComService, logSink agentrpc.LogSink, logTailer agentrpc.LogPublisher, allowInsecureSecrets bool, secretScoping, secretLivenessMode string, maxAttemptLifetime time.Duration, exchange *tokenExchange, tlsCert, tlsKey string, warmPools *agentrpc.WorkerRegistry, logger *slog.Logger) (srv *grpc.Server, agentSrv *agentrpc.Server, err error) {
 	var lc net.ListenConfig
 	lis, err := lc.Listen(ctx, "tcp", addr)
 	if err != nil {
-		return nil, fmt.Errorf("listening for agent grpc on %s: %w", addr, err)
+		return nil, nil, fmt.Errorf("listening for agent grpc on %s: %w", addr, err)
 	}
-	agentSrv := agentrpc.NewServer(authn, store, xcomSvc)
+	agentSrv = agentrpc.NewServer(authn, store, xcomSvc)
 	agentSrv.SetLogSink(logSink)
 	agentSrv.SetLogPublisher(logTailer)
 	agentSrv.SetSecrets(secretsStore, allowInsecureSecrets)
@@ -651,11 +660,11 @@ func startAgentGRPC(ctx context.Context, addr string, authn *auth.JWTAuthenticat
 	if secure {
 		creds, cerr := credentials.NewServerTLSFromFile(tlsCert, tlsKey)
 		if cerr != nil {
-			return nil, fmt.Errorf("loading agent grpc TLS cert: %w", cerr)
+			return nil, nil, fmt.Errorf("loading agent grpc TLS cert: %w", cerr)
 		}
 		opts = append(opts, grpc.Creds(creds))
 	}
-	srv := grpc.NewServer(opts...)
+	srv = grpc.NewServer(opts...)
 	agentv1.RegisterAgentServiceServer(srv, agentSrv)
 	go func() {
 		if serr := srv.Serve(lis); serr != nil && !errors.Is(serr, grpc.ErrServerStopped) {
@@ -663,7 +672,7 @@ func startAgentGRPC(ctx context.Context, addr string, authn *auth.JWTAuthenticat
 		}
 	}()
 	logger.Info("agent grpc server started", "grpc_addr", addr, "tls", secure)
-	return srv, nil
+	return srv, agentSrv, nil
 }
 
 // tokenExchange bundles the Kubernetes-backed dependencies of the agent

--- a/internal/agent/warm.go
+++ b/internal/agent/warm.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	mathrand "math/rand/v2"
 	"os"
 	"path/filepath"
 	"time"
@@ -84,15 +85,109 @@ type WarmRunner struct {
 	MaxLifetime     time.Duration
 	IdleTTL         time.Duration
 	AttemptWatchdog time.Duration
+
+	// Reconnect-toward-the-leader bounds (warm-pool Hole B). On a not-leader
+	// rejection (FailedPrecondition — the leader-gate refusal, or warm-pools not
+	// serving on this endpoint) the worker RECONNECTS with jittered exponential
+	// backoff instead of exiting: a single pod finds the leader across the Service's
+	// rotation without the pod-create-die-recreate churn a fresh pod would cause. The
+	// reconnect is bounded so a genuinely misconfigured deployment eventually exits
+	// (non-zero) and lets the reconciler replace it, rather than spinning forever.
+	// Zero values fall back to production defaults; tests inject tiny ones.
+	//
+	//   - ReconnectBackoff: base backoff, doubled each consecutive reconnect.
+	//   - ReconnectMaxBackoff: ceiling on a single backoff sleep.
+	//   - MaxReconnects: consecutive not-leader reconnects before giving up.
+	ReconnectBackoff    time.Duration
+	ReconnectMaxBackoff time.Duration
+	MaxReconnects       int
+
+	// Redial re-establishes the StreamClient toward the control plane for the next
+	// reconnect. A FRESH dial is what lets the worker reach the leader: a single gRPC
+	// connection sticks to one Service backend, so retrying the same client would
+	// re-hit the same follower forever — only a new connection re-rotates. It returns
+	// the new stream client and a closer for the connection it opened (closed on the
+	// next reconnect / exit). Nil disables re-dial — the reconnect then retries the
+	// existing StreamClient (tests inject a fake that eventually serves); production
+	// wires a real re-dial via agent.Dial.
+	Redial func() (agentv1.AgentServiceClient, io.Closer, error)
+
+	// streamCloser holds the connection the most recent Redial opened, so it can be
+	// closed on the following reconnect (or on exit) rather than leaked.
+	streamCloser io.Closer
 }
 
-// Run registers the worker once, opens the assignment stream, and serves
-// assignments until the stream ends (server close / drain) or ctx is canceled —
-// returning nil in both those cases. It returns a non-nil error only on a
-// registration failure, a stream transport failure, or a failure to guarantee a
-// clean scratch (isolation is fail-closed). A failed TASK is a normal outcome and
-// never ends the loop.
+// Reconnect defaults (warm-pool Hole B) used when the corresponding WarmRunner
+// field is zero. The base/cap are deliberately short: a Service rotation resolves
+// in a few dials, and a persistent rejection should surface quickly.
+const (
+	reconnectBackoffBaseDefault = 500 * time.Millisecond
+	reconnectBackoffMaxDefault  = 5 * time.Second
+	maxReconnectsDefault        = 10
+)
+
+// Run serves the warm-worker lifecycle, reconnecting toward the scheduler leader
+// on a not-leader rejection (warm-pool Hole B). Each serve() registers, opens the
+// assignment stream, and serves assignments until the stream ends (server close /
+// drain), ctx is canceled, or a self-lifecycle bound trips — all clean exits
+// (nil). A FailedPrecondition from serve() is the not-leader rejection (the
+// leader-gate, or warm pools not serving on this endpoint): Run re-dials and
+// retries with jittered exponential backoff so one pod finds the leader across the
+// Service's rotation, bounded by MaxReconnects so a misconfigured deployment
+// eventually exits and lets the reconciler replace it. Any other error (a real
+// registration / stream transport failure, or a fail-closed scratch failure) is
+// returned as before. A failed TASK is a normal outcome and never ends serve().
 func (w *WarmRunner) Run(ctx context.Context, dagVersionID string) error {
+	base := w.ReconnectBackoff
+	if base <= 0 {
+		base = reconnectBackoffBaseDefault
+	}
+	maxBackoff := w.ReconnectMaxBackoff
+	if maxBackoff <= 0 {
+		maxBackoff = reconnectBackoffMaxDefault
+	}
+	maxReconnects := w.MaxReconnects
+	if maxReconnects <= 0 {
+		maxReconnects = maxReconnectsDefault
+	}
+
+	defer w.closeRedialConn()
+
+	reconnects := 0
+	for {
+		err := w.serve(ctx, dagVersionID)
+		if err == nil {
+			return nil
+		}
+		// Only a not-leader rejection triggers reconnect; every other error (real
+		// transport failure, fail-closed scratch) surfaces as before.
+		if status.Code(err) != codes.FailedPrecondition {
+			return err
+		}
+		reconnects++
+		if reconnects > maxReconnects {
+			return fmt.Errorf("giving up after %d consecutive not-leader reconnects: %w", maxReconnects, err)
+		}
+		slog.Warn("warm worker not served by this endpoint (not the scheduler leader); reconnecting toward the leader",
+			"reconnect", reconnects, "max_reconnects", maxReconnects, "error", err)
+		if serr := w.backoffSleep(ctx, base, maxBackoff, reconnects); serr != nil {
+			// ctx canceled during backoff (SIGTERM / parent shutdown) => clean exit.
+			return nil
+		}
+		if rerr := w.redialStream(); rerr != nil {
+			return fmt.Errorf("redialing control plane after not-leader rejection: %w", rerr)
+		}
+	}
+}
+
+// serve runs one connection's worth of the warm lifecycle: register the worker,
+// open the assignment stream, and serve assignments until the stream ends (server
+// close / drain) or ctx is canceled — returning nil in both those cases. It
+// returns a non-nil error only on a registration failure, a stream transport
+// failure, or a failure to guarantee a clean scratch (isolation is fail-closed). A
+// FailedPrecondition-coded error is the not-leader rejection Run reconnects on. A
+// failed TASK is a normal outcome and never ends the loop.
+func (w *WarmRunner) serve(ctx context.Context, dagVersionID string) error {
 	if _, err := w.StreamClient.Register(ctx, &agentv1.RegisterRequest{
 		AgentVersion: w.Version,
 		Hostname:     w.Hostname,
@@ -160,6 +255,62 @@ func (w *WarmRunner) Run(ctx context.Context, dagVersionID string) error {
 				"age", time.Since(workerStart), "max_lifetime", w.MaxLifetime)
 			return nil
 		}
+	}
+}
+
+// backoffSleep waits a jittered exponential backoff before reconnect n (1-based),
+// capped at maxBackoff, returning ctx.Err() if ctx is canceled first (so a SIGTERM
+// during backoff exits cleanly). The doubling loop stops once the cap is reached so
+// a large n can never overflow the shift. Full jitter (a uniform draw in [d/2, d])
+// spreads a fleet's reconnects so they do not stampede the leader in lockstep;
+// math/rand is fine here — this is backoff jitter, nothing security-relevant.
+func (w *WarmRunner) backoffSleep(ctx context.Context, base, maxBackoff time.Duration, n int) error {
+	d := base
+	for i := 1; i < n && d < maxBackoff; i++ {
+		d *= 2
+	}
+	if d <= 0 || d > maxBackoff {
+		d = maxBackoff
+	}
+	if half := d / 2; half > 0 {
+		d = half + time.Duration(mathrand.Int64N(int64(half)+1)) //nolint:gosec // G404: backoff jitter, not security-relevant
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// redialStream re-establishes the StreamClient for the next reconnect via Redial (a
+// fresh dial => a fresh Service backend, so the worker can reach the leader across
+// the rotation). It closes the previous reconnect's connection first so reconnects
+// do not leak connections. With no Redial wired it is a no-op: the reconnect then
+// retries the existing StreamClient (tests / single-dial).
+func (w *WarmRunner) redialStream() error {
+	if w.Redial == nil {
+		return nil
+	}
+	client, closer, err := w.Redial()
+	if err != nil {
+		return err
+	}
+	w.closeRedialConn()
+	w.StreamClient = client
+	w.streamCloser = closer
+	return nil
+}
+
+// closeRedialConn best-effort closes the connection the most recent Redial opened.
+func (w *WarmRunner) closeRedialConn() {
+	if w.streamCloser != nil {
+		if cerr := w.streamCloser.Close(); cerr != nil {
+			slog.Warn("closing previous warm stream connection after reconnect", "error", cerr)
+		}
+		w.streamCloser = nil
 	}
 }
 

--- a/internal/agent/warm_test.go
+++ b/internal/agent/warm_test.go
@@ -485,6 +485,113 @@ func TestWarmWorkerWatchdogKillsWedgedAttempt(t *testing.T) {
 	}
 }
 
+// noopCloser is an io.Closer that does nothing — the test double for a redial's
+// connection closer.
+type noopCloser struct{}
+
+func (noopCloser) Close() error { return nil }
+
+// notLeaderFake models the Service fronting an HA scheduler (warm-pool Hole B):
+// AwaitAssignment is refused with FailedPrecondition on the first rejectN calls
+// (the worker landed on a follower, or the leader-gate refuses), then a working
+// stream is returned (a re-dial finally reached the leader). Register always
+// succeeds — it is a unary ack and is NOT leader-gated.
+type notLeaderFake struct {
+	*fakeClient
+	rejectN    int
+	awaitCalls int
+	stream     *fakeAssignmentStream
+}
+
+func (c *notLeaderFake) AwaitAssignment(context.Context, ...grpc.CallOption) (grpc.BidiStreamingClient[agentv1.WorkerMessage, agentv1.WorkAssignment], error) {
+	c.awaitCalls++
+	if c.awaitCalls <= c.rejectN {
+		return nil, status.Error(codes.FailedPrecondition, "not the scheduler leader; reconnect to reach the leader")
+	}
+	return c.stream, nil
+}
+
+// TestWarmWorkerReconnectsTowardLeader is the client side of the warm-pool Hole B
+// fix: a not-leader rejection (FailedPrecondition) must make the worker RECONNECT
+// toward the leader with backoff — re-dialing, re-registering, re-opening the
+// stream — rather than returning the error and letting the pod die (which forces a
+// reconciler pod-recreate that may re-hit a follower: churn). After the follower
+// rejections stop, the leader serves and the worker exits cleanly on stream EOF.
+func TestWarmWorkerReconnectsTowardLeader(t *testing.T) {
+	scratch := filepath.Join(t.TempDir(), "scratch")
+	client := &notLeaderFake{
+		fakeClient: &fakeClient{},
+		rejectN:    3,
+		stream:     &fakeAssignmentStream{ctx: context.Background()}, // empty => EOF once served
+	}
+	redials := 0
+	w := &WarmRunner{
+		StreamClient:  client,
+		WorkClient:    client,
+		AttemptTokens: NewTokenSource("bootstrap"),
+		Cmd:           &scratchProbeCmd{scratchDir: scratch},
+		Hostname:      "warm-pod-1", Version: "test", ScratchDir: scratch,
+		// Tiny backoff so the test never really sleeps; a generous cap on reconnects.
+		ReconnectBackoff: time.Microsecond, ReconnectMaxBackoff: time.Millisecond, MaxReconnects: 10,
+		Redial: func() (agentv1.AgentServiceClient, io.Closer, error) {
+			redials++
+			return client, noopCloser{}, nil
+		},
+	}
+
+	if err := w.Run(context.Background(), "dagver-1"); err != nil {
+		t.Fatalf("WarmRunner.Run: %v, want nil (reconnect until the leader serves)", err)
+	}
+	if client.awaitCalls != 4 {
+		t.Fatalf("AwaitAssignment calls = %d, want 4 (3 follower rejections + 1 leader serve)", client.awaitCalls)
+	}
+	if redials != 3 {
+		t.Fatalf("redials = %d, want 3 (one re-dial per not-leader reconnect)", redials)
+	}
+	if !client.registered {
+		t.Error("worker must (re-)register when it finally reaches the leader")
+	}
+}
+
+// TestWarmWorkerReconnectGivesUpAfterCap bounds the reconnect: a genuinely
+// misconfigured deployment (persistent FailedPrecondition) must eventually exit
+// non-zero — letting the reconciler replace the pod — rather than spin forever.
+func TestWarmWorkerReconnectGivesUpAfterCap(t *testing.T) {
+	scratch := filepath.Join(t.TempDir(), "scratch")
+	client := &notLeaderFake{
+		fakeClient: &fakeClient{},
+		rejectN:    1 << 20, // always reject
+		stream:     &fakeAssignmentStream{ctx: context.Background()},
+	}
+	redials := 0
+	w := &WarmRunner{
+		StreamClient:  client,
+		WorkClient:    client,
+		AttemptTokens: NewTokenSource("bootstrap"),
+		Cmd:           &scratchProbeCmd{scratchDir: scratch},
+		Hostname:      "warm-pod-1", Version: "test", ScratchDir: scratch,
+		ReconnectBackoff: time.Microsecond, ReconnectMaxBackoff: time.Millisecond, MaxReconnects: 3,
+		Redial: func() (agentv1.AgentServiceClient, io.Closer, error) {
+			redials++
+			return client, noopCloser{}, nil
+		},
+	}
+
+	err := w.Run(context.Background(), "dagver-1")
+	if err == nil {
+		t.Fatal("persistent not-leader must give up with a non-nil error, not spin forever")
+	}
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("give-up error should carry the not-leader code, got %v", err)
+	}
+	if client.awaitCalls != 4 {
+		t.Fatalf("AwaitAssignment calls = %d, want 4 (initial + 3 bounded reconnects)", client.awaitCalls)
+	}
+	if redials != 3 {
+		t.Fatalf("redials = %d, want 3 (bounded to MaxReconnects)", redials)
+	}
+}
+
 // TestRunnerRunIsRegisterThenOneAttempt locks the single-shot refactor: Run must
 // still be exactly "register, then run one attempt" — one GetTaskSpec, one
 // RUNNING→SUCCESS pair — with no warm-loop behavior leaking in.

--- a/internal/agentrpc/await_assignment.go
+++ b/internal/agentrpc/await_assignment.go
@@ -18,6 +18,14 @@ import (
 // registry with a deterministic lease; callers wire it via EnableWarmPools.
 func (s *Server) SetWarmPools(reg *WorkerRegistry) { s.warmPools = reg }
 
+// SetLeaderCheck gates AwaitAssignment to the scheduler leader (warm-pool Hole B).
+// Each scheduler replica wires its OWN leadership predicate, so a follower refuses
+// the stream (FailedPrecondition) and only the leader — whose leader-only placer
+// consults the same in-memory registry the worker registers into — serves it. A
+// nil predicate (the default) leaves the handler unchecked, so a single-node or
+// unwired deployment serves exactly as before.
+func (s *Server) SetLeaderCheck(fn func() bool) { s.leaderCheck = fn }
+
 // EnableWarmPools turns on the warm-worker assignment transport with a
 // production registry (ADR 0058 N1b). onReclaim (may be nil) observes reclaim
 // events for the future placement layer to consume. Call only when
@@ -49,6 +57,13 @@ func (s *Server) EnableWarmPools(onReclaim func(ReclaimEvent)) {
 func (s *Server) AwaitAssignment(stream agentv1.AgentService_AwaitAssignmentServer) error {
 	if s.warmPools == nil {
 		return status.Error(codes.FailedPrecondition, "warm pools disabled")
+	}
+	// Leader gate (warm-pool Hole B): a follower's in-memory registry is never
+	// consulted by the leader-only placer, so a follower refuses the stream and the
+	// worker reconnects toward the leader. A nil predicate is unchecked (single-node
+	// / tests serve as before).
+	if s.leaderCheck != nil && !s.leaderCheck() {
+		return status.Error(codes.FailedPrecondition, "not the scheduler leader; reconnect to reach the leader")
 	}
 	ctx := stream.Context()
 	id, err := s.identify(ctx)

--- a/internal/agentrpc/await_assignment_test.go
+++ b/internal/agentrpc/await_assignment_test.go
@@ -105,6 +105,49 @@ func TestAwaitAssignmentInertWhenWarmPoolsOff(t *testing.T) {
 	}
 }
 
+// ─── leader gate (warm-pool Hole B) ─────────────────────────────────────────
+
+// TestAwaitAssignmentRefusedOnFollower is the server side of the warm-pool
+// leader-gate fix: with warm pools ON but this replica NOT the scheduler leader,
+// AwaitAssignment refuses with FailedPrecondition BEFORE the worker is registered,
+// so a warm worker never lands in a follower's in-memory registry that the
+// leader-only placer never consults.
+func TestAwaitAssignmentRefusedOnFollower(t *testing.T) {
+	srv, a, reg := newWarmServer(t, nil)
+	srv.SetLeaderCheck(func() bool { return false })
+	stream := newFakeAwaitStream(ctxWithToken(t, a))
+	err := srv.AwaitAssignment(stream)
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Fatalf("follower AwaitAssignment: got %v, want FailedPrecondition", err)
+	}
+	if reg.registered("ti-1") {
+		t.Fatal("a follower must not register the worker in its own registry")
+	}
+}
+
+// TestAwaitAssignmentProceedsOnLeader: with leaderCheck true the handler proceeds
+// to registration exactly as an unchecked server does — the leader serves.
+func TestAwaitAssignmentProceedsOnLeader(t *testing.T) {
+	srv, a, reg := newWarmServer(t, nil)
+	srv.SetLeaderCheck(func() bool { return true })
+	stream := newFakeAwaitStream(ctxWithToken(t, a))
+	stream.pushMsg(regMsg("dagver-1"))
+	go func() { _ = srv.AwaitAssignment(stream) }()
+	awaitEventually(t, func() bool { return reg.registered("ti-1") })
+	stream.pushErr(io.EOF) // clean shutdown
+}
+
+// TestAwaitAssignmentNilLeaderCheckUnchecked: a nil leaderCheck means "unchecked"
+// (single-node / tests without wiring), so the handler serves as before.
+func TestAwaitAssignmentNilLeaderCheckUnchecked(t *testing.T) {
+	srv, a, reg := newWarmServer(t, nil) // no SetLeaderCheck
+	stream := newFakeAwaitStream(ctxWithToken(t, a))
+	stream.pushMsg(regMsg("dagver-1"))
+	go func() { _ = srv.AwaitAssignment(stream) }()
+	awaitEventually(t, func() bool { return reg.registered("ti-1") })
+	stream.pushErr(io.EOF) // clean shutdown
+}
+
 // ─── (b) non-register first message ─────────────────────────────────────────
 
 func TestAwaitAssignmentRequiresRegisterFirst(t *testing.T) {

--- a/internal/agentrpc/server.go
+++ b/internal/agentrpc/server.go
@@ -172,6 +172,15 @@ type Server struct {
 	// AwaitAssignment is inert (returns FailedPrecondition) unless the operator
 	// enabled warm pools and the server wired a registry via SetWarmPools.
 	warmPools *WorkerRegistry
+	// leaderCheck gates AwaitAssignment to the scheduler LEADER (warm-pool Hole B).
+	// The warm-pool placer + reconciler run leader-only, but startAgentGRPC (and its
+	// in-memory WorkerRegistry) runs on every scheduler replica; behind one Service,
+	// a warm worker's stream can load-balance onto a FOLLOWER whose registry the
+	// leader's placer never consults — orphaning that worker. A follower therefore
+	// refuses the stream so the worker reconnects toward the leader. nil means
+	// "unchecked" (single-node / tests serve as before); production wires it to the
+	// scheduler's own leadership so exactly one replica — the leader — serves.
+	leaderCheck func() bool
 }
 
 // NewServer builds an AgentService server backed by the given authenticator,


### PR DESCRIPTION
Final-stretch review **Hole B** (HA topology). The `AwaitAssignment` handler runs on every scheduler replica but the placer/reconciler are leader-only with a per-replica in-memory registry, so on an HA scheduler behind one Service a worker on a FOLLOWER is never assigned (~1/N effective, (N−1)/N orphaned). Behind `execution.warm_pools_enabled` (off ⇒ unchanged).

**Part A (server):** `Server.leaderCheck` + `SetLeaderCheck`; `AwaitAssignment` refuses `FailedPrecondition` when not leader (nil = unchecked, single-node/tests). `main.go` wires each replica's `SetLeaderCheck(sched.IsLeading)` only when warm on → exactly the leader serves.
**Part B (agent):** `WarmRunner.Run` is a reconnect loop; on a not-leader `FailedPrecondition` it reconnects with jittered backoff and re-dials the stream connection (two-client separation preserved), so one pod finds the leader without churn. Bounded by `MaxReconnects` (default 10) → no infinite spin. EOF/Canceled/drain unchanged.

Tests (RED-first): refuses-on-follower / proceeds-on-leader / nil-unchecked; reconnects-then-serves + gives-up-after-cap. `go vet ./...` **and** `-tags integration` clean · build + `-tags integration` green · `go test -race` clean · `golangci-lint` 0.