### PR TITLE
ci(docs): version published docs by release tag with mike

### DIFF
--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -1,0 +1,96 @@
+name: Docs release
+
+# Publish a versioned docs snapshot for a release tag, using mike (same site,
+# same gh-pages branch as the main "Docs" workflow — see docs.yml).
+#
+# This is a SEPARATE workflow from docs.yml because docs.yml uses a `paths:`
+# filter, and `paths:` filters silently drop tag pushes — a tag would never
+# match doc file paths, so the release build would never run. Tags get their
+# own filter-free trigger here.
+#
+# Version naming: the leading `v` is STRIPPED from the tag, so tag v1.2.3
+# publishes as docs version "1.2.3" (and v1.2.3-rc.1 as "1.2.3-rc.1"). This is
+# applied consistently for both stable and RC releases.
+#
+# Alias scheme:
+#   - stable  vX.Y.Z        -> mike deploy --update-aliases <ver> latest
+#     (moves the `latest` alias to this release)
+#   - RC / pre-release      -> mike deploy <ver>
+#     (published and selectable, but `latest` is NOT moved to a pre-release)
+# The site default is owned by docs.yml (dev pre-GA); this workflow never
+# touches set-default.
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+# Shared with docs.yml so a tag release and a main deploy serialize against
+# each other on the gh-pages branch instead of racing into a rejected push.
+concurrency:
+  group: docs-gh-pages
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write   # mike pushes the built site to gh-pages.
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with: { go-version: stable }
+      # --- Same doc-generation steps as docs.yml (mike builds the SAME site) ---
+      - run: go run ./cmd/leoflow gen-docs --dir docs/cli
+      - run: |
+          go run github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest --output 'docs/go/{{.Dir}}.md' \
+            --repository.url https://github.com/neochaotic/leoflow --repository.default-branch main \
+            ./internal/domain ./internal/scheduler ./internal/executor ./internal/dispatch \
+            ./internal/agent ./internal/agentrpc ./internal/storage ./internal/auth \
+            ./internal/config ./internal/cli ./internal/api ./pkg/client
+      # Static redirect stub for the old go/reference.html path (see docs.yml).
+      - run: |
+          cat > docs/go/reference.html <<'HTML'
+          <!doctype html><html lang="en"><head><meta charset="utf-8">
+          <title>Redirecting…</title>
+          <meta http-equiv="refresh" content="0; url=../go-api.html">
+          <link rel="canonical" href="../go-api.html">
+          </head><body>The Go reference moved. Redirecting to
+          <a href="../go-api.html">Go packages</a>…</body></html>
+          HTML
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with: { python-version: "3.12" }
+      - run: sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update && sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
+      - run: pip install "mkdocs-material[imaging]" "mkdocstrings[python]" mike
+      - run: pip install -e ./runtime/python
+      - run: cp docs/api/openapi.yaml docs/openapi.yaml
+      - run: cp helm/leoflow/README.md docs/helm-chart.md
+      - run: scripts/gen-adr-index.sh --check
+      # Validate before publishing (mike's own build is not strict).
+      - run: mkdocs build --strict
+
+      # --- Publish the tagged version ---
+      - name: Configure git identity for mike
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Publish release docs with mike
+        env:
+          TAG: ${{ github.ref_name }}   # e.g. v1.2.3 or v1.2.3-rc.1
+        run: |
+          ver="${TAG#v}"                # strip leading v -> 1.2.3 / 1.2.3-rc.1
+          case "$ver" in
+            *-*)
+              # Any semver pre-release suffix (e.g. -rc.1) publishes the version
+              # without moving the `latest` alias.
+              echo "Pre-release '$ver' — publishing without moving 'latest'."
+              mike deploy --push "$ver"
+              ;;
+            *)
+              # Stable release: publish and move `latest` to it.
+              echo "Stable '$ver' — publishing and updating 'latest' alias."
+              mike deploy --push --update-aliases "$ver" latest
+              ;;
+          esac

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,22 @@
 name: Docs
 
-# Build the MkDocs site and publish it to GitHub Pages.
-# Enable once: Settings → Pages → Build and deployment → Source: GitHub Actions.
+# Build the MkDocs site and publish it with mike, which commits the built site
+# into the `gh-pages` branch (one directory per version). GitHub Pages then
+# serves that branch.
 #
-# Build runs on PRs too (#155) so an ADR added without regenerating
-# docs/adrs.md, or a broken mkdocs link, fails the PR before merge instead
-# of breaking the published site post-merge. The deploy job only runs on
-# pushes to main — PR runs build + check, never publish.
+# One-time setup (repo owner, AFTER the first push-to-main run creates gh-pages):
+#   Settings → Pages → Build and deployment → Source: "Deploy from a branch"
+#   → Branch: gh-pages → /(root).
+#
+# Push to main publishes the `dev` version (the moving tip of the docs) and,
+# pre-GA, keeps `dev` as the site default. Tagged releases are handled by
+# docs-release.yaml (a `paths:` filter here would drop tag builds, so releases
+# live in their own workflow).
+#
+# The build runs on PRs too (#155): an ADR added without regenerating
+# docs/adrs.md, or a broken mkdocs link, fails the PR before merge instead of
+# breaking the published site. PR runs build + validate only — never mike,
+# never a deploy (the mike/publish steps are gated to `push`).
 on:
   push:
     branches: [main]
@@ -16,20 +26,28 @@ on:
     paths: ["docs/**", "mkdocs.yml", ".github/workflows/docs.yml", "internal/cli/**", "parser/**", "runtime/python/**", "helm/leoflow/README.md", "helm/leoflow/values.yaml", "helm/leoflow/README.md.gotmpl"]
   workflow_dispatch:
 
-# Least-privilege default: read-only at the top level. Only the deploy job
-# (push-to-main) needs to write to Pages; the build job (which runs on PRs too)
-# stays read-only so a PR cannot accidentally publish.
+# Least-privilege default: read-only at the top level.
 permissions:
   contents: read
 
+# Serialize every writer of the gh-pages branch so concurrent deploys never
+# race into a non-fast-forward push. The group name is shared with
+# docs-release.yaml so a main deploy and a tag release also serialize against
+# each other. cancel-in-progress is false: each version publish must finish
+# rather than be killed mid-push, which could leave gh-pages half-written.
 concurrency:
-  group: pages
-  cancel-in-progress: true
+  group: docs-gh-pages
+  cancel-in-progress: false
 
 jobs:
-  build:
+  docs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # mike pushes the built site to gh-pages, so the job can write contents.
+    # The publish steps below are gated to `push`, so PR runs never deploy;
+    # fork-PR tokens are downgraded to read-only by GitHub regardless.
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -45,11 +63,25 @@ jobs:
             ./internal/domain ./internal/scheduler ./internal/executor ./internal/dispatch \
             ./internal/agent ./internal/agentrpc ./internal/storage ./internal/auth \
             ./internal/config ./internal/cli ./internal/api ./pkg/client
+      # The Go reference used to be one page at go/reference.html; it is now split
+      # per package. Write a static redirect stub (into the git-ignored, generated
+      # docs/go/ dir) BEFORE the build so mkdocs copies it into every published
+      # version — including the ones mike builds — instead of a post-build patch
+      # of site/ that mike's own build would drop.
+      - run: |
+          cat > docs/go/reference.html <<'HTML'
+          <!doctype html><html lang="en"><head><meta charset="utf-8">
+          <title>Redirecting…</title>
+          <meta http-equiv="refresh" content="0; url=../go-api.html">
+          <link rel="canonical" href="../go-api.html">
+          </head><body>The Go reference moved. Redirecting to
+          <a href="../go-api.html">Go packages</a>…</body></html>
+          HTML
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with: { python-version: "3.12" }
       # Imaging libs for the Material social-cards plugin.
       - run: sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update && sudo apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev
-      - run: pip install "mkdocs-material[imaging]" "mkdocstrings[python]"
+      - run: pip install "mkdocs-material[imaging]" "mkdocstrings[python]" mike
       # Python docstrings (the task runtime) for the Python API page.
       - run: pip install -e ./runtime/python
       # Scalar reads the spec from the site root.
@@ -62,34 +94,34 @@ jobs:
       - run: cp helm/leoflow/README.md docs/helm-chart.md
       # The ADR index (docs/adrs.md) is generated from the ADR files; fail if stale.
       - run: scripts/gen-adr-index.sh --check
+      # Validation gate — runs on every event (PR included). --strict turns
+      # broken links / stale nav into failures. mike's own build is not strict,
+      # so this is where doc breakage is caught before it can publish.
       - run: mkdocs build --strict   # CI=true enables the social plugin
-      # The Go reference used to be one page at go/reference.html; it is now split
-      # per package. Write a static redirect stub so old links don't 404 (no plugin
-      # dependency needed).
-      - run: |
-          cat > site/go/reference.html <<'HTML'
-          <!doctype html><html lang="en"><head><meta charset="utf-8">
-          <title>Redirecting…</title>
-          <meta http-equiv="refresh" content="0; url=../go-api.html">
-          <link rel="canonical" href="../go-api.html">
-          </head><body>The Go reference moved. Redirecting to
-          <a href="../go-api.html">Go packages</a>…</body></html>
-          HTML
-      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
-        with: { path: site }
-  deploy:
-    needs: build
-    # Only publish on a real push to main, never on a PR run (#155). PR runs
-    # exist to gate the build; the published site is updated by main.
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    permissions:
-      pages: write      # Publish the built site to GitHub Pages.
-      id-token: write   # OIDC token for the Pages deployment.
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
-    steps:
-      - id: deploy
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+
+      # ---- Publish (push to main only; skipped on PRs and workflow_dispatch) ----
+      - name: Configure git identity for mike
+        if: github.event_name == 'push'
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      # Publish the moving tip of the docs as the `dev` version. mike rebuilds
+      # the site and commits it into gh-pages; that commit IS the publish.
+      - name: Publish dev docs with mike
+        if: github.event_name == 'push'
+        run: mike deploy --push --update-aliases dev
+      # Pre-GA there is no stable release, so `dev` is the site default (what a
+      # bare / URL redirects to). Guarded: mike stores the default as a root
+      # index.html redirect on gh-pages, so only (re)set it when it isn't
+      # already `dev`. This is a no-op on every run after the first.
+      # NOTE: at GA this default should flip to `latest` (see docs-release.yaml).
+      - name: Ensure dev is the default version
+        if: github.event_name == 'push'
+        run: |
+          current="$(git show gh-pages:index.html 2>/dev/null | sed -n 's/.*url=\([^"/]*\).*/\1/p' | head -n1 || true)"
+          if [ "$current" != "dev" ]; then
+            echo "Default is '${current:-<unset>}'; setting it to 'dev'."
+            mike set-default --push dev
+          else
+            echo "Default is already 'dev'; nothing to do."
+          fi

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,14 @@ exclude_docs: |
   agent-templates/
   reference/airflow-real/
 
+# Version selector (rendered by mkdocs-material) backed by mike. mike publishes
+# each version into the gh-pages branch; the selector switches between them.
+# See .github/workflows/docs.yml (dev, on push to main) and docs-release.yaml
+# (tagged releases: latest for stable, unaliased for RCs).
+extra:
+  version:
+    provider: mike
+
 extra_css:
   - assets/extra.css
 


### PR DESCRIPTION
## What

Switches docs publishing from **artifact-based GitHub Pages** to the **canonical mkdocs-material + [mike](https://github.com/jimporter/mike) setup**: mike commits the built site into the `gh-pages` branch (one directory per version), and GitHub Pages serves that branch. This gives the docs a version selector driven by release tags.

## ⚠️ One-time repo-owner action required (AFTER merge)

This PR does **not** and **cannot** change repo settings. After this merges and the first push-to-`main` run creates the `gh-pages` branch, the repo owner must do this once:

> **Settings → Pages → Build and deployment → Source: "Deploy from a branch" → Branch: `gh-pages` → Folder: `/ (root)` → Save.**

Until that flip, the site keeps serving the old artifact deployment (or 404s if the old source is removed). The first `main` run after merge is what creates `gh-pages`.

## Changes

- **`mkdocs.yml`** — add `extra.version.provider: mike` (renders the version selector). Nav untouched.
- **`.github/workflows/docs.yml`** — keep the entire doc-generation pipeline (CLI docs, gomarkdoc, openapi/helm copies, ADR-index check, runtime install) and the `mkdocs build --strict` gate. The strict build still runs on **PRs** (and `workflow_dispatch`) as a build-only gate — **no mike, no deploy** there. On **push to `main`** it then runs `mike deploy --push --update-aliases dev` and a guarded `mike set-default --push dev`. The `upload-pages-artifact`/`deploy-pages` jobs are removed. The `go/reference.html` redirect stub moved from a post-build patch of `site/` to a **pre-build source file** so mike's own build includes it.
- **`.github/workflows/docs-release.yaml`** — *new*. Triggers on tags `v*` (a `paths:` filter would silently drop tag builds, so releases get their own filter-free workflow). Runs the same doc-gen + strict build, then publishes the tag.

## RC-vs-stable + dev-default logic

- **Version naming:** the leading `v` is **stripped** — tag `v1.2.3` → docs version `1.2.3`; `v1.2.3-rc.1` → `1.2.3-rc.1`. Applied consistently to both paths.
- **Stable `vX.Y.Z`:** `mike deploy --push --update-aliases <ver> latest` (moves the `latest` alias to the release).
- **Pre-release (any semver `-suffix`, e.g. `-rc.1`):** `mike deploy --push <ver>` — published and selectable, but **`latest` is not moved**.
- **Default:** pre-GA there is no stable, so the site default is **`dev`** (set on `main` by a guarded `mike set-default` — mike stores the default as a root `index.html` redirect, and the step only re-sets it when it isn't already `dev`, so re-runs are no-ops). **At GA this default should flip to `latest`.**
- **Alias scheme summary:** `dev` = tip of `main`; `latest` = last stable release; RCs are published but never aliased; default = `dev` (→ `latest` at GA).

## Concurrency / safety

Both workflows share the concurrency group `docs-gh-pages` (`cancel-in-progress: false`) so a `main` deploy and a tag release serialize on `gh-pages` instead of racing into a non-fast-forward push. Top-level permissions stay `contents: read`; only the publishing jobs elevate to `contents: write` (mike pushes to `gh-pages`), and the publish steps are gated to push events so PR runs never deploy (fork-PR tokens are read-only regardless).

## Verification (all commands terminate — no servers)

- `actionlint` on both workflows: clean (exit 0).
- `mkdocs build --strict`: passes (exit 0), reproducing CI-generated inputs (gen-docs, gomarkdoc, openapi/helm copies, ADR check). Social-cards plugin is CI-only (`!ENV [CI, false]`) so it's disabled in the local run.
- `mike --version` → `mike 2.2.0`.
- Local throwaway `mike deploy` (no `--push`, throwaway branch) exercising `dev`, stable `1.2.3 latest`, and RC `1.3.0-rc.1` → `mike list` shows `dev`, `1.3.0-rc.1`, `1.2.3 [latest]`; root redirect `url=dev/`; throwaway branch deleted. Origin `gh-pages` untouched.
- Built HTML contains the version-selector signal `"version": {"provider": "mike"}` in `__config`.