### PR TITLE
fix(compile): dbt image installs deps as root + writes artifacts to /tmp (#852)

### DIFF
--- a/internal/cli/compile_build.go
+++ b/internal/cli/compile_build.go
@@ -67,6 +67,15 @@ func generatedDockerfile(cfg *domain.LeoflowConfig, dagSource string) (string, e
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "FROM %s\n", resolveBaseImage(cfg))
+	// apt requires root, and pip as the base's non-root USER (65532) falls back to a
+	// `--user` install whose console scripts (e.g. `dbt`) land in ~/.local/bin, which
+	// is not on PATH — so a synthesized dbt image would fail `dbt: command not found`.
+	// Install as root (system site → /usr/local/bin on PATH), then drop back to the
+	// non-root runtime USER before the source COPY (#852).
+	rootForInstall := len(cfg.SystemPackages) > 0 || len(deps) > 0
+	if rootForInstall {
+		b.WriteString("USER root\n")
+	}
 	if len(cfg.SystemPackages) > 0 {
 		// Single RUN so the apt cache cleanup stays in the same layer as the install.
 		fmt.Fprintf(&b, "RUN apt-get update && apt-get install -y --no-install-recommends %s "+
@@ -83,12 +92,20 @@ func generatedDockerfile(cfg *domain.LeoflowConfig, dagSource string) (string, e
 		// + models/ + baked manifest.json) to the workdir and set no PYTHONPATH. The
 		// task runs `dbt --project-dir <project>` from WORKDIR /home/leoflow, so the
 		// project must land at /home/leoflow/<project> matching the baked --project-dir.
+		// COPYed while still root, so the project is read-only to the task: dbt writes
+		// target/, logs/, and profiles.yml to /tmp (base ENV), never the project (#852).
 		project := filepath.Clean(cfg.Dbt.Project)
 		fmt.Fprintf(&b, "COPY %s /home/leoflow/%s\n", project, project)
+		if rootForInstall {
+			b.WriteString("USER 65532:65532\n")
+		}
 		return b.String(), nil
 	}
 	base := filepath.Base(dagSource)
 	fmt.Fprintf(&b, "COPY %s /home/leoflow/%s\nENV PYTHONPATH=/home/leoflow\n", base, base)
+	if rootForInstall {
+		b.WriteString("USER 65532:65532\n")
+	}
 	return b.String(), nil
 }
 

--- a/internal/cli/compile_build_test.go
+++ b/internal/cli/compile_build_test.go
@@ -206,3 +206,49 @@ func TestEnsureDockerfileGeneratesWhenAbsent(t *testing.T) {
 		t.Errorf("cleanup did not remove the generated Dockerfile %q", path)
 	}
 }
+
+// The synthesized Dockerfile must install deps as root (so console scripts like
+// dbt land on PATH, not ~/.local/bin) and drop back to the non-root runtime USER,
+// keeping the COPYed project root-owned/read-only (#852).
+func TestGeneratedDockerfileInstallsAsRoot(t *testing.T) {
+	cfg := &domain.LeoflowConfig{
+		PythonVersion: "3.11",
+		Dependencies:  []string{"dbt-postgres==1.9.0"},
+		Dbt:           &domain.DbtConfig{Project: "analytics"},
+	}
+	df, err := generatedDockerfile(cfg, "dag.py")
+	if err != nil {
+		t.Fatalf("generatedDockerfile() error = %v", err)
+	}
+	// USER root must precede the pip install, and USER 65532 must be the last USER.
+	iRoot := strings.Index(df, "USER root")
+	iPip := strings.Index(df, "pip install")
+	iNonRoot := strings.LastIndex(df, "USER 65532:65532")
+	if iRoot < 0 || iPip < 0 || iNonRoot < 0 {
+		t.Fatalf("expected USER root, pip install, and a trailing USER 65532:65532 in:\n%s", df)
+	}
+	if iRoot >= iPip || iPip >= iNonRoot {
+		t.Errorf("order must be USER root -> pip install -> USER 65532:65532, got:\n%s", df)
+	}
+	// The runtime USER must be non-root (PSA runAsNonRoot): no USER directive after it.
+	if strings.Contains(df[iNonRoot+len("USER 65532:65532"):], "USER ") {
+		t.Errorf("a USER directive follows the final non-root USER:\n%s", df)
+	}
+	// The project stays read-only — no chown makes it task-writable.
+	if strings.Contains(df, "chown") {
+		t.Errorf("project must stay read-only (no chown); got:\n%s", df)
+	}
+}
+
+// A pure-Python DAG with NO deps needs no root switch (nothing to install) and
+// stays on the base's non-root USER.
+func TestGeneratedDockerfileNoDepsNoRootSwitch(t *testing.T) {
+	cfg := &domain.LeoflowConfig{PythonVersion: "3.11"}
+	df, err := generatedDockerfile(cfg, "dag.py")
+	if err != nil {
+		t.Fatalf("generatedDockerfile() error = %v", err)
+	}
+	if strings.Contains(df, "USER root") {
+		t.Errorf("no deps → no root switch needed; got:\n%s", df)
+	}
+}

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -52,6 +52,16 @@ RUN pip install --no-cache-dir /opt/leoflow-runtime
 ARG AIRFLOW_TASK_SDK_VERSION=1.3.1
 RUN pip install --no-cache-dir "apache-airflow-task-sdk==${AIRFLOW_TASK_SDK_VERSION}"
 
+# dbt defaults its writable artifacts (target/, logs/, profiles.yml) to the project
+# directory, but a compiled DAG image COPYs the project read-only (root-owned), so
+# dbt would explode writing there. Point them at an ephemeral, always-writable /tmp
+# dir instead — keeps the project read-only (a stronger posture) and lets the chart
+# run task pods with readOnlyRootFilesystem + a /tmp emptyDir. Harmless for non-dbt
+# tasks (they never read these). See #852.
+ENV DBT_PROFILES_DIR=/tmp/leoflow/dbt \
+    DBT_TARGET_PATH=/tmp/leoflow/dbt/target \
+    DBT_LOG_PATH=/tmp/leoflow/dbt/logs
+
 USER 65532:65532
 WORKDIR /home/leoflow
 

--- a/runtime/python/leoflow_runtime/dbt.py
+++ b/runtime/python/leoflow_runtime/dbt.py
@@ -211,8 +211,12 @@ def write_dbt_profile(
         output["schema"] = schema  # explicit leoflow.yaml schema wins over the URI/default
     profile = {profile_name: {"target": "dev", "outputs": {"dev": output}}}
     path = os.path.join(profiles_dir, "profiles.yml")
-    with open(path, "w", encoding="utf-8") as handle:
+    # profiles.yml carries warehouse credentials (password / private key / keyfile /
+    # token), so write it owner-only (0600), not the default 0644. The opener sets
+    # the mode on create; chmod also covers a pre-existing file.
+    with open(path, "w", encoding="utf-8", opener=lambda p, f: os.open(p, f, 0o600)) as handle:
         json.dump(profile, handle)
+    os.chmod(path, 0o600)
     return path
 
 

--- a/runtime/python/tests/test_dbt.py
+++ b/runtime/python/tests/test_dbt.py
@@ -360,3 +360,19 @@ def test_write_dbt_profile_missing_conn_no_backend_no_hint(tmp_path):
     msg = str(e.value)
     assert "was not delivered" in msg
     assert "ServiceAccount" not in msg
+
+
+def test_write_dbt_profile_is_owner_only(tmp_path):
+    # profiles.yml carries warehouse credentials, so it must be written 0600
+    # (owner-only), not the default world-readable 0644 (#852 security review).
+    import os
+    import stat
+
+    from leoflow_runtime.dbt import write_dbt_profile
+
+    path = write_dbt_profile(
+        "warehouse", "shop", str(tmp_path),
+        env={"AIRFLOW_CONN_WAREHOUSE": "postgres://u:p@h:5432/db"},
+    )
+    mode = stat.S_IMODE(os.stat(path).st_mode)
+    assert mode == 0o600, f"profiles.yml mode = {oct(mode)}, want 0o600"


### PR DESCRIPTION
Field feedback (issue #852), refined fix. A dbt DAG built via `leoflow compile --build` (the synthesized Dockerfile) produced a broken image: `dbt: command not found`.

## Root cause
The synthesized Dockerfile ran `apt`/`pip` as the base image’s non-root `USER 65532`, so pip fell back to a `--user` install and dbt’s console script landed in `~/.local/bin` — **not on PATH**; `apt` failed outright. The e2e masked it by hand-writing a Dockerfile with `USER root`.

## Fix (refined — read-only project, no chown)
- `generatedDockerfile`: install deps as **root** (console scripts → `/usr/local/bin`, on PATH), then drop back to `USER 65532:65532`. The COPYed dbt project stays **root-owned / read-only** to the task.
- `runtime/Dockerfile`: point `DBT_PROFILES_DIR` / `DBT_TARGET_PATH` / `DBT_LOG_PATH` at an ephemeral `/tmp/leoflow/dbt` dir, so dbt writes its artifacts there — never the read-only project. Harmless for non-dbt tasks.

## Security posture
Build-time root is standard (apt/pip need it); the **runtime** container is non-root (`USER 65532`, PSA `runAsNonRoot`). The project being read-only is a *stronger* posture (a task cannot modify its own code), and routing dbt’s writes to `/tmp` lets a task pod run with `readOnlyRootFilesystem: true` + a `/tmp` emptyDir (follow-up).

## Tests
- `generatedDockerfile`: USER root precedes pip and USER 65532 is the last USER (runtime non-root); no chown (project read-only); no-deps build needs no root switch.
- Existing generatedDockerfile tests still green; `golangci-lint --new-from-rev origin/main` 0 issues.

## Follow-up
Refactor `dbt-connection-e2e.sh` to build via the **synthesized** Dockerfile (deps in leoflow.yaml, no hand-written Dockerfile) so this class is gated in CI; and flip the chart to `readOnlyRootFilesystem: true` with a `/tmp` emptyDir.