### PR TITLE
docs(connections): normalize connection guides to one valid template

### DIFF
--- a/docs/connections/athena.md
+++ b/docs/connections/athena.md
@@ -7,7 +7,10 @@ group live in **Extra**.
 ## Declare the provider
 
 ```yaml
-connectors: [athena]
+# leoflow.yaml
+dag_id: athena_demo
+connectors:
+  - athena
 ```
 
 ## URI shape
@@ -43,31 +46,30 @@ The provider import goes **inside** the `@task` body — a top-level provider
 import fails the compile.
 
 ```python
-from datetime import datetime
-from airflow.decorators import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, start_date=datetime(2024, 1, 1), catchup=False)
-def athena_demo():
-    @task
-    def query() -> str:
-        from airflow.providers.amazon.aws.hooks.athena_sql import AthenaSQLHook
+@task
+def query() -> str:
+    from airflow.providers.amazon.aws.hooks.athena_sql import AthenaSQLHook
 
-        hook = AthenaSQLHook(athena_conn_id="athena_lake")
-        rows = hook.get_records("SELECT count(*) FROM events")
-        return str(rows[0][0])
+    hook = AthenaSQLHook(athena_conn_id="athena_lake")
+    rows = hook.get_records("SELECT count(*) FROM events")
+    return str(rows[0][0])
 
+
+with DAG("athena_demo", schedule=None, catchup=False, tags=["example"]):
     query()
-
-
-athena_demo()
 ```
 
 ```yaml
 # leoflow.yaml
+schema_version: "1.0"
 dag_id: athena_demo
-python: "3.12"
-connectors: [athena]
+python_version: "3.12"
+connectors:
+  - athena
 ```
 
 ## Security notes

--- a/docs/connections/cassandra.md
+++ b/docs/connections/cassandra.md
@@ -3,6 +3,15 @@
 Connect a task to an Apache Cassandra cluster (the `CassandraHook`) over a
 managed Leoflow Connection. The keyspace lives in the Schema field.
 
+## Declare the provider
+
+```yaml
+# leoflow.yaml
+dag_id: cassandra_smoke
+connectors:
+  - cassandra
+```
+
 ## URI shape
 
 ```
@@ -34,36 +43,31 @@ The provider import must live **inside** the task body — a top-level
 provider import fails compilation in the parser sidecar.
 
 ```python
-from datetime import datetime
-from airflow.decorators import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, start_date=datetime(2024, 1, 1), catchup=False)
-def cassandra_smoke():
-    @task
-    def query():
-        from airflow.providers.apache.cassandra.hooks.cassandra import CassandraHook
+@task
+def query():
+    from airflow.providers.apache.cassandra.hooks.cassandra import CassandraHook
 
-        hook = CassandraHook(cassandra_conn_id="cassandra_target")
-        session = hook.get_conn()
-        row = session.execute("SELECT release_version FROM system.local").one()
-        print("cassandra up:", row.release_version)
+    hook = CassandraHook(cassandra_conn_id="cassandra_target")
+    session = hook.get_conn()
+    row = session.execute("SELECT release_version FROM system.local").one()
+    print("cassandra up:", row.release_version)
 
+
+with DAG("cassandra_smoke", schedule=None, catchup=False, tags=["example"]):
     query()
-
-
-cassandra_smoke()
 ```
 
 ```yaml
 # leoflow.yaml
-name: cassandra_smoke
-schedule: null
-image:
-  python: "3.11"
-  requirements:
-    - apache-airflow-providers-apache-cassandra
-connectors: [cassandra]
+schema_version: "1.0"
+dag_id: cassandra_smoke
+python_version: "3.11"
+connectors:
+  - cassandra
 ```
 
 ## Security notes

--- a/docs/connections/datadog.md
+++ b/docs/connections/datadog.md
@@ -1,12 +1,17 @@
----
-connectors: [datadog]
----
-
 # Datadog connection
 
 Submit metrics, events, and query monitors from a task over a managed
 Leoflow Connection. `DatadogHook` authenticates with an API key + app key
 against the Datadog site (US, EU, …).
+
+## Declare the provider
+
+```yaml
+# leoflow.yaml
+dag_id: datadog_metric
+connectors:
+  - datadog
+```
 
 ## URI shape
 
@@ -40,37 +45,35 @@ extra-only shape.
 ## Example DAG
 
 ```python
-from airflow.sdk import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, catchup=False, tags=["datadog"])
-def datadog_metric():
-    @task
-    def send():
-        from airflow.providers.datadog.hooks.datadog import DatadogHook
+@task
+def send():
+    from airflow.providers.datadog.hooks.datadog import DatadogHook
 
-        hook = DatadogHook(datadog_conn_id="datadog_default")
-        hook.send_metric(
-            metric_name="leoflow.dag.runs",
-            datapoint=1,
-            tags=["dag:datadog_metric"],
-        )
+    hook = DatadogHook(datadog_conn_id="datadog_default")
+    hook.send_metric(
+        metric_name="leoflow.dag.runs",
+        datapoint=1,
+        tags=["dag:datadog_metric"],
+    )
 
+
+with DAG("datadog_metric", schedule=None, catchup=False, tags=["example"]):
     send()
-
-
-datadog_metric()
 ```
 
 ```yaml
 # leoflow.yaml
+schema_version: "1.0"
 dag_id: datadog_metric
-runtime: python3.12
-requirements:
-  - apache-airflow-providers-datadog
+python_version: "3.12"
+connectors:
+  - datadog
 connections:
-  - conn_id: datadog_default
-    conn_type: datadog
+  - datadog_default
 ```
 
 ## Security notes

--- a/docs/connections/discord.md
+++ b/docs/connections/discord.md
@@ -1,11 +1,16 @@
----
-connectors: [discord]
----
-
 # Discord connection
 
 Post messages to a Discord channel from a task over a managed Leoflow
 Connection. `DiscordWebhookHook` sends to a channel webhook.
+
+## Declare the provider
+
+```yaml
+# leoflow.yaml
+dag_id: discord_notify
+connectors:
+  - discord
+```
 
 ## URI shape
 
@@ -31,38 +36,36 @@ endpoint to post.
 ## Example DAG
 
 ```python
-from airflow.sdk import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, catchup=False, tags=["discord"])
-def discord_notify():
-    @task
-    def send():
-        from airflow.providers.discord.hooks.discord_webhook import (
-            DiscordWebhookHook,
-        )
+@task
+def send():
+    from airflow.providers.discord.hooks.discord_webhook import (
+        DiscordWebhookHook,
+    )
 
-        hook = DiscordWebhookHook(
-            http_conn_id="discord_default",
-            message="DAG finished",
-        )
-        hook.execute()
+    hook = DiscordWebhookHook(
+        http_conn_id="discord_default",
+        message="DAG finished",
+    )
+    hook.execute()
 
+
+with DAG("discord_notify", schedule=None, catchup=False, tags=["example"]):
     send()
-
-
-discord_notify()
 ```
 
 ```yaml
 # leoflow.yaml
+schema_version: "1.0"
 dag_id: discord_notify
-runtime: python3.12
-requirements:
-  - apache-airflow-providers-discord
+python_version: "3.12"
+connectors:
+  - discord
 connections:
-  - conn_id: discord_default
-    conn_type: discord
+  - discord_default
 ```
 
 ## Security notes

--- a/docs/connections/docker.md
+++ b/docs/connections/docker.md
@@ -1,12 +1,17 @@
----
-connectors: [docker]
----
-
 # Docker registry connection
 
 Connect a task to a Docker registry (Docker Hub, GHCR, ECR, a private
 Harbor/Nexus) over a managed Leoflow Connection. `DockerHook` authenticates
 to the registry so the `DockerOperator` can pull/run images.
+
+## Declare the provider
+
+```yaml
+# leoflow.yaml
+dag_id: docker_login
+connectors:
+  - docker
+```
 
 ## URI shape
 
@@ -33,34 +38,32 @@ options ride in `Extra` under `__extra__`.
 ## Example DAG
 
 ```python
-from airflow.sdk import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, catchup=False, tags=["docker"])
-def docker_login():
-    @task
-    def whoami():
-        from airflow.providers.docker.hooks.docker import DockerHook
+@task
+def whoami():
+    from airflow.providers.docker.hooks.docker import DockerHook
 
-        hook = DockerHook(docker_conn_id="docker_registry")
-        client = hook.get_conn()
-        print("api version:", client.version()["ApiVersion"])
+    hook = DockerHook(docker_conn_id="docker_registry")
+    client = hook.get_conn()
+    print("api version:", client.version()["ApiVersion"])
 
+
+with DAG("docker_login", schedule=None, catchup=False, tags=["example"]):
     whoami()
-
-
-docker_login()
 ```
 
 ```yaml
 # leoflow.yaml
+schema_version: "1.0"
 dag_id: docker_login
-runtime: python3.12
-requirements:
-  - apache-airflow-providers-docker
+python_version: "3.12"
+connectors:
+  - docker
 connections:
-  - conn_id: docker_registry
-    conn_type: docker
+  - docker_registry
 ```
 
 ## Security notes

--- a/docs/connections/druid.md
+++ b/docs/connections/druid.md
@@ -3,6 +3,15 @@
 Connect a task to an Apache Druid cluster (the `DruidDbApiHook`) over a
 managed Leoflow Connection. The query path goes through the Druid broker.
 
+## Declare the provider
+
+```yaml
+# leoflow.yaml
+dag_id: druid_smoke
+connectors:
+  - druid
+```
+
 ## URI shape
 
 ```
@@ -34,35 +43,30 @@ The provider import must live **inside** the task body — a top-level
 provider import fails compilation in the parser sidecar.
 
 ```python
-from datetime import datetime
-from airflow.decorators import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, start_date=datetime(2024, 1, 1), catchup=False)
-def druid_smoke():
-    @task
-    def query():
-        from airflow.providers.apache.druid.hooks.druid import DruidDbApiHook
+@task
+def query():
+    from airflow.providers.apache.druid.hooks.druid import DruidDbApiHook
 
-        hook = DruidDbApiHook(druid_broker_conn_id="druid_target")
-        rows = hook.get_records("SELECT 1")
-        print("druid up:", rows)
+    hook = DruidDbApiHook(druid_broker_conn_id="druid_target")
+    rows = hook.get_records("SELECT 1")
+    print("druid up:", rows)
 
+
+with DAG("druid_smoke", schedule=None, catchup=False, tags=["example"]):
     query()
-
-
-druid_smoke()
 ```
 
 ```yaml
 # leoflow.yaml
-name: druid_smoke
-schedule: null
-image:
-  python: "3.11"
-  requirements:
-    - apache-airflow-providers-apache-druid
-connectors: [druid]
+schema_version: "1.0"
+dag_id: druid_smoke
+python_version: "3.11"
+connectors:
+  - druid
 ```
 
 ## Security notes

--- a/docs/connections/elasticsearch.md
+++ b/docs/connections/elasticsearch.md
@@ -3,6 +3,15 @@
 Connect a task to an Elasticsearch cluster's SQL endpoint (the
 `ElasticsearchSQLHook`) over a managed Leoflow Connection.
 
+## Declare the provider
+
+```yaml
+# leoflow.yaml
+dag_id: elasticsearch_smoke
+connectors:
+  - elasticsearch
+```
+
 ## URI shape
 
 ```
@@ -34,35 +43,30 @@ The provider import must live **inside** the task body — a top-level
 provider import fails compilation in the parser sidecar.
 
 ```python
-from datetime import datetime
-from airflow.decorators import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, start_date=datetime(2024, 1, 1), catchup=False)
-def elasticsearch_smoke():
-    @task
-    def query():
-        from airflow.providers.elasticsearch.hooks.elasticsearch import ElasticsearchSQLHook
+@task
+def query():
+    from airflow.providers.elasticsearch.hooks.elasticsearch import ElasticsearchSQLHook
 
-        hook = ElasticsearchSQLHook(elasticsearch_conn_id="es_target")
-        rows = hook.get_records("SELECT 1")
-        print("elasticsearch up:", rows)
+    hook = ElasticsearchSQLHook(elasticsearch_conn_id="es_target")
+    rows = hook.get_records("SELECT 1")
+    print("elasticsearch up:", rows)
 
+
+with DAG("elasticsearch_smoke", schedule=None, catchup=False, tags=["example"]):
     query()
-
-
-elasticsearch_smoke()
 ```
 
 ```yaml
 # leoflow.yaml
-name: elasticsearch_smoke
-schedule: null
-image:
-  python: "3.11"
-  requirements:
-    - apache-airflow-providers-elasticsearch
-connectors: [elasticsearch]
+schema_version: "1.0"
+dag_id: elasticsearch_smoke
+python_version: "3.11"
+connectors:
+  - elasticsearch
 ```
 
 ## Security notes

--- a/docs/connections/emr.md
+++ b/docs/connections/emr.md
@@ -7,7 +7,10 @@ Connection. EMR carries no host and no password — only the AWS region lives in
 ## Declare the provider
 
 ```yaml
-connectors: [emr]
+# leoflow.yaml
+dag_id: emr_demo
+connectors:
+  - emr
 ```
 
 ## URI shape
@@ -40,32 +43,31 @@ The provider import goes **inside** the `@task` body — a top-level provider
 import fails the compile.
 
 ```python
-from datetime import datetime
-from airflow.decorators import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, start_date=datetime(2024, 1, 1), catchup=False)
-def emr_demo():
-    @task
-    def list_clusters() -> int:
-        from airflow.providers.amazon.aws.hooks.emr import EmrHook
+@task
+def list_clusters() -> int:
+    from airflow.providers.amazon.aws.hooks.emr import EmrHook
 
-        hook = EmrHook(aws_conn_id="emr_batch")
-        client = hook.get_conn()
-        resp = client.list_clusters(ClusterStates=["WAITING", "RUNNING"])
-        return len(resp.get("Clusters", []))
+    hook = EmrHook(aws_conn_id="emr_batch")
+    client = hook.get_conn()
+    resp = client.list_clusters(ClusterStates=["WAITING", "RUNNING"])
+    return len(resp.get("Clusters", []))
 
+
+with DAG("emr_demo", schedule=None, catchup=False, tags=["example"]):
     list_clusters()
-
-
-emr_demo()
 ```
 
 ```yaml
 # leoflow.yaml
+schema_version: "1.0"
 dag_id: emr_demo
-python: "3.12"
-connectors: [emr]
+python_version: "3.12"
+connectors:
+  - emr
 ```
 
 ## Security notes

--- a/docs/connections/gcpbigquery.md
+++ b/docs/connections/gcpbigquery.md
@@ -7,7 +7,10 @@ location live in **Extra**, and auth is keyless (Workload Identity / ADC).
 ## Declare the provider
 
 ```yaml
-connectors: [gcpbigquery]
+# leoflow.yaml
+dag_id: bigquery_demo
+connectors:
+  - gcpbigquery
 ```
 
 ## URI shape
@@ -39,31 +42,30 @@ The provider import goes **inside** the `@task` body — a top-level provider
 import fails the compile.
 
 ```python
-from datetime import datetime
-from airflow.decorators import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, start_date=datetime(2024, 1, 1), catchup=False)
-def bigquery_demo():
-    @task
-    def count_rows() -> int:
-        from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
+@task
+def count_rows() -> int:
+    from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
 
-        hook = BigQueryHook(gcp_conn_id="bq_warehouse")
-        rows = hook.get_records("SELECT count(*) FROM `my-proj.analytics.events`")
-        return int(rows[0][0])
+    hook = BigQueryHook(gcp_conn_id="bq_warehouse")
+    rows = hook.get_records("SELECT count(*) FROM `my-proj.analytics.events`")
+    return int(rows[0][0])
 
+
+with DAG("bigquery_demo", schedule=None, catchup=False, tags=["example"]):
     count_rows()
-
-
-bigquery_demo()
 ```
 
 ```yaml
 # leoflow.yaml
+schema_version: "1.0"
 dag_id: bigquery_demo
-python: "3.12"
-connectors: [gcpbigquery]
+python_version: "3.12"
+connectors:
+  - gcpbigquery
 ```
 
 ## Security notes

--- a/docs/connections/gcpcloudsql.md
+++ b/docs/connections/gcpcloudsql.md
@@ -8,7 +8,10 @@ runtime identity (ADC).
 ## Declare the provider
 
 ```yaml
-connectors: [gcpcloudsql]
+# leoflow.yaml
+dag_id: cloudsql_demo
+connectors:
+  - gcpcloudsql
 ```
 
 ## URI shape
@@ -41,31 +44,30 @@ The provider import goes **inside** the `@task` body — a top-level provider
 import fails the compile.
 
 ```python
-from datetime import datetime
-from airflow.decorators import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, start_date=datetime(2024, 1, 1), catchup=False)
-def cloudsql_demo():
-    @task
-    def ping() -> str:
-        from airflow.providers.google.cloud.hooks.cloud_sql import CloudSQLHook
+@task
+def ping() -> str:
+    from airflow.providers.google.cloud.hooks.cloud_sql import CloudSQLHook
 
-        hook = CloudSQLHook(gcp_cloudsql_conn_id="cloudsql_app", api_version="v1beta4")
-        instance = hook.get_instance(instance="my-inst")
-        return instance["state"]
+    hook = CloudSQLHook(gcp_cloudsql_conn_id="cloudsql_app", api_version="v1beta4")
+    instance = hook.get_instance(instance="my-inst")
+    return instance["state"]
 
+
+with DAG("cloudsql_demo", schedule=None, catchup=False, tags=["example"]):
     ping()
-
-
-cloudsql_demo()
 ```
 
 ```yaml
 # leoflow.yaml
+schema_version: "1.0"
 dag_id: cloudsql_demo
-python: "3.12"
-connectors: [gcpcloudsql]
+python_version: "3.12"
+connectors:
+  - gcpcloudsql
 ```
 
 ## Security notes

--- a/docs/connections/gcpssh.md
+++ b/docs/connections/gcpssh.md
@@ -4,8 +4,13 @@ Run commands on a Google Compute Engine VM over SSH from a task, via a managed
 Leoflow Connection. The host, port, and credentials are encrypted at rest and
 delivered to the task as `AIRFLOW_CONN_<CONN_ID>`.
 
+## Declare the provider
+
 ```yaml
-connectors: [gcpssh]
+# leoflow.yaml
+dag_id: gcpssh_run
+connectors:
+  - gcpssh
 ```
 
 ## URI shape
@@ -34,32 +39,33 @@ parses `AIRFLOW_CONN_<ID>`) un-escapes it back.
 The hook is imported inside the task body so DAG parsing stays import-light.
 
 ```python
-from airflow.decorators import dag, task
-from pendulum import datetime
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, start_date=datetime(2026, 1, 1), catchup=False)
-def gcpssh_run():
-    @task
-    def remote():
-        from airflow.providers.google.cloud.hooks.compute_ssh import (
-            ComputeEngineSSHHook,
-        )
+@task
+def remote():
+    from airflow.providers.google.cloud.hooks.compute_ssh import (
+        ComputeEngineSSHHook,
+    )
 
-        hook = ComputeEngineSSHHook(gcp_conn_id="gcpssh_default")
-        client = hook.get_conn()
-        _, stdout, _ = client.exec_command("uname -a")
-        return stdout.read().decode()
+    hook = ComputeEngineSSHHook(gcp_conn_id="gcpssh_default")
+    client = hook.get_conn()
+    _, stdout, _ = client.exec_command("uname -a")
+    return stdout.read().decode()
 
+
+with DAG("gcpssh_run", schedule=None, catchup=False, tags=["example"]):
     remote()
-
-
-gcpssh_run()
 ```
 
 ```yaml
 # leoflow.yaml
-connectors: [gcpssh]
+schema_version: "1.0"
+dag_id: gcpssh_run
+python_version: "3.11"
+connectors:
+  - gcpssh
 ```
 
 ## Security notes

--- a/docs/connections/github.md
+++ b/docs/connections/github.md
@@ -1,12 +1,17 @@
----
-connectors: [github]
----
-
 # GitHub connection
 
 Connect a task to the GitHub API to read repos, manage issues/PRs, or
 trigger workflows over a managed Leoflow Connection. `GithubHook`
 authenticates with a personal access token (PAT).
+
+## Declare the provider
+
+```yaml
+# leoflow.yaml
+dag_id: github_repo
+connectors:
+  - github
+```
 
 ## URI shape
 
@@ -31,35 +36,33 @@ via `Extra`.
 ## Example DAG
 
 ```python
-from airflow.sdk import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, catchup=False, tags=["github"])
-def github_repo():
-    @task
-    def stars():
-        from airflow.providers.github.hooks.github import GithubHook
+@task
+def stars():
+    from airflow.providers.github.hooks.github import GithubHook
 
-        hook = GithubHook(github_conn_id="github_default")
-        client = hook.get_conn()
-        repo = client.get_repo("apache/airflow")
-        print("stars:", repo.stargazers_count)
+    hook = GithubHook(github_conn_id="github_default")
+    client = hook.get_conn()
+    repo = client.get_repo("apache/airflow")
+    print("stars:", repo.stargazers_count)
 
+
+with DAG("github_repo", schedule=None, catchup=False, tags=["example"]):
     stars()
-
-
-github_repo()
 ```
 
 ```yaml
 # leoflow.yaml
+schema_version: "1.0"
 dag_id: github_repo
-runtime: python3.12
-requirements:
-  - apache-airflow-providers-github
+python_version: "3.12"
+connectors:
+  - github
 connections:
-  - conn_id: github_default
-    conn_type: github
+  - github_default
 ```
 
 ## Security notes

--- a/docs/connections/imap.md
+++ b/docs/connections/imap.md
@@ -4,8 +4,13 @@ Connect a task to an IMAP mailbox over a managed Leoflow Connection — to poll
 for incoming files or messages. The host, port, and credentials are encrypted
 at rest and delivered to the task as `AIRFLOW_CONN_<CONN_ID>`.
 
+## Declare the provider
+
 ```yaml
-connectors: [imap]
+# leoflow.yaml
+dag_id: imap_poll
+connectors:
+  - imap
 ```
 
 ## URI shape
@@ -34,28 +39,29 @@ The control plane percent-escapes the password; `ImapHook` (which parses
 The hook is imported inside the task body so DAG parsing stays import-light.
 
 ```python
-from airflow.decorators import dag, task
-from pendulum import datetime
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, start_date=datetime(2026, 1, 1), catchup=False)
-def imap_poll():
-    @task
-    def check():
-        from airflow.providers.imap.hooks.imap import ImapHook
+@task
+def check():
+    from airflow.providers.imap.hooks.imap import ImapHook
 
-        with ImapHook(imap_conn_id="imap_default") as hook:
-            return hook.has_mail_attachment("report-*.csv")
+    with ImapHook(imap_conn_id="imap_default") as hook:
+        return hook.has_mail_attachment("report-*.csv")
 
+
+with DAG("imap_poll", schedule=None, catchup=False, tags=["example"]):
     check()
-
-
-imap_poll()
 ```
 
 ```yaml
 # leoflow.yaml
-connectors: [imap]
+schema_version: "1.0"
+dag_id: imap_poll
+python_version: "3.11"
+connectors:
+  - imap
 ```
 
 ## Security notes

--- a/docs/connections/index.md
+++ b/docs/connections/index.md
@@ -115,61 +115,79 @@ When you press **Test** on a connection of a known type, the result line also
 reminds you to declare the provider (`connectors: [<type>]`) — a Connection in the
 UI carries credentials, but the DAG still has to install the hook to use them.
 
-## Locally-testable (Docker / Lima)
+## Connector matrix
 
-| Type | Doc | Example DAG | Status |
-|---|---|---|---|
-| `postgres` | [postgres.md](postgres.md) | [examples/postgres_load](https://github.com/neochaotic/leoflow/tree/main/examples/postgres_load) | ✅ documented + automated test (#138) |
-| `mysql` / `mariadb` | [mysql.md](mysql.md) | [examples/mysql_load](https://github.com/neochaotic/leoflow/tree/main/examples/mysql_load) | ✅ documented + automated test (#69, table-driven via #138) |
-| `mssql` | [mssql.md](mssql.md) | [examples/mssql_load](https://github.com/neochaotic/leoflow/tree/main/examples/mssql_load) | ✅ documented + automated test (#71, table-driven via #138) |
-| `sqlite` | [sqlite.md](sqlite.md) | [examples/sqlite_load](https://github.com/neochaotic/leoflow/tree/main/examples/sqlite_load) | ✅ documented + automated test (#70, dedicated test for file-path shape; Tier 1 — no service needed) |
-| `redis` | [redis.md](redis.md) | [examples/redis_load](https://github.com/neochaotic/leoflow/tree/main/examples/redis_load) | ✅ documented + automated test (#73, table-driven via #138; Tier 1 — redis already in CI services) |
-| `http` / `https` | [http.md](http.md) | [examples/http_load](https://github.com/neochaotic/leoflow/tree/main/examples/http_load) | ✅ documented + automated test (#75, dedicated test for `__extra__` round-trip; Tier 1 — no service needed) |
-| `oracle` | [oracle.md](oracle.md) | doc-only | ✅ documented + delivery test (table-driven, oracle row); service-name in Schema |
-| `mongo` | [mongo.md](mongo.md) | doc-only | ✅ documented + delivery test (table-driven, mongo row); db in Schema, `srv` for Atlas |
-| `ssh` / `sftp` / `ftp` | [file-transfer.md](file-transfer.md) | doc-only | ✅ documented + delivery test (`TestFileTransferConnectionURIShapeIntegration`); key auth in Extra |
+Every documented connector, its `conn_type`, the provider package the
+`connectors:` sugar expands to (ADR 0038), the **auth shape** (where the
+credential lives), the **local-testable tier**, and a runnable example. Each ships
+a chain-of-custody delivery test; the tier-1 rows also ship an automated example
+test (see [the contract below](#contract-every-entry-honours)). Cloud families
+share a provider package (e.g. `redshift`/`athena`/`emr` →
+`apache-airflow-providers-amazon`; `gcpbigquery`/`gcpcloudsql`/`gcp_looker` →
+`…-google`); the boundary is curated, not a mechanical join of the hook path.
 
-## Cloud (documented)
+| Connector | `conn_type` | Provider package | Auth shape | Local tier | Example |
+|---|---|---|---|---|---|
+| [postgres](postgres.md) | `postgres` | `apache-airflow-providers-postgres` | host + login/password | local (Docker) | [postgres_load](https://github.com/neochaotic/leoflow/tree/main/examples/postgres_load) |
+| [mysql](mysql.md) | `mysql` / `mariadb` | `apache-airflow-providers-mysql` | host + login/password | local (Docker) | [mysql_load](https://github.com/neochaotic/leoflow/tree/main/examples/mysql_load) |
+| [mssql](mssql.md) | `mssql` | `apache-airflow-providers-microsoft-mssql` | host + login/password | local (Docker) | [mssql_load](https://github.com/neochaotic/leoflow/tree/main/examples/mssql_load) |
+| [sqlite](sqlite.md) | `sqlite` | `apache-airflow-providers-sqlite` | file path | local (tier 1) | [sqlite_load](https://github.com/neochaotic/leoflow/tree/main/examples/sqlite_load) |
+| [redis](redis.md) | `redis` | `apache-airflow-providers-redis` | host + password | local (tier 1) | [redis_load](https://github.com/neochaotic/leoflow/tree/main/examples/redis_load) |
+| [http](http.md) | `http` / `https` | `apache-airflow-providers-http` | base URL + Extra | local (tier 1) | [http_load](https://github.com/neochaotic/leoflow/tree/main/examples/http_load) |
+| [oracle](oracle.md) | `oracle` | `apache-airflow-providers-oracle` | host + login/password (service in Schema) | doc-only | recipe |
+| [mongo](mongo.md) | `mongo` | `apache-airflow-providers-mongo` | host + login/password (db in Schema) | doc-only | recipe |
+| [file-transfer](file-transfer.md) | `ssh` / `sftp` / `ftp` | `apache-airflow-providers-ssh` / `-sftp` / `-ftp` | host + login/password (key in Extra) | doc-only | recipe |
+| [google_cloud_platform](google_cloud_platform.md) | `google_cloud_platform` | `apache-airflow-providers-google` | keyless (Workload Identity / ADC) or key in Extra | doc-only | [gcp_gcs_load](https://github.com/neochaotic/leoflow/tree/main/examples/gcp_gcs_load) |
+| [snowflake](snowflake.md) | `snowflake` | `apache-airflow-providers-snowflake` | login/password + account in Extra (or key-pair) | doc-only | recipe |
+| [aws](aws.md) | `aws` | `apache-airflow-providers-amazon` | keyless (IAM role) or access key | doc-only | recipe |
+| [slack](slack.md) | `slack` / `slackwebhook` | `apache-airflow-providers-slack` | token in password | doc-only | recipe |
+| [databricks](databricks.md) | `databricks` | `apache-airflow-providers-databricks` | host + PAT (or OAuth M2M) | doc-only | recipe |
+| [azure](azure.md) | `wasb` / `adls` / `azure_*` | `apache-airflow-providers-microsoft-azure` | keyless (managed identity) or key | doc-only | recipe |
+| [spark](spark.md) | `spark` / `spark_sql` / `spark_connect` / `spark_jdbc` | `apache-airflow-providers-apache-spark` | host:port + tuning Extra | doc-only | recipe |
+| [kafka](kafka.md) | `kafka` | `apache-airflow-providers-apache-kafka` | all-Extra client config (SASL) | doc-only | recipe |
+| [redshift](redshift.md) | `redshift` | `apache-airflow-providers-amazon` | host + login/password (or keyless IAM) | doc-only | recipe |
+| [athena](athena.md) | `athena` | `apache-airflow-providers-amazon` | keyless IAM (region in Extra) | doc-only | recipe |
+| [emr](emr.md) | `emr` | `apache-airflow-providers-amazon` | keyless IAM (region in Extra) | doc-only | recipe |
+| [gcpbigquery](gcpbigquery.md) | `gcpbigquery` | `apache-airflow-providers-google` | keyless (WI / ADC), project in Extra | doc-only | recipe |
+| [gcpcloudsql](gcpcloudsql.md) | `gcpcloudsql` | `apache-airflow-providers-google` | keyless (WI / ADC), instance in Extra | doc-only | recipe |
+| [google_ads](google_ads.md) | `google_ads` | `apache-airflow-providers-google` | OAuth material in Extra | doc-only | recipe |
+| [gcp_looker](gcp_looker.md) | `gcp_looker` | `apache-airflow-providers-google` | API3 client_id/secret in Extra | doc-only | recipe |
+| [gcpssh](gcpssh.md) | `gcpssh` | `apache-airflow-providers-google` | host + login/password | doc-only | recipe |
+| [cassandra](cassandra.md) | `cassandra` | `apache-airflow-providers-apache-cassandra` | host + login/password (keyspace in Schema) | doc-only | recipe |
+| [neo4j](neo4j.md) | `neo4j` | `apache-airflow-providers-neo4j` | host + login/password (db in Schema) | doc-only | recipe |
+| [vertica](vertica.md) | `vertica` | `apache-airflow-providers-vertica` | host + login/password | doc-only | recipe |
+| [influxdb](influxdb.md) | `influxdb` | `apache-airflow-providers-influxdb` | org + token in Extra | doc-only | recipe |
+| [druid](druid.md) | `druid` | `apache-airflow-providers-apache-druid` | host + login/password | doc-only | recipe |
+| [pinot](pinot.md) | `pinot` | `apache-airflow-providers-apache-pinot` | host + login/password (optional) | doc-only | recipe |
+| [trino](trino.md) | `trino` | `apache-airflow-providers-trino` | host + login/password (optional) | doc-only | recipe |
+| [presto](presto.md) | `presto` | `apache-airflow-providers-presto` | host + login/password (optional) | doc-only | recipe |
+| [jdbc](jdbc.md) | `jdbc` | `apache-airflow-providers-jdbc` | host + login/password + driver in Extra | doc-only | recipe |
+| [docker](docker.md) | `docker` | `apache-airflow-providers-docker` | host + login/password | doc-only | recipe |
+| [salesforce](salesforce.md) | `salesforce` | `apache-airflow-providers-salesforce` | login/password + token in Extra | doc-only | recipe |
+| [telegram](telegram.md) | `telegram` | `apache-airflow-providers-telegram` | token in password | doc-only | recipe |
+| [discord](discord.md) | `discord` | `apache-airflow-providers-discord` | token in password + endpoint in Extra | doc-only | recipe |
+| [pagerduty](pagerduty.md) | `pagerduty` | `apache-airflow-providers-pagerduty` | token in password + routing key in Extra | doc-only | recipe |
+| [datadog](datadog.md) | `datadog` | `apache-airflow-providers-datadog` | API + app keys in Extra | doc-only | recipe |
+| [tableau](tableau.md) | `tableau` | `apache-airflow-providers-tableau` | host + login/password (or PAT) | doc-only | recipe |
+| [github](github.md) | `github` | `apache-airflow-providers-github` | PAT in password | doc-only | recipe |
+| [elasticsearch](elasticsearch.md) | `elasticsearch` | `apache-airflow-providers-elasticsearch` | host + login/password | doc-only | recipe |
+| [smtp](smtp.md) | `smtp` | `apache-airflow-providers-smtp` | host + login/password | doc-only | recipe |
+| [imap](imap.md) | `imap` | `apache-airflow-providers-imap` | host + login/password | doc-only | recipe |
+| [opsgenie](opsgenie.md) | `opsgenie` | `apache-airflow-providers-opsgenie` | API key in password | doc-only | recipe |
+| [zendesk](zendesk.md) | `zendesk` | `apache-airflow-providers-zendesk` | agent email + API token | doc-only | recipe |
+| [samba](samba.md) | `samba` | `apache-airflow-providers-samba` | host + login/password | doc-only | recipe |
+| [dbt_cloud](dbt_cloud.md) | `dbt_cloud` | `apache-airflow-providers-dbt-cloud` | account id (login) + API token | doc-only | recipe |
+| [hiveserver2](hiveserver2.md) | `hiveserver2` | `apache-airflow-providers-apache-hive` | host + login/password (db in Schema) | doc-only | recipe |
+| [hive_cli](hive_cli.md) | `hive_cli` | `apache-airflow-providers-apache-hive` | host + login/password + beeline/kerberos in Extra | doc-only | recipe |
+| [powerbi](powerbi.md) | `powerbi` | `apache-airflow-providers-microsoft-azure` | client id/secret + tenant in Extra | doc-only | recipe |
+| [msgraph](msgraph.md) | `msgraph` | `apache-airflow-providers-microsoft-azure` | client id/secret + tenant in Extra | doc-only | recipe |
+| [livy](livy.md) | `livy` | `apache-airflow-providers-apache-livy` | host + login/password | doc-only | recipe |
 
-| Type | Doc | Example DAG | Status |
-|---|---|---|---|
-| `google_cloud_platform` | [google_cloud_platform.md](google_cloud_platform.md) | [examples/gcp_gcs_load](https://github.com/neochaotic/leoflow/tree/main/examples/gcp_gcs_load) | ✅ documented — **key + keyless (Workload Identity)** (#77, #56); delivery test with a synthetic key; real-cloud e2e is manual |
-| `snowflake` | [snowflake.md](snowflake.md) | doc-only (needs a Snowflake account) | ✅ documented + delivery test (`TestSnowflakeConnectionURIShapeIntegration`); account/warehouse/role round-trip via `__extra__`; real-cloud e2e is manual |
-| `aws` | [aws.md](aws.md) | doc-only (needs an AWS account) | ✅ documented — **keyless (IAM role) + key-based** (ADR 0035); delivery test (`TestAWSConnectionURIShapeIntegration`); real-cloud e2e is manual |
-| `slack` / `slackwebhook` | [slack.md](slack.md) | doc-only (needs a Slack workspace) | ✅ documented + delivery test (`TestSlackConnectionURIShapeIntegration`); bot-token round-trip; real-workspace e2e is manual |
-| `databricks` | [databricks.md](databricks.md) | doc-only (needs a Databricks workspace) | ✅ documented + delivery test (`TestDatabricksConnectionURIShapeIntegration`); host + PAT + http_path round-trip; real e2e is manual |
-| `wasb` / `adls` / `azure_*` | [azure.md](azure.md) | doc-only (needs an Azure account) | ✅ documented — **managed identity + key** (ADR 0035); delivery test (`TestWasbConnectionURIShapeIntegration`); real e2e is manual |
-| `spark` / `spark_sql` / … | [spark.md](spark.md) | doc-only (needs a Spark cluster) | ✅ documented + delivery test (`TestSparkConnectionURIShapeIntegration`); host:port + tuning Extra round-trip |
-| `kafka` | [kafka.md](kafka.md) | doc-only (needs a Kafka cluster) | ✅ documented + delivery test (`TestKafkaConnectionURIShapeIntegration`); full client config (incl. SASL) Extra round-trip |
-
-## More connectors (documented + delivery test)
-
-Each ships with a chain-of-custody delivery test and a cookbook recipe; all are
-doc-only (a real run needs the external account/service). Cloud families share a
-provider package (e.g. redshift/athena/emr → `apache-airflow-providers-amazon`;
-bigquery/cloudsql/ads → `…-google`).
-
-| Type | Doc | Type | Doc |
-|---|---|---|---|
-| `redshift` | [redshift.md](redshift.md) | `trino` | [trino.md](trino.md) |
-| `athena` | [athena.md](athena.md) | `presto` | [presto.md](presto.md) |
-| `emr` | [emr.md](emr.md) | `jdbc` | [jdbc.md](jdbc.md) |
-| `gcpbigquery` | [gcpbigquery.md](gcpbigquery.md) | `docker` | [docker.md](docker.md) |
-| `gcpcloudsql` | [gcpcloudsql.md](gcpcloudsql.md) | `salesforce` | [salesforce.md](salesforce.md) |
-| `google_ads` | [google_ads.md](google_ads.md) | `telegram` | [telegram.md](telegram.md) |
-| `cassandra` | [cassandra.md](cassandra.md) | `discord` | [discord.md](discord.md) |
-| `neo4j` | [neo4j.md](neo4j.md) | `pagerduty` | [pagerduty.md](pagerduty.md) |
-| `vertica` | [vertica.md](vertica.md) | `datadog` | [datadog.md](datadog.md) |
-| `influxdb` | [influxdb.md](influxdb.md) | `tableau` | [tableau.md](tableau.md) |
-| `druid` | [druid.md](druid.md) | `github` | [github.md](github.md) |
-| `pinot` | [pinot.md](pinot.md) | `elasticsearch` | [elasticsearch.md](elasticsearch.md) |
-| `dbt_cloud` | [dbt_cloud.md](dbt_cloud.md) | `smtp` | [smtp.md](smtp.md) |
-| `hiveserver2` | [hiveserver2.md](hiveserver2.md) | `imap` | [imap.md](imap.md) |
-| `hive_cli` | [hive_cli.md](hive_cli.md) | `opsgenie` | [opsgenie.md](opsgenie.md) |
-| `powerbi` | [powerbi.md](powerbi.md) | `zendesk` | [zendesk.md](zendesk.md) |
-| `msgraph` | [msgraph.md](msgraph.md) | `samba` | [samba.md](samba.md) |
-| `livy` | [livy.md](livy.md) | `gcpssh` | [gcpssh.md](gcpssh.md) |
-| `gcp_looker` | [gcp_looker.md](gcp_looker.md) | | |
+**Local tier** — *local (Docker)*: spin the service up with Docker/Lima and run the
+example end-to-end; *local (tier 1)*: no external service needed (or already in CI);
+*doc-only*: a real run needs the external account/service, so the page is a recipe with
+a delivery test rather than a runnable example. **Example** — *recipe* links back to the
+connector's own page (the copy-paste DAG lives there).
 
 ## The long tail
 

--- a/docs/connections/influxdb.md
+++ b/docs/connections/influxdb.md
@@ -4,6 +4,15 @@ Connect a task to an InfluxDB time-series database (the `InfluxDBHook`) over a
 managed Leoflow Connection. InfluxDB 2.x authenticates with an **org + token**
 carried in Extra — not login/password.
 
+## Declare the provider
+
+```yaml
+# leoflow.yaml
+dag_id: influxdb_smoke
+connectors:
+  - influxdb
+```
+
 ## URI shape
 
 ```
@@ -38,35 +47,30 @@ The provider import must live **inside** the task body — a top-level
 provider import fails compilation in the parser sidecar.
 
 ```python
-from datetime import datetime
-from airflow.decorators import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, start_date=datetime(2024, 1, 1), catchup=False)
-def influxdb_smoke():
-    @task
-    def query():
-        from airflow.providers.influxdb.hooks.influxdb import InfluxDBHook
+@task
+def query():
+    from airflow.providers.influxdb.hooks.influxdb import InfluxDBHook
 
-        hook = InfluxDBHook(conn_id="influxdb_target")
-        client = hook.get_conn()
-        print("influxdb up:", client.ping())
+    hook = InfluxDBHook(conn_id="influxdb_target")
+    client = hook.get_conn()
+    print("influxdb up:", client.ping())
 
+
+with DAG("influxdb_smoke", schedule=None, catchup=False, tags=["example"]):
     query()
-
-
-influxdb_smoke()
 ```
 
 ```yaml
 # leoflow.yaml
-name: influxdb_smoke
-schedule: null
-image:
-  python: "3.11"
-  requirements:
-    - apache-airflow-providers-influxdb
-connectors: [influxdb]
+schema_version: "1.0"
+dag_id: influxdb_smoke
+python_version: "3.11"
+connectors:
+  - influxdb
 ```
 
 ## Security notes

--- a/docs/connections/jdbc.md
+++ b/docs/connections/jdbc.md
@@ -1,12 +1,17 @@
----
-connectors: [jdbc]
----
-
 # JDBC connection
 
 Connect a task to any database that ships a JDBC driver (DB2, Oracle,
 SAP HANA, Vertica, …) over a managed Leoflow Connection. `JdbcHook` runs
 queries through a JVM driver loaded via JayDeBeApi.
+
+## Declare the provider
+
+```yaml
+# leoflow.yaml
+dag_id: jdbc_query
+connectors:
+  - jdbc
+```
 
 ## URI shape
 
@@ -48,35 +53,34 @@ the password are percent-escaped; `JdbcHook` un-escapes them.
 ## Example DAG
 
 ```python
-from airflow.sdk import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, catchup=False, tags=["jdbc"])
-def jdbc_query():
-    @task
-    def fetch_one():
-        from airflow.providers.jdbc.hooks.jdbc import JdbcHook
+@task
+def fetch_one():
+    from airflow.providers.jdbc.hooks.jdbc import JdbcHook
 
-        hook = JdbcHook(jdbc_conn_id="jdbc_default")
-        rows = hook.get_records("SELECT 1")
-        print("result:", rows[0][0])
+    hook = JdbcHook(jdbc_conn_id="jdbc_default")
+    rows = hook.get_records("SELECT 1")
+    print("result:", rows[0][0])
 
+
+with DAG("jdbc_query", schedule=None, catchup=False, tags=["example"]):
     fetch_one()
-
-
-jdbc_query()
 ```
 
 ```yaml
 # leoflow.yaml
+schema_version: "1.0"
 dag_id: jdbc_query
-runtime: python3.12
-requirements:
-  - apache-airflow-providers-jdbc
+python_version: "3.12"
+connectors:
+  - jdbc
+dependencies:
   - JPype1
 connections:
-  - conn_id: jdbc_default
-    conn_type: jdbc
+  - jdbc_default
 ```
 
 The runtime image must also bundle a JRE/JDK and the driver `.jar`

--- a/docs/connections/mongo.md
+++ b/docs/connections/mongo.md
@@ -71,6 +71,17 @@ For MongoDB Atlas set `Extra: {"srv": true}` and use the cluster host
 (`cluster0.xxxx.mongodb.net`) without a port — `MongoHook` builds the
 `mongodb+srv://` URI.
 
+## Security notes
+
+- **TLS in transit**: set TLS options in **Extra** (`{"tls": true}`), or use the
+  `mongodb+srv://` form (`{"srv": true}`, Atlas) which negotiates TLS by default.
+- **Least privilege**: scope the Mongo user to the target database and set
+  `authSource` in **Extra** — avoid a cluster-wide admin user.
+- **Secrets in logs**: never `print()` the URI — it carries the password. Log
+  the host + database + login only.
+- **gRPC channel (agent ↔ control plane)**: secrets are served only over an
+  authenticated channel (ADR 0021); Pro must run with TLS.
+
 ## Related
 
 - `docs/connections/index.md` — *Installing a connector's provider*.

--- a/docs/connections/neo4j.md
+++ b/docs/connections/neo4j.md
@@ -3,6 +3,15 @@
 Connect a task to a Neo4j graph database (the `Neo4jHook`) over a managed
 Leoflow Connection. The database name lives in the Schema field.
 
+## Declare the provider
+
+```yaml
+# leoflow.yaml
+dag_id: neo4j_smoke
+connectors:
+  - neo4j
+```
+
 ## URI shape
 
 ```
@@ -34,35 +43,30 @@ The provider import must live **inside** the task body — a top-level
 provider import fails compilation in the parser sidecar.
 
 ```python
-from datetime import datetime
-from airflow.decorators import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, start_date=datetime(2024, 1, 1), catchup=False)
-def neo4j_smoke():
-    @task
-    def query():
-        from airflow.providers.neo4j.hooks.neo4j import Neo4jHook
+@task
+def query():
+    from airflow.providers.neo4j.hooks.neo4j import Neo4jHook
 
-        hook = Neo4jHook(conn_id="neo4j_target")
-        rows = hook.run("RETURN 1 AS ok")
-        print("neo4j up:", rows)
+    hook = Neo4jHook(conn_id="neo4j_target")
+    rows = hook.run("RETURN 1 AS ok")
+    print("neo4j up:", rows)
 
+
+with DAG("neo4j_smoke", schedule=None, catchup=False, tags=["example"]):
     query()
-
-
-neo4j_smoke()
 ```
 
 ```yaml
 # leoflow.yaml
-name: neo4j_smoke
-schedule: null
-image:
-  python: "3.11"
-  requirements:
-    - apache-airflow-providers-neo4j
-connectors: [neo4j]
+schema_version: "1.0"
+dag_id: neo4j_smoke
+python_version: "3.11"
+connectors:
+  - neo4j
 ```
 
 ## Security notes

--- a/docs/connections/opsgenie.md
+++ b/docs/connections/opsgenie.md
@@ -4,8 +4,13 @@ Send alerts to Opsgenie from a task over a managed Leoflow Connection. The
 host and API key are encrypted at rest and delivered to the task as
 `AIRFLOW_CONN_<CONN_ID>`.
 
+## Declare the provider
+
 ```yaml
-connectors: [opsgenie]
+# leoflow.yaml
+dag_id: opsgenie_alert
+connectors:
+  - opsgenie
 ```
 
 ## URI shape
@@ -35,28 +40,29 @@ port.
 The hook is imported inside the task body so DAG parsing stays import-light.
 
 ```python
-from airflow.decorators import dag, task
-from pendulum import datetime
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, start_date=datetime(2026, 1, 1), catchup=False)
-def opsgenie_alert():
-    @task
-    def page():
-        from airflow.providers.opsgenie.hooks.opsgenie import OpsgenieAlertHook
+@task
+def page():
+    from airflow.providers.opsgenie.hooks.opsgenie import OpsgenieAlertHook
 
-        hook = OpsgenieAlertHook(opsgenie_conn_id="opsgenie_default")
-        hook.create_alert(payload={"message": "Leoflow pipeline failed"})
+    hook = OpsgenieAlertHook(opsgenie_conn_id="opsgenie_default")
+    hook.create_alert(payload={"message": "Leoflow pipeline failed"})
 
+
+with DAG("opsgenie_alert", schedule=None, catchup=False, tags=["example"]):
     page()
-
-
-opsgenie_alert()
 ```
 
 ```yaml
 # leoflow.yaml
-connectors: [opsgenie]
+schema_version: "1.0"
+dag_id: opsgenie_alert
+python_version: "3.11"
+connectors:
+  - opsgenie
 ```
 
 ## Security notes

--- a/docs/connections/oracle.md
+++ b/docs/connections/oracle.md
@@ -69,6 +69,18 @@ connectors:
     features need the Oracle Instant Client in the image (`system_packages:` or a
     custom base).
 
+## Security notes
+
+- **TLS in transit**: Oracle supports encrypted transport (TCPS / native
+  network encryption). Configure it in the service descriptor or **Extra**;
+  never run credentials over an unencrypted listener.
+- **Least privilege**: connect as a dedicated schema user scoped to the objects
+  the DAG needs — never `SYS`/`SYSTEM`.
+- **Secrets in logs**: never `print()` the URI — it carries the password. Log
+  the host + service name + login only.
+- **gRPC channel (agent ↔ control plane)**: secrets are served only over an
+  authenticated channel (ADR 0021); Pro must run with TLS.
+
 ## Related
 
 - `docs/connections/index.md` — *Installing a connector's provider*.

--- a/docs/connections/pagerduty.md
+++ b/docs/connections/pagerduty.md
@@ -1,12 +1,17 @@
----
-connectors: [pagerduty]
----
-
 # PagerDuty connection
 
 Trigger PagerDuty incidents and alerts from a task over a managed Leoflow
 Connection. `PagerdutyHook` uses a REST API token for the REST API and an
 Events-API routing key (integration key) for Events v2 alerts.
+
+## Declare the provider
+
+```yaml
+# leoflow.yaml
+dag_id: pagerduty_alert
+connectors:
+  - pagerduty
+```
 
 ## URI shape
 
@@ -30,39 +35,37 @@ and the Events-API routing key rides in `Extra` under `__extra__`.
 ## Example DAG
 
 ```python
-from airflow.sdk import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, catchup=False, tags=["pagerduty"])
-def pagerduty_alert():
-    @task
-    def trigger():
-        from airflow.providers.pagerduty.hooks.pagerduty_events import (
-            PagerdutyEventsHook,
-        )
+@task
+def trigger():
+    from airflow.providers.pagerduty.hooks.pagerduty_events import (
+        PagerdutyEventsHook,
+    )
 
-        hook = PagerdutyEventsHook(pagerduty_events_conn_id="pagerduty_default")
-        hook.create_event(
-            summary="DAG failed",
-            severity="critical",
-            source="leoflow",
-        )
+    hook = PagerdutyEventsHook(pagerduty_events_conn_id="pagerduty_default")
+    hook.create_event(
+        summary="DAG failed",
+        severity="critical",
+        source="leoflow",
+    )
 
+
+with DAG("pagerduty_alert", schedule=None, catchup=False, tags=["example"]):
     trigger()
-
-
-pagerduty_alert()
 ```
 
 ```yaml
 # leoflow.yaml
+schema_version: "1.0"
 dag_id: pagerduty_alert
-runtime: python3.12
-requirements:
-  - apache-airflow-providers-pagerduty
+python_version: "3.12"
+connectors:
+  - pagerduty
 connections:
-  - conn_id: pagerduty_default
-    conn_type: pagerduty
+  - pagerduty_default
 ```
 
 ## Security notes

--- a/docs/connections/pinot.md
+++ b/docs/connections/pinot.md
@@ -3,6 +3,15 @@
 Connect a task to an Apache Pinot real-time OLAP store (the `PinotDbApiHook`)
 over a managed Leoflow Connection. Queries go through the Pinot broker.
 
+## Declare the provider
+
+```yaml
+# leoflow.yaml
+dag_id: pinot_smoke
+connectors:
+  - pinot
+```
+
 ## URI shape
 
 ```
@@ -34,35 +43,30 @@ The provider import must live **inside** the task body — a top-level
 provider import fails compilation in the parser sidecar.
 
 ```python
-from datetime import datetime
-from airflow.decorators import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, start_date=datetime(2024, 1, 1), catchup=False)
-def pinot_smoke():
-    @task
-    def query():
-        from airflow.providers.apache.pinot.hooks.pinot import PinotDbApiHook
+@task
+def query():
+    from airflow.providers.apache.pinot.hooks.pinot import PinotDbApiHook
 
-        hook = PinotDbApiHook(pinot_broker_conn_id="pinot_target")
-        rows = hook.get_records("SELECT 1")
-        print("pinot up:", rows)
+    hook = PinotDbApiHook(pinot_broker_conn_id="pinot_target")
+    rows = hook.get_records("SELECT 1")
+    print("pinot up:", rows)
 
+
+with DAG("pinot_smoke", schedule=None, catchup=False, tags=["example"]):
     query()
-
-
-pinot_smoke()
 ```
 
 ```yaml
 # leoflow.yaml
-name: pinot_smoke
-schedule: null
-image:
-  python: "3.11"
-  requirements:
-    - apache-airflow-providers-apache-pinot
-connectors: [pinot]
+schema_version: "1.0"
+dag_id: pinot_smoke
+python_version: "3.11"
+connectors:
+  - pinot
 ```
 
 ## Security notes

--- a/docs/connections/presto.md
+++ b/docs/connections/presto.md
@@ -1,13 +1,18 @@
----
-connectors: [presto]
----
-
 # Presto connection
 
 Connect a task to a [Presto](https://prestodb.io/) coordinator to run
 distributed SQL over a managed Leoflow Connection. Presto is the upstream
 project Trino forked from; the Connection shape is identical, only the
 scheme and hook differ.
+
+## Declare the provider
+
+```yaml
+# leoflow.yaml
+dag_id: presto_query
+connectors:
+  - presto
+```
 
 ## URI shape
 
@@ -35,34 +40,32 @@ percent-escaped; `PrestoHook` un-escapes them on the way out.
 ## Example DAG
 
 ```python
-from airflow.sdk import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, catchup=False, tags=["presto"])
-def presto_query():
-    @task
-    def count_rows():
-        from airflow.providers.presto.hooks.presto import PrestoHook
+@task
+def count_rows():
+    from airflow.providers.presto.hooks.presto import PrestoHook
 
-        hook = PrestoHook(presto_conn_id="presto_default")
-        rows = hook.get_records("SELECT count(*) FROM hive.default.events")
-        print("event count:", rows[0][0])
+    hook = PrestoHook(presto_conn_id="presto_default")
+    rows = hook.get_records("SELECT count(*) FROM hive.default.events")
+    print("event count:", rows[0][0])
 
+
+with DAG("presto_query", schedule=None, catchup=False, tags=["example"]):
     count_rows()
-
-
-presto_query()
 ```
 
 ```yaml
 # leoflow.yaml
+schema_version: "1.0"
 dag_id: presto_query
-runtime: python3.12
-requirements:
-  - apache-airflow-providers-presto
+python_version: "3.12"
+connectors:
+  - presto
 connections:
-  - conn_id: presto_default
-    conn_type: presto
+  - presto_default
 ```
 
 ## Security notes

--- a/docs/connections/redshift.md
+++ b/docs/connections/redshift.md
@@ -10,7 +10,10 @@ Each DAG image bundles only the providers it declares. Add Redshift in
 `leoflow.yaml`:
 
 ```yaml
-connectors: [redshift]
+# leoflow.yaml
+dag_id: redshift_demo
+connectors:
+  - redshift
 ```
 
 ## URI shape
@@ -50,31 +53,30 @@ import runs at parse time and fails the compile (the parser image doesn't carry
 provider deps).
 
 ```python
-from datetime import datetime
-from airflow.decorators import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, start_date=datetime(2024, 1, 1), catchup=False)
-def redshift_demo():
-    @task
-    def count_rows() -> int:
-        from airflow.providers.amazon.aws.hooks.redshift_sql import RedshiftSQLHook
+@task
+def count_rows() -> int:
+    from airflow.providers.amazon.aws.hooks.redshift_sql import RedshiftSQLHook
 
-        hook = RedshiftSQLHook(redshift_conn_id="redshift_dw")
-        rows = hook.get_records("SELECT count(*) FROM analytics.events")
-        return int(rows[0][0])
+    hook = RedshiftSQLHook(redshift_conn_id="redshift_dw")
+    rows = hook.get_records("SELECT count(*) FROM analytics.events")
+    return int(rows[0][0])
 
+
+with DAG("redshift_demo", schedule=None, catchup=False, tags=["example"]):
     count_rows()
-
-
-redshift_demo()
 ```
 
 ```yaml
 # leoflow.yaml
+schema_version: "1.0"
 dag_id: redshift_demo
-python: "3.12"
-connectors: [redshift]
+python_version: "3.12"
+connectors:
+  - redshift
 ```
 
 ## Security notes

--- a/docs/connections/salesforce.md
+++ b/docs/connections/salesforce.md
@@ -1,13 +1,18 @@
----
-connectors: [salesforce]
----
-
 # Salesforce connection
 
 Connect a task to a Salesforce org to run SOQL queries and read/write
 objects over a managed Leoflow Connection. `SalesforceHook` (built on
 `simple-salesforce`) authenticates with username + password + security
 token, or with a connected-app flow configured in `Extra`.
+
+## Declare the provider
+
+```yaml
+# leoflow.yaml
+dag_id: salesforce_query
+connectors:
+  - salesforce
+```
 
 ## URI shape
 
@@ -33,34 +38,32 @@ ride in `Extra` under `__extra__`.
 ## Example DAG
 
 ```python
-from airflow.sdk import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, catchup=False, tags=["salesforce"])
-def salesforce_query():
-    @task
-    def count_accounts():
-        from airflow.providers.salesforce.hooks.salesforce import SalesforceHook
+@task
+def count_accounts():
+    from airflow.providers.salesforce.hooks.salesforce import SalesforceHook
 
-        hook = SalesforceHook(salesforce_conn_id="salesforce_default")
-        result = hook.make_query("SELECT count() FROM Account")
-        print("account count:", result["totalSize"])
+    hook = SalesforceHook(salesforce_conn_id="salesforce_default")
+    result = hook.make_query("SELECT count() FROM Account")
+    print("account count:", result["totalSize"])
 
+
+with DAG("salesforce_query", schedule=None, catchup=False, tags=["example"]):
     count_accounts()
-
-
-salesforce_query()
 ```
 
 ```yaml
 # leoflow.yaml
+schema_version: "1.0"
 dag_id: salesforce_query
-runtime: python3.12
-requirements:
-  - apache-airflow-providers-salesforce
+python_version: "3.12"
+connectors:
+  - salesforce
 connections:
-  - conn_id: salesforce_default
-    conn_type: salesforce
+  - salesforce_default
 ```
 
 ## Security notes

--- a/docs/connections/samba.md
+++ b/docs/connections/samba.md
@@ -4,8 +4,13 @@ Connect a task to an SMB/CIFS file share over a managed Leoflow Connection.
 The host, port, credentials, and an Extra blob (`share_type`) are encrypted at
 rest and delivered to the task as `AIRFLOW_CONN_<CONN_ID>`.
 
+## Declare the provider
+
 ```yaml
-connectors: [samba]
+# leoflow.yaml
+dag_id: samba_pull
+connectors:
+  - samba
 ```
 
 ## URI shape
@@ -34,28 +39,29 @@ The control plane percent-escapes the password; `SambaHook` (which parses
 The hook is imported inside the task body so DAG parsing stays import-light.
 
 ```python
-from airflow.decorators import dag, task
-from pendulum import datetime
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, start_date=datetime(2026, 1, 1), catchup=False)
-def samba_pull():
-    @task
-    def download():
-        from airflow.providers.samba.hooks.samba import SambaHook
+@task
+def download():
+    from airflow.providers.samba.hooks.samba import SambaHook
 
-        hook = SambaHook(samba_conn_id="samba_default")
-        hook.get_file("/incoming/report.csv", "/tmp/report.csv")
+    hook = SambaHook(samba_conn_id="samba_default")
+    hook.get_file("/incoming/report.csv", "/tmp/report.csv")
 
+
+with DAG("samba_pull", schedule=None, catchup=False, tags=["example"]):
     download()
-
-
-samba_pull()
 ```
 
 ```yaml
 # leoflow.yaml
-connectors: [samba]
+schema_version: "1.0"
+dag_id: samba_pull
+python_version: "3.11"
+connectors:
+  - samba
 ```
 
 ## Security notes

--- a/docs/connections/smtp.md
+++ b/docs/connections/smtp.md
@@ -4,8 +4,13 @@ Connect a task to an SMTP mail relay over a managed Leoflow Connection. The
 host, port, credentials, and an Extra blob (`from_email`, `timeout`) are
 encrypted at rest and delivered to the task as `AIRFLOW_CONN_<CONN_ID>`.
 
+## Declare the provider
+
 ```yaml
-connectors: [smtp]
+# leoflow.yaml
+dag_id: smtp_notify
+connectors:
+  - smtp
 ```
 
 ## URI shape
@@ -35,32 +40,33 @@ The control plane percent-escapes the password; `SmtpHook` (which parses
 The hook is imported inside the task body so DAG parsing stays import-light.
 
 ```python
-from airflow.decorators import dag, task
-from pendulum import datetime
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, start_date=datetime(2026, 1, 1), catchup=False)
-def smtp_notify():
-    @task
-    def send():
-        from airflow.providers.smtp.hooks.smtp import SmtpHook
+@task
+def send():
+    from airflow.providers.smtp.hooks.smtp import SmtpHook
 
-        with SmtpHook(smtp_conn_id="smtp_default") as hook:
-            hook.send_email_smtp(
-                to="ops@example.com",
-                subject="Leoflow run complete",
-                html_content="<p>The pipeline finished.</p>",
-            )
+    with SmtpHook(smtp_conn_id="smtp_default") as hook:
+        hook.send_email_smtp(
+            to="ops@example.com",
+            subject="Leoflow run complete",
+            html_content="<p>The pipeline finished.</p>",
+        )
 
+
+with DAG("smtp_notify", schedule=None, catchup=False, tags=["example"]):
     send()
-
-
-smtp_notify()
 ```
 
 ```yaml
 # leoflow.yaml
-connectors: [smtp]
+schema_version: "1.0"
+dag_id: smtp_notify
+python_version: "3.11"
+connectors:
+  - smtp
 ```
 
 ## Security notes

--- a/docs/connections/spark.md
+++ b/docs/connections/spark.md
@@ -81,6 +81,19 @@ connectors:
     task image. Add it via `system_packages:` or a custom base image. The
     Connection only carries where to submit, not the binary.
 
+## Security notes
+
+- **Keytab / principal stay in Extra**: for Kerberos-secured clusters keep
+  `principal` and `keytab` in **Extra** (encrypted at rest, ADR 0019) — never
+  inline them in the DAG source.
+- **Authenticated submit endpoint**: submit to a master/Connect endpoint that
+  enforces auth and TLS where the cluster supports it; the Connection only
+  carries where to submit, not the transport policy.
+- **Secrets in logs**: never `print()` the URI — it may carry credentials. Log
+  the host + port only.
+- **gRPC channel (agent ↔ control plane)**: secrets are served only over an
+  authenticated channel (ADR 0021); Pro must run with TLS.
+
 ## Related
 
 - `docs/connections/index.md` — *Installing a connector's provider*.

--- a/docs/connections/tableau.md
+++ b/docs/connections/tableau.md
@@ -1,12 +1,17 @@
----
-connectors: [tableau]
----
-
 # Tableau connection
 
 Connect a task to Tableau Server or Tableau Cloud to refresh extracts,
 publish workbooks, or query metadata over a managed Leoflow Connection.
 `TableauHook` signs in to the REST API.
+
+## Declare the provider
+
+```yaml
+# leoflow.yaml
+dag_id: tableau_signin
+connectors:
+  - tableau
+```
 
 ## URI shape
 
@@ -33,34 +38,32 @@ is percent-escaped.
 ## Example DAG
 
 ```python
-from airflow.sdk import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, catchup=False, tags=["tableau"])
-def tableau_signin():
-    @task
-    def list_workbooks():
-        from airflow.providers.tableau.hooks.tableau import TableauHook
+@task
+def list_workbooks():
+    from airflow.providers.tableau.hooks.tableau import TableauHook
 
-        with TableauHook(tableau_conn_id="tableau_default") as hook:
-            workbooks = hook.get_all(resource_name="workbooks")
-            print("workbook count:", len(list(workbooks)))
+    with TableauHook(tableau_conn_id="tableau_default") as hook:
+        workbooks = hook.get_all(resource_name="workbooks")
+        print("workbook count:", len(list(workbooks)))
 
+
+with DAG("tableau_signin", schedule=None, catchup=False, tags=["example"]):
     list_workbooks()
-
-
-tableau_signin()
 ```
 
 ```yaml
 # leoflow.yaml
+schema_version: "1.0"
 dag_id: tableau_signin
-runtime: python3.12
-requirements:
-  - apache-airflow-providers-tableau
+python_version: "3.12"
+connectors:
+  - tableau
 connections:
-  - conn_id: tableau_default
-    conn_type: tableau
+  - tableau_default
 ```
 
 ## Security notes

--- a/docs/connections/telegram.md
+++ b/docs/connections/telegram.md
@@ -1,11 +1,16 @@
----
-connectors: [telegram]
----
-
 # Telegram connection
 
 Send messages to a Telegram chat or channel from a task over a managed
 Leoflow Connection. `TelegramHook` posts to the Bot API using a bot token.
+
+## Declare the provider
+
+```yaml
+# leoflow.yaml
+dag_id: telegram_notify
+connectors:
+  - telegram
+```
 
 ## URI shape
 
@@ -30,33 +35,31 @@ message by the operator, or carried in `Extra`.
 ## Example DAG
 
 ```python
-from airflow.sdk import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, catchup=False, tags=["telegram"])
-def telegram_notify():
-    @task
-    def send():
-        from airflow.providers.telegram.hooks.telegram import TelegramHook
+@task
+def send():
+    from airflow.providers.telegram.hooks.telegram import TelegramHook
 
-        hook = TelegramHook(telegram_conn_id="telegram_default")
-        hook.send_message({"chat_id": "-1001234567890", "text": "DAG finished"})
+    hook = TelegramHook(telegram_conn_id="telegram_default")
+    hook.send_message({"chat_id": "-1001234567890", "text": "DAG finished"})
 
+
+with DAG("telegram_notify", schedule=None, catchup=False, tags=["example"]):
     send()
-
-
-telegram_notify()
 ```
 
 ```yaml
 # leoflow.yaml
+schema_version: "1.0"
 dag_id: telegram_notify
-runtime: python3.12
-requirements:
-  - apache-airflow-providers-telegram
+python_version: "3.12"
+connectors:
+  - telegram
 connections:
-  - conn_id: telegram_default
-    conn_type: telegram
+  - telegram_default
 ```
 
 ## Security notes

--- a/docs/connections/trino.md
+++ b/docs/connections/trino.md
@@ -1,12 +1,17 @@
----
-connectors: [trino]
----
-
 # Trino connection
 
 Connect a task to a [Trino](https://trino.io/) coordinator to run
 federated SQL across Hive, Iceberg, PostgreSQL, and other catalogs over a
 managed Leoflow Connection.
+
+## Declare the provider
+
+```yaml
+# leoflow.yaml
+dag_id: trino_query
+connectors:
+  - trino
+```
 
 ## URI shape
 
@@ -37,34 +42,32 @@ The hook is imported **inside** the task body so the DAG file parses even
 where the provider isn't installed.
 
 ```python
-from airflow.sdk import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, catchup=False, tags=["trino"])
-def trino_query():
-    @task
-    def count_rows():
-        from airflow.providers.trino.hooks.trino import TrinoHook
+@task
+def count_rows():
+    from airflow.providers.trino.hooks.trino import TrinoHook
 
-        hook = TrinoHook(trino_conn_id="trino_default")
-        rows = hook.get_records("SELECT count(*) FROM hive.default.events")
-        print("event count:", rows[0][0])
+    hook = TrinoHook(trino_conn_id="trino_default")
+    rows = hook.get_records("SELECT count(*) FROM hive.default.events")
+    print("event count:", rows[0][0])
 
+
+with DAG("trino_query", schedule=None, catchup=False, tags=["example"]):
     count_rows()
-
-
-trino_query()
 ```
 
 ```yaml
 # leoflow.yaml
+schema_version: "1.0"
 dag_id: trino_query
-runtime: python3.12
-requirements:
-  - apache-airflow-providers-trino
+python_version: "3.12"
+connectors:
+  - trino
 connections:
-  - conn_id: trino_default
-    conn_type: trino
+  - trino_default
 ```
 
 ## Security notes

--- a/docs/connections/vertica.md
+++ b/docs/connections/vertica.md
@@ -3,6 +3,15 @@
 Connect a task to a Vertica analytics database (the `VerticaHook`) over a
 managed Leoflow Connection. The database lives in the Schema field.
 
+## Declare the provider
+
+```yaml
+# leoflow.yaml
+dag_id: vertica_smoke
+connectors:
+  - vertica
+```
+
 ## URI shape
 
 ```
@@ -34,35 +43,30 @@ The provider import must live **inside** the task body — a top-level
 provider import fails compilation in the parser sidecar.
 
 ```python
-from datetime import datetime
-from airflow.decorators import dag, task
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, start_date=datetime(2024, 1, 1), catchup=False)
-def vertica_smoke():
-    @task
-    def query():
-        from airflow.providers.vertica.hooks.vertica import VerticaHook
+@task
+def query():
+    from airflow.providers.vertica.hooks.vertica import VerticaHook
 
-        hook = VerticaHook(vertica_conn_id="vertica_target")
-        rows = hook.get_records("SELECT version()")
-        print("vertica up:", rows)
+    hook = VerticaHook(vertica_conn_id="vertica_target")
+    rows = hook.get_records("SELECT version()")
+    print("vertica up:", rows)
 
+
+with DAG("vertica_smoke", schedule=None, catchup=False, tags=["example"]):
     query()
-
-
-vertica_smoke()
 ```
 
 ```yaml
 # leoflow.yaml
-name: vertica_smoke
-schedule: null
-image:
-  python: "3.11"
-  requirements:
-    - apache-airflow-providers-vertica
-connectors: [vertica]
+schema_version: "1.0"
+dag_id: vertica_smoke
+python_version: "3.11"
+connectors:
+  - vertica
 ```
 
 ## Security notes

--- a/docs/connections/zendesk.md
+++ b/docs/connections/zendesk.md
@@ -4,8 +4,13 @@ Connect a task to the Zendesk Support API over a managed Leoflow Connection.
 The subdomain host, agent email, API token, and an Extra blob are encrypted at
 rest and delivered to the task as `AIRFLOW_CONN_<CONN_ID>`.
 
+## Declare the provider
+
 ```yaml
-connectors: [zendesk]
+# leoflow.yaml
+dag_id: zendesk_export
+connectors:
+  - zendesk
 ```
 
 ## URI shape
@@ -34,28 +39,29 @@ Extra blob (`token`, `use_token`) rides in `__extra__`.
 The hook is imported inside the task body so DAG parsing stays import-light.
 
 ```python
-from airflow.decorators import dag, task
-from pendulum import datetime
+# dag.py
+from airflow.sdk import DAG, task
 
 
-@dag(schedule=None, start_date=datetime(2026, 1, 1), catchup=False)
-def zendesk_export():
-    @task
-    def fetch():
-        from airflow.providers.zendesk.hooks.zendesk import ZendeskHook
+@task
+def fetch():
+    from airflow.providers.zendesk.hooks.zendesk import ZendeskHook
 
-        hook = ZendeskHook(zendesk_conn_id="zendesk_default")
-        return hook.get_ticket(ticket_id=1)
+    hook = ZendeskHook(zendesk_conn_id="zendesk_default")
+    return hook.get_ticket(ticket_id=1)
 
+
+with DAG("zendesk_export", schedule=None, catchup=False, tags=["example"]):
     fetch()
-
-
-zendesk_export()
 ```
 
 ```yaml
 # leoflow.yaml
-connectors: [zendesk]
+schema_version: "1.0"
+dag_id: zendesk_export
+python_version: "3.11"
+connectors:
+  - zendesk
 ```
 
 ## Security notes


### PR DESCRIPTION
## What

Normalizes the connection cookbook (`docs/connections/*.md`) so every copy-paste `leoflow.yaml` example is **valid against `docs/api/leoflow-yaml-schema.json`** and the pages follow **one template** (`postgres.md` / `snowflake.md` as the reference shape). Refs #659.

## Changes

**33 files** (29 thin pages normalized + `oracle`/`spark`/`mongo` security sections + `index.md`):

- **Fixed every schema-invalid `leoflow.yaml`.** Replaced the three obsolete dialects:
  - `runtime:` + `requirements:` + inline `connections:` objects + `---` front-matter (datadog, discord, docker, github, jdbc, pagerduty, presto, salesforce, tableau, telegram, trino)
  - `name:` (dag id) + `image:` block (cassandra, druid, elasticsearch, influxdb, neo4j, pinot, vertica)
  - `python:` instead of `python_version` (athena, emr, gcpbigquery, gcpcloudsql, redshift)
  - → all now use `schema_version` / `dag_id` / `python_version` / `dependencies` / `connectors`, with `connections:` as a **string list of connection-ids** (ADR 0045/0055).
- **Removed the dead `connectors:` YAML front-matter blocks** (Material never consumed them).
- **Added the missing `## Declare the provider` section** to the 24 thin pages that lacked it (the `connectors:` sugar).
- **Unified Python imports on `from airflow.sdk import DAG, task`** with the `with DAG(...)` context-manager form, replacing the old `from airflow.decorators import dag, task` decorator style.
- **Added `## Security notes`** to `oracle.md`, `spark.md`, `mongo.md` (mirroring peer pages).
- **`index.md`:** folded the three tiered tables into a single **connector matrix** (connector | conn_type | provider package | auth shape | local tier | example).

**Preserved:** bespoke rich pages (`http`, `mssql`, `mysql`, `redis`, `sqlite`, `postgres`) untouched — they were already schema-valid. `google_ads.md` left untouched (owned separately). Each page keeps its own `conn_id`/`conn_type` (no invented connector facts).

## Verification

- `mkdocs build --strict` → **passes, 0 warnings** (after the git-ignored `docs/cli`, `docs/go`, `docs/helm-chart.md` are generated exactly as `.github/workflows/docs.yml` does).
- **All 94 `leoflow.yaml` blocks** across the pages validate against the schema (manual key-check **and** `jsonschema` strict) — 94/94 OK.
- `grep -nE "^runtime:|^requirements:|^name:|^python:|^image:" docs/connections` → **0** (excluding `google_ads.md`, owned separately).
- No dead links.

Do not merge — for review.
