### PR TITLE
fix(storage): resolve tenant by id in secret-audit writes (scope-warning + liveness-denial)

### DIFF
--- a/internal/agentrpc/secrets.go
+++ b/internal/agentrpc/secrets.go
@@ -49,7 +49,9 @@ const (
 // best-effort: a nil auditor or a write error only skips the audit row; it never
 // changes what is delivered.
 type SecretScopeAuditor interface {
-	RecordSecretScopeWarning(ctx context.Context, tenant, dagID, runID, taskID, kind string, declared, total int) error
+	// tenantID is the tenant UUID the agent token carries (AgentIdentity.TenantID),
+	// not the tenant name.
+	RecordSecretScopeWarning(ctx context.Context, tenantID, dagID, runID, taskID, kind string, declared, total int) error
 }
 
 // Secret-path liveness gate modes (ADR 0055 E2). The gate consults the
@@ -81,7 +83,9 @@ type TaskLivenessChecker interface {
 // names or values. Optional and best-effort: a nil auditor or a write error only
 // skips the row; it never changes the gate's decision.
 type SecretLivenessAuditor interface {
-	RecordSecretLivenessDenial(ctx context.Context, tenant, dagID, runID, taskID string, tryNumber int, kind, mode string) error
+	// tenantID is the tenant UUID the agent token carries (AgentIdentity.TenantID),
+	// not the tenant name.
+	RecordSecretLivenessDenial(ctx context.Context, tenantID, dagID, runID, taskID string, tryNumber int, kind, mode string) error
 }
 
 // SetSecrets attaches the secrets store. allowInsecure permits serving secrets

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -720,8 +720,13 @@ func (r *Repository) RecordAuthEvent(ctx context.Context, tenant, actorUserID, a
 // the DAG resource so the event surfaces on the DAG's Audit Log tab, with the
 // kind ("variables" or "connections"), the run and task, and the declared/total
 // counts in metadata. It records counts only — never secret names or values.
-func (r *Repository) RecordSecretScopeWarning(ctx context.Context, tenant, dagID, runID, taskID, kind string, declared, total int) error {
-	tid, err := r.tenantID(ctx, tenant)
+//
+// tenantID is the tenant UUID the agent token carries (not the tenant name): the
+// caller is the agent RPC path, which passes AgentIdentity.TenantID. Resolving it
+// by name silently dropped every row (#722), so mirror the secret-delivery path
+// and parse it as a UUID.
+func (r *Repository) RecordSecretScopeWarning(ctx context.Context, tenantID, dagID, runID, taskID, kind string, declared, total int) error {
+	tid, err := parseUUID(tenantID)
 	if err != nil {
 		return err
 	}
@@ -748,8 +753,13 @@ func (r *Repository) RecordSecretScopeWarning(ctx context.Context, tenant, dagID
 // kind ("variables" or "connections"), the run, task, attempt, and the gate mode
 // in metadata. It records identity + kind + mode only — never secret names or
 // values.
-func (r *Repository) RecordSecretLivenessDenial(ctx context.Context, tenant, dagID, runID, taskID string, tryNumber int, kind, mode string) error {
-	tid, err := r.tenantID(ctx, tenant)
+//
+// tenantID is the tenant UUID the agent token carries (not the tenant name): the
+// caller is the agent RPC path, which passes AgentIdentity.TenantID. Resolving it
+// by name silently dropped every row (#722) — including enforce-mode security
+// denials — so mirror the secret-delivery path and parse it as a UUID.
+func (r *Repository) RecordSecretLivenessDenial(ctx context.Context, tenantID, dagID, runID, taskID string, tryNumber int, kind, mode string) error {
+	tid, err := parseUUID(tenantID)
 	if err != nil {
 		return err
 	}

--- a/internal/storage/ui_queries_integration_test.go
+++ b/internal/storage/ui_queries_integration_test.go
@@ -445,12 +445,26 @@ func TestListAuditLogsIntegration(t *testing.T) {
 // (ADR 0045, ADR 0055): a task that received the full vault while declaring a
 // narrower set records a secret.scope_warning row against the DAG, carrying the
 // kind and the declared/total counts in metadata — and no secret names.
+//
+// The tenant argument is the tenant UUID the agent token carries (the value
+// recordSecretScope passes from AgentIdentity.TenantID), NOT the tenant name.
+// Feeding the name here is the wrong contract that let #722 slip through: a name
+// resolved by a UUID-keyed lookup silently dropped every audit row.
 func TestRecordSecretScopeWarningIntegration(t *testing.T) {
 	repo, _, ctx := openRepo(t)
 	dagID := fmt.Sprintf("uiq_scopewarn_%d", time.Now().UnixNano())
 	registerSpec(t, repo, ctx, dagID, []domain.TaskSpec{{TaskID: "t", Type: domain.TaskTypePython}})
 
-	if err := repo.RecordSecretScopeWarning(ctx, "default", dagID, "run-1", "t", "connections", 1, 3); err != nil {
+	tenantUUID, err := repo.TenantUUID(ctx, "default")
+	if err != nil {
+		t.Fatalf("TenantUUID: %v", err)
+	}
+	// The tenant NAME must NOT resolve (it is not a UUID) — guards the #722 bug.
+	if err := repo.RecordSecretScopeWarning(ctx, "default", dagID, "run-1", "t", "connections", 1, 3); err == nil {
+		t.Error("RecordSecretScopeWarning should require a tenant UUID, not the name")
+	}
+
+	if err := repo.RecordSecretScopeWarning(ctx, tenantUUID, dagID, "run-1", "t", "connections", 1, 3); err != nil {
 		t.Fatalf("RecordSecretScopeWarning: %v", err)
 	}
 
@@ -492,6 +506,82 @@ func TestRecordSecretScopeWarningIntegration(t *testing.T) {
 	}
 	if meta["total"] != float64(3) {
 		t.Errorf("total = %v, want 3", meta["total"])
+	}
+}
+
+// TestRecordSecretLivenessDenialIntegration checks the secret-path liveness
+// audit event (ADR 0055): a not-live task instance records a liveness row
+// against the DAG, with distinct actions per gate mode — secret.liveness_denied
+// in enforce mode, secret.liveness_would_deny in observe mode — and the kind,
+// run/task/attempt, and mode in metadata (never secret names or values).
+//
+// As with the scope-warning event, the tenant argument is the tenant UUID the
+// agent token carries (recordLiveness passes AgentIdentity.TenantID), NOT the
+// name. #722's sibling bug resolved it by name, so an ENFORCE-mode security
+// denial wrote no audit record at all.
+func TestRecordSecretLivenessDenialIntegration(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	dagID := fmt.Sprintf("uiq_livedeny_%d", time.Now().UnixNano())
+	registerSpec(t, repo, ctx, dagID, []domain.TaskSpec{{TaskID: "t", Type: domain.TaskTypePython}})
+
+	tenantUUID, err := repo.TenantUUID(ctx, "default")
+	if err != nil {
+		t.Fatalf("TenantUUID: %v", err)
+	}
+	// The tenant NAME must NOT resolve (it is not a UUID) — guards the #722 bug.
+	if err := repo.RecordSecretLivenessDenial(ctx, "default", dagID, "run-1", "t", 2, "variables", "enforce"); err == nil {
+		t.Error("RecordSecretLivenessDenial should require a tenant UUID, not the name")
+	}
+
+	if err := repo.RecordSecretLivenessDenial(ctx, tenantUUID, dagID, "run-1", "t", 2, "variables", "enforce"); err != nil {
+		t.Fatalf("RecordSecretLivenessDenial(enforce): %v", err)
+	}
+	if err := repo.RecordSecretLivenessDenial(ctx, tenantUUID, dagID, "run-1", "t", 3, "connections", "observe"); err != nil {
+		t.Fatalf("RecordSecretLivenessDenial(observe): %v", err)
+	}
+
+	entries, _, err := repo.ListAuditLogs(ctx, "default", dagID, 50, 0)
+	if err != nil {
+		t.Fatalf("ListAuditLogs: %v", err)
+	}
+	var denied, wouldDeny *domain.AuditLogEntry
+	for i := range entries {
+		switch entries[i].Action {
+		case "secret.liveness_denied":
+			denied = &entries[i]
+		case "secret.liveness_would_deny":
+			wouldDeny = &entries[i]
+		}
+	}
+	if denied == nil {
+		t.Fatalf("secret.liveness_denied entry not found for %s: %+v", dagID, entries)
+	}
+	if wouldDeny == nil {
+		t.Fatalf("secret.liveness_would_deny entry not found for %s: %+v", dagID, entries)
+	}
+	if denied.ResourceType != "dag" || denied.ResourceID != dagID {
+		t.Errorf("resource = %s/%s, want dag/%s", denied.ResourceType, denied.ResourceID, dagID)
+	}
+	// Enforce-mode metadata: parse JSON (jsonb normalizes spacing; numbers decode
+	// to float64).
+	var meta map[string]any
+	if err := json.Unmarshal([]byte(denied.Extra), &meta); err != nil {
+		t.Fatalf("metadata is not valid JSON: %v (%q)", err, denied.Extra)
+	}
+	if meta["kind"] != "variables" {
+		t.Errorf("kind = %v, want variables", meta["kind"])
+	}
+	if meta["mode"] != "enforce" {
+		t.Errorf("mode = %v, want enforce", meta["mode"])
+	}
+	if meta["run_id"] != "run-1" {
+		t.Errorf("run_id = %v, want run-1", meta["run_id"])
+	}
+	if meta["task_id"] != "t" {
+		t.Errorf("task_id = %v, want t", meta["task_id"])
+	}
+	if meta["try_number"] != float64(2) {
+		t.Errorf("try_number = %v, want 2", meta["try_number"])
 	}
 }
 


### PR DESCRIPTION
## Root cause

`RecordSecretScopeWarning` and `RecordSecretLivenessDenial` (`internal/storage/repository.go`) resolved their tenant argument **by name** via `r.tenantID(ctx, tenant)` → `GetTenantByName`. But both are called from the agent RPC path with `AgentIdentity.TenantID`, which is the tenant **UUID** the agent token carries (`internal/agentrpc/secrets.go`; `internal/auth/agent_token.go`). A UUID never matches a tenant *name*, so the lookup returned `resource not found` and the audit row was **never written** — a 100% silent loss of the ADR 0055 observe-before-enforce trails an operator relies on to decide readiness to flip `secret_scoping` / `secret_liveness_mode` to `enforce`.

The delivery path already proved the correct resolution: `SecretVariables`/`SecretConnectionURIs` do `parseUUID(tenantID)` with a comment noting tenantID is the UUID carried by the agent token.

## The sibling bug

The originally-reported bug was `RecordSecretScopeWarning` (observe-mode only). The identical by-name resolution in `RecordSecretLivenessDenial` is worse: `recordLiveness` (`secrets.go`) fires it in **both** observe and **enforce** mode. So an **enforce-mode security denial** (`secret.liveness_denied`) also wrote no audit record at all. Both are fixed in this PR.

## The corrected wrong-contract test

`internal/storage/ui_queries_integration_test.go`'s `TestRecordSecretScopeWarningIntegration` fed the tenant **name** `"default"` — encoding the wrong contract, which is why the bug slipped through. It now feeds the tenant **UUID** (via `repo.TenantUUID`) exactly as production does, and additionally asserts the bare name does **not** resolve.

## Red → green tests (TDD)

Test commit landed before the fix commit. Both integration tests failed today with `resource not found` (UUID passed to a by-name lookup) and pass after the fix:

- `TestRecordSecretScopeWarningIntegration` — writes with the tenant UUID, asserts the `secret.scope_warning` row lands via the `ListAuditLogs` read path; asserts the name does not resolve.
- `TestRecordSecretLivenessDenialIntegration` (new) — writes enforce-mode (`secret.liveness_denied`) and observe-mode (`secret.liveness_would_deny`) rows with the UUID, asserts both land with correct action/kind/mode/attempt metadata; asserts the name does not resolve.

Both follow the suite's shared-default-tenant isolation discipline: they assert on their own seeded DAG id (presence), never on absolute counts.

Red proof (pre-fix):
```
--- FAIL: TestRecordSecretScopeWarningIntegration (0.03s)
    ui_queries_integration_test.go:464: RecordSecretScopeWarning should require a tenant UUID, not the name
    ui_queries_integration_test.go:468: RecordSecretScopeWarning: resource not found
--- FAIL: TestRecordSecretLivenessDenialIntegration (0.01s)
    ui_queries_integration_test.go:533: RecordSecretLivenessDenial should require a tenant UUID, not the name
    ui_queries_integration_test.go:537: RecordSecretLivenessDenial(enforce): resource not found
```

## Other call sites checked

Grepped every `Record*` / `secretAudit` call site. The remaining tenant-resolving audit writers resolve **by name correctly**, because their callers pass a tenant *name*, not a UUID:

- `RecordAuthEvent`, `RecordTaskActionAudit`, `RecordUserCreatedAudit` — called from the API layer with `tenantOf(c)` / the JWT claim. `tenantOf` returns the JWT user's `TenantID`, which `FindUserByLogin` sets to the tenant **name**. Correct as-is; left unchanged.

Only the two agent-RPC-fed writers had the UUID/name mismatch.

## Pre-push gate

```
$ go build ./...
BUILD_OK

$ go vet ./...
VET_OK

$ golangci-lint run ./internal/storage/... ./internal/agentrpc/...
0 issues.

$ DATABASE_URL=<test-db> go test -tags integration -race ./internal/storage/... ./internal/agentrpc/...
ok  	github.com/neochaotic/leoflow/internal/storage	83.316s
ok  	github.com/neochaotic/leoflow/internal/agentrpc	2.056s
```

Closes #722
