### PR TITLE
feat(cli): pin the versioned base image by default (#3)

### DIFF
--- a/internal/cli/compile_build.go
+++ b/internal/cli/compile_build.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/version"
 )
 
 // generatedDockerfileName is the file a yaml-driven build writes its synthesized
@@ -31,7 +33,31 @@ func resolveBaseImage(cfg *domain.LeoflowConfig) string {
 	if cfg.BaseImage != "" {
 		return cfg.BaseImage
 	}
-	return publishedBaseRepo + ":py" + cfg.PythonVersion
+	base := publishedBaseRepo + ":py" + cfg.PythonVersion
+	// Pin the base to THIS CLI's release, so a compile reproduces byte-for-byte: the
+	// release publishes an immutable py<ver>-<release> tag, and a compile from that
+	// release FROMs exactly it instead of the moving py<ver> line (ADR 0003). A dev/
+	// dirty/`git describe` build has no published versioned base, so it falls back to
+	// the moving tag. An explicit base_image (above) always wins.
+	if tag := releaseBaseTag(version.Get().Version); tag != "" {
+		return base + "-" + tag
+	}
+	return base
+}
+
+// devDescribeRe matches the `git describe` suffix a non-release build carries
+// (`-<commits>-g<sha>`), which has no published versioned base image.
+var devDescribeRe = regexp.MustCompile(`-\d+-g[0-9a-f]+`)
+
+// releaseBaseTag returns v when it names a clean release (a tag the release
+// workflow published a py<ver>-<v> base for), or "" for a dev/dirty/describe build
+// that has no such base. Keeps a source build working (moving tag) while a real
+// release pins its immutable base.
+func releaseBaseTag(v string) string {
+	if v == "" || v == "dev" || strings.HasSuffix(v, "-dirty") || devDescribeRe.MatchString(v) {
+		return ""
+	}
+	return v
 }
 
 // resolveBuildImage decides the image reference for a build. An explicit --image

--- a/internal/cli/compile_build.go
+++ b/internal/cli/compile_build.go
@@ -33,14 +33,22 @@ func resolveBaseImage(cfg *domain.LeoflowConfig) string {
 	if cfg.BaseImage != "" {
 		return cfg.BaseImage
 	}
-	base := publishedBaseRepo + ":py" + cfg.PythonVersion
-	// Pin the base to THIS CLI's release, so a compile reproduces byte-for-byte: the
-	// release publishes an immutable py<ver>-<release> tag, and a compile from that
-	// release FROMs exactly it instead of the moving py<ver> line (ADR 0003). A dev/
-	// dirty/`git describe` build has no published versioned base, so it falls back to
-	// the moving tag. An explicit base_image (above) always wins.
-	if tag := releaseBaseTag(version.Get().Version); tag != "" {
-		return base + "-" + tag
+	return baseImageRef(publishedBaseRepo, cfg.PythonVersion, version.Get().Version)
+}
+
+// baseImageRef composes the task base image reference for a CLI of version
+// cliVersion. It pins the immutable per-release base (repo:py<ver>-v<X.Y.Z>) so a
+// compile from a release reproduces byte-for-byte (ADR 0003); a dev/dirty/`git
+// describe` build has no published versioned base and falls back to the moving
+// repo:py<ver> line. The published tag is ALWAYS `py<ver>-v<X.Y.Z>` (release.yaml
+// stamps `github.ref_name`, the git tag WITH its leading `v`), but GoReleaser
+// stamps the CLI's version WITHOUT the `v` (`{{ .Version }}`), so normalize to
+// exactly one leading `v` — otherwise a released CLI would FROM a `py<ver>-X.Y.Z`
+// tag that was never pushed.
+func baseImageRef(repo, pythonVersion, cliVersion string) string {
+	base := repo + ":py" + pythonVersion
+	if tag := releaseBaseTag(cliVersion); tag != "" {
+		return base + "-v" + strings.TrimPrefix(tag, "v")
 	}
 	return base
 }

--- a/internal/cli/compile_build.go
+++ b/internal/cli/compile_build.go
@@ -73,14 +73,14 @@ func releaseBaseTag(v string) string {
 // derived from the registry block (url/image_name:version); a missing url or
 // image_name yields "" so the caller can fail with an actionable message rather
 // than building an untagged image.
-func resolveBuildImage(flagImage string, cfg *domain.LeoflowConfig, version string) string {
+func resolveBuildImage(flagImage string, cfg *domain.LeoflowConfig, dagVersion string) string {
 	if flagImage != "" {
 		return flagImage
 	}
 	if cfg.Registry == nil || cfg.Registry.URL == "" || cfg.Registry.ImageName == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s/%s:%s", strings.TrimRight(cfg.Registry.URL, "/"), cfg.Registry.ImageName, version)
+	return fmt.Sprintf("%s/%s:%s", strings.TrimRight(cfg.Registry.URL, "/"), cfg.Registry.ImageName, dagVersion)
 }
 
 // generatedDockerfile renders the Dockerfile for a project that does not ship its

--- a/internal/cli/compile_build_baseimage_test.go
+++ b/internal/cli/compile_build_baseimage_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+func TestReleaseBaseTag(t *testing.T) {
+	cases := map[string]string{
+		"v0.4.2":                  "v0.4.2",      // clean release tag → pin
+		"v0.4.3-rc.1":             "v0.4.3-rc.1", // rc tag is still a release
+		"v1.2.3-beta.4":           "v1.2.3-beta.4",
+		"v0.4.2-9-gabc1234":       "", // git describe (commits after tag) → moving
+		"v0.4.2-9-gabc1234-dirty": "", // describe + dirty
+		"v0.4.2-dirty":            "", // dirty tree
+		"dev":                     "", // default source build
+		"":                        "", // unset
+	}
+	for in, want := range cases {
+		if got := releaseBaseTag(in); got != want {
+			t.Errorf("releaseBaseTag(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestResolveBaseImage(t *testing.T) {
+	// An explicit base_image always wins.
+	if got := resolveBaseImage(&domain.LeoflowConfig{BaseImage: "my/base:tag", PythonVersion: "3.11"}); got != "my/base:tag" {
+		t.Errorf("base_image override = %q, want my/base:tag", got)
+	}
+	// A dev/test build (version = "dev") pins the moving py<ver> tag — no versioned
+	// base is published for a non-release build.
+	got := resolveBaseImage(&domain.LeoflowConfig{PythonVersion: "3.11"})
+	if got != publishedBaseRepo+":py3.11" {
+		t.Errorf("dev build base = %q, want %q (moving tag)", got, publishedBaseRepo+":py3.11")
+	}
+	if strings.Contains(got, "-") && !strings.HasPrefix(got, publishedBaseRepo) {
+		t.Errorf("unexpected version suffix on a dev build: %q", got)
+	}
+}

--- a/internal/cli/compile_build_baseimage_test.go
+++ b/internal/cli/compile_build_baseimage_test.go
@@ -1,11 +1,6 @@
 package cli
 
-import (
-	"strings"
-	"testing"
-
-	"github.com/neochaotic/leoflow/internal/domain"
-)
+import "testing"
 
 func TestReleaseBaseTag(t *testing.T) {
 	cases := map[string]string{
@@ -25,18 +20,23 @@ func TestReleaseBaseTag(t *testing.T) {
 	}
 }
 
-func TestResolveBaseImage(t *testing.T) {
-	// An explicit base_image always wins.
-	if got := resolveBaseImage(&domain.LeoflowConfig{BaseImage: "my/base:tag", PythonVersion: "3.11"}); got != "my/base:tag" {
-		t.Errorf("base_image override = %q, want my/base:tag", got)
+func TestBaseImageRef(t *testing.T) {
+	const repo = "ghcr.io/neochaotic/leoflow-runtime"
+	cases := map[string]string{
+		// GoReleaser stamps the CLI version WITHOUT the leading v; the published base
+		// tag ALWAYS has it. Both forms must resolve to the same py<ver>-v<X> tag.
+		"0.4.2":      repo + ":py3.11-v0.4.2",
+		"v0.4.2":     repo + ":py3.11-v0.4.2",
+		"0.4.3-rc.1": repo + ":py3.11-v0.4.3-rc.1",
+		// dev/dirty/describe → moving tag (no versioned base is published for them).
+		"0.4.2-9-gabc1234": repo + ":py3.11",
+		"v0.4.2-dirty":     repo + ":py3.11",
+		"dev":              repo + ":py3.11",
+		"":                 repo + ":py3.11",
 	}
-	// A dev/test build (version = "dev") pins the moving py<ver> tag — no versioned
-	// base is published for a non-release build.
-	got := resolveBaseImage(&domain.LeoflowConfig{PythonVersion: "3.11"})
-	if got != publishedBaseRepo+":py3.11" {
-		t.Errorf("dev build base = %q, want %q (moving tag)", got, publishedBaseRepo+":py3.11")
-	}
-	if strings.Contains(got, "-") && !strings.HasPrefix(got, publishedBaseRepo) {
-		t.Errorf("unexpected version suffix on a dev build: %q", got)
+	for ver, want := range cases {
+		if got := baseImageRef(repo, "3.11", ver); got != want {
+			t.Errorf("baseImageRef(_, 3.11, %q) = %q, want %q", ver, got, want)
+		}
 	}
 }


### PR DESCRIPTION
Field feedback #3 (issue #846), final part. `leoflow compile` now FROMs the immutable per-release base (`leoflow-runtime:py<ver>-<release>`) instead of the moving `:py<ver>` tag, so a build from a given release reproduces byte-for-byte (ADR 0003 artifact immutability). A dev/dirty/`git describe` build has no published versioned base, so `releaseBaseTag` returns empty and it falls back to the moving tag; an explicit `base_image` still wins. Tests cover the tag classifier (clean tag vs describe/dirty/dev) and resolveBaseImage precedence.