### PR TITLE
fix(agent): give each warm-pool attempt a fresh TMPDIR (isolation)

### DIFF
--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -68,6 +68,14 @@ type Runner struct {
 	// ReschedulePath is the file a reschedule-mode sensor writes its next-poke time
 	// to before exiting with rescheduleExitCode; empty disables reschedule (#380).
 	ReschedulePath string
+	// TmpDir, when set, is exported to the task as TMPDIR so the child's temp files
+	// land in a per-attempt directory the caller wipes between attempts, instead of
+	// the pod's real /tmp. The warm worker points this at a subdir of its scratch
+	// (reset before every attempt) so no attempt observes another attempt's temp
+	// files — a token cache, a dbt profile, ~/.aws-style credentials (#728). Empty
+	// leaves TMPDIR untouched: a single-shot pod is already destroyed per task, so
+	// its /tmp needs no in-process reset.
+	TmpDir string
 	// TerminationLogPath is where the agent writes its durable outcome record just
 	// before delivering the report, so a pod killed mid-report still leaves the
 	// task's true result behind for the reconciler to recover (ADR 0052). Empty
@@ -194,6 +202,32 @@ func (r *Runner) buildEnv(ctx context.Context, spec *agentv1.TaskSpec) ([]string
 		return nil, err
 	}
 	env = append(env, byTaskEnv...)
+	if callArgs := spec.GetCallArgsJson(); callArgs != "" {
+		// TaskFlow literal call args (#115). The runtime decodes this and merges
+		// values into the user function's kwargs. XCom upstreams take precedence
+		// at runtime for any same-name parameter. The env var name keeps
+		// Airflow's DAG-run `params` term free for a future feature (#148).
+		env = append(env, "LEOFLOW_CALL_ARGS_JSON="+callArgs)
+	}
+	if opArgs := spec.GetOperatorArgsJson(); opArgs != "" {
+		// Operator constructor kwargs (ADR 0040). The runtime's --operator mode
+		// decodes this and instantiates the captured provider operator with it.
+		env = append(env, "LEOFLOW_OPERATOR_ARGS="+opArgs)
+	}
+	env = append(env, r.secretsEnv(ctx)...)
+	pathEnv, err := r.outputPathEnv()
+	if err != nil {
+		return nil, err
+	}
+	return append(env, pathEnv...), nil
+}
+
+// outputPathEnv renders the env vars that point the runtime at the agent-owned
+// per-task output files, plus the TMPDIR redirect. Each is set only when its path
+// field is configured (single-shot leaves some unset). TMPDIR is created and comes
+// last so it overrides any TMPDIR inherited from the pod environment.
+func (r *Runner) outputPathEnv() ([]string, error) {
+	var env []string
 	if r.ReturnPath != "" {
 		// Tell the runtime to write the return value to the agent's per-task path,
 		// not the shared global default — so concurrent tasks and other users never
@@ -214,19 +248,19 @@ func (r *Runner) buildEnv(ctx context.Context, spec *agentv1.TaskSpec) ([]string
 		// rescheduleExitCode; the agent then reports up_for_reschedule (#380).
 		env = append(env, "LEOFLOW_RESCHEDULE_PATH="+r.ReschedulePath)
 	}
-	if callArgs := spec.GetCallArgsJson(); callArgs != "" {
-		// TaskFlow literal call args (#115). The runtime decodes this and merges
-		// values into the user function's kwargs. XCom upstreams take precedence
-		// at runtime for any same-name parameter. The env var name keeps
-		// Airflow's DAG-run `params` term free for a future feature (#148).
-		env = append(env, "LEOFLOW_CALL_ARGS_JSON="+callArgs)
+	if r.TmpDir != "" {
+		// Redirect TMPDIR into the per-attempt scratch dir (wiped by resetScratch
+		// between attempts) so anything the child writes to $TMPDIR — a token cache,
+		// a dbt profile, ~/.aws-style credentials — is gone before the next attempt
+		// runs on this warm worker (#728). Appended last so it overrides any TMPDIR
+		// inherited from the pod's environment; tools treat TMPDIR as ephemeral, so
+		// redirecting it is safe.
+		if err := os.MkdirAll(r.TmpDir, 0o700); err != nil {
+			return nil, fmt.Errorf("creating per-attempt TMPDIR %q: %w", r.TmpDir, err)
+		}
+		env = append(env, "TMPDIR="+r.TmpDir)
 	}
-	if opArgs := spec.GetOperatorArgsJson(); opArgs != "" {
-		// Operator constructor kwargs (ADR 0040). The runtime's --operator mode
-		// decodes this and instantiates the captured provider operator with it.
-		env = append(env, "LEOFLOW_OPERATOR_ARGS="+opArgs)
-	}
-	return append(env, r.secretsEnv(ctx)...), nil
+	return env, nil
 }
 
 // upstreamXComEnv is the env var carrying the upstream task_id -> return_value map the

--- a/internal/agent/warm.go
+++ b/internal/agent/warm.go
@@ -462,10 +462,12 @@ func (w *WarmRunner) serveAssignment(ctx context.Context, stream agentv1.AgentSe
 // resetScratch removes and recreates the agent's per-attempt scratch dir. This is
 // the D4 filesystem scrub: it deletes everything the previous attempt (or its user
 // process) wrote UNDER the agent's own scratch — the return-value, extra-links,
-// xcom-pushes, and reschedule files, plus anything else the runtime staged there —
-// so no attempt observes another attempt's writable fs state. It deletes ONLY the
-// agent-owned scratch; paths outside it (the task image, mounts, the pod's own
-// /tmp) are left untouched.
+// xcom-pushes, and reschedule files, the per-attempt TMPDIR (attemptRunner points
+// the child's TMPDIR at a subdir of scratch, #728), plus anything else the runtime
+// staged there — so no attempt observes another attempt's writable fs state under
+// the agent's control. It deletes ONLY the agent-owned scratch; image-level paths
+// and mounts (and $HOME, unless the pod runs with a read-only root filesystem) are
+// left untouched and persist for the worker's lifetime.
 func (w *WarmRunner) resetScratch() error {
 	if err := os.RemoveAll(w.ScratchDir); err != nil {
 		return fmt.Errorf("removing scratch %q: %w", w.ScratchDir, err)
@@ -496,16 +498,19 @@ func (w *WarmRunner) openSink(ctx context.Context) LogSink {
 // per-attempt RPC carries the attempt_token.
 func (w *WarmRunner) attemptRunner(sink LogSink) *Runner {
 	return &Runner{
-		Client:             w.WorkClient,
-		Cmd:                w.Cmd,
-		Sink:               sink,
-		Hostname:           w.Hostname,
-		Version:            w.Version,
-		Env:                w.Env,
-		ReturnPath:         filepath.Join(w.ScratchDir, "return_value.json"),
-		LinksPath:          filepath.Join(w.ScratchDir, "extra_links.json"),
-		PushesPath:         filepath.Join(w.ScratchDir, "xcom_pushes.json"),
-		ReschedulePath:     filepath.Join(w.ScratchDir, "reschedule.txt"),
+		Client:         w.WorkClient,
+		Cmd:            w.Cmd,
+		Sink:           sink,
+		Hostname:       w.Hostname,
+		Version:        w.Version,
+		Env:            w.Env,
+		ReturnPath:     filepath.Join(w.ScratchDir, "return_value.json"),
+		LinksPath:      filepath.Join(w.ScratchDir, "extra_links.json"),
+		PushesPath:     filepath.Join(w.ScratchDir, "xcom_pushes.json"),
+		ReschedulePath: filepath.Join(w.ScratchDir, "reschedule.txt"),
+		// Per-attempt TMPDIR under the scratch resetScratch wipes, so the child's
+		// temp files never persist into the next attempt on this warm worker (#728).
+		TmpDir:             filepath.Join(w.ScratchDir, "tmp"),
 		TerminationLogPath: w.TerminationLogPath,
 		HeartbeatInterval:  w.HeartbeatInterval,
 		Token:              w.AttemptTokens,

--- a/internal/agent/warm_test.go
+++ b/internal/agent/warm_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -202,6 +203,100 @@ func TestWarmWorkerServesTwoAttempts(t *testing.T) {
 	assertAck(3, "asg-2")
 	if stream.sent[4].GetSlotFree() == nil {
 		t.Errorf("message 4 must be SlotFree, got %+v", stream.sent[4])
+	}
+}
+
+// lastEnvValue returns the value of the last KEY=... entry in env (exec semantics:
+// a duplicated var is resolved to its last occurrence), or "" if unset.
+func lastEnvValue(env []string, key string) string {
+	prefix := key + "="
+	val := ""
+	for _, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			val = kv[len(prefix):]
+		}
+	}
+	return val
+}
+
+// tmpdirProbeCmd is a CommandRunner double that inspects the TMPDIR handed to each
+// child, records it, and — on every invocation — checks whether a sentinel written
+// to $TMPDIR by an earlier attempt still exists, then (re)writes it. A warm worker
+// that gives each attempt a fresh per-attempt TMPDIR (wiped between attempts) makes
+// attempt 2 see the sentinel ABSENT even though attempt 1 wrote one to its TMPDIR —
+// the filesystem-isolation invariant the docs advertise (#728).
+type tmpdirProbeCmd struct {
+	tmpdirs []string // TMPDIR handed to each attempt
+	sawLeak []bool   // whether the previous attempt's $TMPDIR sentinel survived
+}
+
+func (c *tmpdirProbeCmd) Run(_ context.Context, _, env []string, _, _ io.Writer) (int, error) {
+	tmp := lastEnvValue(env, "TMPDIR")
+	c.tmpdirs = append(c.tmpdirs, tmp)
+	if tmp == "" {
+		// No TMPDIR redirect: the child would inherit the pod's real /tmp, which
+		// persists across attempts. Record no leak-file write (avoid polluting cwd)
+		// so the TMPDIR-set assertion is what fails today.
+		c.sawLeak = append(c.sawLeak, false)
+		return 0, nil
+	}
+	sentinel := filepath.Join(tmp, "leaked-sentinel")
+	_, statErr := os.Stat(sentinel)
+	c.sawLeak = append(c.sawLeak, statErr == nil)
+	_ = os.WriteFile(sentinel, []byte("token cache / ~/.aws-style secret from an earlier attempt"), 0o600)
+	return 0, nil
+}
+
+// TestWarmWorkerGivesEachAttemptFreshTmpdir is the #728 regression: a warm worker
+// must hand each attempt a fresh, per-attempt TMPDIR under the agent scratch that
+// resetScratch already wipes, so anything attempt N writes to $TMPDIR (a dbt
+// profile, a token cache, ~/.aws-style credentials) is gone before attempt N+1
+// starts. Without the redirect the child inherits the pod's real /tmp, which
+// persists across attempts on one warm worker.
+func TestWarmWorkerGivesEachAttemptFreshTmpdir(t *testing.T) {
+	scratch := filepath.Join(t.TempDir(), "scratch")
+	stream := &fakeAssignmentStream{
+		ctx: context.Background(),
+		assignments: []*agentv1.WorkAssignment{
+			{AssignmentId: "asg-1", AttemptToken: "tok-1"},
+			{AssignmentId: "asg-2", AttemptToken: "tok-2"},
+		},
+	}
+	tokens := NewTokenSource("bootstrap")
+	client := &warmFake{fakeClient: &fakeClient{}, stream: stream, tokens: tokens, specs: warmSpecs(2)}
+	cmd := &tmpdirProbeCmd{}
+
+	w := &WarmRunner{
+		StreamClient:  client,
+		WorkClient:    client,
+		AttemptTokens: tokens,
+		Cmd:           cmd,
+		Hostname:      "warm-pod-1",
+		Version:       "test",
+		// A base env that already carries a TMPDIR (the pod's real /tmp): the
+		// per-attempt redirect must OVERRIDE it, not defer to it.
+		Env:        []string{"PATH=/usr/bin", "TMPDIR=/tmp"},
+		ScratchDir: scratch,
+	}
+
+	if err := w.Run(context.Background(), "dagver-1"); err != nil {
+		t.Fatalf("WarmRunner.Run: %v", err)
+	}
+	if len(cmd.tmpdirs) != 2 {
+		t.Fatalf("attempts run = %d, want 2", len(cmd.tmpdirs))
+	}
+	for i, tmp := range cmd.tmpdirs {
+		if tmp == "" || tmp == "/tmp" {
+			t.Errorf("attempt %d TMPDIR = %q, want a per-attempt dir under scratch (not the pod /tmp)", i+1, tmp)
+		}
+		if !strings.HasPrefix(tmp, scratch) {
+			t.Errorf("attempt %d TMPDIR = %q, want it under the wiped scratch dir %q", i+1, tmp, scratch)
+		}
+	}
+	// The core isolation guarantee: attempt 2 must not observe the sentinel attempt
+	// 1 wrote to its $TMPDIR.
+	if len(cmd.sawLeak) != 2 || cmd.sawLeak[0] || cmd.sawLeak[1] {
+		t.Errorf("TMPDIR leak across attempts: sawLeak=%v, want [false false]", cmd.sawLeak)
 	}
 }
 

--- a/website/content/operate/warm-pools.md
+++ b/website/content/operate/warm-pools.md
@@ -159,7 +159,7 @@ flowchart TB
     AWAIT --> IDLE{"Idle,<br/>registered"}
     IDLE -->|attempt arrives| LEASE["Lease a slot<br/>(control plane assigns TI)"]
     LEASE --> ACK["Worker acks<br/>(durable binding written)"]
-    ACK --> FORK["Fork a fresh child<br/>from a pristine template<br/>(scrubbed env, fresh /tmp,<br/>fresh per-attempt JWT)"]
+    ACK --> FORK["Fork a fresh child<br/>from a pristine template<br/>(scrubbed env, fresh TMPDIR,<br/>fresh per-attempt JWT)"]
     FORK --> RUN["Run the attempt"]
     RUN --> OUT["Report outcome<br/>in-band, durably<br/>(write-then-ack)"]
     OUT --> FREE["Slot freed"]
@@ -205,16 +205,33 @@ template — never from a sibling attempt.** Before each attempt the worker:
 - **rebuilds the environment from scratch** — only that attempt's `AIRFLOW_VAR_*` /
   `AIRFLOW_CONN_*` + `LEOFLOW_*`, with no residue from a prior attempt, and the
   agent-only variable strip re-runs per attempt;
-- **resets `/tmp`** and the per-attempt scratch space;
+- **resets the agent scratch and redirects `TMPDIR` into it** — the child's
+  `TMPDIR` points at a per-attempt subdirectory of the agent scratch that is wiped
+  before every attempt, so a token cache, a dbt profile, or `~/.aws`-style
+  credentials written to `$TMPDIR` do not survive into the next attempt;
 - **drops the prior attempt's task JWT** before minting the next one.
 
 The invariant, tested rather than best-effort: *each attempt's child forks from a
 pristine template, never from a sibling attempt; no attempt observes another
-attempt's secrets, environment, or writable filesystem state.* A long-lived shared
-interpreter (state persisting across attempts) is explicitly rejected. Phrasing the
-invariant as "fork from pristine" keeps a future forkserver optimization open
-without reopening the guarantee — library code carries no tenant data, and secrets
-re-enter per child.
+attempt's secrets, environment, or the writable filesystem state under the agent's
+control — the agent scratch and the `TMPDIR` redirected into it.* A long-lived
+shared interpreter (state persisting across attempts) is explicitly rejected.
+Phrasing the invariant as "fork from pristine" keeps a future forkserver
+optimization open without reopening the guarantee — library code carries no tenant
+data, and secrets re-enter per child.
+
+{{% alert title="Image-level paths persist for the worker's lifetime" color="warning" %}}
+The per-attempt scrub covers what the agent owns: the scratch space and the
+`TMPDIR` redirected into it. It does **not** reset paths outside the agent's
+control on a writable root filesystem — most notably **`$HOME`** (which keeps its
+image-baked `~/.config` and anything a task writes there, e.g. `~/.aws/credentials`
+or a `~/.dbt/profiles.yml`), the container image layers, and mounted volumes. These
+persist for the whole worker's lifetime and are shared by every attempt the worker
+serves (same tenant + DAG version). Tasks that write secrets to `$HOME` rather than
+`$TMPDIR` should run warm pods with a **read-only task root filesystem**
+(`read_only_task_root_filesystem`) so those writes fail closed instead of leaking to
+the next attempt.
+{{% /alert %}}
 
 Because a fresh scrubbed child and a fresh per-attempt token are mandatory, there is
 **no per-pod secret cache** to leak across attempts: each attempt does exactly one


### PR DESCRIPTION
## Root cause (#728)

A warm worker (ADR 0058 D4) reuses one pod across many attempts. Two things left `/tmp` and `$HOME` shared across attempts on one warm worker:

- **`resetScratch`** (`internal/agent/warm.go`) wipes **only** the agent's own `ScratchDir`; its own comment stated the pod's `/tmp` is *left untouched*.
- **`buildEnv`** (`internal/agent/runner.go`) never set `TMPDIR` or `HOME`, so a forked child inherited the pod's real `/tmp` / `$HOME`, and the root fs is writable by default (`ReadOnlyRootFilesystem` is opt-in).

The code already *knew* `/tmp` persists: it redirects `LEOFLOW_RETURN_VALUE_PATH` off `/tmp` precisely because concurrent tasks/users collide there.

**Impact:** two tasks on one warm worker (pool keyed by `dag_version_id`) — anything task N writes to `$TMPDIR`/`$HOME` (a dbt profile, `~/.aws/credentials`, a token cache) is readable by task N+1. The filesystem routes around the per-task secret scoping the release advertises. Blast radius: same tenant + DAG version.

## Framing correction

The leak is **orthogonal to `secret_scoping`**. Warm pools gate on `agent_token_transport=exchange` **and** `secret_liveness_mode=enforce` (`internal/config/server.go`), **not** on scoping — so this filesystem channel is present in any mode, regardless of the scoping setting.

## The fix — TMPDIR (the real fix, not doc-only)

Redirect `TMPDIR` into a subdirectory of the agent scratch that `resetScratch` already wipes before every attempt:

- `Runner` grows an optional `TmpDir` field.
- `attemptRunner` points it at `ScratchDir/tmp`.
- `buildEnv` creates the dir and exports `TMPDIR=<dir>` **last**, so it overrides any `TMPDIR` inherited from the pod environment.
- Single-shot mode leaves `TmpDir` empty → `TMPDIR` untouched (a per-task pod is destroyed after each attempt, so no in-process reset is needed).

Tools treat `TMPDIR` as ephemeral, so redirecting it is safe.

## `$HOME` — explicit decision for the maintainer: **option (b)**

I left `$HOME` **as-is** and documented + recommended `read_only_task_root_filesystem` for warm pods instead. Reseeding a fresh per-attempt `$HOME` under scratch would drop the image-baked `~/.config` and has a real compatibility blast radius, and I could **not** confirm from the source that tasks never depend on image-baked `$HOME` contents at runtime. Per the smaller-and-safe rule this is deferred to you as a design decision — say the word if you'd rather seed a per-attempt `$HOME` under scratch.

## Docs

`website/content/operate/warm-pools.md` corrected (lifecycle diagram, isolation bullet, invariant statement) to describe the **actual** guarantee: the agent scratch and the `TMPDIR` redirected into it are per-attempt; **image-level paths and `$HOME` persist for the worker's lifetime** unless the pod runs with a read-only task root filesystem (added a warning callout).

## Test — red → green

`TestWarmWorkerGivesEachAttemptFreshTmpdir` (`internal/agent/warm_test.go`): writes a sentinel to `$TMPDIR` during attempt N and asserts its absence at the start of attempt N+1 on the same warm worker, plus that `TMPDIR` points into the wiped scratch dir. Base env seeds `TMPDIR=/tmp` so the redirect must *override* an inherited value.

- **Red** (before fix): `attempt 1/2 TMPDIR = "/tmp"` … `TMPDIR leak across attempts: sawLeak=[false true]` — attempt 1's sentinel in the inherited `/tmp` survived into attempt 2.
- **Green** (after fix): PASS.

(Test committed before the implementation commit.)

## Pre-push gate

```
go build ./...          -> exit 0
go vet ./...            -> exit 0
golangci-lint run ./internal/agent/...  -> 0 issues
go test ./internal/agent/...  -> ok
go test ./cmd/leoflow-agent/... -> ok  (constructs WarmRunner)
```

(A repo-root `golangci-lint run` also surfaces findings from *sibling* agent worktrees under `.claude/worktrees/` — those are other branches' files, not part of this change.)

Closes #728
