### PR TITLE
release: prepare v0.4.4-rc.2

### DIFF
--- a/helm/leoflow/Chart.yaml
+++ b/helm/leoflow/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version is the chart version; appVersion tracks the leoflow-server image.
 # Both move in lockstep with the release tag (ADR 0028); decouple only if the
 # chart ever needs a cadence of its own for a template-only fix.
-version: 0.4.4-rc.1
-appVersion: "0.4.4-rc.1"
+version: 0.4.4-rc.2
+appVersion: "0.4.4-rc.2"
 home: https://github.com/neochaotic/leoflow
 sources:
   - https://github.com/neochaotic/leoflow

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -1,6 +1,6 @@
 # leoflow
 
-![Version: 0.4.4-rc.1](https://img.shields.io/badge/Version-0.4.4--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.4-rc.1](https://img.shields.io/badge/AppVersion-0.4.4--rc.1-informational?style=flat-square)
+![Version: 0.4.4-rc.2](https://img.shields.io/badge/Version-0.4.4--rc.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.4-rc.2](https://img.shields.io/badge/AppVersion-0.4.4--rc.2-informational?style=flat-square)
 
 Leoflow control plane — a GitOps-first, container-native workflow orchestrator (Airflow 3.2.x UI/API compatible).
 


### PR DESCRIPTION
Chart version/appVersion -> 0.4.4-rc.2 (ADR 0028 lockstep). rc keeps [Unreleased].