### PR TITLE
fix(cli): stop nil context panicking the dev version probe (#699)

### DIFF
--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -608,7 +608,7 @@ func runDev(cmd *cobra.Command, dir string, o devOptions) error {
 	if herr != nil {
 		return herr
 	}
-	serverBin, berr := resolveAndReport(cmd.Context(), cmd, o.serverBin, "leoflow-server")
+	serverBin, berr := resolveAndReport(cmdContext(cmd), cmd, o.serverBin, "leoflow-server")
 	if berr != nil {
 		return berr
 	}
@@ -1276,7 +1276,17 @@ func reportCompanionBinary(ctx context.Context, cmd *cobra.Command, kind, path s
 
 // companionVersion asks a binary for its version, returning "" when it cannot
 // be determined. Bounded so a wedged binary cannot hang startup.
+//
+// The version check is best-effort and must never take the CLI down with it: a
+// nil parent context — which context.WithTimeout would panic on ("cannot create
+// context from nil parent") — is treated as no context rather than a fatal
+// error.
+//
+//nolint:contextcheck // the nil-ctx fallback below has no parent to inherit; a fresh root is the only safe choice, and the CLI must not panic over a best-effort version probe.
 func companionVersion(ctx context.Context, path string) string {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, path, "version").Output() //nolint:gosec // path resolved by resolveBinary, not user input

--- a/internal/cli/dev_test.go
+++ b/internal/cli/dev_test.go
@@ -207,17 +207,22 @@ func TestDevPrintHelpers(t *testing.T) {
 
 func TestRunDevValidatesProject(t *testing.T) {
 	cmd := devTestCmd()
-	// Missing leoflow.yaml.
-	if err := runDev(cmd, t.TempDir(), devOptions{}); err == nil {
-		t.Error("expected error for a project without leoflow.yaml")
-	}
-	// Present but invalid (missing dag_id).
+	// A discoverable project (it has a dag.py) whose leoflow.yaml is invalid: an
+	// unknown alert type the schema rejects. runDev validates every project up
+	// front — prepareWorkspace is its first step — so it must refuse before it
+	// touches any infrastructure. This stays at the validation gate on purpose:
+	// letting runDev proceed would start Postgres and a companion server and hang
+	// the test, exactly the host-dependent boot that hid behind the #699 panic.
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "leoflow.yaml"), []byte("description: x\n"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "dag.py"), []byte("# dag\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	invalid := "dag_id: sales\nalerts:\n  on_failure:\n    - type: carrier-pigeon\n      conn: x\n"
+	if err := os.WriteFile(filepath.Join(dir, "leoflow.yaml"), []byte(invalid), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if err := runDev(cmd, dir, devOptions{}); err == nil {
-		t.Error("expected validation error for missing dag_id")
+		t.Error("expected runDev to refuse a project with an invalid leoflow.yaml")
 	}
 }
 
@@ -677,6 +682,20 @@ func TestResolveBinaryIgnoresDirectories(t *testing.T) {
 	}
 	if _, err := resolveBinary("", name); err == nil {
 		t.Error("a directory with the binary's name must not resolve as the binary")
+	}
+}
+
+// TestCompanionVersionNilContextDoesNotPanic locks the #699 regression: the
+// best-effort companion version check must never panic the CLI. A nil parent
+// reaching context.WithTimeout aborts ("cannot create context from nil parent")
+// and takes the whole internal/cli test binary down with it, hiding every other
+// test in the package. companionVersion is documented best-effort, so an
+// unresolvable binary simply yields "" — never a panic.
+func TestCompanionVersionNilContextDoesNotPanic(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "leoflow-server")
+	//nolint:staticcheck // SA1012: passing a nil context is exactly the guarded case under test.
+	if got := companionVersion(nil, missing); got != "" {
+		t.Errorf("companionVersion with a nil context: got %q, want \"\"", got)
 	}
 }
 


### PR DESCRIPTION
Fixes #699.

## Problem
`go test ./internal/cli/...` aborted the entire package test binary on macOS:

```
panic: cannot create context from nil parent
context.WithTimeout({0x0, 0x0}, 0xb2d05e00)
  ...companionVersion(...)  internal/cli/dev.go:1280
  ...reportCompanionBinary(...) internal/cli/dev.go:1259
  ...resolveAndReport(...) internal/cli/dev.go:1240
  ...runDev(...) internal/cli/dev.go:611
  ...TestRunDevValidatesProject(...) internal/cli/dev_test.go:211
```

A panic aborts the whole binary, so *every* test in `internal/cli` was lost, masking unrelated regressions.

## Root cause
`runDev` passed a raw `cmd.Context()` (line 611) into `resolveAndReport` → `reportCompanionBinary` → `companionVersion`. `cmd.Context()` is `nil` when the command was never `Execute()`d (as in a direct-invocation test), and `context.WithTimeout(nil, …)` panics. Every other context access in the package — including the very next one in the same function (line 585) — already routes through the nil-guarding `cmdContext(cmd)` helper; line 611 was the lone deviation.

The CI/local divergence: the panic is only reached when `resolveBinary` actually *finds* a companion binary to version-check. Linux CI has none on `PATH` and returns early; a macOS dev box with `leoflow-server`/`leoflow-agent` installed proceeds and panics.

## Fix (production, at the right layer)
- `runDev` now derives the companion-resolution context via `cmdContext(cmd)`, matching the package convention, so the reported path no longer originates a nil context.
- `companionVersion` guards a nil parent by falling back to `context.Background()`. The probe is best-effort by contract (its own doc comment) and must never panic the CLI — a defensive backstop at the boundary. `//nolint:contextcheck` documents why a fresh root is correct on the nil path.

## Tests
- **`TestCompanionVersionNilContextDoesNotPanic`** — deterministic regression lock. Panics before the fix (RED), passes after. Host-independent: an unresolvable path yields `""`, no companion binary required.
- **`TestRunDevValidatesProject`** — was stale. An empty or yaml-only temp dir is no longer an invalid project (empty dirs get scaffolded; a `leoflow.yaml` with no `dag.py`/dbt block is not discovered as a project), so both original cases fell through to a full, host-dependent `runDev` boot — starting Postgres + a companion server and hanging to the test timeout — that the panic had been masking. Rewritten to assert the real validation gate (`prepareWorkspace`, runDev's first step) with a discoverable-but-invalid project (has `dag.py`, invalid alert type), which `runDev` refuses before touching any infrastructure. Runs in ~0.01s, fully hermetic.

## Verification
- `go vet ./...` — clean
- `go build ./...` — clean
- `go test ./internal/cli/...` — `ok` (~36s), the exact command from the issue, no panic, no hang
- `golangci-lint run ./internal/cli/...` — `0 issues`