### PR TITLE
feat(warm): worker-scoped bootstrap exchange — no plaintext warm credential (ADR 0058 D2)

### DIFF
--- a/cmd/leoflow-agent/main.go
+++ b/cmd/leoflow-agent/main.go
@@ -124,7 +124,7 @@ func run() int {
 	// from the same path as single-shot. Anything else falls through to the
 	// byte-identical single-shot path below.
 	if os.Getenv("LEOFLOW_WARM_WORKER") == "1" {
-		return runWarm(ctx, client, addr, token, allowInsecure, caFile)
+		return runWarm(ctx, client, tokens, exchange, addr, token, allowInsecure, caFile)
 	}
 
 	// Exchange the projected bootstrap token for the task-scoped JWT before any
@@ -198,13 +198,19 @@ func run() int {
 }
 
 // runWarm serves the warm-worker loop (ADR 0058). streamClient carries the
-// worker's bootstrap identity (Register + AwaitAssignment). A SECOND dial gives
-// the WorkClient its own connection bound to an attempt-scoped TokenSource, which
-// the loop swaps to each assignment's attempt_token — so the per-attempt work RPCs
-// authenticate as the attempt while the stream keeps the bootstrap identity it was
-// opened with. The work dial is seeded with the bootstrap token only to satisfy
-// Dial's non-empty check; no work RPC fires before the first attempt_token swap.
-func runWarm(ctx context.Context, streamClient agentv1.AgentServiceClient, addr, seedToken string, allowInsecure bool, caFile string) int {
+// worker's bootstrap identity (Register + AwaitAssignment). streamTokens is that
+// stream's bearer source: under the exchange transport it seeds the projected
+// ServiceAccount token, which the warm loop swaps for a WORKER-scoped JWT (before
+// Register, on every connect) so the control channel authenticates as a warm
+// worker that authorizes ONLY Register + AwaitAssignment (never secrets/task).
+//
+// A SECOND dial gives the WorkClient its own connection bound to an attempt-scoped
+// TokenSource, which the loop swaps to each assignment's attempt_token — so the
+// per-attempt work RPCs authenticate as the attempt while the stream keeps the
+// worker identity it was opened with. The work dial is seeded with the bootstrap
+// token only to satisfy Dial's non-empty check; no work RPC fires before the first
+// attempt_token swap, and the per-attempt flow is unchanged by the exchange.
+func runWarm(ctx context.Context, streamClient agentv1.AgentServiceClient, streamTokens *agent.TokenSource, exchange bool, addr, seedToken string, allowInsecure bool, caFile string) int {
 	dagVersionID := os.Getenv("LEOFLOW_DAG_VERSION_ID")
 	if dagVersionID == "" {
 		slog.Error("warm worker requires LEOFLOW_DAG_VERSION_ID")
@@ -240,6 +246,10 @@ func runWarm(ctx context.Context, streamClient agentv1.AgentServiceClient, addr,
 		StreamClient:  streamClient,
 		WorkClient:    workClient,
 		AttemptTokens: attemptTokens,
+		// Under the exchange transport the stream bearer starts as the projected SA
+		// token; ExchangeBootstrap swaps a worker-scoped JWT into it before Register.
+		StreamTokens:      streamTokens,
+		ExchangeBootstrap: exchange,
 		// A fresh per-attempt log sink on the work client, so each attempt's logs
 		// ship under its own attempt_token.
 		NewSink: func(ctx context.Context) (agent.LogSink, error) {
@@ -258,15 +268,28 @@ func runWarm(ctx context.Context, streamClient agentv1.AgentServiceClient, addr,
 		HeartbeatInterval:  agent.DefaultHeartbeatInterval,
 		// Warm-pool Hole B: on a not-leader rejection, re-dial the STREAM connection
 		// so a fresh Service backend can reach the scheduler leader (a single gRPC
-		// connection sticks to one backend). Re-dials with the bootstrap token, like
-		// the initial stream dial; the work connection is untouched. The returned conn
-		// is closed by WarmRunner on the next reconnect / exit.
-		Redial: func() (agentv1.AgentServiceClient, io.Closer, error) {
-			c, conn, _, derr := agent.Dial(addr, seedToken, allowInsecure, caFile)
-			if derr != nil {
-				return nil, nil, derr
+		// connection sticks to one backend). The work connection is untouched. The
+		// returned conn is closed by WarmRunner on the next reconnect / exit, and the
+		// returned TokenSource becomes the new stream bearer — under the exchange
+		// transport WarmRunner re-runs the exchange into it before Register, so a
+		// reconnect gets a FRESH worker JWT (the initial one may have lapsed). The
+		// projected token is re-read from disk so a kubelet-rotated token is honored.
+		Redial: func() (agentv1.AgentServiceClient, *agent.TokenSource, io.Closer, error) {
+			seed := seedToken
+			if exchange {
+				if path := os.Getenv("LEOFLOW_AGENT_TOKEN_PATH"); path != "" {
+					if fresh, rerr := agent.ReadTokenFile(path); rerr == nil {
+						seed = fresh
+					} else {
+						slog.Warn("re-reading projected token on reconnect; falling back to the startup token", "error", rerr)
+					}
+				}
 			}
-			return c, conn, nil
+			c, conn, newTokens, derr := agent.Dial(addr, seed, allowInsecure, caFile)
+			if derr != nil {
+				return nil, nil, nil, derr
+			}
+			return c, newTokens, conn, nil
 		},
 		// Self-lifecycle caps, injected by BuildWarmPod from the operator's
 		// execution.* config (ADR 0058 N1d-d). Zero (unset/invalid) disables that

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -1011,31 +1011,32 @@ func startWarmPoolReconciler(ctx context.Context, targets executor.WarmTargetSou
 // (each worker registers as a distinct member of its dag_version pool) and stamps
 // the connection + hardening fields.
 //
-// The bootstrap token rides the ENV-VAR transport deliberately, regardless of
-// auth.agent_token_transport: it authorizes ONLY Register + AwaitAssignment and
-// resolves no secrets, so it needs neither the projected-token exchange nor the
-// liveness enforcement that guard the per-attempt credential. The warm agent
-// registers with it directly (it does not exchange a bootstrap token), so env-var
-// is the transport that actually works against the warm loop. The per-attempt
-// token — the one that resolves secrets — arrives in-band over AwaitAssignment and
-// is exchange/liveness-gated upstream (N1b1/N1b2a); the durable identity binding
-// (H2) is deferred to N1d.
+// The bootstrap credential authorizes ONLY Register + AwaitAssignment (the warm
+// control channel) and resolves NO secrets or task — a warm-worker-scoped token
+// (ADR 0058 D2). It reaches the pod by the operator's auth.agent_token_transport:
+//
+//   - exchange (the transport the N1a boot guard forces on when warm pools are
+//     enabled): the pod projects a ServiceAccount token and NO plaintext token; the
+//     warm agent exchanges it once per connect, and the control plane — recognizing
+//     the warm-worker LABEL — mints the worker-scoped JWT. This is the default and
+//     the whole point of this change: the bootstrap credential is never a plaintext
+//     env var on the pod.
+//   - env-var (dev / explicit fallback): a worker-scoped JWT is minted here and
+//     ridden in as a plaintext env var. Even this fallback is control-channel-only,
+//     so a leaked warm bootstrap token can never read the vault.
+//
+// The per-attempt token — the one that resolves secrets — arrives in-band over
+// AwaitAssignment and is exchange/liveness-gated upstream (N1b1/N1b2a).
 func warmPodSpecFunc(cfg *config.ServerConfig, authn *auth.JWTAuthenticator, controlAddr string) executor.WarmPodSpecFunc {
 	defaults := platformDefaults(cfg.Executor.Defaults)
+	useExchange := cfg.Auth.AgentTokenTransport == config.AgentTokenTransportExchange
 	return func(t executor.WarmTarget) (executor.WarmPodSpec, error) {
-		token, err := authn.IssueAgentToken(auth.AgentIdentity{
-			TaskInstanceID: "warm-" + t.DagVersionID + "-" + uuid.NewString(),
-		}, warmBootstrapTokenTTL(cfg))
-		if err != nil {
-			return executor.WarmPodSpec{}, fmt.Errorf("minting warm bootstrap token: %w", err)
-		}
-		return executor.WarmPodSpec{
+		spec := executor.WarmPodSpec{
 			DagVersionID:        t.DagVersionID,
 			Image:               t.Image,
 			TenantID:            t.TenantID,
 			ControlPlaneAddr:    controlAddr,
 			AgentTLSCAConfigMap: cfg.Executor.AgentTLSCAConfigMap,
-			BootstrapToken:      token,
 			PodSecurity:         defaults.PodSecurity,
 			// Self-lifecycle caps (ADR 0058 D9/D10/D6/H3). The attempt watchdog is
 			// anchored to the credential ceiling: an attempt can never validly outlive
@@ -1045,7 +1046,32 @@ func warmPodSpecFunc(cfg *config.ServerConfig, authn *auth.JWTAuthenticator, con
 			MaxWorkerLifetimeSeconds: int64(cfg.Execution.MaxWorkerLifetime.Seconds()),
 			WorkerIdleTTLSeconds:     int64(cfg.Execution.WorkerIdleTTL.Seconds()),
 			AttemptWatchdogSeconds:   int64(cfg.Auth.MaxAttemptCredentialLifetime.Seconds()),
-		}, nil
+		}
+		if useExchange {
+			// Exchange transport: project an SA token, no plaintext bootstrap token.
+			// BuildWarmPod (identity nil) projects the token and stamps the warm-worker
+			// LABEL the exchange resolver keys on; the control plane mints the
+			// worker-scoped JWT. Audience/expiration mirror the task-pod projected token
+			// (executor floors the expiration).
+			spec.AgentTokenTransport = config.AgentTokenTransportExchange
+			spec.AgentTokenAudience = executor.DefaultAgentTokenAudience
+			return spec, nil
+		}
+		// Env-var fallback: mint a WORKER-scoped (control-channel-only) bootstrap JWT
+		// and ride it in as a plaintext env var. The unique worker id is the token
+		// Subject; the scope claim makes AwaitAssignment accept it and every secret/
+		// task RPC reject it.
+		token, err := authn.IssueAgentToken(auth.AgentIdentity{
+			Scope:        auth.ScopeWarmWorker,
+			WorkerID:     "warm-" + t.DagVersionID + "-" + uuid.NewString(),
+			DagVersionID: t.DagVersionID,
+			TenantID:     t.TenantID,
+		}, warmBootstrapTokenTTL(cfg))
+		if err != nil {
+			return executor.WarmPodSpec{}, fmt.Errorf("minting warm bootstrap token: %w", err)
+		}
+		spec.BootstrapToken = token
+		return spec, nil
 	}
 }
 

--- a/cmd/leoflow-server/warm_bootstrap_transport_test.go
+++ b/cmd/leoflow-server/warm_bootstrap_transport_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/config"
+	"github.com/neochaotic/leoflow/internal/executor"
+)
+
+// TestWarmPodSpecFuncExchangeTransport: under auth.agent_token_transport=exchange
+// the warm pod carries NO plaintext bootstrap token — it projects a ServiceAccount
+// token instead (the whole point of ADR 0058 D2), with the control-plane audience.
+func TestWarmPodSpecFuncExchangeTransport(t *testing.T) {
+	cfg := &config.ServerConfig{}
+	cfg.Auth.AgentTokenTransport = config.AgentTokenTransportExchange
+	authn := auth.NewJWTAuthenticator(nil, "secret", time.Hour)
+
+	spec, err := warmPodSpecFunc(cfg, authn, "cp:9000")(executor.WarmTarget{DagVersionID: "dv-1", Image: "reg/dag:v1"})
+	if err != nil {
+		t.Fatalf("warmPodSpecFunc: %v", err)
+	}
+	if spec.BootstrapToken != "" {
+		t.Error("under the exchange transport the warm pod must carry NO plaintext bootstrap token")
+	}
+	if spec.AgentTokenTransport != config.AgentTokenTransportExchange {
+		t.Errorf("AgentTokenTransport = %q, want exchange", spec.AgentTokenTransport)
+	}
+	if spec.AgentTokenAudience != executor.DefaultAgentTokenAudience {
+		t.Errorf("AgentTokenAudience = %q, want %q", spec.AgentTokenAudience, executor.DefaultAgentTokenAudience)
+	}
+}
+
+// TestWarmPodSpecFuncEnvVarFallbackIsWorkerScoped: the env-var fallback mints a
+// bootstrap token that is WORKER-scoped (control-channel only), so even a leaked
+// plaintext warm bootstrap token can never resolve secrets — it names its pool and
+// worker id and carries no task claims.
+func TestWarmPodSpecFuncEnvVarFallbackIsWorkerScoped(t *testing.T) {
+	cfg := &config.ServerConfig{} // transport unset => env-var fallback
+	cfg.Execution.MaxWorkerLifetime = time.Hour
+	authn := auth.NewJWTAuthenticator(nil, "secret", time.Hour)
+
+	spec, err := warmPodSpecFunc(cfg, authn, "cp:9000")(executor.WarmTarget{DagVersionID: "dv-1", Image: "reg/dag:v1", TenantID: "acme"})
+	if err != nil {
+		t.Fatalf("warmPodSpecFunc: %v", err)
+	}
+	if spec.BootstrapToken == "" {
+		t.Fatal("env-var fallback must mint a plaintext bootstrap token")
+	}
+	id, verr := authn.AuthenticateAgent(spec.BootstrapToken)
+	if verr != nil {
+		t.Fatalf("bootstrap token does not verify: %v", verr)
+	}
+	if id.Scope != auth.ScopeWarmWorker {
+		t.Errorf("bootstrap token scope = %q, want %q (control-channel only)", id.Scope, auth.ScopeWarmWorker)
+	}
+	if id.DagVersionID != "dv-1" || id.TenantID != "acme" {
+		t.Errorf("bootstrap identity dag_version/tenant = %q/%q", id.DagVersionID, id.TenantID)
+	}
+	if id.TaskInstanceID != "" || id.RunID != "" || id.TaskID != "" || id.TryNumber != 0 {
+		t.Errorf("warm bootstrap token must carry NO task claims, got %+v", *id)
+	}
+	if id.WorkerID == "" {
+		t.Error("warm bootstrap token must carry a worker id (the Subject)")
+	}
+}

--- a/internal/agent/warm.go
+++ b/internal/agent/warm.go
@@ -42,6 +42,20 @@ type WarmRunner struct {
 	WorkClient    agentv1.AgentServiceClient
 	AttemptTokens *TokenSource
 
+	// StreamTokens is the bootstrap stream's own TokenSource (the source
+	// StreamClient's per-RPC credential reads). Under the exchange transport it is
+	// seeded with the projected ServiceAccount token; the exchange step below swaps
+	// the WORKER-scoped JWT into it before Register, so Register + AwaitAssignment
+	// carry the worker credential. Distinct from AttemptTokens (the WorkClient's
+	// per-attempt source). Unused under the env-var transport.
+	StreamTokens *TokenSource
+
+	// ExchangeBootstrap runs the projected-token → worker-JWT exchange (ADR 0058 D2)
+	// on StreamClient before Register, on the INITIAL connect and on every reconnect,
+	// swapping the minted worker JWT into StreamTokens. It is set under the exchange
+	// transport; false under the env-var default (Register uses the seed token as-is).
+	ExchangeBootstrap bool
+
 	// NewSink opens a fresh per-attempt log sink on the WorkClient, so each
 	// attempt's logs are shipped under its own attempt_token. Nil (or a returned
 	// error) falls back to NoopLogSink — logs are best-effort, never fatal.
@@ -106,11 +120,12 @@ type WarmRunner struct {
 	// reconnect. A FRESH dial is what lets the worker reach the leader: a single gRPC
 	// connection sticks to one Service backend, so retrying the same client would
 	// re-hit the same follower forever — only a new connection re-rotates. It returns
-	// the new stream client and a closer for the connection it opened (closed on the
-	// next reconnect / exit). Nil disables re-dial — the reconnect then retries the
-	// existing StreamClient (tests inject a fake that eventually serves); production
-	// wires a real re-dial via agent.Dial.
-	Redial func() (agentv1.AgentServiceClient, io.Closer, error)
+	// the new stream client, its TokenSource (so an exchange-transport worker
+	// re-exchanges into the fresh connection's bearer), and a closer for the
+	// connection it opened (closed on the next reconnect / exit). Nil disables
+	// re-dial — the reconnect then retries the existing StreamClient (tests inject a
+	// fake that eventually serves); production wires a real re-dial via agent.Dial.
+	Redial func() (agentv1.AgentServiceClient, *TokenSource, io.Closer, error)
 
 	// streamCloser holds the connection the most recent Redial opened, so it can be
 	// closed on the following reconnect (or on exit) rather than leaked.
@@ -188,25 +203,9 @@ func (w *WarmRunner) Run(ctx context.Context, dagVersionID string) error {
 // FailedPrecondition-coded error is the not-leader rejection Run reconnects on. A
 // failed TASK is a normal outcome and never ends the loop.
 func (w *WarmRunner) serve(ctx context.Context, dagVersionID string) error {
-	if _, err := w.StreamClient.Register(ctx, &agentv1.RegisterRequest{
-		AgentVersion: w.Version,
-		Hostname:     w.Hostname,
-	}); err != nil {
-		return fmt.Errorf("registering warm worker: %w", err)
-	}
-
-	stream, err := w.StreamClient.AwaitAssignment(ctx)
+	stream, err := w.connect(ctx, dagVersionID)
 	if err != nil {
-		return fmt.Errorf("opening assignment stream: %w", err)
-	}
-	// The mandatory first WorkerMessage names which pool (dag_version) this worker
-	// serves, so the control plane only dispatches matching assignments to it.
-	if serr := stream.Send(&agentv1.WorkerMessage{
-		Msg: &agentv1.WorkerMessage_Register{
-			Register: &agentv1.WorkerRegister{DagVersionId: dagVersionID, PodName: w.PodName},
-		},
-	}); serr != nil {
-		return fmt.Errorf("sending worker register: %w", serr)
+		return err
 	}
 
 	// D9/D10 accounting: bound the worker by attempts served and wall-clock age.
@@ -258,6 +257,43 @@ func (w *WarmRunner) serve(ctx context.Context, dagVersionID string) error {
 	}
 }
 
+// connect establishes one connection's control channel: it exchanges the bootstrap
+// token for a worker JWT (under the exchange transport), registers the worker, opens
+// the AwaitAssignment stream, and sends the mandatory first WorkerRegister naming the
+// pool. It runs on the initial connect and on every reconnect. A rejected exchange is
+// fatal (the worker has no valid control-channel credential); every error is wrapped
+// so serve()'s caller can tell a not-leader FailedPrecondition apart.
+func (w *WarmRunner) connect(ctx context.Context, dagVersionID string) (agentv1.AgentService_AwaitAssignmentClient, error) {
+	// Exchange the projected bootstrap token for a WORKER-scoped JWT before any RPC
+	// (ADR 0058 D2), swapping it into the stream's bearer so Register + AwaitAssignment
+	// authenticate as the warm worker.
+	if w.ExchangeBootstrap {
+		if err := ExchangeToken(ctx, w.StreamClient, w.StreamTokens); err != nil {
+			return nil, fmt.Errorf("exchanging warm bootstrap token for a worker JWT: %w", err)
+		}
+	}
+	if _, err := w.StreamClient.Register(ctx, &agentv1.RegisterRequest{
+		AgentVersion: w.Version,
+		Hostname:     w.Hostname,
+	}); err != nil {
+		return nil, fmt.Errorf("registering warm worker: %w", err)
+	}
+	stream, err := w.StreamClient.AwaitAssignment(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("opening assignment stream: %w", err)
+	}
+	// The mandatory first WorkerMessage names which pool (dag_version) this worker
+	// serves, so the control plane only dispatches matching assignments to it.
+	if serr := stream.Send(&agentv1.WorkerMessage{
+		Msg: &agentv1.WorkerMessage_Register{
+			Register: &agentv1.WorkerRegister{DagVersionId: dagVersionID, PodName: w.PodName},
+		},
+	}); serr != nil {
+		return nil, fmt.Errorf("sending worker register: %w", serr)
+	}
+	return stream, nil
+}
+
 // backoffSleep waits a jittered exponential backoff before reconnect n (1-based),
 // capped at maxBackoff, returning ctx.Err() if ctx is canceled first (so a SIGTERM
 // during backoff exits cleanly). The doubling loop stops once the cap is reached so
@@ -294,12 +330,17 @@ func (w *WarmRunner) redialStream() error {
 	if w.Redial == nil {
 		return nil
 	}
-	client, closer, err := w.Redial()
+	client, tokens, closer, err := w.Redial()
 	if err != nil {
 		return err
 	}
 	w.closeRedialConn()
 	w.StreamClient = client
+	// Adopt the fresh connection's bearer source so serve()'s exchange (under the
+	// exchange transport) swaps the new worker JWT into the source THIS client reads.
+	if tokens != nil {
+		w.StreamTokens = tokens
+	}
 	w.streamCloser = closer
 	return nil
 }

--- a/internal/agent/warm_test.go
+++ b/internal/agent/warm_test.go
@@ -533,9 +533,9 @@ func TestWarmWorkerReconnectsTowardLeader(t *testing.T) {
 		Hostname:      "warm-pod-1", Version: "test", ScratchDir: scratch,
 		// Tiny backoff so the test never really sleeps; a generous cap on reconnects.
 		ReconnectBackoff: time.Microsecond, ReconnectMaxBackoff: time.Millisecond, MaxReconnects: 10,
-		Redial: func() (agentv1.AgentServiceClient, io.Closer, error) {
+		Redial: func() (agentv1.AgentServiceClient, *TokenSource, io.Closer, error) {
 			redials++
-			return client, noopCloser{}, nil
+			return client, nil, noopCloser{}, nil
 		},
 	}
 
@@ -571,9 +571,9 @@ func TestWarmWorkerReconnectGivesUpAfterCap(t *testing.T) {
 		Cmd:           &scratchProbeCmd{scratchDir: scratch},
 		Hostname:      "warm-pod-1", Version: "test", ScratchDir: scratch,
 		ReconnectBackoff: time.Microsecond, ReconnectMaxBackoff: time.Millisecond, MaxReconnects: 3,
-		Redial: func() (agentv1.AgentServiceClient, io.Closer, error) {
+		Redial: func() (agentv1.AgentServiceClient, *TokenSource, io.Closer, error) {
 			redials++
-			return client, noopCloser{}, nil
+			return client, nil, noopCloser{}, nil
 		},
 	}
 
@@ -608,5 +608,80 @@ func TestRunnerRunIsRegisterThenOneAttempt(t *testing.T) {
 	wantStates := []agentv1.TaskState{agentv1.TaskState_TASK_STATE_RUNNING, agentv1.TaskState_TASK_STATE_SUCCESS}
 	if len(client.states) != 2 || client.states[0] != wantStates[0] || client.states[1] != wantStates[1] {
 		t.Errorf("states = %v, want exactly one attempt (running then success)", client.states)
+	}
+}
+
+// warmExchangeFake is the control-plane double for the warm bootstrap exchange: it
+// returns a worker JWT from ExchangeToken and records the bearer the stream carried
+// when Register ran, so a test can prove the exchange happens BEFORE Register and
+// that Register authenticates with the exchanged worker token.
+type warmExchangeFake struct {
+	*fakeClient
+	stream          *fakeAssignmentStream
+	streamTokens    *TokenSource
+	workerJWT       string
+	exchangeCalls   int
+	registerCalls   int
+	tokenAtRegister string
+	exchangedFirst  bool
+}
+
+func (c *warmExchangeFake) ExchangeToken(context.Context, *agentv1.ExchangeTokenRequest, ...grpc.CallOption) (*agentv1.ExchangeTokenResponse, error) {
+	c.exchangeCalls++
+	return &agentv1.ExchangeTokenResponse{AgentToken: c.workerJWT}, nil
+}
+
+func (c *warmExchangeFake) Register(context.Context, *agentv1.RegisterRequest, ...grpc.CallOption) (*agentv1.RegisterResponse, error) {
+	c.registerCalls++
+	c.tokenAtRegister = c.streamTokens.Token()
+	c.exchangedFirst = c.exchangeCalls > 0
+	return &agentv1.RegisterResponse{SessionId: "s1"}, nil
+}
+
+func (c *warmExchangeFake) AwaitAssignment(context.Context, ...grpc.CallOption) (grpc.BidiStreamingClient[agentv1.WorkerMessage, agentv1.WorkAssignment], error) {
+	return c.stream, nil
+}
+
+// TestWarmWorkerExchangesBootstrapBeforeRegister: under the exchange transport the
+// warm worker swaps its projected bootstrap token for a WORKER-scoped JWT before
+// Register, and Register (and thus AwaitAssignment) then carry the worker JWT — the
+// per-attempt token flow (AttemptTokens) is untouched.
+func TestWarmWorkerExchangesBootstrapBeforeRegister(t *testing.T) {
+	scratch := filepath.Join(t.TempDir(), "scratch")
+	streamTokens := NewTokenSource("projected-bootstrap")
+	client := &warmExchangeFake{
+		fakeClient:   &fakeClient{},
+		stream:       &fakeAssignmentStream{ctx: context.Background()}, // empty => clean EOF
+		streamTokens: streamTokens,
+		workerJWT:    "worker-jwt",
+	}
+	w := &WarmRunner{
+		StreamClient:      client,
+		WorkClient:        client,
+		AttemptTokens:     NewTokenSource("attempt-seed"),
+		StreamTokens:      streamTokens,
+		ExchangeBootstrap: true,
+		Cmd:               &scratchProbeCmd{scratchDir: scratch},
+		Hostname:          "warm-pod-1", Version: "test", ScratchDir: scratch,
+	}
+
+	if err := w.Run(context.Background(), "dagver-1"); err != nil {
+		t.Fatalf("WarmRunner.Run: %v", err)
+	}
+	if client.exchangeCalls != 1 {
+		t.Errorf("ExchangeToken calls = %d, want exactly 1", client.exchangeCalls)
+	}
+	if !client.exchangedFirst {
+		t.Error("the exchange must run BEFORE Register")
+	}
+	if client.tokenAtRegister != "worker-jwt" {
+		t.Errorf("bearer at Register = %q, want the exchanged worker JWT", client.tokenAtRegister)
+	}
+	if got := streamTokens.Token(); got != "worker-jwt" {
+		t.Errorf("stream bearer after exchange = %q, want worker-jwt", got)
+	}
+	// The per-attempt source is untouched by the bootstrap exchange.
+	if got := w.AttemptTokens.Token(); got != "attempt-seed" {
+		t.Errorf("attempt token source = %q, want unchanged", got)
 	}
 }

--- a/internal/agentrpc/authz.go
+++ b/internal/agentrpc/authz.go
@@ -1,0 +1,47 @@
+package agentrpc
+
+import (
+	"github.com/neochaotic/leoflow/internal/auth"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Scope gating (ADR 0058 D2) — the security guarantee that a warm worker's
+// bootstrap credential authorizes ONLY the control channel and can never resolve
+// secrets or a task. It is enforced per-RPC, right after identify(), so a
+// leaked or forged warm-worker token that reaches a secret/task handler is
+// rejected before it touches the vault, the task spec, or XCom.
+//
+// The two credentials are disjoint by scope:
+//   - a warm-worker token (Scope == auth.ScopeWarmWorker) is accepted ONLY on
+//     Register + AwaitAssignment (the control channel) and PermissionDenied on
+//     every secret/task RPC (requireAttemptToken);
+//   - a task ("attempt") token (Scope == "") is accepted on every secret/task RPC
+//     as before and PermissionDenied on AwaitAssignment (requireWarmWorkerToken).
+//
+// Register accepts both: warm workers and task pods both register.
+
+// requireAttemptToken rejects a warm-worker-scoped credential on a secret/task
+// RPC. A warm worker's control-channel token must never resolve secrets, the task
+// spec, or XCom, nor report/heartbeat a task — those are the per-attempt token's
+// sole province (delivered in-band over WorkAssignment). Returns nil for a task
+// token (the default scope), leaving today's behavior unchanged.
+func (s *Server) requireAttemptToken(id *auth.AgentIdentity) error {
+	if id.Scope == auth.ScopeWarmWorker {
+		return status.Error(codes.PermissionDenied,
+			"a warm-worker token authorizes only Register and AwaitAssignment, not secrets or task RPCs")
+	}
+	return nil
+}
+
+// requireWarmWorkerToken rejects a task-scoped credential on the warm-worker
+// control stream (AwaitAssignment). Only a warm worker's bootstrap token may open
+// the assignment stream; a task token calling it is a misuse (or an attempt to
+// pull assignments with the wrong credential) and is denied.
+func (s *Server) requireWarmWorkerToken(id *auth.AgentIdentity) error {
+	if id.Scope != auth.ScopeWarmWorker {
+		return status.Error(codes.PermissionDenied,
+			"AwaitAssignment requires a warm-worker token")
+	}
+	return nil
+}

--- a/internal/agentrpc/authz_scope_test.go
+++ b/internal/agentrpc/authz_scope_test.go
@@ -1,0 +1,142 @@
+package agentrpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// warmServerWithSecrets builds a server with secrets wired over the (dev) insecure
+// channel AND a task spec, so a TASK token would succeed on every secret/task RPC.
+// That isolates the scope gate: when a warm token is denied, it is denied by the
+// scope check, not by the secret-channel or spec-load guards.
+func warmServerWithSecrets(t *testing.T) (srv *Server, store *fakeStore, sec *fakeSecrets, warmCtx, taskCtx context.Context) {
+	t.Helper()
+	store = &fakeStore{spec: TaskSpec{
+		Operator: "python", Entrypoint: "dag:x",
+		XComInputMapping: map[string][]string{"in": {"up"}},
+	}}
+	sec = &fakeSecrets{vars: map[string]string{"FOO": "bar"}, conns: map[string]string{"pg": "postgres://u:p@h/db"}}
+	var a *auth.JWTAuthenticator
+	srv, a = newServerX(store, &fakeXCom{})
+	srv.SetSecrets(sec, true) // dev: allow over the insecure test channel
+	warmCtx = ctxWithWarmToken(t, a)
+	taskCtx = ctxWithToken(t, a)
+	return srv, store, sec, warmCtx, taskCtx
+}
+
+// TestWarmTokenDeniedOnEverySecretAndTaskRPC is the DP2 security invariant: a
+// warm-worker-scoped token — a leaked or forged one included — is PermissionDenied
+// on every RPC that reads secrets, the task spec, or XCom, or that reports/
+// heartbeats a task. It must never reach the vault. Each RPC is asserted
+// individually so a newly-added-but-ungated handler is caught.
+func TestWarmTokenDeniedOnEverySecretAndTaskRPC(t *testing.T) {
+	srv, _, sec, warmCtx, _ := warmServerWithSecrets(t)
+
+	cases := []struct {
+		name string
+		call func(context.Context) error
+	}{
+		{"GetVariables", func(ctx context.Context) error {
+			_, err := srv.GetVariables(ctx, &agentv1.GetVariablesRequest{})
+			return err
+		}},
+		{"GetConnections", func(ctx context.Context) error {
+			_, err := srv.GetConnections(ctx, &agentv1.GetConnectionsRequest{})
+			return err
+		}},
+		{"GetTaskSpec", func(ctx context.Context) error {
+			_, err := srv.GetTaskSpec(ctx, &agentv1.GetTaskSpecRequest{})
+			return err
+		}},
+		{"ReportState", func(ctx context.Context) error {
+			_, err := srv.ReportState(ctx, &agentv1.ReportStateRequest{State: agentv1.TaskState_TASK_STATE_SUCCESS})
+			return err
+		}},
+		{"Heartbeat", func(ctx context.Context) error {
+			_, err := srv.Heartbeat(ctx, &agentv1.HeartbeatRequest{})
+			return err
+		}},
+		{"PushXCom", func(ctx context.Context) error {
+			_, err := srv.PushXCom(ctx, &agentv1.PushXComRequest{Value: []byte("v")})
+			return err
+		}},
+		{"FetchXCom", func(ctx context.Context) error {
+			_, err := srv.FetchXCom(ctx, &agentv1.FetchXComRequest{UpstreamTaskId: "up"})
+			return err
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.call(warmCtx); status.Code(err) != codes.PermissionDenied {
+				t.Fatalf("%s with a warm-worker token = %v, want PermissionDenied", tc.name, err)
+			}
+		})
+	}
+	// The vault store must never have been consulted for the warm caller.
+	if sec.gotVarTn != "" {
+		t.Errorf("secrets store was queried for a warm caller (tenant %q); the scope gate must reject before any vault read", sec.gotVarTn)
+	}
+}
+
+// TestWarmTokenDeniedOnStreamLogs: StreamLogs writes to a task-instance-keyed log
+// ref, so it is a task RPC too — a warm-worker token is denied before the sink opens.
+func TestWarmTokenDeniedOnStreamLogs(t *testing.T) {
+	srv, _, _, warmCtx, _ := warmServerWithSecrets(t)
+	stream := &fakeStreamLogsServer{ctx: warmCtx}
+	if err := srv.StreamLogs(stream); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("StreamLogs with a warm-worker token = %v, want PermissionDenied", err)
+	}
+}
+
+// TestTaskTokenStillWorksOnSecretAndTaskRPCs: the task ("attempt") token — the
+// default scope — is UNCHANGED: it still resolves secrets, the task spec, and
+// reports state. The scope gate does not touch the attempt path.
+func TestTaskTokenStillWorksOnSecretAndTaskRPCs(t *testing.T) {
+	srv, _, _, _, taskCtx := warmServerWithSecrets(t)
+
+	if _, err := srv.GetVariables(taskCtx, &agentv1.GetVariablesRequest{}); err != nil {
+		t.Errorf("GetVariables with a task token: %v", err)
+	}
+	if _, err := srv.GetConnections(taskCtx, &agentv1.GetConnectionsRequest{}); err != nil {
+		t.Errorf("GetConnections with a task token: %v", err)
+	}
+	if _, err := srv.GetTaskSpec(taskCtx, &agentv1.GetTaskSpecRequest{}); err != nil {
+		t.Errorf("GetTaskSpec with a task token: %v", err)
+	}
+	if _, err := srv.Heartbeat(taskCtx, &agentv1.HeartbeatRequest{}); err != nil {
+		t.Errorf("Heartbeat with a task token: %v", err)
+	}
+	if _, err := srv.ReportState(taskCtx, &agentv1.ReportStateRequest{State: agentv1.TaskState_TASK_STATE_RUNNING}); err != nil {
+		t.Errorf("ReportState with a task token: %v", err)
+	}
+}
+
+// TestRegisterAcceptsBothScopes: Register is the one control RPC both a warm worker
+// and a task pod call, so it accepts either scope.
+func TestRegisterAcceptsBothScopes(t *testing.T) {
+	srv, a := newServer(&fakeStore{})
+	if _, err := srv.Register(ctxWithToken(t, a), &agentv1.RegisterRequest{}); err != nil {
+		t.Errorf("Register with a task token: %v", err)
+	}
+	if _, err := srv.Register(ctxWithWarmToken(t, a), &agentv1.RegisterRequest{}); err != nil {
+		t.Errorf("Register with a warm-worker token: %v", err)
+	}
+}
+
+// TestAwaitAssignmentRejectsTaskToken: the mirror gate — a task ("attempt") token
+// may NOT open the warm-worker assignment stream. It is denied before registration.
+func TestAwaitAssignmentRejectsTaskToken(t *testing.T) {
+	srv, a, reg := newWarmServer(t, nil)
+	stream := newFakeAwaitStream(ctxWithToken(t, a)) // a TASK token, wrong scope
+	if err := srv.AwaitAssignment(stream); status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("AwaitAssignment with a task token = %v, want PermissionDenied", err)
+	}
+	if reg.registered("ti-1") {
+		t.Error("a task token must not land in the warm registry")
+	}
+}

--- a/internal/agentrpc/await_assignment.go
+++ b/internal/agentrpc/await_assignment.go
@@ -70,7 +70,17 @@ func (s *Server) AwaitAssignment(stream agentv1.AgentService_AwaitAssignmentServ
 	if err != nil {
 		return err
 	}
-	worker, err := s.registerFromStream(stream, id.TaskInstanceID)
+	// Scope gate (ADR 0058 D2): the assignment stream is the warm-worker control
+	// channel — only a warm-worker-scoped token may open it. A task ("attempt")
+	// token is PermissionDenied here, the mirror of requireAttemptToken on the
+	// secret/task RPCs.
+	if werr := s.requireWarmWorkerToken(id); werr != nil {
+		return werr
+	}
+	// The registry key is the worker's AUTHENTICATED identity — its WorkerID (the
+	// token Subject), not the register payload — so a worker cannot claim an
+	// arbitrary identity through the message.
+	worker, err := s.registerFromStream(stream, id.WorkerID)
 	if err != nil {
 		return err
 	}
@@ -79,7 +89,7 @@ func (s *Server) AwaitAssignment(stream agentv1.AgentService_AwaitAssignmentServ
 	// Receive loop: acks and slot-free signals feed the registry. It ends on EOF
 	// (clean close) or any transport error, reported once on recvErr.
 	recvErr := make(chan error, 1)
-	go s.pumpWorkerMessages(stream, id.TaskInstanceID, recvErr)
+	go s.pumpWorkerMessages(stream, id.WorkerID, recvErr)
 
 	for {
 		select {

--- a/internal/agentrpc/await_assignment_test.go
+++ b/internal/agentrpc/await_assignment_test.go
@@ -98,7 +98,7 @@ func awaitEventually(t *testing.T, cond func() bool) {
 
 func TestAwaitAssignmentInertWhenWarmPoolsOff(t *testing.T) {
 	srv, a := newServer(&fakeStore{}) // no SetWarmPools => off
-	stream := newFakeAwaitStream(ctxWithToken(t, a))
+	stream := newFakeAwaitStream(ctxWithWarmToken(t, a))
 	err := srv.AwaitAssignment(stream)
 	if status.Code(err) != codes.FailedPrecondition {
 		t.Fatalf("warm pools off: got %v, want FailedPrecondition", err)
@@ -115,7 +115,7 @@ func TestAwaitAssignmentInertWhenWarmPoolsOff(t *testing.T) {
 func TestAwaitAssignmentRefusedOnFollower(t *testing.T) {
 	srv, a, reg := newWarmServer(t, nil)
 	srv.SetLeaderCheck(func() bool { return false })
-	stream := newFakeAwaitStream(ctxWithToken(t, a))
+	stream := newFakeAwaitStream(ctxWithWarmToken(t, a))
 	err := srv.AwaitAssignment(stream)
 	if status.Code(err) != codes.FailedPrecondition {
 		t.Fatalf("follower AwaitAssignment: got %v, want FailedPrecondition", err)
@@ -130,7 +130,7 @@ func TestAwaitAssignmentRefusedOnFollower(t *testing.T) {
 func TestAwaitAssignmentProceedsOnLeader(t *testing.T) {
 	srv, a, reg := newWarmServer(t, nil)
 	srv.SetLeaderCheck(func() bool { return true })
-	stream := newFakeAwaitStream(ctxWithToken(t, a))
+	stream := newFakeAwaitStream(ctxWithWarmToken(t, a))
 	stream.pushMsg(regMsg("dagver-1"))
 	go func() { _ = srv.AwaitAssignment(stream) }()
 	awaitEventually(t, func() bool { return reg.registered("ti-1") })
@@ -141,7 +141,7 @@ func TestAwaitAssignmentProceedsOnLeader(t *testing.T) {
 // (single-node / tests without wiring), so the handler serves as before.
 func TestAwaitAssignmentNilLeaderCheckUnchecked(t *testing.T) {
 	srv, a, reg := newWarmServer(t, nil) // no SetLeaderCheck
-	stream := newFakeAwaitStream(ctxWithToken(t, a))
+	stream := newFakeAwaitStream(ctxWithWarmToken(t, a))
 	stream.pushMsg(regMsg("dagver-1"))
 	go func() { _ = srv.AwaitAssignment(stream) }()
 	awaitEventually(t, func() bool { return reg.registered("ti-1") })
@@ -152,7 +152,7 @@ func TestAwaitAssignmentNilLeaderCheckUnchecked(t *testing.T) {
 
 func TestAwaitAssignmentRequiresRegisterFirst(t *testing.T) {
 	srv, a, _ := newWarmServer(t, nil)
-	stream := newFakeAwaitStream(ctxWithToken(t, a))
+	stream := newFakeAwaitStream(ctxWithWarmToken(t, a))
 	stream.pushMsg(ackMsg("as-1", true)) // first message is an ack, not a register
 	err := srv.AwaitAssignment(stream)
 	if status.Code(err) != codes.FailedPrecondition {
@@ -164,7 +164,7 @@ func TestAwaitAssignmentRequiresRegisterFirst(t *testing.T) {
 
 func TestAwaitAssignmentRegistersWorker(t *testing.T) {
 	srv, a, reg := newWarmServer(t, nil)
-	stream := newFakeAwaitStream(ctxWithToken(t, a))
+	stream := newFakeAwaitStream(ctxWithWarmToken(t, a))
 	stream.pushMsg(regMsg("dagver-1"))
 	go func() { _ = srv.AwaitAssignment(stream) }()
 
@@ -179,7 +179,7 @@ func TestAwaitAssignmentRegistersWorker(t *testing.T) {
 
 func TestAwaitAssignmentDeliversAssignment(t *testing.T) {
 	srv, a, reg := newWarmServer(t, nil)
-	stream := newFakeAwaitStream(ctxWithToken(t, a))
+	stream := newFakeAwaitStream(ctxWithWarmToken(t, a))
 	stream.pushMsg(regMsg("dagver-1"))
 	go func() { _ = srv.AwaitAssignment(stream) }()
 	awaitEventually(t, func() bool { return reg.registered("ti-1") })
@@ -391,7 +391,7 @@ func TestReclaimRefusedCarriesAttemptIdentity(t *testing.T) {
 
 func TestAwaitAssignmentDeregistersOnStreamClose(t *testing.T) {
 	srv, a, reg := newWarmServer(t, nil)
-	stream := newFakeAwaitStream(ctxWithToken(t, a))
+	stream := newFakeAwaitStream(ctxWithWarmToken(t, a))
 	stream.pushMsg(regMsg("dagver-1"))
 	done := make(chan error, 1)
 	go func() { done <- srv.AwaitAssignment(stream) }()
@@ -410,13 +410,13 @@ func TestAwaitAssignmentDeregistersOnStreamClose(t *testing.T) {
 func TestAwaitAssignmentReconnectSameIdentitySingleEntry(t *testing.T) {
 	srv, a, reg := newWarmServer(t, nil)
 
-	s1 := newFakeAwaitStream(ctxWithToken(t, a))
+	s1 := newFakeAwaitStream(ctxWithWarmToken(t, a))
 	s1.pushMsg(regMsg("v1"))
 	go func() { _ = srv.AwaitAssignment(s1) }()
 	awaitEventually(t, func() bool { return reg.dagVersionOf("ti-1") == "v1" })
 
 	// A reconnect with the SAME authenticated identity but a new registration.
-	s2 := newFakeAwaitStream(ctxWithToken(t, a))
+	s2 := newFakeAwaitStream(ctxWithWarmToken(t, a))
 	s2.pushMsg(regMsg("v2"))
 	go func() { _ = srv.AwaitAssignment(s2) }()
 	awaitEventually(t, func() bool { return reg.dagVersionOf("ti-1") == "v2" })
@@ -439,7 +439,7 @@ func TestAwaitAssignmentPersistsBindingOnStartedAck(t *testing.T) {
 	reg.leaseFor = func(*agentv1.WorkAssignment) time.Duration { return time.Hour } // no reclaim mid-test
 	srv.SetWarmPools(reg)
 
-	stream := newFakeAwaitStream(ctxWithToken(t, a))
+	stream := newFakeAwaitStream(ctxWithWarmToken(t, a))
 	stream.pushMsg(regMsgPod("dagver-1", "warm-pod-7"))
 	go func() { _ = srv.AwaitAssignment(stream) }()
 	awaitEventually(t, func() bool { return reg.registered("ti-1") })
@@ -471,7 +471,7 @@ func TestAwaitAssignmentDoesNotPersistOnRefusedAck(t *testing.T) {
 	reg.leaseFor = func(*agentv1.WorkAssignment) time.Duration { return time.Hour }
 	srv.SetWarmPools(reg)
 
-	stream := newFakeAwaitStream(ctxWithToken(t, a))
+	stream := newFakeAwaitStream(ctxWithWarmToken(t, a))
 	stream.pushMsg(regMsgPod("dagver-1", "warm-pod-7"))
 	go func() { _ = srv.AwaitAssignment(stream) }()
 	awaitEventually(t, func() bool { return reg.registered("ti-1") })

--- a/internal/agentrpc/exchange.go
+++ b/internal/agentrpc/exchange.go
@@ -36,13 +36,19 @@ type TokenReviewer interface {
 	ReviewProjectedToken(ctx context.Context, token string) (ReviewedPod, error)
 }
 
-// PodTaskResolver maps a reviewed pod to the task-instance identity it runs, so
-// the minted JWT is scoped to the attempt (the identity Fix #1 filters on and
-// Fix #2 liveness-checks). It is an interface so it is mocked in unit tests. The
-// concrete resolver reads the identity the control plane itself stamped on the
-// pod object at dispatch, keyed on the apiserver-validated pod reference.
+// PodTaskResolver maps a reviewed pod to the agent identity it runs, so the
+// minted JWT is scoped correctly. It is an interface so it is mocked in unit
+// tests; the concrete resolver reads the pod the apiserver validated.
+//
+// ResolveAgent is the branch point the exchange uses (ADR 0058 D1): a pod carrying
+// the warm-worker LABEL resolves to a warm-worker identity (Scope ==
+// ScopeWarmWorker, naming its dag_version pool + worker id, no task claims); any
+// other pod resolves to the task-instance identity the control plane stamped on it
+// at dispatch — exactly what ResolveTaskInstance returns. ResolveTaskInstance is
+// kept for the pure task path and callers that only ever expect a task instance.
 type PodTaskResolver interface {
 	ResolveTaskInstance(ctx context.Context, pod ReviewedPod) (auth.AgentIdentity, error)
+	ResolveAgent(ctx context.Context, pod ReviewedPod) (auth.AgentIdentity, error)
 }
 
 // AgentTokenMinter issues a task-scoped agent JWT for a resolved identity. It is
@@ -97,21 +103,32 @@ func (s *Server) ExchangeToken(ctx context.Context, _ *agentv1.ExchangeTokenRequ
 		slog.Warn("rejecting agent token exchange: projected token review failed", "error", err)
 		return nil, status.Error(codes.Unauthenticated, "projected token is not valid")
 	}
-	id, err := s.podResolver.ResolveTaskInstance(ctx, pod)
+	// A warm-worker pod (by LABEL, DP1) resolves to a worker-scoped identity that
+	// authorizes ONLY the control channel; any other pod resolves to its task
+	// instance exactly as before. IssueAgentToken mints whichever flavor.
+	id, err := s.podResolver.ResolveAgent(ctx, pod)
 	if err != nil {
-		slog.Warn("agent token exchange: cannot resolve reviewed pod to a task instance",
+		slog.Warn("agent token exchange: cannot resolve reviewed pod to an agent identity",
 			"namespace", pod.Namespace, "pod", pod.PodName, "pod_uid", pod.PodUID, "error", err)
-		return nil, status.Errorf(codes.Internal, "resolving pod to task instance: %v", err)
+		return nil, status.Errorf(codes.Internal, "resolving pod to agent identity: %v", err)
 	}
 	minted, err := s.tokenMinter.IssueAgentToken(id, s.exchangeTTL)
 	if err != nil {
-		slog.Warn("agent token exchange: minting task-scoped token failed",
-			"ti", id.TaskInstanceID, "run", id.RunID, "task", id.TaskID, "try", id.TryNumber, "error", err)
-		return nil, status.Errorf(codes.Internal, "minting task-scoped token: %v", err)
+		slog.Warn("agent token exchange: minting agent token failed",
+			"scope", id.Scope, "ti", id.TaskInstanceID, "worker", id.WorkerID, "error", err)
+		return nil, status.Errorf(codes.Internal, "minting agent token: %v", err)
 	}
-	slog.Info("exchanged projected token for a task-scoped agent JWT",
-		"ti", id.TaskInstanceID, "tenant", id.TenantID, "dag", id.DagID,
-		"run", id.RunID, "task", id.TaskID, "try", id.TryNumber, "namespace", pod.Namespace, "pod", pod.PodName)
+	if id.Scope == auth.ScopeWarmWorker {
+		// Log the warm case distinctly (worker/dag_version, never the token): the
+		// credential authorizes only Register + AwaitAssignment, no secrets or task.
+		slog.Info("exchanged projected token for a WORKER-scoped agent JWT (control channel only: Register + AwaitAssignment)",
+			"worker", id.WorkerID, "dag_version", id.DagVersionID, "tenant", id.TenantID,
+			"namespace", pod.Namespace, "pod", pod.PodName)
+	} else {
+		slog.Info("exchanged projected token for a task-scoped agent JWT",
+			"ti", id.TaskInstanceID, "tenant", id.TenantID, "dag", id.DagID,
+			"run", id.RunID, "task", id.TaskID, "try", id.TryNumber, "namespace", pod.Namespace, "pod", pod.PodName)
+	}
 	return &agentv1.ExchangeTokenResponse{AgentToken: minted}, nil
 }
 

--- a/internal/agentrpc/exchange_test.go
+++ b/internal/agentrpc/exchange_test.go
@@ -31,17 +31,34 @@ func (r *fakeReviewer) ReviewProjectedToken(_ context.Context, token string) (Re
 	return r.pod, nil
 }
 
-// fakeResolver maps a reviewed pod to the task-instance identity it runs.
+// fakeResolver maps a reviewed pod to an agent identity. warmID (when the pod
+// carries the warm-worker label) lets a test drive the warm branch of ResolveAgent
+// distinctly from the task branch (id).
 type fakeResolver struct {
-	id   auth.AgentIdentity
-	err  error
-	seen ReviewedPod
+	id     auth.AgentIdentity
+	warmID auth.AgentIdentity
+	err    error
+	seen   ReviewedPod
 }
 
 func (r *fakeResolver) ResolveTaskInstance(_ context.Context, pod ReviewedPod) (auth.AgentIdentity, error) {
 	r.seen = pod
 	if r.err != nil {
 		return auth.AgentIdentity{}, r.err
+	}
+	return r.id, nil
+}
+
+// ResolveAgent mirrors the concrete resolver's DP1 branch: a pod flagged warm (its
+// ServiceAccount carries the "warm" marker in this fake) resolves to the
+// warm-worker identity; anything else resolves to the task identity.
+func (r *fakeResolver) ResolveAgent(_ context.Context, pod ReviewedPod) (auth.AgentIdentity, error) {
+	r.seen = pod
+	if r.err != nil {
+		return auth.AgentIdentity{}, r.err
+	}
+	if pod.ServiceAccount == "warm" {
+		return r.warmID, nil
 	}
 	return r.id, nil
 }
@@ -155,5 +172,67 @@ func TestNormalRPCsNeverInvokeTokenReview(t *testing.T) {
 	}
 	if rev.calls != 0 {
 		t.Errorf("TokenReview was called %d times on the steady-state path, want 0", rev.calls)
+	}
+}
+
+// warmReviewedPod is a reviewed pod the fake resolver treats as a warm worker
+// (ServiceAccount == "warm"), so ExchangeToken takes the DP1 warm branch.
+func warmReviewedPod() ReviewedPod {
+	return ReviewedPod{Namespace: "leoflow", PodName: "leoflow-warm-dagver-9-abcd", PodUID: "uid-w", ServiceAccount: "warm"}
+}
+
+func warmWorkerID() auth.AgentIdentity {
+	return auth.AgentIdentity{Scope: auth.ScopeWarmWorker, DagVersionID: "dagver-9", TenantID: "acme", WorkerID: "leoflow-warm-dagver-9-abcd"}
+}
+
+// TestExchangeTokenMintsWorkerScopedJWT: a reviewed pod WITH the warm-worker label
+// is exchanged for a WORKER-scoped agent JWT (scope=warm-worker, dag_version set,
+// NO task claims), verifiable back to the same worker identity.
+func TestExchangeTokenMintsWorkerScopedJWT(t *testing.T) {
+	srv, a := newServer(&fakeStore{})
+	rev := &fakeReviewer{pod: warmReviewedPod()}
+	res := &fakeResolver{id: testIdentity(), warmID: warmWorkerID()}
+	srv.SetTokenExchange(rev, res, a, time.Hour, true)
+
+	resp, err := srv.ExchangeToken(ctxWithBootstrap("projected-sa-token"), &agentv1.ExchangeTokenRequest{})
+	if err != nil {
+		t.Fatalf("ExchangeToken: %v", err)
+	}
+	id, verr := a.AuthenticateAgent(resp.GetAgentToken())
+	if verr != nil {
+		t.Fatalf("minted worker token does not verify: %v", verr)
+	}
+	if id.Scope != auth.ScopeWarmWorker {
+		t.Errorf("scope = %q, want %q", id.Scope, auth.ScopeWarmWorker)
+	}
+	if id.DagVersionID != "dagver-9" {
+		t.Errorf("dag_version_id = %q, want dagver-9", id.DagVersionID)
+	}
+	if id.TaskInstanceID != "" || id.RunID != "" || id.TaskID != "" || id.TryNumber != 0 {
+		t.Errorf("worker token must carry no task claims, got %+v", *id)
+	}
+}
+
+// TestExchangeTokenWithoutWarmLabelMintsTaskToken: a pod WITHOUT the warm-worker
+// label is exchanged for the task-scoped token exactly as today (Scope empty).
+func TestExchangeTokenWithoutWarmLabelMintsTaskToken(t *testing.T) {
+	srv, a := newServer(&fakeStore{})
+	rev := &fakeReviewer{pod: reviewedPod()} // ServiceAccount != "warm"
+	res := &fakeResolver{id: testIdentity(), warmID: warmWorkerID()}
+	srv.SetTokenExchange(rev, res, a, time.Hour, true)
+
+	resp, err := srv.ExchangeToken(ctxWithBootstrap("projected-sa-token"), &agentv1.ExchangeTokenRequest{})
+	if err != nil {
+		t.Fatalf("ExchangeToken: %v", err)
+	}
+	id, verr := a.AuthenticateAgent(resp.GetAgentToken())
+	if verr != nil {
+		t.Fatalf("minted token does not verify: %v", verr)
+	}
+	if id.Scope != "" {
+		t.Errorf("task path scope = %q, want empty", id.Scope)
+	}
+	if *id != testIdentity() {
+		t.Errorf("minted identity = %+v, want %+v", *id, testIdentity())
 	}
 }

--- a/internal/agentrpc/secrets.go
+++ b/internal/agentrpc/secrets.go
@@ -218,6 +218,9 @@ func (s *Server) GetVariables(ctx context.Context, _ *agentv1.GetVariablesReques
 	if err != nil {
 		return nil, err
 	}
+	if aerr := s.requireAttemptToken(id); aerr != nil {
+		return nil, aerr
+	}
 	if gerr := s.guardSecretChannel(ctx); gerr != nil {
 		return nil, gerr
 	}
@@ -252,6 +255,9 @@ func (s *Server) GetConnections(ctx context.Context, _ *agentv1.GetConnectionsRe
 	id, err := s.identify(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if aerr := s.requireAttemptToken(id); aerr != nil {
+		return nil, aerr
 	}
 	if gerr := s.guardSecretChannel(ctx); gerr != nil {
 		return nil, gerr

--- a/internal/agentrpc/server.go
+++ b/internal/agentrpc/server.go
@@ -226,6 +226,9 @@ func (s *Server) GetTaskSpec(ctx context.Context, _ *agentv1.GetTaskSpecRequest)
 	if err != nil {
 		return nil, err
 	}
+	if aerr := s.requireAttemptToken(id); aerr != nil {
+		return nil, aerr
+	}
 	spec, err := s.store.TaskSpec(ctx, *id)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "loading task spec: %v", err)
@@ -261,6 +264,9 @@ func (s *Server) ReportState(ctx context.Context, req *agentv1.ReportStateReques
 	id, err := s.identify(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if aerr := s.requireAttemptToken(id); aerr != nil {
+		return nil, aerr
 	}
 	// A reschedule-mode sensor reports up_for_reschedule + its next-poke time; route
 	// it to the dedicated store path that persists reschedule_at, instead of the
@@ -308,6 +314,9 @@ func (s *Server) Heartbeat(ctx context.Context, _ *agentv1.HeartbeatRequest) (*a
 	id, err := s.identify(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if aerr := s.requireAttemptToken(id); aerr != nil {
+		return nil, aerr
 	}
 	if hbErr := s.store.RecordHeartbeat(ctx, *id); hbErr != nil {
 		// A stale heartbeat is the guard working, not a fault: the row moved on —
@@ -378,6 +387,9 @@ func (s *Server) PushXCom(ctx context.Context, req *agentv1.PushXComRequest) (*a
 	if err != nil {
 		return nil, err
 	}
+	if aerr := s.requireAttemptToken(id); aerr != nil {
+		return nil, aerr
+	}
 	spec, err := s.store.TaskSpec(ctx, *id)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "loading task spec: %v", err)
@@ -402,6 +414,9 @@ func (s *Server) FetchXCom(ctx context.Context, req *agentv1.FetchXComRequest) (
 	id, err := s.identify(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if aerr := s.requireAttemptToken(id); aerr != nil {
+		return nil, aerr
 	}
 	spec, err := s.store.TaskSpec(ctx, *id)
 	if err != nil {
@@ -436,6 +451,9 @@ func (s *Server) StreamLogs(stream agentv1.AgentService_StreamLogsServer) (err e
 	id, ierr := s.identify(stream.Context())
 	if ierr != nil {
 		return ierr
+	}
+	if aerr := s.requireAttemptToken(id); aerr != nil {
+		return aerr
 	}
 	if s.logs == nil {
 		return status.Error(codes.Unimplemented, "log shipping is not configured")

--- a/internal/agentrpc/server_test.go
+++ b/internal/agentrpc/server_test.go
@@ -97,12 +97,34 @@ func testIdentity() auth.AgentIdentity {
 	}
 }
 
-// ctxWithToken builds an incoming context carrying a freshly minted agent token.
+// ctxWithToken builds an incoming context carrying a freshly minted (task-scoped)
+// agent token — the default per-attempt credential.
 func ctxWithToken(t *testing.T, a *auth.JWTAuthenticator) context.Context {
 	t.Helper()
 	token, err := a.IssueAgentToken(testIdentity(), time.Hour)
 	if err != nil {
 		t.Fatalf("IssueAgentToken: %v", err)
+	}
+	md := metadata.Pairs("authorization", "Bearer "+token)
+	return metadata.NewIncomingContext(context.Background(), md)
+}
+
+// warmTokenIdentity is the warm-worker credential the assignment stream authorizes
+// (ADR 0058 D2): a control-channel-only token whose WorkerID is the registry key.
+// It reuses "ti-1" as the worker id so the warm-pool tests' registry assertions
+// (reg.registered("ti-1")) read the authenticated identity.
+func warmTokenIdentity() auth.AgentIdentity {
+	return auth.AgentIdentity{Scope: auth.ScopeWarmWorker, WorkerID: "ti-1", DagVersionID: "v1", TenantID: "acme"}
+}
+
+// ctxWithWarmToken builds an incoming context carrying a freshly minted
+// WARM-WORKER-scoped token — the bootstrap credential that authorizes only
+// Register + AwaitAssignment.
+func ctxWithWarmToken(t *testing.T, a *auth.JWTAuthenticator) context.Context {
+	t.Helper()
+	token, err := a.IssueAgentToken(warmTokenIdentity(), time.Hour)
+	if err != nil {
+		t.Fatalf("IssueAgentToken (warm): %v", err)
 	}
 	md := metadata.Pairs("authorization", "Bearer "+token)
 	return metadata.NewIncomingContext(context.Background(), md)

--- a/internal/auth/agent_token.go
+++ b/internal/auth/agent_token.go
@@ -13,7 +13,19 @@ import (
 // user-facing API (see audienceUser).
 const audienceAgent = "leoflow-agent"
 
-// AgentIdentity is the task instance a verified agent token represents.
+// ScopeWarmWorker marks an agent token that authorizes ONLY the warm-worker
+// control channel — Register + AwaitAssignment — and NOTHING that resolves
+// secrets or a task (ADR 0058 D2). It is the value of AgentIdentity.Scope for a
+// warm worker's bootstrap credential; the empty scope is the default task
+// credential, which resolves secrets exactly as before. The control plane gates
+// every secret/task RPC on this value (see agentrpc.requireAttemptToken).
+const ScopeWarmWorker = "warm-worker"
+
+// AgentIdentity is the identity a verified agent token represents. By default
+// (Scope == "") it is a single task instance — the task-scoped credential that
+// resolves secrets. When Scope == ScopeWarmWorker it is instead a warm worker's
+// bootstrap credential, which names its dag_version pool (DagVersionID) and its
+// worker id (WorkerID, the token Subject) and carries NO task claims.
 type AgentIdentity struct {
 	TaskInstanceID string
 	TenantID       string
@@ -21,6 +33,17 @@ type AgentIdentity struct {
 	RunID          string
 	TaskID         string
 	TryNumber      int
+	// Scope is "" for a task credential (the default, byte-compatible with every
+	// token minted before this field existed) or ScopeWarmWorker for a warm
+	// worker's control-channel-only bootstrap credential.
+	Scope string
+	// DagVersionID names the warm pool a warm-worker credential serves. Empty on a
+	// task credential.
+	DagVersionID string
+	// WorkerID is the warm worker's stable identifier (its pod name), minted as the
+	// token Subject for a warm-worker credential. Empty on a task credential (whose
+	// Subject is TaskInstanceID instead).
+	WorkerID string
 }
 
 // agentClaims is the JWT payload of an agent identity token.
@@ -30,6 +53,12 @@ type agentClaims struct {
 	RunID     string `json:"run_id"`
 	TaskID    string `json:"task_id"`
 	TryNumber int    `json:"try_number"`
+	// Scope and DagVersionID describe a warm-worker credential (ADR 0058 D2). Both
+	// are omitempty so a task credential's payload is byte-identical to before these
+	// fields existed — an existing task token still verifies unchanged, and a freshly
+	// minted task token carries neither claim.
+	Scope        string `json:"scope,omitempty"`
+	DagVersionID string `json:"dag_version_id,omitempty"`
 	// OriginIssuedAt records when this attempt's credential was FIRST minted (at
 	// dispatch). Unlike iat, it is preserved verbatim across heartbeat renewals so
 	// the control plane can bound an attempt's total credential lifetime no matter
@@ -53,15 +82,25 @@ func (a *JWTAuthenticator) IssueAgentToken(id AgentIdentity, ttl time.Duration) 
 // renewal passes the incoming token's origin so it never advances.
 func (a *JWTAuthenticator) mintAgentToken(id AgentIdentity, ttl time.Duration, origin time.Time) (string, error) {
 	now := a.clock()
+	// The Subject is the worker id for a warm-worker credential and the task
+	// instance id for a task credential. A warm-worker identity carries no task
+	// claims (RunID/TaskID/TryNumber empty), so those fields serialize empty —
+	// the worker credential names only its pool (dag_version_id) and its scope.
+	subject := id.TaskInstanceID
+	if id.Scope == ScopeWarmWorker {
+		subject = id.WorkerID
+	}
 	c := agentClaims{
 		TenantID:       id.TenantID,
 		DagID:          id.DagID,
 		RunID:          id.RunID,
 		TaskID:         id.TaskID,
 		TryNumber:      id.TryNumber,
+		Scope:          id.Scope,
+		DagVersionID:   id.DagVersionID,
 		OriginIssuedAt: jwt.NewNumericDate(origin),
 		RegisteredClaims: jwt.RegisteredClaims{
-			Subject:   id.TaskInstanceID,
+			Subject:   subject,
 			Issuer:    tokenIssuer,
 			Audience:  jwt.ClaimStrings{audienceAgent},
 			IssuedAt:  jwt.NewNumericDate(now),
@@ -111,15 +150,7 @@ func (a *JWTAuthenticator) RenewAgentToken(token string, ttl, maxLifetime time.D
 	if maxLifetime > 0 && !origin.IsZero() && a.clock().Sub(origin) > maxLifetime {
 		return "", false, nil // past the ceiling: let the credential lapse
 	}
-	id := AgentIdentity{
-		TaskInstanceID: c.Subject,
-		TenantID:       c.TenantID,
-		DagID:          c.DagID,
-		RunID:          c.RunID,
-		TaskID:         c.TaskID,
-		TryNumber:      c.TryNumber,
-	}
-	renewed, err = a.mintAgentToken(id, ttl, origin)
+	renewed, err = a.mintAgentToken(identityFromClaims(c), ttl, origin)
 	if err != nil {
 		return "", false, err
 	}
@@ -136,12 +167,29 @@ func (a *JWTAuthenticator) AuthenticateAgent(token string) (*AgentIdentity, erro
 	if err != nil || !parsed.Valid {
 		return nil, errors.Join(ErrInvalidToken, err)
 	}
-	return &AgentIdentity{
-		TaskInstanceID: c.Subject,
-		TenantID:       c.TenantID,
-		DagID:          c.DagID,
-		RunID:          c.RunID,
-		TaskID:         c.TaskID,
-		TryNumber:      c.TryNumber,
-	}, nil
+	id := identityFromClaims(c)
+	return &id, nil
+}
+
+// identityFromClaims reconstructs the AgentIdentity a verified token represents,
+// routing the Subject to WorkerID for a warm-worker credential and to
+// TaskInstanceID for a task credential. It is the single read side shared by
+// AuthenticateAgent and RenewAgentToken so a warm-worker token is never silently
+// downgraded to a task token on re-mint.
+func identityFromClaims(c agentClaims) AgentIdentity {
+	id := AgentIdentity{
+		TenantID:     c.TenantID,
+		DagID:        c.DagID,
+		RunID:        c.RunID,
+		TaskID:       c.TaskID,
+		TryNumber:    c.TryNumber,
+		Scope:        c.Scope,
+		DagVersionID: c.DagVersionID,
+	}
+	if c.Scope == ScopeWarmWorker {
+		id.WorkerID = c.Subject
+	} else {
+		id.TaskInstanceID = c.Subject
+	}
+	return id
 }

--- a/internal/auth/agent_token_test.go
+++ b/internal/auth/agent_token_test.go
@@ -77,3 +77,68 @@ func TestAgentTokenRejectsExpired(t *testing.T) {
 		t.Error("an expired agent token must be rejected")
 	}
 }
+
+// warmWorkerIdentity is the identity ExchangeToken resolves for a warm pod: a
+// worker credential that names its dag_version pool and its worker id, carries
+// its tenant, and has NO task claims (no task instance, run, task, or try).
+func warmWorkerIdentity() AgentIdentity {
+	return AgentIdentity{
+		Scope:        ScopeWarmWorker,
+		DagVersionID: "dagver-9",
+		TenantID:     "acme",
+		WorkerID:     "leoflow-warm-dagver-9-abcd",
+	}
+}
+
+// TestWarmWorkerTokenRoundTrip: a warm-worker identity is minted with the worker
+// id as Subject, a scope=warm-worker claim, and dag_version_id, then verifies back
+// to the SAME identity — Scope, DagVersionID, WorkerID preserved and NO task
+// claims (TaskInstanceID/RunID/TaskID/TryNumber empty).
+func TestWarmWorkerTokenRoundTrip(t *testing.T) {
+	a := NewJWTAuthenticator(nil, "secret", time.Hour)
+	token, err := a.IssueAgentToken(warmWorkerIdentity(), time.Hour)
+	if err != nil {
+		t.Fatalf("IssueAgentToken: %v", err)
+	}
+	got, err := a.AuthenticateAgent(token)
+	if err != nil {
+		t.Fatalf("AuthenticateAgent: %v", err)
+	}
+	want := warmWorkerIdentity()
+	if *got != want {
+		t.Errorf("warm identity = %+v, want %+v", *got, want)
+	}
+	if got.Scope != ScopeWarmWorker {
+		t.Errorf("scope = %q, want %q", got.Scope, ScopeWarmWorker)
+	}
+	// No task claims leaked onto the worker credential.
+	if got.TaskInstanceID != "" || got.RunID != "" || got.TaskID != "" || got.TryNumber != 0 {
+		t.Errorf("warm-worker token must carry no task claims, got %+v", *got)
+	}
+	if got.WorkerID != want.WorkerID {
+		t.Errorf("worker id = %q, want %q (the token Subject)", got.WorkerID, want.WorkerID)
+	}
+}
+
+// TestTaskTokenScopeIsEmpty: a task identity round-trips with Scope=="" exactly as
+// before this field existed — the byte-compatibility guard for existing tokens.
+func TestTaskTokenScopeIsEmpty(t *testing.T) {
+	a := NewJWTAuthenticator(nil, "secret", time.Hour)
+	token, err := a.IssueAgentToken(agentIdentity(), time.Hour)
+	if err != nil {
+		t.Fatalf("IssueAgentToken: %v", err)
+	}
+	got, err := a.AuthenticateAgent(token)
+	if err != nil {
+		t.Fatalf("AuthenticateAgent: %v", err)
+	}
+	if got.Scope != "" {
+		t.Errorf("task token scope = %q, want empty", got.Scope)
+	}
+	if got.WorkerID != "" || got.DagVersionID != "" {
+		t.Errorf("task token must not carry worker/dag-version fields, got %+v", *got)
+	}
+	if got.TaskInstanceID != "ti-1" {
+		t.Errorf("task instance id = %q, want ti-1 (the Subject)", got.TaskInstanceID)
+	}
+}

--- a/internal/executor/warmpod.go
+++ b/internal/executor/warmpod.go
@@ -34,6 +34,23 @@ const (
 	warmAnchorLabelVal = "true"
 )
 
+// Exported warm-worker label contract (ADR 0058 D1/D2). The token-exchange
+// resolver reads these off a reviewed pod to decide whether it is a warm worker
+// (and which pool/tenant it serves), so the SAME label BuildWarmPod stamps is the
+// one the resolver keys on — single-sourced, no drift. They alias the package's
+// stamping constants above.
+const (
+	// WarmWorkerLabel marks a pod as a warm worker; WarmWorkerLabelValue is its
+	// value. A reviewed pod carrying this label is resolved to a warm-worker
+	// (control-channel-only) identity rather than a task instance.
+	WarmWorkerLabel      = warmWorkerLabelKey
+	WarmWorkerLabelValue = warmWorkerLabelVal
+	// WarmDagVersionLabel names the dag_version pool a warm worker serves.
+	WarmDagVersionLabel = warmDagVersionLabelKey
+	// WarmTenantLabel names the tenant that owns a warm worker's dag_version.
+	WarmTenantLabel = warmTenantLabelKey
+)
+
 // WarmPodSpec is everything BuildWarmPod needs to build one long-lived warm-worker
 // pod: which dag_version pool it serves, the image (the DAG's image — a warm
 // worker runs the agent in warm mode and forks a child per attempt), the

--- a/internal/kubeexchange/kubeexchange.go
+++ b/internal/kubeexchange/kubeexchange.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	authv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -124,33 +125,83 @@ func NewPodResolver(client kubernetes.Interface, namespace string) *PodResolver 
 	return &PodResolver{client: client, namespace: namespace}
 }
 
-// ResolveTaskInstance fetches the reviewed pod and reads the identity annotation
-// the executor wrote (the shared executor.AgentIdentityAnnotation contract), so
-// the minted JWT is scoped to the true attempt rather than a lossy label read. A
-// UID mismatch (a name reused by a newer pod) or a missing annotation fails
-// closed.
+// ResolveAgent fetches the reviewed pod once and resolves it to an agent identity,
+// branching on the warm-worker LABEL (ADR 0058 D1): a pod carrying
+// executor.WarmWorkerLabel resolves to a WORKER-scoped identity (its dag_version
+// pool + tenant from labels, its worker id from the pod name, no task claims); any
+// other pod resolves to the task instance the executor stamped on it, exactly as
+// ResolveTaskInstance does. A UID mismatch (a name reused by a newer pod) fails
+// closed for both flavors.
+func (r *PodResolver) ResolveAgent(ctx context.Context, pod agentrpc.ReviewedPod) (auth.AgentIdentity, error) {
+	ns, got, err := r.getReviewedPod(ctx, pod)
+	if err != nil {
+		return auth.AgentIdentity{}, err
+	}
+	if got.Labels[executor.WarmWorkerLabel] == executor.WarmWorkerLabelValue {
+		dagVersion := got.Labels[executor.WarmDagVersionLabel]
+		if dagVersion == "" {
+			return auth.AgentIdentity{}, fmt.Errorf("warm pod %s/%s has no %s label", ns, pod.PodName, executor.WarmDagVersionLabel)
+		}
+		workerID := pod.PodName
+		if workerID == "" {
+			workerID = pod.PodUID
+		}
+		return auth.AgentIdentity{
+			Scope:        auth.ScopeWarmWorker,
+			DagVersionID: dagVersion,
+			TenantID:     got.Labels[executor.WarmTenantLabel],
+			WorkerID:     workerID,
+		}, nil
+	}
+	return taskIdentityFromPod(ns, pod.PodName, got)
+}
+
+// ResolveTaskInstance resolves the reviewed pod to the task instance the executor
+// stamped on it (the shared executor.AgentIdentityAnnotation contract), so the
+// minted JWT is scoped to the true attempt rather than a lossy label read. It is
+// the pure task path — a warm pod has no task instance and is an error here; the
+// exchange takes the warm branch via ResolveAgent instead. A UID mismatch or a
+// missing annotation fails closed.
 func (r *PodResolver) ResolveTaskInstance(ctx context.Context, pod agentrpc.ReviewedPod) (auth.AgentIdentity, error) {
+	ns, got, err := r.getReviewedPod(ctx, pod)
+	if err != nil {
+		return auth.AgentIdentity{}, err
+	}
+	return taskIdentityFromPod(ns, pod.PodName, got)
+}
+
+// getReviewedPod fetches the reviewed pod from its namespace (falling back to the
+// resolver's configured task namespace) and guards against a stale pod whose name
+// was reused by a newer UID.
+func (r *PodResolver) getReviewedPod(ctx context.Context, pod agentrpc.ReviewedPod) (string, *corev1.Pod, error) {
 	ns := pod.Namespace
 	if ns == "" {
 		ns = r.namespace
 	}
 	got, err := r.client.CoreV1().Pods(ns).Get(ctx, pod.PodName, metav1.GetOptions{})
 	if err != nil {
-		return auth.AgentIdentity{}, fmt.Errorf("getting pod %s/%s: %w", ns, pod.PodName, err)
+		return ns, nil, fmt.Errorf("getting pod %s/%s: %w", ns, pod.PodName, err)
 	}
 	if pod.PodUID != "" && string(got.UID) != pod.PodUID {
-		return auth.AgentIdentity{}, fmt.Errorf("pod %s/%s uid mismatch: reviewed %q, current %q (stale pod)", ns, pod.PodName, pod.PodUID, got.UID)
+		return ns, nil, fmt.Errorf("pod %s/%s uid mismatch: reviewed %q, current %q (stale pod)", ns, pod.PodName, pod.PodUID, got.UID)
 	}
+	return ns, got, nil
+}
+
+// taskIdentityFromPod reads the executor-stamped identity annotation off a fetched
+// pod into a task-scoped AgentIdentity, failing closed on a missing/empty
+// annotation or a missing task instance id.
+func taskIdentityFromPod(ns, podName string, got *corev1.Pod) (auth.AgentIdentity, error) {
 	raw, ok := got.Annotations[executor.AgentIdentityAnnotation]
 	if !ok || raw == "" {
-		return auth.AgentIdentity{}, fmt.Errorf("pod %s/%s has no %s annotation", ns, pod.PodName, executor.AgentIdentityAnnotation)
+		return auth.AgentIdentity{}, fmt.Errorf("pod %s/%s has no %s annotation", ns, podName, executor.AgentIdentityAnnotation)
 	}
 	id, err := executor.ParseAgentIdentity(raw)
 	if err != nil {
 		return auth.AgentIdentity{}, err
 	}
 	if id.TaskInstanceID == "" {
-		return auth.AgentIdentity{}, fmt.Errorf("pod %s/%s identity annotation carries no task instance id", ns, pod.PodName)
+		return auth.AgentIdentity{}, fmt.Errorf("pod %s/%s identity annotation carries no task instance id", ns, podName)
 	}
 	return auth.AgentIdentity{
 		TaskInstanceID: id.TaskInstanceID,

--- a/internal/kubeexchange/kubeexchange_test.go
+++ b/internal/kubeexchange/kubeexchange_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/neochaotic/leoflow/internal/agentrpc"
+	"github.com/neochaotic/leoflow/internal/auth"
 	"github.com/neochaotic/leoflow/internal/executor"
 )
 
@@ -104,5 +105,64 @@ func TestPodResolverRejectsMissingAnnotation(t *testing.T) {
 	r := NewPodResolver(cs, "leoflow")
 	if _, err := r.ResolveTaskInstance(context.Background(), agentrpc.ReviewedPod{PodName: "p", PodUID: "u"}); err == nil {
 		t.Error("a pod without the identity annotation must be an error")
+	}
+}
+
+// TestPodResolverResolvesWarmWorkerByLabel: a pod carrying the warm-worker label
+// resolves (via ResolveAgent, DP1) to a WORKER-scoped identity — its dag_version
+// pool + tenant from labels and its worker id from the pod name — with NO task
+// claims, even though it has no identity annotation.
+func TestPodResolverResolvesWarmWorkerByLabel(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "leoflow-warm-dagver-9-abcd",
+		Namespace: "leoflow",
+		UID:       "uid-w",
+		Labels: map[string]string{
+			executor.WarmWorkerLabel:     executor.WarmWorkerLabelValue,
+			executor.WarmDagVersionLabel: "dagver-9",
+			executor.WarmTenantLabel:     "acme",
+		},
+	}}
+	cs := fake.NewClientset(pod)
+	r := NewPodResolver(cs, "leoflow")
+
+	id, err := r.ResolveAgent(context.Background(), agentrpc.ReviewedPod{Namespace: "leoflow", PodName: "leoflow-warm-dagver-9-abcd", PodUID: "uid-w"})
+	if err != nil {
+		t.Fatalf("ResolveAgent (warm): %v", err)
+	}
+	if id.Scope != auth.ScopeWarmWorker {
+		t.Errorf("scope = %q, want %q", id.Scope, auth.ScopeWarmWorker)
+	}
+	if id.DagVersionID != "dagver-9" || id.TenantID != "acme" {
+		t.Errorf("warm identity dag_version/tenant = %q/%q", id.DagVersionID, id.TenantID)
+	}
+	if id.WorkerID != "leoflow-warm-dagver-9-abcd" {
+		t.Errorf("worker id = %q, want the pod name", id.WorkerID)
+	}
+	if id.TaskInstanceID != "" || id.RunID != "" || id.TaskID != "" || id.TryNumber != 0 {
+		t.Errorf("warm identity must carry no task claims, got %+v", id)
+	}
+}
+
+// TestPodResolverResolveAgentTaskPath: a non-warm pod resolves (via ResolveAgent)
+// to its task instance exactly as ResolveTaskInstance does — the DP1 default branch.
+func TestPodResolverResolveAgentTaskPath(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name:      "leoflow-etl-extract-1-abcd",
+		Namespace: "leoflow",
+		UID:       "uid-123",
+		Annotations: map[string]string{
+			executor.AgentIdentityAnnotation: `{"ti":"ti-1","tenant":"acme","dag":"ETL","run":"run-1","task":"Extract","try":2}`,
+		},
+	}}
+	cs := fake.NewClientset(pod)
+	r := NewPodResolver(cs, "leoflow")
+
+	id, err := r.ResolveAgent(context.Background(), agentrpc.ReviewedPod{Namespace: "leoflow", PodName: "leoflow-etl-extract-1-abcd", PodUID: "uid-123"})
+	if err != nil {
+		t.Fatalf("ResolveAgent (task): %v", err)
+	}
+	if id.Scope != "" || id.TaskInstanceID != "ti-1" {
+		t.Errorf("task path identity = %+v, want scope empty + ti-1", id)
 	}
 }


### PR DESCRIPTION
**The last pre-enable warm-pool security item (ADR 0058 D2).** A warm pod's bootstrap credential was a **plaintext task-scoped env var** on the pod spec — a pod-spec reader on a shared cluster could lift it, register a rogue warm worker, receive the per-attempt tokens the control plane pushes, and read secrets / hijack execution. Now the warm pod carries a **projected SA token** the server exchanges for a **worker-scoped JWT** that authorizes only the control channel; the per-attempt task token (in-band, D2) stays the sole secret-bearing credential. Behind `execution.warm_pools_enabled` (off ⇒ unchanged).

## Design (maintainer-ratified)
- **auth:** `AgentIdentity.Scope` (`""`=task / `ScopeWarmWorker`) + `DagVersionID` + `WorkerID`. Warm token: Subject=WorkerID + scope/dag_version, **no task claims**; task token **byte-identical** (omitempty). Shared `identityFromClaims` → no downgrade on re-mint.
- **exchange (DP1, by label):** `ResolveAgent` fetches the pod once, branches on `leoflow.io/warm-worker=true` → warm identity, else task. Warm-label contract single-sourced from executor.
- **authz (DP2, airtight):** `requireAttemptToken` → `PermissionDenied` for a warm token on **GetVariables, GetConnections, GetTaskSpec, ReportState, Heartbeat, FetchXCom, PushXCom, StreamLogs**; `requireWarmWorkerToken` → task token denied on `AwaitAssignment`; `Register` accepts both. A leaked/forged worker token **cannot read the vault**.
- **agent:** `runWarm` exchanges the projected token → worker JWT before Register (re-reads the rotated token on redial); registry key is now the authenticated `WorkerID` (closes the N1b1 placeholder). `warmPodSpecFunc` → `transport=exchange` (no plaintext on the spec); the env-var fallback now mints a **worker-scoped** bootstrap (was task-scoped — a latent hole).

## Tests (RED-first, security-critical)
warm/task round-trip (task byte-compatible); ExchangeToken warm-vs-task by label; **a warm token is PermissionDenied on EACH secret/task RPC** (RED: without the gate GetVariables hits the vault, tenant leaked) and accepted on Register+AwaitAssignment; task token unchanged + denied on AwaitAssignment; runWarm exchanges before Register. `go vet ./...` **and** `-tags integration` clean · build + `-tags integration` green · `go test -race` clean · `golangci-lint` 0 · no proto change.

**With this, the warm-pool autonomous track is complete.** Remaining is operator/cluster-gated: the RC-in-staging real-cluster e2e (the 9-scenario enable-readiness checklist), the D2 enforce flips, and #659 user docs (tied to the GA release).