### PR TITLE
compat: accept Airflow-3 alias imports; name providers.standard for removed core operators

### DIFF
--- a/parser/leoflow_parser/_shim/airflow/__init__.py
+++ b/parser/leoflow_parser/_shim/airflow/__init__.py
@@ -1,5 +1,12 @@
 """Structural Airflow shim (ADR 0024). On import it installs the generic
-provider-operator capture finder (ADR 0040, Phase A)."""
+provider-operator capture finder (ADR 0040, Phase A).
+
+``DAG`` is re-exported here so the deprecated-but-valid Airflow-3 convenience
+spelling ``from airflow import DAG`` resolves to the same shim as
+``from airflow.sdk import DAG``."""
 from airflow import _generic
+from airflow._core import DAG
+
+__all__ = ["DAG"]
 
 _generic.install()

--- a/parser/leoflow_parser/_shim/airflow/decorators/__init__.py
+++ b/parser/leoflow_parser/_shim/airflow/decorators/__init__.py
@@ -1,0 +1,12 @@
+"""Shim of `airflow.decorators`.
+
+In Airflow 3 the TaskFlow decorators live in `airflow.sdk`, but the pre-3
+spelling ``from airflow.decorators import task``/``dag`` is still valid (only
+deprecated). Both spellings must resolve to the SAME shim objects, so the parser
+accepts a canonical Airflow-3 DAG regardless of which one an author wrote.
+"""
+from __future__ import annotations
+
+from airflow.sdk import dag, task
+
+__all__ = ["task", "dag"]

--- a/parser/leoflow_parser/_shim/airflow/operators/__init__.py
+++ b/parser/leoflow_parser/_shim/airflow/operators/__init__.py
@@ -1,0 +1,10 @@
+"""Placeholder `airflow.operators` package.
+
+The core ``airflow.operators.*`` operators were removed from Airflow in 3.0 and
+relocated to apache-airflow-providers-standard, so the shim deliberately provides
+NO submodules here — importing one must fail. This package exists only so that
+``from airflow.operators.<x> import <Op>`` fails on ``airflow.operators.<x>``
+(surfacing the specific submodule name) rather than on the bare
+``airflow.operators`` parent, letting the loader name the canonical
+``airflow.providers.standard.operators.<x>`` replacement in its error.
+"""

--- a/parser/leoflow_parser/_shim/airflow/sdk/__init__.py
+++ b/parser/leoflow_parser/_shim/airflow/sdk/__init__.py
@@ -5,7 +5,15 @@ import functools
 
 from airflow._core import DAG, BaseOperator, XComArg
 
-__all__ = ["DAG", "BaseOperator", "XComArg", "task", "EmptyOperator", "PythonOperator"]
+__all__ = [
+    "DAG",
+    "BaseOperator",
+    "XComArg",
+    "task",
+    "dag",
+    "EmptyOperator",
+    "PythonOperator",
+]
 
 
 class PythonOperator(BaseOperator):
@@ -56,3 +64,25 @@ def task(fn=None, **dec_kwargs):
         return maker
 
     return wrap(fn) if callable(fn) else wrap
+
+
+def dag(dag_id=None, **dag_kwargs):
+    """TaskFlow @dag: decorate a function that defines a DAG's tasks. Calling the
+    decorated function builds a DAG (id defaults to the function name) and collects
+    the tasks its body defines within the DAG context — exactly like a
+    ``with DAG(...)`` block. Used bare (``@dag``) the first argument is the
+    decorated function; with arguments (``@dag(schedule=…)``) it is the dag_id."""
+    func = dag_id if callable(dag_id) else None
+    explicit_id = None if callable(dag_id) else dag_id
+
+    def wrap(defining_fn):
+        @functools.wraps(defining_fn)
+        def factory(*args, **kwargs):
+            built = DAG(explicit_id or defining_fn.__name__, **dag_kwargs)
+            with built:
+                defining_fn(*args, **kwargs)
+            return built
+
+        return factory
+
+    return wrap(func) if func is not None else wrap

--- a/parser/leoflow_parser/compiler.py
+++ b/parser/leoflow_parser/compiler.py
@@ -171,6 +171,8 @@ def _load_dags_shim(source: str):
     try:
         runpy.run_path(source, run_name="__leoflow_dag__")
     except ModuleNotFoundError as exc:
+        if _is_removed_core_operator_module(exc.name):
+            return {}, _removed_core_operator_hint(exc.name)
         if _is_provider_module(exc.name):
             return {}, _provider_import_hint(exc.name)
         return {}, _unsupported(f"module {exc.name!r}")
@@ -196,6 +198,37 @@ def _load_dags_shim(source: str):
 def _unsupported(detail: str) -> str:
     return (f"{detail}: not supported by Leoflow "
             f"(supported: Bash, Http, Python/@task; no dynamic task mapping or task groups)")
+
+
+_REMOVED_CORE_OPERATORS_PREFIX = "airflow.operators."
+
+
+def _is_removed_core_operator_module(name: str | None) -> bool:
+    """True for a core ``airflow.operators.<x>`` module. These operators were
+    removed from Airflow core in 3.0 and relocated to
+    apache-airflow-providers-standard, so they are never aliasable: aliasing the
+    2.x-only spelling would accept a DAG that no Airflow-3 install can run."""
+    return bool(name) and name.startswith(_REMOVED_CORE_OPERATORS_PREFIX)
+
+
+def _removed_core_operator_hint(name: str) -> str:
+    """Actionable message for a removed core-operator import. It names the
+    canonical ``airflow.providers.standard.operators.<x>`` replacement (which the
+    shim supports) instead of falling through to the generic operator-unsupported
+    wording, so a migrating author sees the exact spelling to switch to.
+
+    ``name`` is the failed module, e.g. 'airflow.operators.bash'; the submodule
+    tail (``bash``) maps 1:1 onto the standard provider's operators package."""
+    submodule = name[len(_REMOVED_CORE_OPERATORS_PREFIX):]
+    canonical = "airflow.providers.standard.operators"
+    if submodule:
+        canonical = f"{canonical}.{submodule}"
+    return (
+        f"{name!r} was removed from Airflow core in 3.0 and relocated to the "
+        f"standard provider. Import from {canonical!r} instead "
+        f"(the apache-airflow-providers-standard package). Leoflow targets "
+        f"Airflow 3, so the pre-3 core-operator spelling is not accepted."
+    )
 
 
 def _is_provider_module(name: str | None) -> bool:

--- a/parser/tests/test_shim_edges.py
+++ b/parser/tests/test_shim_edges.py
@@ -529,3 +529,111 @@ def test_empty_callback_list_is_not_marked(monkeypatch, tmp_path):
             a()
     """)
     assert _task(spec, "a").get("on_failure_callback") is None
+
+
+# ─── Airflow-3 canonical import spellings (import-alias compatibility) ───
+# Airflow 3 kept `from airflow.decorators import task/dag` and
+# `from airflow import DAG` as deprecated-but-valid spellings that map onto
+# `airflow.sdk`. The shim only exposed `airflow.sdk`, so these line-1 imports
+# were rejected. `airflow.operators.*`, by contrast, was REMOVED from core in
+# 3.0 (relocated to apache-airflow-providers-standard): it must not be aliased,
+# but the error must name the canonical providers.standard path.
+
+
+def test_decorators_task_matches_sdk_task(monkeypatch, tmp_path):
+    """`from airflow.decorators import task` must resolve to the SAME shim object
+    as `from airflow.sdk import task` — identical captured graph."""
+    sdk_spec = _compile(monkeypatch, tmp_path, """
+        from airflow.sdk import DAG, task
+        @task
+        def extract() -> None: ...
+        @task
+        def load() -> None: ...
+        with DAG("g"):
+            extract() >> load()
+    """)
+    dec_spec = _compile(monkeypatch, tmp_path, """
+        from airflow.decorators import task
+        from airflow.sdk import DAG
+        @task
+        def extract() -> None: ...
+        @task
+        def load() -> None: ...
+        with DAG("g"):
+            extract() >> load()
+    """)
+    assert dec_spec["tasks"] == sdk_spec["tasks"]
+    assert [t["task_id"] for t in dec_spec["tasks"]] == ["extract", "load"]
+    assert _task(dec_spec, "load")["depends_on"] == ["extract"]
+
+
+def test_decorators_dag_matches_sdk_dag(monkeypatch, tmp_path):
+    """`from airflow.decorators import dag` must resolve to the SAME shim object as
+    `from airflow.sdk import dag`; the @dag TaskFlow decorator builds an equivalent
+    graph either way."""
+    sdk_spec = _compile(monkeypatch, tmp_path, """
+        from airflow.sdk import dag, task
+        @task
+        def a() -> None: ...
+        @dag(schedule="@daily")
+        def pipeline():
+            a()
+        pipeline()
+    """)
+    dec_spec = _compile(monkeypatch, tmp_path, """
+        from airflow.decorators import dag, task
+        @task
+        def a() -> None: ...
+        @dag(schedule="@daily")
+        def pipeline():
+            a()
+        pipeline()
+    """)
+    assert dec_spec == sdk_spec
+    assert dec_spec["dag_id"] == "pipeline"
+    assert dec_spec.get("schedule") == "@daily"
+    assert [t["task_id"] for t in dec_spec["tasks"]] == ["a"]
+
+
+def test_from_airflow_import_dag_matches_sdk(monkeypatch, tmp_path):
+    """`from airflow import DAG` (deprecated Airflow-3 convenience alias) resolves
+    to the same DAG shim as `from airflow.sdk import DAG`."""
+    top_spec = _compile(monkeypatch, tmp_path, """
+        from airflow import DAG
+        from airflow.sdk import task
+        @task
+        def a() -> None: ...
+        with DAG("g"):
+            a()
+    """)
+    sdk_spec = _compile(monkeypatch, tmp_path, """
+        from airflow.sdk import DAG, task
+        @task
+        def a() -> None: ...
+        with DAG("g"):
+            a()
+    """)
+    assert top_spec == sdk_spec
+
+
+@pytest.mark.parametrize("submodule", ["bash", "python"])
+def test_removed_core_operator_import_names_providers_standard(
+    monkeypatch, tmp_path, submodule
+):
+    """`airflow.operators.*` was removed from Airflow core in 3.0 and relocated to
+    apache-airflow-providers-standard. It must NOT be aliased (that would be a
+    2.x-only spelling); it must raise a clear compile error naming the canonical
+    airflow.providers.standard.operators.<x> path — not the generic
+    operator-unsupported fall-through."""
+    op = {"bash": "BashOperator", "python": "PythonOperator"}[submodule]
+    with pytest.raises(ValueError) as ei:
+        _compile(monkeypatch, tmp_path, f"""
+            from airflow.operators.{submodule} import {op}
+            from airflow.sdk import DAG
+            with DAG("g"):
+                pass
+        """)
+    msg = str(ei.value)
+    assert f"airflow.providers.standard.operators.{submodule}" in msg
+    # Must NOT fall through to the generic operator-unsupported wording.
+    assert "supported: Bash, Http" not in msg

--- a/website/content/author-dags/dag-authoring.md
+++ b/website/content/author-dags/dag-authoring.md
@@ -97,6 +97,19 @@ with DAG("my_pipeline", schedule="@daily", catchup=False, tags=["etl"]):
     transform(extract())
 ```
 
+`from airflow.sdk import …` is the canonical Airflow 3 spelling and what we
+recommend. The deprecated-but-still-valid Airflow 3 aliases resolve to the same
+objects, so a migrated DAG compiles unchanged:
+
+- `from airflow.decorators import task, dag` → the `airflow.sdk` decorators.
+- `from airflow import DAG` → `airflow.sdk.DAG`.
+
+The core `airflow.operators.*` operators, however, were **removed** from Airflow
+in 3.0 and relocated to `apache-airflow-providers-standard`. Importing one (e.g.
+`from airflow.operators.bash import BashOperator`) fails the compile with a
+message pointing at the replacement — use
+`from airflow.providers.standard.operators.bash import BashOperator` instead.
+
 ### Supported task types
 
 Leoflow runs the common types on a **native fast path** and everything else — any


### PR DESCRIPTION
Closes #786.

## What changed

leoflow's compile-time structural shim (ADR 0024) only exposed the `airflow.sdk` namespace, so canonical Airflow-3 import spellings that map onto it were rejected on line 1 of a DAG. This makes the shim accept the deprecated-but-valid Airflow-3 alias spellings, and gives a targeted error for the operators that Airflow 3 actually removed.

**Aliased to the SAME shim objects** (both spellings now compile to an identical graph):

| Spelling | Resolves to |
| --- | --- |
| `from airflow.decorators import task, dag` | the `airflow.sdk` decorators |
| `from airflow import DAG` | `airflow.sdk.DAG` |

Implementation:
- `airflow.sdk` gains a `dag` TaskFlow decorator (builds a DAG and collects its body's tasks, exactly like a `with DAG(...)` block).
- New `airflow.decorators` shim package re-exports `task`/`dag` from `airflow.sdk`.
- Top-level `airflow` shim package re-exports `DAG`.

**NOT aliased — intentionally.** `airflow.operators.*` was *removed* from Airflow core in 3.0 and relocated to `apache-airflow-providers-standard`. Aliasing that 2.x-only spelling would accept a DAG no Airflow-3 install can run, which violates the Airflow-3-only requirement. It stays a compile error, but a helpful one:
- A placeholder `airflow.operators` package makes the failing import surface the specific submodule name (`airflow.operators.bash`) rather than the bare parent.
- The loader emits a dedicated message naming the canonical `airflow.providers.standard.operators.<x>` replacement, instead of falling through to the generic "not supported by Leoflow (supported: Bash, Http, …)" wording.

The canonical `providers.standard` path was already supported by the shim (`_shim/airflow/providers/standard/operators/bash.py` et al.), so the error points at a spelling that actually works.

Docs: the DAG-authoring guide now notes the accepted aliases and the removed-core-operator error.

## TDD evidence

Failing tests written first, then minimal shim/compiler code until green. New tests in `parser/tests/test_shim_edges.py`:

- `test_decorators_task_matches_sdk_task` — `from airflow.decorators import task` compiles to the SAME captured graph (task ids + edges) as `from airflow.sdk import task`.
- `test_decorators_dag_matches_sdk_dag` — `@dag` from `airflow.decorators` equals `@dag` from `airflow.sdk` (same dag_id, schedule, tasks).
- `test_from_airflow_import_dag_matches_sdk` — `from airflow import DAG` produces the same spec as `from airflow.sdk import DAG`.
- `test_removed_core_operator_import_names_providers_standard[bash|python]` — `from airflow.operators.<x> import …` raises a `ValueError` whose message contains `airflow.providers.standard.operators.<x>` and does NOT fall through to the generic operator-unsupported wording.

Before: all 5 red (aliases raised generic "not supported by Leoflow"; `airflow.operators.bash` reported the bare parent `airflow.operators`).
After: all 5 green.

## Results

- `cd parser && python3 -m pytest -q` → **85 passed** (was 80; +5 new).
- `python3 -m ruff check leoflow_parser tests` → **All checks passed**.
- No Go touched.