### PR TITLE
feat(cli): add `runs list`; clarify --skip-build recompiles the spec

### DIFF
--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -46,7 +46,7 @@ func newDeployCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&o.all, "all", false, "deploy every DAG project in the workspace")
-	cmd.Flags().BoolVar(&o.skipBuild, "skip-build", false, "re-use the already-built image (promote without rebuilding)")
+	cmd.Flags().BoolVar(&o.skipBuild, "skip-build", false, "reuse the existing image (skip docker build/push) but still recompile dag.json from leoflow.yaml/dag.py")
 	cmd.Flags().BoolVar(&o.trigger, "trigger", false, "trigger a run immediately after registering")
 	cmd.Flags().BoolVarP(&o.yes, "yes", "y", false, "skip the confirmation prompt (for automation)")
 	cmd.Flags().StringVar(&o.serverURL, "server", "", "control plane base URL (default: config server_url)")

--- a/internal/cli/runs.go
+++ b/internal/cli/runs.go
@@ -20,7 +20,11 @@ func newRunsCommand() *cobra.Command {
 		Use:   "runs",
 		Short: "Trigger and inspect DAG runs.",
 	}
-	cmd.AddCommand(newRunsTriggerCommand(), newRunsStatusCommand())
+	// `runs list` is where users instinctively look; it reuses the exact
+	// command the operator alias `admin runs list` is built from, so the two
+	// share one lister, one set of flags (--state/--dag/--older-than), and one
+	// output format — no duplicated API calls.
+	cmd.AddCommand(newRunsTriggerCommand(), newRunsStatusCommand(), newAdminRunsListCommand())
 	return cmd
 }
 

--- a/internal/cli/runs_test.go
+++ b/internal/cli/runs_test.go
@@ -5,7 +5,9 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 // seedSessionConfig writes the config file `leoflow auth login` produces — a
@@ -36,6 +38,43 @@ func authRecorder(t *testing.T, body string) (srv *httptest.Server, got *string)
 	}))
 	t.Cleanup(srv.Close)
 	return srv, &auth
+}
+
+// TestRunsListRegistered pins the ergonomics fix that `leoflow runs list`
+// exists: users reach for it before discovering the operator alias
+// `leoflow admin runs list`. It must resolve to a `list` subcommand under
+// `runs`, not fall back to the `runs` group itself.
+func TestRunsListRegistered(t *testing.T) {
+	root := NewRootCommand()
+	cmd, _, err := root.Find([]string{"runs", "list"})
+	if err != nil {
+		t.Fatalf("finding `runs list`: %v", err)
+	}
+	if cmd.Name() != "list" {
+		t.Fatalf("`runs list` resolved to %q, want a registered `list` subcommand", cmd.Name())
+	}
+}
+
+// TestRunsListInvokesLister proves `runs list` drives the same lister as
+// `admin runs list`: the same server-side --state filter, the same --older-than
+// age filter, and the same tabular output. It reuses runsServer, the mock
+// control plane shared with the admin runs tests.
+func TestRunsListInvokesLister(t *testing.T) {
+	now := time.Now()
+	srv := runsServer(t, now)
+	defer srv.Close()
+
+	out, _, err := run(t, "runs", "list", "--state", "running", "--older-than", "2h",
+		"--server", srv.URL, "--token", "x")
+	if err != nil {
+		t.Fatalf("runs list: %v", err)
+	}
+	if !strings.Contains(out, "run-old") {
+		t.Errorf("output = %q, want it to include run-old", out)
+	}
+	if strings.Contains(out, "run-new") || strings.Contains(out, "run-done") {
+		t.Errorf("output = %q, should have filtered out run-new and run-done", out)
+	}
 }
 
 // TestRunsTriggerUsesConfigToken pins the contract that a user who just ran

--- a/website/content/operate/first-pro-dag.md
+++ b/website/content/operate/first-pro-dag.md
@@ -165,7 +165,7 @@ shows state and logs. That is the whole Pro lifecycle, in one verb.
 ```bash
 leoflow deploy <dag_id>     # a specific DAG in a multi-DAG workspace
 leoflow deploy --all        # every DAG in the workspace (best-effort; non-zero exit if any fail)
-leoflow deploy --skip-build # promote an already-built image without rebuilding
+leoflow deploy --skip-build # reuse the existing image (skip docker build/push); dag.json is still recompiled from leoflow.yaml/dag.py
 ```
 
 ## The complete path — your own DAG, yaml-driven

--- a/website/content/project/adrs/0041-leoflow-deploy-pipelineless.md
+++ b/website/content/project/adrs/0041-leoflow-deploy-pipelineless.md
@@ -118,7 +118,8 @@ is what keeps that option open.
 - **Confirmation** when interactive and the server is non-loopback (a real Pro):
   `Deploy <dag> → <server>? [y/N]`. `--yes` skips it (CI/automation).
 - **Rebuilds** the image by default (simple, deterministic); `--skip-build`
-  re-uses an already-built image (promote without rebuild).
+  reuses an already-built image (skips docker build/push) but still recompiles
+  `dag.json` from `leoflow.yaml`/`dag.py` — the spec is always refreshed.
 - **Pins by digest:** the push captures the image digest and writes
   `registry/img@sha256:…` into `dag.json` — Pro pulls **exactly** the bytes that
   were built; there is no `:latest` lookup. The first deploy *registers* the

--- a/website/content/reference/cli/leoflow_deploy.md
+++ b/website/content/reference/cli/leoflow_deploy.md
@@ -23,7 +23,7 @@ leoflow deploy [path | dag_id] [flags]
       --dockerfile string    Dockerfile path relative to the DAG directory (default "Dockerfile")
   -h, --help                 help for deploy
       --server string        control plane base URL (default: config server_url)
-      --skip-build           re-use the already-built image (promote without rebuilding)
+      --skip-build           reuse the existing image (skip docker build/push) but still recompile dag.json from leoflow.yaml/dag.py
       --token string         JWT bearer token (default: config token)
       --trigger              trigger a run immediately after registering
   -y, --yes                  skip the confirmation prompt (for automation)

--- a/website/content/reference/cli/leoflow_runs.md
+++ b/website/content/reference/cli/leoflow_runs.md
@@ -27,6 +27,7 @@ Trigger and inspect DAG runs.
 ### SEE ALSO
 
 * [leoflow](/reference/cli/leoflow/)	 - Leoflow is a GitOps-first, container-native workflow orchestrator.
+* [leoflow runs list](/reference/cli/leoflow_runs_list/)	 - List DAG runs, filtered by --state, --older-than, and/or --dag.
 * [leoflow runs status](/reference/cli/leoflow_runs_status/)	 - Show the state of a DAG run (the latest by default).
 * [leoflow runs trigger](/reference/cli/leoflow_runs_trigger/)	 - Trigger a new run of a DAG.
 

--- a/website/content/reference/cli/leoflow_runs_list.md
+++ b/website/content/reference/cli/leoflow_runs_list.md
@@ -1,0 +1,39 @@
+---
+# --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
+aliases:
+  - /cli/leoflow_runs_list.html
+# --- end AUTO redirect aliases ---
+title: "leoflow runs list"
+linkTitle: "runs list"
+weight: 38
+---
+
+List DAG runs, filtered by --state, --older-than, and/or --dag.
+
+```
+leoflow runs list [flags]
+```
+
+### Options
+
+```
+      --dag string            limit to a single DAG id (default: all DAGs)
+  -h, --help                  help for list
+      --older-than duration   only runs whose start time is older than this (e.g. 2h)
+      --server string         control plane base URL (default: config server_url)
+      --state string          filter by run state: queued, running, success, or failed
+      --token string          JWT bearer token (default: config token)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file path (default ~/.leoflow/config.yaml)
+      --log-level string    log level: debug, info, warn, error
+      --server-url string   control plane API base URL
+```
+
+### SEE ALSO
+
+* [leoflow runs](/reference/cli/leoflow_runs/)	 - Trigger and inspect DAG runs.
+

--- a/website/content/reference/cli/leoflow_runs_status.md
+++ b/website/content/reference/cli/leoflow_runs_status.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow runs status"
 linkTitle: "runs status"
-weight: 38
+weight: 39
 ---
 
 Show the state of a DAG run (the latest by default).

--- a/website/content/reference/cli/leoflow_runs_trigger.md
+++ b/website/content/reference/cli/leoflow_runs_trigger.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow runs trigger"
 linkTitle: "runs trigger"
-weight: 39
+weight: 40
 ---
 
 Trigger a new run of a DAG.

--- a/website/content/reference/cli/leoflow_server.md
+++ b/website/content/reference/cli/leoflow_server.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow server"
 linkTitle: "server"
-weight: 40
+weight: 41
 ---
 
 Information about running the control plane.

--- a/website/content/reference/cli/leoflow_setup.md
+++ b/website/content/reference/cli/leoflow_setup.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow setup"
 linkTitle: "setup"
-weight: 41
+weight: 42
 ---
 
 Bootstrap the managed Leoflow runtime (Python, parser, workspace).

--- a/website/content/reference/cli/leoflow_uninstall.md
+++ b/website/content/reference/cli/leoflow_uninstall.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow uninstall"
 linkTitle: "uninstall"
-weight: 42
+weight: 43
 ---
 
 Remove the Leoflow installation (~/.leoflow).

--- a/website/content/reference/cli/leoflow_validate.md
+++ b/website/content/reference/cli/leoflow_validate.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow validate"
 linkTitle: "validate"
-weight: 43
+weight: 44
 ---
 
 Validate leoflow.yaml and the DAG source against the schema.

--- a/website/content/reference/cli/leoflow_version.md
+++ b/website/content/reference/cli/leoflow_version.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow version"
 linkTitle: "version"
-weight: 44
+weight: 45
 ---
 
 Print the version, git commit, and build date.


### PR DESCRIPTION
Two small CLI ergonomics fixes surfaced during EKS validation arestas #4 and #2.

## Fix #4 — `leoflow runs list` now exists
`leoflow runs` exposed only `trigger` + `status`; the only run listing lived at the operator alias `leoflow admin runs list`, which is where users did **not** think to look. This registers a `list` subcommand under `runs` that **reuses the exact command builder the admin alias uses** (`newAdminRunsListCommand`) — one lister, one set of flags (`--state` / `--dag` / `--older-than`), one output format. No duplicated API call.

TDD: the red tests landed first (`TestRunsListRegistered`, `TestRunsListInvokesLister` in `internal/cli/runs_test.go`), asserting the subcommand is registered and drives the shared lister against the mock control plane; then the one-line wiring in `internal/cli/runs.go` turned them green.

## Fix #2 — document that `--skip-build` still recompiles `dag.json`
`--skip-build` sets `build=false`/`push=false` (`deploy.go:248-249`), but `deploy` **always** calls `runCompile` (`deploy.go:251`), which **always** rewrites `dag.json` (`compile.go`); only `buildAndPush` is gated. So `--skip-build` reuses the image but still recompiles the spec from `leoflow.yaml`/`dag.py`. A tester was confused, expecting the old `dag.json` to be reused.

Doc/help only — **no behavior change**. Clarified:
- the `--skip-build` flag help in `internal/cli/deploy.go`
- the deploy prose doc (`website/content/operate/first-pro-dag.md`)
- ADR-0041 (`website/content/project/adrs/0041-leoflow-deploy-pipelineless.md`)
- the auto-generated CLI reference (regenerated via `website/scripts/gen-cli.sh` + `build_redirects.py`; also adds the new `leoflow_runs_list` page and restores redirect aliases)

## Gate
- `go build ./...` — clean
- `go vet ./...` — clean
- `golangci-lint run ./internal/cli/...` — 0 issues
- `go test ./internal/cli/...` — pass