### PR TITLE
release: promote v0.4.3 GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-09-01
+
 ### Added
 
 - **Task pods default to the operator's task ServiceAccount (#844).** A new

--- a/helm/leoflow/Chart.yaml
+++ b/helm/leoflow/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version is the chart version; appVersion tracks the leoflow-server image.
 # Both move in lockstep with the release tag (ADR 0028); decouple only if the
 # chart ever needs a cadence of its own for a template-only fix.
-version: 0.4.3-rc.1
-appVersion: "0.4.3-rc.1"
+version: 0.4.3
+appVersion: "0.4.3"
 home: https://github.com/neochaotic/leoflow
 sources:
   - https://github.com/neochaotic/leoflow

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -1,6 +1,6 @@
 # leoflow
 
-![Version: 0.4.3-rc.1](https://img.shields.io/badge/Version-0.4.3--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.3-rc.1](https://img.shields.io/badge/AppVersion-0.4.3--rc.1-informational?style=flat-square)
+![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.3](https://img.shields.io/badge/AppVersion-0.4.3-informational?style=flat-square)
 
 Leoflow control plane — a GitOps-first, container-native workflow orchestrator (Airflow 3.2.x UI/API compatible).
 


### PR DESCRIPTION
Promotes **v0.4.3** to GA from `v0.4.3-rc.1` (mirrors the v0.4.2 GA promotion #832).

- `CHANGELOG.md`: `[Unreleased]` → `[0.4.3] - 2026-09-01` (payload unchanged from the rc; fresh empty `[Unreleased]` kept on top).
- `helm/leoflow/Chart.yaml`: `version`/`appVersion` → `0.4.3` (ADR 0028 lockstep, drops `-rc.1`); chart README regenerated via helm-docs 1.14.2.

**Validated as v0.4.3-rc.1** against the released artifacts:
- CLI + agent version stamp = 0.4.3-rc.1; published base tags `py3.11-v0.4.3-rc.1` / `py3.12-...` exist; signed checksums verify.
- #851 base-image pin (CLI FROMs the immutable per-release tag), #850 agent stamp.
- #852/#854 dbt: read-only project, `dbt` on PATH, artifacts + 0600 profiles.yml to /tmp — warehouse materialized end-to-end.
- #834 external-secrets resolver: clean-JSON stdout under a backend that floods stdout.
- #844 on a real k3d cluster: operator-default task SA applied; a task pinning `tasks.<id>.execution.service_account` still wins.

Mechanical gates green locally: `check-chart-version-matches-tag v0.4.3`, `check-dependabot-dirs`, `check-no-stale-deploy-path`. Tag `v0.4.3` goes on the merge of this PR. Follow-up #856 (top-level leoflow.yaml key validation) is out of scope.