### PR TITLE
feat(parser): reject deferrable=True at compile time (closes #794)

### DIFF
--- a/parser/leoflow_parser/compiler.py
+++ b/parser/leoflow_parser/compiler.py
@@ -319,8 +319,28 @@ def _check_literal_payload_size(task_id: str, kind: str, payload: dict[str, Any]
         )
 
 
+def _reject_deferrable(task) -> None:
+    """Refuse an operator that sets ``deferrable=True`` at COMPILE time, before the
+    image build — rather than letting it fail inside the pod after ``execute()``
+    raises TaskDeferred (the runtime keeps its own reject as defense-in-depth).
+    Explicit-kwarg only: an operator whose deferrable defaults through Airflow
+    config carries no kwarg here, so this never fires on it. Leoflow has no
+    triggerer, so deferral is not supported; the fix is a synchronous poke or a
+    reschedule-mode sensor.
+    """
+    args = getattr(task, "__leoflow_args__", None) or {}
+    if getattr(task, "deferrable", None) is True or args.get("deferrable") is True:
+        raise ValueError(
+            f"task {task.task_id!r} sets deferrable=True, which Leoflow does not "
+            "support (no triggerer). Set deferrable=False so the operator runs "
+            "synchronously in the pod (poke-style), or use a reschedule-mode "
+            "sensor for a long wait."
+        )
+
+
 def _map_task(task, source: str, dag=None) -> dict[str, Any]:
     task_type = _operator_type(task)
+    _reject_deferrable(task)
     entry: dict[str, Any] = {"task_id": task.task_id, "type": task_type}
 
     upstream = sorted(task.upstream_task_ids)

--- a/parser/tests/test_shim_edges.py
+++ b/parser/tests/test_shim_edges.py
@@ -659,3 +659,29 @@ def test_task_branch_rejected_cleanly_not_attributeerror(monkeypatch, tmp_path):
     msg = str(ei.value)
     assert "not supported by Leoflow" in msg
     assert "branching" in msg
+
+
+def test_deferrable_operator_rejected_at_compile(monkeypatch, tmp_path):
+    """deferrable=True is refused at compile (before the image build), not left to
+    fail inside the pod: Leoflow has no triggerer (ADR 0040 Phase C)."""
+    with pytest.raises(ValueError) as ei:
+        _compile(monkeypatch, tmp_path, """
+            from airflow.sdk import DAG
+            from airflow.providers.amazon.aws.sensors.s3 import S3KeySensor
+            with DAG("g"):
+                S3KeySensor(task_id="wait", bucket_key="k", bucket_name="b", deferrable=True)
+        """)
+    msg = str(ei.value)
+    assert "deferrable" in msg
+    assert "reschedule" in msg or "synchronously" in msg
+
+
+def test_non_deferrable_operator_compiles(monkeypatch, tmp_path):
+    """The guard is explicit-kwarg-only: deferrable=False compiles cleanly."""
+    spec = _compile(monkeypatch, tmp_path, """
+        from airflow.sdk import DAG
+        from airflow.providers.amazon.aws.sensors.s3 import S3KeySensor
+        with DAG("g"):
+            S3KeySensor(task_id="wait", bucket_key="k", bucket_name="b", deferrable=False)
+    """)
+    assert any(t["task_id"] == "wait" for t in spec["tasks"])


### PR DESCRIPTION
Closes #794. Catches `deferrable=True` at **compile** (before the image build) instead of letting it fail inside the pod after `execute()` raises `TaskDeferred` — Leoflow has no triggerer.

- `compiler.py`: new `_reject_deferrable` in the `_map_task` path raises a clear `ValueError` naming the fix (`deferrable=False` synchronous poke, or a reschedule-mode sensor). **Explicit-kwarg only** — an operator whose deferrable defaults via Airflow config carries no kwarg, so it never false-fires; the runtime reject (`runner.py`) stays as defense-in-depth. Covers native + generically-captured operators.
- Tests: `deferrable=True` → ValueError at compile; `deferrable=False` compiles.
- Full `pytest` + `ruff` green.

Follows the deferrable non-goal docs shipped in v0.4.1 (#795, ADR 0016).