### PR TITLE
test(scheduler): fix flaky TestStepDedupsAlertPerEpisode (closes #609)

### DIFF
--- a/internal/scheduler/scheduler_alerts_test.go
+++ b/internal/scheduler/scheduler_alerts_test.go
@@ -106,8 +106,20 @@ func TestStepDedupsAlertPerEpisode(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("expected the first failure to alert")
 	}
+	// The page is sent from a dispatch goroutine that stamps delivery
+	// (MarkRunAlertDelivered) only after the send returns. Wait for that stamp
+	// before re-ticking: the invariant under test is "a re-tick of an
+	// already-DELIVERED episode must not re-alert", so racing the async stamp
+	// would be testing a different (unstamped) state — the #609 flake.
+	deadline := time.Now().Add(2 * time.Second)
+	for !store.wasDelivered("r1") {
+		if time.Now().After(deadline) {
+			t.Fatal("first alert was not stamped delivered within 2s")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 	// Second tick: the fake still returns the run as active (re-tick of the same
-	// failed episode, no clear). The claim is already held, so no second page.
+	// failed episode, no clear). The episode is stamped delivered, so no second page.
 	if err := s.Step(context.Background()); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Closes #609. Test-only fix for the flaky `TestStepDedupsAlertPerEpisode`.

**Root cause:** the dedup invariant is enforced by the **delivered stamp** (`MarkRunAlertDelivered`), written by the alert **dispatch goroutine after the send returns**. The test re-ticked immediately after the first page, racing that async stamp; when the second `Step`'s claim beat the stamp, it re-paged — the intermittent failure that gated unrelated PRs and the v0.4.1 cut.

**Fix (test-only):** wait for the delivery stamp (via the **existing** `fakeStore.wasDelivered` accessor — no new helper) before the second `Step`, so the test exercises *a re-tick of an already-DELIVERED episode* rather than racing the stamp. The fake's `ClaimAlertAttempt` is untouched, so the retry/budget path (`TestStepStopsRetryingAfterAttemptBudget`) is unaffected.

**Verified:** full `internal/scheduler` green; dedup test green under `-race -count=100`; the only diff vs main is the wait loop.