### PR TITLE
feat: required (no-default) DAG params enforced at trigger — closes #798

### DIFF
--- a/docs/api/dag-schema.json
+++ b/docs/api/dag-schema.json
@@ -153,13 +153,12 @@
       "additionalProperties": {
         "type": "object",
         "properties": {
-          "default": { "description": "Default value merged into a run's conf when the trigger omits this key." },
+          "default": { "description": "Default value merged into a run's conf when the trigger omits this key. Absent means the param is required — the trigger must supply it." },
           "schema": {
             "type": "object",
             "description": "JSON Schema the trigger-time conf value is validated against; {} means no constraints."
           }
         },
-        "required": ["default"],
         "additionalProperties": false
       }
     },

--- a/internal/api/resources.go
+++ b/internal/api/resources.go
@@ -371,8 +371,24 @@ func applyDeclaredParams(c *gin.Context, specs DagSpecReader, dagID string, conf
 	if len(spec.Params) == 0 {
 		return nil, false
 	}
-	merged := make(map[string]json.RawMessage, len(spec.Params)+len(conf))
-	for name, p := range spec.Params {
+	merged := mergeParams(spec.Params, conf)
+	if !validateMergedParams(c, spec.Params, merged) {
+		return nil, false
+	}
+	out, merr := json.Marshal(merged)
+	if merr != nil {
+		AbortProblem(c, http.StatusInternalServerError, "internal error", "encoding merged conf: "+merr.Error())
+		return nil, false
+	}
+	return out, true
+}
+
+// mergeParams overlays the supplied conf onto the declared param defaults (conf
+// wins per key). A param with no default contributes nothing; undeclared conf
+// keys are carried through.
+func mergeParams(params map[string]domain.ParamSpec, conf map[string]json.RawMessage) map[string]json.RawMessage {
+	merged := make(map[string]json.RawMessage, len(params)+len(conf))
+	for name, p := range params {
 		if len(p.Default) > 0 {
 			merged[name] = p.Default
 		}
@@ -380,7 +396,25 @@ func applyDeclaredParams(c *gin.Context, specs DagSpecReader, dagID string, conf
 	for k, v := range conf {
 		merged[k] = v
 	}
-	for name, p := range spec.Params {
+	return merged
+}
+
+// validateMergedParams enforces required params (a declared param with no
+// default must be supplied) and validates each declared value against its JSON
+// Schema. It aborts the request with 400 on the first violation and returns
+// false; true means the merged conf is valid to persist.
+func validateMergedParams(c *gin.Context, params map[string]domain.ParamSpec, merged map[string]json.RawMessage) bool {
+	for name, p := range params {
+		if len(p.Default) != 0 {
+			continue
+		}
+		if _, ok := merged[name]; !ok {
+			AbortProblem(c, http.StatusBadRequest, "bad request",
+				fmt.Sprintf("conf param %q is required (the DAG declares it with no default)", name))
+			return false
+		}
+	}
+	for name, p := range params {
 		if len(p.Schema) == 0 || string(p.Schema) == "{}" {
 			continue
 		}
@@ -391,15 +425,10 @@ func applyDeclaredParams(c *gin.Context, specs DagSpecReader, dagID string, conf
 		if verr := validateParamValue(p.Schema, val); verr != nil {
 			AbortProblem(c, http.StatusBadRequest, "bad request",
 				fmt.Sprintf("conf param %q: %s", name, verr.Error()))
-			return nil, false
+			return false
 		}
 	}
-	out, merr := json.Marshal(merged)
-	if merr != nil {
-		AbortProblem(c, http.StatusInternalServerError, "internal error", "encoding merged conf: "+merr.Error())
-		return nil, false
-	}
-	return out, true
+	return true
 }
 
 // validateParamValue checks one conf value against a param's JSON Schema,

--- a/internal/api/resources_params_test.go
+++ b/internal/api/resources_params_test.go
@@ -176,3 +176,30 @@ func TestTriggerFailsLoudOnSpecReadError(t *testing.T) {
 		t.Fatalf("spec-read error trigger = %d, want 500 (fail loud, not a silent validation skip); body=%q", rec.Code, rec.Body.String())
 	}
 }
+
+// TestTriggerRejectsMissingRequiredParam pins that a param declared with no
+// default is required: a trigger that omits it is a 400.
+func TestTriggerRejectsMissingRequiredParam(t *testing.T) {
+	srv, _ := triggerServer(specWithParams(map[string]domain.ParamSpec{
+		"n": {Schema: json.RawMessage(`{"type":"integer"}`)}, // no Default -> required
+	}))
+	rec := authGet(srv, http.MethodPost, "/api/v2/dags/etl/dagRuns", `{}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("missing required param = %d, want 400; body=%q", rec.Code, rec.Body.String())
+	}
+}
+
+// TestTriggerAcceptsProvidedRequiredParam pins that supplying the required param
+// in conf passes and is persisted.
+func TestTriggerAcceptsProvidedRequiredParam(t *testing.T) {
+	srv, _ := triggerServer(specWithParams(map[string]domain.ParamSpec{
+		"n": {Schema: json.RawMessage(`{"type":"integer"}`)},
+	}))
+	rec := authGet(srv, http.MethodPost, "/api/v2/dags/etl/dagRuns", `{"conf":{"n":7}}`)
+	if rec.Code >= http.StatusMultipleChoices {
+		t.Fatalf("provided required param = %d, want 2xx; body=%q", rec.Code, rec.Body.String())
+	}
+	if conf := confOf(t, rec.Body); conf["n"] != float64(7) {
+		t.Errorf("conf = %v, want n=7 persisted", conf)
+	}
+}

--- a/internal/domain/dag.go
+++ b/internal/domain/dag.go
@@ -133,7 +133,10 @@ type DAGSpec struct {
 // verbatim. Schema is {} (or absent) when the author declared a bare default
 // with no constraints, in which case any conf value for that key is accepted.
 type ParamSpec struct {
-	Default json.RawMessage `json:"default"`
+	// Default is the value merged into a run's conf when the trigger omits this
+	// key. Absent (omitempty, len 0) means the param is REQUIRED — the trigger
+	// must supply it — as distinct from an explicit JSON null default.
+	Default json.RawMessage `json:"default,omitempty"`
 	Schema  json.RawMessage `json:"schema,omitempty"`
 }
 

--- a/internal/domain/params_test.go
+++ b/internal/domain/params_test.go
@@ -130,3 +130,25 @@ func TestValidateAllowsNullDefaultWithSchema(t *testing.T) {
 		t.Errorf("a null default with a schema should register: %v", err)
 	}
 }
+
+// TestRequiredParamOmitsDefaultOnMarshal pins that a param with no default (a
+// required param) marshals without a default key, so the trigger-time check can
+// distinguish required from a null default.
+func TestRequiredParamOmitsDefaultOnMarshal(t *testing.T) {
+	b, err := json.Marshal(ParamSpec{Schema: json.RawMessage(`{"type":"integer"}`)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(b); got != `{"schema":{"type":"integer"}}` {
+		t.Errorf("required param marshaled to %s, want no default key", got)
+	}
+}
+
+// TestValidateAllowsRequiredParam pins that a required param (no default) with a
+// schema registers cleanly — there is no default to check against the schema.
+func TestValidateAllowsRequiredParam(t *testing.T) {
+	spec := paramSpecWith("n", ParamSpec{Schema: json.RawMessage(`{"type":"integer","minimum":1}`)})
+	if err := spec.Validate(); err != nil {
+		t.Errorf("a required param should register: %v", err)
+	}
+}

--- a/internal/domain/schemas/dag-schema.json
+++ b/internal/domain/schemas/dag-schema.json
@@ -153,13 +153,12 @@
       "additionalProperties": {
         "type": "object",
         "properties": {
-          "default": { "description": "Default value merged into a run's conf when the trigger omits this key." },
+          "default": { "description": "Default value merged into a run's conf when the trigger omits this key. Absent means the param is required — the trigger must supply it." },
           "schema": {
             "type": "object",
             "description": "JSON Schema the trigger-time conf value is validated against; {} means no constraints."
           }
         },
-        "required": ["default"],
         "additionalProperties": false
       }
     },

--- a/parser/leoflow_parser/_shim/airflow/_core.py
+++ b/parser/leoflow_parser/_shim/airflow/_core.py
@@ -45,6 +45,11 @@ def _as_operator(node):
 # collects every non-default/description kwarg into the param's JSON Schema; we
 # pass through the recognised keyword set so the compiled schema is a clean,
 # validator-ready JSON-Schema object (unknown kwargs are ignored, not emitted).
+# Sentinel marking a Param declared with no default (a required parameter),
+# distinct from an explicit default of None.
+_UNSET = object()
+
+
 class Param:
     """Structural stand-in for Airflow's ``airflow.sdk.Param``.
 
@@ -58,8 +63,12 @@ class Param:
     validated here — the control plane validates the run conf against this schema
     at trigger time."""
 
-    def __init__(self, default=None, description=None, **kwargs):
-        self.default = default
+    def __init__(self, default=_UNSET, description=None, **kwargs):
+        # Distinguish "no default given" (a required param) from an explicit
+        # None/null default. Airflow uses the same sentinel technique; the
+        # compiler omits the `default` key entirely for a required param.
+        self.has_default = default is not _UNSET
+        self.default = None if default is _UNSET else default
         self.description = description
         schema = dict(kwargs.pop("schema", None) or {})
         schema.update(kwargs)

--- a/parser/leoflow_parser/compiler.py
+++ b/parser/leoflow_parser/compiler.py
@@ -675,9 +675,15 @@ def _params(dag) -> dict[str, Any]:
         return {}
     out: dict[str, Any] = {}
     for name, value in declared.items():
-        default = getattr(value, "default", value)
         schema = getattr(value, "schema", None)
-        out[name] = {"default": default, "schema": dict(schema) if schema else {}}
+        entry: dict[str, Any] = {"schema": dict(schema) if schema else {}}
+        # Omit `default` for a required Param (one declared with no default), so
+        # the trigger-time check can distinguish required from a null default. A
+        # bare value (params={"limit": 5}) has no has_default attr → it IS its
+        # own default.
+        if getattr(value, "has_default", True):
+            entry["default"] = getattr(value, "default", value)
+        out[name] = entry
     return out
 
 

--- a/parser/tests/test_params.py
+++ b/parser/tests/test_params.py
@@ -86,3 +86,30 @@ def test_no_params_declared_emits_no_params_key(monkeypatch, tmp_path):
             a()
     """)
     assert "params" not in spec
+
+
+def test_required_param_no_default_omits_default_key(monkeypatch, tmp_path):
+    # A Param with no default is required: the compiler omits the default key so
+    # the control plane can tell required apart from a null default.
+    spec = _compile(monkeypatch, tmp_path, """
+        from airflow.sdk import DAG, Param, task
+        @task
+        def a() -> None: ...
+        with DAG("g", params={"n": Param(type="integer", minimum=1)}):
+            a()
+    """)
+    assert spec["params"] == {"n": {"schema": {"type": "integer", "minimum": 1}}}
+    assert "default" not in spec["params"]["n"]
+
+
+def test_explicit_null_default_is_kept(monkeypatch, tmp_path):
+    # An explicit None default is a real default of null, distinct from required.
+    spec = _compile(monkeypatch, tmp_path, """
+        from airflow.sdk import DAG, Param, task
+        @task
+        def a() -> None: ...
+        with DAG("g", params={"n": Param(None, type="integer")}):
+            a()
+    """)
+    assert "default" in spec["params"]["n"]
+    assert spec["params"]["n"]["default"] is None


### PR DESCRIPTION
Part of #798 (backend half; UI typed-form stays open). A `Param` declared with **no default** is *required* in Airflow; leoflow now enforces that instead of silently running it as `null`.

## Changes
- **parser** — the `Param` shim distinguishes "no default given" from an explicit `None` via a sentinel; the compiler **omits the `default` key** for a required param.
- **domain** — `ParamSpec.Default` is now `omitempty` (so absence is presence-detectable and survives a re-marshal — the reliability review confirmed this is *mandatory*, not cosmetic); the `dag-schema.json` (both byte-identical copies) no longer requires `default`.
- **api** — `applyDeclaredParams` returns **400** when a required param (no default) is absent from the conf, *before* schema validation; merge/validate extracted into helpers (keeps gocyclo in bounds).

Additive/back-compatible — only a bare `Param()` with no default changes shape (correctly a new canonical version).

## Tests
Parser: required param omits `default`; explicit null default kept. Domain: required param marshals without `default` and still registers. API: missing required → 400; provided → ok.
`go build`/`go test ./...` green; `pytest` green; schema copies byte-identical (`TestEmbeddedSchemasMatchDocs`); changed files lint-clean.

The UI typed-form half of #798 stays open for a separate lf-devex pass.