### PR TITLE
docs(operate): cluster-validation runbook for the native secrets resolver

### DIFF
--- a/website/content/operate/external-secrets-cluster-validation.md
+++ b/website/content/operate/external-secrets-cluster-validation.md
@@ -1,0 +1,120 @@
+---
+title: Validate the native resolver on a real cluster (before enabling)
+weight: 59
+description: A turnkey runbook to prove the keyless external-secrets resolver end-to-end on EKS or GKE — the one thing an emulated store cannot validate — before turning the backend on in production.
+---
+
+The native external-secrets resolver ([external secrets, section 4]({{< relref "external-secrets" >}})) ships **off by default**. Its whole surface — declaration scoping, the pod-side resolve chain, fail-closed behaviour, and the NetworkPolicy metadata-egress guard — is exercised in CI against an emulated AWS Secrets Manager (LocalStack). The **one** thing an emulator cannot prove is the **keyless identity handshake**: IRSA, EKS Pod Identity, and GKE Workload Identity all depend on the cloud's own OIDC provider and metadata path, injected at pod admission.
+
+This runbook is that missing gate. Run it on a real EKS or GKE cluster and complete the [sign-off checklist](#sign-off-checklist) before you set `secrets.backend` in a production values file. It changes nothing permanent — it deploys one canary DAG and one throwaway secret, then tears both down.
+
+## Before you start
+
+- A cluster with the keyless mechanism you intend to use already wired at the **cloud** side (the IAM role / service account, the trust policy, and the identity webhook or agent). This runbook validates that Leoflow drives it correctly; it does not set up the cloud IAM.
+- `kubectl` context on that cluster and permission to install/upgrade the Leoflow Helm release in a throwaway namespace.
+- Access to the provider secret store to create and delete one test secret.
+- The provider's Airflow backend package available in your task image (e.g. `apache-airflow-providers-amazon` for AWS, `-google` for GCP). A `leoflow.yaml` `dependencies:` entry bakes it in.
+
+Do this in a **non-production namespace** first.
+
+## 1. Seed one throwaway secret
+
+Create a secret the canary will resolve, under the prefix you will configure. Keep the value recognisable so the assertion is unambiguous, and note it — you will delete it at the end.
+
+- **AWS Secrets Manager:** `aws secretsmanager create-secret --name airflow/variables/canary_region --secret-string "eu-west-canary-42"`
+- **GCP Secret Manager:** `gcloud secrets create airflow-variables-canary_region --data-file=- <<< "eu-west-canary-42"` (map the separator to your `backendKwargs`).
+
+## 2. Configure the backend + keyless identity (+ egress for GKE / Pod Identity)
+
+Install/upgrade the release in the test namespace with the backend pointed at your store, the task ServiceAccount bound to the reader identity, and — only for the mechanisms that reach the metadata range — the scoped egress exception.
+
+```yaml
+# values-canary.yaml
+secrets:
+  backend: "airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend"
+  backendKwargs: '{"connections_prefix":"airflow/connections","variables_prefix":"airflow/variables","region_name":"eu-west-1"}'
+
+taskServiceAccount:
+  create: true
+  annotations:
+    # AWS IRSA / Pod Identity:
+    eks.amazonaws.com/role-arn: arn:aws:iam::<acct>:role/<leoflow-secrets-reader>
+    # GKE Workload Identity instead:
+    # iam.gke.io/gcp-service-account: <leoflow-secrets-reader>@<project>.iam.gserviceaccount.com
+
+taskNetworkPolicy:
+  enabled: true
+  # ONLY for EKS Pod Identity or GKE WI — IRSA needs no exception (public STS).
+  allowMetadataEgress: []
+    # - 169.254.170.23/32   # EKS Pod Identity agent
+    # - 169.254.169.254/32  # GKE metadata server
+```
+
+Match the `allowMetadataEgress` line to your mechanism:
+
+| Mechanism | Reaches | `allowMetadataEgress` needed |
+|---|---|---|
+| AWS **IRSA** | public STS | no |
+| AWS **Pod Identity** | `169.254.170.23` | `169.254.170.23/32` |
+| **GKE Workload Identity** | `169.254.169.254` | `169.254.169.254/32` |
+
+## 3. Deploy the canary DAG
+
+A one-task DAG that **declares** the seeded name and asserts the value it receives came from the store, not the vault (the vault has no such name):
+
+```python
+# canary_secrets/dag.py
+import os
+from airflow.sdk import DAG, task
+
+
+@task
+def check() -> None:
+    got = os.environ.get("AIRFLOW_VAR_CANARY_REGION", "<MISSING>")
+    print(f"CANARY_RESOLVED={got}")
+    assert got == "eu-west-canary-42", f"resolver did not deliver the store value: {got!r}"
+
+
+with DAG("canary_secrets", schedule=None, catchup=False):
+    check()
+```
+
+```yaml
+# canary_secrets/leoflow.yaml
+dag_id: canary_secrets
+dependencies: [apache-airflow-providers-amazon]   # or -google for GKE
+variables:
+  - canary_region
+```
+
+Compile, push, and trigger it (`leoflow compile … && leoflow push … && curl -X POST …/dagRuns`).
+
+## 4. Assert — the four things only a real cluster proves
+
+1. **Keyless resolve works.** The `check` task reaches `success`, and its logs contain `CANARY_RESOLVED=eu-west-canary-42`. This proves the pod authenticated as its ServiceAccount, the cloud injected the token, and the resolver read the store — the whole keyless path.
+2. **Egress guard holds.** For Pod Identity / GKE WI, confirm the task pod's NetworkPolicy allows **only** the `/32` you listed: a probe to any other `169.254.0.0/16` address from the pod must be refused. For IRSA, confirm no metadata exception was added.
+3. **Fail-closed on missing permission.** Remove the store read permission from the reader role (or point at a name the role cannot read) and re-run. The task must **fail** with a sanitized reason — never the secret value, never a fallback to a wrong value. A clean miss (a name absent from the store) must instead fall through to the vault and, if also absent there, simply not export the name.
+4. **Declaration is the scope authority.** A task that does **not** declare `canary_region` must **not** receive it, even with the backend configured.
+
+## 5. Tear down
+
+- Delete the canary DAG (`leoflow forget canary_secrets` / remove and reconcile).
+- Delete the throwaway secret from the store.
+- Restore any permission you removed for assertion 3.
+- Uninstall the canary release / namespace.
+
+## Sign-off checklist
+
+Enable `secrets.backend` in production only when all of these passed on the target cluster:
+
+- [ ] Canary task succeeded and logged the exact store value (assertion 1).
+- [ ] Metadata egress is scoped to the single `/32` required, or none for IRSA (assertion 2).
+- [ ] A permission-denied read failed the task closed with no secret in the error (assertion 3).
+- [ ] An undeclared name was not delivered (assertion 4).
+- [ ] The provider backend package is baked into the production task image.
+- [ ] Both EKS and GKE were validated **separately** if you run both — the keyless mechanisms differ and do not transfer.
+
+## See also
+
+- [External secrets (keyless, ESO, mounted)]({{< relref "external-secrets" >}}) — the full option matrix and the resolver's guarantees.
+- [Agent credential transport]({{< relref "agent-credential-transport" >}}) — how the vault path delivers secrets, for contrast.

--- a/website/content/operate/external-secrets.md
+++ b/website/content/operate/external-secrets.md
@@ -192,6 +192,20 @@ with DAG("etl", ...):
 Leoflow resolves `warehouse` from `<connections_prefix>/warehouse` in the store,
 renders it as an Airflow connection URI, and exports `AIRFLOW_CONN_WAREHOUSE`.
 
+{{% alert title="Required: the provider package in the task image" color="warning" %}}
+The pod-side resolver drives the provider's Airflow secrets backend, so that
+provider package must be present in the **task image** — the base image does not
+bundle it. Declare it as a DAG dependency (baked at build time), e.g. for AWS:
+
+```yaml
+# leoflow.yaml
+dependencies: [apache-airflow-providers-amazon]   # -google / -microsoft-azure / -hashicorp for other providers
+```
+
+Without it the resolver fails to import the backend class and the task fails
+closed. See the [cluster-validation runbook]({{< relref "external-secrets-cluster-validation" >}}).
+{{% /alert %}}
+
 **Provider-neutral.** AWS is the reference; GCP Secret Manager, Azure Key Vault,
 and HashiCorp Vault use the same `secrets.backend` + `backendKwargs` with that
 provider's backend class and keyless mechanism.

--- a/website/content/operate/external-secrets.md
+++ b/website/content/operate/external-secrets.md
@@ -250,13 +250,13 @@ endpoint, not the metadata range).
   from **GCP Secret Manager** via ADC at task time (still needs a keyless
   identity to *read* the secret). That's a per-connection escape hatch, not the
   general mechanism this page covers.
-- **Resolving an arbitrary Connection/Variable directly from the external store**
-  — so a token-style secret in AWS Secrets Manager becomes a Leoflow Connection
-  with no Kubernetes Secret in between — is **not yet** built. It's tracked as an
-  open feature request ([#811](https://github.com/neochaotic/leoflow/issues/811))
-  with an advisory design study, but there's no accepted ADR or shipped code yet.
-  Until it lands, use keyless (option 1) for token-style access, or sync via ESO
-  (option 2).
+- **Resolving a declared Connection/Variable directly from the external store**
+  — so a secret in AWS Secrets Manager becomes a Leoflow Connection/Variable with
+  no Kubernetes Secret in between — is **option 4 above** (the native resolver,
+  ADR 0060, [#811](https://github.com/neochaotic/leoflow/issues/811)). It ships
+  **off by default**; enable it with `secrets.backend` after validating keyless
+  end-to-end on your cluster (see
+  [Validate the native resolver on a real cluster]({{< relref "external-secrets-cluster-validation" >}})).
 
 ## Scoping — which pod sees which secret
 
@@ -297,6 +297,7 @@ How a credential is isolated to the right task depends on the path it takes:
 
 ## See also
 
+- [Validate the native resolver on a real cluster]({{< relref "external-secrets-cluster-validation" >}}) — the EKS/GKE keyless gate before enabling option 4.
 - [ADR 0035 — Cloud connector auth: keyless-first](/project/adrs/0035-cloud-connector-auth-keyless-first/)
 - [Variables & Connections](/author-dags/variables-connections/) — how secrets reach a task.
 - [Connections reference](/connections/) — per-type `extra` fields (`key_path`, …).


### PR DESCRIPTION
Item from the post-v0.4.2 follow-up list: the turnkey **EKS/GKE validation runbook** for the native external-secrets resolver (ADR 0060), so enabling `secrets.backend` in production is a checklist rather than an ad-hoc cluster session.

## Why
The resolver ships off by default. Its full surface is exercised in CI against an emulated Secrets Manager (LocalStack) — but the **keyless identity handshake** (IRSA / EKS Pod Identity / GKE Workload Identity) depends on the cloud OIDC provider + metadata path and **cannot** be emulated. This runbook is that missing gate, fulfilling the ADR 0060 promise to validate keyless on a real cluster before enabling.

## What it adds
`website/content/operate/external-secrets-cluster-validation.md` — a how-to: seed a throwaway secret, configure backend + keyless SA (+ scoped `allowMetadataEgress` for Pod Identity/GKE WI), deploy a canary DAG, and run the **four assertions only a real cluster proves** (keyless resolve, egress guard scoped to the `/32`, fail-closed on denied read, declaration-scoping), then teardown + a sign-off checklist. EKS and GKE validated separately.

## Also
Fixes a stale note on `external-secrets.md` that still claimed resolving a declared Connection/Variable from the store was "not yet built / no accepted ADR" — it shipped as option 4 (ADR 0060) in 0.4.2, off by default. Now points at option 4 and the new runbook.

## Verification
`hugo --gc --minify` builds clean (relrefs resolve).