### PR TITLE
fix(executor): surface the non-root cause in CreateContainerConfigError

### DIFF
--- a/internal/executor/reconcile.go
+++ b/internal/executor/reconcile.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -44,11 +45,12 @@ type verdict struct {
 // unrecoverableWaiting lists container "waiting" reasons that never self-resolve
 // and mean the agent never started, so no state will be reported.
 var unrecoverableWaiting = map[string]bool{
-	"ImagePullBackOff":     true,
-	"ErrImagePull":         true,
-	"InvalidImageName":     true,
-	"CreateContainerError": true,
-	"CrashLoopBackOff":     true,
+	"ImagePullBackOff":           true,
+	"ErrImagePull":               true,
+	"InvalidImageName":           true,
+	"CreateContainerError":       true,
+	"CreateContainerConfigError": true,
+	"CrashLoopBackOff":           true,
 }
 
 // taskContainerName is the task pod's single container (see BuildPod).
@@ -84,7 +86,7 @@ func classifyPod(pod *corev1.Pod) verdict {
 	case corev1.PodPending, corev1.PodRunning, corev1.PodUnknown:
 		for _, cs := range pod.Status.ContainerStatuses {
 			if w := cs.State.Waiting; w != nil && unrecoverableWaiting[w.Reason] {
-				return verdict{terminal: true, settle: settleFailed, reason: waitingFailureReason(w.Reason)}
+				return verdict{terminal: true, settle: settleFailed, reason: waitingFailureReason(w.Reason, w.Message)}
 			}
 		}
 		return verdict{terminal: false}
@@ -161,8 +163,11 @@ func podFailureReason(pod *corev1.Pod) string {
 // waitingFailureReason explains a container stuck in an unrecoverable waiting
 // state. It names the Kubernetes reason (what an operator greps for and what
 // `kubectl describe` shows) and adds the context that makes it actionable, since
-// the bare enum alone is what left operators reaching for kubectl.
-func waitingFailureReason(reason string) string {
+// the bare enum alone is what left operators reaching for kubectl. The kubelet
+// message is consulted only to distinguish reasons that share one enum but need
+// different guidance (CreateContainerConfigError); it is never echoed, so an
+// unbounded, operator-controlled string cannot reach the end-user field.
+func waitingFailureReason(reason, message string) string {
 	switch reason {
 	case "ImagePullBackOff", "ErrImagePull", "InvalidImageName":
 		return boundReason(fmt.Sprintf(
@@ -170,6 +175,19 @@ func waitingFailureReason(reason string) string {
 	case "CreateContainerError":
 		return boundReason(fmt.Sprintf(
 			"%s: the task container could not be created; check the pod spec, mounts, and image entrypoint.", reason))
+	case "CreateContainerConfigError":
+		// The kubelet raises this both for a missing ConfigMap/Secret and for the
+		// runAsNonRoot admission refusal. The latter is a distinct, common cause
+		// under the non-root default and needs its own fix, so we match the
+		// kubelet's signature substring rather than lump it into the generic bucket.
+		if strings.Contains(message, "runAsNonRoot") {
+			return boundReason(fmt.Sprintf(
+				"%s: the DAG image runs as root, but task pods run as non-root by default; "+
+					"end the Dockerfile with a numeric `USER 65532`, "+
+					"or set `taskPodSecurity.runAsNonRoot=false` for the cluster.", reason))
+		}
+		return boundReason(fmt.Sprintf(
+			"%s: the task container could not be configured; check its ConfigMap, Secret, and env-var references.", reason))
 	case "CrashLoopBackOff":
 		return boundReason(fmt.Sprintf(
 			"%s: the task container keeps exiting at startup; inspect the task image entrypoint.", reason))

--- a/internal/executor/reconcile_test.go
+++ b/internal/executor/reconcile_test.go
@@ -18,10 +18,14 @@ func podPhase(phase corev1.PodPhase) *corev1.Pod {
 }
 
 func podWaiting(reason string) *corev1.Pod {
+	return podWaitingMsg(reason, "")
+}
+
+func podWaitingMsg(reason, message string) *corev1.Pod {
 	return &corev1.Pod{Status: corev1.PodStatus{
 		Phase: corev1.PodPending,
 		ContainerStatuses: []corev1.ContainerStatus{
-			{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: reason}}},
+			{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: reason, Message: message}}},
 		},
 	}}
 }
@@ -373,5 +377,44 @@ func TestPodWaitingReasonExplainsItself(t *testing.T) {
 	}
 	if !strings.Contains(got.reason, "image") {
 		t.Errorf("reason = %q, want operator-facing context about the image", got.reason)
+	}
+}
+
+// TestClassifyPodSurfacesNonRootConfigError pins the runAsNonRoot case of
+// CreateContainerConfigError: a root task image under the non-root default is
+// refused by the kubelet before the container starts, so no agent ever reports a
+// cause. The classified reason must name the non-root cause and carry both the
+// image-side and the operator-side fixes, not degrade to the generic bucket.
+func TestClassifyPodSurfacesNonRootConfigError(t *testing.T) {
+	pod := podWaitingMsg("CreateContainerConfigError",
+		"container has runAsNonRoot and image will run as root")
+	got := classifyPod(pod)
+	if !got.terminal || got.settle != settleFailed {
+		t.Fatalf("classifyPod = {terminal:%v settle:%v}, want a terminal failure",
+			got.terminal, got.settle)
+	}
+	for _, want := range []string{"runAsNonRoot", "USER 65532", "taskPodSecurity.runAsNonRoot"} {
+		if !strings.Contains(got.reason, want) {
+			t.Errorf("reason = %q, want it to mention %q", got.reason, want)
+		}
+	}
+}
+
+// TestClassifyPodConfigErrorWithoutNonRoot keeps the generic
+// CreateContainerConfigError path (a missing ConfigMap/Secret, a bad env-var
+// reference) actionable without misattributing it to the non-root cause.
+func TestClassifyPodConfigErrorWithoutNonRoot(t *testing.T) {
+	pod := podWaitingMsg("CreateContainerConfigError",
+		`configmap "missing" not found`)
+	got := classifyPod(pod)
+	if !got.terminal || got.settle != settleFailed {
+		t.Fatalf("classifyPod = {terminal:%v settle:%v}, want a terminal failure",
+			got.terminal, got.settle)
+	}
+	if !strings.Contains(got.reason, "CreateContainerConfigError") {
+		t.Errorf("reason = %q, want it to name the waiting reason", got.reason)
+	}
+	if strings.Contains(got.reason, "runAsNonRoot") {
+		t.Errorf("reason = %q, must not attribute an unrelated config error to non-root", got.reason)
 	}
 }


### PR DESCRIPTION
> ## 🛑 HOLD — v0.4.1
> **DO NOT MERGE.** Awaiting maintainer review.

Closes #766

## Problem
When a DAG image runs as root under the non-root task-pod default, the kubelet refuses the pod before the container starts:

```
CreateContainerConfigError: container has runAsNonRoot and image will run as root
```

The reason classifier in `internal/executor/reconcile.go` handled generic `CreateContainerError` and the image-pull family, but `CreateContainerConfigError` was not in the unrecoverable-waiting set. The pod was therefore treated as non-terminal (it never self-resolves), and once it did settle the `failure_reason` (#698) never named the cause — leaving operators reaching for `kubectl describe`.

## Fix
- Add `CreateContainerConfigError` to `unrecoverableWaiting`.
- Give `waitingFailureReason` the kubelet `Waiting.Message` and a dedicated `CreateContainerConfigError` case that splits the two distinct causes behind that one enum:
  - **runAsNonRoot admission refusal** (message contains `runAsNonRoot`): names the non-root cause and gives both fixes — end the Dockerfile with a numeric `USER 65532`, or set `taskPodSecurity.runAsNonRoot=false` for the cluster.
  - **generic config error** (missing ConfigMap/Secret, bad env-var ref): points at ConfigMap/Secret/env-var references.

The message is only *inspected* for the signature substring, never echoed, so an unbounded operator-controlled string cannot reach the end-user field. The result is a closed-set, operator-facing string bounded to `MaxReasonLen` (rendered length 206 B) — same discipline as #698.

## Tests (red → green)
- `TestClassifyPodSurfacesNonRootConfigError` — pins the runAsNonRoot case: terminal failure whose reason mentions `runAsNonRoot`, `USER 65532`, and `taskPodSecurity.runAsNonRoot`. Red against the old generic bucket (pod classified non-terminal).
- `TestClassifyPodConfigErrorWithoutNonRoot` — a `configmap not found` config error stays a terminal failure that names the enum and is **not** misattributed to non-root.

## Gate
- `go build ./...` — clean
- `go vet ./internal/executor/...` — clean
- `golangci-lint run ./internal/executor/...` — 0 issues
- `go test ./internal/executor/...` — ok
