### PR TITLE
ci: revert golangci-lint-action v9 (#451) — broke the A+ lint gate on main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
           cache: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
           version: ${{ env.GOLANGCI_LINT_VERSION }}
 


### PR DESCRIPTION
The #451 major bump (golangci-lint-action 8→9.3.0) broke the `Lint (golangci-lint A+ enforcement)` job on main (red since it merged). Reverting to v8 to restore green; v9 needs a proper investigation on a branch with green CI before re-attempting. (The v9 evidence in triage was from a stale base.)