### PR TITLE
docs(install): cloud-first Pro install — OCI chart + auto-TLS, honest prereqs

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -268,9 +268,11 @@ into.
 
 Deploying the control plane itself (Helm chart, published `leoflow-server`/
 `leoflow-migrate` images, TLS on the agent channel, keyless cloud auth) is the
-**Pro** track. One command installs the chart from its OCI artifact
-(`helm install leoflow oci://ghcr.io/neochaotic/charts/leoflow --version <VERSION>`,
-auto-generated TLS, no cert-manager) — see [Install Pro](installation.md#install-pro).
+**Pro** track. One command installs the chart with auto-generated TLS and no
+cert-manager — from source on `main` today
+(`helm install lf ./helm/leoflow …`), and from its OCI artifact
+(`helm install leoflow oci://ghcr.io/neochaotic/charts/leoflow --version <VERSION>`)
+from the first release cut after this change. See [Install Pro](installation.md#install-pro).
 The chart is installable today and in validation — see the
 [Helm chart](https://github.com/neochaotic/leoflow/blob/main/helm/leoflow/README.md), the reproducible
 [Kubernetes test setup](https://github.com/neochaotic/leoflow/blob/main/deploy/k8s/README.md)

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -268,9 +268,14 @@ into.
 
 Deploying the control plane itself (Helm chart, published `leoflow-server`/
 `leoflow-migrate` images, TLS on the agent channel, keyless cloud auth) is the
-**Pro** track. The chart is installable today and in validation against GKE —
-see the [Helm chart](https://github.com/neochaotic/leoflow/blob/main/helm/leoflow/README.md), the reproducible
-[GKE test setup](https://github.com/neochaotic/leoflow/blob/main/deploy/k8s/README.md), [Operating modes](operating-modes.md),
+**Pro** track. One command installs the chart from its OCI artifact
+(`helm install leoflow oci://ghcr.io/neochaotic/charts/leoflow --version <VERSION>`,
+auto-generated TLS, no cert-manager) — see [Install Pro](installation.md#install-pro).
+The chart is installable today and in validation — see the
+[Helm chart](https://github.com/neochaotic/leoflow/blob/main/helm/leoflow/README.md), the reproducible
+[Kubernetes test setup](https://github.com/neochaotic/leoflow/blob/main/deploy/k8s/README.md)
+(the `deploy/k8s` recipe is cloud-portable — it runs unchanged on EKS / GKE / AKS),
+[Operating modes](operating-modes.md),
 and the [Roadmap](roadmap-to-release.md). The product proves itself in **Lite** first.
 
 See also: [DAG authoring](dag-authoring.md) · [Operating modes](operating-modes.md).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -202,44 +202,51 @@ chart. Task pods are scheduled into the cluster by the same control plane —
 no host-side process supervisor, no managed Python sidecar. DAGs ship as
 **container images** built in CI ([CI/CD & deploy examples](deploy.md)).
 
-### What you need
+The chart is **cloud-portable** — the same commands install unchanged on
+**EKS, GKE, AKS**, or any conformant Kubernetes cluster.
 
-| Requirement | Why |
-|---|---|
-| A **Kubernetes cluster** (1.27+ recommended) | runs the control plane and task pods |
-| `kubectl` configured against that cluster | applies the chart and lets the chart's pre-install Job run migrations |
-| **Helm 3.12+** | installs the chart |
-| An **external Postgres** (PostgreSQL **13+**) | Pro datastore — the chart refuses to install without `database.url` (the embedded datastore is Lite-only) |
-| An **external Redis** (Redis **6.0+**) | XCom + advisory locks — the chart refuses to install without `redis.url` |
+### Quickstart (one command, any cloud)
 
-Managed services are first-class — RDS / Cloud SQL / Azure Database for
-Postgres on the SQL side; ElastiCache / Memorystore / Azure Cache for Redis.
-See the chart's [Datastore compatibility](helm-chart.md#datastore-compatibility)
-table for tested versions; managed providers that present a per-instance or
-provider-specific CA expose a `caConfigMap` knob (Postgres and Redis sides
-respectively) for verified TLS.
+Since **v0.3.0** the chart is published as an **OCI artifact** next to the
+images, and it **auto-generates its own agent-TLS certificate** by default. So
+there is **no cert-manager to install and no TLS Secret to pre-create** — TLS
+on the agent gRPC channel stays **mandatory**, the chart just mints a stable
+self-signed CA + server cert for you and reuses it across upgrades. Point the
+chart at your external Postgres and Redis and go:
 
-!!! note "No managed datastore yet? There's a PoC path."
-    For a one-cluster evaluation (kind, minikube, k3d, scratch namespace), the
-    chart deliberately won't fall back to embedded datastores — that's Lite's
-    job. The supported PoC path is to install plain Postgres + Redis
-    manifests alongside the chart, then point Leoflow at the in-cluster
-    Services. Recipe: [`helm/leoflow/examples/README.md`](https://github.com/neochaotic/leoflow/tree/main/helm/leoflow/examples/README.md).
-    **Not for production.**
+```bash
+helm install leoflow oci://ghcr.io/neochaotic/charts/leoflow --version 0.3.0 \
+  -n leoflow --create-namespace \
+  --set database.url='postgres://USER:PASS@HOST:5432/leoflow?sslmode=verify-full' \
+  --set redis.url='rediss://HOST:6380/0' \
+  --set auth.jwtSecret="$(openssl rand -base64 64)" \
+  --set secretKey="$(openssl rand -hex 32)" \
+  --set bootstrap.password='change-me'
+```
 
-### Install with Helm
+That's the whole install — **no cert-manager, no pre-created Secret**. The only
+values you must supply are your two datastore URLs and the three credentials.
+`--version` takes the chart version (the release tag with the leading `v`
+stripped, per SemVer2 — chart `0.3.0` for release `v0.3.0`); use the
+[latest release](https://github.com/neochaotic/leoflow/releases).
 
-The chart is published per release (and built from `helm/leoflow` in the
-repo). One simple path is to install directly from the cloned repo at a
-checked-out tag (replace `v0.3.0` with the [latest release](https://github.com/neochaotic/leoflow/releases)):
+!!! note "OCI chart availability"
+    The OCI chart is published from the **v0.3.0** release onward (older tags
+    predate it). For the bleeding edge — current `main`, or a fresh commit a
+    tag hasn't republished the chart for yet — [install from
+    source](#install-from-source) instead.
+
+### Install from source
+
+Installing the chart straight from a checkout is the **works-today** path for
+the bleeding edge — current `main`, or any commit before a tag republishes the
+OCI chart. Same required values, from the `helm/leoflow` directory in the repo:
 
 ```bash
 git clone --depth 1 --branch v0.3.0 https://github.com/neochaotic/leoflow
 cd leoflow
 
-kubectl create namespace leoflow
-
-helm install lf ./helm/leoflow -n leoflow \
+helm install lf ./helm/leoflow -n leoflow --create-namespace \
   --set image.tag=v0.3.0 \
   --set migrations.image.tag=v0.3.0 \
   --set database.url='postgres://USER:PASS@HOST:5432/leoflow?sslmode=verify-full' \
@@ -248,6 +255,11 @@ helm install lf ./helm/leoflow -n leoflow \
   --set secretKey="$(openssl rand -hex 32)" \
   --set bootstrap.password='change-me'
 ```
+
+Replace `v0.3.0` with the [latest release](https://github.com/neochaotic/leoflow/releases),
+or drop `--branch` to track `main`. From a source checkout the image tags are
+not baked in, so `--set image.tag` / `--set migrations.image.tag` pin which
+images the chart pulls.
 
 What this installs (one Deployment, one Service, RBAC for the pod-per-task
 executor, a pre-install/upgrade migrations Job; optional Ingress, PDB, HPA,
@@ -267,6 +279,47 @@ with a controller of your choice — see the chart's
 [ingress values](helm-chart.md) for the field shape. Log in as the bootstrap
 admin (`admin@leoflow.local` / the password you set above) and rotate it.
 
+### Prerequisites
+
+Two external datastores and one cluster capability — that's all a default
+install needs. **cert-manager is NOT required** (the chart auto-generates
+agent TLS, above).
+
+| Requirement | Why |
+|---|---|
+| A **Kubernetes cluster** (1.27+ recommended) | runs the control plane and task pods |
+| `kubectl` + **Helm 3.8+** | apply the chart; Helm 3.8+ is required to `helm install` an OCI chart |
+| An **external Postgres** (PostgreSQL **13+**) | Pro datastore — the chart refuses to install without `database.url` (the embedded datastore is Lite-only) |
+| An **external Redis** (Redis **6.0+**) | XCom + advisory locks — the chart refuses to install without `redis.url` |
+| A **default StorageClass** | the control-plane logs PVC (`logs.persistence.enabled: true`, on by default) binds to it |
+
+Managed services are first-class — RDS / Cloud SQL / Azure Database for
+Postgres on the SQL side; ElastiCache / Memorystore / Azure Cache for Redis.
+See the chart's [Datastore compatibility](helm-chart.md#datastore-compatibility)
+table for tested versions; managed providers that present a per-instance or
+provider-specific CA expose a `caConfigMap` knob (Postgres and Redis sides
+respectively) for verified TLS.
+
+!!! warning "A fresh cluster with no default StorageClass (e.g. EKS Auto Mode)"
+    The logs PVC binds to the cluster's **default StorageClass**. On a truly
+    fresh cluster that has **none** — notably **EKS Auto Mode**, which ships
+    without a default — the PVC hangs `Pending` and the control-plane pod never
+    starts. Two fixes:
+
+    - **Name a StorageClass:** `--set logs.persistence.storageClass=gp2` on EKS
+      (use e.g. `standard-rwo` on GKE, `managed-csi` on AKS), or mark one
+      StorageClass as the cluster default.
+    - **Ephemeral trial:** `--set logs.persistence.enabled=false` uses an
+      `emptyDir` instead — **logs are lost on every pod restart**; dev only.
+
+!!! note "No managed datastore yet? There's a PoC path."
+    For a one-cluster evaluation (kind, minikube, k3d, scratch namespace), the
+    chart deliberately won't fall back to embedded datastores — that's Lite's
+    job. The supported PoC path is to install plain Postgres + Redis
+    manifests alongside the chart, then point Leoflow at the in-cluster
+    Services. Recipe: [`helm/leoflow/examples/README.md`](https://github.com/neochaotic/leoflow/tree/main/helm/leoflow/examples/README.md).
+    **Not for production.**
+
 ### Bring-your-own Secrets
 
 Inline `--set` values bake credentials into the chart-managed Secret.
@@ -285,6 +338,43 @@ When **every** credential comes from an existing Secret, the chart creates
 no Secret of its own. The `checksum/secret` annotation on the pod template
 only sees the chart-managed Secret, so rotation of an
 `existingSecret` requires a manual `kubectl rollout restart deploy/lf-leoflow`.
+
+### Production hardening
+
+The quickstart is production-*shaped* but not production-*hardened*. For a real
+deploy, layer on:
+
+- **cert-manager / BYO TLS.** The default auto-generated cert is a stable
+  self-signed CA — fine for the in-cluster agent channel, but many orgs want
+  cert-manager-issued or externally-rooted certs with automatic rotation. Set
+  `agentTLS.serverCertSecret` + `agentTLS.caConfigMap` and the chart uses them
+  verbatim (skipping auto-gen). Full recipe: [Pro TLS with cert-manager](pro-tls.md).
+- **External Postgres / Redis** on managed services (see [Prerequisites](#prerequisites)),
+  with **verified** TLS via the `database.caConfigMap` / `redis.caConfigMap` knobs.
+- **StorageClass sizing.** The logs PVC defaults to `50Gi` (~1 GB/day per
+  ~1000 active task runs). For multi-replica HA use a **ReadWriteMany**
+  StorageClass (`--set logs.persistence.accessMode=ReadWriteMany` with NFS /
+  Longhorn-rwx / CephFS / EFS / Azure Files / GCP Filestore) or ship logs to an
+  object store (`logs.sink`); a `ReadWriteOnce` PVC pins you to a single
+  replica.
+- **NetworkPolicy.** Set `networkPolicy.enabled=true` to restrict the control
+  plane and task pods to only the flows they need.
+
+!!! info "The agent channel is server TLS, not mutual mTLS"
+    The agent↔control-plane gRPC channel is **one-way (server) TLS**: the agent
+    verifies the control-plane's **server** certificate, but the agent does
+    **not** present a client certificate. The agent's *identity* is a **bearer
+    JWT**, not an mTLS client cert. So "provision the cert" only ever concerns
+    the server side — there are no per-agent client certs to mint or rotate.
+
+!!! warning "GitOps (ArgoCD / Flux): don't rely on auto-gen"
+    Auto-generation uses Helm's `lookup` to find and reuse the existing cert
+    Secret across upgrades. Cluster-less rendering — ArgoCD/Flux diffing or
+    templating **without** live cluster access — can't `lookup`, so it either
+    regenerates the CA on every sync (breaking every already-running agent's
+    trust) or renders an empty cert. Under GitOps, use **BYO / cert-manager**
+    (`agentTLS.serverCertSecret` + `agentTLS.caConfigMap`) rather than auto-gen.
+    See [Pro TLS](pro-tls.md).
 
 ### Upgrades
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -207,15 +207,15 @@ The chart is **cloud-portable** — the same commands install unchanged on
 
 ### Quickstart (one command, any cloud)
 
-Since **v0.3.0** the chart is published as an **OCI artifact** next to the
-images, and it **auto-generates its own agent-TLS certificate** by default. So
-there is **no cert-manager to install and no TLS Secret to pre-create** — TLS
-on the agent gRPC channel stays **mandatory**, the chart just mints a stable
-self-signed CA + server cert for you and reuses it across upgrades. Point the
-chart at your external Postgres and Redis and go:
+The chart is published as an **OCI artifact** next to the images, and it
+**auto-generates its own agent-TLS certificate** by default. So there is **no
+cert-manager to install and no TLS Secret to pre-create** — TLS on the agent
+gRPC channel stays **mandatory**, the chart just mints a stable self-signed CA
++ server cert for you and reuses it across upgrades. Point the chart at your
+external Postgres and Redis and go:
 
 ```bash
-helm install leoflow oci://ghcr.io/neochaotic/charts/leoflow --version 0.3.0 \
+helm install leoflow oci://ghcr.io/neochaotic/charts/leoflow --version <VERSION> \
   -n leoflow --create-namespace \
   --set database.url='postgres://USER:PASS@HOST:5432/leoflow?sslmode=verify-full' \
   --set redis.url='rediss://HOST:6380/0' \
@@ -226,24 +226,26 @@ helm install leoflow oci://ghcr.io/neochaotic/charts/leoflow --version 0.3.0 \
 
 That's the whole install — **no cert-manager, no pre-created Secret**. The only
 values you must supply are your two datastore URLs and the three credentials.
-`--version` takes the chart version (the release tag with the leading `v`
-stripped, per SemVer2 — chart `0.3.0` for release `v0.3.0`); use the
-[latest release](https://github.com/neochaotic/leoflow/releases).
+`--version` takes the chart version — the
+[latest release](https://github.com/neochaotic/leoflow/releases) tag with the
+leading `v` stripped (per SemVer2).
 
 !!! note "OCI chart availability"
-    The OCI chart is published from the **v0.3.0** release onward (older tags
-    predate it). For the bleeding edge — current `main`, or a fresh commit a
-    tag hasn't republished the chart for yet — [install from
-    source](#install-from-source) instead.
+    The OCI chart and the auto-generated agent TLS ship in the **first release
+    cut after this change**; until that release is published, [install from
+    source](#install-from-source) (below) to use them on `main` today. Source
+    is also the path for the bleeding edge in general.
 
 ### Install from source
 
-Installing the chart straight from a checkout is the **works-today** path for
-the bleeding edge — current `main`, or any commit before a tag republishes the
-OCI chart. Same required values, from the `helm/leoflow` directory in the repo:
+Installing the chart straight from a checkout of **`main`** is the
+**works-today** path for the OCI-chart and auto-generated-TLS features: both
+are live on `main` now, ahead of the release that first publishes the OCI
+chart. It is also the path for the bleeding edge in general. Same required
+values, from the `helm/leoflow` directory in the repo:
 
 ```bash
-git clone --depth 1 --branch v0.3.0 https://github.com/neochaotic/leoflow
+git clone --depth 1 https://github.com/neochaotic/leoflow   # current main
 cd leoflow
 
 helm install lf ./helm/leoflow -n leoflow --create-namespace \
@@ -256,10 +258,13 @@ helm install lf ./helm/leoflow -n leoflow --create-namespace \
   --set bootstrap.password='change-me'
 ```
 
-Replace `v0.3.0` with the [latest release](https://github.com/neochaotic/leoflow/releases),
-or drop `--branch` to track `main`. From a source checkout the image tags are
-not baked in, so `--set image.tag` / `--set migrations.image.tag` pin which
-images the chart pulls.
+The chart auto-generates the agent TLS cert regardless of image version, so
+this works on `main` today. Pin `--set image.tag` / `--set migrations.image.tag`
+to a published release tag (`v0.3.0` shown — see the
+[releases](https://github.com/neochaotic/leoflow/releases)); from a source
+checkout the image tags are not baked in, so set them explicitly. Add
+`--branch <TAG>` to the clone to install the chart at a specific tag instead of
+`main`.
 
 What this installs (one Deployment, one Service, RBAC for the pod-per-task
 executor, a pre-install/upgrade migrations Job; optional Ingress, PDB, HPA,

--- a/docs/pro-tls.md
+++ b/docs/pro-tls.md
@@ -5,10 +5,12 @@ gRPC. In Pro that channel **must be TLS** — the server refuses to boot without
 (#281).
 
 !!! note "You don't need this for a default install"
-    Since v0.3.0 the chart **auto-generates** a stable self-signed CA + server
-    cert by default (`agentTLS.autoGenerate: true`, reused across upgrades) — so
+    The chart **auto-generates** a stable self-signed CA + server cert by
+    default (`agentTLS.autoGenerate: true`, reused across upgrades) — so
     `helm install` needs **no cert-manager and no pre-created Secret**, and TLS
-    is still on. See the [Quickstart](installation.md#quickstart-one-command-any-cloud).
+    is still on. That default is live on `main` today and ships in the first
+    release cut after it; see the
+    [Quickstart](installation.md#quickstart-one-command-any-cloud).
     This page is the **opt-in production path**: cert-manager-issued (or
     externally-rooted) certs with automatic rotation. It is also the path you
     **must** use under **GitOps** (ArgoCD/Flux), where cluster-less rendering
@@ -96,7 +98,7 @@ standard way, or copy the issuer's `ca.crt` into a ConfigMap keyed `ca.crt`. Set
 ## 5. Install
 
 ```console
-$ helm install leoflow oci://ghcr.io/neochaotic/charts/leoflow --version 0.3.0 \
+$ helm install leoflow oci://ghcr.io/neochaotic/charts/leoflow --version <VERSION> \
     -n leoflow --create-namespace \
     -f values-pro-tls.yaml
 ```

--- a/docs/pro-tls.md
+++ b/docs/pro-tls.md
@@ -2,9 +2,21 @@
 
 The Pro control plane delivers secrets (Connections, Variables) to task pods over
 gRPC. In Pro that channel **must be TLS** — the server refuses to boot without it
-(#281), and the chart refuses to install when `agentTLS.enabled` but the cert
-Secret or CA ConfigMap is missing (#280). The clean way to provision the cert is
-[cert-manager](https://cert-manager.io).
+(#281).
+
+!!! note "You don't need this for a default install"
+    Since v0.3.0 the chart **auto-generates** a stable self-signed CA + server
+    cert by default (`agentTLS.autoGenerate: true`, reused across upgrades) — so
+    `helm install` needs **no cert-manager and no pre-created Secret**, and TLS
+    is still on. See the [Quickstart](installation.md#quickstart-one-command-any-cloud).
+    This page is the **opt-in production path**: cert-manager-issued (or
+    externally-rooted) certs with automatic rotation. It is also the path you
+    **must** use under **GitOps** (ArgoCD/Flux), where cluster-less rendering
+    can't `lookup` the existing Secret and auto-gen is unsafe.
+
+Setting `agentTLS.serverCertSecret` **and** `agentTLS.caConfigMap` makes the
+chart use them verbatim and skip auto-generation. The clean way to provision
+that cert is [cert-manager](https://cert-manager.io).
 
 An operator-ready values file is at
 [`helm/leoflow/examples/values-pro-tls.yaml`](https://github.com/neochaotic/leoflow/blob/main/helm/leoflow/examples/values-pro-tls.yaml)
@@ -84,9 +96,14 @@ standard way, or copy the issuer's `ca.crt` into a ConfigMap keyed `ca.crt`. Set
 ## 5. Install
 
 ```console
-$ helm install leoflow leoflow/leoflow -n leoflow \
+$ helm install leoflow oci://ghcr.io/neochaotic/charts/leoflow --version 0.3.0 \
+    -n leoflow --create-namespace \
     -f values-pro-tls.yaml
 ```
+
+(Use the chart version for the [latest release](https://github.com/neochaotic/leoflow/releases) —
+the tag with the leading `v` stripped. From a source checkout, swap the OCI
+reference for `./helm/leoflow`.)
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What & why

Rewrites the Pro install documentation to be **cloud-first and honest**, building on the two chart changes already on `main`:

- **#691** — the chart is published as an OCI artifact at `oci://ghcr.io/neochaotic/charts/leoflow` (the old `helm repo add … github.io/leoflow` path never worked); `deploy/gke` → `deploy/k8s`.
- **#692** — the chart auto-generates a stable self-signed agent-TLS cert by default (`agentTLS.autoGenerate`), so a default install needs no cert-manager and no pre-created Secret while keeping TLS mandatory.

Closes the docs side of **#690** points 1–4; part of the **#659** user-documentation release gate.

## Changes

`docs/installation.md` — Pro section restructured into:
1. **Quickstart (one command, any cloud)** — OCI install + auto-TLS, `--version 0.3.0` (latest release `v0.3.0`, `v` stripped per SemVer2). Explicit: no cert-manager, no Secret to pre-create. The command still passes `database.url`/`redis.url` + credentials because the chart hard-`fail`s without an external Postgres/Redis (embedded is Lite-only) — that is the honest shape of "one command".
2. **Install from source** — the works-today `./helm/leoflow` path for `main`/pre-release.
3. **Prerequisites (honest)** — cert-manager NOT required; the one real cluster capability is a **default StorageClass** for the logs PVC. Warns that **EKS Auto Mode has no default StorageClass** (PVC hangs `Pending`) → `--set logs.persistence.storageClass=gp2` or `--set logs.persistence.enabled=false` (ephemeral, logs lost on restart).
4. **Production hardening** — cert-manager/BYO TLS (→ `pro-tls.md`), external Postgres/Redis, StorageClass/RWX sizing, NetworkPolicy. Clarifies the agent channel is **server TLS, not mutual mTLS** (agent identity is a bearer JWT). GitOps note: ArgoCD/Flux can't `lookup` the auto-gen Secret → use BYO/cert-manager.

`docs/pro-tls.md` — reframed as the opt-in production TLS path (auto-gen is now the default); fixed the broken `helm install leoflow leoflow/leoflow` repo reference → OCI command.

`docs/deploy.md` — OCI install pointer; `deploy/k8s` labelled cloud-portable (EKS/GKE/AKS), replacing GKE-only framing.

`docs/helm-chart.md` is intentionally untouched — it is CI-generated (`cp helm/leoflow/README.md docs/helm-chart.md`) from the helm-docs output.

## Verification

- `git grep -n "helm repo add" docs/` → only `jetstack` (cert-manager, intentional).
- `git grep -n "github.io/leoflow\|neochaotic.github.io" docs/` → 0.
- `git grep -n "deploy/gke" docs/` → 0.
- `git grep -n "leoflow/leoflow -n" docs/` → 0.
- OCI command + StorageClass/EKS note present in `installation.md`.
- `mkdocs build --strict` not run locally: mkdocs/plugins aren't installed and a faithful build needs the CI-generated `docs/helm-chart.md`, CLI/Go references, and the mkdocstrings Python env. Proven via grep instead (above); anchors linked across pages resolve to real headings (`#install-pro`, `#quickstart-one-command-any-cloud`, `#prerequisites`).
