### PR TITLE
docs: versioned documentation site with per-release archives

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -1,93 +1,53 @@
 ##############################################################################
-# DRAFT — NOT ACTIVE. This file ends in `.yml.draft`, so GitHub Actions IGNORES
-# it (only *.yml / *.yaml under .github/workflows/ are ever scheduled). It is the
-# staged cutover workflow for the Hugo + Docsy site under website/, kept next to
-# the live workflows for review. Activating it is a deliberate, maintainer-only
-# step (see CUTOVER below) — do NOT rename it to .yml until the maintainer gives
-# the go.
+# Website deploy — Hugo + Docsy, MULTI-VERSION (issue #814).
 #
-# What it does once activated: regenerate the four reference trees, build the
-# Hugo site with `hugo --gc --minify`, and deploy website/public to GitHub Pages
-# via the native Pages Actions flow (upload-pages-artifact + deploy-pages). It
-# REPLACES the mike/MkDocs deploy (docs.yml + docs-release.yaml), which must be
-# retired in the same cutover so two workflows never fight over Pages.
+# Publishes a combined tree to GitHub Pages with FOUR legs, each built from its
+# own git ref with its own baseURL:
 #
-# ─────────────────────────────────────────────────────────────────────────────
-# VERSION HANDLING (dev / latest) — replaces mike's per-version gh-pages dirs.
+#   https://neochaotic.github.io/leoflow/         <- latest GA  (ref: a tag)
+#   https://neochaotic.github.io/leoflow/dev/     <- main tip   (ref: the
+#                                                    commit that triggered this run)
+#   https://neochaotic.github.io/leoflow/vX.Y.Z/  <- one archived tree per
+#                                                    released tag (frozen)
 #
-# mike published each version into its own gh-pages subdirectory and stored the
-# public default as a root redirect (dev pre-GA, flipped to latest at GA — see
-# docs.yml / docs-release.yaml). Docsy does NOT version by subdirectory; the
-# version selector is the `[params.versions]` dropdown in hugo.toml, and the
-# "current" label is `params.version`. This site ships a single published tree
-# whose dropdown lists dev + latest (both pointing at the same base pre-GA, per
-# hugo.toml). The dev→latest GA flip is therefore a CONFIG flip, not a deploy
-# mechanic:
-#   * pre-GA  → params.version = "dev"    (hugo.toml default, or the input below)
-#   * at GA   → params.version = "latest" (set the input to `latest`, or edit
-#                hugo.toml once; mirrors the mike set-default flip in #719)
-# The `site_version` dispatch input overrides params.version for a one-off build
-# without editing config (HUGO_PARAMS_VERSION). If a future release needs true
-# multi-version archives (frozen /v1.2.3/ trees), that is a follow-up: build each
-# tag into its own subdir and list them in [params.versions] — out of scope here.
-# ─────────────────────────────────────────────────────────────────────────────
+# The version list — which tag is "latest", which tags are archived, and their
+# subpaths — is data, not workflow logic: website/scripts/ci/versions.json.
+# Cutting a new GA touches ONLY that file (see the comment inside it).
 #
-# ════════════════════════════════════════════════════════════════════════════
-# CUTOVER RUNBOOK — the EXACT steps the maintainer runs to go live. Nothing here
-# happens automatically; this workflow is inert until step 2.
+# WHY A COMBINED BUILD (not one `hugo` run): Docsy does not version content by
+# directory the way mike did for the old MkDocs site — a single Hugo site has
+# one baseURL and one content tree. So each leg is built SEPARATELY (its own
+# checkout, its own baseURL, its own rendered `public/`), and the results are
+# assembled into one directory tree before the single `upload-pages-artifact`
+# / `deploy-pages` step. GitHub Pages only ever sees ONE deploy per run.
 #
-#   0. Pre-flight (on the merged branch):
-#        cd website && hugo --gc --minify   # must be clean
-#        python3 scripts/migration/check_links.py     # 0 broken internal links
-#        # confirm public/ has the 211 alias stubs and offline-search-index.json
+# HOW AN ARCHIVED TAG IS HANDLED: an old tag's own website/hugo.toml predates
+# (or only has a stale copy of) this versioning scheme, so the build NEVER
+# trusts it for that. Two checkouts happen per leg:
+#   - `tooling/`  — this workflow's own ref (always current: versions.json +
+#                   the overlay-rendering script), used only to compute config;
+#   - `src/`      — the leg's ref (a GA tag, or the triggering commit for the
+#                   dev leg), used for EVERYTHING that renders the site: the
+#                   Hugo content tree, hugo.toml, layouts, and that ref's own
+#                   copy of the four reference generators (gen-cli.sh etc.),
+#                   so an archived tag reflects the CLI/Go/API/Python surface
+#                   AS IT WAS at that release, not as it is on main today.
+# `render-version-config.py` (run from `tooling/`) renders a small overlay TOML
+# from versions.json, and the build runs
+#     hugo --config hugo.toml,<overlay>.toml --gc --minify
+# Hugo merges multiple --config files left-to-right with the LAST file
+# winning per key (arrays replaced wholesale, not appended) — verified locally
+# against hugo v0.165.0 — so the overlay fully determines baseURL, the active
+# version label, the archived-version banner, and the complete 4-entry version
+# dropdown for every leg, regardless of what that leg's own hugo.toml contains.
 #
-#   1. Flip the Pages source (repo Settings → Pages → Build and deployment):
-#        Source: "Deploy from a branch" (gh-pages)  →  "GitHub Actions".
-#      This detaches Pages from the mike gh-pages branch. Until this flip, the
-#      deploy-pages step below cannot publish.
-#
-#   2. Activate THIS workflow:
-#        git mv .github/workflows/website-deploy.yml.draft \
-#               .github/workflows/website-deploy.yml
-#      (Keep the body unchanged; only the extension changes.)
-#
-#   3. Retire the mike / MkDocs deploy in the SAME change so nothing races Pages:
-#        git rm .github/workflows/docs.yml .github/workflows/docs-release.yaml
-#      The build-only website-build.yml can also be removed now (this workflow
-#      supersedes it: it both builds and deploys), or kept as a PR-only check by
-#      dropping its main-push trigger — either is fine; do not leave it deploying.
-#
-#   4. Promote website/ to the sole docs tree and archive the old MkDocs content.
-#      DO NOT blanket-remove docs/ — docs/api/ is NOT docs-site content: it holds
-#      the source-of-truth openapi.yaml + JSON schemas consumed by the Go codegen
-#      (`make pkg-client` / oapi-codegen), internal/api/docs_test.go, the CI
-#      redocly + pkg/client-sync gates, AND this workflow's own gen-openapi.sh.
-#      Deleting or moving it breaks the build, a unit test, CI, and the next docs
-#      deploy. Remove only the migrated MkDocs tree and KEEP docs/api/ in place:
-#        # remove every tracked file under docs/ EXCEPT docs/api/ (shared source)
-#        git ls-files docs/ | grep -v '^docs/api/' | xargs git rm
-#        git rm mkdocs.yml overrides/ mkdocs_templates/ -r            # live MkDocs
-#      (the generated docs/cli, docs/go, docs/openapi.yaml — the root copy — are
-#      git-ignored and vanish on their own). The `edit_uri`/github_subdir already
-#      points Docsy at website/, so "Edit this page" keeps working.
-#
-#   5. Merge to main. This workflow runs, builds, and publishes website/public to
-#      Pages at https://neochaotic.github.io/leoflow/ (same origin as today).
-#
-#   6. Post-cutover checks:
-#        * https://neochaotic.github.io/leoflow/ loads the Docsy home
-#        * a moved old URL redirects, e.g.
-#          /leoflow/warm-pools.html → /leoflow/operate/warm-pools/
-#          /leoflow/adr/0001-why-leoflow.html → /leoflow/project/adrs/0001-why-leoflow/
-#        * navbar search returns results (offline index)
-#        * the gh-pages branch can be deleted once Pages serves from Actions.
-#
-#   7. GA version flip (later, when the first stable release ships): run this
-#      workflow with site_version=latest (or set params.version="latest" in
-#      hugo.toml), mirroring the mike default flip.
-# ════════════════════════════════════════════════════════════════════════════
+# SAFETY: `build` failing on any leg (bad content, broken generator, whatever)
+# fails the workflow before `assemble`/`deploy` ever run — nothing reaches
+# Pages from a partially-broken run. The live site is only touched by the
+# `deploy` job, which runs last and only after every leg built cleanly.
+##############################################################################
 
-name: Website deploy (Hugo+Docsy → Pages)
+name: Website deploy (Hugo+Docsy → Pages, multi-version)
 
 on:
   push:
@@ -99,57 +59,82 @@ on:
       - "runtime/python/**"      # Python runtime API is generated by pdoc
       - "docs/api/openapi.yaml"  # Scalar spec source of truth
       - ".github/workflows/website-deploy.yml"
-  workflow_dispatch:
-    inputs:
-      site_version:
-        description: "Docsy version label for this build (params.version)."
-        type: choice
-        options: [dev, latest]
-        default: dev
+  workflow_dispatch: {}
 
 # Native Pages deploy needs pages:write + id-token:write; everything else stays
-# read-only. Unlike the mike flow this NEVER pushes to a git branch.
+# read-only. This NEVER pushes to a git branch.
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# One in-flight Pages deploy at a time. Not shared with docs-gh-pages (that group
-# belongs to the retiring mike flow); after cutover the mike workflows are gone.
+# One in-flight Pages deploy at a time.
 concurrency:
   group: pages-deploy
   cancel-in-progress: false
 
 env:
   HUGO_VERSION: "0.165.0"
-  # dispatch input wins; default to dev for push builds (pre-GA).
-  HUGO_PARAMS_VERSION: ${{ github.event.inputs.site_version || 'dev' }}
 
 jobs:
-  build:
-    name: generate + hugo build
+  plan:
+    name: resolve version matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 5
+    outputs:
+      matrix: ${{ steps.resolve.outputs.matrix }}
     steps:
-      - name: Checkout
+      - name: Checkout (for versions.json only)
         uses: actions/checkout@v4
         with:
+          fetch-depth: 1
+
+      - name: Resolve the dev leg's ref and emit the build matrix
+        id: resolve
+        run: |
+          set -euo pipefail
+          # versions.json's "dev" entry has ref: "" — meaning "whatever ref
+          # triggered this run". Resolve that to a concrete SHA here so every
+          # downstream checkout gets an unambiguous, checkout-able ref.
+          matrix="$(jq -c --arg sha "${{ github.sha }}" \
+            '{include: (.versions | map(if .ref == "" then .ref = $sha else . end))}' \
+            website/scripts/ci/versions.json)"
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+          echo "Resolved matrix:"
+          echo "${matrix}" | jq .
+
+  build:
+    name: build (${{ matrix.id }})
+    needs: plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
+    steps:
+      - name: Checkout tooling (this workflow's own ref — CI scripts only)
+        uses: actions/checkout@v4
+        with:
+          path: tooling
+          fetch-depth: 1
+
+      - name: Checkout version content (${{ matrix.id }} @ ${{ matrix.ref }})
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.ref }}
+          path: src
           fetch-depth: 0   # Docsy "last modified" + enableGitInfo want history
 
       - name: Setup Go (Hugo Modules + generators)
         uses: actions/setup-go@v5
         with:
-          go-version-file: website/go.mod
+          go-version-file: src/website/go.mod
 
       - name: Setup Node (Docsy PostCSS/autoprefixer)
         uses: actions/setup-node@v7
         with:
           # Node 22 LTS (NOT 20): Hugo Extended sandboxes the PostCSS/autoprefixer
-          # subprocess with Node's Permission Model (`node --permission
-          # --allow-fs-read=... --import=<resolver> postcss`). The `--permission`
-          # flag only exists on Node >= 22.13 / 24; on Node 20.x node aborts with
-          # `bad option: --permission`, failing the main.css transform and the whole
-          # `hugo --gc --minify` build. Must match website-build.yml. See PR #721.
+          # subprocess with Node's Permission Model. See PR #721.
           node-version: "22"
 
       - name: Setup Python (pdoc + generator post-processing)
@@ -166,37 +151,90 @@ jobs:
           hugo version
 
       - name: Install PostCSS toolchain
-        working-directory: website
+        working-directory: src/website
         run: npm ci
 
-      # The four generators — parity with the live docs.yml pipeline. Each script
-      # cd's to the repo root itself, so run them from root.
+      # Regenerate the reference trees from THIS LEG'S OWN source (an archived
+      # tag's generators reflect the CLI/Go/API/Python surface as it was at
+      # that release, not as it is on main today). Each script cd's to its own
+      # repo root, so run them from the `src` checkout root.
       - name: Generate CLI reference (Cobra)
+        working-directory: src
         run: ./website/scripts/gen-cli.sh
       - name: Generate Go reference (gomarkdoc)
+        working-directory: src
         run: ./website/scripts/gen-go.sh
       - name: Refresh OpenAPI spec (Scalar)
+        working-directory: src
         run: ./website/scripts/gen-openapi.sh
       - name: Generate Python runtime API (pdoc)
+        working-directory: src
         run: ./website/scripts/gen-python.sh
 
-      # Redirect aliases are front matter on the pages (committed); no build step
-      # is needed for them — Hugo emits the alias stubs during the build below.
+      - name: Render version-selector config overlay (issue #814)
+        run: |
+          python3 tooling/website/scripts/ci/render-version-config.py \
+            --versions-file tooling/website/scripts/ci/versions.json \
+            --leg-id "${{ matrix.id }}" \
+            --out "${{ github.workspace }}/version-overlay.toml"
 
       - name: Build (production — enables fingerprinted offline search index)
-        working-directory: website
+        working-directory: src/website
         env:
           HUGO_ENVIRONMENT: production
-        run: hugo --gc --minify --logLevel info
+        run: |
+          hugo --config "hugo.toml,${{ github.workspace }}/version-overlay.toml" \
+               --gc --minify --logLevel info
+
+      - name: Upload leg artifact (not a Pages artifact — combined in `assemble`)
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-${{ matrix.id }}
+          path: src/website/public
+          retention-days: 1
+          if-no-files-found: error
+
+  assemble:
+    name: assemble combined tree
+    needs: [plan, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout (for versions.json only)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Download every leg's built site
+        uses: actions/download-artifact@v4
+        with:
+          pattern: site-*
+          path: artifacts
+
+      - name: Assemble the combined public/ tree
+        run: |
+          set -euo pipefail
+          mkdir -p combined
+          jq -c '.versions[]' website/scripts/ci/versions.json | while read -r entry; do
+            id="$(echo "${entry}" | jq -r '.id')"
+            subpath="$(echo "${entry}" | jq -r '.subpath')"
+            dest="combined"
+            [ -n "${subpath}" ] && dest="combined/${subpath}"
+            mkdir -p "${dest}"
+            cp -r "artifacts/site-${id}/." "${dest}/"
+            echo "assembled ${id} -> ${dest}/"
+          done
+          echo "--- combined/ top level ---"
+          find combined -maxdepth 1 | sort
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: website/public
+          path: combined
 
   deploy:
     name: deploy to GitHub Pages
-    needs: build
+    needs: assemble
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment:

--- a/website/hugo.toml
+++ b/website/hugo.toml
@@ -96,19 +96,34 @@ enableGitInfo = true
     [params.ui.feedback]
       enable = false
 
-  # Version selector (LOCKED: replicate the dev/latest scheme mike gave us).
-  # Docsy renders these into the navbar dropdown. "dev" is the live tip today; the
-  # "latest" (GA) entry is wired now but points at the same base until we cut a tag.
+  # Version selector (issue #814: real multi-version archives, replacing the
+  # old cosmetic dev/latest pair that both pointed at the same base).
+  #
+  # This config is what a PLAIN `hugo` build (no CI) uses, and is also the
+  # fallback if an overlay were ever skipped — so it must stand on its own:
+  # a local/dev build defaults to version="dev" and lists all four published
+  # legs. .github/workflows/website-deploy.yml OVERRIDES version/versions/
+  # archived_version/baseURL per leg at build time (see
+  # website/scripts/ci/render-version-config.py) — that is the single source
+  # of truth for what actually ships; keep this block in sync by hand when
+  # website/scripts/ci/versions.json changes (a new GA, a newly-archived tag).
   version = "dev"
   version_menu = "Releases"
   version_menu_pagelinks = false
   archived_version = false
-  [[params.versions]]
-    version = "dev"
-    url = "https://neochaotic.github.io/leoflow/"
+  url_latest_version = "https://neochaotic.github.io/leoflow/"
   [[params.versions]]
     version = "latest"
     url = "https://neochaotic.github.io/leoflow/"
+  [[params.versions]]
+    version = "v0.4.1"
+    url = "https://neochaotic.github.io/leoflow/v0.4.1/"
+  [[params.versions]]
+    version = "v0.4.0"
+    url = "https://neochaotic.github.io/leoflow/v0.4.0/"
+  [[params.versions]]
+    version = "dev"
+    url = "https://neochaotic.github.io/leoflow/dev/"
 
   [params.links]
     [[params.links.user]]

--- a/website/scripts/ci/render-version-config.py
+++ b/website/scripts/ci/render-version-config.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Render a Hugo config OVERLAY for one leg of the multi-version Pages build
+(issue #814).
+
+Why an overlay instead of editing hugo.toml in place: the four legs (latest
+GA / dev / each archived tag) are built from FOUR DIFFERENT git refs, and an
+archived tag's own website/hugo.toml predates this versioning scheme (it may
+have only the old cosmetic dev/latest pair, or none at all). We never rely on
+the checked-out ref's hugo.toml to already know about the other legs. Instead
+this script reads website/scripts/ci/versions.json from THIS ref (the ref
+that triggered the workflow, i.e. always the current tooling) and renders a
+second TOML file. The build then runs:
+
+    hugo --config hugo.toml,<this-overlay> --baseURL <leg-url> ...
+
+Hugo merges multiple --config files left-to-right with the LAST file winning
+per key (arrays are replaced wholesale, not appended) — verified locally
+against hugo v0.165.0. So the overlay fully determines baseURL, the active
+version label, the archived-version banner, and the complete version
+dropdown for every leg, regardless of what that leg's own hugo.toml contains.
+
+The "dev" leg's ref in versions.json is the empty string (meaning "whatever
+ref triggered this workflow run"); that resolution happens in the workflow's
+`plan` job (via jq, against github.sha), not here — this script only cares
+about labels/subpaths/archived flags, which are static.
+
+Usage:
+    render-version-config.py --versions-file website/scripts/ci/versions.json \\
+        --leg-id v0.4.0 --out overlay.toml
+"""
+import argparse
+import json
+import sys
+
+
+def build_url(root_url: str, subpath: str) -> str:
+    root = root_url.rstrip("/") + "/"
+    if not subpath:
+        return root
+    return root + subpath.strip("/") + "/"
+
+
+def toml_string(value: str) -> str:
+    # Values here are URLs / version labels — no embedded quotes/newlines expected,
+    # but escape defensively rather than assume.
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--versions-file", required=True)
+    ap.add_argument("--leg-id", required=True, help="id of the leg being built (matches versions.json)")
+    ap.add_argument("--out", required=True, help="path to write the overlay TOML")
+    args = ap.parse_args()
+
+    with open(args.versions_file, encoding="utf-8") as f:
+        manifest = json.load(f)
+
+    root_url = manifest["root_url"]
+    entries = manifest["versions"]
+
+    this = next((e for e in entries if e["id"] == args.leg_id), None)
+    if this is None:
+        print(f"error: leg id {args.leg_id!r} not found in {args.versions_file}", file=sys.stderr)
+        return 1
+
+    leg_url = build_url(root_url, this["subpath"])
+
+    lines = [
+        f"baseURL = {toml_string(leg_url)}",
+        "[params]",
+        f"  version = {toml_string(this['label'])}",
+        '  version_menu = "Releases"',
+        f"  archived_version = {'true' if this['archived'] else 'false'}",
+        f"  url_latest_version = {toml_string(root_url)}",
+    ]
+    for e in entries:
+        entry_url = build_url(root_url, e["subpath"])
+        lines.append("  [[params.versions]]")
+        lines.append(f"    version = {toml_string(e['label'])}")
+        lines.append(f"    url = {toml_string(entry_url)}")
+
+    with open(args.out, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines) + "\n")
+
+    print(f"render-version-config: wrote {args.out} (leg={args.leg_id}, baseURL={leg_url})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/website/scripts/ci/versions.json
+++ b/website/scripts/ci/versions.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "Single source of truth for the multi-version Pages tree (issue #814). One entry per published leg. `id` names the build's artifact/subdir; `ref` is the git ref to build from (empty string means \"whatever ref triggered the workflow\" — resolved to github.sha by the plan job); `subpath` is where it lands under https://neochaotic.github.io/leoflow/ (empty = site root); `label` is the string shown in the version dropdown and written to params.version; `archived` marks a superseded GA so Docsy renders the archived-version banner.\n\nCutting a new GA release (e.g. v0.4.2) touches ONLY this file: add a new entry for the outgoing GA (ref=<tag>, subpath=<tag>, archived=true), and repoint the `latest` entry's `ref`/`label` at the new tag.",
+  "root_url": "https://neochaotic.github.io/leoflow/",
+  "versions": [
+    { "id": "latest", "ref": "v0.4.1", "subpath": "", "label": "latest", "archived": false },
+    { "id": "v0.4.1", "ref": "v0.4.1", "subpath": "v0.4.1", "label": "v0.4.1", "archived": false },
+    { "id": "v0.4.0", "ref": "v0.4.0", "subpath": "v0.4.0", "label": "v0.4.0", "archived": true },
+    { "id": "dev", "ref": "", "subpath": "dev", "label": "dev", "archived": false }
+  ]
+}


### PR DESCRIPTION
Closes #814.

## What
Replaces the single "latest" Hugo+Docsy build with a real multi-version Pages tree:

- `https://neochaotic.github.io/leoflow/` — **latest GA** (currently v0.4.1) — new default root
- `https://neochaotic.github.io/leoflow/dev/` — main tip
- `https://neochaotic.github.io/leoflow/v0.4.1/` — archived GA
- `https://neochaotic.github.io/leoflow/v0.4.0/` — archived GA

The navbar version dropdown lists all four with correct absolute URLs, and archived (superseded) versions show Docsy's "this is an archived snapshot" banner linking back to latest.

## How it works
- `website/scripts/ci/versions.json` is the single source of truth for the version list (id/ref/subpath/label/archived). Cutting a new GA touches only this file: add an entry for the outgoing GA, repoint `latest`'s ref.
- `website/scripts/ci/render-version-config.py` renders a small Hugo config **overlay** per leg (baseURL, `params.version`, the full dropdown, `archived_version`) from that manifest. The build runs `hugo --config hugo.toml,<overlay> --gc --minify`; Hugo merges `--config` files left-to-right with the last file winning per key (verified locally against hugo v0.165.0), so the overlay is authoritative regardless of what an old tag's own `hugo.toml` contains (older tags predate this scheme).
- `.github/workflows/website-deploy.yml` is restructured into four jobs:
  - `plan` resolves the "dev" leg's ref (empty in the manifest, meaning "whatever ref triggered this run") to a concrete SHA and emits the build matrix.
  - `build` (matrix, one job per leg) does **two checkouts**: `tooling/` at this workflow's own ref (for the overlay script + manifest — always current), and `src/` at that leg's own ref (a GA tag, or the triggering commit for dev). Everything that renders the site — content, hugo.toml, layouts, and that ref's own copies of the four reference generators (gen-cli.sh/gen-go.sh/gen-openapi.sh/gen-python.sh) — comes from `src/`, so an archived tag's CLI/Go/API/Python reference reflects that release, not main.
  - `assemble` downloads all four built legs and arranges them into one combined tree (root = latest, others under their subpath).
  - `deploy` uploads/publishes that single combined tree — unchanged from before.
- `website/hugo.toml`'s `[params.versions]` now has the real four entries (previously two cosmetic entries both pointing at the same URL), so a plain local `hugo` build also shows a correct dropdown.

## Behavior change (intended, per #814)
**Root now serves the latest GA instead of the dev tip.** Main's docs move to `/dev/`.

## Safety
- `build` failing on any leg fails the workflow before `assemble`/`deploy` run — nothing partially-broken reaches Pages.
- The live site is only touched by `deploy`, unchanged from the current single-version workflow (`upload-pages-artifact` + `deploy-pages`), so this is a straight swap of what feeds it, not a new publish mechanism.
- `website-build.yml` (the PR-time build+lychee gate) is untouched and still checks a single-version build; verified locally that lychee's `--offline` mode excludes the new absolute dropdown URLs (doesn't try to resolve `/v0.4.1/` etc. against the single-version `public/` tree), so that gate is unaffected.

## Local verification (hugo v0.165.0, since CI can't run interactively here)
Built all four legs locally via `git worktree` (v0.4.1, v0.4.0) + the main checkout (dev/latest), assembled them the same way `assemble` does, and confirmed against the rendered HTML:
- Each leg's internal links are absolute and carry the right prefix (`grep` on rendered `href=`/`src=` — e.g. `/v0.4.1/concepts/...` under the v0.4.1 leg, `/dev/concepts/...` under dev, none under root/latest).
- The version dropdown renders all four entries with correct URLs in every leg, and correctly marks the active one.
- `v0.4.0` (the superseded GA) shows the archived-version banner; `latest`/`v0.4.1`/`dev` do not.
- Root serves the v0.4.1 (latest GA) content; alias/redirect stubs (the old flat-URL → new-URL redirects) resolve under the right subpath in every leg.
- `actionlint` is clean on the changed workflow.
- A plain `hugo --gc --minify` on `website/` (no CI overlay) still builds cleanly with the updated `hugo.toml` defaults.

## Risk / what I'd still want eyes on before merge
- I could not execute the GitHub Actions workflow itself (no CI dispatch from this environment) — the logic is verified by hand-reproducing each job's steps locally, not by an actual Action run. Recommend a `workflow_dispatch` run on this branch (or after merge, since it only triggers on push to `main`/dispatch) before trusting it end-to-end, particularly the `download-artifact`/`upload-pages-artifact` handoff between jobs, which I couldn't simulate outside GH Actions.
- "Edit this page" links on archived-tag pages point at `main` (pre-existing `github_branch = "main"` in hugo.toml, unchanged by this PR) — arguably fine (you'd fix current docs, not history) but worth a conscious call.
- Every push now rebuilds all four legs (previously one) — acceptable given a docs site build parallelizes fine and Hugo builds in ~1s each, but worth noting as ~4x the runner time.