### PR TITLE
fix(cli): make generated Dockerfile dbt-aware (#769)

### DIFF
--- a/internal/cli/compile_build.go
+++ b/internal/cli/compile_build.go
@@ -56,12 +56,15 @@ func resolveBuildImage(flagImage string, cfg *domain.LeoflowConfig, version stri
 // to their provider packages, ADR 0038), and finally the DAG source COPY with the
 // agent's PYTHONPATH convention. An unknown connector name is a hard error
 // (surfaced from EffectiveDependencies) rather than a runtime ModuleNotFoundError.
+//
+// For a dbt project (cfg.Dbt set, ADR 0042) the source is the dbt project
+// directory, not a dag.py: the final layer COPYs that directory to the workdir
+// and sets no PYTHONPATH, since dbt ships no importable Python module.
 func generatedDockerfile(cfg *domain.LeoflowConfig, dagSource string) (string, error) {
 	deps, err := cfg.EffectiveDependencies()
 	if err != nil {
 		return "", err
 	}
-	base := filepath.Base(dagSource)
 	var b strings.Builder
 	fmt.Fprintf(&b, "FROM %s\n", resolveBaseImage(cfg))
 	if len(cfg.SystemPackages) > 0 {
@@ -74,6 +77,17 @@ func generatedDockerfile(cfg *domain.LeoflowConfig, dagSource string) (string, e
 		// edits to the DAG source.
 		fmt.Fprintf(&b, "RUN pip install --no-cache-dir %s\n", strings.Join(deps, " "))
 	}
+	if cfg.Dbt != nil {
+		// A dbt project is the DAG source (ADR 0042): there is no dag.py to COPY and
+		// no Python module to import, so COPY the project directory (dbt_project.yml
+		// + models/ + baked manifest.json) to the workdir and set no PYTHONPATH. The
+		// task runs `dbt --project-dir <project>` from WORKDIR /home/leoflow, so the
+		// project must land at /home/leoflow/<project> matching the baked --project-dir.
+		project := filepath.Clean(cfg.Dbt.Project)
+		fmt.Fprintf(&b, "COPY %s /home/leoflow/%s\n", project, project)
+		return b.String(), nil
+	}
+	base := filepath.Base(dagSource)
 	fmt.Fprintf(&b, "COPY %s /home/leoflow/%s\nENV PYTHONPATH=/home/leoflow\n", base, base)
 	return b.String(), nil
 }

--- a/internal/cli/compile_build_test.go
+++ b/internal/cli/compile_build_test.go
@@ -86,6 +86,72 @@ func TestGeneratedDockerfileLayers(t *testing.T) {
 	}
 }
 
+// TestGeneratedDockerfileDbtCopiesProject verifies that for a dbt project the
+// generated Dockerfile COPYs the dbt project directory (dbt_project.yml + models/
+// + baked manifest.json) to the workdir instead of the nonexistent dag.py, and
+// does not set a PYTHONPATH pointing at a Python module that dbt does not ship
+// (#769). The dbt task runs `dbt --project-dir <project>` from WORKDIR
+// /home/leoflow, so the project must land at /home/leoflow/<project>.
+func TestGeneratedDockerfileDbtCopiesProject(t *testing.T) {
+	cfg := &domain.LeoflowConfig{
+		PythonVersion: "3.11",
+		Dependencies:  []string{"dbt-duckdb==1.8.0"},
+		Dbt:           &domain.DbtConfig{Project: "analytics"},
+	}
+	// A dbt-only project defaults DagSource to dag.py, which does not exist —
+	// the pre-fix COPY dag.py is what fails the build.
+	df, err := generatedDockerfile(cfg, "dag.py")
+	if err != nil {
+		t.Fatalf("generatedDockerfile() error = %v", err)
+	}
+	if !strings.Contains(df, "COPY analytics /home/leoflow/analytics") {
+		t.Errorf("generatedDockerfile() should COPY the dbt project dir, got:\n%s", df)
+	}
+	if strings.Contains(df, "dag.py") {
+		t.Errorf("generatedDockerfile() must not reference dag.py for a dbt project:\n%s", df)
+	}
+	if strings.Contains(df, "PYTHONPATH") {
+		t.Errorf("generatedDockerfile() must not set PYTHONPATH for a dbt project:\n%s", df)
+	}
+	// The dependency layer (dbt adapter) is still emitted before the COPY.
+	if !strings.Contains(df, "pip install") || !strings.Contains(df, "dbt-duckdb==1.8.0") {
+		t.Errorf("generatedDockerfile() should keep the pip dependency layer:\n%s", df)
+	}
+}
+
+// TestGeneratedDockerfileDbtProjectPathCleaned verifies a project declared with a
+// leading ./ lands at a clean /home/leoflow/<project> path matching the baked
+// --project-dir, so `dbt --project-dir ./transform` resolves inside the image.
+func TestGeneratedDockerfileDbtProjectPathCleaned(t *testing.T) {
+	cfg := &domain.LeoflowConfig{PythonVersion: "3.11", Dbt: &domain.DbtConfig{Project: "./transform"}}
+	df, err := generatedDockerfile(cfg, "dag.py")
+	if err != nil {
+		t.Fatalf("generatedDockerfile() error = %v", err)
+	}
+	if !strings.Contains(df, "COPY transform /home/leoflow/transform") {
+		t.Errorf("generatedDockerfile() should COPY the cleaned project path, got:\n%s", df)
+	}
+}
+
+// TestEnsureDockerfileDbtUsesExisting verifies a dbt project that ships its own
+// Dockerfile still wins — ensureDockerfile honors it verbatim and never generates.
+func TestEnsureDockerfileDbtUsesExisting(t *testing.T) {
+	dir := t.TempDir()
+	existing := filepath.Join(dir, "Dockerfile")
+	if err := os.WriteFile(existing, []byte("FROM ghcr.io/acme/dbt:custom\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &domain.LeoflowConfig{PythonVersion: "3.11", Dbt: &domain.DbtConfig{Project: "analytics"}}
+	path, cleanup, err := ensureDockerfile(dir, "Dockerfile", cfg, "dag.py")
+	if err != nil {
+		t.Fatalf("ensureDockerfile() error = %v", err)
+	}
+	defer cleanup()
+	if path != existing {
+		t.Errorf("path = %q, want the existing Dockerfile %q", path, existing)
+	}
+}
+
 // TestGeneratedDockerfileUnknownConnectorErrors verifies a typo'd connector name
 // fails generation loudly (it cannot resolve to a pip package) rather than
 // silently producing an image that ModuleNotFoundErrors at run time.


### PR DESCRIPTION
## 🛑 HOLD — v0.4.1

**Do not merge.** Queued for the v0.4.1 cut; awaiting maintainer authorization.

---

## Problem — #769
`leoflow deploy --build` fails for a pure-dbt DAG. The dbt path
(`runDbtCompile → buildAndPush → ensureDockerfile → generatedDockerfile`)
reaches `generatedDockerfile` with `dagSource=dag.py` (the schema default),
but a dbt-only project ships no `dag.py`. `generatedDockerfile` had no dbt
branch, so it always emitted `COPY dag.py /home/leoflow/dag.py` +
`ENV PYTHONPATH=/home/leoflow` — the `COPY` fails the build on the missing file.

## Fix
Make `generatedDockerfile` dbt-aware. When `cfg.Dbt != nil`:
- COPY the dbt project directory (`filepath.Clean(cfg.Dbt.Project)`:
  `dbt_project.yml` + `models/` + baked `manifest.json`) to
  `/home/leoflow/<project>`, matching the baked `dbt --project-dir` and the
  image `WORKDIR /home/leoflow`.
- Emit no `PYTHONPATH` — dbt ships no importable Python module.

The Python-DAG path stays **byte-identical**. The `FROM` / `system_packages` /
pip-dependency layers are unchanged (a dbt adapter installs through them). A
project shipping its own Dockerfile still wins — `ensureDockerfile` honors it
before generation is ever reached.

## Tests (red → green, TDD)
- `TestGeneratedDockerfileDbtCopiesProject` — dbt project COPYs the project dir,
  never `dag.py`, sets no `PYTHONPATH`, keeps the pip layer. (failed pre-fix)
- `TestGeneratedDockerfileDbtProjectPathCleaned` — `./transform` lands at a clean
  `/home/leoflow/transform`. (failed pre-fix)
- `TestEnsureDockerfileDbtUsesExisting` — a dbt project's own Dockerfile still wins.
- Existing `TestGeneratedDockerfileLayers` / `...UnknownConnectorErrors` /
  `TestEnsureDockerfile*` unchanged and green (Python path unaffected).

## Gate
- `go build ./...` — ok
- `go vet ./...` — ok
- `golangci-lint run ./internal/cli/...` — 0 issues
- `go test ./internal/cli/...` — ok

Closes #769