### PR TITLE
release: prepare v0.4.1 GA (promote changelog + chart bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-08-28
+
 ### Added
 
 - **`leoflow runs logs <dag> <run> <task> [--try N] [-f]` (#768).** Read a task
@@ -66,6 +68,19 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **Release image signing retries transient OIDC flakes (#773).** Every `cosign sign`
   now retries with backoff, so a momentary Sigstore/OIDC blip no longer drafts an
   otherwise-good release.
+
+### Docs
+
+- **External secrets how-to (#812).** Reaching a credential that lives in AWS
+  Secrets Manager / GCP Secret Manager / Azure Key Vault / HashiCorp Vault from a
+  task pod — keyless (Workload Identity) first, then an ESO/CSI-synced or mounted
+  Kubernetes Secret — without duplicating it in Leoflow, plus how a secret is
+  scoped to the right pod.
+- **The pod model — "when you pay for a pod" (#785).** Pod-per-task and the levers
+  that avoid its cold-start cost (the subprocess dev executor, `dbt_group`, warm
+  pools); records the generic fused-`TaskGroup` as a deliberate, deferred non-goal.
+- **Deferrable operators recorded as a conscious non-goal (ADR 0016, #795),** with
+  reschedule-mode sensors documented as the supported alternative.
 
 ## [0.4.0] - 2026-08-26
 

--- a/helm/leoflow/Chart.yaml
+++ b/helm/leoflow/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version is the chart version; appVersion tracks the leoflow-server image.
 # Both move in lockstep with the release tag (ADR 0028); decouple only if the
 # chart ever needs a cadence of its own for a template-only fix.
-version: 0.4.1-rc.1
-appVersion: "0.4.1-rc.1"
+version: 0.4.1
+appVersion: "0.4.1"
 home: https://github.com/neochaotic/leoflow
 sources:
   - https://github.com/neochaotic/leoflow

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -1,6 +1,6 @@
 # leoflow
 
-![Version: 0.4.1-rc.1](https://img.shields.io/badge/Version-0.4.1--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.1-rc.1](https://img.shields.io/badge/AppVersion-0.4.1--rc.1-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.1](https://img.shields.io/badge/AppVersion-0.4.1-informational?style=flat-square)
 
 Leoflow control plane — a GitOps-first, container-native workflow orchestrator (Airflow 3.2.x UI/API compatible).
 


### PR DESCRIPTION
GA promotion prep for **v0.4.1** (no code change). Promotes CHANGELOG `[Unreleased]` → `[0.4.1] - 2026-08-28` (complete: Added/Fixed/Security/Docs, everything since v0.4.0), bumps `Chart.yaml` version/appVersion to `0.4.1` (ADR 0028 lockstep, gate green), regenerates the chart README. The `v0.4.1` tag is cut from this commit; the release body will be set to the complete curated notes (goreleaser's auto-changelog only spans since v0.4.1-rc.1 and would drop the features).