### PR TITLE
docs(changelog): headline the v0.4.0 flagship features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,137 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.4.0] - 2026-08-26
 
+> Leoflow's biggest release to date. The headline work: **warm worker pools**
+> (N:1 pod reuse across attempts, ADR 0058), first-class support for a
+> **shared, multi-team Kubernetes cluster** (named task pools, per-DAG
+> admission, a shared-informer read path, full placement/DRA passthrough, and
+> quota/APF backpressure that no longer burns a task's retry budget — ADR
+> 0053/0054), **RBAC + OIDC/SSO** with fail-closed tenant pinning, **per-task
+> secret scoping and short-lived agent credentials** (the mechanism ADR 0045
+> left unshipped, ADR 0055), a **durable task-outcome** model that stops
+> pod-death-mid-report from reading as a false failure (ADR 0051/0052), and a
+> native **S3/GCS object log sink** (ADR 0056). Below that sits the rc.1→rc.4
+> hardening batch (Helm-reachability fixes, diagnostics, CLI polish).
+
 ### Added
+
+#### Warm worker pools — N:1 pod reuse across attempts (ADR 0058)
+
+- **A task pod can now be reused across attempts instead of spawned fresh for
+  every one.** A warm worker's agent runs in a long-lived fork-per-attempt
+  mode (#676) over a dedicated gRPC assignment transport with ack/lease
+  semantics (#673), wired into scheduler dispatch (#675). Off by default —
+  `execution.warm_pools_enabled` defaults to `false`, a byte-for-byte no-op —
+  and the control plane **fails closed at boot** if it is turned on without
+  the ADR 0058 D2 security prerequisites already in force: the projected-SA
+  token-exchange transport and enforce-mode secret liveness (#671).
+- **Pool lifecycle.** A min-idle reconciler provisions warm pods and never
+  deletes a busy worker (#677, busy-aware fix #681, terminal-pod-skip fix
+  #678); each attempt gets a durable attempt→worker binding persisted on ack
+  (#679), backed by a failover reaper and double-run guard so two agents can
+  never claim the same binding (#680); an idle-slot reclaim path unstrands a
+  worker and fast-re-places its next attempt (#682); and every warm worker
+  enforces its own lifecycle — max attempts, max lifetime, an idle TTL, a
+  drain path, and an attempt watchdog (#683).
+- **Guardrails.** A per-tenant aggregate cap on warm pods, reserved and
+  rationed rather than first-come (#686); a per-DAG-version ConfigMap
+  GC-anchor so a warm pod can't outlive the DAG version it was spawned for
+  (#687); and a worker-scoped bootstrap token exchange so a warm pod never
+  holds a long-lived plaintext credential across the attempts it serves
+  (#689).
+- **Reachable from the Helm chart, with the same fail-closed guard the server
+  enforces (#695)** — see the full entry below.
+
+#### Shared-cluster / multi-team Kubernetes (ADR 0053, ADR 0054)
+
+- **Leoflow can now share a cluster without starving its neighbors or letting
+  them starve it.** A per-DAG `max_active_tasks` admission gate caps how many
+  of one DAG's tasks may be queued/running at once (#632), and named,
+  cross-DAG task pools (Pro-only) add a second, budget-based admission gate on
+  top of it (#642) — replacing the long-standing `/api/v2/pools` stub. A
+  shared pod informer replaces the reapers' per-second `LIST` storm and the
+  reconciler's 30-second `LIST` with one long-lived watch (#634).
+- **Placement and scheduling passthrough.** Declared tolerations (#621) and
+  the rest of the placement surface — `priorityClassName`,
+  `terminationGracePeriodSeconds`, `runtimeClassName`, topology-spread
+  constraints, affinity, DRA resource claims, ephemeral-storage, and custom
+  labels/annotations (#630) — now actually reach the pod spec instead of
+  being accepted at push and silently dropped.
+- **Quota/APF backpressure is no longer billed to the task's retry budget.** A
+  `ResourceQuota` 403 or an API Priority & Fairness 429 on pod create now
+  retries forever without incrementing `dispatch_attempts`, so a fan-out under
+  a tight quota self-throttles instead of producing a wave of false
+  `dispatch_failed` terminal states (#631).
+
+#### Identity & access
+
+- **RBAC foundation.** A seeded viewer/editor/operator role ladder, with roles
+  and permissions reloaded from the store on every token verify — so a
+  deactivated or deleted user loses access immediately, not at token TTL —
+  and nav menus filtered to what the caller can actually do (#654).
+- **OIDC/SSO with fail-closed tenant pinning (ADR 0057), Pro-gated.**
+  Authorization Code + PKCE against an external IdP (Entra ID / Google Cloud
+  Identity / Okta and any standard OIDC provider), JIT-provisioned users, and
+  every login reconciling the user's roles to the IdP-mapped set — a pin
+  failure is a 403, never a default-identity fallback (#656).
+- **User management.** `POST /api/v2/users` to create an account and
+  `GET /api/v2/users` to list them, admin-gated (#627, #649); `leoflow admin
+  users list` (#651); and a new `leoflow admin` operator CLI —
+  `health`/`dags pause`/`drain`/`runs list` — for operating a running Pro
+  control plane over the typed client (#635).
+
+#### Secret scoping & agent credentials (ADR 0055 — the ADR 0045 follow-up)
+
+- **The mechanism to stop every task from receiving the whole tenant vault.**
+  ADR 0045 was accepted but never shipped; this is that code. A declared-secret
+  schema lets a DAG or task name the variables/connections it actually needs
+  (#660), narrowing is enforced by a scope-by-policy gate paired with a
+  task-liveness check that stops a superseded or finished attempt's still-valid
+  token from resolving secrets (#663), and a task that is narrowly declared but
+  would still receive the full vault now gets a warning (#661). **Ships in
+  observe/permissive mode by default — nothing is denied yet** until an
+  operator flips it to enforce. Agent credentials also got shorter-lived:
+  a per-attempt token is now renewed on every heartbeat instead of living for
+  the whole attempt (#665), and a projected-ServiceAccount token-exchange
+  transport replaces the plaintext-env-var credential, flag-gated off (#667).
+
+#### Durable execution (ADR 0051, ADR 0052)
+
+- **A task's true outcome is no longer conflated with whether its report
+  survived.** If a pod dies mid-report (OOM, eviction) after the task itself
+  succeeded, the reconciler can now recover that success from a durable
+  outcome record instead of settling it as a failure (#615). Infra faults —
+  a lost agent, pod, or dispatch — now re-place the task without consuming
+  its own retry budget, bounded instead by a separate infra-attempt limit, so
+  an exhausted infra budget with retries remaining still finalizes rather
+  than hanging (#614). The four backstop reapers and the pod lifecycle moved
+  behind a dedicated execution seam ahead of warm pools, with no behavior
+  change (#669, #670).
+
+#### Object log sink (ADR 0056)
+
+- **Task logs can now be written straight to S3 or GCS instead of an
+  in-cluster PVC.** A native dual-SDK backend (`aws-sdk-go-v2` for S3/MinIO,
+  the native `cloud.google.com/go/storage` client for GCS — not the S3
+  interop endpoint, which cannot use Workload Identity) is keyless-first via
+  IRSA or GKE Workload Identity. Off by default; the on-disk sink is
+  unchanged for every deployment that does not opt in (#640).
+
+#### Deploy & MCP
+
+- **`helm install` no longer requires cert-manager just to turn on agent
+  TLS.** The chart now auto-generates a stable self-signed CA and gRPC server
+  cert by default (`agentTLS.autoGenerate`), reusing the same CA across `helm
+  upgrade` so it never silently rotates and breaks running agents; bring-your-
+  own/cert-manager remains the opt-in production path (#690, #692).
+  - The Helm chart is now published as a signed OCI artifact on every release
+    and RC tag (`oci://ghcr.io/neochaotic/charts/leoflow`) (#691).
+- **MCP `search_logs` can search a whole run, not just one known task.**
+  `task_id` is now optional — when omitted, the tool enumerates the run's
+  task instances and searches each one, tagging every match with the
+  `task_id`/`try_number` it came from (#612).
+
+#### Diagnostics & CLI
 
 - **Transparent CLI token renewal — no more hourly re-login (#755).** The CLI now
   silently refreshes a file-persisted session token once it passes the halfway


### PR DESCRIPTION
## Why

The `[0.4.0]` section of `CHANGELOG.md` reads like a list of rc-era fixes and
undersells what is Leoflow's biggest release. 39 `feat:` commits landed
between `v0.3.0` and the `v0.4.0` GA, but the hand-written section headlined
only ~10 of them and was dominated by the rc.1-rc.4 hardening batch (#695-#755).
The GitHub release page auto-generates from commits so it's complete there —
this PR only fixes `CHANGELOG.md`.

## What changed

Rewrote `### Added` under `## [0.4.0]` to lead with the flagship work, grouped
by theme, ahead of the existing entries:

- **Warm worker pools — N:1 pod reuse across attempts (ADR 0058)**
- **Shared-cluster / multi-team Kubernetes (ADR 0053, ADR 0054)**
- **Identity & access** — RBAC foundation, OIDC/SSO, user management
- **Secret scoping & agent credentials (ADR 0055 — the ADR 0045 follow-up)**
- **Durable execution (ADR 0051, ADR 0052)**
- **Object log sink (ADR 0056)**
- **Deploy & MCP** — zero-prereq agent TLS, OCI chart publish, run-wide MCP search

Also added a short blockquote summary under the version header (matching the
file's own convention for other multi-line release sections), orienting the
reader before the themed list.

## Verification

- Every headline is checked against the actual commit (`git log
  v0.3.0..origin/main`) and, where cited, the accepted/proposed ADR text
  under `website/content/project/adrs/`. Defaults, gating (Pro-only vs. not),
  and off-by-default/observe-mode framing are quoted from the commit bodies,
  not assumed.
- Two items suggested in the original task brief — dbt cloud-auth and the
  api/scheduler split (ADR 0049) — were checked and are **not** part of the
  `v0.3.0..v0.4.0` diff (`#514`, `#577`, `#581`, `#590` all predate `v0.3.0`
  and are already documented under the `0.3.0-rc.*` sections), so they were
  **not** added here to avoid mis-attributing a v0.3.0 feature to v0.4.0.
- I could not verify "Pro-gated" for warm worker pools specifically (no
  edition check found in `internal/config` or the boot guard), so that claim
  was dropped from the warm-pools headline — only OIDC and named task pools
  are described as Pro-gated, both confirmed in their commit bodies.

## Scope

`### Fixed` and `### Changed` under `[0.4.0]` are untouched (diff is 130
insertions, 0 deletions), as is every other version section and
`[Unreleased]`.

Do not merge — flagged for a manual check before merge.