### PR TITLE
docs: surface pod-cost levers + record generic fused-TaskGroup deferral

### DIFF
--- a/website/content/author-dags/dbt.md
+++ b/website/content/author-dags/dbt.md
@@ -143,7 +143,18 @@ this problem.
 ## 2. Mixing dbt with operators
 
 To run operators **before/after** your models in the same DAG, author a `dag.py`
-and embed the dbt project with `dbt_group("<name>")`:
+and embed the dbt project with `dbt_group("<name>")`.
+
+{{% alert title="Packing models into fewer pods" color="info" %}}
+By default (`granularity: node`) each model is its own pod — like Cosmos. Set
+`granularity: level` or `folder` (as below) to pack models into **grouped tasks**:
+each group compiles to a single `dbt build --select …` task — one pod that dbt runs
+internally — so a project of *N* models needn't become *N* pods. This is Leoflow's
+answer to pod sprawl for dbt; see
+[Core concepts → When you pay for a pod](/concepts/core-concepts/#when-you-pay-for-a-pod-and-when-you-dont).
+{{% /alert %}}
+
+Embed the dbt project between your operators with `dbt_group("<name>")`:
 
 ```python
 # sales/dag.py

--- a/website/content/concepts/core-concepts.md
+++ b/website/content/concepts/core-concepts.md
@@ -57,5 +57,34 @@ own container image** — no shared `/dags` filesystem, no dependency hell. See
 [ADR 0001](/project/adrs/0001-why-leoflow/) and
 [ADR 0003](/project/adrs/0003-dag-as-image/).
 
+## When you pay for a pod (and when you don't)
+
+Every task runs in **its own fresh pod** — one task, one pod, by default
+([ADR 0002](/project/adrs/0002-pod-per-task/)). That is deliberate: each task gets
+**failure isolation** (an OOM or crash can't touch a sibling), **its own retry**,
+**right-sized CPU/memory**, and **its own secret scope**. For production — and
+especially for audit and compliance — those per-task properties are the feature,
+not overhead.
+
+The trade is a **cold start per task** (image pull, schedule, container start, the
+agent handshake). For a DAG of many short tasks that overhead can dominate. Leoflow
+gives you three levers so you don't over-pay — pick by the situation, not by
+reaching for a generic "pack tasks together" switch (there isn't one — see below):
+
+| Situation | Lever | What it does |
+|---|---|---|
+| **Iterating on DAG logic locally** | `leoflow lite --executor subprocess` | Runs tasks as host processes — **no pods, no image build** — the fast inner loop. (`--executor auto`, the default, uses a real k3d pod-per-task when Docker is present, for fidelity.) Dev-only, unsandboxed. |
+| **A dbt project with many models** | [`dbt_group()`](/author-dags/dbt/) with `granularity: level` or `folder` | Packs the project's models into **grouped tasks** (each group is one `dbt build` = one pod) that dbt orchestrates internally, so *N* models needn't be *N* pods. The default `granularity: node` is one pod per model. |
+| **Amortizing cold start across attempts** | [Warm worker pools](/operate/warm-pools/) (Pro, operator-set) | Reuse **one pod across many attempts of the same DAG version** ([ADR 0058](/project/adrs/0058-warm-worker-pools/)). An operator knob, not a DAG attribute — by design; it never groups *different* tasks. |
+
+{{% alert title="There is no generic pack-tasks-into-one-pod knob" color="info" %}}
+Fusing arbitrary operators into a single pod (a generic fused `TaskGroup`) is
+**designed but deliberately not built** ([ADR 0043](/project/adrs/0043-taskgroup-split-fused-execution/)):
+the levers above already cover the real pod-cost cases, and fusing would trade away
+the per-task isolation, retry, and secret scoping that pod-per-task exists to give.
+If you hit genuine pod-startup pain on a **non-dbt** DAG of many tiny tasks, that's
+the signal to revisit ADR 0043 — not a gap to work around.
+{{% /alert %}}
+
 See also: [Architecture](/concepts/architecture/) ·
 [DAG authoring](/author-dags/dag-authoring/) · [Glossary](/reference/glossary/).

--- a/website/content/project/adrs/0002-pod-per-task.md
+++ b/website/content/project/adrs/0002-pod-per-task.md
@@ -48,6 +48,8 @@ In standalone mode, each task is either a Docker container (default) or a subpro
 
 The hybrid model resolves this without forcing every HTTP call to pay pod startup cost. Inline (goroutine) is the default and remains fast for the common short-call case. Pod mode is opt-in for the long-call case and inherits all the robustness, isolation, and observability of the standard pod-per-task model. A server-side cap on inline duration prevents misuse of the inline path for tasks that should be pod-based.
 
+**2026-08-27:** The "cold start matters more" consequence is addressed by three deliberate levers, each scoped to a real situation, so pod-per-task is not over-engineering for the cases where the per-pod overhead would otherwise dominate: (1) the **subprocess executor** for the local dev loop (`leoflow lite --executor subprocess`) runs tasks as host processes with no pod and no image build; (2) **`dbt_group()`** (ADR 0042/0043) runs a whole dbt project as one grouped task whose models dbt orchestrates internally, so N models are not N pods; (3) **warm worker pools** (ADR 0058, operator-set) reuse one pod across attempts of a DAG version. A *generic* "fuse arbitrary operators into one pod" capability was evaluated and **deliberately deferred** — see ADR 0043's decision log for the rationale. The pod-per-task default therefore stands unchanged; these levers relieve the cold-start cost without eroding the per-task isolation/retry/secret-scope the model exists to provide. The author-facing explanation lives in [Core concepts → When you pay for a pod](/concepts/core-concepts/#when-you-pay-for-a-pod-and-when-you-dont).
+
 ## Alternatives Rejected
 
 - **Persistent worker pool:** rejected because it reintroduces every problem Leoflow is trying to solve.

--- a/website/content/project/adrs/0043-taskgroup-split-fused-execution.md
+++ b/website/content/project/adrs/0043-taskgroup-split-fused-execution.md
@@ -138,6 +138,20 @@ questions — shared image, sequential vs parallel, failure domain); split of ar
   stays observable per model even when packed into one pod (ties to ADR 0042 #397).
 - Real-pod fused validation (one pod runs `dbt build --select group` with threads).
 
+## Decision log
+
+**2026-08-27 — the generic in-pod runner stays deferred, as a product decision (not merely "unbuilt").** A viability review confirmed the generic fused path is feasible but is the **lowest value-per-effort** capability on the table, and re-confirmed a framing point worth recording: the dbt slice does **not** already give us a generic in-pod machine. A `dbt_group` collapses its models into **one leoflow task = one pod = one task-instance**; the ordered execution and per-model status are **dbt's own** doing (its manifest + `threads` + `run_results.json`), not a Leoflow in-pod runner. Leoflow has no way to run a heterogeneous sub-DAG in a pod, nor to report N task states from one pod. Building that runner is the real cost.
+
+Rationale for deferring:
+
+- **The headline capability already ships.** The need this ADR opened with — *mix operators + dbt in one DAG* — is delivered today by `dbt_group()`. What a generic fused group adds beyond that is a **pod-startup-cost optimization**, not a missing capability.
+- **The pod-cost cases are already covered** by the three levers recorded in ADR 0002's 2026-08-27 note (subprocess executor for the dev loop; `dbt_group` for dbt sprawl; warm pools for cold-start amortization). The residual case — a *non-dbt* DAG of many small, sequential, same-secret-scope, same-resource-profile tasks — is narrow, and every constraint it relaxes is a case where pod-per-task is *correct*.
+- **It trades away what the model exists to protect.** Fusing shares one pod's failure domain, one resource envelope, and (critically) **one per-attempt credential** (ADR 0055) across members — so fusing tasks with different declared `Variables`/`Connections` would silently widen secret scope. Per-task isolation, retry, and secret scoping are exactly the properties a production/audit posture values.
+
+Effort, if it is ever built: **M** for the smallest viable slice — shim `TaskGroup` capture (ADR 0024 rejects it today), an additive `dag.json` group node + `fuse` flag reusing the dbt embed wiring, the `groups:` overlay already specified above, and a **new sequential in-pod runner**, with **group = one task instance** (whole-group retry, single resource limit, refuse to fuse differing secret scopes). **L** for the full vision (per-member status, in-pod parallelism, per-member retry). No scheduler change is needed for the one-instance slice.
+
+**Revisit trigger:** demonstrated pod-startup pain on a real non-dbt DAG of many tiny tasks. Until then the parser keeps rejecting generic `TaskGroup` with a clear error, and this remains designed-not-built. Do not "finish wiring" the generic runner without re-opening this decision and writing an implementation ADR (retry model, secret-scope gate, resource rule, `dag.json` shape, XCom semantics).
+
 ## Consequences
 
 - Operators + dbt coexist in one DAG (the Cosmos `DbtTaskGroup` capability) without


### PR DESCRIPTION
## Why

A real author question — *"how do I group tasks into one pod in `leoflow.yaml`?"* — surfaced a DevEx gap: the warm-pool **N:1** feature (ADR 0058) is easy to mistake for task-grouping, but it reuses **one pod across attempts of a DAG version**, not across different tasks, and it's operator-set with no author knob by design. The capability the author was reaching for — fusing arbitrary tasks into one pod — is designed (ADR 0043) but deliberately not built. Meanwhile the two real pod-cost escape hatches that *do* exist were invisible.

## What

**Make the two existing exits discoverable**, and **record the deferral decision** so a future contributor doesn't "finish wiring" the generic fused path prematurely.

- **`concepts/core-concepts`** — new *"When you pay for a pod (and when you don't)"* section: the pod-per-task default (per-task isolation, retry, right-sized resources, secret scope) and the three levers —
  - subprocess executor for the local dev loop (`leoflow lite --executor subprocess` — no pods, no image build),
  - `dbt_group()` with `granularity: level|folder` for dbt model sprawl,
  - warm worker pools (operator-set) for cold-start amortization,
  - and an explicit note that there is **no generic pack-tasks-into-one-pod knob**, with why.
- **`author-dags/dbt`** — note that `granularity: level|folder` packs models into fewer pods (default `node` = one pod per model).
- **ADR 0002** — revision-history note tying the "cold start matters more" consequence to the three levers; the default stands unchanged.
- **ADR 0043** — decision log (2026-08-27): the **generic in-pod runner stays deferred as a product decision**. Rationale (headline capability already ships via `dbt_group`; the pod-cost cases are covered; fusing erodes per-task isolation/secret scope), effort if ever built (**M** smallest slice / **L** full), and the **revisit trigger** (demonstrated non-dbt pod-startup pain). Also corrects a framing error: a `dbt_group` is **one task = one pod = one task-instance** — the ordered in-pod execution + per-model status are **dbt's own** (manifest + `run_results.json`), not a generic Leoflow in-pod runner.

## Validation

- `hugo --gc --minify` clean (237 pages, no errors).
- New heading anchor `#when-you-pay-for-a-pod-and-when-you-dont` verified in generated HTML; all cross-links resolve.
- Docs/ADR only — no code, no schema, no release touched.