### PR TITLE
fix(reaper): mark a reaped task's log with agent_lost instead of silent truncation (#861)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **A task killed by the agent-lost reaper now ends its log with a marker
+  (#861).** When the control plane fails a task whose agent went silent, it
+  deletes the pod and the log stream stops — previously leaving the task log
+  truncated mid-line (e.g. `Running with dbt…`), indistinguishable from a hang.
+  The reaper now appends a final `killed: agent_lost (last heartbeat …)` line to
+  the reaped attempt's log before tearing the pod down, so the reason is visible
+  where the operator tails it. Best-effort: the marker never blocks the reap.
+
 ## [0.4.3] - 2026-09-01
 
 ### Added

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -1465,9 +1465,14 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 	// pod liveness (#474, #461), so it is wired only on the pod path. Lite/
 	// subprocess leaves the scheduler's reaper unset and does no reaping.
 	reaper := executor.NewReaper(store, podExec, cache, warmLister, metrics, logger, executor.DefaultReaperConfig(), sched.SteppingDown)
-	// Give the reaper the log sink so a reaped attempt's log ends with a
-	// "killed: agent_lost" marker instead of a silent truncation (#861).
-	reaper.SetLogSink(logSink)
+	// Give the reaper an append-aware marker sink so a reaped attempt's log ends
+	// with a "killed: agent_lost" marker instead of a silent truncation (#861).
+	// Both DiskSink and ObjectSink implement MarkerSink (append preserves the
+	// agent's streamed content on either backend); the assertion holds for every
+	// sink NewDurableSink returns.
+	if ms, ok := logSink.(logs.MarkerSink); ok {
+		reaper.SetLogSink(ms)
+	}
 	sched.SetExecutionReaper(reaper)
 	startReconciler(ctx, cs, cfg.Executor.TaskNamespace, execStore, sched.IsLeading, logger, snapshotter)
 	startStagingGC(ctx, cs, cfg.Executor.TaskNamespace, store, sched.IsLeading, logger)

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -441,7 +441,7 @@ func startSchedulerSide(ctx context.Context, cfg *config.ServerConfig, pg *stora
 
 	drain := func() {}
 	if cfg.Scheduler.Enabled {
-		sched, dispatchOn, dispatchCloser, serr := startScheduler(ctx, cfg, pg, repo, execStore, authn, warmReg, logger, metrics)
+		sched, dispatchOn, dispatchCloser, serr := startScheduler(ctx, cfg, pg, repo, execStore, authn, warmReg, logSink, logger, metrics)
 		if serr != nil {
 			grpcSrv.GracefulStop()
 			return nil, false, nil, serr
@@ -1144,7 +1144,7 @@ func startStagingGC(ctx context.Context, cs kubernetes.Interface, namespace stri
 	})
 }
 
-func startScheduler(ctx context.Context, cfg *config.ServerConfig, pg *storage.Postgres, repo *storage.Repository, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, warmPools *agentrpc.WorkerRegistry, logger *slog.Logger, metrics *observability.Metrics) (*scheduler.Scheduler, bool, io.Closer, error) {
+func startScheduler(ctx context.Context, cfg *config.ServerConfig, pg *storage.Postgres, repo *storage.Repository, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, warmPools *agentrpc.WorkerRegistry, logSink logs.Sink, logger *slog.Logger, metrics *observability.Metrics) (*scheduler.Scheduler, bool, io.Closer, error) {
 	leaderPool, err := storage.NewLeaderPool(ctx, cfg.Database)
 	if err != nil {
 		return nil, false, nil, fmt.Errorf("leader pool: %w", err)
@@ -1168,7 +1168,7 @@ func startScheduler(ctx context.Context, cfg *config.ServerConfig, pg *storage.P
 		metrics,
 		logger,
 	))
-	podDispatch, dispatchCloser := setupDispatch(ctx, cfg, sched, execStore, authn, store, warmPools, logger, metrics)
+	podDispatch, dispatchCloser := setupDispatch(ctx, cfg, sched, execStore, authn, store, warmPools, logSink, logger, metrics)
 	leader := scheduler.NewLeader(leaderPool)
 	go func() {
 		defer leaderPool.Close()
@@ -1359,11 +1359,11 @@ func serve(s *http.Server, errCh chan<- error) {
 // setupDispatch wires the pod-path executor selected by executor.type onto the
 // scheduler and returns whether pod dispatch is active. "subprocess" runs the
 // agent on the host (dev only); "kubernetes" (default) launches task pods.
-func setupDispatch(ctx context.Context, cfg *config.ServerConfig, sched *scheduler.Scheduler, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, store *storage.SchedulerStore, warmPools *agentrpc.WorkerRegistry, logger *slog.Logger, metrics *observability.Metrics) (bool, io.Closer) {
+func setupDispatch(ctx context.Context, cfg *config.ServerConfig, sched *scheduler.Scheduler, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, store *storage.SchedulerStore, warmPools *agentrpc.WorkerRegistry, logSink logs.Sink, logger *slog.Logger, metrics *observability.Metrics) (bool, io.Closer) {
 	if cfg.Executor.Type == "subprocess" {
 		return setupSubprocessDispatch(cfg, sched, execStore, authn, warmPools, logger, store, metrics) //nolint:contextcheck // buffered worker deliberately detaches from caller ctx
 	}
-	return setupK8sDispatch(ctx, cfg, sched, execStore, authn, store, warmPools, logger, metrics) //nolint:contextcheck // buffered worker deliberately detaches from caller ctx
+	return setupK8sDispatch(ctx, cfg, sched, execStore, authn, store, warmPools, logSink, logger, metrics) //nolint:contextcheck // buffered worker deliberately detaches from caller ctx
 }
 
 // setWarmPlacer attaches the warm-worker placement seam to the dispatcher, but
@@ -1404,7 +1404,7 @@ func setupSubprocessDispatch(cfg *config.ServerConfig, sched *scheduler.Schedule
 // setupK8sDispatch wires the production pod-per-task executor; it is a no-op
 // (tasks have no executor and are failed as undispatchable) when no Kubernetes
 // client is available.
-func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *scheduler.Scheduler, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, store *storage.SchedulerStore, warmPools *agentrpc.WorkerRegistry, logger *slog.Logger, metrics *observability.Metrics) (bool, io.Closer) {
+func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *scheduler.Scheduler, execStore *storage.ExecutionStore, authn *auth.JWTAuthenticator, store *storage.SchedulerStore, warmPools *agentrpc.WorkerRegistry, logSink logs.Sink, logger *slog.Logger, metrics *observability.Metrics) (bool, io.Closer) {
 	cs, perr := buildK8sClient()
 	if perr != nil {
 		logger.Warn("pod dispatch disabled; tasks have no executor and will fail as undispatchable", "error", perr)
@@ -1465,6 +1465,9 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 	// pod liveness (#474, #461), so it is wired only on the pod path. Lite/
 	// subprocess leaves the scheduler's reaper unset and does no reaping.
 	reaper := executor.NewReaper(store, podExec, cache, warmLister, metrics, logger, executor.DefaultReaperConfig(), sched.SteppingDown)
+	// Give the reaper the log sink so a reaped attempt's log ends with a
+	// "killed: agent_lost" marker instead of a silent truncation (#861).
+	reaper.SetLogSink(logSink)
 	sched.SetExecutionReaper(reaper)
 	startReconciler(ctx, cs, cfg.Executor.TaskNamespace, execStore, sched.IsLeading, logger, snapshotter)
 	startStagingGC(ctx, cs, cfg.Executor.TaskNamespace, store, sched.IsLeading, logger)

--- a/internal/executor/heartbeat_reap.go
+++ b/internal/executor/heartbeat_reap.go
@@ -10,13 +10,16 @@ import (
 	"github.com/neochaotic/leoflow/internal/logs"
 )
 
-// logSink is the slice of logs.Sink a reaper needs to append a final marker to
-// a reaped attempt's log stream (#861). A reaper-killed pod stops mid-stream, so
-// without this the task log ends with a silent truncation; the marker turns it
-// into a diagnosable "killed: agent_lost …" line. Nil disables the marker (Lite
-// or an unwired sink) — the reaper's core work is unaffected.
+// logSink is the slice of the log backend a reaper needs to append a final
+// marker to a reaped attempt's log stream (#861). A reaper-killed pod stops
+// mid-stream, so without this the task log ends with a silent truncation; the
+// marker turns it into a diagnosable "killed: agent_lost …" line. It is
+// logs.MarkerSink: AppendEvent preserves prior content on BOTH backends
+// (O_APPEND on disk, read-modify-write on an object store), so the marker never
+// clobbers the agent's streamed log. Nil disables the marker (Lite or an unwired
+// sink) — the reaper's core work is unaffected.
 type logSink interface {
-	Open(ref logs.Ref) (logs.LogWriter, error)
+	AppendEvent(ref logs.Ref, ev logs.Event) error
 }
 
 // AgentLostCandidate is one task instance in `running` whose agent may have
@@ -156,20 +159,14 @@ func (r *agentLostReaper) writeAgentLostMarker(c AgentLostCandidate, now time.Ti
 	if r.sink == nil {
 		return
 	}
-	w, err := r.sink.Open(logs.Ref{
-		TenantID: c.TenantID, DagID: c.DagID, RunID: c.DagRunID, TaskID: c.TaskID, TryNumber: c.TryNumber,
-	})
-	if err != nil {
-		r.record("agent_lost_log_marker_error")
-		return
-	}
-	werr := w.WriteEvent(logs.Event{
+	ref := logs.Ref{TenantID: c.TenantID, DagID: c.DagID, RunID: c.DagRunID, TaskID: c.TaskID, TryNumber: c.TryNumber}
+	ev := logs.Event{
 		Time:    now,
 		Level:   "error",
 		Stream:  "system",
 		Message: fmt.Sprintf("killed: agent_lost (last heartbeat %s, silent past %s threshold)", c.LastHeartbeat.UTC().Format(time.RFC3339), r.threshold),
-	})
-	if cerr := w.Close(); werr != nil || cerr != nil {
+	}
+	if err := r.sink.AppendEvent(ref, ev); err != nil {
 		r.record("agent_lost_log_marker_error")
 	}
 }

--- a/internal/executor/heartbeat_reap.go
+++ b/internal/executor/heartbeat_reap.go
@@ -2,10 +2,22 @@ package executor
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"runtime/debug"
 	"time"
+
+	"github.com/neochaotic/leoflow/internal/logs"
 )
+
+// logSink is the slice of logs.Sink a reaper needs to append a final marker to
+// a reaped attempt's log stream (#861). A reaper-killed pod stops mid-stream, so
+// without this the task log ends with a silent truncation; the marker turns it
+// into a diagnosable "killed: agent_lost …" line. Nil disables the marker (Lite
+// or an unwired sink) — the reaper's core work is unaffected.
+type logSink interface {
+	Open(ref logs.Ref) (logs.LogWriter, error)
+}
 
 // AgentLostCandidate is one task instance in `running` whose agent may have
 // gone silent, with the timestamp of its most recent heartbeat. The reaper
@@ -14,6 +26,7 @@ import (
 // and the TI is failed with reason "agent_lost".
 type AgentLostCandidate struct {
 	TaskInstanceID string
+	TenantID       string
 	DagRunID       string
 	DagID          string
 	TaskID         string
@@ -69,6 +82,10 @@ type agentLostReaper struct {
 	// silent agent may be a network-partitioned but still-running container;
 	// deleting the pod is what actually stops the abandoned work. Nil in Lite.
 	pods PodManager
+	// sink appends a final "killed: agent_lost" marker to the reaped attempt's
+	// log stream so a killed task's log does not end in a silent truncation
+	// (#861). Nil disables the marker; the reap itself is unaffected.
+	sink logSink
 }
 
 func newAgentLostReaper(store HeartbeatReapStore, logger *slog.Logger, threshold time.Duration, rec DecisionRecorder) *agentLostReaper {
@@ -112,6 +129,10 @@ func (r *agentLostReaper) run(ctx context.Context) error {
 			"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID,
 			"last_heartbeat", c.LastHeartbeat)
 		r.record("agent_lost")
+		// Append a final marker to the attempt's log BEFORE deleting the pod, so a
+		// killed task's log ends with the reason instead of a silent truncation
+		// (#861) — the log stream stops the moment the pod is gone.
+		r.writeAgentLostMarker(c, now)
 		// The TI is now durably failed; delete its pod so a partitioned-but-alive
 		// container stops (#474). Pinned to (run, task, try) so a retry's newer
 		// pod is never touched. Only reached after the DB mark, so we never delete
@@ -125,6 +146,32 @@ func (r *agentLostReaper) run(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+// writeAgentLostMarker appends one terminal line to the reaped attempt's log
+// stream so the user tailing it sees why it stopped instead of a truncation
+// (#861). Best-effort: a nil sink or an open/write error never blocks the reap —
+// the DB state and server slog remain the source of truth.
+func (r *agentLostReaper) writeAgentLostMarker(c AgentLostCandidate, now time.Time) {
+	if r.sink == nil {
+		return
+	}
+	w, err := r.sink.Open(logs.Ref{
+		TenantID: c.TenantID, DagID: c.DagID, RunID: c.DagRunID, TaskID: c.TaskID, TryNumber: c.TryNumber,
+	})
+	if err != nil {
+		r.record("agent_lost_log_marker_error")
+		return
+	}
+	werr := w.WriteEvent(logs.Event{
+		Time:    now,
+		Level:   "error",
+		Stream:  "system",
+		Message: fmt.Sprintf("killed: agent_lost (last heartbeat %s, silent past %s threshold)", c.LastHeartbeat.UTC().Format(time.RFC3339), r.threshold),
+	})
+	if cerr := w.Close(); werr != nil || cerr != nil {
+		r.record("agent_lost_log_marker_error")
+	}
 }
 
 func (r *agentLostReaper) record(decision string) {

--- a/internal/executor/heartbeat_reap_test.go
+++ b/internal/executor/heartbeat_reap_test.go
@@ -12,37 +12,27 @@ import (
 )
 
 // fakeLogSink captures the final markers a reaper appends to a task's log
-// stream (#861), keyed by the same identity the disk sink uses.
+// stream (#861) via the MarkerSink seam, keyed by the same identity the disk
+// sink uses. appendErr lets a test exercise the best-effort error path.
 type fakeLogSink struct {
-	openErr error
-	events  map[string][]logs.Event
+	appendErr error
+	events    map[string][]logs.Event
 }
 
 func refKey(ref logs.Ref) string {
 	return ref.TenantID + "/" + ref.DagID + "/" + ref.RunID + "/" + ref.TaskID + "/" + strconv.Itoa(ref.TryNumber)
 }
 
-func (f *fakeLogSink) Open(ref logs.Ref) (logs.LogWriter, error) {
-	if f.openErr != nil {
-		return nil, f.openErr
+func (f *fakeLogSink) AppendEvent(ref logs.Ref, ev logs.Event) error {
+	if f.appendErr != nil {
+		return f.appendErr
 	}
-	return &fakeLogWriter{sink: f, ref: ref}, nil
-}
-
-type fakeLogWriter struct {
-	sink *fakeLogSink
-	ref  logs.Ref
-}
-
-func (w *fakeLogWriter) WriteEvent(ev logs.Event) error {
-	if w.sink.events == nil {
-		w.sink.events = map[string][]logs.Event{}
+	if f.events == nil {
+		f.events = map[string][]logs.Event{}
 	}
-	w.sink.events[refKey(w.ref)] = append(w.sink.events[refKey(w.ref)], ev)
+	f.events[refKey(ref)] = append(f.events[refKey(ref)], ev)
 	return nil
 }
-
-func (w *fakeLogWriter) Close() error { return nil }
 
 // TestIsAgentLost: the pure decision returns true iff the gap between the
 // candidate's last heartbeat and now reaches the threshold. A zero
@@ -195,6 +185,37 @@ func TestReapAgentLost_NoMarkerOnNoop(t *testing.T) {
 	}
 	if len(sink.events) != 0 {
 		t.Errorf("no marker should be written for a settled TI, got %v", sink.events)
+	}
+}
+
+// TestReapAgentLost_MarkerErrorDoesNotBlockReap: a marker append failure is
+// best-effort — it records a metric but must NOT stop the TI being failed or its
+// pod being torn down. The log marker is a diagnostic nicety, never a gate.
+func TestReapAgentLost_MarkerErrorDoesNotBlockReap(t *testing.T) {
+	now := time.Now().UTC()
+	store := &fakeHeartbeatStore{candidates: []AgentLostCandidate{
+		{TaskInstanceID: "ti1", TenantID: "tnt", DagID: "dag", DagRunID: "run", TaskID: "task", TryNumber: 1, LastHeartbeat: now.Add(-5 * time.Minute)},
+	}}
+	rec := &capturingRecorder{}
+	pods := &fakePodManager{active: map[string]bool{}}
+	r := newAgentLostReaper(store, reapTestLogger(), 90*time.Second, rec)
+	r.pods = pods
+	r.sink = &fakeLogSink{appendErr: errors.New("sink down")}
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(store.failed) != 1 {
+		t.Errorf("TI must still be failed despite a marker error, failed=%v", store.failed)
+	}
+	if len(pods.deletedTasks) != 1 {
+		t.Errorf("pod must still be deleted despite a marker error, deleted=%v", pods.deletedTasks)
+	}
+	if got := rec.count("agent_lost_log_marker_error"); got != 1 {
+		t.Errorf("agent_lost_log_marker_error = %d, want 1", got)
+	}
+	if got := rec.count("agent_lost"); got != 1 {
+		t.Errorf("agent_lost = %d, want 1 (reap still counts)", got)
 	}
 }
 

--- a/internal/executor/heartbeat_reap_test.go
+++ b/internal/executor/heartbeat_reap_test.go
@@ -3,9 +3,46 @@ package executor
 import (
 	"context"
 	"errors"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/neochaotic/leoflow/internal/logs"
 )
+
+// fakeLogSink captures the final markers a reaper appends to a task's log
+// stream (#861), keyed by the same identity the disk sink uses.
+type fakeLogSink struct {
+	openErr error
+	events  map[string][]logs.Event
+}
+
+func refKey(ref logs.Ref) string {
+	return ref.TenantID + "/" + ref.DagID + "/" + ref.RunID + "/" + ref.TaskID + "/" + strconv.Itoa(ref.TryNumber)
+}
+
+func (f *fakeLogSink) Open(ref logs.Ref) (logs.LogWriter, error) {
+	if f.openErr != nil {
+		return nil, f.openErr
+	}
+	return &fakeLogWriter{sink: f, ref: ref}, nil
+}
+
+type fakeLogWriter struct {
+	sink *fakeLogSink
+	ref  logs.Ref
+}
+
+func (w *fakeLogWriter) WriteEvent(ev logs.Event) error {
+	if w.sink.events == nil {
+		w.sink.events = map[string][]logs.Event{}
+	}
+	w.sink.events[refKey(w.ref)] = append(w.sink.events[refKey(w.ref)], ev)
+	return nil
+}
+
+func (w *fakeLogWriter) Close() error { return nil }
 
 // TestIsAgentLost: the pure decision returns true iff the gap between the
 // candidate's last heartbeat and now reaches the threshold. A zero
@@ -113,6 +150,51 @@ func TestReapAgentLost_NoopWhenAlreadyTransitioned(t *testing.T) {
 	}
 	if len(pods.deletedTasks) != 0 {
 		t.Errorf("no pod should be deleted for a settled TI, got %v", pods.deletedTasks)
+	}
+}
+
+// TestReapAgentLost_WritesLogMarker: when a TI is reaped, a final marker is
+// appended to that attempt's log stream (#861), at the exact Ref, so a killed
+// task's log ends with "agent_lost" instead of a silent truncation.
+func TestReapAgentLost_WritesLogMarker(t *testing.T) {
+	now := time.Now().UTC()
+	store := &fakeHeartbeatStore{candidates: []AgentLostCandidate{
+		{TaskInstanceID: "ti1", TenantID: "tnt", DagID: "dag", DagRunID: "run", TaskID: "task", TryNumber: 2, LastHeartbeat: now.Add(-5 * time.Minute)},
+	}}
+	sink := &fakeLogSink{}
+	r := newAgentLostReaper(store, reapTestLogger(), 90*time.Second, nil)
+	r.sink = sink
+
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	evs := sink.events[refKey(logs.Ref{TenantID: "tnt", DagID: "dag", RunID: "run", TaskID: "task", TryNumber: 2})]
+	if len(evs) != 1 {
+		t.Fatalf("want exactly 1 marker at the reaped attempt's Ref, got %d (%v)", len(evs), sink.events)
+	}
+	if !strings.Contains(evs[0].Message, "agent_lost") {
+		t.Errorf("marker msg = %q, want it to mention agent_lost", evs[0].Message)
+	}
+}
+
+// TestReapAgentLost_NoMarkerOnNoop: a raced no-op mark must not write a log
+// marker (the TI was settled by a late terminal report; its log is not ours).
+func TestReapAgentLost_NoMarkerOnNoop(t *testing.T) {
+	now := time.Now().UTC()
+	store := &fakeHeartbeatStore{
+		candidates: []AgentLostCandidate{
+			{TaskInstanceID: "raced", TenantID: "tnt", DagID: "dag", DagRunID: "run", TaskID: "task", TryNumber: 1, LastHeartbeat: now.Add(-5 * time.Minute)},
+		},
+		markNoop: true,
+	}
+	sink := &fakeLogSink{}
+	r := newAgentLostReaper(store, reapTestLogger(), 90*time.Second, nil)
+	r.sink = sink
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(sink.events) != 0 {
+		t.Errorf("no marker should be written for a settled TI, got %v", sink.events)
 	}
 }
 

--- a/internal/executor/reaper.go
+++ b/internal/executor/reaper.go
@@ -130,6 +130,14 @@ func NewReaper(store ReaperStore, pods PodManager, cache PodPresenceCache, warmP
 	}
 }
 
+// SetLogSink wires the sink the agent-lost reaper uses to append a final
+// "killed: agent_lost" marker to a reaped attempt's log stream (#861), so a
+// killed task's log ends with the reason instead of a silent truncation. Any
+// logs.Sink satisfies the parameter; nil (Lite / unwired) leaves markers off.
+func (r *Reaper) SetLogSink(s logSink) {
+	r.agentLost.sink = s
+}
+
 // ReapOnce runs the four reapers once, in the same order the scheduler drove
 // them: orphan-run, then agent-lost, then dispatch-lost, then pod-lost. The
 // dispatch-lost reaper runs AFTER the orphan-run reaper so a clean

--- a/internal/logs/logs.go
+++ b/internal/logs/logs.go
@@ -135,6 +135,16 @@ type Sink interface {
 	Read(ref Ref) (io.ReadCloser, error)
 }
 
+// MarkerSink appends a single event to an attempt's existing log while
+// PRESERVING prior content: O_APPEND on disk, read-modify-write on an object
+// store (which has no native append, so Open+Close there would overwrite the
+// whole object). A reaper uses it to add a terminal marker to a killed task's
+// log without clobbering the streamed output (#861). DiskSink and ObjectSink
+// both implement it; a caller holding a Sink type-asserts to reach it.
+type MarkerSink interface {
+	AppendEvent(ref Ref, ev Event) error
+}
+
 // DiskSink writes logs to ${root}/{tenant}/{dag}/{run}/{task}/{try}.log.
 type DiskSink struct {
 	root string
@@ -242,6 +252,17 @@ func (d *DiskSink) Open(ref Ref) (LogWriter, error) {
 		return nil, err
 	}
 	return &diskWriter{f: f, buf: bufio.NewWriterSize(f, flushThreshold)}, nil
+}
+
+// AppendEvent adds one event to the attempt's log file. The disk sink already
+// opens with O_APPEND, so this is a plain open-write-close that preserves the
+// streamed content — the marker lands after whatever the agent wrote (#861).
+func (d *DiskSink) AppendEvent(ref Ref, ev Event) error {
+	w, err := d.Open(ref)
+	if err != nil {
+		return err
+	}
+	return errors.Join(w.WriteEvent(ev), w.Close())
 }
 
 // Prune deletes log files whose last modification is older than retention,

--- a/internal/logs/logs_test.go
+++ b/internal/logs/logs_test.go
@@ -19,6 +19,39 @@ func TestRefChannel(t *testing.T) {
 	}
 }
 
+// TestDiskSinkAppendEventPreservesExisting: the marker seam appends after the
+// agent's streamed lines on disk (O_APPEND), never truncating them (#861).
+func TestDiskSinkAppendEventPreservesExisting(t *testing.T) {
+	dir := t.TempDir()
+	sink := NewDiskSink(dir)
+	w, err := sink.Open(ref())
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	if werr := w.WriteEvent(Event{Level: "info", Message: "Running with dbt=1.12.3"}); werr != nil {
+		t.Fatalf("WriteEvent() error = %v", werr)
+	}
+	if cerr := w.Close(); cerr != nil {
+		t.Fatalf("Close() error = %v", cerr)
+	}
+	if aerr := sink.AppendEvent(ref(), Event{Level: "error", Stream: "system", Message: "killed: agent_lost"}); aerr != nil {
+		t.Fatalf("AppendEvent() error = %v", aerr)
+	}
+	rc, err := sink.Read(ref())
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+	raw, _ := io.ReadAll(rc)
+	lines := strings.Split(strings.TrimRight(string(raw), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want 2 lines (streamed + marker), got %d: %q", len(lines), string(raw))
+	}
+	if !strings.Contains(DecodeLine(lines[1]).Message, "agent_lost") {
+		t.Errorf("last line = %q, want appended marker", lines[1])
+	}
+}
+
 func TestDiskSinkWriteThenReadBack(t *testing.T) {
 	dir := t.TempDir()
 	sink := NewDiskSink(dir)

--- a/internal/logs/object.go
+++ b/internal/logs/object.go
@@ -85,6 +85,39 @@ func (o *ObjectSink) Read(ref Ref) (io.ReadCloser, error) {
 	return rc, nil
 }
 
+// AppendEvent adds one event to the attempt's stored object WITHOUT clobbering
+// it. Object stores have no append, so a plain Open+Close would Put a
+// marker-only object over the agent's streamed log; instead this reads the
+// existing object (tolerating a not-yet-written one), appends the event as a
+// JSONL line, and Puts the combined object back (#861). Best-effort read-modify-
+// write: a lost task's agent is silent, so there is no concurrent writer to race.
+func (o *ObjectSink) AppendEvent(ref Ref, ev Event) error {
+	if err := ref.validate(); err != nil {
+		return err
+	}
+	key := o.key(ref)
+	var buf bytes.Buffer
+	rc, err := o.store.Get(o.ctx, key)
+	switch {
+	case err == nil:
+		if _, cerr := io.Copy(&buf, rc); cerr != nil {
+			return errors.Join(fmt.Errorf("reading log object for append: %w", cerr), rc.Close())
+		}
+		if cerr := rc.Close(); cerr != nil {
+			return fmt.Errorf("closing log object after read: %w", cerr)
+		}
+	case errors.Is(err, ErrObjectNotFound):
+		// No prior object (agent Put nothing yet): the marker is the whole object.
+	default:
+		return fmt.Errorf("reading log object for append: %w", err)
+	}
+	buf.WriteString(EncodeLine(ev) + "\n")
+	if err := o.store.Put(o.ctx, key, bytes.NewReader(buf.Bytes())); err != nil {
+		return fmt.Errorf("writing appended log object: %w", err)
+	}
+	return nil
+}
+
 // maxBufferedAttemptBytes caps how much of a single task attempt the object sink
 // buffers in the control plane. Object stores have no append, so the whole
 // attempt is held in RAM until Close; without a cap one chatty task could OOM the

--- a/internal/logs/object_test.go
+++ b/internal/logs/object_test.go
@@ -98,6 +98,72 @@ func TestObjectSinkRoundTrip(t *testing.T) {
 	}
 }
 
+// TestObjectSinkAppendEventPreservesExisting is the #861 regression: over an
+// object store (no native append), adding a marker MUST read-modify-write, not
+// overwrite the agent's streamed log with a marker-only object. This is the
+// EKS/S3 path the disk-sink tests never exercise.
+func TestObjectSinkAppendEventPreservesExisting(t *testing.T) {
+	store := newMemStore()
+	sink := NewObjectSink(context.Background(), store, "logs")
+	ref := sampleRef()
+
+	// The agent streamed two lines and its object was Put.
+	w, err := sink.Open(ref)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	for _, ev := range []Event{{Level: "info", Message: "starting"}, {Level: "info", Message: "Running with dbt=1.12.3"}} {
+		if werr := w.WriteEvent(ev); werr != nil {
+			t.Fatalf("WriteEvent() error = %v", werr)
+		}
+	}
+	if cerr := w.Close(); cerr != nil {
+		t.Fatalf("Close() error = %v", cerr)
+	}
+
+	// The reaper appends a marker via the MarkerSink seam.
+	if aerr := sink.AppendEvent(ref, Event{Level: "error", Stream: "system", Message: "killed: agent_lost (last heartbeat ...)"}); aerr != nil {
+		t.Fatalf("AppendEvent() error = %v", aerr)
+	}
+
+	rc, err := sink.Read(ref)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+	raw, _ := io.ReadAll(rc)
+	lines := strings.Split(strings.TrimRight(string(raw), "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("want 3 lines (2 streamed + marker), got %d: %q", len(lines), string(raw))
+	}
+	if got := DecodeLine(lines[0]).Message; got != "starting" {
+		t.Errorf("first line = %q, want the agent's original output preserved", got)
+	}
+	if got := DecodeLine(lines[2]).Message; !strings.Contains(got, "agent_lost") {
+		t.Errorf("last line = %q, want the appended agent_lost marker", got)
+	}
+}
+
+// TestObjectSinkAppendEventCreatesWhenAbsent: appending to a ref with no prior
+// object (the agent Put nothing yet) writes a marker-only object, tolerating the
+// not-found rather than erroring.
+func TestObjectSinkAppendEventCreatesWhenAbsent(t *testing.T) {
+	sink := NewObjectSink(context.Background(), newMemStore(), "")
+	ref := sampleRef()
+	if err := sink.AppendEvent(ref, Event{Level: "error", Message: "killed: agent_lost"}); err != nil {
+		t.Fatalf("AppendEvent(absent) error = %v", err)
+	}
+	rc, err := sink.Read(ref)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+	raw, _ := io.ReadAll(rc)
+	if !strings.Contains(string(raw), "agent_lost") {
+		t.Errorf("stored object = %q, want the marker", string(raw))
+	}
+}
+
 func TestObjectSinkKeyLayoutIncludesPrefix(t *testing.T) {
 	store := newMemStore()
 	sink := NewObjectSink(context.Background(), store, "acme/logs")

--- a/internal/storage/queries/runs.sql
+++ b/internal/storage/queries/runs.sql
@@ -805,6 +805,7 @@ WHERE ti.state IN ('queued', 'running')
 -- reaper. The LIMIT bounds a single tick's reap work even after a large
 -- outage; the rest are picked up on the next tick.
 SELECT ti.id AS task_instance_id,
+       ti.tenant_id AS tenant_id,
        ti.dag_run_id AS dag_run_id,
        d.dag_id AS dag_id_text,
        ti.task_id AS task_id,

--- a/internal/storage/queries/runs.sql.go
+++ b/internal/storage/queries/runs.sql.go
@@ -688,6 +688,7 @@ func (q *Queries) ListActiveDagRuns(ctx context.Context) ([]DagRun, error) {
 
 const listAgentLostCandidates = `-- name: ListAgentLostCandidates :many
 SELECT ti.id AS task_instance_id,
+       ti.tenant_id AS tenant_id,
        ti.dag_run_id AS dag_run_id,
        d.dag_id AS dag_id_text,
        ti.task_id AS task_id,
@@ -704,6 +705,7 @@ LIMIT 100
 
 type ListAgentLostCandidatesRow struct {
 	TaskInstanceID  pgtype.UUID        `json:"task_instance_id"`
+	TenantID        pgtype.UUID        `json:"tenant_id"`
 	DagRunID        pgtype.UUID        `json:"dag_run_id"`
 	DagIDText       string             `json:"dag_id_text"`
 	TaskID          string             `json:"task_id"`
@@ -728,6 +730,7 @@ func (q *Queries) ListAgentLostCandidates(ctx context.Context) ([]ListAgentLostC
 		var i ListAgentLostCandidatesRow
 		if err := rows.Scan(
 			&i.TaskInstanceID,
+			&i.TenantID,
 			&i.DagRunID,
 			&i.DagIDText,
 			&i.TaskID,

--- a/internal/storage/scheduler_store.go
+++ b/internal/storage/scheduler_store.go
@@ -700,6 +700,7 @@ func (s *SchedulerStore) ListAgentLostCandidates(ctx context.Context) ([]executo
 		}
 		out = append(out, executor.AgentLostCandidate{
 			TaskInstanceID: uuidToString(r.TaskInstanceID),
+			TenantID:       uuidToString(r.TenantID),
 			DagRunID:       uuidToString(r.DagRunID),
 			DagID:          r.DagIDText,
 			TaskID:         r.TaskID,


### PR DESCRIPTION
Closes part of #861 (agent-lost path; pod-lost + orphan markers follow in the same RC).

## Problem
When the agent-lost reaper fails a task whose agent went silent, it deletes the pod and the per-task log stream stops wherever it was — the log ends truncated mid-line (the 2026-09-01 field report's `Running with dbt…` with nothing after), indistinguishable from a dbt hang. The reason was only in the server slog + DB `error_message`, never in the log the operator tails.

## Fix
The reaper appends a final `killed: agent_lost (last heartbeat …, silent past … threshold)` event to the reaped attempt's log stream **before** tearing the pod down.
- `ListAgentLostCandidates` now selects `ti.tenant_id` so the marker lands at the exact log `Ref{tenant,dag,run,task,try}`.
- New `logSink` seam on the reaper + `Reaper.SetLogSink`, wired from `main.go` with the same `logs.Sink` the server already uses. Nil (Lite / unwired) leaves the marker off.
- Best-effort: a nil or failing sink never blocks the reap; DB state + server slog stay the source of truth. A raced no-op mark writes no marker.

## Tests (TDD, red first)
- `TestReapAgentLost_WritesLogMarker`: exactly one marker at the reaped attempt's Ref, message mentions `agent_lost`.
- `TestReapAgentLost_NoMarkerOnNoop`: a settled (raced) TI gets no marker.
- Existing reaper suite unchanged/green; golangci-lint clean; sqlc regenerated.

## Scope
Agent-lost only (the incident path). pod-lost (`pod_lost_reap.go`) and orphan (`reap.go`, run-level) have the same truncation and get the same treatment in a follow-up tracked in #861.