### PR TITLE
feat: field-feedback round 2 — resolver observability, dags list, login hint (#1, #4, #8)

### DIFF
--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -435,6 +435,35 @@ func (r *Runner) secretsEnv(ctx context.Context, spec *agentv1.TaskSpec) ([]stri
 		}
 	}
 
+	// Observability for the top field-support signal (#1): when an external backend
+	// is configured but a DECLARED name resolves from neither the backend nor the
+	// vault, the task will later fail with a bare "not delivered / AIRFLOW_*_ unset"
+	// and no trace of why. A backend miss is often not a clean miss at all — the
+	// provider backend reports an auth/permission failure (e.g. the pod ran as the
+	// wrong ServiceAccount) as a None, indistinguishable from "no such secret". Log
+	// the unresolved names with that pointer so the cause is one glance away. Skipped
+	// when the vault RPC was liveness-denied (a non-live TI resolves nothing by
+	// design, B2).
+	if r.Resolver != nil && !vaultDenied {
+		var unresolved []string
+		for _, n := range spec.GetDeclaredVariables() {
+			if _, ok := vars[n]; !ok {
+				unresolved = append(unresolved, "variable "+n)
+			}
+		}
+		for _, n := range spec.GetDeclaredConnections() {
+			if _, ok := conns[n]; !ok {
+				unresolved = append(unresolved, "connection "+n)
+			}
+		}
+		if len(unresolved) > 0 {
+			slog.Warn("declared secrets unresolved after the external backend and the vault; "+
+				"if these should come from the external backend, check the task pod's identity and permissions "+
+				"(the provider backend reports an auth failure as a miss, not an error)",
+				"unresolved", unresolved)
+		}
+	}
+
 	out := make([]string, 0, len(vars)+len(conns))
 	for k, v := range vars {
 		out = append(out, "AIRFLOW_VAR_"+strings.ToUpper(k)+"="+v)

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -433,35 +433,11 @@ func (r *Runner) secretsEnv(ctx context.Context, spec *agentv1.TaskSpec) ([]stri
 				vars[ref.Name] = val
 			}
 		}
-	}
-
-	// Observability for the top field-support signal (#1): when an external backend
-	// is configured but a DECLARED name resolves from neither the backend nor the
-	// vault, the task will later fail with a bare "not delivered / AIRFLOW_*_ unset"
-	// and no trace of why. A backend miss is often not a clean miss at all — the
-	// provider backend reports an auth/permission failure (e.g. the pod ran as the
-	// wrong ServiceAccount) as a None, indistinguishable from "no such secret". Log
-	// the unresolved names with that pointer so the cause is one glance away. Skipped
-	// when the vault RPC was liveness-denied (a non-live TI resolves nothing by
-	// design, B2).
-	if r.Resolver != nil && !vaultDenied {
-		var unresolved []string
-		for _, n := range spec.GetDeclaredVariables() {
-			if _, ok := vars[n]; !ok {
-				unresolved = append(unresolved, "variable "+n)
-			}
-		}
-		for _, n := range spec.GetDeclaredConnections() {
-			if _, ok := conns[n]; !ok {
-				unresolved = append(unresolved, "connection "+n)
-			}
-		}
-		if len(unresolved) > 0 {
-			slog.Warn("declared secrets unresolved after the external backend and the vault; "+
-				"if these should come from the external backend, check the task pod's identity and permissions "+
-				"(the provider backend reports an auth failure as a miss, not an error)",
-				"unresolved", unresolved)
-		}
+		// Observability for the top field-support signal (#1): a declared name that
+		// resolves from neither the backend nor the vault otherwise fails downstream
+		// with a bare "not delivered / AIRFLOW_*_ unset" and no trace of why. conns
+		// and vars are final here (vault populated above, external override applied).
+		r.warnUnresolvedDeclared(spec, vars, conns)
 	}
 
 	out := make([]string, 0, len(vars)+len(conns))
@@ -472,6 +448,37 @@ func (r *Runner) secretsEnv(ctx context.Context, spec *agentv1.TaskSpec) ([]stri
 		out = append(out, "AIRFLOW_CONN_"+strings.ToUpper(id)+"="+uri)
 	}
 	return out, nil
+}
+
+// warnUnresolvedDeclared logs the declared names the operator's backend covers but
+// that resolved from neither the backend nor the vault (#1). A backend miss is
+// often not a clean miss: the provider backend reports an auth/permission failure
+// (e.g. the pod ran as the wrong ServiceAccount) as a None, indistinguishable from
+// "no such secret", so the task otherwise fails downstream with no trace. Only
+// names of kinds the backend covers are checked, so a plain author typo on a
+// non-covered name is not misattributed to the backend identity.
+func (r *Runner) warnUnresolvedDeclared(spec *agentv1.TaskSpec, vars, conns map[string]string) {
+	var unresolved []string
+	if r.SecretBackend.Covers(secretsource.KindVariable) {
+		for _, n := range spec.GetDeclaredVariables() {
+			if _, ok := vars[n]; !ok {
+				unresolved = append(unresolved, "variable "+n)
+			}
+		}
+	}
+	if r.SecretBackend.Covers(secretsource.KindConnection) {
+		for _, n := range spec.GetDeclaredConnections() {
+			if _, ok := conns[n]; !ok {
+				unresolved = append(unresolved, "connection "+n)
+			}
+		}
+	}
+	if len(unresolved) > 0 {
+		slog.Warn("declared secrets unresolved after the external backend and the vault; "+
+			"if these should come from the external backend, check the task pod's identity and permissions "+
+			"(the provider backend reports an auth failure as a miss, not an error)",
+			"unresolved", unresolved)
+	}
 }
 
 // coveredRefs is the set of declared names the operator's backend covers — the

--- a/internal/agent/secrets_backend_observability_test.go
+++ b/internal/agent/secrets_backend_observability_test.go
@@ -1,0 +1,76 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/agent/secretsource"
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+)
+
+// captureWarn swaps the default slog logger for a buffer for the duration of a
+// test and returns the buffer.
+func captureWarn(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
+// With a backend configured, a declared name that resolves from NEITHER the
+// backend NOR the vault must be logged with a pointer at the pod's identity —
+// the top field-support signal (#1): a backend auth failure surfaces as a miss,
+// so the task otherwise fails downstream with a bare "not delivered".
+func TestSecretsEnvWarnsOnUnresolvedDeclaredWithBackend(t *testing.T) {
+	buf := captureWarn(t)
+	r := &Runner{
+		Client:        &fakeClient{},  // empty vault
+		Resolver:      fakeResolver{}, // no external hits
+		SecretBackend: secretsource.Backend{Connections: true, Variables: true},
+	}
+	if _, err := r.secretsEnv(context.Background(), &agentv1.TaskSpec{DeclaredConnections: []string{"warehouse"}}); err != nil {
+		t.Fatalf("secretsEnv: %v", err)
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "unresolved") || !strings.Contains(logged, "warehouse") {
+		t.Errorf("expected a warn naming the unresolved declared connection; got: %q", logged)
+	}
+	if !strings.Contains(logged, "identity") {
+		t.Errorf("warn should point at the pod's identity/permissions; got: %q", logged)
+	}
+}
+
+// When the backend resolves the declared name, there is nothing unresolved and no
+// warning — the common case must stay quiet.
+func TestSecretsEnvNoWarnWhenResolved(t *testing.T) {
+	buf := captureWarn(t)
+	r := &Runner{
+		Client:        &fakeClient{},
+		Resolver:      fakeResolver{conns: map[string]string{"warehouse": "postgres://w"}},
+		SecretBackend: secretsource.Backend{Connections: true},
+	}
+	if _, err := r.secretsEnv(context.Background(), &agentv1.TaskSpec{DeclaredConnections: []string{"warehouse"}}); err != nil {
+		t.Fatalf("secretsEnv: %v", err)
+	}
+	if strings.Contains(buf.String(), "unresolved") {
+		t.Errorf("no unresolved warn expected when the backend resolved the name; got: %q", buf.String())
+	}
+}
+
+// With NO backend configured, an unresolved declared name is the pre-existing
+// vault-only behavior — the backend-identity warning must not fire.
+func TestSecretsEnvNoBackendNoWarn(t *testing.T) {
+	buf := captureWarn(t)
+	r := &Runner{Client: &fakeClient{}} // no Resolver
+	if _, err := r.secretsEnv(context.Background(), &agentv1.TaskSpec{DeclaredConnections: []string{"warehouse"}}); err != nil {
+		t.Fatalf("secretsEnv: %v", err)
+	}
+	if strings.Contains(buf.String(), "unresolved") {
+		t.Errorf("no backend configured → no backend-identity warn; got: %q", buf.String())
+	}
+}

--- a/internal/agent/secrets_backend_observability_test.go
+++ b/internal/agent/secrets_backend_observability_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/neochaotic/leoflow/internal/agent/secretsource"
 	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // captureWarn swaps the default slog logger for a buffer for the duration of a
@@ -59,6 +61,41 @@ func TestSecretsEnvNoWarnWhenResolved(t *testing.T) {
 	}
 	if strings.Contains(buf.String(), "unresolved") {
 		t.Errorf("no unresolved warn expected when the backend resolved the name; got: %q", buf.String())
+	}
+}
+
+// A declared name present only in the VAULT (not the backend) is resolved, so the
+// backend-identity warning must stay quiet — the normal external-miss-then-
+// vault-hit case is not a problem.
+func TestSecretsEnvNoWarnWhenVaultOnly(t *testing.T) {
+	buf := captureWarn(t)
+	r := &Runner{
+		Client:        &fakeClient{conns: map[string]string{"warehouse": "postgres://vault"}},
+		Resolver:      fakeResolver{}, // backend has no hit
+		SecretBackend: secretsource.Backend{Connections: true},
+	}
+	if _, err := r.secretsEnv(context.Background(), &agentv1.TaskSpec{DeclaredConnections: []string{"warehouse"}}); err != nil {
+		t.Fatalf("secretsEnv: %v", err)
+	}
+	if strings.Contains(buf.String(), "unresolved") {
+		t.Errorf("a vault-resolved name must not warn; got: %q", buf.String())
+	}
+}
+
+// A liveness-denied vault RPC (B2) skips external resolution AND the warning — a
+// non-live TI resolves nothing by design, so it is not a backend-identity signal.
+func TestSecretsEnvNoWarnWhenVaultDenied(t *testing.T) {
+	buf := captureWarn(t)
+	r := &Runner{
+		Client:        &fakeClient{getVarsErr: status.Error(codes.PermissionDenied, "task instance not live")},
+		Resolver:      fakeResolver{},
+		SecretBackend: secretsource.Backend{Connections: true},
+	}
+	if _, err := r.secretsEnv(context.Background(), &agentv1.TaskSpec{DeclaredConnections: []string{"warehouse"}}); err != nil {
+		t.Fatalf("secretsEnv: %v", err)
+	}
+	if strings.Contains(buf.String(), "unresolved") {
+		t.Errorf("vaultDenied must suppress the warn; got: %q", buf.String())
 	}
 }
 

--- a/internal/cli/dags.go
+++ b/internal/cli/dags.go
@@ -8,9 +8,12 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/spf13/cobra"
+
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
 )
 
 // newDagsCommand groups DAG-management subcommands.
@@ -19,8 +22,72 @@ func newDagsCommand() *cobra.Command {
 		Use:   "dags",
 		Short: "Manage registered DAGs.",
 	}
+	cmd.AddCommand(newDagsListCommand())
 	cmd.AddCommand(newDagsDeleteCommand())
 	return cmd
+}
+
+// newDagsListCommand lists registered DAGs — the read counterpart to delete, so
+// verifying a registration no longer means hitting /api/v2/dags by hand.
+func newDagsListCommand() *cobra.Command {
+	var serverURL, token string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List registered DAGs.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			base, bearer, err := resolveServerToken(cmd, serverURL, token)
+			if err != nil {
+				return err
+			}
+			c, err := apiclient.New(base, bearer)
+			if err != nil {
+				return err
+			}
+			resp, err := c.ListDagsWithResponse(cmdContext(cmd), nil)
+			if err != nil {
+				return fmt.Errorf("listing DAGs: %w", err)
+			}
+			if resp.StatusCode() != http.StatusOK {
+				return fmt.Errorf("server returned %d: %s", resp.StatusCode(), string(resp.Body))
+			}
+			return printDagList(cmd.OutOrStdout(), resp.JSON200)
+		},
+	}
+	cmd.Flags().StringVar(&serverURL, "server", "", "control plane base URL (default: config server_url)")
+	cmd.Flags().StringVar(&token, "token", os.Getenv("LEOFLOW_TOKEN"), "JWT bearer token (default: config token)")
+	return cmd
+}
+
+// printDagList renders the DAG collection as an aligned table (DAG_ID, PAUSED,
+// OWNERS), or a friendly line when nothing is registered.
+func printDagList(w io.Writer, coll *apiclient.DAGCollection) error {
+	if coll == nil || coll.Dags == nil || len(*coll.Dags) == 0 {
+		_, err := fmt.Fprintln(w, "No DAGs registered.")
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "DAG_ID\tPAUSED\tOWNERS"); err != nil {
+		return err
+	}
+	for _, d := range *coll.Dags {
+		id := ""
+		if d.DagId != nil {
+			id = *d.DagId
+		}
+		paused := "no"
+		if d.IsPaused != nil && *d.IsPaused {
+			paused = "yes"
+		}
+		owners := ""
+		if d.Owners != nil {
+			owners = strings.Join(*d.Owners, ",")
+		}
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\n", id, paused, owners); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
 }
 
 // newDagsDeleteCommand clears a DAG's history or deregisters it (ADR 0020).

--- a/internal/cli/dags_list_test.go
+++ b/internal/cli/dags_list_test.go
@@ -1,0 +1,39 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
+)
+
+func TestPrintDagListEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := printDagList(&buf, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "No DAGs registered") {
+		t.Errorf("empty collection = %q, want the friendly line", buf.String())
+	}
+}
+
+func TestPrintDagListRows(t *testing.T) {
+	sp := func(s string) *string { return &s }
+	paused := true
+	owners := []string{"team-a"}
+	coll := &apiclient.DAGCollection{Dags: &[]apiclient.DAG{
+		{DagId: sp("etl"), IsPaused: &paused, Owners: &owners},
+		{DagId: sp("ingest")}, // no paused/owners → defaults
+	}}
+	var buf bytes.Buffer
+	if err := printDagList(&buf, coll); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, want := range []string{"DAG_ID", "PAUSED", "OWNERS", "etl", "yes", "team-a", "ingest", "no"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q; got:\n%s", want, out)
+		}
+	}
+}

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -45,7 +45,7 @@ func newLoginCommand() *cobra.Command {
 			}
 			token, err := requestToken(cmdContext(cmd), serverURL, username, password)
 			if err != nil {
-				return err
+				return hintEmailUsername(username, err)
 			}
 			path, perr := sessionConfigPath(cmd)
 			if perr != nil {
@@ -103,6 +103,21 @@ func resolveCredentials(cmd *cobra.Command, username, password string) (user, pa
 }
 
 // promptValue prints a label and reads a trimmed line of input.
+// hintEmailUsername appends a first-login hint when authentication fails (a 401)
+// with a username that is not an e-mail. The bootstrap admin is
+// admin@leoflow.local, and a bare "admin" returns a generic "invalid
+// credentials"; the hint saves the trip. It is safe: it reveals nothing about
+// which accounts exist, only the expected username format.
+func hintEmailUsername(username string, err error) error {
+	if err == nil || username == "" || strings.Contains(username, "@") {
+		return err
+	}
+	if !strings.Contains(err.Error(), "401") {
+		return err
+	}
+	return fmt.Errorf("%w\nhint: the username is an e-mail address (the bootstrap admin is admin@leoflow.local)", err)
+}
+
 // readPasswordStdin reads one line — the password — from r. It backs the
 // --password-stdin flag: the CI-safe way to supply a credential without it
 // appearing on argv (visible in `ps` and the shell history) or in an env var. The

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -112,7 +112,9 @@ func hintEmailUsername(username string, err error) error {
 	if err == nil || username == "" || strings.Contains(username, "@") {
 		return err
 	}
-	if !strings.Contains(err.Error(), "401") {
+	// Match the exact shape requestToken formats ("server returned 401:"), not a
+	// bare "401" that a host:port or a response body could contain by accident.
+	if !strings.Contains(err.Error(), "server returned 401") {
 		return err
 	}
 	return fmt.Errorf("%w\nhint: the username is an e-mail address (the bootstrap admin is admin@leoflow.local)", err)

--- a/internal/cli/login_hint_test.go
+++ b/internal/cli/login_hint_test.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestHintEmailUsername(t *testing.T) {
+	auth401 := fmt.Errorf("server returned 401: invalid credentials")
+
+	// A bare username + a 401 gets the e-mail hint.
+	if got := hintEmailUsername("admin", auth401); !strings.Contains(got.Error(), "e-mail") {
+		t.Errorf("bare username + 401 should hint at the e-mail form; got %v", got)
+	}
+	// An e-mail username is already correct — no hint.
+	if got := hintEmailUsername("admin@leoflow.local", auth401); strings.Contains(got.Error(), "hint:") {
+		t.Errorf("e-mail username should not get a hint; got %v", got)
+	}
+	// A non-401 error (e.g. network) must not get the credential hint.
+	netErr := fmt.Errorf("posting to x: connection refused")
+	if got := hintEmailUsername("admin", netErr); strings.Contains(got.Error(), "hint:") {
+		t.Errorf("non-401 error should not get the hint; got %v", got)
+	}
+	// A nil error stays nil; an empty username gets nothing.
+	if hintEmailUsername("admin", nil) != nil {
+		t.Error("nil error must stay nil")
+	}
+	if got := hintEmailUsername("", auth401); strings.Contains(got.Error(), "hint:") {
+		t.Error("empty username should not get a hint")
+	}
+}

--- a/internal/cli/token.go
+++ b/internal/cli/token.go
@@ -124,7 +124,7 @@ func newCreateTokenCommand() *cobra.Command {
 			}
 			token, err := requestToken(cmdContext(cmd), serverURL, username, pw)
 			if err != nil {
-				return err
+				return hintEmailUsername(username, err)
 			}
 			_, err = fmt.Fprintln(cmd.OutOrStdout(), token)
 			return err

--- a/runtime/python/leoflow_runtime/dbt.py
+++ b/runtime/python/leoflow_runtime/dbt.py
@@ -194,9 +194,18 @@ def write_dbt_profile(
     key = f"AIRFLOW_CONN_{conn_id.upper()}"
     uri = env.get(key)
     if not uri:
-        raise RuntimeError(
-            f"dbt connection {conn_id!r} was not delivered to the task ({key} is unset)"
-        )
+        msg = f"dbt connection {conn_id!r} was not delivered to the task ({key} is unset)"
+        # Backend-aware hint (#1): when an external secrets backend is configured, a
+        # missing declared connection is most often the pod identity/permissions —
+        # the provider backend reports an auth failure as a miss, so it falls through
+        # silently. Point at that instead of leaving a bare "unset".
+        if env.get("LEOFLOW_SECRETS_BACKEND"):
+            msg += (
+                "; an external secrets backend is configured — if this connection "
+                "should come from it, check the task pod's ServiceAccount and the "
+                "backend's read permissions (an auth failure surfaces as a miss)"
+            )
+        raise RuntimeError(msg)
     output = dbt_profile_from_uri(uri)
     if schema:
         output["schema"] = schema  # explicit leoflow.yaml schema wins over the URI/default

--- a/runtime/python/tests/test_dbt.py
+++ b/runtime/python/tests/test_dbt.py
@@ -337,3 +337,26 @@ def test_write_dbt_profile_schema_override(tmp_path, monkeypatch):
     write_dbt_profile("wh", "p", str(tmp_path), schema="marts")
     data = json.loads((tmp_path / "profiles.yml").read_text())
     assert data["p"]["outputs"]["dev"]["schema"] == "marts"
+
+
+def test_write_dbt_profile_missing_conn_is_backend_aware(tmp_path):
+    # With an external secrets backend configured, a missing declared connection is
+    # most often the pod identity/permissions (the provider backend reports an auth
+    # failure as a miss). The error must point there instead of a bare "unset" (#1).
+    with pytest.raises(RuntimeError) as e:
+        write_dbt_profile(
+            "warehouse", "shop", str(tmp_path),
+            env={"LEOFLOW_SECRETS_BACKEND": "some.Backend"},
+        )
+    msg = str(e.value)
+    assert "was not delivered" in msg
+    assert "ServiceAccount" in msg
+
+
+def test_write_dbt_profile_missing_conn_no_backend_no_hint(tmp_path):
+    # With no backend configured, the message stays the plain vault-only form.
+    with pytest.raises(RuntimeError) as e:
+        write_dbt_profile("warehouse", "shop", str(tmp_path), env={})
+    msg = str(e.value)
+    assert "was not delivered" in msg
+    assert "ServiceAccount" not in msg


### PR DESCRIPTION
Three confirmed items from the 0.4.2 EKS field feedback (the other two, #3 dbt stderr and #5 --password-stdin, already shipped in #838). No behavior change — observability + CLI DX. The one behavior change (#2, default task ServiceAccount) is a separate PR for scrutiny.

## #1 — surface an external-backend miss (top field item)
When the in-pod resolver runs as the wrong ServiceAccount, AWS returns NoCredentials — but the Airflow provider backend **swallows that to a `None`**, indistinguishable from a clean miss. The chain falls through to an empty vault and the task fails downstream with a bare `AIRFLOW_CONN_WAREHOUSE is unset`, no trace of the backend. Now: when a backend is configured and a **declared** name resolves from neither backend nor vault, the agent logs the unresolved names with a pointer at the pod identity/permissions (`internal/agent/runner.go`), and the dbt profile error carries the same backend-aware hint (`runtime/python/leoflow_runtime/dbt.py`). Low-noise: only fires on a truly-unresolved declared name with a backend configured (a normal external-miss-then-vault-hit stays quiet).

## #4 — hint the e-mail username on a failed login
`--username admin` returns a generic 401 (the bootstrap admin is `admin@leoflow.local`). On a 401 with a non-e-mail username, `auth login`/`create-token` append a format hint. Safe: reveals nothing about account existence.

## #8 — `leoflow dags list`
`dags` only had `delete`. Adds a read counterpart (DAG_ID / PAUSED / OWNERS) via the typed client, so verifying a registration no longer means `curl`-ing `/api/v2/dags`.

## Tests
- `internal/agent`: warns on unresolved-declared-with-backend, stays quiet when resolved and when no backend is configured.
- `internal/cli`: `printDagList` (empty + rows), `hintEmailUsername` (401+bare → hint; e-mail/non-401/nil/empty → none).
- `runtime/python`: dbt profile error is backend-aware when configured, plain otherwise.
- `go test ./internal/cli/ ./internal/agent/`, `pytest test_dbt.py`, `golangci-lint --new-from-rev origin/main` (0 issues), `ruff` — all green.