### PR TITLE
ci(docs): auto-flip site default to latest at GA

### DIFF
--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -81,23 +81,33 @@ jobs:
           TAG: ${{ github.ref_name }}   # e.g. v1.2.3 or v1.2.3-rc.1
         run: |
           ver="${TAG#v}"                # strip leading v -> 1.2.3 / 1.2.3-rc.1
-          # Build mike's args by release kind; any semver pre-release suffix
-          # (e.g. -rc.1) publishes the version WITHOUT moving the `latest` alias.
+          # Build mike's args by release kind. A semver pre-release suffix
+          # (e.g. -rc.1) publishes the version WITHOUT moving `latest`; a stable
+          # release moves `latest` AND becomes the site default — this is the GA
+          # flip of the public default from `dev` to `latest`.
+          stable=false
           case "$ver" in
             *-*)
               echo "Pre-release '$ver' — publishing without moving 'latest'."
               args=(deploy --push "$ver") ;;
             *)
-              echo "Stable '$ver' — publishing and updating 'latest' alias."
-              args=(deploy --push --update-aliases "$ver" latest) ;;
+              echo "Stable '$ver' — publishing, updating 'latest', and making it the default."
+              args=(deploy --push --update-aliases "$ver" latest); stable=true ;;
           esac
           # The checkout omits gh-pages, so mike's local branch would diverge from
-          # origin and its push be rejected non-fast-forward. Sync local gh-pages
-          # to origin before each attempt, and retry to absorb a concurrent writer.
-          for attempt in 1 2 3; do
-            git fetch origin gh-pages 2>/dev/null && git branch -f gh-pages origin/gh-pages 2>/dev/null || true
-            if mike "${args[@]}"; then exit 0; fi
-            echo "mike deploy rejected (attempt $attempt); refetching gh-pages and retrying"
-            sleep $((attempt * 3))
-          done
-          echo "mike deploy failed after 3 attempts"; exit 1
+          # origin and its push be rejected non-fast-forward. Sync local gh-pages to
+          # origin before each mike push, and retry to absorb a concurrent writer.
+          run_mike() {
+            for attempt in 1 2 3; do
+              git fetch origin gh-pages 2>/dev/null && git branch -f gh-pages origin/gh-pages 2>/dev/null || true
+              if mike "$@"; then return 0; fi
+              echo "mike $1 rejected (attempt $attempt); refetching gh-pages and retrying"
+              sleep $((attempt * 3))
+            done
+            return 1
+          }
+          run_mike "${args[@]}" || { echo "mike deploy failed after 3 attempts"; exit 1; }
+          if [ "$stable" = true ]; then
+            run_mike set-default --push latest || { echo "mike set-default latest failed after 3 attempts"; exit 1; }
+            echo "Default flipped to 'latest'."
+          fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -131,10 +131,19 @@ jobs:
       - name: Ensure dev is the default version
         if: github.event_name == 'push'
         run: |
-          current="$(git show gh-pages:index.html 2>/dev/null | sed -n 's/.*url=\([^"/]*\).*/\1/p' | head -n1 || true)"
-          if [ "$current" != "dev" ]; then
-            echo "Default is '${current:-<unset>}'; setting it to 'dev'."
-            mike set-default --push dev
+          git fetch origin gh-pages 2>/dev/null && git branch -f gh-pages origin/gh-pages 2>/dev/null || true
+          # Only claim `dev` as the site default PRE-GA. Once a stable release has
+          # created the `latest` alias, the default is `latest` (set by
+          # docs-release.yaml) and main must NOT override it — otherwise every push
+          # would yank the public default back to the unreleased `dev` docs.
+          if git show gh-pages:versions.json 2>/dev/null | grep -q '"latest"'; then
+            echo "A 'latest' alias exists; the default is release-managed — leaving it."
           else
-            echo "Default is already 'dev'; nothing to do."
+            current="$(git show gh-pages:index.html 2>/dev/null | sed -n 's/.*url=\([^"/]*\).*/\1/p' | head -n1 || true)"
+            if [ "$current" != "dev" ]; then
+              echo "Pre-GA: setting default to 'dev' (was '${current:-<unset>}')."
+              mike set-default --push dev
+            else
+              echo "Default is already 'dev'; nothing to do."
+            fi
           fi


### PR DESCRIPTION
Makes "default becomes `latest` at GA" actually happen. Today docs.yml forces default=`dev` on every main push (would revert a GA flip) and docs-release.yaml moves the `latest` alias but never sets it default. Fix: docs.yml only defaults to `dev` while no `latest` exists; docs-release.yaml sets default=`latest` on a stable (non-RC) tag. **No-op until the first stable release.** actionlint clean.