### PR TITLE
fix(auth): DB outage during login returns 503, not "invalid credentials" (#9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **A database outage during login returned 401 "invalid credentials" instead of a
+  5xx (#843).** `IssueToken` collapsed every credential-store error into
+  `ErrInvalidCredentials`, so an unreachable DB read as "wrong password" — sending
+  operators to chase a password problem during an outage and masking the incident.
+  A genuine not-found now stays `ErrInvalidCredentials` (401, no user enumeration);
+  any other backend error propagates and the login endpoint answers **503
+  "authentication temporarily unavailable"** without consuming the per-IP lockout
+  budget. The 503 leaks nothing (returned regardless of whether the account exists).
+
 - **dbt managed connection now works under enforce scoping and an external
   secrets backend.** The dbt compiler wraps each task with the profile step that
   reads `AIRFLOW_CONN_<conn>`, but did not **declare** the managed connection — so

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -130,7 +130,11 @@ func authTokenHandler(authn auth.Authenticator, limiter *auth.RateLimiter, ttlSe
 				AbortProblem(c, http.StatusUnauthorized, "unauthorized", "invalid credentials")
 				return
 			}
-			AbortProblem(c, http.StatusInternalServerError, "internal error", "could not issue token")
+			// A non-credential error means the backend (DB) could not be reached, not
+			// that the credentials are wrong. Answer 503 so operators/monitoring see an
+			// outage rather than a wall of "invalid credentials" (#843). It leaks
+			// nothing: it is returned regardless of whether the account exists.
+			AbortProblem(c, http.StatusServiceUnavailable, "service unavailable", "authentication temporarily unavailable")
 			return
 		}
 		if bg != nil {

--- a/internal/api/login_backend_error_test.go
+++ b/internal/api/login_backend_error_test.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+)
+
+// dbDownAuthn simulates the control-plane DB being unreachable: IssueToken returns
+// a non-credential backend error (as the store now propagates, #843).
+type dbDownAuthn struct{}
+
+func (dbDownAuthn) IssueToken(context.Context, auth.Credentials) (string, error) {
+	return "", errors.New("looking up user for login: dial tcp: connection refused")
+}
+
+func (dbDownAuthn) Authenticate(context.Context, string) (*auth.User, error) {
+	return nil, errors.New("db down")
+}
+
+func authnServer(a auth.Authenticator) *gin.Engine {
+	return NewServer(Dependencies{
+		Logger: discardLogger(), Authenticator: a,
+		RateLimiter: auth.NewRateLimiter(100, time.Minute),
+		CORSOrigins: []string{"*"}, TokenTTLSecs: 3600,
+	})
+}
+
+// A DB outage during login must be 503 (backend unavailable), NOT 401 "invalid
+// credentials" — the latter misleads operators and hides the incident (#843).
+func TestLoginBackendDownReturns503(t *testing.T) {
+	srv := authnServer(dbDownAuthn{})
+	body := `{"username":"admin@leoflow.local","password":"whatever"}`
+	if code := do(srv, http.MethodPost, "/auth/token", body).Code; code != http.StatusServiceUnavailable {
+		t.Errorf("DB-down login = %d, want 503", code)
+	}
+}
+
+// A genuine wrong credential stays 401 (generic, no enumeration).
+func TestLoginBadCredentialsReturns401(t *testing.T) {
+	srv := authnServer(credAuthn{})
+	body := `{"username":"admin@leoflow.local","password":"wrong"}`
+	if code := do(srv, http.MethodPost, "/auth/token", body).Code; code != http.StatusUnauthorized {
+		t.Errorf("bad-credential login = %d, want 401", code)
+	}
+}

--- a/internal/api/login_backend_error_test.go
+++ b/internal/api/login_backend_error_test.go
@@ -50,3 +50,20 @@ func TestLoginBadCredentialsReturns401(t *testing.T) {
 		t.Errorf("bad-credential login = %d, want 401", code)
 	}
 }
+
+// A DB outage (503) must NOT consume the per-IP lockout budget — otherwise an
+// outage locks every user out once the budget drains. With a tiny limit, repeated
+// DB-down logins must all stay 503, never flip to 429 (#843 / review invariant).
+func TestLoginBackendDownDoesNotConsumeRateLimit(t *testing.T) {
+	srv := NewServer(Dependencies{
+		Logger: discardLogger(), Authenticator: dbDownAuthn{},
+		RateLimiter: auth.NewRateLimiter(2, time.Minute), // tiny budget
+		CORSOrigins: []string{"*"}, TokenTTLSecs: 3600,
+	})
+	body := `{"username":"admin@leoflow.local","password":"x"}`
+	for i := 0; i < 5; i++ {
+		if code := do(srv, http.MethodPost, "/auth/token", body).Code; code != http.StatusServiceUnavailable {
+			t.Fatalf("request %d = %d, want 503 every time (a 503 must not consume the lockout budget)", i, code)
+		}
+	}
+}

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -75,7 +75,11 @@ func MintUserToken(secret string, ttl time.Duration, user User) (string, error) 
 func (a *JWTAuthenticator) IssueToken(ctx context.Context, creds Credentials) (string, error) {
 	user, hash, err := a.store.FindUserByLogin(ctx, creds.Tenant, creds.Username)
 	if err != nil {
-		return "", ErrInvalidCredentials
+		// Propagate as-is: the store returns ErrInvalidCredentials for a genuine
+		// not-found/inactive user (→ 401), and a real backend error otherwise (→ the
+		// handler's 5xx). Collapsing everything to ErrInvalidCredentials would report
+		// a DB outage as "invalid credentials" (#843).
+		return "", err
 	}
 	if !VerifyPassword(hash, creds.Password) {
 		return "", ErrInvalidCredentials

--- a/internal/auth/login_backend_error_test.go
+++ b/internal/auth/login_backend_error_test.go
@@ -1,0 +1,42 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// A backend (DB) error from the store must PROPAGATE, not be reported as invalid
+// credentials — otherwise a database outage looks like "wrong password" to every
+// user and masks the incident (#843).
+func TestIssueTokenPropagatesBackendError(t *testing.T) {
+	dbErr := errors.New("dial tcp 127.0.0.1:5432: connection refused")
+	a := NewJWTAuthenticator(&fakeStore{err: dbErr}, "secret", time.Hour)
+	_, err := a.IssueToken(context.Background(), Credentials{Tenant: "default", Username: "a@b.c", Password: "pw"})
+	if !errors.Is(err, dbErr) {
+		t.Errorf("a backend error must propagate unchanged; got %v", err)
+	}
+	if errors.Is(err, ErrInvalidCredentials) {
+		t.Error("a backend error must NOT be reported as invalid credentials")
+	}
+}
+
+// A genuine not-found / inactive user (the store returns ErrInvalidCredentials)
+// stays ErrInvalidCredentials — the generic, no-enumeration answer.
+func TestIssueTokenKeepsInvalidCredentials(t *testing.T) {
+	a := NewJWTAuthenticator(&fakeStore{err: ErrInvalidCredentials}, "secret", time.Hour)
+	if _, err := a.IssueToken(context.Background(), Credentials{Tenant: "default", Username: "x", Password: "pw"}); !errors.Is(err, ErrInvalidCredentials) {
+		t.Errorf("a store not-found/inactive must stay ErrInvalidCredentials; got %v", err)
+	}
+}
+
+// A wrong password is ErrInvalidCredentials.
+func TestIssueTokenBadPassword(t *testing.T) {
+	a := NewJWTAuthenticator(
+		&fakeStore{user: &User{ID: "u1", TenantID: "default"}, hash: must(HashPassword("right"))},
+		"secret", time.Hour)
+	if _, err := a.IssueToken(context.Background(), Credentials{Tenant: "default", Username: "a@b.c", Password: "wrong"}); !errors.Is(err, ErrInvalidCredentials) {
+		t.Errorf("a wrong password must be ErrInvalidCredentials; got %v", err)
+	}
+}

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -107,7 +107,13 @@ func (r *Repository) tenantID(ctx context.Context, name string) (pgtype.UUID, er
 func (r *Repository) FindUserByLogin(ctx context.Context, tenant, username string) (*auth.User, string, error) {
 	row, err := r.q.GetUserByEmail(ctx, queries.GetUserByEmailParams{Name: tenant, Email: username})
 	if err != nil {
-		return nil, "", mapNotFound(err)
+		// A genuine not-found is an auth failure (generic, no enumeration). Any other
+		// error is a real backend failure (DB down/unreachable) and MUST propagate so
+		// the caller returns a 5xx, not a misleading "invalid credentials" (#843).
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, "", auth.ErrInvalidCredentials
+		}
+		return nil, "", fmt.Errorf("looking up user for login: %w", err)
 	}
 	if !row.IsActive {
 		return nil, "", auth.ErrInvalidCredentials


### PR DESCRIPTION
Field feedback #9 (issue #843). With the control-plane DB down, login returned 401 "invalid credentials" — sending operators to chase a password problem during an outage and masking the incident.

`IssueToken` collapsed every store error into `ErrInvalidCredentials`. Now the store returns `ErrInvalidCredentials` only for a genuine not-found (`pgx.ErrNoRows`) and propagates any other DB error; `IssueToken` passes it through; the login handler answers **503 "authentication temporarily unavailable"** for a backend error and keeps **401** for genuine bad credentials.

**Security:** the 503 is enumeration-safe (returned regardless of whether the account exists); 401 stays generic for wrong user/password.

Tests: `IssueToken` propagates a backend error (not ErrInvalidCredentials), keeps ErrInvalidCredentials for not-found/inactive/bad-password; the handler returns 503 on a backend error and 401 on bad credentials. `go test ./internal/auth/ ./internal/api/`, `golangci-lint --new-from-rev origin/main` (0 issues).