### PR TITLE
fix(compile): apply leoflow.yaml defaults.resources + defaults.node_selector to tasks

### DIFF
--- a/docs/api/leoflow-yaml-schema.json
+++ b/docs/api/leoflow-yaml-schema.json
@@ -122,18 +122,27 @@
 
     "defaults": {
       "type": "object",
+      "description": "DAG-wide task defaults. A task that declares its own value always wins; these only fill the gaps (ADR 0023). resources and node_selector are baked onto every task at compile time; retries/retry_delay/timeout flow through the parser's Airflow default_args.",
       "properties": {
         "retries": { "type": "integer", "minimum": 0 },
         "retry_delay_seconds": { "type": "integer", "minimum": 0 },
         "execution_timeout_seconds": { "type": "integer", "minimum": 1 },
         "resources": {
           "type": "object",
+          "description": "Default CPU/memory for tasks that declare none; expanded to requests == limits so the task reaches Guaranteed QoS (#725).",
           "properties": {
             "cpu": { "type": "string" },
             "memory": { "type": "string" }
-          }
+          },
+          "additionalProperties": false
+        },
+        "node_selector": {
+          "type": "object",
+          "description": "Default pod placement for tasks that declare no execution.node_selector of their own.",
+          "additionalProperties": { "type": "string" }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "staging": {
       "type": "object",

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -627,7 +627,7 @@ func parserErrorSummary(stderr string) string {
 // Per-task overrides are bound by task_id; an entry naming a task absent from the
 // DAG is a hard error (no silent drop). No-op when nothing is configured.
 func overlayProject(dagJSONPath string, cfg *domain.LeoflowConfig) error {
-	if cfg.Staging == nil && cfg.Alerts == nil && len(cfg.Tasks) == 0 {
+	if cfg.Staging == nil && cfg.Alerts == nil && len(cfg.Tasks) == 0 && !hasDAGDefaults(cfg.Defaults) {
 		return nil
 	}
 	data, err := os.ReadFile(dagJSONPath) //nolint:gosec // G304: output path is operator-supplied on the CLI.
@@ -651,6 +651,11 @@ func overlayProject(dagJSONPath string, cfg *domain.LeoflowConfig) error {
 		if override := cfg.Tasks[spec.Tasks[i].TaskID]; override != nil {
 			applyTaskOverride(&spec.Tasks[i], override)
 		}
+		// DAG-wide defaults are a fallback, applied after the per-task override so
+		// the most-specific value always wins (task > defaults). Baking them here
+		// lands them in dag.json and flows them through dispatch→BuildPod exactly
+		// like the per-task values already do.
+		applyDAGDefaults(&spec.Tasks[i], cfg.Defaults)
 	}
 	out, err := json.MarshalIndent(&spec, "", "  ")
 	if err != nil {
@@ -718,6 +723,41 @@ func applyTaskOverride(task *domain.TaskSpec, o *domain.TaskConfig) {
 		for k, v := range o.Env {
 			task.Env[k] = v
 		}
+	}
+}
+
+// hasDAGDefaults reports whether the leoflow.yaml defaults block carries a
+// DAG-wide value the overlay must bake onto tasks (resources or node_selector).
+// Retries/retry_delay/timeout are handled upstream by the parser's default_args,
+// so they don't count here.
+func hasDAGDefaults(d *domain.ConfigDefaults) bool {
+	return d != nil && (d.Resources.AsResources() != nil || len(d.NodeSelector) > 0)
+}
+
+// applyDAGDefaults fills a task's resources and node_selector from the DAG-wide
+// leoflow.yaml defaults when the task declares none of its own. Per-task values
+// (set by applyTaskOverride or compiled from the DAG) always win; the default
+// never partially merges into an explicit block. Closes the accepted-but-ignored
+// footgun where defaults.resources / defaults.node_selector reached neither
+// dag.json nor the task pod (EKS validation aresta #6).
+func applyDAGDefaults(task *domain.TaskSpec, d *domain.ConfigDefaults) {
+	if d == nil {
+		return
+	}
+	if task.Resources == nil {
+		if r := d.Resources.AsResources(); r != nil {
+			task.Resources = r
+		}
+	}
+	if len(d.NodeSelector) > 0 && (task.Execution == nil || len(task.Execution.NodeSelector) == 0) {
+		if task.Execution == nil {
+			task.Execution = &domain.Execution{}
+		}
+		sel := make(map[string]string, len(d.NodeSelector))
+		for k, v := range d.NodeSelector {
+			sel[k] = v
+		}
+		task.Execution.NodeSelector = sel
 	}
 }
 

--- a/internal/cli/compile_overlay_test.go
+++ b/internal/cli/compile_overlay_test.go
@@ -134,6 +134,96 @@ func TestOverlayProjectAppliesDeclaredSecretNarrowing(t *testing.T) {
 	}
 }
 
+// A leoflow.yaml `defaults` block with resources/node_selector is a DAG-wide
+// fallback: every task that declares neither of its own inherits them, so a user
+// relying on defaults.resources reaches Guaranteed QoS (requests == limits)
+// instead of silently getting BestEffort (EKS validation aresta #6; the QoS story
+// of #725). Before the fix these keys were accepted by the config and then
+// dropped — never reaching dag.json or the task pod.
+func TestOverlayProjectAppliesDAGDefaults(t *testing.T) {
+	path := writeDagJSON(t)
+	cfg := &domain.LeoflowConfig{
+		DagID: "proj",
+		Defaults: &domain.ConfigDefaults{
+			Resources:    &domain.DefaultResources{CPU: "1", Memory: "1Gi"},
+			NodeSelector: map[string]string{"disktype": "ssd"},
+		},
+	}
+	if err := overlayProject(path, cfg); err != nil {
+		t.Fatalf("overlayProject: %v", err)
+	}
+	got := readSpec(t, path)
+
+	for _, id := range []string{"extract", "transform"} {
+		ts, ok := taskByID(got, id)
+		if !ok {
+			t.Fatalf("%s task missing after overlay", id)
+		}
+		if ts.Resources == nil || ts.Resources.Requests == nil || ts.Resources.Limits == nil {
+			t.Fatalf("%s resources not filled from defaults: %+v", id, ts.Resources)
+		}
+		if ts.Resources.Requests.CPU != "1" || ts.Resources.Requests.Memory != "1Gi" {
+			t.Errorf("%s requests = %+v, want cpu 1 / mem 1Gi", id, ts.Resources.Requests)
+		}
+		if ts.Resources.Limits.CPU != "1" || ts.Resources.Limits.Memory != "1Gi" {
+			t.Errorf("%s limits = %+v, want cpu 1 / mem 1Gi (Guaranteed QoS)", id, ts.Resources.Limits)
+		}
+		if ts.Execution == nil || ts.Execution.NodeSelector["disktype"] != "ssd" {
+			t.Errorf("%s node_selector = %+v, want disktype=ssd", id, ts.Execution)
+		}
+	}
+}
+
+// Per-task resources/node_selector always beat the DAG-wide defaults (most
+// specific wins). The default must not overwrite a task's explicit choice nor
+// merge partial fields (e.g. inject default Limits into an explicit request-only
+// resources block).
+func TestOverlayProjectPerTaskOverridesBeatDAGDefaults(t *testing.T) {
+	path := writeDagJSON(t)
+	cfg := &domain.LeoflowConfig{
+		DagID: "proj",
+		Defaults: &domain.ConfigDefaults{
+			Resources:    &domain.DefaultResources{CPU: "1", Memory: "1Gi"},
+			NodeSelector: map[string]string{"disktype": "ssd"},
+		},
+		Tasks: map[string]*domain.TaskConfig{
+			"transform": {
+				Resources: &domain.Resources{Requests: &domain.ResourceQuantity{CPU: "8", Memory: "16Gi"}},
+				Execution: &domain.Execution{NodeSelector: map[string]string{"gpu": "true"}},
+			},
+		},
+	}
+	if err := overlayProject(path, cfg); err != nil {
+		t.Fatalf("overlayProject: %v", err)
+	}
+	got := readSpec(t, path)
+
+	transform, _ := taskByID(got, "transform")
+	if transform.Resources == nil || transform.Resources.Requests == nil || transform.Resources.Requests.CPU != "8" {
+		t.Errorf("per-task resources should win: %+v", transform.Resources)
+	}
+	// The default (which sets both requests and limits) must not have its Limits
+	// merged onto the explicit request-only per-task resources.
+	if transform.Resources != nil && transform.Resources.Limits != nil {
+		t.Errorf("default limits leaked onto explicit per-task resources: %+v", transform.Resources.Limits)
+	}
+	if transform.Execution == nil || transform.Execution.NodeSelector["gpu"] != "true" {
+		t.Errorf("per-task node_selector should win: %+v", transform.Execution)
+	}
+	if transform.Execution != nil && transform.Execution.NodeSelector["disktype"] != "" {
+		t.Errorf("default node_selector merged into an explicit one: %+v", transform.Execution.NodeSelector)
+	}
+
+	// The task with no override still inherits the DAG-wide defaults.
+	extract, _ := taskByID(got, "extract")
+	if extract.Resources == nil || extract.Resources.Requests == nil || extract.Resources.Requests.CPU != "1" {
+		t.Errorf("extract should inherit default resources: %+v", extract.Resources)
+	}
+	if extract.Execution == nil || extract.Execution.NodeSelector["disktype"] != "ssd" {
+		t.Errorf("extract should inherit default node_selector: %+v", extract.Execution)
+	}
+}
+
 func TestOverlayProjectUnknownTaskIDErrors(t *testing.T) {
 	path := writeDagJSON(t)
 	cfg := &domain.LeoflowConfig{

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -145,12 +145,33 @@ type ConfigDefaults struct {
 	RetryDelaySeconds       int               `json:"retry_delay_seconds,omitempty" yaml:"retry_delay_seconds,omitempty"`
 	ExecutionTimeoutSeconds int               `json:"execution_timeout_seconds,omitempty" yaml:"execution_timeout_seconds,omitempty"`
 	Resources               *DefaultResources `json:"resources,omitempty" yaml:"resources,omitempty"`
+	// NodeSelector is the DAG-wide pod placement fallback applied to every task
+	// that declares no execution.node_selector of its own. Like Resources it is a
+	// default, so the most-specific per-task value always wins. Consumed at
+	// compile time by the overlay, which bakes it onto each task in dag.json.
+	NodeSelector map[string]string `json:"node_selector,omitempty" yaml:"node_selector,omitempty"`
 }
 
 // DefaultResources expresses default CPU and memory for generated tasks.
 type DefaultResources struct {
 	CPU    string `json:"cpu,omitempty" yaml:"cpu,omitempty"`
 	Memory string `json:"memory,omitempty" yaml:"memory,omitempty"`
+}
+
+// AsResources expands the simplified default cpu/memory into a full Resources
+// with requests == limits, so a task that inherits the DAG-wide default reaches
+// Guaranteed QoS rather than BestEffort/Burstable (the QoS story of #725). This
+// mirrors how the per-cluster platform default is built at dispatch. Returns nil
+// when the receiver is nil or declares no quantity, so callers can treat a
+// missing default as "leave the task untouched".
+func (d *DefaultResources) AsResources() *Resources {
+	if d == nil || (d.CPU == "" && d.Memory == "") {
+		return nil
+	}
+	return &Resources{
+		Requests: &ResourceQuantity{CPU: d.CPU, Memory: d.Memory},
+		Limits:   &ResourceQuantity{CPU: d.CPU, Memory: d.Memory},
+	}
 }
 
 // ApplyDefaults fills zero-valued fields with the defaults declared in the

--- a/internal/domain/config_defaults_schema_test.go
+++ b/internal/domain/config_defaults_schema_test.go
@@ -1,0 +1,42 @@
+package domain
+
+import "testing"
+
+// A leoflow.yaml `defaults` block declaring resources and node_selector (the
+// DAG-wide placement/QoS fallback, EKS validation aresta #6) validates against
+// the canonical schema.
+func TestDefaultsBlockWithNodeSelectorValidates(t *testing.T) {
+	c := &LeoflowConfig{
+		DagID: "sales",
+		Defaults: &ConfigDefaults{
+			Resources:    &DefaultResources{CPU: "1", Memory: "1Gi"},
+			NodeSelector: map[string]string{"disktype": "ssd"},
+		},
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("valid defaults block rejected: %v", err)
+	}
+}
+
+// An unknown key under `defaults` fails validation loudly
+// (additionalProperties:false) instead of being silently accepted-and-dropped —
+// the exact footgun that hid node_selector before it became a wired field. This
+// guards the whole "accepted but never reaches the pod" class: a future unwired
+// default key fails at compile, not at runtime.
+func TestDefaultsBlockUnknownKeyRejected(t *testing.T) {
+	s, err := schemas()
+	if err != nil {
+		t.Fatalf("compile schemas: %v", err)
+	}
+	inst := map[string]any{
+		"dag_id": "sales",
+		"defaults": map[string]any{
+			"resources": map[string]any{"cpu": "1", "memory": "1Gi"},
+			// Typo / unwired key: must be rejected, not silently discarded.
+			"nodeselector": map[string]any{"disktype": "ssd"},
+		},
+	}
+	if verr := validateAgainst(s.leoflow, inst); verr == nil {
+		t.Fatal("expected unknown key under defaults to be rejected (additionalProperties:false)")
+	}
+}

--- a/internal/domain/schemas/leoflow-yaml-schema.json
+++ b/internal/domain/schemas/leoflow-yaml-schema.json
@@ -122,18 +122,27 @@
 
     "defaults": {
       "type": "object",
+      "description": "DAG-wide task defaults. A task that declares its own value always wins; these only fill the gaps (ADR 0023). resources and node_selector are baked onto every task at compile time; retries/retry_delay/timeout flow through the parser's Airflow default_args.",
       "properties": {
         "retries": { "type": "integer", "minimum": 0 },
         "retry_delay_seconds": { "type": "integer", "minimum": 0 },
         "execution_timeout_seconds": { "type": "integer", "minimum": 1 },
         "resources": {
           "type": "object",
+          "description": "Default CPU/memory for tasks that declare none; expanded to requests == limits so the task reaches Guaranteed QoS (#725).",
           "properties": {
             "cpu": { "type": "string" },
             "memory": { "type": "string" }
-          }
+          },
+          "additionalProperties": false
+        },
+        "node_selector": {
+          "type": "object",
+          "description": "Default pod placement for tasks that declare no execution.node_selector of their own.",
+          "additionalProperties": { "type": "string" }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "staging": {
       "type": "object",


### PR DESCRIPTION
## Root cause — accepted but ignored

`leoflow.yaml` accepted `defaults.resources` and `defaults.node_selector` but neither ever reached the task pod (EKS validation aresta #6):

- **`defaults.node_selector` was not even a schema field.** `ConfigDefaults` (`internal/domain/config.go`) had only `Retries`, `RetryDelaySeconds`, `ExecutionTimeoutSeconds`, `Resources`. The JSON-schema `defaults` block lacked `node_selector` **and** had no `additionalProperties:false`, so the key passed validation and was silently dropped at unmarshal.
- **`defaults.resources` was a valid field that nothing consumed.** The Python parser's `_default_args` copies only retries/retry_delay/timeout; the Go overlay `overlayProject` applied staging/alerts/per-task overrides but **never read `cfg.Defaults`**.

For contrast, per-**task** `execution.node_selector` / `resources` DO work (`applyTaskOverride` → `task.Execution`/`task.Resources` → dispatch → `BuildPod`), and `defaults.retries` works via the parser's Airflow `default_args`. So this was a silent-drop **asymmetry** that undercut the QoS story of #725: a user relying on `defaults.resources` silently got BestEffort.

## Fix — per-task fallback, baked at compile time

Implemented entirely in the Go compile path (+ schema) so the values land in `dag.json` and flow through `dispatch → BuildPod` exactly like the per-task ones already do:

- Added `NodeSelector map[string]string` to `ConfigDefaults` and to the schema `defaults` block.
- `DefaultResources.AsResources()` expands the simplified `cpu`/`memory` into a full `Resources` with **requests == limits** → Guaranteed QoS, mirroring how the per-cluster platform default is built at dispatch.
- `overlayProject` now fills each task's `resources`/`node_selector` from `cfg.Defaults` **only when the task declares none of its own**. Per-task always wins; no partial merge (the default's limits are not spliced into an explicit request-only block; a default node_selector is not merged into an explicit one). The overlay early-return guard now also fires the pass when only `defaults` is set.

## additionalProperties:false

Added `additionalProperties:false` to the `defaults` sub-object (and its `resources` child) so a future unknown/unwired key **fails loudly at compile** instead of being silently ignored — closing the whole "accepted but never reaches the pod" class. The canonical `docs/api/leoflow-yaml-schema.json` was kept byte-identical to the embedded copy (guarded by `TestEmbeddedSchemasMatchDocs`).

## Red → green (TDD)

Test commit precedes the fix. New tests:

- `TestOverlayProjectAppliesDAGDefaults` — a project with `defaults.{resources,node_selector}` and a task overriding neither → the generated task carries the resources (requests+limits) AND node_selector.
- `TestOverlayProjectPerTaskOverridesBeatDAGDefaults` — a task with its own resources/node_selector → per-task wins, no default merge; the untouched task still inherits the defaults.
- `TestDefaultsBlockWithNodeSelectorValidates` / `TestDefaultsBlockUnknownKeyRejected` — the new `node_selector` validates; an unknown key under `defaults` is rejected (`additionalProperties:false`).

## Pre-push gate (all green)

- `go build ./...` — ok
- `go vet ./...` — ok
- `golangci-lint run ./internal/cli/... ./internal/domain/...` — **0 issues**
- `go test ./internal/cli/... ./internal/domain/...` — ok

The Python parser was **not** touched (fix is Go compile path + schema only), so its test suite was not in scope.
