### PR TITLE
fix(api): mask sensitive values in connection extra on read (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Security
+
+- **Sensitive values in a connection's `extra` are masked in read API responses
+  (#11).** `GET /api/v2/connections` (list and by-id) returned the free-form
+  `extra` verbatim, so provider secrets that ride there — OAuth `client_secret`,
+  PATs/`token`, `private_key`, BigQuery `keyfile_dict` — were echoed in clear (the
+  `password` field was already withheld). Secret-bearing keys are now redacted to
+  `***` on read, matching the Variable masking; non-secret keys (host, http_path,
+  account, schema, method) are preserved.
+
 ### Changed
 
 - **The control-plane Helm defaults no longer let the kubelet kill the server

--- a/internal/api/ui_connections.go
+++ b/internal/api/ui_connections.go
@@ -2,12 +2,46 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/neochaotic/leoflow/internal/domain"
 )
+
+// redactExtra masks secret-bearing values in a connection's free-form `extra`
+// before it is returned by the read API (#11). The extra is where provider
+// secrets live — Databricks `client_secret`/`token`, Snowflake/`private_key`,
+// BigQuery `keyfile_dict` — so echoing it verbatim leaks credentials on a plain
+// GET. Non-sensitive keys (host, http_path, account, warehouse, schema, method)
+// are preserved so the UI/operator can still read the connection's shape.
+//
+// Keys are matched by name via isSensitiveKey, which also covers Airflow's
+// prefixed form (extra__<type>__client_secret). If the extra is not a JSON
+// object (unexpected), it is redacted wholesale — fail closed rather than risk
+// echoing a secret. NOTE: a masked read that is written straight back would
+// persist "***"; the write path should treat "***" as "unchanged" (tracked as a
+// follow-up) — the same round-trip caveat the variable mask already carries.
+func redactExtra(extra string) string {
+	if extra == "" {
+		return extra
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(extra), &m); err != nil {
+		return "***"
+	}
+	for k := range m {
+		if isSensitiveKey(k) {
+			m[k] = "***"
+		}
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return "***"
+	}
+	return string(b)
+}
 
 // ConnectionStore reads and writes Airflow-style Connections for the Admin UI.
 // Password is encrypted at rest by the store (ADR 0019) and never returned.
@@ -45,7 +79,7 @@ func toConnectionDTO(c domain.Connection) connectionDTO {
 		Login:        strPtrOrNil(c.Login),
 		Schema:       strPtrOrNil(c.Schema),
 		Port:         c.Port,
-		Extra:        strPtrOrNil(c.Extra),
+		Extra:        strPtrOrNil(redactExtra(c.Extra)),
 	}
 }
 

--- a/internal/api/ui_connections.go
+++ b/internal/api/ui_connections.go
@@ -29,18 +29,38 @@ func redactExtra(extra string) string {
 	}
 	var m map[string]any
 	if err := json.Unmarshal([]byte(extra), &m); err != nil {
-		return "***"
+		return "***" // not a JSON object → fail closed rather than echo a possible secret
 	}
-	for k := range m {
-		if isSensitiveKey(k) {
-			m[k] = "***"
-		}
-	}
+	redactMap(m)
 	b, err := json.Marshal(m)
 	if err != nil {
 		return "***"
 	}
 	return string(b)
+}
+
+// redactMap masks, to "***", every value whose key is sensitive, recursing into
+// nested objects and arrays so a secret nested under a non-sensitive key (extra
+// is free-form) is still caught, not just top-level ones.
+func redactMap(m map[string]any) {
+	for k, v := range m {
+		if isSensitiveKey(k) {
+			m[k] = "***"
+			continue
+		}
+		redactAny(v)
+	}
+}
+
+func redactAny(v any) {
+	switch t := v.(type) {
+	case map[string]any:
+		redactMap(t)
+	case []any:
+		for _, e := range t {
+			redactAny(e)
+		}
+	}
 }
 
 // ConnectionStore reads and writes Airflow-style Connections for the Admin UI.

--- a/internal/api/ui_connections_test.go
+++ b/internal/api/ui_connections_test.go
@@ -103,6 +103,48 @@ func TestConnectionCRUDNeverReturnsPassword(t *testing.T) {
 	}
 }
 
+// TestConnectionGetMasksSensitiveExtra: the read API must not echo secrets that
+// ride in a connection's `extra` (#11). A Databricks OAuth connection keeps its
+// client_secret/token there, and BigQuery its keyfile_dict — GET previously
+// returned them in clear, which cost a credential rotation in the field.
+func TestConnectionGetMasksSensitiveExtra(t *testing.T) {
+	store := &fakeConnStore{conns: map[string]domain.Connection{
+		"wh": {
+			ConnID: "wh", ConnType: "databricks",
+			Extra: `{"client_secret":"shhh","token":"tok-123","http_path":"/sql/1.0/x","account":"acme","keyfile_dict":"{\"p\":\"k\"}"}`,
+		},
+	}}
+	srv := connServer(store)
+
+	rec := authGet(srv, http.MethodGet, "/api/v2/connections/wh", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get = %d (%s)", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, leaked := range []string{"shhh", "tok-123"} {
+		if strings.Contains(body, leaked) {
+			t.Errorf("GET leaked a secret from extra (%q): %s", leaked, body)
+		}
+	}
+	var dto connectionDTO
+	if err := json.Unmarshal(rec.Body.Bytes(), &dto); err != nil {
+		t.Fatal(err)
+	}
+	if dto.Extra == nil {
+		t.Fatal("extra should still be present (masked, not dropped)")
+	}
+	var ex map[string]any
+	if err := json.Unmarshal([]byte(*dto.Extra), &ex); err != nil {
+		t.Fatalf("extra not valid json: %v", err)
+	}
+	if ex["client_secret"] != "***" || ex["token"] != "***" || ex["keyfile_dict"] != "***" {
+		t.Errorf("sensitive extra keys must be masked to ***: %v", ex)
+	}
+	if ex["http_path"] != "/sql/1.0/x" || ex["account"] != "acme" {
+		t.Errorf("non-sensitive extra keys must survive: %v", ex)
+	}
+}
+
 func TestConnectionWriteWithoutKeyReturns503(t *testing.T) {
 	// The store reports no encryption key -> the API refuses the write (never
 	// stores a credential in plaintext), surfaced as 503.

--- a/internal/api/ui_connections_test.go
+++ b/internal/api/ui_connections_test.go
@@ -145,6 +145,24 @@ func TestConnectionGetMasksSensitiveExtra(t *testing.T) {
 	}
 }
 
+// TestRedactExtraNestedAndFailClosed: secrets nested under a non-sensitive key
+// are still masked (extra is free-form), and a non-object extra fails closed.
+func TestRedactExtraNestedAndFailClosed(t *testing.T) {
+	nested := redactExtra(`{"config":{"client_secret":"deep"},"opts":[{"token":"t"}],"schema":"public"}`)
+	if strings.Contains(nested, "deep") || strings.Contains(nested, "\"t\"") {
+		t.Errorf("nested secrets must be masked: %s", nested)
+	}
+	if !strings.Contains(nested, "public") {
+		t.Errorf("nested non-secret must survive: %s", nested)
+	}
+	if got := redactExtra(`"a-bare-secret-string"`); got != "***" {
+		t.Errorf("non-object extra must fail closed to ***, got %q", got)
+	}
+	if got := redactExtra(""); got != "" {
+		t.Errorf("empty extra stays empty, got %q", got)
+	}
+}
+
 func TestConnectionWriteWithoutKeyReturns503(t *testing.T) {
 	// The store reports no encryption key -> the API refuses the write (never
 	// stores a credential in plaintext), surfaced as 503.

--- a/internal/api/ui_variables.go
+++ b/internal/api/ui_variables.go
@@ -23,15 +23,26 @@ type VariableStore interface {
 var sensitiveKeyParts = []string{
 	"secret", "password", "passwd", "passphrase", "token",
 	"apikey", "api_key", "access_key", "private_key", "authorization", "credential",
+	// keyfile covers a service-account JSON (BigQuery keyfile_dict / keyfile_json).
+	"keyfile",
+}
+
+// isSensitiveKey reports whether a key name looks like it holds a secret, so its
+// value is masked in API responses (variables and connection `extra`).
+func isSensitiveKey(key string) bool {
+	lower := strings.ToLower(key)
+	for _, part := range sensitiveKeyParts {
+		if strings.Contains(lower, part) {
+			return true
+		}
+	}
+	return false
 }
 
 // maskedValue returns "***" when the key looks sensitive, else the value.
 func maskedValue(key, value string) string {
-	lower := strings.ToLower(key)
-	for _, part := range sensitiveKeyParts {
-		if strings.Contains(lower, part) {
-			return "***"
-		}
+	if isSensitiveKey(key) {
+		return "***"
 	}
 	return value
 }


### PR DESCRIPTION
Field-reported (#11): the connection read API echoed the free-form `extra` verbatim, so provider secrets that ride there were returned in clear on a plain `GET`.

## Change
- `redactExtra` masks secret-bearing keys in `extra` to `***` on read (list + by-id), reusing the `isSensitiveKey` matcher that already backs Variable masking; adds `keyfile` to cover BigQuery service-account JSON.
- Non-secret keys (host, http_path, account, schema, method, warehouse) are preserved so the connection's shape is still readable.
- Covers Airflow's prefixed form (`extra__<type>__client_secret`) via substring match. Unparseable `extra` is redacted wholesale (fail closed).
- `password` was already withheld; this closes the parallel gap in `extra`.

## Test
- `TestConnectionGetMasksSensitiveExtra`: client_secret/token/keyfile_dict → `***`, http_path/account survive. Variable + connection suites green; golangci-lint clean.

## Follow-up (noted, not in this PR)
The write path should treat an incoming `***` as "unchanged" so a masked read written straight back does not persist `***` — the same round-trip caveat the Variable mask already carries.

## Disclosure
Coordinated-disclosure ceremony (GHSA / CVE / advisory wording + timing) is the maintainer's call at release, mirroring GHSA-3r74 (#828). This PR is the defensive fix.