### PR TITLE
ci: add lychee link & image checker as a PR gate

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,66 @@
+name: Link & image check (Markdown)
+
+# Link + image checker for the repo's hand-written governance Markdown (README and
+# friends). It exists because two breakages shipped with nothing guarding them:
+# README images 404'd after the Hugo migration moved their assets, and README doc
+# links 404'd — both are dead *relative* paths a build-time check catches instantly.
+#
+# Companion coverage: the built Hugo site (website/public) is link-checked inside
+# website-build.yml, so between the two workflows we cover (a) the rendered site and
+# (b) the tracked Markdown. Behaviour (retries, accepted status codes, loopback) is
+# in lychee.toml; flaky-host ignores are in .lycheeignore — both at the repo root.
+#
+# Scoped to the checked files + the checker's own config so it only fires when a
+# change can actually affect the result.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "CODE_OF_CONDUCT.md"
+      - "SECURITY.md"
+      - "lychee.toml"
+      - ".lycheeignore"
+      - ".github/workflows/link-check.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "README.md"
+      - "CONTRIBUTING.md"
+      - "CODE_OF_CONDUCT.md"
+      - "SECURITY.md"
+      - "lychee.toml"
+      - ".lycheeignore"
+      - ".github/workflows/link-check.yml"
+  workflow_dispatch:
+
+# Least-privilege: read-only. No write scopes — this job only reports.
+permissions:
+  contents: read
+
+jobs:
+  markdown-links:
+    name: lychee (README + governance docs)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # lychee resolves relative links/images against each file's own directory, so
+      # a dead `docs/assets/x.png` in README (the #758 class) or a moved doc link
+      # (the #740 class) fails here. External links are checked too but softened by
+      # lychee.toml (429/403/timeouts tolerated) and .lycheeignore (flaky hosts).
+      - name: Check links & images
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --config lychee.toml
+            --no-progress
+            README.md CONTRIBUTING.md CODE_OF_CONDUCT.md SECURITY.md
+          # Fail the job (and thus the PR gate) when a link/image is broken.
+          fail: true
+          # Authenticated github.com requests dodge the anonymous rate limit that
+          # would otherwise flake links to the repo's own issues/PRs.
+          token: ${{ secrets.GITHUB_TOKEN }}
+          jobSummary: true

--- a/.github/workflows/website-build.yml
+++ b/.github/workflows/website-build.yml
@@ -91,6 +91,24 @@ jobs:
         working-directory: website
         run: hugo --gc --minify --logLevel info
 
+      # Link/image check over the RENDERED site. Nothing checked internal links
+      # before, so a page or asset that moved (the README-image / doc-link 404 class)
+      # shipped silently. Run OFFLINE on purpose: the bug class is broken *internal*
+      # relative links/images, and offline resolves every root-relative /leoflow/…
+      # href and img src against the built output deterministically — no flaky
+      # external fan-out across thousands of doc links. External-link and governance-
+      # Markdown coverage lives in link-check.yml. Behaviour is in ../lychee.toml.
+      - name: Check links & images in the built site
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --config lychee.toml
+            --no-progress
+            --offline
+            --root-dir "${{ github.workspace }}/website/public"
+            "website/public/**/*.html"
+          fail: true
+
       - name: Upload built site (artifact only — NOT a deploy)
         uses: actions/upload-artifact@v4
         with:

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,22 @@
+# Hosts / URL patterns lychee should NOT check (one regex per line). This is the
+# single place to silence a genuinely flaky or auth-walled host — behavioural
+# settings (retries, timeouts, accepted status codes) live in lychee.toml.
+#
+# Keep this list tight: every entry here is a link we've chosen to STOP verifying,
+# which is exactly how the README image/link 404s slipped through before. Only add a
+# host that is valid for humans but blocks or throttles CI runners.
+
+# Shields.io / badge endpoints — dynamic SVGs that rate-limit and occasionally 5xx
+# from CI IPs; the badge being reachable is not what this gate protects.
+^https?://img\.shields\.io/
+^https?://shields\.io/
+
+# GitHub avatars / user-content CDN — throttles anonymous CI traffic.
+^https?://avatars\.githubusercontent\.com/
+^https?://.*\.githubusercontent\.com/
+
+# Local dev / example endpoints that appear in docs as illustrations, not live URLs.
+^https?://localhost(:\d+)?
+^https?://127\.0\.0\.1(:\d+)?
+^https?://0\.0\.0\.0(:\d+)?
+^https?://example\.(com|org|net)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,14 +5,14 @@ Thank you for your interest in contributing to Leoflow! This document explains h
 ## Before You Start
 
 1. Read [`README.md`](README.md) to understand what Leoflow is.
-2. Read the [Architecture Decision Records](docs/adr/) under `docs/adr/`. These document non-negotiable design choices. Contributions that contradict an ADR will be rejected unless the ADR is first amended via a separate PR.
+2. Read the [Architecture Decision Records](website/content/project/adrs/) under `website/content/project/adrs/`. These document non-negotiable design choices. Contributions that contradict an ADR will be rejected unless the ADR is first amended via a separate PR.
 3. Read [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
 
 ## How to Contribute
 
 ### Reporting Bugs
 
-1. Search [existing issues](../../issues) to confirm the bug has not been reported.
+1. Search [existing issues](https://github.com/neochaotic/leoflow/issues) to confirm the bug has not been reported.
 2. If not, open a new issue using the **Bug Report** template.
 3. Include reproduction steps, expected behavior, actual behavior, and environment details (OS, Go version, K8s version if applicable).
 
@@ -20,7 +20,7 @@ Thank you for your interest in contributing to Leoflow! This document explains h
 
 1. Open an issue using the **Feature Request** template.
 2. Describe the use case and the proposed solution.
-3. **For significant features, propose an ADR.** Open a PR adding a draft ADR under `docs/adr/` with status "Proposed." Discussion happens on the PR.
+3. **For significant features, propose an ADR.** Open a PR adding a draft ADR under `website/content/project/adrs/` with status "Proposed." Discussion happens on the PR.
 
 ### Submitting Code
 
@@ -34,9 +34,9 @@ Open an issue or comment on an existing one before starting work on anything bey
 
 Leoflow has strict engineering standards documented in the ADRs:
 
-- **[ADR 0011 — TDD Strict](docs/adr/0011-tdd-strict.md):** every production change is preceded by a failing test. Two-commit pattern preferred (`test:` followed by `feat:`).
-- **[ADR 0012 — Code Quality Standards](docs/adr/0012-code-quality-standards.md):** Go Report Card A+ as floor. GoDocs mandatory on every exported identifier. Cyclomatic complexity ≤ 15.
-- **[ADR 0014 — Supply Chain Security](docs/adr/0014-supply-chain-security.md):** vulnerability scans, signed commits encouraged, no introduction of unsafe patterns.
+- **[ADR 0011 — TDD Strict](website/content/project/adrs/0011-tdd-strict.md):** every production change is preceded by a failing test. Two-commit pattern preferred (`test:` followed by `feat:`).
+- **[ADR 0012 — Code Quality Standards](website/content/project/adrs/0012-code-quality-standards.md):** Go Report Card A+ as floor. GoDocs mandatory on every exported identifier. Cyclomatic complexity ≤ 15.
+- **[ADR 0014 — Supply Chain Security](website/content/project/adrs/0014-supply-chain-security.md):** vulnerability scans, signed commits encouraged, no introduction of unsafe patterns.
 
 CI enforces all of the above automatically. PRs that fail CI cannot be merged.
 
@@ -105,7 +105,7 @@ make lint test    # the quality gates you must pass before pushing
 ```
 
 For an end-to-end author→run loop without Kubernetes, use `leoflow dev`
-(see [`docs/operating-modes.md`](docs/operating-modes.md)).
+(see [Editions & operating modes](website/content/concepts/editions.md)).
 
 ## Project Layout
 
@@ -123,6 +123,6 @@ By contributing, you agree that your contributions will be licensed under the [A
 
 ## Recognition
 
-All contributors are listed in [`CONTRIBUTORS.md`](CONTRIBUTORS.md) (updated periodically by maintainers). Significant contributions are also highlighted in release notes.
+All contributors are shown on the repository's [contributors page](https://github.com/neochaotic/leoflow/graphs/contributors). Significant contributions are also highlighted in release notes.
 
 Thank you for helping make Leoflow better!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -80,7 +80,7 @@ days", which described a versioning shape the project does not have.
 
 ## Recognition
 
-We maintain a [Security Hall of Fame](docs/security-hall-of-fame.md) acknowledging researchers who have responsibly disclosed vulnerabilities. With your permission, we credit you publicly when we publish the fix.
+We maintain a Security Hall of Fame acknowledging researchers who have responsibly disclosed vulnerabilities. With your permission, we credit you publicly when we publish the fix.
 
 ## Out of Scope
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,45 @@
+# lychee link/image checker configuration — shared by the CI PR gate
+# (.github/workflows/link-check.yml, which checks the tracked Markdown, and
+# .github/workflows/website-build.yml, which checks the built Hugo site under
+# website/public). Host-level ignore patterns live in .lycheeignore next to this.
+#
+# Why this exists: two recent breakages shipped because nothing checked links or
+# images — README images 404'd after the Hugo migration moved docs/assets, and
+# README doc links 404'd. Both are broken *relative* paths a build-time link check
+# catches. Keep this file behaviour-only; put flaky-host regexes in .lycheeignore.
+
+############################  Requests  ############################
+# Give transient network conditions a couple of chances before failing the gate,
+# so a single blip on an external host does not red a PR.
+max_retries = 3
+retry_wait_time = 2
+timeout = 20
+
+# Treat rate-limiting as success: shared CI runner IPs routinely get 429/403 from
+# GitHub and other popular hosts even though the target is perfectly valid. We are
+# gating on *broken* links (4xx/5xx that mean "gone"), not on throttling.
+accept = ["200..=299", "429", "403"]
+
+# Accept a timed-out request rather than failing on it — a slow external host is a
+# network condition, not a broken link. Local (file://) targets never time out, so
+# the dead-relative-path case we care about is unaffected.
+accept_timeouts = true
+
+############################  Scope  ###############################
+# Never resolve loopback / localhost examples in docs (curl http://localhost:8080,
+# 127.0.0.1 dev URLs, etc.) — they are illustrative, not live.
+exclude_loopback = true
+
+# mailto: links are not reachable over HTTP; don't try (this is lychee's default,
+# stated explicitly).
+include_mail = false
+
+# Fragment/anchor checking is OFF (lychee default). Hugo + Docsy slugify headings at
+# render time and inject anchors the raw Markdown source doesn't carry, so verifying
+# `#section` fragments against source produces false failures. Do NOT turn this on
+# (no --include-fragments) without re-checking the rendered anchors instead.
+
+############################  Exclusions  ##########################
+# Host-level and known-flaky exclusions are kept in .lycheeignore (one regex/line)
+# so contributors have a single obvious place to silence a genuinely flaky host
+# without editing this behavioural config.


### PR DESCRIPTION
> # 🛑 HOLD — v0.4.1
> **DO NOT MERGE.** Opened for review only, pending maintainer sign-off.

## What & why

Nothing in CI verified links or images, which is the root cause of the
**#740/#758 broken-link/image class**: README images 404'd after the Hugo
migration moved `docs/assets` (fixed reactively in #758), and README doc links
404'd (#740). `website-build.yml` ran only `hugo --gc --minify`, and `hugo.toml`
sets no `refLinksErrorLevel` — so a moved page or asset shipped silently.

This adds [**lychee**](https://github.com/lycheeverse/lychee) (`lycheeverse/lychee-action@v2`)
as a PR gate over both surfaces the class hides in.

## Scope

**`.github/workflows/link-check.yml`** (new) — checks the tracked governance
Markdown: `README.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`.
lychee resolves each relative link/image against the file's own directory, so a
dead `docs/assets/x.png` `src` or a moved doc target fails the gate. External
links are checked too. Triggers on changes to those files or the checker config.

**`.github/workflows/website-build.yml`** (edited) — a new step link-checks the
**rendered** site (`website/public`) right after the existing `hugo` build,
`--offline`, resolving every root-relative `/leoflow/…` href and `img src`
against the built output. Offline on purpose: the bug class is broken *internal*
relative links/images, not external fan-out across thousands of doc links.

**Config (repo root):**
- `lychee.toml` — behaviour: retries, tolerate `429`/`403`/timeouts (shared CI
  IPs get throttled), exclude loopback/localhost, fragments **off** (Docsy
  slugifies anchors at render time, so source-side fragment checks false-fail).
- `.lycheeignore` — flaky/auth-walled hosts (shields.io badges, GitHub avatar
  CDN) and local example URLs.

Both jobs are `permissions: contents: read` — report-only, no write scopes.

## Would it have caught #740/#758?

Yes — that is the whole point. And it already did: running it surfaced **7
pre-existing dead relative links** of the exact same class, now fixed in this PR:

| File | Dead link | Fix |
|---|---|---|
| CONTRIBUTING.md | `docs/adr/`, `docs/adr/0011/0012/0014-*.md` | → `website/content/project/adrs/…` (moved by the migration) |
| CONTRIBUTING.md | `docs/operating-modes.md` | → `website/content/concepts/editions.md` (has the `/operating-modes.html` alias) |
| CONTRIBUTING.md | `CONTRIBUTORS.md` (never existed) | → GitHub contributors page |
| CONTRIBUTING.md | `../../issues` (GitHub-relative) | → absolute repo issues URL |
| SECURITY.md | `docs/security-hall-of-fame.md` (never existed) | de-linked, sentence kept |

## Validation

- **actionlint** — clean on both `link-check.yml` and `website-build.yml`.
- **lychee 0.24.2 locally**:
  - Governance Markdown: **0 errors** (68 OK online / 17 file-links offline).
  - Built Hugo site (`hugo --gc --minify` then lychee `--offline`): **0 errors, 3540 internal links/images OK**.
  - **Deliberate-break demo**: a scratch `.md` with `![](docs/assets/x.png)` and a
    dead `docs/…md` link failed with exit 2, while a valid `LICENSE` link passed.
    Scratch file removed afterward.

## Notes

- `CHANGELOG.md` intentionally untouched.
- Follow-up candidate: widen the Markdown job to `articles/`, `examples/`, and
  per-module READMEs once their links are audited (kept out of this PR to stay
  focused and land green).
