### PR TITLE
docs(readme): fix broken images after Hugo migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/assets/icon-256.png" alt="Leoflow" width="140">
+  <img src="website/static/assets/icon-256.png" alt="Leoflow" width="140">
 </p>
 
 <h1 align="center">Leoflow</h1>
@@ -46,7 +46,7 @@
 
 <p align="center">
   <a href="https://neochaotic.github.io/leoflow/">
-    <img src="docs/assets/screenshots/dev-grid-tasks.png" alt="Leoflow running the Apache Airflow 3.2 UI — a DAG's grid view, task list, and run-duration overview" width="860">
+    <img src="website/static/assets/screenshots/dev-grid-tasks.png" alt="Leoflow running the Apache Airflow 3.2 UI — a DAG's grid view, task list, and run-duration overview" width="860">
   </a>
 </p>
 


### PR DESCRIPTION
The Hugo migration removed `docs/assets/`, 404-ing the README logo and the Airflow-UI screenshot on GitHub. Both assets exist under `website/static/assets/` with identical names; repointed the two `<img src>`. Verified both target files exist in-repo.