### PR TITLE
chore(docs): replace mkdocs gate with hugo, fix CONTRIBUTING template + ci filters

### DIFF
--- a/.github/CLAUDE.md.template
+++ b/.github/CLAUDE.md.template
@@ -1,0 +1,157 @@
+# CLAUDE.md — Leoflow Project Context
+
+This file provides essential context for AI coding agents working on the Leoflow codebase. Read this entirely before making any changes.
+
+## What Leoflow Is
+
+Leoflow is a **GitOps-first, container-native workflow orchestrator** written in Go, designed to replace Apache Airflow's control plane while maintaining UI compatibility with Airflow 3.2.x.
+
+The core insight: the **pod-per-task** execution model is correct (Airflow proved this with KubernetesExecutor), but the **Python control plane** is what makes Airflow slow. Leoflow keeps the model, rewrites the control plane in Go, and eliminates dependency hell by making each DAG its own container image.
+
+## Non-Negotiable Principles
+
+1. **All code, comments, commit messages, documentation, and identifiers MUST be in English.** No exceptions.
+2. **Strict TDD.** Every line of production code is written in response to a failing test. Red → Green → Refactor. See ADR 0011 for the full discipline. AI agents follow this without exception: write the test, run it, see it fail, then implement. Never write production code first.
+3. **Go Report Card A+ is the quality floor.** Every commit passes all seven goreportcard checks at 100% (gofmt, govet, gocyclo with max 15, golint with GoDocs on all exports, ineffassign, misspell, license). Plus the extended golangci-lint stack in `.golangci.yaml`. See ADR 0012.
+4. **GoDocs on every exported identifier.** Functions, types, methods, constants, and variables visible outside their package have a doc comment starting with the identifier name and ending with a period. No exceptions.
+5. **No GIL, no Python in the hot path.** Python is only allowed in: (a) the DAG parser sidecar, and (b) inside user task containers.
+6. **DAGs are immutable artifacts.** A `dag.json` + container image, versioned together, never mutated after compilation.
+7. **Each DAG has its own container image.** No shared `/dags` filesystem, no monolithic worker image.
+8. **Airflow UI is a hard compatibility target for the MVP.** The HTTP API at `/api/v2/` must match Airflow 3.2.x semantics. Internal models can be richer, but the public API translates to Airflow's vocabulary.
+9. **Enterprise architecture, MVP features.** Schemas, interfaces, and middleware are enterprise-ready from day one. Implementations start simple.
+10. **Observability is not optional.** Prometheus metrics, OpenTelemetry tracing, and structured logs ship from the first commit.
+11. **Supply chain security is built-in.** govulncheck + gosec + Trivy + CodeQL run on every PR. See ADR 0014.
+
+## Architectural Overview
+
+```
+Dev / CI                Control Plane (Go)              Worker Pod
+─────────               ──────────────────              ──────────
+leoflow.yaml ─┐                                         ┌─ leoflow-agent (Go)
+dag.py        ├─► leoflow compile ─► dag.json ─► API ─► │   ↕ gRPC
+Dockerfile    ┘                              │          └─ User Python code
+                                             │
+                                    ┌────────┴────────┐
+                                    │ Scheduler (Go)  │
+                                    │ - State machine │
+                                    │ - Goroutines    │
+                                    └────────┬────────┘
+                                             │
+                                    ┌────────┴────────┐
+                                    │ Executor Router │
+                                    │ - K8s (client-go)
+                                    │ - Docker socket │
+                                    │ - Subprocess    │
+                                    └─────────────────┘
+                                             │
+                              Postgres (metadata) + Redis (XCom + locks)
+```
+
+## Tech Stack (Locked)
+
+| Layer | Choice |
+|---|---|
+| Language (control plane, agent, CLI) | Go 1.22+ |
+| HTTP framework | Gin |
+| SQL access | sqlc (no ORM magic) |
+| Migrations | golang-migrate |
+| gRPC | google.golang.org/grpc |
+| Kubernetes client | client-go (official) |
+| Logging | log/slog (stdlib) |
+| Metrics | prometheus/client_golang |
+| Tracing | OpenTelemetry SDK |
+| Config | Viper |
+| CLI | Cobra |
+| Redis | go-redis/v9 |
+| Tests | testify + gomock |
+| DAG parser | Python 3.11 + Apache Airflow SDK 3.2.x |
+| Container base images | Debian slim + Python 3.10 / 3.11 / 3.12 |
+
+## Repository Layout
+
+```
+leoflow/
+├── CLAUDE.md                  # This file
+├── README.md
+├── LICENSE                    # Apache 2.0
+├── Makefile
+├── go.mod
+├── docs/
+│   ├── adr/                   # Architecture Decision Records (read these!)
+│   ├── architecture.md
+│   └── api/                   # OpenAPI specs
+├── cmd/
+│   ├── leoflow/               # Dev CLI binary
+│   ├── leoflow-server/        # Control plane binary
+│   └── leoflow-agent/         # Worker agent binary
+├── internal/
+│   ├── api/                   # HTTP handlers (/api/v2/...)
+│   ├── auth/                  # JWT + RBAC
+│   ├── domain/                # Core types (DAG, Task, Run, etc.)
+│   ├── executor/              # K8s, Docker, subprocess executors
+│   ├── logs/                  # Log shipping (S3/GCS/disk)
+│   ├── observability/         # Metrics + tracing setup
+│   ├── scheduler/             # State machine
+│   ├── storage/               # Postgres + Redis
+│   └── xcom/                  # XCom backend
+├── proto/                     # gRPC .proto files
+├── parser/                    # Python DAG parser (sidecar)
+├── migrations/                # SQL migrations
+├── runtime/                   # Base Docker images for user DAGs
+└── helm/                      # Helm chart for K8s deployment
+```
+
+## Code Conventions
+
+- **Package names:** lowercase, single word, no underscores (`scheduler`, not `task_scheduler`).
+- **Error handling:** always wrap with context using `fmt.Errorf("doing X: %w", err)`. Never swallow errors.
+- **Logging:** use `slog` with structured fields. Never use `fmt.Println` in production code.
+- **Context:** every function that does I/O takes `context.Context` as first parameter.
+- **Tests:** every behavior has a test written before the implementation. Every package has `_test.go` files. Integration tests gated by `//go:build integration` tag. Per-package coverage floors enforced in CI (see ADR 0011).
+- **No global state** except for metrics registries and config (which lives in `internal/config`).
+- **Interfaces near consumers:** define interfaces in the package that uses them, not in the package that implements them.
+
+## Critical Rules for AI Agents
+
+1. **TDD is mandatory and observable.** Every production code change must be preceded by a failing test commit (or a test added in the same commit that initially fails). The workflow is: write test → run test → see it fail → implement → run test → see it pass → refactor. Never claim "this should work" without running the test. Never write production code first and tests after. See ADR 0011.
+2. **Go Report Card A+ is the floor, not the ceiling.** Every commit maintains the grade. Every exported identifier (function, type, method, constant, variable) has a GoDoc comment starting with its name and ending with a period. Cyclomatic complexity ≤ 15 per function. `make lint` must be clean before any commit. See ADR 0012.
+3. **Run `make lint` and `go test ./...` before claiming a task is done.** Show the output. "Tests should pass" is never acceptable; "tests passed (here is the output)" is the bar.
+4. **Never modify `docs/adr/*.md` files without explicit user approval.** ADRs are immutable decisions.
+5. **Always read relevant ADRs before writing code in a new area.** They explain *why* decisions were made.
+6. **Never introduce new dependencies without checking the tech stack table above.** Every new dep is a supply chain surface; if added, ensure it appears in `govulncheck` clean and Dependabot can track it.
+7. **Never break the `/api/v2/` API surface.** It must remain Airflow 3.2.x compatible.
+8. **Never use Python outside of `parser/` and inside user task containers.**
+9. **When in doubt about an architectural choice, stop and ask.** Don't guess on irreversible decisions.
+10. **Agent context files (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, etc.) are gitignored.** They are never committed. The template at `.github/CLAUDE.md.template` is the source of truth for the canonical context; copy from it.
+
+## Domain Vocabulary
+
+| Term | Meaning |
+|---|---|
+| DAG | Directed Acyclic Graph of tasks. Immutable artifact (`dag.json` + image). |
+| Task | A unit of work within a DAG. Has a `task_id`, type, and config. |
+| TaskInstance | A specific execution of a Task within a DagRun. Has state. |
+| DagRun | A specific execution of a DAG. Identified by `dag_id` + `logical_date`. |
+| Logical Date | The "business" date for a DAG run (renamed from `execution_date` in Airflow 3). |
+| Trigger Rule | Condition for a task to run based on upstream states. |
+| XCom | Small (≤256KB) typed payload passed between tasks. Stored in Redis. |
+| Executor | Component that physically runs a task (K8s, Docker, subprocess). |
+| Agent | Small Go binary inside the user's container that talks gRPC to the Core. |
+
+## Roadmap Phases
+
+The MVP is broken into 6 phases. Always check which phase is active before starting work:
+
+- **Phase 1:** Foundation — repo, schemas, CLI, parser
+- **Phase 2:** Control Plane Core — API server, scheduler, auth
+- **Phase 3:** Executor + Agent — task execution end-to-end
+- **Phase 4:** XCom + Logs — data flow between tasks, log shipping
+- **Phase 5:** UI Integration — Airflow UI talking to Leoflow
+- **Phase 6:** Hardening — load tests, docs, Helm chart
+
+These phases were delivered through v0.1.0; they remain here as historical context
+for the project's shape.
+
+## When You're Stuck
+
+If something contradicts what you read in an ADR, the ADR wins. If something contradicts this file, this file wins. If you're unsure, ask the user before guessing.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -549,7 +549,7 @@ jobs:
           fetch-depth: 0
       # Docs/tooling-only PRs validate nothing here; skip the ~40-min k3d run but
       # keep reporting this required check. Computes the base..head diff and runs
-      # the heavy steps only when a non-docs/spec/load-test/markdown file changed.
+      # the heavy steps only when a non-docs/spec/load-test/website/markdown file changed.
       - name: Gate heavy E2E on code changes
         id: gate
         run: |
@@ -562,7 +562,7 @@ jobs:
           git fetch --depth=1 origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
           FILES=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
           echo "Changed files:"; echo "$FILES"
-          if [ -n "$FILES" ] && ! echo "$FILES" | grep -qvE '^(docs/|spec/|test/load/|.*\.md$)'; then
+          if [ -n "$FILES" ] && ! echo "$FILES" | grep -qvE '^(docs/|spec/|test/load/|website/|.*\.md$)'; then
             echo "run=false" >> "$GITHUB_OUTPUT"
             echo "docs/tooling-only change — skipping heavy k3d E2E."
           else
@@ -636,7 +636,7 @@ jobs:
           fetch-depth: 0
       # Docs/tooling-only PRs validate nothing here; skip the ~40-min k3d run but
       # keep reporting this required check. Computes the base..head diff and runs
-      # the heavy steps only when a non-docs/spec/load-test/markdown file changed.
+      # the heavy steps only when a non-docs/spec/load-test/website/markdown file changed.
       - name: Gate heavy E2E on code changes
         id: gate
         run: |
@@ -649,7 +649,7 @@ jobs:
           git fetch --depth=1 origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
           FILES=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
           echo "Changed files:"; echo "$FILES"
-          if [ -n "$FILES" ] && ! echo "$FILES" | grep -qvE '^(docs/|spec/|test/load/|.*\.md$)'; then
+          if [ -n "$FILES" ] && ! echo "$FILES" | grep -qvE '^(docs/|spec/|test/load/|website/|.*\.md$)'; then
             echo "run=false" >> "$GITHUB_OUTPUT"
             echo "docs/tooling-only change — skipping heavy k3d E2E."
           else
@@ -720,7 +720,7 @@ jobs:
           fetch-depth: 0
       # Docs/tooling-only PRs validate nothing here; skip the ~40-min k3d run but
       # keep reporting this required check. Computes the base..head diff and runs
-      # the heavy steps only when a non-docs/spec/load-test/markdown file changed.
+      # the heavy steps only when a non-docs/spec/load-test/website/markdown file changed.
       - name: Gate heavy E2E on code changes
         id: gate
         run: |
@@ -733,7 +733,7 @@ jobs:
           git fetch --depth=1 origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
           FILES=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
           echo "Changed files:"; echo "$FILES"
-          if [ -n "$FILES" ] && ! echo "$FILES" | grep -qvE '^(docs/|spec/|test/load/|.*\.md$)'; then
+          if [ -n "$FILES" ] && ! echo "$FILES" | grep -qvE '^(docs/|spec/|test/load/|website/|.*\.md$)'; then
             echo "run=false" >> "$GITHUB_OUTPUT"
             echo "docs/tooling-only change — skipping heavy k3d E2E."
           else
@@ -838,7 +838,7 @@ jobs:
           fetch-depth: 0
       # Docs/tooling-only PRs validate nothing here; skip the ~40-min k3d run but
       # keep reporting this required check. Computes the base..head diff and runs
-      # the heavy steps only when a non-docs/spec/load-test/markdown file changed.
+      # the heavy steps only when a non-docs/spec/load-test/website/markdown file changed.
       - name: Gate heavy E2E on code changes
         id: gate
         run: |
@@ -851,7 +851,7 @@ jobs:
           git fetch --depth=1 origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
           FILES=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
           echo "Changed files:"; echo "$FILES"
-          if [ -n "$FILES" ] && ! echo "$FILES" | grep -qvE '^(docs/|spec/|test/load/|.*\.md$)'; then
+          if [ -n "$FILES" ] && ! echo "$FILES" | grep -qvE '^(docs/|spec/|test/load/|website/|.*\.md$)'; then
             echo "run=false" >> "$GITHUB_OUTPUT"
             echo "docs/tooling-only change — skipping heavy k3d E2E."
           else

--- a/.github/workflows/website-build.yml
+++ b/.github/workflows/website-build.yml
@@ -1,12 +1,12 @@
 name: Website (Hugo+Docsy) build check
 
-# PHASE 0 of the docs migration to Hugo + Docsy. This workflow ONLY builds the new
-# site under website/ with `hugo --gc --minify` to prove it stays green — it never
-# deploys anywhere and never touches the gh-pages branch. The live MkDocs+mike site
-# (docs/, mkdocs.yml, docs.yml, docs-release.yaml) is a SEPARATE, untouched track
-# and remains the published documentation until the cutover happens at full parity.
+# Build check for the Hugo + Docsy documentation site under website/. The MkDocs +
+# mike migration is complete: Hugo is now the published docs (deployed separately by
+# website-deploy.yml). This workflow ONLY builds the site with `hugo --gc --minify`
+# to prove a PR keeps it green — it never deploys anywhere and never touches the
+# gh-pages branch.
 #
-# Scoped to website/** so it never fires on changes to the live docs, and vice versa.
+# Scoped to website/** so it only fires on changes that can affect the site build.
 on:
   push:
     branches: [main]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ docker compose --profile demo up --build
 
 ```bash
 # Optional, for Claude Code users (the file is gitignored):
-cp docs/agent-templates/CLAUDE.md.template ./CLAUDE.md
+cp .github/CLAUDE.md.template ./CLAUDE.md
 
 make setup        # Go tools, Python parser/runtime, pre-commit hook
 make build        # build bin/leoflow, bin/leoflow-server, bin/leoflow-agent

--- a/Makefile
+++ b/Makefile
@@ -244,16 +244,20 @@ ci-local: ## Run every CI gate locally — pre-push tripwire so a PR does not ar
 	@command -v python3 >/dev/null && (cd parser && python3 -m pytest -q) || echo "skip pytest (no python3)"
 	@echo "▸ ADR index check"
 	@bash scripts/gen-adr-index.sh --check
-	@echo "▸ mkdocs build --strict"
-	@(command -v mkdocs >/dev/null && mkdocs build --strict --quiet) \
-		|| (command -v python3 >/dev/null && python3 -c "import mkdocs" 2>/dev/null && python3 -m mkdocs build --strict --quiet) \
-		|| echo "skip mkdocs (not installed: pip install mkdocs-material mkdocs-mermaid2-plugin)"
+	@echo "▸ hugo --gc --minify (website/)"
+	@if ! command -v hugo >/dev/null; then \
+		echo "skip hugo (not installed: https://gohugo.io/installation/ — needs the extended build)"; \
+	elif [ ! -x website/node_modules/.bin/postcss ]; then \
+		echo "skip hugo (Docsy PostCSS toolchain missing: run 'npm --prefix website ci')"; \
+	else \
+		(cd website && hugo --gc --minify --quiet); \
+	fi
 	@echo "✅ ci-local clean — push when ready"
 
 .PHONY: install-pre-push-hook
 install-pre-push-hook: ## Install a pre-push hook that runs `make ci-local` automatically
 	@mkdir -p .git/hooks
-	@printf '#!/usr/bin/env bash\n# Auto-installed by `make install-pre-push-hook`.\n# Runs every CI gate locally so a PR never lands red on infra-class checks\n# (govulncheck advisories, helm tests, mkdocs --strict) the per-commit hook\n# does not cover. Skip with: git push --no-verify.\nset -euo pipefail\nexec make ci-local\n' > .git/hooks/pre-push
+	@printf '#!/usr/bin/env bash\n# Auto-installed by `make install-pre-push-hook`.\n# Runs every CI gate locally so a PR never lands red on infra-class checks\n# (govulncheck advisories, helm tests, hugo build) the per-commit hook\n# does not cover. Skip with: git push --no-verify.\nset -euo pipefail\nexec make ci-local\n' > .git/hooks/pre-push
 	@chmod +x .git/hooks/pre-push
 	@echo "▸ installed .git/hooks/pre-push → runs 'make ci-local' on every push"
 

--- a/website/content/contribute/contributing.md
+++ b/website/content/contribute/contributing.md
@@ -49,7 +49,7 @@ described in [Operating modes](/concepts/editions/).
 ## 2. Set up for development
 
 ```bash
-cp docs/agent-templates/CLAUDE.md.template ./CLAUDE.md  # optional (Claude Code; gitignored)
+cp .github/CLAUDE.md.template ./CLAUDE.md  # optional (Claude Code; gitignored)
 
 make setup        # Go tools, Python parser/runtime, and the pre-commit hook
 make build        # bin/leoflow, bin/leoflow-server, bin/leoflow-agent


### PR DESCRIPTION
Clears the leftovers from the MkDocs -> Hugo + Docsy cutover flagged in #744. Each item below was confirmed against source before fixing.

## 1. `make ci-local` docs gate was a no-op
`Makefile:247-250` ran `mkdocs build --strict`, but `mkdocs.yml` was removed in the cutover — so it errored where mkdocs is installed and printed "skip mkdocs" elsewhere; either way it validated nothing, while the pre-push hook (`install-pre-push-hook`) still advertised "mkdocs --strict" as a covered gate.

**Fix:** replaced the block with `hugo --gc --minify` against `website/` (matching `.github/workflows/website-build.yml`). It skips cleanly when `hugo` is absent, and also when the Docsy PostCSS toolchain (`website/node_modules/.bin/postcss`) is missing — Hugo Extended shells out to `postcss` for the SCSS→CSS transform, so without `npm --prefix website ci` the build fails rather than skips. Real enforcement stays in CI (`website-build.yml` runs `npm ci` first). Also fixed the hook's `printf` comment (`mkdocs --strict` → `hugo build`).

## 2. CONTRIBUTING template pointed at a deleted path — DECISION: RESTORE
Both `CONTRIBUTING.md:99` and `website/content/contribute/contributing.md:52` ran `cp docs/agent-templates/CLAUDE.md.template ./CLAUDE.md`, but `docs/agent-templates/` was deleted in the cutover.

The template is a substantial, current 157-line project-context file (TDD discipline, Go Report Card floor, architecture, domain vocabulary) — genuinely useful to Claude Code contributors, **not obsolete**. **Decision: RESTORE** (not drop). Recovered from git history to the tracked path `.github/CLAUDE.md.template`, repointed both references, and fixed the template's own internal self-reference to the old path.

## 3. ci.yaml path filters — reporter correction confirmed
Confirmed the specialist's correction: the skip guard (`ci.yaml:565` and its 3 siblings) already has a `.*\.md$` branch, so **markdown-only** docs changes correctly skip the heavy k3d E2E, and `docs/` is NOT dead (`docs/api/openapi.yaml`, ADR sources remain). Only **non-markdown** `website/` assets (hugo.toml, layouts, SCSS, images) were missing from the filter and needlessly triggered the full E2E.

**Fix:** ADDED `website/` to the skip filter in all 4 guard blocks; `docs/` was NOT removed. Accompanying comments updated to match.

## 4. Stale `website-build.yml` header
Refreshed the top comment — it still called the workflow "PHASE 0" and described MkDocs as "the published documentation until the cutover." Rewritten to state the migration is complete and Hugo is now the published docs (deployed by `website-deploy.yml`).

## 5. (Optional) link checker — DEFERRED
Not wired in. Neither `lychee` nor `htmltest` is installed locally, so I could not prove the check runs clean end-to-end (a currently-broken link would land the PR red on arrival), and adding a full job enlarges the `website-build.yml` footprint against the noted in-flight workflow PR. Left for a focused follow-up where it can be verified against the built site.

## Gate output
- `make ci-local` docs gate: recipe parses (`make -n ci-local` exit 0) and runs clean — `hugo --gc --minify` on `website/` exits 0 with the PostCSS toolchain installed; skips cleanly without it.
- `hugo --gc --minify` builds `website/`: **green** (exit 0), including the edited `contributing.md`.
- `grep -rn docs/agent-templates` across tracked files: **no matches**.
- `actionlint .github/workflows/ci.yaml .github/workflows/website-build.yml`: **clean**.

## Merge note
Edits kept localized (the mkdocs→hugo block + hook comment, the 4 ci.yaml filter lines, the website-build.yml header) so they auto-merge cleanly with any in-flight chart-version/release workflow PR. No CHANGELOG changes.

Closes #744
