### PR TITLE
fix(cli): a per-task override must not drop a dbt task's managed connection

### DIFF
--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -689,6 +689,30 @@ func validateTaskBindings(overrides map[string]*domain.TaskConfig, tasks []domai
 	return nil
 }
 
+// dbtProfileConn extracts the managed connection id from a dbt task's compiled
+// entrypoint (`python -m leoflow_runtime --dbt-profile <conn> <profile> && …`),
+// or "" if the task has no dbt profile step. It is how applyTaskOverride knows a
+// task depends on a specific connection the author's override must not drop.
+func dbtProfileConn(entrypoint string) string {
+	fields := strings.Fields(entrypoint)
+	for i, f := range fields {
+		if f == "--dbt-profile" && i+1 < len(fields) {
+			return fields[i+1]
+		}
+	}
+	return ""
+}
+
+// containsString reports whether xs contains s.
+func containsString(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
 // applyTaskOverride sets each override field that is present onto the task,
 // leaving unset fields as compiled. Env entries are merged over any existing env.
 func applyTaskOverride(task *domain.TaskSpec, o *domain.TaskConfig) {
@@ -712,6 +736,14 @@ func applyTaskOverride(task *domain.TaskSpec, o *domain.TaskConfig) {
 	// matching the override semantics of the other scalar/struct fields above.
 	if len(o.Connections) > 0 {
 		task.Connections = o.Connections
+		// A dbt task's managed connection is a compiler-injected DEPENDENCY — its
+		// profile step reads AIRFLOW_CONN_<conn> — not an author preference. An
+		// override that narrows connections must not silently drop it, or the task
+		// fails "not delivered" under enforce scoping / an external backend (#10).
+		// Re-add it if the override omitted it.
+		if conn := dbtProfileConn(task.Entrypoint); conn != "" && !containsString(task.Connections, conn) {
+			task.Connections = append(task.Connections, conn)
+		}
 	}
 	if len(o.Variables) > 0 {
 		task.Variables = o.Variables

--- a/internal/cli/dbt_override_test.go
+++ b/internal/cli/dbt_override_test.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+func TestDbtProfileConn(t *testing.T) {
+	got := dbtProfileConn("python -m leoflow_runtime --dbt-profile warehouse_pg shop && dbt run --select stg")
+	if got != "warehouse_pg" {
+		t.Errorf("dbtProfileConn = %q, want warehouse_pg", got)
+	}
+	if c := dbtProfileConn("dbt run --select stg"); c != "" {
+		t.Errorf("no profile step should yield empty, got %q", c)
+	}
+}
+
+// A per-task connections override on a dbt task must NOT drop the compiler-injected
+// managed connection the profile step depends on (#10 regression guard): it is
+// re-added, while the author's extra connection is still applied.
+func TestApplyTaskOverrideKeepsDbtConnection(t *testing.T) {
+	task := &domain.TaskSpec{
+		TaskID:      "stg",
+		Entrypoint:  "python -m leoflow_runtime --dbt-profile warehouse_pg shop && dbt run --select stg",
+		Connections: []string{"warehouse_pg"}, // as the dbt compiler declared it
+	}
+	applyTaskOverride(task, &domain.TaskConfig{Connections: []string{"other_conn"}})
+
+	if !containsString(task.Connections, "warehouse_pg") {
+		t.Errorf("override dropped the dbt managed connection: %v", task.Connections)
+	}
+	if !containsString(task.Connections, "other_conn") {
+		t.Errorf("author's override connection not applied: %v", task.Connections)
+	}
+}
+
+// A non-dbt task keeps the documented replace semantics — no phantom connection
+// is invented.
+func TestApplyTaskOverrideNonDbtReplaces(t *testing.T) {
+	task := &domain.TaskSpec{
+		TaskID:      "t",
+		Entrypoint:  "python -m leoflow_runtime run",
+		Connections: []string{"compiled_conn"},
+	}
+	applyTaskOverride(task, &domain.TaskConfig{Connections: []string{"only_this"}})
+	if len(task.Connections) != 1 || task.Connections[0] != "only_this" {
+		t.Errorf("non-dbt override must replace, got %v", task.Connections)
+	}
+}


### PR DESCRIPTION
Follow-up from the #10 review. The dbt compiler declares the managed connection on each task (the profile step reads `AIRFLOW_CONN_<conn>`). A leoflow.yaml `tasks.<id>.connections` override replaces the compiled list, which would silently drop that dependency and reintroduce the not-delivered failure under enforce scoping / an external backend for that task.

`applyTaskOverride` now re-adds the dbt-profile connection when an override omits it (parsed from the compiled entrypoint), while still applying the author's own connections. Non-dbt tasks keep the documented replace semantics.

Tests: `dbtProfileConn` parsing; override keeps the dbt connection + applies the author's; non-dbt replaces. `golangci-lint --new-from-rev origin/main` 0 issues.