### PR TITLE
docs: deploy prerequisites, variable declaration, ADR status, dbt manifest/serverless (v0.4.1)

### DIFF
--- a/website/content/author-dags/dag-authoring.md
+++ b/website/content/author-dags/dag-authoring.md
@@ -183,8 +183,10 @@ How it works, and the Phase-A limits:
 - The provider must be declared in `leoflow.yaml` (`connectors:` or
   `dependencies:`). If it isn't, `leoflow compile` fails and prints the exact line
   to add — no surprise `ModuleNotFoundError` in the pod.
-- **Sensors** run in **poke mode** (the pod holds until the condition is met).
-  `mode="reschedule"` is not supported yet and fails with a clear message.
+- **Sensors** run in **poke mode** by default (the pod holds until the
+  condition is met), or `mode="reschedule"` (ADR 0040 Phase B, #380/#389) — the
+  pod is released between pokes and the scheduler re-dispatches the sensor,
+  preserving its `try_number`, once its next-poke time passes.
 - **Jinja templating** is best-effort (`render_template_fields` runs with a
   minimal context); for rich macros (`{{ ds }}`, `{{ ti }}`, custom params),
   compute the value in a `@task` and pass it in.
@@ -204,11 +206,6 @@ refused at compile with a clear error naming the construct
 The unsupported set, with the things Airflow users most often expect to
 "just work" called out first:
 
-- **Reschedule-mode sensors** — a sensor with `mode="reschedule"` (frees the
-  worker between pokes) is not supported yet; it fails at runtime with a clear
-  message. Use the default `mode="poke"` (the pod holds until the condition is
-  met). *Poke-mode sensors and provider operators ARE supported* — see
-  [`airflow_operator`](#provider-operators-sensors-airflow_operator) above.
 - **Deferrable operators / sensors** — anything with `deferrable=True` (it suspends
   the task onto a *trigger*) is not supported yet: Leoflow has no triggerer (ADR
   0040 Phase C). It fails at runtime with a clear message. Pass `deferrable=False`

--- a/website/content/author-dags/dbt.md
+++ b/website/content/author-dags/dbt.md
@@ -79,6 +79,45 @@ You never write task dependencies — `{{ ref('stg_orders') }}` **is** the edge.
 > image-build time in Pro). Set `dbt.manifest: target/manifest.json` to point at a
 > pre-built one.
 
+{{% alert title="No local dbt, or your adapter has no wheel for your Python? Pre-build the manifest in a container" color="warning" %}}
+`leoflow compile`/`--build` shells out to `dbt parse` on your machine (the
+runtime never needs dbt — only compile-time manifest generation does). If your
+host has no dbt installed, or your adapter has no prebuilt wheel for your
+Python (a common one: `dbt-databricks` publishes wheels for 3.10–3.12, not the
+Python 3.9 that ships as the default `python3` on some LTS distros/older
+macOS), `dbt parse` fails or the adapter refuses to install — before Leoflow
+ever gets involved.
+
+**Escape hatch: generate the manifest in a throwaway container with a Python
+`dbt-databricks` actually supports, then point `dbt.manifest:` at the result.**
+
+`dbt parse` does not open a warehouse connection, so a **`profiles.yml` with
+placeholder values** (matching the profile name in `dbt_project.yml`) is
+enough — no real credentials need to enter the container:
+
+```console
+$ docker run --rm -v "$PWD":/proj -w /proj python:3.11-slim bash -c "
+    pip install --no-cache-dir dbt-databricks &&
+    dbt parse --profiles-dir . "
+$ ls target/manifest.json     # now sitting in your project dir
+```
+
+```yaml
+# leoflow.yaml
+dbt:
+  project: .
+  manifest: target/manifest.json   # pinned — leoflow compile skips `dbt parse` entirely
+  connection: warehouse_databricks
+```
+
+A pinned manifest is used **as-is** (see `loadDbtManifest` — no local dbt
+required at all from that point on); regenerate it in the container whenever
+you change models. This is the same trick CI runners use when their base image
+doesn't carry a compatible Python for every adapter — see [Python on the
+runner](/operate/cicd-deploy/#python-on-the-runner) for the CI-side version of
+this problem.
+{{% /alert %}}
+
 ---
 
 ## 2. Mixing dbt with operators
@@ -214,6 +253,19 @@ The compiled command becomes:
 python -m leoflow_runtime --dbt-profile warehouse_pg <profile> && dbt run --select …
 ```
 
+{{% alert title="Serverless warehouse cold-start (Databricks, and similar)" color="info" %}}
+A serverless SQL warehouse auto-stops after a period of inactivity (Databricks
+serverless: ~5 min by default). The `dbt-databricks` adapter wakes it
+transparently on the next query — no manual "resume" step — but the **first**
+task to hit a stopped warehouse pays a cold-start delay (observed ~10s) before
+its query starts. This is warehouse behavior, not a Leoflow limitation: a
+scheduled dbt DAG that runs at the top of every hour, say, should expect that
+delay on its first model each run (subsequent models in the same run land on
+the now-warm warehouse). Pre-warming (a scheduled no-op query shortly before
+your DAG's run time) is a warehouse-side mitigation if the delay matters for
+your SLA.
+{{% /alert %}}
+
 > **vs Cosmos.** Cosmos bridges Airflow connections to dbt profiles with a
 > per-warehouse `profile_mapping` class declared in Python. Leoflow does it from
 > the connection automatically — one `connection:` line, zero mapping classes,
@@ -345,7 +397,7 @@ is tested varies by adapter:
 | **duckdb** | contract + live | ✅ real dbt on Lite (`e2e-lite-dbt`) |
 | **snowflake** | ✅ contract-tested | ⚠️ hand-verified only |
 | **bigquery** | ✅ contract-tested | ⚠️ hand-verified only |
-| **databricks** | ✅ contract-tested | ⚠️ hand-verified only |
+| **databricks** | ✅ contract-tested | ⚠️ hand-verified (see below) |
 
 **Contract-tested** means CI feeds Leoflow's emitted profile through the *real* dbt
 adapter's own credential parsing (`dbt-adapter-contracts` job): correct field
@@ -357,7 +409,19 @@ succeeds against your account.
 **Live-query verification for the cloud adapters is maintainer-owned** — it needs
 real warehouse accounts + CI secrets. The template is `test/e2e/dbt-connection-e2e.sh`
 (today it runs against a local Postgres warehouse); pointing it at a real Snowflake/
-BigQuery/Databricks account, gated on org secrets, is the remaining step.
+BigQuery/Databricks account, gated on org secrets, is the remaining step — the
+`⚠️` stays until that runs in CI on every change, not just once by hand.
+
+{{% alert title="Databricks: hand-verified end-to-end on a real serverless account" color="success" %}}
+The full path has been validated against a real Databricks serverless SQL
+warehouse: managed **`connection:`** → Leoflow-generated `profiles.yml` →
+**service-principal OAuth M2M** auth → **pod-per-model** execution (`granularity:
+node`) → a `view` and a `Delta` table materialized → the warehouse's
+**transparent cold-start** observed and confirmed non-blocking (see the
+[serverless cold-start note](#4-the-warehouse-connection) in §4). This
+confirms the adapter integration works against a real account; it is still a
+**hand run**, not a CI-gated one — see the note above on closing that gap.
+{{% /alert %}}
 
 ---
 

--- a/website/content/author-dags/variables-connections.md
+++ b/website/content/author-dags/variables-connections.md
@@ -57,6 +57,47 @@ a host only resolvable inside the cluster (e.g. `host.k3d.internal` in dev) read
 as unreachable there even though pods can reach it. Full per-provider credential
 validation needs the provider hooks (a later addition).
 
+## Declare what a task consumes
+
+A task doesn't automatically get the value just because it exists on the
+control plane — the DAG that consumes a Variable or Connection should
+**declare** it in `leoflow.yaml`, the same consumption-declared model
+[declared secrets](/project/adrs/0045-declared-secret-delivery/) use:
+
+```yaml
+# leoflow.yaml
+dag_id: sales_report
+variables:
+  - greeting
+connections:
+  - warehouse
+```
+
+The three-step flow is: **create** the Variable/Connection (UI or API, above) →
+**declare** it in `leoflow.yaml` → **read** it in the task (below).
+
+{{% alert title="What declaring actually controls today" color="warning" %}}
+The control plane's secret-delivery policy (`auth.secret_scoping`, [ADR
+0055](/project/adrs/0055-secret-scoping-and-token-liveness/)) has two modes:
+
+- **`permissive`** (the shipped default) delivers the **whole tenant vault** to
+  every task regardless of declaration, and only logs a warning when a task's
+  declared set is narrower than what it received. An **undeclared** Variable or
+  Connection still resolves — `Variable.get` does **not** return empty under
+  this default.
+- **`enforce`** delivers **only** the declared subset — an undeclared name is
+  not delivered, and `Variable.get`/`BaseHook.get_connection` for it comes back
+  empty/missing, exactly like a declared-secrets task that requested nothing.
+
+**Declare anyway, even under `permissive`.** It documents your DAG's real
+dependencies, matches how a deploy already warns you about missing
+*connections* (see [Deploy your first Pro DAG](/operate/first-pro-dag/#when-it-doesnt-work)),
+and is what makes the DAG portable to a tenant running `enforce` — the
+direction least-privilege delivery is headed (tracked in
+[#59](https://github.com/neochaotic/leoflow/issues/59)). An operator sets the
+policy cluster-wide; it is never a DAG-author setting.
+{{% /alert %}}
+
 ## Read them in a task
 The agent injects each tenant's Variables/Connections before running your code:
 

--- a/website/content/operate/_index.md
+++ b/website/content/operate/_index.md
@@ -14,6 +14,8 @@ the day-2 operations that keep a control plane healthy.
 
 - **[Deploy your first Pro DAG](/operate/first-pro-dag/)** — take a DAG from Lite to
   a Kubernetes control plane.
+- **[Deploy prerequisites & why shortcuts fail](/operate/deploy-prerequisites/)** —
+  every gate a Pro deploy enforces, its exact error, and the fix.
 - **[CI/CD & deploy](/operate/cicd-deploy/)** — build, push, and register DAGs from
   CI (GitHub Actions, GitLab, Cloud Build).
 - **[Helm chart](/operate/helm-chart/)** — install and configure the Pro control

--- a/website/content/operate/cicd-deploy.md
+++ b/website/content/operate/cicd-deploy.md
@@ -63,6 +63,15 @@ manually so you can watch the DAG cross each boundary. Come back here to wire
 the same steps into CI.
 {{% /alert %}}
 
+{{% alert title="A CI run failing? Check the prerequisites" color="info" %}}
+Registry auth, RBAC scope, non-root images, private-registry pulls, and the
+`--dag-version`/`409` gotcha are exactly the errors CI hits first, since a
+runner has none of a laptop's ambient state (no `docker login`, no
+`leoflow auth login` session, no git history for `--dag-version` to resolve
+against). **[Deploy prerequisites & why shortcuts fail](/operate/deploy-prerequisites/)**
+has the exact error and fix for each.
+{{% /alert %}}
+
 ## Your repo of DAGs (CI is the recommended path)
 
 In Pro you keep your DAGs in a Git repository — one directory per DAG — and **CI**

--- a/website/content/operate/deploy-prerequisites.md
+++ b/website/content/operate/deploy-prerequisites.md
@@ -1,0 +1,205 @@
+---
+title: "Deploy prerequisites & why shortcuts fail"
+linkTitle: "Deploy prerequisites"
+weight: 15
+description: "Every gate leoflow deploy/push enforces — the exact error, why it exists, and the fix."
+---
+
+`leoflow deploy` (and its explicit-steps sibling `leoflow push`) is **fail-closed
+by design** — it registers a DAG only when the artifact and the caller both meet
+every gate below. That is deliberate: a Pro control plane runs task pods with
+your DAG's image and credentials, so the gates are the boundary between "code a
+teammate wrote" and "code that runs with real access." When a deploy is
+rejected, the error tells you which gate and how to satisfy it — this page is
+the one place that collects all of them, so you are not re-discovering each one
+by trial and error.
+
+{{% alert title="`leoflow deploy`/`push` is the only supported registration path" color="warning" %}}
+There is no `kubectl apply` shortcut for a DAG. `POST /api/v2/dags/{id}/versions`
+(what `deploy`/`push` call) is the **only** way a DAG version is registered, and
+it re-validates the full spec server-side on every call — the same guardrails
+that reject a bad DAG locally reject it again here, so a hand-crafted or
+CI-bypassing request cannot sneak an invalid artifact past compile-time checks.
+{{% /alert %}}
+
+## The gates
+
+### 1. A configured registry
+
+Pro has no single-node image-import path — Kubernetes pulls images from a
+registry, so a Pro deploy needs one, full stop (Lite runs locally and needs
+none). Missing `registry:` in `leoflow.yaml` fails immediately:
+
+```
+error: deploy requires a container registry, but none is configured.
+  A Pro deploy pushes the DAG image to a registry your cluster can pull from
+  (Lite runs locally and needs none). Add to leoflow.yaml:
+
+      registry:
+        url: ghcr.io/<your-org>     # or ECR / Artifact Registry / ACR / private
+        image_name: <name>
+
+  Then authenticate your builder once:  docker login ghcr.io
+```
+
+**Fix:** add the `registry:` block, then `docker login <registry>` once (builder
+auth is separate from the control-plane login — see [gate 5](#5-auth--writedag-rbac-scope)).
+See [ADR 0041](/project/adrs/0041-leoflow-deploy-pipelineless/).
+
+### 2. Digest-pinned, immutable artifact — no `:latest`
+
+A DAG is an **immutable artifact**: `dag.json` + a container image, versioned
+together ([ADR 0003](/project/adrs/0003-dag-as-image/)). `deploy` captures the
+pushed image's **digest** and rewrites it into `dag.json` as `registry/image@sha256:…`
+before registering — Pro never resolves a tag at pull time, so there is no
+`:latest` drift and no way to point a DAG version at a moving target. This is
+automatic; there is nothing to configure, but it explains why re-running the
+same tag with different content produces a **new**, distinct artifact rather
+than silently replacing the old one.
+
+### 3. Supported task types only
+
+`leoflow compile` accepts a closed set of task types — `python` (`@task`/
+`PythonOperator`), `bash` (`BashOperator`), and `airflow_operator` (any provider
+operator/sensor, run through the generic executor — [ADR 0040](/project/adrs/0040-airflow-operator-support/)).
+Everything else is a **loud compile-time rejection**, never a silent
+mistranslation — including a message shaped like:
+
+```
+<construct>: not supported by Leoflow (supported: Bash, Http, Python/@task; no dynamic task mapping or task groups)
+```
+
+The construct named most often in real deploys:
+
+- **`KubernetesPodOperator` — always refused.** Every Leoflow task already runs
+  in its own pod (the pod *is* the execution unit); `KubernetesPodOperator` lets
+  a DAG author specify an **arbitrary pod spec** — service account, volumes,
+  host networking, capabilities — which would hand the author the exact
+  privilege-escalation surface Leoflow's pod-per-task model exists to contain.
+  Wrapping a task in another pod is redundant on top of that, and the author-
+  controlled pod spec is precisely the escalation surface Leoflow retains
+  control of. There is no workaround; express the work as `python`/`bash`, or
+  as a provider operator via `airflow_operator`.
+- **Dynamic task mapping** (`.expand`/`.partial`) — refused; static fan-in works,
+  dynamic fan-**out** does not yet.
+- **Task groups** (`TaskGroup`, `@task_group`) — refused outside the dbt
+  integration's own group construct (`dbt_group()`); a general-purpose `dag.py`
+  `TaskGroup` is not supported.
+
+The full, current, authoritative list (including reschedule-mode sensors,
+deferrable operators, branching, `PythonVirtualenvOperator`, per-task
+`default_args`) lives in
+[DAG authoring → Not supported](/author-dags/dag-authoring/#not-supported--leoflow-compile-rejects-these) —
+this page only calls out the ones deploy attempts hit most.
+
+### 4. Non-root task image
+
+A task container whose image runs as **UID 0** is refused by the control
+plane's pod security defaults. On Pro, this is the executor's
+`taskPodSecurity.runAsNonRoot` Helm value (`true` by default — see
+`helm/leoflow/values.yaml`). When it rejects your image, the **task pod**
+fails to start with:
+
+```
+CreateContainerConfigError: container has runAsNonRoot and image will run as root
+```
+
+This is easy to miss because it surfaces as a **pod** failure, not a `deploy`
+CLI error — `deploy` succeeds (the artifact registers fine), and the rejection
+only shows up when the scheduler tries to run a task.
+
+**Fix — pick one:**
+- End your custom `Dockerfile` with a **numeric** non-root user, e.g.
+  `USER 65532:65532` (the published Leoflow runtime base already does this — you
+  only hit this gate with a **custom** Dockerfile that overrides `USER`). A
+  *name* (`USER leoflow`) is not enough: the kubelet can only verify a numeric
+  UID, so a name is rejected as unresolvable even when it maps to a non-root
+  user.
+- Or, cluster-wide, an operator sets `taskPodSecurity.runAsNonRoot: false` in
+  the Helm values — this is deliberately a cluster-operator switch, not a
+  per-DAG one, so a DAG author cannot elevate their own task's privilege.
+
+### 5. Auth + `write:dag` RBAC scope
+
+Registering a version (`POST /api/v2/dags/{id}/versions`, what `deploy`/`push`
+call) requires the **`write:dag`** permission on the caller's token:
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `401` — `"unauthorized" / "no authenticated user"` | No token, or an invalid/expired one | `leoflow auth login --server <pro>` once; `deploy` then needs no auth flags |
+| `403` — `"forbidden" / "missing permission write:dag"` | A valid token whose role does not grant `write:dag` | Log in as (or ask an admin to grant) a role with `write:dag` — Admin → Users/Roles on the control plane |
+
+Registry auth (`docker login`, step 1) and control-plane auth (`leoflow auth
+login`) are **two separate credentials** — a push failing with `denied`/
+`unauthorized` is the *registry* rejecting the builder, not the control plane.
+
+### 6. Private-registry pull (the cluster's half, not just the push)
+
+Pushing successfully is not the same as the **cluster** being able to pull. A
+private registry needs the task pod to carry pull credentials:
+
+- **`imagePullSecrets` on the task ServiceAccount** —
+  `taskServiceAccount.imagePullSecrets` in the Helm values, referencing an
+  existing `docker-registry` Secret (e.g. `regcred`, created with
+  `kubectl create secret docker-registry regcred --docker-server=… --docker-username=… --docker-password=…`).
+  Kubernetes auto-injects a ServiceAccount's pull secrets into every pod that
+  runs as it.
+- **The task must actually run as that ServiceAccount** — set
+  `execution.service_account: <taskServiceAccount.name>` in the DAG's
+  `leoflow.yaml`. Without it, task pods use the namespace `default` SA, which
+  carries no pull secrets, and the pod fails with `ErrImagePull`/`ImagePullBackOff`
+  even though `imagePullSecrets` is configured in the chart.
+- **On ECR specifically**, you have the same two options infra teams already
+  know: a long-lived `regcred` (`aws ecr get-login-password | kubectl create
+  secret docker-registry …`, needs periodic rotation — ECR tokens expire), or
+  node/pod-level IAM (IRSA / EKS Pod Identity) paired with an ECR credential
+  helper so the kubelet authenticates without a static secret. Leoflow does not
+  care which — it only needs the pull to work; either path satisfies this gate.
+
+See the chart-wiring detail in [ADR 0041 → Cluster wiring](/project/adrs/0041-leoflow-deploy-pipelineless/#cluster-wiring-helm--required-for-the-deploy-path-to-actually-pull).
+
+### 7. Where task logs actually live — not `kubectl logs`
+
+`kubectl logs <pod>` shows only the **agent wrapper's** own stderr — it is not
+where task output goes. Task stdout/stderr streams from the agent over gRPC to
+the control plane's log sink. Read it from:
+
+- **The UI** — the task instance's log drill-down (Airflow-compatible).
+- **The API** — `GET /api/v2/dags/{dag_id}/dagRuns/{dag_run_id}/taskInstances/{task_id}/logs/{try_number}`.
+- **The CLI** — `leoflow runs logs <dag_id> <run_id> <task_id> [--try N] [-f/--follow]`,
+  landing in v0.4.1 (reads the same endpoint as the UI, so it works over a
+  plain `--server`/token session with no cluster access needed).
+
+See [Troubleshooting → Logs](/operate/troubleshooting/#logs) for where the sink
+directory and control-plane request logs live.
+
+### 8. `--dag-version` outside a git repo — the `dev` default and its 409
+
+`--dag-version` defaults to `git describe` in the project's directory; **outside
+a git repo it falls back to the literal string `"dev"`.** DAG versions are
+immutable and unique per `(dag_id, version)` — a second deploy that reuses the
+same version string with **different content** is a genuine conflict, not an
+overwrite, and is rejected:
+
+```
+server returned 409: {"title":"conflict","status":409,"detail":"inserting version: …"}
+```
+
+An identical re-push of the same content short-circuits (idempotent, no error);
+only a version string collision with **different** content 409s. This bites
+example DAGs, scratch projects, and CI checkouts that clone with `--depth 1`
+outside `.git` scope — anything not resolvable by `git describe`.
+
+**Fix:** pass an explicit, changing `--dag-version` (`--dag-version
+$(date +%s)` for scratch iteration, or your CI's commit SHA), or run inside a
+real git checkout so `git describe`/`tag_strategy: git_sha` gives you a fresh
+version automatically on every commit.
+
+## From here
+
+- **[Deploy your first Pro DAG](/operate/first-pro-dag/)** — the walkthrough
+  these gates protect.
+- **[CI/CD & deploy examples](/operate/cicd-deploy/)** — wiring `deploy`/`push`
+  into a pipeline, where most of gates 5–8 get automated away.
+- **[Troubleshooting & observability](/operate/troubleshooting/)** — symptoms
+  once a DAG is already running.

--- a/website/content/operate/first-pro-dag.md
+++ b/website/content/operate/first-pro-dag.md
@@ -160,6 +160,11 @@ shows state and logs. That is the whole Pro lifecycle, in one verb.
 | Task pod: `exec format error` | image arch ≠ cluster arch | already handled — deploy builds `linux/amd64`; for a Graviton cluster pass `--platform linux/arm64` |
 | DAG runs but a task fails on a missing `conn_id` | connections live in the control plane, **not** in the image | deploy prints `note: this DAG expects connection(s): …` — create them on Pro (UI/API) first; see [Variables & Connections](/author-dags/variables-connections/) |
 
+Hit something not on this list — an unsupported task type, `CreateContainerConfigError`,
+a `401`/`403`, a private-registry `ErrImagePull`, or a `409` on a second deploy?
+**[Deploy prerequisites & why shortcuts fail](/operate/deploy-prerequisites/)**
+collects every gate `deploy`/`push` enforce, with the exact error and the fix.
+
 ## Deploy more than one DAG
 
 ```bash

--- a/website/content/operate/troubleshooting.md
+++ b/website/content/operate/troubleshooting.md
@@ -59,11 +59,13 @@ leoflow-mcp --version
 | Symptom | Cause / fix |
 |---|---|
 | `leoflow compile` dumps a Python traceback with internal parser paths first | Recent builds lead the failure with the user-facing line (e.g. `SyntaxError: ...`) and put the parser paths in the bounded tail. If you still see the internal-first dump, you are on an older release — update. |
-| `leoflow compile` rejects a sensor / Jinja template / branching operator | This is **intentional** — Leoflow accepts a closed set of task types (`python`, `bash`, `airflow_operator`). See [DAG authoring → Not supported](/author-dags/dag-authoring/#not-supported-leoflow-compile-rejects-these) for the full list and workarounds (`@task` + poll loop for sensors; build values from `airflow.sdk` context for Jinja). |
+| `leoflow compile` rejects a sensor / Jinja template / branching operator | This is **intentional** — Leoflow accepts a closed set of task types (`python`, `bash`, `airflow_operator`). See [DAG authoring → Not supported](/author-dags/dag-authoring/#not-supported--leoflow-compile-rejects-these) for the full list and workarounds (`@task` + poll loop for sensors; build values from `airflow.sdk` context for Jinja). |
 | `Compiled .../dag.py -> dag.json (image , version dev)` (dangling comma) | Older build — update. Recent versions render `(no image, version dev)` when `--image` is unset. |
 | Task pod `ErrImagePull` (cluster mode) | The DAG's image is not in the cluster — rebuild + import. Cluster-mode rebuilds on save; for a manual push, `leoflow compile --build --push`. |
 | Run stuck at `queued` (subprocess) | The agent must reach the control plane — Lite uses `127.0.0.1:<grpc>`. The executor launches async and the agent reports state back. Look for the agent process in `ps`; if it exited, check `/tmp/leoflow-lite.log` for the launch error. |
 | Run stuck at `running` long after the task finished | The agent's heartbeat reaper picks these up after the configured window. Check `LEOFLOW_TI_HEARTBEAT_TIMEOUT_SECONDS` and look for a `reaped` log line. |
+| Task pod `CreateContainerConfigError: container has runAsNonRoot and image will run as root` | Your task image runs as UID 0; the executor's `taskPodSecurity.runAsNonRoot` default refuses it. Fix: numeric `USER 65532:65532` in your Dockerfile, or an operator sets `taskPodSecurity.runAsNonRoot: false`. See [Deploy prerequisites](/operate/deploy-prerequisites/#4-non-root-task-image). |
+| `leoflow deploy`/`push` fails on auth, registry, or a version conflict | One of the deploy-time gates. [Deploy prerequisites & why shortcuts fail](/operate/deploy-prerequisites/) covers every gate with the exact error and fix. |
 
 ## UI / browser
 
@@ -90,8 +92,15 @@ leoflow uninstall --purge                               # also remove the worksp
 Task logs stream from the agent over gRPC to the control plane's log sink and
 are served at
 `/api/v2/dags/<dag>/dagRuns/<run>/taskInstances/<task>/logs/<try>` (the UI's
-drill-down). The sink directory is `LEOFLOW_LOGS_DIR` (must be writable;
-`leoflow lite` points it at a temp dir).
+drill-down), or from the CLI: `leoflow runs logs <dag_id> <run_id> <task_id>
+[--try N] [-f]` (landing in v0.4.1). The sink directory is `LEOFLOW_LOGS_DIR`
+(must be writable; `leoflow lite` points it at a temp dir).
+
+{{% alert title="Not kubectl logs" color="warning" %}}
+On Pro, `kubectl logs <pod>` shows only the **agent wrapper's** own stderr —
+never the task's stdout/stderr, which the agent ships to the control plane's
+log sink instead. Use the UI, the API route above, or `leoflow runs logs`.
+{{% /alert %}}
 
 Control-plane logs are structured `slog` (JSON by default), one line per HTTP
 request with a request id — `grep <request_id>` correlates a UI click to its

--- a/website/content/project/adrs/0040-airflow-operator-support.md
+++ b/website/content/project/adrs/0040-airflow-operator-support.md
@@ -9,7 +9,15 @@ weight: 400
 description: "ADR 0040: Airflow operator + sensor execution — native fast path + generic executor"
 ---
 
-**Status:** Accepted (design; implementation post-RC, phased)
+**Status:** Accepted — **Phase A + B shipped**. `airflow_operator` is a live,
+validated task type (`internal/domain/dag.go` `TaskTypeAirflowOperator`;
+`internal/agent/command.go`, `internal/agentrpc/server.go`; parser support in
+`parser/leoflow_parser/compiler.py`) covering the generic executor for
+synchronous operators and poke-mode sensors (Phase A) and reschedule-mode
+sensors (Phase B — `task_reschedule` state in `internal/scheduler`,
+migrations 017/018). Phase C (deferrable operators/triggerer) and the
+goroutine-based native sensor engine remain **not started**, per the "Explicitly
+NOT in this pass" scope below.
 **Date:** 2026-06-04
 **Companions:** ADR 0038 (`connectors:` sugar), ADR 0039 (generated connector catalog), ADR 0024 (parser structural shim), ADR 0036 (runtime compat shim — deferred), ADR 0022/0023 (task config)
 

--- a/website/content/project/adrs/0041-leoflow-deploy-pipelineless.md
+++ b/website/content/project/adrs/0041-leoflow-deploy-pipelineless.md
@@ -9,7 +9,17 @@ weight: 410
 description: "ADR 0041: `leoflow deploy` — pipeline-less promotion from Lite to Pro"
 ---
 
-**Status:** Accepted — implementation in progress (branch `feat/deploy`, PR #367); target **v0.0.2-rc.2**, independent of the held v0.1.0 connectors epic
+**Status:** Accepted — **shipped**. `leoflow deploy`/`push` is implemented
+(`internal/cli/deploy.go`), end-to-end tested (`test/e2e/deploy-e2e.sh`), and
+was the registration path used in the v0.4.0-rc.4 EKS validation. The registry
+requirement, digest-pinning, `--platform` cross-build default, and the
+[Cluster wiring](#cluster-wiring-helm--required-for-the-deploy-path-to-actually-pull)
+Helm changes below are all live. The rc.2-era markers left in the sections
+below ("target v0.0.2-rc.2", the `feat/deploy` branch-sync note) are the
+historical record of the branch this shipped on, not open work; whether the
+**Tier 2** (Dockerfile-free, yaml-driven build) happy path described under
+"Two-tier happy path" is the current default is tracked in the DAG-authoring
+docs, not restated here.
 **Date:** 2026-06-04
 **Companions:** ADR 0003 (DAG as immutable artifact), ADR 0019 (secret encryption), ADR 0021 (AIRFLOW_CONN delivery), the editions split (Lite/Pro)
 

--- a/website/content/project/adrs/0050-mcp-server.md
+++ b/website/content/project/adrs/0050-mcp-server.md
@@ -9,7 +9,13 @@ weight: 500
 description: "ADR 0050: Model Context Protocol (MCP) server"
 ---
 
-**Status:** Accepted — design ratified in a scoping review; implementation phased and **not started**.
+**Status:** Accepted — **Phases 1–3 shipped** (`internal/mcp`, `cmd/leoflow-mcp`):
+the read-only resources (`dag://`, `run://`, `task://`, `log://`,
+`health://control-plane`), the `list_dags`/`diagnose_run`/`search_logs` tools,
+and the Streamable HTTP transport for Pro are live. The **authoring** half of
+the Phase 1 MVP (`scaffold_dag`/`validate_dag`, the `dag_authoring` prompt) and
+**Phase 4** (run control) described under "Prerequisites and phasing" below
+remain **not started**.
 **Date:** 2026-08-10
 **Relates:** ADR 0008 (JWT auth), ADR 0024 (DAG parsing structural shim → `dag.json`), ADR 0040 (Airflow operator execution), ADR 0041 (build/push/register deploy), ADR 0048 (no user code in the control plane), ADR 0049 (split API/scheduler roles), ADR 0019 (secret encryption at rest)
 **Issues:** #228 (per-tenant auth), #508 (tenant isolation is a caller convention, not a SQL predicate), #66 (restrict `MintUserToken`), #59 / #388 (least-privilege secret delivery), H4 / #537 (no token revocation)


### PR DESCRIPTION
## **HOLD — v0.4.1**

Per the branch-hold in effect since v0.4.0 GA: **do not merge.** This lands the four v0.4.1 doc gaps (workstream 2 of `spec/v0.4.1-plan.md`) on a held branch, ready to merge when the v0.4.1 window opens.

## What's here, mapped to each issue

### #763 — Deploy prerequisites & why shortcuts fail
New page **`website/content/operate/deploy-prerequisites.md`** — the single discoverable place for every `leoflow deploy`/`push` gate, each with the exact error string and the fix:
1. registry required (`deploy.go:149`)
2. digest-pinned immutable artifact, no `:latest` (ADR 0003)
3. supported task types only — `python`/`bash`/`airflow_operator`; **no** `KubernetesPodOperator` (pod-spec is the escalation surface leoflow retains), dynamic task mapping, or task groups — with a link to DAG authoring's authoritative "Not supported" list
4. non-root task image (`taskPodSecurity.runAsNonRoot`, the real Helm key) → `CreateContainerConfigError`, with the fix
5. auth + `write:dag` RBAC scope, the real 401/403 strings
6. private-registry pull (ECR: regcred vs IRSA/Pod Identity)
7. where task logs actually live — the UI, the `taskInstances/{task}/logs/{try}` API, and `leoflow runs logs` (landing in v0.4.1) — **not** `kubectl logs`
8. `--dag-version` outside a git repo → `dev` → a second-with-different-content deploy 409s

States plainly that `leoflow deploy`/`push` is the only registration path (no `kubectl apply` shortcut). Cross-linked from `first-pro-dag.md`, `cicd-deploy.md`, `troubleshooting.md`, and `operate/_index.md`.

Closes #763.

### #764 — declare `variables:`/`connections:` in leoflow.yaml
`author-dags/variables-connections.md` now leads with **create → declare in `leoflow.yaml` → read**, the same consumption-declared model as declared secrets.

One correction to the issue's framing, checked against the actual code (`internal/config/server.go`, `internal/agentrpc/secrets.go`, ADR 0055): the **shipped default** is `auth.secret_scoping: permissive`, which still delivers the whole tenant vault and only *warns* on a narrow declaration — `Variable.get` does **not** return empty for an undeclared name under today's default. It *does* return empty under `enforce` (the direction #59 is headed, not yet flipped). The page documents both accurately and still leads with "declare it" as the front-and-center, forward-compatible practice.

Closes #764.

### #765 — fix stale ADR status
- ADR 0041 (`leoflow deploy`): "implementation in progress … target v0.0.2-rc.2" → shipped, with the evidence cited (`internal/cli/deploy.go`, `test/e2e/deploy-e2e.sh`, used in the rc.4 EKS validation). Decision text untouched.
- ADR 0040 (Airflow operators): "post-RC, phased" → Phase A + B shipped (evidence cited), Phase C and the goroutine sensor engine still not started.
- **Scanned every ADR status line for the same drift** and found one more real one: ADR 0050 (MCP server) claimed "not started" despite `internal/mcp`/`cmd/leoflow-mcp` shipping Phases 1–3 (resources, `list_dags`/`diagnose_run`/`search_logs`, Streamable HTTP transport) — fixed, with the still-missing authoring tools and Phase 4 named explicitly so "shipped" isn't overclaimed.
- One directly-adjacent fix: `dag-authoring.md` still said reschedule-mode sensors are "not supported yet" — that's the same Phase B that ADR 0040 confirms shipped (`internal/scheduler` reschedule state, `#380`/`#389`), so leaving it would have made this PR self-contradictory. Fixed the one stale line.

Closes #765.

### #770 — dbt docs
`author-dags/dbt.md`:
- (a) a "no local dbt / adapter has no wheel for your Python" callout in §1 with the py3.11-container recipe, pinning the result via `dbt.manifest:`.
- (b) a serverless cold-start note in §4 (Databricks auto-stop ~5 min, adapter wakes it transparently, ~10s observed).
- (c) §7 records the hand-verified end-to-end Databricks serverless validation (managed connection → generated `profiles.yml`, SP OAuth M2M, pod-per-model, view + Delta table, transparent cold-start) — kept honest that it's hand-verified, not yet CI-gated, so the `⚠️` stays until `test/e2e/dbt-connection-e2e.sh` runs against a real account in CI.

Closes #770.

## Build

`hugo --gc --minify` in `website/` builds clean (233 pages, only pre-existing deprecation warnings unrelated to this change). Every internal link/anchor added or touched in this PR was checked against the built `public/` output and resolves.

## Not in this PR (tracked separately per `spec/v0.4.1-plan.md`)
Workstream 1 code fixes (#769 dbt `--build`, #766 non-root error classification) and workstream 3 CI hygiene (link checker) are separate held branches, not part of this doc-only PR.