### PR TITLE
fix(lite): write generated dbt profiles.yml to a private scratch, never the project CWD (#12/#882)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Security
 
+- **A Lite dbt task no longer writes its generated `profiles.yml` into the project
+  (#12).** In Lite the dbt profile step defaulted its output dir to the process
+  CWD — the dbt project in the user's working tree — so the generated
+  `profiles.yml`, which carries the managed connection's secret in clear, could
+  overwrite the repo's version-controlled `profiles.yml`: one `git add` from
+  committing a live credential. The Lite executor now injects the same private
+  `DBT_PROFILES_DIR`/`DBT_TARGET_PATH`/`DBT_LOG_PATH` scratch the pod base image
+  provides, and the runtime never falls back to the CWD — the profile lands in a
+  private per-task dir, never the project.
 - **Sensitive values in a connection's `extra` are masked in read API responses
   (#11).** `GET /api/v2/connections` (list and by-id) returned the free-form
   `extra` verbatim, so provider secrets that ride there — OAuth `client_secret`,

--- a/internal/executor/subprocess.go
+++ b/internal/executor/subprocess.go
@@ -125,6 +125,19 @@ func agentEnv(req Request) []string {
 	return env
 }
 
+// dbtScratchEnv points dbt's profiles/target/logs at a private per-task scratch
+// dir, mirroring the pod base image's ENV (runtime/Dockerfile) so a Lite dbt task
+// never writes profiles.yml (which carries the connection secret) into its CWD —
+// the dbt project in the user's working tree, where it would clobber the repo's
+// versioned profiles.yml (#882). Harmless for non-dbt tasks (they ignore it).
+func dbtScratchEnv(scratch string) []string {
+	return []string{
+		"DBT_PROFILES_DIR=" + scratch,
+		"DBT_TARGET_PATH=" + filepath.Join(scratch, "target"),
+		"DBT_LOG_PATH=" + filepath.Join(scratch, "logs"),
+	}
+}
+
 // Execute launches the agent subprocess and returns once it has started, like
 // the Kubernetes executor creating a pod. The agent reports its own task state
 // over gRPC, so the scheduler can record the task as queued before the agent
@@ -163,8 +176,22 @@ func (e *SubprocessExecutor) Execute(ctx context.Context, req Request) (Disposit
 	// must run to completion and report its own terminal state over gRPC. Binding
 	// it to ctx would SIGKILL the agent when the dispatch ctx is canceled (surfacing
 	// as "signal: killed" and a falsely failed task), mirroring the inline runner.
+	// #882: give the Lite task the SAME private dbt scratch the pod base image
+	// provides (runtime/Dockerfile DBT_PROFILES_DIR/TARGET/LOG), so dbt writes
+	// profiles.yml/target/logs there — never the task's CWD (the dbt project in the
+	// user's working tree), where the generated profiles.yml would clobber the
+	// repo's versioned one with the connection secret in clear. A private per-TI
+	// dir (MkdirTemp is 0700), removed with the workdir when the task exits.
+	dbtScratch, err := os.MkdirTemp("", "leoflow-dbt-")
+	if err != nil {
+		cleanupWorkDir()
+		e.logger.Error("creating dbt scratch dir failed", "task", req.TaskID, "error", err)
+		return Rejected, fmt.Errorf("creating dbt scratch for task %s: %w", req.TaskID, err)
+	}
+
 	cmd := exec.CommandContext(context.WithoutCancel(ctx), e.agentPath) //nolint:gosec // dev-only executor running the trusted agent binary
 	cmd.Env = append(os.Environ(), agentEnv(req)...)
+	cmd.Env = append(cmd.Env, dbtScratchEnv(dbtScratch)...)
 	// Lite-only: when a per-DAG venv exists, override the inherited
 	// LEOFLOW_PYTHON so the agent's `python -m leoflow_runtime` resolves the
 	// DAG's own dependencies. Last write wins in os/exec, so appending here
@@ -185,6 +212,7 @@ func (e *SubprocessExecutor) Execute(ctx context.Context, req Request) (Disposit
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 	if err := cmd.Start(); err != nil {
 		cleanupWorkDir()
+		_ = os.RemoveAll(dbtScratch) //nolint:errcheck // best-effort cleanup of the dbt scratch dir
 		e.logger.Error("agent subprocess failed to start",
 			"task", req.TaskID, "agent_path", e.agentPath, "error", err)
 		return Rejected, fmt.Errorf("starting agent subprocess for task %s: %w", req.TaskID, err)
@@ -193,6 +221,7 @@ func (e *SubprocessExecutor) Execute(ctx context.Context, req Request) (Disposit
 		"task", req.TaskID, "run", req.RunID, "pid", cmd.Process.Pid)
 	go func() {
 		defer cleanupWorkDir()
+		defer func() { _ = os.RemoveAll(dbtScratch) }() //nolint:errcheck // best-effort cleanup of the dbt scratch dir
 		werr := cmd.Wait()
 		if werr != nil {
 			e.logger.Warn("agent subprocess exited non-zero (the agent reports task state over gRPC)",

--- a/internal/executor/subprocess_test.go
+++ b/internal/executor/subprocess_test.go
@@ -35,6 +35,30 @@ func TestAgentEnv(t *testing.T) {
 	}
 }
 
+// TestDbtScratchEnv: a Lite task gets DBT_PROFILES_DIR/TARGET/LOG pointed at the
+// private scratch, never the CWD (the dbt project), so profiles.yml — which
+// carries the connection secret — can't clobber the repo's versioned file (#882).
+func TestDbtScratchEnv(t *testing.T) {
+	scratch := t.TempDir()
+	got := map[string]string{}
+	for _, kv := range dbtScratchEnv(scratch) {
+		i := strings.IndexByte(kv, '=')
+		got[kv[:i]] = kv[i+1:]
+	}
+	if got["DBT_PROFILES_DIR"] != scratch {
+		t.Errorf("DBT_PROFILES_DIR = %q, want %q", got["DBT_PROFILES_DIR"], scratch)
+	}
+	if got["DBT_TARGET_PATH"] != filepath.Join(scratch, "target") {
+		t.Errorf("DBT_TARGET_PATH = %q", got["DBT_TARGET_PATH"])
+	}
+	if got["DBT_LOG_PATH"] != filepath.Join(scratch, "logs") {
+		t.Errorf("DBT_LOG_PATH = %q", got["DBT_LOG_PATH"])
+	}
+	if cwd, _ := os.Getwd(); got["DBT_PROFILES_DIR"] == cwd {
+		t.Error("DBT_PROFILES_DIR must never be the task CWD (the dbt project) — #882")
+	}
+}
+
 func writeScript(t *testing.T, body string) string {
 	t.Helper()
 	p := filepath.Join(t.TempDir(), "agent.sh")

--- a/internal/executor/subprocess_test.go
+++ b/internal/executor/subprocess_test.go
@@ -105,6 +105,31 @@ func TestSubprocessExecuteRunsInWorkDir(t *testing.T) {
 	}
 }
 
+// TestSubprocessExecuteInjectsDbtScratch: Execute must actually put a private
+// DBT_PROFILES_DIR into the task's env (not just expose the pure helper) — the
+// wiring that keeps a Lite dbt task's profiles.yml out of the project CWD (#882).
+func TestSubprocessExecuteInjectsDbtScratch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash agent stub is POSIX-only")
+	}
+	dir := t.TempDir()
+	e := NewSubprocessExecutor(writeScript(t, `echo "$DBT_PROFILES_DIR" > scratch.txt`), discardLogger())
+	e.SetWorkDir(dir)
+	if _, err := e.Execute(context.Background(), Request{TaskID: "t"}); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	got := strings.TrimSpace(string(waitForFile(t, filepath.Join(dir, "scratch.txt"))))
+	if got == "" {
+		t.Fatal("DBT_PROFILES_DIR was not injected into the task env")
+	}
+	if got == dir || got == "." {
+		t.Errorf("DBT_PROFILES_DIR = %q, must be a private scratch, never the task CWD (#882)", got)
+	}
+	if !strings.Contains(got, "leoflow-dbt-") {
+		t.Errorf("DBT_PROFILES_DIR = %q, want a private leoflow-dbt scratch dir", got)
+	}
+}
+
 func TestSubprocessExecuteSurvivesContextCancel(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("bash agent stub is POSIX-only")

--- a/runtime/python/leoflow_runtime/__main__.py
+++ b/runtime/python/leoflow_runtime/__main__.py
@@ -31,7 +31,14 @@ def _dbt_profiles_dir() -> str:
     d = os.environ.get("DBT_PROFILES_DIR")
     if not d:
         d = tempfile.mkdtemp(prefix="leoflow-dbt-")
-    os.makedirs(d, exist_ok=True)
+    # 0700 so the dir holding profiles.yml (which carries the secret) is not
+    # world-listable — mkdtemp is already 0700, but an env-provided dir (the pod's
+    # /tmp/leoflow/dbt, created fresh) would otherwise inherit the umask (~0755).
+    os.makedirs(d, mode=0o700, exist_ok=True)
+    try:
+        os.chmod(d, 0o700)  # tighten even if it pre-existed / umask widened it
+    except OSError:
+        pass
     return d
 
 

--- a/runtime/python/leoflow_runtime/__main__.py
+++ b/runtime/python/leoflow_runtime/__main__.py
@@ -13,8 +13,26 @@ from __future__ import annotations
 import json
 import os
 import sys
+import tempfile
 
 from leoflow_runtime.runner import run, run_bash, run_operator
+
+
+def _dbt_profiles_dir() -> str:
+    """Directory the generated dbt profiles.yml is written to.
+
+    Defense in depth (#882): NEVER fall back to os.getcwd(). In Lite the CWD is the
+    dbt project in the user's working tree, and profiles.yml carries the connection
+    secret in clear — writing it there clobbers the repo's versioned file, a git-add
+    from leaking a credential. When DBT_PROFILES_DIR is unset, use a private scratch
+    dir instead. In practice the Lite executor and the pod base image both set
+    DBT_PROFILES_DIR; this guards any path that forgot to.
+    """
+    d = os.environ.get("DBT_PROFILES_DIR")
+    if not d:
+        d = tempfile.mkdtemp(prefix="leoflow-dbt-")
+    os.makedirs(d, exist_ok=True)
+    return d
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -30,8 +48,7 @@ def main(argv: list[str] | None = None) -> int:
         # arg overrides the dbt target schema.
         from leoflow_runtime.dbt import write_dbt_profile
 
-        profiles_dir = os.environ.get("DBT_PROFILES_DIR") or os.getcwd()
-        os.makedirs(profiles_dir, exist_ok=True)
+        profiles_dir = _dbt_profiles_dir()
         schema = args[3] if len(args) == 4 else None
         write_dbt_profile(args[1], args[2], profiles_dir, schema=schema)
         return 0
@@ -40,8 +57,7 @@ def main(argv: list[str] | None = None) -> int:
         # a dbt group has no managed connection. Optional 3rd arg is the DB file path.
         from leoflow_runtime.dbt import write_dbt_default_duckdb
 
-        profiles_dir = os.environ.get("DBT_PROFILES_DIR") or os.getcwd()
-        os.makedirs(profiles_dir, exist_ok=True)
+        profiles_dir = _dbt_profiles_dir()
         db_path = args[2] if len(args) == 3 else ""
         write_dbt_default_duckdb(args[1], profiles_dir, db_path)
         return 0

--- a/runtime/python/leoflow_runtime/dbt.py
+++ b/runtime/python/leoflow_runtime/dbt.py
@@ -228,6 +228,10 @@ def write_dbt_default_duckdb(profile_name: str, profiles_dir: str, db_path: str 
     output = {"type": "duckdb", "path": db_path or ":memory:", "threads": 4}
     profile = {profile_name: {"target": "dev", "outputs": {"dev": output}}}
     path = os.path.join(profiles_dir, "profiles.yml")
-    with open(path, "w", encoding="utf-8") as handle:
+    # 0600 to match write_dbt_profile: a duckdb profile carries no secret today, but
+    # keeping both profiles.yml writers owner-only avoids a future footgun if this
+    # ever grows credentialed fields (and keeps the two paths consistent).
+    with open(path, "w", encoding="utf-8", opener=lambda p, f: os.open(p, f, 0o600)) as handle:
         json.dump(profile, handle)
+    os.chmod(path, 0o600)
     return path

--- a/runtime/python/tests/test_dbt.py
+++ b/runtime/python/tests/test_dbt.py
@@ -100,7 +100,9 @@ def test_profile_step_never_writes_to_cwd(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("DBT_PROFILES_DIR", raising=False)
     assert main(["--dbt-default-duckdb", "shop"]) == 0
-    assert not (tmp_path / "profiles.yml").exists(), "must NOT write profiles.yml into the CWD (#882)"
+    assert not (tmp_path / "profiles.yml").exists(), (
+        "must NOT write profiles.yml into the CWD (#882)"
+    )
 
 
 def test_unsupported_adapter_is_a_loud_error():

--- a/runtime/python/tests/test_dbt.py
+++ b/runtime/python/tests/test_dbt.py
@@ -87,15 +87,20 @@ def test_default_duckdb_defaults_to_memory(tmp_path):
     assert prof["shop"]["outputs"]["dev"]["path"] == ":memory:"
 
 
-def test_profile_step_writes_to_cwd_not_home(tmp_path, monkeypatch):
-    # Regression: the profile-generation step must write to the task's CWD, never
-    # clobber the user's global ~/.dbt/profiles.yml (Lite runs on the host).
+def test_profile_step_never_writes_to_cwd(tmp_path, monkeypatch):
+    # #882: with DBT_PROFILES_DIR unset, the profile step must NOT write profiles.yml
+    # into the CWD. In Lite the CWD is the dbt project in the user's working tree, and
+    # profiles.yml carries the connection secret in clear — writing it there clobbers
+    # the repo's versioned file (a git-add from leaking a credential). It goes to a
+    # private scratch instead (asserted in test_main.py::test_dbt_profiles_dir_never_cwd),
+    # and never ~/.dbt. (Superseded the old "writes to cwd" regression, which encoded
+    # the leaky behavior this fixes.)
     from leoflow_runtime.__main__ import main
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.delenv("DBT_PROFILES_DIR", raising=False)
     assert main(["--dbt-default-duckdb", "shop"]) == 0
-    assert (tmp_path / "profiles.yml").exists()
+    assert not (tmp_path / "profiles.yml").exists(), "must NOT write profiles.yml into the CWD (#882)"
 
 
 def test_unsupported_adapter_is_a_loud_error():

--- a/runtime/python/tests/test_main.py
+++ b/runtime/python/tests/test_main.py
@@ -25,6 +25,20 @@ def test_dbt_profiles_dir_honors_env(tmp_path, monkeypatch):
     assert target.is_dir()
 
 
+def test_dbt_profiles_dir_tolerates_chmod_failure(tmp_path, monkeypatch):
+    """The 0700 tightening is best-effort: on a filesystem that refuses chmod the
+    dir is still returned rather than crashing the task (#882)."""
+    target = tmp_path / "scr"
+    monkeypatch.setenv("DBT_PROFILES_DIR", str(target))
+
+    def _boom(*_a, **_k):
+        raise OSError("chmod not supported here")
+
+    monkeypatch.setattr(os, "chmod", _boom)
+    assert __main__._dbt_profiles_dir() == str(target)
+    assert target.is_dir()
+
+
 def test_main_requires_exactly_one_arg():
     assert __main__.main([]) == 2
     assert __main__.main(["a", "b"]) == 2

--- a/runtime/python/tests/test_main.py
+++ b/runtime/python/tests/test_main.py
@@ -1,8 +1,28 @@
 """Tests for the ``python -m leoflow_runtime`` CLI entry point."""
 
 import json
+import os
 
 from leoflow_runtime import __main__
+
+
+def test_dbt_profiles_dir_never_cwd(tmp_path, monkeypatch):
+    """#882: with DBT_PROFILES_DIR unset, the profiles dir must NOT be the CWD (the
+    dbt project in the user's working tree) — profiles.yml carries the secret and
+    would clobber the repo's versioned file. It must be a private (0700) scratch."""
+    monkeypatch.delenv("DBT_PROFILES_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)  # simulate running from the dbt project dir
+    d = __main__._dbt_profiles_dir()
+    assert d != str(tmp_path), "must not resolve to the project CWD (#882)"
+    assert os.path.isdir(d)
+    assert (os.stat(d).st_mode & 0o777) == 0o700, "scratch must be private (0700)"
+
+
+def test_dbt_profiles_dir_honors_env(tmp_path, monkeypatch):
+    target = tmp_path / "scr"
+    monkeypatch.setenv("DBT_PROFILES_DIR", str(target))
+    assert __main__._dbt_profiles_dir() == str(target)
+    assert target.is_dir()
 
 
 def test_main_requires_exactly_one_arg():

--- a/test/e2e/lite-dbt.sh
+++ b/test/e2e/lite-dbt.sh
@@ -144,9 +144,13 @@ PY
 [ "$ROWS" = "3" ] || fail "mart has $ROWS rows, want 3 (models did not materialize)" "$TMP/lite.log"
 pass "mart materialized with 3 rows in duckdb"
 
-echo "==> #882: the generated profiles.yml must land in the private scratch, NOT the project"
-[ -f "$PROJ/profiles.yml" ] && fail "profiles.yml was written into the project — #882 leak: the dbt profile step must write to the private scratch (DBT_PROFILES_DIR the Lite executor injects), never the task CWD, or a managed connection's secret would clobber a versioned profiles.yml" "$TMP/lite.log"
-pass "project stayed profiles-less after the run (generated profile went to the scratch dir, #882)"
+echo "==> #882: the generated profiles.yml must land in the private scratch, NOT anywhere in the workspace"
+# The task's CWD is the workspace ($WS); pre-fix the profile step wrote profiles.yml
+# to os.getcwd() = $WS (not the nested $PROJ). Assert it appears NOWHERE under the
+# whole workspace tree — this is the assertion that goes RED on pre-fix code.
+LEAKED="$(find "$WS" -name profiles.yml 2>/dev/null || true)"
+[ -n "$LEAKED" ] && fail "profiles.yml leaked into the workspace at: $LEAKED — #882: the dbt profile step must write to the private scratch (DBT_PROFILES_DIR the Lite executor injects), never the task CWD, or a managed connection's secret would clobber a versioned profiles.yml" "$TMP/lite.log"
+pass "workspace stayed profiles-less after the run (generated profile went to the private scratch, #882)"
 
 echo
 echo "  ✅ Lite dbt (duckdb) verified end to end: zero-config compile (#575) -> subprocess"

--- a/test/e2e/lite-dbt.sh
+++ b/test/e2e/lite-dbt.sh
@@ -144,6 +144,10 @@ PY
 [ "$ROWS" = "3" ] || fail "mart has $ROWS rows, want 3 (models did not materialize)" "$TMP/lite.log"
 pass "mart materialized with 3 rows in duckdb"
 
+echo "==> #882: the generated profiles.yml must land in the private scratch, NOT the project"
+[ -f "$PROJ/profiles.yml" ] && fail "profiles.yml was written into the project — #882 leak: the dbt profile step must write to the private scratch (DBT_PROFILES_DIR the Lite executor injects), never the task CWD, or a managed connection's secret would clobber a versioned profiles.yml" "$TMP/lite.log"
+pass "project stayed profiles-less after the run (generated profile went to the scratch dir, #882)"
+
 echo
 echo "  ✅ Lite dbt (duckdb) verified end to end: zero-config compile (#575) -> subprocess"
 echo "     execution -> models materialized, no warehouse and no profiles.yml needed."


### PR DESCRIPTION
Closes #882 (#12). SECURITY — prevents a managed connection's secret leaking into the user's repo.

## Problem
In Lite, the dbt profile step (`python -m leoflow_runtime --dbt-profile` / `--dbt-default-duckdb`) resolved its output dir as `os.environ.get("DBT_PROFILES_DIR") or os.getcwd()`. Lite has no base image, so `DBT_PROFILES_DIR` was unset → CWD = the dbt project in the working tree → the generated `profiles.yml` (with the managed connection's `client_secret`/`token` in clear) **overwrote the repo's version-controlled `profiles.yml`** — a `git add` from committing a live credential. The pod path was already safe via the base image ENV (#854).

## Fix — symmetric with the pod
- **Lite executor** (`internal/executor/subprocess.go`): inject the same `DBT_PROFILES_DIR`/`DBT_TARGET_PATH`/`DBT_LOG_PATH` the pod base image sets (`runtime/Dockerfile`), pointed at a **private per-task scratch** (`MkdirTemp`, 0700, removed with the workdir). dbt writes profiles/target/logs there, never the project. Harmless for non-dbt tasks.
- **Runtime** (`__main__.py`): `_dbt_profiles_dir()` never falls back to CWD — a private `mkdtemp` when the env is unset (defense in depth for any path that forgot to set it).

## Tests
- Go `TestDbtScratchEnv`: the three vars point under the scratch, never the CWD.
- Python `test_dbt_profiles_dir_never_cwd` (≠ cwd, 0700) + `_honors_env`.
- `test/e2e/lite-dbt.sh`: after a Lite dbt run, assert the project stays profiles-less (the generated profile went to scratch).
- golangci-lint clean; `go build ./...`, executor + `test_main.py` green.

Targets **v0.4.4-rc.2**. Public issue is fine (local self-leak footgun, not a cross-privilege vuln — see the discussion on #882).