### PR TITLE
ci: CHANGELOG-entry gate per PR + cut-release.sh jq int hardening

### DIFF
--- a/.github/workflows/changelog-guard.yaml
+++ b/.github/workflows/changelog-guard.yaml
@@ -1,0 +1,32 @@
+# Requires a CHANGELOG entry per PR (see scripts/check-changelog-entry.sh).
+#
+# A standalone workflow — not a job in ci.yaml — so it can trigger on `labeled`
+# / `unlabeled` too: applying the `skip-changelog` label re-runs THIS guard (and
+# only this guard, not all of CI) with the updated label set, so the exemption
+# takes effect immediately. Entries under `## [Unreleased]` were manual and
+# repeatedly forgotten, back-filled by separate "docs(changelog)" PRs
+# (#529/#532/#708/#739/#756/#780/#781/#888); this ends that pattern.
+name: CHANGELOG guard
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  changelog-guard:
+    name: CHANGELOG entry present
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Exempt PRs with no user-facing change (release-prep, chore, dependabot,
+    # docs-only). The `labeled`/`unlabeled` triggers above make this re-evaluate
+    # as soon as the label is added or removed.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Fetch the base branch tip
+        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+      - name: Require a CHANGELOG [Unreleased] entry (or the skip-changelog label)
+        run: bash scripts/check-changelog-entry.sh "origin/${{ github.base_ref }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1027,27 +1027,6 @@ jobs:
         run: bash scripts/check-no-stale-deploy-path.sh
 
   # ─────────────────────────────────────────────────────────────────────
-  # CHANGELOG entry guard. Entries under `## [Unreleased]` were manual and
-  # repeatedly forgotten, so features merged with no changelog line and were
-  # back-filled by separate "docs(changelog)" PRs (#529/#532/#708/#739/#756/
-  # #780/#781/#888). This fails a PR whose [Unreleased] section is unchanged
-  # from the base — unless it carries the `skip-changelog` label (release-prep,
-  # chore, dependabot, docs-only). It compares section bodies (not a 3-dot
-  # diff), so it needs no merge base and is immune to the shallow-fetch trap.
-  # ─────────────────────────────────────────────────────────────────────
-  changelog-guard:
-    name: CHANGELOG entry present
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Fetch the base branch tip
-        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
-      - name: Require a CHANGELOG [Unreleased] entry (or the skip-changelog label)
-        run: bash scripts/check-changelog-entry.sh "origin/${{ github.base_ref }}"
-
-  # ─────────────────────────────────────────────────────────────────────
   # Python parser tests — matrix across every Python the host detector
   # claims to support (`internal/setup/detect.go` pythonCandidates). If a
   # new minor is added to that list, add it here too — otherwise the

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1027,6 +1027,27 @@ jobs:
         run: bash scripts/check-no-stale-deploy-path.sh
 
   # ─────────────────────────────────────────────────────────────────────
+  # CHANGELOG entry guard. Entries under `## [Unreleased]` were manual and
+  # repeatedly forgotten, so features merged with no changelog line and were
+  # back-filled by separate "docs(changelog)" PRs (#529/#532/#708/#739/#756/
+  # #780/#781/#888). This fails a PR whose [Unreleased] section is unchanged
+  # from the base — unless it carries the `skip-changelog` label (release-prep,
+  # chore, dependabot, docs-only). It compares section bodies (not a 3-dot
+  # diff), so it needs no merge base and is immune to the shallow-fetch trap.
+  # ─────────────────────────────────────────────────────────────────────
+  changelog-guard:
+    name: CHANGELOG entry present
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Fetch the base branch tip
+        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+      - name: Require a CHANGELOG [Unreleased] entry (or the skip-changelog label)
+        run: bash scripts/check-changelog-entry.sh "origin/${{ github.base_ref }}"
+
+  # ─────────────────────────────────────────────────────────────────────
   # Python parser tests — matrix across every Python the host detector
   # claims to support (`internal/setup/detect.go` pythonCandidates). If a
   # new minor is added to that list, add it here too — otherwise the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,6 +4,16 @@ Cutting a release is one command: `scripts/cut-release.sh <version>`. The script
 owns the mechanical flow so it is not re-derived (and re-broken) by hand each time
 (#879). You own the *decisions*: whether to cut, the version, and rc-vs-GA.
 
+## The changelog fills itself, per PR
+
+Every PR records its own user-facing change under `## [Unreleased]` in
+`CHANGELOG.md`, enforced by the **`changelog-guard`** CI job
+(`scripts/check-changelog-entry.sh`). So by the time you cut, `[Unreleased]` is
+already the complete release note — no scramble to reconstruct it, and no
+back-fill "docs(changelog)" PRs (the recurring pattern this gate ends). A PR with
+no user-facing change (release-prep, chore, dependabot, docs-only) carries the
+**`skip-changelog`** label to bypass the gate.
+
 ## The flow the script runs
 
 1. **Preflight** — required tools, clean tree, on `main`, version validated,

--- a/scripts/check-changelog-entry.sh
+++ b/scripts/check-changelog-entry.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Fail a PR that changes shipped behavior without recording it in the CHANGELOG.
+#
+# Leoflow keeps a hand-written Keep-a-Changelog `CHANGELOG.md`; entries are added
+# manually under `## [Unreleased]` and `cut-release.sh` dates that section at a GA.
+# Nothing forced an entry per PR, so features repeatedly merged with none and had
+# to be back-filled by separate "docs(changelog): record …" PRs (#529, #532, #708,
+# #739, #756, #780, #781, #888 — at least eight). Each wastes a cycle and risks a
+# release shipping an incomplete changelog (v0.4.4's headline #881 nearly did).
+#
+# This gate passes when a PR's `[Unreleased]` section differs from the base
+# branch's — i.e. the PR added/changed a changelog entry. Pure-mechanics PRs that
+# legitimately have no user-facing change (release-prep, chore, dependabot,
+# docs-only) carry the `skip-changelog` label, which the CI job honors before
+# invoking this script.
+#
+# Usage:
+#   scripts/check-changelog-entry.sh [base-ref]   # default: origin/main
+#   scripts/check-changelog-entry.sh --self-test
+set -euo pipefail
+
+CHANGELOG="CHANGELOG.md"
+
+# unreleased_section reads a CHANGELOG on stdin and prints the body of its
+# `## [Unreleased]` section (everything up to the next `## [` header). Kept as a
+# pure filter so --self-test can exercise it without git.
+unreleased_section() {
+	awk '
+		/^## \[Unreleased\]/ { inu = 1; next }
+		inu && /^## \[/       { exit }
+		inu                   { print }
+	'
+}
+
+self_test() {
+	local fail=0
+	_eq() { # <got> <want> <name>
+		if [ "$1" = "$2" ]; then printf '  ok   %s\n' "$3"; else printf '  FAIL %s\n    got:  %q\n    want: %q\n' "$3" "$1" "$2"; fail=1; fi
+	}
+	local doc
+	doc=$'# Changelog\n\n## [Unreleased]\n\n### Added\n- a new thing (#1)\n\n## [1.0.0] - 2026-01-01\n\n### Fixed\n- old (#0)\n'
+	_eq "$(printf '%s' "$doc" | unreleased_section | grep -c 'new thing')" "1" "extracts the Unreleased body"
+	_eq "$(printf '%s' "$doc" | unreleased_section | grep -c 'old (#0)')" "0" "stops at the next dated section"
+	# An empty Unreleased (just dated below, as right after a GA cut) yields blank.
+	local dated
+	dated=$'## [Unreleased]\n\n## [1.0.0] - 2026-01-01\n- x\n'
+	_eq "$(printf '%s' "$dated" | unreleased_section | tr -d '[:space:]')" "" "empty Unreleased extracts blank"
+	if [ "$fail" -eq 0 ]; then echo "self-test: PASS"; return 0; else echo "self-test: FAIL"; return 1; fi
+}
+
+[ "${1:-}" = "--self-test" ] && { self_test; exit $?; }
+
+cd "$(dirname "$0")/.."
+base="${1:-origin/main}"
+
+if [ ! -f "$CHANGELOG" ]; then
+	echo "FAIL: $CHANGELOG not found"; exit 1
+fi
+
+base_section="$(git show "${base}:${CHANGELOG}" 2>/dev/null | unreleased_section || true)"
+head_section="$(unreleased_section <"$CHANGELOG")"
+
+if [ "$base_section" = "$head_section" ]; then
+	echo "FAIL: this PR does not add a CHANGELOG entry under '## [Unreleased]'."
+	echo
+	echo "Add a Keep-a-Changelog entry describing the user-facing change (Added /"
+	echo "Changed / Fixed / Security), or — if the PR has no user-facing change"
+	echo "(release-prep, chore, dependabot, docs-only) — apply the 'skip-changelog'"
+	echo "label to the PR."
+	exit 1
+fi
+
+echo "OK: CHANGELOG [Unreleased] updated relative to ${base}."

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -75,9 +75,13 @@ wait_sha_green() {
     fi
     j=$(gh run list --limit 40 --json databaseId,status,conclusion,headSha \
           -q "[.[] | select(.headSha==\"$sha\")]" 2>/dev/null)
-    [ "$(echo "$j" | jq 'length' 2>/dev/null || echo 0)" -eq 0 ] && { sleep 25; continue; }
-    pend=$(echo "$j" | jq '[.[] | select(.status!="completed")] | length')
-    [ "${pend:-1}" -gt 0 ] && { sleep 45; continue; }
+    # jq can emit partial output or `null` before erroring, so coerce to a real
+    # integer before any [ -eq/-gt ] (else "integer expression expected"). Safe
+    # defaults keep the loop waiting rather than falsely declaring a verdict.
+    cnt=$(printf '%s' "$j" | jq 'length' 2>/dev/null); [[ "$cnt" =~ ^[0-9]+$ ]] || cnt=0
+    [ "$cnt" -eq 0 ] && { sleep 25; continue; }
+    pend=$(printf '%s' "$j" | jq '[.[] | select(.status!="completed")] | length' 2>/dev/null); [[ "$pend" =~ ^[0-9]+$ ]] || pend=1
+    [ "$pend" -gt 0 ] && { sleep 45; continue; }
     failed=$(echo "$j" | jq -r '.[] | select(.conclusion=="failure") | .databaseId')
     [ -z "$failed" ] && { echo GREEN; return 0; }
     isflake=1
@@ -227,9 +231,11 @@ main() {
       break
     fi
     j=$(gh run list --limit 25 --json databaseId,status,conclusion,headBranch -q "[.[] | select(.headBranch==\"$tag\")]" 2>/dev/null)
-    [ "$(echo "$j" | jq 'length' 2>/dev/null || echo 0)" -eq 0 ] && { sleep 20; continue; }
-    pend=$(echo "$j" | jq '[.[] | select(.status!="completed")] | length')
-    [ "${pend:-1}" -gt 0 ] && { sleep 45; continue; }
+    # Coerce jq output to an integer before [ -eq/-gt ] (see wait_sha_green).
+    cnt=$(printf '%s' "$j" | jq 'length' 2>/dev/null); [[ "$cnt" =~ ^[0-9]+$ ]] || cnt=0
+    [ "$cnt" -eq 0 ] && { sleep 20; continue; }
+    pend=$(printf '%s' "$j" | jq '[.[] | select(.status!="completed")] | length' 2>/dev/null); [[ "$pend" =~ ^[0-9]+$ ]] || pend=1
+    [ "$pend" -gt 0 ] && { sleep 45; continue; }
     failed=$(echo "$j" | jq -r '.[] | select(.conclusion=="failure") | .databaseId')
     if [ -z "$failed" ]; then log "$tag PUBLISHED"; break; fi
     isflake=1; for rid in $failed; do gh run view "$rid" --log-failed 2>/dev/null | grep -qE "$FLAKE_RE" || isflake=0; done


### PR DESCRIPTION
Ends the recurring "forgot the changelog entry → back-fill PR" pattern (#529/#532/#708/#739/#756/#780/#781/#888) and fixes the `cut-release.sh` `integer expression expected` warnings seen during the v0.4.4 GA cut.

- `scripts/check-changelog-entry.sh` (+`--self-test`): fails a PR whose `[Unreleased]` section is unchanged from base; compares section bodies, so no merge base / shallow-fetch trap. New `changelog-guard` CI job honors a `skip-changelog` label.
- `cut-release.sh`: coerce jq lengths to integers before `[ -eq/-gt ]` (partial/null jq output caused the warnings).

This PR carries `skip-changelog` itself (tooling/CI, no user-facing change) — dogfooding the escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)