### PR TITLE
feat(runtime): bump Airflow Task SDK to 3.3.x (1.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **Airflow Task SDK bumped to 3.3.x (`apache-airflow-task-sdk==1.3.1`).** DAGs
+  now run under the Airflow 3.3 Task SDK in the task pod and the `leoflow lite`
+  dev venv; the 3.3 SDK surface is additive over 3.2 (no removed `airflow.sdk`
+  exports), and the airflow-free parser shim is unaffected. The parser's optional
+  real-Airflow backend accepts `apache-airflow>=3.2,<3.4`. The embedded web UI
+  stays on the Airflow 3.2.x SPA and `/api/v2/` remains 3.2.x-compatible — the SPA
+  upgrade is tracked separately. Validated on the pod-path e2e against a 3.3.1
+  runtime image.
+
 ### Fixed
 
 - **External secrets resolver failed against a real provider backend (ADR 0060).**

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -57,7 +57,7 @@ const (
 	devMigrateURL = "pgx5://leoflow:leoflow@localhost:5432/leoflow_dev?sslmode=disable"
 	// taskSDKVersion matches the task image (runtime/Dockerfile); the dev venv
 	// installs it so dag.py's `from airflow.sdk import ...` resolves.
-	taskSDKVersion = "apache-airflow-task-sdk==1.2.1"
+	taskSDKVersion = "apache-airflow-task-sdk==1.3.1"
 	// devJWTSecret is the legacy/fallback Lite JWT signing secret used only when a
 	// pre-#121 install has no jwt_secret in its config.yaml. Modern setups write a
 	// random per-install secret (rotated on every fresh install), so tokens from a

--- a/internal/setup/extract_test.go
+++ b/internal/setup/extract_test.go
@@ -44,7 +44,7 @@ func TestProvisionVenv(t *testing.T) {
 		parserSrc := filepath.Join(venvDir, "..", "pysrc", "parser")
 		venvPy, err := ProvisionVenv(context.Background(), run,
 			pythonPath, venvDir,
-			[]string{parserSrc, "apache-airflow-task-sdk==1.2.1"})
+			[]string{parserSrc, "apache-airflow-task-sdk==1.3.1"})
 		if err != nil {
 			t.Fatalf("err = %v, want nil", err)
 		}
@@ -67,7 +67,7 @@ func TestProvisionVenv(t *testing.T) {
 			if a == parserSrc {
 				sawParser = true
 			}
-			if a == "apache-airflow-task-sdk==1.2.1" {
+			if a == "apache-airflow-task-sdk==1.3.1" {
 				sawSDK = true
 			}
 		}

--- a/parser/pyproject.toml
+++ b/parser/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = []
 [project.optional-dependencies]
 # Opt-in fallback backend: LEOFLOW_PARSER_BACKEND=airflow uses the real DagBag.
 airflow = [
-    "apache-airflow>=3.2,<3.3",
+    "apache-airflow>=3.2,<3.4",
     "apache-airflow-providers-standard",
     "apache-airflow-providers-http",
 ]

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -48,8 +48,8 @@ RUN pip install --no-cache-dir /opt/leoflow-runtime
 # Leoflow DAGs are authored with the Apache Airflow Task SDK (`from airflow.sdk
 # import DAG, task`), so the task container must be able to import it to load the
 # user's dag.py. This is the lightweight Task SDK, not airflow-core, pinned to
-# the 3.2.x line Leoflow targets (ADR 0003 / parser SDK version).
-ARG AIRFLOW_TASK_SDK_VERSION=1.2.1
+# the 3.3.x line Leoflow targets (ADR 0003 / parser SDK version).
+ARG AIRFLOW_TASK_SDK_VERSION=1.3.1
 RUN pip install --no-cache-dir "apache-airflow-task-sdk==${AIRFLOW_TASK_SDK_VERSION}"
 
 USER 65532:65532


### PR DESCRIPTION
Runs DAGs under the **Airflow 3.3 Task SDK** (`apache-airflow-task-sdk==1.3.1`). Supersedes #825 (parser constraint).

## What moves
- `runtime/Dockerfile` — task pod SDK pin `1.2.1 → 1.3.1` (this is what actually executes DAGs).
- `internal/cli/dev.go` — `leoflow lite` dev venv SDK pin, in lockstep.
- `internal/setup/extract_test.go` — the test that locks the installer string.
- `parser/pyproject.toml` — optional real-Airflow backend `apache-airflow>=3.2,<3.4` (= #825).
- `CHANGELOG.md` — Unreleased `Changed` entry.

## What deliberately does NOT move
- The embedded web UI stays on the **Airflow 3.2.1 SPA** and `/api/v2/` stays 3.2.x-compatible — the SPA upgrade is a separate, riskier project (#835). Only SDK-runtime prose moves to 3.3.x; the UI/API compatibility prose is unchanged.
- The default parser path is the airflow-free structural shim — unaffected.

## Why it is low-risk
The 3.3 SDK surface is **additive** over 3.2: no removed `airflow.sdk` exports, and the internal accessors leoflow consumes (`ConnectionAccessor`, `VariableAccessor`, the monkeypatched `BaseXCom.get_value`) have identical signatures in 1.3.1. Verified by static wheel diff.

## Validation (the gate that turns "static-diff clean" into "trusted")
Ran the operators pod-path e2e (`test/e2e/e2e.sh` — var/conn accessor templating, XCom push/pull, `on_failure_callback`) against a **rebuilt 3.3.1 runtime image**, in an isolated git worktree, with an explicit assert that the built base image carries `apache-airflow-task-sdk==1.3.1` (guarding a cached-layer false green):

```
e2e rc=0
image task-sdk version: 1.3.1
SPIKE PASS: operators e2e green AND image confirmed task-sdk 1.3.1
```

Plus `go build ./...`, `go test ./internal/setup/ ./internal/cli/`, and `golangci-lint --new-from-rev origin/main` all green.

Closes #825.