### PR TITLE
feat: runs trigger --conf / --conf-file with end-to-end conf persistence (step 1 of #545)

### DIFF
--- a/internal/api/dto.go
+++ b/internal/api/dto.go
@@ -138,11 +138,20 @@ func toDagRunDTO(r domain.DagRun) dagRunDTO {
 		DataIntervalEnd:   &logical,
 		State:             string(r.State),
 		RunType:           r.RunType,
-		Conf:              json.RawMessage("{}"),
+		Conf:              confOrEmptyObject(r.Conf),
 		Note:              strPtrOrNil(r.Note),
 		DagVersions:       []any{},
 		Duration:          dur,
 	}
+}
+
+// confOrEmptyObject renders a run's conf for the API, defaulting an unset conf
+// to the empty object so the field is never null.
+func confOrEmptyObject(conf json.RawMessage) json.RawMessage {
+	if len(conf) == 0 {
+		return json.RawMessage("{}")
+	}
+	return conf
 }
 
 // taskInstanceDTO is the Airflow 3.2.1 TaskInstanceResponse. Every spec-required

--- a/internal/api/resources.go
+++ b/internal/api/resources.go
@@ -345,13 +345,24 @@ func getDagRunHandler(repo DagRunRepository) gin.HandlerFunc {
 func createDagRunHandler(repo DagRunRepository, audit AuditWriter) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var body struct {
-			DagRunID    string     `json:"dag_run_id"`
-			LogicalDate *time.Time `json:"logical_date"`
-			Note        string     `json:"note"`
+			DagRunID    string          `json:"dag_run_id"`
+			LogicalDate *time.Time      `json:"logical_date"`
+			Note        string          `json:"note"`
+			Conf        json.RawMessage `json:"conf"`
 		}
 		if err := c.ShouldBindJSON(&body); err != nil {
 			AbortProblem(c, http.StatusBadRequest, "bad request", err.Error())
 			return
+		}
+		// conf becomes the run's params; it must be a JSON object so it maps to
+		// keyed values, not an array or scalar. Absent conf leaves the run at the
+		// persisted empty-object default.
+		if len(body.Conf) > 0 {
+			var obj map[string]json.RawMessage
+			if err := json.Unmarshal(body.Conf, &obj); err != nil {
+				AbortProblem(c, http.StatusBadRequest, "bad request", "conf must be a JSON object: "+err.Error())
+				return
+			}
 		}
 		logical := time.Now().UTC()
 		if body.LogicalDate != nil {
@@ -377,6 +388,7 @@ func createDagRunHandler(repo DagRunRepository, audit AuditWriter) gin.HandlerFu
 			RunType:     "manual",
 			QueuedAt:    time.Now().UTC(),
 			Note:        body.Note,
+			Conf:        body.Conf,
 		}
 		created, err := repo.CreateDagRun(c.Request.Context(), tenantOf(c), c.Param("dag_id"), run)
 		if err != nil {

--- a/internal/api/resources.go
+++ b/internal/api/resources.go
@@ -363,6 +363,12 @@ func createDagRunHandler(repo DagRunRepository, audit AuditWriter) gin.HandlerFu
 				AbortProblem(c, http.StatusBadRequest, "bad request", "conf must be a JSON object: "+err.Error())
 				return
 			}
+			// A JSON null unmarshals into a nil map without error; treat it as
+			// absent so the run defaults to the empty object rather than
+			// persisting a literal null (conf is contractually never null).
+			if obj == nil {
+				body.Conf = nil
+			}
 		}
 		logical := time.Now().UTC()
 		if body.LogicalDate != nil {

--- a/internal/api/resources_dagrun_test.go
+++ b/internal/api/resources_dagrun_test.go
@@ -1,12 +1,65 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/neochaotic/leoflow/internal/domain"
 )
+
+// TestTriggerDagRunPersistsConf pins that a conf object in the trigger request
+// is carried onto the created run and reflected back in the response, rather
+// than dropped. This is the server half of the CLI --conf plumbing: the
+// stored conf is what the agent later exposes to tasks as params.
+func TestTriggerDagRunPersistsConf(t *testing.T) {
+	srv := authedServer()
+	rec := authGet(srv, http.MethodPost, "/api/v2/dags/etl/dagRuns",
+		`{"conf":{"date":"2026-01-01","limit":10}}`)
+	if rec.Code >= http.StatusMultipleChoices {
+		t.Fatalf("trigger with conf = %d, want 2xx; body=%q", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		Conf map[string]any `json:"conf"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parsing response %q: %v", rec.Body.String(), err)
+	}
+	if got.Conf["date"] != "2026-01-01" || got.Conf["limit"] != float64(10) {
+		t.Errorf("conf = %v, want the posted conf carried onto the run", got.Conf)
+	}
+}
+
+// TestTriggerDagRunDefaultsConfToEmptyObject pins that a trigger with no conf
+// still reports conf as {}, preserving the prior contract.
+func TestTriggerDagRunDefaultsConfToEmptyObject(t *testing.T) {
+	srv := authedServer()
+	rec := authGet(srv, http.MethodPost, "/api/v2/dags/etl/dagRuns", `{}`)
+	if rec.Code >= http.StatusMultipleChoices {
+		t.Fatalf("trigger without conf = %d, want 2xx; body=%q", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		Conf json.RawMessage `json:"conf"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parsing response %q: %v", rec.Body.String(), err)
+	}
+	if string(got.Conf) != "{}" {
+		t.Errorf("conf = %s, want {} when no conf is supplied", got.Conf)
+	}
+}
+
+// TestTriggerDagRunRejectsNonObjectConf pins that a conf that is valid JSON but
+// not an object (an array or scalar) is a 400: conf must map to task params.
+func TestTriggerDagRunRejectsNonObjectConf(t *testing.T) {
+	for _, body := range []string{`{"conf":[1,2]}`, `{"conf":5}`, `{"conf":"x"}`} {
+		rec := authGet(authedServer(), http.MethodPost, "/api/v2/dags/etl/dagRuns", body)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("POST %s = %d, want 400", body, rec.Code)
+		}
+	}
+}
 
 func TestGetDagRunHandler(t *testing.T) {
 	srv := authedServer() // has run "r1"

--- a/internal/api/resources_dagrun_test.go
+++ b/internal/api/resources_dagrun_test.go
@@ -50,6 +50,26 @@ func TestTriggerDagRunDefaultsConfToEmptyObject(t *testing.T) {
 	}
 }
 
+// TestTriggerDagRunNormalizesNullConf pins that an explicit JSON null conf is
+// treated as absent and persisted as the empty object, not the literal null —
+// the run's conf is contractually never null.
+func TestTriggerDagRunNormalizesNullConf(t *testing.T) {
+	srv := authedServer()
+	rec := authGet(srv, http.MethodPost, "/api/v2/dags/etl/dagRuns", `{"conf":null}`)
+	if rec.Code >= http.StatusMultipleChoices {
+		t.Fatalf("trigger with null conf = %d, want 2xx; body=%q", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		Conf json.RawMessage `json:"conf"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("parsing response %q: %v", rec.Body.String(), err)
+	}
+	if string(got.Conf) != "{}" {
+		t.Errorf("conf = %s, want {} when conf is JSON null", got.Conf)
+	}
+}
+
 // TestTriggerDagRunRejectsNonObjectConf pins that a conf that is valid JSON but
 // not an object (an array or scalar) is a 400: conf must map to task params.
 func TestTriggerDagRunRejectsNonObjectConf(t *testing.T) {

--- a/internal/cli/runs.go
+++ b/internal/cli/runs.go
@@ -30,7 +30,7 @@ func newRunsCommand() *cobra.Command {
 }
 
 func newRunsTriggerCommand() *cobra.Command {
-	var serverURL, token string
+	var serverURL, token, conf, confFile string
 	cmd := &cobra.Command{
 		Use:   "trigger <dag_id>",
 		Short: "Trigger a new run of a DAG.",
@@ -40,8 +40,12 @@ func newRunsTriggerCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			body, err := triggerBody(conf, confFile)
+			if err != nil {
+				return err
+			}
 			url := strings.TrimRight(base, "/") + "/api/v2/dags/" + args[0] + "/dagRuns"
-			status, raw, err := apiRequest(cmdContext(cmd), http.MethodPost, url, bearer, []byte("{}"))
+			status, raw, err := apiRequest(cmdContext(cmd), http.MethodPost, url, bearer, body)
 			if err != nil {
 				return err
 			}
@@ -60,7 +64,41 @@ func newRunsTriggerCommand() *cobra.Command {
 		},
 	}
 	addRunsFlags(cmd, &serverURL, &token)
+	cmd.Flags().StringVar(&conf, "conf", "", "run configuration as an inline JSON object, exposed to tasks as params (e.g. --conf '{\"date\":\"2026-01-01\"}')")
+	cmd.Flags().StringVar(&confFile, "conf-file", "", "path to a JSON file whose object contents become the run configuration; mutually exclusive with --conf")
 	return cmd
+}
+
+// triggerBody builds the JSON request body for a trigger, folding an optional
+// run configuration into its conf field. The configuration may come inline via
+// --conf or from a file via --conf-file, but not both. Whichever source is
+// used, the payload must be a JSON object so it maps to the task params the
+// runtime exposes as {{ params.X }}; an array or scalar is rejected. With
+// neither flag the body is an empty object, preserving the prior behavior.
+func triggerBody(conf, confFile string) ([]byte, error) {
+	if conf != "" && confFile != "" {
+		return nil, fmt.Errorf("--conf and --conf-file are mutually exclusive; pass only one")
+	}
+	raw := conf
+	if confFile != "" {
+		data, err := os.ReadFile(confFile)
+		if err != nil {
+			return nil, fmt.Errorf("reading --conf-file %q: %w", confFile, err)
+		}
+		raw = string(data)
+	}
+	if strings.TrimSpace(raw) == "" {
+		return []byte("{}"), nil
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &obj); err != nil {
+		return nil, fmt.Errorf("conf must be a JSON object: %w", err)
+	}
+	body, err := json.Marshal(map[string]json.RawMessage{"conf": json.RawMessage(raw)})
+	if err != nil {
+		return nil, fmt.Errorf("building request body: %w", err)
+	}
+	return body, nil
 }
 
 func newRunsStatusCommand() *cobra.Command {

--- a/internal/cli/runs_test.go
+++ b/internal/cli/runs_test.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -90,6 +92,104 @@ func TestRunsTriggerUsesConfigToken(t *testing.T) {
 	}
 	if *gotAuth != "Bearer jwt-from-config" {
 		t.Errorf("auth = %q, want the token persisted by login (Bearer jwt-from-config)", *gotAuth)
+	}
+}
+
+// bodyRecorder is an httptest server that records the raw request body of the
+// last request it served, together with a canned JSON response body. The trigger
+// command POSTs its conf payload, so a test can prove exactly what reached the
+// control plane.
+func bodyRecorder(t *testing.T, body string) (srv *httptest.Server, got *string) {
+	t.Helper()
+	var reqBody string
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		reqBody = string(raw)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &reqBody
+}
+
+// TestRunsTriggerSendsConf proves an inline --conf JSON object reaches the
+// control plane as the request's conf field, lighting up the downstream
+// conf -> LEOFLOW_PARAMS -> {{ params.X }} pipeline that already exists.
+func TestRunsTriggerSendsConf(t *testing.T) {
+	srv, gotBody := bodyRecorder(t, `{"dag_run_id":"run-1","state":"queued"}`)
+
+	if _, _, err := run(t, "runs", "trigger", "etl",
+		"--conf", `{"x":1}`, "--server", srv.URL, "--token", "t"); err != nil {
+		t.Fatalf("runs trigger --conf: %v", err)
+	}
+	var sent struct {
+		Conf map[string]any `json:"conf"`
+	}
+	if err := json.Unmarshal([]byte(*gotBody), &sent); err != nil {
+		t.Fatalf("parsing request body %q: %v", *gotBody, err)
+	}
+	if got, ok := sent.Conf["x"]; !ok || got != float64(1) {
+		t.Errorf("conf = %v, want {\"x\":1} sent to the control plane", sent.Conf)
+	}
+}
+
+// TestRunsTriggerSendsConfFromFile proves --conf-file reads a JSON file from
+// disk and sends its contents as the run's conf.
+func TestRunsTriggerSendsConfFromFile(t *testing.T) {
+	srv, gotBody := bodyRecorder(t, `{"dag_run_id":"run-1","state":"queued"}`)
+	confPath := filepath.Join(t.TempDir(), "conf.json")
+	if err := os.WriteFile(confPath, []byte(`{"owner":"alice","limit":10}`), 0o600); err != nil {
+		t.Fatalf("write conf file: %v", err)
+	}
+
+	if _, _, err := run(t, "runs", "trigger", "etl",
+		"--conf-file", confPath, "--server", srv.URL, "--token", "t"); err != nil {
+		t.Fatalf("runs trigger --conf-file: %v", err)
+	}
+	var sent struct {
+		Conf map[string]any `json:"conf"`
+	}
+	if err := json.Unmarshal([]byte(*gotBody), &sent); err != nil {
+		t.Fatalf("parsing request body %q: %v", *gotBody, err)
+	}
+	if sent.Conf["owner"] != "alice" || sent.Conf["limit"] != float64(10) {
+		t.Errorf("conf = %v, want the file contents sent to the control plane", sent.Conf)
+	}
+}
+
+// TestRunsTriggerRejectsInvalidConf proves malformed JSON in --conf fails with a
+// CLI error rather than silently sending an empty conf.
+func TestRunsTriggerRejectsInvalidConf(t *testing.T) {
+	srv, _ := bodyRecorder(t, `{"dag_run_id":"run-1","state":"queued"}`)
+	if _, _, err := run(t, "runs", "trigger", "etl",
+		"--conf", "not json", "--server", srv.URL, "--token", "t"); err == nil {
+		t.Error("invalid --conf JSON should error")
+	}
+}
+
+// TestRunsTriggerRejectsNonObjectConf proves a valid-but-non-object top-level
+// (an array or a scalar) is rejected: conf must be a JSON object so it maps to
+// task params.
+func TestRunsTriggerRejectsNonObjectConf(t *testing.T) {
+	srv, _ := bodyRecorder(t, `{"dag_run_id":"run-1","state":"queued"}`)
+	for _, bad := range []string{`[1,2]`, `5`} {
+		if _, _, err := run(t, "runs", "trigger", "etl",
+			"--conf", bad, "--server", srv.URL, "--token", "t"); err == nil {
+			t.Errorf("non-object --conf %q should error", bad)
+		}
+	}
+}
+
+// TestRunsTriggerRejectsBothConfFlags proves --conf and --conf-file are mutually
+// exclusive: passing both is an operator mistake, not a silent precedence rule.
+func TestRunsTriggerRejectsBothConfFlags(t *testing.T) {
+	srv, _ := bodyRecorder(t, `{"dag_run_id":"run-1","state":"queued"}`)
+	confPath := filepath.Join(t.TempDir(), "conf.json")
+	if err := os.WriteFile(confPath, []byte(`{"a":1}`), 0o600); err != nil {
+		t.Fatalf("write conf file: %v", err)
+	}
+	if _, _, err := run(t, "runs", "trigger", "etl",
+		"--conf", `{"a":1}`, "--conf-file", confPath, "--server", srv.URL, "--token", "t"); err == nil {
+		t.Error("passing both --conf and --conf-file should error")
 	}
 }
 

--- a/internal/domain/run.go
+++ b/internal/domain/run.go
@@ -1,6 +1,9 @@
 package domain
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // DAG is a registered DAG with its scheduling metadata (distinct from DAGSpec,
 // which is the compiled artifact).
@@ -42,6 +45,10 @@ type DagRun struct {
 	StartedAt   *time.Time
 	EndedAt     *time.Time
 	Note        string
+	// Conf is the run's configuration as a JSON object, supplied at trigger time
+	// and exposed to tasks as params. Empty means no configuration; storage
+	// persists the empty-object default so downstream readers never see NULL.
+	Conf json.RawMessage
 }
 
 // TaskInstance is an execution of a task within a DagRun.

--- a/internal/storage/dagrun_conf_integration_test.go
+++ b/internal/storage/dagrun_conf_integration_test.go
@@ -4,8 +4,10 @@ package storage_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
+	"reflect"
 	"testing"
 	"time"
 
@@ -13,6 +15,22 @@ import (
 	"github.com/neochaotic/leoflow/internal/domain"
 	"github.com/neochaotic/leoflow/internal/storage"
 )
+
+// confEqual compares two conf payloads by value, not by bytes: the conf column
+// is jsonb, so a round-trip re-serializes with canonical spacing (and unordered
+// keys). Byte comparison would fail on that cosmetic reformat even though the
+// data is identical.
+func confEqual(t *testing.T, got, want []byte) bool {
+	t.Helper()
+	var g, w any
+	if err := json.Unmarshal(got, &g); err != nil {
+		t.Fatalf("unmarshal got conf %s: %v", got, err)
+	}
+	if err := json.Unmarshal(want, &w); err != nil {
+		t.Fatalf("unmarshal want conf %s: %v", want, err)
+	}
+	return reflect.DeepEqual(g, w)
+}
 
 // TestCreateDagRunPersistsConf proves the conf column is written at create time
 // and reads back unchanged. The conf -> LEOFLOW_PARAMS -> task params pipeline
@@ -52,16 +70,16 @@ func TestCreateDagRunPersistsConf(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create run with conf: %v", err)
 	}
-	if string(created.Conf) != string(conf) {
-		t.Errorf("created run conf = %s, want %s", created.Conf, conf)
+	if !confEqual(t, created.Conf, conf) {
+		t.Errorf("created run conf = %s, want %s (by value)", created.Conf, conf)
 	}
 
 	got, err := repo.GetDagRun(ctx, "default", dagID, "r1")
 	if err != nil {
 		t.Fatalf("get run: %v", err)
 	}
-	if string(got.Conf) != string(conf) {
-		t.Errorf("read-back conf = %s, want %s (the column must round-trip)", got.Conf, conf)
+	if !confEqual(t, got.Conf, conf) {
+		t.Errorf("read-back conf = %s, want %s (the column must round-trip by value)", got.Conf, conf)
 	}
 }
 

--- a/internal/storage/dagrun_conf_integration_test.go
+++ b/internal/storage/dagrun_conf_integration_test.go
@@ -1,0 +1,109 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/config"
+	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/storage"
+)
+
+// TestCreateDagRunPersistsConf proves the conf column is written at create time
+// and reads back unchanged. The conf -> LEOFLOW_PARAMS -> task params pipeline
+// reads the persisted column, so a run created with no conf persisted was the
+// break that left trigger-time params always empty.
+func TestCreateDagRunPersistsConf(t *testing.T) {
+	url := os.Getenv("DATABASE_URL")
+	if url == "" {
+		t.Skip("DATABASE_URL must point at a migrated database for the conf round-trip test")
+	}
+	ctx := context.Background()
+	pg, err := storage.NewPostgres(ctx, config.DatabaseSection{URL: url})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pg.Close()
+
+	repo := storage.NewRepository(pg)
+	dagID := fmt.Sprintf("conf_%d", time.Now().UnixNano())
+	spec := domain.DAGSpec{
+		SchemaVersion: "1.0", DagID: dagID, DagVersion: "v1", Image: "img:v1",
+		Tasks: []domain.TaskSpec{{TaskID: "a", Type: domain.TaskTypePython, Entrypoint: "dag:a"}},
+	}
+	hash, err := spec.CanonicalHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created, rerr := repo.RegisterDagVersion(ctx, "default", spec, hash); rerr != nil || !created {
+		t.Fatalf("register version: created=%v err=%v", created, rerr)
+	}
+
+	conf := []byte(`{"date":"2026-01-01","limit":10}`)
+	created, err := repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+		RunID: "r1", State: domain.DagRunStateQueued, RunType: "manual",
+		LogicalDate: time.Now().UTC(), Conf: conf,
+	})
+	if err != nil {
+		t.Fatalf("create run with conf: %v", err)
+	}
+	if string(created.Conf) != string(conf) {
+		t.Errorf("created run conf = %s, want %s", created.Conf, conf)
+	}
+
+	got, err := repo.GetDagRun(ctx, "default", dagID, "r1")
+	if err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if string(got.Conf) != string(conf) {
+		t.Errorf("read-back conf = %s, want %s (the column must round-trip)", got.Conf, conf)
+	}
+}
+
+// TestCreateDagRunDefaultsConfWhenAbsent proves a run created without conf keeps
+// the empty-object default rather than a NULL that downstream params handling
+// would have to special-case.
+func TestCreateDagRunDefaultsConfWhenAbsent(t *testing.T) {
+	url := os.Getenv("DATABASE_URL")
+	if url == "" {
+		t.Skip("DATABASE_URL must point at a migrated database for the conf default test")
+	}
+	ctx := context.Background()
+	pg, err := storage.NewPostgres(ctx, config.DatabaseSection{URL: url})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pg.Close()
+
+	repo := storage.NewRepository(pg)
+	dagID := fmt.Sprintf("confdef_%d", time.Now().UnixNano())
+	spec := domain.DAGSpec{
+		SchemaVersion: "1.0", DagID: dagID, DagVersion: "v1", Image: "img:v1",
+		Tasks: []domain.TaskSpec{{TaskID: "a", Type: domain.TaskTypePython, Entrypoint: "dag:a"}},
+	}
+	hash, err := spec.CanonicalHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created, rerr := repo.RegisterDagVersion(ctx, "default", spec, hash); rerr != nil || !created {
+		t.Fatalf("register version: created=%v err=%v", created, rerr)
+	}
+
+	if _, rerr := repo.CreateDagRun(ctx, "default", dagID, domain.DagRun{
+		RunID: "r1", State: domain.DagRunStateQueued, RunType: "manual", LogicalDate: time.Now().UTC(),
+	}); rerr != nil {
+		t.Fatalf("create run without conf: %v", rerr)
+	}
+	got, err := repo.GetDagRun(ctx, "default", dagID, "r1")
+	if err != nil {
+		t.Fatalf("get run: %v", err)
+	}
+	if string(got.Conf) != "{}" {
+		t.Errorf("conf = %s, want {} default when no conf supplied", got.Conf)
+	}
+}

--- a/internal/storage/mappers.go
+++ b/internal/storage/mappers.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -99,6 +100,7 @@ func mapDagRun(r queries.DagRun, dagID string) domain.DagRun {
 		StartedAt:   timePtr(r.StartedAt),
 		EndedAt:     timePtr(r.EndedAt),
 		Note:        strOrEmpty(r.Note),
+		Conf:        json.RawMessage(r.Conf),
 	}
 }
 

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -1,6 +1,6 @@
 -- name: CreateDagRun :one
-INSERT INTO dag_runs (tenant_id, dag_id, dag_version_id, run_id, logical_date, state, trigger, note)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+INSERT INTO dag_runs (tenant_id, dag_id, dag_version_id, run_id, logical_date, state, trigger, note, conf)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 RETURNING *;
 
 -- name: GetDagRun :one

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -236,8 +236,8 @@ func (q *Queries) CountTaskInstanceStatesInWindow(ctx context.Context, arg Count
 }
 
 const createDagRun = `-- name: CreateDagRun :one
-INSERT INTO dag_runs (tenant_id, dag_id, dag_version_id, run_id, logical_date, state, trigger, note)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+INSERT INTO dag_runs (tenant_id, dag_id, dag_version_id, run_id, logical_date, state, trigger, note, conf)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 RETURNING id, tenant_id, dag_id, dag_version_id, run_id, logical_date, data_interval_start, data_interval_end, state, trigger, conf, triggered_by, queued_at, started_at, ended_at, note, alerted_at, alert_attempts, next_alert_attempt_at
 `
 
@@ -250,6 +250,7 @@ type CreateDagRunParams struct {
 	State        DagRunState        `json:"state"`
 	Trigger      DagRunTrigger      `json:"trigger"`
 	Note         *string            `json:"note"`
+	Conf         []byte             `json:"conf"`
 }
 
 func (q *Queries) CreateDagRun(ctx context.Context, arg CreateDagRunParams) (DagRun, error) {
@@ -262,6 +263,7 @@ func (q *Queries) CreateDagRun(ctx context.Context, arg CreateDagRunParams) (Dag
 		arg.State,
 		arg.Trigger,
 		arg.Note,
+		arg.Conf,
 	)
 	var i DagRun
 	err := row.Scan(

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -424,6 +424,12 @@ func (r *Repository) CreateDagRun(ctx context.Context, tenant, dagID string, run
 			return domain.DagRun{}, fmt.Errorf("dag %q is at max_active_runs cap of %d: %w", dagID, maxActive, domain.ErrConflict)
 		}
 	}
+	// Persist an explicit empty object when the run carries no conf, so the
+	// column is never NULL and downstream params readers see a valid object.
+	conf := []byte(run.Conf)
+	if len(conf) == 0 {
+		conf = []byte("{}")
+	}
 	created, err := r.q.CreateDagRun(ctx, queries.CreateDagRunParams{
 		TenantID:     dag.TenantID,
 		DagID:        dag.ID,
@@ -433,6 +439,7 @@ func (r *Repository) CreateDagRun(ctx context.Context, tenant, dagID string, run
 		State:        queries.DagRunState(run.State),
 		Trigger:      queries.DagRunTrigger(run.RunType),
 		Note:         strPtr(run.Note),
+		Conf:         conf,
 	})
 	if err != nil {
 		return domain.DagRun{}, fmt.Errorf("creating dag run: %w", mapConflict(err))

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -424,10 +424,11 @@ func (r *Repository) CreateDagRun(ctx context.Context, tenant, dagID string, run
 			return domain.DagRun{}, fmt.Errorf("dag %q is at max_active_runs cap of %d: %w", dagID, maxActive, domain.ErrConflict)
 		}
 	}
-	// Persist an explicit empty object when the run carries no conf, so the
-	// column is never NULL and downstream params readers see a valid object.
+	// Persist an explicit empty object when the run carries no conf (or an
+	// explicit JSON null), so the column is never NULL and downstream params
+	// readers see a valid object.
 	conf := []byte(run.Conf)
-	if len(conf) == 0 {
+	if len(conf) == 0 || string(conf) == "null" {
 		conf = []byte("{}")
 	}
 	created, err := r.q.CreateDagRun(ctx, queries.CreateDagRunParams{


### PR DESCRIPTION
## Summary

Complete **step 1 of #545**: pass run configuration from `leoflow runs trigger` and persist it end-to-end so tasks actually receive it as params. This is a working, mergeable feature — CLI flags **and** the server-side conf persistence they depend on.

### CLI (`internal/cli/runs.go`)
- `--conf` — inline JSON object string, e.g. `--conf '{"date":"2026-01-01"}'`
- `--conf-file` — path to a JSON file whose object contents become the conf
- Mutually exclusive; non-object input (invalid JSON, array, scalar) errors; with neither flag the body stays `{}`.

### Server-side conf persistence (the prerequisite that was missing)
The `conf` column existed and was read back everywhere but was never written at trigger time, so trigger-time params always resolved to `{}`. Now wired end to end:
- **domain** (`internal/domain/run.go`): `DagRun` gains a `Conf` field.
- **api** (`internal/api/resources.go`): `createDagRunHandler` binds `conf`, rejects a non-object with 400, and carries it onto the run; the response DTO (`internal/api/dto.go`) reflects the run's conf instead of a hard-coded `{}`.
- **storage** (`internal/storage/queries/runs.sql` + regenerated `runs.sql.go`, `repository.go`, `mappers.go`): `CreateDagRun` writes the `conf` column, defaulting an empty conf to `{}` (never NULL) and reads it back.

**Handler note:** `POST /api/v2/dags/{dag_id}/dagRuns` is the single create path — the CLI's `runs trigger` hits it, and it is the same Airflow-compat v2 endpoint whose response DTO is at `internal/api/dto.go:100`. There is no second create handler; fixing `createDagRunHandler` makes both the CLI-targeted and v2-compat behavior correct. **Loop closes automatically:** `internal/storage/agent_store.go` already reads the run's `conf` column into `LEOFLOW_PARAMS` (runtime `context['params']` / `{{ params.X }}`), so persisting the column lights up the full pipeline.

## Scope

**Step 1** = `--conf` plumbing + raw conf persistence (above). **Step 2** — typed `params=` declaration/validation (schema, coercion, required/defaults) — remains a separate follow-up and is intentionally not included here.

## TDD evidence (failing first, then green)

CLI (`internal/cli/runs_test.go`):
- `TestRunsTriggerSendsConf`, `TestRunsTriggerSendsConfFromFile`, `TestRunsTriggerRejectsInvalidConf`, `TestRunsTriggerRejectsNonObjectConf`, `TestRunsTriggerRejectsBothConfFlags`

API handler (`internal/api/resources_dagrun_test.go`) — initially failed (`conf = map[]` / non-object returned 201):
- `TestTriggerDagRunPersistsConf` — posted conf round-trips in the response.
- `TestTriggerDagRunDefaultsConfToEmptyObject` — absent conf stays `{}`.
- `TestTriggerDagRunRejectsNonObjectConf` — array/scalar conf → 400.

Storage round-trip (`internal/storage/dagrun_conf_integration_test.go`, `//go:build integration`):
- `TestCreateDagRunPersistsConf` — `CreateDagRun` writes conf and `GetDagRun` reads it back unchanged.
- `TestCreateDagRunDefaultsConfWhenAbsent` — absent conf persists as `{}`.

## Gates
- `sqlc generate` — regenerated; diff is only the conf param/column wiring (committed).
- `go test ./...` — all packages green.
- `golangci-lint run ./...` (repo `.golangci.yml`) — **0 issues**.
- Integration tests require `DATABASE_URL` (skipped in the unit gate, per repo convention).

Refs #545