### PR TITLE
fix(dispatch): a task pinning a ServiceAccount skips warm placement

### DIFF
--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -154,6 +154,18 @@ func (d *Dispatcher) SetSecretsBackend(class, kwargs string) {
 	d.secretsBackend, d.secretsBackendKwargs = class, kwargs
 }
 
+// warmSACompatible reports whether a task can run on a warm worker, whose
+// ServiceAccount is the operator default fixed at pod creation. A task that pins a
+// different execution.service_account is incompatible (the warm pod cannot adopt
+// it) and must take the dedicated path; a task with no SA (uses the default) or one
+// equal to the default is compatible.
+func warmSACompatible(task domain.TaskSpec, warmSA string) bool {
+	if task.Execution == nil || task.Execution.ServiceAccount == "" {
+		return true
+	}
+	return task.Execution.ServiceAccount == warmSA
+}
+
 // SetDefaultTaskServiceAccount sets the ServiceAccount task pods run as when a
 // DAG's task does not specify execution.service_account. Empty leaves pods on the
 // namespace default SA (today's behavior). Wiring the chart's task ServiceAccount
@@ -238,7 +250,12 @@ func (d *Dispatcher) Dispatch(ctx context.Context, runID, dagID, dagVersionID st
 	// per-run /staging mount, so a staging attempt placed on one would silently
 	// lose the run's shared volume. Staging attempts always take the dedicated
 	// path below, which provisions the StagingClaim.
-	if d.placer != nil && (r.Staging == nil || !r.Staging.Enabled) {
+	// A warm worker is pre-created with the operator's default task ServiceAccount,
+	// fixed for its lifetime, so a task that pins a DIFFERENT execution.service_account
+	// cannot run on it (it would silently run as the wrong identity and break keyless
+	// resolution). Such a task takes the dedicated path below, which sets its own SA —
+	// the same degrade-not-strand exclusion as staging (ADR 0058 D5).
+	if d.placer != nil && (r.Staging == nil || !r.Staging.Enabled) && warmSACompatible(task, d.defaultTaskServiceAccount) {
 		wa := &agentv1.WorkAssignment{
 			AssignmentId: uuid.NewString(),
 			AttemptToken: token,

--- a/internal/dispatch/warm_serviceaccount_test.go
+++ b/internal/dispatch/warm_serviceaccount_test.go
@@ -1,0 +1,67 @@
+package dispatch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/executor"
+)
+
+func TestWarmSACompatible(t *testing.T) {
+	cases := []struct {
+		name   string
+		task   domain.TaskSpec
+		warmSA string
+		want   bool
+	}{
+		{"no execution", domain.TaskSpec{}, "leoflow-task", true},
+		{"empty SA uses default", domain.TaskSpec{Execution: &domain.Execution{}}, "leoflow-task", true},
+		{"SA equals warm default", domain.TaskSpec{Execution: &domain.Execution{ServiceAccount: "leoflow-task"}}, "leoflow-task", true},
+		{"pinned different SA", domain.TaskSpec{Execution: &domain.Execution{ServiceAccount: "custom-sa"}}, "leoflow-task", false},
+		{"pinned SA, no warm default", domain.TaskSpec{Execution: &domain.Execution{ServiceAccount: "custom-sa"}}, "", false},
+	}
+	for _, c := range cases {
+		if got := warmSACompatible(c.task, c.warmSA); got != c.want {
+			t.Errorf("%s: warmSACompatible = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// A task pinning a ServiceAccount different from the warm workers' must NOT be
+// placed on a warm worker (which can't adopt it) — it takes the dedicated path,
+// which honors the pinned SA.
+func TestDispatchSkipsWarmForPinnedSA(t *testing.T) {
+	placer := &fakePlacer{ok: true}
+	exec := &fakeExecutor{}
+	d := newDispatcher(&fakeResolver{resolved: Resolved{TaskInstanceID: "ti", Image: "etl:v1"}}, &fakeIssuer{token: "t"}, exec)
+	d.SetWarmPlacer(placer)
+	d.SetDefaultTaskServiceAccount("leoflow-task") // what warm workers run as
+
+	task := pythonTask()
+	task.Execution = &domain.Execution{ServiceAccount: "custom-sa"} // pins a different SA
+	if _, err := d.Dispatch(context.Background(), "run", "etl", "ver-1", task); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if placer.calls != 0 {
+		t.Errorf("warm placer called %d times; a pinned non-default SA must skip warm placement", placer.calls)
+	}
+	if exec.req.Execution.ServiceAccount != "custom-sa" {
+		t.Errorf("dedicated pod must carry the pinned SA, got %q", exec.req.Execution.ServiceAccount)
+	}
+}
+
+// A task with no pinned SA (uses the default) is still eligible for warm placement.
+func TestDispatchUsesWarmForDefaultSA(t *testing.T) {
+	placer := &fakePlacer{ok: true}
+	d := newDispatcher(&fakeResolver{resolved: Resolved{TaskInstanceID: "ti", Image: "etl:v1"}}, &fakeIssuer{token: "t"}, &fakeExecutor{})
+	d.SetWarmPlacer(placer)
+	d.SetDefaultTaskServiceAccount("leoflow-task")
+	if _, err := d.Dispatch(context.Background(), "run", "etl", "ver-1", pythonTask()); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if placer.calls != 1 {
+		t.Errorf("a task with no pinned SA should be warm-eligible; placer calls = %d, want 1", placer.calls)
+	}
+	_ = executor.Dispatched
+}


### PR DESCRIPTION
Review follow-up on #2/#844 (warm-pool interaction). A warm worker is pre-created with the operator default task ServiceAccount, fixed for its lifetime — so a task that pins a *different* `execution.service_account` cannot run on it (it would run as the wrong identity and break keyless resolution, an intermittent placement-dependent footgun).

Such a task is now excluded from warm placement and takes the dedicated path (which sets its own SA) — the same degrade-not-strand exclusion staging already uses (ADR 0058 D5). A task with no SA (uses the default) or one equal to the default stays warm-eligible.

Tests: `warmSACompatible` truth table; dispatch skips the placer for a pinned non-default SA (and the dedicated req carries it); dispatch still uses the placer for the default-SA case. `golangci-lint --new-from-rev origin/main` 0 issues.