### PR TITLE
fix(setup): version-sentinel managed CPython + reject unsupported interpreters; robust re-extract

### DIFF
--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -1034,23 +1034,117 @@ func venvPython(home string) string {
 	return filepath.Join(home, "venv", "bin", "python")
 }
 
+// minPythonMinor is the lowest Python 3.x the task runtime + Airflow SDK
+// support; the managed relocatable CPython is pinned to this minor.
+const minPythonMinor = 11
+
 // devBasePython returns the interpreter used to CREATE a dev venv: the managed
 // relocatable CPython 3.11 (installed by `leoflow setup` under ~/.leoflow/python)
 // when present, since it bundles venv + ensurepip. It falls back to a python3.11
-// / python3 on PATH. Using the managed interpreter avoids needing the system
-// python3-venv package, which Debian/Ubuntu split out (the common first-run
-// failure: "ensurepip is not available").
-func devBasePython(home string) string {
+// / python3 on PATH that reports >= 3.11. Using the managed interpreter avoids
+// needing the system python3-venv package, which Debian/Ubuntu split out (the
+// common first-run failure: "ensurepip is not available").
+//
+// It errors when an interpreter IS present but reports an unsupported version,
+// or when none is found at all — a venv cannot be built without a base — rather
+// than returning a bare "python3" that fails opaquely later (#742).
+func devBasePython(ctx context.Context, home string) (string, error) {
 	managed := filepath.Join(filepath.Dir(home), "python", "bin", "python3.11")
-	if _, err := os.Stat(managed); err == nil {
-		return managed
+	p, err := resolvePython3(ctx, managed, exec.LookPath, pythonVersion)
+	if err != nil {
+		return "", err
 	}
-	for _, name := range []string{"python3.11", "python3"} {
-		if p, lerr := exec.LookPath(name); lerr == nil {
-			return p
+	if p == "" {
+		return "", fmt.Errorf("no Python interpreter found; run `leoflow setup` to provision a managed CPython 3.%d", minPythonMinor)
+	}
+	return p, nil
+}
+
+// leoflowManagedPython returns the path to the managed relocatable CPython that
+// `leoflow setup` installs under ~/.leoflow/python, or "" if the home directory
+// cannot be resolved.
+func leoflowManagedPython() string {
+	h, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(h, ".leoflow", "python", "bin", "python3.11")
+}
+
+// resolvePython3 returns a usable Python >= 3.11 with a single, unified
+// precedence shared by `leoflow dev` and `leoflow validate` (#742):
+//
+//   - the managed pinned build (when present) wins — it is the checksum-verified
+//     CPython `leoflow setup` provisioned at exactly the pinned version, so it is
+//     trusted without being re-executed;
+//   - otherwise the first host python3.11/python3 that reports >= 3.11 is used;
+//   - a host interpreter that IS present but reports an unsupported version is
+//     rejected with an actionable `leoflow setup` hint, so a half-provisioned
+//     host never silently runs an unsupported interpreter that fails later at an
+//     unrelated component;
+//   - when no interpreter exists at all, it returns ("", nil) and lets the
+//     caller decide whether that is fatal.
+//
+// managed is the managed interpreter path (may be ""); lookPath and runVersion
+// are injectable for tests.
+func resolvePython3(ctx context.Context, managed string, lookPath func(string) (string, error), runVersion func(context.Context, string) (int, int, error)) (string, error) {
+	if managed != "" {
+		if _, err := os.Stat(managed); err == nil {
+			return managed, nil
 		}
 	}
-	return "python3"
+	sawUnsupported := false
+	for _, name := range []string{"python3.11", "python3"} {
+		p, err := lookPath(name)
+		if err != nil {
+			continue
+		}
+		major, minor, verr := runVersion(ctx, p)
+		if verr != nil {
+			continue // cannot determine version; try the next candidate
+		}
+		if major > 3 || (major == 3 && minor >= minPythonMinor) {
+			return p, nil
+		}
+		sawUnsupported = true
+	}
+	if sawUnsupported {
+		return "", fmt.Errorf("found a Python interpreter but it is older than 3.%d; run `leoflow setup` to provision a managed CPython", minPythonMinor)
+	}
+	return "", nil
+}
+
+// pythonVersion runs `<py> --version` and returns the reported major.minor.
+func pythonVersion(ctx context.Context, py string) (major, minor int, err error) {
+	out, err := exec.CommandContext(ctx, py, "--version").CombinedOutput() //nolint:gosec // py is a resolved interpreter path (managed or LookPath result)
+	if err != nil {
+		return 0, 0, fmt.Errorf("running %s --version: %w", py, err)
+	}
+	return parsePythonVersion(string(out))
+}
+
+// parsePythonVersion extracts the major and minor from a `python --version` line
+// such as "Python 3.11.15" (the version token may carry a patch and a pre-release
+// suffix, e.g. "3.12.0rc1").
+func parsePythonVersion(s string) (major, minor int, err error) {
+	fields := strings.Fields(s)
+	if len(fields) < 2 {
+		return 0, 0, fmt.Errorf("unrecognized python version output %q", strings.TrimSpace(s))
+	}
+	ver := fields[len(fields)-1] // "3.11.15"
+	parts := strings.SplitN(ver, ".", 3)
+	if len(parts) < 2 {
+		return 0, 0, fmt.Errorf("unrecognized python version %q", ver)
+	}
+	major, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("parsing python major from %q: %w", ver, err)
+	}
+	minor, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("parsing python minor from %q: %w", ver, err)
+	}
+	return major, minor, nil
 }
 
 // resolveRuntimeSrc returns the leoflow_runtime package source to pip-install

--- a/internal/cli/dev_dag_venv.go
+++ b/internal/cli/dev_dag_venv.go
@@ -141,8 +141,11 @@ func ensureDagVenv(ctx context.Context, cmd *cobra.Command, home, dagID, runtime
 
 	if _, err := os.Stat(py); err != nil {
 		devPrintf(cmd.OutOrStdout(), "▸ creating isolated dev venv for %q …\n", dagID)
-		base := devBasePython(home)
-		mk := exec.CommandContext(ctx, base, "-m", "venv", dir) //nolint:gosec // base is the managed CPython or a resolved python3
+		base, berr := devBasePython(ctx, home)
+		if berr != nil {
+			return "", berr
+		}
+		mk := exec.CommandContext(ctx, base, "-m", "venv", dir) //nolint:gosec // base is the managed CPython or a resolved python3 >= 3.11
 		mk.Stdout, mk.Stderr = cmd.OutOrStdout(), cmd.ErrOrStderr()
 		if e := mk.Run(); e != nil {
 			return "", fmt.Errorf("creating dev venv for %q with %s (the managed CPython bundles venv; a system python3 may need its python3-venv package): %w", dagID, base, e)

--- a/internal/cli/lite_project_test.go
+++ b/internal/cli/lite_project_test.go
@@ -98,15 +98,21 @@ func TestDevBasePythonPrefersManaged(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(managed), 0o750); err != nil {
 		t.Fatal(err)
 	}
-	// Before the managed CPython exists, it falls back to a PATH python.
-	if got := devBasePython(home); got == managed {
+	// Before the managed CPython exists, it must not return the managed path
+	// (it resolves a host python3 or reports none — never the absent managed one).
+	if got, _ := devBasePython(home); got == managed {
 		t.Errorf("should not return the managed path before it exists")
 	}
-	// Once present, the managed interpreter (which bundles venv) is preferred.
+	// Once present, the managed interpreter (which bundles venv) is preferred and
+	// trusted at the pinned version without re-executing it.
 	if err := os.WriteFile(managed, []byte("#!/bin/sh\n"), 0o755); err != nil { //nolint:gosec // test fixture
 		t.Fatal(err)
 	}
-	if got := devBasePython(home); got != managed {
+	got, err := devBasePython(home)
+	if err != nil {
+		t.Fatalf("devBasePython err = %v, want nil", err)
+	}
+	if got != managed {
 		t.Errorf("devBasePython = %q, want the managed %q", got, managed)
 	}
 }

--- a/internal/cli/lite_project_test.go
+++ b/internal/cli/lite_project_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -100,7 +101,7 @@ func TestDevBasePythonPrefersManaged(t *testing.T) {
 	}
 	// Before the managed CPython exists, it must not return the managed path
 	// (it resolves a host python3 or reports none — never the absent managed one).
-	if got, _ := devBasePython(home); got == managed {
+	if got, _ := devBasePython(context.Background(), home); got == managed {
 		t.Errorf("should not return the managed path before it exists")
 	}
 	// Once present, the managed interpreter (which bundles venv) is preferred and
@@ -108,7 +109,7 @@ func TestDevBasePythonPrefersManaged(t *testing.T) {
 	if err := os.WriteFile(managed, []byte("#!/bin/sh\n"), 0o755); err != nil { //nolint:gosec // test fixture
 		t.Fatal(err)
 	}
-	got, err := devBasePython(home)
+	got, err := devBasePython(context.Background(), home)
 	if err != nil {
 		t.Fatalf("devBasePython err = %v, want nil", err)
 	}

--- a/internal/cli/python_resolve_test.go
+++ b/internal/cli/python_resolve_test.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestResolvePython3 pins the unified interpreter precedence (#742): the managed
+// pinned build wins; otherwise the first host python3.11/python3 that reports
+// >= 3.11 is used; a present-but-unsupported interpreter is rejected with the
+// `leoflow setup` hint instead of being returned; and no interpreter at all is
+// reported as ("", nil) so callers can decide whether that is fatal.
+func TestResolvePython3(t *testing.T) {
+	notFound := func(string) (string, error) { return "", os.ErrNotExist }
+	neverRun := func(string) (int, int, error) {
+		t.Helper()
+		t.Error("runVersion called for a trusted/absent interpreter")
+		return 0, 0, nil
+	}
+
+	t.Run("managed build is trusted and preferred without exec", func(t *testing.T) {
+		managed := filepath.Join(t.TempDir(), "python3.11")
+		if err := os.WriteFile(managed, []byte("#!/fake"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		got, err := resolvePython3(managed,
+			func(string) (string, error) { return "/usr/bin/python3.11", nil },
+			neverRun)
+		if err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+		if got != managed {
+			t.Errorf("path = %q, want the managed build %q", got, managed)
+		}
+	})
+
+	t.Run("present but unsupported host interpreter is rejected with setup hint", func(t *testing.T) {
+		lookPath := func(name string) (string, error) {
+			if name == "python3" {
+				return "/usr/bin/python3", nil
+			}
+			return "", os.ErrNotExist
+		}
+		got, err := resolvePython3("", lookPath,
+			func(string) (int, int, error) { return 3, 9, nil })
+		if err == nil {
+			t.Fatal("err = nil, want an unsupported-interpreter rejection")
+		}
+		if got != "" {
+			t.Errorf("path = %q, want empty on rejection", got)
+		}
+		if !strings.Contains(err.Error(), "leoflow setup") {
+			t.Errorf("error %q, want an actionable `leoflow setup` hint", err)
+		}
+	})
+
+	t.Run("supported host interpreter is returned", func(t *testing.T) {
+		lookPath := func(name string) (string, error) {
+			if name == "python3.11" {
+				return "/usr/bin/python3.11", nil
+			}
+			return "", os.ErrNotExist
+		}
+		got, err := resolvePython3("", lookPath,
+			func(string) (int, int, error) { return 3, 11, nil })
+		if err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+		if got != "/usr/bin/python3.11" {
+			t.Errorf("path = %q, want the host python3.11", got)
+		}
+	})
+
+	t.Run("newer host interpreter (3.12 as python3) is accepted", func(t *testing.T) {
+		lookPath := func(name string) (string, error) {
+			if name == "python3" {
+				return "/usr/bin/python3", nil
+			}
+			return "", os.ErrNotExist
+		}
+		got, err := resolvePython3("", lookPath,
+			func(string) (int, int, error) { return 3, 12, nil })
+		if err != nil || got != "/usr/bin/python3" {
+			t.Fatalf("got (%q, %v), want the host python3", got, err)
+		}
+	})
+
+	t.Run("no interpreter at all is reported as empty, no error", func(t *testing.T) {
+		got, err := resolvePython3("", notFound, neverRun)
+		if err != nil {
+			t.Fatalf("err = %v, want nil when nothing is found", err)
+		}
+		if got != "" {
+			t.Errorf("path = %q, want empty when no interpreter exists", got)
+		}
+	})
+}
+
+// TestParsePythonVersion covers extraction of major/minor from `--version` output.
+func TestParsePythonVersion(t *testing.T) {
+	cases := []struct {
+		in                string
+		major, minor      int
+		wantErr           bool
+	}{
+		{"Python 3.11.15\n", 3, 11, false},
+		{"Python 3.9.18", 3, 9, false},
+		{"Python 3.12.0rc1", 3, 12, false},
+		{"garbage", 0, 0, true},
+		{"", 0, 0, true},
+	}
+	for _, tc := range cases {
+		maj, min, err := parsePythonVersion(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("parsePythonVersion(%q): err = nil, want error", tc.in)
+			}
+			continue
+		}
+		if err != nil || maj != tc.major || min != tc.minor {
+			t.Errorf("parsePythonVersion(%q) = (%d,%d,%v), want (%d,%d,nil)", tc.in, maj, min, err, tc.major, tc.minor)
+		}
+	}
+}

--- a/internal/cli/python_resolve_test.go
+++ b/internal/cli/python_resolve_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,8 +14,9 @@ import (
 // `leoflow setup` hint instead of being returned; and no interpreter at all is
 // reported as ("", nil) so callers can decide whether that is fatal.
 func TestResolvePython3(t *testing.T) {
+	ctx := context.Background()
 	notFound := func(string) (string, error) { return "", os.ErrNotExist }
-	neverRun := func(string) (int, int, error) {
+	neverRun := func(context.Context, string) (int, int, error) {
 		t.Helper()
 		t.Error("runVersion called for a trusted/absent interpreter")
 		return 0, 0, nil
@@ -25,7 +27,7 @@ func TestResolvePython3(t *testing.T) {
 		if err := os.WriteFile(managed, []byte("#!/fake"), 0o700); err != nil {
 			t.Fatal(err)
 		}
-		got, err := resolvePython3(managed,
+		got, err := resolvePython3(ctx, managed,
 			func(string) (string, error) { return "/usr/bin/python3.11", nil },
 			neverRun)
 		if err != nil {
@@ -43,8 +45,8 @@ func TestResolvePython3(t *testing.T) {
 			}
 			return "", os.ErrNotExist
 		}
-		got, err := resolvePython3("", lookPath,
-			func(string) (int, int, error) { return 3, 9, nil })
+		got, err := resolvePython3(ctx, "", lookPath,
+			func(context.Context, string) (int, int, error) { return 3, 9, nil })
 		if err == nil {
 			t.Fatal("err = nil, want an unsupported-interpreter rejection")
 		}
@@ -63,8 +65,8 @@ func TestResolvePython3(t *testing.T) {
 			}
 			return "", os.ErrNotExist
 		}
-		got, err := resolvePython3("", lookPath,
-			func(string) (int, int, error) { return 3, 11, nil })
+		got, err := resolvePython3(ctx, "", lookPath,
+			func(context.Context, string) (int, int, error) { return 3, 11, nil })
 		if err != nil {
 			t.Fatalf("err = %v, want nil", err)
 		}
@@ -80,15 +82,15 @@ func TestResolvePython3(t *testing.T) {
 			}
 			return "", os.ErrNotExist
 		}
-		got, err := resolvePython3("", lookPath,
-			func(string) (int, int, error) { return 3, 12, nil })
+		got, err := resolvePython3(ctx, "", lookPath,
+			func(context.Context, string) (int, int, error) { return 3, 12, nil })
 		if err != nil || got != "/usr/bin/python3" {
 			t.Fatalf("got (%q, %v), want the host python3", got, err)
 		}
 	})
 
 	t.Run("no interpreter at all is reported as empty, no error", func(t *testing.T) {
-		got, err := resolvePython3("", notFound, neverRun)
+		got, err := resolvePython3(ctx, "", notFound, neverRun)
 		if err != nil {
 			t.Fatalf("err = %v, want nil when nothing is found", err)
 		}
@@ -101,9 +103,9 @@ func TestResolvePython3(t *testing.T) {
 // TestParsePythonVersion covers extraction of major/minor from `--version` output.
 func TestParsePythonVersion(t *testing.T) {
 	cases := []struct {
-		in                string
-		major, minor      int
-		wantErr           bool
+		in           string
+		major, minor int
+		wantErr      bool
 	}{
 		{"Python 3.11.15\n", 3, 11, false},
 		{"Python 3.9.18", 3, 9, false},
@@ -112,15 +114,15 @@ func TestParsePythonVersion(t *testing.T) {
 		{"", 0, 0, true},
 	}
 	for _, tc := range cases {
-		maj, min, err := parsePythonVersion(tc.in)
+		maj, mnr, err := parsePythonVersion(tc.in)
 		if tc.wantErr {
 			if err == nil {
 				t.Errorf("parsePythonVersion(%q): err = nil, want error", tc.in)
 			}
 			continue
 		}
-		if err != nil || maj != tc.major || min != tc.minor {
-			t.Errorf("parsePythonVersion(%q) = (%d,%d,%v), want (%d,%d,nil)", tc.in, maj, min, err, tc.major, tc.minor)
+		if err != nil || maj != tc.major || mnr != tc.minor {
+			t.Errorf("parsePythonVersion(%q) = (%d,%d,%v), want (%d,%d,nil)", tc.in, maj, mnr, err, tc.major, tc.minor)
 		}
 	}
 }

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -47,7 +47,15 @@ func newValidateCommand() *cobra.Command {
 // (managed or system), we warn instead of failing — a fresh install that has
 // not yet run `leoflow setup` should still be able to lint its leoflow.yaml.
 func checkDagPythonSyntax(cmd *cobra.Command, dagPath string) error {
-	py := findPythonForValidate()
+	// Unified precedence with `leoflow dev` (#742): managed pinned build, then a
+	// host python3.11/python3 that reports >= 3.11. A present-but-unsupported
+	// interpreter is a hard error (validate must not lint under 3.9 a DAG that
+	// will run under 3.11), while no interpreter at all is a soft skip so a fresh
+	// install that has not run `leoflow setup` can still lint its leoflow.yaml.
+	py, err := resolvePython3(cmd.Context(), leoflowManagedPython(), exec.LookPath, pythonVersion)
+	if err != nil {
+		return err
+	}
 	if py == "" {
 		if _, werr := fmt.Fprintln(cmd.ErrOrStderr(),
 			"warning: skipping dag.py syntax check (no python3 found; run `leoflow setup` to provision one)"); werr != nil {
@@ -64,20 +72,4 @@ func checkDagPythonSyntax(cmd *cobra.Command, dagPath string) error {
 		msg = err.Error()
 	}
 	return fmt.Errorf("dag.py has a syntax error: %s", msg)
-}
-
-// findPythonForValidate prefers the managed interpreter that `leoflow setup`
-// installs (~/.leoflow/python/bin/python3.11), then falls back to whatever
-// `python3` resolves to on PATH. Empty when neither is available.
-func findPythonForValidate() string {
-	if home, err := os.UserHomeDir(); err == nil {
-		managed := home + "/.leoflow/python/bin/python3.11"
-		if _, err := os.Stat(managed); err == nil {
-			return managed
-		}
-	}
-	if p, err := exec.LookPath("python3"); err == nil {
-		return p
-	}
-	return ""
 }

--- a/internal/setup/install.go
+++ b/internal/setup/install.go
@@ -19,6 +19,12 @@ import (
 // runaway or hostile response (the real archive is ~30 MB).
 const maxPythonArchiveBytes = 200 << 20 // 200 MiB
 
+// pyVersionFile names the sentinel, written under Home/python after a successful
+// extraction, that records which managed CPython version is on disk. The
+// presence guard keys on it (symmetric with pgVersionFile) so an upgrade
+// re-extracts instead of silently keeping the prior release's interpreter.
+const pyVersionFile = ".py-version"
+
 // EnsureOpts configures EnsurePython.
 type EnsureOpts struct {
 	Home     string // the managed root, e.g. ~/.leoflow
@@ -36,15 +42,32 @@ type EnsureOpts struct {
 // Home, or a freshly downloaded-and-verified pinned build otherwise. The managed
 // build is extracted to Home/python (the archive's top-level "python/" dir).
 func EnsurePython(ctx context.Context, o EnsureOpts) (string, error) {
-	if o.LookPath != nil {
-		if p, err := o.LookPath("python3.11"); err == nil {
-			return p, nil
+	pyRoot := filepath.Join(o.Home, "python")
+	managed := filepath.Join(pyRoot, "bin", "python3.11")
+	stat := o.Stat
+	if stat == nil {
+		stat = os.Stat
+	}
+	// A COMPLETE managed install of the PINNED version wins over any host
+	// interpreter: it is the checksum-verified build Lite provisioned, at the
+	// exact version the runtime expects. Keying on mere presence (the pre-#742
+	// behavior) meant (a) a clean upgrade never re-extracted — it silently kept
+	// the prior release — and (b) LookPath("python3.11") ran FIRST, so a host
+	// python3.11 outranked the pinned managed one. Check the sentinel first.
+	managedPresent := false
+	if _, err := stat(managed); err == nil {
+		managedPresent = true
+		if readManagedPythonVersion(pyRoot) == pyVersion {
+			return managed, nil
 		}
 	}
-	managed := filepath.Join(o.Home, "python", "bin", "python3.11")
-	if o.Stat != nil {
-		if _, err := o.Stat(managed); err == nil {
-			return managed, nil
+	// No CURRENT managed install. Prefer a host python3.11 to avoid a download,
+	// but only when there is no managed tree to repair — a version-mismatched or
+	// half-extracted managed tree must be re-installed, not shadowed by a host
+	// interpreter of unknown version.
+	if !managedPresent && o.LookPath != nil {
+		if p, err := o.LookPath("python3.11"); err == nil {
+			return p, nil
 		}
 	}
 	build, err := ResolvePython(o.GOOS, o.GOARCH, o.Libc)
@@ -56,11 +79,39 @@ func EnsurePython(ctx context.Context, o EnsureOpts) (string, error) {
 	if client == nil {
 		client = http.DefaultClient
 	}
-	if derr := downloadVerifyExtract(ctx, client, build, o.Home); derr != nil {
-		return "", derr
+	data, err := fetchVerify(ctx, client, build.URL, build.SHA256, maxPythonArchiveBytes, "CPython")
+	if err != nil {
+		return "", err
+	}
+	// Wipe any prior (stale, wrong-version, or half-extracted) managed tree before
+	// re-extracting, so no file from an older on-disk layout survives and no tar
+	// TYPE change (e.g. a dir becoming a file) collides with an existing entry.
+	// Done only after the download verified, so a network failure never destroys a
+	// working install.
+	if rmErr := os.RemoveAll(pyRoot); rmErr != nil {
+		return "", fmt.Errorf("removing prior managed CPython: %w", rmErr)
+	}
+	if xerr := extractTarGz(data, o.Home); xerr != nil {
+		return "", xerr
+	}
+	// Record the extracted version LAST, so an interrupted extract leaves no
+	// sentinel and is re-installed on the next run rather than trusted.
+	if werr := os.WriteFile(filepath.Join(pyRoot, pyVersionFile), []byte(build.Version), 0o600); werr != nil {
+		return "", fmt.Errorf("recording managed CPython version: %w", werr)
 	}
 	logf(o.Logf, "CPython installed at %s", managed)
 	return managed, nil
+}
+
+// readManagedPythonVersion returns the managed CPython version recorded under
+// pyRoot by the last successful extraction, or "" if none is recorded (a
+// pre-sentinel install or an interrupted extract).
+func readManagedPythonVersion(pyRoot string) string {
+	b, err := os.ReadFile(filepath.Join(pyRoot, pyVersionFile))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(b))
 }
 
 // logf invokes the optional progress callback, ignoring a nil one.
@@ -149,10 +200,27 @@ func extractEntry(tr *tar.Reader, hdr *tar.Header, destDir, name string) error {
 	}
 	switch hdr.Typeflag {
 	case tar.TypeDir:
+		// A prior extract of an older layout may have left a non-directory here;
+		// MkdirAll would then fail. Clear the conflicting entry so the re-extract
+		// is idempotent across a tar TYPE change (file -> directory).
+		if fi, lerr := os.Lstat(target); lerr == nil && !fi.IsDir() {
+			if rmErr := os.RemoveAll(target); rmErr != nil {
+				return fmt.Errorf("removing conflicting %q before dir: %w", target, rmErr)
+			}
+		}
 		return os.MkdirAll(target, 0o750)
 	case tar.TypeReg:
 		if mkErr := os.MkdirAll(filepath.Dir(target), 0o750); mkErr != nil {
 			return fmt.Errorf("creating parent of %q: %w", target, mkErr)
+		}
+		// Symmetric to the dir branch: if a prior extract left a directory (or a
+		// symlink) where a regular file now belongs, O_TRUNC would fail EISDIR.
+		// Clear any non-regular entry first so the re-extract is idempotent across
+		// a TYPE change (directory -> file).
+		if fi, lerr := os.Lstat(target); lerr == nil && !fi.Mode().IsRegular() {
+			if rmErr := os.RemoveAll(target); rmErr != nil {
+				return fmt.Errorf("removing conflicting %q before file: %w", target, rmErr)
+			}
 		}
 		// Preserve only the executable bit (interpreters, scripts); everything
 		// else is owner read/write. This sidesteps trusting arbitrary archive
@@ -206,9 +274,12 @@ func extractSymlink(hdr *tar.Header, destDir, target, name string) error {
 	}
 	// os.Symlink fails EEXIST if target is already present, which breaks a
 	// re-extract over an existing install (the regular-file branch overwrites via
-	// O_TRUNC). Remove any prior entry first to match that idempotent behavior;
-	// target is already sanitized by the containment checks above.
-	if rmErr := os.Remove(target); rmErr != nil && !os.IsNotExist(rmErr) {
+	// O_TRUNC). Remove any prior entry first to match that idempotent behavior.
+	// RemoveAll (not os.Remove) so a TYPE change — a prior extract leaving a
+	// non-empty directory where a symlink now belongs — is cleared too, rather
+	// than failing with a non-IsNotExist ENOTEMPTY. Target is already sanitized by
+	// the containment checks above.
+	if rmErr := os.RemoveAll(target); rmErr != nil {
 		return fmt.Errorf("removing existing %q before symlink: %w", target, rmErr)
 	}
 	return os.Symlink(hdr.Linkname, target) //nolint:gosec // target sanitized; link resolved within destDir

--- a/internal/setup/install_test.go
+++ b/internal/setup/install_test.go
@@ -114,7 +114,7 @@ func TestEnsurePythonBranches(t *testing.T) {
 		}
 	})
 
-	t.Run("managed python is reused when present", func(t *testing.T) {
+	t.Run("managed python at the pinned version is reused when present", func(t *testing.T) {
 		home := t.TempDir()
 		managed := filepath.Join(home, "python", "bin", "python3.11")
 		if err := os.MkdirAll(filepath.Dir(managed), 0o750); err != nil {
@@ -123,18 +123,55 @@ func TestEnsurePythonBranches(t *testing.T) {
 		if err := os.WriteFile(managed, []byte("#!/fake"), 0o700); err != nil {
 			t.Fatal(err)
 		}
+		// A COMPLETE managed install records the pinned version in its sentinel;
+		// only then may EnsurePython short-circuit (symmetric with Postgres).
+		if err := os.WriteFile(filepath.Join(home, "python", pyVersionFile), []byte(pyVersion), 0o600); err != nil {
+			t.Fatal(err)
+		}
 		got, err := EnsurePython(context.Background(), EnsureOpts{
 			Home:     home,
 			GOOS:     "linux",
 			GOARCH:   "amd64",
 			LookPath: func(string) (string, error) { return "", os.ErrNotExist },
 			Stat:     os.Stat,
+			Client:   &http.Client{Transport: errRoundTripper{t}},
 		})
 		if err != nil {
 			t.Fatalf("err = %v, want nil", err)
 		}
 		if got != managed {
 			t.Errorf("path = %q, want managed %q", got, managed)
+		}
+	})
+
+	t.Run("managed pinned build wins over a host python3.11", func(t *testing.T) {
+		// Regression for #742: the pre-fix EnsurePython did LookPath("python3.11")
+		// BEFORE checking the managed tree, so a host interpreter outranked the
+		// pinned, checksum-verified managed build. The managed build must win.
+		home := t.TempDir()
+		managed := filepath.Join(home, "python", "bin", "python3.11")
+		if err := os.MkdirAll(filepath.Dir(managed), 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(managed, []byte("#!/fake"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(home, "python", pyVersionFile), []byte(pyVersion), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		got, err := EnsurePython(context.Background(), EnsureOpts{
+			Home:     home,
+			GOOS:     "linux",
+			GOARCH:   "amd64",
+			LookPath: func(string) (string, error) { return "/usr/bin/python3.11", nil },
+			Stat:     os.Stat,
+			Client:   &http.Client{Transport: errRoundTripper{t}},
+		})
+		if err != nil {
+			t.Fatalf("err = %v, want nil", err)
+		}
+		if got != managed {
+			t.Errorf("path = %q, want the managed build %q to outrank the host python3.11", got, managed)
 		}
 	})
 
@@ -192,6 +229,129 @@ func TestExtractTarGzDirAndSymlink(t *testing.T) {
 	if err != nil || link != "python3.11" {
 		t.Errorf("symlink = %q err = %v, want -> python3.11", link, err)
 	}
+}
+
+// TestEnsurePythonReextractsOnVersionMismatch proves the presence guard is
+// version-aware (#742): when the managed CPython on disk records a DIFFERENT
+// version than the pinned one, EnsurePython re-installs (reaches the download)
+// instead of silently keeping the stale interpreter. Without a sentinel it would
+// short-circuit forever, so a half-upgraded install would keep running an
+// unsupported interpreter and fail later at an unrelated component.
+func TestEnsurePythonReextractsOnVersionMismatch(t *testing.T) {
+	home := t.TempDir()
+	managed := filepath.Join(home, "python", "bin", "python3.11")
+	if err := os.MkdirAll(filepath.Dir(managed), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(managed, []byte("#!/fake"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Sentinel records an OLDER managed version than the pinned pyVersion.
+	if err := os.WriteFile(filepath.Join(home, "python", pyVersionFile), []byte("3.10.0"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rt := &recordingRoundTripper{}
+	_, err := EnsurePython(context.Background(), EnsureOpts{
+		Home: home, GOOS: "linux", GOARCH: "amd64",
+		LookPath: func(string) (string, error) { return "", os.ErrNotExist },
+		Stat:     os.Stat,
+		Client:   &http.Client{Transport: rt},
+	})
+	if err == nil {
+		t.Fatal("err = nil, want a download attempt on version change")
+	}
+	if !rt.called {
+		t.Error("expected a re-download when the on-disk CPython version differs from the pinned one")
+	}
+}
+
+// TestEnsurePythonReextractsWhenVersionUnknown proves a managed install with no
+// version sentinel (a pre-#742 install, or an interrupted extract) is treated as
+// needing re-installation rather than trusted blindly.
+func TestEnsurePythonReextractsWhenVersionUnknown(t *testing.T) {
+	home := t.TempDir()
+	managed := filepath.Join(home, "python", "bin", "python3.11")
+	if err := os.MkdirAll(filepath.Dir(managed), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(managed, []byte("#!/fake"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	rt := &recordingRoundTripper{}
+	_, err := EnsurePython(context.Background(), EnsureOpts{
+		Home: home, GOOS: "linux", GOARCH: "amd64",
+		LookPath: func(string) (string, error) { return "", os.ErrNotExist },
+		Stat:     os.Stat,
+		Client:   &http.Client{Transport: rt},
+	})
+	if err == nil {
+		t.Fatal("err = nil, want a download attempt when no version is recorded")
+	}
+	if !rt.called {
+		t.Error("expected a re-download when no version sentinel is present")
+	}
+}
+
+// TestExtractEntryHandlesTypeChange proves a re-extract whose archive changed an
+// entry's TYPE is idempotent (#729 follow-up): a TypeReg landing where a prior
+// extract left a directory must not fail EISDIR, and a TypeSymlink landing where
+// a non-empty directory exists must not fail with a non-IsNotExist os.Remove.
+func TestExtractEntryHandlesTypeChange(t *testing.T) {
+	t.Run("regular file over an existing directory", func(t *testing.T) {
+		dest := t.TempDir()
+		// First layout: python/foo is a directory (holds a child file).
+		first, _ := makeTarGz(t, map[string]string{"python/foo/child": "x"})
+		if err := extractTarGz(first, dest); err != nil {
+			t.Fatalf("first extract: %v", err)
+		}
+		// Second layout: python/foo is now a regular file — a type change.
+		second, _ := makeTarGz(t, map[string]string{"python/foo": "iam a file now"})
+		if err := extractTarGz(second, dest); err != nil {
+			t.Fatalf("re-extract over a directory must not fail EISDIR: %v", err)
+		}
+		got, rerr := os.ReadFile(filepath.Join(dest, "python", "foo"))
+		if rerr != nil || string(got) != "iam a file now" {
+			t.Errorf("python/foo = %q (err %v), want the new file content", got, rerr)
+		}
+	})
+
+	t.Run("symlink over an existing non-empty directory", func(t *testing.T) {
+		dest := t.TempDir()
+		// Pre-existing non-empty directory where a symlink will later belong.
+		linkDir := filepath.Join(dest, "python", "link")
+		if err := os.MkdirAll(linkDir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(linkDir, "leftover"), []byte("old"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		// Archive turns python/link into a symlink to a sibling file.
+		var buf bytes.Buffer
+		gz := gzip.NewWriter(&buf)
+		tw := tar.NewWriter(gz)
+		if err := tw.WriteHeader(&tar.Header{Name: "python/target", Typeflag: tar.TypeReg, Mode: 0o644, Size: 2}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte("ok")); err != nil {
+			t.Fatal(err)
+		}
+		if err := tw.WriteHeader(&tar.Header{Name: "python/link", Typeflag: tar.TypeSymlink, Linkname: "target"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := tw.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := gz.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if err := extractTarGz(buf.Bytes(), dest); err != nil {
+			t.Fatalf("symlink over a non-empty directory must not fail: %v", err)
+		}
+		link, rerr := os.Readlink(filepath.Join(dest, "python", "link"))
+		if rerr != nil || link != "target" {
+			t.Errorf("symlink = %q err = %v, want -> target", link, rerr)
+		}
+	})
 }
 
 func TestDownloadVerifyExtractErrors(t *testing.T) {


### PR DESCRIPTION
## Bug 1 — #742: managed CPython has no version sentinel; resolvers silently fall back to system python3

Confirmed against source:

- `EnsurePython` (`internal/setup/install.go`) short-circuited on the **mere presence** of `~/.leoflow/python/bin/python3.11` — the pre-#729 pattern, with no `.py-version` sentinel — and ran `LookPath("python3.11")` **before** the managed check, so a host python3.11 outranked the pinned, checksum-verified build. A clean upgrade therefore never re-extracted.
- Contrast the already-fixed Postgres path (`install_postgres.go`), which gates on `stat(managed)==nil && readManagedPostgresVersion(pgRoot) == pgVersion` with the sentinel written last.
- `internal/cli/dev.go` (`devBasePython`) and `internal/cli/validate.go` (`findPythonForValidate`) each `os.Stat` the managed path once, then silently `LookPath` a host `python3.11`/`python3` of unknown version — a half-upgraded install ran an unsupported interpreter and failed later at an unrelated component. `validate.go` didn't even try 3.11 first, so a DAG could validate under one interpreter and run under another.

### Fix

1. **Sentinel + version gate.** `EnsurePython` writes a `.py-version` sentinel **last** and short-circuits only when the managed interpreter is present **and** records the pinned `pyVersion` (symmetric with `.pg-version`). A mismatch or a missing sentinel re-installs.
2. **Managed wins over host.** The managed check runs before the host `LookPath`; a version-mismatched managed tree is repaired rather than shadowed by a host interpreter. A host `python3.11` is used only when there is no managed tree to repair (still avoids a needless download on a machine that never provisioned one).
3. **Interpreter floor + unified precedence.** A single `resolvePython3` helper now backs both `dev.go` and `validate.go`: managed (trusted at the pinned version) → first host `python3.11`/`python3` reporting **>= 3.11** (verified via `--version`). A present-but-unsupported interpreter is rejected with an actionable `run leoflow setup` hint. "No interpreter at all" stays a soft skip for `validate` (a fresh install can still lint `leoflow.yaml`) and a hard error for `dev` (a venv needs a base).

## Bug 2 — #729 follow-up (folded in): symlink/regular-file extract idempotency was intra-type only

`extractEntry` was idempotent only within a single entry type. A tar **type change** on re-extract still failed: `TypeReg` over an existing directory → `EISDIR`; `TypeSymlink` over a non-empty directory → `os.Remove` returned a non-`IsNotExist` error. The extraction never wiped first, so the "older on-disk layout" claim was stronger than the code.

### Fix

- `EnsurePython` `RemoveAll`s the managed root before re-extracting — **after** the download verifies, so a network failure never destroys a working install — so no file from an older on-disk layout survives.
- `extractEntry` now clears a conflicting entry of the wrong type before writing (dir↔file), and the symlink branch uses `RemoveAll`. This hardens **both** the CPython and PostgreSQL extractors (shared code) against type-change upgrades.

This also hardens the #729 extract against a tar entry type change.

## Red → green (tests first)

Test commit (`540bcf1`) lands before the implementation (`7d2af54`). New/updated tests:

- `TestEnsurePythonReextractsOnVersionMismatch` / `TestEnsurePythonReextractsWhenVersionUnknown` — a managed tree whose recorded `.py-version` differs from (or is missing vs) the pinned version must re-extract (red today — no sentinel).
- `TestEnsurePythonBranches/managed pinned build wins over a host python3.11` — the pinned managed build outranks a host `python3.11` on PATH.
- `TestEnsurePythonBranches/managed python at the pinned version is reused` — updated to write a matching sentinel.
- `TestResolvePython3` — a present-but-unsupported interpreter (reports 3.9) is rejected with the setup hint, not returned; managed is trusted without exec; supported host is accepted; none-found is `("", nil)`. Plus `TestParsePythonVersion`.
- `TestExtractEntryHandlesTypeChange` — a `TypeReg` entry landing where a directory already exists (and a symlink over a non-empty directory) re-extracts cleanly, not `EISDIR`.

## Pre-push gate (all green)

```
go build ./...          -> exit 0
go vet ./...            -> exit 0
golangci-lint run ./internal/setup/... ./internal/cli/...  -> 0 issues
go test ./internal/setup/... ./internal/cli/...            -> ok  (both packages)
```

`test/e2e/lite-selfheal.sh` was not modified.
