### PR TITLE
Typed trigger form: serve declared DAG params to the SPA (#798, UI half)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -493,6 +493,11 @@ jobs:
           # `leoflow setup` prints the admin password once; capture it.
           PW=$(leoflow setup 2>&1 | tee /tmp/setup.log | grep -oiE 'password:[[:space:]]*[A-Za-z0-9]+' | head -1 | awk '{print $NF}')
           [ -n "$PW" ] || { echo "could not capture admin password"; cat /tmp/setup.log; exit 1; }
+          # Register the typed-params fixture DAG alongside the scaffolded hello so
+          # the trigger dialog has declared params to render its native form from.
+          # It lands in the workspace leoflow setup chose (~/leoflow by default).
+          mkdir -p "$HOME/leoflow/params_demo"
+          cp examples/params_demo/dag.py examples/params_demo/leoflow.yaml "$HOME/leoflow/params_demo/"
           leoflow lite --port 18080 --postgres managed --executor subprocess \
             --server-bin "$PWD/bin/leoflow-server" --agent-bin "$PWD/bin/leoflow-agent" > /tmp/lite.log 2>&1 &
           for _ in $(seq 1 60); do curl -fsS http://localhost:18080/readyz >/dev/null 2>&1 && break; sleep 3; done
@@ -502,6 +507,8 @@ jobs:
           for _ in $(seq 1 40); do curl -fsS -H "Authorization: Bearer $TOK" http://localhost:18080/api/v2/dags/hello >/dev/null 2>&1 && break; sleep 3; done
           curl -fsS -X POST -H "Authorization: Bearer $TOK" -H 'Content-Type: application/json' -d '{}' \
             http://localhost:18080/api/v2/dags/hello/dagRuns >/dev/null 2>&1 || true
+          # Wait for the typed-params fixture DAG to register too (the trigger-form step needs it).
+          for _ in $(seq 1 40); do curl -fsS -H "Authorization: Bearer $TOK" http://localhost:18080/api/v2/dags/params_demo >/dev/null 2>&1 && break; sleep 3; done
           sleep 10
           LEOFLOW_URL=http://localhost:18080 LEOFLOW_USER=admin@leoflow.local LEOFLOW_PASS="$PW" \
             node test/e2e/ui-smoke.js

--- a/examples/README.md
+++ b/examples/README.md
@@ -69,6 +69,7 @@ a `README.md` walking through their specific Connection wiring.
 | [montecarlo_pi](montecarlo_pi/) | Estimate pi with parallel Monte-Carlo workers, then combine. |
 | [mssql_load](mssql_load/) | Compute rows and load them into an external Microsoft SQL Server via a managed Connection. |
 | [mysql_load](mysql_load/) | Compute rows and load them into an external MySQL/MariaDB via a managed Connection. |
+| [params_demo](params_demo/) | Declares typed run `params` (bare default, typed enum, required) so the trigger dialog renders its native typed form. |
 | [postgres_load](postgres_load/) | Compute rows and load them into an external Postgres via a managed Connection. |
 | [redis_load](redis_load/) | Compute a key-value payload and write it into a Redis hash via a managed Connection. |
 | [sqlite_load](sqlite_load/) | Compute rows and load them into a sqlite file via a managed Connection. |

--- a/examples/params_demo/Dockerfile
+++ b/examples/params_demo/Dockerfile
@@ -1,0 +1,8 @@
+# Standard DAG image (#318). Built by 'leoflow compile --build' or by hand:
+#   docker build -t my-registry/params_demo:<tag> .
+# Synthesized by scripts/sync-example-dockerfiles.sh from leoflow.yaml; do
+# not hand-edit — re-run the script after changing python_version or
+# dependencies, or CI's drift check fails.
+FROM leoflow-base:py3.11
+COPY dag.py /home/leoflow/dag.py
+ENV PYTHONPATH=/home/leoflow

--- a/examples/params_demo/dag.py
+++ b/examples/params_demo/dag.py
@@ -1,0 +1,42 @@
+"""params_demo — declares typed run params so the trigger dialog renders its
+native form.
+
+A DAG's ``params=`` are the run parameters an operator supplies at trigger time.
+Leoflow serves them to the embedded UI in Airflow's param-dict shape, so the
+"Trigger Dag w/ config" dialog renders a generated form (with the raw JSON editor
+still one toggle away) instead of an empty config box. This example declares one
+of each shape the form handles:
+
+- ``sample_size`` — a bare default (no schema): any value is accepted, the field
+  is prefilled with the default.
+- ``region`` — a typed enum with a default: renders as a select of its choices.
+- ``run_label`` — a required param (no default): the form flags it until filled,
+  and the backend rejects a trigger that omits it.
+
+The single task echoes the three values via Jinja templating (``{{ params.x }}``),
+the documented way to read a run's params in a task command.
+"""
+from __future__ import annotations
+
+from airflow.providers.standard.operators.bash import BashOperator
+from airflow.sdk import DAG, Param
+
+with DAG(
+    "params_demo",
+    schedule=None,
+    catchup=False,
+    tags=["example"],
+    params={
+        "sample_size": 100,
+        "region": Param("us", type="string", enum=["us", "eu", "apac"], title="Region"),
+        "run_label": Param(type="string", title="Run label"),
+    },
+):
+    BashOperator(
+        task_id="report",
+        bash_command=(
+            "echo 'run_label={{ params.run_label }} "
+            "region={{ params.region }} "
+            "sample_size={{ params.sample_size }}'"
+        ),
+    )

--- a/examples/params_demo/leoflow.yaml
+++ b/examples/params_demo/leoflow.yaml
@@ -1,0 +1,8 @@
+schema_version: "1.0"
+dag_id: params_demo
+description: Declares typed run params (bare default, typed enum, required) so the trigger dialog renders its native form.
+owner: examples
+tags:
+  - example
+python_version: "3.11"
+dependencies: []

--- a/internal/api/resources.go
+++ b/internal/api/resources.go
@@ -1038,7 +1038,7 @@ func registerResources(r gin.IRouter, deps Dependencies) {
 		g := r.Group("/api/v2/dags")
 		g.GET("", RequirePermission("read", "dag"), listDagsHandler(deps.Dags))
 		g.GET("/:dag_id", RequirePermission("read", "dag"), getDagHandler(deps.Dags))
-		g.GET("/:dag_id/details", RequirePermission("read", "dag"), dagDetailsHandler(deps.Dags, deps.DagVersions))
+		g.GET("/:dag_id/details", RequirePermission("read", "dag"), dagDetailsHandler(deps.Dags, deps.DagVersions, deps.Specs))
 		g.PATCH("/:dag_id", RequirePermission("write", "dag"), patchDagHandler(deps.Dags))
 		g.DELETE("/:dag_id", RequirePermission("write", "dag"), deleteDagHandler(deps.Dags))
 	}

--- a/internal/api/ui_dags_test.go
+++ b/internal/api/ui_dags_test.go
@@ -27,6 +27,13 @@ func (f *fakeLatestRuns) LatestRunsForDags(_ context.Context, _ string, _ []stri
 }
 
 func uiDagsServer(dags []domain.DAG, latest *fakeLatestRuns) *gin.Engine {
+	return uiDagsServerWithSpecs(dags, latest, nil)
+}
+
+// uiDagsServerWithSpecs is uiDagsServer with a DagSpecReader wired, so the
+// details endpoint can serve declared params. A nil reader reproduces the
+// param-free wiring exactly.
+func uiDagsServerWithSpecs(dags []domain.DAG, latest *fakeLatestRuns, specs DagSpecReader) *gin.Engine {
 	return NewServer(Dependencies{
 		Logger:        discardLogger(),
 		Authenticator: &fakeAuthn{user: &auth.User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}},
@@ -34,6 +41,7 @@ func uiDagsServer(dags []domain.DAG, latest *fakeLatestRuns) *gin.Engine {
 		CORSOrigins:   []string{"*"},
 		Dags:          &fakeDagRepo{dags: dags},
 		LatestRuns:    latest,
+		Specs:         specs,
 	})
 }
 

--- a/internal/api/ui_details.go
+++ b/internal/api/ui_details.go
@@ -174,6 +174,48 @@ func toDagDetailsDTO(d domain.DAG) dagDetailsDTO {
 	}
 }
 
+// paramsToAirflowDict reshapes Leoflow's stored declared params
+// (map[name]{default, schema}) into the Airflow 3.2.1 serialized param-dict the
+// trigger dialog's flexible form renders from: {name: {value, schema,
+// description}}. Three transforms carry the whole feature:
+//   - default -> value (the form reads entry.value for the prefilled value).
+//   - a required param (no default) still emits an entry, as value:null, so the
+//     field renders and the form's required-detector flags an empty required
+//     value.
+//   - schema is carried verbatim (type/title/enum/section/description drive the
+//     widget choice and grouping); an absent schema becomes {} so the entry is
+//     well-formed.
+//
+// description is null for now — the compiled artifact does not yet carry a
+// per-param description. An empty (or nil) param map yields {}, so a param-free
+// DAG serializes exactly as before and the dialog stays JSON-only.
+func paramsToAirflowDict(params map[string]domain.ParamSpec) json.RawMessage {
+	type airflowParam struct {
+		Value       json.RawMessage `json:"value"`
+		Schema      json.RawMessage `json:"schema"`
+		Description *string         `json:"description"`
+	}
+	out := make(map[string]airflowParam, len(params))
+	for name, p := range params {
+		value := json.RawMessage("null")
+		if len(p.Default) > 0 {
+			value = p.Default
+		}
+		schema := json.RawMessage("{}")
+		if len(p.Schema) > 0 {
+			schema = p.Schema
+		}
+		out[name] = airflowParam{Value: value, Schema: schema, Description: nil}
+	}
+	raw, err := json.Marshal(out)
+	if err != nil {
+		// The inputs are already valid raw JSON, so marshaling the wrapper
+		// cannot realistically fail; degrade to {} rather than break details.
+		return json.RawMessage("{}")
+	}
+	return raw
+}
+
 // rfc3339Ptr formats a time pointer as an RFC3339 string pointer (nil-safe).
 func rfc3339Ptr(t *time.Time) *string {
 	if t == nil {
@@ -190,7 +232,7 @@ func boolPtr(b bool) *bool { return &b }
 // latest_dag_version from the version lister — the Graph view reads the
 // version_number from there to fetch version-scoped structure, so a null version
 // leaves the graph blank.
-func dagDetailsHandler(repo DagRepository, versions DagVersionLister) gin.HandlerFunc {
+func dagDetailsHandler(repo DagRepository, versions DagVersionLister, specs DagSpecReader) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		dagID := c.Param("dag_id")
 		d, err := repo.GetDag(c.Request.Context(), tenantOf(c), dagID)
@@ -199,6 +241,16 @@ func dagDetailsHandler(repo DagRepository, versions DagVersionLister) gin.Handle
 			return
 		}
 		dto := toDagDetailsDTO(d)
+		// Serve the DAG's author-declared params in Airflow's param-dict shape so
+		// the trigger dialog renders its native typed form. This read is
+		// best-effort: any spec-read failure leaves params as {} and the dialog
+		// falls back to JSON-only — details must never break on it.
+		if specs != nil {
+			if spec, serr := specs.GetCurrentSpec(c.Request.Context(), tenantOf(c), dagID); serr == nil && len(spec.Params) > 0 {
+				raw := paramsToAirflowDict(spec.Params)
+				dto.Params = &raw
+			}
+		}
 		if versions != nil {
 			if vs, verr := versions.ListDagVersions(c.Request.Context(), tenantOf(c), dagID); verr == nil && len(vs) > 0 {
 				latest := vs[0] // ListDagVersions is newest-first.

--- a/internal/api/ui_details_test.go
+++ b/internal/api/ui_details_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 
@@ -77,5 +78,133 @@ func TestDagDetailsFullShape(t *testing.T) {
 	_ = json.Unmarshal(d["timetable_description"], &desc)
 	if desc != "At 05:00, every day" {
 		t.Errorf("timetable_description = %q", desc)
+	}
+	// A DAG with no declared params (and no Specs reader) must emit params: {}
+	// exactly as before — back-compatible with the pre-params wiring.
+	if got := string(d["params"]); got != "{}" {
+		t.Errorf("param-free DAG params = %s, want {}", got)
+	}
+}
+
+// airflowParam mirrors the Airflow 3.2.1 serialized param entry the trigger
+// dialog's flexible form consumes, used to assert the mapper's exact output.
+type airflowParam struct {
+	Value       json.RawMessage `json:"value"`
+	Schema      json.RawMessage `json:"schema"`
+	Description *string         `json:"description"`
+}
+
+// paramsFixtureSpec is a DAGSpec declaring one bare-default, one typed-enum
+// (with default), and one required (no-default) param — the three shapes the
+// mapper must reshape into Airflow's {value, schema, description} form.
+func paramsFixtureSpec() domain.DAGSpec {
+	return domain.DAGSpec{
+		DagID: "etl",
+		Params: map[string]domain.ParamSpec{
+			"limit":  {Default: json.RawMessage("5")},
+			"region": {Default: json.RawMessage(`"us"`), Schema: json.RawMessage(`{"type":"string","enum":["us","eu"]}`)},
+			"token":  {Schema: json.RawMessage(`{"type":"string"}`)},
+		},
+	}
+}
+
+func TestParamsToAirflowDict(t *testing.T) {
+	raw := paramsToAirflowDict(paramsFixtureSpec().Params)
+	var got map[string]airflowParam
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("mapper output is not valid JSON: %v (%s)", err, raw)
+	}
+	if len(got) != 3 {
+		t.Fatalf("want 3 params, got %d (%s)", len(got), raw)
+	}
+
+	// bare default -> value carried, schema defaults to {}, description null.
+	if v := string(got["limit"].Value); v != "5" {
+		t.Errorf("limit.value = %s, want 5", v)
+	}
+	if s := string(got["limit"].Schema); s != "{}" {
+		t.Errorf("limit.schema = %s, want {}", s)
+	}
+	if got["limit"].Description != nil {
+		t.Errorf("limit.description = %v, want null", *got["limit"].Description)
+	}
+
+	// typed enum -> default renamed to value, schema carried verbatim.
+	if v := string(got["region"].Value); v != `"us"` {
+		t.Errorf("region.value = %s, want \"us\"", v)
+	}
+	if s := string(got["region"].Schema); s != `{"type":"string","enum":["us","eu"]}` {
+		t.Errorf("region.schema = %s", s)
+	}
+
+	// required (no default) -> value:null so the field still renders and the
+	// form's required-detector flags it; schema carried verbatim.
+	if v := string(got["token"].Value); v != "null" {
+		t.Errorf("token.value = %s, want null", v)
+	}
+	if s := string(got["token"].Schema); s != `{"type":"string"}` {
+		t.Errorf("token.schema = %s", s)
+	}
+}
+
+func TestParamsToAirflowDictEmpty(t *testing.T) {
+	if got := string(paramsToAirflowDict(nil)); got != "{}" {
+		t.Errorf("nil params -> %s, want {}", got)
+	}
+	if got := string(paramsToAirflowDict(map[string]domain.ParamSpec{})); got != "{}" {
+		t.Errorf("empty params -> %s, want {}", got)
+	}
+}
+
+// TestDagDetailsParamsShape is the durable contract guard: it drives the real
+// details handler with a DagSpecReader and asserts the exact params JSON the
+// endpoint emits for a bare-default + typed-enum + required param.
+func TestDagDetailsParamsShape(t *testing.T) {
+	srv := uiDagsServerWithSpecs(
+		[]domain.DAG{{DagID: "etl"}},
+		&fakeLatestRuns{},
+		&fakeSpecReader{spec: paramsFixtureSpec()},
+	)
+	rec := authGet(srv, http.MethodGet, "/api/v2/dags/etl/details", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("details = %d (%s)", rec.Code, rec.Body.String())
+	}
+	var d map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &d); err != nil {
+		t.Fatal(err)
+	}
+	var params map[string]airflowParam
+	if err := json.Unmarshal(d["params"], &params); err != nil {
+		t.Fatalf("params is not the Airflow param-dict shape: %v (%s)", err, d["params"])
+	}
+	if string(params["limit"].Value) != "5" || string(params["limit"].Schema) != "{}" {
+		t.Errorf("limit = %+v", params["limit"])
+	}
+	if string(params["region"].Value) != `"us"` || string(params["region"].Schema) != `{"type":"string","enum":["us","eu"]}` {
+		t.Errorf("region = %+v", params["region"])
+	}
+	if string(params["token"].Value) != "null" || string(params["token"].Schema) != `{"type":"string"}` {
+		t.Errorf("token = %+v", params["token"])
+	}
+}
+
+// TestDagDetailsParamsReadErrorFallsBack proves the details endpoint never
+// breaks on a spec-read error: it degrades to params: {} (JSON-only dialog).
+func TestDagDetailsParamsReadErrorFallsBack(t *testing.T) {
+	srv := uiDagsServerWithSpecs(
+		[]domain.DAG{{DagID: "etl"}},
+		&fakeLatestRuns{},
+		&fakeSpecReader{err: errors.New("boom")},
+	)
+	rec := authGet(srv, http.MethodGet, "/api/v2/dags/etl/details", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("details = %d (%s)", rec.Code, rec.Body.String())
+	}
+	var d map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &d); err != nil {
+		t.Fatal(err)
+	}
+	if got := string(d["params"]); got != "{}" {
+		t.Errorf("spec-read error should fall back to {}, got %s", got)
 	}
 }

--- a/test/e2e/ui-smoke.js
+++ b/test/e2e/ui-smoke.js
@@ -149,6 +149,81 @@ const CRASH_RE = /Cannot read properties|is not a function|client-side exception
     }
   });
 
+  // The typed trigger form (#798 UI half). params_demo declares a bare default,
+  // a typed enum, and a required param; the details endpoint now serves them in
+  // Airflow's {value, schema} param-dict shape, so the native trigger dialog
+  // renders a generated form AND still offers the JSON editor. Prove it against
+  // the real Lite (no route mocking): the details shape, both surfaces render,
+  // and a real form submit creates a run carrying the expected conf.
+  const paramsDag = 'params_demo';
+  const mintToken = async () => {
+    const auth = await (await page.request.post(URL + '/auth/token',
+      { data: { username: USER, password: PASS } })).json().catch(() => ({}));
+    if (!auth.access_token) throw new Error('POST /auth/token returned no access_token');
+    return auth.access_token;
+  };
+
+  await step('params DAG: /details serves typed params in Airflow shape', async () => {
+    const tok = await mintToken();
+    const det = await (await page.request.get(`${URL}/api/v2/dags/${paramsDag}/details`,
+      { headers: { Authorization: 'Bearer ' + tok } })).json().catch(() => ({}));
+    const p = det.params || {};
+    // The leoflow seam: declared params reshaped to {value, schema, description}.
+    if (!p.region || !('value' in p.region) || !p.region.schema || p.region.schema.type !== 'string') {
+      throw new Error('region not served as {value, schema:{type}} (params wiring): ' + JSON.stringify(p.region));
+    }
+    if (!('run_label' in p) || p.run_label.value !== null) {
+      throw new Error('required param run_label should serve value:null: ' + JSON.stringify(p.run_label));
+    }
+  });
+
+  await step('trigger dialog: generated form + JSON editor both render', async () => {
+    await page.goto(`${URL}/dags/${paramsDag}`, { waitUntil: 'networkidle' });
+    const trig = page.getByRole('button', { name: /^trigger/i }).first();
+    if (!(await trig.count())) throw new Error('no Trigger button on the params DAG page');
+    await trig.click({ timeout: 5000 });
+    await page.waitForTimeout(1000);
+    // (a) a generated form field for a declared param (the enum "Region" or the
+    //     required "Run label") — proves the declared params drove the flexible form.
+    if (!(await page.getByText(/Run label|Region/i).first().count())) {
+      throw new Error('no generated form field rendered from declared params');
+    }
+    // (b) the JSON editor is still offered (form + JSON coexist — the "both" requirement).
+    if (!(await page.getByText(/Configuration JSON|Advanced Options/i).first().count())) {
+      throw new Error('Configuration JSON editor not offered alongside the form');
+    }
+  });
+
+  await step('trigger form: submit creates a run with the expected conf', async () => {
+    const tok = await mintToken();
+    const label = 'smoke-' + Date.now();
+    // Fill the required field (label = the param's title), then submit via the
+    // dialog's Trigger button. A missing required value would 400 server-side and
+    // create no run, so a created run proves the form fed a valid conf through.
+    const input = page.getByLabel(/Run label/i).first();
+    if (await input.count()) {
+      await input.fill(label).catch(() => {});
+    } else {
+      // Fallback: the first empty textbox inside the open dialog.
+      await page.getByRole('textbox').first().fill(label).catch(() => {});
+    }
+    await page.getByRole('button', { name: /^trigger$/i }).last().click({ timeout: 5000 }).catch(() => {});
+    // Poll for a run whose conf carries our unique label (order-independent).
+    let created = null;
+    for (let i = 0; i < 20 && !created; i++) {
+      await page.waitForTimeout(1000);
+      const runs = await (await page.request.get(`${URL}/api/v2/dags/${paramsDag}/dagRuns?limit=100`,
+        { headers: { Authorization: 'Bearer ' + tok } })).json().catch(() => ({}));
+      created = (runs.dag_runs || []).find((r) => r && r.conf && r.conf.run_label === label);
+    }
+    if (!created) throw new Error('form submit did not create a run carrying the submitted run_label conf');
+    // The v0.4.1 backend merges declared defaults under the conf, so the untouched
+    // enum defaults to "us" — the form is a faithful preview of what's enforced.
+    if (created.conf.region !== 'us') {
+      throw new Error('declared default region=us not materialized into conf: ' + JSON.stringify(created.conf));
+    }
+  });
+
   await browser.close();
 
   const failed = results.filter((r) => r.bad);

--- a/test/e2e/ui-smoke.js
+++ b/test/e2e/ui-smoke.js
@@ -200,13 +200,18 @@ const CRASH_RE = /Cannot read properties|is not a function|client-side exception
     // Fill the required field (label = the param's title), then submit via the
     // dialog's Trigger button. A missing required value would 400 server-side and
     // create no run, so a created run proves the form fed a valid conf through.
-    const input = page.getByLabel(/Run label/i).first();
-    if (await input.count()) {
-      await input.fill(label).catch(() => {});
-    } else {
-      // Fallback: the first empty textbox inside the open dialog.
-      await page.getByRole('textbox').first().fill(label).catch(() => {});
-    }
+    // Airflow's FlexibleForm names each generated param field input
+    // `element_<param>`. For a plain-string field it renders the <label> with a
+    // generated `for` id that does NOT match the input's own id
+    // (id="element_run_label"), so the accessible-name association is broken and
+    // getByLabel(/Run label/) resolves nothing — and a generic first-textbox
+    // fallback lands on the logical-date picker (a datetime-local), leaving the
+    // required run_label empty so the dialog's Trigger button stays disabled and no
+    // run is ever created. Target the field by its stable, param-specific name; keep
+    // the label lookup first so a future Airflow that fixes the association still works.
+    let input = page.getByLabel(/Run label/i).first();
+    if (!(await input.count())) input = page.locator('input[name="element_run_label"]');
+    await input.fill(label);
     await page.getByRole('button', { name: /^trigger$/i }).last().click({ timeout: 5000 }).catch(() => {});
     // Poll for a run whose conf carries our unique label (order-independent).
     let created = null;


### PR DESCRIPTION
## What / why

This is the **UI half** of #798. The backend/required half — required-param enforcement and JSON-Schema validation of run conf — already shipped in v0.4.1; this makes those declared params *visible and editable before submit* instead of a 400 after a hand-edited JSON blob.

**One-line wiring root cause:** the embedded Airflow 3.2.1 SPA already contains a complete trigger dialog (a generated form *and* a Monaco JSON editor), but it rendered no form for leoflow because `GET /api/v2/dags/{dag_id}/details` hardcoded `params: {}` — the handler worked off `domain.DAG` (which carries no params) and was never given a `DagSpecReader`, so the form had nothing to iterate.

**Verdict A (API-shape wiring) — no SPA/bundle change.** Thread the existing `deps.Specs` reader into the details handler and map the DAG's stored params into Airflow's serialized param-dict shape.

## Shape mapping

leoflow stores `{name: {default, schema}}`; the SPA's flexible form consumes `{name: {value, schema, description}}`. `paramsToAirflowDict`:

- `default` → `value`
- required param (no `default`) → `value: null` (so the field renders and the required-detector flags it)
- `schema` carried verbatim (`type`/`title`/`enum`/`section` drive the widgets)
- `description` → `null` for now (not yet captured by the compiler)
- param-free DAG (and all of Lite) → `{}` exactly as before (back-compat)
- spec-read error is **non-fatal**: details falls back to `{}` and the dialog degrades to JSON-only, never breaks

Because this is Airflow's own dialog, wiring the shape unlocks **both** the typed form **and** the JSON editor natively — no bundle fork. The form's submit feeds the same v0.4.1 merge/validate path, so the form is a faithful preview of what the server enforces.

## Tests

- **Go shape guard (durable regression test — shape is the real risk):** `TestParamsToAirflowDict` (pure mapper table test: bare default, typed enum, required→`value:null`), `TestParamsToAirflowDictEmpty`, and a handler-contract test `TestDagDetailsParamsShape` asserting the exact `params` JSON the endpoint emits for a bare-default + typed-enum + required param. `TestDagDetailsParamsReadErrorFallsBack` proves the non-fatal fallback. `TestDagDetailsFullShape` now also asserts the param-free `{}`.
- **ui-smoke (real-backend Playwright, no route mocking):** extends `test/e2e/ui-smoke.js` (the existing `playwright-core` + Chromium harness driving a live Lite) to open the trigger dialog on the params DAG and assert (a) a generated form field renders, (b) the Configuration JSON editor is still offered, (c) a real form submit creates a run whose conf carries the submitted `run_label` and the merged default `region=us`. The `ui-smoke` CI job registers the fixture DAG into the Lite workspace.
- **Fixture:** `examples/params_demo` declares a bare default, a typed enum, and a required param — doubles as a user-facing example. Verified it compiles to the expected `{default, schema}` shape through the real parser.

## Gates

- `go test ./...` — green.
- `golangci-lint run ./...` — clean for all changed files (mapper package `internal/api` = 0 issues).
- ui-smoke not run locally (needs Docker/Postgres like `leoflow lite`); the extension + fixture are in place and the `ui-smoke` CI job will exercise them against a real Lite.

Refs #798.