### PR TITLE
docs: deferrable operators are a conscious non-goal + fix stale reschedule claim

### DIFF
--- a/website/content/author-dags/operators-sensors.md
+++ b/website/content/author-dags/operators-sensors.md
@@ -239,11 +239,30 @@ value from an untrusted `conf` cannot inject shell — write interpolations unqu
 Capabilities that need scheduler/control-plane work are rejected loudly rather
 than half-running:
 
-- **Reschedule-mode sensors** — need the scheduler to persist the next-poke time,
-  free the pod, and re-dispatch ([#380](https://github.com/neochaotic/leoflow/issues/380)).
-- **Deferrable operators** (the async triggerer) — [#374](https://github.com/neochaotic/leoflow/issues/374).
 - **Dynamic task mapping** — [#376](https://github.com/neochaotic/leoflow/issues/376).
 - **Branching** — [#377](https://github.com/neochaotic/leoflow/issues/377).
+
+**Reschedule-mode sensors *are* supported.** Set `mode="reschedule"` and the
+scheduler persists the next-poke time, frees the pod between pokes, and
+re-dispatches the sensor preserving its `try_number` — the idiomatic way to wait
+in leoflow (see [DAG authoring](/author-dags/dag-authoring/)).
+
+{{% alert title="`deferrable=True` is not supported — a conscious non-goal" color="warning" %}}
+Airflow's deferrable operators offload a wait to a shared **async triggerer** that
+runs user trigger code in a long-lived process. leoflow's control plane
+deliberately runs no user code or network
+([ADR 0048](/project/adrs/0048-no-user-code-in-control-plane/)), and pod-per-task
+plus reschedule already deliver what deferrable exists for — freeing the slot
+during a wait — so a triggerer would add multi-tenant risk for no gain. A task
+that sets `deferrable=True` **fails rather than defers**; the parameter is not
+honored. Use instead:
+
+- `mode="reschedule"` on a sensor — the direct replacement;
+- `deferrable=False` — a synchronous poke; or
+- compute or poll the condition inside a `@task`.
+
+Full rationale: [ADR 0016](/project/adrs/0016-deferrable-tasks/).
+{{% /alert %}}
 
 ## See also
 

--- a/website/content/project/adrs/0016-deferrable-tasks.md
+++ b/website/content/project/adrs/0016-deferrable-tasks.md
@@ -9,8 +9,8 @@ weight: 160
 description: "ADR 0016: Deferrable Tasks (Deferred to v0.3)"
 ---
 
-**Status:** Deferred — Not implemented in v0.1.0
-**Date:** 2026-05-22
+**Status:** Rejected — conscious non-goal (superseded by ADR 0048). See the Decision log at the end.
+**Date:** 2026-05-22 (rejected 2026-08-27)
 
 ## Context
 
@@ -99,3 +99,36 @@ Revisit this ADR when:
   Airflow's complexity without inheriting its constraints.
 - **Never implement:** rejected because the dispatch+poll pattern
   is real and common in production data pipelines.
+
+## Decision log
+
+**2026-08-27 — Rejected as a conscious non-goal.** This ADR's original "deferred,
+revisit after MVP" framing is retired. Deferrable execution is now a deliberate
+non-goal, on two grounds that did not exist (or were not decided) in 2026-05:
+
+- **The motivation is already satisfied.** Deferrable exists to free a worker slot
+  during a long wait. leoflow is pod-per-task with no persistent worker pool, and
+  reschedule-mode sensors already release the pod between pokes and re-dispatch
+  preserving `try_number`. There is no standing slot to free, so the efficiency
+  win is delivered by the existing model, not by a triggerer.
+- **A triggerer is foreclosed by [ADR 0048](/project/adrs/0048-no-user-code-in-control-plane/).**
+  Airflow compatibility requires running user-authored trigger coroutines
+  (`Trigger.run()`, Python asyncio) in a shared, long-lived process. That is
+  exactly the user-code/network-in-the-control-plane that ADR 0048 (2026-07-31)
+  prohibits, and in a shared triggerer it is a multi-tenant regression (shared-fate
+  event-loop starvation, co-mingled per-tenant secrets). The 2026-05 note above —
+  "a Go process avoids Airflow's GIL reason for a separate triggerer" — is moot: a
+  Go goroutine cannot run a Python trigger, and the compatible form is the
+  forbidden one. A compliant fallback (an ephemeral pod per trigger) is the very
+  pod deferrable was meant to avoid — zero net win.
+
+**Author-facing behavior:** `deferrable=True` is not honored; the task fails rather
+than defers. The supported alternatives are reschedule-mode sensors
+(`mode="reschedule"`), a synchronous poke (`deferrable=False`), or polling inside a
+`@task`. See [Operators & sensors](/author-dags/operators-sensors/).
+
+**Go/no-go:** NO-GO while ADR 0048 stands. **Revisit trigger:** a measured workload
+on a real cluster proving reschedule/poke churn is materially unacceptable, *and* a
+per-tenant-isolated trigger design that does not run user code in the shared control
+plane. The reserved `'deferred'` task state (migration 006) is kept as cheap
+insurance against that future, not as a signal that this is planned.


### PR DESCRIPTION
Docs-only, per the deferrable study (`spec/deferrable-operators-study.md`) and issue #794. Makes it unambiguous to authors that `deferrable=True` has no effect, and fixes a stale claim that steered them away from the recommended alternative. **No code guard in this PR** (that stays tracked in #794).

## Changes
- **`author-dags/operators-sensors.md`**
  - Removes the stale "**Reschedule-mode sensors** — not yet supported" bullet — reschedule mode **is** supported (#380, wired end-to-end), and it's the recommended way to wait. Added a positive statement + cross-link.
  - Adds a warning callout: **`deferrable=True` is not supported — a conscious non-goal**. A task that sets it fails rather than defers; alternatives are `mode="reschedule"`, `deferrable=False` (synchronous poke), or polling inside a `@task`. Links ADR 0048 (the controlling reason) + ADR 0016.
- **ADR 0016** — status `Deferred` → **`Rejected — conscious non-goal (superseded by ADR 0048)`**, with a Decision log: the benefit is already delivered by pod-per-task + reschedule; a triggerer would run user code in the control plane (ADR 0048) and is a multi-tenant regression; go/no-go = NO-GO while ADR 0048 stands; revisit trigger recorded; the reserved `'deferred'` enum kept as insurance.

## Validation
`hugo --gc --minify` clean; the non-goal callout and the ADR status/Decision-log render; internal links (ADR 0016/0048, dag-authoring) resolve.