### PR TITLE
fix(dbt): declare the managed connection the profile step reads (#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **dbt managed connection now works under enforce scoping and an external
+  secrets backend.** The dbt compiler wraps each task with the profile step that
+  reads `AIRFLOW_CONN_<conn>`, but did not **declare** the managed connection — so
+  the agent injected it only under permissive scoping (the whole vault). Under
+  enforce scoping or the external secrets resolver (which deliver declared names
+  only) the connection was missing and the task failed "not delivered". The
+  compiler now declares it on every dbt task, across all warehouse adapters
+  (postgres, snowflake, bigquery, databricks, duckdb). **Behavior change:** a dbt
+  DAG with `connection:` now validates that connection at registration (it must
+  exist, or be covered by an external backend) — create the connection before
+  deploying, the same order any declared connection follows.
 - **External secrets resolver failed against a real provider backend (ADR 0060).**
   Importing and initialising an Airflow provider secrets backend emits log lines
   on stdout (structlog, alembic, the secrets masker). The resolver's stdout is the

--- a/internal/dbt/compile_test.go
+++ b/internal/dbt/compile_test.go
@@ -102,3 +102,27 @@ func TestCompileRequiresDagID(t *testing.T) {
 		t.Fatal("expected an error for an empty dag_id, got nil")
 	}
 }
+
+// A dbt DAG with a managed connection must emit a spec whose tasks DECLARE that
+// connection — the end-to-end lock for #10 (declaration is what makes the agent
+// inject AIRFLOW_CONN_<conn> under enforce scoping / an external backend; without
+// it the profile step fails "not delivered").
+func TestCompileDeclaresManagedConnection(t *testing.T) {
+	spec, err := Compile(loadManifest(t, "manifest_chain.json"), Meta{
+		DagID:      "shop",
+		Image:      "img",
+		Connection: "warehouse_pg",
+		Profile:    "transform",
+	})
+	if err != nil {
+		t.Fatalf("Compile() error: %v", err)
+	}
+	if len(spec.Tasks) == 0 {
+		t.Fatal("no tasks emitted")
+	}
+	for _, task := range spec.Tasks {
+		if !contains(task.Connections, "warehouse_pg") {
+			t.Errorf("task %q does not declare warehouse_pg: %v", task.TaskID, task.Connections)
+		}
+	}
+}

--- a/internal/dbt/render.go
+++ b/internal/dbt/render.go
@@ -198,6 +198,15 @@ func decorateCommands(tasks []domain.TaskSpec, opts Options) {
 	}
 	for i := range tasks {
 		tasks[i].Entrypoint = prefix + tasks[i].Entrypoint
+		// Declare the managed connection the profile step reads, so the agent
+		// injects AIRFLOW_CONN_<conn> under ANY scoping mode and resolves it from an
+		// external backend — declaration is the scope authority (ADR 0055 / 0060).
+		// Without this, a dbt DAG with a connection breaks under enforce scoping and
+		// with the external secrets backend: the profile step reads an env the agent
+		// never delivered (#10).
+		if opts.Connection != "" {
+			tasks[i].Connections = append(tasks[i].Connections, opts.Connection)
+		}
 	}
 }
 

--- a/internal/dbt/render_test.go
+++ b/internal/dbt/render_test.go
@@ -223,3 +223,25 @@ func TestRenderNodeGranularity(t *testing.T) {
 		}
 	}
 }
+
+// The managed-connection declaration must reach grouped-granularity tasks too
+// (folder/level), not just per-node — they share decorateCommands, but lock it
+// so the grouped path can't regress (#10, review nit).
+func TestRenderGroupedDeclaresManagedConnection(t *testing.T) {
+	for _, gran := range []Granularity{GranularityFolder, GranularityLevel} {
+		tasks, err := Render(loadManifest(t, "manifest_wide.json"), Options{
+			Granularity: gran, Connection: "warehouse_pg", Profile: "transform",
+		})
+		if err != nil {
+			t.Fatalf("Render(%v) error: %v", gran, err)
+		}
+		if len(tasks) == 0 {
+			t.Fatalf("Render(%v) emitted no tasks", gran)
+		}
+		for _, task := range tasks {
+			if !contains(task.Connections, "warehouse_pg") {
+				t.Errorf("gran=%v task %q does not declare warehouse_pg: %v", gran, task.TaskID, task.Connections)
+			}
+		}
+	}
+}

--- a/internal/dbt/render_test.go
+++ b/internal/dbt/render_test.go
@@ -70,6 +70,39 @@ func TestRenderWrapsManagedConnection(t *testing.T) {
 	if got != want {
 		t.Errorf("entrypoint = %q, want %q", got, want)
 	}
+	// The managed connection the profile step reads must also be DECLARED on every
+	// task, or the agent never injects AIRFLOW_CONN_<conn> under enforce scoping /
+	// an external backend and the profile step fails "not delivered" (#10).
+	for _, task := range tasks {
+		if !contains(task.Connections, "warehouse_pg") {
+			t.Errorf("task %q does not declare the managed connection warehouse_pg: %v", task.TaskID, task.Connections)
+		}
+	}
+}
+
+// Without a managed connection, tasks declare none (the local/duckdb and
+// baked-profile paths must not invent a declaration).
+func TestRenderNoConnectionDeclaresNone(t *testing.T) {
+	tasks, err := Render(loadManifest(t, "manifest_chain.json"), Options{
+		Granularity: GranularityNode, Profile: "transform", Local: true,
+	})
+	if err != nil {
+		t.Fatalf("Render() error: %v", err)
+	}
+	for _, task := range tasks {
+		if len(task.Connections) != 0 {
+			t.Errorf("task %q declared connections with no managed connection: %v", task.TaskID, task.Connections)
+		}
+	}
+}
+
+func contains(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
 }
 
 // TestRenderDefaultDuckdbGatedOnLocal: with no connection, a local build prefixes the

--- a/test/e2e/dbt-connection-e2e.sh
+++ b/test/e2e/dbt-connection-e2e.sh
@@ -129,6 +129,11 @@ export LEOFLOW_SERVER_HTTP_ADDR="0.0.0.0:${HTTP_PORT}"
 export LEOFLOW_SERVER_METRICS_ADDR="0.0.0.0:${METRICS_PORT}"
 export LEOFLOW_AGENT_ALLOW_INSECURE_SECRETS=true
 export LEOFLOW_SECRET_KEY="e2e-secret-key-32-bytes-padding!"
+# Run under ENFORCE scoping so this gates #10: only DECLARED names are delivered,
+# so the task only gets AIRFLOW_CONN_WAREHOUSE_PG because the compiler declared the
+# dbt managed connection. Under permissive (the old default) the whole vault would
+# be delivered and the declaration bug would hide.
+export LEOFLOW_AUTH_SECRET_SCOPING=enforce
 "$ROOT/bin/leoflow-server" >"$WORKDIR/server.log" 2>&1 &
 SERVER_PID=$!
 sleep 5
@@ -139,12 +144,17 @@ jq -e '.tasks[] | select(.entrypoint | startswith("python -m leoflow_runtime --d
   "$PROJ/dag.json" >/dev/null || fail "task commands are not wrapped with the managed-profile step"
 k3d_import "$CLUSTER" "$BASE_IMAGE" "$DAG_IMAGE"
 
-log "Pushing the DAG and creating the managed Postgres connection"
+log "Creating the managed Postgres connection FIRST, then pushing the DAG"
+# The DAG declares warehouse_pg (the dbt compiler declares the managed connection,
+# #10). Under enforce scoping, registration validates a declared connection exists
+# (ADR 0055 D6), so the connection must be created BEFORE the push — the correct
+# create-then-deploy order. (An external secrets backend would satisfy D6 via
+# coverage instead, with no pre-created vault entry.)
 TOKEN="$("$ROOT/bin/leoflow" auth create-token --server "$API" --username admin@leoflow.local --password admin)"
-"$ROOT/bin/leoflow" push "$PROJ/dag.json" --server "$API" --token "$TOKEN"
 curl -fsS -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
   -d "{\"connection_id\":\"warehouse_pg\",\"conn_type\":\"postgres\",\"host\":\"${HOST_ADDR}\",\"port\":${WH_PORT},\"login\":\"postgres\",\"password\":\"pw\",\"schema\":\"wh\"}" \
   "$API/api/v2/connections" >/dev/null || fail "creating the warehouse_pg connection"
+"$ROOT/bin/leoflow" push "$PROJ/dag.json" --server "$API" --token "$TOKEN"
 
 log "Triggering a run"
 RUN_ID="$(curl -fsS -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \

--- a/website/content/author-dags/dbt.md
+++ b/website/content/author-dags/dbt.md
@@ -278,6 +278,18 @@ $ curl -X POST .../api/v2/connections -d '{
     "host":"db.internal","port":5432,"login":"etl","password":"…","schema":"transform"}'
 ```
 
+{{% alert title="Create the connection before you deploy" color="info" %}}
+The compiler **declares** the managed connection on the dbt tasks, so Leoflow
+validates it at registration: `leoflow push`/`deploy` is rejected if
+`connection:` names a connection that neither exists in the vault nor is covered
+by an [external secrets backend](/operate/external-secrets/). Create the
+connection first (or configure the backend), then deploy — the same
+create-then-deploy order any declared connection follows. This also means the
+connection is delivered under every [secret-scoping](/operate/agent-credential-transport/)
+mode (enforce included) and resolvable from an external backend, not only under
+permissive scoping.
+{{% /alert %}}
+
 The compiled command becomes:
 
 ```


### PR DESCRIPTION
Field-feedback bug — the deeper root cause of "dbt connection was not delivered".

A whole-DAG dbt compile with a managed connection prefixes each task with `python -m leoflow_runtime --dbt-profile <conn> <profile>` (`internal/dbt/render.go`), which reads `AIRFLOW_CONN_<conn>` — but the renderer never DECLARED that connection. Declaration is the scope authority (ADR 0055/0060):

- Permissive scoping (default): the whole vault is injected, so it appeared to work.
- Enforce scoping: only declared names delivered → missing → "not delivered".
- External secrets backend (ADR 0060): resolves declared names only → never resolved → same failure.

Fix: the renderer declares the managed connection on every task it wraps, so the agent injects `AIRFLOW_CONN_<conn>` under any scoping mode and resolves it from an external backend.

Tests: render (tasks declare it; no-connection declares none), compile (spec tasks declare it — end-to-end through the real compiler, no dbt binary), plus existing enforce-scoping + LocalStack coverage for the injection half. `go test ./internal/dbt/` + `golangci-lint --new-from-rev origin/main` green.

E2e note: a k8s dbt-under-enforce gate needs the dbt binary (the dbt-connection-e2e CI job has it but runs permissive today, so it does not yet catch this class) — strengthening it to enforce is a CI follow-up, not validated locally without dbt.