### PR TITLE
docs(adr): ADR 0061 secret locality + feature-author how-to (#882 follow-up)

### DIFF
--- a/website/content/contribute/_index.md
+++ b/website/content/contribute/_index.md
@@ -31,4 +31,10 @@ How to work on Leoflow itself.
     <span class="lf-card__desc">Build and preview this Hugo + Docsy site locally.</span>
     <span class="lf-card__more">Build the site →</span>
   </a>
+  <a class="lf-card" href="/contribute/secret-handling/">
+    <span class="lf-card__icon"><i class="fa-solid fa-key"></i></span>
+    <span class="lf-card__title">Handling secrets</span>
+    <span class="lf-card__desc">The two rules — private locality and masked-on-read — every feature that touches a credential must follow (<a href="/project/adrs/0061-secret-locality/">ADR 0061</a>).</span>
+    <span class="lf-card__more">Read the rules →</span>
+  </a>
 </div>

--- a/website/content/contribute/secret-handling.md
+++ b/website/content/contribute/secret-handling.md
@@ -10,7 +10,8 @@ URI, a generated `profiles.yml`, a keyfile, a token, an API key — it is bound 
 the two invariants in [ADR 0061](/project/adrs/0061-secret-locality/). This page
 is the practical how-to. Both rules exist because the same leak has happened three
 times ([#882](https://github.com/neochaotic/leoflow/issues/882),
-#11, GHSA-3r74-9w27-v32f) — each avoidable.
+[PR #867](https://github.com/neochaotic/leoflow/pull/867) (field report #11),
+GHSA-3r74-9w27-v32f) — each avoidable.
 
 ## Rule 1 — Private locality: never write a secret where it could be committed
 
@@ -19,17 +20,18 @@ removed when the task ends) — **never** the project directory, the process CWD
 the repo, or a committable dotfile. The default output location must be a private
 `mkdtemp`, never `os.getcwd()` / `"."`.
 
-leoflow already provides the scratch on both execution paths — use it, don't
-reinvent it:
+leoflow provides the scratch on both execution paths — use it, don't reinvent it:
 
 - **Pod**: the base image sets `DBT_PROFILES_DIR` / `DBT_TARGET_PATH` /
   `DBT_LOG_PATH` to `/tmp/leoflow/...` (`runtime/Dockerfile`).
 - **Lite**: the subprocess executor injects the same three at a per-task
-  `MkdirTemp` (`internal/executor/subprocess.go`, `dbtScratchEnv`).
+  `MkdirTemp` (`internal/executor/subprocess.go`, `dbtScratchEnv`) — this Lite-side
+  injection lands with the #882 fix.
 
 So a task reads `DBT_PROFILES_DIR` and writes there. The runtime's own fallback,
-for any path that forgot to set it, is a private `mkdtemp` — **never the CWD**
-(`runtime/python/leoflow_runtime/__main__.py`, `_dbt_profiles_dir`):
+for any path that forgot to set it, must be a private `mkdtemp` — **never the CWD**
+(`runtime/python/leoflow_runtime/__main__.py`, `_dbt_profiles_dir`, also part of the
+#882 fix):
 
 ```python
 d = os.environ.get("DBT_PROFILES_DIR")

--- a/website/content/project/adrs/0061-secret-locality.md
+++ b/website/content/project/adrs/0061-secret-locality.md
@@ -1,0 +1,93 @@
+---
+# --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
+aliases:
+  - /adr/0061-secret-locality.html
+# --- end AUTO redirect aliases ---
+title: "ADR 0061: Secret material never lands in the user's tree — private scratch, masked on read"
+linkTitle: "0061 · Secret locality — private scratch, masked on read"
+weight: 610
+description: "ADR 0061: Secret material is written only to a private, ephemeral scratch (never the project/CWD/repo) and masked on read — the invariant that prevents the credential-leak class."
+---
+
+**Status:** Accepted
+**Date:** 2026-09-02
+**Accepted:** 2026-09-02
+**Relates:** ADR 0019 (secret encryption at rest — the vault), ADR 0021 (exposing variables/connections to pods), ADR 0045 (declared secret delivery), ADR 0055 (secret scoping + token liveness), ADR 0060 (external secrets resolution). This ADR is the cross-cutting *locality* invariant those composed decisions all assume but none stated.
+**Issues:** #882 (#12, Lite dbt `profiles.yml` written to the project CWD), #11 (connection `extra` echoed on read), GHSA-3r74-9w27-v32f / #828 (author env override) — three instances of one class.
+
+## Context
+
+leoflow keeps secrets in the control-plane vault, encrypted at rest (ADR 0019),
+and delivers them to a task pod-side as `AIRFLOW_CONN_<ID>` / `AIRFLOW_VAR_<KEY>`
+over the ADR 0055 exchange (ADR 0021/0045/0060). That covers the secret's life
+*in transit* and *at rest in the vault*. It does **not** state where a task or a
+feature may put a secret once it holds one — and that gap has now produced the
+same bug three times:
+
+- **#882 (#12).** A Lite dbt task's profile step defaulted its output dir to the
+  process CWD — the dbt project in the user's working tree — so the generated
+  `profiles.yml`, carrying the managed connection's secret in clear, overwrote
+  the repo's version-controlled `profiles.yml`. One `git add` from committing a
+  live credential. (The pod path was safe only because the base image happened to
+  set `DBT_PROFILES_DIR` to `/tmp`.)
+- **#11.** `GET /api/v2/connections` returned the free-form `extra` verbatim, so
+  provider secrets (`client_secret`, `token`, `keyfile_dict`) were echoed to any
+  reader — the write-only `password` field was protected, `extra` was not.
+- **#828 (GHSA-3r74-9w27-v32f).** A DAG's `env:` could override reserved
+  `LEOFLOW_` variables and redirect the in-pod agent's credentials.
+
+Each was fixed in isolation. None of them had to happen: they share a single
+missing rule about **where a secret is allowed to be** and **who is allowed to
+read it back**.
+
+## Decision
+
+Two invariants, binding on all code — core, runtime, CLI, connectors, and any
+future feature:
+
+1. **Private locality.** Secret material — connection URIs, generated
+   `profiles.yml`, keyfiles, tokens, any credential-bearing artifact — is written
+   **only** to a private, ephemeral, non-committable location: a per-task scratch
+   dir (`0700`, created fresh, removed when the task ends). It is **never** written
+   to the project directory, the process CWD, the repo, `$HOME` dotfiles a user
+   might commit, or any path visible in the user's working tree. A default output
+   location for a secret-bearing file must be a private scratch (`mkdtemp`), never
+   `os.getcwd()` / `.`.
+
+2. **Masked on read.** A secret is never echoed back by a read path — API
+   responses, the UI, logs, audit records, error messages. Secret-bearing fields
+   are redacted (`***`) on serialization; the write path accepts them, the read
+   path never returns them. (Free-form blobs like a connection `extra` are
+   redacted by key name — `isSensitiveKey` — recursively.)
+
+The two paths mirror each other: locality keeps a secret off disk where it could
+be committed; masking keeps it out of responses where it could be observed.
+
+## Consequences
+
+Enforcement — every feature touching a secret carries this, and review checks it:
+
+- **Materializing a credential to disk** → target the executor-injected scratch
+  (the `DBT_PROFILES_DIR`/`DBT_TARGET_PATH`/`DBT_LOG_PATH` pattern: the pod base
+  image and the Lite subprocess executor both provide one), and the code's own
+  fallback, when the env is unset, is a private `mkdtemp` — **never the CWD**.
+- **Serializing a secret to a response/log/audit** → mask secret-bearing fields
+  (reuse `isSensitiveKey`); prefer omitting write-only fields entirely.
+- **Tests are mandatory and specific**: a feature that writes a credential proves
+  (unit + an inner-loop e2e) that nothing lands in the CWD/project; a feature that
+  reads one proves the response is masked. UI-surfaced behavior additionally
+  carries Playwright coverage against a real backend.
+- **Symmetry Lite ↔ pod**: the two execution paths must provide the *same* secret
+  locality. A fix that only lands in the pod base image (as ADR 0060's `/tmp`
+  default did) but not in the Lite executor is incomplete — #882 was exactly that
+  asymmetry.
+- Optional CI guard: flag a secret-writing path that resolves its dir from
+  `os.getcwd()` / `"."`.
+
+The cost is small — a scratch dir and a masking helper — and it is paid once per
+feature, against a class of leak that is severe (a committed or echoed live
+credential) and, as the three issues show, easy to reintroduce by omission.
+
+This ADR is a locality/read invariant, not a new mechanism; it does not change the
+vault, the exchange, or scoping. It states the rule those already assume so the
+next feature does not have to rediscover it through an incident.

--- a/website/content/project/adrs/0061-secret-locality.md
+++ b/website/content/project/adrs/0061-secret-locality.md
@@ -13,7 +13,7 @@ description: "ADR 0061: Secret material is written only to a private, ephemeral 
 **Date:** 2026-09-02
 **Accepted:** 2026-09-02
 **Relates:** ADR 0019 (secret encryption at rest — the vault), ADR 0021 (exposing variables/connections to pods), ADR 0045 (declared secret delivery), ADR 0055 (secret scoping + token liveness), ADR 0060 (external secrets resolution). This ADR is the cross-cutting *locality* invariant those composed decisions all assume but none stated.
-**Issues:** #882 (#12, Lite dbt `profiles.yml` written to the project CWD), #11 (connection `extra` echoed on read), GHSA-3r74-9w27-v32f / #828 (author env override) — three instances of one class.
+**Issues:** #882 (#12, Lite dbt `profiles.yml` written to the project CWD — fix in progress), PR #867 (connection `extra` echoed on read; field report #11), GHSA-3r74-9w27-v32f / #828 (author env override) — three instances of one class.
 
 ## Context
 
@@ -30,9 +30,10 @@ same bug three times:
   the repo's version-controlled `profiles.yml`. One `git add` from committing a
   live credential. (The pod path was safe only because the base image happened to
   set `DBT_PROFILES_DIR` to `/tmp`.)
-- **#11.** `GET /api/v2/connections` returned the free-form `extra` verbatim, so
-  provider secrets (`client_secret`, `token`, `keyfile_dict`) were echoed to any
-  reader — the write-only `password` field was protected, `extra` was not.
+- **PR #867 (field report #11).** `GET /api/v2/connections` returned the free-form
+  `extra` verbatim, so provider secrets (`client_secret`, `token`, `keyfile_dict`)
+  were echoed to any reader — the write-only `password` field was protected,
+  `extra` was not.
 - **#828 (GHSA-3r74-9w27-v32f).** A DAG's `env:` could override reserved
   `LEOFLOW_` variables and redirect the in-pod agent's credentials.
 
@@ -68,9 +69,11 @@ be committed; masking keeps it out of responses where it could be observed.
 Enforcement — every feature touching a secret carries this, and review checks it:
 
 - **Materializing a credential to disk** → target the executor-injected scratch
-  (the `DBT_PROFILES_DIR`/`DBT_TARGET_PATH`/`DBT_LOG_PATH` pattern: the pod base
-  image and the Lite subprocess executor both provide one), and the code's own
-  fallback, when the env is unset, is a private `mkdtemp` — **never the CWD**.
+  (the `DBT_PROFILES_DIR`/`DBT_TARGET_PATH`/`DBT_LOG_PATH` pattern). The pod base
+  image sets these to `/tmp/leoflow/...` today; the Lite subprocess executor **must**
+  inject the same, and the code's own fallback, when the env is unset, **must** be a
+  private `mkdtemp` — **never the CWD**. (Bringing the Lite path into compliance is
+  the #882 fix; the pod path was already compliant via the base image.)
 - **Serializing a secret to a response/log/audit** → mask secret-bearing fields
   (reuse `isSensitiveKey`); prefer omitting write-only fields entirely.
 - **Tests are mandatory and specific**: a feature that writes a credential proves
@@ -91,3 +94,7 @@ credential) and, as the three issues show, easy to reintroduce by omission.
 This ADR is a locality/read invariant, not a new mechanism; it does not change the
 vault, the exchange, or scoping. It states the rule those already assume so the
 next feature does not have to rediscover it through an incident.
+
+The practical how-to for satisfying both invariants — the scratch pattern, the
+masking helper, and the tests each requires — is
+[Handling secrets in a feature](/contribute/secret-handling/).

--- a/website/content/project/adrs/0061-secret-locality.md
+++ b/website/content/project/adrs/0061-secret-locality.md
@@ -13,7 +13,7 @@ description: "ADR 0061: Secret material is written only to a private, ephemeral 
 **Date:** 2026-09-02
 **Accepted:** 2026-09-02
 **Relates:** ADR 0019 (secret encryption at rest — the vault), ADR 0021 (exposing variables/connections to pods), ADR 0045 (declared secret delivery), ADR 0055 (secret scoping + token liveness), ADR 0060 (external secrets resolution). This ADR is the cross-cutting *locality* invariant those composed decisions all assume but none stated.
-**Issues:** #882 (#12, Lite dbt `profiles.yml` written to the project CWD — fix in progress), PR #867 (connection `extra` echoed on read; field report #11), GHSA-3r74-9w27-v32f / #828 (author env override) — three instances of one class.
+**Issues:** #882 (field report #12, Lite dbt `profiles.yml` written to the project CWD — fix in progress), PR #867 (connection `extra` echoed on read; field report #11), GHSA-3r74-9w27-v32f / #828 (author env override) — three instances of one class.
 
 ## Context
 
@@ -24,7 +24,7 @@ over the ADR 0055 exchange (ADR 0021/0045/0060). That covers the secret's life
 feature may put a secret once it holds one — and that gap has now produced the
 same bug three times:
 
-- **#882 (#12).** A Lite dbt task's profile step defaulted its output dir to the
+- **#882 (field report #12).** A Lite dbt task's profile step defaulted its output dir to the
   process CWD — the dbt project in the user's working tree — so the generated
   `profiles.yml`, carrying the managed connection's secret in clear, overwrote
   the repo's version-controlled `profiles.yml`. One `git add` from committing a

--- a/website/content/project/adrs/_index.md
+++ b/website/content/project/adrs/_index.md
@@ -71,3 +71,5 @@ The *why* behind Leoflow's design. ADRs are immutable once accepted.
 - [ADR 0057: OIDC/SSO authentication with fail-closed tenant pinning](/project/adrs/0057-oidc-sso/)
 - [ADR 0058: Warm worker pools — pod-reuse semantics (N:1)](/project/adrs/0058-warm-worker-pools/)
 - [ADR 0059: OpenLineage emission from the Go control plane → OpenMetadata](/project/adrs/0059-openlineage-emission/)
+- [ADR 0060: External secrets resolution — pod-side, provider-neutral SecretResolver](/project/adrs/0060-external-secrets-resolution/)
+- [ADR 0061: Secret locality — private scratch, masked on read](/project/adrs/0061-secret-locality/)

--- a/website/content/project/secret-handling.md
+++ b/website/content/project/secret-handling.md
@@ -1,0 +1,74 @@
+---
+title: "Handling secrets in a feature"
+linkTitle: "Handling secrets"
+weight: 40
+description: "The two rules every feature that touches a credential must follow — private locality and masked-on-read — with the patterns to satisfy them."
+---
+
+If your change reads, writes, delivers, or displays a **secret** — a connection
+URI, a generated `profiles.yml`, a keyfile, a token, an API key — it is bound by
+the two invariants in [ADR 0061](/project/adrs/0061-secret-locality/). This page
+is the practical how-to. Both rules exist because the same leak has happened three
+times ([#882](https://github.com/neochaotic/leoflow/issues/882),
+#11, GHSA-3r74-9w27-v32f) — each avoidable.
+
+## Rule 1 — Private locality: never write a secret where it could be committed
+
+A secret-bearing file goes to a **private, ephemeral scratch** (0700, per-task,
+removed when the task ends) — **never** the project directory, the process CWD,
+the repo, or a committable dotfile. The default output location must be a private
+`mkdtemp`, never `os.getcwd()` / `"."`.
+
+leoflow already provides the scratch on both execution paths — use it, don't
+reinvent it:
+
+- **Pod**: the base image sets `DBT_PROFILES_DIR` / `DBT_TARGET_PATH` /
+  `DBT_LOG_PATH` to `/tmp/leoflow/...` (`runtime/Dockerfile`).
+- **Lite**: the subprocess executor injects the same three at a per-task
+  `MkdirTemp` (`internal/executor/subprocess.go`, `dbtScratchEnv`).
+
+So a task reads `DBT_PROFILES_DIR` and writes there. The runtime's own fallback,
+for any path that forgot to set it, is a private `mkdtemp` — **never the CWD**
+(`runtime/python/leoflow_runtime/__main__.py`, `_dbt_profiles_dir`):
+
+```python
+d = os.environ.get("DBT_PROFILES_DIR")
+if not d:
+    d = tempfile.mkdtemp(prefix="leoflow-dbt-")  # NOT os.getcwd()
+```
+
+**Symmetry matters.** A fix that lands only in the pod base image but not in the
+Lite executor (or vice-versa) is incomplete — that asymmetry *was* #882. Whatever
+locality the pod gets, Lite gets the same.
+
+## Rule 2 — Masked on read: never echo a secret back
+
+A read path — API response, UI, logs, audit, error message — never returns a
+secret. The write path accepts it; the read path masks it. Reuse the shared
+matcher rather than hand-rolling a key list:
+
+```go
+// internal/api — mask secret-bearing keys on serialize; recurse into free-form blobs.
+if isSensitiveKey(key) {
+    value = "***"
+}
+```
+
+Prefer omitting a write-only field entirely (as the connection `password` is). For
+a free-form blob like a connection's `extra`, redact by key name **recursively**,
+and fail closed (redact the whole thing) if it can't be parsed.
+
+## The tests are part of the feature
+
+- **Writes a credential** → a unit test proving the target is not the CWD/project
+  (and is `0700`), plus an inner-loop e2e asserting nothing secret lands under the
+  repo (see `test/e2e/lite-dbt.sh`'s profiles-less assertion).
+- **Reads a credential** → a test proving the response is masked (see
+  `TestConnectionGetMasksSensitiveExtra`).
+- **Surfaces in the UI** → Playwright against a real backend, per the SPA testing
+  rule — the embedded Airflow UI reads the same `/api/v2/*`, so a masked value must
+  render masked there too.
+
+If you're adding a connector, an operator, or a task type that handles a
+credential and you're unsure, treat ADR 0061 as the checklist: *where does the
+secret land on disk, and can any read echo it?*


### PR DESCRIPTION
Turns the pointwise fixes (#882/#12, #11, #828) into the **invariant** that prevents the whole class, so a future feature can't reintroduce it by omission.

- **ADR 0061 — Secret locality**: secret material is written ONLY to a private, ephemeral, non-committable scratch (never the project/CWD/repo) AND masked on read (API/UI/logs/audit). States the locality/read rule the vault (0019), delivery (0021/0045/0060), and scoping (0055) ADRs all assumed but none wrote down. Enforcement: the scratch pattern, `isSensitiveKey` masking, mandatory write-not-to-CWD + masked-on-read tests, and Lite↔pod symmetry.
- **project/secret-handling.md** — the practical how-to for feature/connector authors (the two rules + code patterns + the test requirement).
- Registers ADR 0060 + 0061 in the ADR index (0060 was missing).

Docs-only; independent of the v0.4.4-rc.2 code (#884 is the #12 fix). Pairs with the SPA-Playwright + UI-integration testing rules.