### PR TITLE
ci(helm): gate chart version against the release tag + publish OCI chart

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -34,6 +34,30 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v4.2.0
+
+      # ── Preflight: gate the OCI publish on a passing chart check ──
+      # `helm package` below stamps version/appVersion from the tag, so the
+      # PUBLISHED chart is always correct — but the source Chart.yaml is what
+      # the from-source `helm install ./helm/leoflow` and the RC cluster-
+      # validation runbook use, and ADR 0028 says the two move in lockstep.
+      # This step FAILS the tag if Chart.yaml lags the tag (arestas #3), so a
+      # cut cannot ship a source tree whose default image tags point at the
+      # previous release. The full chart contract suite (helm unittest,
+      # template-checks, rbac-covers-executor, kubeconform) runs per-PR in
+      # helm-ci.yaml; here we run the fast, tag-specific gates that guard the
+      # release artifact before it is packaged and pushed.
+      - name: Gate — chart version + appVersion match the tag (ADR 0028)
+        run: bash scripts/check-chart-version-matches-tag.sh
+
+      - name: Gate — helm lint
+        run: helm lint helm/leoflow
+
+      - name: Gate — chart contract (env + Secret keys render)
+        run: bash scripts/helm-template-checks.sh
+
       # ── Sigstore cosign for keyless signing (same pin as release.yaml) ──
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -23,8 +23,28 @@ production-like install — distinct from the host-run `test/e2e/e2e.sh` smoke.
 
 ## Quick start
 
+Every release tag publishes this chart as a signed **OCI artifact** to
+`oci://ghcr.io/neochaotic/charts/leoflow` (ADR 0028), so you can install a
+pinned version without cloning the repo:
+
 ```bash
 kubectl create namespace leoflow
+helm install lf oci://ghcr.io/neochaotic/charts/leoflow --version <x.y.z> -n leoflow \
+  --set database.url='postgres://user:pass@postgres:5432/leoflow?sslmode=disable' \
+  --set redis.url='redis://redis:6379/0' \
+  --set auth.jwtSecret='change-me' \
+  --set bootstrap.password='admin'
+```
+
+Use the release tag **without** the leading `v` as `--version` (tag `v0.4.0` →
+`--version 0.4.0`); the chart `version`/`appVersion` move in lockstep with the
+tag. The chart is cosign-signed by digest — verify it with
+`cosign verify ghcr.io/neochaotic/charts/leoflow --certificate-identity-regexp '…' --certificate-oidc-issuer https://token.actions.githubusercontent.com`.
+
+To install from a source checkout instead (e.g. an unreleased branch), point
+Helm at the chart directory:
+
+```bash
 helm install lf ./helm/leoflow -n leoflow \
   --set database.url='postgres://user:pass@postgres:5432/leoflow?sslmode=disable' \
   --set redis.url='redis://redis:6379/0' \

--- a/helm/leoflow/README.md.gotmpl
+++ b/helm/leoflow/README.md.gotmpl
@@ -23,8 +23,28 @@ production-like install — distinct from the host-run `test/e2e/e2e.sh` smoke.
 
 ## Quick start
 
+Every release tag publishes this chart as a signed **OCI artifact** to
+`oci://ghcr.io/neochaotic/charts/leoflow` (ADR 0028), so you can install a
+pinned version without cloning the repo:
+
 ```bash
 kubectl create namespace leoflow
+helm install lf oci://ghcr.io/neochaotic/charts/leoflow --version <x.y.z> -n leoflow \
+  --set database.url='postgres://user:pass@postgres:5432/leoflow?sslmode=disable' \
+  --set redis.url='redis://redis:6379/0' \
+  --set auth.jwtSecret='change-me' \
+  --set bootstrap.password='admin'
+```
+
+Use the release tag **without** the leading `v` as `--version` (tag `v0.4.0` →
+`--version 0.4.0`); the chart `version`/`appVersion` move in lockstep with the
+tag. The chart is cosign-signed by digest — verify it with
+`cosign verify ghcr.io/neochaotic/charts/leoflow --certificate-identity-regexp '…' --certificate-oidc-issuer https://token.actions.githubusercontent.com`.
+
+To install from a source checkout instead (e.g. an unreleased branch), point
+Helm at the chart directory:
+
+```bash
 helm install lf ./helm/leoflow -n leoflow \
   --set database.url='postgres://user:pass@postgres:5432/leoflow?sslmode=disable' \
   --set redis.url='redis://redis:6379/0' \

--- a/scripts/check-chart-version-matches-tag.sh
+++ b/scripts/check-chart-version-matches-tag.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Fail if the Helm chart's version/appVersion lags the release tag.
+#
+# ADR 0028: the chart `version` and `appVersion` move in lockstep with the
+# release tag — a `vX.Y.Z` tag ships a chart pinned to `X.Y.Z`. The image tags
+# default to `.Values.image.tag | default .Chart.AppVersion`
+# (helm/leoflow/templates/_helpers.tpl, migration-job.yaml), so if a cut tags
+# `v0.4.0-rc.3` while Chart.yaml still says `0.4.0-rc.2`, a DEFAULT
+# `helm install ./helm/leoflow` pulls the WRONG (previous) images and the
+# operator has to `--set image.tag=… --set migrations.image.tag=…` by hand.
+# The published OCI chart stamps version/appVersion from the tag at package
+# time, so this gate protects the source tree (the from-source install path and
+# the RC cluster-validation runbook) and enforces the lockstep invariant so a
+# future cut cannot tag with a stale Chart.yaml.
+#
+# Usage:
+#   scripts/check-chart-version-matches-tag.sh [TAG]
+#       TAG defaults to $GITHUB_REF_NAME (the pushed tag in CI). A leading `v`
+#       is stripped: a Helm chart version must be SemVer 2 (no `v` prefix),
+#       matching how GoReleaser's semver image tag strips it too.
+#   scripts/check-chart-version-matches-tag.sh --self-test
+#       Run the built-in pass/fail cases and exit; no repo state is touched.
+#
+# Overridable for the self-test only:
+#   CHART_FILE   path to the Chart.yaml to inspect (default: helm/leoflow/Chart.yaml)
+set -euo pipefail
+
+CHART_FILE="${CHART_FILE:-helm/leoflow/Chart.yaml}"
+
+# Read a top-level scalar key from Chart.yaml without a yq dependency (the helm
+# lint job has helm but not yq). Strips surrounding quotes and inline comments.
+chart_key() {
+	local key="$1" file="$2"
+	awk -v k="^${key}:" '
+		$0 ~ k {
+			sub(/^[^:]*:[[:space:]]*/, "")   # drop "key:" and leading space
+			sub(/[[:space:]]*#.*$/, "")      # drop trailing inline comment
+			gsub(/^["'\'']|["'\'']$/, "")    # drop surrounding quotes
+			print
+			exit
+		}
+	' "$file"
+}
+
+# Compare Chart.yaml version/appVersion against an expected (v-stripped) version.
+# Prints a diagnostic and returns non-zero on any mismatch or missing key.
+check_chart() {
+	local file="$1" want="$2"
+	local version appversion rc=0
+
+	if [ ! -f "$file" ]; then
+		echo "FAIL: chart file not found: $file" >&2
+		return 1
+	fi
+
+	version="$(chart_key version "$file")"
+	appversion="$(chart_key appVersion "$file")"
+
+	if [ -z "$version" ]; then
+		echo "FAIL: could not read 'version' from $file" >&2
+		rc=1
+	elif [ "$version" != "$want" ]; then
+		echo "FAIL: chart version '$version' != tag '$want' (from $file)" >&2
+		rc=1
+	fi
+
+	if [ -z "$appversion" ]; then
+		echo "FAIL: could not read 'appVersion' from $file" >&2
+		rc=1
+	elif [ "$appversion" != "$want" ]; then
+		echo "FAIL: chart appVersion '$appversion' != tag '$want' (from $file)" >&2
+		rc=1
+	fi
+
+	if [ "$rc" -ne 0 ]; then
+		echo >&2
+		echo "Bump helm/leoflow/Chart.yaml 'version' and 'appVersion' to '$want'" >&2
+		echo "BEFORE cutting the tag (ADR 0028: chart moves in lockstep with the tag)." >&2
+		return 1
+	fi
+
+	echo "OK: chart version + appVersion == '$want' ($file)"
+}
+
+self_test() {
+	local tmp rc=0 out
+	tmp="$(mktemp -d)"
+	trap 'rm -rf "${tmp:-}"' EXIT
+
+	# Case 1: matching version + appVersion → pass.
+	cat > "$tmp/Chart.yaml" <<-'EOF'
+		apiVersion: v2
+		name: leoflow
+		# version tracks the tag (ADR 0028)
+		version: 0.4.0-rc.3
+		appVersion: "0.4.0-rc.3"
+	EOF
+	if out="$(check_chart "$tmp/Chart.yaml" "0.4.0-rc.3" 2>&1)"; then
+		echo "self-test 1 (match) PASS"
+	else
+		echo "self-test 1 (match) FAIL — expected pass, got:"; echo "$out"; rc=1
+	fi
+
+	# Case 2: stale version + appVersion vs the tag → fail (the #3 bug).
+	if out="$(check_chart "$tmp/Chart.yaml" "0.4.0" 2>&1)"; then
+		echo "self-test 2 (stale) FAIL — expected fail, got pass:"; echo "$out"; rc=1
+	else
+		echo "self-test 2 (stale) PASS"
+	fi
+
+	# Case 3: leading `v` on the tag is stripped by the caller, not here — verify
+	# a bare-vs-v mismatch is caught (defends the v-strip contract at the CLI).
+	if check_chart "$tmp/Chart.yaml" "v0.4.0-rc.3" >/dev/null 2>&1; then
+		echo "self-test 3 (v-prefix) FAIL — 'v0.4.0-rc.3' should not equal '0.4.0-rc.3'"; rc=1
+	else
+		echo "self-test 3 (v-prefix) PASS"
+	fi
+
+	# Case 4: appVersion lags while version matches → still fails (both keys checked).
+	cat > "$tmp/Chart.yaml" <<-'EOF'
+		version: 0.4.0-rc.3
+		appVersion: "0.4.0-rc.2"
+	EOF
+	if check_chart "$tmp/Chart.yaml" "0.4.0-rc.3" >/dev/null 2>&1; then
+		echo "self-test 4 (appVersion lag) FAIL — expected fail, got pass"; rc=1
+	else
+		echo "self-test 4 (appVersion lag) PASS"
+	fi
+
+	if [ "$rc" -eq 0 ]; then
+		echo "self-test: all cases passed"
+	fi
+	return "$rc"
+}
+
+main() {
+	cd "$(dirname "$0")/.."
+
+	if [ "${1:-}" = "--self-test" ]; then
+		self_test
+		return
+	fi
+
+	local tag="${1:-${GITHUB_REF_NAME:-}}"
+	if [ -z "$tag" ]; then
+		echo "FAIL: no tag given (pass one as \$1 or set \$GITHUB_REF_NAME)" >&2
+		echo "Usage: $0 [TAG] | --self-test" >&2
+		return 2
+	fi
+
+	# Strip a single leading `v`: `v0.4.0-rc.3` → `0.4.0-rc.3`.
+	local want="${tag#v}"
+	check_chart "$CHART_FILE" "$want"
+}
+
+main "$@"

--- a/test/release/rc-cluster-validation.md
+++ b/test/release/rc-cluster-validation.md
@@ -52,6 +52,24 @@ install page <https://neochaotic.github.io/leoflow/get-started/installation/>.
 
 ## §1 Install (Helm / Pro)
 
+> **Before the tag is cut (maintainer preflight).** The chart `version` and
+> `appVersion` in `helm/leoflow/Chart.yaml` must equal the release tag (minus the
+> leading `v`) **before** you `git tag` — ADR 0028 keeps them in lockstep, and the
+> image tags default to `.Chart.AppVersion`, so a stale Chart.yaml makes a default
+> `helm install ./helm/leoflow` pull the **previous** release's images (this bit
+> `v0.4.0-rc.3`, which shipped with Chart.yaml still on `rc.2` — arestas #3).
+> Bump both keys, then verify with:
+>
+> ```bash
+> scripts/check-chart-version-matches-tag.sh vX.Y.Z   # or $GITHUB_REF_NAME in CI
+> ```
+>
+> The same gate runs automatically on every `v*` tag in
+> `.github/workflows/helm-release.yaml`, so a cut with a stale chart fails the
+> Helm chart release job rather than shipping wrong image defaults. Once tagged,
+> install the **published OCI chart** (`--version` = tag without the `v`) rather
+> than a source checkout — see the [chart README](https://github.com/neochaotic/leoflow/blob/main/helm/leoflow/README.md#quick-start).
+
 Confirmed chart value keys used below (defaults in parens) — see the chart README
 for the datastore/secret keys this runbook intentionally does not spell out:
 

--- a/website/content/operate/helm-chart.md
+++ b/website/content/operate/helm-chart.md
@@ -13,6 +13,26 @@ The **Pro** control plane installs on Kubernetes via the official Helm chart. Th
 chart is chart-test gated, publishes multi-arch images per release, and signs them
 with cosign. It runs on any cluster with an external Postgres + Redis.
 
+## Install from the published OCI chart
+
+Every release tag publishes the chart as a **cosign-signed OCI artifact** to
+`oci://ghcr.io/neochaotic/charts/leoflow` ([ADR 0028](/project/adrs/0028-release-versioning-two-editions/)),
+co-versioned with the release tag — so you can install a pinned version without
+cloning the repo:
+
+```bash
+helm install leoflow oci://ghcr.io/neochaotic/charts/leoflow --version <x.y.z> \
+  -n leoflow --create-namespace \
+  -f values.yaml
+```
+
+Pass the release tag **without** the leading `v` (tag `v0.4.0` → `--version 0.4.0`):
+the chart `version`/`appVersion` move in lockstep with the tag, so this also pins
+the control-plane image. Installing from a source checkout
+(`helm install ./helm/leoflow`) is still supported for unreleased branches — see
+the [chart README](https://github.com/neochaotic/leoflow/blob/main/helm/leoflow/README.md#quick-start)
+for both paths and the full values surface.
+
 {{% alert title="Reference lives with the chart" color="info" %}}
 This operator-journey page is the entry point; the exhaustive values reference is
 maintained **alongside the chart source** so it never drifts from `values.yaml`:


### PR DESCRIPTION
Closes two release-infra gaps found during EKS validation — **arestas #3 and #7**.

## Gap #3 — chart version lags the release tag

On `v0.4.0-rc.3`, `helm/leoflow/Chart.yaml` still pinned `version: 0.4.0-rc.2` / `appVersion: "0.4.0-rc.2"`. Image tags default to `.Values.image.tag | default .Chart.AppVersion` (`_helpers.tpl:167`, `migration-job.yaml:9`), so a **default** `helm install ./helm/leoflow` pulled **rc.2** images — the operator had to `--set image.tag=… --set migrations.image.tag=…` by hand. Chart.yaml's own comment says version+appVersion move in lockstep with the tag (ADR 0028); the cut just didn't bump it.

**Fix — a self-testing gate:** `scripts/check-chart-version-matches-tag.sh`
- Takes the tag from `$1` or `$GITHUB_REF_NAME`, strips the leading `v`, and fails if Chart.yaml `version` **or** `appVersion` differ. No `yq` dependency (helm-only runners).
- `--self-test` runs four built-in cases (match / stale / v-prefix / appVersion-lag) touching no repo state.
- Wired as a **preflight in `.github/workflows/helm-release.yaml`** (tag-triggered only — on PRs Chart.yaml legitimately lags the not-yet-cut tag), alongside `helm lint` and the existing contract render. A future cut with a stale chart now fails the release job instead of shipping wrong image defaults.
- Pre-tag bump step documented in `test/release/rc-cluster-validation.md` §1 (there is no `prepare-release.sh` in this repo — none invented).

**Sample output (run locally):**
```
# PASS — tag matches current Chart.yaml
$ scripts/check-chart-version-matches-tag.sh v0.4.0-rc.2
OK: chart version + appVersion == '0.4.0-rc.2' (helm/leoflow/Chart.yaml)   # exit 0

# FAIL — reproduces the exact #3 bug (rc.3 tag vs rc.2 chart)
$ scripts/check-chart-version-matches-tag.sh v0.4.0-rc.3
FAIL: chart version '0.4.0-rc.2' != tag '0.4.0-rc.3' (from helm/leoflow/Chart.yaml)
FAIL: chart appVersion '0.4.0-rc.2' != tag '0.4.0-rc.3' (from helm/leoflow/Chart.yaml)
Bump helm/leoflow/Chart.yaml 'version' and 'appVersion' to '0.4.0-rc.3'
BEFORE cutting the tag (ADR 0028: chart moves in lockstep with the tag).       # exit 1

$ scripts/check-chart-version-matches-tag.sh --self-test
self-test 1 (match) PASS
self-test 2 (stale) PASS
self-test 3 (v-prefix) PASS
self-test 4 (appVersion lag) PASS
self-test: all cases passed                                                    # exit 0
```

I did **not** bump Chart.yaml to a specific version — the next cut owns that; this PR only adds the gate + docs.

## Gap #7 — published Helm/OCI chart

**Finding:** `.github/workflows/helm-release.yaml` **already** packages, pushes, and cosign-signs the chart to `oci://ghcr.io/neochaotic/charts/leoflow` on every `v*` tag (version/appVersion stamped from the tag at package time). What was missing: (a) the publish ran with **no preceding chart check**, and (b) the OCI install path was **undocumented**.

**Fix:**
- Gated the existing package/push/sign behind the new version gate + `helm lint` + `helm-template-checks.sh` (fast, tag-specific; the full contract suite — helm unittest, rbac-covers-executor, kubeconform — stays in `helm-ci.yaml` per-PR). Publish now only happens **after** the checks pass.
- Documented `helm install oci://ghcr.io/neochaotic/charts/leoflow --version <x.y.z>` (with the "drop the leading `v`" note and cosign-verify) in the **chart README** (`README.md.gotmpl`, regenerated via helm-docs so the sync gate stays green) and the **operator docs** page `website/content/operate/helm-chart.md`, keeping the from-source path for unreleased branches.

## Gate (all run locally)
- `helm lint helm/leoflow` → `1 chart(s) linted, 0 chart(s) failed`
- new check script both passing and failing → shown above; `shellcheck` clean; `--self-test` green
- `helm template …` still renders → `helm template RENDER OK`
- `actionlint .github/workflows/helm-release.yaml` → clean
- `helm-docs` regenerated; README in sync with values.yaml (helm-ci gate)

**Not touched:** CHANGELOG.md.
