### PR TITLE
fix(executor): pin try-number in TaskPodActive + CachedPodActive so a retried TI isn't false-deferred

### DIFF
--- a/internal/executor/pod_cache_reap_test.go
+++ b/internal/executor/pod_cache_reap_test.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -11,11 +12,11 @@ import (
 // reading is never authoritative and the reaper must fall through to the live
 // TaskPodActive read.
 type fakePresenceCache struct {
-	active map[string]bool // "runID/taskID" -> cached Pending/Running
+	active map[string]bool // "runID/taskID/try" -> cached Pending/Running
 }
 
-func (c *fakePresenceCache) CachedPodActive(runID, taskID string) bool {
-	return c.active[runID+"/"+taskID]
+func (c *fakePresenceCache) CachedPodActive(runID, taskID string, try int) bool {
+	return c.active[fmt.Sprintf("%s/%s/%d", runID, taskID, try)]
 }
 
 // --- pod-lost reaper -------------------------------------------------------
@@ -31,7 +32,7 @@ func TestPodLostReaper_CacheAbsentButLiveRunning_DoesNotReap(t *testing.T) {
 	store := &fakePodLostStore{candidates: []PodLostCandidate{
 		{TaskInstanceID: "live", DagRunID: "run-a", TaskID: "work", TryNumber: 1, RunningSince: past},
 	}}
-	pods := &fakePodManager{active: map[string]bool{"run-a/work": true}} // live says Running
+	pods := &fakePodManager{active: map[string]bool{"run-a/work/1": true}} // live says Running
 	r := newPodLostReaper(store, reapTestLogger(), 60*time.Second, nil)
 	r.pods = pods
 	r.cache = &fakePresenceCache{active: map[string]bool{}} // cache says absent (lag)
@@ -61,7 +62,7 @@ func TestPodLostReaper_CacheActive_SkipsLiveList(t *testing.T) {
 	pods := &fakePodManager{active: map[string]bool{}}
 	r := newPodLostReaper(store, reapTestLogger(), 60*time.Second, nil)
 	r.pods = pods
-	r.cache = &fakePresenceCache{active: map[string]bool{"run-a/work": true}}
+	r.cache = &fakePresenceCache{active: map[string]bool{"run-a/work/1": true}}
 
 	if err := r.run(context.Background()); err != nil {
 		t.Fatalf("run: %v", err)
@@ -136,7 +137,7 @@ func TestDispatchLostReaper_CacheAbsentButLiveActive_DoesNotReap(t *testing.T) {
 	store := &fakeStaleQueuedStore{candidates: []StaleQueuedCandidate{
 		{TaskInstanceID: "slow", DagRunID: "run-a", TaskID: "work", TryNumber: 1, QueuedAt: past},
 	}}
-	pods := &fakePodManager{active: map[string]bool{"run-a/work": true}}
+	pods := &fakePodManager{active: map[string]bool{"run-a/work/1": true}}
 	r := newDispatchLostReaper(store, reapTestLogger(), 3*time.Minute, nil)
 	r.pods = pods
 	r.cache = &fakePresenceCache{active: map[string]bool{}} // cache absent
@@ -162,7 +163,7 @@ func TestDispatchLostReaper_CacheActive_SkipsLiveList(t *testing.T) {
 	pods := &fakePodManager{active: map[string]bool{}}
 	r := newDispatchLostReaper(store, reapTestLogger(), 3*time.Minute, nil)
 	r.pods = pods
-	r.cache = &fakePresenceCache{active: map[string]bool{"run-a/work": true}}
+	r.cache = &fakePresenceCache{active: map[string]bool{"run-a/work/1": true}}
 
 	if err := r.run(context.Background()); err != nil {
 		t.Fatalf("run: %v", err)

--- a/internal/executor/pod_informer.go
+++ b/internal/executor/pod_informer.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"errors"
+	"strconv"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
@@ -19,8 +20,9 @@ import (
 // reusing the same transform is load-bearing: a lookup built from a different key
 // would silently miss every pod and quietly return the storm PR-10 removes.
 const (
-	podLabelRunID  = "leoflow.io/run-id"
-	podLabelTaskID = "leoflow.io/task-id"
+	podLabelRunID     = "leoflow.io/run-id"
+	podLabelTaskID    = "leoflow.io/task-id"
+	podLabelTryNumber = "leoflow.io/try-number"
 )
 
 // errCacheNotSynced is returned by SnapshotTaskPods before the informer's initial
@@ -107,19 +109,21 @@ func (p *PodInformer) Shutdown() {
 	p.factory.Shutdown()
 }
 
-// CachedPodActive reports whether the cache holds a pod for (run, task) that is
-// Pending or Running — the exact predicate TaskPodActive uses. It is the safe
+// CachedPodActive reports whether the cache holds a pod for exactly the
+// (run, task, try) attempt that is Pending or Running — the exact predicate
+// TaskPodActive uses, pinned to the same attempt (#723). It is the safe
 // direction of the asymmetric-trust contract: a true return may DEFER a reap; a
 // false return is NEVER authoritative and the caller must fall through to the live
 // read. Before the cache has synced it returns false, so a cold cache degrades to
 // the live path rather than misreporting absence.
-func (p *PodInformer) CachedPodActive(runID, taskID string) bool {
+func (p *PodInformer) CachedPodActive(runID, taskID string, tryNumber int) bool {
 	if !p.informer.HasSynced() {
 		return false
 	}
 	selector := labels.SelectorFromSet(labels.Set{
-		podLabelRunID:  sanitizeLabel(runID),
-		podLabelTaskID: sanitizeLabel(taskID),
+		podLabelRunID:     sanitizeLabel(runID),
+		podLabelTaskID:    sanitizeLabel(taskID),
+		podLabelTryNumber: strconv.Itoa(tryNumber),
 	})
 	pods, err := p.lister.Pods(p.namespace).List(selector)
 	if err != nil {

--- a/internal/executor/pod_informer_test.go
+++ b/internal/executor/pod_informer_test.go
@@ -62,13 +62,13 @@ func TestPodInformer_SeesAddAndDelete(t *testing.T) {
 		t.Fatal("cache did not sync")
 	}
 
-	if !pi.CachedPodActive("Run_A", "extract") {
+	if !pi.CachedPodActive("Run_A", "extract", 1) {
 		t.Error("a Running pod must read as active (with sanitized labels)")
 	}
-	if pi.CachedPodActive("Run_A", "done-task") {
+	if pi.CachedPodActive("Run_A", "done-task", 1) {
 		t.Error("a Succeeded pod must not read as active")
 	}
-	if pi.CachedPodActive("Run_A", "never-existed") {
+	if pi.CachedPodActive("Run_A", "never-existed", 1) {
 		t.Error("an unknown task must read as not active")
 	}
 
@@ -76,7 +76,7 @@ func TestPodInformer_SeesAddAndDelete(t *testing.T) {
 	if err := cs.CoreV1().Pods("leoflow").Delete(ctx, "p-run", metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
-	if !waitFor(t, func() bool { return !pi.CachedPodActive("Run_A", "extract") }) {
+	if !waitFor(t, func() bool { return !pi.CachedPodActive("Run_A", "extract", 1) }) {
 		t.Error("cache did not observe the pod deletion")
 	}
 
@@ -84,7 +84,7 @@ func TestPodInformer_SeesAddAndDelete(t *testing.T) {
 	if _, err := cs.CoreV1().Pods("leoflow").Create(ctx, informerPod("p-new", "Run_A", "load", corev1.PodPending), metav1.CreateOptions{}); err != nil {
 		t.Fatalf("create: %v", err)
 	}
-	if !waitFor(t, func() bool { return pi.CachedPodActive("Run_A", "load") }) {
+	if !waitFor(t, func() bool { return pi.CachedPodActive("Run_A", "load", 1) }) {
 		t.Error("cache did not observe the added Pending pod")
 	}
 }
@@ -97,7 +97,7 @@ func TestPodInformer_BeforeSync_ReturnsFalse(t *testing.T) {
 	cs := fake.NewClientset(informerPod("p-run", "r1", "t1", corev1.PodRunning))
 	pi := NewPodInformer(cs, "leoflow")
 	// Deliberately NOT started / not synced.
-	if pi.CachedPodActive("r1", "t1") {
+	if pi.CachedPodActive("r1", "t1", 1) {
 		t.Error("an unsynced cache must return false (fall through to the live read)")
 	}
 	if _, err := pi.SnapshotTaskPods(); err == nil {

--- a/internal/executor/pod_lost_reap.go
+++ b/internal/executor/pod_lost_reap.go
@@ -110,7 +110,7 @@ func (r *podLostReaper) run(ctx context.Context) error {
 		// Cache fast-path (PR-10), safe direction only: a cached Pending/Running
 		// pod defers the reap without an apiserver read. A cache MISS is NOT
 		// trusted — fall through to the live read below, preserving the #461 fix.
-		if r.cache != nil && r.cache.CachedPodActive(c.DagRunID, c.TaskID) {
+		if r.cache != nil && r.cache.CachedPodActive(c.DagRunID, c.TaskID, c.TryNumber) {
 			r.record("pod_lost_cache_active")
 			continue
 		}
@@ -119,7 +119,7 @@ func (r *podLostReaper) run(ctx context.Context) error {
 		//   * pod Pending/Running -> a pod exists; not lost. Silence, if any, is
 		//                            the agent-lost reaper's job.
 		//   * no live pod       -> the pod is genuinely gone; fail as pod_lost.
-		active, perr := r.pods.TaskPodActive(ctx, c.DagRunID, c.TaskID)
+		active, perr := r.pods.TaskPodActive(ctx, c.DagRunID, c.TaskID, c.TryNumber)
 		if perr != nil {
 			r.logger.Warn("pod-lost: pod liveness unknown; deferring",
 				"ti", c.TaskInstanceID, "run", c.DagRunID, "task", c.TaskID, "error", perr)

--- a/internal/executor/pod_lost_reap_test.go
+++ b/internal/executor/pod_lost_reap_test.go
@@ -86,7 +86,7 @@ func TestPodLostReaper(t *testing.T) {
 		store := &fakePodLostStore{candidates: []PodLostCandidate{
 			{TaskInstanceID: "live", DagRunID: "run-a", TaskID: "work", TryNumber: 1, RunningSince: past},
 		}}
-		pods := &fakePodManager{active: map[string]bool{"run-a/work": true}}
+		pods := &fakePodManager{active: map[string]bool{"run-a/work/1": true}}
 		if err := newReaper(store, pods).run(context.Background()); err != nil {
 			t.Fatalf("run: %v", err)
 		}

--- a/internal/executor/pod_manager.go
+++ b/internal/executor/pod_manager.go
@@ -26,10 +26,12 @@ type PodManager interface {
 	// orphan-run reaper, which abandons the whole run. The run-id is unique
 	// per run, so no other run's pod can match. Tolerates missing pods.
 	DeleteRunPods(ctx context.Context, runID string) error
-	// TaskPodActive reports whether a pod for (run, task) exists and is
-	// Pending or Running. The dispatch-lost reaper defers when it is true —
-	// the dispatch landed, the node is merely slow (#461).
-	TaskPodActive(ctx context.Context, runID, taskID string) (bool, error)
+	// TaskPodActive reports whether a pod for exactly the (run, task, try)
+	// attempt exists and is Pending or Running. The reaper defers when it is
+	// true — the dispatch landed, the node is merely slow (#461). Try-number is
+	// pinned so a retried TI's liveness gate asks about the attempt it is about
+	// to fail, not any older attempt whose pod may still linger (#723).
+	TaskPodActive(ctx context.Context, runID, taskID string, tryNumber int) (bool, error)
 }
 
 // PodPresenceCache is an optional read-through cache of pod presence — backed by
@@ -50,7 +52,9 @@ type PodManager interface {
 // and before the informer warms: every candidate then uses the live path.
 type PodPresenceCache interface {
 	// CachedPodActive reports whether the cache holds a Pending/Running pod for
-	// (run, task). Only a true return is trusted (to defer); false is a "no
-	// speedup" signal that must not drive a reap.
-	CachedPodActive(runID, taskID string) bool
+	// exactly the (run, task, try) attempt. Only a true return is trusted (to
+	// defer); false is a "no speedup" signal that must not drive a reap.
+	// Try-number is pinned so the cache gate cannot defer on an older attempt's
+	// lingering pod (#723).
+	CachedPodActive(runID, taskID string, tryNumber int) bool
 }

--- a/internal/executor/pod_terminate.go
+++ b/internal/executor/pod_terminate.go
@@ -68,18 +68,23 @@ func (e *KubernetesExecutor) deletePodsBySelector(ctx context.Context, selector 
 	return errors.Join(errs...)
 }
 
-// TaskPodActive reports whether a pod for the given (run, task) exists and is
-// still Pending or Running. The dispatch-lost reaper consults this before
-// failing a `queued` TI: a live pod means the dispatch actually landed and the
-// node is merely slow to pull the image (#461), so the reaper must DEFER. No
-// pod, or only terminal (Failed/Succeeded/Unknown) pods, means the dispatch is
-// genuinely lost and the reaper may proceed. Try-number is deliberately NOT
-// pinned here: a `queued` TI has not been retried, so run-id+task-id already
-// identifies its single pod, and matching any live pod for the task is the
-// safer (more deferring) choice.
-func (e *KubernetesExecutor) TaskPodActive(ctx context.Context, runID, taskID string) (bool, error) {
-	selector := fmt.Sprintf("leoflow.io/run-id=%s,leoflow.io/task-id=%s",
-		sanitizeLabel(runID), sanitizeLabel(taskID))
+// TaskPodActive reports whether a pod for exactly the (run, task, try) attempt
+// exists and is still Pending or Running. The dispatch-lost and pod-lost reapers
+// consult this before failing a TI: a live pod means the dispatch actually landed
+// and the node is merely slow to pull the image (#461), so the reaper must DEFER.
+// No pod, or only terminal (Failed/Succeeded/Unknown) pods, means the attempt is
+// genuinely lost and the reaper may proceed.
+//
+// Try-number is pinned — the same invariant guard as DeleteTaskPod above. The
+// retry rail resets up_for_retry -> none with try_number+1 and the planner
+// re-queues the TI (storage/queries/runs.sql), so a `queued`/`running` TI can be
+// on try 2 while try 1's pod still lingers Pending after a failed best-effort
+// delete. Selecting on (run, task) alone would match that stale older pod and
+// false-defer the reap of the current attempt forever (#723). Asking about the
+// attempt the reaper is about to fail is the correct liveness question.
+func (e *KubernetesExecutor) TaskPodActive(ctx context.Context, runID, taskID string, tryNumber int) (bool, error) {
+	selector := fmt.Sprintf("leoflow.io/run-id=%s,leoflow.io/task-id=%s,leoflow.io/try-number=%s",
+		sanitizeLabel(runID), sanitizeLabel(taskID), strconv.Itoa(tryNumber))
 	pods, err := e.clientset.CoreV1().Pods(e.namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
 		return false, fmt.Errorf("listing pods for liveness (%s): %w", selector, err)

--- a/internal/executor/pod_terminate_test.go
+++ b/internal/executor/pod_terminate_test.go
@@ -129,7 +129,7 @@ func TestTaskPodActive(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cs := fake.NewSimpleClientset(taskPod("p", "run-a", "extract", 1, tc.phase))
 			e := NewKubernetesExecutor(cs, "leoflow")
-			active, err := e.TaskPodActive(context.Background(), "run-a", "extract")
+			active, err := e.TaskPodActive(context.Background(), "run-a", "extract", 1)
 			if err != nil {
 				t.Fatalf("TaskPodActive: %v", err)
 			}
@@ -140,12 +140,37 @@ func TestTaskPodActive(t *testing.T) {
 	}
 }
 
+// TestTaskPodActive_PinsTryNumber is the #723 selector lock: a try-1 pod lingers
+// Pending, but a liveness query for try 2 must NOT match it. Asking whether the
+// attempt the reaper is about to fail (try 2) is live must return false, so the
+// reaper does not false-defer on a stale older attempt's pod.
+func TestTaskPodActive_PinsTryNumber(t *testing.T) {
+	cs := fake.NewSimpleClientset(taskPod("try1", "run-a", "extract", 1, corev1.PodPending))
+	e := NewKubernetesExecutor(cs, "leoflow")
+
+	active, err := e.TaskPodActive(context.Background(), "run-a", "extract", 2)
+	if err != nil {
+		t.Fatalf("TaskPodActive: %v", err)
+	}
+	if active {
+		t.Errorf("#723: a try-2 liveness query matched a lingering try-1 pod; try-number must be pinned")
+	}
+	// Sanity: the same query for the attempt that DOES have a Pending pod is active.
+	active, err = e.TaskPodActive(context.Background(), "run-a", "extract", 1)
+	if err != nil {
+		t.Fatalf("TaskPodActive(try1): %v", err)
+	}
+	if !active {
+		t.Errorf("try-1's own Pending pod must read as active")
+	}
+}
+
 // TestTaskPodActive_AbsentIsNotActive: no pod at all means the dispatch never
 // landed — not active, so the reaper proceeds.
 func TestTaskPodActive_AbsentIsNotActive(t *testing.T) {
 	cs := fake.NewSimpleClientset()
 	e := NewKubernetesExecutor(cs, "leoflow")
-	active, err := e.TaskPodActive(context.Background(), "run-a", "extract")
+	active, err := e.TaskPodActive(context.Background(), "run-a", "extract", 1)
 	if err != nil {
 		t.Fatalf("TaskPodActive: %v", err)
 	}

--- a/internal/executor/reap_pod_teardown_test.go
+++ b/internal/executor/reap_pod_teardown_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -13,7 +14,9 @@ import (
 type fakePodManager struct {
 	deletedTasks []deletedTask
 	deletedRuns  []string
-	// active maps "runID/taskID" -> whether a live pod exists; absent key is false.
+	// active maps "runID/taskID/try" -> whether a live pod exists for exactly
+	// that attempt; absent key is false. Keying by try mirrors the real
+	// executor's try-pinned selector (#723).
 	active map[string]bool
 	// activeCalls counts TaskPodActive invocations, so a test can assert the live
 	// (quorum) read was skipped when the presence cache already deferred.
@@ -45,12 +48,12 @@ func (f *fakePodManager) DeleteRunPods(_ context.Context, runID string) error {
 	return nil
 }
 
-func (f *fakePodManager) TaskPodActive(_ context.Context, runID, taskID string) (bool, error) {
+func (f *fakePodManager) TaskPodActive(_ context.Context, runID, taskID string, try int) (bool, error) {
 	f.activeCalls++
 	if f.activeErr != nil {
 		return false, f.activeErr
 	}
-	return f.active[runID+"/"+taskID], nil
+	return f.active[fmt.Sprintf("%s/%s/%d", runID, taskID, try)], nil
 }
 
 // --- Dispatch-lost reaper: K8s-aware deferral (part C) ---------------------
@@ -65,7 +68,7 @@ func TestDispatchLostReaper_DefersWhenPodLive(t *testing.T) {
 	store := &fakeStaleQueuedStore{candidates: []StaleQueuedCandidate{
 		{TaskInstanceID: "slow-pull", DagRunID: "run-a", TaskID: "extract", TryNumber: 1, QueuedAt: now.Add(-10 * time.Minute)},
 	}}
-	pods := &fakePodManager{active: map[string]bool{"run-a/extract": true}}
+	pods := &fakePodManager{active: map[string]bool{"run-a/extract/1": true}}
 	r := newDispatchLostReaper(store, reapTestLogger(), 3*time.Minute, nil)
 	r.pods = pods
 

--- a/internal/executor/reap_try_number_test.go
+++ b/internal/executor/reap_try_number_test.go
@@ -1,0 +1,135 @@
+package executor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// The tests in this file lock issue #723: the reapers' liveness gate must ask
+// about the exact ATTEMPT it is about to fail, not the (run, task) as a whole.
+//
+// The retry rail resets up_for_retry -> none with try_number = try_number + 1
+// (storage/queries/runs.sql) and the planner re-queues the TI, so a `queued` (or
+// `running`) TI can legitimately be on try 2 while try 1's pod still lingers
+// Pending (unschedulable / image-pull backoff) after a best-effort delete failed.
+// A liveness selector pinned only to (run, task) then matches the stale try-1 pod
+// and false-defers forever — the wedge #723 describes. Pinning try-number makes
+// the reaper ask about try 2's pod, which is genuinely gone, so the reap proceeds.
+//
+// Each test wires the REAL executor / informer against a fake cluster holding
+// only the older attempt's pod, so it exercises the actual label selector rather
+// than a hand-rolled fake predicate.
+
+// TestDispatchLostReaper_TryNumberPinned_LiveRead is the #723 lock on the
+// dispatch-lost/queued path via the live TaskPodActive read: a try-1 pod lingers
+// Pending, but the dispatch-lost candidate is on try 2. Try 2's dispatch is
+// genuinely lost, so the reaper MUST fail it as dispatch_lost — it must not defer
+// on the stale try-1 pod.
+func TestDispatchLostReaper_TryNumberPinned_LiveRead(t *testing.T) {
+	now := time.Now().UTC()
+	cs := fake.NewSimpleClientset(
+		taskPod("try1-pending", "run-a", "extract", 1, corev1.PodPending), // stale older attempt
+	)
+	store := &fakeStaleQueuedStore{candidates: []StaleQueuedCandidate{
+		{TaskInstanceID: "stuck", DagRunID: "run-a", TaskID: "extract", TryNumber: 2, QueuedAt: now.Add(-10 * time.Minute)},
+	}}
+	r := newDispatchLostReaper(store, reapTestLogger(), 3*time.Minute, nil)
+	r.pods = NewKubernetesExecutor(cs, "leoflow")
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.failed) != 1 || store.failed[0] != "stuck" {
+		t.Fatalf("#723: try-2 dispatch is lost (only try-1 pod lingers) — TI must be failed dispatch_lost, got %v", store.failed)
+	}
+}
+
+// TestDispatchLostReaper_TryNumberPinned_CacheRead is the #723 lock on the same
+// path via the informer cache fast-path (CachedPodActive). The cache holds only
+// the stale try-1 pod; the candidate is try 2. The cache lookup must be pinned to
+// try 2, miss, and fall through to the live read (also try-2-absent) so the reap
+// proceeds — the cache branch must not false-defer on the older attempt.
+func TestDispatchLostReaper_TryNumberPinned_CacheRead(t *testing.T) {
+	now := time.Now().UTC()
+	cs := fake.NewClientset(
+		taskPod("try1-pending", "run-a", "extract", 1, corev1.PodPending),
+	)
+	pi := NewPodInformer(cs, "leoflow")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pi.Start(ctx)
+	if !pi.WaitForCacheSync(ctx) {
+		t.Fatal("cache did not sync")
+	}
+	store := &fakeStaleQueuedStore{candidates: []StaleQueuedCandidate{
+		{TaskInstanceID: "stuck", DagRunID: "run-a", TaskID: "extract", TryNumber: 2, QueuedAt: now.Add(-10 * time.Minute)},
+	}}
+	r := newDispatchLostReaper(store, reapTestLogger(), 3*time.Minute, nil)
+	r.pods = NewKubernetesExecutor(cs, "leoflow")
+	r.cache = pi
+
+	if err := r.run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.failed) != 1 || store.failed[0] != "stuck" {
+		t.Fatalf("#723: cache fast-path must pin try-number and not defer on the stale try-1 pod, got %v", store.failed)
+	}
+}
+
+// TestPodLostReaper_TryNumberPinned_LiveRead is the #723 lock on the pod-lost/
+// running path via the live read: a try-1 pod lingers Running, but the running
+// candidate is on try 2 whose pod is genuinely gone. The reaper must fail it as
+// pod_lost rather than false-defer on the stale try-1 pod.
+func TestPodLostReaper_TryNumberPinned_LiveRead(t *testing.T) {
+	past := time.Now().UTC().Add(-2 * time.Minute)
+	cs := fake.NewSimpleClientset(
+		taskPod("try1-running", "run-a", "work", 1, corev1.PodRunning), // stale older attempt
+	)
+	store := &fakePodLostStore{candidates: []PodLostCandidate{
+		{TaskInstanceID: "lost", DagRunID: "run-a", TaskID: "work", TryNumber: 2, RunningSince: past},
+	}}
+	r := newPodLostReaper(store, reapTestLogger(), 60*time.Second, nil)
+	r.pods = NewKubernetesExecutor(cs, "leoflow")
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.marked) != 1 || store.marked[0] != "lost" {
+		t.Fatalf("#723: try-2 running pod is gone (only try-1 pod lingers) — TI must be failed pod_lost, got %v", store.marked)
+	}
+}
+
+// TestPodLostReaper_TryNumberPinned_CacheRead is the #723 lock on the pod-lost
+// path via the informer cache: the cache holds only the stale try-1 pod, the
+// candidate is try 2. The cache lookup must pin try 2, miss, and fall through to
+// the live read so the reap proceeds.
+func TestPodLostReaper_TryNumberPinned_CacheRead(t *testing.T) {
+	past := time.Now().UTC().Add(-2 * time.Minute)
+	cs := fake.NewClientset(
+		taskPod("try1-running", "run-a", "work", 1, corev1.PodRunning),
+	)
+	pi := NewPodInformer(cs, "leoflow")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pi.Start(ctx)
+	if !pi.WaitForCacheSync(ctx) {
+		t.Fatal("cache did not sync")
+	}
+	store := &fakePodLostStore{candidates: []PodLostCandidate{
+		{TaskInstanceID: "lost", DagRunID: "run-a", TaskID: "work", TryNumber: 2, RunningSince: past},
+	}}
+	r := newPodLostReaper(store, reapTestLogger(), 60*time.Second, nil)
+	r.pods = NewKubernetesExecutor(cs, "leoflow")
+	r.cache = pi
+
+	if err := r.run(ctx); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.marked) != 1 || store.marked[0] != "lost" {
+		t.Fatalf("#723: cache fast-path must pin try-number and not defer on the stale try-1 pod, got %v", store.marked)
+	}
+}

--- a/internal/executor/reaper_test.go
+++ b/internal/executor/reaper_test.go
@@ -119,7 +119,7 @@ func TestReaperThreadsPresenceCacheToDispatchLost(t *testing.T) {
 		},
 	}
 	pods := &fakePodManager{active: map[string]bool{}}
-	cache := &fakePresenceCache{active: map[string]bool{"run-a/work": true}}
+	cache := &fakePresenceCache{active: map[string]bool{"run-a/work/0": true}}
 	r := NewReaper(store, pods, cache, nil, nil, reapTestLogger(), DefaultReaperConfig(), nil)
 
 	if err := r.ReapOnce(context.Background()); err != nil {

--- a/internal/executor/stale_queued_reap.go
+++ b/internal/executor/stale_queued_reap.go
@@ -144,12 +144,12 @@ func (r *dispatchLostReaper) run(ctx context.Context) error {
 		// Cache fast-path (PR-10), safe direction only: a cached Pending/Running
 		// pod defers without an apiserver read. A cache MISS is NOT trusted — fall
 		// through to the live read below, preserving the #461 fix.
-		if r.cache != nil && r.cache.CachedPodActive(c.DagRunID, c.TaskID) {
+		if r.cache != nil && r.cache.CachedPodActive(c.DagRunID, c.TaskID, c.TryNumber) {
 			r.record("dispatch_lost_cache_active")
 			continue
 		}
 		if r.pods != nil {
-			active, perr := r.pods.TaskPodActive(ctx, c.DagRunID, c.TaskID)
+			active, perr := r.pods.TaskPodActive(ctx, c.DagRunID, c.TaskID, c.TryNumber)
 			if perr != nil {
 				r.logger.Warn("dispatch-lost: pod liveness unknown; deferring",
 					"ti", c.TaskInstanceID, "run", c.DagRunID, "task", c.TaskID, "error", perr)


### PR DESCRIPTION
## Root cause

`TaskPodActive` (`internal/executor/pod_terminate.go`) built a **2-label** selector
(`leoflow.io/run-id`, `/task-id`) and its rationale comment claimed "a `queued` TI
has not been retried." That is false: the retry rail resets `up_for_retry → none`
with `try_number = try_number + 1` (`internal/storage/queries/runs.sql`) and the
planner re-queues the TI, so a `queued`/`running` TI can legitimately be on **try 2**
while **try 1's** pod still lingers `Pending` (unschedulable / image-pull backoff)
after a best-effort `DeleteTaskPod` failed.

**Failure path (#723):** try-1 pod lingers `Pending` → TI retries to try 2 → try-2
dispatch is genuinely lost → the dispatch-lost reaper calls the 2-label
`TaskPodActive`, matches try-1's still-`Pending` pod → `active=true` → **defers**.
Nothing else reaps a `queued` TI, so it stays `queued` indefinitely, silently.

The sibling `DeleteTaskPod` (directly above) and the reconciler's `tryNumberOf`
already treat `leoflow.io/try-number` as the invariant guard; the liveness gate was
the one place that dropped it.

## The two extra call sites the fix covers

The originally-reported report named only the direct `TaskPodActive`/queued path.
This fix also covers the two sites a Kubernetes review flagged:

- **The informer cache fast-path `CachedPodActive`** (`internal/executor/pod_informer.go`)
  built the same 2-label selector and is consulted by both
  `stale_queued_reap.go` and `pod_lost_reap.go`. Without the fix, the cache branch
  still false-defers before the live read is ever reached.
- **`pod_lost_reap.go`'s running path** had the identical false-defer for `running`
  TIs, not just the dispatch-lost/queued path. Both callers now pass the candidate's
  `TryNumber`.

## The fix

Thread `tryNumber` into `TaskPodActive` and `CachedPodActive`, add
`leoflow.io/try-number` to both selectors, and update both reaper call sites
(`stale_queued_reap.go`, `pod_lost_reap.go`) to pass the candidate's `TryNumber`
(already carried on the reaper candidate). The liveness gate now asks about the
*attempt* the reaper is about to fail, not the task as a whole — the same guard
`DeleteTaskPod`/`tryNumberOf` already use.

## Tests (red → green)

Written first and confirmed failing against `main` (each false-deferred: empty
`failed`/`marked`), then green after the fix. `reap_try_number_test.go` wires the
**real** executor and informer against a fake cluster holding only the older
attempt's pod, so it exercises the actual label selector rather than a hand-rolled
predicate:

- `TestDispatchLostReaper_TryNumberPinned_LiveRead` — queued path, live read.
- `TestDispatchLostReaper_TryNumberPinned_CacheRead` — queued path, informer cache.
- `TestPodLostReaper_TryNumberPinned_LiveRead` — running path, live read.
- `TestPodLostReaper_TryNumberPinned_CacheRead` — running path, informer cache.
- `TestTaskPodActive_PinsTryNumber` — direct executor-level selector lock.

Existing fakes (`fakePodManager`, `fakePresenceCache`) and their tests were updated
to key liveness by `(run, task, try)`, matching the real selector.

## Pre-push gate

```
$ go build ./...
OK

$ go vet ./internal/executor/...
OK

$ golangci-lint run ./internal/executor/
0 issues.

$ golangci-lint run ./...
0 issues.

$ go test ./internal/executor/...
ok  	github.com/neochaotic/leoflow/internal/executor	2.844s
```

(Also green: `go test ./internal/storage/... ./cmd/...`.)

Closes #723
