### PR TITLE
fix(warm): count queued-bound workers busy + clear binding on re-dispatch (ADR 0058 Hole A)

### DIFF
--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -170,15 +170,29 @@ type Querier interface {
 	// outage; the rest are picked up on the next tick.
 	ListAgentLostCandidates(ctx context.Context) ([]ListAgentLostCandidatesRow, error)
 	ListAuditLogs(ctx context.Context, arg ListAuditLogsParams) ([]ListAuditLogsRow, error)
-	// Lists the DISTINCT warm-worker pod names currently serving a `running` attempt
-	// (ADR 0058 N1d-b): a warm worker is BUSY iff some `running` task_instance is
-	// durably bound to it (warm_worker_id = the pod's own name — the binding landed
-	// in N1d-a1/a2). The busy-aware warm-pool reconciler reads this once per tick to
-	// classify each live warm pod as busy (serving an attempt) or idle, so
-	// scale-down and drain delete only IDLE workers and never kill an in-flight
-	// attempt (review findings M1/M2). With warm pools off no TI is ever bound, so
-	// this is always empty and every worker classifies as idle — byte-for-byte
-	// today's dedicated pod-per-task behavior.
+	// Lists the DISTINCT warm-worker pod names currently serving an active attempt
+	// (ADR 0058 N1d-b): a warm worker is BUSY iff some task_instance in an active
+	// state (`queued` or `running`) is durably bound to it (warm_worker_id = the
+	// pod's own name — the binding landed in N1d-a1/a2). The busy-aware warm-pool
+	// reconciler reads this once per tick to classify each live warm pod as busy
+	// (serving an attempt) or idle, so scale-down and drain delete only IDLE workers
+	// and never kill an in-flight attempt (review findings M1/M2).
+	//
+	// The `queued` state MUST be in the busy set, not just `running`: BindWarmAttempt
+	// stamps warm_worker_id the instant a warm worker ACKs an assignment as started,
+	// while the TI is still `queued`, and the child only reports RUNNING
+	// (queued->running) a moment later. Between the ack and that report the worker is
+	// actively STARTING the attempt; counting only `running` would classify it IDLE
+	// in that window and let the excess-idle-tail delete remove a worker that is
+	// starting an attempt — an M1 violation that kills a just-started attempt. The
+	// BindWarmAttempt guard binds exactly the queued/running window, and every
+	// re-dispatch/reset that moves a bound row back out of that window clears
+	// warm_worker_id, so a queued+bound row here is always a live starting attempt,
+	// never a stale binding.
+	//
+	// With warm pools off no TI is ever bound, so this is always empty and every
+	// worker classifies as idle — byte-for-byte today's dedicated pod-per-task
+	// behavior.
 	ListBusyWarmWorkerPods(ctx context.Context) ([]*string, error)
 	// All of a tenant's connections WITH the encrypted password, for delivering
 	// credentials to task pods (ADR 0021). Never use this for UI/API responses,
@@ -404,6 +418,13 @@ type Querier interface {
 	// bump try_number or infra_attempts: the attempt never ran, this is a re-offer of
 	// the SAME attempt, and the existing dispatch_attempts/backoff on the re-dispatch
 	// bounds a reclaim loop.
+	//
+	// warm_worker_id is CLEARED: the reclaimed worker demonstrably will not run this
+	// attempt, so the SAME row must not carry its stale binding back into the next
+	// queued/running window — with the busy set now spanning queued+running
+	// (ListBusyWarmWorkerPods), a stale binding would falsely mark the OLD (gone)
+	// worker busy. This is a same-row re-dispatch (the try_number is preserved), so
+	// the clear must happen here; a fresh try lands on a new row that is already NULL.
 	RequeueForRedispatch(ctx context.Context, arg RequeueForRedispatchParams) (int64, error)
 	// A reschedule-mode sensor (mode='reschedule') poked not-ready: park the active TI
 	// in up_for_reschedule with its next-poke time ($3) so the scheduler re-dispatches

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -312,6 +312,7 @@ SET state = 'none',
     reschedule_at = NULL,
     first_reschedule_at = NULL,
     last_failure_kind = NULL,
+    warm_worker_id = NULL,
     try_number = ti.try_number + 1
 WHERE ti.dag_run_id = $1 AND ti.task_id = $2;
 
@@ -349,6 +350,7 @@ SET state = 'none',
     reschedule_at = NULL,
     first_reschedule_at = NULL,
     last_failure_kind = NULL,
+    warm_worker_id = NULL,
     try_number = ti.try_number + 1
 WHERE ti.dag_run_id = $1 AND ti.task_id = $2 AND ti.state = 'up_for_retry';
 
@@ -390,6 +392,7 @@ SET state = 'none',
     reschedule_at = NULL,
     first_reschedule_at = NULL,
     last_failure_kind = NULL,
+    warm_worker_id = NULL,
     infra_attempts = ti.infra_attempts + 1
 WHERE ti.dag_run_id = $1 AND ti.task_id = $2
   AND ti.state = 'failed' AND ti.last_failure_kind = 'infra';
@@ -408,7 +411,8 @@ SET state = 'none',
     queued_at = NULL,
     scheduled_at = NULL,
     reschedule_at = NULL,
-    last_failure_kind = NULL
+    last_failure_kind = NULL,
+    warm_worker_id = NULL
 WHERE dag_run_id = $1 AND task_id = $2 AND state = 'up_for_reschedule';
 
 -- name: TaskInstanceFirstRescheduleAt :one
@@ -593,6 +597,7 @@ SET state = 'none',
     dispatch_attempts = 0,
     next_dispatch_at = NULL,
     last_failure_kind = NULL,
+    warm_worker_id = NULL,
     try_number = ti.try_number + 1
 WHERE ti.dag_run_id = $1 AND ti.task_id = $2
   AND ti.state IN ('failed', 'upstream_failed', 'up_for_retry');
@@ -625,6 +630,7 @@ SET state = 'none',
     dispatch_attempts = 0,
     next_dispatch_at = NULL,
     last_failure_kind = NULL,
+    warm_worker_id = NULL,
     try_number = ti.try_number + 1
 WHERE ti.dag_run_id = $1
   AND ti.state IN ('failed', 'upstream_failed', 'up_for_retry');
@@ -763,18 +769,32 @@ ORDER BY ti.started_at NULLS LAST
 LIMIT 100;
 
 -- name: ListBusyWarmWorkerPods :many
--- Lists the DISTINCT warm-worker pod names currently serving a `running` attempt
--- (ADR 0058 N1d-b): a warm worker is BUSY iff some `running` task_instance is
--- durably bound to it (warm_worker_id = the pod's own name — the binding landed
--- in N1d-a1/a2). The busy-aware warm-pool reconciler reads this once per tick to
--- classify each live warm pod as busy (serving an attempt) or idle, so
--- scale-down and drain delete only IDLE workers and never kill an in-flight
--- attempt (review findings M1/M2). With warm pools off no TI is ever bound, so
--- this is always empty and every worker classifies as idle — byte-for-byte
--- today's dedicated pod-per-task behavior.
+-- Lists the DISTINCT warm-worker pod names currently serving an active attempt
+-- (ADR 0058 N1d-b): a warm worker is BUSY iff some task_instance in an active
+-- state (`queued` or `running`) is durably bound to it (warm_worker_id = the
+-- pod's own name — the binding landed in N1d-a1/a2). The busy-aware warm-pool
+-- reconciler reads this once per tick to classify each live warm pod as busy
+-- (serving an attempt) or idle, so scale-down and drain delete only IDLE workers
+-- and never kill an in-flight attempt (review findings M1/M2).
+--
+-- The `queued` state MUST be in the busy set, not just `running`: BindWarmAttempt
+-- stamps warm_worker_id the instant a warm worker ACKs an assignment as started,
+-- while the TI is still `queued`, and the child only reports RUNNING
+-- (queued->running) a moment later. Between the ack and that report the worker is
+-- actively STARTING the attempt; counting only `running` would classify it IDLE
+-- in that window and let the excess-idle-tail delete remove a worker that is
+-- starting an attempt — an M1 violation that kills a just-started attempt. The
+-- BindWarmAttempt guard binds exactly the queued/running window, and every
+-- re-dispatch/reset that moves a bound row back out of that window clears
+-- warm_worker_id, so a queued+bound row here is always a live starting attempt,
+-- never a stale binding.
+--
+-- With warm pools off no TI is ever bound, so this is always empty and every
+-- worker classifies as idle — byte-for-byte today's dedicated pod-per-task
+-- behavior.
 SELECT DISTINCT ti.warm_worker_id AS warm_worker_id
 FROM task_instances ti
-WHERE ti.state = 'running'
+WHERE ti.state IN ('queued', 'running')
   AND ti.warm_worker_id IS NOT NULL;
 
 -- name: ListAgentLostCandidates :many
@@ -910,8 +930,16 @@ WHERE dag_run_id = $1 AND task_id = $2 AND state = 'scheduled';
 -- bump try_number or infra_attempts: the attempt never ran, this is a re-offer of
 -- the SAME attempt, and the existing dispatch_attempts/backoff on the re-dispatch
 -- bounds a reclaim loop.
+--
+-- warm_worker_id is CLEARED: the reclaimed worker demonstrably will not run this
+-- attempt, so the SAME row must not carry its stale binding back into the next
+-- queued/running window — with the busy set now spanning queued+running
+-- (ListBusyWarmWorkerPods), a stale binding would falsely mark the OLD (gone)
+-- worker busy. This is a same-row re-dispatch (the try_number is preserved), so
+-- the clear must happen here; a fresh try lands on a new row that is already NULL.
 UPDATE task_instances
-SET state = 'scheduled'
+SET state = 'scheduled',
+    warm_worker_id = NULL
 WHERE dag_run_id = $1 AND task_id = $2 AND try_number = $3 AND state = 'queued';
 
 -- name: FailDispatchExhausted :exec

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -745,19 +745,33 @@ func (q *Queries) ListAgentLostCandidates(ctx context.Context) ([]ListAgentLostC
 const listBusyWarmWorkerPods = `-- name: ListBusyWarmWorkerPods :many
 SELECT DISTINCT ti.warm_worker_id AS warm_worker_id
 FROM task_instances ti
-WHERE ti.state = 'running'
+WHERE ti.state IN ('queued', 'running')
   AND ti.warm_worker_id IS NOT NULL
 `
 
-// Lists the DISTINCT warm-worker pod names currently serving a `running` attempt
-// (ADR 0058 N1d-b): a warm worker is BUSY iff some `running` task_instance is
-// durably bound to it (warm_worker_id = the pod's own name — the binding landed
-// in N1d-a1/a2). The busy-aware warm-pool reconciler reads this once per tick to
-// classify each live warm pod as busy (serving an attempt) or idle, so
-// scale-down and drain delete only IDLE workers and never kill an in-flight
-// attempt (review findings M1/M2). With warm pools off no TI is ever bound, so
-// this is always empty and every worker classifies as idle — byte-for-byte
-// today's dedicated pod-per-task behavior.
+// Lists the DISTINCT warm-worker pod names currently serving an active attempt
+// (ADR 0058 N1d-b): a warm worker is BUSY iff some task_instance in an active
+// state (`queued` or `running`) is durably bound to it (warm_worker_id = the
+// pod's own name — the binding landed in N1d-a1/a2). The busy-aware warm-pool
+// reconciler reads this once per tick to classify each live warm pod as busy
+// (serving an attempt) or idle, so scale-down and drain delete only IDLE workers
+// and never kill an in-flight attempt (review findings M1/M2).
+//
+// The `queued` state MUST be in the busy set, not just `running`: BindWarmAttempt
+// stamps warm_worker_id the instant a warm worker ACKs an assignment as started,
+// while the TI is still `queued`, and the child only reports RUNNING
+// (queued->running) a moment later. Between the ack and that report the worker is
+// actively STARTING the attempt; counting only `running` would classify it IDLE
+// in that window and let the excess-idle-tail delete remove a worker that is
+// starting an attempt — an M1 violation that kills a just-started attempt. The
+// BindWarmAttempt guard binds exactly the queued/running window, and every
+// re-dispatch/reset that moves a bound row back out of that window clears
+// warm_worker_id, so a queued+bound row here is always a live starting attempt,
+// never a stale binding.
+//
+// With warm pools off no TI is ever bound, so this is always empty and every
+// worker classifies as idle — byte-for-byte today's dedicated pod-per-task
+// behavior.
 func (q *Queries) ListBusyWarmWorkerPods(ctx context.Context) ([]*string, error) {
 	rows, err := q.db.Query(ctx, listBusyWarmWorkerPods)
 	if err != nil {
@@ -1535,7 +1549,8 @@ SET state = 'none',
     queued_at = NULL,
     scheduled_at = NULL,
     reschedule_at = NULL,
-    last_failure_kind = NULL
+    last_failure_kind = NULL,
+    warm_worker_id = NULL
 WHERE dag_run_id = $1 AND task_id = $2 AND state = 'up_for_reschedule'
 `
 
@@ -1625,7 +1640,8 @@ func (q *Queries) ReportTaskResult(ctx context.Context, arg ReportTaskResultPara
 
 const requeueForRedispatch = `-- name: RequeueForRedispatch :execrows
 UPDATE task_instances
-SET state = 'scheduled'
+SET state = 'scheduled',
+    warm_worker_id = NULL
 WHERE dag_run_id = $1 AND task_id = $2 AND try_number = $3 AND state = 'queued'
 `
 
@@ -1649,6 +1665,13 @@ type RequeueForRedispatchParams struct {
 // bump try_number or infra_attempts: the attempt never ran, this is a re-offer of
 // the SAME attempt, and the existing dispatch_attempts/backoff on the re-dispatch
 // bounds a reclaim loop.
+//
+// warm_worker_id is CLEARED: the reclaimed worker demonstrably will not run this
+// attempt, so the SAME row must not carry its stale binding back into the next
+// queued/running window — with the busy set now spanning queued+running
+// (ListBusyWarmWorkerPods), a stale binding would falsely mark the OLD (gone)
+// worker busy. This is a same-row re-dispatch (the try_number is preserved), so
+// the clear must happen here; a fresh try lands on a new row that is already NULL.
 func (q *Queries) RequeueForRedispatch(ctx context.Context, arg RequeueForRedispatchParams) (int64, error) {
 	result, err := q.db.Exec(ctx, requeueForRedispatch, arg.DagRunID, arg.TaskID, arg.TryNumber)
 	if err != nil {
@@ -1734,6 +1757,7 @@ SET state = 'none',
     dispatch_attempts = 0,
     next_dispatch_at = NULL,
     last_failure_kind = NULL,
+    warm_worker_id = NULL,
     try_number = ti.try_number + 1
 WHERE ti.dag_run_id = $1
   AND ti.state IN ('failed', 'upstream_failed', 'up_for_retry')
@@ -1802,6 +1826,7 @@ SET state = 'none',
     dispatch_attempts = 0,
     next_dispatch_at = NULL,
     last_failure_kind = NULL,
+    warm_worker_id = NULL,
     try_number = ti.try_number + 1
 WHERE ti.dag_run_id = $1 AND ti.task_id = $2
   AND ti.state IN ('failed', 'upstream_failed', 'up_for_retry')
@@ -1849,6 +1874,7 @@ SET state = 'none',
     reschedule_at = NULL,
     first_reschedule_at = NULL,
     last_failure_kind = NULL,
+    warm_worker_id = NULL,
     try_number = ti.try_number + 1
 WHERE ti.dag_run_id = $1 AND ti.task_id = $2 AND ti.state = 'up_for_retry'
 `
@@ -1901,6 +1927,7 @@ SET state = 'none',
     reschedule_at = NULL,
     first_reschedule_at = NULL,
     last_failure_kind = NULL,
+    warm_worker_id = NULL,
     infra_attempts = ti.infra_attempts + 1
 WHERE ti.dag_run_id = $1 AND ti.task_id = $2
   AND ti.state = 'failed' AND ti.last_failure_kind = 'infra'
@@ -1956,6 +1983,7 @@ SET state = 'none',
     reschedule_at = NULL,
     first_reschedule_at = NULL,
     last_failure_kind = NULL,
+    warm_worker_id = NULL,
     try_number = ti.try_number + 1
 WHERE ti.dag_run_id = $1 AND ti.task_id = $2
 `

--- a/internal/storage/warm_busy_window_integration_test.go
+++ b/internal/storage/warm_busy_window_integration_test.go
@@ -1,0 +1,157 @@
+//go:build integration
+
+// Package storage_test — the warm busy-window reliability guard (ADR 0058 N1d-b,
+// review finding "Hole A").
+//
+// BindWarmAttempt stamps warm_worker_id the instant a warm worker ACKs an
+// assignment as started, while the TI is still `queued`; the child reports
+// RUNNING (queued->running) only a moment later. The old ListBusyWarmWorkerPods
+// counted a worker busy ONLY when state='running', so between the ack and the
+// RUNNING report the starting worker classified as IDLE — and if that tick had
+// len(idle) > EffectiveMinIdle (min_idle lowered, a burst subsiding, a draining
+// sibling) the excess-idle-tail delete removed a worker that was actively
+// starting an attempt: an M1 violation that kills a just-started attempt.
+//
+// Two integration cases lock the fix against real Postgres, since both turn on a
+// SQL predicate a fake-store unit test cannot prove:
+//
+//   - The full seam (real busy source + real reconciler): a warm pod bound to a
+//     queued (not-yet-running) TI must be classified BUSY and NOT deleted even
+//     when the idle target says to scale down. RED before the fix (the pod was
+//     deleted — the M1 kill), green after.
+//   - The widened busy query + the same-row re-dispatch clear:
+//     ListBusyWarmWorkerPods returns a worker for a queued+bound TI, and does NOT
+//     return one for a row that was bound then re-dispatched (RequeueForRedispatch
+//     cleared warm_worker_id so a stale binding can't falsely mark the gone worker
+//     busy).
+//
+// The shared-DB harness means these rows live alongside whatever else the suite
+// seeded, so each test seeds its own uniquely-named DAG/pod and asserts only on
+// rows and pod names it owns.
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/executor"
+)
+
+// fakeWarmTargetsPG is a canned executor.WarmTargetSource for the full-seam test.
+type fakeWarmTargetsPG struct {
+	targets []executor.WarmTarget
+}
+
+func (f *fakeWarmTargetsPG) ActiveWarmTargets(context.Context) ([]executor.WarmTarget, error) {
+	return f.targets, nil
+}
+
+// fakeWarmPodsPG is a canned executor.WarmPodClient: it lists a fixed fleet and
+// records every delete so the test can assert exactly which workers the
+// reconciler removed.
+type fakeWarmPodsPG struct {
+	existing []executor.WarmPodInfo
+	created  []executor.WarmTarget
+	deleted  []string
+}
+
+func (f *fakeWarmPodsPG) ListWarmPods(context.Context) ([]executor.WarmPodInfo, error) {
+	return f.existing, nil
+}
+
+func (f *fakeWarmPodsPG) CreateWarmPod(_ context.Context, t executor.WarmTarget) error {
+	f.created = append(f.created, t)
+	return nil
+}
+
+func (f *fakeWarmPodsPG) DeleteWarmPod(_ context.Context, name string) error {
+	f.deleted = append(f.deleted, name)
+	return nil
+}
+
+// TestWarmPoolReconcileKeepsQueuedBoundWorkerIntegration is the load-bearing
+// busy-window regression (Hole A). It drives the REAL warm-pool reconciler with
+// the REAL busy source (SchedulerStore.ListBusyWarmWorkerPods) over a TI that a
+// warm worker has bound while still `queued` — the exact starting-but-not-yet-
+// running window. The reconciler's target says to scale the idle buffer to 0
+// (EffectiveMinIdle=0), so the ONLY thing keeping the pod alive is being seen as
+// busy.
+//
+// Before the fix the busy query filtered state='running', so a queued+bound TI
+// produced an EMPTY busy set: the reconciler saw one IDLE worker over a target of
+// 0 and DELETED it — killing an attempt the worker was starting. After the fix
+// the busy set spans queued+running, so the worker is BUSY and is left to finish.
+func TestWarmPoolReconcileKeepsQueuedBoundWorkerIntegration(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	stamp := time.Now().UnixNano()
+
+	// A warm worker acked an assignment as started: the TI is `queued` and bound
+	// to this pod, but has not yet reported RUNNING.
+	dagID := fmt.Sprintf("warm_busywin_%d", stamp)
+	warmPod := fmt.Sprintf("leoflow-warm-busywin-%d", stamp)
+	seedQueuedWarmTask(t, repo, sched, exec, ctx, dagID, "load", warmPod)
+
+	// The fleet the reconciler sees is exactly this one starting worker, on a
+	// version whose idle target is 0 (a scale-down / burst-subsiding tick). If the
+	// worker is classified idle it is the excess-idle tail and gets deleted.
+	dagVersion := fmt.Sprintf("dv-busywin-%d", stamp)
+	pods := &fakeWarmPodsPG{existing: []executor.WarmPodInfo{{Name: warmPod, DagVersionID: dagVersion}}}
+	targets := &fakeWarmTargetsPG{targets: []executor.WarmTarget{
+		{DagVersionID: dagVersion, Image: "img", EffectiveMinIdle: 0, MaxPoolSize: 8},
+	}}
+
+	r := executor.NewWarmPoolReconciler(targets, pods, sched, nil, nil)
+	if err := r.Reconcile(ctx); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	for _, d := range pods.deleted {
+		if d == warmPod {
+			t.Fatalf("reconciler deleted %q — a warm worker STARTING a queued+bound attempt "+
+				"must be classified busy and never deleted (M1 / Hole A)", warmPod)
+		}
+	}
+}
+
+// TestListBusyWarmWorkerPodsQueuedBoundIntegration locks the widened busy query
+// and the same-row re-dispatch clear directly against Postgres:
+//
+//   - a queued+bound TI's worker IS in the busy set (the widened predicate), and
+//   - a worker whose bound row was re-dispatched via RequeueForRedispatch is NOT
+//     in the busy set (the clear worked — the re-dispatched row carries no stale
+//     binding, so the gone worker is not falsely marked busy).
+func TestListBusyWarmWorkerPodsQueuedBoundIntegration(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	stamp := time.Now().UnixNano()
+
+	// (1) queued + bound — its worker MUST be in the busy set.
+	liveDag := fmt.Sprintf("busy_queued_live_%d", stamp)
+	livePod := fmt.Sprintf("leoflow-warm-bqlive-%d", stamp)
+	seedQueuedWarmTask(t, repo, sched, exec, ctx, liveDag, "load", livePod)
+
+	// (2) bound-then-re-dispatched — its worker must NOT be in the busy set. Bind
+	// while queued, then RequeueForRedispatch moves the SAME row queued->scheduled
+	// and (with the fix) clears warm_worker_id.
+	reDag := fmt.Sprintf("busy_queued_redispatch_%d", stamp)
+	rePod := fmt.Sprintf("leoflow-warm-bqredis-%d", stamp)
+	reRun := seedQueuedWarmTask(t, repo, sched, exec, ctx, reDag, "load", rePod)
+	if err := exec.RequeueForRedispatch(ctx, reRun, "load", 1); err != nil {
+		t.Fatalf("RequeueForRedispatch: %v", err)
+	}
+
+	busy, err := sched.ListBusyWarmWorkerPods(ctx)
+	if err != nil {
+		t.Fatalf("ListBusyWarmWorkerPods: %v", err)
+	}
+
+	if !busy[livePod] {
+		t.Errorf("busy set is missing %q — a queued+bound worker (starting an attempt) "+
+			"must be counted busy so the reconciler never deletes it", livePod)
+	}
+	if busy[rePod] {
+		t.Errorf("busy set contains %q — a re-dispatched row must clear warm_worker_id, "+
+			"so the gone worker is not falsely marked busy (stale-binding vector)", rePod)
+	}
+}


### PR DESCRIPTION
Final-stretch review **Hole A** — a latent **M1 violation**. `BindWarmAttempt` stamps `warm_worker_id` while a TI is still `queued` (the instant a warm worker acks started, before the child reports RUNNING), but `ListBusyWarmWorkerPods` counted busy only `state='running'`. In the ack→running window a **starting** worker was invisible to the reconciler's busy set → classified IDLE → the excess-idle-tail delete could remove it, **killing a just-started attempt**. Behind `execution.warm_pools_enabled` (off ⇒ busy set empty ⇒ unchanged).

- `ListBusyWarmWorkerPods` now counts `state IN ('queued','running') AND warm_worker_id IS NOT NULL`.
- Clear `warm_worker_id = NULL` on all **7** same-row re-dispatch/reset transitions (audit found 2 beyond the initial list: `ResetFailedTaskInstance`/`ResetAllFailedTaskInstances`) so a re-dispatched row can't carry a stale binding into its next queued/running window. `task_instances` is one row per (run,task,map,try) → a retry is a fresh NULL row; settle-to-terminal needs no clear (state filter excludes it).

Tests (RED-first): reconciler **keeps a queued-bound worker** (deleted under the old query — the M1 kill regression); `ListBusyWarmWorkerPods` returns queued-bound + excludes a re-dispatched row. Integration tests run in **CI** (Postgres); logic + vet green locally; all 20 N1d-b reconciler tests pass. `go vet ./...` **and** `-tags integration` clean · sqlc idempotent · build + `-tags integration` green · `golangci-lint` 0.