### PR TITLE
feat(runtime): version-stamp the in-pod agent baked into the base image (#3)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -203,15 +203,25 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ github.ref_name }}
 
+      - name: Stamp build date
+        id: stamp
+        run: echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: Build + push (multi-arch)
         id: build
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: runtime/Dockerfile
+          # Stamp the baked agent with the release version/commit/date, so
+          # `leoflow-agent version` in a task pod is traceable to a commit (matches
+          # the cosign-signed release binaries' provenance).
           build-args: |
             PYTHON_VERSION=${{ matrix.python }}
             GO_VERSION=${{ env.GO_VERSION }}
+            VERSION=${{ github.ref_name }}
+            GIT_COMMIT=${{ github.sha }}
+            BUILD_DATE=${{ steps.stamp.outputs.date }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **The in-pod agent baked into the runtime base image is now version-stamped.**
+  `leoflow-agent version` in a task pod reports the version, commit, and build date
+  it was built from (the same `-ldflags -X` as the release binaries), instead of an
+  empty/`none` build. This restores commit-level traceability for the task pod and
+  makes a control-plane↔agent version skew diagnosable. The runtime-image release
+  job already publishes an immutable per-release tag (`py<ver>-<release>`) alongside
+  the moving `py<ver>` line.
 - **Airflow Task SDK bumped to 3.3.x (`apache-airflow-task-sdk==1.3.1`).** DAGs
   now run under the Airflow 3.3 Task SDK in the task pod and the `leoflow lite`
   dev venv; the 3.3 SDK surface is additive over 3.2 (no removed `airflow.sdk`

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -21,7 +21,17 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -trimpath -o /out/leoflow-agent ./cmd/leoflow-agent
+# Stamp the agent with version/commit/date, exactly as the release binaries are
+# (Makefile LDFLAGS). Without this the baked agent reports empty version/commit,
+# so `leoflow-agent version` in a task pod is untraceable to a commit and a
+# control-plane↔agent version skew is undiagnosable. Defaults keep a local/source
+# build meaningful; the release passes the real values as build-args.
+ARG VERSION=dev
+ARG GIT_COMMIT=none
+ARG BUILD_DATE=unknown
+RUN CGO_ENABLED=0 go build -trimpath \
+	-ldflags="-s -w -X 'github.com/neochaotic/leoflow/internal/version.version=${VERSION}' -X 'github.com/neochaotic/leoflow/internal/version.gitCommit=${GIT_COMMIT}' -X 'github.com/neochaotic/leoflow/internal/version.buildDate=${BUILD_DATE}'" \
+	-o /out/leoflow-agent ./cmd/leoflow-agent
 
 # ── Stage 2: runtime base ─────────────────────────────────────────────────────
 FROM python:${PYTHON_VERSION}-slim-bookworm


### PR DESCRIPTION
Field feedback #3 (issue #846), safe parts. The agent baked into the runtime base image was built without `-ldflags`, so `leoflow-agent version` in a task pod reported an empty version/commit — untraceable to a commit, a control-plane↔agent skew undiagnosable, and inconsistent with the cosign-signed release binaries.

## Change
- `runtime/Dockerfile`: build the agent with `VERSION`/`GIT_COMMIT`/`BUILD_DATE` args + the same `-X` ldflags as the release binaries (defaults keep a local build meaningful).
- `release.yaml` runtime-image: pass the tag/sha/date as build-args.

## Verified locally
```
$ docker build -f runtime/Dockerfile --build-arg VERSION=stamp-test-v0.4.3 --build-arg GIT_COMMIT=deadbeef99 ... 
$ docker run --rm --entrypoint leoflow-agent <img> version
leoflow stamp-test-v0.4.3 (commit deadbeef99, built 2026-09-01T00:00:00Z, go1.26.3)
```
(before: empty version / `commit none`).

## Scope
The immutable per-release tag (`py<ver>-<release>`) the feedback asked for **already exists** in the runtime-image job. The remaining ask — the CLI pinning the versioned base by default — is a separate, behavior-changing follow-up (it must handle dev/dirty versions that have no published base tag), deferred. `actionlint` clean.