### PR TITLE
release: promote v0.4.2 GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-08-31
+
 ### Added
 
 - **Typed trigger form in the UI (#798).** The "Trigger DAG w/ config" dialog

--- a/helm/leoflow/Chart.yaml
+++ b/helm/leoflow/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version is the chart version; appVersion tracks the leoflow-server image.
 # Both move in lockstep with the release tag (ADR 0028); decouple only if the
 # chart ever needs a cadence of its own for a template-only fix.
-version: 0.4.2-rc.1
-appVersion: "0.4.2-rc.1"
+version: 0.4.2
+appVersion: "0.4.2"
 home: https://github.com/neochaotic/leoflow
 sources:
   - https://github.com/neochaotic/leoflow

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -1,6 +1,6 @@
 # leoflow
 
-![Version: 0.4.2-rc.1](https://img.shields.io/badge/Version-0.4.2--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.2-rc.1](https://img.shields.io/badge/AppVersion-0.4.2--rc.1-informational?style=flat-square)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.2](https://img.shields.io/badge/AppVersion-0.4.2-informational?style=flat-square)
 
 Leoflow control plane — a GitOps-first, container-native workflow orchestrator (Airflow 3.2.x UI/API compatible).
 


### PR DESCRIPTION
Promote v0.4.2 to GA.

- CHANGELOG `[Unreleased]` -> `[0.4.2] - 2026-08-31` (payload: typed trigger form #798, external secrets resolver #811 off-by-default, deferrable guard #794, OTLP off by default, SSO/security hardening #827, vuln fix #829/GHSA-3r74-9w27-v32f, versioned docs #814, flake #609).
- `helm/leoflow` Chart `version` + `appVersion` -> `0.4.2` (lockstep, ADR 0028); helm-docs regenerated.

Validated as v0.4.2-rc.1: CI 8-distro install smoke + upgrade + server-image signature, and the published darwin artifact QA'd locally (checksum + cosign keyless + feature ui-smoke 22/22). Tag `v0.4.2` after merge triggers the release workflow; the security advisory GHSA-3r74-9w27-v32f is published with this GA.