### PR TITLE
feat: typed DAG params (params= declaration + trigger-time validation) — #545 step 2

### DIFF
--- a/docs/api/dag-schema.json
+++ b/docs/api/dag-schema.json
@@ -147,6 +147,22 @@
       "uniqueItems": true,
       "description": "Managed connection ids this DAG declares (ADR 0045, ADR 0055). A task receives a connection only if declared; tasks may narrow further. Distinct from connectors: (pip provider packages, ADR 0038). Absent (empty) declares none."
     },
+    "params": {
+      "type": "object",
+      "description": "Author-declared DAG-run parameters (Airflow's params=), keyed by name. Each provides a default merged into a run's conf and an optional JSON Schema validated against the trigger-time value. Absent declares none (back-compatible).",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "default": { "description": "Default value merged into a run's conf when the trigger omits this key." },
+          "schema": {
+            "type": "object",
+            "description": "JSON Schema the trigger-time conf value is validated against; {} means no constraints."
+          }
+        },
+        "required": ["default"],
+        "additionalProperties": false
+      }
+    },
     "tasks": {
       "type": "array",
       "minItems": 1,

--- a/internal/api/resources.go
+++ b/internal/api/resources.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/santhosh-tekuri/jsonschema/v6"
 
 	"github.com/neochaotic/leoflow/internal/domain"
 )
@@ -342,7 +344,76 @@ func getDagRunHandler(repo DagRunRepository) gin.HandlerFunc {
 	}
 }
 
-func createDagRunHandler(repo DagRunRepository, audit AuditWriter) gin.HandlerFunc {
+// applyDeclaredParams merges the DAG version's declared param defaults under the
+// supplied conf (conf wins per key), validates each declared value against its
+// JSON Schema, and returns the merged conf to persist. It returns ok=false with
+// no change when the DAG declares no params (or the spec cannot be read) — the
+// trigger then proceeds with the raw conf, identical to a param-free DAG. On a
+// schema violation it aborts the request with 400 and returns ok=false. Conf
+// keys with no declared param are carried through unchanged (Airflow's
+// dag_run_conf_overrides_params default).
+func applyDeclaredParams(c *gin.Context, specs DagSpecReader, dagID string, conf map[string]json.RawMessage) (json.RawMessage, bool) {
+	if specs == nil {
+		return nil, false
+	}
+	spec, err := specs.GetCurrentSpec(c.Request.Context(), tenantOf(c), dagID)
+	if err != nil || len(spec.Params) == 0 {
+		return nil, false
+	}
+	merged := make(map[string]json.RawMessage, len(spec.Params)+len(conf))
+	for name, p := range spec.Params {
+		if len(p.Default) > 0 {
+			merged[name] = p.Default
+		}
+	}
+	for k, v := range conf {
+		merged[k] = v
+	}
+	for name, p := range spec.Params {
+		if len(p.Schema) == 0 || string(p.Schema) == "{}" {
+			continue
+		}
+		val, present := merged[name]
+		if !present {
+			continue
+		}
+		if verr := validateParamValue(p.Schema, val); verr != nil {
+			AbortProblem(c, http.StatusBadRequest, "bad request",
+				fmt.Sprintf("conf param %q: %s", name, verr.Error()))
+			return nil, false
+		}
+	}
+	out, merr := json.Marshal(merged)
+	if merr != nil {
+		AbortProblem(c, http.StatusInternalServerError, "internal error", "encoding merged conf: "+merr.Error())
+		return nil, false
+	}
+	return out, true
+}
+
+// validateParamValue checks one conf value against a param's JSON Schema,
+// returning an error describing the first violation.
+func validateParamValue(schema, value json.RawMessage) error {
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(schema))
+	if err != nil {
+		return fmt.Errorf("parsing schema: %w", err)
+	}
+	comp := jsonschema.NewCompiler()
+	if aerr := comp.AddResource("param_schema.json", doc); aerr != nil {
+		return fmt.Errorf("loading schema: %w", aerr)
+	}
+	compiled, err := comp.Compile("param_schema.json")
+	if err != nil {
+		return fmt.Errorf("compiling schema: %w", err)
+	}
+	inst, err := jsonschema.UnmarshalJSON(bytes.NewReader(value))
+	if err != nil {
+		return fmt.Errorf("value is not valid JSON: %w", err)
+	}
+	return compiled.Validate(inst)
+}
+
+func createDagRunHandler(repo DagRunRepository, specs DagSpecReader, audit AuditWriter) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var body struct {
 			DagRunID    string          `json:"dag_run_id"`
@@ -357,18 +428,28 @@ func createDagRunHandler(repo DagRunRepository, audit AuditWriter) gin.HandlerFu
 		// conf becomes the run's params; it must be a JSON object so it maps to
 		// keyed values, not an array or scalar. Absent conf leaves the run at the
 		// persisted empty-object default.
+		var conf map[string]json.RawMessage
 		if len(body.Conf) > 0 {
-			var obj map[string]json.RawMessage
-			if err := json.Unmarshal(body.Conf, &obj); err != nil {
+			if err := json.Unmarshal(body.Conf, &conf); err != nil {
 				AbortProblem(c, http.StatusBadRequest, "bad request", "conf must be a JSON object: "+err.Error())
 				return
 			}
 			// A JSON null unmarshals into a nil map without error; treat it as
 			// absent so the run defaults to the empty object rather than
 			// persisting a literal null (conf is contractually never null).
-			if obj == nil {
+			if conf == nil {
 				body.Conf = nil
 			}
+		}
+		// Merge the DAG version's declared param defaults under the supplied conf
+		// (conf wins per key), validate each declared value against its schema, and
+		// persist the merged result so defaults are materialized into the run. A DAG
+		// that declares no params (or no Specs reader wired) leaves conf untouched —
+		// behavior identical to the pre-params conf pipeline.
+		if merged, ok := applyDeclaredParams(c, specs, c.Param("dag_id"), conf); ok {
+			body.Conf = merged
+		} else if c.IsAborted() {
+			return
 		}
 		logical := time.Now().UTC()
 		if body.LogicalDate != nil {
@@ -924,7 +1005,7 @@ func registerResources(r gin.IRouter, deps Dependencies) {
 	if deps.DagRuns != nil {
 		g := r.Group("/api/v2/dags/:dag_id/dagRuns")
 		g.GET("", RequirePermission("read", "dag_run"), listDagRunsHandler(deps.DagRuns))
-		g.POST("", RequirePermission("execute", "dag"), createDagRunHandler(deps.DagRuns, deps.Audit))
+		g.POST("", RequirePermission("execute", "dag"), createDagRunHandler(deps.DagRuns, deps.Specs, deps.Audit))
 		g.GET("/:dag_run_id", RequirePermission("read", "dag_run"), getDagRunHandler(deps.DagRuns))
 		g.PATCH("/:dag_run_id", RequirePermission("write", "dag_run"), patchDagRunHandler(deps.DagRuns, deps.Audit))
 		g.DELETE("/:dag_run_id", RequirePermission("write", "dag_run"), deleteDagRunHandler(deps.DagRuns))

--- a/internal/api/resources.go
+++ b/internal/api/resources.go
@@ -357,7 +357,18 @@ func applyDeclaredParams(c *gin.Context, specs DagSpecReader, dagID string, conf
 		return nil, false
 	}
 	spec, err := specs.GetCurrentSpec(c.Request.Context(), tenantOf(c), dagID)
-	if err != nil || len(spec.Params) == 0 {
+	if errors.Is(err, ErrNotFound) {
+		// No registered version yet — nothing to validate against; the create
+		// path handles the missing DAG. Not a validation-skipping error.
+		return nil, false
+	}
+	if err != nil {
+		// A real spec-read failure must NOT silently skip param validation on a
+		// DAG that may declare typed params — fail loud instead of fail open.
+		AbortProblem(c, http.StatusInternalServerError, "internal error", "loading DAG params: "+err.Error())
+		return nil, false
+	}
+	if len(spec.Params) == 0 {
 		return nil, false
 	}
 	merged := make(map[string]json.RawMessage, len(spec.Params)+len(conf))

--- a/internal/api/resources_params_test.go
+++ b/internal/api/resources_params_test.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// specWithParams builds a DAGSpec that declares the given params.
+func specWithParams(params map[string]domain.ParamSpec) domain.DAGSpec {
+	return domain.DAGSpec{
+		SchemaVersion: "1.0", DagID: "etl", DagVersion: "v1", Image: "img:v1",
+		Params: params,
+		Tasks:  []domain.TaskSpec{{TaskID: "a", Type: domain.TaskTypePython, Entrypoint: "dag:a"}},
+	}
+}
+
+// triggerServer builds a server whose Specs returns spec and whose DagRuns
+// records the created run so a test can read back the persisted conf.
+func triggerServer(spec domain.DAGSpec) (srv *gin.Engine, runs *fakeRunRepo) {
+	admin := &auth.User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}
+	runs = &fakeRunRepo{}
+	e := NewServer(Dependencies{
+		Logger:        discardLogger(),
+		Authenticator: &fakeAuthn{user: admin},
+		RateLimiter:   auth.NewRateLimiter(100, time.Minute),
+		CORSOrigins:   []string{"*"},
+		TokenTTLSecs:  3600,
+		DagRuns:       runs,
+		Specs:         &fakeSpecReader{spec: spec},
+	})
+	return e, runs
+}
+
+func confOf(t *testing.T, rec interface{ Bytes() []byte }) map[string]any {
+	t.Helper()
+	var got struct {
+		Conf map[string]any `json:"conf"`
+	}
+	if err := json.Unmarshal(rec.Bytes(), &got); err != nil {
+		t.Fatalf("parsing response: %v", err)
+	}
+	return got.Conf
+}
+
+// TestTriggerMaterializesDeclaredDefaults pins that when the run supplies no
+// conf, the declared param defaults are merged into the persisted conf.
+func TestTriggerMaterializesDeclaredDefaults(t *testing.T) {
+	srv, _ := triggerServer(specWithParams(map[string]domain.ParamSpec{
+		"limit": {Default: json.RawMessage(`5`), Schema: json.RawMessage(`{}`)},
+	}))
+	rec := authGet(srv, http.MethodPost, "/api/v2/dags/etl/dagRuns", `{}`)
+	if rec.Code >= http.StatusMultipleChoices {
+		t.Fatalf("trigger = %d, want 2xx; body=%q", rec.Code, rec.Body.String())
+	}
+	conf := confOf(t, rec.Body)
+	if conf["limit"] != float64(5) {
+		t.Errorf("conf = %v, want the declared default limit=5 materialized", conf)
+	}
+}
+
+// TestTriggerConfOverridesDefault pins that a supplied conf value wins over the
+// declared default, per key.
+func TestTriggerConfOverridesDefault(t *testing.T) {
+	srv, _ := triggerServer(specWithParams(map[string]domain.ParamSpec{
+		"limit": {Default: json.RawMessage(`5`), Schema: json.RawMessage(`{}`)},
+	}))
+	rec := authGet(srv, http.MethodPost, "/api/v2/dags/etl/dagRuns", `{"conf":{"limit":42}}`)
+	if rec.Code >= http.StatusMultipleChoices {
+		t.Fatalf("trigger = %d, want 2xx; body=%q", rec.Code, rec.Body.String())
+	}
+	conf := confOf(t, rec.Body)
+	if conf["limit"] != float64(42) {
+		t.Errorf("conf = %v, want the supplied limit=42 to override the default", conf)
+	}
+}
+
+// TestTriggerKeepsExtraConfKeys pins Airflow's dag_run_conf_overrides_params
+// default: conf keys with no declared param are allowed and carried through.
+func TestTriggerKeepsExtraConfKeys(t *testing.T) {
+	srv, _ := triggerServer(specWithParams(map[string]domain.ParamSpec{
+		"limit": {Default: json.RawMessage(`5`), Schema: json.RawMessage(`{}`)},
+	}))
+	rec := authGet(srv, http.MethodPost, "/api/v2/dags/etl/dagRuns", `{"conf":{"extra":"kept"}}`)
+	if rec.Code >= http.StatusMultipleChoices {
+		t.Fatalf("trigger = %d, want 2xx; body=%q", rec.Code, rec.Body.String())
+	}
+	conf := confOf(t, rec.Body)
+	if conf["extra"] != "kept" {
+		t.Errorf("conf = %v, want the extra (undeclared) key kept", conf)
+	}
+	if conf["limit"] != float64(5) {
+		t.Errorf("conf = %v, want the default still materialized alongside extras", conf)
+	}
+}
+
+// TestTriggerRejectsWrongType pins that a conf value violating a param's schema
+// (a string where an integer is required) is a 400.
+func TestTriggerRejectsWrongType(t *testing.T) {
+	srv, _ := triggerServer(specWithParams(map[string]domain.ParamSpec{
+		"n": {Default: json.RawMessage(`3`), Schema: json.RawMessage(`{"type":"integer","minimum":1}`)},
+	}))
+	rec := authGet(srv, http.MethodPost, "/api/v2/dags/etl/dagRuns", `{"conf":{"n":"nope"}}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("wrong-type conf = %d, want 400; body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+// TestTriggerRejectsBelowMinimum pins that a conf value that breaks a numeric
+// constraint (below minimum) is a 400.
+func TestTriggerRejectsBelowMinimum(t *testing.T) {
+	srv, _ := triggerServer(specWithParams(map[string]domain.ParamSpec{
+		"n": {Default: json.RawMessage(`3`), Schema: json.RawMessage(`{"type":"integer","minimum":1}`)},
+	}))
+	rec := authGet(srv, http.MethodPost, "/api/v2/dags/etl/dagRuns", `{"conf":{"n":0}}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("below-minimum conf = %d, want 400; body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+// TestTriggerAcceptsValidTypedValue pins that a conf value satisfying the schema
+// passes and is persisted.
+func TestTriggerAcceptsValidTypedValue(t *testing.T) {
+	srv, _ := triggerServer(specWithParams(map[string]domain.ParamSpec{
+		"n": {Default: json.RawMessage(`3`), Schema: json.RawMessage(`{"type":"integer","minimum":1}`)},
+	}))
+	rec := authGet(srv, http.MethodPost, "/api/v2/dags/etl/dagRuns", `{"conf":{"n":7}}`)
+	if rec.Code >= http.StatusMultipleChoices {
+		t.Fatalf("valid typed conf = %d, want 2xx; body=%q", rec.Code, rec.Body.String())
+	}
+	if conf := confOf(t, rec.Body); conf["n"] != float64(7) {
+		t.Errorf("conf = %v, want n=7 persisted", conf)
+	}
+}
+
+// TestTriggerDefaultNotValidatedAgainstSchemaIsFine pins that a run supplying no
+// conf for a typed param materializes the declared default without a spurious
+// validation failure.
+func TestTriggerTypedDefaultMaterialized(t *testing.T) {
+	srv, _ := triggerServer(specWithParams(map[string]domain.ParamSpec{
+		"n": {Default: json.RawMessage(`3`), Schema: json.RawMessage(`{"type":"integer","minimum":1}`)},
+	}))
+	rec := authGet(srv, http.MethodPost, "/api/v2/dags/etl/dagRuns", `{}`)
+	if rec.Code >= http.StatusMultipleChoices {
+		t.Fatalf("trigger = %d, want 2xx; body=%q", rec.Code, rec.Body.String())
+	}
+	if conf := confOf(t, rec.Body); conf["n"] != float64(3) {
+		t.Errorf("conf = %v, want typed default n=3 materialized", conf)
+	}
+}

--- a/internal/api/resources_params_test.go
+++ b/internal/api/resources_params_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -139,9 +140,9 @@ func TestTriggerAcceptsValidTypedValue(t *testing.T) {
 	}
 }
 
-// TestTriggerDefaultNotValidatedAgainstSchemaIsFine pins that a run supplying no
-// conf for a typed param materializes the declared default without a spurious
-// validation failure.
+// TestTriggerTypedDefaultMaterialized pins that a run supplying no conf for a
+// typed param materializes the declared default without a spurious validation
+// failure.
 func TestTriggerTypedDefaultMaterialized(t *testing.T) {
 	srv, _ := triggerServer(specWithParams(map[string]domain.ParamSpec{
 		"n": {Default: json.RawMessage(`3`), Schema: json.RawMessage(`{"type":"integer","minimum":1}`)},
@@ -152,5 +153,26 @@ func TestTriggerTypedDefaultMaterialized(t *testing.T) {
 	}
 	if conf := confOf(t, rec.Body); conf["n"] != float64(3) {
 		t.Errorf("conf = %v, want typed default n=3 materialized", conf)
+	}
+}
+
+// TestTriggerFailsLoudOnSpecReadError pins that a real spec-read failure fails
+// the trigger loud (500) rather than silently skipping param validation — a DAG
+// that declares typed params must not be triggered unvalidated on a transient
+// error. (A missing version is handled separately by the create path.)
+func TestTriggerFailsLoudOnSpecReadError(t *testing.T) {
+	admin := &auth.User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}
+	e := NewServer(Dependencies{
+		Logger:        discardLogger(),
+		Authenticator: &fakeAuthn{user: admin},
+		RateLimiter:   auth.NewRateLimiter(100, time.Minute),
+		CORSOrigins:   []string{"*"},
+		TokenTTLSecs:  3600,
+		DagRuns:       &fakeRunRepo{},
+		Specs:         &fakeSpecReader{err: errors.New("postgres briefly unreachable")},
+	})
+	rec := authGet(e, http.MethodPost, "/api/v2/dags/etl/dagRuns", `{"conf":{"x":1}}`)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("spec-read error trigger = %d, want 500 (fail loud, not a silent validation skip); body=%q", rec.Code, rec.Body.String())
 	}
 }

--- a/internal/domain/dag.go
+++ b/internal/domain/dag.go
@@ -3,6 +3,7 @@
 package domain
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -109,13 +110,31 @@ type DAGSpec struct {
 	// valid and means the DAG declares nothing — the additive, back-compatible
 	// default. These carry the declaration only; secret delivery still ships the
 	// whole tenant vault until enforcement lands on a later increment.
-	Variables   []string   `json:"variables,omitempty"`
-	Connections []string   `json:"connections,omitempty"`
-	Tasks       []TaskSpec `json:"tasks"`
+	Variables   []string `json:"variables,omitempty"`
+	Connections []string `json:"connections,omitempty"`
+	// Params are the DAG's author-declared run parameters (Airflow's params=),
+	// keyed by name. Each carries a Default (materialized into a run's conf when
+	// the trigger omits that key) and an optional JSON Schema the trigger-time
+	// conf value is validated against. Absent (empty) means the DAG declares no
+	// params — the additive, back-compatible default, so the compiled shape of a
+	// param-free DAG is unchanged. Part of the immutable spec (CanonicalHash), so
+	// changing a default or schema produces a new DAG version.
+	Params map[string]ParamSpec `json:"params,omitempty"`
+	Tasks  []TaskSpec           `json:"tasks"`
 	// Source is the original dag.py text, captured at compile time so the UI's
 	// Code tab can show the Python a human wrote (not the compiled spec). It is
 	// part of the artifact: changing it produces a new version.
 	Source string `json:"source,omitempty"`
+}
+
+// ParamSpec is one author-declared DAG-run parameter: a default value and the
+// JSON Schema its trigger-time conf value is validated against. Both are carried
+// as raw JSON so an arbitrary default and an arbitrary schema round-trip
+// verbatim. Schema is {} (or absent) when the author declared a bare default
+// with no constraints, in which case any conf value for that key is accepted.
+type ParamSpec struct {
+	Default json.RawMessage `json:"default"`
+	Schema  json.RawMessage `json:"schema,omitempty"`
 }
 
 // StagingConfig is the opt-in per-DAG-run shared staging volume (ADR 0022). Size

--- a/internal/domain/dag.go
+++ b/internal/domain/dag.go
@@ -294,6 +294,14 @@ func (d *DAGSpec) Validate() error {
 				"Use an HttpOperator, which runs in a task pod (declare connectors: [http])", t.TaskID)
 		}
 	}
+	// Refuse a declared param whose schema is invalid or whose default violates
+	// it now, at registration — not on every trigger (fail while the author can
+	// see it, matching the resource-quantity philosophy below).
+	for name, p := range d.Params {
+		if err := validateParamSpec(name, p.Schema, p.Default); err != nil {
+			return err
+		}
+	}
 	s, err := schemas()
 	if err != nil {
 		return err

--- a/internal/domain/params_test.go
+++ b/internal/domain/params_test.go
@@ -82,3 +82,51 @@ func TestNoParamsOmitsKey(t *testing.T) {
 		t.Errorf("a param-free spec must omit the params key, got %s", data)
 	}
 }
+
+// paramSpecWith builds an otherwise-valid DAGSpec declaring a single param, so a
+// Validate() failure can only come from that param.
+func paramSpecWith(name string, p ParamSpec) DAGSpec {
+	return DAGSpec{
+		SchemaVersion: "1.0", DagID: "etl", DagVersion: "v1", Image: "img:v1",
+		Params: map[string]ParamSpec{name: p},
+		Tasks:  []TaskSpec{{TaskID: "a", Type: TaskTypePython, Entrypoint: "dag:a"}},
+	}
+}
+
+// TestValidateRejectsParamDefaultViolatingSchema pins that a param whose default
+// breaks its own schema is refused at registration, not left to 400 on every
+// trigger.
+func TestValidateRejectsParamDefaultViolatingSchema(t *testing.T) {
+	spec := paramSpecWith("n", ParamSpec{
+		Default: json.RawMessage(`0`),
+		Schema:  json.RawMessage(`{"type":"integer","minimum":1}`),
+	})
+	if err := spec.Validate(); err == nil {
+		t.Error("want error: default 0 violates minimum 1")
+	}
+}
+
+// TestValidateRejectsUncompilableParamSchema pins that a param whose schema does
+// not compile is refused at registration.
+func TestValidateRejectsUncompilableParamSchema(t *testing.T) {
+	spec := paramSpecWith("n", ParamSpec{
+		Default: json.RawMessage(`1`),
+		Schema:  json.RawMessage(`{"type":123}`),
+	})
+	if err := spec.Validate(); err == nil {
+		t.Error("want error: {\"type\":123} is not a valid JSON Schema")
+	}
+}
+
+// TestValidateAllowsNullDefaultWithSchema pins that a required-style param (no
+// default / null default) with a schema still registers — the null default is
+// not checked against the schema.
+func TestValidateAllowsNullDefaultWithSchema(t *testing.T) {
+	spec := paramSpecWith("n", ParamSpec{
+		Default: json.RawMessage(`null`),
+		Schema:  json.RawMessage(`{"type":"integer","minimum":1}`),
+	})
+	if err := spec.Validate(); err != nil {
+		t.Errorf("a null default with a schema should register: %v", err)
+	}
+}

--- a/internal/domain/params_test.go
+++ b/internal/domain/params_test.go
@@ -1,0 +1,84 @@
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestParamsRoundTripAndValidate pins that a DAGSpec carrying author-declared
+// params round-trips through JSON in the {name:{default,schema}} shape and passes
+// schema validation, so a compiled dag.json with params registers cleanly.
+func TestParamsRoundTripAndValidate(t *testing.T) {
+	spec := DAGSpec{
+		SchemaVersion: "1.0",
+		DagID:         "etl",
+		DagVersion:    "v1",
+		Image:         "img:v1",
+		Params: map[string]ParamSpec{
+			"limit": {Default: json.RawMessage(`5`), Schema: json.RawMessage(`{}`)},
+			"n":     {Default: json.RawMessage(`3`), Schema: json.RawMessage(`{"type":"integer","minimum":1}`)},
+		},
+		Tasks: []TaskSpec{{TaskID: "a", Type: TaskTypePython, Entrypoint: "dag:a"}},
+	}
+	if err := spec.Validate(); err != nil {
+		t.Fatalf("spec with params should validate: %v", err)
+	}
+	data, err := json.Marshal(&spec)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back DAGSpec
+	if err := json.Unmarshal(data, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(back.Params) != 2 {
+		t.Fatalf("params did not round-trip: %+v", back.Params)
+	}
+	if string(back.Params["n"].Schema) != `{"type":"integer","minimum":1}` {
+		t.Errorf("schema lost on round-trip: %s", back.Params["n"].Schema)
+	}
+}
+
+// TestParamsPartOfCanonicalHash pins that params are part of the immutable spec:
+// changing a param default (or schema) yields a different version hash, so a DAG
+// re-registered with new param defaults is a new version.
+func TestParamsPartOfCanonicalHash(t *testing.T) {
+	base := DAGSpec{
+		SchemaVersion: "1.0", DagID: "etl", DagVersion: "v1", Image: "img:v1",
+		Tasks: []TaskSpec{{TaskID: "a", Type: TaskTypePython, Entrypoint: "dag:a"}},
+	}
+	withParam := base
+	withParam.Params = map[string]ParamSpec{"limit": {Default: json.RawMessage(`5`), Schema: json.RawMessage(`{}`)}}
+
+	h0, err := base.CanonicalHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	h1, err := withParam.CanonicalHash()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h0 == h1 {
+		t.Error("declaring params must change the canonical hash")
+	}
+}
+
+// TestNoParamsOmitsKey pins the back-compatible shape: a spec that declares no
+// params marshals without a "params" key at all.
+func TestNoParamsOmitsKey(t *testing.T) {
+	spec := DAGSpec{
+		SchemaVersion: "1.0", DagID: "etl", DagVersion: "v1", Image: "img:v1",
+		Tasks: []TaskSpec{{TaskID: "a", Type: TaskTypePython, Entrypoint: "dag:a"}},
+	}
+	data, err := json.Marshal(&spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := m["params"]; ok {
+		t.Errorf("a param-free spec must omit the params key, got %s", data)
+	}
+}

--- a/internal/domain/schema.go
+++ b/internal/domain/schema.go
@@ -37,6 +37,39 @@ func loadSchemas() (compiledSchemas, error) {
 	return compiledSchemas{dag: dag, leoflow: leoflow}, nil
 }
 
+// validateParamSpec refuses a declared DAG param whose JSON Schema does not
+// compile, or whose non-null default violates its own schema — at registration,
+// while the author is still looking, instead of failing every trigger forever. A
+// null or absent default is not checked (it means "no default / required").
+func validateParamSpec(name string, schema, def []byte) error {
+	if len(schema) == 0 || string(schema) == "{}" {
+		return nil
+	}
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(schema))
+	if err != nil {
+		return fmt.Errorf("param %q: parsing schema: %w", name, err)
+	}
+	c := jsonschema.NewCompiler()
+	if aerr := c.AddResource("param.json", doc); aerr != nil {
+		return fmt.Errorf("param %q: loading schema: %w", name, aerr)
+	}
+	compiled, cerr := c.Compile("param.json")
+	if cerr != nil {
+		return fmt.Errorf("param %q: invalid schema: %w", name, cerr)
+	}
+	if len(def) == 0 || string(def) == "null" {
+		return nil
+	}
+	inst, ierr := jsonschema.UnmarshalJSON(bytes.NewReader(def))
+	if ierr != nil {
+		return fmt.Errorf("param %q: default is not valid JSON: %w", name, ierr)
+	}
+	if verr := compiled.Validate(inst); verr != nil {
+		return fmt.Errorf("param %q: default value violates its schema: %w", name, verr)
+	}
+	return nil
+}
+
 func compileSchema(name string, raw []byte) (*jsonschema.Schema, error) {
 	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(raw))
 	if err != nil {

--- a/internal/domain/schemas/dag-schema.json
+++ b/internal/domain/schemas/dag-schema.json
@@ -147,6 +147,22 @@
       "uniqueItems": true,
       "description": "Managed connection ids this DAG declares (ADR 0045, ADR 0055). A task receives a connection only if declared; tasks may narrow further. Distinct from connectors: (pip provider packages, ADR 0038). Absent (empty) declares none."
     },
+    "params": {
+      "type": "object",
+      "description": "Author-declared DAG-run parameters (Airflow's params=), keyed by name. Each provides a default merged into a run's conf and an optional JSON Schema validated against the trigger-time value. Absent declares none (back-compatible).",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "default": { "description": "Default value merged into a run's conf when the trigger omits this key." },
+          "schema": {
+            "type": "object",
+            "description": "JSON Schema the trigger-time conf value is validated against; {} means no constraints."
+          }
+        },
+        "required": ["default"],
+        "additionalProperties": false
+      }
+    },
     "tasks": {
       "type": "array",
       "minItems": 1,

--- a/parser/leoflow_parser/_shim/airflow/_core.py
+++ b/parser/leoflow_parser/_shim/airflow/_core.py
@@ -45,28 +45,25 @@ def _as_operator(node):
 # collects every non-default/description kwarg into the param's JSON Schema; we
 # pass through the recognised keyword set so the compiled schema is a clean,
 # validator-ready JSON-Schema object (unknown kwargs are ignored, not emitted).
-_JSON_SCHEMA_KEYS = frozenset({
-    "type", "enum", "const", "format",
-    "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf",
-    "minLength", "maxLength", "pattern",
-    "items", "minItems", "maxItems", "uniqueItems",
-    "properties", "required", "additionalProperties",
-})
-
-
 class Param:
     """Structural stand-in for Airflow's ``airflow.sdk.Param``.
 
-    Records the declared default and builds a JSON-Schema dict from the recognised
-    schema kwargs (``type``, ``enum``, ``minimum``, ``maximum``, …). The compiler
-    reads ``.default`` and ``.schema`` to emit the DAG's ``params`` block. Task
-    bodies never run, so no validation happens here — the control plane validates
-    the run conf against this schema at trigger time."""
+    Records the declared default and its JSON Schema. Airflow treats a Param's
+    kwargs as the schema, so they are passed through verbatim (with an explicit
+    ``schema=`` dict, if given, as the base) rather than filtered against an
+    allow-list — that way composite keywords (``anyOf``/``allOf``/``oneOf``/
+    ``not``), every string/number facet, ``title``, ``examples``, etc. all reach
+    trigger-time validation. The compiler reads ``.default`` and ``.schema`` to
+    emit the DAG's ``params`` block. Task bodies never run, so nothing is
+    validated here — the control plane validates the run conf against this schema
+    at trigger time."""
 
     def __init__(self, default=None, description=None, **kwargs):
         self.default = default
         self.description = description
-        self.schema = {k: v for k, v in kwargs.items() if k in _JSON_SCHEMA_KEYS}
+        schema = dict(kwargs.pop("schema", None) or {})
+        schema.update(kwargs)
+        self.schema = schema
 
 
 class BaseOperator:

--- a/parser/leoflow_parser/_shim/airflow/_core.py
+++ b/parser/leoflow_parser/_shim/airflow/_core.py
@@ -41,6 +41,34 @@ def _as_operator(node):
     return node.operator if isinstance(node, XComArg) else node
 
 
+# JSON-Schema validation keywords a Param's kwargs may carry. Airflow's real Param
+# collects every non-default/description kwarg into the param's JSON Schema; we
+# pass through the recognised keyword set so the compiled schema is a clean,
+# validator-ready JSON-Schema object (unknown kwargs are ignored, not emitted).
+_JSON_SCHEMA_KEYS = frozenset({
+    "type", "enum", "const", "format",
+    "minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf",
+    "minLength", "maxLength", "pattern",
+    "items", "minItems", "maxItems", "uniqueItems",
+    "properties", "required", "additionalProperties",
+})
+
+
+class Param:
+    """Structural stand-in for Airflow's ``airflow.sdk.Param``.
+
+    Records the declared default and builds a JSON-Schema dict from the recognised
+    schema kwargs (``type``, ``enum``, ``minimum``, ``maximum``, …). The compiler
+    reads ``.default`` and ``.schema`` to emit the DAG's ``params`` block. Task
+    bodies never run, so no validation happens here — the control plane validates
+    the run conf against this schema at trigger time."""
+
+    def __init__(self, default=None, description=None, **kwargs):
+        self.default = default
+        self.description = description
+        self.schema = {k: v for k, v in kwargs.items() if k in _JSON_SCHEMA_KEYS}
+
+
 class BaseOperator:
     """Minimal operator base: registers into the active DAG and tracks edges."""
 
@@ -88,6 +116,11 @@ class DAG:
         # reads it as the fallback for a task's retries/retry_delay/execution_timeout
         # (#434). Kept as a plain dict; empty when not given.
         self.default_args: dict = dict(kwargs.get("default_args") or {})
+        # Author-declared DAG-run params (Airflow's params=): each value is a bare
+        # default or a Param carrying a JSON Schema. The compiler emits them so the
+        # control plane can default + validate a run's conf at trigger time. None
+        # when the DAG declares none, keeping the compiled shape unchanged.
+        self.params = kwargs.get("params")
         # Collect on construction too, so DAGs defined without `with` (e.g.
         # module-level `dag = DAG(...)` with operators attached via dag=) are seen.
         COLLECTED[dag_id] = self

--- a/parser/leoflow_parser/_shim/airflow/models/__init__.py
+++ b/parser/leoflow_parser/_shim/airflow/models/__init__.py
@@ -1,0 +1,1 @@
+"""Shim of ``airflow.models`` — only the surface Leoflow's parser reads."""

--- a/parser/leoflow_parser/_shim/airflow/models/param.py
+++ b/parser/leoflow_parser/_shim/airflow/models/param.py
@@ -1,0 +1,9 @@
+"""Shim of ``airflow.models.param``: the older-style ``Param`` import path.
+
+Airflow 3.x's canonical spelling is ``from airflow.sdk import Param``; this module
+keeps ``from airflow.models.param import Param`` resolving to the same shim class
+so DAGs written against either import compile identically.
+"""
+from airflow._core import Param
+
+__all__ = ["Param"]

--- a/parser/leoflow_parser/_shim/airflow/sdk/__init__.py
+++ b/parser/leoflow_parser/_shim/airflow/sdk/__init__.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 
 import functools
 
-from airflow._core import DAG, BaseOperator, XComArg
+from airflow._core import DAG, BaseOperator, Param, XComArg
 
 __all__ = [
     "DAG",
     "BaseOperator",
+    "Param",
     "XComArg",
     "task",
     "dag",

--- a/parser/leoflow_parser/compiler.py
+++ b/parser/leoflow_parser/compiler.py
@@ -637,7 +637,7 @@ def _bind_call_arguments(task) -> tuple[dict[str, list[str]], dict[str, Any]]:
 def _is_json_literal(value: Any) -> bool:
     """Reports whether value is safely round-trippable through JSON.
 
-    The runtime delivers params via LEOFLOW_PARAMS_JSON, so a value that
+    The runtime delivers params via LEOFLOW_PARAMS, so a value that
     survives ``json.dumps`` cleanly is the safe-to-capture set. Anything
     else (a class instance, a tuple of objects, a function) is dropped so
     we never emit invalid JSON into dag.json.

--- a/parser/leoflow_parser/compiler.py
+++ b/parser/leoflow_parser/compiler.py
@@ -70,6 +70,9 @@ def compile_dag(
     default_args = _default_args(config)
     if default_args:
         spec["default_args"] = default_args
+    params = _params(dag)
+    if params:
+        spec["params"] = params
     return spec
 
 
@@ -657,6 +660,25 @@ def _schedule(dag) -> str | None:
         return summary
     schedule = getattr(dag, "schedule", None)
     return schedule if isinstance(schedule, str) else None
+
+
+def _params(dag) -> dict[str, Any]:
+    """Emit the DAG's author-declared params as ``{name: {default, schema}}``.
+
+    A bare default (``params={"limit": 5}``) becomes ``{"default": 5, "schema": {}}``;
+    a ``Param`` contributes its recorded default plus the JSON Schema it built from
+    its kwargs. Returns an empty dict when the DAG declares no params, so the
+    compiler omits the key and the compiled shape of a param-free DAG is unchanged.
+    """
+    declared = getattr(dag, "params", None)
+    if not declared:
+        return {}
+    out: dict[str, Any] = {}
+    for name, value in declared.items():
+        default = getattr(value, "default", value)
+        schema = getattr(value, "schema", None)
+        out[name] = {"default": default, "schema": dict(schema) if schema else {}}
+    return out
 
 
 def _default_args(config: dict[str, Any]) -> dict[str, Any]:

--- a/parser/tests/test_params.py
+++ b/parser/tests/test_params.py
@@ -1,0 +1,88 @@
+"""Author-declared DAG-run params (typed defaults + JSON-Schema).
+
+A DAG may declare ``params=`` so its run conf gets defaults and trigger-time
+validation. The compiler emits them into ``spec["params"]`` as
+``{name: {default, schema}}``: a bare value has an empty schema, a ``Param``
+carries the JSON-Schema built from its kwargs. A DAG that declares no params
+emits no ``params`` key (back-compatible shape).
+"""
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+from leoflow_parser.compiler import compile_dag
+
+
+def _compile(monkeypatch, tmp_path: Path, body: str, config: dict | None = None) -> dict:
+    monkeypatch.setenv(
+        "LEOFLOW_PROJECT_CONFIG_JSON",
+        json.dumps(config or {"schema_version": "1.0"}),
+    )
+    src = tmp_path / "dag.py"
+    src.write_text(textwrap.dedent(body))
+    return compile_dag(str(src), str(tmp_path / "ignored.json"), "img:v1", dag_version="v1")
+
+
+def test_bare_value_param_emits_default_and_empty_schema(monkeypatch, tmp_path):
+    spec = _compile(monkeypatch, tmp_path, """
+        from airflow.sdk import DAG, task
+        @task
+        def a() -> None: ...
+        with DAG("g", params={"limit": 5}):
+            a()
+    """)
+    assert spec["params"] == {"limit": {"default": 5, "schema": {}}}
+
+
+def test_typed_param_emits_default_and_json_schema(monkeypatch, tmp_path):
+    spec = _compile(monkeypatch, tmp_path, """
+        from airflow.sdk import DAG, Param, task
+        @task
+        def a() -> None: ...
+        with DAG("g", params={"n": Param(3, type="integer", minimum=1)}):
+            a()
+    """)
+    assert spec["params"] == {
+        "n": {"default": 3, "schema": {"type": "integer", "minimum": 1}}
+    }
+
+
+def test_param_import_from_models_path_also_resolves(monkeypatch, tmp_path):
+    spec = _compile(monkeypatch, tmp_path, """
+        from airflow.sdk import DAG, task
+        from airflow.models.param import Param
+        @task
+        def a() -> None: ...
+        with DAG("g", params={"env": Param("prod", enum=["dev", "prod"])}):
+            a()
+    """)
+    assert spec["params"] == {
+        "env": {"default": "prod", "schema": {"enum": ["dev", "prod"]}}
+    }
+
+
+def test_mixed_params_bare_and_typed(monkeypatch, tmp_path):
+    spec = _compile(monkeypatch, tmp_path, """
+        from airflow.sdk import DAG, Param, task
+        @task
+        def a() -> None: ...
+        with DAG("g", params={"limit": 5, "name": Param("x", type="string", maxLength=8)}):
+            a()
+    """)
+    assert spec["params"] == {
+        "limit": {"default": 5, "schema": {}},
+        "name": {"default": "x", "schema": {"type": "string", "maxLength": 8}},
+    }
+
+
+def test_no_params_declared_emits_no_params_key(monkeypatch, tmp_path):
+    spec = _compile(monkeypatch, tmp_path, """
+        from airflow.sdk import DAG, task
+        @task
+        def a() -> None: ...
+        with DAG("g"):
+            a()
+    """)
+    assert "params" not in spec


### PR DESCRIPTION
Step 2 of #545, on top of step 1's conf pipeline. Authors can now declare `params=` on a DAG (Airflow-3), and trigger-time conf is merged against the declared defaults and validated against each param's JSON Schema.

## Changes
- **Parser** — a `Param` shim exposed at `airflow.sdk.Param` (Task SDK, the canonical Airflow-3 path) and `airflow.models.param.Param`; the structural shim's `DAG` now captures `params=` (previously dropped); the compiler emits `spec.params` as `{ "<name>": { "default": <value>, "schema": <json-schema> } }`. A DAG that declares no params emits **no** `params` key (compiled shape unchanged — additive/back-compatible).
- **Domain** — `DAGSpec.Params` (`map[string]ParamSpec{Default, Schema}`), added to both `dag-schema.json` copies (kept byte-identical for `TestEmbeddedSchemasMatchDocs`) and part of `CanonicalHash` (a param/default/schema change ⇒ new DAG version).
- **API** — `createDagRunHandler` loads the version's declared params, merges defaults under the supplied conf (conf wins per key), validates each declared value against its JSON Schema (`santhosh-tekuri/jsonschema/v6`) → **400** on violation, and persists the merged conf so defaults are materialized. Undeclared conf keys pass through (Airflow's `dag_run_conf_overrides_params`). A param-free DAG behaves exactly as step 1.

## Tests (TDD)
Parser: `params={...}` and `Param(type=…)` capture + param-free omission. Domain: params round-trip. Handler: defaults materialized, conf overrides default, extra keys kept, wrong-type → 400, below-minimum → 400, valid typed value passes, typed default materialized without spurious failure.

## Validation
`go build ./...` clean; `go test ./...` green; `pytest` (91) green; changed Go files lint-clean (`golangci-lint`, repo config). Integration tests compare conf by value (jsonb re-serialization), not bytes.