### PR TITLE
fix(helm): disable ServiceAccount token automount on the migration Job

### DIFF
--- a/helm/leoflow/templates/migration-job.yaml
+++ b/helm/leoflow/templates/migration-job.yaml
@@ -26,6 +26,12 @@ spec:
         {{- include "leoflow.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: Never
+      # The migrate binary talks only to Postgres via LEOFLOW_DATABASE_URL and
+      # never calls the Kubernetes API, so it has no use for a projected
+      # ServiceAccount token. Declining the automount keeps this pod from being
+      # handed the namespace default SA's credential. Mirrors the task pod in
+      # internal/executor/kubernetes.go.
+      automountServiceAccountToken: false
       securityContext:
         {{- toYaml .Values.migrations.podSecurityContext | nindent 8 }}
       containers:

--- a/helm/leoflow/tests/migration_job_test.yaml
+++ b/helm/leoflow/tests/migration_job_test.yaml
@@ -79,3 +79,17 @@ tests:
       - equal:
           path: spec.template.spec.securityContext.seccompProfile.type
           value: RuntimeDefault
+
+  - it: "issue #727 — migration Job pod disables ServiceAccount token automount"
+    # The migrate binary talks only to Postgres via LEOFLOW_DATABASE_URL; it
+    # never calls the Kubernetes API, so it has no need for a projected SA
+    # token. Leaving automount on hands the most-hardened pod in the chart the
+    # namespace default SA's token — an unused credential and needless attack
+    # surface. Mirrors internal/executor/kubernetes.go, which already sets
+    # AutomountServiceAccountToken:false on the task pod.
+    set:
+      database.url: postgres://h/d
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false


### PR DESCRIPTION
## Root cause

`helm/leoflow/templates/migration-job.yaml` set pod and container `securityContext` but declared no `serviceAccountName` and no `automountServiceAccountToken`. The pod therefore received the namespace **default** ServiceAccount and its projected API token.

The migrate binary talks only to Postgres via `LEOFLOW_DATABASE_URL` (an advisory-lock migration; see the Job's `args`/`env`) and never calls the Kubernetes API. The mounted token is an unused credential — and needless attack surface — on what is otherwise the most-hardened pod in the chart (`readOnlyRootFilesystem: true`, `seccompProfile: RuntimeDefault`, `runAsNonRoot`, UID 65532, `capabilities.drop: [ALL]`).

The task-pod path already does exactly this in Go: `internal/executor/kubernetes.go` sets `AutomountServiceAccountToken: ptr(false)` with the same rationale. This change is the chart catching up.

## Fix

Set `automountServiceAccountToken: false` on the migration Job's `spec.template.spec`.

## Red → green test

Added to `helm/leoflow/tests/migration_job_test.yaml`:

> `issue #727 — migration Job pod disables ServiceAccount token automount`

asserting `spec.template.spec.automountServiceAccountToken: false`.

- **Red** (before fix): `unknown path spec.template.spec.automountServiceAccountToken` — 1 failed, 5 passed.
- **Green** (after fix): whole suite passes.

Test commit lands before the implementation commit.

## Pre-push gate

```
helm lint helm/leoflow          → 1 chart(s) linted, 0 chart(s) failed
helm template (db+redis set)    → renders clean; automountServiceAccountToken: false present
helm unittest helm/leoflow      → Test Suites: 20 passed, 20 total
                                  Tests: 122 passed, 122 total
```

`helm-docs` not run — no `values.yaml` change (nothing configurable added).

Closes #727