### PR TITLE
feat(cli): leoflow runs logs — read a task attempt's logs from the CLI

### DIFF
--- a/internal/cli/runs.go
+++ b/internal/cli/runs.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -24,7 +25,7 @@ func newRunsCommand() *cobra.Command {
 	// command the operator alias `admin runs list` is built from, so the two
 	// share one lister, one set of flags (--state/--dag/--older-than), and one
 	// output format — no duplicated API calls.
-	cmd.AddCommand(newRunsTriggerCommand(), newRunsStatusCommand(), newAdminRunsListCommand())
+	cmd.AddCommand(newRunsTriggerCommand(), newRunsStatusCommand(), newRunsLogsCommand(), newAdminRunsListCommand())
 	return cmd
 }
 
@@ -133,6 +134,118 @@ func decodeRun(ctx context.Context, url, token string) (state, id string, err er
 	return r.State, r.DagRunID, nil
 }
 
+// newRunsLogsCommand builds `leoflow runs logs <dag_id> <run_id> <task_id>`:
+// read one task attempt's logs from the CLI. The logs already exist end to end —
+// the agent captures stdout/stderr, the control plane persists and serves them
+// at the Airflow-compatible taskInstances logs route — but until now only the
+// web UI could read them, leaving a CLI/agent workflow with no path in.
+//
+// The task_id is required (not listed-when-omitted): it keeps this command a
+// single, predictable stream, consistent with `runs status` requiring its
+// dag_id. `--try` defaults to the task instance's current try_number, so the
+// common case ("show me the latest attempt") needs no attempt bookkeeping.
+// `--follow` streams live because the endpoint tails a running attempt.
+func newRunsLogsCommand() *cobra.Command {
+	var serverURL, token string
+	var try int
+	var follow bool
+	cmd := &cobra.Command{
+		Use:   "logs <dag_id> <run_id> <task_id>",
+		Short: "Stream a task attempt's logs (the latest attempt by default).",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			base, bearer, err := resolveServerToken(cmd, serverURL, token)
+			if err != nil {
+				return err
+			}
+			ctx := cmdContext(cmd)
+			dagID, runID, taskID := args[0], args[1], args[2]
+			attempt := try
+			if attempt <= 0 {
+				attempt, err = latestTryNumber(ctx, base, bearer, dagID, runID, taskID)
+				if err != nil {
+					return err
+				}
+			}
+			return streamTaskLogs(ctx, cmd.OutOrStdout(), base, bearer, dagID, runID, taskID, attempt, follow)
+		},
+	}
+	addRunsFlags(cmd, &serverURL, &token)
+	cmd.Flags().IntVar(&try, "try", 0, "attempt number to read (default: the task's latest attempt)")
+	cmd.Flags().BoolVarP(&follow, "follow", "f", false, "keep streaming new log lines while the task is still running")
+	return cmd
+}
+
+// taskInstanceURL builds the Airflow-compatible task-instance base path shared
+// by the instance lookup and the logs sub-resource.
+func taskInstanceURL(base, dagID, runID, taskID string) string {
+	return strings.TrimRight(base, "/") + "/api/v2/dags/" + dagID +
+		"/dagRuns/" + runID + "/taskInstances/" + taskID
+}
+
+// latestTryNumber resolves the attempt to read when --try is omitted, from the
+// task instance's current try_number. A task that has not recorded an attempt
+// (nil/zero try_number) still has its first attempt served under try 1, so we
+// fall back to 1 rather than erroring.
+func latestTryNumber(ctx context.Context, base, token, dagID, runID, taskID string) (int, error) {
+	status, raw, err := apiRequest(ctx, http.MethodGet, taskInstanceURL(base, dagID, runID, taskID), token, nil)
+	if err != nil {
+		return 0, err
+	}
+	if status >= http.StatusMultipleChoices {
+		return 0, fmt.Errorf("server returned %d: %s", status, raw)
+	}
+	var ti struct {
+		TryNumber *int `json:"try_number"`
+	}
+	if jerr := json.Unmarshal(raw, &ti); jerr != nil {
+		return 0, fmt.Errorf("parsing task instance: %w", jerr)
+	}
+	if ti.TryNumber == nil || *ti.TryNumber < 1 {
+		return 1, nil
+	}
+	return *ti.TryNumber, nil
+}
+
+// streamTaskLogs streams one attempt's logs to w. It reuses newAPIRequest's
+// bearer-token injection (the same auth path as apiRequest) but copies the body
+// through as a stream rather than buffering, so `--follow` shows live lines as
+// the endpoint tails a running attempt. The endpoint answers an attempt with no
+// stored logs with a 200 and the "No logs available for this attempt." body,
+// which therefore passes straight through here.
+func streamTaskLogs(ctx context.Context, w io.Writer, base, token, dagID, runID, taskID string, try int, follow bool) error {
+	url := taskInstanceURL(base, dagID, runID, taskID) + "/logs/" + strconv.Itoa(try)
+	if follow {
+		url += "?follow=true"
+	}
+	req, err := newAPIRequest(ctx, http.MethodGet, url, token, nil)
+	if err != nil {
+		return err
+	}
+	// No client timeout: a followed stream is intentionally long-lived, and an
+	// un-followed read completes as soon as the body is drained.
+	resp, err := (&http.Client{}).Do(req)
+	if err != nil {
+		return fmt.Errorf("requesting %s: %w", url, err)
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("closing response: %w", cerr)
+		}
+	}()
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		raw, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return fmt.Errorf("server returned %d (and its error body could not be read: %w)", resp.StatusCode, readErr)
+		}
+		return fmt.Errorf("server returned %d: %s", resp.StatusCode, raw)
+	}
+	if _, err = io.Copy(w, resp.Body); err != nil {
+		return fmt.Errorf("streaming logs: %w", err)
+	}
+	return nil
+}
+
 // addRunsFlags registers the --server/--token flags shared by the runs
 // subcommands. The token default carries LEOFLOW_TOKEN so that resolveServerToken
 // falls back to the persisted session only when neither flag nor env supplies one.
@@ -141,22 +254,33 @@ func addRunsFlags(cmd *cobra.Command, serverURL, token *string) {
 	cmd.Flags().StringVar(token, "token", os.Getenv("LEOFLOW_TOKEN"), "JWT bearer token (default: config token)")
 }
 
-// apiRequest performs a JSON HTTP request to the control plane and returns the
-// status code and raw body.
-func apiRequest(ctx context.Context, method, url, token string, body []byte) (status int, raw []byte, err error) {
+// newAPIRequest builds a control-plane request with the shared bearer-token
+// injection, so every call path (buffered apiRequest and the streaming logs
+// reader) authenticates identically.
+func newAPIRequest(ctx context.Context, method, url, token string, body []byte) (*http.Request, error) {
 	var reader io.Reader
 	if body != nil {
 		reader = bytes.NewReader(body)
 	}
 	req, err := http.NewRequestWithContext(ctx, method, url, reader)
 	if err != nil {
-		return 0, nil, fmt.Errorf("building request: %w", err)
+		return nil, fmt.Errorf("building request: %w", err)
 	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return req, nil
+}
+
+// apiRequest performs a JSON HTTP request to the control plane and returns the
+// status code and raw body.
+func apiRequest(ctx context.Context, method, url, token string, body []byte) (status int, raw []byte, err error) {
+	req, err := newAPIRequest(ctx, method, url, token, body)
+	if err != nil {
+		return 0, nil, err
 	}
 	resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
 	if err != nil {

--- a/internal/cli/runs_test.go
+++ b/internal/cli/runs_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -160,6 +161,143 @@ func TestRunsTriggerEnvTokenBeatsConfig(t *testing.T) {
 	}
 	if *gotAuth != "Bearer env-token" {
 		t.Errorf("auth = %q, want the env var to win over config (Bearer env-token)", *gotAuth)
+	}
+}
+
+// logsServer mounts the Airflow-compatible task-instance endpoints the
+// `runs logs` command talks to: the single task-instance lookup (which carries
+// try_number, used to resolve the latest attempt) and the catch-all logs route
+// (`.../logs/{try}`). Each attempt's body is keyed by its try number so a test
+// can prove which attempt was streamed; the special try -1 stands in for the
+// graceful "no logs" passthrough. It records the last logs path + Authorization
+// header it served.
+func logsServer(t *testing.T, tryNumber int, bodyByTry map[int]string) (srv *httptest.Server, gotLogsPath, gotAuth *string) {
+	t.Helper()
+	var logsPath, auth string
+	mux := http.NewServeMux()
+	// GET .../taskInstances/etl-task -> the instance, carrying its try_number.
+	mux.HandleFunc("/api/v2/dags/etl/dagRuns/run-1/taskInstances/etl-task",
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/v2/dags/etl/dagRuns/run-1/taskInstances/etl-task" {
+				http.NotFound(w, r)
+				return
+			}
+			_, _ = w.Write([]byte(`{"task_id":"etl-task","try_number":` + itoa(tryNumber) + `}`))
+		})
+	// GET .../taskInstances/etl-task/logs/{try} -> the attempt's plain-text logs.
+	mux.HandleFunc("/api/v2/dags/etl/dagRuns/run-1/taskInstances/etl-task/logs/",
+		func(w http.ResponseWriter, r *http.Request) {
+			logsPath = r.URL.Path
+			auth = r.Header.Get("Authorization")
+			try := 0
+			_, _ = fmt.Sscanf(strings.TrimPrefix(r.URL.Path,
+				"/api/v2/dags/etl/dagRuns/run-1/taskInstances/etl-task/logs/"), "%d", &try)
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			if body, ok := bodyByTry[try]; ok {
+				_, _ = w.Write([]byte(body))
+				return
+			}
+			_, _ = w.Write([]byte("No logs available for this attempt.\n"))
+		})
+	srv = httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, &logsPath, &auth
+}
+
+func itoa(n int) string { return fmt.Sprintf("%d", n) }
+
+// TestRunsLogsRegistered pins that `leoflow runs logs` exists as a subcommand
+// under `runs`, next to `trigger`/`status`/`list`.
+func TestRunsLogsRegistered(t *testing.T) {
+	root := NewRootCommand()
+	cmd, _, err := root.Find([]string{"runs", "logs"})
+	if err != nil {
+		t.Fatalf("finding `runs logs`: %v", err)
+	}
+	if cmd.Name() != "logs" {
+		t.Fatalf("`runs logs` resolved to %q, want a registered `logs` subcommand", cmd.Name())
+	}
+}
+
+// TestRunsLogsStreamsAttempt proves the command hits the task-instance logs
+// endpoint for the requested --try, injects the bearer token, and streams the
+// body to stdout.
+func TestRunsLogsStreamsAttempt(t *testing.T) {
+	srv, gotPath, gotAuth := logsServer(t, 2, map[int]string{2: "boot\nrunning task\ndone\n"})
+
+	out, _, err := run(t, "runs", "logs", "etl", "run-1", "etl-task",
+		"--try", "2", "--server", srv.URL, "--token", "jwt-xyz")
+	if err != nil {
+		t.Fatalf("runs logs: %v", err)
+	}
+	if *gotPath != "/api/v2/dags/etl/dagRuns/run-1/taskInstances/etl-task/logs/2" {
+		t.Errorf("hit %q, want the try-2 logs endpoint", *gotPath)
+	}
+	if *gotAuth != "Bearer jwt-xyz" {
+		t.Errorf("auth = %q, want Bearer jwt-xyz", *gotAuth)
+	}
+	if !strings.Contains(out, "running task") || !strings.Contains(out, "done") {
+		t.Errorf("output = %q, want the streamed log body", out)
+	}
+}
+
+// TestRunsLogsDefaultsToLatestTry proves that with no --try the command reads
+// the task instance's current try_number and streams that attempt.
+func TestRunsLogsDefaultsToLatestTry(t *testing.T) {
+	srv, gotPath, _ := logsServer(t, 3, map[int]string{3: "third attempt output\n"})
+
+	out, _, err := run(t, "runs", "logs", "etl", "run-1", "etl-task",
+		"--server", srv.URL, "--token", "t")
+	if err != nil {
+		t.Fatalf("runs logs (default try): %v", err)
+	}
+	if *gotPath != "/api/v2/dags/etl/dagRuns/run-1/taskInstances/etl-task/logs/3" {
+		t.Errorf("hit %q, want the latest attempt (try 3) resolved from the task instance", *gotPath)
+	}
+	if !strings.Contains(out, "third attempt output") {
+		t.Errorf("output = %q, want the latest attempt's logs", out)
+	}
+}
+
+// TestRunsLogsNoLogsMessagePassesThrough proves the endpoint's graceful
+// "No logs available for this attempt." body reaches stdout as-is, not an error.
+func TestRunsLogsNoLogsMessagePassesThrough(t *testing.T) {
+	srv, _, _ := logsServer(t, 1, map[int]string{}) // no body for any try -> the graceful message
+
+	out, _, err := run(t, "runs", "logs", "etl", "run-1", "etl-task",
+		"--try", "1", "--server", srv.URL, "--token", "t")
+	if err != nil {
+		t.Fatalf("the no-logs path must not error, got %v", err)
+	}
+	if !strings.Contains(out, "No logs available for this attempt.") {
+		t.Errorf("output = %q, want the graceful no-logs message passed through", out)
+	}
+}
+
+// TestRunsLogsUsesConfigToken is the logs-side counterpart of the trigger/status
+// config-token tests: a logged-in session's persisted token must reach the
+// endpoint without repeating the credential.
+func TestRunsLogsUsesConfigToken(t *testing.T) {
+	srv, _, gotAuth := logsServer(t, 1, map[int]string{1: "ok\n"})
+	cfgPath := seedSessionConfig(t, srv.URL, "jwt-from-config")
+
+	if _, _, err := run(t, "runs", "logs", "etl", "run-1", "etl-task", "--try", "1", "--config", cfgPath); err != nil {
+		t.Fatalf("runs logs with a logged-in session: %v", err)
+	}
+	if *gotAuth != "Bearer jwt-from-config" {
+		t.Errorf("auth = %q, want the token persisted by login (Bearer jwt-from-config)", *gotAuth)
+	}
+}
+
+// TestRunsLogsErrorsOnServerFailure pins that a non-2xx (that is not the
+// graceful no-logs 200) surfaces as a CLI error rather than empty success.
+func TestRunsLogsErrorsOnServerFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	if _, _, err := run(t, "runs", "logs", "etl", "run-1", "etl-task", "--try", "1", "--server", srv.URL); err == nil {
+		t.Error("a non-2xx logs response should error")
 	}
 }
 

--- a/website/content/reference/cli/leoflow_runs.md
+++ b/website/content/reference/cli/leoflow_runs.md
@@ -28,6 +28,7 @@ Trigger and inspect DAG runs.
 
 * [leoflow](/reference/cli/leoflow/)	 - Leoflow is a GitOps-first, container-native workflow orchestrator.
 * [leoflow runs list](/reference/cli/leoflow_runs_list/)	 - List DAG runs, filtered by --state, --older-than, and/or --dag.
+* [leoflow runs logs](/reference/cli/leoflow_runs_logs/)	 - Stream a task attempt's logs (the latest attempt by default).
 * [leoflow runs status](/reference/cli/leoflow_runs_status/)	 - Show the state of a DAG run (the latest by default).
 * [leoflow runs trigger](/reference/cli/leoflow_runs_trigger/)	 - Trigger a new run of a DAG.
 

--- a/website/content/reference/cli/leoflow_runs_logs.md
+++ b/website/content/reference/cli/leoflow_runs_logs.md
@@ -1,25 +1,27 @@
 ---
 # --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
 aliases:
-  - /cli/leoflow_runs_trigger.html
+  - /cli/leoflow_runs_logs.html
 # --- end AUTO redirect aliases ---
-title: "leoflow runs trigger"
-linkTitle: "runs trigger"
-weight: 41
+title: "leoflow runs logs"
+linkTitle: "runs logs"
+weight: 39
 ---
 
-Trigger a new run of a DAG.
+Stream a task attempt's logs (the latest attempt by default).
 
 ```
-leoflow runs trigger <dag_id> [flags]
+leoflow runs logs <dag_id> <run_id> <task_id> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help            help for trigger
+  -f, --follow          keep streaming new log lines while the task is still running
+  -h, --help            help for logs
       --server string   control plane base URL (default: config server_url)
       --token string    JWT bearer token (default: config token)
+      --try int         attempt number to read (default: the task's latest attempt)
 ```
 
 ### Options inherited from parent commands

--- a/website/content/reference/cli/leoflow_runs_status.md
+++ b/website/content/reference/cli/leoflow_runs_status.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow runs status"
 linkTitle: "runs status"
-weight: 39
+weight: 40
 ---
 
 Show the state of a DAG run (the latest by default).

--- a/website/content/reference/cli/leoflow_server.md
+++ b/website/content/reference/cli/leoflow_server.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow server"
 linkTitle: "server"
-weight: 41
+weight: 42
 ---
 
 Information about running the control plane.

--- a/website/content/reference/cli/leoflow_setup.md
+++ b/website/content/reference/cli/leoflow_setup.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow setup"
 linkTitle: "setup"
-weight: 42
+weight: 43
 ---
 
 Bootstrap the managed Leoflow runtime (Python, parser, workspace).

--- a/website/content/reference/cli/leoflow_uninstall.md
+++ b/website/content/reference/cli/leoflow_uninstall.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow uninstall"
 linkTitle: "uninstall"
-weight: 43
+weight: 44
 ---
 
 Remove the Leoflow installation (~/.leoflow).

--- a/website/content/reference/cli/leoflow_validate.md
+++ b/website/content/reference/cli/leoflow_validate.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow validate"
 linkTitle: "validate"
-weight: 44
+weight: 45
 ---
 
 Validate leoflow.yaml and the DAG source against the schema.

--- a/website/content/reference/cli/leoflow_version.md
+++ b/website/content/reference/cli/leoflow_version.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow version"
 linkTitle: "version"
-weight: 45
+weight: 46
 ---
 
 Print the version, git commit, and build date.


### PR DESCRIPTION
> **HOLD — do not merge; queued for the v0.4.1 window.** This branch is complete and green but is intentionally parked, not for merge now.

## Problem (#762)
Task logs already exist end to end: the agent captures task stdout/stderr (`internal/agent/runner.go`), streams them over gRPC, and the control plane persists (`logs.dir`) and serves them at the Airflow-compatible route `GET /api/v2/dags/{dag}/dagRuns/{run}/taskInstances/{task}/logs/{try}` (`internal/api/logs.go` — `serveLogs`/`tailLogs`, including the graceful "No logs available for this attempt." path). But `leoflow runs` exposed only `trigger` and `status`, so a CLI/agent workflow had **no path** to read them.

## Implementation
Adds `leoflow runs logs <dag_id> <run_id> <task_id> [--try N] [-f]` under the `runs` command (`internal/cli/runs.go`). It **reuses the existing endpoint and the existing runs HTTP client** rather than adding anything server-side:

- **Auth/precedence:** resolves server URL + token via the same `resolveServerToken` precedence (`--token` → `LEOFLOW_TOKEN` → config) and the same `--server`/`--token` flags as `runs trigger`/`status`.
- **Reuses the client's auth injection:** `apiRequest` and the new streaming reader now share a single `newAPIRequest` builder, so both inject the bearer token identically — no hand-rolled request that bypasses auth.
- **Latest attempt by default:** `--try` defaults to the task instance's current `try_number` (fetched from the `taskInstances/{task}` endpoint the API already exposes), falling back to try 1 when none is recorded.
- **Graceful no-logs passthrough:** the body streams straight to stdout, so the endpoint's 200 `No logs available for this attempt.` reaches the user as-is instead of erroring.
- **`-f`/`--follow`:** tailing is cheap — the endpoint tails a running attempt via `?follow=true` — so follow is supported and streams live (the stream copy uses no client timeout).
- **`task_id` required** (not listing instances when omitted): keeps the command a single predictable stream, consistent with `runs status`.

## Red → green (strict TDD)
1. Test commit first (`test(cli): red spec …`): registration under `runs`, streaming a chosen `--try`, defaulting to the latest `try_number`, no-logs passthrough, config-token auth, and non-2xx erroring. Confirmed **red** (`unknown flag`, `logs` unresolved).
2. Impl commit turns it **green**.

## Pre-push gate (all green)
```
go build ./...                      -> ok
go vet ./internal/cli/...           -> ok
golangci-lint run ./internal/cli/.. -> 0 issues
go test ./internal/cli/...          -> ok
```

## CLI reference (auto-generated)
Regenerated the committed Hugo CLI reference via `website/scripts/gen-cli.sh`, then re-ran the idempotent `website/scripts/migration/build_redirects.py` so the `AUTO redirect aliases` blocks gen-cli strips are restored. Net doc churn is scoped: the new `leoflow_runs_logs.md` page, the `runs` SEE-ALSO link, and `weight:` renumbering on the pages that sort after it. Expected pipeline output.

Closes #762
