### PR TITLE
fix(warm): exclude staging DAGs from warm-pool reuse (ADR 0058 D5) — closes #788

### DIFF
--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -179,7 +179,12 @@ func (d *Dispatcher) Dispatch(ctx context.Context, runID, dagID, dagVersionID st
 	// N1b1-place is assign-if-free-else-dedicated. The pool-size cap and
 	// defer-at-max belong to N1b2/N1d, where real pool accounting (registered
 	// workers + in-flight pods) exists; there is no admission cap here.
-	if d.placer != nil {
+	//
+	// Staging is excluded from warm reuse (ADR 0058 D5): a warm worker carries no
+	// per-run /staging mount, so a staging attempt placed on one would silently
+	// lose the run's shared volume. Staging attempts always take the dedicated
+	// path below, which provisions the StagingClaim.
+	if d.placer != nil && (r.Staging == nil || !r.Staging.Enabled) {
 		wa := &agentv1.WorkAssignment{
 			AssignmentId: uuid.NewString(),
 			AttemptToken: token,

--- a/internal/dispatch/dispatch_staging_test.go
+++ b/internal/dispatch/dispatch_staging_test.go
@@ -73,3 +73,32 @@ func TestDispatchSetsAgentTLSCAConfigMap(t *testing.T) {
 		t.Errorf("agent TLS CA configmap = %q, want agent-ca", exec.req.AgentTLSCAConfigMap)
 	}
 }
+
+// TestDispatchSkipsWarmForStagingRun pins ADR 0058 D5: a staging attempt is
+// never offered to a warm worker (which carries no per-run /staging mount). Even
+// with a placer that WOULD accept, the staging run must take the dedicated path
+// and get its StagingClaim.
+func TestDispatchSkipsWarmForStagingRun(t *testing.T) {
+	res := &fakeResolver{resolved: Resolved{
+		TaskInstanceID: "ti-1", TenantID: "acme", Image: "etl:v1",
+		Staging: &domain.StagingConfig{Enabled: true},
+	}}
+	exec := &fakeExecutor{}
+	placer := &fakePlacer{ok: true} // would place if it were ever offered
+	d := newDispatcher(res, &fakeIssuer{token: "t"}, exec)
+	d.SetWarmPlacer(placer)
+
+	disp, err := d.Dispatch(context.Background(), "run-1", "etl", "ver-7", pythonTask())
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if placer.calls != 0 {
+		t.Errorf("staging attempt offered to the warm placer %d times, want 0 (ADR 0058 D5)", placer.calls)
+	}
+	if disp != executor.Dispatched {
+		t.Errorf("disposition = %v, want Dispatched via the dedicated path", disp)
+	}
+	if want := executor.StagingClaimName("etl", "run-1"); exec.req.StagingClaim != want {
+		t.Errorf("dedicated staging claim = %q, want %q", exec.req.StagingClaim, want)
+	}
+}

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -186,6 +186,11 @@ type activeWarmVersion struct {
 	// can enforce the per-tenant aggregate warm-pod cap (M4). Many active runs of a
 	// version share one tenant, so it dedupes with the version.
 	tenantID string
+	// staging marks a version whose DAG opted into the per-run shared /staging
+	// volume (ADR 0022). Such versions are excluded from warm pools (ADR 0058 D5):
+	// a warm worker carries no per-run /staging mount, so its attempts must run on
+	// dedicated pods. Kept on the pure input so the exclusion is unit-testable.
+	staging bool
 }
 
 // warmTargets dedupes the active versions (many runs share one immutable
@@ -201,6 +206,10 @@ func warmTargets(versions []activeWarmVersion, exec config.ExecutionSection) []e
 			continue
 		}
 		seen[v.dagVersionID] = true
+		if v.staging {
+			// ADR 0058 D5: staging versions never get a warm pool.
+			continue
+		}
 		out = append(out, executor.WarmTarget{
 			DagVersionID:     v.dagVersionID,
 			Image:            v.image,
@@ -245,6 +254,9 @@ func (s *SchedulerStore) ActiveWarmTargets(ctx context.Context) ([]executor.Warm
 			image:        spec.Image,
 			dagMinIdle:   spec.MinIdleWorkers,
 			tenantID:     uuidToString(run.TenantID),
+			// ADR 0058 D5: a staging version is excluded from warm pools by
+			// warmTargets. Defense-in-depth alongside the dispatch-path guard.
+			staging: spec.Staging != nil && spec.Staging.Enabled,
 		})
 	}
 	return warmTargets(versions, s.warmExec), nil

--- a/internal/storage/warm_targets_test.go
+++ b/internal/storage/warm_targets_test.go
@@ -61,3 +61,18 @@ func TestWarmTargetsWarmPoolsOff(t *testing.T) {
 		t.Errorf("warmTargets with pools off = %+v, want single dv1 with target 0", got)
 	}
 }
+
+// TestWarmTargetsExcludesStagingVersion pins ADR 0058 D5: a version whose DAG
+// opted into the per-run /staging volume gets no warm target, so the reconciler
+// never creates a warm pod (which lacks the mount) for it.
+func TestWarmTargetsExcludesStagingVersion(t *testing.T) {
+	exec := config.ExecutionSection{WarmPoolsEnabled: true, MinIdleWorkers: 1, MaxPoolSize: 8}
+	versions := []activeWarmVersion{
+		{dagVersionID: "dv1", image: "i", dagMinIdle: 2, tenantID: "tA"},
+		{dagVersionID: "dv2", image: "i", dagMinIdle: 2, tenantID: "tA", staging: true},
+	}
+	got := warmTargets(versions, exec)
+	if len(got) != 1 || got[0].DagVersionID != "dv1" {
+		t.Errorf("staging version must be excluded from warm targets, got %+v", got)
+	}
+}


### PR DESCRIPTION
**Confirmed bug** (triage in `spec/followups-triage.md`, evidence-backed): ADR 0058 **D5** (staging DAGs excluded from warm reuse) was **not enforced anywhere** on the warm path. A warm worker carries no per-run `/staging` mount, so a staging attempt placed on one runs without the run's shared volume → silent cross-task data divergence.

## Fix (two layers, both cheap)
- **Correctness** — `internal/dispatch/dispatch.go`: warm placement is skipped for a staging-enabled attempt (`d.placer != nil && (r.Staging == nil || !r.Staging.Enabled)`), so it falls through to the dedicated path that provisions the `StagingClaim`.
- **Defense-in-depth** — `internal/storage/scheduler_store.go`: staging versions are excluded from `ActiveWarmTargets` (via a `staging` flag on the pure `warmTargets` projection), so the reconciler never creates an unusable warm pod for them.

## Blast radius
Only reachable with warm pools **ON** (Pro) and `min_idle>0` — both off by default — so nothing shipped is affected. This gates **warm-pool GA**, not core.

## Tests (red-first verified)
- `TestDispatchSkipsWarmForStagingRun` — a staging attempt is never offered to the placer (even one that would accept) and takes the dedicated path with its `StagingClaim`. Confirmed failing without the guard.
- `TestWarmTargetsExcludesStagingVersion` — `warmTargets` drops a staging version.
- `go build`/`go test ./...` green; changed files lint-clean.

## Still needs a cluster (RC gate, not this PR)
The exact runtime data-divergence signature is only observable on EKS + EFS (real RWX): with warm pools ON, assert staging DAGs always land on dedicated pods and no warm pod is ever created for a staging dag_version.

Closes #788.