### PR TITLE
release: prepare v0.4.2-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,47 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Typed trigger form in the UI (#798).** The "Trigger DAG w/ config" dialog
+  renders a generated form from a DAG's declared `params=`, with the raw JSON
+  editor still one toggle away.
+- **External secrets resolver (#811, ADR 0060) — off by default.** A declared
+  Connection/Variable can be resolved pod-side from a provider store (AWS Secrets
+  Manager reference; GCP / Azure / Vault via config) under the pod's own keyless
+  identity, instead of the Leoflow vault. Operator-configured (`secrets.backend`
+  + Helm); declaration-scoped, fail-closed, no copy at rest. Keyless end-to-end is
+  validated on a real cluster (EKS/GKE RC) before enabling; the vault stays the
+  only source when unset.
+
+### Changed
+
+- **`deferrable=True` rejected at compile time (#794, ADR 0016).** A clear error
+  points to `deferrable=False` / `mode="reschedule"` instead of compiling a task
+  that cannot defer at runtime.
+- **OpenTelemetry tracing is off by default** — opt in via `observability.otel`.
+
+### Security
+
+- **OIDC break-glass is SSO-only (#827).** Under `provider: oidc`, an empty
+  break-glass allowlist now denies all password logins instead of leaving
+  `POST /auth/token` open.
+- **Author task env can no longer override reserved `LEOFLOW_` variables
+  (GHSA-3r74-9w27-v32f).** Closes an in-pod agent control-plane / credential
+  redirect via a DAG's `env:`.
+- **OIDC hardening (#827):** dotted tenant/group config keys, returning-user
+  tenant-mismatch reject, rate-limited login/callback, and fail-closed handling of
+  Entra group-claim overage.
+
+### Fixed
+
+- **Flaky scheduler alert-dedup test (#609).**
+
+### Docs
+
+- **Versioned documentation site with per-release archives (#814).**
+- **External secrets how-to** (`operate/external-secrets.md`).
+
 ## [0.4.1] - 2026-08-28
 
 ### Added

--- a/helm/leoflow/Chart.yaml
+++ b/helm/leoflow/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version is the chart version; appVersion tracks the leoflow-server image.
 # Both move in lockstep with the release tag (ADR 0028); decouple only if the
 # chart ever needs a cadence of its own for a template-only fix.
-version: 0.4.1
-appVersion: "0.4.1"
+version: 0.4.2-rc.1
+appVersion: "0.4.2-rc.1"
 home: https://github.com/neochaotic/leoflow
 sources:
   - https://github.com/neochaotic/leoflow

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -1,6 +1,6 @@
 # leoflow
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.1](https://img.shields.io/badge/AppVersion-0.4.1-informational?style=flat-square)
+![Version: 0.4.2-rc.1](https://img.shields.io/badge/Version-0.4.2--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.2-rc.1](https://img.shields.io/badge/AppVersion-0.4.2--rc.1-informational?style=flat-square)
 
 Leoflow control plane — a GitOps-first, container-native workflow orchestrator (Airflow 3.2.x UI/API compatible).
 


### PR DESCRIPTION
Prep for the v0.4.2-rc.1 cut:

- CHANGELOG `[Unreleased]` populated with the payload since v0.4.1 (typed trigger form #798, external secrets resolver #811 off-by-default, deferrable guard #794, OTLP off by default, SSO/security hardening #827, vuln fix #829/GHSA-3r74-9w27-v32f, versioned docs #814, flake fix #609).
- `helm/leoflow` Chart `version` + `appVersion` → `0.4.2-rc.1` (lockstep, ADR 0028); helm-docs regenerated.

rc keeps `[Unreleased]` (GA promotes it). Tag `v0.4.2-rc.1` after merge triggers the release workflow.