### PR TITLE
fix(setup): idempotent symlink extraction + version-aware managed-Postgres guard

### DIFF
--- a/internal/setup/install.go
+++ b/internal/setup/install.go
@@ -204,6 +204,13 @@ func extractSymlink(hdr *tar.Header, destDir, target, name string) error {
 	if mkErr := os.MkdirAll(filepath.Dir(target), 0o750); mkErr != nil {
 		return fmt.Errorf("creating parent of %q: %w", target, mkErr)
 	}
+	// os.Symlink fails EEXIST if target is already present, which breaks a
+	// re-extract over an existing install (the regular-file branch overwrites via
+	// O_TRUNC). Remove any prior entry first to match that idempotent behavior;
+	// target is already sanitized by the containment checks above.
+	if rmErr := os.Remove(target); rmErr != nil && !os.IsNotExist(rmErr) {
+		return fmt.Errorf("removing existing %q before symlink: %w", target, rmErr)
+	}
 	return os.Symlink(hdr.Linkname, target) //nolint:gosec // target sanitized; link resolved within destDir
 }
 

--- a/internal/setup/install_postgres.go
+++ b/internal/setup/install_postgres.go
@@ -30,13 +30,18 @@ const pgVersionFile = ".pg-version"
 // — the point of Fase 2 — it needs no Docker. The data directory and process
 // lifecycle are the caller's concern (see the Lite runner).
 func EnsurePostgres(ctx context.Context, o EnsureOpts) (string, error) {
-	binDir := filepath.Join(o.Home, "postgres", "bin")
+	pgRoot := filepath.Join(o.Home, "postgres")
+	binDir := filepath.Join(pgRoot, "bin")
 	managed := filepath.Join(binDir, "postgres")
 	stat := o.Stat
 	if stat == nil {
 		stat = os.Stat
 	}
-	if _, err := stat(managed); err == nil {
+	// Short-circuit only when a COMPLETE install of the BUNDLED version is present.
+	// Keying on presence alone (the pre-#729 behavior) meant a clean upgrade never
+	// re-extracted — it silently kept the prior release's Postgres — and a partial
+	// extract (interrupted, or an older on-disk layout) was trusted blindly.
+	if _, err := stat(managed); err == nil && readManagedPostgresVersion(pgRoot) == pgVersion {
 		return binDir, nil
 	}
 	build, err := ResolvePostgres(o.GOOS, o.GOARCH, o.Libc)
@@ -55,11 +60,27 @@ func EnsurePostgres(ctx context.Context, o EnsureOpts) (string, error) {
 	// theseus-rs nests everything under a single postgresql-<version>-<triple>/
 	// directory; strip it so bin/postgres lands at Home/postgres/bin/postgres
 	// regardless of the triple.
-	if err := extractTarGzStrip(data, filepath.Join(o.Home, "postgres"), 1); err != nil {
+	if err := extractTarGzStrip(data, pgRoot, 1); err != nil {
 		return "", err
+	}
+	// Record the extracted version last, so an interrupted extract leaves no
+	// sentinel and is re-installed on the next run rather than trusted.
+	if err := os.WriteFile(filepath.Join(pgRoot, pgVersionFile), []byte(build.Version), 0o600); err != nil {
+		return "", fmt.Errorf("recording managed PostgreSQL version: %w", err)
 	}
 	logf(o.Logf, "PostgreSQL installed at %s", binDir)
 	return binDir, nil
+}
+
+// readManagedPostgresVersion returns the managed PostgreSQL version recorded
+// under pgRoot by the last successful extraction, or "" if none is recorded
+// (a pre-sentinel install or an interrupted extract).
+func readManagedPostgresVersion(pgRoot string) string {
+	b, err := os.ReadFile(filepath.Join(pgRoot, pgVersionFile))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
 }
 
 // extractTarGzStrip unpacks a gzipped tar into destDir, dropping the first strip

--- a/internal/setup/install_postgres.go
+++ b/internal/setup/install_postgres.go
@@ -17,6 +17,12 @@ import (
 // archive is ~11 MB; the bound guards against a runaway/hostile response.
 const maxPostgresArchiveBytes = 150 << 20 // 150 MiB
 
+// pgVersionFile names the sentinel, written under Home/postgres after a
+// successful extraction, that records which managed PostgreSQL version is on
+// disk. The presence guard keys on it so an upgrade re-extracts instead of
+// silently keeping the prior release's binaries.
+const pgVersionFile = ".pg-version"
+
 // EnsurePostgres returns the bin directory of a managed relocatable PostgreSQL
 // (Home/postgres/bin), downloading + verifying + extracting the pinned build if
 // it is not already present. Unlike Python there is NO system fallback: Lite

--- a/internal/setup/install_postgres_test.go
+++ b/internal/setup/install_postgres_test.go
@@ -99,6 +99,38 @@ func (e errRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
 	return nil, errors.New("no network")
 }
 
+// recordingRoundTripper records that a request was made (without failing the
+// test) and returns an error, so a test can assert a code path DID reach out.
+type recordingRoundTripper struct{ called bool }
+
+func (r *recordingRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	r.called = true
+	return nil, errors.New("network blocked")
+}
+
+// TestExtractSymlinkIsIdempotent proves a re-extract over an existing install
+// does not fail on a pre-existing symlink entry (#729: os.Symlink returns EEXIST
+// when the target already exists, unlike the O_TRUNC regular-file branch).
+func TestExtractSymlinkIsIdempotent(t *testing.T) {
+	data := tarGz(t,
+		[]*tar.Header{
+			{Name: "pg/lib/libpq.so.5", Typeflag: tar.TypeReg, Mode: 0o755},
+			{Name: "pg/lib/libpq.so", Linkname: "libpq.so.5", Typeflag: tar.TypeSymlink, Mode: 0o777},
+		},
+		[]string{"SO", ""})
+	dest := t.TempDir()
+	if err := extractTarGzStrip(data, dest, 1); err != nil {
+		t.Fatalf("first extract: %v", err)
+	}
+	if err := extractTarGzStrip(data, dest, 1); err != nil {
+		t.Fatalf("second extract over existing install: %v", err)
+	}
+	link, err := os.Readlink(filepath.Join(dest, "lib", "libpq.so"))
+	if err != nil || link != "libpq.so.5" {
+		t.Errorf("symlink = %q err = %v, want -> libpq.so.5", link, err)
+	}
+}
+
 func TestEnsurePostgresReturnsExistingManaged(t *testing.T) {
 	home := t.TempDir()
 	binDir := filepath.Join(home, "postgres", "bin")
@@ -108,7 +140,11 @@ func TestEnsurePostgresReturnsExistingManaged(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(binDir, "postgres"), []byte("#!/bin/sh\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	// A managed Postgres already present must short-circuit before any download.
+	// A managed Postgres already present AT THE BUNDLED VERSION must short-circuit
+	// before any download.
+	if err := os.WriteFile(filepath.Join(home, "postgres", pgVersionFile), []byte(pgVersion), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	got, err := EnsurePostgres(context.Background(), EnsureOpts{
 		Home: home, GOOS: "linux", GOARCH: "arm64",
 		Client: &http.Client{Transport: errRoundTripper{t}},
@@ -118,6 +154,62 @@ func TestEnsurePostgresReturnsExistingManaged(t *testing.T) {
 	}
 	if got != binDir {
 		t.Errorf("bin dir = %q, want %q", got, binDir)
+	}
+}
+
+// TestEnsurePostgresReextractsOnVersionChange proves the presence guard is
+// version-aware: when the managed Postgres on disk records a DIFFERENT version
+// than the bundled one, EnsurePostgres re-installs (reaches the download) instead
+// of silently keeping the stale release. Without a version sentinel it would
+// short-circuit forever, so a clean upgrade would never re-extract.
+func TestEnsurePostgresReextractsOnVersionChange(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, "postgres", "bin")
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "postgres"), []byte("#!/bin/sh\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Sentinel records an OLDER managed version than the bundled pgVersion.
+	if err := os.WriteFile(filepath.Join(home, "postgres", pgVersionFile), []byte("15.0.0"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rt := &recordingRoundTripper{}
+	_, err := EnsurePostgres(context.Background(), EnsureOpts{
+		Home: home, GOOS: "linux", GOARCH: "arm64",
+		Client: &http.Client{Transport: rt},
+	})
+	if err == nil {
+		t.Fatal("EnsurePostgres: err = nil, want a download attempt on version change")
+	}
+	if !rt.called {
+		t.Error("expected a re-download when the on-disk PG version differs from the bundled one")
+	}
+}
+
+// TestEnsurePostgresReextractsWhenVersionUnknown proves a managed install with no
+// version sentinel (a pre-#729 install, or an interrupted extract) is treated as
+// needing re-installation rather than trusted blindly.
+func TestEnsurePostgresReextractsWhenVersionUnknown(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, "postgres", "bin")
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "postgres"), []byte("#!/bin/sh\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rt := &recordingRoundTripper{}
+	_, err := EnsurePostgres(context.Background(), EnsureOpts{
+		Home: home, GOOS: "linux", GOARCH: "arm64",
+		Client: &http.Client{Transport: rt},
+	})
+	if err == nil {
+		t.Fatal("EnsurePostgres: err = nil, want a download attempt when no version is recorded")
+	}
+	if !rt.called {
+		t.Error("expected a re-download when no version sentinel is present")
 	}
 }
 

--- a/test/e2e/lite-managed-pg-reextract.sh
+++ b/test/e2e/lite-managed-pg-reextract.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# End-to-end gate for the managed-Postgres re-extract idempotency fix (#729).
+#
+# `leoflow lite --postgres managed` downloads a relocatable PostgreSQL under
+# ~/.leoflow/postgres and extracts it. A re-run over an EXISTING install used to
+# break two ways:
+#   1. extractSymlink ended with os.Symlink, which fails EEXIST when the link
+#      target already exists (the regular-file branch overwrites via O_TRUNC), so
+#      only symlinked entries broke a re-extract over a non-empty postgres dir
+#      (a partial/interrupted prior extract, or a cross-version layout change).
+#   2. the presence guard keyed on the mere presence of bin/postgres, not its
+#      version — so a clean upgrade silently kept the prior release's Postgres and
+#      never re-extracted.
+#
+# This test boots managed Postgres, then simulates a cross-version on-disk state
+# (older version sentinel) plus a pre-existing symlink, and asserts a second boot
+# re-extracts idempotently (no EEXIST) and records the bundled version.
+#
+# Opt-in: it downloads a ~11 MB PostgreSQL from GitHub and needs a host where the
+# relocatable build can run (glibc + ICU/Kerberos). Skipped unless enabled:
+#   LEOFLOW_E2E_MANAGED_PG=1 bash test/e2e/lite-managed-pg-reextract.sh
+set -euo pipefail
+
+if [ "${LEOFLOW_E2E_MANAGED_PG:-0}" != "1" ]; then
+  echo "SKIP lite-managed-pg-reextract: set LEOFLOW_E2E_MANAGED_PG=1 to run (needs network + a host that can run the managed PG)."
+  exit 0
+fi
+
+PORT="${LEOFLOW_E2E_PORT:-18098}"
+BASE="http://127.0.0.1:${PORT}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+HOME_DIR="$TMP/home"          # sandbox ~/.leoflow so we never touch the real one
+WS="$TMP/ws"                  # empty workspace: no DAGs => no venv installs
+LEO_HOME="$HOME_DIR/.leoflow"
+PG_DIR="$LEO_HOME/postgres"
+LITE_PID=""
+
+pass() { printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+fail() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; [ -n "${2:-}" ] && tail -60 "$2"; cleanup; exit 1; }
+cleanup() {
+  [ -n "$LITE_PID" ] && kill "$LITE_PID" 2>/dev/null || true
+  # stop any managed PG started under the sandbox home
+  if [ -x "$PG_DIR/bin/pg_ctl" ] && [ -d "$LEO_HOME/pgdata" ]; then
+    "$PG_DIR/bin/pg_ctl" -D "$LEO_HOME/pgdata" stop -m fast >/dev/null 2>&1 || true
+  fi
+  chmod -R u+w "$TMP" 2>/dev/null || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+export HOME="$HOME_DIR"
+export LEOFLOW_AUTH_JWT_SECRET="e2e-insecure-jwt-secret-please-change"
+export LEOFLOW_SECRET_KEY="e2e-insecure-secret-key-32bytes!"
+export LEOFLOW_LOGS_DIR="$TMP/logs"
+export PYTHONPATH="${PYTHONPATH:-$ROOT/parser}"
+mkdir -p "$HOME_DIR" "$WS" "$TMP/logs"
+
+echo "==> building binaries"
+go build -o "$TMP/leoflow" ./cmd/leoflow
+go build -o "$TMP/leoflow-server" ./cmd/leoflow-server
+go build -o "$TMP/leoflow-agent" ./cmd/leoflow-agent
+export PATH="$TMP:$PATH"
+
+start_lite() { # $1=logfile
+  "$TMP/leoflow" lite --postgres managed --executor subprocess --port "$PORT" "$WS" >"$1" 2>&1 &
+  LITE_PID=$!
+  for _ in $(seq 1 "${LITE_READY_TRIES:-300}"); do
+    curl -fsS "${BASE}/readyz" >/dev/null 2>&1 && return 0
+    kill -0 "$LITE_PID" 2>/dev/null || { tail -60 "$1"; return 1; }
+    sleep 1
+  done
+  return 1
+}
+stop_lite() {
+  [ -n "$LITE_PID" ] && kill "$LITE_PID" 2>/dev/null || true
+  wait "$LITE_PID" 2>/dev/null || true
+  LITE_PID=""
+  if [ -x "$PG_DIR/bin/pg_ctl" ] && [ -d "$LEO_HOME/pgdata" ]; then
+    "$PG_DIR/bin/pg_ctl" -D "$LEO_HOME/pgdata" stop -m fast >/dev/null 2>&1 || true
+  fi
+  sleep 2
+}
+
+echo "==> session 1: first boot installs + extracts the managed Postgres"
+start_lite "$TMP/s1.log" || fail "session 1 did not become ready" "$TMP/s1.log"
+[ -x "$PG_DIR/bin/postgres" ] || fail "managed postgres binary was not extracted" "$TMP/s1.log"
+[ -f "$PG_DIR/.pg-version" ] || fail "managed PG version sentinel was not recorded" "$TMP/s1.log"
+BUNDLED="$(cat "$PG_DIR/.pg-version")"
+pass "session 1 extracted managed PostgreSQL ($BUNDLED)"
+stop_lite
+
+echo "==> simulate a cross-version / partial prior extract"
+# (a) older version on disk -> the guard must re-extract on the next boot
+printf '15.0.0' > "$PG_DIR/.pg-version"
+# (b) a pre-existing symlink that the re-extract will overwrite: the old
+#     os.Symlink would fail EEXIST here.
+ln -sf postgres "$PG_DIR/bin/leoflow-eexist-probe"
+pass "planted stale version sentinel + pre-existing symlink"
+
+echo "==> session 2: second boot must re-extract idempotently (no EEXIST)"
+start_lite "$TMP/s2.log" || fail "session 2 did not become ready (re-extract likely failed with EEXIST)" "$TMP/s2.log"
+[ -x "$PG_DIR/bin/postgres" ] || fail "managed postgres binary missing after re-extract" "$TMP/s2.log"
+GOT="$(cat "$PG_DIR/.pg-version")"
+[ "$GOT" = "$BUNDLED" ] || fail "version sentinel not refreshed on upgrade: got '$GOT', want '$BUNDLED'" "$TMP/s2.log"
+pass "session 2 re-extracted cleanly and refreshed the version sentinel to $GOT"
+stop_lite
+
+echo
+echo "  ✅ Managed-Postgres re-extract verified: idempotent symlink extraction + version-aware guard (#729)."


### PR DESCRIPTION
## Root cause (#729)

`leoflow lite --postgres managed` extracts a relocatable PostgreSQL into `~/.leoflow/postgres`. Two non-idempotency bugs made a re-extract over an existing install fail or silently do the wrong thing.

1. **`extractSymlink` is not idempotent.** It ends with `os.Symlink(hdr.Linkname, target)` (`internal/setup/install.go`), which fails `EEXIST` when `target` already exists. The regular-file branch overwrites via `O_CREATE|O_WRONLY|O_TRUNC` (`install.go` ~164), so **only symlinked entries** break a re-extract. The path-containment checks are correct; only the create was non-idempotent.

2. **The presence guard is version-blind.** `EnsurePostgres` short-circuits on `stat(Home/postgres/bin/postgres)` (`internal/setup/install_postgres.go`), keying on *presence*, not *version*.

## Corrected (narrower) trigger

The issue headline implied "every binary upgrade re-extracts and breaks". It does **not**: because the guard short-circuits a complete prior install, a clean A→upgrade→re-run never re-extracts today. The `EEXIST` is reachable only when extraction actually runs over a **non-empty** `~/.leoflow/postgres` — a partial/interrupted prior extract, or a cross-version on-disk layout change. The version-blind guard also has a latent coupling: a clean upgrade silently **keeps release A's managed Postgres** and never re-extracts it.

## Changes

1. **Idempotent symlink extraction** — `extractSymlink` now `os.Remove`s any existing target (ignoring `IsNotExist`) before `os.Symlink`, matching the regular-file `O_TRUNC` behavior. Safe: `target` is already sanitized by the containment checks above.
2. **Version-aware guard** — extraction records the installed version in a `~/.leoflow/postgres/.pg-version` sentinel (written **last**, so an interrupted extract leaves none). The guard short-circuits only when `bin/postgres` exists **and** the sentinel equals the binary's bundled `pgVersion`; otherwise it re-installs. Keyed on the **bundled Postgres version**, not the leoflow version, so a plain leoflow bump does not re-download PG.

### ⚠️ Behavior change (maintainer flag)
A leoflow binary bundling a **newer pinned PostgreSQL** now re-downloads + re-extracts the managed PG on next `leoflow lite --postgres managed`. Previously it silently kept the old one. Pre-`.pg-version` installs (and interrupted extracts) have no sentinel and are treated as "needs re-install" once. This is the intended fix for the latent coupling, but it is a change in upgrade behavior — flagging for review.

## Tests (red → green)

Red first, confirmed failing before the fix:
- `TestExtractSymlinkIsIdempotent` — a second `extractTarGzStrip` over an existing install failed `EEXIST` on the pre-existing symlink; now passes.
- `TestEnsurePostgresReextractsOnVersionChange` — an older on-disk version now falls through to a (blocked) download; previously short-circuited.
- `TestEnsurePostgresReextractsWhenVersionUnknown` — a sentinel-less install is re-installed rather than trusted.
- `TestEnsurePostgresReturnsExistingManaged` updated to the new contract (present **at bundled version** ⇒ short-circuit, no network).

E2E: **new** `test/e2e/lite-managed-pg-reextract.sh` (opt-in, `LEOFLOW_E2E_MANAGED_PG=1`) — two managed-PG boots with a simulated cross-version sentinel + a pre-existing symlink between them; asserts the second boot re-extracts without `EEXIST` and refreshes the sentinel. **Deviation from the reporter's "extend lite-selfheal.sh" suggestion:** that script is external-Postgres + DAG-reconcile themed and offline; grafting a ~11 MB network download onto it fit poorly, so this went into a dedicated, network-gated script. It is `bash -n` + `shellcheck` clean; the full run was **not executed here** (needs network + a host that can run the managed PG). The regression lock is the unit tests.

## Pre-push gate

```
go build ./...                    OK
go vet ./...                      OK
golangci-lint run (setup+cli)     0 issues
go test ./internal/setup/...      ok
go test ./internal/cli/...        ok
bash -n + shellcheck e2e script   clean
```
(Whole-repo `golangci-lint run` surfaces findings only in a sibling agent worktree's generated `client.gen.go`, unrelated to this change.)

Closes #729