### PR TITLE
fix(server): fail closed when exchange transport has no k8s client (#700)

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -405,7 +405,16 @@ func startSchedulerSide(ctx context.Context, cfg *config.ServerConfig, pg *stora
 		})
 		logger.Warn("warm worker pools enabled (ADR 0058 N1b1-place); admitted tasks place on a free warm worker of their dag_version, else dispatch dedicated")
 	}
-	grpcSrv, agentSrv, gerr := startAgentGRPC(ctx, cfg.Server.GRPCAddr, authn, execStore, repo, xcomSvc, logSink, logTailer, allowInsecureSecrets, cfg.Auth.SecretScoping, cfg.Auth.SecretLivenessMode, cfg.Auth.MaxAttemptCredentialLifetime, buildTokenExchange(cfg, logger), cfg.Server.GRPCTLSCert, cfg.Server.GRPCTLSKey, warmReg, logger)
+	// Fail closed (#700): when the operator selected the exchange transport, the
+	// Kubernetes client is a hard prerequisite. buildTokenExchange returns an
+	// error here rather than leaving the exchange unwired, so the server refuses
+	// to boot instead of advertising itself healthy while every task pod's
+	// ExchangeToken bootstrap fails Unimplemented.
+	xchg, xerr := buildTokenExchange(cfg, buildK8sClient)
+	if xerr != nil {
+		return nil, false, nil, xerr
+	}
+	grpcSrv, agentSrv, gerr := startAgentGRPC(ctx, cfg.Server.GRPCAddr, authn, execStore, repo, xcomSvc, logSink, logTailer, allowInsecureSecrets, cfg.Auth.SecretScoping, cfg.Auth.SecretLivenessMode, cfg.Auth.MaxAttemptCredentialLifetime, xchg, cfg.Server.GRPCTLSCert, cfg.Server.GRPCTLSKey, warmReg, logger)
 	if gerr != nil {
 		return nil, false, nil, gerr
 	}
@@ -685,24 +694,31 @@ type tokenExchange struct {
 }
 
 // buildTokenExchange constructs the exchange dependencies when the operator
-// selected the exchange transport on a Kubernetes executor; it returns nil
-// otherwise (env-var default, or the subprocess executor, which has no pod/SA/
-// TokenReview). A Kubernetes client that cannot be built leaves the exchange
-// unwired with a warning — matching pod dispatch's warn-and-disable posture —
-// rather than failing boot, since the transport flip is a deliberate opt-in.
-func buildTokenExchange(cfg *config.ServerConfig, logger *slog.Logger) *tokenExchange {
+// selected the exchange transport on a Kubernetes executor; it returns (nil,
+// nil) otherwise (env-var default, or the subprocess executor, which has no
+// pod/SA/TokenReview and needs no client). newK8sClient is the seam that
+// supplies the Kubernetes client (buildK8sClient in production); it is consulted
+// only when the exchange transport is actually selected.
+//
+// When the exchange transport IS selected on a Kubernetes executor and no client
+// can be built, this FAILS CLOSED and returns an error so the server refuses to
+// boot. An unwired exchange makes ExchangeToken report Unimplemented, so every
+// task pod fails at bootstrap while the control plane reports itself healthy —
+// a fail-open on a security-critical transport the operator explicitly opted
+// into. The transport flip is a deliberate opt-in, which is an argument for
+// honoring it strictly, not for silently ignoring it.
+func buildTokenExchange(cfg *config.ServerConfig, newK8sClient func() (kubernetes.Interface, error)) (*tokenExchange, error) {
 	if cfg.Auth.AgentTokenTransport != config.AgentTokenTransportExchange || cfg.Executor.Type != "kubernetes" {
-		return nil
+		return nil, nil //nolint:nilnil // env-var transport or non-Kubernetes executor needs no exchange; a nil exchange is the correct wiring, not an error
 	}
-	cs, err := buildK8sClient()
+	cs, err := newK8sClient()
 	if err != nil {
-		logger.Warn("agent token exchange selected but no Kubernetes client is available; exchange disabled (agents on the exchange transport will fail to start)", "error", err)
-		return nil
+		return nil, fmt.Errorf("agent token transport %q requires a Kubernetes client, but none is available (no in-cluster config or kubeconfig): %w", config.AgentTokenTransportExchange, err)
 	}
 	return &tokenExchange{
 		reviewer: kubeexchange.NewTokenReviewer(cs, executor.DefaultAgentTokenAudience),
 		resolver: kubeexchange.NewPodResolver(cs, cfg.Executor.TaskNamespace),
-	}
+	}, nil
 }
 
 // buildPodExecutor constructs a Kubernetes executor from the in-cluster config

--- a/cmd/leoflow-server/token_exchange_wiring_test.go
+++ b/cmd/leoflow-server/token_exchange_wiring_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/config"
+	"k8s.io/client-go/kubernetes"
+)
+
+// failingK8sClient stands in for buildK8sClient when neither in-cluster config
+// nor a kubeconfig is available (the #700 reproduction: exchange selected, no
+// client reachable).
+func failingK8sClient() (kubernetes.Interface, error) {
+	return nil, errors.New("no in-cluster config or kubeconfig")
+}
+
+// TestBuildTokenExchange_FailsClosedWhenClientUnavailable locks the #700 fix:
+// with the exchange transport explicitly selected on a Kubernetes executor, a
+// Kubernetes client that cannot be built must FAIL BOOT — not warn-and-continue
+// with the exchange unwired, which turns every task pod's bootstrap into an
+// Unimplemented ExchangeToken while /readyz stays green.
+func TestBuildTokenExchange_FailsClosedWhenClientUnavailable(t *testing.T) {
+	cfg := &config.ServerConfig{}
+	cfg.Auth.AgentTokenTransport = config.AgentTokenTransportExchange
+	cfg.Executor.Type = "kubernetes"
+
+	xchg, err := buildTokenExchange(cfg, failingK8sClient)
+	if err == nil {
+		t.Fatal("buildTokenExchange returned nil error when the exchange transport is selected but no Kubernetes client is available; must fail closed (#700)")
+	}
+	if xchg != nil {
+		t.Errorf("buildTokenExchange returned a non-nil exchange (%v) alongside the error; a failed build must wire nothing", xchg)
+	}
+}
+
+// TestBuildTokenExchange_EnvVarTransportNeedsNoClient locks the preserved
+// early-return: the default env-var transport needs no Kubernetes client, so a
+// failing builder must never be consulted and boot must proceed with a nil
+// exchange and no error.
+func TestBuildTokenExchange_EnvVarTransportNeedsNoClient(t *testing.T) {
+	cfg := &config.ServerConfig{}
+	cfg.Auth.AgentTokenTransport = config.AgentTokenTransportEnvVar
+	cfg.Executor.Type = "kubernetes"
+
+	xchg, err := buildTokenExchange(cfg, failingK8sClient)
+	if err != nil {
+		t.Fatalf("buildTokenExchange returned error %v for the env-var transport; that transport needs no Kubernetes client", err)
+	}
+	if xchg != nil {
+		t.Errorf("buildTokenExchange wired an exchange (%v) for the env-var transport; want nil", xchg)
+	}
+}
+
+// TestBuildTokenExchange_NonKubernetesExecutorNeedsNoClient locks the other
+// half of the early-return: even with the exchange transport selected, a
+// non-Kubernetes executor (e.g. subprocess) has no pod/SA/TokenReview, so no
+// client is needed and boot proceeds with a nil exchange and no error.
+func TestBuildTokenExchange_NonKubernetesExecutorNeedsNoClient(t *testing.T) {
+	cfg := &config.ServerConfig{}
+	cfg.Auth.AgentTokenTransport = config.AgentTokenTransportExchange
+	cfg.Executor.Type = "subprocess"
+
+	xchg, err := buildTokenExchange(cfg, failingK8sClient)
+	if err != nil {
+		t.Fatalf("buildTokenExchange returned error %v for a non-Kubernetes executor; no client is needed there", err)
+	}
+	if xchg != nil {
+		t.Errorf("buildTokenExchange wired an exchange (%v) for a non-Kubernetes executor; want nil", xchg)
+	}
+}


### PR DESCRIPTION
Fixes #700.

## Problem

`buildTokenExchange` (`cmd/leoflow-server/main.go`) logged a warning and returned an unwired exchange when `buildK8sClient()` failed — even when the operator had explicitly selected `auth.agent_token_transport=exchange` on a Kubernetes executor. An unwired exchange makes `ExchangeToken` report `Unimplemented`, so **every** task pod fails at bootstrap while the control plane reports itself healthy (`/readyz` green, no restarts, no failing probe). That is a fail-**open** on a security-critical transport the operator deliberately opted into.

This is inconsistent with the adjacent posture: `validateExecution` already fails closed at boot for the ADR 0058 D2 coupling. The codebase already treats "the exchange transport must actually work" as a boot-time invariant in one place, then silently tolerated the exchange being non-functional here.

## Fix

Fail **closed**. `buildTokenExchange` now returns `(*tokenExchange, error)`:

- `transport=exchange` + `executor=kubernetes` + no Kubernetes client → returns an error naming the missing prerequisite; the scheduler-side wiring propagates it so `main` exits non-zero and the server refuses to boot. No more warn-and-continue.
- The correct early-return is preserved unchanged: the env-var transport, and any non-Kubernetes executor (no pod/SA/TokenReview), still return a nil exchange and **no** error.

The Kubernetes client builder is injected as a `func() (kubernetes.Interface, error)` seam (production passes `buildK8sClient`), which is the minimal idiomatic hook that makes both the fail-closed and needs-no-client paths unit-testable.

## Tests (strict TDD, RED → green)

Added `cmd/leoflow-server/token_exchange_wiring_test.go`:

- `TestBuildTokenExchange_FailsClosedWhenClientUnavailable` — exchange + kubernetes + failing builder ⇒ error, nil exchange (the #700 lock).
- `TestBuildTokenExchange_EnvVarTransportNeedsNoClient` — env-var transport ⇒ no error, nil exchange, builder never consulted.
- `TestBuildTokenExchange_NonKubernetesExecutorNeedsNoClient` — exchange + subprocess executor ⇒ no error, nil exchange.

RED first: the new signature `(cfg, newK8sClient) (*tokenExchange, error)` failed to compile against the old one-return form; after the implementation all three pass.

## Gates

- `go vet ./...` and `go vet -tags integration ./...` — clean
- `go build ./...` and `-tags integration` — clean
- `go test ./cmd/leoflow-server/...` — `ok`
- `golangci-lint run ./cmd/leoflow-server/...` — `0 issues`

## Follow-up flag (not in scope)

There is an analogous warn-and-disable in `setupK8sDispatch` (`cmd/leoflow-server/main.go`, ~L1387): when `buildK8sClient()` fails, pod dispatch is disabled and tasks fail as undispatchable rather than refusing boot. Per the issue's own analysis these degrade **differently** — pod dispatch degrades to "nothing runs," visibly `queued` and metered by `leoflow_tasks_undispatchable_total`, whereas the exchange degraded to "everything fails" invisibly. So this PR deliberately does **not** change `setupK8sDispatch`; flagging it here for a separate decision on whether that posture should also tighten (or at least fail the readiness probe) when a Kubernetes executor is explicitly configured.