### PR TITLE
fix(scheduler): survive a control-plane restart — grace + backoff on infra reap (#858, #859)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **A control-plane restart no longer fails healthy in-flight tasks (#858).**
+  The agent-lost reaper failed any task whose last heartbeat was older than the
+  threshold — but a control-plane restart (rollout, node drain, kubelet kill)
+  makes *every* in-flight task look stale, because the process that records
+  heartbeats is the one that was down. The new leader would then mass-reap
+  healthy, still-running tasks. The reaper now honors a post-leadership **grace
+  window** (2× the agent-lost threshold, 180s) measured from when this instance
+  acquired leadership, so the fleet has time to re-heartbeat before any reap; a
+  genuinely lost agent is still reaped once the grace elapses.
+- **Infra re-placement is now backed off and jittered to avoid a thundering herd
+  (#859).** When a task fails for an infrastructure reason (agent/pod/dispatch
+  lost) it re-places without consuming its retry budget — but it did so
+  immediately, so a mass infra fault (a restart marking a whole run agent_lost at
+  once) re-dispatched every sibling on the same tick, stampeding the just-
+  recovered kube-apiserver and re-throttling the scheduler. Re-placement now
+  waits out an exponential backoff from the failure time (the same curve as a
+  synchronous dispatch failure, keyed on the infra-attempt count) plus a
+  deterministic per-task jitter, so siblings spread across a window instead of
+  firing together.
 - **A task killed by the agent-lost reaper now ends its log with a marker
   (#861).** When the control plane fails a task whose agent went silent, it
   deletes the pod and the log stream stops — previously leaving the task log

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -1473,6 +1473,10 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 	if ms, ok := logSink.(logs.MarkerSink); ok {
 		reaper.SetLogSink(ms)
 	}
+	// Suppress agent-lost reaping for a grace window after this instance acquires
+	// leadership, so a control-plane restart doesn't mass-reap in-flight tasks
+	// whose heartbeats went stale during the outage (#858).
+	reaper.SetLeaderSince(sched.LeaderSince)
 	sched.SetExecutionReaper(reaper)
 	startReconciler(ctx, cs, cfg.Executor.TaskNamespace, execStore, sched.IsLeading, logger, snapshotter)
 	startStagingGC(ctx, cs, cfg.Executor.TaskNamespace, store, sched.IsLeading, logger)

--- a/internal/executor/heartbeat_reap.go
+++ b/internal/executor/heartbeat_reap.go
@@ -115,10 +115,6 @@ func (r *agentLostReaper) run(ctx context.Context) error {
 			r.record("agent_lost_panic")
 		}
 	}()
-	candidates, err := r.store.ListAgentLostCandidates(ctx)
-	if err != nil {
-		return err
-	}
 	now := time.Now().UTC()
 	// Post-leadership grace (#858): a control-plane restart manufactures the very
 	// silence this reaper punishes — every in-flight TI's last heartbeat elapses
@@ -127,11 +123,19 @@ func (r *agentLostReaper) run(ctx context.Context) error {
 	// re-heartbeat under the recovered leader; a genuinely lost agent stays stale
 	// past the grace and is reaped on a later tick. The window is measured from
 	// leadership acquisition, not startup, so a re-election also resets it.
+	// Checked before the list so a grace tick does no query at all. NOTE: if
+	// leadership flaps with a period shorter than the grace, leaderSince keeps
+	// restamping and this reaper never fires — the orphan-run reaper (5m) is the
+	// backstop for that pathological case; steady-state leadership is the norm.
 	if r.leaderSince != nil && r.grace > 0 {
 		if ls := r.leaderSince(); !ls.IsZero() && now.Sub(ls) < r.grace {
 			r.record("agent_lost_grace_skip")
 			return nil
 		}
+	}
+	candidates, err := r.store.ListAgentLostCandidates(ctx)
+	if err != nil {
+		return err
 	}
 	for _, c := range candidates {
 		if !IsAgentLost(c, r.threshold, now) {

--- a/internal/executor/heartbeat_reap.go
+++ b/internal/executor/heartbeat_reap.go
@@ -89,6 +89,16 @@ type agentLostReaper struct {
 	// log stream so a killed task's log does not end in a silent truncation
 	// (#861). Nil disables the marker; the reap itself is unaffected.
 	sink logSink
+	// grace suppresses reaping for this long after leadership is (re-)acquired
+	// (#858). A control-plane restart makes every in-flight TI's heartbeat look
+	// stale — the silence was manufactured by the outage, not a dead agent — so
+	// the new leader must wait for the fleet to re-heartbeat before reaping.
+	// Zero disables the grace (with a nil leaderSince). See DefaultReaperConfig.
+	grace time.Duration
+	// leaderSince reports when this instance last acquired scheduler leadership,
+	// so the grace is measured from recovery, not wall-clock. Nil (Lite/tests
+	// without leadership) disables the grace check.
+	leaderSince func() time.Time
 }
 
 func newAgentLostReaper(store HeartbeatReapStore, logger *slog.Logger, threshold time.Duration, rec DecisionRecorder) *agentLostReaper {
@@ -110,6 +120,19 @@ func (r *agentLostReaper) run(ctx context.Context) error {
 		return err
 	}
 	now := time.Now().UTC()
+	// Post-leadership grace (#858): a control-plane restart manufactures the very
+	// silence this reaper punishes — every in-flight TI's last heartbeat elapses
+	// during the outage, and the heartbeat receiver is the same process that just
+	// came back. Suppress reaping until the fleet has had a full grace window to
+	// re-heartbeat under the recovered leader; a genuinely lost agent stays stale
+	// past the grace and is reaped on a later tick. The window is measured from
+	// leadership acquisition, not startup, so a re-election also resets it.
+	if r.leaderSince != nil && r.grace > 0 {
+		if ls := r.leaderSince(); !ls.IsZero() && now.Sub(ls) < r.grace {
+			r.record("agent_lost_grace_skip")
+			return nil
+		}
+	}
 	for _, c := range candidates {
 		if !IsAgentLost(c, r.threshold, now) {
 			continue

--- a/internal/executor/heartbeat_reap_test.go
+++ b/internal/executor/heartbeat_reap_test.go
@@ -219,6 +219,49 @@ func TestReapAgentLost_MarkerErrorDoesNotBlockReap(t *testing.T) {
 	}
 }
 
+// TestReapAgentLost_GraceAfterLeadership: after a control-plane restart, the new
+// leader must NOT immediately reap TIs whose heartbeats went stale DURING the
+// outage — the silence was manufactured by the control plane being down, not by
+// a dead agent (#858). A post-leadership grace window suppresses reaping until
+// the fleet has had time to re-heartbeat; past the grace, a still-silent TI is
+// reaped normally.
+func TestReapAgentLost_GraceAfterLeadership(t *testing.T) {
+	now := time.Now().UTC()
+	newStore := func() *fakeHeartbeatStore {
+		return &fakeHeartbeatStore{candidates: []AgentLostCandidate{
+			{TaskInstanceID: "stale", DagRunID: "r", TaskID: "t", TryNumber: 1, LastHeartbeat: now.Add(-2 * time.Minute)},
+		}}
+	}
+
+	// Just became leader (10s ago) — within the 180s grace — must NOT reap.
+	within := newStore()
+	rec := &capturingRecorder{}
+	r := newAgentLostReaper(within, reapTestLogger(), 90*time.Second, rec)
+	r.grace = 180 * time.Second
+	r.leaderSince = func() time.Time { return now.Add(-10 * time.Second) }
+	if err := r.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(within.failed) != 0 {
+		t.Errorf("must not reap within the post-leadership grace, failed=%v", within.failed)
+	}
+	if rec.count("agent_lost_grace_skip") != 1 {
+		t.Errorf("agent_lost_grace_skip = %d, want 1", rec.count("agent_lost_grace_skip"))
+	}
+
+	// Leader well past the grace — a still-stale TI is reaped.
+	past := newStore()
+	r2 := newAgentLostReaper(past, reapTestLogger(), 90*time.Second, &capturingRecorder{})
+	r2.grace = 180 * time.Second
+	r2.leaderSince = func() time.Time { return now.Add(-10 * time.Minute) }
+	if err := r2.run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(past.failed) != 1 || past.failed[0] != "stale" {
+		t.Errorf("must reap after the grace elapses, failed=%v", past.failed)
+	}
+}
+
 // TestReapAgentLost_ListErrorSurfaces: a list failure is returned so the
 // caller can log it (the scheduler's reapHeartbeatLossesIfLeader treats this
 // as a "next tick will try again" condition). It must NEVER panic.

--- a/internal/executor/reaper.go
+++ b/internal/executor/reaper.go
@@ -44,6 +44,13 @@ const (
 	defaultAgentLostThreshold    = 90 * time.Second
 	defaultDispatchLostThreshold = 3 * time.Minute
 	defaultPodLostGrace          = 60 * time.Second
+	// defaultAgentLostGrace is the post-leadership window during which the
+	// agent-lost reaper does not fire (#858). Set to 2× the agent-lost threshold
+	// so a single control-plane restart + re-election (whose recorded silence can
+	// approach the threshold) cannot trip a mass false reap, while staying well
+	// under the 10-minute agent token TTL so a re-heartbeat still authenticates.
+	// Ladder: heartbeat(15s) < threshold(90s) < grace(180s) < tokenTTL(600s).
+	defaultAgentLostGrace = 2 * defaultAgentLostThreshold
 )
 
 // ReaperConfig holds the four idle thresholds the reapers apply. Zero values are
@@ -52,6 +59,7 @@ const (
 type ReaperConfig struct {
 	OrphanThreshold       time.Duration
 	AgentLostThreshold    time.Duration
+	AgentLostGrace        time.Duration
 	DispatchLostThreshold time.Duration
 	PodLostGrace          time.Duration
 }
@@ -62,6 +70,7 @@ func DefaultReaperConfig() ReaperConfig {
 	return ReaperConfig{
 		OrphanThreshold:       defaultOrphanThreshold,
 		AgentLostThreshold:    defaultAgentLostThreshold,
+		AgentLostGrace:        defaultAgentLostGrace,
 		DispatchLostThreshold: defaultDispatchLostThreshold,
 		PodLostGrace:          defaultPodLostGrace,
 	}
@@ -105,6 +114,7 @@ func NewReaper(store ReaperStore, pods PodManager, cache PodPresenceCache, warmP
 
 	agentLost := newAgentLostReaper(store, logger, cfg.AgentLostThreshold, rec)
 	agentLost.pods = pods
+	agentLost.grace = cfg.AgentLostGrace
 
 	dispatchLost := newDispatchLostReaper(store, logger, cfg.DispatchLostThreshold, rec)
 	dispatchLost.pods = pods
@@ -136,6 +146,14 @@ func NewReaper(store ReaperStore, pods PodManager, cache PodPresenceCache, warmP
 // logs.Sink satisfies the parameter; nil (Lite / unwired) leaves markers off.
 func (r *Reaper) SetLogSink(s logSink) {
 	r.agentLost.sink = s
+}
+
+// SetLeaderSince wires the accessor the agent-lost reaper uses to measure its
+// post-leadership grace (#858) — the window after a (re-)election during which a
+// stale heartbeat is assumed to be the outage's doing, not a dead agent, and is
+// not reaped. Nil (Lite / no leadership) leaves the grace off.
+func (r *Reaper) SetLeaderSince(fn func() time.Time) {
+	r.agentLost.leaderSince = fn
 }
 
 // ReapOnce runs the four reapers once, in the same order the scheduler drove

--- a/internal/scheduler/plan.go
+++ b/internal/scheduler/plan.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"hash/fnv"
 	"math"
 	"time"
 
@@ -171,7 +172,7 @@ func planRetryTransitions(run RunState, effective map[string]domain.TaskState, d
 				// infra-attempt limit so a poison placement can't loop forever;
 				// exhausted → terminal (no fallback to the app-retry budget). The
 				// store bumps infra_attempts (not try_number) when applying failed→none.
-				if infraReplaceable(run, t.TaskID) {
+				if infraReplaceable(run, t.TaskID) && readyToInfraReplace(run, t.TaskID) {
 					out = append(out, PlannedTransition{TaskID: t.TaskID, To: domain.TaskStateNone})
 					effective[t.TaskID] = domain.TaskStateNone
 				}
@@ -306,6 +307,42 @@ func triggerRuleOf(t domain.TaskSpec) domain.TriggerRule {
 // the run active until the retry resolves.
 func infraReplaceable(run RunState, taskID string) bool {
 	return run.InfraFailed[taskID] && run.InfraAttempts[taskID] < infraMaxAttempts
+}
+
+// infraReplaceJitterWindow spreads sibling infra re-placements across this window
+// so N tasks reaped in one tick (a control-plane restart marking the whole run
+// agent_lost) do not all re-dispatch simultaneously. 2× the heartbeat interval —
+// enough to de-synchronize the herd without materially delaying recovery.
+const infraReplaceJitterWindow = 30 * time.Second
+
+// readyToInfraReplace gates the infra re-placement (failed→none) behind the same
+// exponential backoff as a synchronous dispatch failure, keyed on the
+// infra-attempt count and measured from the reap's ended_at, plus a deterministic
+// per-task jitter (#859). Without it, a mass infra fault re-dispatches every
+// sibling on the next tick — a thundering herd of pod create/delete against the
+// kube-apiserver from the just-recovered scheduler, which re-throttles it. Honors
+// the "absent ended_at / zero clock → immediate" convention (mirroring
+// readyToRetry) so the never-failed common case and tests are unaffected.
+func readyToInfraReplace(run RunState, taskID string) bool {
+	ended := run.EndedAt[taskID]
+	if ended == nil {
+		return true
+	}
+	if run.Now.IsZero() {
+		return true
+	}
+	delay := dispatchBackoff(run.InfraAttempts[taskID]+1) + infraReplaceJitter(run.RunID, taskID)
+	return !run.Now.Before(ended.Add(delay))
+}
+
+// infraReplaceJitter returns a stable per-(run,task) offset in
+// [0, infraReplaceJitterWindow). Deterministic (FNV-1a over the key, no rand) so
+// the planner stays reproducible and unit-testable; distinct across sibling
+// task_ids so they spread rather than fire together.
+func infraReplaceJitter(runID, taskID string) time.Duration {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(runID + "\x00" + taskID))
+	return time.Duration(h.Sum64() % uint64(infraReplaceJitterWindow))
 }
 
 // FinalizeRun reports the terminal dag-run state once every task is terminal.

--- a/internal/scheduler/plan_test.go
+++ b/internal/scheduler/plan_test.go
@@ -137,6 +137,85 @@ func TestPlanRunInfraBudgetExhaustedIsTerminal(t *testing.T) {
 	}
 }
 
+// TestPlanRunInfraReplaceRespectsBackoff: an infra-failed task is NOT re-placed
+// immediately — it waits out an exponential backoff from its ended_at (#859), so
+// a mass infra fault (a control-plane restart marking many TIs agent_lost at
+// once) cannot re-dispatch every sibling on the same tick and stampede the
+// just-recovered kube-apiserver. Within the backoff the task stays parked in
+// failed (no transition); past it, it re-places to none.
+func TestPlanRunInfraReplaceRespectsBackoff(t *testing.T) {
+	now := time.Now().UTC()
+	ended := now.Add(-2 * time.Second) // < 5s base backoff
+	run := RunState{
+		RunID:         "run-1",
+		Tasks:         linear(),
+		States:        map[string]domain.TaskState{"a": domain.TaskStateFailed, "b": domain.TaskStateNone},
+		Tries:         map[string]int{"a": 0},
+		MaxTries:      map[string]int{"a": 3},
+		InfraFailed:   map[string]bool{"a": true},
+		InfraAttempts: map[string]int{"a": 0},
+		EndedAt:       map[string]*time.Time{"a": &ended},
+		Now:           now,
+	}
+	if _, ok := planMap(run)["a"]; ok {
+		t.Error("infra-failed task within backoff must stay parked in failed (no transition)")
+	}
+	// Past the base backoff plus the whole jitter window, it must re-place.
+	run.Now = ended.Add(dispatchBackoffBase + infraReplaceJitterWindow)
+	if got := planMap(run)["a"]; got != domain.TaskStateNone {
+		t.Errorf("infra-failed task past backoff must re-place (none), got %q", got)
+	}
+}
+
+// TestReadyToInfraReplace pins the gate's edges: nil ended / zero clock fall back
+// to immediate (test seam + never-failed), and the delay grows with attempts.
+func TestReadyToInfraReplace(t *testing.T) {
+	now := time.Now().UTC()
+	ended := now.Add(-3 * time.Second)
+	run := RunState{
+		RunID:         "run-1",
+		EndedAt:       map[string]*time.Time{"a": &ended},
+		InfraAttempts: map[string]int{"a": 0},
+		Now:           now,
+	}
+	if readyToInfraReplace(run, "a") {
+		t.Error("3s elapsed < 5s base backoff: must not be ready")
+	}
+	run.Now = ended.Add(dispatchBackoffBase + infraReplaceJitterWindow)
+	if !readyToInfraReplace(run, "a") {
+		t.Error("past base backoff + jitter window: must be ready")
+	}
+	run.Now = time.Time{}
+	if !readyToInfraReplace(run, "a") {
+		t.Error("zero clock is the immediate test seam")
+	}
+	empty := RunState{RunID: "r", EndedAt: map[string]*time.Time{}, InfraAttempts: map[string]int{}, Now: now}
+	if !readyToInfraReplace(empty, "a") {
+		t.Error("nil ended must fall back to immediate")
+	}
+}
+
+// TestInfraReplaceJitterSpreadsSiblings: the jitter is deterministic per (run,
+// task) and spreads siblings across the window so N tasks reaped together do not
+// re-dispatch simultaneously.
+func TestInfraReplaceJitterSpreadsSiblings(t *testing.T) {
+	seen := map[time.Duration]bool{}
+	for _, task := range []string{"a", "b", "c", "d", "e", "f"} {
+		j := infraReplaceJitter("run-1", task)
+		if j < 0 || j >= infraReplaceJitterWindow {
+			t.Errorf("jitter %v out of [0,%v)", j, infraReplaceJitterWindow)
+		}
+		seen[j] = true
+	}
+	if len(seen) < 3 {
+		t.Errorf("expected the jitter to spread siblings, got %d distinct values", len(seen))
+	}
+	j1, j2 := infraReplaceJitter("run-1", "a"), infraReplaceJitter("run-1", "a")
+	if j1 != j2 {
+		t.Errorf("jitter must be deterministic for a given (run, task): %v != %v", j1, j2)
+	}
+}
+
 func TestPlanRunResetsUpForRetry(t *testing.T) {
 	run := RunState{
 		Tasks:    linear(),

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -285,6 +285,7 @@ type Scheduler struct {
 	executionReaper ExecutionReaper
 	lastTick        atomic.Int64 // unix-nano of the last loop iteration; 0 = not yet ticked
 	leading         atomic.Bool  // true only while this instance holds leadership and ticks
+	leaderSince     atomic.Int64 // unix-nano when leadership was last acquired; 0 = not leading. Drives the agent-lost reaper's post-recovery grace (#858)
 	steppingDown    atomic.Bool  // true only during a leader step-down — the campaign loop sets it before canceling the run-context so the expected cancel-fanout logs at WARN, not ERROR (#311 tripwire preserved when it's false)
 	// warnedSchedules dedupes the "unparseable schedule" warning per DAG (keyed by
 	// the offending expression) so a bad cron logs once, not every tick. Accessed
@@ -348,8 +349,25 @@ func (s *Scheduler) SetStepTimeout(d time.Duration) { s.stepTimeout = d }
 func (s *Scheduler) SetLeading(on bool) {
 	if on {
 		s.lastTick.Store(0)
+		// Stamp when leadership was acquired so the agent-lost reaper measures its
+		// post-recovery grace from now, not from wall-clock (#858). Clear it on
+		// loss so a non-leader reports no leadership window.
+		s.leaderSince.Store(time.Now().UnixNano())
+	} else {
+		s.leaderSince.Store(0)
 	}
 	s.leading.Store(on)
+}
+
+// LeaderSince reports when this instance last acquired scheduler leadership, or
+// the zero time if it is not currently leading. The agent-lost reaper uses it to
+// suppress reaping within a grace window after a (re-)election (#858).
+func (s *Scheduler) LeaderSince() time.Time {
+	ns := s.leaderSince.Load()
+	if ns == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns)
 }
 
 // IsLeading reports whether this instance currently holds scheduler leadership.

--- a/internal/storage/infra_replace_integration_test.go
+++ b/internal/storage/infra_replace_integration_test.go
@@ -68,6 +68,16 @@ func seedInfraFailed(t *testing.T, repo *storage.Repository, sched *storage.Sche
 	if err != nil || !ok {
 		t.Fatalf("MarkTaskAgentLost ok=%v err=%v", ok, err)
 	}
+	// #859: infra re-placement is now backoff-gated from ended_at (readyToInfraReplace).
+	// These tests exercise the reap→re-place *loop*, not the backoff timing, so
+	// backdate ended_at past the backoff window to make the seeded infra failure
+	// immediately re-placeable. The timing gate itself is unit-tested in
+	// plan_test.go (TestPlanRunInfraReplaceRespectsBackoff).
+	if _, err := pg.Pool.Exec(ctx,
+		"UPDATE task_instances SET ended_at = now() - interval '1 hour' WHERE dag_run_id=$1::uuid AND task_id='t'",
+		runUUID); err != nil {
+		t.Fatalf("backdate ended_at: %v", err)
+	}
 	return runID, runUUID
 }
 


### PR DESCRIPTION
Closes #858 and #859 — the two GA-blocker-class resilience findings from the 2026-09-01 EKS incident (a liveness-killed control plane mass-reaped healthy in-flight tasks, then re-placed them in a herd that re-killed it).

## #858 — post-leadership grace (stop the false mass-reap)
A control-plane restart makes every in-flight task's heartbeat look stale, because the heartbeat *receiver* (`agentrpc.Server`) and the agent-lost *reaper* are the same process. The recovered leader reaped healthy, still-running tasks on its first tick.
- `Scheduler.SetLeading` now stamps `leaderSince`; `Scheduler.LeaderSince()` exposes it.
- The agent-lost reaper skips reaping while `now - leaderSince < grace`. `defaultAgentLostGrace = 2× threshold = 180s`. Ladder: `heartbeat 15s < threshold 90s < grace 180s < token TTL 600s`.
- Wired via `Reaper.SetLeaderSince`; nil (Lite) leaves it off. The grace **is** the reconcile — a wedged-but-pod-alive task stays reapable past the grace (no pod-presence defer that would neuter agent-lost's purpose).

## #859 — backoff + jitter on infra re-placement (kill the herd)
Infra-failed tasks (agent/pod/dispatch lost) re-placed immediately, so a mass fault re-dispatched every sibling on one tick.
- New `readyToInfraReplace` gate in `planRetryTransitions`, mirroring `readyToRetry`: exponential backoff from `ended_at` (`dispatchBackoff(infra_attempts+1)`) + deterministic per-`(run,task)` FNV jitter over a 30s window.
- Task stays parked in `failed` during the backoff; `FinalizeRun` already treats an `infraReplaceable` failed task as non-terminal, so the run stays active. `ResetTaskInstanceInfraReplace` unchanged (`next_dispatch_at=NULL`; the gate lives in the planner).

## Warm pool
Covered for free: warm-bound attempts flow through the **shared** agent-lost reaper (so the #858 grace protects them), and the warm-worker-lost reaper is pod-liveness-based (already restart-safe — must NOT get a grace). Confirmed by the expert review.

## Tests (TDD, red first)
- `TestReapAgentLost_GraceAfterLeadership` (skip within grace, reap after).
- `TestPlanRunInfraReplaceRespectsBackoff` (parked within backoff, re-place after), `TestReadyToInfraReplace` (edges), `TestInfraReplaceJitterSpreadsSiblings` (deterministic + spread).
- Full scheduler/executor/storage suites green; golangci-lint clean.

Cluster-validation (next EKS RC): kill the leader mid-run on a ~24-task DAG; assert in-flight tasks survive (no agent_lost cascade) and re-dispatch spreads. Grace 180s / jitter 30s are safe defaults to confirm against measured leader-reacquire + apiserver load.