### PR TITLE
feat(warm): per-dag-version ConfigMap GC-anchor for warm pods (ADR 0058 D11)

### DIFF
--- a/helm/leoflow/templates/rbac.yaml
+++ b/helm/leoflow/templates/rbac.yaml
@@ -31,6 +31,15 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["create", "delete"]
+  # The warm-pool GC anchor (ADR 0058 D11): a per-dag-version ConfigMap that owns
+  # the version's warm pods via an ownerReference, so on control-plane loss /
+  # namespace teardown the pods are cascade-GC'd — the one orphan class the
+  # reconciler-as-deleter cannot cover. EnsureWarmAnchor creates it (idempotent,
+  # tolerating AlreadyExists) and GETs it to read the UID stamped on the owned
+  # pods; the reconciler deletes it only once the version has fully drained.
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "get", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/internal/executor/warmpod.go
+++ b/internal/executor/warmpod.go
@@ -6,6 +6,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // Warm-worker pod labels (ADR 0058 N1b2b). The warm-pool reconciler lists and
@@ -25,6 +26,12 @@ const (
 	// enforce the per-tenant aggregate cap (M4). It is stamped from
 	// WarmPodSpec.TenantID and read back into WarmPodInfo.TenantID by ListWarmPods.
 	warmTenantLabelKey = "leoflow.io/tenant-id"
+	// warmAnchorLabelKey marks a ConfigMap as a warm-pool GC anchor (ADR 0058 D11);
+	// its value is always "true". Together with warmDagVersionLabelKey it makes an
+	// anchor discoverable (which version it anchors), so an operator can see the
+	// GC-owner ConfigMaps the reconciler creates alongside the warm fleet.
+	warmAnchorLabelKey = "leoflow.io/warm-anchor"
+	warmAnchorLabelVal = "true"
 )
 
 // WarmPodSpec is everything BuildWarmPod needs to build one long-lived warm-worker
@@ -84,6 +91,15 @@ type WarmPodSpec struct {
 	// PodSecurity carries the same container/pod hardening choices as a task pod.
 	PodSecurity PodSecurity
 
+	// AnchorName / AnchorUID identify the per-dag-version GC-anchor ConfigMap this
+	// warm pod is owned by (ADR 0058 D11). When BOTH are set, BuildWarmPod stamps an
+	// ownerReference to the anchor, so on control-plane loss / namespace teardown the
+	// pod is cascade-GC'd with the anchor — the one orphan class the reconciler (as
+	// deleter) cannot cover. When either is empty (off-cluster/pre-anchor builds and
+	// tests) the pod is built bare, exactly as before D11.
+	AnchorName string
+	AnchorUID  types.UID
+
 	// Labels / Annotations are operator-declared metadata overlaid onto the pod;
 	// Leoflow's own warm-worker labels always win a collision (see mergeMetadata).
 	Labels      map[string]string
@@ -109,8 +125,9 @@ type WarmPodSpec struct {
 //     attempt caps and the idle-TTL recycle that drive drains are deferred to N1d.
 //
 // It is pure (modulo the random name suffix) and unit-tested independently of any
-// cluster. It bakes NO task token in; the GC-anchor ConfigMap (D11) is deferred to
-// N1d — a bare warm pod deleted by the reconciler is fine for now.
+// cluster. It bakes NO task token in. When the spec carries a GC anchor (D11) it
+// stamps an ownerReference to that anchor ConfigMap so the pod is cascade-GC'd on
+// external teardown; without an anchor it builds a bare pod, unchanged.
 func BuildWarmPod(spec WarmPodSpec) *corev1.Pod {
 	pullPolicy := corev1.PullIfNotPresent
 	if spec.ImagePullPolicy != "" {
@@ -118,9 +135,10 @@ func BuildWarmPod(spec WarmPodSpec) *corev1.Pod {
 	}
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        warmPodName(spec.DagVersionID),
-			Labels:      warmPodLabels(spec),
-			Annotations: map[string]string{},
+			Name:            warmPodName(spec.DagVersionID),
+			Labels:          warmPodLabels(spec),
+			Annotations:     map[string]string{},
+			OwnerReferences: warmAnchorOwnerRefs(spec),
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy:   corev1.RestartPolicyNever,
@@ -163,6 +181,40 @@ func warmPodLabels(spec WarmPodSpec) map[string]string {
 		labels[warmTenantLabelKey] = sanitizeLabel(spec.TenantID)
 	}
 	return labels
+}
+
+// warmAnchorOwnerRefs builds the pod's ownerReference to its dag_version's GC
+// anchor (ADR 0058 D11) — but ONLY when the spec carries BOTH the anchor name and
+// UID. The controller/blockOwnerDeletion pair makes the anchor the pod's GC owner,
+// so deleting the anchor cascade-deletes the pod (the teardown backstop). When
+// either field is empty the pod is built bare (no ownerReference), exactly as
+// pre-D11: off-cluster/pre-anchor builds and unit tests that do not set an anchor
+// get today's ephemeral bare warm pod.
+func warmAnchorOwnerRefs(spec WarmPodSpec) []metav1.OwnerReference {
+	if spec.AnchorName == "" || spec.AnchorUID == "" {
+		return nil
+	}
+	return []metav1.OwnerReference{{
+		APIVersion:         "v1",
+		Kind:               "ConfigMap",
+		Name:               spec.AnchorName,
+		UID:                spec.AnchorUID,
+		Controller:         ptr(true),
+		BlockOwnerDeletion: ptr(true),
+	}}
+}
+
+// warmAnchorName is the DNS-safe name of a dag_version's GC-anchor ConfigMap
+// (ADR 0058 D11): leoflow-pool-<sanitized dag_version>, truncated to the 253-char
+// object-name limit. It is deterministic per version so EnsureWarmAnchor is
+// idempotent (a re-create hits AlreadyExists) and DeleteWarmAnchor can address the
+// anchor by version alone.
+func warmAnchorName(dagVersionID string) string {
+	name := "leoflow-pool-" + sanitizeLabel(dagVersionID)
+	if len(name) > 253 {
+		name = strings.TrimRight(name[:253], "-")
+	}
+	return name
 }
 
 // warmContainerName is the warm worker's single container.

--- a/internal/executor/warmpod_test.go
+++ b/internal/executor/warmpod_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // warmEnvMap projects the warm pod's single container env into a name->value map,
@@ -210,6 +211,58 @@ func TestBuildWarmPodExchangeTransport(t *testing.T) {
 	}
 	if !found {
 		t.Error("exchange: projected agent-token volume must be mounted")
+	}
+}
+
+// TestBuildWarmPodStampsAnchorOwnerReference locks the D11 GC anchor: when the spec
+// carries BOTH an anchor name and UID, BuildWarmPod stamps a single controlling
+// ownerReference to the anchor ConfigMap (Controller + BlockOwnerDeletion true), so
+// deleting the anchor cascade-GCs the pod on external teardown.
+func TestBuildWarmPodStampsAnchorOwnerReference(t *testing.T) {
+	spec := baseWarmSpec()
+	spec.AnchorName = "leoflow-pool-dv-abc"
+	spec.AnchorUID = types.UID("anchor-uid-xyz")
+	pod := BuildWarmPod(spec)
+
+	if len(pod.OwnerReferences) != 1 {
+		t.Fatalf("ownerReferences = %d, want exactly 1 (the GC anchor)", len(pod.OwnerReferences))
+	}
+	o := pod.OwnerReferences[0]
+	if o.APIVersion != "v1" || o.Kind != "ConfigMap" {
+		t.Errorf("ownerReference APIVersion/Kind = %s/%s, want v1/ConfigMap", o.APIVersion, o.Kind)
+	}
+	if o.Name != "leoflow-pool-dv-abc" || o.UID != types.UID("anchor-uid-xyz") {
+		t.Errorf("ownerReference Name/UID = %s/%s, want leoflow-pool-dv-abc/anchor-uid-xyz", o.Name, o.UID)
+	}
+	if o.Controller == nil || !*o.Controller {
+		t.Error("ownerReference Controller must be true (the anchor is the pod's controlling owner)")
+	}
+	if o.BlockOwnerDeletion == nil || !*o.BlockOwnerDeletion {
+		t.Error("ownerReference BlockOwnerDeletion must be true")
+	}
+}
+
+// TestBuildWarmPodBarePodWhenAnchorUnset locks the do-no-harm default: with no
+// anchor (or only one of name/UID) BuildWarmPod produces a BARE pod with no
+// ownerReference — exactly today's ephemeral warm pod. This keeps off-cluster /
+// pre-anchor builds and tests that don't set an anchor unchanged.
+func TestBuildWarmPodBarePodWhenAnchorUnset(t *testing.T) {
+	// Neither set.
+	if refs := BuildWarmPod(baseWarmSpec()).OwnerReferences; len(refs) != 0 {
+		t.Errorf("bare spec produced %d ownerReferences, want 0 (unchanged bare pod)", len(refs))
+	}
+	// Only name set (no UID): still bare — a half-set anchor must not stamp a
+	// dangling owner with an empty UID.
+	nameOnly := baseWarmSpec()
+	nameOnly.AnchorName = "leoflow-pool-dv-abc"
+	if refs := BuildWarmPod(nameOnly).OwnerReferences; len(refs) != 0 {
+		t.Errorf("name-only spec produced %d ownerReferences, want 0", len(refs))
+	}
+	// Only UID set (no name): still bare.
+	uidOnly := baseWarmSpec()
+	uidOnly.AnchorUID = types.UID("anchor-uid-xyz")
+	if refs := BuildWarmPod(uidOnly).OwnerReferences; len(refs) != 0 {
+		t.Errorf("uid-only spec produced %d ownerReferences, want 0", len(refs))
 	}
 }
 

--- a/internal/executor/warmpool.go
+++ b/internal/executor/warmpool.go
@@ -84,13 +84,24 @@ type WarmPodInfo struct {
 // WarmPodClient is the cluster side of warm-pool reconciliation: list the warm
 // fleet, create a new warm worker for a target (which mints the bootstrap token,
 // builds the pod via BuildWarmPod, and Creates it — the auth/config-aware half,
-// wired in main.go), and delete one by name. Kept as a narrow seam so the
-// reconciler is unit-tested with a fake and the executor imports neither auth nor
-// config. KubernetesWarmPods is the production implementation.
+// wired in main.go), delete one by name, and manage the per-dag-version GC-anchor
+// ConfigMap (ADR 0058 D11). Kept as a narrow seam so the reconciler is unit-tested
+// with a fake and the executor imports neither auth nor config. KubernetesWarmPods
+// is the production implementation.
+//
+// EnsureWarmAnchor creates (idempotently) the version's anchor ConfigMap and
+// returns its UID; every warm pod created for the version is stamped with an
+// ownerReference to it, so on control-plane loss / namespace teardown the pods are
+// cascade-GC'd. CreateWarmPod threads that anchor name+UID onto the pod. The
+// reconciler ensures the anchor before any create and deletes it (DeleteWarmAnchor)
+// ONLY once the version has fully drained to zero live pods — so the cascade is
+// always a no-op and never kills a live attempt.
 type WarmPodClient interface {
 	ListWarmPods(ctx context.Context) ([]WarmPodInfo, error)
-	CreateWarmPod(ctx context.Context, t WarmTarget) error
+	CreateWarmPod(ctx context.Context, t WarmTarget, anchorName, anchorUID string) error
 	DeleteWarmPod(ctx context.Context, name string) error
+	EnsureWarmAnchor(ctx context.Context, dagVersionID string) (uid string, err error)
+	DeleteWarmAnchor(ctx context.Context, dagVersionID string) error
 }
 
 // WarmPoolReconciler maintains the IDLE warm-worker buffer per active dag_version
@@ -119,9 +130,12 @@ type WarmPodClient interface {
 // busy worker could be deleted, so a nil busy source or a busy-list error aborts
 // the tick with zero mutations (do-no-harm).
 //
-// Deferred beyond this brick: the idle-TTL freshness recycle (D6), the D9 worker
-// lifetime / attempts-per-worker caps, and the GC-anchor ConfigMap (D11); a bare
-// warm pod deleted here is fine until then.
+// GC anchor (D11): before creating any pod for a version the reconciler ensures a
+// per-dag-version anchor ConfigMap and stamps every warm pod with an ownerReference
+// to it, so on control-plane loss / namespace teardown the fleet is cascade-GC'd.
+// The anchor is create-only during a version's active life and deleted only once an
+// inactive version has fully drained to zero pods (the footgun guard in Reconcile),
+// so the cascade never kills a live attempt.
 type WarmPoolReconciler struct {
 	targets WarmTargetSource
 	pods    WarmPodClient
@@ -210,13 +224,30 @@ func (r *WarmPoolReconciler) Reconcile(ctx context.Context) error {
 	active := make(map[string]bool, len(targets))
 	for _, t := range targets {
 		active[t.DagVersionID] = true
+		// An ACTIVE version's anchor is create-only during its life: reconcileVersion
+		// ensures it before creating, and it is NEVER deleted here — so a scale-down
+		// (deleting idle excess) can never trigger the cascade. The remaining-pod
+		// count is irrelevant for an active version and deliberately ignored.
 		r.reconcileVersion(ctx, t, byVersion[t.DagVersionID], busy, allowanceFor(allow, t.DagVersionID))
 	}
 	for dagVersionID, have := range byVersion {
 		if active[dagVersionID] {
 			continue
 		}
-		r.reconcileVersion(ctx, WarmTarget{DagVersionID: dagVersionID, EffectiveMinIdle: 0}, have, busy, unlimitedAllowance)
+		remaining := r.reconcileVersion(ctx, WarmTarget{DagVersionID: dagVersionID, EffectiveMinIdle: 0}, have, busy, unlimitedAllowance)
+		// DELETE FOOTGUN GUARD (ADR 0058 D11). The anchor's ownerReference makes
+		// deleting it CASCADE-delete every pod that still references it. So the anchor
+		// is deleted ONLY when, in THIS tick, the version is INACTIVE (not in
+		// ActiveWarmTargets, drained with target 0) AND the drain above left ZERO live
+		// pods referencing it (remaining == 0 — busy workers, un-reaped idle, and
+		// failed deletes all keep it > 0). At zero pods the cascade is a no-op, so it
+		// can NEVER kill a live (busy OR idle) warm attempt. The anchor's normal role
+		// is create-only; this delete is bookkeeping to stop the anchor leaking once
+		// its version is gone — the cascade itself is the BACKSTOP for external
+		// teardown (namespace delete / uninstall), never for scale-down.
+		if remaining == 0 {
+			r.deleteWarmAnchor(ctx, dagVersionID)
+		}
 	}
 	return nil
 }
@@ -392,12 +423,15 @@ func (r *WarmPoolReconciler) rationTenant(versions []WarmTarget, stat map[string
 // create is bounded by the per-version floor/MaxPoolSize gate alone — the pre-M4
 // behavior. The allowance gates CREATES only; the terminal reap and the
 // excess-idle delete are unchanged, so the cap never deletes a busy worker.
-func (r *WarmPoolReconciler) reconcileVersion(ctx context.Context, t WarmTarget, have []WarmPodInfo, busy map[string]bool, createAllowance int) {
+func (r *WarmPoolReconciler) reconcileVersion(ctx context.Context, t WarmTarget, have []WarmPodInfo, busy map[string]bool, createAllowance int) (remaining int) {
 	defer func() {
 		if p := recover(); p != nil {
 			r.logger.ErrorContext(ctx, "warm-pool reconcile panicked for a dag_version; other versions unaffected",
 				"dag_version", t.DagVersionID, "panic", p)
 			r.record("warm_pool_version_panic")
+			// Conservative on panic: report every listed pod as still present so the
+			// caller's footgun guard never deletes an anchor after a half-done drain.
+			remaining = len(have)
 		}
 	}()
 
@@ -410,11 +444,18 @@ func (r *WarmPoolReconciler) reconcileVersion(ctx context.Context, t WarmTarget,
 	// partition the live pods into BUSY (currently serving a running attempt) and
 	// IDLE (the rest) — the reconciler only ever creates toward, or deletes from,
 	// the IDLE set; busy workers are never touched (M1).
+	//
+	// `remaining` counts pods that STILL reference the version's anchor after this
+	// tick's deletes (busy workers, kept idle, and any delete/reap that FAILED). The
+	// caller uses it as the footgun guard: an inactive version's anchor is deleted
+	// only when remaining == 0, so the cascade can never catch a live pod.
 	idle := make([]WarmPodInfo, 0, len(have))
 	busyCount := 0
 	for _, p := range have {
 		if p.Terminal {
-			r.deleteWarmPod(ctx, t, p, "deleting terminal warm worker")
+			if !r.deleteWarmPod(ctx, t, p, "deleting terminal warm worker") {
+				remaining++ // reap failed: the pod still exists and references the anchor
+			}
 			continue
 		}
 		if busy[p.Name] {
@@ -423,6 +464,7 @@ func (r *WarmPoolReconciler) reconcileVersion(ctx context.Context, t WarmTarget,
 		}
 		idle = append(idle, p)
 	}
+	remaining += busyCount // busy workers are never deleted this tick — they still reference the anchor
 	live := busyCount + len(idle)
 
 	// Effective ceiling: the idle buffer must always be creatable, so never let the
@@ -449,15 +491,8 @@ func (r *WarmPoolReconciler) reconcileVersion(ctx context.Context, t WarmTarget,
 		if createAllowance >= 0 && create > createAllowance {
 			create = createAllowance
 		}
-		for i := 0; i < create; i++ {
-			if err := r.pods.CreateWarmPod(ctx, t); err != nil {
-				r.logger.ErrorContext(ctx, "creating warm worker",
-					"dag_version", t.DagVersionID, "image", t.Image, "error", err)
-				r.record("warm_pool_create_error")
-				continue
-			}
-			r.record("warm_pool_pod_created")
-		}
+		remaining += len(idle) // no idle deleted on the create path; every idle pod survives
+		r.ensureAnchorAndCreate(ctx, t, create)
 	case len(idle) > t.EffectiveMinIdle:
 		// Too many idle workers (over target, or the version is no longer active so
 		// the idle target is 0): delete the excess IDLE workers only. Busy workers
@@ -465,22 +500,76 @@ func (r *WarmPoolReconciler) reconcileVersion(ctx context.Context, t WarmTarget,
 		// kill an in-flight attempt (M1) — a busy worker is deleted only on a later
 		// tick, once it has gone idle. Deleting the tail is arbitrary but stable:
 		// every idle worker of a version is interchangeable.
+		remaining += t.EffectiveMinIdle // the idle workers kept within the target survive
 		for _, p := range idle[t.EffectiveMinIdle:] {
-			r.deleteWarmPod(ctx, t, p, "deleting excess idle warm worker")
+			if !r.deleteWarmPod(ctx, t, p, "deleting excess idle warm worker") {
+				remaining++ // delete failed: the pod still exists and references the anchor
+			}
 		}
+	default:
+		remaining += len(idle) // steady state / at-ceiling: the idle workers survive
+	}
+	return remaining
+}
+
+// ensureAnchorAndCreate creates `create` new warm workers for the version, after
+// ensuring the version's GC anchor exists and learning its UID so every pod is
+// stamped with an ownerReference to it (ADR 0058 D11). It is the ONLY place the
+// reconciler creates the anchor — create-only during a version's active life. If
+// the anchor cannot be ensured it skips ALL creates for this version this tick
+// (do-no-harm: a missed create beats a warm pod with no GC owner) and lets other
+// versions proceed. Each create is isolated so one apiserver rejection does not
+// stop the rest of this version's workers.
+func (r *WarmPoolReconciler) ensureAnchorAndCreate(ctx context.Context, t WarmTarget, create int) {
+	if create <= 0 {
+		return
+	}
+	uid, err := r.pods.EnsureWarmAnchor(ctx, t.DagVersionID)
+	if err != nil {
+		r.logger.ErrorContext(ctx, "ensuring warm anchor; skipping creates for this dag_version this tick to avoid a warm pod with no GC owner",
+			"dag_version", t.DagVersionID, "error", err)
+		r.record("warm_pool_anchor_ensure_error")
+		return
+	}
+	anchorName := warmAnchorName(t.DagVersionID)
+	for i := 0; i < create; i++ {
+		if err := r.pods.CreateWarmPod(ctx, t, anchorName, uid); err != nil {
+			r.logger.ErrorContext(ctx, "creating warm worker",
+				"dag_version", t.DagVersionID, "image", t.Image, "error", err)
+			r.record("warm_pool_create_error")
+			continue
+		}
+		r.record("warm_pool_pod_created")
 	}
 }
 
 // deleteWarmPod deletes one warm worker by name, logging/metering a failure
-// without aborting the sweep. msg names why (terminal cleanup vs excess).
-func (r *WarmPoolReconciler) deleteWarmPod(ctx context.Context, t WarmTarget, p WarmPodInfo, msg string) {
+// without aborting the sweep. msg names why (terminal cleanup vs excess). It
+// returns true iff the delete succeeded, so the caller can tell whether the pod
+// still references its anchor (the footgun guard must not delete an anchor while
+// any pod — including one whose delete failed — remains).
+func (r *WarmPoolReconciler) deleteWarmPod(ctx context.Context, t WarmTarget, p WarmPodInfo, msg string) bool {
 	if err := r.pods.DeleteWarmPod(ctx, p.Name); err != nil {
 		r.logger.ErrorContext(ctx, msg,
 			"dag_version", t.DagVersionID, "pod", p.Name, "error", err)
 		r.record("warm_pool_delete_error")
-		return
+		return false
 	}
 	r.record("warm_pool_pod_deleted")
+	return true
+}
+
+// deleteWarmAnchor deletes a fully-drained inactive version's GC anchor, metering
+// the outcome. It is called by Reconcile ONLY when the version has zero live pods
+// remaining (the footgun guard), so the ownerReference cascade is a no-op.
+func (r *WarmPoolReconciler) deleteWarmAnchor(ctx context.Context, dagVersionID string) {
+	if err := r.pods.DeleteWarmAnchor(ctx, dagVersionID); err != nil {
+		r.logger.ErrorContext(ctx, "deleting drained warm anchor",
+			"dag_version", dagVersionID, "error", err)
+		r.record("warm_pool_anchor_delete_error")
+		return
+	}
+	r.record("warm_pool_anchor_deleted")
 }
 
 func (r *WarmPoolReconciler) record(decision string) {

--- a/internal/executor/warmpool_k8s.go
+++ b/internal/executor/warmpool_k8s.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -68,7 +70,12 @@ func (k *KubernetesWarmPods) ListWarmPods(ctx context.Context) ([]WarmPodInfo, e
 }
 
 // CreateWarmPod mints the target's warm-pod spec, builds the pod, and creates it.
-func (k *KubernetesWarmPods) CreateWarmPod(ctx context.Context, t WarmTarget) error {
+// anchorName/anchorUID identify the version's GC-anchor ConfigMap (ADR 0058 D11);
+// when non-empty they are threaded onto the spec so BuildWarmPod stamps the pod's
+// ownerReference to the anchor. The reconciler ensures the anchor and reads its
+// UID before any create, so both are populated on the live path; a caller that
+// passes them empty gets a bare pod, unchanged.
+func (k *KubernetesWarmPods) CreateWarmPod(ctx context.Context, t WarmTarget, anchorName, anchorUID string) error {
 	if k.newSpec == nil {
 		return fmt.Errorf("warm pod creation requires a spec builder")
 	}
@@ -77,6 +84,8 @@ func (k *KubernetesWarmPods) CreateWarmPod(ctx context.Context, t WarmTarget) er
 		return fmt.Errorf("building warm pod spec for dag_version %s: %w", t.DagVersionID, err)
 	}
 	spec.Namespace = k.namespace
+	spec.AnchorName = anchorName
+	spec.AnchorUID = types.UID(anchorUID)
 	pod := BuildWarmPod(spec)
 	if _, err := k.clientset.CoreV1().Pods(k.namespace).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("creating warm pod for dag_version %s: %w", t.DagVersionID, err)
@@ -88,6 +97,53 @@ func (k *KubernetesWarmPods) CreateWarmPod(ctx context.Context, t WarmTarget) er
 func (k *KubernetesWarmPods) DeleteWarmPod(ctx context.Context, name string) error {
 	if err := k.clientset.CoreV1().Pods(k.namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
 		return fmt.Errorf("deleting warm pod %s: %w", name, err)
+	}
+	return nil
+}
+
+// EnsureWarmAnchor ensures the per-dag-version GC-anchor ConfigMap exists and
+// returns its UID (ADR 0058 D11). The anchor owns the version's warm pods via an
+// ownerReference, so on control-plane loss / namespace teardown the pods are
+// cascade-GC'd — the orphan class the reconciler-as-deleter cannot cover. It is
+// create-then-read and idempotent: an AlreadyExists (a prior tick, or another
+// leader) is success, and the UID is read back with a GET so every pod created
+// this tick is stamped with the SAME owner UID. The anchor carries no data (empty
+// ConfigMap); the labels only make it discoverable.
+func (k *KubernetesWarmPods) EnsureWarmAnchor(ctx context.Context, dagVersionID string) (string, error) {
+	name := warmAnchorName(dagVersionID)
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: k.namespace,
+			Labels: map[string]string{
+				warmAnchorLabelKey:     warmAnchorLabelVal,
+				warmDagVersionLabelKey: sanitizeLabel(dagVersionID),
+			},
+		},
+	}
+	created, err := k.clientset.CoreV1().ConfigMaps(k.namespace).Create(ctx, cm, metav1.CreateOptions{})
+	if err == nil {
+		return string(created.UID), nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		return "", fmt.Errorf("creating warm anchor for dag_version %s: %w", dagVersionID, err)
+	}
+	// Already exists (idempotent): read the live anchor to recover its UID.
+	got, gerr := k.clientset.CoreV1().ConfigMaps(k.namespace).Get(ctx, name, metav1.GetOptions{})
+	if gerr != nil {
+		return "", fmt.Errorf("reading existing warm anchor for dag_version %s: %w", dagVersionID, gerr)
+	}
+	return string(got.UID), nil
+}
+
+// DeleteWarmAnchor deletes the per-dag-version GC-anchor ConfigMap (ADR 0058 D11),
+// tolerating NotFound (already gone / never created). The reconciler calls this
+// ONLY for a fully-drained inactive version (zero live pods), so the cascade the
+// ownerReference sets up is a no-op — it can never kill a live warm attempt.
+func (k *KubernetesWarmPods) DeleteWarmAnchor(ctx context.Context, dagVersionID string) error {
+	name := warmAnchorName(dagVersionID)
+	if err := k.clientset.CoreV1().ConfigMaps(k.namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("deleting warm anchor for dag_version %s: %w", dagVersionID, err)
 	}
 	return nil
 }

--- a/internal/executor/warmpool_k8s_test.go
+++ b/internal/executor/warmpool_k8s_test.go
@@ -5,8 +5,12 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
 )
 
 // TestKubernetesWarmPodsListSelectsWarmOnly proves the cluster-backed client lists
@@ -110,7 +114,7 @@ func TestKubernetesWarmPodsCreateBuildsAndCreates(t *testing.T) {
 		return WarmPodSpec{DagVersionID: t.DagVersionID, Image: t.Image, BootstrapToken: "tok"}, nil
 	}
 	k := NewKubernetesWarmPods(cs, "leoflow", newSpec)
-	if err := k.CreateWarmPod(context.Background(), WarmTarget{DagVersionID: "dv1", Image: "img", EffectiveMinIdle: 1}); err != nil {
+	if err := k.CreateWarmPod(context.Background(), WarmTarget{DagVersionID: "dv1", Image: "img", EffectiveMinIdle: 1}, "", ""); err != nil {
 		t.Fatalf("CreateWarmPod: %v", err)
 	}
 	pods, err := cs.CoreV1().Pods("leoflow").List(context.Background(), metav1.ListOptions{
@@ -124,6 +128,103 @@ func TestKubernetesWarmPodsCreateBuildsAndCreates(t *testing.T) {
 	}
 	if got := pods.Items[0].Spec.Containers[0].Image; got != "img" {
 		t.Errorf("created pod image = %q, want img", got)
+	}
+}
+
+// TestKubernetesWarmPodsCreateStampsAnchorOwner proves CreateWarmPod threads the
+// anchor name+UID onto the spec so the created pod carries the D11 ownerReference
+// to its GC anchor.
+func TestKubernetesWarmPodsCreateStampsAnchorOwner(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	newSpec := func(t WarmTarget) (WarmPodSpec, error) {
+		return WarmPodSpec{DagVersionID: t.DagVersionID, Image: t.Image}, nil
+	}
+	k := NewKubernetesWarmPods(cs, "leoflow", newSpec)
+	if err := k.CreateWarmPod(context.Background(), WarmTarget{DagVersionID: "dv1", Image: "img"}, "leoflow-pool-dv1", "anchor-uid-123"); err != nil {
+		t.Fatalf("CreateWarmPod: %v", err)
+	}
+	pods, err := cs.CoreV1().Pods("leoflow").List(context.Background(), metav1.ListOptions{
+		LabelSelector: warmWorkerLabelKey + "=" + warmWorkerLabelVal,
+	})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(pods.Items) != 1 {
+		t.Fatalf("created %d warm pods, want 1", len(pods.Items))
+	}
+	owners := pods.Items[0].OwnerReferences
+	if len(owners) != 1 {
+		t.Fatalf("created pod has %d ownerReferences, want exactly 1 (the GC anchor)", len(owners))
+	}
+	o := owners[0]
+	if o.Kind != "ConfigMap" || o.Name != "leoflow-pool-dv1" || o.UID != types.UID("anchor-uid-123") {
+		t.Errorf("ownerReference = %+v, want ConfigMap/leoflow-pool-dv1/anchor-uid-123", o)
+	}
+}
+
+// TestKubernetesEnsureWarmAnchorIdempotent proves EnsureWarmAnchor creates the
+// anchor ConfigMap and returns its UID on the first call, and on a second call
+// (AlreadyExists) is NOT an error and returns the SAME UID — so every warm pod
+// created across ticks is stamped with the same owner UID. The apiserver-assigned
+// UID is simulated by a create reactor (the fake tracker assigns none).
+func TestKubernetesEnsureWarmAnchorIdempotent(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	cs.PrependReactor("create", "configmaps", func(action ktesting.Action) (bool, runtime.Object, error) {
+		cm := action.(ktesting.CreateAction).GetObject().(*corev1.ConfigMap)
+		if cm.UID == "" {
+			cm.UID = types.UID("uid-" + cm.Name)
+		}
+		return false, nil, nil // fall through to the tracker so it is stored + AlreadyExists works
+	})
+	k := NewKubernetesWarmPods(cs, "leoflow", nil)
+
+	uid1, err := k.EnsureWarmAnchor(context.Background(), "dv1")
+	if err != nil {
+		t.Fatalf("EnsureWarmAnchor (first): %v", err)
+	}
+	if uid1 == "" {
+		t.Fatal("EnsureWarmAnchor returned an empty UID on create, want a non-empty UID")
+	}
+
+	// The anchor exists with the discoverability labels and no data.
+	cm, err := cs.CoreV1().ConfigMaps("leoflow").Get(context.Background(), warmAnchorName("dv1"), metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("anchor not created: %v", err)
+	}
+	if cm.Labels[warmAnchorLabelKey] != warmAnchorLabelVal || cm.Labels[warmDagVersionLabelKey] != "dv1" {
+		t.Errorf("anchor labels = %v, want warm-anchor=true + dag-version-id=dv1", cm.Labels)
+	}
+	if len(cm.Data) != 0 || len(cm.BinaryData) != 0 {
+		t.Errorf("anchor carries data (%v/%v), want empty (it is a GC anchor)", cm.Data, cm.BinaryData)
+	}
+
+	uid2, err := k.EnsureWarmAnchor(context.Background(), "dv1")
+	if err != nil {
+		t.Fatalf("EnsureWarmAnchor (second, AlreadyExists) = %v, want nil (idempotent)", err)
+	}
+	if uid2 != uid1 {
+		t.Errorf("second EnsureWarmAnchor UID = %q, want the same as the first %q", uid2, uid1)
+	}
+}
+
+// TestKubernetesDeleteWarmAnchor proves DeleteWarmAnchor removes the anchor and
+// tolerates NotFound (a second delete, or a version whose anchor was never created).
+func TestKubernetesDeleteWarmAnchor(t *testing.T) {
+	cs := fake.NewSimpleClientset(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name: warmAnchorName("dv1"), Namespace: "leoflow",
+		Labels: map[string]string{warmAnchorLabelKey: warmAnchorLabelVal, warmDagVersionLabelKey: "dv1"},
+	}})
+	k := NewKubernetesWarmPods(cs, "leoflow", nil)
+
+	if err := k.DeleteWarmAnchor(context.Background(), "dv1"); err != nil {
+		t.Fatalf("DeleteWarmAnchor: %v", err)
+	}
+	if _, err := cs.CoreV1().ConfigMaps("leoflow").Get(context.Background(), warmAnchorName("dv1"), metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+		t.Errorf("anchor still present after delete (err=%v), want NotFound", err)
+	}
+	// NotFound is tolerated: deleting an already-gone anchor is not an error.
+	if err := k.DeleteWarmAnchor(context.Background(), "dv1"); err != nil {
+		t.Errorf("second DeleteWarmAnchor = %v, want nil (NotFound tolerated)", err)
 	}
 }
 

--- a/internal/executor/warmpool_test.go
+++ b/internal/executor/warmpool_test.go
@@ -17,7 +17,9 @@ func (f *fakeWarmTargets) ActiveWarmTargets(context.Context) ([]WarmTarget, erro
 }
 
 // fakeWarmPods records the reconciler's create/delete calls against a canned
-// existing-pod set, so a test can assert exactly what the reconciler did.
+// existing-pod set, so a test can assert exactly what the reconciler did. It also
+// records the GC-anchor calls (ADR 0058 D11): which versions had EnsureWarmAnchor /
+// DeleteWarmAnchor called, and the anchor name+UID each create was stamped with.
 type fakeWarmPods struct {
 	existing  []WarmPodInfo
 	created   []WarmTarget
@@ -25,6 +27,15 @@ type fakeWarmPods struct {
 	listErr   error
 	createErr map[string]error // per dag_version create error (nil = ok)
 	panicOn   string           // dag_version whose create panics (isolation test)
+	deleteErr map[string]error // per pod-name delete error (nil = ok)
+
+	// Anchor recording (D11).
+	createdAnchorName []string          // anchorName passed to CreateWarmPod, parallel to created
+	createdAnchorUID  []string          // anchorUID passed to CreateWarmPod, parallel to created
+	ensured           []string          // dag_versions EnsureWarmAnchor was called for, in order
+	ensureErr         map[string]error  // per dag_version EnsureWarmAnchor error (nil = ok)
+	anchorUID         map[string]string // dag_version -> UID EnsureWarmAnchor returns (default: "uid-<dv>")
+	deletedAnchors    []string          // dag_versions DeleteWarmAnchor was called for, in order
 }
 
 func (f *fakeWarmPods) ListWarmPods(context.Context) ([]WarmPodInfo, error) {
@@ -34,7 +45,7 @@ func (f *fakeWarmPods) ListWarmPods(context.Context) ([]WarmPodInfo, error) {
 	return f.existing, nil
 }
 
-func (f *fakeWarmPods) CreateWarmPod(_ context.Context, t WarmTarget) error {
+func (f *fakeWarmPods) CreateWarmPod(_ context.Context, t WarmTarget, anchorName, anchorUID string) error {
 	if f.panicOn != "" && t.DagVersionID == f.panicOn {
 		panic("boom creating " + t.DagVersionID)
 	}
@@ -44,11 +55,38 @@ func (f *fakeWarmPods) CreateWarmPod(_ context.Context, t WarmTarget) error {
 		}
 	}
 	f.created = append(f.created, t)
+	f.createdAnchorName = append(f.createdAnchorName, anchorName)
+	f.createdAnchorUID = append(f.createdAnchorUID, anchorUID)
 	return nil
 }
 
 func (f *fakeWarmPods) DeleteWarmPod(_ context.Context, name string) error {
+	if f.deleteErr != nil {
+		if err := f.deleteErr[name]; err != nil {
+			return err
+		}
+	}
 	f.deleted = append(f.deleted, name)
+	return nil
+}
+
+func (f *fakeWarmPods) EnsureWarmAnchor(_ context.Context, dagVersionID string) (string, error) {
+	f.ensured = append(f.ensured, dagVersionID)
+	if f.ensureErr != nil {
+		if err := f.ensureErr[dagVersionID]; err != nil {
+			return "", err
+		}
+	}
+	if f.anchorUID != nil {
+		if uid, ok := f.anchorUID[dagVersionID]; ok {
+			return uid, nil
+		}
+	}
+	return "uid-" + dagVersionID, nil
+}
+
+func (f *fakeWarmPods) DeleteWarmAnchor(_ context.Context, dagVersionID string) error {
+	f.deletedAnchors = append(f.deletedAnchors, dagVersionID)
 	return nil
 }
 
@@ -657,5 +695,165 @@ func TestWarmPoolTenantCapUnattributablePodNotDeleted(t *testing.T) {
 	}
 	if n := rec.count("warm_pool_untenanted_pod"); n < 1 {
 		t.Errorf("warm_pool_untenanted_pod metered %d times, want >= 1", n)
+	}
+}
+
+// ---- ADR 0058 D11: per-dag-version GC-anchor ConfigMap. The reconciler ensures
+// the anchor before creating any pod (so every warm pod is cascade-GC-owned by it)
+// and — the load-bearing reliability guard — deletes the anchor ONLY for an
+// inactive version that has fully drained to ZERO pods, so the ownerReference
+// cascade can never kill a live (busy OR idle) attempt. ----
+
+// anchorDeleted reports whether DeleteWarmAnchor was called for a dag_version.
+func anchorDeleted(pods *fakeWarmPods, dagVersionID string) bool {
+	for _, dv := range pods.deletedAnchors {
+		if dv == dagVersionID {
+			return true
+		}
+	}
+	return false
+}
+
+// TestWarmPoolAnchorNotDeletedWhileInactiveVersionHasPod is the FOOTGUN guard: an
+// INACTIVE version ("gone", not in targets) that still holds a BUSY warm pod must
+// keep its anchor — deleting it would cascade-delete the pod and KILL the live
+// attempt. The busy pod is left to finish (M1) and the anchor is NOT deleted this
+// tick. DeleteWarmAnchor must never be called while any pod still references it.
+func TestWarmPoolAnchorNotDeletedWhileInactiveVersionHasPod(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", EffectiveMinIdle: 1, MaxPoolSize: 8}}}
+	pods := &fakeWarmPods{existing: append(
+		warmPods("dv1", "keep"),
+		warmPods("gone", "busy1")...,
+	)}
+	reconcileWarmBusy(t, targets, pods, busySet("busy1"))
+
+	if deletedSet(pods)["busy1"] {
+		t.Errorf("deleted %v, must LEAVE the inactive version's busy worker to finish (M1)", pods.deleted)
+	}
+	if anchorDeleted(pods, "gone") {
+		t.Errorf("DeleteWarmAnchor called for 'gone' while its busy pod still references the anchor — the cascade would kill a live attempt (FOOTGUN)")
+	}
+	if len(pods.deletedAnchors) != 0 {
+		t.Errorf("deletedAnchors = %v, want none while any pod still exists", pods.deletedAnchors)
+	}
+}
+
+// TestWarmPoolAnchorDeletedWhenInactiveVersionFullyDrained: an INACTIVE version
+// whose pods are ALL idle is drained to zero this tick — so after the drain zero
+// pods reference the anchor and it IS deleted (bookkeeping so the anchor does not
+// leak). At zero pods the cascade is a no-op. The active version's anchor is never
+// touched.
+func TestWarmPoolAnchorDeletedWhenInactiveVersionFullyDrained(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", EffectiveMinIdle: 1, MaxPoolSize: 8}}}
+	pods := &fakeWarmPods{existing: append(
+		warmPods("dv1", "keep"),
+		warmPods("gone", "idle1", "idle2")...,
+	)}
+	reconcileWarmBusy(t, targets, pods, busySet()) // none busy
+
+	del := deletedSet(pods)
+	if !del["idle1"] || !del["idle2"] {
+		t.Errorf("deleted %v, want both idle workers of the inactive version drained", pods.deleted)
+	}
+	if !anchorDeleted(pods, "gone") {
+		t.Errorf("deletedAnchors = %v, want 'gone' deleted (its version fully drained to zero pods)", pods.deletedAnchors)
+	}
+	if anchorDeleted(pods, "dv1") {
+		t.Errorf("deletedAnchors = %v, must NEVER delete an active version's anchor", pods.deletedAnchors)
+	}
+}
+
+// TestWarmPoolAnchorNotDeletedOnActiveScaleDown: an ACTIVE version scaling down
+// (idle excess trimmed) must keep its anchor — anchor deletion is never used to
+// scale down an active version, only as drain bookkeeping for an inactive one.
+func TestWarmPoolAnchorNotDeletedOnActiveScaleDown(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", EffectiveMinIdle: 1, MaxPoolSize: 8}}}
+	pods := &fakeWarmPods{existing: warmPods("dv1", "i1", "i2", "i3")}
+	reconcileWarmBusy(t, targets, pods, busySet())
+
+	if len(pods.deleted) != 2 {
+		t.Errorf("deleted %v, want exactly 2 excess idle trimmed", pods.deleted)
+	}
+	if len(pods.deletedAnchors) != 0 {
+		t.Errorf("deletedAnchors = %v, want none (an active version's anchor is never deleted on scale-down)", pods.deletedAnchors)
+	}
+}
+
+// TestWarmPoolAnchorNeverDeletedWhilePodsExist sweeps the invariant across a mixed
+// fleet: two inactive versions, one with a busy pod (must keep its anchor) and one
+// with a failed idle delete (pod still there — must keep its anchor). Neither
+// anchor may be deleted while a pod remains.
+func TestWarmPoolAnchorNeverDeletedWhilePodsExist(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "active", EffectiveMinIdle: 1, MaxPoolSize: 8}}}
+	pods := &fakeWarmPods{
+		existing: append(append(
+			warmPods("active", "a1"),
+			warmPods("busyver", "b1")...),
+			warmPods("stuckver", "s1")...,
+		),
+		// s1's delete fails, so stuckver still has a pod after the drain.
+		deleteErr: map[string]error{"s1": errors.New("apiserver 500")},
+	}
+	reconcileWarmBusy(t, targets, pods, busySet("b1"))
+
+	if anchorDeleted(pods, "busyver") {
+		t.Errorf("deletedAnchors = %v, must NOT delete busyver's anchor (busy pod still references it)", pods.deletedAnchors)
+	}
+	if anchorDeleted(pods, "stuckver") {
+		t.Errorf("deletedAnchors = %v, must NOT delete stuckver's anchor (its pod's delete failed, so it still exists)", pods.deletedAnchors)
+	}
+}
+
+// TestWarmPoolEnsuresAnchorBeforeCreate: creating warm workers for a version first
+// ensures its GC anchor and stamps every created pod with the anchor's owner UID
+// (so the cascade owner is set on birth).
+func TestWarmPoolEnsuresAnchorBeforeCreate(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{{DagVersionID: "dv1", Image: "img", EffectiveMinIdle: 2, MaxPoolSize: 8}}}
+	pods := &fakeWarmPods{anchorUID: map[string]string{"dv1": "uid-dv1-abc"}}
+	reconcileWarmBusy(t, targets, pods, busySet())
+
+	var ensuredDV1 bool
+	for _, dv := range pods.ensured {
+		if dv == "dv1" {
+			ensuredDV1 = true
+		}
+	}
+	if !ensuredDV1 {
+		t.Fatalf("EnsureWarmAnchor was not called for dv1 before creating its pods (ensured=%v)", pods.ensured)
+	}
+	if len(pods.created) != 2 {
+		t.Fatalf("created %d pods, want 2", len(pods.created))
+	}
+	for i := range pods.created {
+		if pods.createdAnchorUID[i] != "uid-dv1-abc" {
+			t.Errorf("created pod %d anchorUID = %q, want uid-dv1-abc (the ensured anchor's UID)", i, pods.createdAnchorUID[i])
+		}
+		if pods.createdAnchorName[i] != "leoflow-pool-dv1" {
+			t.Errorf("created pod %d anchorName = %q, want leoflow-pool-dv1", i, pods.createdAnchorName[i])
+		}
+	}
+}
+
+// TestWarmPoolEnsureAnchorErrorSkipsCreatesForVersionOnly: if EnsureWarmAnchor fails
+// for one version, NO pod is created for it this tick (do-no-harm: better a missed
+// create than a warm pod with no GC owner), it is metered, and OTHER versions still
+// reconcile normally.
+func TestWarmPoolEnsureAnchorErrorSkipsCreatesForVersionOnly(t *testing.T) {
+	targets := &fakeWarmTargets{targets: []WarmTarget{
+		{DagVersionID: "bad", Image: "img", EffectiveMinIdle: 2, MaxPoolSize: 8},
+		{DagVersionID: "good", Image: "img", EffectiveMinIdle: 2, MaxPoolSize: 8},
+	}}
+	pods := &fakeWarmPods{ensureErr: map[string]error{"bad": errors.New("apiserver 500")}}
+	rec := reconcileWarmCap(t, targets, pods, &fakeBusyWorkers{}, 0)
+
+	byV := createdByVersion(pods)
+	if byV["bad"] != 0 {
+		t.Errorf("bad version created %d pods, want 0 (anchor ensure failed — never create an unowned warm pod)", byV["bad"])
+	}
+	if byV["good"] != 2 {
+		t.Errorf("good version created %d pods, want 2 (a sibling's anchor error must not block it)", byV["good"])
+	}
+	if n := rec.count("warm_pool_anchor_ensure_error"); n < 1 {
+		t.Errorf("warm_pool_anchor_ensure_error metered %d times, want >= 1", n)
 	}
 }

--- a/internal/storage/warm_busy_window_integration_test.go
+++ b/internal/storage/warm_busy_window_integration_test.go
@@ -61,13 +61,24 @@ func (f *fakeWarmPodsPG) ListWarmPods(context.Context) ([]executor.WarmPodInfo, 
 	return f.existing, nil
 }
 
-func (f *fakeWarmPodsPG) CreateWarmPod(_ context.Context, t executor.WarmTarget) error {
+func (f *fakeWarmPodsPG) CreateWarmPod(_ context.Context, t executor.WarmTarget, _, _ string) error {
 	f.created = append(f.created, t)
 	return nil
 }
 
 func (f *fakeWarmPodsPG) DeleteWarmPod(_ context.Context, name string) error {
 	f.deleted = append(f.deleted, name)
+	return nil
+}
+
+// EnsureWarmAnchor / DeleteWarmAnchor satisfy the D11 additions to
+// executor.WarmPodClient; this seam test asserts pod deletes, not anchors, so they
+// are recording no-ops (EnsureWarmAnchor returns a deterministic UID).
+func (f *fakeWarmPodsPG) EnsureWarmAnchor(_ context.Context, dagVersionID string) (string, error) {
+	return "uid-" + dagVersionID, nil
+}
+
+func (f *fakeWarmPodsPG) DeleteWarmAnchor(_ context.Context, _ string) error {
 	return nil
 }
 


### PR DESCRIPTION
**D11 of the warm-pool track (ADR 0058)** — warm pods get an `ownerReference` to a per-dag-version ConfigMap anchor so K8s cascade-GCs them on the one orphan class the reconciler-as-deleter **can't** cover: control-plane down long-term / uninstall, where bare `RestartPolicy:Never` warm pods would run forever burning a shared cluster's quota. Backstop, not hot path. Behind `execution.warm_pools_enabled` (off ⇒ `BuildWarmPod` without an anchor = byte-identical bare pod).

## What
- `EnsureWarmAnchor(dagVersionID) → uid` (idempotent create + GET for stable UID; labeled, empty), `DeleteWarmAnchor` (NotFound-tolerant).
- `BuildWarmPod` sets the ownerReference **only when both AnchorName+UID are set** — else bare pod.
- Reconciler **ensures the anchor before creating** (threads name+uid; ensure-error skips that version's creates, siblings proceed).

## 🔒 Footgun guard (the reliability crux)
The ownerReference makes deleting the anchor **cascade-delete its pods** — so the anchor is deleted **only** for an INACTIVE version and **only** when `reconcileVersion` reports `remaining == 0` (no pod still references it — `remaining` sums busy + kept-idle + any failed delete/reap; a panic → `len(have)`, conservative). Active versions never delete their anchor (create-only; scale-down deletes idle pods directly). Gated on zero pods, the cascade is always a **no-op → can never kill a live busy/idle attempt.**

## RBAC
Executor Role gains `configmaps: [get, create, delete]`; `scripts/rbac-covers-executor.sh` passes.

## Tests (RED-first)
ownerReference present/absent by anchor-set; EnsureWarmAnchor idempotent same-UID; **anchor NOT deleted while an inactive version has a pod**, deleted when fully drained, not on active scale-down, never-deleted-while-pods-exist (mixed fleet + failed delete); ensure-before-create carries owner UID; ensure-error skips only that version. All N1d-b/Hole-A/M4 tests pass. `go vet ./...` **and** `-tags integration` clean · build + `-tags integration` green · `golangci-lint` 0 · rbac guard exit 0.

Remaining pre-enable: **P2c harness** (failure-rate signals — the last autonomous brick), the **bootstrap worker-scoped exchange** (security, needs a design pass with you), and the **real-cluster e2e checklist**. Enable = operator's flip.