### PR TITLE
fix(parser): @task.branch clean reject instead of AttributeError

### DIFF
--- a/parser/leoflow_parser/_shim/airflow/sdk/__init__.py
+++ b/parser/leoflow_parser/_shim/airflow/sdk/__init__.py
@@ -21,6 +21,13 @@ class PythonOperator(BaseOperator):
     """Classic PythonOperator (name carries 'Python' -> Leoflow 'python')."""
 
 
+class _TaskBranchOperator(PythonOperator):
+    """The @task.branch shape. Branching needs scheduler skip-state (ADR 0040
+    Phase D) that Leoflow does not have yet; the 'Branch' in the class name routes
+    it to the compiler's clean #225 reject instead of an opaque AttributeError at
+    import time."""
+
+
 class EmptyOperator(BaseOperator):
     """No-op operator."""
 
@@ -65,6 +72,35 @@ def task(fn=None, **dec_kwargs):
         return maker
 
     return wrap(fn) if callable(fn) else wrap
+
+
+def _task_branch(fn=None, **dec_kwargs):
+    """@task.branch: TaskFlow branching. Captured as a Branch-named operator so
+    the compiler refuses it with the clear ADR 0040 Phase D message, rather than
+    the wrapped ``task`` raising an opaque AttributeError for the missing
+    attribute at import."""
+
+    def wrap(func):
+        @functools.wraps(func)
+        def maker(*args, **kwargs):
+            op = _TaskBranchOperator(task_id=func.__name__, **dec_kwargs)
+            op.python_callable = func
+            op.op_args = args
+            op.op_kwargs = kwargs
+            op.function = func
+            for value in list(args) + list(kwargs.values()):
+                for xarg in _iter_xcomargs(value):
+                    op.upstream_task_ids.add(xarg.operator.task_id)
+            return XComArg(op)
+
+        maker.function = func
+        return maker
+
+    return wrap(fn) if callable(fn) else wrap
+
+
+# @task.branch is an attribute of the @task decorator in the TaskFlow API.
+task.branch = _task_branch
 
 
 def dag(dag_id=None, **dag_kwargs):

--- a/parser/tests/test_shim_edges.py
+++ b/parser/tests/test_shim_edges.py
@@ -637,3 +637,25 @@ def test_removed_core_operator_import_names_providers_standard(
     assert f"airflow.providers.standard.operators.{submodule}" in msg
     # Must NOT fall through to the generic operator-unsupported wording.
     assert "supported: Bash, Http" not in msg
+
+
+def test_task_branch_rejected_cleanly_not_attributeerror(monkeypatch, tmp_path):
+    """@task.branch must fail with the clear branching reject (ADR 0040 Phase D),
+    not an opaque AttributeError from a missing decorator attribute. Branching is
+    parked pending scheduler skip-state; the parser owes a loud, actionable error
+    for the TaskFlow spelling just as it does for BranchPythonOperator."""
+    with pytest.raises(ValueError) as ei:
+        _compile(monkeypatch, tmp_path, """
+            from airflow.sdk import DAG, task
+            @task
+            def a() -> None: ...
+            @task.branch
+            def pick() -> str:
+                return "a"
+            with DAG("g"):
+                a()
+                pick()
+        """)
+    msg = str(ei.value)
+    assert "not supported by Leoflow" in msg
+    assert "branching" in msg


### PR DESCRIPTION
Small correctness fix flagged by the branching design study. The `@task.branch` TaskFlow spelling raised an **opaque `AttributeError`** at import (the shim's `@task` decorator had no `.branch` attribute), so the clean #225 branching reject — which already fires for `BranchPythonOperator` via the compiler's class-name marker (`compiler.py`) — never ran for `@task.branch`.

## Fix (parser-only)
- `_shim/airflow/sdk/__init__.py`: add a `_TaskBranchOperator` (name carries "Branch") and attach `task.branch` to build it. The compiler's existing `_operator_type` marker then refuses it with the clear `ValueError`: *"branching (@task.branch / BranchPythonOperator) is not supported by Leoflow yet … (ADR 0040 Phase D)"*.

Interim behavior until branching lands (design v2 parked); this capture becomes a real branch task then.

## Test
A `@task.branch` DAG now raises `ValueError` mentioning *branching* / *not supported by Leoflow*, not `AttributeError` (red-first by construction). Full `pytest` + `ruff` green.