### PR TITLE
fix(chart): point agent-TLS SAN comment at deploy/k8s, not stale deploy/gke

### DIFF
--- a/helm/leoflow/templates/agent-tls-autogen.yaml
+++ b/helm/leoflow/templates/agent-tls-autogen.yaml
@@ -28,7 +28,7 @@ auto-gen — see the agentTLS note in values.yaml.
 SANs cover every name the agent can dial the control-plane gRPC service by. The
 default ("all") Service is the bare fullname; under split (ADR 0049) the gRPC
 endpoint moves to the "<fullname>-scheduler" Service, so cover both. Mirrors the
-proven set in deploy/gke/02-install-leoflow.sh. Go's TLS verifier ignores the CN,
+proven set in deploy/k8s/02-install-leoflow.sh. Go's TLS verifier ignores the CN,
 so the fullname MUST appear here as a SAN, not only as the Subject CN.
 */ -}}
 {{- $dnsNames := list


### PR DESCRIPTION
## Summary
- `main` has been red since #692 merged: the agent-TLS auto-gen template's SAN comment still says `deploy/gke/02-install-leoflow.sh`, which #691 renamed to `deploy/k8s` in the same wave — the two PRs raced and #692's base predated the guard.
- One-line fix: update the comment to `deploy/k8s/02-install-leoflow.sh`. No behavior change — it's a doc comment, the SAN list itself is untouched.

## Test plan
- [x] `scripts/check-no-stale-deploy-path.sh` → `OK: no stale 'deploy/gke' references`
- [x] `helm lint helm/leoflow` → 0 charts failed
- [x] `scripts/helm-template-checks.sh` → all contracts met