### PR TITLE
fix(api): map repository validation errors to 400 (not 500)

### DIFF
--- a/internal/api/resources.go
+++ b/internal/api/resources.go
@@ -130,6 +130,14 @@ func handleRepoError(c *gin.Context, err error) {
 		AbortProblem(c, statusClientClosedRequest, "client closed request", err.Error())
 		return
 	}
+	// A business-rule input failure (unknown role, undeclared variable/connection)
+	// is the client's to fix, not a server fault. Every domain.ErrValidation wrap
+	// site is client-supplied input, so map the whole class to 400 — otherwise it
+	// reads as a server error and points users at the logs instead of their request.
+	if errors.Is(err, domain.ErrValidation) {
+		AbortProblem(c, http.StatusBadRequest, "invalid request", err.Error())
+		return
+	}
 	AbortProblem(c, http.StatusInternalServerError, "internal error", err.Error())
 }
 

--- a/internal/api/versions_test.go
+++ b/internal/api/versions_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -16,10 +17,14 @@ import (
 type fakeVersionRepo struct {
 	created bool
 	seen    []string
+	err     error
 }
 
 func (f *fakeVersionRepo) RegisterDagVersion(_ context.Context, _ string, _ domain.DAGSpec, hash string) (bool, error) {
 	f.seen = append(f.seen, hash)
+	if f.err != nil {
+		return false, f.err
+	}
 	return f.created, nil
 }
 
@@ -73,6 +78,22 @@ func TestRegisterVersionRejectsRemovedHTTPAPIType(t *testing.T) {
 	rec := authGet(versionServer(&fakeVersionRepo{}), http.MethodPost, "/api/v2/dags/etl/versions", spec)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("removed http_api type = %d, want 400 (%s)", rec.Code, rec.Body.String())
+	}
+}
+
+// A spec that declares a connection (or variable) the tenant has not defined is
+// rejected by the repository as domain.ErrValidation (ADR 0055 D6). That is a
+// client-fixable input error — the author must run `leoflow connections set` or
+// drop the declaration — so the handler must surface it as 400, not 500. Before
+// the handleRepoError ErrValidation branch it fell through to 500, which sent
+// users to server logs instead of to their own DAG (#724).
+func TestRegisterVersionUnknownConnectionReturns400(t *testing.T) {
+	repo := &fakeVersionRepo{err: fmt.Errorf(
+		"dag %q declares unknown connection(s) %s; define them (leoflow connections set) or remove them from the DAG's connections: declaration: %w",
+		"etl", "warehouse", domain.ErrValidation)}
+	rec := authGet(versionServer(repo), http.MethodPost, "/api/v2/dags/etl/versions", validSpecJSON)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("unknown connection = %d, want 400 (%s)", rec.Code, rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Root cause

`handleRepoError` (`internal/api/resources.go`) mapped `ErrNotFound`→404, `domain.ErrConflict`→409 and context cancellation→499, then fell through to `500 internal error` — there was **no `domain.ErrValidation` branch**.

`RegisterDagVersion` rejects a DAG version declaring an unknown variable/connection as `domain.ErrValidation` (`internal/storage/repository.go` `validateDeclaredSecrets`), and `POST /api/v2/dags/{dag}/versions` routes that through `handleRepoError` (`internal/api/versions.go`). Result: a client-fixable input error surfaced as **500** — `leoflow lite` printed `✗ control plane returned 500`, sending authors to server logs instead of `leoflow connections set` / `leoflow variables set`.

The correct mapping already existed on adjacent paths (`handleUserWriteError` in `users.go`, `oidc_handler.go`, and `spec.Validate()` in `versions.go` all return 400), so only the shared repository path was wrong.

## Fix

Add an `errors.Is(err, domain.ErrValidation)` → `400 invalid request` branch to `handleRepoError`, before the 500 fallthrough. This fixes the whole class (~30 handlers share `handleRepoError`).

## Wrap-site audit

`domain.ErrValidation` is wrapped at **5** sites in `internal/storage/repository.go` (the specialist's "~8" counted comment/test lines). Every one is genuinely client-fixable input — none is an internal invariant that should stay 500:

| Line | Function | Cause | Client-fixable? |
|------|----------|-------|-----------------|
| 197  | `CreateOIDCUser` | unknown role name | yes (request roles) |
| 273  | `ReconcileUserRoles` | unknown role name | yes (IdP-mapped role set; rejected login, a 4xx) |
| 998  | `validateDeclaredSecrets` | undeclared **variable** | yes (DAG spec) — the bug |
| 1010 | `validateDeclaredSecrets` | undeclared **connection** | yes (DAG spec) — the bug |
| 1091 | `CreateUser` | unknown role name | yes (request roles) |

The three user/OIDC sites already reach 400 via their own handlers (`handleUserWriteError` / `oidc_handler.go`); mapping the class in `handleRepoError` is consistent with them and harmless there. Blanket-mapping to 400 is therefore correct — no true internal error is being flipped.

## Red → green test

`TestRegisterVersionUnknownConnectionReturns400` (`internal/api/versions_test.go`): posts a valid spec while the repo returns a wrapped `domain.ErrValidation` (mirroring `validateDeclaredSecrets`), asserts **400**.

- Before the fix: `unknown connection = 500, want 400` (red, committed first).
- After the fix: passes. Full `TestRegisterVersion*` suite green.

## Pre-push gate

- `go build ./...` — clean
- `go vet ./...` — clean
- `golangci-lint run ./internal/api/...` — **0 issues** (full-repo run reports issues only from sibling agent worktrees leaked via the shared lint cache — non-existent `agent-a37e…`/`agent-a358…` paths; zero findings reference this worktree)
- `go test ./internal/api/...` — ok

Closes #724
