### PR TITLE
docs: fix broken anchors + dead ADR links (link audit)

### DIFF
--- a/website/content/author-dags/dag-authoring.md
+++ b/website/content/author-dags/dag-authoring.md
@@ -25,7 +25,7 @@ Scaffold one with `leoflow init dags/my_pipeline`.
 > exist only in `leoflow lite` — the developer-mode loop. **Pro** does not have
 > a "workspace"; in Pro every DAG ships as its own image-and-`dag.json` pair,
 > built by CI and registered via `leoflow push dag.json`. See
-> [The development → deploy lifecycle](#the-development-deploy-lifecycle).
+> [The development → deploy lifecycle](#the-development--deploy-lifecycle).
 
 `leoflow lite` watches a **workspace** that can hold many DAGs as sibling
 subdirectories. The default workspace is `~/leoflow/` (set by `leoflow setup`).

--- a/website/content/author-dags/lite-web-editor.md
+++ b/website/content/author-dags/lite-web-editor.md
@@ -89,7 +89,7 @@ A few small UX rules the editor enforces so the cursor never lies to you:
 
 Saving a file is exactly like editing it on disk — the `leoflow lite` watcher
 picks up the change and **hot-reloads** the DAG, same as if you had saved from any
-editor. (Remember the [reload gotcha](/contribute/local-dev-loop/#the-edit-reload-see-it-cycle):
+editor. (Remember the [reload gotcha](/contribute/local-dev-loop/#the-edit--reload--see-it-cycle):
 the open Airflow tab does not auto-refresh DAG *structure* — reload it.)
 
 ## Provisioning the editor assets

--- a/website/content/concepts/architecture.md
+++ b/website/content/concepts/architecture.md
@@ -148,7 +148,7 @@ default** so a stock deployment is byte-for-byte the historical path:
 
 The credential mechanics are already drawn on the credential-transport page and
 are not redrawn here: the one-`TokenReview`-then-task-scoped-JWT handshake is the
-[exchange flow](/operate/agent-credential-transport/#exchange-projected-sa-token-tokenreview),
+[exchange flow](/operate/agent-credential-transport/#exchange--projected-sa-token--tokenreview),
 and the pod-scoped-vs-attempt-scoped split that makes warm-pool reuse safe is the
 [two-token model](/operate/agent-credential-transport/#the-two-token-model) (also reused
 by link from [Warm worker pools](/operate/warm-pools/)).

--- a/website/content/contribute/contributing.md
+++ b/website/content/contribute/contributing.md
@@ -19,7 +19,7 @@ the design *why* lives in the [ADRs](/project/adrs/).
 2. [Set up for development](#2-set-up-for-development) — tools, build, gates.
 3. [Know the quality bar](#3-the-quality-bar-non-negotiable) — TDD, A+, GoDocs.
 4. [Pick or open an issue](#4-pick-or-open-an-issue).
-5. [Fork → branch → TDD → PR](#5-fork-branch-tdd-pr).
+5. [Fork → branch → TDD → PR](#5-fork--branch--tdd--pr).
 6. [Pass the CI gates](#6-the-ci-gates).
 
 ---
@@ -111,7 +111,7 @@ reproduce.
 
 Open a [new issue](https://github.com/neochaotic/leoflow/issues/new/choose) and
 pick **Feature request**. For anything architectural or cross-cutting, also open
-a PR adding a draft ADR under `docs/adr/` with status **Proposed** — the design
+a PR adding a draft ADR under `website/content/project/adrs/` with status **Proposed** — the design
 discussion happens there.
 {{% /tab %}}
 {{< /tabpane >}}

--- a/website/content/contribute/local-dev-loop.md
+++ b/website/content/contribute/local-dev-loop.md
@@ -104,7 +104,7 @@ control plane** (measured against the `lifecycle` example).
 ### Choosing an executor
 
 There are **only these two** — and deliberately **no Docker executor**
-([ADR 0015](https://github.com/neochaotic/leoflow/blob/main/docs/adr/0015-kubernetes-only-execution.md)).
+([ADR 0015](/project/adrs/0015-kubernetes-only-execution/)).
 A Docker-socket executor would mean importing the Docker Go SDK
 (`github.com/docker/docker`), which carries an unfixable advisory (Moby AuthZ
 bypass, GO-2026-4887) reachable from the control-plane binary — it would fail the

--- a/website/content/get-started/installation.md
+++ b/website/content/get-started/installation.md
@@ -42,7 +42,7 @@ Almost nothing. The control plane, CLI, and agent are **static Go binaries**,
 and `leoflow setup` provisions a Python 3.11 itself if you don't have one.
 
 There are **two execution paths** — and **no Docker executor**, on purpose
-([ADR 0015](https://github.com/neochaotic/leoflow/blob/main/docs/adr/0015-kubernetes-only-execution.md)):
+([ADR 0015](/project/adrs/0015-kubernetes-only-execution/)):
 the Docker Go SDK carries an unfixable advisory (Moby AuthZ bypass,
 GO-2026-4887) that would reach the control-plane binary and fail the security
 gate. So:
@@ -312,7 +312,7 @@ agent TLS, above).
 
 Managed services are first-class — RDS / Cloud SQL / Azure Database for
 Postgres on the SQL side; ElastiCache / Memorystore / Azure Cache for Redis.
-See the chart's [Datastore compatibility](/operate/helm-chart/#datastore-compatibility)
+See the chart's [Datastore compatibility](https://github.com/neochaotic/leoflow/blob/main/helm/leoflow/README.md#datastore-compatibility)
 table for tested versions; managed providers that present a per-instance or
 provider-specific CA expose a `caConfigMap` knob (Postgres and Redis sides
 respectively) for verified TLS.

--- a/website/content/operate/first-pro-dag.md
+++ b/website/content/operate/first-pro-dag.md
@@ -29,7 +29,7 @@ flowchart LR
 {{% alert title="Two versions of this walkthrough" color="info" %}}
 - **The simple path (below)** — a minimal DAG with a `Dockerfile`, deployed
   today with `leoflow deploy`. Everything here runs as-is.
-- **[The complete path](#the-complete-path-your-own-dag-yaml-driven)** — author
+- **[The complete path](#the-complete-path--your-own-dag-yaml-driven)** — author
   your own DAG with **no Dockerfile** (the build is synthesized from
   `leoflow.yaml`) and real `connectors:`. That richer flow is still landing;
   it is shown at the end so you can see where this is going.
@@ -103,7 +103,7 @@ Your image layers `FROM` the **published Leoflow task base**
 (`ghcr.io/neochaotic/leoflow-runtime:py3.11`) — it bundles the `leoflow-agent`
 (PID 1, talks gRPC to the control plane) and the `leoflow_runtime` helper, is
 multi-arch and signed, and is built by our CI. You only add your deps and copy
-your DAG in. (In [the complete path](#the-complete-path-your-own-dag-yaml-driven)
+your DAG in. (In [the complete path](#the-complete-path--your-own-dag-yaml-driven)
 even this Dockerfile goes away — it is synthesized from `leoflow.yaml`.)
 {{% /alert %}}
 

--- a/website/content/operate/warm-pools.md
+++ b/website/content/operate/warm-pools.md
@@ -123,7 +123,7 @@ The exchange transport needs a cluster-scoped `tokenreviews` RBAC grant so the
 control plane can validate the projected ServiceAccount token each pod presents.
 The Helm chart renders that `ClusterRole` + binding **only** when the exchange
 transport is selected — see
-[Agent credential transport → RBAC](/operate/agent-credential-transport/#rbac-the-tokenreviews-grant).
+[Agent credential transport → RBAC](/operate/agent-credential-transport/#rbac--the-tokenreviews-grant).
 
 ### 2. Turn on the pool and tune it
 

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -124,7 +124,7 @@ var — viper does not split one env var into a map or list.
 
 | Variable | Default | Edition | Purpose |
 |---|---|---|---|
-| `LEOFLOW_AUTH_PROVIDER` | `jwt` | both | Credential authenticator: `jwt` (default — username/password issues an HS256 token) or `oidc` (adds the OIDC/SSO login flow on top; the JWT authenticator stays the request-path verifier in both modes). `oidc` is Pro-gated and fails boot closed unless its prerequisites are met (see [OIDC / SSO](#oidc-sso-authoidc)). |
+| `LEOFLOW_AUTH_PROVIDER` | `jwt` | both | Credential authenticator: `jwt` (default — username/password issues an HS256 token) or `oidc` (adds the OIDC/SSO login flow on top; the JWT authenticator stays the request-path verifier in both modes). `oidc` is Pro-gated and fails boot closed unless its prerequisites are met (see [OIDC / SSO](#oidc--sso-authoidc)). |
 | `LEOFLOW_AUTH_JWT_SECRET` | — *(required)* | both | Signs API/agent tokens. Required for both `jwt` and `oidc` (both mint the app's own HS256 token). |
 | `LEOFLOW_AUTH_JWT_TOKEN_TTL_SECONDS` | `3600` | both | Lifetime, in seconds, of an issued API token. |
 | `LEOFLOW_AUTH_LOGIN_RATE_LIMIT_PER_MINUTE` | `5` | both | Cap on **failed** `/auth/token` attempts per client IP per minute (anti-brute-force). A successful login consumes no budget. `leoflow lite` raises this well above the default (local single-user tool). |


### PR DESCRIPTION
Fixes the 11 rotted internal links found by a dead-link audit of the docs. Audit summary: **0** dead page paths, **0** bad relative/asset paths, ADR index **in sync**; the only issues were hand-authored link rot.

## Broken anchors (8) — heading slug drift
Goldmark slugifies an em-dash / arrow / slash in a heading to a **double hyphen**, but these links used a single hyphen:

| file | anchor fix |
|---|---|
| `author-dags/dag-authoring.md` | `#the-development--deploy-lifecycle` |
| `author-dags/lite-web-editor.md` | `.../#the-edit--reload--see-it-cycle` |
| `operate/first-pro-dag.md` (×2) | `#the-complete-path--your-own-dag-yaml-driven` |
| `operate/warm-pools.md` | `.../#rbac--the-tokenreviews-grant` |
| `contribute/contributing.md` | `#5-fork--branch--tdd--pr` |
| `concepts/architecture.md` | `.../#exchange--projected-sa-token--tokenreview` |
| `reference/configuration.md` | `#oidc--sso-authoidc` |

## Section moved off-site (1)
- `get-started/installation.md` — the "Datastore compatibility" section moved from `helm-chart.md` to the chart README; link now points at the README anchor.

## Dead ADR links (2 occurrences) + prose drift (1)
- `contribute/local-dev-loop.md` & `get-started/installation.md` — ADR 0015 linked the pre-Hugo `docs/adr/…` path (404 since the Hugo cutover `#721`); now `/project/adrs/0015-kubernetes-only-execution/`.
- `contribute/contributing.md` — "draft ADR under `docs/adr/`" → `website/content/project/adrs/` (the current location). Historical planning-note references to `docs/adr/` left as-is (point-in-time snapshots).

## Not changed
- `prestodb.io` (flagged UNVERIFIED) — confirmed **live** behind a Cloudflare bot-check (403 to fetchers, "Just a moment…" interstitial in a real browser). Not dead; left as-is.

## Validation
`hugo --gc --minify` clean (237 pages); every corrected anchor verified present in the regenerated `public/` HTML.