### PR TITLE
feat(auth): transparent CLI token renewal (no hourly re-login)

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -519,6 +519,8 @@ func buildAPIServer(cfg *config.ServerConfig, tel *observability.Telemetry, auth
 		CORSOrigins:                  cfg.Server.CORS.AllowedOrigins,
 		TrustedProxies:               cfg.Server.TrustedProxies,
 		TokenTTLSecs:                 cfg.Auth.JWT.TokenTTLSeconds,
+		TokenRenewer:                 authn,
+		TokenMaxLifetimeSecs:         cfg.Auth.JWT.MaxLifetimeSeconds,
 		InstanceName:                 cfg.UI.InstanceName,
 		UIAutoRefreshIntervalSeconds: cfg.UI.AutoRefreshIntervalSeconds,
 		DevNoAuth:                    cfg.Auth.DevNoAuth,

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -39,6 +39,28 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 
+  /api/v2/auth/token/renew:
+    post:
+      summary: Renew a still-valid JWT into a fresh short-lived token
+      description: >-
+        Transparent renewal: given a still-valid user bearer, re-mints the same
+        identity with a fresh short TTL, bounded by a server-side max_lifetime
+        measured from first login. Lets a long CLI/dev session avoid re-logging in
+        every token TTL while keeping the access token short-lived. Returns 401
+        when the presented token is invalid, expired, or past max_lifetime, in
+        which case the client must log in again.
+      operationId: renewToken
+      tags: [Auth]
+      responses:
+        "200":
+          description: Token renewed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokenResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
   /api/v2/users:
     get:
       summary: List users

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -4,11 +4,20 @@ import (
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/neochaotic/leoflow/internal/auth"
 )
+
+// TokenRenewer re-mints a still-valid user bearer with a fresh short TTL, bounded
+// by max_lifetime since first login. *auth.JWTAuthenticator implements it via
+// RenewUserToken; the handler depends on this narrow interface so the renew route
+// can be tested without a real signing key.
+type TokenRenewer interface {
+	RenewUserToken(token string, ttl, maxLifetime time.Duration) (renewed string, ok bool, err error)
+}
 
 // breakGlass gates the credential path when the provider is OIDC (D8): only the
 // designated local admin email(s) may log in with a password; every other
@@ -108,6 +117,42 @@ func authTokenHandler(authn auth.Authenticator, limiter *auth.RateLimiter, ttlSe
 			recordBreakGlass(c, bg, tenant, username, "success")
 		}
 		c.JSON(http.StatusOK, tokenResponse{AccessToken: token, TokenType: "bearer", ExpiresIn: ttlSeconds})
+	}
+}
+
+// renewTokenHandler re-mints the caller's still-valid user bearer into a fresh
+// access token, so a long CLI/dev session never has to `leoflow auth login` again
+// on the hour (EKS validation aresta #5). It is the server half of transparent
+// renewal: the short access-token TTL is unchanged (a stolen token still lapses
+// quickly), while max_lifetime bounds how long a session may keep renewing before
+// the user must re-authenticate.
+//
+// The route sits under the public /api/v2/auth/ prefix (like login/logout), so the
+// handler is self-gating: it re-mints ONLY from a cryptographically valid,
+// unexpired, correct-audience bearer (the renewer enforces all of that), and
+// answers 401 both when the token is invalid/expired and when it is past
+// max_lifetime, so the CLI falls back to login in either case. You cannot renew
+// without already holding a valid token. The response mirrors /auth/token so the
+// same client decoder handles both.
+func renewTokenHandler(renewer TokenRenewer, ttlSeconds, maxLifetimeSeconds int) gin.HandlerFunc {
+	ttl := time.Duration(ttlSeconds) * time.Second
+	maxLifetime := time.Duration(maxLifetimeSeconds) * time.Second
+	return func(c *gin.Context) {
+		token := bearerToken(c.GetHeader("Authorization"))
+		if token == "" {
+			AbortProblem(c, http.StatusUnauthorized, "unauthorized", "missing bearer token")
+			return
+		}
+		renewed, ok, err := renewer.RenewUserToken(token, ttl, maxLifetime)
+		if err != nil {
+			AbortProblem(c, http.StatusUnauthorized, "unauthorized", "token cannot be renewed; log in again")
+			return
+		}
+		if !ok {
+			AbortProblem(c, http.StatusUnauthorized, "unauthorized", "session lifetime exceeded; log in again")
+			return
+		}
+		c.JSON(http.StatusOK, tokenResponse{AccessToken: renewed, TokenType: "bearer", ExpiresIn: ttlSeconds})
 	}
 }
 

--- a/internal/api/auth_renew_test.go
+++ b/internal/api/auth_renew_test.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+)
+
+// fakeRenewer records the renewal request and returns a canned result, so the
+// handler's status mapping can be exercised without a real signing key.
+type fakeRenewer struct {
+	renewed string
+	ok      bool
+	err     error
+
+	gotToken string
+	gotTTL   time.Duration
+	gotMax   time.Duration
+}
+
+func (f *fakeRenewer) RenewUserToken(token string, ttl, maxLifetime time.Duration) (renewed string, ok bool, err error) {
+	f.gotToken, f.gotTTL, f.gotMax = token, ttl, maxLifetime
+	return f.renewed, f.ok, f.err
+}
+
+func renewServer(r TokenRenewer) *gin.Engine {
+	return NewServer(Dependencies{
+		Logger:               discardLogger(),
+		Authenticator:        &fakeAuthn{user: &auth.User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}},
+		RateLimiter:          auth.NewRateLimiter(5, time.Minute),
+		HealthChecks:         map[string]HealthChecker{},
+		CORSOrigins:          []string{"*"},
+		TokenTTLSecs:         3600,
+		TokenRenewer:         r,
+		TokenMaxLifetimeSecs: 86400,
+	})
+}
+
+func postRenew(srv *gin.Engine, bearer string) *httptest.ResponseRecorder {
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v2/auth/token/renew", http.NoBody)
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestRenewTokenReturnsFreshToken: a valid bearer is renewed into a fresh access
+// token, returned in the same shape as /auth/token, and the handler passes the
+// configured TTL and max_lifetime to the renewer along with the caller's bearer.
+func TestRenewTokenReturnsFreshToken(t *testing.T) {
+	r := &fakeRenewer{renewed: "new-token", ok: true}
+	rec := postRenew(renewServer(r), "current-token")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("renew = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp tokenResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decoding response: %v", err)
+	}
+	if resp.AccessToken != "new-token" || resp.TokenType != "bearer" || resp.ExpiresIn != 3600 {
+		t.Errorf("response = %+v, want access_token=new-token bearer expires_in=3600", resp)
+	}
+	if r.gotToken != "current-token" {
+		t.Errorf("renewer got token %q, want the caller's bearer", r.gotToken)
+	}
+	if r.gotTTL != time.Hour {
+		t.Errorf("renewer TTL = %v, want 1h (TokenTTLSecs)", r.gotTTL)
+	}
+	if r.gotMax != 24*time.Hour {
+		t.Errorf("renewer max_lifetime = %v, want 24h (TokenMaxLifetimeSecs)", r.gotMax)
+	}
+}
+
+// TestRenewTokenInvalidIsUnauthorized: when the renewer rejects the token (bad
+// signature / expired), the handler answers 401 so the CLI falls back to login.
+func TestRenewTokenInvalidIsUnauthorized(t *testing.T) {
+	r := &fakeRenewer{err: auth.ErrInvalidToken}
+	rec := postRenew(renewServer(r), "expired-token")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("renew of invalid token = %d, want 401", rec.Code)
+	}
+}
+
+// TestRenewTokenPastMaxLifetimeIsUnauthorized: a token past the session
+// max_lifetime (renewer returns ok=false, no error) is refused with 401 — the
+// user must re-authenticate.
+func TestRenewTokenPastMaxLifetimeIsUnauthorized(t *testing.T) {
+	r := &fakeRenewer{ok: false}
+	rec := postRenew(renewServer(r), "aged-token")
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("renew past max_lifetime = %d, want 401", rec.Code)
+	}
+}

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -39,6 +39,28 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 
+  /api/v2/auth/token/renew:
+    post:
+      summary: Renew a still-valid JWT into a fresh short-lived token
+      description: >-
+        Transparent renewal: given a still-valid user bearer, re-mints the same
+        identity with a fresh short TTL, bounded by a server-side max_lifetime
+        measured from first login. Lets a long CLI/dev session avoid re-logging in
+        every token TTL while keeping the access token short-lived. Returns 401
+        when the presented token is invalid, expired, or past max_lifetime, in
+        which case the client must log in again.
+      operationId: renewToken
+      tags: [Auth]
+      responses:
+        "200":
+          description: Token renewed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokenResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
   /api/v2/users:
     get:
       summary: List users

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -42,6 +42,15 @@ type Dependencies struct {
 	// CIDR so per-client rate-limiting and audit see the real client.
 	TrustedProxies []string
 	TokenTTLSecs   int
+	// TokenRenewer re-mints a still-valid user bearer with a fresh short TTL so a
+	// long CLI/dev session need not re-login every TokenTTLSecs (aresta #5). Nil
+	// leaves the renew route unregistered (renewal simply unavailable). In practice
+	// it is the same *auth.JWTAuthenticator as Authenticator.
+	TokenRenewer TokenRenewer
+	// TokenMaxLifetimeSecs is the hard ceiling on a renewed session's total age
+	// since first login; past it, renewal is refused and the user must
+	// re-authenticate. Non-positive disables the ceiling.
+	TokenMaxLifetimeSecs int
 	// InstanceName is shown in the UI navbar (Airflow's instance_name). Empty
 	// falls back to "Leoflow"; `leoflow dev` sets it to mark the DEV environment.
 	InstanceName string
@@ -167,6 +176,13 @@ func NewServer(deps Dependencies) *gin.Engine {
 	// the allowlist is empty, newBreakGlass returns nil, and the path is unchanged.
 	bg := newBreakGlass(deps.OIDCSettings.BreakGlassEmails, deps.AuthAudit)
 	r.POST("/auth/token", authTokenHandler(deps.Authenticator, deps.RateLimiter, deps.TokenTTLSecs, bg))
+	// Transparent renewal (aresta #5): a still-valid bearer is re-minted with a
+	// fresh short TTL, bounded by max_lifetime. Under the public /api/v2/auth/
+	// prefix like login, it is self-gating — only a valid signed bearer can be
+	// renewed. Registered only when a renewer is wired.
+	if deps.TokenRenewer != nil {
+		r.POST("/api/v2/auth/token/renew", renewTokenHandler(deps.TokenRenewer, deps.TokenTTLSecs, deps.TokenMaxLifetimeSecs))
+	}
 	// The Airflow UI redirects unauthenticated users to GET /api/v2/auth/login.
 	r.GET("/api/v2/auth/login", loginPageHandler())
 	r.GET("/api/v2/auth/logout", logoutHandler())

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -25,6 +25,13 @@ type jwtClaims struct {
 	TenantID string   `json:"tenant_id"`
 	Email    string   `json:"email,omitempty"`
 	Roles    []string `json:"roles"`
+	// OriginIssuedAt records when this session's credential was FIRST minted (at
+	// login). Unlike iat, it is preserved verbatim across renewals (RenewUserToken)
+	// so the control plane can bound a session's TOTAL lifetime no matter how many
+	// times its token is transparently re-minted, mirroring the agent token's oiat
+	// (ADR 0055 Fix #4). Omitempty so a token minted before this field existed is
+	// byte-identical; renewal then falls back to iat for such a token.
+	OriginIssuedAt *jwt.NumericDate `json:"oiat,omitempty"`
 	jwt.RegisteredClaims
 }
 
@@ -118,18 +125,30 @@ func (a *JWTAuthenticator) Authenticate(ctx context.Context, token string) (*Use
 	return user, nil
 }
 
+// sign mints a fresh user token for a login: TTL is the authenticator's
+// configured lifetime and the session origin (oiat) is anchored at now.
 func (a *JWTAuthenticator) sign(user *User) (string, error) {
-	now := time.Now()
+	return a.mintUserToken(user, a.ttl, a.clock())
+}
+
+// mintUserToken signs a user token whose iat/exp are anchored at now and whose
+// preserved session origin (oiat) is `origin`. Login passes now as the origin; a
+// renewal passes the incoming token's origin so it never advances. exp is always
+// now+ttl — never accumulated onto the previous exp. It is the single write side
+// shared by login and RenewUserToken, mirroring mintAgentToken.
+func (a *JWTAuthenticator) mintUserToken(user *User, ttl time.Duration, origin time.Time) (string, error) {
+	now := a.clock()
 	c := jwtClaims{
-		TenantID: user.TenantID,
-		Email:    user.Email,
-		Roles:    user.Roles,
+		TenantID:       user.TenantID,
+		Email:          user.Email,
+		Roles:          user.Roles,
+		OriginIssuedAt: jwt.NewNumericDate(origin),
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject:   user.ID,
 			Issuer:    tokenIssuer,
 			Audience:  jwt.ClaimStrings{audienceUser},
 			IssuedAt:  jwt.NewNumericDate(now),
-			ExpiresAt: jwt.NewNumericDate(now.Add(a.ttl)),
+			ExpiresAt: jwt.NewNumericDate(now.Add(ttl)),
 		},
 	}
 	signed, err := jwt.NewWithClaims(jwt.SigningMethodHS256, c).SignedString(a.secret)
@@ -137,4 +156,51 @@ func (a *JWTAuthenticator) sign(user *User) (string, error) {
 		return "", fmt.Errorf("signing token: %w", err)
 	}
 	return signed, nil
+}
+
+// RenewUserToken validates a still-valid user bearer token and re-mints it for the
+// SAME principal (subject, tenant, email, roles) with a fresh short TTL, without
+// ever changing what Authenticate verifies (signature, issuer, leoflow-user
+// audience, HS256). It is the server half of transparent CLI token renewal (EKS
+// validation aresta #5): the short access-token TTL still bounds a stolen token,
+// while renewal keeps a genuinely live session working so a long dev session
+// never has to `leoflow auth login` again on the hour. It is modeled directly on
+// RenewAgentToken.
+//
+// The session's original login time is preserved across every renewal (the oiat
+// claim, falling back to iat for a token minted before that claim existed).
+// maxLifetime is a hard ceiling on that total age: once the session has been
+// alive longer than maxLifetime since first login, renewal is refused (ok=false,
+// empty token, no error) so the user must re-authenticate. A non-positive
+// maxLifetime disables the ceiling. exp is always now+ttl — never accumulated.
+//
+// An invalid incoming token (bad signature, wrong audience, expired) returns an
+// error and is never re-minted. Roles are copied from the incoming token, exactly
+// as they were signed; Authenticate still reloads authorization from the store on
+// every request, so a renewed token confers no more than the original did.
+func (a *JWTAuthenticator) RenewUserToken(token string, ttl, maxLifetime time.Duration) (renewed string, ok bool, err error) {
+	var c jwtClaims
+	parsed, err := jwt.ParseWithClaims(token, &c, func(*jwt.Token) (any, error) {
+		return a.secret, nil
+	}, jwt.WithIssuer(tokenIssuer), jwt.WithAudience(audienceUser), jwt.WithValidMethods([]string{"HS256"}), jwt.WithTimeFunc(a.clock))
+	if err != nil || !parsed.Valid {
+		return "", false, errors.Join(ErrInvalidToken, err)
+	}
+	// Preserve the session's first-login origin across renewals; fall back to iat
+	// for a token minted before the origin claim existed.
+	origin := time.Time{}
+	if c.OriginIssuedAt != nil {
+		origin = c.OriginIssuedAt.Time
+	} else if c.IssuedAt != nil {
+		origin = c.IssuedAt.Time
+	}
+	if maxLifetime > 0 && !origin.IsZero() && a.clock().Sub(origin) > maxLifetime {
+		return "", false, nil // past the ceiling: let the credential lapse
+	}
+	user := &User{ID: c.Subject, TenantID: c.TenantID, Email: c.Email, Roles: c.Roles}
+	renewed, err = a.mintUserToken(user, ttl, origin)
+	if err != nil {
+		return "", false, err
+	}
+	return renewed, true, nil
 }

--- a/internal/auth/user_token_renewal_test.go
+++ b/internal/auth/user_token_renewal_test.go
@@ -1,0 +1,183 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// userClaimsOf decodes a signed user token's registered + custom claims so a test
+// can assert renewal preserves identity and stamps a fresh, non-accumulating exp.
+func userClaimsOf(t *testing.T, a *JWTAuthenticator, token string) jwtClaims {
+	t.Helper()
+	var c jwtClaims
+	if _, err := jwt.ParseWithClaims(token, &c, func(*jwt.Token) (any, error) {
+		return a.secret, nil
+	}, jwt.WithIssuer(tokenIssuer), jwt.WithAudience(audienceUser), jwt.WithValidMethods([]string{"HS256"}), jwt.WithTimeFunc(a.clock)); err != nil {
+		t.Fatalf("parsing user token: %v", err)
+	}
+	return c
+}
+
+// TestRenewUserTokenShortTTLAndPreservedOrigin: a renewal for a live session
+// re-mints the SAME identity/claims with a fresh short TTL (exp = now + ttl, never
+// accumulating) while preserving the original login time (oiat) so the session's
+// total lifetime can be bounded across renewals. This is the transparent CLI
+// renewal that removes the hourly re-login (EKS validation aresta #5), modeled on
+// RenewAgentToken.
+func TestRenewUserTokenShortTTLAndPreservedOrigin(t *testing.T) {
+	a := NewJWTAuthenticator(nil, "secret", time.Hour)
+	t0 := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return t0 }
+
+	// Login mints the initial access token; its origin (oiat) is t0.
+	user := User{ID: "u1", TenantID: "default", Email: "a@b.c", Roles: []string{"admin"}}
+	issued, err := a.mintUserToken(&user, time.Hour, t0)
+	if err != nil {
+		t.Fatalf("mintUserToken: %v", err)
+	}
+	if o := userClaimsOf(t, a, issued).OriginIssuedAt; o == nil || !o.Equal(t0) {
+		t.Fatalf("issued origin = %v, want %v", o, t0)
+	}
+
+	// 55 minutes later, near expiry, the CLI silently renews.
+	t1 := t0.Add(55 * time.Minute)
+	a.now = func() time.Time { return t1 }
+	renewed, ok, err := a.RenewUserToken(issued, time.Hour, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("RenewUserToken: %v", err)
+	}
+	if !ok {
+		t.Fatal("renewal within the ceiling must succeed (ok=false)")
+	}
+
+	// The renewed token verifies unchanged (signature/issuer/leoflow-user
+	// audience/HS256, under the mock clock) and carries the same identity/claims.
+	got := userClaimsOf(t, a, renewed)
+	if got.Subject != "u1" || got.TenantID != "default" || got.Email != "a@b.c" ||
+		len(got.Roles) != 1 || got.Roles[0] != "admin" {
+		t.Errorf("renewed claims = %+v, want same identity as issued", got)
+	}
+
+	// exp = now + ttl exactly (fresh short TTL, never accumulated onto old exp),
+	// and strictly later than the original exp so the session keeps working.
+	if d := got.ExpiresAt.Sub(got.IssuedAt.Time); d != time.Hour {
+		t.Errorf("renewed exp-iat = %v, want 1h (no accumulation)", d)
+	}
+	if !got.IssuedAt.Equal(t1) {
+		t.Errorf("renewed iat = %v, want the renewal instant %v", got.IssuedAt.Time, t1)
+	}
+	origIssued := userClaimsOf(t, a, issued)
+	if !got.ExpiresAt.After(origIssued.ExpiresAt.Time) {
+		t.Errorf("renewed exp %v must be later than original exp %v", got.ExpiresAt.Time, origIssued.ExpiresAt.Time)
+	}
+
+	// Origin is preserved across the renewal — it still points at login.
+	if o := got.OriginIssuedAt; o == nil || !o.Equal(t0) {
+		t.Errorf("renewed origin = %v, want the login time %v (must not advance)", o, t0)
+	}
+}
+
+// TestRenewUserTokenRejectsExpired: an expired token is refused with an error
+// (never silently re-minted). The handler maps this to 401 so the user re-logs in.
+func TestRenewUserTokenRejectsExpired(t *testing.T) {
+	a := NewJWTAuthenticator(nil, "secret", time.Hour)
+	t0 := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return t0 }
+	user := User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}
+	// A short-lived token that is already expired by the time renewal is attempted.
+	expired, err := a.mintUserToken(&user, time.Minute, t0)
+	if err != nil {
+		t.Fatalf("mintUserToken: %v", err)
+	}
+	a.now = func() time.Time { return t0.Add(2 * time.Minute) }
+	renewed, ok, err := a.RenewUserToken(expired, time.Hour, 24*time.Hour)
+	if err == nil || ok || renewed != "" {
+		t.Errorf("renewing an expired token must error and mint nothing; got ok=%v renewed=%q err=%v", ok, renewed, err)
+	}
+	if !errors.Is(err, ErrInvalidToken) {
+		t.Errorf("expired renewal error = %v, want ErrInvalidToken", err)
+	}
+}
+
+// TestRenewUserTokenCeilingStopsRenewal: once a session has been alive past
+// max_lifetime since first login, renewal is refused (ok=false, no token, no
+// error) so the user must re-authenticate — the real security bound on a
+// transparently-renewed credential.
+func TestRenewUserTokenCeilingStopsRenewal(t *testing.T) {
+	a := NewJWTAuthenticator(nil, "secret", time.Hour)
+	t0 := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	// A token freshly minted (still valid) but whose preserved origin is 25h old.
+	a.now = func() time.Time { return t0.Add(25 * time.Hour) }
+	aged, err := a.mintUserToken(&User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}, time.Hour, t0)
+	if err != nil {
+		t.Fatalf("mintUserToken: %v", err)
+	}
+	renewed, ok, err := a.RenewUserToken(aged, time.Hour, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("RenewUserToken must not error past the ceiling: %v", err)
+	}
+	if ok || renewed != "" {
+		t.Errorf("renewal past max_lifetime must be refused with no token; got ok=%v renewed=%q", ok, renewed)
+	}
+}
+
+// TestRenewUserTokenNoCeiling: a non-positive max_lifetime disables the bound —
+// renewal always succeeds regardless of age.
+func TestRenewUserTokenNoCeiling(t *testing.T) {
+	a := NewJWTAuthenticator(nil, "secret", time.Hour)
+	t0 := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return t0.Add(1000 * time.Hour) }
+	aged, err := a.mintUserToken(&User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}, time.Hour, t0)
+	if err != nil {
+		t.Fatalf("mintUserToken: %v", err)
+	}
+	if _, ok, err := a.RenewUserToken(aged, time.Hour, 0); err != nil || !ok {
+		t.Errorf("a non-positive ceiling must never refuse renewal; got ok=%v err=%v", ok, err)
+	}
+}
+
+// TestRenewUserTokenRejectsForeignAndAgentTokens: renewal validates the incoming
+// token exactly as Authenticate does — a foreign-signed token is refused, and an
+// agent-audience token can never be renewed on the user path (audience isolation).
+func TestRenewUserTokenRejectsForeignAndAgentTokens(t *testing.T) {
+	a := NewJWTAuthenticator(nil, "secret", time.Hour)
+
+	other := NewJWTAuthenticator(nil, "different-secret", time.Hour)
+	foreign, err := other.mintUserToken(&User{ID: "u1"}, time.Hour, other.clock())
+	if err != nil {
+		t.Fatalf("mintUserToken: %v", err)
+	}
+	if _, ok, ferr := a.RenewUserToken(foreign, time.Hour, 24*time.Hour); ferr == nil || ok {
+		t.Errorf("renewing a foreign-signed token must fail; got ok=%v err=%v", ok, ferr)
+	}
+
+	agentTok, err := a.IssueAgentToken(agentIdentity(), 10*time.Minute)
+	if err != nil {
+		t.Fatalf("IssueAgentToken: %v", err)
+	}
+	if _, ok, aerr := a.RenewUserToken(agentTok, time.Hour, 24*time.Hour); aerr == nil || ok {
+		t.Errorf("an agent-audience token must not be renewable on the user path; got ok=%v err=%v", ok, aerr)
+	}
+}
+
+// TestIssueTokenStampsOrigin: a freshly issued user token carries an origin (oiat)
+// claim anchored at the issue instant, so the max_lifetime ceiling is measured
+// from first login even across later renewals.
+func TestIssueTokenStampsOrigin(t *testing.T) {
+	store := &fakeStore{user: &User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}, hash: must(HashPassword("pw"))}
+	a := NewJWTAuthenticator(store, "secret", time.Hour)
+	t0 := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return t0 }
+	tok, err := a.IssueToken(context.Background(), Credentials{Tenant: "default", Username: "u1", Password: "pw"})
+	if err != nil {
+		t.Fatalf("IssueToken: %v", err)
+	}
+	c := userClaimsOf(t, a, tok)
+	if c.OriginIssuedAt == nil || !c.OriginIssuedAt.Equal(t0) {
+		t.Errorf("issued origin = %v, want issue instant %v", c.OriginIssuedAt, t0)
+	}
+}

--- a/internal/cli/deploy.go
+++ b/internal/cli/deploy.go
@@ -191,8 +191,15 @@ func deployImageRef(cfg *domain.LeoflowConfig, version, sha string) string {
 // resolveServerToken applies the deploy auth precedence: --server/--token, then
 // LEOFLOW_* env (via the token flag default), then the persisted config written
 // by `leoflow auth login`.
+//
+// When the token comes from that persisted session file (not a --token flag or
+// LEOFLOW_TOKEN env, which are caller- or CI-managed), it is transparently
+// refreshed if near expiry and the file is rewritten with the fresh token (aresta
+// #5), so a long dev session never re-logs in every hour. The refresh is
+// best-effort: on any failure the current token is returned unchanged.
 func resolveServerToken(cmd *cobra.Command, serverFlag, tokenFlag string) (serverURL, token string, err error) {
 	serverURL, token = serverFlag, tokenFlag
+	tokenFromSession := false
 	if serverURL == "" || token == "" {
 		cfg, cerr := config.Load(configFilePath(cmd), cmd.Flags())
 		if cerr != nil {
@@ -203,7 +210,14 @@ func resolveServerToken(cmd *cobra.Command, serverFlag, tokenFlag string) (serve
 		}
 		if token == "" {
 			token = cfg.Token
+			tokenFromSession = true
 		}
+	}
+	// Only auto-refresh a file-persisted session token: a --token flag or a
+	// LEOFLOW_TOKEN env var (which config.Load also surfaces as cfg.Token) is
+	// externally managed and must never be silently rewritten.
+	if tokenFromSession && os.Getenv("LEOFLOW_TOKEN") == "" {
+		token = autoRefreshToken(cmdContext(cmd), configFilePath(cmd), serverURL, token)
 	}
 	return serverURL, token, nil
 }

--- a/internal/cli/token_refresh.go
+++ b/internal/cli/token_refresh.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/neochaotic/leoflow/internal/config"
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
+)
+
+// absoluteRenewWindow is the fallback near-expiry window used when a token carries
+// no iat (so its full lifetime is unknown): renew once it is within this window of
+// expiring. The primary rule is the halfway point of the token's own lifetime.
+const absoluteRenewWindow = 15 * time.Minute
+
+// autoRefreshToken transparently renews a near-expiry persisted session token and
+// rewrites configPath with the fresh one, so a long CLI/dev session never has to
+// `leoflow auth login` again on the hour (EKS validation aresta #5). It is the
+// client half of the short-TTL-plus-renewal design: the access token stays
+// short-lived (good security), while a genuinely live session is kept working
+// silently.
+//
+// It is strictly best-effort. When the token is not a near-expiry Leoflow JWT, or
+// the renew call fails (network, or a 401 because the session is past the
+// server's max_lifetime), the ORIGINAL token is returned unchanged and the config
+// is left untouched — the command then proceeds exactly as it does today and its
+// own 401 handling asks the user to log in again. It never fails a command.
+func autoRefreshToken(ctx context.Context, configPath, serverURL, token string) string {
+	if configPath == "" || serverURL == "" || token == "" {
+		return token
+	}
+	iat, exp, ok := tokenIssuedExpiry(token)
+	if !ok || !nearExpiry(iat, exp, time.Now()) {
+		return token
+	}
+	renewed, err := renewToken(ctx, serverURL, token)
+	if err != nil || renewed == "" {
+		return token
+	}
+	if err := config.PersistSession(configPath, serverURL, renewed); err != nil {
+		return token
+	}
+	return renewed
+}
+
+// tokenIssuedExpiry decodes a JWT's iat/exp WITHOUT verifying its signature — the
+// CLI holds the token but not the signing secret, and it only needs the timing to
+// decide when to renew (the server re-validates the signature on renew). It
+// returns ok=false for an opaque/non-JWT token or one without an exp claim, so
+// such tokens are never touched.
+func tokenIssuedExpiry(token string) (iat, exp time.Time, ok bool) {
+	var c jwt.RegisteredClaims
+	if _, _, err := jwt.NewParser().ParseUnverified(token, &c); err != nil {
+		return time.Time{}, time.Time{}, false
+	}
+	if c.ExpiresAt == nil {
+		return time.Time{}, time.Time{}, false
+	}
+	if c.IssuedAt != nil {
+		iat = c.IssuedAt.Time
+	}
+	return iat, c.ExpiresAt.Time, true
+}
+
+// nearExpiry reports whether it is time to renew: the token is at or past the
+// halfway point of its own lifetime (iat..exp). Renewing at the halfway mark keeps
+// a comfortable margin so no command ever races the expiry. When iat is unknown,
+// it falls back to renewing within absoluteRenewWindow of expiry.
+func nearExpiry(iat, exp, now time.Time) bool {
+	if iat.IsZero() || !exp.After(iat) {
+		return exp.Sub(now) <= absoluteRenewWindow
+	}
+	half := exp.Sub(iat) / 2
+	return exp.Sub(now) <= half
+}
+
+// renewToken posts to /api/v2/auth/token/renew carrying the current bearer and
+// returns the fresh access token, via the shared typed /api/v2 client (ADR 0050
+// D8) rather than hand-rolling HTTP. A non-200 (notably 401 past max_lifetime)
+// is an error, so the caller falls back to the current token.
+func renewToken(ctx context.Context, serverURL, token string) (string, error) {
+	c, err := apiclient.New(serverURL, token)
+	if err != nil {
+		return "", err
+	}
+	resp, err := c.RenewTokenWithResponse(ctx)
+	if err != nil {
+		return "", fmt.Errorf("posting to %s/api/v2/auth/token/renew: %w", serverURL, err)
+	}
+	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil || resp.JSON200.AccessToken == nil {
+		return "", fmt.Errorf("renew returned %d", resp.StatusCode())
+	}
+	return *resp.JSON200.AccessToken, nil
+}

--- a/internal/cli/token_refresh_test.go
+++ b/internal/cli/token_refresh_test.go
@@ -1,0 +1,146 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/neochaotic/leoflow/internal/config"
+)
+
+// testJWT builds a signed HS256 token carrying the given iat/exp. autoRefreshToken
+// reads those claims WITHOUT verifying the signature, so any secret works here.
+func testJWT(t *testing.T, iat, exp time.Time) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.RegisteredClaims{
+		Subject:   "u1",
+		IssuedAt:  jwt.NewNumericDate(iat),
+		ExpiresAt: jwt.NewNumericDate(exp),
+	})
+	s, err := tok.SignedString([]byte("test-secret"))
+	if err != nil {
+		t.Fatalf("signing test JWT: %v", err)
+	}
+	return s
+}
+
+// TestAutoRefreshTokenRenewsNearExpiry: a persisted session token past the halfway
+// point of its life is transparently renewed against the control plane, and the
+// fresh token is written back to the config file — no prompt, no re-login (aresta
+// #5). The renew call carries the current bearer.
+func TestAutoRefreshTokenRenewsNearExpiry(t *testing.T) {
+	now := time.Now()
+	old := testJWT(t, now.Add(-55*time.Minute), now.Add(5*time.Minute)) // 5m left of a 60m TTL
+
+	var called bool
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/auth/token/renew" {
+			t.Errorf("renew posted to %q, want /api/v2/auth/token/renew", r.URL.Path)
+		}
+		called = true
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"renewed-jwt","token_type":"bearer","expires_in":3600}`)
+	}))
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := config.PersistSession(cfgPath, srv.URL, old); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+
+	got := autoRefreshToken(context.Background(), cfgPath, srv.URL, old)
+	if !called {
+		t.Fatal("a near-expiry token must trigger a renew call")
+	}
+	if got != "renewed-jwt" {
+		t.Errorf("returned token = %q, want renewed-jwt", got)
+	}
+	if gotAuth != "Bearer "+old {
+		t.Errorf("renew Authorization = %q, want the current bearer", gotAuth)
+	}
+	cfg, err := config.Load(cfgPath, nil)
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if cfg.Token != "renewed-jwt" {
+		t.Errorf("persisted token = %q, want the renewed one", cfg.Token)
+	}
+}
+
+// TestAutoRefreshTokenSkipsHealthyToken: a token with plenty of life left is not
+// renewed — no network call, config untouched.
+func TestAutoRefreshTokenSkipsHealthyToken(t *testing.T) {
+	now := time.Now()
+	healthy := testJWT(t, now, now.Add(60*time.Minute)) // full life ahead
+
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("a healthy token must NOT trigger a renew call")
+	}))
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := config.PersistSession(cfgPath, srv.URL, healthy); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+
+	if got := autoRefreshToken(context.Background(), cfgPath, srv.URL, healthy); got != healthy {
+		t.Errorf("returned token = %q, want the unchanged healthy token", got)
+	}
+	cfg, _ := config.Load(cfgPath, nil)
+	if cfg.Token != healthy {
+		t.Errorf("config token changed to %q, want it untouched", cfg.Token)
+	}
+}
+
+// TestAutoRefreshTokenFallsBackOnRenewFailure: when renewal fails (e.g. past
+// max_lifetime -> 401), the original token is returned and the config is left
+// untouched, so the command proceeds and its own 401 handling asks the user to log
+// in again — never worse than today's behavior.
+func TestAutoRefreshTokenFallsBackOnRenewFailure(t *testing.T) {
+	now := time.Now()
+	old := testJWT(t, now.Add(-55*time.Minute), now.Add(5*time.Minute))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := config.PersistSession(cfgPath, srv.URL, old); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+
+	if got := autoRefreshToken(context.Background(), cfgPath, srv.URL, old); got != old {
+		t.Errorf("on renew failure, returned %q, want the original token", got)
+	}
+	cfg, _ := config.Load(cfgPath, nil)
+	if cfg.Token != old {
+		t.Errorf("config token = %q, want the original (untouched on failure)", cfg.Token)
+	}
+}
+
+// TestAutoRefreshTokenIgnoresNonJWT: a token that is not a decodable JWT (e.g. an
+// opaque CI token) is returned as-is with no network call — refresh only applies
+// to leoflow's own expiring JWTs.
+func TestAutoRefreshTokenIgnoresNonJWT(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("a non-JWT token must NOT trigger a renew call")
+	}))
+	defer srv.Close()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := config.PersistSession(cfgPath, srv.URL, "opaque-ci-token"); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	if got := autoRefreshToken(context.Background(), cfgPath, srv.URL, "opaque-ci-token"); got != "opaque-ci-token" {
+		t.Errorf("returned %q, want the opaque token unchanged", got)
+	}
+}

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -402,6 +402,16 @@ type AuthSection struct {
 type JWTSection struct {
 	Secret          string `mapstructure:"secret"`
 	TokenTTLSeconds int    `mapstructure:"token_ttl_seconds"`
+	// MaxLifetimeSeconds is the hard ceiling on how long a user session may be kept
+	// alive by transparent token renewal (aresta #5), measured since first login
+	// (the token's oiat claim). Past it, POST /api/v2/auth/token/renew is refused
+	// and the user must `leoflow auth login` again. The short TokenTTLSeconds still
+	// bounds a stolen token independently; this only caps the total renewed
+	// lifetime, mirroring auth.max_attempt_credential_lifetime for agent tokens.
+	// Generous by default (24h) so a normal dev day never re-logs in mid-session; a
+	// non-positive value disables the ceiling (renewal never expires the session).
+	// Bind via LEOFLOW_AUTH_JWT_MAX_LIFETIME_SECONDS.
+	MaxLifetimeSeconds int `mapstructure:"max_lifetime_seconds"`
 }
 
 // OIDCSection configures the OIDC/SSO login flow (Authorization Code + PKCE).
@@ -535,10 +545,16 @@ var serverDefaults = map[string]any{
 	// Registered so AutomaticEnv binds LEOFLOW_REDIS_CA_FILE (the Helm chart sets
 	// it when redis.caConfigMap is configured); without it, verified TLS to a
 	// managed rediss:// endpoint silently falls back to system roots only (#725).
-	"redis.ca_file":                    "",
-	"auth.provider":                    "jwt",
-	"auth.jwt.secret":                  "",
-	"auth.jwt.token_ttl_seconds":       3600,
+	"redis.ca_file":              "",
+	"auth.provider":              "jwt",
+	"auth.jwt.secret":            "",
+	"auth.jwt.token_ttl_seconds": 3600,
+	// Ceiling on a transparently-renewed user session's total lifetime (aresta #5).
+	// 24h mirrors auth.max_attempt_credential_lifetime: a normal dev day renews
+	// silently, and a session must re-authenticate at most once per day. The short
+	// token_ttl_seconds is what bounds a stolen token; this only caps total renewed
+	// age. A non-positive value disables the ceiling.
+	"auth.jwt.max_lifetime_seconds":    86400,
 	"auth.login_rate_limit_per_minute": 5,
 	// Secret scope-by-declaration and token-liveness policies (ADR 0055). Both
 	// ship SAFE by default: permissive delivers the whole tenant vault (today's

--- a/pkg/client/client.gen.go
+++ b/pkg/client/client.gen.go
@@ -499,6 +499,13 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 // The interface specification for the client above.
 type ClientInterface interface {
 
+	// RenewToken Renew a still-valid JWT into a fresh short-lived token
+	//
+	// Transparent renewal: given a still-valid user bearer, re-mints the same identity with a fresh short TTL, bounded by a server-side max_lifetime measured from first login. Lets a long CLI/dev session avoid re-logging in every token TTL while keeping the access token short-lived. Returns 401 when the presented token is invalid, expired, or past max_lifetime, in which case the client must log in again.
+	//
+	// Corresponds with POST /api/v2/auth/token/renew (the `RenewToken` operationId).
+	RenewToken(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetDagSource Get a DAG's source (the dag.py text)
 	//
 	// Corresponds with GET /api/v2/dagSources/{dag_id} (the `GetDagSource` operationId).
@@ -670,6 +677,23 @@ type ClientInterface interface {
 	//
 	// Corresponds with GET /readyz (the `GetReadyz` operationId).
 	GetReadyz(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+}
+
+// RenewToken Renew a still-valid JWT into a fresh short-lived token
+//
+// Transparent renewal: given a still-valid user bearer, re-mints the same identity with a fresh short TTL, bounded by a server-side max_lifetime measured from first login. Lets a long CLI/dev session avoid re-logging in every token TTL while keeping the access token short-lived. Returns 401 when the presented token is invalid, expired, or past max_lifetime, in which case the client must log in again.
+//
+// Corresponds with POST /api/v2/auth/token/renew (the `RenewToken` operationId).
+func (c *Client) RenewToken(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRenewTokenRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
 }
 
 // GetDagSource Get a DAG's source (the dag.py text)
@@ -1122,6 +1146,33 @@ func (c *Client) GetReadyz(ctx context.Context, reqEditors ...RequestEditorFn) (
 		return nil, err
 	}
 	return c.Client.Do(req)
+}
+
+// NewRenewTokenRequest constructs an http.Request for the RenewToken method
+func NewRenewTokenRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v2/auth/token/renew")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
 }
 
 // NewGetDagSourceRequest constructs an http.Request for the GetDagSource method
@@ -2194,6 +2245,15 @@ func WithBaseURL(baseURL string) ClientOption {
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
 
+	// RenewTokenWithResponse Renew a still-valid JWT into a fresh short-lived token
+	//
+	// Transparent renewal: given a still-valid user bearer, re-mints the same identity with a fresh short TTL, bounded by a server-side max_lifetime measured from first login. Lets a long CLI/dev session avoid re-logging in every token TTL while keeping the access token short-lived. Returns 401 when the presented token is invalid, expired, or past max_lifetime, in which case the client must log in again.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with POST /api/v2/auth/token/renew (the `RenewToken` operationId).
+	RenewTokenWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*RenewTokenResponse, error)
+
 	// GetDagSourceWithResponse Get a DAG's source (the dag.py text)
 	//
 	// Returns a wrapper object for the known response body format(s).
@@ -2401,6 +2461,54 @@ type ClientWithResponsesInterface interface {
 	//
 	// Corresponds with GET /readyz (the `GetReadyz` operationId).
 	GetReadyzWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetReadyzResponse, error)
+}
+
+type RenewTokenResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *TokenResponse
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *Unauthorized
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r RenewTokenResponse) GetJSON200() *TokenResponse {
+	return r.JSON200
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r RenewTokenResponse) GetJSON401() *Unauthorized {
+	return r.JSON401
+}
+
+// GetBody returns the raw response body bytes
+func (r RenewTokenResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r RenewTokenResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RenewTokenResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r RenewTokenResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
 }
 
 type GetDagSourceResponse struct {
@@ -3402,6 +3510,21 @@ func (r GetReadyzResponse) ContentType() string {
 	return ""
 }
 
+// RenewTokenWithResponse Renew a still-valid JWT into a fresh short-lived token
+//
+// Transparent renewal: given a still-valid user bearer, re-mints the same identity with a fresh short TTL, bounded by a server-side max_lifetime measured from first login. Lets a long CLI/dev session avoid re-logging in every token TTL while keeping the access token short-lived. Returns 401 when the presented token is invalid, expired, or past max_lifetime, in which case the client must log in again.
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with POST /api/v2/auth/token/renew (the `RenewToken` operationId).
+func (c *ClientWithResponses) RenewTokenWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*RenewTokenResponse, error) {
+	rsp, err := c.RenewToken(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRenewTokenResponse(rsp)
+}
+
 // GetDagSourceWithResponse Get a DAG's source (the dag.py text)
 //
 // Returns a wrapper object for the known response body format(s).
@@ -3776,6 +3899,39 @@ func (c *ClientWithResponses) GetReadyzWithResponse(ctx context.Context, reqEdit
 		return nil, err
 	}
 	return ParseGetReadyzResponse(rsp)
+}
+
+// ParseRenewTokenResponse parses an HTTP response from a RenewTokenWithResponse call
+func ParseRenewTokenResponse(rsp *http.Response) (*RenewTokenResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RenewTokenResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest TokenResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
 }
 
 // ParseGetDagSourceResponse parses an HTTP response from a GetDagSourceWithResponse call

--- a/website/static/openapi.yaml
+++ b/website/static/openapi.yaml
@@ -39,6 +39,28 @@ paths:
         "401":
           $ref: "#/components/responses/Unauthorized"
 
+  /api/v2/auth/token/renew:
+    post:
+      summary: Renew a still-valid JWT into a fresh short-lived token
+      description: >-
+        Transparent renewal: given a still-valid user bearer, re-mints the same
+        identity with a fresh short TTL, bounded by a server-side max_lifetime
+        measured from first login. Lets a long CLI/dev session avoid re-logging in
+        every token TTL while keeping the access token short-lived. Returns 401
+        when the presented token is invalid, expired, or past max_lifetime, in
+        which case the client must log in again.
+      operationId: renewToken
+      tags: [Auth]
+      responses:
+        "200":
+          description: Token renewed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TokenResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
   /api/v2/users:
     get:
       summary: List users


### PR DESCRIPTION
## Problem

The CLI access token has a 1h TTL (`auth.jwt.token_ttl_seconds: 3600`) and there was **no user-token refresh**, so a long dev session had to run `leoflow auth login` again every hour. Surfaced by **EKS validation aresta #5**; the maintainer's preferred fix is *transparent renewal* — silently refresh the token before it expires so the user never re-logs in, keeping the access token short-lived (good security) while removing the friction. A longer TTL was only a weaker fallback and is deliberately **not** used here.

## Design — renew endpoint (modeled on `RenewAgentToken`)

The proven in-repo pattern for the agent token (`internal/auth/agent_token.go` `RenewAgentToken`, ADR 0055 Fix #4) is short-TTL + sliding re-mint bounded by a max-lifetime. This mirrors it for the user token:

- **`auth.RenewUserToken(token, ttl, maxLifetime)`** validates a still-valid user bearer (signature, issuer, `leoflow-user` audience, HS256, not expired) and re-mints the **same principal** (subject/tenant/email/roles) with `exp = now + ttl` (never accumulated).
- A new **`oiat`** claim records the session's first-login time. It is preserved verbatim across every renewal (falling back to `iat` for tokens minted before the claim existed), so the total session age can be bounded regardless of how many times the token is re-minted. `sign()` now stamps `oiat` via a shared `mintUserToken` helper.
- Renewal is refused once the session is older than **`max_lifetime`** (`ok=false`, no token) — the real security bound. An expired/foreign/agent-audience token returns `ErrInvalidToken` and is never re-minted.
- **`POST /api/v2/auth/token/renew`** (`renewTokenHandler`) returns a fresh token for a valid bearer and **401** when the token is invalid/expired or past `max_lifetime`. It sits under the public `/api/v2/auth/` prefix like login and is self-gating: only a cryptographically valid, unexpired, correct-audience bearer can be renewed. Response mirrors `/auth/token`.
- Config: **`auth.jwt.max_lifetime_seconds`**, default **86400 (24h)**, mirroring `auth.max_attempt_credential_lifetime`; non-positive disables the ceiling. Wired in `cmd/leoflow-server/main.go` (the authenticator is passed as the renewer).

## CLI auto-refresh hook

`autoRefreshToken` (wired into `resolveServerToken`) decodes the persisted token's `iat`/`exp` **without verifying** (the CLI holds the token, not the secret), and once the token passes the **halfway point of its own lifetime** calls the renew endpoint (via the typed `pkg/client`, ADR 0050 D8) and rewrites `~/.leoflow/config.yaml` — no prompt, no user action. It only ever touches a **file-persisted session** token (never a `--token` flag or `LEOFLOW_TOKEN` env, which are CI-managed) and is strictly **best-effort**: on any failure it returns the current token so the command falls back to today's behavior (its own 401 → "run `auth login`"). Opaque non-JWT tokens are ignored.

## Red → green (strict TDD)

Tests committed first (`test(auth): red tests…`, commit before impl), then the minimal implementation:

- **Server** (`internal/auth`): valid renewal → new token, later expiry, same subject/claims, origin preserved, `exp = now + ttl` (no accumulation); expired → `ErrInvalidToken`; past `max_lifetime` → refused (`ok=false`, no token); disabled ceiling → always renews; foreign/agent-audience token → refused. Plus login stamps `oiat`.
- **API** (`internal/api`): valid bearer → 200 fresh token (handler passes the configured TTL + max_lifetime and the caller's bearer to the renewer); invalid → 401; past max_lifetime → 401.
- **CLI** (`internal/cli`): near-expiry stored token → renew called + refreshed token persisted; healthy token → no call, config untouched; renew failure → original token kept; non-JWT → ignored.

## Pre-push gate (all green)

```
$ go build ./...            # OK
$ go vet ./...              # OK
$ golangci-lint run ./...   # 0 issues.
$ go test ./internal/auth/... ./internal/api/... ./internal/cli/...
ok  github.com/neochaotic/leoflow/internal/auth
ok  github.com/neochaotic/leoflow/internal/api
ok  github.com/neochaotic/leoflow/internal/cli
```

`make pkg-client` regenerated `pkg/client` from the spec (idempotent; only the `renewToken` op added). The OpenAPI spec was updated in all three copies; `redocly lint` runs in CI (unavailable offline here). The committed gomarkdoc Go-reference tree is CI-regenerated on the website build and was left untouched.

## Security considerations for the maintainer

- **`max_lifetime` default = 24h.** A normal dev day renews silently and re-authenticates at most once/day. If multi-day sessions are common, consider raising it (e.g. 168h); the short `token_ttl_seconds` is what actually bounds a stolen token, so a larger ceiling trades only re-login cadence, not token blast radius. A value ≤ 0 disables the ceiling (renewal never forces re-login) — offered but not recommended for enterprise.
- **Renewal validates crypto only** (parity with `RenewAgentToken`) — it does not reload the store. Revocation is still enforced on every real request by `Authenticate`'s per-request store reload (deactivated/deleted users are rejected within the access-token TTL), and `max_lifetime` bounds the renewal window, so renewal cannot retain privileges or outlive deactivation in practice.
- The renew route is **self-gating** (only a valid signed bearer renews); no credentials cross it.

References **EKS validation aresta #5**.
