### PR TITLE
chore(docs,helm): purge stale alpha nomenclature; honest chart default; nav the orphan page

### DIFF
--- a/docs/connections/index.md
+++ b/docs/connections/index.md
@@ -8,9 +8,9 @@ encrypts at rest (ADR 0019) and delivers to a running task as
 This page is the index. Each linked entry below is a focused recipe with the
 URI shape, an example DAG, and how to test it.
 
-!!! warning "Pre-alpha"
+!!! note "Coverage"
     Only a subset of Airflow's standard connection types are documented +
-    tested at this stage. The list below grows as we land them.
+    tested so far. The list below grows as we land them.
 
 ## Installing a connector's provider
 

--- a/docs/cookbook/map-reduce.md
+++ b/docs/cookbook/map-reduce.md
@@ -196,7 +196,7 @@ return value.
 
 - Dynamic mapping (the parser auto-detects `[f(x) for x in <runtime-list>]`)
   and lifts the fan-in degree from "compile-time literal" to "discovered at
-  run-time." Coming after the alpha cut.
+  run-time." On the roadmap.
 
 ## Reference DAGs
 

--- a/docs/frontend-assessment.md
+++ b/docs/frontend-assessment.md
@@ -30,7 +30,7 @@ The embedded SPA (ADR 0017) hits two surface areas:
 ## Phase 0 baseline — server latency is NOT the bottleneck
 
 Measured median over 10 GETs on local Mac (managed PG on Unix socket,
-prealpha.27 build, idle workspace = 1 DAG):
+an early development build, idle workspace = 1 DAG):
 
 ```
     518 μs  /ui/dags                     (DAGs list)
@@ -74,8 +74,8 @@ payload + push channel**, not query optimisation. ADR-0017 compatible.
 ## View → routes matrix (provisional)
 
 Filled from /tmp/leoflow-lite.log captures and code inspection. Latency
-column is local Mac (managed-PG, prealpha.27 build) and will be re-measured
-in Phase 0.
+column is local Mac (managed-PG, an early development build) and will be
+re-measured in Phase 0.
 
 | View | Routes hit | Latency (local) | Known bugs |
 |---|---|---|---|

--- a/docs/local-deploy.md
+++ b/docs/local-deploy.md
@@ -11,7 +11,7 @@ Makefile target.
   against a real `leoflow lite` boot.
 - Reproducing a runtime bug a user reported, without round-tripping
   through the release machinery.
-- Smoke-testing a fix BEFORE cutting a tag — keeps prealpha tags clean.
+- Smoke-testing a fix BEFORE cutting a tag — keeps release tags clean.
 
 This is **not** an install path. Real users still install via
 `install.sh` from a published release (see `docs/installation.md`).
@@ -89,9 +89,9 @@ this by rebuilding and swapping all three on every invocation.
 The local loop is the **inner ring** — it catches "does my change boot
 at all" in seconds, before you push. The release smoke jobs are
 designed for stable releases; they retract a published tag to a draft
-on any failure. Using the local loop first keeps prealpha tags clean
+on any failure. Using the local loop first keeps release tags clean
 and avoids the retract / re-cut churn.
 
-If you find yourself cutting a prealpha purely to test a Lite change,
+If you find yourself cutting a release tag purely to test a Lite change,
 that is a smell — `make lite-redeploy` will give you the same
 validation in seconds without burning a tag number.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,7 +29,7 @@ journalctl -u leoflow-server -f         # Pro / systemd hosts
 | Symptom | Cause / fix |
 |---|---|
 | `command not found: leoflow` | The binary is not on `PATH` — re-run `curl … \| sh`, or open a fresh shell to pick up the install-script's PATH line. Building from source? `go install .../cmd/leoflow@latest` and add `$(go env GOPATH)/bin` to `PATH`. |
-| `leoflow setup` says "python: none on PATH" but you have `python3.12` | Older Leoflow versions only matched literal `python3.11`. Update to the latest pre-alpha — `setup` now accepts any `python3.11`+ that's on `PATH`. |
+| `leoflow setup` says "python: none on PATH" but you have `python3.12` | Older Leoflow versions only matched literal `python3.11`. Update to the latest release — `setup` now accepts any `python3.11`+ that's on `PATH`. |
 | Install on Alpine / musl fails fetching CPython | The musl-libc relocatable CPython build can be missing system libs. `leoflow lite --postgres docker` falls back to the Docker Postgres path instead of the embedded managed one. |
 
 ## `leoflow lite` boot
@@ -40,13 +40,13 @@ journalctl -u leoflow-server -f         # Pro / systemd hosts
 | `provision incomplete: dev database` | The managed Postgres did not start. End-users run `leoflow setup` to bootstrap the managed runtime. Contributors on a source checkout use `leoflow lite provision`. If Docker is the chosen backend, confirm the daemon is up. |
 | Pro refuses to boot with `LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS=true` set | The Pro edition rejects this flag at boot (it would expose plaintext secrets). Unset it for Pro deployments; it stays valid for Lite where the agent talks loopback gRPC without TLS by design. |
 | `jwt_secret is empty; falling back to the dev-only constant` | First boot before `leoflow setup` has run, or `LEOFLOW_SECRET_KEY` not set. Run `leoflow setup` — it provisions a per-install secret. Not fatal on Lite (the constant works), but rotate before sharing the install. |
-| Permission denied on `/tmp/leoflow-*` | Older Lite versions shared `/tmp/leoflow*` paths across users on multi-user hosts. Update to the latest pre-alpha — paths are now per-user. |
+| Permission denied on `/tmp/leoflow-*` | Older Lite versions shared `/tmp/leoflow*` paths across users on multi-user hosts. Update to the latest release — paths are now per-user. |
 
 ## Running a DAG
 
 | Symptom | Cause / fix |
 |---|---|
-| `leoflow compile` dumps a Python traceback with internal parser paths first | Recent builds lead the failure with the user-facing line (e.g. `SyntaxError: ...`) and put the parser paths in the bounded tail. If you still see the internal-first dump, you are on an older pre-alpha — update. |
+| `leoflow compile` dumps a Python traceback with internal parser paths first | Recent builds lead the failure with the user-facing line (e.g. `SyntaxError: ...`) and put the parser paths in the bounded tail. If you still see the internal-first dump, you are on an older release — update. |
 | `leoflow compile` rejects a sensor / Jinja template / branching operator | This is **intentional** — Leoflow accepts a closed set of task types (`python`, `bash`, `airflow_operator`). See [DAG authoring → Not supported](dag-authoring.md#not-supported-leoflow-compile-rejects-these) for the full list and workarounds (`@task` + poll loop for sensors; build values from `airflow.sdk` context for Jinja). |
 | `Compiled .../dag.py -> dag.json (image , version dev)` (dangling comma) | Older build — update. Recent versions render `(no image, version dev)` when `--image` is unset. |
 | Task pod `ErrImagePull` (cluster mode) | The DAG's image is not in the cluster — rebuild + import. Cluster-mode rebuilds on save; for a manual push, `leoflow compile --build --push`. |
@@ -58,11 +58,11 @@ journalctl -u leoflow-server -f         # Pro / systemd hosts
 | Symptom | Cause / fix |
 |---|---|
 | `Invalid credentials` on the login page even with the right password | Disable autofill or type the password manually — some browsers append a trailing space. Usernames are trimmed, passwords are not (per security best practice). |
-| Login rate-limits you out after a few typos | Older builds counted *every* attempt against a 5/min cap; the fix splits successful and failed attempts so a typo does not block recovery. Update to the latest pre-alpha. |
+| Login rate-limits you out after a few typos | Older builds counted *every* attempt against a 5/min cap; the fix splits successful and failed attempts so a typo does not block recovery. Update to the latest release. |
 | No **Lite** badge on `http://localhost:8088` | You are likely on the **Demo** (production-shaped reference, port `8080`) — Lite runs on `8088` with a silver `Leoflow Lite` badge. See [operating modes](operating-modes.md). |
 | Copy-logs button silently fails over `http://<lan-ip>:8088` | The Clipboard API requires a secure context, so plain HTTP origins (LAN access from another machine) used to break copy. Recent builds inject a polyfill (`document.execCommand('copy')` fallback) — update. |
 | Task state badge does not refresh after "Mark as failed/success" | Known upstream Airflow bug — see [apache/airflow#67883](https://github.com/apache/airflow/issues/67883). The server-side mutation persists correctly; the SPA cache update is the gap. Hard-refresh the page (Cmd+Shift+R) to see the new state. |
-| Browser tab title shows "Airflow" not "Leoflow Lite" | Old build; the SPA shell rewrites the `<title>` to the configured instance name at request time. Update to the latest pre-alpha. |
+| Browser tab title shows "Airflow" not "Leoflow Lite" | Old build; the SPA shell rewrites the `<title>` to the configured instance name at request time. Update to the latest release. |
 
 ## Reset paths (when in doubt)
 

--- a/helm/leoflow/Chart.yaml
+++ b/helm/leoflow/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version is the chart version; appVersion tracks the leoflow-server image.
 # Both move in lockstep with the release tag (ADR 0028); decouple only if the
 # chart ever needs a cadence of its own for a template-only fix.
-version: 0.3.0
-appVersion: "0.3.0"
+version: 0.4.0-rc.2
+appVersion: "0.4.0-rc.2"
 home: https://github.com/neochaotic/leoflow
 sources:
   - https://github.com/neochaotic/leoflow

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -1,6 +1,6 @@
 # leoflow
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.0](https://img.shields.io/badge/AppVersion-0.3.0-informational?style=flat-square)
+![Version: 0.4.0-rc.2](https://img.shields.io/badge/Version-0.4.0--rc.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0-rc.2](https://img.shields.io/badge/AppVersion-0.4.0--rc.2-informational?style=flat-square)
 
 Leoflow control plane — a GitOps-first, container-native workflow orchestrator (Airflow 3.2.x UI/API compatible).
 
@@ -326,7 +326,7 @@ differ from what's committed.
 | extraEnv | list | `[]` | Extra environment variables appended to the control-plane container, for server settings this chart does not model as a first-class value (see `docs/configuration.md` for the full `LEOFLOW_*` surface). Standard K8s `env` entries, so `valueFrom` works, and a `value` is always rendered as a string (Kubernetes rejects a numeric one). Appended AFTER the chart-managed entries; do not use it to redefine one — the chart refuses to render an entry that shadows a variable whose value it guards (the warm-pool / agent-credential coupling). Example: `[{name: LEOFLOW_SCHEDULER_DISPATCH_WORKERS, value: "4"}]`. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/neochaotic/leoflow-server"` | Control-plane image. Published by GoReleaser on every tag, signed with cosign. |
-| image.tag | string | `""` | Image tag. Defaults to `.Chart.appVersion` when empty; pre-alpha installs should pin `--set image.tag=v0.0.1-prealpha.N` (the `v`-prefix and no-`v` forms are both published and resolve to the same digest, so either works). |
+| image.tag | string | `""` | Image tag. Defaults to `.Chart.appVersion` when empty; to pin a specific release set `--set image.tag=v0.4.0-rc.2` (the `v`-prefix and no-`v` forms are both published and resolve to the same digest, so either works). |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` | Ingress annotations (controller-specific: rewrites, TLS, auth, etc.). |
 | ingress.className | string | `""` | Ingress class name (e.g. `nginx`). Leave empty to use the cluster default. |
@@ -352,7 +352,7 @@ differ from what's committed.
 | migrations.enabled | bool | `true` |  |
 | migrations.image.pullPolicy | string | `"IfNotPresent"` |  |
 | migrations.image.repository | string | `"ghcr.io/neochaotic/leoflow-migrate"` | leoflow-migrate image bundling Leoflow SQL migrations on top of `migrate/migrate`. Published per release by `release.yaml`, signed with cosign, multi-arch (amd64 + arm64). |
-| migrations.image.tag | string | `""` | Migration image tag. Defaults to `.Chart.appVersion` when empty. Pin to the same tag as `image.tag` (both server and migrate publish both `v`-prefix and no-`v` forms — use whichever convention you prefer, they resolve to the same digest): `--set migrations.image.tag=v0.0.1-prealpha.N`. |
+| migrations.image.tag | string | `""` | Migration image tag. Defaults to `.Chart.appVersion` when empty. Pin to the same tag as `image.tag` (both server and migrate publish both `v`-prefix and no-`v` forms — use whichever convention you prefer, they resolve to the same digest): `--set migrations.image.tag=v0.4.0-rc.2`. |
 | migrations.path | string | `"/migrations"` | Path inside the migrate image where the SQL files live. Must match the COPY destination in `deploy/Dockerfile.migrate`. |
 | migrations.podSecurityContext.fsGroup | int | `65532` |  |
 | migrations.podSecurityContext.runAsGroup | int | `65532` |  |

--- a/helm/leoflow/values.yaml
+++ b/helm/leoflow/values.yaml
@@ -3,7 +3,7 @@
 image:
   # -- Control-plane image. Published by GoReleaser on every tag, signed with cosign.
   repository: ghcr.io/neochaotic/leoflow-server
-  # -- Image tag. Defaults to `.Chart.appVersion` when empty; pre-alpha installs should pin `--set image.tag=v0.0.1-prealpha.N` (the `v`-prefix and no-`v` forms are both published and resolve to the same digest, so either works).
+  # -- Image tag. Defaults to `.Chart.appVersion` when empty; to pin a specific release set `--set image.tag=v0.4.0-rc.2` (the `v`-prefix and no-`v` forms are both published and resolve to the same digest, so either works).
   tag: ""
   pullPolicy: IfNotPresent
 imagePullSecrets: []
@@ -259,7 +259,7 @@ migrations:
   image:
     # -- leoflow-migrate image bundling Leoflow SQL migrations on top of `migrate/migrate`. Published per release by `release.yaml`, signed with cosign, multi-arch (amd64 + arm64).
     repository: ghcr.io/neochaotic/leoflow-migrate
-    # -- Migration image tag. Defaults to `.Chart.appVersion` when empty. Pin to the same tag as `image.tag` (both server and migrate publish both `v`-prefix and no-`v` forms — use whichever convention you prefer, they resolve to the same digest): `--set migrations.image.tag=v0.0.1-prealpha.N`.
+    # -- Migration image tag. Defaults to `.Chart.appVersion` when empty. Pin to the same tag as `image.tag` (both server and migrate publish both `v`-prefix and no-`v` forms — use whichever convention you prefer, they resolve to the same digest): `--set migrations.image.tag=v0.4.0-rc.2`.
     tag: ""
     pullPolicy: IfNotPresent
   # -- Path inside the migrate image where the SQL files live. Must match the COPY destination in `deploy/Dockerfile.migrate`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -228,3 +228,4 @@ nav:
       - Background:
           - MVP reverse analysis: reverse-analysis-mvp.md
           - UI walk report: ui-walk-report.md
+          - Frontend assessment: frontend-assessment.md

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,5 +1,1 @@
 {% extends "base.html" %}
-{% block announce %}
-  🟡 <strong>Alpha</strong> — Leoflow is dev-first; production is a near-term goal.
-  <a href="{{ 'roadmap-to-release.html' | url }}" style="color:inherit;text-decoration:underline;">See the roadmap →</a>
-{% endblock %}


### PR DESCRIPTION
Follow-ups to the docs/CI cleanup (ref #659), sweeping the pre-alpha remnants that #712 missed and making the in-repo chart default honest.

## 1. Purge stale alpha nomenclature
The project is past alpha (v0.4.0-rc.2), but several pre-alpha remnants lingered:

- **`overrides/main.html`** (site-wide, on every page): removed the `{% block announce %}` "🟡 Alpha — Leoflow is dev-first; production is a near-term goal" bar.
- **`docs/troubleshooting.md`**: 5 cells "Update to the latest **pre-alpha**" → "**release**".
- **`docs/connections/index.md`**: `!!! warning "Pre-alpha"` → a neutral `!!! note "Coverage"`.
- **`docs/cookbook/map-reduce.md`**: "Coming after the alpha cut." → "On the roadmap."
- **`docs/local-deploy.md`** (3×): "prealpha tags"/"cutting a prealpha" → release framing.
- **`docs/frontend-assessment.md`**: measurement build annotations `prealpha.27 build` → "an early development build".
- **`helm/leoflow/values.yaml`**: `image.tag` and `migrations.image.tag` `# --` comments no longer suggest `v0.0.1-prealpha.N`; they now point at a real release tag (`v0.4.0-rc.2`) and note the default is `.Chart.appVersion`.

The ADRs (`docs/adr/*`) and `docs/roadmap-to-release.md` keep their alpha references intentionally — they are historical decision records / a banner-marked historical doc.

`git grep -niE "pre-alpha|prealpha|dev-first"` over `docs`, `helm/leoflow/values.yaml`, and `overrides` now returns only ADR hits.

## 2. PR docs-build gate
The PR-only `mkdocs build --strict` gate (doc-gen steps + strict build on `pull_request`, with mike/deploy gated to `push`) is **already present** in `.github/workflows/docs.yml`, restored by the #717 restructure. No workflow change was needed; `actionlint` is clean.

## 3. Honest chart default
`helm/leoflow/Chart.yaml` `version`/`appVersion` `0.3.0` → `0.4.0-rc.2`. Regenerated `helm/leoflow/README.md` with helm-docs v1.14.2 (the version pinned in `helm-ci.yaml`) so the badge reads `0.4.0-rc.2` and the README↔values sync gate stays green. ADR 0028 still stamps the real version from the release tag at publish time; this only makes the in-repo default honest.

## 4. Orphan page `docs/frontend-assessment.md`
It built but was unreachable (not in `mkdocs.yml` nav, referenced by nothing). It is legitimate background analysis — SPA route mapping, latency baseline, bug clustering, phase plan — the same genre as the UI walk report and MVP reverse analysis already published under **Project > Background**. Added it there rather than deleting.

## Verification
- `git grep -niE "pre-alpha|prealpha" docs/troubleshooting.md helm/leoflow/values.yaml` → 0 matches.
- `actionlint .github/workflows/docs.yml` → clean.
- `mkdocs build --strict` → passes (CI-generated inputs reproduced: gen-docs, gomarkdoc, redirect stub, openapi/README copies, ADR index check).
- `helm lint helm/leoflow` → clean; README badge shows `0.4.0-rc.2`; helm-docs `--dry-run` diff empty (no README↔values drift).
