### PR TITLE
fix(storage): map duplicate dag_version to 409 (not a raw 500)

### DIFF
--- a/internal/api/versions_conflict_integration_test.go
+++ b/internal/api/versions_conflict_integration_test.go
@@ -1,0 +1,66 @@
+//go:build integration
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/config"
+	"github.com/neochaotic/leoflow/internal/storage"
+)
+
+// TestRegisterVersionDuplicateReturns409 drives the full handler + real
+// Repository against Postgres: pushing the same version string with different
+// content collides on dag_versions_unique. The response must be 409, and the
+// body must not leak the raw pg SQLSTATE or the constraint name. Before #746 the
+// repository returned the raw 23505, which handleRepoError mapped to 500 with the
+// constraint name in the detail.
+func TestRegisterVersionDuplicateReturns409(t *testing.T) {
+	url := os.Getenv("DATABASE_URL")
+	if url == "" {
+		t.Skip("DATABASE_URL must point at a migrated database for integration tests")
+	}
+	ctx := context.Background()
+	pg, err := storage.NewPostgres(ctx, config.DatabaseSection{URL: url})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pg.Close)
+
+	srv := NewServer(Dependencies{
+		Logger:        discardLogger(),
+		Authenticator: &fakeAuthn{user: &auth.User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}},
+		RateLimiter:   auth.NewRateLimiter(100, time.Minute),
+		CORSOrigins:   []string{"*"},
+		TokenTTLSecs:  3600,
+		Versions:      storage.NewRepository(pg),
+	})
+
+	dagID := fmt.Sprintf("api_dup_%d", time.Now().UnixNano())
+	path := "/api/v2/dags/" + dagID + "/versions"
+	first := fmt.Sprintf(`{"schema_version":"1.0","dag_id":%q,"dag_version":"dev","image":"img:dev","tasks":[{"task_id":"a","type":"python","entrypoint":"dag:a"}]}`, dagID)
+	// Same dag_version "dev", different task -> different spec hash -> bypasses dedup.
+	second := fmt.Sprintf(`{"schema_version":"1.0","dag_id":%q,"dag_version":"dev","image":"img:dev","tasks":[{"task_id":"b","type":"python","entrypoint":"dag:b"}]}`, dagID)
+
+	if rec := authGet(srv, http.MethodPost, path, first); rec.Code != http.StatusCreated {
+		t.Fatalf("first push = %d, want 201 (%s)", rec.Code, rec.Body.String())
+	}
+
+	rec := authGet(srv, http.MethodPost, path, second)
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("duplicate version push = %d, want 409 (%s)", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, leak := range []string{"23505", "dag_versions_unique", "SQLSTATE"} {
+		if strings.Contains(body, leak) {
+			t.Errorf("409 body leaks raw pg internals (%q): %s", leak, body)
+		}
+	}
+}

--- a/internal/storage/register_version_conflict_integration_test.go
+++ b/internal/storage/register_version_conflict_integration_test.go
@@ -1,0 +1,59 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// TestRegisterDagVersionDuplicateVersionConflict guards the (dag_id, version)
+// unique constraint: pushing the SAME version string with DIFFERENT spec content
+// misses the spec-hash dedup and collides on dag_versions_unique. That collision
+// must surface as domain.ErrConflict (which the API maps to 409), NOT as a raw
+// Postgres 23505 that leaks the constraint name through a 500 (#746).
+func TestRegisterDagVersionDuplicateVersionConflict(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	dagID := fmt.Sprintf("dup_ver_%d", time.Now().UnixNano())
+
+	first := domain.DAGSpec{
+		SchemaVersion: "1.0", DagID: dagID, DagVersion: "dev", Image: "img:dev",
+		Tasks: []domain.TaskSpec{{TaskID: "a", Type: domain.TaskTypePython}},
+	}
+	firstHash, err := first.CanonicalHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created, rerr := repo.RegisterDagVersion(ctx, "default", first, firstHash); rerr != nil || !created {
+		t.Fatalf("first register: created=%v err=%v", created, rerr)
+	}
+
+	// Same version string "dev", different content -> different spec hash, so the
+	// hash dedup does not short-circuit; the insert hits dag_versions_unique.
+	second := first
+	second.Tasks = []domain.TaskSpec{{TaskID: "b", Type: domain.TaskTypePython}}
+	secondHash, err := second.CanonicalHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secondHash == firstHash {
+		t.Fatalf("test setup: spec hashes must differ to bypass the dedup")
+	}
+
+	_, rerr := repo.RegisterDagVersion(ctx, "default", second, secondHash)
+	if rerr == nil {
+		t.Fatal("re-pushing version \"dev\" with new content must error, got nil")
+	}
+	if !errors.Is(rerr, domain.ErrConflict) {
+		t.Fatalf("want errors.Is(err, domain.ErrConflict), got %v", rerr)
+	}
+	// The raw SQLSTATE / constraint name must not leak into the surfaced error.
+	if msg := rerr.Error(); strings.Contains(msg, "23505") || strings.Contains(msg, "dag_versions_unique") {
+		t.Errorf("conflict error leaks the raw pg constraint: %q", msg)
+	}
+}

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -959,7 +959,13 @@ func (r *Repository) RegisterDagVersion(ctx context.Context, tenant string, spec
 		CreatedBy:      pgtype.UUID{},
 	})
 	if err != nil {
-		return false, fmt.Errorf("inserting version: %w", err)
+		// A collision on dag_versions_unique (dag_id, version) means the same
+		// version string was pushed with different content — the hash dedup above
+		// only short-circuits identical re-pushes. Versions are immutable, so this
+		// is a genuine conflict, not an overwrite: map it to domain.ErrConflict
+		// (API 409) instead of leaking the raw pg 23505 through a 500 (#746). Bump
+		// --dag-version to push new content.
+		return false, fmt.Errorf("inserting version: %w", mapConflict(err))
 	}
 	if err := r.q.SetCurrentDagVersion(ctx, queries.SetCurrentDagVersionParams{ID: dag.ID, CurrentVersionID: version.ID}); err != nil {
 		return false, fmt.Errorf("setting current version: %w", err)


### PR DESCRIPTION
## Root cause

`Repository.RegisterDagVersion` (`internal/storage/repository.go`) dedups an
identical re-push by spec hash (`GetDagVersionByHash`), so pushing the exact
same content is an idempotent no-op. But when the **same version string is
pushed with different content** — the common `tag_strategy: version` → `dev`
dev loop — the hash differs, the dedup is skipped, and the insert collides on
the `dag_versions_unique (dag_id, version)` constraint
(`migrations/002_dags_and_versions.up.sql:45`).

The `InsertDagVersion` error path returned that error unwrapped:

```go
return false, fmt.Errorf("inserting version: %w", err)
```

so the raw `SQLSTATE 23505` plus the constraint name propagated up through
`handleRepoError` and was surfaced to the client as **HTTP 500** with the
constraint name leaked in the response body.

## Fix

Wrap the insert error with `mapConflict` — the established helper already used
at the dag-run and connection sites (`repository.go:213`, `438`, `1111`):

```go
return false, fmt.Errorf("inserting version: %w", mapConflict(err))
```

`errors.As` sees the `pgconn.PgError` through the `%w` wrap, `mapConflict`
returns `domain.ErrConflict`, and `handleRepoError` maps that to **409** — the
`SQLSTATE`/constraint name no longer leak.

## Why 409, not 400

A `dag_version` is insert-only / immutable (`internal/storage/spec_cache.go` —
"a changed DAG is a NEW row"). Overwriting is wrong, so a same-version push
with new content is a genuine **conflict** (409), not an upsert. This is
deliberately *not* #724's 400: that was for connections, which are an upsert.
The actionable fix for the caller (bump `--dag-version`) is noted in the code
comment and reachable from the 409.

## Red → green (strict TDD)

Two failing tests committed **before** the fix:

- **Storage integration** (`internal/storage/register_version_conflict_integration_test.go`):
  `RegisterDagVersion` with the same version string but different spec content
  must return an error satisfying `errors.Is(err, domain.ErrConflict)` and must
  not leak `23505` / `dag_versions_unique`.
  Pre-fix: `got inserting version: ERROR: duplicate key value violates unique constraint "dag_versions_unique" (SQLSTATE 23505)`.
- **API integration** (`internal/api/versions_conflict_integration_test.go`):
  wires the real `*storage.Repository` into the server and POSTs a duplicate
  version — must return **409** with no pg internals in the body.
  Pre-fix: `duplicate version push = 500 ... "detail":"inserting version: ERROR: ... dag_versions_unique ... (SQLSTATE 23505)"`.

Both green after the one-line fix.

## Pre-push gate

- `go build ./...` — 0
- `go vet ./...` (and `-tags integration`) — 0
- `golangci-lint run` (repo config) — **0 issues**
- `go test ./internal/storage/... ./internal/api/...` — ok (unit)
- `go test -tags integration ./internal/storage/... ./internal/api/...` — ok (integration, against the migrated test DB)

Closes #746
