### PR TITLE
docs: de-stale alpha-era language and version pins (#659)

### DIFF
--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -3,9 +3,9 @@
 Lite ships two commands that snapshot and re-load the whole install in one
 portable file: `leoflow lite backup` and `leoflow lite restore`. Use them to
 migrate to another machine, survive an OS reinstall, or roll back a botched
-pre-alpha upgrade.
+upgrade.
 
-!!! warning "Pre-alpha"
+!!! note "Archive format"
     The archive format is documented as `manifest_version: 1`. We will not
     silently break it, but we may add fields. A future binary will refuse an
     older archive only if `manifest_version` changes — a pure-version mismatch
@@ -44,7 +44,7 @@ user committed locally but did not push.
 leoflow lite backup
 
 # Custom output path:
-leoflow lite backup --output ~/snapshots/before-alpha-upgrade.tar.gz
+leoflow lite backup --output ~/snapshots/before-upgrade.tar.gz
 ```
 
 `backup` requires Lite to be running (it talks to the managed Postgres via
@@ -55,10 +55,10 @@ terminal first.
 
 ```sh
 # Refuses to overwrite an existing ~/.leoflow install:
-leoflow lite restore --input ~/snapshots/before-alpha-upgrade.tar.gz
+leoflow lite restore --input ~/snapshots/before-upgrade.tar.gz
 
 # Use --force to overwrite explicitly (e.g. after `leoflow uninstall`):
-leoflow lite restore --input ~/snapshots/before-alpha-upgrade.tar.gz --force
+leoflow lite restore --input ~/snapshots/before-upgrade.tar.gz --force
 ```
 
 The restore command refuses, with a clear error, when:
@@ -88,7 +88,7 @@ leoflow lite restore --input ~/snap.tar.gz
 leoflow lite            # boots with the restored datastore + workspace
 ```
 
-## Worked example: roll back a botched pre-alpha upgrade
+## Worked example: roll back a botched upgrade
 
 ```sh
 # Before upgrading: take a snapshot.

--- a/docs/dag-authoring.md
+++ b/docs/dag-authoring.md
@@ -211,19 +211,22 @@ The unsupported set, with the things Airflow users most often expect to
 - **Branching** (`BranchPythonOperator`, `@task.branch`) and
   **short-circuit** (`@task.short_circuit`, `ShortCircuitOperator`) —
   refused for now: the current scheduler does not model
-  skipped-vs-executed downstream paths. On the post-alpha backlog if
+  skipped-vs-executed downstream paths. On the backlog if
   user demand justifies the scheduler change.
 - **Virtualenv operators** (`PythonVirtualenvOperator`,
   `@task.virtualenv`) — refused because each DAG already ships as its
   own image with its own dependencies; spinning up a venv at runtime
   is the problem Leoflow's one-image-per-DAG model already solved.
-- **Dynamic task mapping** (`.expand` / `.partial`) — refused;
-  map-reduce fan-out is on the post-alpha roadmap, tracked separately.
+- **Dynamic task mapping** (`.expand` / `.partial`) — refused. Static
+  fan-**in** (collecting a list of task calls into a downstream task) works
+  today; what does **not** work is *dynamic* fan-**out** — expanding one task
+  into N parallel instances at runtime from an upstream result. That is
+  tracked separately.
 - **KubernetesPodOperator** — refused; the pod is the *runtime
   substrate* for every Leoflow task already, so wrapping a user task
   in another pod is redundant and adds an isolation hole.
 - **Datasets / Assets triggers** — not implemented yet; the asset
-  graph is a 3.x Airflow feature on the post-alpha backlog.
+  graph is a 3.x Airflow feature on the backlog.
 - **Per-task `default_args` in `dag.py`** are ignored at the parser
   level — use `leoflow.yaml`'s `tasks.<id>:` override block instead,
   which is checked at compile time.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -136,7 +136,7 @@ runner's Python has no idea where the parser lives).
 The snippets below all show `leoflow setup` as the step after the install,
 before `leoflow compile`. The follow-up to make this implicit (auto-bootstrap
 on first compile, or embed the parser execution inside the Go binary) is
-tracked separately; for the alpha cut, calling it explicitly is the
+tracked separately; for now, calling it explicitly is the
 recommended path because it's the operation that decides whether managed
 CPython is downloaded, and that's a step CI operators should consciously opt
 into.
@@ -269,10 +269,10 @@ into.
 Deploying the control plane itself (Helm chart, published `leoflow-server`/
 `leoflow-migrate` images, TLS on the agent channel, keyless cloud auth) is the
 **Pro** track. One command installs the chart with auto-generated TLS and no
-cert-manager — from source on `main` today
-(`helm install lf ./helm/leoflow …`), and from its OCI artifact
-(`helm install leoflow oci://ghcr.io/neochaotic/charts/leoflow --version <VERSION>`)
-from the first release cut after this change. See [Install Pro](installation.md#install-pro).
+cert-manager — from its published OCI artifact
+(`helm install leoflow oci://ghcr.io/neochaotic/charts/leoflow --version <VERSION>`),
+or from source on `main` for the bleeding edge
+(`helm install lf ./helm/leoflow …`). See [Install Pro](installation.md#install-pro).
 The chart is installable today and in validation — see the
 [Helm chart](https://github.com/neochaotic/leoflow/blob/main/helm/leoflow/README.md), the reproducible
 [Kubernetes test setup](https://github.com/neochaotic/leoflow/blob/main/deploy/k8s/README.md)

--- a/docs/first-pro-dag.md
+++ b/docs/first-pro-dag.md
@@ -23,8 +23,8 @@ flowchart LR
       today with `leoflow deploy`. Everything here runs as-is.
     - **[The complete path](#the-complete-path-your-own-dag-yaml-driven)** — author
       your own DAG with **no Dockerfile** (the build is synthesized from
-      `leoflow.yaml`) and real `connectors:`. That richer flow lands with the
-      connectors release; it is shown at the end so you can see where this is going.
+      `leoflow.yaml`) and real `connectors:`. That richer flow is still landing;
+      it is shown at the end so you can see where this is going.
 
 ## Prerequisites
 
@@ -159,10 +159,10 @@ leoflow deploy --skip-build # promote an already-built image without rebuilding
 
 ## The complete path — your own DAG, yaml-driven
 
-!!! warning "Lands with the connectors release (v0.1.0)"
+!!! warning "Not yet the default path"
     The flow below is the **complete, Dockerfile-free** authoring experience. The
-    yaml-driven build (synthesizing the image from `leoflow.yaml`) ships with the
-    connectors release. On the current release, keep the `Dockerfile` from Step 1.
+    yaml-driven build (synthesizing the image from `leoflow.yaml`) is still
+    landing. On the current release, keep the `Dockerfile` from Step 1.
     This section shows where the happy path is going.
 
 When the yaml-driven build lands, the project is **two files** — no Dockerfile, no

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -156,7 +156,7 @@ $ leoflow-mcp --version      # MCP server (see the MCP guide)
 
 | Variable | Effect |
 |---|---|
-| `LEOFLOW_VERSION=v0.3.0` | install a specific release (default: newest, including pre-releases). See [Releases](https://github.com/neochaotic/leoflow/releases) for the current tag. |
+| `LEOFLOW_VERSION=v0.4.0-rc.2` | install a specific release (default: newest, including pre-releases). See [Releases](https://github.com/neochaotic/leoflow/releases) for the current tag. |
 | `LEOFLOW_NO_SETUP=1` | install binaries only; run `leoflow setup` yourself later |
 | `LEOFLOW_INSTALL_DIR=~/.leoflow/bin` | where to put the binaries |
 
@@ -230,27 +230,28 @@ values you must supply are your two datastore URLs and the three credentials.
 [latest release](https://github.com/neochaotic/leoflow/releases) tag with the
 leading `v` stripped (per SemVer2).
 
-!!! note "OCI chart availability"
-    The OCI chart and the auto-generated agent TLS ship in the **first release
-    cut after this change**; until that release is published, [install from
-    source](#install-from-source) (below) to use them on `main` today. Source
-    is also the path for the bleeding edge in general.
+!!! note "OCI chart is the primary path"
+    The OCI chart above is **published** and is the recommended way to install
+    Pro — it carries the auto-generated agent TLS by default. [Installing from
+    source](#install-from-source) (below) is the alternative, for the bleeding
+    edge on `main` ahead of the next release.
 
 ### Install from source
 
 Installing the chart straight from a checkout of **`main`** is the
-**works-today** path for the OCI-chart and auto-generated-TLS features: both
-are live on `main` now, ahead of the release that first publishes the OCI
-chart. It is also the path for the bleeding edge in general. Same required
-values, from the `helm/leoflow` directory in the repo:
+**bleeding-edge** alternative to the published OCI chart — use it to pick up
+changes that have merged to `main` but not yet been cut into a release. The
+OCI-chart and auto-generated-TLS features are live in released charts too, so
+this is only needed when you want `main`. Same required values, from the
+`helm/leoflow` directory in the repo:
 
 ```bash
 git clone --depth 1 https://github.com/neochaotic/leoflow   # current main
 cd leoflow
 
 helm install lf ./helm/leoflow -n leoflow --create-namespace \
-  --set image.tag=v0.3.0 \
-  --set migrations.image.tag=v0.3.0 \
+  --set image.tag=v0.4.0-rc.2 \
+  --set migrations.image.tag=v0.4.0-rc.2 \
   --set database.url='postgres://USER:PASS@HOST:5432/leoflow?sslmode=verify-full' \
   --set redis.url='rediss://HOST:6380/0' \
   --set auth.jwtSecret="$(openssl rand -base64 64)" \
@@ -260,7 +261,7 @@ helm install lf ./helm/leoflow -n leoflow --create-namespace \
 
 The chart auto-generates the agent TLS cert regardless of image version, so
 this works on `main` today. Pin `--set image.tag` / `--set migrations.image.tag`
-to a published release tag (`v0.3.0` shown — see the
+to a published release tag (`v0.4.0-rc.2` shown — see the
 [releases](https://github.com/neochaotic/leoflow/releases)); from a source
 checkout the image tags are not baked in, so set them explicitly. Add
 `--branch <TAG>` to the clone to install the chart at a specific tag instead of
@@ -395,7 +396,7 @@ plus `leoflow` and `leoflow-agent` binaries) are published by
 
 ```bash
 # Verify the server image at a release tag.
-cosign verify ghcr.io/neochaotic/leoflow-server:v0.3.0 \
+cosign verify ghcr.io/neochaotic/leoflow-server:v0.4.0-rc.2 \
   --certificate-identity-regexp 'https://github.com/neochaotic/leoflow' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com
 ```

--- a/docs/roadmap-to-release.md
+++ b/docs/roadmap-to-release.md
@@ -1,5 +1,14 @@
 # Roadmap to first release
 
+!!! info "Historical — the first release shipped"
+    This page captured the plan **before v0.1**. The `v0.x` line has since
+    shipped (v0.1 through v0.4 and beyond) and ADR 0037 removed the
+    Alpha/Beta phase framing. It is kept for context; the Alpha/Beta/GA
+    phases and the "must-do before release" list below are **superseded**.
+    For what actually shipped and what is current, see the
+    [GitHub Releases](https://github.com/neochaotic/leoflow/releases) and the
+    [ADRs](adrs.md).
+
 **Goal:** a stable MVP — a clean Airflow-3.2-compatible orchestrator that runs a
 real DAG end to end, with no fancy features — before v0.1.
 
@@ -42,7 +51,8 @@ Run real workloads on a real cluster, deployed via CI.
 - OpenSSF best-practices badge; supply-chain (ADR 0014) green.
 - **Exit:** production-ready, documented, supported.
 
-> Today we are in **Alpha** — no production testing until it earns its way to Beta.
+> *(Historical note: at the time of writing this was the Alpha phase. The
+> phase framing was later removed by ADR 0037 and the `v0.x` line shipped.)*
 
 ## ✅ Done (this cycle) — the MVP happy path works
 
@@ -59,7 +69,11 @@ log levels · #45 Admin Variables+Connections (ADR 0019) · #46 undispatchable
 visibility · #47 executor status / Cluster Activity=Home · #49 Code=Python · #50
 no eternal-running · #51 TaskFlow value passing · #52 graceful logs.
 
-## 🔴 Pre-release must-do (small, stability)
+## 🔴 Pre-release must-do (small, stability) — historical, superseded
+
+*The items below were the pre-v0.1 stability checklist. They have since been
+resolved or superseded as the `v0.x` line shipped; see the release notes for
+the current state.*
 
 1. **Test DB isolation** — integration tests run against the *demo* Postgres,
    polluting the live demo (ghost dags → wrong home stats). Point

--- a/docs/upgrades.md
+++ b/docs/upgrades.md
@@ -1,12 +1,12 @@
 # Upgrading Leoflow
 
-This page is the canonical answer to "I'm on pre-alpha .N and want to install
-.N+1 (or the next alpha) — what happens to my state?"
+This page is the canonical answer to "I'm on `v0.x.y` and want to install a
+newer tag — what happens to my state?"
 
-!!! warning "Pre-alpha"
-    Leoflow is **pre-alpha**. The upgrade contract below is honored by the Lite
-    edition; we test it on every release. We will not knowingly ship a release
-    that breaks it without a clear migration note. We have not yet promised
+!!! note "Upgrade contract"
+    The upgrade contract below is honored by the Lite edition; we test it on
+    every release. We will not knowingly ship a release that breaks it without a
+    clear migration note. On the `v0.x` line we do not yet promise
     forward/backward compatibility across major versions — that is a v1
     concern.
 
@@ -62,7 +62,7 @@ datastore and workspace so a future reinstall picks up where you left off
 
 ## How to test an upgrade safely (recommended)
 
-Before installing a new pre-alpha tag on a Lite install you depend on:
+Before installing a newer tag on a Lite install you depend on:
 
 1. **Back up first.** See [Backup and restore](backup-restore.md):
    ```sh
@@ -72,12 +72,31 @@ Before installing a new pre-alpha tag on a Lite install you depend on:
    downgrade case.
 3. If anything looks off, restore from the tarball.
 
-## Pro — upgrade path (in development)
+## Pro — upgrade path
 
-The Helm chart's upgrade story is being built alongside the chart hardening
-(PR #96). The shape will be the standard Helm `upgrade --install` with the
-migration Job ensuring schema parity, but the doc is not final yet — track
-issue #141.
+The Pro control plane upgrades with the standard Helm flow: re-run
+`helm upgrade` against the same release, pointing the pinned image tag at the
+newer version.
+
+```sh
+# OCI chart (the primary install path — see Installation):
+helm upgrade leoflow oci://ghcr.io/neochaotic/charts/leoflow --version <VERSION> \
+  -n leoflow --reuse-values
+
+# Or pin the image tags explicitly:
+helm upgrade leoflow oci://ghcr.io/neochaotic/charts/leoflow --version <VERSION> \
+  -n leoflow --reuse-values \
+  --set image.tag=<VERSION> \
+  --set migrations.image.tag=<VERSION>
+```
+
+The chart runs a **pre-upgrade migrations Job** (`golang-migrate` against
+`database.url`) before the new `leoflow-server` rolls out, so the schema is
+brought to parity before any new binary serves traffic. The same startup
+**drift detector** described above protects a Pro control plane from being run
+against a database a newer binary already migrated. Use `--version <VERSION>`
+with the chart version — the [latest release](https://github.com/neochaotic/leoflow/releases)
+tag with the leading `v` stripped.
 
 ## Related issues
 


### PR DESCRIPTION
Sweep A of the docs de-stale effort (ref #659). Removes stale "alpha/pre-alpha" era language and stale version pins so the docs match `v0.4.0-rc.2` — ADR 0037 removed the alpha/beta phases and the `v0.x` line shipped long ago.

## Owned files (only these touched)
`upgrades.md`, `backup-restore.md`, `roadmap-to-release.md`, `dag-authoring.md`, `deploy.md`, `first-pro-dag.md`, `installation.md`.

## Changes
- **upgrades.md** — drop the pre-alpha framing; rewrite the Pro section around the real `helm upgrade` + pre-upgrade migrations Job + startup drift-detector story (was "in development / track #141").
- **backup-restore.md** — drop the `!!! warning "Pre-alpha"` and the `before-alpha-upgrade.tar.gz` naming; commands unchanged.
- **roadmap-to-release.md** — add a prominent "historical — the first release shipped" banner pointing at GitHub Releases + ADRs; strike the stale "we are in Alpha" claim and mark the pre-release must-do list as superseded.
- **dag-authoring.md** — remove "post-alpha roadmap/backlog" framing; resolve the map-reduce contradiction (home page headlines "Native map-reduce" while this page called it "post-alpha"): **static fan-IN** (list of task calls) ships today, **dynamic fan-OUT** (`.expand`/`.partial`) does not.
- **deploy.md** — drop "for the alpha cut"; make the published OCI chart the primary control-plane path, source the bleeding-edge alternative.
- **first-pro-dag.md** — drop "Lands with the connectors release (v0.1.0)"; reframe the Dockerfile-free flow as "not yet the default path".
- **installation.md** — bump `v0.3.0` pins to `v0.4.0-rc.2`; the OCI chart `oci://ghcr.io/neochaotic/charts/leoflow` is published, so make it primary and mark install-from-source as the bleeding-edge alternative (was "ships in the first release cut after this change / install from source until then").

## Verification
- `git grep -inE "pre-alpha|post-alpha|alpha cut|the next alpha|before-alpha"` over the owned files → **0 matches** (the only remaining "historical" references are the intentional banner in roadmap-to-release.md).
- `mkdocs build --strict` — 33 warnings identical to the `origin/main` baseline (all pre-existing dead-nav to CI-generated pages: `cli/`, `go/`, `helm-chart.md`); this change introduces **no new warnings or dead links**.
- `helm/leoflow/Chart.yaml` left untouched as instructed.
