### PR TITLE
docs(config): complete the LEOFLOW_* reference, fix the over-promise

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,36 +52,159 @@ roadmap item.
 
 ## Server environment (`LEOFLOW_*`)
 
+This page is hand-maintained against the server's configuration struct and
+default map in
+[`internal/config/server.go`](https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go)
+— treat that source as the final authority. Every `LEOFLOW_*` variable maps to a
+config key by upper-casing it and replacing `.` (and `-`) with `_`: e.g.
+`auth.oidc.client_id` → `LEOFLOW_AUTH_OIDC_CLIENT_ID`. The same keys can be set
+in a YAML config file or the Helm chart's `values.yaml`.
+
+Values resolve in increasing order of precedence — a later source overrides an
+earlier one:
+
+```mermaid
+flowchart LR
+  D["Built-in defaults<br/>(serverDefaults)"] --> C["Config file<br/>(YAML)"]
+  C --> E["LEOFLOW_* env vars"]
+  E --> F["CLI flags"]
+```
+
+The **Edition** column reads `both` (Lite and Pro), `Pro` (Pro / Kubernetes
+topologies only), or `dev-only`. `leoflow lite` sets the dev-appropriate values
+automatically (isolated DB, port 8088, admin login on, no Redis).
+
+Map- and list-valued keys (CORS origins, OIDC role/tenant maps, allowed email
+domains, …) are set from a config file or Helm values, not from a single env
+var — viper does not split one env var into a map or list.
+
+### Server (`server.*`)
+
 | Variable | Default | Edition | Purpose |
 |---|---|---|---|
 | `LEOFLOW_SERVER_ROLE` | `all` | Pro | Which components this process runs ([ADR 0049](adr/0049-split-api-and-scheduler-roles.md)): `all` (default — the Lite monolith; every component in one process), `api` (HTTP + UI only, restricted identity), or `scheduler` (reconciler + dispatch + agent gRPC, privileged). Empty defaults to `all`, which is behavior-identical to the pre-split monolith; splitting is a Pro-only topology. |
 | `LEOFLOW_SERVER_HTTP_ADDR` | `0.0.0.0:8080` | both | HTTP/UI listener. |
 | `LEOFLOW_SERVER_GRPC_ADDR` | `0.0.0.0:9091` | both | Agent gRPC listener. |
 | `LEOFLOW_SERVER_METRICS_ADDR` | `0.0.0.0:9090` | both | Prometheus metrics. |
+| `LEOFLOW_SERVER_GRPC_TLS_CERT` | _(empty)_ | Pro | PEM cert enabling TLS on the agent gRPC listener (#58). Set with `_KEY`; empty means plaintext (dev). The Pro Helm chart requires both (see [Pro TLS](pro-tls.md)). |
+| `LEOFLOW_SERVER_GRPC_TLS_KEY` | _(empty)_ | Pro | PEM private key paired with `LEOFLOW_SERVER_GRPC_TLS_CERT`. Both must be set together to encrypt the agent channel. |
+| `LEOFLOW_SERVER_CORS_ALLOWED_ORIGINS` | `http://localhost:8080` | both | List of browser origins allowed to call the API (`server.cors.allowed_origins`). Set via config file / Helm values (a list). |
 | `LEOFLOW_SERVER_TRUSTED_PROXIES` | *(empty — trust none)* | both | Proxy IPs/CIDRs whose `X-Forwarded-For` is honored for the client IP (`server.trusted_proxies`, a list). See note below. |
-| `LEOFLOW_DATABASE_URL` | `postgres://…/leoflow` | both | Postgres DSN. |
-| `LEOFLOW_REDIS_URL` | `redis://…/0` | **Pro only** | Redis (XCom + locks). Lite stores both in Postgres ([ADR 0026](adr/0026-lite-datastore-no-redis.md)). |
-| `LEOFLOW_AUTH_JWT_SECRET` | — *(required for jwt)* | both | Signs API/agent tokens. |
-| `LEOFLOW_SECRET_KEY` | — | both | 32-byte key encrypting connection secrets ([ADR 0019](adr/0019-secret-encryption-at-rest.md)). |
-| `LEOFLOW_AUTH_AGENT_TOKEN_TRANSPORT` | `envvar` | Pro (K8s) | How the in-pod agent obtains its bearer credential ([ADR 0055](adr/0055-secret-scoping-and-token-liveness.md)): `envvar` (plaintext `LEOFLOW_AGENT_TOKEN` on the pod spec — today's behavior, byte-identical) or `exchange` (projected ServiceAccount token exchanged once via a control-plane `TokenReview` for a task-scoped JWT — nothing secret on the pod object). Operator-scoped. Prerequisite for warm pools. See [Agent credential transport](agent-credential-transport.md). Ignored by the subprocess (Lite) executor. |
-| `LEOFLOW_AUTH_SECRET_LIVENESS_MODE` | `observe` | both | Gates secret delivery on task-instance liveness ([ADR 0055](adr/0055-secret-scoping-and-token-liveness.md)): `observe` (logs + audits a would-have-denied when the caller's task instance is not live, but still delivers) or `enforce` (denies). Liveness renewal is always on regardless of mode; this only chooses whether a not-live token is refused. Required to be `enforce` when warm pools are on. |
+
+### Database (`database.*`)
+
+| Variable | Default | Edition | Purpose |
+|---|---|---|---|
+| `LEOFLOW_DATABASE_URL` | `postgres://leoflow:leoflow@localhost:5432/leoflow?sslmode=disable` | both | Postgres DSN. |
+| `LEOFLOW_DATABASE_MAX_OPEN_CONNS` | `25` | both | Max open connections in the Postgres pool. |
+| `LEOFLOW_DATABASE_MAX_IDLE_CONNS` | `5` | both | Max idle connections retained in the pool. |
+
+### Redis (`redis.*`)
+
+| Variable | Default | Edition | Purpose |
+|---|---|---|---|
+| `LEOFLOW_REDIS_URL` | _(empty)_ | **Pro only** | Redis URL (XCom + locks). Empty selects the embedded Lite edition — XCom on Postgres, in-process log tailer ([ADR 0026](adr/0026-lite-datastore-no-redis.md)). Pro sets it via the Helm chart. |
+| `LEOFLOW_REDIS_CA_FILE` | _(empty)_ | Pro | Absolute path to a PEM CA bundle trusted when negotiating TLS to a `rediss://` URL (#312). Needed for managed Redis (Memorystore, ElastiCache in-transit encryption, Azure Cache) whose server cert is signed by a provider/per-instance CA not in the container's system roots. Empty falls back to system roots only. The Helm chart sets it when `redis.caConfigMap` is configured. |
+
+### Auth (`auth.*`)
+
+| Variable | Default | Edition | Purpose |
+|---|---|---|---|
+| `LEOFLOW_AUTH_PROVIDER` | `jwt` | both | Credential authenticator: `jwt` (default — username/password issues an HS256 token) or `oidc` (adds the OIDC/SSO login flow on top; the JWT authenticator stays the request-path verifier in both modes). `oidc` is Pro-gated and fails boot closed unless its prerequisites are met (see [OIDC / SSO](#oidc-sso-authoidc)). |
+| `LEOFLOW_AUTH_JWT_SECRET` | — *(required)* | both | Signs API/agent tokens. Required for both `jwt` and `oidc` (both mint the app's own HS256 token). |
+| `LEOFLOW_AUTH_JWT_TOKEN_TTL_SECONDS` | `3600` | both | Lifetime, in seconds, of an issued API token. |
+| `LEOFLOW_AUTH_LOGIN_RATE_LIMIT_PER_MINUTE` | `5` | both | Cap on **failed** `/auth/token` attempts per client IP per minute (anti-brute-force). A successful login consumes no budget. `leoflow lite` raises this well above the default (local single-user tool). |
+| `LEOFLOW_SECRET_KEY` | — | both | 32-byte key encrypting connection secrets at rest ([ADR 0019](adr/0019-secret-encryption-at-rest.md)). Raw 32 chars, 64-char hex, or base64. Empty disables connection writes. |
 | `LEOFLOW_AUTH_SECRET_SCOPING` | `permissive` | both | Scope-by-declaration policy ([ADR 0055](adr/0055-secret-scoping-and-token-liveness.md)): `permissive` (delivers the whole tenant vault; warns when a DAG declares a narrower set), `enforce` (delivers only the declared subset — empty declaration ⇒ nothing), or `off` (no scoping). Operator-scoped, never author-settable. |
+| `LEOFLOW_AUTH_SECRET_LIVENESS_MODE` | `observe` | both | Gates secret delivery on task-instance liveness ([ADR 0055](adr/0055-secret-scoping-and-token-liveness.md)): `observe` (logs + audits a would-have-denied when the caller's task instance is not live, but still delivers) or `enforce` (denies). Liveness renewal is always on regardless of mode; this only chooses whether a not-live token is refused. Required to be `enforce` when warm pools are on. Helm: `auth.secretLivenessMode`. |
+| `LEOFLOW_AUTH_AGENT_TOKEN_TRANSPORT` | `envvar` | Pro (K8s) | How the in-pod agent obtains its control-plane bearer credential ([ADR 0055](adr/0055-secret-scoping-and-token-liveness.md)): `envvar` (plaintext `LEOFLOW_AGENT_TOKEN` on the pod spec — today's behavior, byte-identical) or `exchange` (projected ServiceAccount token exchanged once via a control-plane `TokenReview` for a task-scoped JWT — nothing secret on the pod object; requires cluster-scoped `create` on `authentication.k8s.io/tokenreviews`). Operator-scoped. Prerequisite for warm pools. Ignored by the subprocess (Lite) executor. See [Agent credential transport](agent-credential-transport.md). Helm: `auth.agentTokenTransport`. |
 | `LEOFLOW_AUTH_MAX_ATTEMPT_CREDENTIAL_LIFETIME` | `24h` | both | Duration ceiling on how long one attempt's agent credential may be kept alive by heartbeat renewal ([ADR 0055](adr/0055-secret-scoping-and-token-liveness.md)). A runaway-task backstop — the short per-attempt TTL is what bounds a stolen token. A non-positive value disables the ceiling. |
-| `LEOFLOW_EXECUTOR_TYPE` | `kubernetes` (Pro), `subprocess` (Lite) | both | `kubernetes` or `subprocess`. |
-| `LEOFLOW_EXECUTOR_AGENT_CONTROL_PLANE_ADDR` | grpc_addr | both | Address task pods dial back. |
-| `LEOFLOW_EXECUTOR_AGENT_TLS_CA_CONFIGMAP` | — | Pro | CA ConfigMap for agent TLS (#58). |
-| `LEOFLOW_EXECUTOR_DEFAULTS_*` | — | Pro | L0 platform defaults (staging size/class, resources). |
-| `LEOFLOW_AUTH_AGENT_TOKEN_TRANSPORT` | `envvar` | Pro | How the in-pod agent gets its control-plane credential ([ADR 0055](adr/0055-secret-scoping-and-token-liveness.md)): `envvar` puts the task-scoped JWT in a plaintext `LEOFLOW_AGENT_TOKEN` env var on the Pod object; `exchange` mounts a projected ServiceAccount token the agent trades once — via a control-plane TokenReview — for the JWT. **Server-wide**, and `exchange` requires cluster-scoped `create` on `authentication.k8s.io/tokenreviews` (the Helm chart renders it with the value). Helm: `auth.agentTokenTransport`. |
-| `LEOFLOW_AUTH_SECRET_LIVENESS_MODE` | `observe` | Pro | Whether secret delivery is gated on task-instance liveness ([ADR 0055](adr/0055-secret-scoping-and-token-liveness.md)): `observe` logs and audits a would-have-denied but still delivers; `enforce` denies. Helm: `auth.secretLivenessMode`. |
-| `LEOFLOW_EXECUTION_WARM_POOLS_ENABLED` | `false` | Pro | Reuse one task pod across many attempts of the same DAG version ([ADR 0058](adr/0058-warm-worker-pools.md)). Off = dedicated pod-per-task. Validated fail-closed at boot: requires `agent_token_transport=exchange` **and** `secret_liveness_mode=enforce`. Helm: `execution.warmPoolsEnabled`. |
-| `LEOFLOW_EXECUTION_MIN_IDLE_WORKERS` | `0` | Pro | Warm workers kept ready per DAG version when the DAG declares no warmth of its own ([ADR 0058](adr/0058-warm-worker-pools.md) D6). `0` is scale-to-zero. Read only while warm pools are on. |
-| `LEOFLOW_EXECUTION_MAX_POOL_SIZE` | `8` | Pro | Cap on the warm workers one DAG version may hold, and the ceiling a DAG author's warmth request is clamped to ([ADR 0058](adr/0058-warm-worker-pools.md) D6). |
-| `LEOFLOW_EXECUTION_MAX_ATTEMPTS_PER_WORKER` | `50` | Pro | Attempts a warm worker serves before it drains and recycles ([ADR 0058](adr/0058-warm-worker-pools.md) D9). |
-| `LEOFLOW_EXECUTION_MAX_WORKER_LIFETIME` | `1h` | Pro | Wall-clock lifetime of a warm worker before it drains and recycles, independent of the attempt count ([ADR 0058](adr/0058-warm-worker-pools.md) D9). A duration string. |
-| `LEOFLOW_EXECUTION_WORKER_IDLE_TTL` | `5m` | Pro | How long an idle warm worker is kept before it is recycled ([ADR 0058](adr/0058-warm-worker-pools.md) D6). A duration string. |
-| `LEOFLOW_EXECUTION_MAX_WARM_PODS_PER_TENANT` | `100` | Pro | Cap on the total warm pods one tenant may hold across all its DAG versions ([ADR 0058](adr/0058-warm-worker-pools.md) M4), so one team cannot pin idle pods and starve neighbours on a shared cluster. |
-| `LEOFLOW_AUTH_DEV_NO_AUTH` | `false` | dev-only | Legacy escape hatch — bypasses auth (loopback-only). Modern Lite uses a real admin login generated by `leoflow setup`; set this only for ephemeral test scaffolds. |
-| `LEOFLOW_UI_INSTANCE_NAME` | `Leoflow` | both | UI navbar label (`leoflow lite` sets it to `Leoflow Lite`). |
+| `LEOFLOW_AUTH_DEV_NO_AUTH` | `false` | dev-only | Legacy escape hatch — bypasses auth entirely, treating every request as admin. Permitted only on a loopback `http_addr` (boot fails otherwise). Modern Lite uses a real admin login generated by `leoflow setup`; set this only for ephemeral test scaffolds. |
+
+### OIDC / SSO (`auth.oidc.*`)
+
+Read only when `LEOFLOW_AUTH_PROVIDER=oidc`, which is Pro-gated (`ui.edition:
+pro`) and fails boot closed unless `issuer`, `client_id`, and `redirect_url` are
+all set. Verification is keyless — the ID token is validated against the
+issuer's public JWKS — so no secret is stored for the verify path.
+
+| Variable | Default | Edition | Purpose |
+|---|---|---|---|
+| `LEOFLOW_AUTH_OIDC_ISSUER` | _(empty)_ | Pro | The org's single-tenant issuer URL (must be `https://`). Pinned: any ID token whose `iss` differs is rejected. |
+| `LEOFLOW_AUTH_OIDC_CLIENT_ID` | _(empty)_ | Pro | Registered application (client) id; the expected audience of every ID token. |
+| `LEOFLOW_AUTH_OIDC_CLIENT_SECRET` | _(empty)_ | Pro | Used only for the authorization-code exchange. Inject via env; never persist it in a config file, never logged. |
+| `LEOFLOW_AUTH_OIDC_REDIRECT_URL` | _(empty)_ | Pro | This server's callback URL registered with the IdP (`…/api/v2/auth/oidc/callback`). Must be `https://` (http allowed only for loopback hosts). |
+| `LEOFLOW_AUTH_OIDC_SCOPES` | `openid, email, profile` | Pro | OAuth scopes requested (a list; set via config file / Helm values). Add the IdP's groups scope when group→role mapping is used. |
+| `LEOFLOW_AUTH_OIDC_GROUPS_CLAIM` | `groups` | Pro | The ID-token claim carrying the user's IdP groups; its values drive `role_mappings`. |
+| `auth.oidc.role_mappings` | _(empty map)_ | Pro | Maps an IdP group value → an existing Leoflow role name. **Default-DENY** — an unmapped group grants no role. Config file / Helm values only (a map does not bind from one env var). |
+| `LEOFLOW_AUTH_OIDC_DEFAULT_ROLE` | _(empty)_ | Pro | When an authenticated user resolves to zero mapped roles and this is set, grants this single role (advised: a read-only role such as `viewer`). Empty keeps strict default-deny. Must name an existing DB role for the resolved tenant. |
+| `LEOFLOW_AUTH_OIDC_TENANT_CLAIM` | _(empty)_ | Pro | Which IdP claim identifies the tenant: `tid` (Entra) or `hd` (Google Workspace). |
+| `auth.oidc.tenant_claims` | _(empty map)_ | Pro | Maps a `tenant_claim` value → a Leoflow tenant name. A value not present is rejected (403); the login never falls back to `default`. Config file / Helm values only (a map). |
+| `auth.oidc.allowed_email_domains` | _(empty)_ | Pro | Login-level allowlist layered on TOP of the `tid`/`hd` tenant pin (not the pin itself). Empty imposes no domain restriction. Non-empty admits a login only when the verified email's domain is in the list. Config file / Helm values (a list). |
+| `auth.oidc.break_glass_emails` | _(empty)_ | Pro | Allowlist of local password logins permitted while provider is `oidc`; every other password login is rejected (SSO-only). Config file / Helm values (a list). |
+| `LEOFLOW_AUTH_OIDC_JIT_PROVISIONING` | `false` | Pro | Create a user row on first OIDC login when none matches. Off by default (pre-provisioned user required); when on, the new row is granted the roles from `role_mappings`. |
+| `LEOFLOW_AUTH_OIDC_CLOCK_SKEW_SECONDS` | `60` | Pro | Tolerance (seconds) on the ID token's `exp`/`iat`/`nbf` checks to absorb clock differences between the IdP and this server. |
+
+### Scheduler (`scheduler.*`)
+
+| Variable | Default | Edition | Purpose |
+|---|---|---|---|
+| `LEOFLOW_SCHEDULER_ENABLED` | `true` | both | Whether this process runs the scheduler loop. |
+| `LEOFLOW_SCHEDULER_LOOP_INTERVAL_MS` | `1000` | both | Scheduler tick interval, in milliseconds. |
+| `LEOFLOW_SCHEDULER_DISPATCH_BUFFER_SIZE` | `0` | both | Depth of the queued-dispatches channel ([ADR 0031](adr/0031-scheduler-architecture.md), #127). `0` keeps dispatch synchronous with the tick (right for Lite); `>0` enables the worker pool (right for Pro, where K8s API calls add latency). |
+| `LEOFLOW_SCHEDULER_DISPATCH_WORKERS` | `0` | both | Goroutines draining the dispatch queue. Ignored when buffer size ≤ 0; otherwise floored to 1. |
+
+### Executor (`executor.*`)
+
+| Variable | Default | Edition | Purpose |
+|---|---|---|---|
+| `LEOFLOW_EXECUTOR_TYPE` | `kubernetes` | both | Pod-path executor: `kubernetes` (default, pod-per-task) or `subprocess` (dev only — runs the agent on the host without isolation; `leoflow lite`/`leoflow dev` set it). |
+| `LEOFLOW_EXECUTOR_TASK_NAMESPACE` | `leoflow` | Pro | Kubernetes namespace the server creates task pods and per-run staging PVCs in. MUST match the namespace the Helm chart grants the executor Role in (chart `taskNamespace`); a mismatch 403s every dispatch (#480). |
+| `LEOFLOW_EXECUTOR_AGENT_CONTROL_PLANE_ADDR` | _(empty → `server.grpc_addr`)_ | both | gRPC address task pods dial back to. In a local k3d/kind cluster set it to a host-reachable address such as `host.k3d.internal:9091`. |
+| `LEOFLOW_EXECUTOR_AGENT_TLS_CA_CONFIGMAP` | _(empty)_ | Pro | Names a ConfigMap (key `ca.crt`) mounted into task pods so the agent verifies the control plane's gRPC TLS cert (#58). Empty = agents use the insecure channel (dev). |
+| `LEOFLOW_EXECUTOR_TASK_SECRET_NAME` | _(empty)_ | Pro | Names a Kubernetes Secret mounted read-only into every task pod, so a task can read a cluster-stored credential (e.g. a GCP SA key) referenced by a connection's `key_path` ([ADR 0035](adr/0035-cloud-connector-auth-keyless-first.md)). Empty = no secret mounted. |
+| `LEOFLOW_EXECUTOR_TASK_SECRET_MOUNT_PATH` | `/etc/leoflow/secrets` | Pro | Where `LEOFLOW_EXECUTOR_TASK_SECRET_NAME` is mounted in the task pod. |
+| `LEOFLOW_EXECUTOR_AGENT_PATH` | `leoflow-agent` | dev-only | The leoflow-agent binary the subprocess executor runs. |
+| `LEOFLOW_EXECUTOR_SUBPROCESS_WORKDIR` | _(empty)_ | dev-only | Working directory the subprocess executor runs the agent in (so it can import the project's `dag.py`). Empty keeps the server's working directory. |
+| `LEOFLOW_EXECUTOR_HTTP_USER_AGENT` | `leoflow/0.1` | both | Default `User-Agent` header for HTTP requests a task image may make on the platform's behalf. |
+
+### Executor task defaults (`executor.defaults.*`)
+
+Lowest-precedence (L0) per-cluster task defaults, applied at dispatch to fill
+gaps the DAG artifact left empty ([ADR 0023](adr/0023-dag-authoring-config-binding.md)).
+They never override a value baked into `dag.json`, keeping the artifact portable
+across clusters.
+
+| Variable | Default | Edition | Purpose |
+|---|---|---|---|
+| `LEOFLOW_EXECUTOR_DEFAULTS_RUN_TASKS_AS_NON_ROOT` | `true` | Pro | **Refuses to start a task container whose image resolves to UID 0**, completing Pod Security Admission's `restricted` set. On by default — the images this repo ships carry a numeric non-root UID (`USER 65532:65532`) and the executor pairs it with a pod-level `fsGroup` so the staging PVC stays writable. Turn it off only for a cluster whose task images legitimately run as root. Operator-scoped (never a DAG field). |
+| `LEOFLOW_EXECUTOR_DEFAULTS_READ_ONLY_TASK_ROOT_FILESYSTEM` | `false` | Pro | Mounts every task container's root filesystem read-only. Off by default (`restricted` does not require it and it breaks ordinary Python tasks — pip cache, `/tmp`, matplotlib config). Turn on for a fleet of tasks known not to write outside their volumes. |
+| `LEOFLOW_EXECUTOR_DEFAULTS_STAGING_ACCESS_MODE` | `ReadWriteMany` | Pro | PVC access mode for the per-run staging volume. Default `ReadWriteMany` (multi-node prod); single-node dev (k3d local-path, no RWX) sets `ReadWriteOnce`. |
+| `executor.defaults.staging_size` | _(empty)_ | Pro | Default size of the per-run staging volume when the DAG enabled staging without pinning it. **Config file / Helm values only** — this key is not registered as a default, so its env var is not bound. |
+| `executor.defaults.staging_storage_class` | _(empty)_ | Pro | Default StorageClass for the staging volume (e.g. the cluster's RWX class). **Config file / Helm values only** (env var not bound). |
+| `executor.defaults.resources_cpu` | _(empty)_ | Pro | Default CPU request when neither the task override nor the DAG set any (a Kubernetes quantity, e.g. `250m`). **Config file / Helm values only** (env var not bound). |
+| `executor.defaults.resources_memory` | _(empty)_ | Pro | Default memory request when neither the task override nor the DAG set any (e.g. `256Mi`). **Config file / Helm values only** (env var not bound). |
+
+### Warm worker pools (`execution.*`)
+
+Pro-gated N:1 pod reuse ([ADR 0058](adr/0058-warm-worker-pools.md)). Every field
+is operator-set. The default is a byte-for-byte no-op — warm pools OFF means a
+dedicated pod per task attempt.
+
+| Variable | Default | Edition | Purpose |
+|---|---|---|---|
+| `LEOFLOW_EXECUTION_WARM_POOLS_ENABLED` | `false` | Pro | Reuse one task pod across many attempts of the same DAG version. Off = dedicated pod-per-task. Validated fail-closed at boot: requires `agent_token_transport=exchange` **and** `secret_liveness_mode=enforce`. Helm: `execution.warmPoolsEnabled`. |
+| `LEOFLOW_EXECUTION_MIN_IDLE_WORKERS` | `0` | Pro | Warm workers kept ready per DAG version when the DAG declares no warmth of its own (D6). `0` is scale-to-zero. Read only while warm pools are on. |
+| `LEOFLOW_EXECUTION_MAX_POOL_SIZE` | `8` | Pro | Cap on the warm workers one DAG version may hold, and the ceiling a DAG author's warmth request is clamped to (D6). |
+| `LEOFLOW_EXECUTION_MAX_ATTEMPTS_PER_WORKER` | `50` | Pro | Attempts a warm worker serves before it drains and recycles (D9). |
+| `LEOFLOW_EXECUTION_MAX_WORKER_LIFETIME` | `1h` | Pro | Wall-clock lifetime of a warm worker before it drains and recycles, independent of the attempt count (D9). A duration string. |
+| `LEOFLOW_EXECUTION_WORKER_IDLE_TTL` | `5m` | Pro | How long an idle warm worker is kept before it is recycled (D6). A duration string. |
+| `LEOFLOW_EXECUTION_MAX_WARM_PODS_PER_TENANT` | `100` | Pro | Cap on the total warm pods one tenant may hold across all its DAG versions (M4), so one team cannot pin idle pods and starve neighbours on a shared cluster. |
+
+### Logs (`logs.*`)
+
+| Variable | Default | Edition | Purpose |
+|---|---|---|---|
 | `LEOFLOW_LOGS_DIR` | `/var/log/leoflow` | both | Task-log sink directory (used by the default `disk` backend). |
 | `LEOFLOW_LOGS_BACKEND` | `disk` | Pro | Durable task-log store: `disk` (default — the on-disk sink, unchanged; the only backend Lite uses), `s3` (AWS S3, MinIO, Ceph RGW), or `gcs` (Google Cloud Storage, native SDK). See [ADR 0056](adr/0056-task-log-object-sink.md). |
 | `LEOFLOW_LOGS_SINK_BUCKET` | _(empty)_ | Pro | Target bucket. Required when the backend is `s3` or `gcs` (boot fails otherwise). |
@@ -91,12 +214,25 @@ roadmap item.
 | `LEOFLOW_LOGS_SINK_FORCE_PATH_STYLE` | `false` | Pro | **s3-only.** Use path-style addressing (bucket in the path, not the host). Required by MinIO and some S3-compatible stores. |
 | `LEOFLOW_LOGS_SINK_ACCESS_KEY_ID` / `LEOFLOW_LOGS_SINK_SECRET_ACCESS_KEY` | _(empty)_ | Pro | **s3-only.** Static credentials — **discouraged**. Leave empty (recommended) to use the keyless chain (IRSA / instance profile), per [ADR 0035](adr/0035-cloud-connector-auth-keyless-first.md). |
 | `LEOFLOW_LOGS_SINK_CREDENTIALS_FILE` | _(empty)_ | Pro | **gcs-only.** Path to a service-account JSON key — **discouraged**. Leave empty (recommended) to use Application Default Credentials (GKE Workload Identity). |
+
+### Observability (`observability.*`)
+
+| Variable | Default | Edition | Purpose |
+|---|---|---|---|
 | `LEOFLOW_OBSERVABILITY_LOG_LEVEL` | `info` | both | Control-plane log verbosity: `debug`, `info`, `warn` (alias `warning`), or `error`. Unknown values fall back to `info`. |
 | `LEOFLOW_OBSERVABILITY_LOG_FORMAT` | `json` | both | Control-plane log format: `json` (default) or `text`. |
 | `LEOFLOW_OBSERVABILITY_OTEL_ENABLED` | `true` | both | Enable OpenTelemetry trace export. |
 | `LEOFLOW_OBSERVABILITY_OTEL_ENDPOINT` | `localhost:4317` | both | OTLP collector endpoint (when OTel is enabled). |
 
-`leoflow lite` sets the dev-appropriate values automatically (isolated DB, port 8088, admin login on, no Redis).
+### UI (`ui.*`)
+
+| Variable | Default | Edition | Purpose |
+|---|---|---|---|
+| `LEOFLOW_UI_INSTANCE_NAME` | `Leoflow` | both | UI navbar label (`leoflow lite` sets it to mark the environment). |
+| `LEOFLOW_UI_AUTO_REFRESH_INTERVAL_SECONDS` | `0` | both | SPA polling cadence for DAG / DagRun / task-instance state. `0` falls back to the production-safe 30s default; `leoflow lite` sets 1s for a snappy inner loop. |
+| `LEOFLOW_UI_EDITION` | _(empty)_ | both | Edition badge in the UI shell: `lite` shows the silver LITE badge, `pro` the gold PRO badge (independent of the auth mode; also gates `auth.provider: oidc`). Empty/other shows no badge. |
+| `LEOFLOW_UI_WORKSPACE` | _(empty)_ | both | DAG project directory the Lite web editor edits ([ADR 0025](adr/0025-lite-embedded-web-editor.md)). Empty disables the editor. |
+| `LEOFLOW_UI_MONACO_DIR` | _(empty)_ | both | Where the pinned Monaco bundle was fetched by `leoflow setup`; the editor page is served Monaco from it. Empty shows a setup hint. |
 
 ### Trusted proxies and the client IP
 

--- a/docs/pro-tls.md
+++ b/docs/pro-tls.md
@@ -153,7 +153,7 @@ reference for `./helm/leoflow`.)
   install. This chart only deploys the Pro edition, and that edition cannot boot
   without a cert, so turning TLS off buys a `CrashLoopBackOff`, not a plaintext
   deployment. Provision the cert as above; for a plaintext local loop use the Lite
-  dev server (`leoflow dev lite`), not this chart (#459).
+  dev server (`leoflow lite`), not this chart (#459).
 - **`agentTLS.caConfigMap is required when agentTLS.enabled`** — helm refused the
   install because the CA ConfigMap is missing. Without it task pods fail the cert
   chain (`x509: certificate signed by unknown authority`) and hang (#280). Do step 4.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,7 +1,9 @@
 # Reference
 
-Complete, generated-from-source references for every Leoflow surface. Each is
-regenerated on every push, so it never drifts from the code.
+References for every Leoflow surface. The HTTP API, CLI, Go, and Python
+references below are generated from source on every push, so they never drift
+from the code. The [Configuration](configuration.md) page is hand-maintained
+against `internal/config` — treat the server source as the final authority.
 
 <div class="grid cards" markdown>
 
@@ -43,7 +45,8 @@ regenerated on every push, so it never drifts from the code.
 
     ---
 
-    Every environment variable and config key for the server, agent, and CLI.
+    The `LEOFLOW_*` environment variables and config keys for the server,
+    hand-maintained against `internal/config`.
 
     [:octicons-arrow-right-24: Configuration](configuration.md)
 


### PR DESCRIPTION
Makes `docs/configuration.md` a complete, accurate reference of the server's `LEOFLOW_*` surface, verified key-by-key against `internal/config/server.go` (`serverDefaults` + struct `mapstructure` tags). Refs #659.

## configuration.md
- **Dups removed:** `LEOFLOW_AUTH_AGENT_TOKEN_TRANSPORT` and `LEOFLOW_AUTH_SECRET_LIVENESS_MODE` each appeared twice — collapsed to one authoritative row each.
- **Missing keys added** (all confirmed in code): the entire OIDC/SSO block (`LEOFLOW_AUTH_PROVIDER` + all `auth.oidc.*`), `LEOFLOW_SERVER_GRPC_TLS_CERT`/`_KEY`, `LEOFLOW_SERVER_CORS_ALLOWED_ORIGINS`, `LEOFLOW_REDIS_CA_FILE`, `LEOFLOW_DATABASE_MAX_OPEN_CONNS`/`_MAX_IDLE_CONNS`, `LEOFLOW_AUTH_JWT_TOKEN_TTL_SECONDS`, `LEOFLOW_AUTH_LOGIN_RATE_LIMIT_PER_MINUTE`, the full scheduler block (`_ENABLED`/`_LOOP_INTERVAL_MS`/`_DISPATCH_BUFFER_SIZE`/`_DISPATCH_WORKERS`), executor keys (`_TASK_NAMESPACE`, `_AGENT_PATH`, `_SUBPROCESS_WORKDIR`, `_HTTP_USER_AGENT`, `_TASK_SECRET_NAME`/`_MOUNT_PATH`), and the `ui.*` knobs (`_AUTO_REFRESH_INTERVAL_SECONDS`, `_EDITION`, `_WORKSPACE`, `_MONACO_DIR`).
- **`EXECUTOR_DEFAULTS_*` expanded** into explicit rows — `run_tasks_as_non_root` (default **true**, PSA-restricted, called out), `read_only_task_root_filesystem`, `staging_access_mode`, plus `staging_size`/`staging_storage_class`/`resources_cpu`/`resources_memory` (flagged as config-file/Helm-only since they carry no registered default and so their env vars do not bind).
- Grouped by section (server/database/redis/auth/oidc/scheduler/executor/execution/logs/observability/ui), added a theme-safe mermaid precedence diagram (defaults → config file → `LEOFLOW_*` env → flags), and corrected the `redis.url` default (empty, not a `redis://` DSN).

## reference.md
- Softened the false "generated-from-source … never drifts / Every environment variable" claim: the configuration page is hand-maintained against `internal/config`.

## pro-tls.md
- Fixed the stale command `leoflow dev lite` → `leoflow lite` (only change to this file).

## Verify
- `mkdocs build --strict` passes for these files: no new warnings; remaining warnings are all pre-existing links to CI-generated pages (`go/*`, `helm-chart.md`, `cli/leoflow.md`) not produced in a raw local build.