### PR TITLE
fix(executor): mount a writable /tmp so read_only_task_root_filesystem works (warm + task pods)

### DIFF
--- a/internal/executor/kubernetes.go
+++ b/internal/executor/kubernetes.go
@@ -135,6 +135,7 @@ func BuildPod(req Request) *corev1.Pod {
 	}
 	mergeMetadata(pod.Labels, req.Execution.Labels)
 	mergeMetadata(pod.Annotations, req.Execution.Annotations)
+	mountWritableTmp(pod, req.PodSecurity)
 	mountStagingVolume(pod, req)
 	mountAgentTLSCA(pod, req)
 	mountTaskSecret(pod, req)
@@ -365,6 +366,39 @@ func mountAgentTLSCA(pod *corev1.Pod, req Request) {
 	})
 	c := &pod.Spec.Containers[0]
 	c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{Name: agentCAVolumeName, MountPath: agentCADir, ReadOnly: true})
+}
+
+// writableTmpVolumeName / writableTmpMountPath give a read-only-rootfs pod a
+// writable scratch directory at /tmp (issue #741). Pod Security Admission's
+// `restricted` profile is happy with a read-only root filesystem, but nothing on
+// that filesystem is writable — so an ordinary task (pip cache, matplotlib
+// config, temp files) and, worse, the warm agent itself (os.MkdirTemp under /tmp,
+// before it can even register) have nowhere to write. The idiomatic pairing is a
+// read-only rootfs plus a writable emptyDir mounted at /tmp; emptyDir usage
+// counts against the container's ephemeral-storage limit, so a task that sets one
+// bounds this too.
+const (
+	writableTmpVolumeName = "leoflow-tmp"
+	writableTmpMountPath  = "/tmp"
+)
+
+// mountWritableTmp gives a read-only-rootfs pod somewhere writable at /tmp by
+// mounting an emptyDir there. It is a no-op unless ReadOnlyRootFilesystem is set:
+// a pod with a writable rootfs already has a writable /tmp, so mounting an
+// emptyDir would only change the spec for no reason. This makes
+// read_only_task_root_filesystem usable on both task and warm pods.
+func mountWritableTmp(pod *corev1.Pod, ps PodSecurity) {
+	if !ps.ReadOnlyRootFilesystem {
+		return
+	}
+	pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+		Name:         writableTmpVolumeName,
+		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+	})
+	c := &pod.Spec.Containers[0]
+	c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{
+		Name: writableTmpVolumeName, MountPath: writableTmpMountPath,
+	})
 }
 
 // stagingVolumeName is the pod volume name for the per-run staging PVC.

--- a/internal/executor/pod_security_test.go
+++ b/internal/executor/pod_security_test.go
@@ -132,3 +132,55 @@ func TestBuildPodHonorsReadOnlyRootFilesystemOptIn(t *testing.T) {
 		t.Error("ReadOnlyRootFilesystem opt-in was not honored")
 	}
 }
+
+// TestBuildPodMountsWritableTmpForReadOnlyRoot locks the task-pod half of the
+// issue #741 fix: a read-only root filesystem leaves an ordinary task with nowhere
+// writable at /tmp (pip cache, matplotlib config, scratch files), so the knob was
+// unusable. The restricted-profile pattern pairs the ro rootfs with a writable
+// emptyDir at /tmp.
+func TestBuildPodMountsWritableTmpForReadOnlyRoot(t *testing.T) {
+	req := sampleReq()
+	req.PodSecurity.ReadOnlyRootFilesystem = true
+	pod := BuildPod(req)
+
+	var vol *corev1.Volume
+	for i := range pod.Spec.Volumes {
+		if pod.Spec.Volumes[i].Name == writableTmpVolumeName {
+			vol = &pod.Spec.Volumes[i]
+		}
+	}
+	if vol == nil {
+		t.Fatalf("a writable /tmp emptyDir volume must be mounted for a read-only rootfs task: %+v", pod.Spec.Volumes)
+	}
+	if vol.EmptyDir == nil {
+		t.Errorf("the /tmp volume must be an emptyDir, got %+v", vol.VolumeSource)
+	}
+
+	c := pod.Spec.Containers[0]
+	var mount *corev1.VolumeMount
+	for i := range c.VolumeMounts {
+		if c.VolumeMounts[i].Name == writableTmpVolumeName {
+			mount = &c.VolumeMounts[i]
+		}
+	}
+	if mount == nil {
+		t.Fatalf("the /tmp emptyDir must be mounted into the task container: %+v", c.VolumeMounts)
+	}
+	if mount.MountPath != writableTmpMountPath {
+		t.Errorf("/tmp mount path = %q, want %q", mount.MountPath, writableTmpMountPath)
+	}
+	if mount.ReadOnly {
+		t.Error("the /tmp mount must be writable, not read-only")
+	}
+}
+
+// TestBuildPodNoWritableTmpWhenRootWritable keeps the default (writable rootfs)
+// task pod byte-identical: the /tmp emptyDir is the ro-rootfs escape hatch only.
+func TestBuildPodNoWritableTmpWhenRootWritable(t *testing.T) {
+	pod := BuildPod(sampleReq())
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == writableTmpVolumeName {
+			t.Errorf("no /tmp emptyDir must be mounted when the rootfs is writable: %+v", pod.Spec.Volumes)
+		}
+	}
+}

--- a/internal/executor/warmpod.go
+++ b/internal/executor/warmpod.go
@@ -175,6 +175,11 @@ func BuildWarmPod(spec WarmPodSpec) *corev1.Pod {
 	}
 	mergeMetadata(pod.Labels, spec.Labels)
 	mergeMetadata(pod.Annotations, spec.Annotations)
+	// A read-only rootfs otherwise leaves the warm agent's os.MkdirTemp scratch
+	// (under /tmp) with nowhere to write, so it dies before registering and the
+	// reconciler replaces it forever (issue #741). Give it a writable /tmp
+	// emptyDir; warmPodEnv points TMPDIR at it so the scratch lands there.
+	mountWritableTmp(pod, spec.PodSecurity)
 	mountWarmAgentTLSCA(pod, spec)
 	// Bootstrap-credential transport, shared with the task pod. identity is nil: a
 	// warm worker registers under its bearer's own identity, so no task-instance
@@ -293,6 +298,13 @@ func warmPodEnv(spec WarmPodSpec) []corev1.EnvVar {
 			corev1.EnvVar{Name: "LEOFLOW_AGENT_INSECURE", Value: "false"},
 			corev1.EnvVar{Name: "LEOFLOW_AGENT_TLS_CA", Value: agentCADir + "/" + agentCAFile},
 		)
+	}
+	// On a read-only rootfs the warm agent's scratch (os.MkdirTemp("", ...)) would
+	// resolve onto the read-only filesystem and fail before the worker registers
+	// (issue #741). BuildWarmPod mounts a writable emptyDir at /tmp; point TMPDIR at
+	// it so os.MkdirTemp — which honors $TMPDIR — lands the scratch on the emptyDir.
+	if spec.PodSecurity.ReadOnlyRootFilesystem {
+		env = append(env, corev1.EnvVar{Name: "TMPDIR", Value: writableTmpMountPath})
 	}
 	return env
 }

--- a/internal/executor/warmpod_test.go
+++ b/internal/executor/warmpod_test.go
@@ -290,3 +290,68 @@ func TestBuildWarmPodMountsCA(t *testing.T) {
 		t.Error("CA ConfigMap volume must be mounted")
 	}
 }
+
+// TestBuildWarmPodMountsWritableTmpForReadOnlyRoot locks the fix for issue #741:
+// a warm worker built with a read-only root filesystem must still have a writable
+// /tmp, or the warm agent dies at os.MkdirTemp before it can register (RestartPolicy
+// Never turns that into a replacement loop that takes the whole pool down). The
+// restricted-profile pattern is ro rootfs + a writable emptyDir at /tmp, and the
+// agent's scratch (TMPDIR) must resolve onto that emptyDir.
+func TestBuildWarmPodMountsWritableTmpForReadOnlyRoot(t *testing.T) {
+	spec := baseWarmSpec()
+	spec.PodSecurity.ReadOnlyRootFilesystem = true
+	pod := BuildWarmPod(spec)
+
+	var vol *corev1.Volume
+	for i := range pod.Spec.Volumes {
+		if pod.Spec.Volumes[i].Name == writableTmpVolumeName {
+			vol = &pod.Spec.Volumes[i]
+		}
+	}
+	if vol == nil {
+		t.Fatalf("a writable /tmp emptyDir volume must be mounted for a read-only rootfs warm worker: %+v", pod.Spec.Volumes)
+	}
+	if vol.EmptyDir == nil {
+		t.Errorf("the /tmp volume must be an emptyDir, got %+v", vol.VolumeSource)
+	}
+
+	c := pod.Spec.Containers[0]
+	var mount *corev1.VolumeMount
+	for i := range c.VolumeMounts {
+		if c.VolumeMounts[i].Name == writableTmpVolumeName {
+			mount = &c.VolumeMounts[i]
+		}
+	}
+	if mount == nil {
+		t.Fatalf("the /tmp emptyDir must be mounted into the container: %+v", c.VolumeMounts)
+	}
+	if mount.MountPath != writableTmpMountPath {
+		t.Errorf("/tmp mount path = %q, want %q", mount.MountPath, writableTmpMountPath)
+	}
+	if mount.ReadOnly {
+		t.Error("the /tmp mount must be writable, not read-only")
+	}
+
+	// The warm agent's scratch is created with os.MkdirTemp(""), which honors TMPDIR
+	// (falling back to /tmp). Point TMPDIR at the writable emptyDir so the scratch
+	// resolves onto it rather than onto the read-only rootfs.
+	if got := warmEnvMap(pod)["TMPDIR"]; got != writableTmpMountPath {
+		t.Errorf("TMPDIR = %q, want %q so the warm scratch resolves onto the writable emptyDir", got, writableTmpMountPath)
+	}
+}
+
+// TestBuildWarmPodNoWritableTmpWhenRootWritable keeps the default (writable
+// rootfs) warm pod byte-identical: the /tmp emptyDir and TMPDIR are the ro-rootfs
+// escape hatch only, so a default warm pod must not sprout either.
+func TestBuildWarmPodNoWritableTmpWhenRootWritable(t *testing.T) {
+	pod := BuildWarmPod(baseWarmSpec())
+
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == writableTmpVolumeName {
+			t.Errorf("no /tmp emptyDir must be mounted when the rootfs is writable: %+v", pod.Spec.Volumes)
+		}
+	}
+	if _, ok := warmEnvVar(pod, "TMPDIR"); ok {
+		t.Error("TMPDIR must not be set when the rootfs is writable")
+	}
+}

--- a/website/content/project/adrs/0058-warm-worker-pools.md
+++ b/website/content/project/adrs/0058-warm-worker-pools.md
@@ -122,6 +122,24 @@ numbers justify it.
 cost* and *import cost* separately, before the D9 caps and any forkserver decision
 are locked.
 
+> **Correction note (2026-08-25, re: #728 / #741).** Two claims above overstate
+> what the worker resets, and are corrected here rather than by rewriting the
+> accepted text:
+>
+> - The D4 reset described as "resets `/tmp`" is more precisely **resets `TMPDIR`
+>   (redirected into the per-attempt scratch), not `/tmp` itself**. The #728 fix
+>   points each child's `TMPDIR` at a subdir of the agent-owned scratch that
+>   `resetScratch` wipes between attempts; the container's `/tmp` is never reset by
+>   the worker. (With a read-only rootfs, `/tmp` is a shared writable `emptyDir` —
+>   see #741 — and is likewise not per-attempt reset.)
+> - The isolation invariant ("no attempt observes another attempt's secrets, env,
+>   or writable filesystem state") holds only for **writable filesystem state
+>   under the agent's control** — the per-attempt scratch and the `TMPDIR`
+>   redirected into it. State an attempt writes outside that control (a raw path
+>   under `/tmp`, or elsewhere on the image) is **not** wiped between attempts and
+>   can be observed by a later attempt on the same worker. The qualifier belongs
+>   on the invariant as stated.
+
 ### D5 — Staging: exclude staging-dependent DAGs from warm pools in v1
 
 Dynamic per-attempt staging remount is **infeasible** — a pod's volumes/mounts are


### PR DESCRIPTION
## Root cause (#741)

`read_only_task_root_filesystem` was effectively unusable across the whole executor — and, worse, it took the **warm pool down**:

- Warm pods apply the **same** container security context as task pods (`warmpod.go` → `buildSecurityContext`; `kubernetes.go` sets `ReadOnlyRootFilesystem`). There was no warm-specific opt-out.
- **No `emptyDir` at `/tmp`** on either builder — warm pods mount only the TLS CA + agent token; task pods mount only `/staging`. So a read-only rootfs left nothing writable at `/tmp`.
- The warm agent creates its scratch with `os.MkdirTemp("", "leoflow-warm-")` (`cmd/leoflow-agent/main.go:249`), which resolves under `/tmp`. On a read-only rootfs that fails, and `main.go` logs `"preparing warm scratch dir"` and `return 1` **before** `WorkerRegister`. With `RestartPolicy: Never` the reconciler replaces the pod forever — a replacement loop.
- Net effect: the mitigation #728's docs recommend (`read_only_task_root_filesystem`) was a pool-killer, and the knob was unusable for task pods too (pip cache / matplotlib config / scratch).

## Fix (Option 1, specialist-endorsed — extended to task pods)

- New `mountWritableTmp(pod, ps)` in `kubernetes.go`: when `ps.ReadOnlyRootFilesystem` is set, mount a writable `emptyDir` at `/tmp`. **Gated on the flag** — a default (writable-rootfs) pod stays byte-identical, so no existing golden test moves. emptyDir usage counts against the container's `ephemeral-storage` limit, so a task that sets one bounds this too.
- Wired into **both** `BuildPod` and `BuildWarmPod`, alongside the existing staging mount.
- Warm scratch redirect: `warmPodEnv` sets `TMPDIR=/tmp` when the rootfs is read-only, so the agent's `os.MkdirTemp("")` (which honors `$TMPDIR`) lands the scratch on the writable emptyDir. No `main.go` change needed — the redirect is data on the pod spec.

This is the idiomatic PSA-`restricted` pairing (read-only rootfs + writable emptyDir at `/tmp`) and makes `read_only_task_root_filesystem` usable for the first time.

## ADR 0058 correction note (outstanding #728 item)

Appended a dated, append-only **Correction note** to D4 (the accepted text is not rewritten):
- `:100` "resets `/tmp`" → restated as **resets `TMPDIR` (redirected into per-attempt scratch), not `/tmp`** (the #728 fix points each child's `TMPDIR` at a subdir of the agent-owned scratch that `resetScratch` wipes; `/tmp` itself is never reset).
- `:107` isolation invariant now carries the **"under the agent's control"** qualifier — state written outside the agent-owned scratch/`TMPDIR` (a raw path under `/tmp`) is not wiped between attempts.

## Red → green

Test commit lands first (`44a8ca5`) and is red (undefined `writableTmpVolumeName`/`writableTmpMountPath`), impl commit (`8dcd677`) turns it green:
- `TestBuildWarmPodMountsWritableTmpForReadOnlyRoot` — emptyDir volume + writable `/tmp` mount + `TMPDIR=/tmp` so scratch resolves onto it.
- `TestBuildWarmPodNoWritableTmpWhenRootWritable` — default warm pod byte-identical (no emptyDir, no `TMPDIR`).
- `TestBuildPodMountsWritableTmpForReadOnlyRoot` — task-pod mirror.
- `TestBuildPodNoWritableTmpWhenRootWritable` — default task pod byte-identical.

**E2E note:** a "warm worker booted with the flag reaches `WorkerRegister`" check needs a real cluster — the read-only rootfs is kubelet-enforced and the fake clientset harness cannot reproduce it — so it is not feasible in the unit harness. The builder unit tests pin the full wiring (emptyDir + mount + `TMPDIR` → writable storage) that was the actual gap.

## Pre-push gate (all green)

- `go build ./...` — ok
- `go vet ./...` — ok
- `golangci-lint run` — **0 issues**
- `go test ./internal/executor/... ./cmd/leoflow-agent/...` — ok

Closes #741
