### PR TITLE
feat: capture DAG max_active_runs/catchup/start_date/description (closes #797)

### DIFF
--- a/parser/leoflow_parser/_shim/airflow/_core.py
+++ b/parser/leoflow_parser/_shim/airflow/_core.py
@@ -127,6 +127,14 @@ class DAG:
         # control plane can default + validate a run's conf at trigger time. None
         # when the DAG declares none, keeping the compiled shape unchanged.
         self.params = kwargs.get("params")
+        # Scheduling/metadata attributes the domain + scheduler already honor
+        # (max_active_runs concurrency, catchup/start_date backfill, description
+        # for the UI): captured so they are not silently dropped. Absent leaves
+        # them off the compiled spec, keeping a DAG that sets none unchanged.
+        self.description = kwargs.get("description")
+        self.start_date = kwargs.get("start_date")
+        self.max_active_runs = kwargs.get("max_active_runs")
+        self.catchup = kwargs.get("catchup")
         # Collect on construction too, so DAGs defined without `with` (e.g.
         # module-level `dag = DAG(...)` with operators attached via dag=) are seen.
         COLLECTED[dag_id] = self

--- a/parser/leoflow_parser/compiler.py
+++ b/parser/leoflow_parser/compiler.py
@@ -73,6 +73,19 @@ def compile_dag(
     params = _params(dag)
     if params:
         spec["params"] = params
+    # Scheduling/metadata attributes the domain + scheduler honor. Emitted only
+    # when set, so a DAG that declares none keeps its compiled shape.
+    description = getattr(dag, "description", None)
+    if isinstance(description, str) and description:
+        spec["description"] = description
+    start_date = _start_date(dag)
+    if start_date:
+        spec["start_date"] = start_date
+    mar = getattr(dag, "max_active_runs", None)
+    if isinstance(mar, int) and not isinstance(mar, bool) and mar > 0:
+        spec["max_active_runs"] = mar
+    if getattr(dag, "catchup", None) is True:
+        spec["catchup"] = True
     return spec
 
 
@@ -660,6 +673,20 @@ def _schedule(dag) -> str | None:
         return summary
     schedule = getattr(dag, "schedule", None)
     return schedule if isinstance(schedule, str) else None
+
+
+def _start_date(dag) -> str | None:
+    """Serialize the DAG's start_date to an ISO-8601 string (the domain field is
+    a string; the schema wants date-time). Airflow's start_date is a datetime;
+    accept anything with isoformat() and fall back to str()."""
+    value = getattr(dag, "start_date", None)
+    if value is None:
+        return None
+    iso = getattr(value, "isoformat", None)
+    if callable(iso):
+        return iso()
+    text = str(value)
+    return text or None
 
 
 def _params(dag) -> dict[str, Any]:

--- a/parser/tests/test_dag_attrs.py
+++ b/parser/tests/test_dag_attrs.py
@@ -1,0 +1,66 @@
+"""DAG-level scheduling/metadata attributes captured by the shim.
+
+``max_active_runs`` (concurrency), ``catchup``/``start_date`` (backfill) and
+``description`` (UI) are all honored by the domain + scheduler; the shim was
+dropping them silently. The compiler now emits each only when set, so a DAG that
+declares none keeps its compiled shape.
+"""
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+from leoflow_parser.compiler import compile_dag
+
+
+def _compile(monkeypatch, tmp_path: Path, body: str, config: dict | None = None) -> dict:
+    monkeypatch.setenv(
+        "LEOFLOW_PROJECT_CONFIG_JSON",
+        json.dumps(config or {"schema_version": "1.0"}),
+    )
+    src = tmp_path / "dag.py"
+    src.write_text(textwrap.dedent(body))
+    return compile_dag(str(src), str(tmp_path / "ignored.json"), "img:v1", dag_version="v1")
+
+
+def test_dag_attrs_captured(monkeypatch, tmp_path):
+    spec = _compile(monkeypatch, tmp_path, """
+        from datetime import datetime, timezone
+        from airflow.sdk import DAG, task
+        @task
+        def a() -> None: ...
+        with DAG("g", description="nightly etl",
+                 start_date=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                 max_active_runs=3, catchup=True):
+            a()
+    """)
+    assert spec["description"] == "nightly etl"
+    assert spec["start_date"] == "2026-01-01T00:00:00+00:00"
+    assert spec["max_active_runs"] == 3
+    assert spec["catchup"] is True
+
+
+def test_dag_attrs_omitted_when_unset(monkeypatch, tmp_path):
+    spec = _compile(monkeypatch, tmp_path, """
+        from airflow.sdk import DAG, task
+        @task
+        def a() -> None: ...
+        with DAG("g"):
+            a()
+    """)
+    for key in ("description", "start_date", "max_active_runs", "catchup"):
+        assert key not in spec
+
+
+def test_catchup_false_is_omitted(monkeypatch, tmp_path):
+    # catchup defaults to False in Airflow 3; only an explicit True is emitted,
+    # so the domain's zero-value (no backfill) is the compiled default.
+    spec = _compile(monkeypatch, tmp_path, """
+        from airflow.sdk import DAG, task
+        @task
+        def a() -> None: ...
+        with DAG("g", catchup=False):
+            a()
+    """)
+    assert "catchup" not in spec


### PR DESCRIPTION
Closes #797. The structural shim silently dropped these DAG kwargs (the wiring review's Q1 finding), even though the domain + scheduler **already honor** them and the `dag.json` schema **already defines** them — so this is a parser-only capture, no Go change.

## Changes (parser)
- `_shim/airflow/_core.py` — `DAG.__init__` captures `description`, `start_date`, `max_active_runs`, `catchup`.
- `compiler.py` — emits each **only when set** (compiled shape of a DAG that declares none is unchanged); `start_date` → ISO-8601 string (domain field is a string, schema `format: date-time`); `catchup` emits only on explicit `True` (Airflow-3 default is `False` = the domain zero-value); `max_active_runs` only when a positive int (guards against `bool`).

## Why no Go change
`internal/domain/dag.go` already has `Description`/`StartDate`/`MaxActiveRuns`/`Catchup`, the scheduler already reads them (`internal/scheduler/catchup.go`, `scheduler.go`), and `dag-schema.json` already defines them. The gap was purely that the parser never emitted them.

## Tests
All four captured + emitted (tz-aware `start_date` → `2026-01-01T00:00:00+00:00`); all omitted when unset; `catchup=False` omitted. Full `pytest` + `ruff` green.