### PR TITLE
chore: make the dormant warm-pool min_idle_workers seam honest + guarded

### DIFF
--- a/docs/api/dag-schema.json
+++ b/docs/api/dag-schema.json
@@ -78,7 +78,7 @@
     "min_idle_workers": {
       "type": "integer",
       "minimum": 0,
-      "description": "Warm workers the author wants kept ready for this DAG version so its tasks skip cold-pod startup (ADR 0058, warm pools). Operator-capped at execution.max_pool_size and inert unless the operator enabled warm pools; 0 (default) means no warmth."
+      "description": "DORMANT seam, not author-settable today: warm workers an author would want kept ready for this DAG version so its tasks skip cold-pod startup (ADR 0058, warm pools). It is absent from the authoring schema (leoflow.yaml) and the parser never emits it, so a compiled artifact always carries 0. The downstream (EffectiveMinIdle clamp, scheduler store) is intentionally pre-wired, so exposing it to authors later is a schema+parser change only. Would be operator-capped at execution.max_pool_size and inert unless the operator enabled warm pools; 0 (default) means no warmth."
     },
     "catchup": {
       "type": "boolean",

--- a/internal/domain/dag.go
+++ b/internal/domain/dag.go
@@ -77,16 +77,22 @@ type DAGSpec struct {
 	// exactly as before. The scheduler enforces it in PlanRun's scheduled→queued
 	// admission gate.
 	MaxActiveTasks int `json:"max_active_tasks,omitempty"`
-	// MinIdleWorkers is the number of warm workers the DAG AUTHOR wants kept ready
-	// for this DAG version so its tasks skip cold-pod startup (ADR 0058 N1b2b,
-	// warm pools model A2). It mirrors MaxActiveTasks as a per-DAG author-declared
-	// spec field: zero (the default) means no warmth, and a DAG that never sets it
-	// — and all of Lite — behaves exactly as before. It is only a REQUEST: the
-	// operator caps it at execution.max_pool_size, floors an unset value at
-	// execution.min_idle_workers, and the whole thing is inert unless the operator
-	// enabled execution.warm_pools_enabled (see config.ExecutionSection.
-	// EffectiveMinIdle). Whether a pod may be reused across attempts stays the
-	// operator's security decision; this field only tunes how many.
+	// MinIdleWorkers is a DORMANT seam for per-DAG author-declared warmth: the
+	// number of warm workers an author would want kept ready for this DAG version
+	// so its tasks skip cold-pod startup (ADR 0058, warm pools model A2). It is NOT
+	// author-settable today. There is no author entry point: the field is absent
+	// from the authoring schema (leoflow-yaml-schema.json, which is
+	// additionalProperties:false) and the parser never emits it, so after the
+	// parse→compile path this value is ALWAYS 0. The intended split is that the
+	// operator gates IF warmth happens at all (execution.warm_pools_enabled) while
+	// the author would only tune HOW MANY, with the operator clamping the request;
+	// whether a pod may be reused across attempts stays the operator's security
+	// decision. The downstream is intentionally pre-wired around this field —
+	// config.ExecutionSection.EffectiveMinIdle already clamps it and the scheduler
+	// store already reads it — so exposing it to authors later is a schema+parser
+	// change only (add the key to the authoring schema and have the parser emit
+	// it), with no domain/scheduler rework. Until then it stays 0 and every DAG,
+	// and all of Lite, behaves exactly as before.
 	MinIdleWorkers int          `json:"min_idle_workers,omitempty"`
 	Catchup        bool         `json:"catchup,omitempty"`
 	DefaultArgs    *DefaultArgs `json:"default_args,omitempty"`

--- a/internal/domain/min_idle_workers_dormant_test.go
+++ b/internal/domain/min_idle_workers_dormant_test.go
@@ -1,0 +1,67 @@
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// wiringReminder is the single instruction repeated by every failing assertion
+// in this file: it names everything that must change together when the dormant
+// warm-pool seam is finally exposed to authors, so a partial wiring can never
+// pass by fixing only one half.
+const wiringReminder = "the min_idle_workers seam is DORMANT and must stay unwired: " +
+	"absent from the authoring schema (leoflow-yaml-schema.json, " +
+	"additionalProperties:false), never emitted by the parser, so " +
+	"spec.MinIdleWorkers is always 0. To expose it later you must do ALL of: " +
+	"add min_idle_workers to the authoring schema AND emit it from the parser; " +
+	"keep the staging exclusion (staging.enabled => dedicated pod, never warm); " +
+	"and lead the operator docs with the safe default (0 = scale-to-zero)."
+
+// TestMinIdleWorkersAbsentFromCompiledArtifactIsZero locks the value half of
+// the dormant contract: a compiled artifact as the parser emits it (no
+// min_idle_workers key — the parser never writes one) unmarshals to a DAGSpec
+// whose MinIdleWorkers is 0. The downstream (EffectiveMinIdle, scheduler store)
+// is intentionally pre-wired, so this zero is what keeps warm pools inert until
+// the seam is deliberately exposed.
+func TestMinIdleWorkersAbsentFromCompiledArtifactIsZero(t *testing.T) {
+	// A representative parser-emitted dag.json: the parser never writes the
+	// min_idle_workers key, so it is simply absent here.
+	const compiled = `{
+		"schema_version": "1.0",
+		"dag_id": "simple_linear",
+		"dag_version": "test:v1",
+		"image": "test:v1",
+		"tasks": [{"task_id": "extract", "type": "python", "entrypoint": "simple_linear:extract"}]
+	}`
+
+	var spec DAGSpec
+	if err := json.Unmarshal([]byte(compiled), &spec); err != nil {
+		t.Fatalf("unmarshal compiled artifact: %v", err)
+	}
+	if spec.MinIdleWorkers != 0 {
+		t.Fatalf("MinIdleWorkers = %d, want 0; %s", spec.MinIdleWorkers, wiringReminder)
+	}
+}
+
+// TestMinIdleWorkersRejectedFromAuthoringSchema locks the author-entry-point
+// half of the dormant contract: an author who writes min_idle_workers into
+// leoflow.yaml is rejected by schema validation (additionalProperties:false),
+// rather than having it silently accepted-and-dropped. This is what makes the
+// seam honest — there is no author knob today, and an attempt to invent one
+// fails loudly at compile instead of looking like it worked.
+func TestMinIdleWorkersRejectedFromAuthoringSchema(t *testing.T) {
+	s, err := schemas()
+	if err != nil {
+		t.Fatalf("compile schemas: %v", err)
+	}
+	// A raw leoflow.yaml an author might write to request warmth. The struct
+	// cannot even hold this key, so validate the raw instance against the
+	// authoring schema directly.
+	inst := map[string]any{
+		"dag_id":           "sales",
+		"min_idle_workers": 1,
+	}
+	if verr := validateAgainst(s.leoflow, inst); verr == nil {
+		t.Fatalf("authoring schema accepted min_idle_workers; want rejection. %s", wiringReminder)
+	}
+}

--- a/internal/domain/schemas/dag-schema.json
+++ b/internal/domain/schemas/dag-schema.json
@@ -78,7 +78,7 @@
     "min_idle_workers": {
       "type": "integer",
       "minimum": 0,
-      "description": "Warm workers the author wants kept ready for this DAG version so its tasks skip cold-pod startup (ADR 0058, warm pools). Operator-capped at execution.max_pool_size and inert unless the operator enabled warm pools; 0 (default) means no warmth."
+      "description": "DORMANT seam, not author-settable today: warm workers an author would want kept ready for this DAG version so its tasks skip cold-pod startup (ADR 0058, warm pools). It is absent from the authoring schema (leoflow.yaml) and the parser never emits it, so a compiled artifact always carries 0. The downstream (EffectiveMinIdle clamp, scheduler store) is intentionally pre-wired, so exposing it to authors later is a schema+parser change only. Would be operator-capped at execution.max_pool_size and inert unless the operator enabled warm pools; 0 (default) means no warmth."
     },
     "catchup": {
       "type": "boolean",

--- a/parser/tests/test_compiler.py
+++ b/parser/tests/test_compiler.py
@@ -131,3 +131,51 @@ def test_missing_dag_raises(monkeypatch, tmp_path):
     monkeypatch.setenv("LEOFLOW_PROJECT_CONFIG_JSON", json.dumps({"dag_id": "nope"}))
     with pytest.raises(ValueError):
         compile_dag(str(empty), str(tmp_path / "ignored.json"), "test:v1")
+
+
+def test_min_idle_workers_is_never_emitted(monkeypatch, tmp_path, dag_schema):
+    """Pin the dormant warm-pool seam: the compiler MUST NOT emit
+    ``min_idle_workers`` into dag.json.
+
+    The field exists downstream (dag-schema.json accepts it; the Go DAGSpec
+    carries it; EffectiveMinIdle and the scheduler store read it) but has no
+    author entry point today: it is absent from the authoring schema
+    (leoflow.yaml, additionalProperties:false) and the compiler never writes
+    it. So a compiled artifact never carries the key and the Go
+    ``spec.MinIdleWorkers`` is always 0. This test locks that inert contract so
+    the seam cannot silently become half-wired.
+
+    Even a config that smuggles the key in is dropped: the compiler copies only
+    whitelisted config keys, never arbitrary ones.
+
+    When you DO wire author-declared warmth later, this test must change
+    deliberately, and the change is not just here — you must ALSO: add
+    ``min_idle_workers`` to the authoring schema (leoflow-yaml-schema.json) and
+    have the compiler emit it; keep the staging exclusion (a DAG with
+    ``staging.enabled`` falls back to a dedicated pod and cannot be warm); and
+    lead the operator docs with the safe default (0 = scale-to-zero).
+    """
+    monkeypatch.setenv(
+        "LEOFLOW_PROJECT_CONFIG_JSON",
+        json.dumps(
+            {
+                "dag_id": "simple_linear",
+                "python_version": "3.11",
+                # An author trying to smuggle warmth in via the project config:
+                # the compiler must not pass it through.
+                "min_idle_workers": 3,
+            }
+        ),
+    )
+    spec = compile_dag(
+        str(FIXTURES / "simple_linear.py"), str(tmp_path / "ignored.json"), "test:v1"
+    )
+    Draft202012Validator(dag_schema).validate(spec)
+    assert "min_idle_workers" not in spec, (
+        "the compiler emitted min_idle_workers; the warm-pool seam is dormant "
+        "and must stay unwired. To wire it later: add the key to the authoring "
+        "schema (leoflow-yaml-schema.json) AND emit it here; keep the staging "
+        "exclusion (staging.enabled => dedicated pod, never warm); and lead the "
+        "operator docs with the safe default (0 = scale-to-zero). Then update "
+        f"this test deliberately. Got spec keys: {sorted(spec)}"
+    )

--- a/website/content/operate/warm-pools.md
+++ b/website/content/operate/warm-pools.md
@@ -128,20 +128,39 @@ transport is selected — see
 ### 2. Turn on the pool and tune it
 
 The pool knobs live under the chart's `execution` values (which map to the
-`LEOFLOW_EXECUTION_*` server environment). At minimum:
+`LEOFLOW_EXECUTION_*` server environment). Start with the default,
+`minIdleWorkers: 0`:
 
 ```yaml
 execution:
   warmPoolsEnabled: true      # LEOFLOW_EXECUTION_WARM_POOLS_ENABLED
-  minIdleWorkers: 1           # keep 1 warm pod ready per DAG version
+  minIdleWorkers: 0           # default: scale-to-zero, no standing cost
 ```
 
-Everything else carries a sane default (see the [config reference](#configuration-reference)).
-With `minIdleWorkers: 0` (the default) the pool scales to zero — no idle pods are
-kept, preserving the zero-idle floor of pod-per-task; a pod is provisioned on
-demand and then reused while it stays busy or within its idle-TTL. Raise
-`minIdleWorkers` to trade a little idle cost for a warm pod that is ready the
-instant an attempt arrives.
+`minIdleWorkers: 0` is the real code default and the right starting point. The
+pool scales to zero — **no idle pods are kept**, so there is **no standing
+cost**, preserving the zero-idle floor of pod-per-task. A pod is provisioned on
+demand at the first attempt and then reused while it stays busy or within its
+idle-TTL, so you still get the reuse win on a hot version without paying for a
+pod that sits idle. Everything else carries a sane default (see the
+[config reference](#configuration-reference)).
+
+**To see it work — or to measure the latency win — raise it to `1`:**
+
+```yaml
+execution:
+  warmPoolsEnabled: true
+  minIdleWorkers: 1           # keep 1 warm pod ready per DAG version — has a cost
+```
+
+`minIdleWorkers: 1` keeps a pod ready the instant an attempt arrives (no
+first-attempt provisioning wait), which is what you want when demonstrating or
+benchmarking the feature. It is not free: it keeps **one pod warm per DAG
+version** standing idle (multiplied across every active version), and — like
+turning warm pools on at all — it rides on the cluster-wide pod-auth change from
+the `exchange` transport + `enforce` liveness prerequisite above, which alters
+how **every** task pod authenticates, warm or dedicated. Measure the win against
+that cost before raising it in production.
 
 {{% alert title="Enable on a shared production cluster is a reliability decision" color="warning" %}}
 Unit and integration tests prove the *logic* with fakes; they cannot prove the


### PR DESCRIPTION
Closes #789 (R2 + R4).

## Context
`MinIdleWorkers` (`internal/domain/dag.go`) is pre-wired downstream — the output schema `dag-schema.json`, `config.ExecutionSection.EffectiveMinIdle`, and `internal/storage/scheduler_store.go` all read it — but it has **no author entry point**: it is absent from the authoring schema `internal/domain/schemas/leoflow-yaml-schema.json` (`additionalProperties:false`) and the parser never emits it. So after the parse→compile path `spec.MinIdleWorkers` is **always 0**. The author-vs-operator split is intentional (operator gates *IF* warmth via `warm_pools_enabled`; an author would only tune *HOW MANY*; operator clamps), so the seam is kept, not deleted or wired. The problem was the doc comments read in the present tense as if authors already use it.

## R2 — make the dormant seam honest + guarded
- **Doc comment rewrite** on `MinIdleWorkers` in `internal/domain/dag.go`: now states it is DORMANT / not author-settable today (absent from the authoring schema, never emitted by the parser, so always 0), and that the downstream is intentionally pre-wired so exposing it later is a schema+parser change only.
- **Same honesty fix** on the `min_idle_workers` `description` in `dag-schema.json` (embedded copy `internal/domain/schemas/dag-schema.json` + canonical `docs/api/dag-schema.json`, kept byte-identical for `TestEmbeddedSchemasMatchDocs`).
- **Pin test** locking the inert contract (written first; verified it goes red when the seam is wired, then green):
  - Go, `internal/domain/min_idle_workers_dormant_test.go`:
    - `TestMinIdleWorkersAbsentFromCompiledArtifactIsZero` — a compiled artifact as the parser emits it (no `min_idle_workers` key) unmarshals to `MinIdleWorkers == 0`.
    - `TestMinIdleWorkersRejectedFromAuthoringSchema` — an author writing `min_idle_workers` into `leoflow.yaml` is rejected by the authoring schema (`additionalProperties:false`), following the existing `TestDefaultsBlockUnknownKeyRejected` precedent.
  - Parser, `parser/tests/test_compiler.py::test_min_idle_workers_is_never_emitted` — the compiler never emits the key, even when a project config smuggles `min_idle_workers` in.
  - Every failure message names what a future wiring must do **together**: add the key to the authoring schema **and** emit it from the parser; keep the staging exclusion (`staging.enabled` ⇒ dedicated pod, never warm); and lead the operator docs with the safe default (`0` = scale-to-zero).

## R4 — docs lead with the safe default
`website/content/operate/warm-pools.md` "Turn on the pool and tune it" now leads with `execution.minIdleWorkers: 0` (the real code default — scale-to-zero, no standing cost; matches `helm/leoflow/values.yaml:239`) and presents `1` only as "to see it work / measure", noting its cost (one warm pod kept per DAG version, plus the cluster-wide pod-auth change from the `exchange` transport + `enforce` liveness prerequisite).

## Test evidence
- `go test ./...` — exit 0, no failures.
- `golangci-lint run ./...` — `0 issues`.
- `cd parser && python3 -m pytest -q` — all pass (81 tests).
- Red-first verified: temporarily emitting the key from the compiler made `test_min_idle_workers_is_never_emitted` fail with the wiring-reminder message; reverted, green again.