### PR TITLE
fix(deps): bump grpc to v1.83.1 (CVE-2026-84304, HIGH)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Security
+
+- **Bumped `google.golang.org/grpc` to v1.83.1 (CVE-2026-84304, HIGH).** The
+  control plane ↔ agent RPC layer used gRPC-Go v1.83.0, which a HIGH advisory
+  covers; v1.83.1 is the upstream fix. `govulncheck` reports the vulnerable
+  symbol is not reachable from Leoflow's call graph, so no released build was
+  exploitable, but the dependency is patched to clear the advisory outright
+  rather than carry a known-fixable HIGH in the RPC layer.
+
 ### Added
 
 - **First-class `leoflow connections` and `leoflow variables` CLI groups (#881).**

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/term v0.45.0
 	google.golang.org/api v0.293.0
-	google.golang.org/grpc v1.83.0
+	google.golang.org/grpc v1.83.1
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.4

--- a/go.sum
+++ b/go.sum
@@ -410,8 +410,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260803160001-6ac0973c030d h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260803160001-6ac0973c030d/go.mod h1:K/+WGbmBY7aNW1HDw1fJnKYo10i0DkAX6pows00dLig=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260807164820-c8921c73eeea h1:kVhQEPTpKQahD5+JSBTfBB19wcgQTTjAIn45MBqnyHk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260807164820-c8921c73eeea/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.83.0 h1:JeNZEKJFbQxArAMl+hiytHauacDNqJUllNfmIMmpqnQ=
-google.golang.org/grpc v1.83.0/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
+google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
+google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af h1:+5/Sw3GsDNlEmu7TfklWKPdQ0Ykja5VEmq2i817+jbI=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Trivy flagged `google.golang.org/grpc` v1.83.0 for **CVE-2026-84304** (HIGH) after a vuln-DB refresh (same code passed at the v0.4.4-rc.2 cut). Fixed upstream in v1.83.1. `govulncheck`: 0 reachable (vulnerable symbol not called), so no shipped build was exploitable — bumping clears the advisory outright. Blocks the v0.4.4 GA cut (prepare PR #890 red on Trivy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)