### PR TITLE
feat(warm): per-tenant aggregate warm-pod cap, reserve-then-ration (ADR 0058 M4)

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -997,8 +997,8 @@ func startReconciler(ctx context.Context, cs kubernetes.Interface, namespace str
 // the busy set (busy) once per tick to classify workers. Like the pod reconciler
 // it mutates cluster state, so it runs on the leader alone via the gated ticker.
 // It is only called when warm pools are enabled.
-func startWarmPoolReconciler(ctx context.Context, targets executor.WarmTargetSource, pods executor.WarmPodClient, busy executor.BusyWarmWorkerSource, leading func() bool, rec executor.DecisionRecorder, logger *slog.Logger) {
-	rc := executor.NewWarmPoolReconciler(targets, pods, busy, logger, rec)
+func startWarmPoolReconciler(ctx context.Context, targets executor.WarmTargetSource, pods executor.WarmPodClient, busy executor.BusyWarmWorkerSource, maxWarmPodsPerTenant int, leading func() bool, rec executor.DecisionRecorder, logger *slog.Logger) {
+	rc := executor.NewWarmPoolReconciler(targets, pods, busy, maxWarmPodsPerTenant, logger, rec)
 	startGatedTicker(ctx, "warm-pool-reconcile", reconcileInterval, leading, logger, func() {
 		if err := rc.Reconcile(ctx); err != nil {
 			logger.Error("warm pool reconcile", "error", err)
@@ -1032,6 +1032,7 @@ func warmPodSpecFunc(cfg *config.ServerConfig, authn *auth.JWTAuthenticator, con
 		return executor.WarmPodSpec{
 			DagVersionID:        t.DagVersionID,
 			Image:               t.Image,
+			TenantID:            t.TenantID,
 			ControlPlaneAddr:    controlAddr,
 			AgentTLSCAConfigMap: cfg.Executor.AgentTLSCAConfigMap,
 			BootstrapToken:      token,
@@ -1407,7 +1408,7 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 		// The busy set (running attempts durably bound to a warm worker) makes the
 		// reconciler busy-aware (ADR 0058 N1d-b): it scales the IDLE buffer and never
 		// deletes a worker with an in-flight attempt. store implements it.
-		startWarmPoolReconciler(ctx, store, warmPods, store, sched.IsLeading, metrics, logger)
+		startWarmPoolReconciler(ctx, store, warmPods, store, cfg.Execution.MaxWarmPodsPerTenant, sched.IsLeading, metrics, logger)
 		logger.Warn("warm pool reconciler enabled (ADR 0058 N1b2b); maintaining min_idle warm workers per active dag_version", "namespace", cfg.Executor.TaskNamespace)
 	}
 	logger.Info("pod dispatch enabled", "namespace", cfg.Executor.TaskNamespace, "agent_control_plane_addr", controlAddr)

--- a/internal/config/execution_test.go
+++ b/internal/config/execution_test.go
@@ -32,6 +32,9 @@ func TestExecutionDefaults(t *testing.T) {
 	if got := c.Execution.MaxPoolSize; got != 8 {
 		t.Errorf("execution.max_pool_size default = %d, want 8", got)
 	}
+	if got := c.Execution.MaxWarmPodsPerTenant; got != 100 {
+		t.Errorf("execution.max_warm_pods_per_tenant default = %d, want 100", got)
+	}
 }
 
 // TestExecutionEnvBinds proves each execution key binds from its LEOFLOW_* env var
@@ -43,6 +46,7 @@ func TestExecutionEnvBinds(t *testing.T) {
 	t.Setenv("LEOFLOW_EXECUTION_MIN_IDLE_WORKERS", "3")
 	t.Setenv("LEOFLOW_EXECUTION_WORKER_IDLE_TTL", "90s")
 	t.Setenv("LEOFLOW_EXECUTION_MAX_POOL_SIZE", "16")
+	t.Setenv("LEOFLOW_EXECUTION_MAX_WARM_PODS_PER_TENANT", "250")
 	c, err := LoadServer("", nil)
 	if err != nil {
 		t.Fatalf("LoadServer: %v", err)
@@ -65,6 +69,9 @@ func TestExecutionEnvBinds(t *testing.T) {
 	if got := c.Execution.MaxPoolSize; got != 16 {
 		t.Errorf("execution.max_pool_size = %d, want 16 (from env)", got)
 	}
+	if got := c.Execution.MaxWarmPodsPerTenant; got != 250 {
+		t.Errorf("execution.max_warm_pods_per_tenant = %d, want 250 (from env)", got)
+	}
 }
 
 // validWarmConfig returns a ServerConfig that passes the warm-pool boot gate: warm
@@ -83,6 +90,7 @@ func validWarmConfig() *ServerConfig {
 	c.Execution.MaxWorkerLifetime = time.Hour
 	c.Execution.WorkerIdleTTL = 5 * time.Minute
 	c.Execution.MaxPoolSize = 8
+	c.Execution.MaxWarmPodsPerTenant = 100
 	return c
 }
 
@@ -195,6 +203,8 @@ func TestValidateExecutionSanityCaps(t *testing.T) {
 		{"zero idle ttl", func(c *ServerConfig) { c.Execution.WorkerIdleTTL = 0 }, "worker_idle_ttl"},
 		{"zero pool size", func(c *ServerConfig) { c.Execution.MaxPoolSize = 0 }, "max_pool_size"},
 		{"negative pool size", func(c *ServerConfig) { c.Execution.MaxPoolSize = -1 }, "max_pool_size"},
+		{"zero per-tenant cap", func(c *ServerConfig) { c.Execution.MaxWarmPodsPerTenant = 0 }, "max_warm_pods_per_tenant"},
+		{"negative per-tenant cap", func(c *ServerConfig) { c.Execution.MaxWarmPodsPerTenant = -1 }, "max_warm_pods_per_tenant"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c := validWarmConfig()

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -191,6 +191,17 @@ type ExecutionSection struct {
 	// (registered workers + in-flight pods), which arrives with the worker
 	// lifecycle in N1b2/N1d. Today's placer is assign-if-free-else-dedicated.
 	MaxPoolSize int `mapstructure:"max_pool_size"`
+	// MaxWarmPodsPerTenant caps the TOTAL warm pods a single tenant may hold across
+	// ALL its dag_versions on a shared cluster (M4). Where MaxPoolSize bounds one
+	// dag_version's pool, this bounds a tenant's aggregate warm footprint so one
+	// tenant cannot pin unlimited idle pods and starve neighbors on a shared
+	// multi-team cluster. Default 100, operator-set. It is a RESERVE-then-RATION
+	// budget, never a starvation lever: a tenant's promised idle floors (the sum of
+	// its versions' EffectiveMinIdle) are honored even when they exceed this cap
+	// (the reconciler raises the effective budget to the floor sum and meters the
+	// misconfiguration), and the cap is enforced only by refusing to CREATE new
+	// warm pods — never by deleting a busy worker.
+	MaxWarmPodsPerTenant int `mapstructure:"max_warm_pods_per_tenant"`
 }
 
 // EffectiveMinIdle resolves the warm-worker target for one dag_version under
@@ -577,30 +588,31 @@ var serverDefaults = map[string]any{
 	// documented values so an operator who flips warm_pools_enabled on inherits sane
 	// bounds. Durations are written as strings and parsed by viper's decode hook,
 	// matching auth.max_attempt_credential_lifetime.
-	"execution.warm_pools_enabled":      false,
-	"execution.max_attempts_per_worker": 50,
-	"execution.max_worker_lifetime":     "1h",
-	"execution.min_idle_workers":        0,
-	"execution.worker_idle_ttl":         "5m",
-	"execution.max_pool_size":           8,
-	"logs.dir":                          "/var/log/leoflow",
-	"logs.backend":                      "disk",
-	"logs.sink.bucket":                  "",
-	"logs.sink.prefix":                  "",
-	"logs.sink.region":                  "",
-	"logs.sink.endpoint":                "",
-	"logs.sink.force_path_style":        false,
-	"logs.sink.access_key_id":           "",
-	"logs.sink.secret_access_key":       "",
-	"logs.sink.credentials_file":        "",
-	"observability.otel.enabled":        true,
-	"observability.otel.endpoint":       "localhost:4317",
-	"observability.log_level":           "info",
-	"observability.log_format":          "json",
-	"ui.instance_name":                  "Leoflow",
-	"ui.edition":                        "",
-	"ui.workspace":                      "",
-	"ui.monaco_dir":                     "",
+	"execution.warm_pools_enabled":       false,
+	"execution.max_attempts_per_worker":  50,
+	"execution.max_worker_lifetime":      "1h",
+	"execution.min_idle_workers":         0,
+	"execution.worker_idle_ttl":          "5m",
+	"execution.max_pool_size":            8,
+	"execution.max_warm_pods_per_tenant": 100,
+	"logs.dir":                           "/var/log/leoflow",
+	"logs.backend":                       "disk",
+	"logs.sink.bucket":                   "",
+	"logs.sink.prefix":                   "",
+	"logs.sink.region":                   "",
+	"logs.sink.endpoint":                 "",
+	"logs.sink.force_path_style":         false,
+	"logs.sink.access_key_id":            "",
+	"logs.sink.secret_access_key":        "",
+	"logs.sink.credentials_file":         "",
+	"observability.otel.enabled":         true,
+	"observability.otel.endpoint":        "localhost:4317",
+	"observability.log_level":            "info",
+	"observability.log_format":           "json",
+	"ui.instance_name":                   "Leoflow",
+	"ui.edition":                         "",
+	"ui.workspace":                       "",
+	"ui.monaco_dir":                      "",
 	// Must appear here even though the zero value is meaningful (the handler
 	// falls back to api.DefaultUIAutoRefreshIntervalSeconds when ≤ 0): viper's
 	// AutomaticEnv only binds env vars for keys it has seen via SetDefault or
@@ -809,6 +821,9 @@ func (c *ServerConfig) validateExecution() error {
 	}
 	if c.Execution.MaxPoolSize < 1 {
 		return fmt.Errorf("execution.max_pool_size must be >= 1 when execution.warm_pools_enabled (got %d): a zero cap would forbid every warm worker (ADR 0058)", c.Execution.MaxPoolSize)
+	}
+	if c.Execution.MaxWarmPodsPerTenant < 1 {
+		return fmt.Errorf("execution.max_warm_pods_per_tenant must be >= 1 when execution.warm_pools_enabled (got %d): a zero aggregate tenant cap would forbid every warm worker (M4)", c.Execution.MaxWarmPodsPerTenant)
 	}
 	return nil
 }

--- a/internal/executor/warmpod.go
+++ b/internal/executor/warmpod.go
@@ -19,6 +19,12 @@ const (
 	// warmDagVersionLabelKey names the dag_version pool a warm worker serves, so
 	// the reconciler can group and reconcile counts per version.
 	warmDagVersionLabelKey = "leoflow.io/dag-version-id"
+	// warmTenantLabelKey names the tenant that owns a warm worker's dag_version, so
+	// the reconciler can count a tenant's whole warm footprint — including pods of a
+	// draining/inactive version that are absent from the active targets — and
+	// enforce the per-tenant aggregate cap (M4). It is stamped from
+	// WarmPodSpec.TenantID and read back into WarmPodInfo.TenantID by ListWarmPods.
+	warmTenantLabelKey = "leoflow.io/tenant-id"
 )
 
 // WarmPodSpec is everything BuildWarmPod needs to build one long-lived warm-worker
@@ -32,6 +38,12 @@ type WarmPodSpec struct {
 	Image           string
 	ImagePullPolicy string
 	Namespace       string
+
+	// TenantID is the tenant that owns this dag_version. It is stamped onto the pod
+	// as the leoflow.io/tenant-id label so the reconciler can attribute the pod to
+	// its tenant for the per-tenant aggregate warm-pod cap (M4), even after the
+	// version stops being active (the label outlives the active target).
+	TenantID string
 
 	// ControlPlaneAddr / AgentTLSCAConfigMap mirror the task-pod connection knobs:
 	// where the agent dials and (when set) the CA ConfigMap it verifies the server
@@ -106,11 +118,8 @@ func BuildWarmPod(spec WarmPodSpec) *corev1.Pod {
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: warmPodName(spec.DagVersionID),
-			Labels: map[string]string{
-				warmWorkerLabelKey:     warmWorkerLabelVal,
-				warmDagVersionLabelKey: sanitizeLabel(spec.DagVersionID),
-			},
+			Name:        warmPodName(spec.DagVersionID),
+			Labels:      warmPodLabels(spec),
 			Annotations: map[string]string{},
 		},
 		Spec: corev1.PodSpec{
@@ -137,6 +146,23 @@ func BuildWarmPod(spec WarmPodSpec) *corev1.Pod {
 	// identity annotation is stamped even under the exchange transport.
 	mountAgentToken(pod, spec.agentToken())
 	return pod
+}
+
+// warmPodLabels builds the warm worker's stable label set: the warm-worker marker
+// the reconciler lists by, the dag_version pool it serves, and — when the spec
+// carries one — the owning tenant, so the reconciler can attribute the pod to its
+// tenant for the per-tenant aggregate cap (M4) even once the version is inactive.
+// TenantID is omitted when empty rather than stamped blank, so an "absent" tenant
+// label means exactly "pre-label pod" to the reconciler.
+func warmPodLabels(spec WarmPodSpec) map[string]string {
+	labels := map[string]string{
+		warmWorkerLabelKey:     warmWorkerLabelVal,
+		warmDagVersionLabelKey: sanitizeLabel(spec.DagVersionID),
+	}
+	if spec.TenantID != "" {
+		labels[warmTenantLabelKey] = sanitizeLabel(spec.TenantID)
+	}
+	return labels
 }
 
 // warmContainerName is the warm worker's single container.

--- a/internal/executor/warmpod_test.go
+++ b/internal/executor/warmpod_test.go
@@ -106,6 +106,12 @@ func TestBuildWarmPodWarmEnvAndLabels(t *testing.T) {
 		}
 	}
 
+	// No tenant label when the spec carries none: an absent tenant label means
+	// exactly "pre-label pod" to the reconciler (M4).
+	if _, ok := pod.Labels[warmTenantLabelKey]; ok {
+		t.Errorf("warm pod must not carry a blank tenant label when TenantID is unset (got %q)", pod.Labels[warmTenantLabelKey])
+	}
+
 	// A warm worker that exits on drain must be REPLACED by the reconciler, not
 	// restarted in place (a fresh pod re-registers cleanly); RestartPolicy Never.
 	if pod.Spec.RestartPolicy != corev1.RestartPolicyNever {
@@ -114,6 +120,19 @@ func TestBuildWarmPodWarmEnvAndLabels(t *testing.T) {
 	// The agent authenticates over gRPC and never calls the Kubernetes API.
 	if pod.Spec.AutomountServiceAccountToken == nil || *pod.Spec.AutomountServiceAccountToken {
 		t.Error("AutomountServiceAccountToken must be explicitly false")
+	}
+}
+
+// TestBuildWarmPodStampsTenantLabel locks the M4 tenant attribution: when the spec
+// carries a TenantID, BuildWarmPod stamps it as the leoflow.io/tenant-id label so
+// the reconciler can attribute the pod to its tenant for the per-tenant aggregate
+// cap — even after the version stops being active (the label outlives the target).
+func TestBuildWarmPodStampsTenantLabel(t *testing.T) {
+	spec := baseWarmSpec()
+	spec.TenantID = "tenant-xyz"
+	pod := BuildWarmPod(spec)
+	if got := pod.Labels[warmTenantLabelKey]; got != "tenant-xyz" {
+		t.Errorf("label %s = %q, want tenant-xyz", warmTenantLabelKey, got)
 	}
 }
 

--- a/internal/executor/warmpool.go
+++ b/internal/executor/warmpool.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"log/slog"
+	"sort"
 )
 
 // WarmTarget is one active dag_version the warm-pool reconciler keeps warm workers
@@ -23,11 +24,16 @@ import (
 // practice; the reconciler still handles MaxPoolSize < EffectiveMinIdle defensively
 // by taking the effective ceiling as max(EffectiveMinIdle, MaxPoolSize) — the idle
 // buffer must always be creatable.
+// TenantID is the tenant that owns this dag_version, threaded through so the
+// per-tenant aggregate warm-pod cap (M4) can sum a tenant's promised idle floors
+// and ration its shared budget across versions. It comes from the active run's
+// tenant_id; the reconciler groups targets and live pods by it.
 type WarmTarget struct {
 	DagVersionID     string
 	Image            string
 	EffectiveMinIdle int
 	MaxPoolSize      int
+	TenantID         string
 }
 
 // WarmTargetSource yields the currently active dag_versions and their effective
@@ -62,10 +68,17 @@ type BusyWarmWorkerSource interface {
 // a crashed/drained/finished worker lingers as a terminal pod that can never
 // serve again. The reconciler must NOT count terminal pods toward the target
 // (or a dead worker never gets replaced) and always reaps them.
+// TenantID is the tenant that owns the dag_version this pod serves, read from the
+// pod's leoflow.io/tenant-id label (M4). The reconciler counts a tenant's live
+// pods by it — including pods of a draining/inactive version, which are absent
+// from the active targets — so the per-tenant cap sees the tenant's whole warm
+// footprint. A pre-label pod (rolling upgrade) carries "" here; the reconciler
+// attributes it via its version when resolvable and NEVER deletes it for the cap.
 type WarmPodInfo struct {
 	Name         string
 	DagVersionID string
 	Terminal     bool
+	TenantID     string
 }
 
 // WarmPodClient is the cluster side of warm-pool reconciliation: list the warm
@@ -115,6 +128,13 @@ type WarmPoolReconciler struct {
 	busy    BusyWarmWorkerSource
 	logger  *slog.Logger
 	rec     DecisionRecorder
+	// maxWarmPodsPerTenant is the operator's per-tenant aggregate cap (M4,
+	// execution.max_warm_pods_per_tenant): the total warm pods one tenant may hold
+	// across all its dag_versions. <= 0 means "no tenant cap" — the reconciler skips
+	// all tenant accounting and behaves byte-for-byte as the pre-M4 per-version
+	// reconciler (this is what the pre-M4 unit tests exercise). In production it is
+	// always >= 1 (boot validation), so the tenant budget always applies.
+	maxWarmPodsPerTenant int
 }
 
 // NewWarmPoolReconciler builds a reconciler over the given target source, pod
@@ -122,13 +142,15 @@ type WarmPoolReconciler struct {
 // busy or idle so scale-down never kills an in-flight attempt (ADR 0058 N1d-b M1);
 // without it every worker would look idle and a busy worker could be deleted, so a
 // nil busy source (or a busy-list error at tick time) makes the tick do nothing —
-// do-no-harm. logger and rec (metrics) are optional — a nil logger falls back to
-// the default and a nil rec skips metering.
-func NewWarmPoolReconciler(targets WarmTargetSource, pods WarmPodClient, busy BusyWarmWorkerSource, logger *slog.Logger, rec DecisionRecorder) *WarmPoolReconciler {
+// do-no-harm. maxWarmPodsPerTenant is the per-tenant aggregate cap (M4); <= 0
+// disables tenant accounting (pre-M4 per-version behavior). logger and rec
+// (metrics) are optional — a nil logger falls back to the default and a nil rec
+// skips metering.
+func NewWarmPoolReconciler(targets WarmTargetSource, pods WarmPodClient, busy BusyWarmWorkerSource, maxWarmPodsPerTenant int, logger *slog.Logger, rec DecisionRecorder) *WarmPoolReconciler {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &WarmPoolReconciler{targets: targets, pods: pods, busy: busy, logger: logger, rec: rec}
+	return &WarmPoolReconciler{targets: targets, pods: pods, busy: busy, maxWarmPodsPerTenant: maxWarmPodsPerTenant, logger: logger, rec: rec}
 }
 
 // Reconcile brings the warm fleet in line with the active targets for one tick. It
@@ -170,20 +192,187 @@ func (r *WarmPoolReconciler) Reconcile(ctx context.Context) error {
 		byVersion[p.DagVersionID] = append(byVersion[p.DagVersionID], p)
 	}
 
+	// Ration each active version's create allowance under the per-tenant aggregate
+	// cap (M4): reserve every version's promised idle floor, then ration the tenant's
+	// remaining budget across its versions. allow[dagVersionID] is the max NEW warm
+	// pods this version may create this tick under the tenant budget; nil means no
+	// tenant cap is configured (pre-M4 per-version behavior — every version gets its
+	// full idle shortfall). The cap is enforced by capping creates only; deletes
+	// (excess idle + terminal) are untouched, so a busy worker is never killed to
+	// honor the cap.
+	allow := r.createAllowances(ctx, targets, existing, busy)
+
 	// Reconcile every active version to its target, then drain any version that is
-	// present in the fleet but no longer active (its target is implicitly 0).
+	// present in the fleet but no longer active (its target is implicitly 0). A
+	// draining version has target 0, so it never creates — its allowance is moot; it
+	// still counts against its tenant's live budget (its pods carry the tenant label
+	// and were summed into tenant_live above).
 	active := make(map[string]bool, len(targets))
 	for _, t := range targets {
 		active[t.DagVersionID] = true
-		r.reconcileVersion(ctx, t, byVersion[t.DagVersionID], busy)
+		r.reconcileVersion(ctx, t, byVersion[t.DagVersionID], busy, allowanceFor(allow, t.DagVersionID))
 	}
 	for dagVersionID, have := range byVersion {
 		if active[dagVersionID] {
 			continue
 		}
-		r.reconcileVersion(ctx, WarmTarget{DagVersionID: dagVersionID, EffectiveMinIdle: 0}, have, busy)
+		r.reconcileVersion(ctx, WarmTarget{DagVersionID: dagVersionID, EffectiveMinIdle: 0}, have, busy, unlimitedAllowance)
 	}
 	return nil
+}
+
+// unlimitedAllowance is the sentinel create allowance meaning "no per-tenant cap
+// applies to this version" (either no cap is configured, or the version is
+// draining and cannot create anyway). reconcileVersion treats a negative allowance
+// as unbounded and falls back to the per-version floor/MaxPoolSize gate alone.
+const unlimitedAllowance = -1
+
+// allowanceFor reads a version's rationed create allowance. A nil map (no tenant
+// cap configured) yields unlimited, preserving the pre-M4 per-version behavior.
+func allowanceFor(allow map[string]int, dagVersionID string) int {
+	if allow == nil {
+		return unlimitedAllowance
+	}
+	return allow[dagVersionID]
+}
+
+// createAllowances computes, per active dag_version, the maximum number of NEW
+// warm pods it may create this tick under the per-tenant aggregate cap (M4). It
+// returns nil when no cap is configured (maxWarmPodsPerTenant <= 0), so the caller
+// falls back to the unbounded pre-M4 per-version behavior.
+//
+// The algorithm is RESERVE-then-RATION per tenant, tuned so the cap never starves
+// a legitimate tenant and never has to delete a busy worker:
+//
+//   - min_idle is SACRED. The tenant's effective budget is
+//     max(max_warm_pods_per_tenant, Σ EffectiveMinIdle over its ACTIVE versions).
+//     If the promised floors already exceed the cap it is a misconfiguration, not a
+//     reason to starve work: the budget is raised to the floor sum so every floor
+//     is still creatable, and warm_pool_tenant_cap_below_min_idle_sum is logged +
+//     metered loudly so an operator fixes the config.
+//   - tenant_live is the count of the tenant's LIVE (non-terminal) warm pods across
+//     the whole listed fleet, grouped by the tenant label — so it includes pods of a
+//     draining/inactive version (absent from the active targets). A pre-label pod
+//     ("" tenant) is attributed via its version→tenant mapping when resolvable
+//     (metered warm_pool_untenanted_pod) and otherwise left uncounted — it is never
+//     deleted for the cap.
+//   - headroom = budget − tenant_live. It is rationed across the tenant's active
+//     versions still short of their idle floor, in a STABLE order (by DagVersionID),
+//     each taking min(idle shortfall, its own MaxPoolSize headroom, remaining
+//     headroom). Because the budget already covers Σ floors, every floor is granted
+//     unless busy pods have legitimately consumed the budget — and in that case the
+//     cap holds by refusing to create, never by deleting the busy workers (they are
+//     reaped on a later tick once idle).
+func (r *WarmPoolReconciler) createAllowances(ctx context.Context, targets []WarmTarget, existing []WarmPodInfo, busy map[string]bool) map[string]int {
+	if r.maxWarmPodsPerTenant <= 0 {
+		return nil
+	}
+
+	// Active versions: their owning tenant, the per-tenant floor sum, and the set of
+	// versions to ration across.
+	versionTenant := make(map[string]string, len(targets))
+	tenantFloors := make(map[string]int)
+	tenantVersions := make(map[string][]WarmTarget)
+	for _, t := range targets {
+		versionTenant[t.DagVersionID] = t.TenantID
+		tenantFloors[t.TenantID] += t.EffectiveMinIdle
+		tenantVersions[t.TenantID] = append(tenantVersions[t.TenantID], t)
+	}
+
+	stat, tenantLive := r.countLiveByTenant(existing, busy, versionTenant)
+
+	// Reserve-then-ration per tenant: raise the budget to the promised floor sum,
+	// then ration the tenant's remaining headroom across its versions.
+	allow := make(map[string]int, len(targets))
+	for tenant, versions := range tenantVersions {
+		budget := r.tenantBudget(ctx, tenant, tenantFloors[tenant])
+		r.rationTenant(versions, stat, budget-tenantLive[tenant], allow)
+	}
+	return allow
+}
+
+// warmVerStat is one dag_version's live-pod accounting for one tick: idle is the
+// count of live non-busy workers, live is idle + busy (terminal pods excluded).
+type warmVerStat struct{ idle, live int }
+
+// countLiveByTenant classifies the listed fleet ONCE (no second query): per
+// dag_version it counts live idle/total workers, and per tenant it counts live
+// pods attributed by the tenant label. A pre-label pod ("" tenant) is attributed
+// via its version→tenant mapping when resolvable (metered warm_pool_untenanted_pod)
+// and otherwise left uncounted — it is never deleted for the cap either way.
+func (r *WarmPoolReconciler) countLiveByTenant(existing []WarmPodInfo, busy map[string]bool, versionTenant map[string]string) (stat map[string]warmVerStat, tenantLive map[string]int) {
+	stat = make(map[string]warmVerStat, len(versionTenant))
+	tenantLive = make(map[string]int)
+	for _, p := range existing {
+		if p.Terminal {
+			continue
+		}
+		s := stat[p.DagVersionID]
+		s.live++
+		if !busy[p.Name] {
+			s.idle++
+		}
+		stat[p.DagVersionID] = s
+
+		tenant := p.TenantID
+		if tenant == "" {
+			vt, ok := versionTenant[p.DagVersionID]
+			if !ok || vt == "" {
+				r.record("warm_pool_untenanted_pod")
+				continue // unmappable: never counted, never deleted for the cap
+			}
+			r.record("warm_pool_untenanted_pod")
+			tenant = vt
+		}
+		tenantLive[tenant]++
+	}
+	return stat, tenantLive
+}
+
+// tenantBudget is the tenant's effective aggregate budget: the operator's cap,
+// raised to the promised idle-floor sum when the floors exceed the cap so no
+// promised buffer is starved (a misconfiguration, logged + metered loudly).
+func (r *WarmPoolReconciler) tenantBudget(ctx context.Context, tenant string, floorSum int) int {
+	if floorSum <= r.maxWarmPodsPerTenant {
+		return r.maxWarmPodsPerTenant
+	}
+	r.logger.WarnContext(ctx, "warm-pool per-tenant cap is below the tenant's promised idle-floor sum; honoring the floors and raising the effective budget so no promised idle buffer is starved (fix execution.max_warm_pods_per_tenant or the DAGs' min_idle_workers)",
+		"tenant", tenant, "max_warm_pods_per_tenant", r.maxWarmPodsPerTenant, "min_idle_sum", floorSum)
+	r.record("warm_pool_tenant_cap_below_min_idle_sum")
+	return floorSum
+}
+
+// rationTenant distributes a tenant's create headroom across its versions in a
+// stable order (by DagVersionID), writing each version's create allowance into
+// allow. Each version takes min(idle shortfall to its floor, its own MaxPoolSize
+// headroom, remaining tenant headroom). Because the budget already covers the
+// floor sum, every floor is granted unless busy pods have legitimately consumed
+// the budget — in which case the cap holds by granting less, never by deleting.
+func (r *WarmPoolReconciler) rationTenant(versions []WarmTarget, stat map[string]warmVerStat, headroom int, allow map[string]int) {
+	if headroom < 0 {
+		headroom = 0
+	}
+	sort.Slice(versions, func(i, j int) bool { return versions[i].DagVersionID < versions[j].DagVersionID })
+	for _, t := range versions {
+		s := stat[t.DagVersionID]
+		maxPool := t.MaxPoolSize
+		if maxPool < t.EffectiveMinIdle {
+			maxPool = t.EffectiveMinIdle
+		}
+		want := t.EffectiveMinIdle - s.idle // idle shortfall to the floor
+		if poolHeadroom := maxPool - s.live; poolHeadroom < want {
+			want = poolHeadroom
+		}
+		if want < 0 {
+			want = 0
+		}
+		grant := want
+		if headroom < grant {
+			grant = headroom
+		}
+		allow[t.DagVersionID] = grant
+		headroom -= grant
+	}
 }
 
 // reconcileVersion brings one dag_version's IDLE warm-worker buffer to its target
@@ -196,7 +385,14 @@ func (r *WarmPoolReconciler) Reconcile(ctx context.Context) error {
 // grows past min_idle under load (busy workers do not consume the idle buffer) and
 // never exceeds the ceiling, and scale-down/drain deletes only IDLE workers so an
 // in-flight attempt is never killed (M1).
-func (r *WarmPoolReconciler) reconcileVersion(ctx context.Context, t WarmTarget, have []WarmPodInfo, busy map[string]bool) {
+//
+// createAllowance is the per-tenant cap's gate on NEW pods this tick (M4): the
+// version creates min(idle shortfall, MaxPoolSize headroom, createAllowance). A
+// negative allowance (unlimitedAllowance) means no tenant cap applies, so the
+// create is bounded by the per-version floor/MaxPoolSize gate alone — the pre-M4
+// behavior. The allowance gates CREATES only; the terminal reap and the
+// excess-idle delete are unchanged, so the cap never deletes a busy worker.
+func (r *WarmPoolReconciler) reconcileVersion(ctx context.Context, t WarmTarget, have []WarmPodInfo, busy map[string]bool, createAllowance int) {
 	defer func() {
 		if p := recover(); p != nil {
 			r.logger.ErrorContext(ctx, "warm-pool reconcile panicked for a dag_version; other versions unaffected",
@@ -242,12 +438,16 @@ func (r *WarmPoolReconciler) reconcileVersion(ctx context.Context, t WarmTarget,
 	switch {
 	case len(idle) < t.EffectiveMinIdle && live < maxPool:
 		// Idle buffer is short AND the pool is below its total ceiling: create
-		// enough to restore the buffer, but never past the ceiling. create =
-		// min(idle shortfall, headroom to the ceiling). Each create is isolated so
-		// one apiserver rejection does not stop the rest of this version's workers.
+		// enough to restore the buffer, but never past the ceiling OR the tenant's
+		// rationed allowance. create = min(idle shortfall, headroom to the ceiling,
+		// tenant allowance). Each create is isolated so one apiserver rejection does
+		// not stop the rest of this version's workers.
 		create := t.EffectiveMinIdle - len(idle)
 		if headroom := maxPool - live; headroom < create {
 			create = headroom
+		}
+		if createAllowance >= 0 && create > createAllowance {
+			create = createAllowance
 		}
 		for i := 0; i < create; i++ {
 			if err := r.pods.CreateWarmPod(ctx, t); err != nil {

--- a/internal/executor/warmpool_k8s.go
+++ b/internal/executor/warmpool_k8s.go
@@ -57,6 +57,11 @@ func (k *KubernetesWarmPods) ListWarmPods(ctx context.Context) ([]WarmPodInfo, e
 			Name:         p.Name,
 			DagVersionID: p.Labels[warmDagVersionLabelKey],
 			Terminal:     terminal,
+			// Tenant attribution for the per-tenant aggregate cap (M4). A pre-label
+			// pod (rolling upgrade) has no tenant label and reads "" here; the
+			// reconciler attributes it via its version when resolvable and never
+			// deletes it for the cap.
+			TenantID: p.Labels[warmTenantLabelKey],
 		})
 	}
 	return out, nil

--- a/internal/executor/warmpool_k8s_test.go
+++ b/internal/executor/warmpool_k8s_test.go
@@ -36,6 +36,37 @@ func TestKubernetesWarmPodsListSelectsWarmOnly(t *testing.T) {
 	}
 }
 
+// TestKubernetesWarmPodsListReadsTenant proves ListWarmPods reads the tenant label
+// into WarmPodInfo.TenantID (M4), and a pre-label pod (no tenant label) reads "" so
+// the reconciler treats it as unattributable.
+func TestKubernetesWarmPodsListReadsTenant(t *testing.T) {
+	cs := fake.NewSimpleClientset(
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name: "labeled", Namespace: "leoflow",
+			Labels: map[string]string{warmWorkerLabelKey: warmWorkerLabelVal, warmDagVersionLabelKey: "dv1", warmTenantLabelKey: "tenant-a"},
+		}},
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+			Name: "prelabel", Namespace: "leoflow",
+			Labels: map[string]string{warmWorkerLabelKey: warmWorkerLabelVal, warmDagVersionLabelKey: "dv1"},
+		}},
+	)
+	k := NewKubernetesWarmPods(cs, "leoflow", nil)
+	got, err := k.ListWarmPods(context.Background())
+	if err != nil {
+		t.Fatalf("ListWarmPods: %v", err)
+	}
+	tenant := map[string]string{}
+	for _, p := range got {
+		tenant[p.Name] = p.TenantID
+	}
+	if tenant["labeled"] != "tenant-a" {
+		t.Errorf("labeled pod TenantID = %q, want tenant-a", tenant["labeled"])
+	}
+	if tenant["prelabel"] != "" {
+		t.Errorf("pre-label pod TenantID = %q, want \"\" (unattributable)", tenant["prelabel"])
+	}
+}
+
 // TestKubernetesWarmPodsListFlagsTerminal proves ListWarmPods marks Succeeded
 // and Failed warm pods Terminal (dead RestartPolicy:Never workers) while a
 // Running/Pending pod stays live, so the reconciler can replace and reap them.

--- a/internal/executor/warmpool_test.go
+++ b/internal/executor/warmpool_test.go
@@ -102,7 +102,9 @@ func reconcileWarm(t *testing.T, targets *fakeWarmTargets, pods *fakeWarmPods) {
 // reconcileWarmBusy runs a tick against a specific busy set.
 func reconcileWarmBusy(t *testing.T, targets *fakeWarmTargets, pods *fakeWarmPods, busy *fakeBusyWorkers) {
 	t.Helper()
-	r := NewWarmPoolReconciler(targets, pods, busy, nil, nil)
+	// cap 0 = no per-tenant cap, so these pre-M4 cases exercise the unchanged
+	// per-version reconcile behavior.
+	r := NewWarmPoolReconciler(targets, pods, busy, 0, nil, nil)
 	if err := r.Reconcile(context.Background()); err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
@@ -293,7 +295,7 @@ func TestWarmPoolReconcileCreateErrorIsolatedPerPod(t *testing.T) {
 func TestWarmPoolReconcileListErrorReturned(t *testing.T) {
 	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", EffectiveMinIdle: 1}}}
 	pods := &fakeWarmPods{listErr: errors.New("watch broke")}
-	r := NewWarmPoolReconciler(targets, pods, &fakeBusyWorkers{}, nil, nil)
+	r := NewWarmPoolReconciler(targets, pods, &fakeBusyWorkers{}, 0, nil, nil)
 	if err := r.Reconcile(context.Background()); err == nil {
 		t.Fatal("Reconcile = nil on list error, want the error surfaced")
 	}
@@ -306,7 +308,7 @@ func TestWarmPoolReconcileListErrorReturned(t *testing.T) {
 func TestWarmPoolReconcileTargetsErrorReturned(t *testing.T) {
 	targets := &fakeWarmTargets{err: errors.New("db down")}
 	pods := &fakeWarmPods{}
-	r := NewWarmPoolReconciler(targets, pods, &fakeBusyWorkers{}, nil, nil)
+	r := NewWarmPoolReconciler(targets, pods, &fakeBusyWorkers{}, 0, nil, nil)
 	if err := r.Reconcile(context.Background()); err == nil {
 		t.Fatal("Reconcile = nil on targets error, want the error surfaced")
 	}
@@ -447,7 +449,7 @@ func TestWarmPoolReconcileBusyListErrorAborts(t *testing.T) {
 	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", EffectiveMinIdle: 2, MaxPoolSize: 8}}}
 	pods := &fakeWarmPods{existing: warmPods("dv1", "p1", "p2", "p3")}
 	busy := &fakeBusyWorkers{err: errors.New("db down")}
-	r := NewWarmPoolReconciler(targets, pods, busy, nil, nil)
+	r := NewWarmPoolReconciler(targets, pods, busy, 0, nil, nil)
 	if err := r.Reconcile(context.Background()); err != nil {
 		t.Fatalf("Reconcile = %v, want nil (busy-list error is do-no-harm, not surfaced)", err)
 	}
@@ -461,11 +463,199 @@ func TestWarmPoolReconcileBusyListErrorAborts(t *testing.T) {
 func TestWarmPoolReconcileNoBusySourceAborts(t *testing.T) {
 	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", EffectiveMinIdle: 2, MaxPoolSize: 8}}}
 	pods := &fakeWarmPods{existing: warmPods("dv1", "p1", "p2", "p3")}
-	r := NewWarmPoolReconciler(targets, pods, nil, nil, nil)
+	r := NewWarmPoolReconciler(targets, pods, nil, 0, nil, nil)
 	if err := r.Reconcile(context.Background()); err != nil {
 		t.Fatalf("Reconcile = %v, want nil (nil busy source is do-no-harm)", err)
 	}
 	if len(pods.created) != 0 || len(pods.deleted) != 0 {
 		t.Errorf("created %v deleted %v, want NO action without a busy source", pods.created, pods.deleted)
+	}
+}
+
+// ---- M4: per-tenant aggregate warm-pod cap (execution.max_warm_pods_per_tenant).
+// A tenant's TOTAL warm pods across all its dag_versions are bounded on a shared
+// cluster so one tenant cannot pin unlimited idle pods and starve neighbors. The
+// cap is RESERVE-then-RATION and reliability-safe: it never starves a promised
+// idle floor, and it is enforced by refusing to CREATE, never by deleting a busy
+// worker. ----
+
+// warmPodsT builds live warm pods for a dag_version tagged with a tenant, as the
+// tenant label lands on WarmPodInfo.TenantID.
+func warmPodsT(dagVersionID, tenant string, names ...string) []WarmPodInfo {
+	out := make([]WarmPodInfo, 0, len(names))
+	for _, n := range names {
+		out = append(out, WarmPodInfo{Name: n, DagVersionID: dagVersionID, TenantID: tenant})
+	}
+	return out
+}
+
+// reconcileWarmCap runs a tick with a per-tenant cap and a capturing recorder so a
+// test can assert both the create/delete decisions and the metered decisions.
+func reconcileWarmCap(t *testing.T, targets *fakeWarmTargets, pods *fakeWarmPods, busy *fakeBusyWorkers, perTenantCap int) *capturingRecorder {
+	t.Helper()
+	rec := &capturingRecorder{}
+	r := NewWarmPoolReconciler(targets, pods, busy, perTenantCap, nil, rec)
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	return rec
+}
+
+// createdByVersion counts the reconciler's creates per dag_version.
+func createdByVersion(pods *fakeWarmPods) map[string]int {
+	m := map[string]int{}
+	for _, c := range pods.created {
+		m[c.DagVersionID]++
+	}
+	return m
+}
+
+// TestWarmPoolTenantCapFloorHonoredOverCap is the anti-starvation invariant: a
+// tenant whose promised idle floors SUM to more than the cap (3 versions ×
+// EffectiveMinIdle=5 = 15 vs cap 8) must still get EVERY floor — min_idle is
+// sacred, the cap never denies the operator's promised buffer. The reconciler
+// raises the effective budget to the floor sum, creates all 15, and meters
+// warm_pool_tenant_cap_below_min_idle_sum so the misconfiguration is visible.
+func TestWarmPoolTenantCapFloorHonoredOverCap(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{
+		{DagVersionID: "dv1", TenantID: "T", EffectiveMinIdle: 5, MaxPoolSize: 8},
+		{DagVersionID: "dv2", TenantID: "T", EffectiveMinIdle: 5, MaxPoolSize: 8},
+		{DagVersionID: "dv3", TenantID: "T", EffectiveMinIdle: 5, MaxPoolSize: 8},
+	}}
+	pods := &fakeWarmPods{} // zero live
+	rec := reconcileWarmCap(t, targets, pods, &fakeBusyWorkers{}, 8)
+
+	if len(pods.created) != 15 {
+		t.Errorf("created %d, want 15 (every version's floor of 5 honored despite cap 8)", len(pods.created))
+	}
+	byV := createdByVersion(pods)
+	for _, dv := range []string{"dv1", "dv2", "dv3"} {
+		if byV[dv] != 5 {
+			t.Errorf("version %s created %d, want 5 (its promised idle floor, never capped away)", dv, byV[dv])
+		}
+	}
+	if n := rec.count("warm_pool_tenant_cap_below_min_idle_sum"); n < 1 {
+		t.Errorf("warm_pool_tenant_cap_below_min_idle_sum metered %d times, want >= 1 (loud misconfiguration signal)", n)
+	}
+}
+
+// TestWarmPoolTenantCapHeadroomRationedFairly: two versions each with floor 2
+// (floors reserved), tenant cap 8, current live 4 (all busy, split 2/2). Both
+// versions are short of their idle floor; the 4 headroom (8−4) is rationed so BOTH
+// reach their floor — neither version is starved by the other.
+func TestWarmPoolTenantCapHeadroomRationedFairly(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{
+		{DagVersionID: "dv1", TenantID: "T", EffectiveMinIdle: 2, MaxPoolSize: 8},
+		{DagVersionID: "dv2", TenantID: "T", EffectiveMinIdle: 2, MaxPoolSize: 8},
+	}}
+	pods := &fakeWarmPods{existing: append(
+		warmPodsT("dv1", "T", "b1", "b2"),
+		warmPodsT("dv2", "T", "b3", "b4")...,
+	)}
+	reconcileWarmCap(t, targets, pods, busySet("b1", "b2", "b3", "b4"), 8)
+
+	byV := createdByVersion(pods)
+	if byV["dv1"] != 2 || byV["dv2"] != 2 {
+		t.Errorf("created dv1=%d dv2=%d, want 2 each (headroom rationed so both reach their idle floor)", byV["dv1"], byV["dv2"])
+	}
+	if len(pods.deleted) != 0 {
+		t.Errorf("deleted %v, want none (all live workers are busy)", pods.deleted)
+	}
+}
+
+// TestWarmPoolTenantCapAtCapNoCreateBusyUntouched: a tenant AT its cap because busy
+// pods fill the budget. A second version is short of its idle floor, but the tenant
+// has no headroom, so it creates 0 — and no busy worker is deleted to make room.
+// The cap binds at the TENANT level, not the per-version MaxPoolSize (dv2's own
+// pool has ample room).
+func TestWarmPoolTenantCapAtCapNoCreateBusyUntouched(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{
+		{DagVersionID: "dv1", TenantID: "T", EffectiveMinIdle: 2, MaxPoolSize: 8},
+		{DagVersionID: "dv2", TenantID: "T", EffectiveMinIdle: 2, MaxPoolSize: 8},
+	}}
+	// dv1 holds 4 busy pods (fills the cap of 4); dv2 has nothing and is short.
+	pods := &fakeWarmPods{existing: warmPodsT("dv1", "T", "b1", "b2", "b3", "b4")}
+	reconcileWarmCap(t, targets, pods, busySet("b1", "b2", "b3", "b4"), 4)
+
+	if len(pods.created) != 0 {
+		t.Errorf("created %v, want none (tenant is at its aggregate cap)", pods.created)
+	}
+	if len(pods.deleted) != 0 {
+		t.Errorf("deleted %v, want none (never delete a busy worker to satisfy the cap)", pods.deleted)
+	}
+}
+
+// TestWarmPoolTenantCapNeverDeletesBusyOnLoweredCap: the cap is lowered at runtime
+// below the tenant's current busy count. The reconciler must never delete a busy
+// worker to claw back to the cap — it deletes only IDLE excess (via the unchanged
+// per-version path) and leaves every busy worker running.
+func TestWarmPoolTenantCapNeverDeletesBusyOnLoweredCap(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{
+		{DagVersionID: "dv1", TenantID: "T", EffectiveMinIdle: 1, MaxPoolSize: 8},
+	}}
+	// 5 busy + 2 idle; cap 2 is far below the 5 busy. The 2 idle are over the floor
+	// of 1, so the excess-idle path trims exactly 1 idle; the 5 busy stay.
+	pods := &fakeWarmPods{existing: append(
+		warmPodsT("dv1", "T", "b1", "b2", "b3", "b4", "b5"),
+		warmPodsT("dv1", "T", "i1", "i2")...,
+	)}
+	reconcileWarmCap(t, targets, pods, busySet("b1", "b2", "b3", "b4", "b5"), 2)
+
+	if len(pods.created) != 0 {
+		t.Errorf("created %v, want none (tenant is well over the lowered cap)", pods.created)
+	}
+	del := deletedSet(pods)
+	for _, b := range []string{"b1", "b2", "b3", "b4", "b5"} {
+		if del[b] {
+			t.Errorf("deleted busy worker %s, must NEVER delete a busy worker to satisfy a lowered cap", b)
+		}
+	}
+	if len(pods.deleted) != 1 {
+		t.Errorf("deleted %v, want exactly 1 (only the idle excess over the floor)", pods.deleted)
+	}
+}
+
+// TestWarmPoolTenantCapMultiTenantIsolation: tenant A being at its cap must not
+// affect tenant B's creates. B has full headroom and reaches its floor normally.
+func TestWarmPoolTenantCapMultiTenantIsolation(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{
+		{DagVersionID: "dva", TenantID: "A", EffectiveMinIdle: 2, MaxPoolSize: 8},
+		{DagVersionID: "dvb", TenantID: "B", EffectiveMinIdle: 2, MaxPoolSize: 8},
+	}}
+	// A is saturated with 4 busy (cap 4); B has nothing.
+	pods := &fakeWarmPods{existing: warmPodsT("dva", "A", "a1", "a2", "a3", "a4")}
+	reconcileWarmCap(t, targets, pods, busySet("a1", "a2", "a3", "a4"), 4)
+
+	byV := createdByVersion(pods)
+	if byV["dva"] != 0 {
+		t.Errorf("tenant A created %d, want 0 (A is at its cap)", byV["dva"])
+	}
+	if byV["dvb"] != 2 {
+		t.Errorf("tenant B created %d, want 2 (B has its own budget; A being at cap must not affect it)", byV["dvb"])
+	}
+}
+
+// TestWarmPoolTenantCapUnattributablePodNotDeleted: a pre-label pod (no tenant
+// label, "" TenantID) is never deleted to honor the cap. Here the tenant is over
+// budget (busy pods), yet the unlabeled idle pod — within its version's floor —
+// survives, and warm_pool_untenanted_pod is metered.
+func TestWarmPoolTenantCapUnattributablePodNotDeleted(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{
+		{DagVersionID: "dv1", TenantID: "T", EffectiveMinIdle: 1, MaxPoolSize: 8},
+	}}
+	pods := &fakeWarmPods{existing: append(
+		warmPodsT("dv1", "T", "b1", "b2", "b3"),      // busy, labeled
+		WarmPodInfo{Name: "u1", DagVersionID: "dv1"}, // idle, NO tenant label
+	)}
+	rec := reconcileWarmCap(t, targets, pods, busySet("b1", "b2", "b3"), 2)
+
+	if deletedSet(pods)["u1"] {
+		t.Errorf("deleted %v, must NOT delete an unattributable (pre-label) pod for the cap", pods.deleted)
+	}
+	if len(pods.deleted) != 0 {
+		t.Errorf("deleted %v, want none (u1 is within the floor; the cap deletes nothing)", pods.deleted)
+	}
+	if n := rec.count("warm_pool_untenanted_pod"); n < 1 {
+		t.Errorf("warm_pool_untenanted_pod metered %d times, want >= 1", n)
 	}
 }

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -182,6 +182,10 @@ type activeWarmVersion struct {
 	dagVersionID string
 	image        string
 	dagMinIdle   int
+	// tenantID owns this dag_version; threaded onto the WarmTarget so the reconciler
+	// can enforce the per-tenant aggregate warm-pod cap (M4). Many active runs of a
+	// version share one tenant, so it dedupes with the version.
+	tenantID string
 }
 
 // warmTargets dedupes the active versions (many runs share one immutable
@@ -205,6 +209,9 @@ func warmTargets(versions []activeWarmVersion, exec config.ExecutionSection) []e
 			// dag_version (model A2, ADR 0058 N1d-b). The reconciler grows the pool
 			// past min_idle under load up to this cap and never beyond it.
 			MaxPoolSize: exec.MaxPoolSize,
+			// TenantID owns this dag_version; the reconciler sums a tenant's idle
+			// floors and rations its aggregate budget across versions (M4).
+			TenantID: v.tenantID,
 		})
 	}
 	return out
@@ -237,6 +244,7 @@ func (s *SchedulerStore) ActiveWarmTargets(ctx context.Context) ([]executor.Warm
 			dagVersionID: uuidToString(run.DagVersionID),
 			image:        spec.Image,
 			dagMinIdle:   spec.MinIdleWorkers,
+			tenantID:     uuidToString(run.TenantID),
 		})
 	}
 	return warmTargets(versions, s.warmExec), nil

--- a/internal/storage/warm_busy_window_integration_test.go
+++ b/internal/storage/warm_busy_window_integration_test.go
@@ -102,7 +102,7 @@ func TestWarmPoolReconcileKeepsQueuedBoundWorkerIntegration(t *testing.T) {
 		{DagVersionID: dagVersion, Image: "img", EffectiveMinIdle: 0, MaxPoolSize: 8},
 	}}
 
-	r := executor.NewWarmPoolReconciler(targets, pods, sched, nil, nil)
+	r := executor.NewWarmPoolReconciler(targets, pods, sched, 0, nil, nil)
 	if err := r.Reconcile(ctx); err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}

--- a/internal/storage/warm_targets_test.go
+++ b/internal/storage/warm_targets_test.go
@@ -13,10 +13,10 @@ import (
 func TestWarmTargets(t *testing.T) {
 	exec := config.ExecutionSection{WarmPoolsEnabled: true, MinIdleWorkers: 1, MaxPoolSize: 8}
 	versions := []activeWarmVersion{
-		{dagVersionID: "dv1", image: "img1", dagMinIdle: 2},  // author 2 -> 2
-		{dagVersionID: "dv1", image: "img1", dagMinIdle: 2},  // dup of dv1, collapses
-		{dagVersionID: "dv2", image: "img2", dagMinIdle: 0},  // unset -> operator floor 1
-		{dagVersionID: "dv3", image: "img3", dagMinIdle: 20}, // over cap -> clamped 8
+		{dagVersionID: "dv1", image: "img1", dagMinIdle: 2, tenantID: "tA"},  // author 2 -> 2
+		{dagVersionID: "dv1", image: "img1", dagMinIdle: 2, tenantID: "tA"},  // dup of dv1, collapses
+		{dagVersionID: "dv2", image: "img2", dagMinIdle: 0, tenantID: "tB"},  // unset -> operator floor 1
+		{dagVersionID: "dv3", image: "img3", dagMinIdle: 20, tenantID: "tB"}, // over cap -> clamped 8
 	}
 	got := warmTargets(versions, exec)
 	if len(got) != 3 {
@@ -39,6 +39,14 @@ func TestWarmTargets(t *testing.T) {
 	for _, tgt := range got {
 		if tgt.MaxPoolSize != 8 {
 			t.Errorf("target %s MaxPoolSize = %d, want 8 (operator's execution.max_pool_size)", tgt.DagVersionID, tgt.MaxPoolSize)
+		}
+	}
+	// TenantID is threaded onto every target so the reconciler can enforce the
+	// per-tenant aggregate warm-pod cap (M4).
+	wantTenant := map[string]string{"dv1": "tA", "dv2": "tB", "dv3": "tB"}
+	for _, tgt := range got {
+		if w := wantTenant[tgt.DagVersionID]; tgt.TenantID != w {
+			t.Errorf("target %s TenantID = %q, want %q", tgt.DagVersionID, tgt.TenantID, w)
 		}
 	}
 }


### PR DESCRIPTION
**M4 of the warm-pool track (ADR 0058)** — bounds how many warm pods one tenant holds across all its dag_versions, so on a shared multi-team cluster a tenant can't pin `Σ(max_pool_size)` idle pods and starve neighbors into `Pending` (review finding M4). **Reliability-first: the cap never starves a promised idle floor and never deletes a busy worker.** Behind `execution.warm_pools_enabled` (off ⇒ unchanged).

## Design (specialist's reserve-then-ration)
- **Config:** `execution.max_warm_pods_per_tenant` (default 100), validated `≥ 1` when warm on.
- **Attribution by pod label** (no query change): `BuildWarmPod` stamps `leoflow.io/tenant-id`; `ListWarmPods`→`WarmPodInfo.TenantID`; `WarmTarget.TenantID` from the active version.
- **Budget = `max(cap, Σ EffectiveMinIdle)`** — if the floor sum exceeds the cap, **honor every floor** + log/meter `warm_pool_tenant_cap_below_min_idle_sum` (`min_idle` is a promise, never capped away).
- **Ration** `headroom = budget − tenant_live` across the tenant's versions (stable by DagVersionID), each `min(idle shortfall, MaxPoolSize headroom, remaining headroom)` — one hungry version can't starve another's floor.
- **Create-only enforcement:** `reconcileVersion` gains a `createAllowance` (sentinel `-1` = unlimited/pre-M4); at/over budget → stop creating, busy untouched, only idle excess deleted. No cap ⇒ nil allowance ⇒ byte-for-byte the old reconciler.

## Tests (RED-first)
A naive cap (budget-without-floor-reserve) produced genuine RED. Green: **floor-honored-over-cap** (3 versions × min_idle 5, cap 8 → all 15 created + WARN metered), **headroom-rationed-fairly**, at-cap-no-create-busy-untouched, never-delete-busy-on-lowered-cap, multi-tenant-isolation, unattributable-not-deleted; + label + warmTargets threading. All N1d-b + Hole-A tests pass. `go vet ./...` **and** `-tags integration` clean · sqlc no drift · build + `-tags integration` green · `golangci-lint` 0.

Remaining pre-enable: D11 GC-anchor (uninstall backstop), P2c harness (failure-rate signals), the bootstrap worker-scoped exchange (security, needs a design pass), and the real-cluster e2e checklist. Enable = operator's flip.