### PR TITLE
security: strip LEOFLOW_-reserved keys from author task env (#828)

### DIFF
--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -6,6 +6,7 @@ package dispatch
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -14,6 +15,33 @@ import (
 	"github.com/neochaotic/leoflow/internal/executor"
 	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
 )
+
+// reservedEnvPrefix marks env vars owned by leoflow's control plane / agent. An
+// author's task env (leoflow.yaml `env:`) must never set these: they configure
+// the in-pod agent's control-plane address, token transport, and (ADR 0060) the
+// external-secrets backend. An author override reaches the agent's own container
+// (task env is appended last in the pod spec), so it could redirect the agent's
+// credential exchange or downgrade its transport (#828).
+const reservedEnvPrefix = "LEOFLOW_"
+
+// stripReservedEnv returns a copy of env without any leoflow-reserved key, so an
+// author's leoflow.yaml env: cannot override the agent's own configuration. The
+// prefix match is case-insensitive (env keys are case-sensitive on Linux, but the
+// agent only ever reads the canonical uppercase form; drop any case an author
+// tries). A nil map stays nil.
+func stripReservedEnv(env map[string]string) map[string]string {
+	if env == nil {
+		return nil
+	}
+	out := make(map[string]string, len(env))
+	for k, v := range env {
+		if strings.HasPrefix(strings.ToUpper(k), reservedEnvPrefix) {
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
 
 // warmLeaseSeconds is the ack deadline placed on a warm-worker assignment: the
 // worker must ack it as started within this window or the registry reclaims the
@@ -211,7 +239,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, runID, dagID, dagVersionID st
 		Source:           r.Source,
 		Operator:         string(task.Type),
 		Entrypoint:       task.Entrypoint,
-		Env:              task.Env,
+		Env:              stripReservedEnv(task.Env),
 		ControlPlaneAddr: d.controlAddr,
 		AgentToken:       token,
 		// Cluster-operator policy, not a per-task choice — see PlatformDefaults.

--- a/internal/dispatch/dispatch_env_test.go
+++ b/internal/dispatch/dispatch_env_test.go
@@ -1,0 +1,32 @@
+package dispatch
+
+import "testing"
+
+// stripReservedEnv must drop every LEOFLOW_-prefixed key (case-insensitively) an
+// author put in leoflow.yaml env:, so an author cannot override the agent's own
+// control-plane config (#828) — e.g. LEOFLOW_CONTROL_PLANE_ADDR, LEOFLOW_AGENT_
+// INSECURE, or (ADR 0060) LEOFLOW_SECRETS_BACKEND. Non-reserved keys pass through.
+func TestStripReservedEnv(t *testing.T) {
+	in := map[string]string{
+		"MY_VAR":                     "ok",
+		"LEOFLOW_CONTROL_PLANE_ADDR": "http://evil",
+		"LEOFLOW_AGENT_INSECURE":     "true",
+		"leoflow_secrets_backend":    "evil.Class", // lowercase must also be dropped
+		"AIRFLOW_CONN_DB":            "postgres://x",
+	}
+	out := stripReservedEnv(in)
+	if out["MY_VAR"] != "ok" || out["AIRFLOW_CONN_DB"] != "postgres://x" {
+		t.Errorf("non-reserved keys must survive: %v", out)
+	}
+	for _, k := range []string{"LEOFLOW_CONTROL_PLANE_ADDR", "LEOFLOW_AGENT_INSECURE", "leoflow_secrets_backend"} {
+		if _, present := out[k]; present {
+			t.Errorf("reserved key %q must be dropped", k)
+		}
+	}
+}
+
+func TestStripReservedEnvNil(t *testing.T) {
+	if stripReservedEnv(nil) != nil {
+		t.Error("nil env must stay nil")
+	}
+}


### PR DESCRIPTION
Closes #828.

An author's `leoflow.yaml` `env:` reached the task pod unfiltered and **appended last** in the pod spec, so a `LEOFLOW_`-prefixed key set by the author won over the operator/agent value in the container the in-pod agent runs in. An author could set `LEOFLOW_CONTROL_PLANE_ADDR` / `LEOFLOW_AGENT_INSECURE` to redirect the agent's bootstrap/projected-token exchange to an attacker endpoint or downgrade its transport.

Fix: `stripReservedEnv` drops any `LEOFLOW_`-prefixed key (case-insensitive) from author `task.Env` at dispatch. Also the prerequisite for ADR 0060's operator-sourced `LEOFLOW_SECRETS_*` backend config.

Found during the ADR 0060 external-secrets design review (K8s/security specialist). TDD (failing test first), golangci clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)