### PR TITLE
release: prepare v0.4.4-rc.1

### DIFF
--- a/helm/leoflow/Chart.yaml
+++ b/helm/leoflow/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version is the chart version; appVersion tracks the leoflow-server image.
 # Both move in lockstep with the release tag (ADR 0028); decouple only if the
 # chart ever needs a cadence of its own for a template-only fix.
-version: 0.4.3
-appVersion: "0.4.3"
+version: 0.4.4-rc.1
+appVersion: "0.4.4-rc.1"
 home: https://github.com/neochaotic/leoflow
 sources:
   - https://github.com/neochaotic/leoflow

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -1,6 +1,6 @@
 # leoflow
 
-![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.3](https://img.shields.io/badge/AppVersion-0.4.3-informational?style=flat-square)
+![Version: 0.4.4-rc.1](https://img.shields.io/badge/Version-0.4.4--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.4-rc.1](https://img.shields.io/badge/AppVersion-0.4.4--rc.1-informational?style=flat-square)
 
 Leoflow control plane — a GitOps-first, container-native workflow orchestrator (Airflow 3.2.x UI/API compatible).
 


### PR DESCRIPTION
Prepares the **v0.4.4-rc.1** cut (ADR 0028 lockstep: Chart `version`/`appVersion` → `0.4.4-rc.1`, chart README regenerated via helm-docs).

`CHANGELOG.md [Unreleased]` already carries the full v0.4.4 payload:
- **Security** — connection `extra` masked on read (#11).
- **Changed** — control-plane probes tunable + higher requests (#860); `deployment.strategy` exposed, Recreate for RWO logs PVC (#868).
- **Fixed** — control-plane restart no longer fails healthy in-flight tasks (#858); infra re-place backoff+jitter (#859); `agent_lost` log marker (#861).

Mechanical gates green: `check-chart-version-matches-tag v0.4.4-rc.1`, `check-dependabot-dirs`, `check-no-stale-deploy-path`. Tag `v0.4.4-rc.1` goes on the merge of this PR. rc keeps `[Unreleased]`.