### PR TITLE
fix(ci): sync gh-pages before mike deploy (stop non-fast-forward push failures)

### DIFF
--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -81,16 +81,23 @@ jobs:
           TAG: ${{ github.ref_name }}   # e.g. v1.2.3 or v1.2.3-rc.1
         run: |
           ver="${TAG#v}"                # strip leading v -> 1.2.3 / 1.2.3-rc.1
+          # Build mike's args by release kind; any semver pre-release suffix
+          # (e.g. -rc.1) publishes the version WITHOUT moving the `latest` alias.
           case "$ver" in
             *-*)
-              # Any semver pre-release suffix (e.g. -rc.1) publishes the version
-              # without moving the `latest` alias.
               echo "Pre-release '$ver' — publishing without moving 'latest'."
-              mike deploy --push "$ver"
-              ;;
+              args="deploy --push $ver" ;;
             *)
-              # Stable release: publish and move `latest` to it.
               echo "Stable '$ver' — publishing and updating 'latest' alias."
-              mike deploy --push --update-aliases "$ver" latest
-              ;;
+              args="deploy --push --update-aliases $ver latest" ;;
           esac
+          # The checkout omits gh-pages, so mike's local branch would diverge from
+          # origin and its push be rejected non-fast-forward. Sync local gh-pages
+          # to origin before each attempt, and retry to absorb a concurrent writer.
+          for attempt in 1 2 3; do
+            git fetch origin gh-pages 2>/dev/null && git branch -f gh-pages origin/gh-pages 2>/dev/null || true
+            if mike $args; then exit 0; fi
+            echo "mike deploy rejected (attempt $attempt); refetching gh-pages and retrying"
+            sleep $((attempt * 3))
+          done
+          echo "mike deploy failed after 3 attempts"; exit 1

--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -86,17 +86,17 @@ jobs:
           case "$ver" in
             *-*)
               echo "Pre-release '$ver' — publishing without moving 'latest'."
-              args="deploy --push $ver" ;;
+              args=(deploy --push "$ver") ;;
             *)
               echo "Stable '$ver' — publishing and updating 'latest' alias."
-              args="deploy --push --update-aliases $ver latest" ;;
+              args=(deploy --push --update-aliases "$ver" latest) ;;
           esac
           # The checkout omits gh-pages, so mike's local branch would diverge from
           # origin and its push be rejected non-fast-forward. Sync local gh-pages
           # to origin before each attempt, and retry to absorb a concurrent writer.
           for attempt in 1 2 3; do
             git fetch origin gh-pages 2>/dev/null && git branch -f gh-pages origin/gh-pages 2>/dev/null || true
-            if mike $args; then exit 0; fi
+            if mike "${args[@]}"; then exit 0; fi
             echo "mike deploy rejected (attempt $attempt); refetching gh-pages and retrying"
             sleep $((attempt * 3))
           done

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -109,7 +109,20 @@ jobs:
       # the site and commits it into gh-pages; that commit IS the publish.
       - name: Publish dev docs with mike
         if: github.event_name == 'push'
-        run: mike deploy --push --update-aliases dev
+        # The checkout does not include gh-pages, so mike's local branch starts
+        # empty/stale and its push is rejected non-fast-forward ("fetch first").
+        # Sync the local gh-pages branch to origin before each attempt so mike
+        # commits on top of the current remote tip, and retry to absorb a
+        # concurrent writer. First-run (no origin gh-pages) falls through the
+        # guard and mike creates the branch.
+        run: |
+          for attempt in 1 2 3; do
+            git fetch origin gh-pages 2>/dev/null && git branch -f gh-pages origin/gh-pages 2>/dev/null || true
+            if mike deploy --push --update-aliases dev; then exit 0; fi
+            echo "mike deploy rejected (attempt $attempt); refetching gh-pages and retrying"
+            sleep $((attempt * 3))
+          done
+          echo "mike deploy failed after 3 attempts"; exit 1
       # Pre-GA there is no stable release, so `dev` is the site default (what a
       # bare / URL redirects to). Guarded: mike stores the default as a root
       # index.html redirect on gh-pages, so only (re)set it when it isn't


### PR DESCRIPTION
The Docs workflow (added in #710) checks out only the triggering ref, not `gh-pages`, so `mike deploy --push` was rejected **non-fast-forward** on every run after the branch existed — main Docs has been red on each docs merge (#712/#715 both failed the push; `mkdocs build --strict` itself passes). Fix: fetch origin gh-pages + force the local branch to it before each deploy, wrapped in a 3-attempt retry. Applied to `docs.yml` (dev deploy) and `docs-release.yaml` (tag publish). actionlint clean.