### PR TITLE
chore: rc.4 review nits (#754 install crash-safety test, #752 QoS comment)

### DIFF
--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -159,11 +159,15 @@ type DefaultResources struct {
 }
 
 // AsResources expands the simplified default cpu/memory into a full Resources
-// with requests == limits, so a task that inherits the DAG-wide default reaches
-// Guaranteed QoS rather than BestEffort/Burstable (the QoS story of #725). This
-// mirrors how the per-cluster platform default is built at dispatch. Returns nil
-// when the receiver is nil or declares no quantity, so callers can treat a
-// missing default as "leave the task untouched".
+// with requests == limits (the QoS story of #725). This mirrors how the
+// per-cluster platform default is built at dispatch. Returns nil when the
+// receiver is nil or declares no quantity, so callers can treat a missing
+// default as "leave the task untouched".
+//
+// Guaranteed QoS is reached only when BOTH cpu and memory are set (and thus
+// equal across requests and limits). A partial default — only cpu, or only
+// memory — leaves the other dimension unset, so Kubernetes classifies the pod
+// as Burstable, not Guaranteed.
 func (d *DefaultResources) AsResources() *Resources {
 	if d == nil || (d.CPU == "" && d.Memory == "") {
 		return nil

--- a/internal/setup/install_postgres_test.go
+++ b/internal/setup/install_postgres_test.go
@@ -213,6 +213,47 @@ func TestEnsurePostgresReextractsWhenVersionUnknown(t *testing.T) {
 	}
 }
 
+// TestEnsurePostgresFailedDownloadKeepsExistingInstall locks the crash-safety
+// invariant of #754 for the Postgres entry point: EnsurePostgres runs fetchVerify
+// (download + checksum) BEFORE extractTarGzStrip touches the managed tree, so a
+// download that errors must leave a working managed Postgres on disk rather than
+// wiping it. Setup is the upgrade case: a complete install of an OLDER version is
+// present (its sentinel forces EnsurePostgres into the download), the download
+// fails, and the pre-existing binary must survive.
+func TestEnsurePostgresFailedDownloadKeepsExistingInstall(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, "postgres", "bin")
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	managed := filepath.Join(binDir, "postgres")
+	if err := os.WriteFile(managed, []byte("#!/existing postgres\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Sentinel records an OLDER version, so EnsurePostgres reaches the download.
+	if err := os.WriteFile(filepath.Join(home, "postgres", pgVersionFile), []byte("15.0.0"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rt := &recordingRoundTripper{}
+	_, err := EnsurePostgres(context.Background(), EnsureOpts{
+		Home: home, GOOS: "linux", GOARCH: "arm64",
+		Client: &http.Client{Transport: rt},
+	})
+	if err == nil {
+		t.Fatal("EnsurePostgres: err = nil, want the failed download surfaced as an error")
+	}
+	if !rt.called {
+		t.Fatal("expected EnsurePostgres to attempt the download")
+	}
+	got, rerr := os.ReadFile(managed)
+	if rerr != nil {
+		t.Fatalf("existing managed postgres was destroyed by a failed download: %v", rerr)
+	}
+	if string(got) != "#!/existing postgres\n" {
+		t.Errorf("managed postgres = %q, want the pre-existing content intact", got)
+	}
+}
+
 func TestStripComponents(t *testing.T) {
 	cases := map[string]string{
 		"postgresql-16.13.0-x/bin/postgres": filepath.Join("bin", "postgres"),

--- a/internal/setup/install_test.go
+++ b/internal/setup/install_test.go
@@ -189,6 +189,54 @@ func TestEnsurePythonBranches(t *testing.T) {
 	})
 }
 
+// TestEnsurePythonFailedDownloadKeepsExistingInstall locks the crash-safety
+// invariant of #754: EnsurePython runs fetchVerify (download + checksum) BEFORE
+// os.RemoveAll of the managed tree, so a download that errors — the network is
+// down, the mirror 500s, the checksum drifts — must leave a working managed
+// interpreter untouched on disk rather than destroying it and leaving nothing.
+//
+// The setup is the realistic upgrade case: a complete managed install of an
+// OLDER version is present (its sentinel forces EnsurePython past the
+// short-circuit and into the download), and the download fails. The pre-existing
+// binary must survive.
+func TestEnsurePythonFailedDownloadKeepsExistingInstall(t *testing.T) {
+	home := t.TempDir()
+	managed := filepath.Join(home, "python", "bin", "python3.11")
+	if err := os.MkdirAll(filepath.Dir(managed), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(managed, []byte("#!/existing interpreter"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Sentinel records an OLDER version, so EnsurePython reaches the download
+	// instead of short-circuiting on the present-and-current install.
+	if err := os.WriteFile(filepath.Join(home, "python", pyVersionFile), []byte("3.10.0"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rt := &recordingRoundTripper{}
+	_, err := EnsurePython(context.Background(), EnsureOpts{
+		Home: home, GOOS: "linux", GOARCH: "amd64",
+		LookPath: func(string) (string, error) { return "", os.ErrNotExist },
+		Stat:     os.Stat,
+		Client:   &http.Client{Transport: rt},
+	})
+	if err == nil {
+		t.Fatal("err = nil, want the failed download surfaced as an error")
+	}
+	if !rt.called {
+		t.Fatal("expected EnsurePython to attempt the download")
+	}
+	// The invariant: the pre-existing managed interpreter is still on disk,
+	// byte-for-byte, because the failed download returned before os.RemoveAll.
+	got, rerr := os.ReadFile(managed)
+	if rerr != nil {
+		t.Fatalf("existing managed interpreter was destroyed by a failed download: %v", rerr)
+	}
+	if string(got) != "#!/existing interpreter" {
+		t.Errorf("managed interpreter = %q, want the pre-existing content intact", got)
+	}
+}
+
 func TestExtractTarGzDirAndSymlink(t *testing.T) {
 	var buf bytes.Buffer
 	gz := gzip.NewWriter(&buf)


### PR DESCRIPTION
> ## 🛑 HOLD — v0.4.1
> **DO NOT MERGE.** Holding for the v0.4.1 release train.

Two tiny, non-gating nits from the **rc.4 review** (#754 / #752). No behavior change.

## Nit 1 — lock "install survives a failed download" (#754)
`EnsurePython`/`EnsurePostgres` run `fetchVerify` (download + checksum) **before** `os.RemoveAll` of the managed dir, so a failed download can never destroy a working managed install. That invariant had no explicit test.

Added regression tests for **both** entry points (`internal/setup/install_test.go`, `internal/setup/install_postgres_test.go`): with a complete-but-older managed install on disk, a download that errors (failing `RoundTripper`) leaves the existing binary byte-for-byte intact.

✅ **Invariant holds** — both tests pass against current code, confirming a failed download does not wipe a working install.

## Nit 2 — fix the Guaranteed-QoS comment (#752)
In `internal/domain/config.go`, the `DefaultResources.AsResources()` comment claimed Guaranteed QoS unconditionally. Guaranteed requires **both** cpu and memory set-and-equal; a partial default (only cpu, or only memory) leaves the other dimension unset → Kubernetes classifies the pod as **Burstable**. Comment corrected. Comment-only, no behavior change.

## Gate
- `go build ./...` — ✅
- `go vet ./internal/setup/... ./internal/domain/...` — ✅
- `golangci-lint run` (touched packages) — ✅ 0 issues
- `go test ./internal/setup/... ./internal/domain/...` — ✅ pass (both new tests green)