### PR TITLE
release: promote v0.4.0-rc.4 to v0.4.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-08-26
+
 ### Added
 
 - **Transparent CLI token renewal — no more hourly re-login (#755).** The CLI now

--- a/helm/leoflow/Chart.yaml
+++ b/helm/leoflow/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version is the chart version; appVersion tracks the leoflow-server image.
 # Both move in lockstep with the release tag (ADR 0028); decouple only if the
 # chart ever needs a cadence of its own for a template-only fix.
-version: 0.4.0-rc.4
-appVersion: "0.4.0-rc.4"
+version: 0.4.0
+appVersion: "0.4.0"
 home: https://github.com/neochaotic/leoflow
 sources:
   - https://github.com/neochaotic/leoflow

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -1,6 +1,6 @@
 # leoflow
 
-![Version: 0.4.0-rc.4](https://img.shields.io/badge/Version-0.4.0--rc.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0-rc.4](https://img.shields.io/badge/AppVersion-0.4.0--rc.4-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
 
 Leoflow control plane — a GitOps-first, container-native workflow orchestrator (Airflow 3.2.x UI/API compatible).
 


### PR DESCRIPTION
Promote the EKS-validated v0.4.0-rc.4 to the v0.4.0 stable release: Chart.yaml version+appVersion → 0.4.0 (README regenerated), CHANGELOG [Unreleased] → [0.4.0]. GA adds only the README image fix (#758, doc-only) over the tagged rc.4 commit. All check scripts + chart-version gate + helm lint + go build green.