### PR TITLE
fix(cli): real-environment feedback — dbt error visibility + --password-stdin

### DIFF
--- a/internal/cli/dbt_manifest.go
+++ b/internal/cli/dbt_manifest.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -54,8 +56,18 @@ func loadDbtManifest(cmd *cobra.Command, dir string, c *domain.DbtConfig, local 
 			pc.Env = append(pc.Env, "DBT_PROFILES_DIR="+pdir)
 		}
 	}
-	pc.Stderr = cmd.ErrOrStderr()
+	// dbt logs a parse failure's cause (a missing `dbt deps`, a bad profile) to
+	// STDOUT, not stderr — so a bare exec error surfaces as "exit status 2" with no
+	// reason, blinding CI and forcing a manual repro. Tee stderr to the CLI as
+	// before and capture BOTH streams; on failure, attach the tail so the dbt
+	// diagnostic travels with the returned error.
+	var captured bytes.Buffer
+	pc.Stdout = &captured
+	pc.Stderr = io.MultiWriter(cmd.ErrOrStderr(), &captured)
 	if rerr := pc.Run(); rerr != nil {
+		if tail := lastLines(captured.String(), 20); tail != "" {
+			return nil, fmt.Errorf("dbt parse in %s: %w\n%s", projectDir, rerr, tail)
+		}
 		return nil, fmt.Errorf("dbt parse in %s: %w", projectDir, rerr)
 	}
 	path := filepath.Join(projectDir, "target", "manifest.json")

--- a/internal/cli/dbt_manifest_output_test.go
+++ b/internal/cli/dbt_manifest_output_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// A dbt parse failure must carry the cause dbt printed — not just "exit status N".
+// dbt logs parse errors to STDOUT, which the old code dropped, blinding CI (#836).
+func TestLoadDbtManifestParseFailureCarriesCause(t *testing.T) {
+	binDir := t.TempDir()
+	// A fake dbt that logs the real cause to STDOUT (as dbt-core does) and exits
+	// non-zero — the exact shape of the reported failure (missing `dbt deps`).
+	script := "#!/bin/sh\n" +
+		"echo 'Compilation Error: dbt found 1 package(s) missing, run dbt deps'\n" +
+		"exit 2\n"
+	if err := os.WriteFile(filepath.Join(binDir, "dbt"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	proj := t.TempDir()
+	if err := os.WriteFile(filepath.Join(proj, "dbt_project.yml"), []byte("profile: shop\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	_, err := loadDbtManifest(cmd, proj, &domain.DbtConfig{}, false, "dag")
+	if err == nil {
+		t.Fatal("expected a dbt parse error")
+	}
+	if !strings.Contains(err.Error(), "run dbt deps") {
+		t.Errorf("error must carry the dbt stdout cause; got: %v", err)
+	}
+}

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -111,7 +111,13 @@ func readPasswordStdin(r io.Reader) (string, error) {
 	sc := bufio.NewScanner(r)
 	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	if sc.Scan() {
-		return sc.Text(), nil
+		// Treat an empty first line the same as empty stdin: --password-stdin must
+		// never yield a silent empty password (echo '' | ... would otherwise pass
+		// "" downstream). A password is not trimmed — only a truly empty line fails.
+		if line := sc.Text(); line != "" {
+			return line, nil
+		}
+		return "", fmt.Errorf("--password-stdin got an empty password")
 	}
 	if err := sc.Err(); err != nil {
 		return "", fmt.Errorf("reading password from stdin: %w", err)

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -22,6 +22,7 @@ import (
 // token for CI rather than persisting an interactive session.
 func newLoginCommand() *cobra.Command {
 	var serverURL, username, password string
+	var passwordStdin bool
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Authenticate to a control plane (Pro) and store the token.",
@@ -35,6 +36,9 @@ func newLoginCommand() *cobra.Command {
 				serverURL = cfg.ServerURL
 			}
 			var cerr error
+			if password, cerr = resolvePassword(cmd, password, passwordStdin); cerr != nil {
+				return cerr
+			}
 			username, password, cerr = resolveCredentials(cmd, username, password)
 			if cerr != nil {
 				return cerr
@@ -57,6 +61,7 @@ func newLoginCommand() *cobra.Command {
 	cmd.Flags().StringVar(&serverURL, "server", "", "control plane base URL (default: config server_url)")
 	cmd.Flags().StringVar(&username, "username", os.Getenv("LEOFLOW_USERNAME"), "username")
 	cmd.Flags().StringVar(&password, "password", os.Getenv("LEOFLOW_PASSWORD"), "password")
+	cmd.Flags().BoolVar(&passwordStdin, "password-stdin", false, "read the password from stdin instead of --password (avoids ps/shell-history exposure)")
 	return cmd
 }
 
@@ -98,6 +103,38 @@ func resolveCredentials(cmd *cobra.Command, username, password string) (user, pa
 }
 
 // promptValue prints a label and reads a trimmed line of input.
+// readPasswordStdin reads one line — the password — from r. It backs the
+// --password-stdin flag: the CI-safe way to supply a credential without it
+// appearing on argv (visible in `ps` and the shell history) or in an env var. The
+// trailing newline is stripped.
+func readPasswordStdin(r io.Reader) (string, error) {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	if sc.Scan() {
+		return sc.Text(), nil
+	}
+	if err := sc.Err(); err != nil {
+		return "", fmt.Errorf("reading password from stdin: %w", err)
+	}
+	return "", fmt.Errorf("--password-stdin was set but stdin was empty")
+}
+
+// resolvePassword applies the auth commands' credential-source precedence:
+// --password-stdin (read a line from stdin) wins; otherwise the --password flag
+// or its LEOFLOW_PASSWORD default is used. An explicit --password together with
+// --password-stdin is a conflict — but an env-var default is not, so only a flag
+// the user actually set counts. When neither is given the value is returned empty
+// and the caller decides whether to prompt (interactive) or error (CI).
+func resolvePassword(cmd *cobra.Command, passwordFlag string, stdin bool) (string, error) {
+	if !stdin {
+		return passwordFlag, nil
+	}
+	if cmd.Flags().Changed("password") {
+		return "", fmt.Errorf("--password and --password-stdin are mutually exclusive")
+	}
+	return readPasswordStdin(cmd.InOrStdin())
+}
+
 func promptValue(in io.Reader, out io.Writer, label string) (string, error) {
 	devPrintf(out, "%s", label)
 	line, err := bufio.NewReader(in).ReadString('\n')

--- a/internal/cli/password_source_test.go
+++ b/internal/cli/password_source_test.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newPasswordCmd builds a bare command with a --password flag, mirroring the auth
+// commands, so resolvePassword's --password/--password-stdin precedence can be
+// exercised without a server.
+func newPasswordCmd() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("password", "", "")
+	return cmd
+}
+
+func TestResolvePasswordStdinReadsOneLine(t *testing.T) {
+	cmd := newPasswordCmd()
+	cmd.SetIn(bytes.NewBufferString("s3cr3t\nignored second line\n"))
+	got, err := resolvePassword(cmd, "", true)
+	if err != nil {
+		t.Fatalf("resolvePassword: %v", err)
+	}
+	if got != "s3cr3t" {
+		t.Errorf("stdin password = %q, want s3cr3t", got)
+	}
+}
+
+func TestResolvePasswordStdinConflictsWithExplicitFlag(t *testing.T) {
+	cmd := newPasswordCmd()
+	if err := cmd.Flags().Set("password", "onflag"); err != nil { // explicit --password
+		t.Fatal(err)
+	}
+	cmd.SetIn(bytes.NewBufferString("fromstdin\n"))
+	if _, err := resolvePassword(cmd, "onflag", true); err == nil {
+		t.Error("explicit --password + --password-stdin must be a conflict")
+	}
+}
+
+func TestResolvePasswordEnvDefaultDoesNotConflict(t *testing.T) {
+	// The flag carries its LEOFLOW_PASSWORD default but the user did not set it
+	// (Changed==false), so --password-stdin wins with no conflict.
+	cmd := newPasswordCmd()
+	cmd.SetIn(bytes.NewBufferString("fromstdin\n"))
+	got, err := resolvePassword(cmd, "envdefault", true)
+	if err != nil {
+		t.Fatalf("env default must not conflict with --password-stdin: %v", err)
+	}
+	if got != "fromstdin" {
+		t.Errorf("stdin must win over env default; got %q", got)
+	}
+}
+
+func TestResolvePasswordFlagPassthrough(t *testing.T) {
+	cmd := newPasswordCmd()
+	got, err := resolvePassword(cmd, "plain", false)
+	if err != nil || got != "plain" {
+		t.Errorf("no stdin: got (%q, %v), want (plain, nil)", got, err)
+	}
+}
+
+func TestReadPasswordStdinEmptyErrors(t *testing.T) {
+	if _, err := readPasswordStdin(bytes.NewBufferString("")); err == nil {
+		t.Error("empty stdin under --password-stdin must error, not return an empty password")
+	}
+}

--- a/internal/cli/password_source_test.go
+++ b/internal/cli/password_source_test.go
@@ -62,7 +62,11 @@ func TestResolvePasswordFlagPassthrough(t *testing.T) {
 }
 
 func TestReadPasswordStdinEmptyErrors(t *testing.T) {
-	if _, err := readPasswordStdin(bytes.NewBufferString("")); err == nil {
-		t.Error("empty stdin under --password-stdin must error, not return an empty password")
+	// Both no bytes at all and a single empty line must error — never a silent
+	// empty password.
+	for name, in := range map[string]string{"no bytes": "", "empty line": "\n"} {
+		if _, err := readPasswordStdin(bytes.NewBufferString(in)); err == nil {
+			t.Errorf("%s under --password-stdin must error, not return an empty password", name)
+		}
 	}
 }

--- a/internal/cli/token.go
+++ b/internal/cli/token.go
@@ -33,6 +33,7 @@ func newAuthCommand() *cobra.Command {
 // --token, then LEOFLOW_TOKEN, then the session saved by `auth login`.
 func newCreateUserCommand() *cobra.Command {
 	var serverURL, token, email, password string
+	var passwordStdin bool
 	var roles []string
 	cmd := &cobra.Command{
 		Use:   "create-user",
@@ -43,10 +44,14 @@ func newCreateUserCommand() *cobra.Command {
 			if rerr != nil {
 				return rerr
 			}
-			if email == "" || password == "" {
+			pw, perr := resolvePassword(cmd, password, passwordStdin)
+			if perr != nil {
+				return perr
+			}
+			if email == "" || pw == "" {
 				return fmt.Errorf("--email and --password are required")
 			}
-			created, err := createUser(cmdContext(cmd), resolvedServer, resolvedToken, email, password, roles)
+			created, err := createUser(cmdContext(cmd), resolvedServer, resolvedToken, email, pw, roles)
 			if err != nil {
 				return err
 			}
@@ -59,6 +64,7 @@ func newCreateUserCommand() *cobra.Command {
 	cmd.Flags().StringVar(&token, "token", os.Getenv("LEOFLOW_TOKEN"), "admin JWT bearer token (default: config token)")
 	cmd.Flags().StringVar(&email, "email", "", "email of the user to create")
 	cmd.Flags().StringVar(&password, "password", os.Getenv("LEOFLOW_PASSWORD"), "password for the new user")
+	cmd.Flags().BoolVar(&passwordStdin, "password-stdin", false, "read the password from stdin instead of --password (avoids ps/shell-history exposure)")
 	cmd.Flags().StringArrayVar(&roles, "role", nil, "existing role to grant (repeatable); empty grants none")
 	return cmd
 }
@@ -99,6 +105,7 @@ func rolesOrNone(roles []string) string {
 
 func newCreateTokenCommand() *cobra.Command {
 	var serverURL, username, password string
+	var passwordStdin bool
 	cmd := &cobra.Command{
 		Use:   "create-token",
 		Short: "Obtain a JWT from the control plane.",
@@ -111,7 +118,11 @@ func newCreateTokenCommand() *cobra.Command {
 				}
 				serverURL = cfg.ServerURL
 			}
-			token, err := requestToken(cmdContext(cmd), serverURL, username, password)
+			pw, perr := resolvePassword(cmd, password, passwordStdin)
+			if perr != nil {
+				return perr
+			}
+			token, err := requestToken(cmdContext(cmd), serverURL, username, pw)
 			if err != nil {
 				return err
 			}
@@ -122,6 +133,7 @@ func newCreateTokenCommand() *cobra.Command {
 	cmd.Flags().StringVar(&serverURL, "server", "", "control plane base URL (default: config server_url)")
 	cmd.Flags().StringVar(&username, "username", os.Getenv("LEOFLOW_USERNAME"), "username")
 	cmd.Flags().StringVar(&password, "password", os.Getenv("LEOFLOW_PASSWORD"), "password")
+	cmd.Flags().BoolVar(&passwordStdin, "password-stdin", false, "read the password from stdin instead of --password (avoids ps/shell-history exposure)")
 	return cmd
 }
 


### PR DESCRIPTION
Two CLI fixes from real-environment feedback. Closes #836 and #837.

## #836 — `compile` hid the dbt parse cause
A dbt project compile failed with only `error: dbt parse in .: exit status 2` — no cause line (the real case was a missing `dbt deps`), blinding CI and forcing a manual repro. dbt logs parse errors to **stdout**, but the compile path left the subprocess stdout unset (only stderr was teed). Now it captures both streams and attaches the tail to the returned error, so the dbt diagnostic travels with the failure. `internal/cli/dbt_manifest.go`.

## #837 — password on argv leaks into ps / shell history
`auth login`, `auth create-token`, and `auth create-user` took the password via `--password`, which lands on argv (visible in `ps`, saved to history). Add **`--password-stdin`** (the docker pattern) to read it from stdin — the CI-safe path. An explicit `--password` together with `--password-stdin` is a conflict; the `LEOFLOW_PASSWORD` env default is not (only a flag the user actually set counts). `auth login` already prompts hidden when interactive; this covers the scripted path. `internal/cli/login.go`, `internal/cli/token.go`.

## Tests
- `TestLoadDbtManifestParseFailureCarriesCause` — a fake dbt logging the cause to stdout + exit 2; the returned error must contain it (mutation-verified: fails without the capture).
- `resolvePassword` / `readPasswordStdin` — stdin read, explicit-flag conflict, env-default non-conflict, passthrough, empty-stdin error.
- `go test ./internal/cli/` green; `golangci-lint --new-from-rev origin/main` 0 issues; gofmt clean.

## Follow-up (not in this PR)
Migrate scripted docs/examples off `--password` to `--password-stdin` where a credential is piped.