### PR TITLE
SSO hardening: close break-glass bypass, fix #826 dotted keys, tenant-mismatch reject, OTLP default

### DIFF
--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -81,6 +81,23 @@ func main() {
 	}
 }
 
+// openVerifiedPostgres opens the pool and fails fast when the schema is not
+// current, with an actionable message — instead of booting and erroring at the
+// first query against a missing/old table. The check is a read-only SELECT, so it
+// works for the migration-less role:api (ADR 0049); the blessed Helm path applies
+// migrations in a pre-install/upgrade Job before any role starts.
+func openVerifiedPostgres(ctx context.Context, cfg config.DatabaseSection) (*storage.Postgres, error) {
+	pg, err := storage.NewPostgres(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if serr := pg.CheckSchemaCurrent(ctx); serr != nil {
+		pg.Close()
+		return nil, serr
+	}
+	return pg, nil
+}
+
 func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -105,7 +122,7 @@ func run() error {
 	}
 	defer shutdownTel()
 
-	pg, err := storage.NewPostgres(ctx, cfg.Database)
+	pg, err := openVerifiedPostgres(ctx, cfg.Database)
 	if err != nil {
 		return fmt.Errorf("postgres: %w", err)
 	}

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -556,6 +556,7 @@ func buildAPIServer(cfg *config.ServerConfig, tel *observability.Telemetry, auth
 		// OIDC/SSO login flow (nil in JWT mode → routes not registered). The repo
 		// resolves/JIT-provisions identities and records auth-event audit.
 		OIDCFlow:     oidcFlow,
+		OIDCEnabled:  cfg.Auth.Provider == config.AuthProviderOIDC,
 		OIDCSettings: cfg.Auth.OIDC,
 		OIDCUsers:    repo,
 		AuthAudit:    repo,

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -50,6 +50,23 @@ func (b *breakGlass) allows(email string) bool {
 	return b.emails[strings.ToLower(strings.TrimSpace(email))]
 }
 
+// rateLimitByIP is a gin middleware that caps requests per client IP against its
+// own limiter. It backs the OIDC login/callback endpoints (which otherwise had no
+// rate limit), on a limiter separate from the /auth/token one so OIDC traffic and
+// password-login lockouts never contaminate each other's budget.
+func rateLimitByIP(limiter *auth.RateLimiter) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ip := c.ClientIP()
+		if limiter.Blocked(ip) {
+			AbortProblem(c, http.StatusTooManyRequests, "rate limited",
+				"too many requests; wait about a minute and try again")
+			return
+		}
+		limiter.Allow(ip)
+		c.Next()
+	}
+}
+
 type tokenRequest struct {
 	Username string `json:"username" binding:"required"`
 	Password string `json:"password" binding:"required"`

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -28,11 +28,14 @@ type breakGlass struct {
 	audit  AuthAuditWriter
 }
 
-// newBreakGlass builds the gate from the allowlist. It returns nil for an empty
-// allowlist so the caller keeps the ungated behavior (JWT mode, or an OIDC
-// deployment that configured no break-glass account).
-func newBreakGlass(emails []string, audit AuthAuditWriter) *breakGlass {
-	if len(emails) == 0 {
+// newBreakGlass builds the gate from the allowlist. In JWT mode (oidcEnabled
+// false) the credential path is the primary auth, so an empty allowlist returns
+// nil (ungated) — break-glass is an OIDC concept. Under OIDC it ALWAYS gates: an
+// empty allowlist yields a gate that admits no one, i.e. SSO-only (every password
+// login rejected). Returning nil for OIDC + empty was the bypass — POST
+// /auth/token stayed fully open for every password user (e.g. the seeded admin).
+func newBreakGlass(emails []string, audit AuthAuditWriter, oidcEnabled bool) *breakGlass {
+	if len(emails) == 0 && !oidcEnabled {
 		return nil
 	}
 	set := make(map[string]bool, len(emails))

--- a/internal/api/oidc_breakglass_test.go
+++ b/internal/api/oidc_breakglass_test.go
@@ -38,8 +38,27 @@ func breakGlassServer(allow []string, authn auth.Authenticator, audit AuthAuditW
 		CORSOrigins:   []string{"*"},
 		TokenTTLSecs:  3600,
 		AuthAudit:     audit,
+		OIDCEnabled:   true,
 		OIDCSettings:  config.OIDCSection{BreakGlassEmails: allow},
 	})
+}
+
+// Under OIDC, an EMPTY break-glass allowlist must mean SSO-only: every password
+// login is rejected. The bug (ADR 0060 sibling / #826 companion): newBreakGlass
+// returned nil for an empty list, leaving POST /auth/token fully open for every
+// password user (e.g. the seeded admin) — the exact bypass SSO exists to close.
+func TestBreakGlassOIDCEmptyAllowlistDeniesAllPasswordLogins(t *testing.T) {
+	authn := emailPassAuthn{email: "admin@corp.example", pass: "right"}
+	audit := &fakeAuthAudit{}
+	srv := breakGlassServer(nil, authn, audit) // OIDC mode, empty allowlist
+
+	rec := do(srv, http.MethodPost, "/auth/token", `{"username":"admin@corp.example","password":"right"}`)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("password login under OIDC with empty allowlist = %d, want 401 (SSO-only)", rec.Code)
+	}
+	if !audit.has(auditBreakGlass, "denied") {
+		t.Error("SSO-only denial was not audited")
+	}
 }
 
 func TestBreakGlassAllowsOnlyAllowlistedEmail(t *testing.T) {

--- a/internal/api/oidc_flow_test.go
+++ b/internal/api/oidc_flow_test.go
@@ -249,6 +249,19 @@ func (a *fakeAuthAudit) has(action, outcome string) bool {
 	return false
 }
 
+// hasReason reports whether a "denied" event for action carries the given reason
+// in its extra metadata.
+func (a *fakeAuthAudit) hasReason(action, reason string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, e := range a.events {
+		if e.action == action && e.outcome == "denied" && e.extra["reason"] == reason {
+			return true
+		}
+	}
+	return false
+}
+
 // ─────────────────────────── harness ───────────────────────────
 
 const testHS256Secret = "oidc-flow-test-secret"
@@ -427,6 +440,32 @@ func TestOIDCHappyPathResolvesUserAndMintsSession(t *testing.T) {
 	}
 	if !audit.has(auditOIDCLoginSuccess, "success") {
 		t.Error("login success was not audited")
+	}
+}
+
+// A returning user whose STORED tenant differs from the claim-derived tenant must
+// be rejected — never mint a session against a tenant the stored row does not
+// belong to. Not reachable under a pinned single-tenant issuer, but an explicit
+// reject is defense-in-depth (the returning path previously trusted the
+// claim-derived tenant and discarded the stored one).
+func TestOIDCReturningUserTenantMismatchRejected(t *testing.T) {
+	f := newFakeIDP(t)
+	cfg := baseOIDCConfig(f)
+	store := newFakeOIDCStore()
+	store.seed(cfg.Issuer, "subject-123", &auth.User{ID: "user-1", TenantID: "other-tenant", Email: "alice@corp.example", Roles: []string{"editor"}}, true)
+	audit := &fakeAuthAudit{}
+	srv := oidcServer(t, f, cfg, store, audit, nil)
+
+	rec := driveCallback(t, srv, f, cfg, nil)
+
+	if rec.Code == http.StatusFound {
+		t.Fatal("callback minted a session for a tenant-mismatched returning user; want rejection")
+	}
+	if sessionCookie(rec) != nil {
+		t.Error("no session cookie must be set on tenant mismatch")
+	}
+	if !audit.hasReason(auditOIDCLoginFailure, "tenant_mismatch") {
+		t.Error("tenant mismatch was not audited with reason=tenant_mismatch")
 	}
 }
 

--- a/internal/api/oidc_flow_test.go
+++ b/internal/api/oidc_flow_test.go
@@ -469,6 +469,26 @@ func TestOIDCReturningUserTenantMismatchRejected(t *testing.T) {
 	}
 }
 
+// The OIDC login endpoint is rate-limited per client IP (its own limiter, so it
+// never contaminates the /auth/token budget). The 31st request within the window
+// is refused with 429.
+func TestOIDCLoginRateLimited(t *testing.T) {
+	f := newFakeIDP(t)
+	cfg := baseOIDCConfig(f)
+	srv := oidcServer(t, f, cfg, newFakeOIDCStore(), &fakeAuthAudit{}, nil)
+
+	var last int
+	for i := 0; i < 31; i++ {
+		last = do(srv, http.MethodGet, "/api/v2/auth/oidc/login", "").Code
+		if i == 0 && last == http.StatusTooManyRequests {
+			t.Fatal("first OIDC login request was rate-limited")
+		}
+	}
+	if last != http.StatusTooManyRequests {
+		t.Errorf("31st OIDC login request = %d, want 429", last)
+	}
+}
+
 // ─────────────────────────── H1: tenant pin ───────────────────────────
 
 func TestOIDCTenantPinFailsClosed(t *testing.T) {

--- a/internal/api/oidc_handler.go
+++ b/internal/api/oidc_handler.go
@@ -223,7 +223,16 @@ func (d oidcDeps) resolveUser(c *gin.Context, id *oidc.VerifiedIdentity) (*auth.
 			d.deny(c, auditOIDCLoginFailure, id.Tenant, user.ID, id.Email, "inactive")
 			return nil, errRejected
 		}
-		resolved = &auth.User{ID: user.ID, TenantID: id.Tenant, Email: id.Email, Roles: loginRoles}
+		// Defense-in-depth (H1 residual): never mint a session against a tenant the
+		// stored user does not belong to. Unreachable under a pinned single-tenant
+		// issuer (the attacker cannot alter tid/hd), but trusting the claim-derived
+		// tenant while discarding the stored one is a latent confused-deputy path;
+		// reject a mismatch explicitly and bind the session to the stored tenant.
+		if user.TenantID != id.Tenant {
+			d.deny(c, auditOIDCLoginFailure, id.Tenant, user.ID, id.Email, "tenant_mismatch")
+			return nil, errRejected
+		}
+		resolved = &auth.User{ID: user.ID, TenantID: user.TenantID, Email: id.Email, Roles: loginRoles}
 	case errors.Is(err, auth.ErrUserNotFound):
 		resolved, err = d.jitProvision(c, id, loginRoles)
 		if err != nil {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -119,6 +119,10 @@ type Dependencies struct {
 	// OIDCFlow is the discovered Authorization Code + PKCE flow; nil in JWT mode,
 	// in which case the /api/v2/auth/oidc/* routes are not registered.
 	OIDCFlow *oidc.Flow
+	// OIDCEnabled is true when auth.provider is "oidc". It makes the credential
+	// path break-glass-only: with OIDC on, an empty break-glass allowlist means
+	// SSO-only (every password login rejected), NOT ungated — the secure default.
+	OIDCEnabled bool
 	// OIDCSettings carries the role mappings, JIT policy, default_role, and
 	// break-glass allowlist the login flow and the credential gate read.
 	OIDCSettings config.OIDCSection
@@ -171,10 +175,11 @@ func NewServer(deps Dependencies) *gin.Engine {
 	// public API/UI surface. deps.Registry is retained for that listener's wiring.
 	registerDocs(r)
 
-	// Under OIDC the credential path is break-glass-only (D8): pass the allowlist
-	// so every non-allowlisted password login is rejected and audited. In JWT mode
-	// the allowlist is empty, newBreakGlass returns nil, and the path is unchanged.
-	bg := newBreakGlass(deps.OIDCSettings.BreakGlassEmails, deps.AuthAudit)
+	// Under OIDC the credential path is break-glass-only (D8): every non-allowlisted
+	// password login is rejected and audited, and an EMPTY allowlist means SSO-only
+	// (all password logins rejected) — not ungated. In JWT mode the credential path
+	// is the primary auth, so newBreakGlass returns nil (unchanged).
+	bg := newBreakGlass(deps.OIDCSettings.BreakGlassEmails, deps.AuthAudit, deps.OIDCEnabled)
 	r.POST("/auth/token", authTokenHandler(deps.Authenticator, deps.RateLimiter, deps.TokenTTLSecs, bg))
 	// Transparent renewal (aresta #5): a still-valid bearer is re-minted with a
 	// fresh short TTL, bounded by max_lifetime. Under the public /api/v2/auth/

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -194,8 +194,11 @@ func NewServer(deps Dependencies) *gin.Engine {
 	// OIDC/SSO login flow (D1): registered only when a provider was discovered at
 	// boot. Both routes sit under the public /api/v2/auth/ prefix.
 	if deps.OIDCFlow != nil {
-		r.GET("/api/v2/auth/oidc/login", oidcLoginHandler(deps.OIDCFlow, deps.Logger))
-		r.GET("/api/v2/auth/oidc/callback", oidcCallbackHandler(oidcDeps{
+		// Rate-limit the OIDC endpoints on their own per-IP limiter (separate from
+		// the /auth/token budget), bounding state-generation / callback spam.
+		oidcLimiter := auth.NewRateLimiter(30, time.Minute)
+		r.GET("/api/v2/auth/oidc/login", rateLimitByIP(oidcLimiter), oidcLoginHandler(deps.OIDCFlow, deps.Logger))
+		r.GET("/api/v2/auth/oidc/callback", rateLimitByIP(oidcLimiter), oidcCallbackHandler(oidcDeps{
 			flow:      deps.OIDCFlow,
 			users:     deps.OIDCUsers,
 			audit:     deps.AuthAudit,

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -3,9 +3,11 @@ package config
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -722,6 +724,17 @@ func LoadServer(configFile string, flags *pflag.FlagSet) (*ServerConfig, error) 
 // fields are tagged mapstructure:"-", so viper never touches them; this is their
 // only decode path. A file viper already read as YAML re-parses cleanly here.
 func decodeDottedOIDCMaps(configFile string, c *ServerConfig) error {
+	// The out-of-band decode is YAML (JSON is a YAML subset). A non-YAML config
+	// (e.g. TOML) is read by viper but not here — skip rather than hard-fail its
+	// boot; those maps then come back empty (OIDC tenant pinning fails closed).
+	// Production config is YAML (Helm ConfigMap), so this is a narrow edge.
+	switch strings.ToLower(filepath.Ext(configFile)) {
+	case ".yaml", ".yml", ".json", "":
+	default:
+		slog.Warn("dotted OIDC map keys (tenant_claims/role_mappings) are only decoded from YAML/JSON config; skipping for this format",
+			"config_file", configFile)
+		return nil
+	}
 	data, err := os.ReadFile(configFile)
 	if err != nil {
 		return fmt.Errorf("reading config file %q for OIDC maps: %w", configFile, err)

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 )
 
 // ServerConfig is the full configuration for the leoflow-server control plane.
@@ -445,7 +447,12 @@ type OIDCSection struct {
 	// RoleMappings maps an IdP group value to an existing Leoflow role name.
 	// Default-DENY: a group with no mapping grants no role. Configure via the
 	// config file / Helm values (maps do not bind from a single env var).
-	RoleMappings map[string]string `mapstructure:"role_mappings"`
+	//
+	// Decoded OUT-OF-BAND (mapstructure:"-"), not by viper: viper's "." key
+	// delimiter splits a dotted MAP KEY (a dotted IdP group like "app.admins")
+	// into nested maps and fails to decode. LoadServer parses this map straight
+	// from the raw YAML instead (#826). Env-var binding never applied to maps.
+	RoleMappings map[string]string `mapstructure:"-"`
 	// DefaultRole softens the default-deny WITHOUT weakening the secure default:
 	// when an authenticated user resolves to zero mapped roles and DefaultRole is
 	// set, they are granted this single role (operators are advised to use a
@@ -458,7 +465,13 @@ type OIDCSection struct {
 	TenantClaim string `mapstructure:"tenant_claim"`
 	// TenantClaims maps a TenantClaim value to a Leoflow tenant name. A value not
 	// present here is rejected (403) — the login never falls back to "default".
-	TenantClaims map[string]string `mapstructure:"tenant_claims"`
+	//
+	// Decoded OUT-OF-BAND (mapstructure:"-"), not by viper: a Google Workspace
+	// `hd` value is a domain (always dotted, e.g. "example.com" or
+	// "sub.example.co.uk"), which viper's "." delimiter would split into nested
+	// maps and fail to decode — the #826 crash. LoadServer parses this map from
+	// the raw YAML instead.
+	TenantClaims map[string]string `mapstructure:"-"`
 	// AllowedEmailDomains is an install-time, login-level allowlist layered on TOP
 	// of the tid/hd tenant pin — it is NOT the pin itself (that stays issuer +
 	// tid/hd + email_verified per D6). The check runs only AFTER the pin and
@@ -572,20 +585,24 @@ var serverDefaults = map[string]any{
 	// is what bounds a stolen token. Parsed as a duration by viper's decode hook.
 	"auth.max_attempt_credential_lifetime": "24h",
 	// OIDC leaves. Every leaf is registered so viper's AutomaticEnv binds the
-	// scalar LEOFLOW_AUTH_OIDC_* env vars (notably the client secret). The map and
-	// slice leaves are config-file / Helm-values driven — viper does not split a
-	// single env var into a map or list — but they must appear here so Unmarshal
-	// resolves them from the file.
+	// scalar LEOFLOW_AUTH_OIDC_* env vars (notably the client secret). The slice
+	// leaves are config-file / Helm-values driven — viper does not split a single
+	// env var into a list — but they must appear here so Unmarshal resolves them
+	// from the file.
+	//
+	// The two maps (role_mappings, tenant_claims) are deliberately NOT registered
+	// here and are tagged mapstructure:"-": their KEYS can contain dots (a Google
+	// `hd` domain, a dotted IdP group), which viper's "." delimiter would split
+	// into nested maps and fail to decode (#826). LoadServer decodes them straight
+	// from the raw YAML instead.
 	"auth.oidc.issuer":                "",
 	"auth.oidc.client_id":             "",
 	"auth.oidc.client_secret":         "",
 	"auth.oidc.redirect_url":          "",
 	"auth.oidc.scopes":                []string{"openid", "email", "profile"},
 	"auth.oidc.groups_claim":          "groups",
-	"auth.oidc.role_mappings":         map[string]string{},
 	"auth.oidc.default_role":          "",
 	"auth.oidc.tenant_claim":          "",
-	"auth.oidc.tenant_claims":         map[string]string{},
 	"auth.oidc.allowed_email_domains": []string{},
 	"auth.oidc.break_glass_emails":    []string{},
 	"auth.oidc.jit_provisioning":      false,
@@ -643,7 +660,7 @@ var serverDefaults = map[string]any{
 	"logs.sink.access_key_id":            "",
 	"logs.sink.secret_access_key":        "",
 	"logs.sink.credentials_file":         "",
-	"observability.otel.enabled":         true,
+	"observability.otel.enabled":         false,
 	"observability.otel.endpoint":        "localhost:4317",
 	"observability.log_level":            "info",
 	"observability.log_format":           "json",
@@ -689,7 +706,40 @@ func LoadServer(configFile string, flags *pflag.FlagSet) (*ServerConfig, error) 
 	if err := v.Unmarshal(&c); err != nil {
 		return nil, fmt.Errorf("unmarshaling server config: %w", err)
 	}
+	// The OIDC role_mappings / tenant_claims maps are decoded straight from the
+	// raw YAML, bypassing viper's "." key-delimiter flattening that would split a
+	// dotted map key (a Google `hd` domain, a dotted IdP group) and fail (#826).
+	if configFile != "" {
+		if err := decodeDottedOIDCMaps(configFile, &c); err != nil {
+			return nil, err
+		}
+	}
 	return &c, nil
+}
+
+// decodeDottedOIDCMaps reads the OIDC maps whose KEYS may contain dots directly
+// from the raw YAML config, so a dotted key survives verbatim (#826). These
+// fields are tagged mapstructure:"-", so viper never touches them; this is their
+// only decode path. A file viper already read as YAML re-parses cleanly here.
+func decodeDottedOIDCMaps(configFile string, c *ServerConfig) error {
+	data, err := os.ReadFile(configFile)
+	if err != nil {
+		return fmt.Errorf("reading config file %q for OIDC maps: %w", configFile, err)
+	}
+	var raw struct {
+		Auth struct {
+			OIDC struct {
+				RoleMappings map[string]string `yaml:"role_mappings"`
+				TenantClaims map[string]string `yaml:"tenant_claims"`
+			} `yaml:"oidc"`
+		} `yaml:"auth"`
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("decoding OIDC maps from config file %q: %w", configFile, err)
+	}
+	c.Auth.OIDC.RoleMappings = raw.Auth.OIDC.RoleMappings
+	c.Auth.OIDC.TenantClaims = raw.Auth.OIDC.TenantClaims
+	return nil
 }
 
 // Auth providers (auth.provider allowlist). "jwt" is the default credential

--- a/internal/config/server_test.go
+++ b/internal/config/server_test.go
@@ -27,7 +27,7 @@ func TestLoadServerAppliesDefaults(t *testing.T) {
 		// Default is sync passthrough (#127): Pro deployments opt in via values.yaml.
 		"scheduler.dispatch.buffer_size": {c.Scheduler.Dispatch.BufferSize, 0},
 		"scheduler.dispatch.workers":     {c.Scheduler.Dispatch.Workers, 0},
-		"otel.enabled":                   {c.Observability.OTel.Enabled, true},
+		"otel.enabled":                   {c.Observability.OTel.Enabled, false},
 		"log_level":                      {c.Observability.LogLevel, "info"},
 		"log_format":                     {c.Observability.LogFormat, "json"},
 	}
@@ -499,5 +499,45 @@ func TestValidateLogsBackend(t *testing.T) {
 				t.Errorf("backend %q bucket %q: Validate() = %v, want nil", tc.backend, tc.bucket, err)
 			}
 		})
+	}
+}
+
+// TestLoadServerDottedOIDCMapKeys locks the fix for #826: a MAP KEY containing
+// dots (Google Workspace `hd` = a domain; a dotted IdP group name) must survive
+// config decoding. viper's key delimiter is ".", so without the empty-map
+// defaults registered in serverDefaults the key `example.com` is flattened into
+// nested maps and fails to decode into map[string]string. This is a regression
+// lock: if someone removes those "unused" defaults, this test goes red before the
+// bug reaches a user (it manifests only as a rejected Google/Okta login).
+func TestLoadServerDottedOIDCMapKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	yaml := `
+auth:
+  jwt:
+    secret: "test-secret"
+  oidc:
+    tenant_claim: hd
+    tenant_claims:
+      "example.com": acme
+      "sub.example.co.uk": acme
+    role_mappings:
+      "app.admins": admin
+`
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	c, err := LoadServer(path, nil)
+	if err != nil {
+		t.Fatalf("LoadServer with dotted OIDC map keys errored (#826 regression): %v", err)
+	}
+	if got := c.Auth.OIDC.TenantClaims["example.com"]; got != "acme" {
+		t.Errorf("tenant_claims[example.com] = %q, want acme (dotted key was split)", got)
+	}
+	if got := c.Auth.OIDC.TenantClaims["sub.example.co.uk"]; got != "acme" {
+		t.Errorf("tenant_claims[sub.example.co.uk] = %q, want acme (multi-dot key was split)", got)
+	}
+	if got := c.Auth.OIDC.RoleMappings["app.admins"]; got != "admin" {
+		t.Errorf("role_mappings[app.admins] = %q, want admin (dotted group was split)", got)
 	}
 }

--- a/internal/oidc/verify.go
+++ b/internal/oidc/verify.go
@@ -45,6 +45,14 @@ var (
 	// ErrNoSubject is returned when the ID token carries no subject — there is no
 	// stable identity to key on.
 	ErrNoSubject = errors.New("oidc: token has no subject")
+	// ErrGroupOverage signals the IdP omitted the groups claim and returned a
+	// _claim_names overage pointer instead (Azure Entra does this past ~200 group
+	// memberships). Silently treating that as "no groups" would demote a heavily-
+	// grouped user (often the most privileged) to default-deny / default_role with
+	// no signal, so it fails closed with an actionable message: configure Entra
+	// app roles (the "roles" claim) or narrow group membership. Full app-role
+	// resolution is the EKS-validated follow-up.
+	ErrGroupOverage = errors.New("oidc: group claim overage (IdP returned a _claim_names pointer, not the groups) — configure Entra app roles or the groups scope")
 )
 
 // VerifiedIdentity is the result of a fully-checked ID token: a trustworthy
@@ -277,6 +285,15 @@ func extractGroups(idToken *gooidc.IDToken, claimName string) ([]string, error) 
 	}
 	switch v := raw[claimName].(type) {
 	case nil:
+		// The claim is absent. Distinguish a genuine no-groups token from an Entra
+		// group-overage, where the IdP omits `groups` and points to it under
+		// `_claim_names` — treating the latter as "no groups" would silently
+		// deny/demote a heavily-grouped (often privileged) user. Fail closed.
+		if names, ok := raw["_claim_names"].(map[string]any); ok {
+			if _, overage := names[claimName]; overage {
+				return nil, ErrGroupOverage
+			}
+		}
 		return nil, nil
 	case string:
 		if v == "" {

--- a/internal/oidc/verify_test.go
+++ b/internal/oidc/verify_test.go
@@ -529,3 +529,24 @@ func TestVerifyExtractGroups(t *testing.T) {
 		}
 	})
 }
+
+// TestVerifyGroupOverage: an Azure Entra group-overage token omits the groups
+// claim and points to it under _claim_names. It must fail closed (ErrGroupOverage),
+// not be silently treated as "no groups" — which would demote a heavily-grouped,
+// often-privileged user to default-deny with no signal.
+func TestVerifyGroupOverage(t *testing.T) {
+	f := newFakeIDP(t)
+	cfg := baseOIDCConfig(f)
+	v := newTestVerifier(t, cfg)
+	claims := baseClaims(cfg, testNonce)
+	delete(claims, "groups")
+	// A well-formed Entra overage token: _claim_names points groups at a source,
+	// _claim_sources describes it (a Graph endpoint we deliberately never call).
+	claims["_claim_names"] = map[string]any{"groups": "src1"}
+	claims["_claim_sources"] = map[string]any{"src1": map[string]any{"endpoint": "https://graph.microsoft.com/v1.0/users/x/getMemberObjects"}}
+
+	_, err := v.Verify(context.Background(), f.signIDToken(t, claims), testNonce)
+	if !errors.Is(err, ErrGroupOverage) {
+		t.Fatalf("Verify with group overage = %v, want ErrGroupOverage", err)
+	}
+}

--- a/internal/storage/schema_check.go
+++ b/internal/storage/schema_check.go
@@ -1,0 +1,75 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/neochaotic/leoflow/migrations"
+)
+
+// errSchemaNotCurrent is the sentinel for a boot-time schema mismatch, so callers
+// can recognize it distinctly from a transient DB error.
+var errSchemaNotCurrent = errors.New("database schema is not current")
+
+// SchemaVersion reads the applied migration version from golang-migrate's
+// schema_migrations table. exists is false when the table is absent (migrations
+// never ran). It issues only a SELECT, so it is compatible with the read-only
+// role:api DB identity (ADR 0049), which skips migrations by design.
+func (p *Postgres) SchemaVersion(ctx context.Context) (version uint, dirty, exists bool, err error) {
+	var v int64
+	var d bool
+	row := p.Pool.QueryRow(ctx, "SELECT version, dirty FROM schema_migrations LIMIT 1")
+	if scanErr := row.Scan(&v, &d); scanErr != nil {
+		// An absent table (42P01 undefined_table) means migrations never ran — a
+		// legible "exists=false", not a hard error. Anything else is a real fault.
+		var pgErr *pgconn.PgError
+		if errors.As(scanErr, &pgErr) && pgErr.Code == "42P01" {
+			return 0, false, false, nil
+		}
+		return 0, false, false, scanErr
+	}
+	if v < 0 {
+		return 0, false, false, fmt.Errorf("schema_migrations.version is negative (%d)", v)
+	}
+	// #nosec G115 -- a migration version is a small, non-negative counter.
+	return uint(v), d, true, nil
+}
+
+// checkSchemaCurrent fails fast when the database schema does not match the
+// binary's embedded latest migration, with an actionable message — instead of
+// booting and erroring at the first query against a missing/old table.
+func checkSchemaCurrent(dbVersion uint, exists, dirty bool, latest uint) error {
+	switch {
+	case !exists:
+		return fmt.Errorf("%w: schema_migrations is absent — migrations have not run (apply them: the Helm migration Job, or `leoflow migrate`); schema v%d is required",
+			errSchemaNotCurrent, latest)
+	case dirty:
+		return fmt.Errorf("%w: schema is dirty at v%d — a migration did not complete; resolve it before starting",
+			errSchemaNotCurrent, dbVersion)
+	case dbVersion < latest:
+		return fmt.Errorf("%w: schema is at v%d but this binary requires v%d — run the pending migrations (the Helm migration Job, or `leoflow migrate`)",
+			errSchemaNotCurrent, dbVersion, latest)
+	case dbVersion > latest:
+		return fmt.Errorf("%w: schema is at v%d, ahead of this binary's v%d — this server is older than the database; deploy a matching or newer build",
+			errSchemaNotCurrent, dbVersion, latest)
+	default:
+		return nil
+	}
+}
+
+// CheckSchemaCurrent reads the DB schema version and compares it to the binary's
+// embedded latest, failing fast on a mismatch. Called at boot after the pool is
+// open, before the server serves.
+func (p *Postgres) CheckSchemaCurrent(ctx context.Context) error {
+	latest, err := migrations.Latest()
+	if err != nil {
+		return fmt.Errorf("reading embedded schema version: %w", err)
+	}
+	version, dirty, exists, err := p.SchemaVersion(ctx)
+	if err != nil {
+		return fmt.Errorf("reading database schema version: %w", err)
+	}
+	return checkSchemaCurrent(version, exists, dirty, latest)
+}

--- a/internal/storage/schema_check.go
+++ b/internal/storage/schema_check.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/neochaotic/leoflow/migrations"
@@ -43,18 +44,21 @@ func (p *Postgres) SchemaVersion(ctx context.Context) (version uint, dirty, exis
 func checkSchemaCurrent(dbVersion uint, exists, dirty bool, latest uint) error {
 	switch {
 	case !exists:
-		return fmt.Errorf("%w: schema_migrations is absent — migrations have not run (apply them: the Helm migration Job, or `leoflow migrate`); schema v%d is required",
+		return fmt.Errorf("%w: schema_migrations is absent — migrations have not run (apply them: the Helm pre-upgrade migration Job, or `leoflow db migrate` for Lite); schema v%d is required",
 			errSchemaNotCurrent, latest)
 	case dirty:
 		return fmt.Errorf("%w: schema is dirty at v%d — a migration did not complete; resolve it before starting",
 			errSchemaNotCurrent, dbVersion)
 	case dbVersion < latest:
-		return fmt.Errorf("%w: schema is at v%d but this binary requires v%d — run the pending migrations (the Helm migration Job, or `leoflow migrate`)",
-			errSchemaNotCurrent, dbVersion, latest)
-	case dbVersion > latest:
-		return fmt.Errorf("%w: schema is at v%d, ahead of this binary's v%d — this server is older than the database; deploy a matching or newer build",
+		return fmt.Errorf("%w: schema is at v%d but this binary requires v%d — run the pending migrations (the Helm pre-upgrade migration Job, or `leoflow db migrate` for Lite)",
 			errSchemaNotCurrent, dbVersion, latest)
 	default:
+		// dbVersion >= latest. An AHEAD schema (dbVersion > latest) is NOT fatal:
+		// expand-contract migrations are backward-compatible by construction, so
+		// older code is expected to run against a newer schema during a rollout or a
+		// `helm rollback`. Hard-failing here would CrashLoopBackOff the old pods on
+		// rollback and turn a recoverable bad deploy into an outage. The caller logs
+		// a warning for the ahead case; boot proceeds.
 		return nil
 	}
 }
@@ -70,6 +74,13 @@ func (p *Postgres) CheckSchemaCurrent(ctx context.Context) error {
 	version, dirty, exists, err := p.SchemaVersion(ctx)
 	if err != nil {
 		return fmt.Errorf("reading database schema version: %w", err)
+	}
+	if exists && !dirty && version > latest {
+		// Ahead schema (see checkSchemaCurrent): boot proceeds — expand-contract
+		// migrations keep older code working — but surface it, since it means this
+		// binary is older than the DB (a rollout in progress or a rollback).
+		slog.Warn("database schema is ahead of this binary; proceeding (expand-contract assumed backward-compatible)",
+			"db_version", version, "binary_latest", latest)
 	}
 	return checkSchemaCurrent(version, exists, dirty, latest)
 }

--- a/internal/storage/schema_check_test.go
+++ b/internal/storage/schema_check_test.go
@@ -33,10 +33,13 @@ func TestCheckSchemaCurrent(t *testing.T) {
 		}
 	})
 
-	t.Run("ahead = fail (binary older than DB)", func(t *testing.T) {
-		err := checkSchemaCurrent(latest+1, true, false, latest)
-		if err == nil {
-			t.Fatal("a DB ahead of the binary must fail")
+	t.Run("ahead = ok (expand-contract; rollback/rollout must not crash)", func(t *testing.T) {
+		// A DB ahead of the binary (older code after a helm rollback, or an old pod
+		// restarting mid-rollout) must NOT hard-fail — expand-contract migrations
+		// keep older code working. Hard-failing here would CrashLoopBackOff on
+		// rollback. The caller logs a warning; boot proceeds.
+		if err := checkSchemaCurrent(latest+1, true, false, latest); err != nil {
+			t.Errorf("an ahead DB must be accepted (rollback safety), got: %v", err)
 		}
 	})
 

--- a/internal/storage/schema_check_test.go
+++ b/internal/storage/schema_check_test.go
@@ -1,0 +1,55 @@
+package storage
+
+import (
+	"errors"
+	"testing"
+)
+
+// checkSchemaCurrent is the pure boot-time gate: given the DB's schema state and
+// the binary's embedded latest version, it fails fast with an actionable message
+// rather than letting the server boot and error at the first query that touches a
+// missing/old table (ADR 0060 S1). It runs even under role:api (a read-only
+// SELECT), which skips migrations by design (ADR 0049).
+func TestCheckSchemaCurrent(t *testing.T) {
+	const latest = 26
+
+	t.Run("current + clean = ok", func(t *testing.T) {
+		if err := checkSchemaCurrent(latest, true, false, latest); err != nil {
+			t.Errorf("current schema returned error: %v", err)
+		}
+	})
+
+	t.Run("table missing = fail fast", func(t *testing.T) {
+		err := checkSchemaCurrent(0, false, false, latest)
+		if err == nil {
+			t.Fatal("missing schema_migrations must fail")
+		}
+	})
+
+	t.Run("behind = fail with the version gap", func(t *testing.T) {
+		err := checkSchemaCurrent(latest-3, true, false, latest)
+		if err == nil {
+			t.Fatal("a DB behind the binary must fail")
+		}
+	})
+
+	t.Run("ahead = fail (binary older than DB)", func(t *testing.T) {
+		err := checkSchemaCurrent(latest+1, true, false, latest)
+		if err == nil {
+			t.Fatal("a DB ahead of the binary must fail")
+		}
+	})
+
+	t.Run("dirty = fail (a migration did not complete)", func(t *testing.T) {
+		err := checkSchemaCurrent(latest, true, true, latest)
+		if err == nil {
+			t.Fatal("a dirty schema must fail")
+		}
+	})
+
+	t.Run("errors are ErrValidation-wrapped for a clean boot message", func(t *testing.T) {
+		if err := checkSchemaCurrent(0, false, false, latest); !errors.Is(err, errSchemaNotCurrent) {
+			t.Errorf("want errSchemaNotCurrent, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Security + stability hardening of the OIDC/SSO feature, from a K8s/security specialist review. Fixes so far (each TDD, all green + golangci clean):

## 🔴 Security blocker
- **OIDC + empty break-glass allowlist is now SSO-only, not ungated.** `newBreakGlass` returned `nil` for an empty allowlist and the credential handler treats `nil` as ungated — so under `auth.provider=oidc` an empty `break_glass_emails` left `POST /auth/token` fully open to every password user (e.g. the seeded admin). Now threads `OIDCEnabled`: under OIDC, empty allowlist = deny all password logins.

## #826 — dotted OIDC map keys (turned out to be a REAL bug)
- The empty-map default only masked the single-dot case; a **multi-dot** domain like `sub.example.co.uk` (a valid Google `hd`) still crashed at load, so Google Workspace tenant pinning was unconfigurable. `tenant_claims`/`role_mappings` are now decoded out-of-band from the raw YAML (`mapstructure:"-"`), so any-depth dotted keys survive. Regression test locks it.

## Other
- **Tenant-disagreement reject:** a returning OIDC user whose stored tenant differs from the claim is rejected (defense-in-depth), instead of minting a session against the claim-derived tenant.
- **OTLP tracing off by default:** was `enabled:true` → `localhost:4317`, logging an exporter error every ~15s on any deploy without a collector. Opt-in now.

## Still to add on this branch
- Boot-time schema/migration-version fail-fast check (should-fix).
- Rate-limit the two OIDC endpoints (nice-to-have).
- Entra group-overage (>200 groups) handling (nice-to-have; NEEDS-REAL-IDP to fully validate — flagged for the EKS RC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)