### PR TITLE
fix(helm): keep the gRPC TLS key off the api role in split mode

### DIFF
--- a/helm/leoflow/templates/_controlplane-deployment.tpl
+++ b/helm/leoflow/templates/_controlplane-deployment.tpl
@@ -312,7 +312,15 @@ spec:
           volumeMounts:
             - name: logs
               mountPath: {{ .ctx.Values.config.logsDir }}
-            {{- if .ctx.Values.agentTLS.enabled }}
+            {{- if and .ctx.Values.agentTLS.enabled (ne .role "api") }}
+            # #726 — the private key is mounted only into the role that runs the
+            # agent gRPC server. The api role never builds a gRPC server
+            # (startAgentGRPC is reached only from the scheduler side), so mounting
+            # tls.key into its internet-facing pod only widens the blast radius
+            # ADR 0049 set out to shrink. The env vars above stay on every role:
+            # the Pro boot guard (guardTLSForEdition) checks only that both strings
+            # are non-empty, never reading the files, so the dangling path is
+            # harmless on api while scoping the env would CrashLoopBackOff it.
             - name: grpc-tls
               mountPath: /etc/leoflow/grpc-tls
               readOnly: true
@@ -340,7 +348,9 @@ spec:
           # `logs.persistence.enabled` for durable storage (#227).
           emptyDir: {}
           {{- end }}
-        {{- if .ctx.Values.agentTLS.enabled }}
+        {{- if and .ctx.Values.agentTLS.enabled (ne .role "api") }}
+        # #726 — see the matching volumeMount guard above: the api role omits the
+        # gRPC cert Secret volume entirely so tls.key never reaches its pod.
         - name: grpc-tls
           secret:
             # BYO serverCertSecret, or the chart-generated "<fullname>-agent-tls"

--- a/helm/leoflow/tests/split_test.yaml
+++ b/helm/leoflow/tests/split_test.yaml
@@ -147,6 +147,72 @@ tests:
             value: leoflow-scheduler.NAMESPACE.svc.cluster.local:9091
           # helm-unittest renders release namespace as "NAMESPACE" in tests.
 
+  # --- #726: the gRPC TLS private key belongs only to the role that runs the
+  # agent gRPC server (scheduler). The api role never builds a gRPC server
+  # (startAgentGRPC is reached only from the scheduler side), so handing its
+  # internet-facing pod tls.key widens the blast radius ADR 0049 set out to
+  # shrink. The env vars must STAY on both roles though — the Pro boot guard
+  # (guardTLSForEdition) only checks both strings are non-empty and never reads
+  # the files, so scoping the env would CrashLoopBackOff the api pod. Scope only
+  # the volume + volumeMount.
+  - it: the api Deployment keeps both gRPC TLS env vars but never mounts the private key (#726)
+    template: deployment.yaml
+    documentIndex: 0
+    set:
+      split.enabled: true
+      logs.persistence.accessMode: ReadWriteMany
+    asserts:
+      - equal:
+          path: metadata.name
+          value: leoflow-api
+      # The boot guard must still pass: both env vars present so the Pro edition
+      # boots (guardTLSForEdition only asserts the strings are non-empty).
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LEOFLOW_SERVER_GRPC_TLS_CERT
+            value: /etc/leoflow/grpc-tls/tls.crt
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LEOFLOW_SERVER_GRPC_TLS_KEY
+            value: /etc/leoflow/grpc-tls/tls.key
+      # …but the private key never reaches this pod: no grpc-tls volume or mount.
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          any: true
+          content:
+            name: grpc-tls
+      - notContains:
+          path: spec.template.spec.volumes
+          any: true
+          content:
+            name: grpc-tls
+
+  - it: the scheduler Deployment still mounts the gRPC TLS key it actually serves (#726)
+    template: deployment.yaml
+    documentIndex: 1
+    set:
+      split.enabled: true
+      logs.persistence.accessMode: ReadWriteMany
+    asserts:
+      - equal:
+          path: metadata.name
+          value: leoflow-scheduler
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: grpc-tls
+            mountPath: /etc/leoflow/grpc-tls
+            readOnly: true
+      # The scheduler mounts the whole cert Secret (tls.crt + tls.key) — it runs
+      # the agent gRPC server and needs the private key.
+      - contains:
+          path: spec.template.spec.volumes
+          any: true
+          content:
+            name: grpc-tls
+
   # --- Split with the default ReadWriteOnce logs PVC must fail loudly: the
   # scheduler writes logs and the api replicas read them from the SAME PVC, so
   # >=2 pods mount it at once and RWO can never satisfy that (#282 generalized).


### PR DESCRIPTION
## Root cause

In split mode (ADR 0049) both control-plane Deployments render from the single
`_controlplane-deployment.tpl`. The `grpc-tls` **volume** and **volumeMount**
were gated only on `agentTLS.enabled` — never on role — and the volume mounted
the whole cert Secret (no `items:` selecting `tls.crt`). So the internet-facing
**api** pod received `tls.key`, a private key it never uses.

The only consumer is `startAgentGRPC` (`cmd/leoflow-server/main.go`), reached
only from `startSchedulerSide`, which returns early when `!servesScheduler`. An
api pod never builds a gRPC server, so it reads neither the cert nor the key.
ADR 0049 exists to shrink the api role's blast radius; handing it the gRPC
private key works directly against that.

## Why the naive fix crash-loops the api pod

Scoping the **env vars** to `ne .role "api"` would break boot:
`guardTLSForEdition` (`tls_guard.go`) runs for **all** roles and, for
`edition=pro`, fails boot unless both `LEOFLOW_SERVER_GRPC_TLS_CERT` and
`_KEY` are non-empty — so an api pod with the env stripped would
CrashLoopBackOff. Crucially, that guard only checks the strings are non-empty;
it never opens the files. So the env vars are harmless to keep on api (the path
just dangles, and `startAgentGRPC` is never reached to read it).

## Fix (volume-only scoping)

Keep **both** TLS env vars on every role (boot guard passes), and scope **only**
the `grpc-tls` volume + volumeMount to non-api roles (`ne .role "api"`). The api
pod no longer receives `tls.key`; the scheduler (and the monolithic "all" role)
still mount the full Secret they serve. `values.yaml` is untouched, so no
helm-docs regen is needed.

## Red -> green test

`helm/leoflow/tests/split_test.yaml` gains two cases: the api Deployment keeps
both gRPC TLS env vars but carries **no** `grpc-tls` volume/volumeMount, and the
scheduler still mounts the key. Committed red first (failed on the api
volume + volumeMount asserts against the old template), green after the fix.

## Pre-push gate (all green)

- `helm lint helm/leoflow` -> `1 chart(s) linted, 0 chart(s) failed`
- `helm template` renders clean for split (api has env, no key volume; scheduler
  has both) and for the default "all" role (grpc-tls unchanged, 2 refs)
- `helm unittest helm/leoflow` -> `Test Suites: 20 passed, 20 total` /
  `Tests: 123 passed, 123 total`
- No Go touched (Go gates n/a); values surface unchanged (helm-docs n/a)

Closes #726
