### PR TITLE
ci: sign leoflow-server image and retry all cosign signs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -136,7 +136,8 @@ jobs:
       # Mirror the supply-chain posture of leoflow-server: keyless cosign sign
       # every published tag by digest (ADR 0014). Without `--yes` cosign would
       # prompt for OIDC confirmation; CI passes the Sigstore challenge via the
-      # GH OIDC token from id-token: write.
+      # GH OIDC token from id-token: write. Signing goes through the retry
+      # wrapper so a transient OIDC blip (issue #773) retries instead of failing.
       - name: Sign image with cosign (keyless)
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
@@ -144,7 +145,7 @@ jobs:
         run: |
           set -euo pipefail
           for tag in $TAGS; do
-            cosign sign --yes "${tag}@${DIGEST}"
+            ./scripts/cosign-retry.sh sign --yes "${tag}@${DIGEST}"
           done
 
   # ── Build + push the Leoflow task base image (runtime/Dockerfile)
@@ -223,7 +224,7 @@ jobs:
         run: |
           set -euo pipefail
           for tag in $TAGS; do
-            cosign sign --yes "${tag}@${DIGEST}"
+            ./scripts/cosign-retry.sh sign --yes "${tag}@${DIGEST}"
           done
 
   # ── Faithful install smoke: run the REAL `curl | sh` of the just-published
@@ -365,6 +366,48 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: sh test/release/upgrade-smoke.sh
 
+  # ── Verify the control-plane server image is cosign-signed (#772). GoReleaser
+  # signs it keyless in the `release` job via docker_signs; this job proves the
+  # signature is actually there and verifiable, so an unsigned image — or one
+  # whose signing silently flaked past the retry wrapper — cannot ship. The
+  # `gate` job below retracts the release to a draft if this fails.
+  #
+  # Keyless verification pins BOTH the OIDC issuer (GitHub's token provider) and
+  # the certificate identity (the exact workflow file + tag ref that signed),
+  # otherwise `cosign verify` would accept a signature from any Sigstore identity.
+  # Verifying the `:v<tag>` manifest is sufficient: it and the un-prefixed
+  # `:<version>` manifest resolve to the same digest, and both were signed.
+  verify-server-signature:
+    name: Verify leoflow-server image signature
+    needs: release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v2.4.3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: cosign verify leoflow-server
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ github.repository_owner }}/leoflow-server:${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          cosign verify \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            --certificate-identity-regexp "^https://github\.com/${REPO}/\.github/workflows/release\.yaml@refs/tags/" \
+            "${IMAGE}"
+
   # ── Release gate: if any of the smoke jobs OR the migrate-image build
   # failed, retract the pre-release to a draft so `curl | sh` (which resolves
   # the newest public release) and the Helm chart (which references the
@@ -372,8 +415,8 @@ jobs:
   # it can act on any failure; on success it leaves the published pre-release
   # untouched.
   gate:
-    name: Gate release on install + lite-cold-start + upgrade + migrate + runtime image
-    needs: [release, install-smoke, lite-cold-start-smoke, upgrade-smoke, migrate-image, runtime-image]
+    name: Gate release on install + lite-cold-start + upgrade + migrate + runtime image + server signature
+    needs: [release, install-smoke, lite-cold-start-smoke, upgrade-smoke, migrate-image, runtime-image, verify-server-signature]
     if: always() && needs.release.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -381,14 +424,14 @@ jobs:
       contents: write   # Edit the published release back to a draft on failure.
     steps:
       - name: Retract release to draft on smoke or image failure
-        if: needs.install-smoke.result != 'success' || needs.lite-cold-start-smoke.result != 'success' || needs.upgrade-smoke.result != 'success' || needs.migrate-image.result != 'success' || needs.runtime-image.result != 'success'
+        if: needs.install-smoke.result != 'success' || needs.lite-cold-start-smoke.result != 'success' || needs.upgrade-smoke.result != 'success' || needs.migrate-image.result != 'success' || needs.runtime-image.result != 'success' || needs.verify-server-signature.result != 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eu
-          echo "::error::release blocked: install-smoke=${{ needs.install-smoke.result }} lite-cold-start-smoke=${{ needs.lite-cold-start-smoke.result }} upgrade-smoke=${{ needs.upgrade-smoke.result }} migrate-image=${{ needs.migrate-image.result }} runtime-image=${{ needs.runtime-image.result }}; retracting ${GITHUB_REF_NAME} to a draft."
+          echo "::error::release blocked: install-smoke=${{ needs.install-smoke.result }} lite-cold-start-smoke=${{ needs.lite-cold-start-smoke.result }} upgrade-smoke=${{ needs.upgrade-smoke.result }} migrate-image=${{ needs.migrate-image.result }} runtime-image=${{ needs.runtime-image.result }} verify-server-signature=${{ needs.verify-server-signature.result }}; retracting ${GITHUB_REF_NAME} to a draft."
           gh release edit "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" --draft
           exit 1
       - name: Confirm release passed all gates
-        if: needs.install-smoke.result == 'success' && needs.lite-cold-start-smoke.result == 'success' && needs.upgrade-smoke.result == 'success' && needs.migrate-image.result == 'success' && needs.runtime-image.result == 'success'
-        run: echo "install smoke + lite cold-start + upgrade smoke + migrate-image + runtime-image passed; ${GITHUB_REF_NAME} stays published."
+        if: needs.install-smoke.result == 'success' && needs.lite-cold-start-smoke.result == 'success' && needs.upgrade-smoke.result == 'success' && needs.migrate-image.result == 'success' && needs.runtime-image.result == 'success' && needs.verify-server-signature.result == 'success'
+        run: echo "install smoke + lite cold-start + upgrade smoke + migrate-image + runtime-image + server-signature passed; ${GITHUB_REF_NAME} stays published."

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,7 +3,8 @@
 # Produces static (CGO-free) binaries for linux/darwin × amd64/arm64, bundles all
 # three binaries per platform into a single archive (so install.sh fetches the CLI,
 # server, and agent in one download), publishes SHA-256 checksums, an SBOM per
-# archive, cosign keyless signatures, and a control-plane container image on GHCR.
+# archive, cosign keyless signatures (the checksums file AND the control-plane
+# image manifests), and a control-plane container image on GHCR.
 version: 2
 
 project_name: leoflow
@@ -103,14 +104,10 @@ dockers:
   # server symmetric means a chart `--set image.tag=<X>` pin works no matter
   # which convention the operator follows.
   #
-  # NOT signed. This comment used to claim "both shapes are signed by cosign
-  # below" — there is no `docker_signs` block anywhere in this file, and the
-  # release workflow signs only leoflow-migrate and leoflow-runtime. The
-  # `signs:` block above covers the checksums file, which protects the
-  # ARCHIVES, not these images. So the control-plane image the Helm chart
-  # deploys is the one image that is unsigned, and a comment asserted the
-  # opposite. Tracked as its own decision: add docker_signs, or say so in the
-  # supply-chain docs (ADR 0014).
+  # Signed keyless by the `docker_signs:` block below — both manifest tags, by
+  # digest — so the control-plane image the Helm chart deploys carries the same
+  # supply-chain posture (ADR 0014) as leoflow-migrate and leoflow-runtime, which
+  # the release workflow signs in their own jobs.
   - id: server-amd64
     ids: [leoflow-server]
     goarch: amd64
@@ -147,6 +144,28 @@ docker_manifests:
     image_templates:
       - "ghcr.io/neochaotic/leoflow-server:v{{ .Version }}-amd64"
       - "ghcr.io/neochaotic/leoflow-server:v{{ .Version }}-arm64"
+
+# Cosign keyless signing of the control-plane image. `artifacts: manifests`
+# signs each multi-arch manifest (`:{{ .Version }}` and `:v{{ .Version }}`) by
+# its digest — the reference an operator actually pulls — so both tag shapes are
+# covered. GoReleaser resolves the pushed manifest digest and substitutes it for
+# ${digest}; `${artifact}@${digest}` therefore signs by digest, never by the
+# mutable tag. Requires id-token: write (set in the workflow) for the Sigstore
+# OIDC challenge; `--yes` skips cosign's interactive confirmation in CI.
+#
+# The command is the `scripts/cosign-retry.sh` wrapper rather than `cosign`
+# itself: a transient GitHub-OIDC blip once failed a `cosign sign` mid-release
+# and drafted an otherwise-good build, so every signature retries with backoff.
+# The migrate/runtime workflow steps route through the same wrapper.
+docker_signs:
+  - id: server
+    cmd: ./scripts/cosign-retry.sh
+    artifacts: manifests
+    args:
+      - sign
+      - "${artifact}@${digest}"
+      - "--yes"
+    output: true
 
 release:
   github:

--- a/scripts/cosign-retry.sh
+++ b/scripts/cosign-retry.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run `cosign "$@"` with retry + exponential backoff.
+#
+# Keyless cosign signing fetches an ambient OIDC token from the GitHub Actions
+# provider on every invocation. That fetch is a network call to an external
+# service and occasionally returns garbage on a momentary blip — one release cut
+# died mid-sign with `fetching ambient OIDC credentials: invalid character
+# 'u'...`, which drafted an otherwise-good release. A single transient failure
+# should not cost a whole release, so every `cosign sign` in the release
+# pipeline goes through this wrapper: the GoReleaser docker_signs hook that signs
+# the control-plane server manifests AND the migrate/runtime workflow steps, so
+# all image signatures retry identically.
+#
+# Only the invocation is retried; cosign itself is idempotent for an
+# already-signed digest, so a retry after a partial success is safe.
+set -euo pipefail
+
+attempts="${COSIGN_RETRY_ATTEMPTS:-3}"
+delay="${COSIGN_RETRY_DELAY:-5}"
+
+n=1
+while true; do
+	if cosign "$@"; then
+		exit 0
+	fi
+	if [ "$n" -ge "$attempts" ]; then
+		echo "cosign-retry: failed after ${attempts} attempt(s): cosign $*" >&2
+		exit 1
+	fi
+	echo "cosign-retry: attempt ${n}/${attempts} failed; retrying in ${delay}s..." >&2
+	sleep "$delay"
+	n=$((n + 1))
+	delay=$((delay * 2))
+done


### PR DESCRIPTION
> # 🛑 HOLD — v0.4.1
> **Do NOT merge.** This touches the release pipeline; land it deliberately alongside the v0.4.1 cut, not on autopilot.

Closes #772
Closes #773

## Why

- **#772** — the `leoflow-server` control-plane image (the one the Helm chart deploys) was the **only published image never cosign-signed**. `.goreleaser.yaml` built and pushed both manifest tags, but `signs:` covered only the checksums file (which protects the *archives*), and the release workflow signed only `leoflow-migrate` and `leoflow-runtime`. A source comment even claimed the image *was* signed. Confirmed unsigned on `0.4.0` and `0.3.0` (longstanding).
- **#773** — a transient GitHub-OIDC blip failed a `cosign sign` mid-release (`fetching ambient OIDC credentials: invalid character 'u'...`) and drafted an otherwise-good `v0.4.0`. A momentary flake should not cost a release.

## Changes

**`.goreleaser.yaml`**
- New `docker_signs:` block (`artifacts: manifests`) signing **both** server manifest tags — `:{{ .Version }}` and `:v{{ .Version }}` — **keyless, by digest** (`${artifact}@${digest}`, `--yes`). GoReleaser owns the server build/push and resolves the manifest digest, so signing here is digest-accurate without re-resolving in the workflow.
- Corrected the misleading "NOT signed" comment block and the file header.

**`scripts/cosign-retry.sh`** (new, `+x`, `100755`)
- `cosign "$@"` with retry + exponential backoff (default 3 attempts, 5s→10s→20s; tunable via `COSIGN_RETRY_ATTEMPTS` / `COSIGN_RETRY_DELAY`). Single shared wrapper reused everywhere a signature is produced.

**`.github/workflows/release.yaml`**
- `migrate-image` and `runtime-image` sign steps now call `./scripts/cosign-retry.sh sign ...` instead of bare `cosign sign` (both jobs already `actions/checkout`).
- New `verify-server-signature` job: `cosign verify` on the published server image with **pinned OIDC issuer + certificate-identity regexp** (the exact `release.yaml@refs/tags/*` signer), so verification can't be satisfied by an arbitrary Sigstore identity. `packages: read` + GHCR login only; no signing privileges.
- Wired that job into the **release gate** (`needs`, both `if` conditions, and the error echo) so an unsigned or silently-flaked server image **retracts the release to a draft** — same "só corta se passar" posture as the smoke jobs.

## `docker_signs:` vs a workflow step (the choice)

Chose **`docker_signs:` in GoReleaser** for the server image rather than a new workflow sign step, because GoReleaser already builds and pushes the server manifests and knows their digests — a workflow step would have to re-resolve those digests for images GoReleaser produced, which is fragile. #773's retry requirement is met without giving that up: `docker_signs.cmd` points at `scripts/cosign-retry.sh`, the same wrapper the migrate/runtime workflow steps now use, so all three images share one retry path. Verification is kept as a workflow job (a `docker_signs` block can't gate/retract).

## Validation (no live release triggered)

- `actionlint .github/workflows/release.yaml` → **exit 0**, clean.
- `goreleaser check` → **exit 0**, 1 config validated. (Pre-existing `dockers`/`docker_manifests` "phased out → dockers_v2" deprecation notices only — untouched by this PR.)
- `bash -n scripts/cosign-retry.sh` → OK. Functional test with a stubbed `cosign`: always-fail → 3 attempts then exit 1; fail-then-succeed → exits 0 on attempt 2.
- Exec bit tracked in git as `100755`.
