### PR TITLE
feat(cli): `leoflow connections` and `leoflow variables` command groups (#881)

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -114,6 +114,184 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/Error" }
 
+  /api/v2/connections:
+    get:
+      summary: List connections
+      description: |
+        Lists the tenant's Airflow-style connections. Passwords are write-only and
+        never returned; secret-bearing keys inside `extra` are masked server-side.
+        Requires the read:connection permission.
+      operationId: listConnections
+      tags: [Connections]
+      parameters:
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+      responses:
+        "200":
+          description: A page of connections
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ConnectionCollection" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    post:
+      summary: Create or replace a connection (upsert)
+      description: |
+        Upserts a connection: creates it, or replaces an existing one with the same
+        connection_id. The password is write-only and never returned. Requires the
+        write:connection permission and a configured encryption key.
+      operationId: createConnection
+      tags: [Connections]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/ConnectionBody" }
+      responses:
+        "201":
+          description: Connection created or replaced
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Connection" }
+        "400":
+          description: Invalid input (missing connection_id or conn_type)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "503":
+          $ref: "#/components/responses/EncryptionUnavailable"
+
+  /api/v2/connections/{connection_id}:
+    parameters:
+      - $ref: "#/components/parameters/ConnectionID"
+    get:
+      summary: Get a connection
+      operationId: getConnection
+      tags: [Connections]
+      responses:
+        "200":
+          description: Connection detail (password omitted, extra masked)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Connection" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      summary: Update a connection
+      operationId: updateConnection
+      tags: [Connections]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/ConnectionBody" }
+      responses:
+        "200":
+          description: Updated connection
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Connection" }
+        "400":
+          description: Invalid input (missing conn_type)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "503":
+          $ref: "#/components/responses/EncryptionUnavailable"
+    delete:
+      summary: Delete a connection
+      operationId: deleteConnection
+      tags: [Connections]
+      responses:
+        "204":
+          $ref: "#/components/responses/NoContent"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/v2/variables:
+    get:
+      summary: List variables
+      description: |
+        Lists the tenant's Airflow-style variables. Values of secret-ish keys are
+        masked server-side. Requires the read:variable permission.
+      operationId: listVariables
+      tags: [Variables]
+      parameters:
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+      responses:
+        "200":
+          description: A page of variables
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/VariableCollection" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    post:
+      summary: Create or replace a variable (upsert)
+      description: |
+        Upserts a variable: creates it, or replaces an existing one with the same
+        key. Requires the write:variable permission.
+      operationId: createVariable
+      tags: [Variables]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/VariableBody" }
+      responses:
+        "201":
+          description: Variable created or replaced
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Variable" }
+        "400":
+          description: Invalid input (missing key)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/v2/variables/{variable_key}:
+    parameters:
+      - $ref: "#/components/parameters/VariableKey"
+    get:
+      summary: Get a variable
+      operationId: getVariable
+      tags: [Variables]
+      responses:
+        "200":
+          description: Variable detail (value masked when the key looks sensitive)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Variable" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      summary: Delete a variable
+      operationId: deleteVariable
+      tags: [Variables]
+      responses:
+        "204":
+          $ref: "#/components/responses/NoContent"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /api/v2/dags:
     get:
       summary: List DAGs
@@ -481,6 +659,16 @@ components:
       in: path
       required: true
       schema: { type: string }
+    ConnectionID:
+      name: connection_id
+      in: path
+      required: true
+      schema: { type: string }
+    VariableKey:
+      name: variable_key
+      in: path
+      required: true
+      schema: { type: string }
 
   responses:
     Unauthorized:
@@ -490,6 +678,15 @@ components:
           schema: { $ref: "#/components/schemas/Error" }
     NotFound:
       description: Resource not found
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    NoContent:
+      description: Deleted (no content)
+    EncryptionUnavailable:
+      description: >-
+        No encryption key configured, so secrets cannot be stored. Set
+        LEOFLOW_SECRET_KEY on the control plane to manage connections.
       content:
         application/json:
           schema: { $ref: "#/components/schemas/Error" }
@@ -575,6 +772,79 @@ components:
         users:
           type: array
           items: { $ref: "#/components/schemas/UserListItem" }
+        total_entries: { type: integer }
+
+    Connection:
+      type: object
+      required: [connection_id, conn_type]
+      description: >-
+        An Airflow-style connection. The password is write-only and never
+        returned; secret-bearing keys inside `extra` are masked server-side.
+      properties:
+        connection_id: { type: string }
+        conn_type: { type: string }
+        description: { type: string, nullable: true }
+        host: { type: string, nullable: true }
+        login: { type: string, nullable: true }
+        schema: { type: string, nullable: true }
+        port: { type: integer, nullable: true }
+        extra: { type: string, nullable: true }
+
+    ConnectionBody:
+      type: object
+      required: [conn_type]
+      description: >-
+        Connection create/replace payload. connection_id is required on POST
+        (taken from the path on PATCH). password and extra are write-only.
+      properties:
+        connection_id: { type: string }
+        conn_type: { type: string }
+        description: { type: string }
+        host: { type: string }
+        login: { type: string }
+        password:
+          type: string
+          format: password
+          writeOnly: true
+        schema: { type: string }
+        port: { type: integer, nullable: true }
+        extra: { type: string }
+
+    ConnectionCollection:
+      type: object
+      properties:
+        connections:
+          type: array
+          items: { $ref: "#/components/schemas/Connection" }
+        total_entries: { type: integer }
+
+    Variable:
+      type: object
+      required: [key, value, is_encrypted]
+      description: >-
+        An Airflow-style variable. The value is masked server-side when the key
+        looks sensitive (secret/password/token/...).
+      properties:
+        key: { type: string }
+        value: { type: string }
+        description: { type: string, nullable: true }
+        is_encrypted: { type: boolean }
+        team_name: { type: string, nullable: true }
+
+    VariableBody:
+      type: object
+      required: [key]
+      properties:
+        key: { type: string }
+        value: { type: string }
+        description: { type: string }
+
+    VariableCollection:
+      type: object
+      properties:
+        variables:
+          type: array
+          items: { $ref: "#/components/schemas/Variable" }
         total_entries: { type: integer }
 
     DAG:

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -114,6 +114,184 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/Error" }
 
+  /api/v2/connections:
+    get:
+      summary: List connections
+      description: |
+        Lists the tenant's Airflow-style connections. Passwords are write-only and
+        never returned; secret-bearing keys inside `extra` are masked server-side.
+        Requires the read:connection permission.
+      operationId: listConnections
+      tags: [Connections]
+      parameters:
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+      responses:
+        "200":
+          description: A page of connections
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ConnectionCollection" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    post:
+      summary: Create or replace a connection (upsert)
+      description: |
+        Upserts a connection: creates it, or replaces an existing one with the same
+        connection_id. The password is write-only and never returned. Requires the
+        write:connection permission and a configured encryption key.
+      operationId: createConnection
+      tags: [Connections]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/ConnectionBody" }
+      responses:
+        "201":
+          description: Connection created or replaced
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Connection" }
+        "400":
+          description: Invalid input (missing connection_id or conn_type)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "503":
+          $ref: "#/components/responses/EncryptionUnavailable"
+
+  /api/v2/connections/{connection_id}:
+    parameters:
+      - $ref: "#/components/parameters/ConnectionID"
+    get:
+      summary: Get a connection
+      operationId: getConnection
+      tags: [Connections]
+      responses:
+        "200":
+          description: Connection detail (password omitted, extra masked)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Connection" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      summary: Update a connection
+      operationId: updateConnection
+      tags: [Connections]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/ConnectionBody" }
+      responses:
+        "200":
+          description: Updated connection
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Connection" }
+        "400":
+          description: Invalid input (missing conn_type)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "503":
+          $ref: "#/components/responses/EncryptionUnavailable"
+    delete:
+      summary: Delete a connection
+      operationId: deleteConnection
+      tags: [Connections]
+      responses:
+        "204":
+          $ref: "#/components/responses/NoContent"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/v2/variables:
+    get:
+      summary: List variables
+      description: |
+        Lists the tenant's Airflow-style variables. Values of secret-ish keys are
+        masked server-side. Requires the read:variable permission.
+      operationId: listVariables
+      tags: [Variables]
+      parameters:
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+      responses:
+        "200":
+          description: A page of variables
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/VariableCollection" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+    post:
+      summary: Create or replace a variable (upsert)
+      description: |
+        Upserts a variable: creates it, or replaces an existing one with the same
+        key. Requires the write:variable permission.
+      operationId: createVariable
+      tags: [Variables]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/VariableBody" }
+      responses:
+        "201":
+          description: Variable created or replaced
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Variable" }
+        "400":
+          description: Invalid input (missing key)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /api/v2/variables/{variable_key}:
+    parameters:
+      - $ref: "#/components/parameters/VariableKey"
+    get:
+      summary: Get a variable
+      operationId: getVariable
+      tags: [Variables]
+      responses:
+        "200":
+          description: Variable detail (value masked when the key looks sensitive)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Variable" }
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      summary: Delete a variable
+      operationId: deleteVariable
+      tags: [Variables]
+      responses:
+        "204":
+          $ref: "#/components/responses/NoContent"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /api/v2/dags:
     get:
       summary: List DAGs
@@ -481,6 +659,16 @@ components:
       in: path
       required: true
       schema: { type: string }
+    ConnectionID:
+      name: connection_id
+      in: path
+      required: true
+      schema: { type: string }
+    VariableKey:
+      name: variable_key
+      in: path
+      required: true
+      schema: { type: string }
 
   responses:
     Unauthorized:
@@ -490,6 +678,15 @@ components:
           schema: { $ref: "#/components/schemas/Error" }
     NotFound:
       description: Resource not found
+      content:
+        application/json:
+          schema: { $ref: "#/components/schemas/Error" }
+    NoContent:
+      description: Deleted (no content)
+    EncryptionUnavailable:
+      description: >-
+        No encryption key configured, so secrets cannot be stored. Set
+        LEOFLOW_SECRET_KEY on the control plane to manage connections.
       content:
         application/json:
           schema: { $ref: "#/components/schemas/Error" }
@@ -575,6 +772,79 @@ components:
         users:
           type: array
           items: { $ref: "#/components/schemas/UserListItem" }
+        total_entries: { type: integer }
+
+    Connection:
+      type: object
+      required: [connection_id, conn_type]
+      description: >-
+        An Airflow-style connection. The password is write-only and never
+        returned; secret-bearing keys inside `extra` are masked server-side.
+      properties:
+        connection_id: { type: string }
+        conn_type: { type: string }
+        description: { type: string, nullable: true }
+        host: { type: string, nullable: true }
+        login: { type: string, nullable: true }
+        schema: { type: string, nullable: true }
+        port: { type: integer, nullable: true }
+        extra: { type: string, nullable: true }
+
+    ConnectionBody:
+      type: object
+      required: [conn_type]
+      description: >-
+        Connection create/replace payload. connection_id is required on POST
+        (taken from the path on PATCH). password and extra are write-only.
+      properties:
+        connection_id: { type: string }
+        conn_type: { type: string }
+        description: { type: string }
+        host: { type: string }
+        login: { type: string }
+        password:
+          type: string
+          format: password
+          writeOnly: true
+        schema: { type: string }
+        port: { type: integer, nullable: true }
+        extra: { type: string }
+
+    ConnectionCollection:
+      type: object
+      properties:
+        connections:
+          type: array
+          items: { $ref: "#/components/schemas/Connection" }
+        total_entries: { type: integer }
+
+    Variable:
+      type: object
+      required: [key, value, is_encrypted]
+      description: >-
+        An Airflow-style variable. The value is masked server-side when the key
+        looks sensitive (secret/password/token/...).
+      properties:
+        key: { type: string }
+        value: { type: string }
+        description: { type: string, nullable: true }
+        is_encrypted: { type: boolean }
+        team_name: { type: string, nullable: true }
+
+    VariableBody:
+      type: object
+      required: [key]
+      properties:
+        key: { type: string }
+        value: { type: string }
+        description: { type: string }
+
+    VariableCollection:
+      type: object
+      properties:
+        variables:
+          type: array
+          items: { $ref: "#/components/schemas/Variable" }
         total_entries: { type: integer }
 
     DAG:

--- a/internal/cli/connections.go
+++ b/internal/cli/connections.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -89,7 +90,7 @@ func newConnectionsSetCommand() *cobra.Command {
 	cmd.Flags().StringVar(&f.password, "password", "", "connection password (prefer --password-stdin)")
 	cmd.Flags().BoolVar(&f.passwordStdin, "password-stdin", false, "read the password from stdin instead of --password (avoids ps/shell-history exposure)")
 	cmd.Flags().StringVar(&f.schema, "schema", "", "connection schema/database")
-	cmd.Flags().IntVar(&f.port, "port", 0, "connection port (0 leaves it unset)")
+	cmd.Flags().IntVar(&f.port, "port", 0, "connection port (omit to keep the stored value; an explicit value, including 0, overwrites it)")
 	cmd.Flags().StringVar(&f.extra, "extra", "", "extra JSON blob (provider-specific; secrets here are masked on read)")
 	cmd.Flags().StringVar(&f.extraFile, "extra-file", "", "read the extra JSON from a file instead of --extra (keeps provider secrets out of argv)")
 	cmd.Flags().StringVar(&f.desc, "description", "", "human-readable description")
@@ -111,7 +112,9 @@ func resolveConnectionExtra(cmd *cobra.Command, inline, file string) (string, er
 		if err != nil {
 			return "", fmt.Errorf("reading --extra-file: %w", err)
 		}
-		return string(data), nil
+		// Drop a single trailing newline so a normal text editor's file and an
+		// inline --extra produce the identical stored blob (matches --value-stdin).
+		return strings.TrimSuffix(string(data), "\n"), nil
 	}
 	return inline, nil
 }

--- a/internal/cli/connections.go
+++ b/internal/cli/connections.go
@@ -35,6 +35,7 @@ func newConnectionsCommand() *cobra.Command {
 type connectionSetFlags struct {
 	serverURL, token                                     string
 	connType, host, login, password, schema, extra, desc string
+	extraFile                                            string
 	port                                                 int
 	passwordStdin                                        bool
 }
@@ -44,10 +45,15 @@ func newConnectionsSetCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set <connection_id>",
 		Short: "Create or replace a connection (upsert).",
-		Long: "Upserts a connection: creates it, or replaces an existing one with the " +
-			"same id. --conn-type is required. The password and extra are sent to the " +
-			"control plane but never printed back; read commands show masked values.\n\n" +
-			"Prefer --password-stdin over --password so the secret never lands in your " +
+		Long: "Creates a connection, or replaces an existing one with the same id. " +
+			"--conn-type is required.\n\n" +
+			"This is a full replace, not a partial patch: the connection is set to " +
+			"exactly the fields you pass, so any field you omit is cleared on an " +
+			"existing connection — including the password. To change one field, pass " +
+			"the others too (the password cannot be read back, so re-supply it).\n\n" +
+			"The password and extra are sent to the control plane but never printed " +
+			"back; read commands show masked values. Prefer --password-stdin / " +
+			"--extra-file over --password / --extra so a secret never lands in your " +
 			"shell history or the process table.",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -63,7 +69,11 @@ func newConnectionsSetCommand() *cobra.Command {
 			if perr != nil {
 				return perr
 			}
-			body := connectionBodyFromFlags(cmd, connID, f, pw)
+			extra, xerr := resolveConnectionExtra(cmd, f.extra, f.extraFile)
+			if xerr != nil {
+				return xerr
+			}
+			body := connectionBodyFromFlags(cmd, connID, f, pw, extra)
 			conn, err := setConnectionReq(cmdContext(cmd), base, bearer, body)
 			if err != nil {
 				return err
@@ -81,14 +91,38 @@ func newConnectionsSetCommand() *cobra.Command {
 	cmd.Flags().StringVar(&f.schema, "schema", "", "connection schema/database")
 	cmd.Flags().IntVar(&f.port, "port", 0, "connection port (0 leaves it unset)")
 	cmd.Flags().StringVar(&f.extra, "extra", "", "extra JSON blob (provider-specific; secrets here are masked on read)")
+	cmd.Flags().StringVar(&f.extraFile, "extra-file", "", "read the extra JSON from a file instead of --extra (keeps provider secrets out of argv)")
 	cmd.Flags().StringVar(&f.desc, "description", "", "human-readable description")
 	return cmd
 }
 
+// resolveConnectionExtra applies the extra-source precedence: --extra-file reads
+// the JSON blob from a file (keeping a provider secret out of argv/shell history)
+// and is mutually exclusive with the inline --extra. Returns whether an extra was
+// supplied at all so the caller can leave it untouched when neither flag was used.
+func resolveConnectionExtra(cmd *cobra.Command, inline, file string) (string, error) {
+	byFlag := cmd.Flags().Changed("extra")
+	byFile := cmd.Flags().Changed("extra-file")
+	if byFlag && byFile {
+		return "", fmt.Errorf("--extra and --extra-file are mutually exclusive")
+	}
+	if byFile {
+		data, err := os.ReadFile(file) //nolint:gosec // path is operator-supplied on their own CLI.
+		if err != nil {
+			return "", fmt.Errorf("reading --extra-file: %w", err)
+		}
+		return string(data), nil
+	}
+	return inline, nil
+}
+
 // connectionBodyFromFlags maps the CLI flags to the typed request body, sending
-// only the fields the operator actually set (so an omitted flag never clobbers an
-// existing value with an empty string on the upsert).
-func connectionBodyFromFlags(cmd *cobra.Command, connID string, f connectionSetFlags, password string) apiclient.ConnectionBody {
+// only the fields the operator actually set. NOTE the control plane currently
+// applies a write as a full replace, so an omitted field is cleared server-side
+// regardless — the `set` help states this. Sending nil (not "") for an unset
+// field is nonetheless forward-compatible with a future merge-on-omit server
+// semantics (the invariant tracked alongside the masked-write follow-up).
+func connectionBodyFromFlags(cmd *cobra.Command, connID string, f connectionSetFlags, password, extra string) apiclient.ConnectionBody {
 	body := apiclient.ConnectionBody{ConnectionId: &connID, ConnType: f.connType}
 	if cmd.Flags().Changed("host") {
 		body.Host = &f.host
@@ -106,8 +140,8 @@ func connectionBodyFromFlags(cmd *cobra.Command, connID string, f connectionSetF
 		p := f.port
 		body.Port = &p
 	}
-	if cmd.Flags().Changed("extra") {
-		body.Extra = &f.extra
+	if cmd.Flags().Changed("extra") || cmd.Flags().Changed("extra-file") {
+		body.Extra = &extra
 	}
 	if cmd.Flags().Changed("description") {
 		body.Description = &f.desc

--- a/internal/cli/connections.go
+++ b/internal/cli/connections.go
@@ -1,0 +1,318 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
+)
+
+// newConnectionsCommand groups the Airflow-style Connection CRUD subcommands.
+// It is the first-class replacement for hand-rolled curl against
+// /api/v2/connections, and makes the repository's "run `leoflow connections set`"
+// hint real (#881). Secrets (password, extra) are sent on write but never echoed
+// back — reads are masked by the server and the printers omit the extra column.
+func newConnectionsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "connections",
+		Short: "Manage control-plane connections.",
+	}
+	cmd.AddCommand(newConnectionsSetCommand())
+	cmd.AddCommand(newConnectionsListCommand())
+	cmd.AddCommand(newConnectionsGetCommand())
+	cmd.AddCommand(newConnectionsDeleteCommand())
+	return cmd
+}
+
+// connectionSetFlags holds the write-path flags for `connections set`.
+type connectionSetFlags struct {
+	serverURL, token                                     string
+	connType, host, login, password, schema, extra, desc string
+	port                                                 int
+	passwordStdin                                        bool
+}
+
+func newConnectionsSetCommand() *cobra.Command {
+	var f connectionSetFlags
+	cmd := &cobra.Command{
+		Use:   "set <connection_id>",
+		Short: "Create or replace a connection (upsert).",
+		Long: "Upserts a connection: creates it, or replaces an existing one with the " +
+			"same id. --conn-type is required. The password and extra are sent to the " +
+			"control plane but never printed back; read commands show masked values.\n\n" +
+			"Prefer --password-stdin over --password so the secret never lands in your " +
+			"shell history or the process table.",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			connID := args[0]
+			if f.connType == "" {
+				return fmt.Errorf("--conn-type is required")
+			}
+			base, bearer, err := resolveServerToken(cmd, f.serverURL, f.token)
+			if err != nil {
+				return err
+			}
+			pw, perr := resolvePassword(cmd, f.password, f.passwordStdin)
+			if perr != nil {
+				return perr
+			}
+			body := connectionBodyFromFlags(cmd, connID, f, pw)
+			conn, err := setConnectionReq(cmdContext(cmd), base, bearer, body)
+			if err != nil {
+				return err
+			}
+			return printConnectionSet(cmd.OutOrStdout(), conn)
+		},
+	}
+	cmd.Flags().StringVar(&f.serverURL, "server", "", "control plane base URL (default: config server_url)")
+	cmd.Flags().StringVar(&f.token, "token", os.Getenv("LEOFLOW_TOKEN"), "JWT bearer token (default: config token)")
+	cmd.Flags().StringVar(&f.connType, "conn-type", "", "connection type, e.g. postgres, http, aws (required)")
+	cmd.Flags().StringVar(&f.host, "host", "", "connection host")
+	cmd.Flags().StringVar(&f.login, "login", "", "connection login/username")
+	cmd.Flags().StringVar(&f.password, "password", "", "connection password (prefer --password-stdin)")
+	cmd.Flags().BoolVar(&f.passwordStdin, "password-stdin", false, "read the password from stdin instead of --password (avoids ps/shell-history exposure)")
+	cmd.Flags().StringVar(&f.schema, "schema", "", "connection schema/database")
+	cmd.Flags().IntVar(&f.port, "port", 0, "connection port (0 leaves it unset)")
+	cmd.Flags().StringVar(&f.extra, "extra", "", "extra JSON blob (provider-specific; secrets here are masked on read)")
+	cmd.Flags().StringVar(&f.desc, "description", "", "human-readable description")
+	return cmd
+}
+
+// connectionBodyFromFlags maps the CLI flags to the typed request body, sending
+// only the fields the operator actually set (so an omitted flag never clobbers an
+// existing value with an empty string on the upsert).
+func connectionBodyFromFlags(cmd *cobra.Command, connID string, f connectionSetFlags, password string) apiclient.ConnectionBody {
+	body := apiclient.ConnectionBody{ConnectionId: &connID, ConnType: f.connType}
+	if cmd.Flags().Changed("host") {
+		body.Host = &f.host
+	}
+	if cmd.Flags().Changed("login") {
+		body.Login = &f.login
+	}
+	if password != "" {
+		body.Password = &password
+	}
+	if cmd.Flags().Changed("schema") {
+		body.Schema = &f.schema
+	}
+	if cmd.Flags().Changed("port") {
+		p := f.port
+		body.Port = &p
+	}
+	if cmd.Flags().Changed("extra") {
+		body.Extra = &f.extra
+	}
+	if cmd.Flags().Changed("description") {
+		body.Description = &f.desc
+	}
+	return body
+}
+
+func newConnectionsListCommand() *cobra.Command {
+	var serverURL, token string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List connections (secrets never shown).",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			base, bearer, err := resolveServerToken(cmd, serverURL, token)
+			if err != nil {
+				return err
+			}
+			coll, err := listConnectionsReq(cmdContext(cmd), base, bearer)
+			if err != nil {
+				return err
+			}
+			return printConnectionList(cmd.OutOrStdout(), coll)
+		},
+	}
+	cmd.Flags().StringVar(&serverURL, "server", "", "control plane base URL (default: config server_url)")
+	cmd.Flags().StringVar(&token, "token", os.Getenv("LEOFLOW_TOKEN"), "JWT bearer token (default: config token)")
+	return cmd
+}
+
+func newConnectionsGetCommand() *cobra.Command {
+	var serverURL, token string
+	cmd := &cobra.Command{
+		Use:   "get <connection_id>",
+		Short: "Show a connection (password omitted, extra masked).",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			base, bearer, err := resolveServerToken(cmd, serverURL, token)
+			if err != nil {
+				return err
+			}
+			conn, err := getConnectionReq(cmdContext(cmd), base, bearer, args[0])
+			if err != nil {
+				return err
+			}
+			return printConnection(cmd.OutOrStdout(), conn)
+		},
+	}
+	cmd.Flags().StringVar(&serverURL, "server", "", "control plane base URL (default: config server_url)")
+	cmd.Flags().StringVar(&token, "token", os.Getenv("LEOFLOW_TOKEN"), "JWT bearer token (default: config token)")
+	return cmd
+}
+
+func newConnectionsDeleteCommand() *cobra.Command {
+	var serverURL, token string
+	cmd := &cobra.Command{
+		Use:   "delete <connection_id>",
+		Short: "Delete a connection.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			connID := args[0]
+			base, bearer, err := resolveServerToken(cmd, serverURL, token)
+			if err != nil {
+				return err
+			}
+			if err := deleteConnectionReq(cmdContext(cmd), base, bearer, connID); err != nil {
+				return err
+			}
+			_, werr := fmt.Fprintf(cmd.OutOrStdout(), "Deleted connection %q.\n", connID)
+			return werr
+		},
+	}
+	cmd.Flags().StringVar(&serverURL, "server", "", "control plane base URL (default: config server_url)")
+	cmd.Flags().StringVar(&token, "token", os.Getenv("LEOFLOW_TOKEN"), "JWT bearer token (default: config token)")
+	return cmd
+}
+
+// setConnectionReq posts (upserts) a connection through the shared typed client
+// and returns the masked connection the server echoes back.
+func setConnectionReq(ctx context.Context, serverURL, token string, body apiclient.ConnectionBody) (apiclient.Connection, error) {
+	c, err := apiclient.New(serverURL, token)
+	if err != nil {
+		return apiclient.Connection{}, err
+	}
+	resp, err := c.CreateConnectionWithResponse(ctx, body)
+	if err != nil {
+		return apiclient.Connection{}, fmt.Errorf("posting to %s/api/v2/connections: %w", serverURL, err)
+	}
+	if resp.StatusCode() != http.StatusCreated {
+		return apiclient.Connection{}, connError(resp.StatusCode(), resp.Body)
+	}
+	if resp.JSON201 == nil {
+		return apiclient.Connection{}, fmt.Errorf("server returned no connection")
+	}
+	return *resp.JSON201, nil
+}
+
+// listConnectionsReq gets the connection collection through the typed client.
+func listConnectionsReq(ctx context.Context, serverURL, token string) (*apiclient.ConnectionCollection, error) {
+	c, err := apiclient.New(serverURL, token)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.ListConnectionsWithResponse(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing connections: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, connError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON200, nil
+}
+
+// getConnectionReq fetches one connection through the typed client.
+func getConnectionReq(ctx context.Context, serverURL, token, connID string) (apiclient.Connection, error) {
+	c, err := apiclient.New(serverURL, token)
+	if err != nil {
+		return apiclient.Connection{}, err
+	}
+	resp, err := c.GetConnectionWithResponse(ctx, connID)
+	if err != nil {
+		return apiclient.Connection{}, fmt.Errorf("getting connection %q: %w", connID, err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return apiclient.Connection{}, connError(resp.StatusCode(), resp.Body)
+	}
+	if resp.JSON200 == nil {
+		return apiclient.Connection{}, fmt.Errorf("server returned no connection")
+	}
+	return *resp.JSON200, nil
+}
+
+// deleteConnectionReq deletes one connection through the typed client.
+func deleteConnectionReq(ctx context.Context, serverURL, token, connID string) error {
+	c, err := apiclient.New(serverURL, token)
+	if err != nil {
+		return err
+	}
+	resp, err := c.DeleteConnectionWithResponse(ctx, connID)
+	if err != nil {
+		return fmt.Errorf("deleting connection %q: %w", connID, err)
+	}
+	if resp.StatusCode() != http.StatusNoContent {
+		return connError(resp.StatusCode(), resp.Body)
+	}
+	return nil
+}
+
+// connError renders a non-2xx response as an error carrying the server's body,
+// so the encryption-unavailable (503) message and 404s reach the operator.
+func connError(status int, body []byte) error {
+	return fmt.Errorf("server returned %d: %s", status, string(body))
+}
+
+// printConnectionSet prints a concise, secret-free confirmation of an upsert.
+func printConnectionSet(w io.Writer, c apiclient.Connection) error {
+	_, err := fmt.Fprintf(w, "Set connection %q (type %s).\n", c.ConnectionId, c.ConnType)
+	return err
+}
+
+// printConnectionList renders the collection as an aligned table. The extra
+// column is deliberately omitted so no secret can surface, even masked.
+func printConnectionList(w io.Writer, coll *apiclient.ConnectionCollection) error {
+	if coll == nil || coll.Connections == nil || len(*coll.Connections) == 0 {
+		_, err := fmt.Fprintln(w, "No connections.")
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "CONNECTION_ID\tTYPE\tHOST\tLOGIN\tSCHEMA"); err != nil {
+		return err
+	}
+	for _, c := range *coll.Connections {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+			c.ConnectionId, c.ConnType, deref(c.Host), deref(c.Login), deref(c.Schema)); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+// printConnection prints a single connection's masked fields as key/value lines.
+func printConnection(w io.Writer, c apiclient.Connection) error {
+	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+	rows := [][2]string{
+		{"connection_id", c.ConnectionId},
+		{"conn_type", c.ConnType},
+		{"description", deref(c.Description)},
+		{"host", deref(c.Host)},
+		{"login", deref(c.Login)},
+		{"schema", deref(c.Schema)},
+		{"port", intPtrString(c.Port)},
+		{"extra", deref(c.Extra)},
+	}
+	for _, r := range rows {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\n", r[0], r[1]); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+// intPtrString renders a nullable int pointer, showing an empty string for nil.
+func intPtrString(p *int) string {
+	if p == nil {
+		return ""
+	}
+	return strconv.Itoa(*p)
+}

--- a/internal/cli/connections.go
+++ b/internal/cli/connections.go
@@ -44,13 +44,13 @@ func newConnectionsSetCommand() *cobra.Command {
 	var f connectionSetFlags
 	cmd := &cobra.Command{
 		Use:   "set <connection_id>",
-		Short: "Create or replace a connection (upsert).",
-		Long: "Creates a connection, or replaces an existing one with the same id. " +
+		Short: "Create or update a connection (upsert).",
+		Long: "Creates a connection, or updates an existing one with the same id. " +
 			"--conn-type is required.\n\n" +
-			"This is a full replace, not a partial patch: the connection is set to " +
-			"exactly the fields you pass, so any field you omit is cleared on an " +
-			"existing connection — including the password. To change one field, pass " +
-			"the others too (the password cannot be read back, so re-supply it).\n\n" +
+			"Only the fields you pass are changed; any field you omit keeps its " +
+			"current value. So you can change just --host without re-supplying the " +
+			"password (which cannot be read back anyway). To clear a field, delete " +
+			"and recreate the connection.\n\n" +
 			"The password and extra are sent to the control plane but never printed " +
 			"back; read commands show masked values. Prefer --password-stdin / " +
 			"--extra-file over --password / --extra so a secret never lands in your " +
@@ -117,11 +117,10 @@ func resolveConnectionExtra(cmd *cobra.Command, inline, file string) (string, er
 }
 
 // connectionBodyFromFlags maps the CLI flags to the typed request body, sending
-// only the fields the operator actually set. NOTE the control plane currently
-// applies a write as a full replace, so an omitted field is cleared server-side
-// regardless — the `set` help states this. Sending nil (not "") for an unset
-// field is nonetheless forward-compatible with a future merge-on-omit server
-// semantics (the invariant tracked alongside the masked-write follow-up).
+// only the fields the operator actually set: an unset flag is left out (nil), and
+// the control plane preserves the stored value for any omitted field (its upsert
+// COALESCEs EXCLUDED over the existing row). So changing one field never wipes the
+// others — in particular the unreadable password survives a `set --host x`.
 func connectionBodyFromFlags(cmd *cobra.Command, connID string, f connectionSetFlags, password, extra string) apiclient.ConnectionBody {
 	body := apiclient.ConnectionBody{ConnectionId: &connID, ConnType: f.connType}
 	if cmd.Flags().Changed("host") {

--- a/internal/cli/connections_test.go
+++ b/internal/cli/connections_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -131,6 +133,59 @@ func TestSetConnectionCommandRequiresConnType(t *testing.T) {
 	cfg := seedSessionConfig(t, "http://127.0.0.1:0", "tok")
 	if _, _, err := run(t, "connections", "set", "pg", "--config", cfg); err == nil {
 		t.Error("expected an error when --conn-type is missing")
+	}
+}
+
+// TestSetConnectionExtraFile: --extra-file reads the provider-secret JSON from a
+// file so it never lands on argv/shell history; the file's contents must reach
+// the server as the connection's extra.
+func TestSetConnectionExtraFile(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"connection_id":"pg","conn_type":"postgres"}`)
+	}))
+	defer srv.Close()
+
+	extraPath := filepath.Join(t.TempDir(), "extra.json")
+	extraJSON := `{"token":"FROM-FILE-SECRET"}`
+	if werr := os.WriteFile(extraPath, []byte(extraJSON), 0o600); werr != nil {
+		t.Fatal(werr)
+	}
+	cfg := seedSessionConfig(t, srv.URL, "tok")
+	out, _, err := run(t, "connections", "set", "pg", "--config", cfg,
+		"--conn-type", "postgres", "--extra-file", extraPath)
+	if err != nil {
+		t.Fatalf("connections set --extra-file: %v", err)
+	}
+	var sent apiclient.ConnectionBody
+	if uerr := json.Unmarshal([]byte(gotBody), &sent); uerr != nil {
+		t.Fatalf("request body not JSON: %v (%s)", uerr, gotBody)
+	}
+	if sent.Extra == nil || *sent.Extra != extraJSON {
+		t.Errorf("extra from file not sent verbatim: %s", gotBody)
+	}
+	if strings.Contains(out, "FROM-FILE-SECRET") {
+		t.Errorf("output leaked the extra secret: %q", out)
+	}
+}
+
+// TestSetConnectionExtraFlagsMutuallyExclusive: --extra and --extra-file name the
+// same field from two sources, so supplying both is a user error rather than a
+// silent pick-one.
+func TestSetConnectionExtraFlagsMutuallyExclusive(t *testing.T) {
+	extraPath := filepath.Join(t.TempDir(), "extra.json")
+	if werr := os.WriteFile(extraPath, []byte(`{"a":"b"}`), 0o600); werr != nil {
+		t.Fatal(werr)
+	}
+	cfg := seedSessionConfig(t, "http://127.0.0.1:0", "tok")
+	_, _, err := run(t, "connections", "set", "pg", "--config", cfg,
+		"--conn-type", "postgres", "--extra", `{"a":"b"}`, "--extra-file", extraPath)
+	if err == nil {
+		t.Error("expected an error when both --extra and --extra-file are given")
 	}
 }
 

--- a/internal/cli/connections_test.go
+++ b/internal/cli/connections_test.go
@@ -152,7 +152,9 @@ func TestSetConnectionExtraFile(t *testing.T) {
 
 	extraPath := filepath.Join(t.TempDir(), "extra.json")
 	extraJSON := `{"token":"FROM-FILE-SECRET"}`
-	if werr := os.WriteFile(extraPath, []byte(extraJSON), 0o600); werr != nil {
+	// Write with a trailing newline (as an editor would) to prove it is trimmed
+	// so the stored blob matches an inline --extra byte-for-byte.
+	if werr := os.WriteFile(extraPath, []byte(extraJSON+"\n"), 0o600); werr != nil {
 		t.Fatal(werr)
 	}
 	cfg := seedSessionConfig(t, srv.URL, "tok")

--- a/internal/cli/connections_test.go
+++ b/internal/cli/connections_test.go
@@ -191,6 +191,53 @@ func TestSetConnectionExtraFlagsMutuallyExclusive(t *testing.T) {
 	}
 }
 
+// TestConnectionsGetCommand exercises the full `connections get` path (request +
+// single-connection printer): it shows the metadata and the server-masked extra,
+// and never prints a password.
+func TestConnectionsGetCommand(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"connection_id":"pg","conn_type":"postgres","host":"db","login":"u","schema":"public","port":5432,"extra":"{\"token\":\"***\"}"}`)
+	}))
+	defer srv.Close()
+
+	cfg := seedSessionConfig(t, srv.URL, "tok")
+	out, _, err := run(t, "connections", "get", "pg", "--config", cfg)
+	if err != nil {
+		t.Fatalf("connections get: %v", err)
+	}
+	for _, want := range []string{"pg", "postgres", "db", "5432", "***"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("get output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "password") {
+		t.Errorf("get output should not mention a password field:\n%s", out)
+	}
+}
+
+// TestConnectionsListCommand exercises the full `connections list` path (request +
+// table printer): the row is present and no secret column is rendered.
+func TestConnectionsListCommand(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"connections":[{"connection_id":"pg","conn_type":"postgres","host":"db","login":"u","schema":"public","extra":"{\"token\":\"***\"}"}],"total_entries":1}`)
+	}))
+	defer srv.Close()
+
+	cfg := seedSessionConfig(t, srv.URL, "tok")
+	out, _, err := run(t, "connections", "list", "--config", cfg)
+	if err != nil {
+		t.Fatalf("connections list: %v", err)
+	}
+	if !strings.Contains(out, "pg") || !strings.Contains(out, "postgres") {
+		t.Errorf("list output missing the connection:\n%s", out)
+	}
+	if strings.Contains(out, "token") || strings.Contains(out, "extra") {
+		t.Errorf("list output must not render the extra column:\n%s", out)
+	}
+}
+
 func TestSetConnectionSurfaces503(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)

--- a/internal/cli/connections_test.go
+++ b/internal/cli/connections_test.go
@@ -1,0 +1,250 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
+)
+
+// runWithStdin runs the root command with the given stdin, capturing stdout and
+// stderr — the stdin-fed counterpart to run(), for --password-stdin/--value-stdin.
+func runWithStdin(t *testing.T, stdin string, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	root := NewRootCommand()
+	var out, errb bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errb)
+	root.SetIn(strings.NewReader(stdin))
+	root.SetArgs(args)
+	err = root.Execute()
+	return out.String(), errb.String(), err
+}
+
+func TestSetConnectionReqSendsBodyAndReturnsConnection(t *testing.T) {
+	var gotMethod, gotPath, gotBody, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		// The server masks: extra's token becomes ***, password is omitted.
+		_, _ = io.WriteString(w, `{"connection_id":"pg","conn_type":"postgres","host":"db","login":"u","extra":"{\"token\":\"***\"}"}`)
+	}))
+	defer srv.Close()
+
+	host, login, pw, extra := "db", "u", "PWSECRET", `{"token":"TOPSECRET"}`
+	body := apiclient.ConnectionBody{
+		ConnectionId: strp("pg"),
+		ConnType:     "postgres",
+		Host:         &host,
+		Login:        &login,
+		Password:     &pw,
+		Extra:        &extra,
+	}
+	conn, err := setConnectionReq(context.Background(), srv.URL, "admin-jwt", body)
+	if err != nil {
+		t.Fatalf("setConnectionReq: %v", err)
+	}
+	if gotMethod != http.MethodPost || gotPath != "/api/v2/connections" {
+		t.Errorf("request = %s %s, want POST /api/v2/connections", gotMethod, gotPath)
+	}
+	if gotAuth != "Bearer admin-jwt" {
+		t.Errorf("Authorization = %q, want the bearer", gotAuth)
+	}
+	// The password AND the extra secret must be sent to the server on set.
+	if !strings.Contains(gotBody, "PWSECRET") {
+		t.Errorf("request body missing the password: %s", gotBody)
+	}
+	if !strings.Contains(gotBody, "TOPSECRET") {
+		t.Errorf("request body missing the extra: %s", gotBody)
+	}
+	if conn.ConnectionId != "pg" || conn.ConnType != "postgres" {
+		t.Errorf("unexpected connection: %+v", conn)
+	}
+}
+
+// TestSetConnectionCommandNeverPrintsSecrets is the core safety pin: `set` sends
+// the password/extra but must never echo either back to the terminal.
+func TestSetConnectionCommandNeverPrintsSecrets(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"connection_id":"pg","conn_type":"postgres","host":"db","login":"u","extra":"{\"token\":\"***\"}"}`)
+	}))
+	defer srv.Close()
+
+	cfg := seedSessionConfig(t, srv.URL, "tok")
+	out, _, err := run(t, "connections", "set", "pg",
+		"--config", cfg, "--conn-type", "postgres",
+		"--host", "db", "--login", "u",
+		"--password", "PWSECRET", "--extra", `{"token":"TOPSECRET"}`)
+	if err != nil {
+		t.Fatalf("connections set: %v", err)
+	}
+	if strings.Contains(out, "PWSECRET") || strings.Contains(out, "TOPSECRET") {
+		t.Errorf("output leaked a secret: %q", out)
+	}
+	if !strings.Contains(out, "pg") || !strings.Contains(out, "postgres") {
+		t.Errorf("output = %q, want a confirmation naming the connection", out)
+	}
+}
+
+func TestSetConnectionCommandPasswordStdin(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"connection_id":"pg","conn_type":"postgres"}`)
+	}))
+	defer srv.Close()
+
+	cfg := seedSessionConfig(t, srv.URL, "tok")
+	out, _, err := runWithStdin(t, "STDIN-PW\n", "connections", "set", "pg",
+		"--config", cfg, "--conn-type", "postgres", "--password-stdin")
+	if err != nil {
+		t.Fatalf("connections set --password-stdin: %v", err)
+	}
+	var sent apiclient.ConnectionBody
+	if uerr := json.Unmarshal([]byte(gotBody), &sent); uerr != nil {
+		t.Fatalf("request body not JSON: %v (%s)", uerr, gotBody)
+	}
+	if sent.Password == nil || *sent.Password != "STDIN-PW" {
+		t.Errorf("password from stdin not sent: %s", gotBody)
+	}
+	if strings.Contains(out, "STDIN-PW") {
+		t.Errorf("output leaked the stdin password: %q", out)
+	}
+}
+
+func TestSetConnectionCommandRequiresConnType(t *testing.T) {
+	cfg := seedSessionConfig(t, "http://127.0.0.1:0", "tok")
+	if _, _, err := run(t, "connections", "set", "pg", "--config", cfg); err == nil {
+		t.Error("expected an error when --conn-type is missing")
+	}
+}
+
+func TestSetConnectionSurfaces503(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = io.WriteString(w, `{"title":"encryption unavailable","detail":"set LEOFLOW_SECRET_KEY to manage connections"}`)
+	}))
+	defer srv.Close()
+
+	_, err := setConnectionReq(context.Background(), srv.URL, "t",
+		apiclient.ConnectionBody{ConnectionId: strp("pg"), ConnType: "postgres"})
+	if err == nil {
+		t.Fatal("expected an error on 503")
+	}
+	if !strings.Contains(err.Error(), "LEOFLOW_SECRET_KEY") {
+		t.Errorf("error should carry the server's message, got: %v", err)
+	}
+}
+
+func TestListConnectionsReq(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v2/connections" {
+			t.Errorf("request = %s %s, want GET /api/v2/connections", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"connections":[{"connection_id":"pg","conn_type":"postgres","host":"db","login":"u","schema":"public"}],"total_entries":1}`)
+	}))
+	defer srv.Close()
+
+	coll, err := listConnectionsReq(context.Background(), srv.URL, "t")
+	if err != nil {
+		t.Fatalf("listConnectionsReq: %v", err)
+	}
+	if coll == nil || coll.Connections == nil || len(*coll.Connections) != 1 {
+		t.Fatalf("unexpected collection: %+v", coll)
+	}
+}
+
+func TestGetConnectionReq(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/connections/pg" {
+			t.Errorf("path = %s, want /api/v2/connections/pg", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"connection_id":"pg","conn_type":"postgres"}`)
+	}))
+	defer srv.Close()
+
+	conn, err := getConnectionReq(context.Background(), srv.URL, "t", "pg")
+	if err != nil {
+		t.Fatalf("getConnectionReq: %v", err)
+	}
+	if conn.ConnectionId != "pg" {
+		t.Errorf("connection = %+v", conn)
+	}
+}
+
+func TestDeleteConnectionReq(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/api/v2/connections/pg" {
+			t.Errorf("request = %s %s, want DELETE /api/v2/connections/pg", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	if err := deleteConnectionReq(context.Background(), srv.URL, "t", "pg"); err != nil {
+		t.Fatalf("deleteConnectionReq: %v", err)
+	}
+}
+
+func TestDeleteConnectionReqNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	if err := deleteConnectionReq(context.Background(), srv.URL, "t", "ghost"); err == nil {
+		t.Error("expected an error deleting a missing connection")
+	}
+}
+
+func TestPrintConnectionListNeverShowsSecrets(t *testing.T) {
+	extra := `{"token":"***"}`
+	host, login, schema := "db", "u", "public"
+	coll := &apiclient.ConnectionCollection{Connections: &[]apiclient.Connection{
+		{ConnectionId: "pg", ConnType: "postgres", Host: &host, Login: &login, Schema: &schema, Extra: &extra},
+	}}
+	var buf bytes.Buffer
+	if err := printConnectionList(&buf, coll); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, want := range []string{"CONNECTION_ID", "TYPE", "HOST", "pg", "postgres", "db"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table missing %q; got:\n%s", want, out)
+		}
+	}
+	// The extra column must not be rendered at all — no secrets in the table.
+	if strings.Contains(out, "token") {
+		t.Errorf("table leaked the extra field: %q", out)
+	}
+}
+
+func TestPrintConnectionListEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := printConnectionList(&buf, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "No connections") {
+		t.Errorf("empty = %q, want the friendly line", buf.String())
+	}
+}
+
+// strp is a local string-pointer helper for the connection/variable tests.
+func strp(s string) *string { return &s }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -43,7 +43,7 @@ func NewRootCommand() *cobra.Command {
 	authoring := []*cobra.Command{newInitCommand(), newValidateCommand(), newCompileCommand(), newPushCommand(), newDeployCommand()}
 	runtime := []*cobra.Command{newLiteCommand(), newServerCommand()}
 	inspection := []*cobra.Command{newDagsCommand(), newRunsCommand(), newAuthCommand()}
-	operations := []*cobra.Command{newAdminCommand()}
+	operations := []*cobra.Command{newAdminCommand(), newConnectionsCommand(), newVariablesCommand()}
 	lifecycle := []*cobra.Command{newSetupCommand(), newDoctorCommand(), newDBCommand(), newUninstallCommand(), newVersionCommand()}
 
 	for _, c := range authoring {

--- a/internal/cli/variables.go
+++ b/internal/cli/variables.go
@@ -1,0 +1,286 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
+)
+
+// newVariablesCommand groups the Airflow-style Variable CRUD subcommands, the
+// first-class replacement for curl against /api/v2/variables (#881). The server
+// masks values of secret-ish keys on read; the list printer never prints the
+// value column, so a secret cannot leak through the table.
+func newVariablesCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "variables",
+		Short: "Manage control-plane variables.",
+	}
+	cmd.AddCommand(newVariablesSetCommand())
+	cmd.AddCommand(newVariablesListCommand())
+	cmd.AddCommand(newVariablesGetCommand())
+	cmd.AddCommand(newVariablesDeleteCommand())
+	return cmd
+}
+
+func newVariablesSetCommand() *cobra.Command {
+	var serverURL, token, desc string
+	var valueStdin bool
+	cmd := &cobra.Command{
+		Use:   "set <key> [value]",
+		Short: "Create or replace a variable (upsert).",
+		Long: "Upserts a variable: creates it, or replaces an existing one with the " +
+			"same key. Pass the value as the second argument, or use --value-stdin to " +
+			"read it from stdin (keeps a secret out of your shell history and argv).",
+		Args: cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key := args[0]
+			var positional string
+			var havePositional bool
+			if len(args) == 2 {
+				positional, havePositional = args[1], true
+			}
+			base, bearer, err := resolveServerToken(cmd, serverURL, token)
+			if err != nil {
+				return err
+			}
+			value, verr := resolveVariableValue(cmd, positional, havePositional, valueStdin)
+			if verr != nil {
+				return verr
+			}
+			body := apiclient.VariableBody{Key: key, Value: &value}
+			if cmd.Flags().Changed("description") {
+				body.Description = &desc
+			}
+			v, err := setVariableReq(cmdContext(cmd), base, bearer, body)
+			if err != nil {
+				return err
+			}
+			_, werr := fmt.Fprintf(cmd.OutOrStdout(), "Set variable %q.\n", v.Key)
+			return werr
+		},
+	}
+	cmd.Flags().StringVar(&serverURL, "server", "", "control plane base URL (default: config server_url)")
+	cmd.Flags().StringVar(&token, "token", os.Getenv("LEOFLOW_TOKEN"), "JWT bearer token (default: config token)")
+	cmd.Flags().StringVar(&desc, "description", "", "human-readable description")
+	cmd.Flags().BoolVar(&valueStdin, "value-stdin", false, "read the value from stdin instead of the positional argument")
+	return cmd
+}
+
+// resolveVariableValue applies the value-source precedence: --value-stdin reads
+// stdin (and conflicts with a positional value); otherwise the positional value
+// is used, defaulting to empty when neither is given.
+func resolveVariableValue(cmd *cobra.Command, positional string, havePositional, stdin bool) (string, error) {
+	if stdin {
+		if havePositional {
+			return "", fmt.Errorf("a positional value and --value-stdin are mutually exclusive")
+		}
+		return readValueStdin(cmd.InOrStdin())
+	}
+	return positional, nil
+}
+
+// readValueStdin reads the whole of stdin as the variable value, stripping a
+// single trailing newline so `printf '%s' v | ...` and `echo v | ...` agree.
+func readValueStdin(r io.Reader) (string, error) {
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return "", fmt.Errorf("reading value from stdin: %w", err)
+	}
+	return strings.TrimSuffix(string(raw), "\n"), nil
+}
+
+func newVariablesListCommand() *cobra.Command {
+	var serverURL, token string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List variables (encrypted values not shown).",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			base, bearer, err := resolveServerToken(cmd, serverURL, token)
+			if err != nil {
+				return err
+			}
+			coll, err := listVariablesReq(cmdContext(cmd), base, bearer)
+			if err != nil {
+				return err
+			}
+			return printVariableList(cmd.OutOrStdout(), coll)
+		},
+	}
+	cmd.Flags().StringVar(&serverURL, "server", "", "control plane base URL (default: config server_url)")
+	cmd.Flags().StringVar(&token, "token", os.Getenv("LEOFLOW_TOKEN"), "JWT bearer token (default: config token)")
+	return cmd
+}
+
+func newVariablesGetCommand() *cobra.Command {
+	var serverURL, token string
+	cmd := &cobra.Command{
+		Use:   "get <key>",
+		Short: "Show a variable (value masked when the key looks sensitive).",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			base, bearer, err := resolveServerToken(cmd, serverURL, token)
+			if err != nil {
+				return err
+			}
+			v, err := getVariableReq(cmdContext(cmd), base, bearer, args[0])
+			if err != nil {
+				return err
+			}
+			return printVariable(cmd.OutOrStdout(), v)
+		},
+	}
+	cmd.Flags().StringVar(&serverURL, "server", "", "control plane base URL (default: config server_url)")
+	cmd.Flags().StringVar(&token, "token", os.Getenv("LEOFLOW_TOKEN"), "JWT bearer token (default: config token)")
+	return cmd
+}
+
+func newVariablesDeleteCommand() *cobra.Command {
+	var serverURL, token string
+	cmd := &cobra.Command{
+		Use:   "delete <key>",
+		Short: "Delete a variable.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key := args[0]
+			base, bearer, err := resolveServerToken(cmd, serverURL, token)
+			if err != nil {
+				return err
+			}
+			if err := deleteVariableReq(cmdContext(cmd), base, bearer, key); err != nil {
+				return err
+			}
+			_, werr := fmt.Fprintf(cmd.OutOrStdout(), "Deleted variable %q.\n", key)
+			return werr
+		},
+	}
+	cmd.Flags().StringVar(&serverURL, "server", "", "control plane base URL (default: config server_url)")
+	cmd.Flags().StringVar(&token, "token", os.Getenv("LEOFLOW_TOKEN"), "JWT bearer token (default: config token)")
+	return cmd
+}
+
+// setVariableReq posts (upserts) a variable through the shared typed client and
+// returns the masked variable the server echoes back.
+func setVariableReq(ctx context.Context, serverURL, token string, body apiclient.VariableBody) (apiclient.Variable, error) {
+	c, err := apiclient.New(serverURL, token)
+	if err != nil {
+		return apiclient.Variable{}, err
+	}
+	resp, err := c.CreateVariableWithResponse(ctx, body)
+	if err != nil {
+		return apiclient.Variable{}, fmt.Errorf("posting to %s/api/v2/variables: %w", serverURL, err)
+	}
+	if resp.StatusCode() != http.StatusCreated {
+		return apiclient.Variable{}, connError(resp.StatusCode(), resp.Body)
+	}
+	if resp.JSON201 == nil {
+		return apiclient.Variable{}, fmt.Errorf("server returned no variable")
+	}
+	return *resp.JSON201, nil
+}
+
+// listVariablesReq gets the variable collection through the typed client.
+func listVariablesReq(ctx context.Context, serverURL, token string) (*apiclient.VariableCollection, error) {
+	c, err := apiclient.New(serverURL, token)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.ListVariablesWithResponse(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("listing variables: %w", err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, connError(resp.StatusCode(), resp.Body)
+	}
+	return resp.JSON200, nil
+}
+
+// getVariableReq fetches one variable through the typed client.
+func getVariableReq(ctx context.Context, serverURL, token, key string) (apiclient.Variable, error) {
+	c, err := apiclient.New(serverURL, token)
+	if err != nil {
+		return apiclient.Variable{}, err
+	}
+	resp, err := c.GetVariableWithResponse(ctx, key)
+	if err != nil {
+		return apiclient.Variable{}, fmt.Errorf("getting variable %q: %w", key, err)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return apiclient.Variable{}, connError(resp.StatusCode(), resp.Body)
+	}
+	if resp.JSON200 == nil {
+		return apiclient.Variable{}, fmt.Errorf("server returned no variable")
+	}
+	return *resp.JSON200, nil
+}
+
+// deleteVariableReq deletes one variable through the typed client.
+func deleteVariableReq(ctx context.Context, serverURL, token, key string) error {
+	c, err := apiclient.New(serverURL, token)
+	if err != nil {
+		return err
+	}
+	resp, err := c.DeleteVariableWithResponse(ctx, key)
+	if err != nil {
+		return fmt.Errorf("deleting variable %q: %w", key, err)
+	}
+	if resp.StatusCode() != http.StatusNoContent {
+		return connError(resp.StatusCode(), resp.Body)
+	}
+	return nil
+}
+
+// printVariableList renders the collection as an aligned table. The value column
+// is deliberately omitted: encrypted values are masked server-side anyway, and
+// omitting it entirely keeps even non-sensitive values off an operator's screen
+// by default (use `variables get <key>` to read one).
+func printVariableList(w io.Writer, coll *apiclient.VariableCollection) error {
+	if coll == nil || coll.Variables == nil || len(*coll.Variables) == 0 {
+		_, err := fmt.Fprintln(w, "No variables.")
+		return err
+	}
+	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "KEY\tDESCRIPTION\tENCRYPTED"); err != nil {
+		return err
+	}
+	for _, v := range *coll.Variables {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%s\n", v.Key, deref(v.Description), yesNo(v.IsEncrypted)); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+// printVariable prints a single variable's fields as key/value lines. The value
+// is whatever the server returned — already masked when the key looks sensitive.
+func printVariable(w io.Writer, v apiclient.Variable) error {
+	tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
+	rows := [][2]string{
+		{"key", v.Key},
+		{"value", v.Value},
+		{"description", deref(v.Description)},
+		{"is_encrypted", yesNo(v.IsEncrypted)},
+	}
+	for _, r := range rows {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\n", r[0], r[1]); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+// yesNo renders a bool as the "yes"/"no" the tables use elsewhere.
+func yesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}

--- a/internal/cli/variables.go
+++ b/internal/cli/variables.go
@@ -76,13 +76,20 @@ func newVariablesSetCommand() *cobra.Command {
 
 // resolveVariableValue applies the value-source precedence: --value-stdin reads
 // stdin (and conflicts with a positional value); otherwise the positional value
-// is used, defaulting to empty when neither is given.
+// is used. A value must be supplied one way or the other — omitting it entirely
+// is an error rather than a silent overwrite-to-empty (which would quietly blank
+// an existing variable on an upsert). An explicit empty value is still allowed
+// via `set <key> ""`.
 func resolveVariableValue(cmd *cobra.Command, positional string, havePositional, stdin bool) (string, error) {
 	if stdin {
 		if havePositional {
 			return "", fmt.Errorf("a positional value and --value-stdin are mutually exclusive")
 		}
 		return readValueStdin(cmd.InOrStdin())
+	}
+	if !havePositional {
+		return "", fmt.Errorf("a value is required: pass it as the second argument or via --value-stdin " +
+			"(use `set <key> \"\"` to set an explicit empty value)")
 	}
 	return positional, nil
 }

--- a/internal/cli/variables_test.go
+++ b/internal/cli/variables_test.go
@@ -152,6 +152,49 @@ func TestSetVariableCommandExplicitEmptyValue(t *testing.T) {
 	}
 }
 
+// TestVariablesGetCommand exercises the full `variables get` path (request +
+// single-variable printer).
+func TestVariablesGetCommand(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"key":"region","value":"us-east-1","description":"default region","is_encrypted":false}`)
+	}))
+	defer srv.Close()
+
+	cfg := seedSessionConfig(t, srv.URL, "tok")
+	out, _, err := run(t, "variables", "get", "region", "--config", cfg)
+	if err != nil {
+		t.Fatalf("variables get: %v", err)
+	}
+	for _, want := range []string{"region", "us-east-1", "default region"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("get output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestVariablesListCommand exercises the full `variables list` path (request +
+// table printer); the value column is never rendered.
+func TestVariablesListCommand(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"variables":[{"key":"region","value":"us-east-1","is_encrypted":false},{"key":"api_token","value":"***","is_encrypted":true}],"total_entries":2}`)
+	}))
+	defer srv.Close()
+
+	cfg := seedSessionConfig(t, srv.URL, "tok")
+	out, _, err := run(t, "variables", "list", "--config", cfg)
+	if err != nil {
+		t.Fatalf("variables list: %v", err)
+	}
+	if !strings.Contains(out, "region") || !strings.Contains(out, "api_token") {
+		t.Errorf("list output missing a key:\n%s", out)
+	}
+	if strings.Contains(out, "us-east-1") {
+		t.Errorf("list output must not render the value column:\n%s", out)
+	}
+}
+
 func TestGetVariableReq(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v2/variables/region" {

--- a/internal/cli/variables_test.go
+++ b/internal/cli/variables_test.go
@@ -106,6 +106,52 @@ func TestSetVariableCommandRequiresKey(t *testing.T) {
 	}
 }
 
+// TestSetVariableCommandRequiresValue: `variables set <key>` with no value and no
+// --value-stdin must error, not silently overwrite an existing variable's value
+// with the empty string. It must never reach the server.
+func TestSetVariableCommandRequiresValue(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	cfg := seedSessionConfig(t, srv.URL, "tok")
+	if _, _, err := run(t, "variables", "set", "onlykey", "--config", cfg); err == nil {
+		t.Error("expected an error when no value is supplied")
+	}
+	if called {
+		t.Error("no request should be sent when the value is missing")
+	}
+}
+
+// TestSetVariableCommandExplicitEmptyValue: an explicit empty value (`set k ""`)
+// is a deliberate write and must be allowed through.
+func TestSetVariableCommandExplicitEmptyValue(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"key":"k","value":"","is_encrypted":false}`)
+	}))
+	defer srv.Close()
+
+	cfg := seedSessionConfig(t, srv.URL, "tok")
+	if _, _, err := run(t, "variables", "set", "k", "", "--config", cfg); err != nil {
+		t.Fatalf("explicit empty value should be allowed: %v", err)
+	}
+	var sent apiclient.VariableBody
+	if uerr := json.Unmarshal([]byte(gotBody), &sent); uerr != nil {
+		t.Fatalf("request body not JSON: %v (%s)", uerr, gotBody)
+	}
+	if sent.Value == nil || *sent.Value != "" {
+		t.Errorf("explicit empty value not sent: %s", gotBody)
+	}
+}
+
 func TestGetVariableReq(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v2/variables/region" {

--- a/internal/cli/variables_test.go
+++ b/internal/cli/variables_test.go
@@ -1,0 +1,179 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
+)
+
+func TestSetVariableReqSendsBodyAndReturnsVariable(t *testing.T) {
+	var gotMethod, gotPath, gotBody, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"key":"region","value":"us-east-1","is_encrypted":false}`)
+	}))
+	defer srv.Close()
+
+	value, desc := "us-east-1", "default region"
+	v, err := setVariableReq(context.Background(), srv.URL, "admin-jwt", apiclient.VariableBody{
+		Key: "region", Value: &value, Description: &desc,
+	})
+	if err != nil {
+		t.Fatalf("setVariableReq: %v", err)
+	}
+	if gotMethod != http.MethodPost || gotPath != "/api/v2/variables" {
+		t.Errorf("request = %s %s, want POST /api/v2/variables", gotMethod, gotPath)
+	}
+	if gotAuth != "Bearer admin-jwt" {
+		t.Errorf("Authorization = %q, want the bearer", gotAuth)
+	}
+	if !strings.Contains(gotBody, `"key":"region"`) || !strings.Contains(gotBody, "us-east-1") {
+		t.Errorf("request body missing key/value: %s", gotBody)
+	}
+	if v.Key != "region" || v.Value != "us-east-1" {
+		t.Errorf("unexpected variable: %+v", v)
+	}
+}
+
+func TestSetVariableCommandPositionalValue(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"key":"region","value":"us-east-1","is_encrypted":false}`)
+	}))
+	defer srv.Close()
+
+	cfg := seedSessionConfig(t, srv.URL, "tok")
+	out, _, err := run(t, "variables", "set", "region", "us-east-1", "--config", cfg)
+	if err != nil {
+		t.Fatalf("variables set: %v", err)
+	}
+	if !strings.Contains(gotBody, "us-east-1") {
+		t.Errorf("positional value not sent: %s", gotBody)
+	}
+	if !strings.Contains(out, "region") {
+		t.Errorf("output = %q, want a confirmation naming the key", out)
+	}
+}
+
+func TestSetVariableCommandValueStdin(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"key":"apikey","value":"***","is_encrypted":false}`)
+	}))
+	defer srv.Close()
+
+	cfg := seedSessionConfig(t, srv.URL, "tok")
+	out, _, err := runWithStdin(t, "SECRET-VALUE\n", "variables", "set", "apikey", "--config", cfg, "--value-stdin")
+	if err != nil {
+		t.Fatalf("variables set --value-stdin: %v", err)
+	}
+	var sent apiclient.VariableBody
+	if uerr := json.Unmarshal([]byte(gotBody), &sent); uerr != nil {
+		t.Fatalf("request body not JSON: %v (%s)", uerr, gotBody)
+	}
+	if sent.Value == nil || *sent.Value != "SECRET-VALUE" {
+		t.Errorf("value from stdin not sent: %s", gotBody)
+	}
+	if strings.Contains(out, "SECRET-VALUE") {
+		t.Errorf("output leaked the stdin value: %q", out)
+	}
+}
+
+func TestSetVariableCommandRequiresKey(t *testing.T) {
+	cfg := seedSessionConfig(t, "http://127.0.0.1:0", "tok")
+	if _, _, err := run(t, "variables", "set", "--config", cfg); err == nil {
+		t.Error("expected an error when the key is missing")
+	}
+}
+
+func TestGetVariableReq(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/variables/region" {
+			t.Errorf("path = %s, want /api/v2/variables/region", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"key":"region","value":"us-east-1","is_encrypted":false}`)
+	}))
+	defer srv.Close()
+
+	v, err := getVariableReq(context.Background(), srv.URL, "t", "region")
+	if err != nil {
+		t.Fatalf("getVariableReq: %v", err)
+	}
+	if v.Key != "region" || v.Value != "us-east-1" {
+		t.Errorf("variable = %+v", v)
+	}
+}
+
+func TestDeleteVariableReq(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || r.URL.Path != "/api/v2/variables/region" {
+			t.Errorf("request = %s %s, want DELETE /api/v2/variables/region", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	if err := deleteVariableReq(context.Background(), srv.URL, "t", "region"); err != nil {
+		t.Fatalf("deleteVariableReq: %v", err)
+	}
+}
+
+func TestDeleteVariableReqNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	if err := deleteVariableReq(context.Background(), srv.URL, "t", "ghost"); err == nil {
+		t.Error("expected an error deleting a missing variable")
+	}
+}
+
+func TestPrintVariableListMasksEncryptedValues(t *testing.T) {
+	descA, descB := "region", "secret"
+	coll := &apiclient.VariableCollection{Variables: &[]apiclient.Variable{
+		{Key: "region", Value: "us-east-1", Description: &descA, IsEncrypted: false},
+		{Key: "api_token", Value: "***", Description: &descB, IsEncrypted: true},
+	}}
+	var buf bytes.Buffer
+	if err := printVariableList(&buf, coll); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, want := range []string{"KEY", "DESCRIPTION", "ENCRYPTED", "region", "api_token"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintVariableListEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	if err := printVariableList(&buf, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "No variables") {
+		t.Errorf("empty = %q, want the friendly line", buf.String())
+	}
+}

--- a/internal/storage/connection_partial_upsert_integration_test.go
+++ b/internal/storage/connection_partial_upsert_integration_test.go
@@ -1,0 +1,108 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/secrets"
+)
+
+// TestConnectionPartialUpsertPreservesOmittedFields locks the safe-by-default
+// upsert semantics (#881): a write changes only the fields it carries and leaves
+// every omitted field intact. The load-bearing case is the password — it is
+// write-only (never read back), so a partial `connections set --host newhost`
+// that forgot to re-supply it must NOT wipe it, or the next DAG run fails auth
+// with no visible cause. Before the COALESCE upsert this test's second write
+// nulled the password, extra, login and port.
+func TestConnectionPartialUpsertPreservesOmittedFields(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 7)
+	}
+	cipher, err := secrets.NewAESGCM(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo.SetCipher(cipher)
+
+	connID := fmt.Sprintf("uiq_partial_%d", time.Now().UnixNano())
+	port := 5432
+	if err := repo.SetConnection(ctx, "default", domain.Connection{
+		ConnID: connID, ConnType: "postgres", Host: "db", Login: "u",
+		Password: "s3cr3t", Schema: "public", Port: &port, Extra: `{"sslmode":"require"}`,
+		Description: "primary warehouse",
+	}); err != nil {
+		t.Fatalf("initial SetConnection: %v", err)
+	}
+
+	// Partial write: change ONLY the host. Every other field is omitted (zero
+	// value), which maps to a NULL param and must be preserved by the upsert.
+	if err := repo.SetConnection(ctx, "default", domain.Connection{
+		ConnID: connID, ConnType: "postgres", Host: "db2",
+	}); err != nil {
+		t.Fatalf("partial SetConnection: %v", err)
+	}
+
+	got, err := repo.GetConnection(ctx, "default", connID)
+	if err != nil {
+		t.Fatalf("GetConnection: %v", err)
+	}
+	if got.Host != "db2" {
+		t.Errorf("host not updated: got %q, want db2", got.Host)
+	}
+	if got.Login != "u" {
+		t.Errorf("login was clobbered: got %q, want u (preserved)", got.Login)
+	}
+	if got.Port == nil || *got.Port != 5432 {
+		t.Errorf("port was clobbered: got %v, want 5432 (preserved)", got.Port)
+	}
+	if got.Extra != `{"sslmode":"require"}` {
+		t.Errorf("extra was clobbered: got %q, want the original (preserved)", got.Extra)
+	}
+	if got.Description != "primary warehouse" {
+		t.Errorf("description was clobbered: got %q (preserved)", got.Description)
+	}
+
+	// The password is write-only, so prove its survival through the delivery path
+	// (the decrypted AIRFLOW_CONN_<id> URI a task receives), not GetConnection.
+	tenantUUID, err := repo.TenantUUID(ctx, "default")
+	if err != nil {
+		t.Fatalf("TenantUUID: %v", err)
+	}
+	uris, err := repo.SecretConnectionURIs(ctx, tenantUUID)
+	if err != nil {
+		t.Fatalf("SecretConnectionURIs: %v", err)
+	}
+	uri, ok := uris[connID]
+	if !ok {
+		t.Fatalf("connection %s missing from delivered URIs", connID)
+	}
+	if !strings.Contains(uri, "s3cr3t") {
+		t.Errorf("password was wiped by the partial upsert: delivered URI %q no longer carries it", uri)
+	}
+	if !strings.Contains(uri, "db2") {
+		t.Errorf("delivered URI did not reflect the updated host: %q", uri)
+	}
+
+	// A write that DOES carry a new password replaces it (not a no-op merge).
+	if err := repo.SetConnection(ctx, "default", domain.Connection{
+		ConnID: connID, ConnType: "postgres", Password: "rotated",
+	}); err != nil {
+		t.Fatalf("password-rotating SetConnection: %v", err)
+	}
+	uris, err = repo.SecretConnectionURIs(ctx, tenantUUID)
+	if err != nil {
+		t.Fatalf("SecretConnectionURIs (after rotate): %v", err)
+	}
+	if u := uris[connID]; strings.Contains(u, "s3cr3t") || !strings.Contains(u, "rotated") {
+		t.Errorf("password was not rotated: %q", u)
+	}
+
+	_ = repo.DeleteConnection(ctx, "default", connID)
+}

--- a/internal/storage/queries/connections.sql
+++ b/internal/storage/queries/connections.sql
@@ -42,17 +42,23 @@ SELECT conn_id FROM connections
 WHERE tenant_id = $1 AND conn_id = ANY(sqlc.arg(conn_ids)::text[]);
 
 -- name: UpsertConnection :exec
+-- A write preserves any nullable field the caller left NULL, rather than
+-- clobbering it: COALESCE(EXCLUDED.col, connections.col) keeps the stored value
+-- when the request omits that field. This is what makes a partial `set` safe —
+-- e.g. changing only --host must not wipe the (unreadable) password. conn_type is
+-- required on every write, so it is a plain overwrite. To clear a field, delete
+-- and recreate the connection.
 INSERT INTO connections (tenant_id, conn_id, conn_type, host, conn_schema, login, password, port, extra, description)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 ON CONFLICT (tenant_id, conn_id) DO UPDATE SET
     conn_type = EXCLUDED.conn_type,
-    host = EXCLUDED.host,
-    conn_schema = EXCLUDED.conn_schema,
-    login = EXCLUDED.login,
-    password = EXCLUDED.password,
-    port = EXCLUDED.port,
-    extra = EXCLUDED.extra,
-    description = EXCLUDED.description,
+    host = COALESCE(EXCLUDED.host, connections.host),
+    conn_schema = COALESCE(EXCLUDED.conn_schema, connections.conn_schema),
+    login = COALESCE(EXCLUDED.login, connections.login),
+    password = COALESCE(EXCLUDED.password, connections.password),
+    port = COALESCE(EXCLUDED.port, connections.port),
+    extra = COALESCE(EXCLUDED.extra, connections.extra),
+    description = COALESCE(EXCLUDED.description, connections.description),
     updated_at = now();
 
 -- name: DeleteConnection :execrows

--- a/internal/storage/queries/connections.sql.go
+++ b/internal/storage/queries/connections.sql.go
@@ -279,13 +279,13 @@ INSERT INTO connections (tenant_id, conn_id, conn_type, host, conn_schema, login
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 ON CONFLICT (tenant_id, conn_id) DO UPDATE SET
     conn_type = EXCLUDED.conn_type,
-    host = EXCLUDED.host,
-    conn_schema = EXCLUDED.conn_schema,
-    login = EXCLUDED.login,
-    password = EXCLUDED.password,
-    port = EXCLUDED.port,
-    extra = EXCLUDED.extra,
-    description = EXCLUDED.description,
+    host = COALESCE(EXCLUDED.host, connections.host),
+    conn_schema = COALESCE(EXCLUDED.conn_schema, connections.conn_schema),
+    login = COALESCE(EXCLUDED.login, connections.login),
+    password = COALESCE(EXCLUDED.password, connections.password),
+    port = COALESCE(EXCLUDED.port, connections.port),
+    extra = COALESCE(EXCLUDED.extra, connections.extra),
+    description = COALESCE(EXCLUDED.description, connections.description),
     updated_at = now()
 `
 
@@ -302,6 +302,12 @@ type UpsertConnectionParams struct {
 	Description *string     `json:"description"`
 }
 
+// A write preserves any nullable field the caller left NULL, rather than
+// clobbering it: COALESCE(EXCLUDED.col, connections.col) keeps the stored value
+// when the request omits that field. This is what makes a partial `set` safe —
+// e.g. changing only --host must not wipe the (unreadable) password. conn_type is
+// required on every write, so it is a plain overwrite. To clear a field, delete
+// and recreate the connection.
 func (q *Queries) UpsertConnection(ctx context.Context, arg UpsertConnectionParams) error {
 	_, err := q.db.Exec(ctx, upsertConnection,
 		arg.TenantID,

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -522,10 +522,19 @@ type Querier interface {
 	// self-referential, so an already-stamped row is never re-stamped.
 	UpdateTaskInstanceStatesByRunTasks(ctx context.Context, arg UpdateTaskInstanceStatesByRunTasksParams) error
 	UpdateUserPassword(ctx context.Context, arg UpdateUserPasswordParams) (int64, error)
+	// A write preserves any nullable field the caller left NULL, rather than
+	// clobbering it: COALESCE(EXCLUDED.col, connections.col) keeps the stored value
+	// when the request omits that field. This is what makes a partial `set` safe —
+	// e.g. changing only --host must not wipe the (unreadable) password. conn_type is
+	// required on every write, so it is a plain overwrite. To clear a field, delete
+	// and recreate the connection.
 	UpsertConnection(ctx context.Context, arg UpsertConnectionParams) error
 	UpsertDag(ctx context.Context, arg UpsertDagParams) (Dag, error)
 	UpsertImportError(ctx context.Context, arg UpsertImportErrorParams) error
 	UpsertPool(ctx context.Context, arg UpsertPoolParams) error
+	// value is always supplied (a variable is its value), so it is overwritten;
+	// description is preserved when the request omits it (NULL) rather than being
+	// wiped — see the COALESCE rationale on UpsertConnection.
 	UpsertVariable(ctx context.Context, arg UpsertVariableParams) error
 }
 

--- a/internal/storage/queries/variables.sql
+++ b/internal/storage/queries/variables.sql
@@ -32,11 +32,14 @@ SELECT key FROM variables
 WHERE tenant_id = $1 AND key = ANY(sqlc.arg(keys)::text[]);
 
 -- name: UpsertVariable :exec
+-- value is always supplied (a variable is its value), so it is overwritten;
+-- description is preserved when the request omits it (NULL) rather than being
+-- wiped — see the COALESCE rationale on UpsertConnection.
 INSERT INTO variables (tenant_id, key, value, description)
 VALUES ($1, $2, $3, $4)
 ON CONFLICT (tenant_id, key) DO UPDATE SET
     value = EXCLUDED.value,
-    description = EXCLUDED.description,
+    description = COALESCE(EXCLUDED.description, variables.description),
     updated_at = now();
 
 -- name: DeleteVariable :execrows

--- a/internal/storage/queries/variables.sql.go
+++ b/internal/storage/queries/variables.sql.go
@@ -184,7 +184,7 @@ INSERT INTO variables (tenant_id, key, value, description)
 VALUES ($1, $2, $3, $4)
 ON CONFLICT (tenant_id, key) DO UPDATE SET
     value = EXCLUDED.value,
-    description = EXCLUDED.description,
+    description = COALESCE(EXCLUDED.description, variables.description),
     updated_at = now()
 `
 
@@ -195,6 +195,9 @@ type UpsertVariableParams struct {
 	Description *string     `json:"description"`
 }
 
+// value is always supplied (a variable is its value), so it is overwritten;
+// description is preserved when the request omits it (NULL) rather than being
+// wiped — see the COALESCE rationale on UpsertConnection.
 func (q *Queries) UpsertVariable(ctx context.Context, arg UpsertVariableParams) error {
 	_, err := q.db.Exec(ctx, upsertVariable,
 		arg.TenantID,

--- a/internal/storage/ui_queries_integration_test.go
+++ b/internal/storage/ui_queries_integration_test.go
@@ -735,12 +735,16 @@ func TestVariablesIntegration(t *testing.T) {
 	if err != nil || got.Value != "v1" || got.Description != "first" {
 		t.Fatalf("GetVariable = %+v, err=%v", got, err)
 	}
-	// Upsert updates in place.
+	// Upsert updates the value in place but preserves a description the write
+	// omits (COALESCE), rather than wiping it — the safe-by-default upsert (#881).
 	if err := repo.SetVariable(ctx, "default", domain.Variable{Key: key, Value: "v2"}); err != nil {
 		t.Fatal(err)
 	}
 	if got, _ := repo.GetVariable(ctx, "default", key); got.Value != "v2" {
 		t.Errorf("upsert did not update: %q", got.Value)
+	}
+	if got, _ := repo.GetVariable(ctx, "default", key); got.Description != "first" {
+		t.Errorf("upsert clobbered the omitted description: got %q, want first (preserved)", got.Description)
 	}
 	// List includes it.
 	vars, total, err := repo.ListVariables(ctx, "default", 1000, 0)

--- a/pkg/client/client.gen.go
+++ b/pkg/client/client.gen.go
@@ -145,6 +145,37 @@ type ComponentHealth struct {
 	Status                      *string `json:"status,omitempty"`
 }
 
+// Connection An Airflow-style connection. The password is write-only and never returned; secret-bearing keys inside `extra` are masked server-side.
+type Connection struct {
+	ConnType     string  `json:"conn_type"`
+	ConnectionId string  `json:"connection_id"`
+	Description  *string `json:"description,omitempty"`
+	Extra        *string `json:"extra,omitempty"`
+	Host         *string `json:"host,omitempty"`
+	Login        *string `json:"login,omitempty"`
+	Port         *int    `json:"port,omitempty"`
+	Schema       *string `json:"schema,omitempty"`
+}
+
+// ConnectionBody Connection create/replace payload. connection_id is required on POST (taken from the path on PATCH). password and extra are write-only.
+type ConnectionBody struct {
+	ConnType     string  `json:"conn_type"`
+	ConnectionId *string `json:"connection_id,omitempty"`
+	Description  *string `json:"description,omitempty"`
+	Extra        *string `json:"extra,omitempty"`
+	Host         *string `json:"host,omitempty"`
+	Login        *string `json:"login,omitempty"`
+	Password     *string `json:"password,omitempty"`
+	Port         *int    `json:"port,omitempty"`
+	Schema       *string `json:"schema,omitempty"`
+}
+
+// ConnectionCollection defines model for ConnectionCollection.
+type ConnectionCollection struct {
+	Connections  *[]Connection `json:"connections,omitempty"`
+	TotalEntries *int          `json:"total_entries,omitempty"`
+}
+
 // CreateUserRequest defines model for CreateUserRequest.
 type CreateUserRequest struct {
 	// Email Login email. Normalized to lowercase, so it is unique case-insensitively within the tenant.
@@ -348,6 +379,28 @@ type UserListItem struct {
 	Roles     []string  `json:"roles"`
 }
 
+// Variable An Airflow-style variable. The value is masked server-side when the key looks sensitive (secret/password/token/...).
+type Variable struct {
+	Description *string `json:"description,omitempty"`
+	IsEncrypted bool    `json:"is_encrypted"`
+	Key         string  `json:"key"`
+	TeamName    *string `json:"team_name,omitempty"`
+	Value       string  `json:"value"`
+}
+
+// VariableBody defines model for VariableBody.
+type VariableBody struct {
+	Description *string `json:"description,omitempty"`
+	Key         string  `json:"key"`
+	Value       *string `json:"value,omitempty"`
+}
+
+// VariableCollection defines model for VariableCollection.
+type VariableCollection struct {
+	TotalEntries *int        `json:"total_entries,omitempty"`
+	Variables    *[]Variable `json:"variables,omitempty"`
+}
+
 // VersionInfo defines model for VersionInfo.
 type VersionInfo struct {
 	GitVersion *string `json:"git_version,omitempty"`
@@ -364,6 +417,9 @@ type XComEntry struct {
 	Value     interface{} `json:"value,omitempty"`
 }
 
+// ConnectionID defines model for ConnectionID.
+type ConnectionID = string
+
 // DagID defines model for DagID.
 type DagID = string
 
@@ -379,11 +435,23 @@ type Offset = int
 // TaskID defines model for TaskID.
 type TaskID = string
 
+// VariableKey defines model for VariableKey.
+type VariableKey = string
+
+// EncryptionUnavailable defines model for EncryptionUnavailable.
+type EncryptionUnavailable = Error
+
 // NotFound defines model for NotFound.
 type NotFound = Error
 
 // Unauthorized defines model for Unauthorized.
 type Unauthorized = Error
+
+// ListConnectionsParams defines parameters for ListConnections.
+type ListConnectionsParams struct {
+	Limit  *Limit  `form:"limit,omitempty" json:"limit,omitempty"`
+	Offset *Offset `form:"offset,omitempty" json:"offset,omitempty"`
+}
 
 // ListDagsParams defines parameters for ListDags.
 type ListDagsParams struct {
@@ -410,6 +478,18 @@ type ListUsersParams struct {
 	Offset *Offset `form:"offset,omitempty" json:"offset,omitempty"`
 }
 
+// ListVariablesParams defines parameters for ListVariables.
+type ListVariablesParams struct {
+	Limit  *Limit  `form:"limit,omitempty" json:"limit,omitempty"`
+	Offset *Offset `form:"offset,omitempty" json:"offset,omitempty"`
+}
+
+// CreateConnectionJSONRequestBody defines body for CreateConnection for application/json ContentType.
+type CreateConnectionJSONRequestBody = ConnectionBody
+
+// UpdateConnectionJSONRequestBody defines body for UpdateConnection for application/json ContentType.
+type UpdateConnectionJSONRequestBody = ConnectionBody
+
 // UpdateDagJSONRequestBody defines body for UpdateDag for application/json ContentType.
 type UpdateDagJSONRequestBody = DAGUpdate
 
@@ -421,6 +501,9 @@ type TriggerDagRunJSONRequestBody = DAGRunCreate
 
 // CreateUserJSONRequestBody defines body for CreateUser for application/json ContentType.
 type CreateUserJSONRequestBody = CreateUserRequest
+
+// CreateVariableJSONRequestBody defines body for CreateVariable for application/json ContentType.
+type CreateVariableJSONRequestBody = VariableBody
 
 // IssueTokenJSONRequestBody defines body for IssueToken for application/json ContentType.
 type IssueTokenJSONRequestBody = TokenRequest
@@ -505,6 +588,61 @@ type ClientInterface interface {
 	//
 	// Corresponds with POST /api/v2/auth/token/renew (the `RenewToken` operationId).
 	RenewToken(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListConnections List connections
+	//
+	// Lists the tenant's Airflow-style connections. Passwords are write-only and
+	// never returned; secret-bearing keys inside `extra` are masked server-side.
+	// Requires the read:connection permission.
+	//
+	// Corresponds with GET /api/v2/connections (the `ListConnections` operationId).
+	ListConnections(ctx context.Context, params *ListConnectionsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateConnectionWithBody Create or replace a connection (upsert)
+	//
+	// Upserts a connection: creates it, or replaces an existing one with the same
+	// connection_id. The password is write-only and never returned. Requires the
+	// write:connection permission and a configured encryption key.
+	//
+	// Takes any type of body and a specified content type.
+	//
+	// Corresponds with POST /api/v2/connections (the `CreateConnection` operationId).
+	CreateConnectionWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateConnection Create or replace a connection (upsert)
+	//
+	// Upserts a connection: creates it, or replaces an existing one with the same
+	// connection_id. The password is write-only and never returned. Requires the
+	// write:connection permission and a configured encryption key.
+	//
+	// Takes a body of the `application/json` content type.
+	//
+	// Corresponds with POST /api/v2/connections (the `CreateConnection` operationId).
+	CreateConnection(ctx context.Context, body CreateConnectionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteConnection Delete a connection
+	//
+	// Corresponds with DELETE /api/v2/connections/{connection_id} (the `DeleteConnection` operationId).
+	DeleteConnection(ctx context.Context, connectionId ConnectionID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetConnection Get a connection
+	//
+	// Corresponds with GET /api/v2/connections/{connection_id} (the `GetConnection` operationId).
+	GetConnection(ctx context.Context, connectionId ConnectionID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateConnectionWithBody Update a connection
+	//
+	// Takes any type of body and a specified content type.
+	//
+	// Corresponds with PATCH /api/v2/connections/{connection_id} (the `UpdateConnection` operationId).
+	UpdateConnectionWithBody(ctx context.Context, connectionId ConnectionID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UpdateConnection Update a connection
+	//
+	// Takes a body of the `application/json` content type.
+	//
+	// Corresponds with PATCH /api/v2/connections/{connection_id} (the `UpdateConnection` operationId).
+	UpdateConnection(ctx context.Context, connectionId ConnectionID, body UpdateConnectionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetDagSource Get a DAG's source (the dag.py text)
 	//
@@ -644,6 +782,44 @@ type ClientInterface interface {
 	// Corresponds with POST /api/v2/users (the `CreateUser` operationId).
 	CreateUser(ctx context.Context, body CreateUserJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ListVariables List variables
+	//
+	// Lists the tenant's Airflow-style variables. Values of secret-ish keys are
+	// masked server-side. Requires the read:variable permission.
+	//
+	// Corresponds with GET /api/v2/variables (the `ListVariables` operationId).
+	ListVariables(ctx context.Context, params *ListVariablesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateVariableWithBody Create or replace a variable (upsert)
+	//
+	// Upserts a variable: creates it, or replaces an existing one with the same
+	// key. Requires the write:variable permission.
+	//
+	// Takes any type of body and a specified content type.
+	//
+	// Corresponds with POST /api/v2/variables (the `CreateVariable` operationId).
+	CreateVariableWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateVariable Create or replace a variable (upsert)
+	//
+	// Upserts a variable: creates it, or replaces an existing one with the same
+	// key. Requires the write:variable permission.
+	//
+	// Takes a body of the `application/json` content type.
+	//
+	// Corresponds with POST /api/v2/variables (the `CreateVariable` operationId).
+	CreateVariable(ctx context.Context, body CreateVariableJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeleteVariable Delete a variable
+	//
+	// Corresponds with DELETE /api/v2/variables/{variable_key} (the `DeleteVariable` operationId).
+	DeleteVariable(ctx context.Context, variableKey VariableKey, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetVariable Get a variable
+	//
+	// Corresponds with GET /api/v2/variables/{variable_key} (the `GetVariable` operationId).
+	GetVariable(ctx context.Context, variableKey VariableKey, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetVersion Control-plane version (Airflow VersionInfo shape)
 	//
 	// Corresponds with GET /api/v2/version (the `GetVersion` operationId).
@@ -686,6 +862,131 @@ type ClientInterface interface {
 // Corresponds with POST /api/v2/auth/token/renew (the `RenewToken` operationId).
 func (c *Client) RenewToken(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewRenewTokenRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// ListConnections List connections
+//
+// Lists the tenant's Airflow-style connections. Passwords are write-only and
+// never returned; secret-bearing keys inside `extra` are masked server-side.
+// Requires the read:connection permission.
+//
+// Corresponds with GET /api/v2/connections (the `ListConnections` operationId).
+func (c *Client) ListConnections(ctx context.Context, params *ListConnectionsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListConnectionsRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// CreateConnectionWithBody Create or replace a connection (upsert)
+//
+// Upserts a connection: creates it, or replaces an existing one with the same
+// connection_id. The password is write-only and never returned. Requires the
+// write:connection permission and a configured encryption key.
+//
+// Takes any type of body and a specified content type.
+//
+// Corresponds with POST /api/v2/connections (the `CreateConnection` operationId).
+func (c *Client) CreateConnectionWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateConnectionRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// CreateConnection Create or replace a connection (upsert)
+//
+// Upserts a connection: creates it, or replaces an existing one with the same
+// connection_id. The password is write-only and never returned. Requires the
+// write:connection permission and a configured encryption key.
+//
+// Takes a body of the `application/json` content type.
+//
+// Corresponds with POST /api/v2/connections (the `CreateConnection` operationId).
+func (c *Client) CreateConnection(ctx context.Context, body CreateConnectionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateConnectionRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// DeleteConnection Delete a connection
+//
+// Corresponds with DELETE /api/v2/connections/{connection_id} (the `DeleteConnection` operationId).
+func (c *Client) DeleteConnection(ctx context.Context, connectionId ConnectionID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteConnectionRequest(c.Server, connectionId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// GetConnection Get a connection
+//
+// Corresponds with GET /api/v2/connections/{connection_id} (the `GetConnection` operationId).
+func (c *Client) GetConnection(ctx context.Context, connectionId ConnectionID, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetConnectionRequest(c.Server, connectionId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// UpdateConnectionWithBody Update a connection
+//
+// Takes any type of body and a specified content type.
+//
+// Corresponds with PATCH /api/v2/connections/{connection_id} (the `UpdateConnection` operationId).
+func (c *Client) UpdateConnectionWithBody(ctx context.Context, connectionId ConnectionID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateConnectionRequestWithBody(c.Server, connectionId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// UpdateConnection Update a connection
+//
+// Takes a body of the `application/json` content type.
+//
+// Corresponds with PATCH /api/v2/connections/{connection_id} (the `UpdateConnection` operationId).
+func (c *Client) UpdateConnection(ctx context.Context, connectionId ConnectionID, body UpdateConnectionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateConnectionRequest(c.Server, connectionId, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1054,6 +1355,94 @@ func (c *Client) CreateUser(ctx context.Context, body CreateUserJSONRequestBody,
 	return c.Client.Do(req)
 }
 
+// ListVariables List variables
+//
+// Lists the tenant's Airflow-style variables. Values of secret-ish keys are
+// masked server-side. Requires the read:variable permission.
+//
+// Corresponds with GET /api/v2/variables (the `ListVariables` operationId).
+func (c *Client) ListVariables(ctx context.Context, params *ListVariablesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListVariablesRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// CreateVariableWithBody Create or replace a variable (upsert)
+//
+// Upserts a variable: creates it, or replaces an existing one with the same
+// key. Requires the write:variable permission.
+//
+// Takes any type of body and a specified content type.
+//
+// Corresponds with POST /api/v2/variables (the `CreateVariable` operationId).
+func (c *Client) CreateVariableWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateVariableRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// CreateVariable Create or replace a variable (upsert)
+//
+// Upserts a variable: creates it, or replaces an existing one with the same
+// key. Requires the write:variable permission.
+//
+// Takes a body of the `application/json` content type.
+//
+// Corresponds with POST /api/v2/variables (the `CreateVariable` operationId).
+func (c *Client) CreateVariable(ctx context.Context, body CreateVariableJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateVariableRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// DeleteVariable Delete a variable
+//
+// Corresponds with DELETE /api/v2/variables/{variable_key} (the `DeleteVariable` operationId).
+func (c *Client) DeleteVariable(ctx context.Context, variableKey VariableKey, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteVariableRequest(c.Server, variableKey)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+// GetVariable Get a variable
+//
+// Corresponds with GET /api/v2/variables/{variable_key} (the `GetVariable` operationId).
+func (c *Client) GetVariable(ctx context.Context, variableKey VariableKey, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetVariableRequest(c.Server, variableKey)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 // GetVersion Control-plane version (Airflow VersionInfo shape)
 //
 // Corresponds with GET /api/v2/version (the `GetVersion` operationId).
@@ -1171,6 +1560,227 @@ func NewRenewTokenRequest(server string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewListConnectionsRequest constructs an http.Request for the ListConnections method
+func NewListConnectionsRequest(server string, params *ListConnectionsParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v2/connections")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "limit", *params.Limit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Offset != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "offset", *params.Offset, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateConnectionRequest calls the generic CreateConnection builder with application/json body
+func NewCreateConnectionRequest(server string, body CreateConnectionJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateConnectionRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateConnectionRequestWithBody constructs an http.Request for the CreateConnection method, with any body, and a specified content type
+func NewCreateConnectionRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v2/connections")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteConnectionRequest constructs an http.Request for the DeleteConnection method
+func NewDeleteConnectionRequest(server string, connectionId ConnectionID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "connection_id", connectionId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v2/connections/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetConnectionRequest constructs an http.Request for the GetConnection method
+func NewGetConnectionRequest(server string, connectionId ConnectionID) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "connection_id", connectionId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v2/connections/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUpdateConnectionRequest calls the generic UpdateConnection builder with application/json body
+func NewUpdateConnectionRequest(server string, connectionId ConnectionID, body UpdateConnectionJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUpdateConnectionRequestWithBody(server, connectionId, "application/json", bodyReader)
+}
+
+// NewUpdateConnectionRequestWithBody constructs an http.Request for the UpdateConnection method, with any body, and a specified content type
+func NewUpdateConnectionRequestWithBody(server string, connectionId ConnectionID, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "connection_id", connectionId, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v2/connections/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPatch, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -2025,6 +2635,180 @@ func NewCreateUserRequestWithBody(server string, contentType string, body io.Rea
 	return req, nil
 }
 
+// NewListVariablesRequest constructs an http.Request for the ListVariables method
+func NewListVariablesRequest(server string, params *ListVariablesParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v2/variables")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		// queryValues collects non-styled parameters (passthrough, JSON)
+		// that are safe to round-trip through url.Values.Encode().
+		queryValues := queryURL.Query()
+		// rawQueryFragments collects pre-encoded query fragments from
+		// styled parameters, preserving literal commas as delimiters
+		// per the OpenAPI spec (e.g. "color=blue,black,brown").
+		var rawQueryFragments []string
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "limit", *params.Limit, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if params.Offset != nil {
+
+			if queryFrag, err := runtime.StyleParamWithOptions("form", true, "offset", *params.Offset, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationQuery, Type: "integer", Format: ""}); err != nil {
+				return nil, err
+			} else {
+				for _, qp := range strings.Split(queryFrag, "&") {
+					rawQueryFragments = append(rawQueryFragments, qp)
+				}
+			}
+
+		}
+
+		if encoded := queryValues.Encode(); encoded != "" {
+			rawQueryFragments = append(rawQueryFragments, encoded)
+		}
+		queryURL.RawQuery = strings.Join(rawQueryFragments, "&")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateVariableRequest calls the generic CreateVariable builder with application/json body
+func NewCreateVariableRequest(server string, body CreateVariableJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewCreateVariableRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewCreateVariableRequestWithBody constructs an http.Request for the CreateVariable method, with any body, and a specified content type
+func NewCreateVariableRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v2/variables")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteVariableRequest constructs an http.Request for the DeleteVariable method
+func NewDeleteVariableRequest(server string, variableKey VariableKey) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "variable_key", variableKey, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v2/variables/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetVariableRequest constructs an http.Request for the GetVariable method
+func NewGetVariableRequest(server string, variableKey VariableKey) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithOptions("simple", false, "variable_key", variableKey, runtime.StyleParamOptions{ParamLocation: runtime.ParamLocationPath, Type: "string", Format: ""})
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v2/variables/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetVersionRequest constructs an http.Request for the GetVersion method
 func NewGetVersionRequest(server string) (*http.Request, error) {
 	var err error
@@ -2254,6 +3038,67 @@ type ClientWithResponsesInterface interface {
 	// Corresponds with POST /api/v2/auth/token/renew (the `RenewToken` operationId).
 	RenewTokenWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*RenewTokenResponse, error)
 
+	// ListConnectionsWithResponse List connections
+	//
+	// Lists the tenant's Airflow-style connections. Passwords are write-only and
+	// never returned; secret-bearing keys inside `extra` are masked server-side.
+	// Requires the read:connection permission.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with GET /api/v2/connections (the `ListConnections` operationId).
+	ListConnectionsWithResponse(ctx context.Context, params *ListConnectionsParams, reqEditors ...RequestEditorFn) (*ListConnectionsResponse, error)
+
+	// CreateConnectionWithBodyWithResponse Create or replace a connection (upsert)
+	//
+	// Upserts a connection: creates it, or replaces an existing one with the same
+	// connection_id. The password is write-only and never returned. Requires the
+	// write:connection permission and a configured encryption key.
+	//
+	// Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with POST /api/v2/connections (the `CreateConnection` operationId).
+	CreateConnectionWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateConnectionResponse, error)
+
+	// CreateConnectionWithResponse Create or replace a connection (upsert)
+	//
+	// Upserts a connection: creates it, or replaces an existing one with the same
+	// connection_id. The password is write-only and never returned. Requires the
+	// write:connection permission and a configured encryption key.
+	//
+	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with POST /api/v2/connections (the `CreateConnection` operationId).
+	CreateConnectionWithResponse(ctx context.Context, body CreateConnectionJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateConnectionResponse, error)
+
+	// DeleteConnectionWithResponse Delete a connection
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with DELETE /api/v2/connections/{connection_id} (the `DeleteConnection` operationId).
+	DeleteConnectionWithResponse(ctx context.Context, connectionId ConnectionID, reqEditors ...RequestEditorFn) (*DeleteConnectionResponse, error)
+
+	// GetConnectionWithResponse Get a connection
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with GET /api/v2/connections/{connection_id} (the `GetConnection` operationId).
+	GetConnectionWithResponse(ctx context.Context, connectionId ConnectionID, reqEditors ...RequestEditorFn) (*GetConnectionResponse, error)
+
+	// UpdateConnectionWithBodyWithResponse Update a connection
+	//
+	// Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with PATCH /api/v2/connections/{connection_id} (the `UpdateConnection` operationId).
+	UpdateConnectionWithBodyWithResponse(ctx context.Context, connectionId ConnectionID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateConnectionResponse, error)
+
+	// UpdateConnectionWithResponse Update a connection
+	//
+	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with PATCH /api/v2/connections/{connection_id} (the `UpdateConnection` operationId).
+	UpdateConnectionWithResponse(ctx context.Context, connectionId ConnectionID, body UpdateConnectionJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateConnectionResponse, error)
+
 	// GetDagSourceWithResponse Get a DAG's source (the dag.py text)
 	//
 	// Returns a wrapper object for the known response body format(s).
@@ -2420,6 +3265,50 @@ type ClientWithResponsesInterface interface {
 	// Corresponds with POST /api/v2/users (the `CreateUser` operationId).
 	CreateUserWithResponse(ctx context.Context, body CreateUserJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateUserResponse, error)
 
+	// ListVariablesWithResponse List variables
+	//
+	// Lists the tenant's Airflow-style variables. Values of secret-ish keys are
+	// masked server-side. Requires the read:variable permission.
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with GET /api/v2/variables (the `ListVariables` operationId).
+	ListVariablesWithResponse(ctx context.Context, params *ListVariablesParams, reqEditors ...RequestEditorFn) (*ListVariablesResponse, error)
+
+	// CreateVariableWithBodyWithResponse Create or replace a variable (upsert)
+	//
+	// Upserts a variable: creates it, or replaces an existing one with the same
+	// key. Requires the write:variable permission.
+	//
+	// Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with POST /api/v2/variables (the `CreateVariable` operationId).
+	CreateVariableWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateVariableResponse, error)
+
+	// CreateVariableWithResponse Create or replace a variable (upsert)
+	//
+	// Upserts a variable: creates it, or replaces an existing one with the same
+	// key. Requires the write:variable permission.
+	//
+	// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with POST /api/v2/variables (the `CreateVariable` operationId).
+	CreateVariableWithResponse(ctx context.Context, body CreateVariableJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateVariableResponse, error)
+
+	// DeleteVariableWithResponse Delete a variable
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with DELETE /api/v2/variables/{variable_key} (the `DeleteVariable` operationId).
+	DeleteVariableWithResponse(ctx context.Context, variableKey VariableKey, reqEditors ...RequestEditorFn) (*DeleteVariableResponse, error)
+
+	// GetVariableWithResponse Get a variable
+	//
+	// Returns a wrapper object for the known response body format(s).
+	//
+	// Corresponds with GET /api/v2/variables/{variable_key} (the `GetVariable` operationId).
+	GetVariableWithResponse(ctx context.Context, variableKey VariableKey, reqEditors ...RequestEditorFn) (*GetVariableResponse, error)
+
 	// GetVersionWithResponse Control-plane version (Airflow VersionInfo shape)
 	//
 	// Returns a wrapper object for the known response body format(s).
@@ -2505,6 +3394,288 @@ func (r RenewTokenResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r RenewTokenResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type ListConnectionsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *ConnectionCollection
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *Unauthorized
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r ListConnectionsResponse) GetJSON200() *ConnectionCollection {
+	return r.JSON200
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r ListConnectionsResponse) GetJSON401() *Unauthorized {
+	return r.JSON401
+}
+
+// GetBody returns the raw response body bytes
+func (r ListConnectionsResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r ListConnectionsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListConnectionsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListConnectionsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CreateConnectionResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON201 the response for an HTTP 201 `application/json` response
+	JSON201 *Connection
+	// JSON400 the response for an HTTP 400 `application/json` response
+	JSON400 *Error
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *Unauthorized
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *EncryptionUnavailable
+}
+
+// GetJSON201 returns the response for an HTTP 201 `application/json` response
+func (r CreateConnectionResponse) GetJSON201() *Connection {
+	return r.JSON201
+}
+
+// GetJSON400 returns the response for an HTTP 400 `application/json` response
+func (r CreateConnectionResponse) GetJSON400() *Error {
+	return r.JSON400
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r CreateConnectionResponse) GetJSON401() *Unauthorized {
+	return r.JSON401
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r CreateConnectionResponse) GetJSON503() *EncryptionUnavailable {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r CreateConnectionResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateConnectionResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateConnectionResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CreateConnectionResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteConnectionResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *Unauthorized
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFound
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r DeleteConnectionResponse) GetJSON401() *Unauthorized {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r DeleteConnectionResponse) GetJSON404() *NotFound {
+	return r.JSON404
+}
+
+// GetBody returns the raw response body bytes
+func (r DeleteConnectionResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteConnectionResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteConnectionResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteConnectionResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetConnectionResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *Connection
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *Unauthorized
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFound
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r GetConnectionResponse) GetJSON200() *Connection {
+	return r.JSON200
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r GetConnectionResponse) GetJSON401() *Unauthorized {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r GetConnectionResponse) GetJSON404() *NotFound {
+	return r.JSON404
+}
+
+// GetBody returns the raw response body bytes
+func (r GetConnectionResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r GetConnectionResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetConnectionResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetConnectionResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type UpdateConnectionResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *Connection
+	// JSON400 the response for an HTTP 400 `application/json` response
+	JSON400 *Error
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *Unauthorized
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFound
+	// JSON503 the response for an HTTP 503 `application/json` response
+	JSON503 *EncryptionUnavailable
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r UpdateConnectionResponse) GetJSON200() *Connection {
+	return r.JSON200
+}
+
+// GetJSON400 returns the response for an HTTP 400 `application/json` response
+func (r UpdateConnectionResponse) GetJSON400() *Error {
+	return r.JSON400
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r UpdateConnectionResponse) GetJSON401() *Unauthorized {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r UpdateConnectionResponse) GetJSON404() *NotFound {
+	return r.JSON404
+}
+
+// GetJSON503 returns the response for an HTTP 503 `application/json` response
+func (r UpdateConnectionResponse) GetJSON503() *EncryptionUnavailable {
+	return r.JSON503
+}
+
+// GetBody returns the raw response body bytes
+func (r UpdateConnectionResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r UpdateConnectionResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UpdateConnectionResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r UpdateConnectionResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -3305,6 +4476,212 @@ func (r CreateUserResponse) ContentType() string {
 	return ""
 }
 
+type ListVariablesResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *VariableCollection
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *Unauthorized
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r ListVariablesResponse) GetJSON200() *VariableCollection {
+	return r.JSON200
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r ListVariablesResponse) GetJSON401() *Unauthorized {
+	return r.JSON401
+}
+
+// GetBody returns the raw response body bytes
+func (r ListVariablesResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r ListVariablesResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListVariablesResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r ListVariablesResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type CreateVariableResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON201 the response for an HTTP 201 `application/json` response
+	JSON201 *Variable
+	// JSON400 the response for an HTTP 400 `application/json` response
+	JSON400 *Error
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *Unauthorized
+}
+
+// GetJSON201 returns the response for an HTTP 201 `application/json` response
+func (r CreateVariableResponse) GetJSON201() *Variable {
+	return r.JSON201
+}
+
+// GetJSON400 returns the response for an HTTP 400 `application/json` response
+func (r CreateVariableResponse) GetJSON400() *Error {
+	return r.JSON400
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r CreateVariableResponse) GetJSON401() *Unauthorized {
+	return r.JSON401
+}
+
+// GetBody returns the raw response body bytes
+func (r CreateVariableResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateVariableResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateVariableResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r CreateVariableResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type DeleteVariableResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *Unauthorized
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFound
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r DeleteVariableResponse) GetJSON401() *Unauthorized {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r DeleteVariableResponse) GetJSON404() *NotFound {
+	return r.JSON404
+}
+
+// GetBody returns the raw response body bytes
+func (r DeleteVariableResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteVariableResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteVariableResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r DeleteVariableResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetVariableResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	// JSON200 the response for an HTTP 200 `application/json` response
+	JSON200 *Variable
+	// JSON401 the response for an HTTP 401 `application/json` response
+	JSON401 *Unauthorized
+	// JSON404 the response for an HTTP 404 `application/json` response
+	JSON404 *NotFound
+}
+
+// GetJSON200 returns the response for an HTTP 200 `application/json` response
+func (r GetVariableResponse) GetJSON200() *Variable {
+	return r.JSON200
+}
+
+// GetJSON401 returns the response for an HTTP 401 `application/json` response
+func (r GetVariableResponse) GetJSON401() *Unauthorized {
+	return r.JSON401
+}
+
+// GetJSON404 returns the response for an HTTP 404 `application/json` response
+func (r GetVariableResponse) GetJSON404() *NotFound {
+	return r.JSON404
+}
+
+// GetBody returns the raw response body bytes
+func (r GetVariableResponse) GetBody() []byte {
+	return r.Body
+}
+
+// Status returns HTTPResponse.Status
+func (r GetVariableResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetVariableResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetVariableResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
 type GetVersionResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -3523,6 +4900,109 @@ func (c *ClientWithResponses) RenewTokenWithResponse(ctx context.Context, reqEdi
 		return nil, err
 	}
 	return ParseRenewTokenResponse(rsp)
+}
+
+// ListConnectionsWithResponse List connections
+//
+// Lists the tenant's Airflow-style connections. Passwords are write-only and
+// never returned; secret-bearing keys inside `extra` are masked server-side.
+// Requires the read:connection permission.
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with GET /api/v2/connections (the `ListConnections` operationId).
+func (c *ClientWithResponses) ListConnectionsWithResponse(ctx context.Context, params *ListConnectionsParams, reqEditors ...RequestEditorFn) (*ListConnectionsResponse, error) {
+	rsp, err := c.ListConnections(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListConnectionsResponse(rsp)
+}
+
+// CreateConnectionWithBodyWithResponse Create or replace a connection (upsert)
+//
+// Upserts a connection: creates it, or replaces an existing one with the same
+// connection_id. The password is write-only and never returned. Requires the
+// write:connection permission and a configured encryption key.
+//
+// Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
+//
+// Corresponds with POST /api/v2/connections (the `CreateConnection` operationId).
+func (c *ClientWithResponses) CreateConnectionWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateConnectionResponse, error) {
+	rsp, err := c.CreateConnectionWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateConnectionResponse(rsp)
+}
+
+// CreateConnectionWithResponse Create or replace a connection (upsert)
+//
+// Upserts a connection: creates it, or replaces an existing one with the same
+// connection_id. The password is write-only and never returned. Requires the
+// write:connection permission and a configured encryption key.
+//
+// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+//
+// Corresponds with POST /api/v2/connections (the `CreateConnection` operationId).
+func (c *ClientWithResponses) CreateConnectionWithResponse(ctx context.Context, body CreateConnectionJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateConnectionResponse, error) {
+	rsp, err := c.CreateConnection(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateConnectionResponse(rsp)
+}
+
+// DeleteConnectionWithResponse Delete a connection
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with DELETE /api/v2/connections/{connection_id} (the `DeleteConnection` operationId).
+func (c *ClientWithResponses) DeleteConnectionWithResponse(ctx context.Context, connectionId ConnectionID, reqEditors ...RequestEditorFn) (*DeleteConnectionResponse, error) {
+	rsp, err := c.DeleteConnection(ctx, connectionId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteConnectionResponse(rsp)
+}
+
+// GetConnectionWithResponse Get a connection
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with GET /api/v2/connections/{connection_id} (the `GetConnection` operationId).
+func (c *ClientWithResponses) GetConnectionWithResponse(ctx context.Context, connectionId ConnectionID, reqEditors ...RequestEditorFn) (*GetConnectionResponse, error) {
+	rsp, err := c.GetConnection(ctx, connectionId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetConnectionResponse(rsp)
+}
+
+// UpdateConnectionWithBodyWithResponse Update a connection
+//
+// Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
+//
+// Corresponds with PATCH /api/v2/connections/{connection_id} (the `UpdateConnection` operationId).
+func (c *ClientWithResponses) UpdateConnectionWithBodyWithResponse(ctx context.Context, connectionId ConnectionID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateConnectionResponse, error) {
+	rsp, err := c.UpdateConnectionWithBody(ctx, connectionId, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateConnectionResponse(rsp)
+}
+
+// UpdateConnectionWithResponse Update a connection
+//
+// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+//
+// Corresponds with PATCH /api/v2/connections/{connection_id} (the `UpdateConnection` operationId).
+func (c *ClientWithResponses) UpdateConnectionWithResponse(ctx context.Context, connectionId ConnectionID, body UpdateConnectionJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateConnectionResponse, error) {
+	rsp, err := c.UpdateConnection(ctx, connectionId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUpdateConnectionResponse(rsp)
 }
 
 // GetDagSourceWithResponse Get a DAG's source (the dag.py text)
@@ -3823,6 +5303,80 @@ func (c *ClientWithResponses) CreateUserWithResponse(ctx context.Context, body C
 	return ParseCreateUserResponse(rsp)
 }
 
+// ListVariablesWithResponse List variables
+//
+// Lists the tenant's Airflow-style variables. Values of secret-ish keys are
+// masked server-side. Requires the read:variable permission.
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with GET /api/v2/variables (the `ListVariables` operationId).
+func (c *ClientWithResponses) ListVariablesWithResponse(ctx context.Context, params *ListVariablesParams, reqEditors ...RequestEditorFn) (*ListVariablesResponse, error) {
+	rsp, err := c.ListVariables(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListVariablesResponse(rsp)
+}
+
+// CreateVariableWithBodyWithResponse Create or replace a variable (upsert)
+//
+// Upserts a variable: creates it, or replaces an existing one with the same
+// key. Requires the write:variable permission.
+//
+// Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
+//
+// Corresponds with POST /api/v2/variables (the `CreateVariable` operationId).
+func (c *ClientWithResponses) CreateVariableWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateVariableResponse, error) {
+	rsp, err := c.CreateVariableWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateVariableResponse(rsp)
+}
+
+// CreateVariableWithResponse Create or replace a variable (upsert)
+//
+// Upserts a variable: creates it, or replaces an existing one with the same
+// key. Requires the write:variable permission.
+//
+// Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+//
+// Corresponds with POST /api/v2/variables (the `CreateVariable` operationId).
+func (c *ClientWithResponses) CreateVariableWithResponse(ctx context.Context, body CreateVariableJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateVariableResponse, error) {
+	rsp, err := c.CreateVariable(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateVariableResponse(rsp)
+}
+
+// DeleteVariableWithResponse Delete a variable
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with DELETE /api/v2/variables/{variable_key} (the `DeleteVariable` operationId).
+func (c *ClientWithResponses) DeleteVariableWithResponse(ctx context.Context, variableKey VariableKey, reqEditors ...RequestEditorFn) (*DeleteVariableResponse, error) {
+	rsp, err := c.DeleteVariable(ctx, variableKey, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteVariableResponse(rsp)
+}
+
+// GetVariableWithResponse Get a variable
+//
+// Returns a wrapper object for the known response body format(s).
+//
+// Corresponds with GET /api/v2/variables/{variable_key} (the `GetVariable` operationId).
+func (c *ClientWithResponses) GetVariableWithResponse(ctx context.Context, variableKey VariableKey, reqEditors ...RequestEditorFn) (*GetVariableResponse, error) {
+	rsp, err := c.GetVariable(ctx, variableKey, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetVariableResponse(rsp)
+}
+
 // GetVersionWithResponse Control-plane version (Airflow VersionInfo shape)
 //
 // Returns a wrapper object for the known response body format(s).
@@ -3928,6 +5482,216 @@ func ParseRenewTokenResponse(rsp *http.Response) (*RenewTokenResponse, error) {
 			return nil, err
 		}
 		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListConnectionsResponse parses an HTTP response from a ListConnectionsWithResponse call
+func ParseListConnectionsResponse(rsp *http.Response) (*ListConnectionsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListConnectionsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ConnectionCollection
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateConnectionResponse parses an HTTP response from a CreateConnectionWithResponse call
+func ParseCreateConnectionResponse(rsp *http.Response) (*CreateConnectionResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateConnectionResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest Connection
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest EncryptionUnavailable
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteConnectionResponse parses an HTTP response from a DeleteConnectionWithResponse call
+func ParseDeleteConnectionResponse(rsp *http.Response) (*DeleteConnectionResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteConnectionResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.StatusCode == 204:
+		break // No content-type
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetConnectionResponse parses an HTTP response from a GetConnectionWithResponse call
+func ParseGetConnectionResponse(rsp *http.Response) (*GetConnectionResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetConnectionResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Connection
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUpdateConnectionResponse parses an HTTP response from a UpdateConnectionWithResponse call
+func ParseUpdateConnectionResponse(rsp *http.Response) (*UpdateConnectionResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UpdateConnectionResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Connection
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 503:
+		var dest EncryptionUnavailable
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON503 = &dest
 
 	}
 
@@ -4449,6 +6213,155 @@ func ParseCreateUserResponse(rsp *http.Response) (*CreateUserResponse, error) {
 			return nil, err
 		}
 		response.JSON409 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListVariablesResponse parses an HTTP response from a ListVariablesWithResponse call
+func ParseListVariablesResponse(rsp *http.Response) (*ListVariablesResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListVariablesResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest VariableCollection
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateVariableResponse parses an HTTP response from a CreateVariableWithResponse call
+func ParseCreateVariableResponse(rsp *http.Response) (*CreateVariableResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateVariableResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest Variable
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest Error
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteVariableResponse parses an HTTP response from a DeleteVariableWithResponse call
+func ParseDeleteVariableResponse(rsp *http.Response) (*DeleteVariableResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteVariableResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case rsp.StatusCode == 204:
+		break // No content-type
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetVariableResponse parses an HTTP response from a GetVariableWithResponse call
+func ParseGetVariableResponse(rsp *http.Response) (*GetVariableResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetVariableResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Variable
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
 
 	}
 

--- a/test/e2e/lite-connections.sh
+++ b/test/e2e/lite-connections.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# End-to-end gate for the `leoflow connections` and `leoflow variables` CLI groups
+# (#881) on the LITE edition (no-auth loopback). The unit tests prove the flag ->
+# request mapping against an httptest server; what they cannot prove is the CLI
+# talking to the REAL control plane and — the load-bearing claim — that the same
+# masking the embedded Airflow Admin UI relies on is applied to what the CLI and
+# a raw curl see. So this:
+#   1. `connections set` a connection carrying a secret in BOTH --password and
+#      --extra (a token),
+#   2. asserts `connections get`/`list` never print either secret,
+#   3. curls the SAME GET /api/v2/connections/<id> the UI reads and asserts the
+#      response masks the extra token and omits the password — the CLI<->UI-data
+#      integration proof,
+#   4. runs the same round-trip for `variables set/get/list/delete` and
+#      `connections delete`,
+#   5. cleans up every planted connection/variable before exit.
+#
+# Needs a local Postgres (docker-compose.dev.yaml). Run from the repo root:
+#   bash test/e2e/lite-connections.sh
+set -euo pipefail
+
+PORT=18097
+DB_URL="${LEOFLOW_E2E_DB_URL:-postgres://leoflow:leoflow@localhost:5432/leoflow_dev?sslmode=disable}"
+BASE="http://127.0.0.1:${PORT}"
+CONN_ID="e2e_pg"
+VAR_PLAIN="e2e_region"
+VAR_SECRET="e2e_api_token"
+# Distinctive sentinels: if either appears in CLI output or a curl body, a secret
+# leaked. They must never be echoed anywhere.
+PW_SENTINEL="PWSENTINEL_do_not_leak_2f9c"
+EXTRA_SENTINEL="EXTRASECRET_do_not_leak_7b1a"
+VALUE_SENTINEL="VARSECRET_do_not_leak_c3d5"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP="$(mktemp -d)"
+WS="$TMP/ws"
+LITE_PID=""
+CLEANED=""
+pass() { printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+fail() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; [ -n "${2:-}" ] && tail -60 "$2"; exit 1; }
+
+# plant_cleanup best-effort deletes everything this script created, so a failed
+# run never ambushes the operator's next real action with leftover test data.
+plant_cleanup() {
+  [ -n "$CLEANED" ] && return 0
+  CLEANED=1
+  if [ -n "$LITE_PID" ] && kill -0 "$LITE_PID" 2>/dev/null; then
+    "$TMP/leoflow" connections delete "$CONN_ID" --server "$BASE" >/dev/null 2>&1 || true
+    "$TMP/leoflow" variables delete "$VAR_PLAIN" --server "$BASE" >/dev/null 2>&1 || true
+    "$TMP/leoflow" variables delete "$VAR_SECRET" --server "$BASE" >/dev/null 2>&1 || true
+  fi
+}
+cleanup() {
+  plant_cleanup
+  [ -n "$LITE_PID" ] && kill "$LITE_PID" 2>/dev/null || true
+  chmod -R u+w "$TMP" 2>/dev/null || true
+  rm -rf "$TMP"
+}
+trap cleanup EXIT
+
+# Isolate HOME so Lite runs no-auth loopback with a clean config.
+export HOME="$TMP/home"; mkdir -p "$HOME" "$WS"
+export LEOFLOW_DATABASE_URL="$DB_URL"
+export LEOFLOW_LOGS_DIR="$TMP/logs"
+# leoflow lite spawns the parser via `python3 -m leoflow_parser`; put it on PYTHONPATH.
+export PYTHONPATH="${PYTHONPATH:-$ROOT/parser}"
+
+echo "==> building binaries"
+go build -o "$TMP/leoflow" ./cmd/leoflow
+go build -o "$TMP/leoflow-server" ./cmd/leoflow-server
+go build -o "$TMP/leoflow-agent" ./cmd/leoflow-agent
+export PATH="$TMP:$PATH"
+
+echo "==> resetting the database"
+"$TMP/leoflow" db reset --yes >/dev/null
+
+echo "==> booting Lite (subprocess executor, no-auth loopback)"
+"$TMP/leoflow" lite --no-up --executor subprocess --port "$PORT" "$WS" >"$TMP/lite.log" 2>&1 &
+LITE_PID=$!
+disown "$LITE_PID" 2>/dev/null || true
+ready=""
+for _ in $(seq 1 "${LITE_READY_TRIES:-600}"); do
+  curl -fsS "${BASE}/readyz" >/dev/null 2>&1 && { ready=1; break; }
+  kill -0 "$LITE_PID" 2>/dev/null || fail "Lite exited early" "$TMP/lite.log"
+  sleep 1
+done
+[ -n "$ready" ] || fail "Lite did not become ready" "$TMP/lite.log"
+pass "Lite control plane is ready"
+
+CLI=("$TMP/leoflow")
+srv=(--server "$BASE")
+
+# ---------------------------------------------------------------------------
+echo "==> connections set (with a secret in --password AND --extra)"
+"${CLI[@]}" connections set "$CONN_ID" "${srv[@]}" \
+  --conn-type postgres --host db.internal --login analytics \
+  --schema public --port 5432 \
+  --password "$PW_SENTINEL" \
+  --extra "{\"token\":\"${EXTRA_SENTINEL}\"}" >"$TMP/set.out" 2>&1 \
+  || fail "connections set failed" "$TMP/set.out"
+grep -q "$CONN_ID" "$TMP/set.out" || fail "set output did not name the connection" "$TMP/set.out"
+grep -q "$PW_SENTINEL" "$TMP/set.out" && fail "set output LEAKED the password" "$TMP/set.out"
+grep -q "$EXTRA_SENTINEL" "$TMP/set.out" && fail "set output LEAKED the extra secret" "$TMP/set.out"
+pass "connections set upserted ${CONN_ID} and printed no secret"
+
+echo "==> connections get / list never print secrets"
+"${CLI[@]}" connections get "$CONN_ID" "${srv[@]}" >"$TMP/get.out" 2>&1 \
+  || fail "connections get failed" "$TMP/get.out"
+grep -q "$CONN_ID" "$TMP/get.out" || fail "get did not show the connection" "$TMP/get.out"
+grep -q "$PW_SENTINEL" "$TMP/get.out" && fail "get LEAKED the password" "$TMP/get.out"
+grep -q "$EXTRA_SENTINEL" "$TMP/get.out" && fail "get LEAKED the extra secret" "$TMP/get.out"
+"${CLI[@]}" connections list "${srv[@]}" >"$TMP/list.out" 2>&1 \
+  || fail "connections list failed" "$TMP/list.out"
+grep -q "$CONN_ID" "$TMP/list.out" || fail "list did not include the connection" "$TMP/list.out"
+grep -q "$PW_SENTINEL" "$TMP/list.out" && fail "list LEAKED the password" "$TMP/list.out"
+grep -q "$EXTRA_SENTINEL" "$TMP/list.out" && fail "list LEAKED the extra secret" "$TMP/list.out"
+pass "connections get/list show the connection with secrets masked"
+
+echo "==> curl the SAME endpoint the embedded Airflow UI reads (masking proof)"
+curl -fsS "${BASE}/api/v2/connections/${CONN_ID}" >"$TMP/ui.json" \
+  || fail "curl GET /api/v2/connections/${CONN_ID} failed" "$TMP/lite.log"
+grep -q "$PW_SENTINEL" "$TMP/ui.json" && fail "UI endpoint returned the password" "$TMP/ui.json"
+grep -q "$EXTRA_SENTINEL" "$TMP/ui.json" && fail "UI endpoint returned the raw extra secret" "$TMP/ui.json"
+# The extra's token key is present but masked to *** (Airflow-style redaction).
+grep -q '\*\*\*' "$TMP/ui.json" || fail "UI endpoint did not mask the extra token" "$TMP/ui.json"
+# password must be entirely absent from the JSON (write-only).
+python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if "password" not in d else 1)' "$TMP/ui.json" \
+  || fail "UI endpoint response contained a password field" "$TMP/ui.json"
+pass "UI-data endpoint masks extra and omits password (CLI<->UI integration proof)"
+
+# ---------------------------------------------------------------------------
+echo "==> variables set (plain + a secret-keyed one) via positional and --value-stdin"
+"${CLI[@]}" variables set "$VAR_PLAIN" us-east-1 "${srv[@]}" --description "default region" >"$TMP/vset.out" 2>&1 \
+  || fail "variables set (plain) failed" "$TMP/vset.out"
+grep -q "$VAR_PLAIN" "$TMP/vset.out" || fail "variables set did not name the key" "$TMP/vset.out"
+printf '%s\n' "$VALUE_SENTINEL" | "${CLI[@]}" variables set "$VAR_SECRET" "${srv[@]}" --value-stdin >"$TMP/vset2.out" 2>&1 \
+  || fail "variables set (--value-stdin) failed" "$TMP/vset2.out"
+grep -q "$VALUE_SENTINEL" "$TMP/vset2.out" && fail "variables set LEAKED the stdin value" "$TMP/vset2.out"
+pass "variables set upserted both keys; the stdin value was not echoed"
+
+echo "==> variables get / list mask the secret-keyed value"
+"${CLI[@]}" variables get "$VAR_PLAIN" "${srv[@]}" >"$TMP/vget.out" 2>&1 \
+  || fail "variables get (plain) failed" "$TMP/vget.out"
+grep -q "us-east-1" "$TMP/vget.out" || fail "plain variable value not shown" "$TMP/vget.out"
+"${CLI[@]}" variables get "$VAR_SECRET" "${srv[@]}" >"$TMP/vget2.out" 2>&1 \
+  || fail "variables get (secret) failed" "$TMP/vget2.out"
+grep -q "$VALUE_SENTINEL" "$TMP/vget2.out" && fail "variables get LEAKED the secret value" "$TMP/vget2.out"
+"${CLI[@]}" variables list "${srv[@]}" >"$TMP/vlist.out" 2>&1 \
+  || fail "variables list failed" "$TMP/vlist.out"
+grep -q "$VAR_PLAIN" "$TMP/vlist.out" || fail "variables list missing the plain key" "$TMP/vlist.out"
+grep -q "$VAR_SECRET" "$TMP/vlist.out" || fail "variables list missing the secret key" "$TMP/vlist.out"
+grep -q "$VALUE_SENTINEL" "$TMP/vlist.out" && fail "variables list LEAKED the secret value" "$TMP/vlist.out"
+pass "variables get/list show keys; the secret-keyed value stays masked"
+
+echo "==> curl the SAME variables endpoint the UI reads (masking proof)"
+curl -fsS "${BASE}/api/v2/variables/${VAR_SECRET}" >"$TMP/uv.json" \
+  || fail "curl GET /api/v2/variables/${VAR_SECRET} failed" "$TMP/lite.log"
+grep -q "$VALUE_SENTINEL" "$TMP/uv.json" && fail "UI variables endpoint returned the raw secret value" "$TMP/uv.json"
+grep -q '\*\*\*' "$TMP/uv.json" || fail "UI variables endpoint did not mask the secret value" "$TMP/uv.json"
+pass "UI-data variables endpoint masks the secret-keyed value"
+
+# ---------------------------------------------------------------------------
+echo "==> delete round-trip (variables + connection) and confirm they are gone"
+"${CLI[@]}" variables delete "$VAR_PLAIN" "${srv[@]}" >/dev/null 2>&1 || fail "variables delete (plain) failed"
+"${CLI[@]}" variables delete "$VAR_SECRET" "${srv[@]}" >/dev/null 2>&1 || fail "variables delete (secret) failed"
+"${CLI[@]}" connections delete "$CONN_ID" "${srv[@]}" >/dev/null 2>&1 || fail "connections delete failed"
+# A follow-up get must now fail (deleted).
+"${CLI[@]}" connections get "$CONN_ID" "${srv[@]}" >/dev/null 2>&1 && fail "connection still present after delete"
+code="$(curl -s -o /dev/null -w '%{http_code}' "${BASE}/api/v2/variables/${VAR_SECRET}")"
+[ "$code" = "404" ] || fail "deleted variable returned $code (want 404)"
+CLEANED=1  # everything already removed
+pass "connections/variables delete removed every planted record"
+
+echo
+echo "  ✅ leoflow connections + variables verified end to end: CLI upsert/list/get/delete,"
+echo "     secrets never printed, and the UI-data endpoints mask extra/value and omit password."

--- a/test/e2e/lite-connections.sh
+++ b/test/e2e/lite-connections.sh
@@ -127,6 +127,19 @@ python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if "pass
   || fail "UI endpoint response contained a password field" "$TMP/ui.json"
 pass "UI-data endpoint masks extra and omits password (CLI<->UI integration proof)"
 
+echo "==> partial set (change only --host) must PRESERVE the omitted secret extra"
+"${CLI[@]}" connections set "$CONN_ID" "${srv[@]}" \
+  --conn-type postgres --host db.internal2 >"$TMP/partial.out" 2>&1 \
+  || fail "partial connections set failed" "$TMP/partial.out"
+curl -fsS "${BASE}/api/v2/connections/${CONN_ID}" >"$TMP/ui2.json" \
+  || fail "curl after partial set failed" "$TMP/lite.log"
+# The host changed; the extra we did NOT pass must still be there (masked), not
+# wiped. Before the COALESCE upsert this partial write nulled the extra + password.
+python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if d.get("host")=="db.internal2" else 1)' "$TMP/ui2.json" \
+  || fail "partial set did not update the host" "$TMP/ui2.json"
+grep -q '\*\*\*' "$TMP/ui2.json" || fail "partial set WIPED the omitted extra (no masked value remains)" "$TMP/ui2.json"
+pass "partial set changed the host and preserved the omitted extra (safe merge)"
+
 # ---------------------------------------------------------------------------
 echo "==> variables set (plain + a secret-keyed one) via positional and --value-stdin"
 "${CLI[@]}" variables set "$VAR_PLAIN" us-east-1 "${srv[@]}" --description "default region" >"$TMP/vset.out" 2>&1 \

--- a/website/content/reference/cli/leoflow.md
+++ b/website/content/reference/cli/leoflow.md
@@ -25,6 +25,7 @@ Leoflow is a GitOps-first, container-native workflow orchestrator.
 * [leoflow auth](/reference/cli/leoflow_auth/)	 - Manage authentication tokens.
 * [leoflow compile](/reference/cli/leoflow_compile/)	 - Compile a DAG project into dag.json via the Python parser.
 * [leoflow completion](/reference/cli/leoflow_completion/)	 - Generate the autocompletion script for the specified shell
+* [leoflow connections](/reference/cli/leoflow_connections/)	 - Manage control-plane connections.
 * [leoflow dags](/reference/cli/leoflow_dags/)	 - Manage registered DAGs.
 * [leoflow db](/reference/cli/leoflow_db/)	 - Manage the local Lite database (schema name leoflow_dev for upgrade safety).
 * [leoflow deploy](/reference/cli/leoflow_deploy/)	 - Build, push, and register a DAG to a control plane (Pro).
@@ -37,5 +38,6 @@ Leoflow is a GitOps-first, container-native workflow orchestrator.
 * [leoflow setup](/reference/cli/leoflow_setup/)	 - Bootstrap the managed Leoflow runtime (Python, parser, workspace).
 * [leoflow uninstall](/reference/cli/leoflow_uninstall/)	 - Remove the Leoflow installation (~/.leoflow).
 * [leoflow validate](/reference/cli/leoflow_validate/)	 - Validate leoflow.yaml and the DAG source against the schema.
+* [leoflow variables](/reference/cli/leoflow_variables/)	 - Manage control-plane variables.
 * [leoflow version](/reference/cli/leoflow_version/)	 - Print the version, git commit, and build date.
 

--- a/website/content/reference/cli/leoflow_auth_create-token.md
+++ b/website/content/reference/cli/leoflow_auth_create-token.md
@@ -19,6 +19,7 @@ leoflow auth create-token [flags]
 ```
   -h, --help              help for create-token
       --password string   password
+      --password-stdin    read the password from stdin instead of --password (avoids ps/shell-history exposure)
       --server string     control plane base URL (default: config server_url)
       --username string   username
 ```

--- a/website/content/reference/cli/leoflow_auth_create-user.md
+++ b/website/content/reference/cli/leoflow_auth_create-user.md
@@ -20,6 +20,7 @@ leoflow auth create-user [flags]
       --email string       email of the user to create
   -h, --help               help for create-user
       --password string    password for the new user
+      --password-stdin     read the password from stdin instead of --password (avoids ps/shell-history exposure)
       --role stringArray   existing role to grant (repeatable); empty grants none
       --server string      control plane base URL (default: config server_url)
       --token string       admin JWT bearer token (default: config token)

--- a/website/content/reference/cli/leoflow_auth_login.md
+++ b/website/content/reference/cli/leoflow_auth_login.md
@@ -19,6 +19,7 @@ leoflow auth login [flags]
 ```
   -h, --help              help for login
       --password string   password
+      --password-stdin    read the password from stdin instead of --password (avoids ps/shell-history exposure)
       --server string     control plane base URL (default: config server_url)
       --username string   username
 ```

--- a/website/content/reference/cli/leoflow_connections.md
+++ b/website/content/reference/cli/leoflow_connections.md
@@ -1,0 +1,34 @@
+---
+# --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
+aliases:
+  - /cli/leoflow_connections.html
+# --- end AUTO redirect aliases ---
+title: "leoflow connections"
+linkTitle: "connections"
+weight: 22
+---
+
+Manage control-plane connections.
+
+### Options
+
+```
+  -h, --help   help for connections
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file path (default ~/.leoflow/config.yaml)
+      --log-level string    log level: debug, info, warn, error
+      --server-url string   control plane API base URL
+```
+
+### SEE ALSO
+
+* [leoflow](/reference/cli/leoflow/)	 - Leoflow is a GitOps-first, container-native workflow orchestrator.
+* [leoflow connections delete](/reference/cli/leoflow_connections_delete/)	 - Delete a connection.
+* [leoflow connections get](/reference/cli/leoflow_connections_get/)	 - Show a connection (password omitted, extra masked).
+* [leoflow connections list](/reference/cli/leoflow_connections_list/)	 - List connections (secrets never shown).
+* [leoflow connections set](/reference/cli/leoflow_connections_set/)	 - Create or replace a connection (upsert).
+

--- a/website/content/reference/cli/leoflow_connections.md
+++ b/website/content/reference/cli/leoflow_connections.md
@@ -30,5 +30,5 @@ Manage control-plane connections.
 * [leoflow connections delete](/reference/cli/leoflow_connections_delete/)	 - Delete a connection.
 * [leoflow connections get](/reference/cli/leoflow_connections_get/)	 - Show a connection (password omitted, extra masked).
 * [leoflow connections list](/reference/cli/leoflow_connections_list/)	 - List connections (secrets never shown).
-* [leoflow connections set](/reference/cli/leoflow_connections_set/)	 - Create or replace a connection (upsert).
+* [leoflow connections set](/reference/cli/leoflow_connections_set/)	 - Create or update a connection (upsert).
 

--- a/website/content/reference/cli/leoflow_connections_delete.md
+++ b/website/content/reference/cli/leoflow_connections_delete.md
@@ -1,24 +1,23 @@
 ---
 # --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
 aliases:
-  - /cli/leoflow_runs_status.html
+  - /cli/leoflow_connections_delete.html
 # --- end AUTO redirect aliases ---
-title: "leoflow runs status"
-linkTitle: "runs status"
-weight: 46
+title: "leoflow connections delete"
+linkTitle: "connections delete"
+weight: 23
 ---
 
-Show the state of a DAG run (the latest by default).
+Delete a connection.
 
 ```
-leoflow runs status <dag_id> [flags]
+leoflow connections delete <connection_id> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help            help for status
-      --run string      specific dag_run_id (default: the most recent run)
+  -h, --help            help for delete
       --server string   control plane base URL (default: config server_url)
       --token string    JWT bearer token (default: config token)
 ```
@@ -33,5 +32,5 @@ leoflow runs status <dag_id> [flags]
 
 ### SEE ALSO
 
-* [leoflow runs](/reference/cli/leoflow_runs/)	 - Trigger and inspect DAG runs.
+* [leoflow connections](/reference/cli/leoflow_connections/)	 - Manage control-plane connections.
 

--- a/website/content/reference/cli/leoflow_connections_get.md
+++ b/website/content/reference/cli/leoflow_connections_get.md
@@ -1,24 +1,23 @@
 ---
 # --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
 aliases:
-  - /cli/leoflow_runs_status.html
+  - /cli/leoflow_connections_get.html
 # --- end AUTO redirect aliases ---
-title: "leoflow runs status"
-linkTitle: "runs status"
-weight: 46
+title: "leoflow connections get"
+linkTitle: "connections get"
+weight: 24
 ---
 
-Show the state of a DAG run (the latest by default).
+Show a connection (password omitted, extra masked).
 
 ```
-leoflow runs status <dag_id> [flags]
+leoflow connections get <connection_id> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help            help for status
-      --run string      specific dag_run_id (default: the most recent run)
+  -h, --help            help for get
       --server string   control plane base URL (default: config server_url)
       --token string    JWT bearer token (default: config token)
 ```
@@ -33,5 +32,5 @@ leoflow runs status <dag_id> [flags]
 
 ### SEE ALSO
 
-* [leoflow runs](/reference/cli/leoflow_runs/)	 - Trigger and inspect DAG runs.
+* [leoflow connections](/reference/cli/leoflow_connections/)	 - Manage control-plane connections.
 

--- a/website/content/reference/cli/leoflow_connections_list.md
+++ b/website/content/reference/cli/leoflow_connections_list.md
@@ -1,24 +1,23 @@
 ---
 # --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
 aliases:
-  - /cli/leoflow_runs_status.html
+  - /cli/leoflow_connections_list.html
 # --- end AUTO redirect aliases ---
-title: "leoflow runs status"
-linkTitle: "runs status"
-weight: 46
+title: "leoflow connections list"
+linkTitle: "connections list"
+weight: 25
 ---
 
-Show the state of a DAG run (the latest by default).
+List connections (secrets never shown).
 
 ```
-leoflow runs status <dag_id> [flags]
+leoflow connections list [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help            help for status
-      --run string      specific dag_run_id (default: the most recent run)
+  -h, --help            help for list
       --server string   control plane base URL (default: config server_url)
       --token string    JWT bearer token (default: config token)
 ```
@@ -33,5 +32,5 @@ leoflow runs status <dag_id> [flags]
 
 ### SEE ALSO
 
-* [leoflow runs](/reference/cli/leoflow_runs/)	 - Trigger and inspect DAG runs.
+* [leoflow connections](/reference/cli/leoflow_connections/)	 - Manage control-plane connections.
 

--- a/website/content/reference/cli/leoflow_connections_set.md
+++ b/website/content/reference/cli/leoflow_connections_set.md
@@ -8,13 +8,13 @@ linkTitle: "connections set"
 weight: 26
 ---
 
-Create or replace a connection (upsert).
+Create or update a connection (upsert).
 
 ### Synopsis
 
-Creates a connection, or replaces an existing one with the same id. --conn-type is required.
+Creates a connection, or updates an existing one with the same id. --conn-type is required.
 
-This is a full replace, not a partial patch: the connection is set to exactly the fields you pass, so any field you omit is cleared on an existing connection — including the password. To change one field, pass the others too (the password cannot be read back, so re-supply it).
+Only the fields you pass are changed; any field you omit keeps its current value. So you can change just --host without re-supplying the password (which cannot be read back anyway). To clear a field, delete and recreate the connection.
 
 The password and extra are sent to the control plane but never printed back; read commands show masked values. Prefer --password-stdin / --extra-file over --password / --extra so a secret never lands in your shell history or the process table.
 

--- a/website/content/reference/cli/leoflow_connections_set.md
+++ b/website/content/reference/cli/leoflow_connections_set.md
@@ -34,7 +34,7 @@ leoflow connections set <connection_id> [flags]
       --login string         connection login/username
       --password string      connection password (prefer --password-stdin)
       --password-stdin       read the password from stdin instead of --password (avoids ps/shell-history exposure)
-      --port int             connection port (0 leaves it unset)
+      --port int             connection port (omit to keep the stored value; an explicit value, including 0, overwrites it)
       --schema string        connection schema/database
       --server string        control plane base URL (default: config server_url)
       --token string         JWT bearer token (default: config token)

--- a/website/content/reference/cli/leoflow_connections_set.md
+++ b/website/content/reference/cli/leoflow_connections_set.md
@@ -1,0 +1,51 @@
+---
+# --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
+aliases:
+  - /cli/leoflow_connections_set.html
+# --- end AUTO redirect aliases ---
+title: "leoflow connections set"
+linkTitle: "connections set"
+weight: 26
+---
+
+Create or replace a connection (upsert).
+
+### Synopsis
+
+Upserts a connection: creates it, or replaces an existing one with the same id. --conn-type is required. The password and extra are sent to the control plane but never printed back; read commands show masked values.
+
+Prefer --password-stdin over --password so the secret never lands in your shell history or the process table.
+
+```
+leoflow connections set <connection_id> [flags]
+```
+
+### Options
+
+```
+      --conn-type string     connection type, e.g. postgres, http, aws (required)
+      --description string   human-readable description
+      --extra string         extra JSON blob (provider-specific; secrets here are masked on read)
+  -h, --help                 help for set
+      --host string          connection host
+      --login string         connection login/username
+      --password string      connection password (prefer --password-stdin)
+      --password-stdin       read the password from stdin instead of --password (avoids ps/shell-history exposure)
+      --port int             connection port (0 leaves it unset)
+      --schema string        connection schema/database
+      --server string        control plane base URL (default: config server_url)
+      --token string         JWT bearer token (default: config token)
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file path (default ~/.leoflow/config.yaml)
+      --log-level string    log level: debug, info, warn, error
+      --server-url string   control plane API base URL
+```
+
+### SEE ALSO
+
+* [leoflow connections](/reference/cli/leoflow_connections/)	 - Manage control-plane connections.
+

--- a/website/content/reference/cli/leoflow_connections_set.md
+++ b/website/content/reference/cli/leoflow_connections_set.md
@@ -12,9 +12,11 @@ Create or replace a connection (upsert).
 
 ### Synopsis
 
-Upserts a connection: creates it, or replaces an existing one with the same id. --conn-type is required. The password and extra are sent to the control plane but never printed back; read commands show masked values.
+Creates a connection, or replaces an existing one with the same id. --conn-type is required.
 
-Prefer --password-stdin over --password so the secret never lands in your shell history or the process table.
+This is a full replace, not a partial patch: the connection is set to exactly the fields you pass, so any field you omit is cleared on an existing connection — including the password. To change one field, pass the others too (the password cannot be read back, so re-supply it).
+
+The password and extra are sent to the control plane but never printed back; read commands show masked values. Prefer --password-stdin / --extra-file over --password / --extra so a secret never lands in your shell history or the process table.
 
 ```
 leoflow connections set <connection_id> [flags]
@@ -26,6 +28,7 @@ leoflow connections set <connection_id> [flags]
       --conn-type string     connection type, e.g. postgres, http, aws (required)
       --description string   human-readable description
       --extra string         extra JSON blob (provider-specific; secrets here are masked on read)
+      --extra-file string    read the extra JSON from a file instead of --extra (keeps provider secrets out of argv)
   -h, --help                 help for set
       --host string          connection host
       --login string         connection login/username

--- a/website/content/reference/cli/leoflow_dags.md
+++ b/website/content/reference/cli/leoflow_dags.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow dags"
 linkTitle: "dags"
-weight: 22
+weight: 27
 ---
 
 Manage registered DAGs.
@@ -28,4 +28,5 @@ Manage registered DAGs.
 
 * [leoflow](/reference/cli/leoflow/)	 - Leoflow is a GitOps-first, container-native workflow orchestrator.
 * [leoflow dags delete](/reference/cli/leoflow_dags_delete/)	 - Clear a DAG's run history, or fully deregister it with --deregister.
+* [leoflow dags list](/reference/cli/leoflow_dags_list/)	 - List registered DAGs.
 

--- a/website/content/reference/cli/leoflow_dags_delete.md
+++ b/website/content/reference/cli/leoflow_dags_delete.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow dags delete"
 linkTitle: "dags delete"
-weight: 23
+weight: 28
 ---
 
 Clear a DAG's run history, or fully deregister it with --deregister.

--- a/website/content/reference/cli/leoflow_dags_list.md
+++ b/website/content/reference/cli/leoflow_dags_list.md
@@ -1,23 +1,25 @@
 ---
 # --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
 aliases:
-  - /cli/leoflow_validate.html
+  - /cli/leoflow_dags_list.html
 # --- end AUTO redirect aliases ---
-title: "leoflow validate"
-linkTitle: "validate"
-weight: 51
+title: "leoflow dags list"
+linkTitle: "dags list"
+weight: 29
 ---
 
-Validate leoflow.yaml and the DAG source against the schema.
+List registered DAGs.
 
 ```
-leoflow validate [path] [flags]
+leoflow dags list [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for validate
+  -h, --help            help for list
+      --server string   control plane base URL (default: config server_url)
+      --token string    JWT bearer token (default: config token)
 ```
 
 ### Options inherited from parent commands
@@ -30,5 +32,5 @@ leoflow validate [path] [flags]
 
 ### SEE ALSO
 
-* [leoflow](/reference/cli/leoflow/)	 - Leoflow is a GitOps-first, container-native workflow orchestrator.
+* [leoflow dags](/reference/cli/leoflow_dags/)	 - Manage registered DAGs.
 

--- a/website/content/reference/cli/leoflow_db.md
+++ b/website/content/reference/cli/leoflow_db.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow db"
 linkTitle: "db"
-weight: 24
+weight: 30
 ---
 
 Manage the local Lite database (schema name leoflow_dev for upgrade safety).

--- a/website/content/reference/cli/leoflow_db_migrate.md
+++ b/website/content/reference/cli/leoflow_db_migrate.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow db migrate"
 linkTitle: "db migrate"
-weight: 25
+weight: 31
 ---
 
 Create (if needed) and migrate the Lite database to the latest schema.

--- a/website/content/reference/cli/leoflow_db_reset.md
+++ b/website/content/reference/cli/leoflow_db_reset.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow db reset"
 linkTitle: "db reset"
-weight: 26
+weight: 32
 ---
 
 Drop, recreate, and migrate the Lite database (DESTRUCTIVE).

--- a/website/content/reference/cli/leoflow_deploy.md
+++ b/website/content/reference/cli/leoflow_deploy.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow deploy"
 linkTitle: "deploy"
-weight: 27
+weight: 33
 ---
 
 Build, push, and register a DAG to a control plane (Pro).

--- a/website/content/reference/cli/leoflow_doctor.md
+++ b/website/content/reference/cli/leoflow_doctor.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow doctor"
 linkTitle: "doctor"
-weight: 28
+weight: 34
 ---
 
 Report host platform, dependencies, and the achievable operating tier.

--- a/website/content/reference/cli/leoflow_init.md
+++ b/website/content/reference/cli/leoflow_init.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow init"
 linkTitle: "init"
-weight: 29
+weight: 35
 ---
 
 Scaffold a new DAG project (leoflow.yaml + dag.py).

--- a/website/content/reference/cli/leoflow_lite.md
+++ b/website/content/reference/cli/leoflow_lite.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow lite"
 linkTitle: "lite"
-weight: 30
+weight: 36
 ---
 
 Run Leoflow Lite locally with hot reload.

--- a/website/content/reference/cli/leoflow_lite_backup.md
+++ b/website/content/reference/cli/leoflow_lite_backup.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow lite backup"
 linkTitle: "lite backup"
-weight: 31
+weight: 37
 ---
 
 Snapshot the Lite install (workspace + datastore + config) into a portable archive.

--- a/website/content/reference/cli/leoflow_lite_forget.md
+++ b/website/content/reference/cli/leoflow_lite_forget.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow lite forget"
 linkTitle: "lite forget"
-weight: 32
+weight: 38
 ---
 
 Remove a DAG (and all its history) from the Lite registry without touching the source files.

--- a/website/content/reference/cli/leoflow_lite_provision.md
+++ b/website/content/reference/cli/leoflow_lite_provision.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow lite provision"
 linkTitle: "lite provision"
-weight: 33
+weight: 39
 ---
 
 Check and provision the local deps the from-source `leoflow lite` loop needs.

--- a/website/content/reference/cli/leoflow_lite_reset-password.md
+++ b/website/content/reference/cli/leoflow_lite_reset-password.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow lite reset-password"
 linkTitle: "lite reset-password"
-weight: 34
+weight: 40
 ---
 
 Reset the Leoflow Lite admin password.

--- a/website/content/reference/cli/leoflow_lite_restore.md
+++ b/website/content/reference/cli/leoflow_lite_restore.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow lite restore"
 linkTitle: "lite restore"
-weight: 35
+weight: 41
 ---
 
 Restore a Lite install from an archive produced by `leoflow lite backup`.

--- a/website/content/reference/cli/leoflow_push.md
+++ b/website/content/reference/cli/leoflow_push.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow push"
 linkTitle: "push"
-weight: 36
+weight: 42
 ---
 
 Register a compiled dag.json with the control plane.

--- a/website/content/reference/cli/leoflow_runs.md
+++ b/website/content/reference/cli/leoflow_runs.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow runs"
 linkTitle: "runs"
-weight: 37
+weight: 43
 ---
 
 Trigger and inspect DAG runs.

--- a/website/content/reference/cli/leoflow_runs_list.md
+++ b/website/content/reference/cli/leoflow_runs_list.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow runs list"
 linkTitle: "runs list"
-weight: 38
+weight: 44
 ---
 
 List DAG runs, filtered by --state, --older-than, and/or --dag.

--- a/website/content/reference/cli/leoflow_runs_logs.md
+++ b/website/content/reference/cli/leoflow_runs_logs.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow runs logs"
 linkTitle: "runs logs"
-weight: 39
+weight: 45
 ---
 
 Stream a task attempt's logs (the latest attempt by default).

--- a/website/content/reference/cli/leoflow_runs_trigger.md
+++ b/website/content/reference/cli/leoflow_runs_trigger.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow runs trigger"
 linkTitle: "runs trigger"
-weight: 41
+weight: 47
 ---
 
 Trigger a new run of a DAG.
@@ -17,9 +17,11 @@ leoflow runs trigger <dag_id> [flags]
 ### Options
 
 ```
-  -h, --help            help for trigger
-      --server string   control plane base URL (default: config server_url)
-      --token string    JWT bearer token (default: config token)
+      --conf string        run configuration as an inline JSON object, exposed to tasks as params (e.g. --conf '{"date":"2026-01-01"}')
+      --conf-file string   path to a JSON file whose object contents become the run configuration; mutually exclusive with --conf
+  -h, --help               help for trigger
+      --server string      control plane base URL (default: config server_url)
+      --token string       JWT bearer token (default: config token)
 ```
 
 ### Options inherited from parent commands

--- a/website/content/reference/cli/leoflow_server.md
+++ b/website/content/reference/cli/leoflow_server.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow server"
 linkTitle: "server"
-weight: 42
+weight: 48
 ---
 
 Information about running the control plane.

--- a/website/content/reference/cli/leoflow_setup.md
+++ b/website/content/reference/cli/leoflow_setup.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow setup"
 linkTitle: "setup"
-weight: 43
+weight: 49
 ---
 
 Bootstrap the managed Leoflow runtime (Python, parser, workspace).

--- a/website/content/reference/cli/leoflow_uninstall.md
+++ b/website/content/reference/cli/leoflow_uninstall.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow uninstall"
 linkTitle: "uninstall"
-weight: 44
+weight: 50
 ---
 
 Remove the Leoflow installation (~/.leoflow).

--- a/website/content/reference/cli/leoflow_variables.md
+++ b/website/content/reference/cli/leoflow_variables.md
@@ -1,0 +1,34 @@
+---
+# --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
+aliases:
+  - /cli/leoflow_variables.html
+# --- end AUTO redirect aliases ---
+title: "leoflow variables"
+linkTitle: "variables"
+weight: 52
+---
+
+Manage control-plane variables.
+
+### Options
+
+```
+  -h, --help   help for variables
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file path (default ~/.leoflow/config.yaml)
+      --log-level string    log level: debug, info, warn, error
+      --server-url string   control plane API base URL
+```
+
+### SEE ALSO
+
+* [leoflow](/reference/cli/leoflow/)	 - Leoflow is a GitOps-first, container-native workflow orchestrator.
+* [leoflow variables delete](/reference/cli/leoflow_variables_delete/)	 - Delete a variable.
+* [leoflow variables get](/reference/cli/leoflow_variables_get/)	 - Show a variable (value masked when the key looks sensitive).
+* [leoflow variables list](/reference/cli/leoflow_variables_list/)	 - List variables (encrypted values not shown).
+* [leoflow variables set](/reference/cli/leoflow_variables_set/)	 - Create or replace a variable (upsert).
+

--- a/website/content/reference/cli/leoflow_variables_delete.md
+++ b/website/content/reference/cli/leoflow_variables_delete.md
@@ -1,24 +1,23 @@
 ---
 # --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
 aliases:
-  - /cli/leoflow_runs_status.html
+  - /cli/leoflow_variables_delete.html
 # --- end AUTO redirect aliases ---
-title: "leoflow runs status"
-linkTitle: "runs status"
-weight: 46
+title: "leoflow variables delete"
+linkTitle: "variables delete"
+weight: 53
 ---
 
-Show the state of a DAG run (the latest by default).
+Delete a variable.
 
 ```
-leoflow runs status <dag_id> [flags]
+leoflow variables delete <key> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help            help for status
-      --run string      specific dag_run_id (default: the most recent run)
+  -h, --help            help for delete
       --server string   control plane base URL (default: config server_url)
       --token string    JWT bearer token (default: config token)
 ```
@@ -33,5 +32,5 @@ leoflow runs status <dag_id> [flags]
 
 ### SEE ALSO
 
-* [leoflow runs](/reference/cli/leoflow_runs/)	 - Trigger and inspect DAG runs.
+* [leoflow variables](/reference/cli/leoflow_variables/)	 - Manage control-plane variables.
 

--- a/website/content/reference/cli/leoflow_variables_get.md
+++ b/website/content/reference/cli/leoflow_variables_get.md
@@ -1,24 +1,23 @@
 ---
 # --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
 aliases:
-  - /cli/leoflow_runs_status.html
+  - /cli/leoflow_variables_get.html
 # --- end AUTO redirect aliases ---
-title: "leoflow runs status"
-linkTitle: "runs status"
-weight: 46
+title: "leoflow variables get"
+linkTitle: "variables get"
+weight: 54
 ---
 
-Show the state of a DAG run (the latest by default).
+Show a variable (value masked when the key looks sensitive).
 
 ```
-leoflow runs status <dag_id> [flags]
+leoflow variables get <key> [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help            help for status
-      --run string      specific dag_run_id (default: the most recent run)
+  -h, --help            help for get
       --server string   control plane base URL (default: config server_url)
       --token string    JWT bearer token (default: config token)
 ```
@@ -33,5 +32,5 @@ leoflow runs status <dag_id> [flags]
 
 ### SEE ALSO
 
-* [leoflow runs](/reference/cli/leoflow_runs/)	 - Trigger and inspect DAG runs.
+* [leoflow variables](/reference/cli/leoflow_variables/)	 - Manage control-plane variables.
 

--- a/website/content/reference/cli/leoflow_variables_list.md
+++ b/website/content/reference/cli/leoflow_variables_list.md
@@ -1,24 +1,23 @@
 ---
 # --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
 aliases:
-  - /cli/leoflow_runs_status.html
+  - /cli/leoflow_variables_list.html
 # --- end AUTO redirect aliases ---
-title: "leoflow runs status"
-linkTitle: "runs status"
-weight: 46
+title: "leoflow variables list"
+linkTitle: "variables list"
+weight: 55
 ---
 
-Show the state of a DAG run (the latest by default).
+List variables (encrypted values not shown).
 
 ```
-leoflow runs status <dag_id> [flags]
+leoflow variables list [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help            help for status
-      --run string      specific dag_run_id (default: the most recent run)
+  -h, --help            help for list
       --server string   control plane base URL (default: config server_url)
       --token string    JWT bearer token (default: config token)
 ```
@@ -33,5 +32,5 @@ leoflow runs status <dag_id> [flags]
 
 ### SEE ALSO
 
-* [leoflow runs](/reference/cli/leoflow_runs/)	 - Trigger and inspect DAG runs.
+* [leoflow variables](/reference/cli/leoflow_variables/)	 - Manage control-plane variables.
 

--- a/website/content/reference/cli/leoflow_variables_set.md
+++ b/website/content/reference/cli/leoflow_variables_set.md
@@ -1,0 +1,42 @@
+---
+# --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
+aliases:
+  - /cli/leoflow_variables_set.html
+# --- end AUTO redirect aliases ---
+title: "leoflow variables set"
+linkTitle: "variables set"
+weight: 56
+---
+
+Create or replace a variable (upsert).
+
+### Synopsis
+
+Upserts a variable: creates it, or replaces an existing one with the same key. Pass the value as the second argument, or use --value-stdin to read it from stdin (keeps a secret out of your shell history and argv).
+
+```
+leoflow variables set <key> [value] [flags]
+```
+
+### Options
+
+```
+      --description string   human-readable description
+  -h, --help                 help for set
+      --server string        control plane base URL (default: config server_url)
+      --token string         JWT bearer token (default: config token)
+      --value-stdin          read the value from stdin instead of the positional argument
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       config file path (default ~/.leoflow/config.yaml)
+      --log-level string    log level: debug, info, warn, error
+      --server-url string   control plane API base URL
+```
+
+### SEE ALSO
+
+* [leoflow variables](/reference/cli/leoflow_variables/)	 - Manage control-plane variables.
+

--- a/website/content/reference/cli/leoflow_version.md
+++ b/website/content/reference/cli/leoflow_version.md
@@ -5,7 +5,7 @@ aliases:
 # --- end AUTO redirect aliases ---
 title: "leoflow version"
 linkTitle: "version"
-weight: 46
+weight: 57
 ---
 
 Print the version, git commit, and build date.


### PR DESCRIPTION
Closes #881.

First-class `leoflow connections` and `leoflow variables` CLI groups so the Lite inner loop (and Pro) can manage connections/variables without curl. The error at `internal/storage/repository.go:1055` already tells users to run `leoflow connections set`; this makes that command real.

## Commands
- `connections set <id> --conn-type <t> [--host --login --password/--password-stdin --schema --port --extra/--extra-file --description]` (upsert), `connections list|get <id>|delete <id>`
- `variables set <key> [value]/--value-stdin [--description]` (upsert), `variables list|get <key>|delete <key>`
- All take `--server`/`--token` (shared `resolveServerToken`, mirrors `token.go`).

## Approach
Typed OpenAPI client: the already-served `/api/v2/connections` + `/api/v2/variables` endpoints are added to `docs/api/openapi.yaml`, `pkg/client` regenerated, CLI built on the generated types (same pattern as `token.go` for users).

## Safe-by-default write semantics
`set` is an upsert that **merges**: only the fields you pass change; omitted fields are preserved (upsert `COALESCE`s `EXCLUDED` over the stored row). This closes an invisible-password-wipe footgun — a partial `set --host x` no longer nulls the write-only password. Same fix covers the Admin UI + PATCH write paths. Orthogonal to the masked-`***`-write follow-up (#874). To clear a field: delete + recreate.

## Secret hygiene
Secrets are sent on write but never printed (list/get omit secret columns; server masks `extra`/sensitive-keyed values). `--password-stdin` / `--extra-file` keep secrets off argv & shell history.

## Tests
- 24 CLI unit tests (`httptest`), incl. never-print-secret, stdin/file inputs, value-required, extra mutual-exclusion.
- Storage integration: partial `set` preserves the password (verified via the delivered `AIRFLOW_CONN_` URI), plus extra/login/port/description; a password-carrying write still rotates. Variables: omitted description preserved.
- API-level e2e `test/e2e/lite-connections.sh` (maintainer chose this over Playwright — leoflow's UI is the embedded Airflow SPA): boots Lite, round-trips both resources, curls the same `/api/v2/*` the SPA reads to assert `extra`/value masked + password omitted, proves a partial set preserves the omitted extra, cleans up all planted data.
- Reviewed pre-merge by the devex specialist; MAJOR (upsert clobber) + 2 MEDIUMs fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)