### PR TITLE
feat(api): tri-state connection/variable write (null=preserve, ""=clear, ***=unchanged) — closes #887, #874

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Connection/variable writes are now tri-state, restoring explicit-clear and
+  fixing the masked write-back overwrite (#887, subsumes #874).** The safe-merge
+  upsert (v0.4.4) preserved any omitted field, but because the API request body
+  used plain strings it could not tell "field omitted" (preserve) from "field
+  present and empty" (clear), so `connections set c --login ""` was a silent
+  no-op and a masked secret (`***`) read back from a GET and re-submitted — as
+  the Admin UI does — overwrote the real secret with the literal mask. The write
+  body is now tri-state: an omitted field preserves the stored value, an explicit
+  empty string clears it, and a secret field equal to the mask (a password, or
+  any key inside `extra` whose value is exactly `***`, or a sensitive-keyed
+  variable value) is treated as unchanged and preserved. `leoflow connections set`
+  can now clear a field by passing it as an empty string (e.g. `--login ''`)
+  instead of "delete and recreate", and re-saving a connection/variable read
+  from the API no longer clobbers its unreadable secrets.
+
 ## [0.4.4] - 2026-09-03
 
 ### Security

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -796,6 +796,13 @@ components:
       description: >-
         Connection create/replace payload. connection_id is required on POST
         (taken from the path on PATCH). password and extra are write-only.
+        Every optional field is tri-state: omit the key to preserve the stored
+        value (a partial write never wipes a field it does not mention, so the
+        unreadable password survives a `--host`-only edit), send an empty string
+        to clear the field, or send a value to set it. A password equal to the
+        mask `***`, and any key inside `extra` whose value is exactly `***`, is
+        treated as "unchanged" — so re-submitting a connection read back from GET
+        (whose secrets are masked) never overwrites the real secret with the mask.
       properties:
         connection_id: { type: string }
         conn_type: { type: string }
@@ -834,6 +841,13 @@ components:
     VariableBody:
       type: object
       required: [key]
+      description: >-
+        Variable create/replace payload. value and description are tri-state:
+        omit the key to preserve the stored value, send an empty string to clear
+        it, or send a value to set it. A value equal to the mask `***` for a
+        sensitive-looking key (secret/password/token/...) is treated as
+        "unchanged", so re-submitting a variable read back from GET (whose
+        sensitive value is masked) never overwrites the real value with the mask.
       properties:
         key: { type: string }
         value: { type: string }

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -796,6 +796,13 @@ components:
       description: >-
         Connection create/replace payload. connection_id is required on POST
         (taken from the path on PATCH). password and extra are write-only.
+        Every optional field is tri-state: omit the key to preserve the stored
+        value (a partial write never wipes a field it does not mention, so the
+        unreadable password survives a `--host`-only edit), send an empty string
+        to clear the field, or send a value to set it. A password equal to the
+        mask `***`, and any key inside `extra` whose value is exactly `***`, is
+        treated as "unchanged" — so re-submitting a connection read back from GET
+        (whose secrets are masked) never overwrites the real secret with the mask.
       properties:
         connection_id: { type: string }
         conn_type: { type: string }
@@ -834,6 +841,13 @@ components:
     VariableBody:
       type: object
       required: [key]
+      description: >-
+        Variable create/replace payload. value and description are tri-state:
+        omit the key to preserve the stored value, send an empty string to clear
+        it, or send a value to set it. A value equal to the mask `***` for a
+        sensitive-looking key (secret/password/token/...) is treated as
+        "unchanged", so re-submitting a variable read back from GET (whose
+        sensitive value is masked) never overwrites the real value with the mask.
       properties:
         key: { type: string }
         value: { type: string }

--- a/internal/api/ui_connections.go
+++ b/internal/api/ui_connections.go
@@ -190,7 +190,7 @@ func unmaskExtra(incoming, stored string) (result string, preserve bool) {
 	if err := json.Unmarshal([]byte(stored), &st); err != nil {
 		st = nil // stored may be "" or a non-object → merge against an empty map
 	}
-	unmaskMap(in, st)
+	unmaskMap(in, st, true)
 	if containsMask(in) {
 		return "", true // a mask we could not resolve remains → preserve, fail closed
 	}
@@ -202,25 +202,72 @@ func unmaskExtra(incoming, stored string) (result string, preserve bool) {
 }
 
 // unmaskMap replaces, in place, every masked value in in with the value at the
-// same key in stored, recursing into nested objects (mirroring redactMap). A
-// masked key absent from stored is deleted — never persisted as a literal mask.
-func unmaskMap(in, stored map[string]any) {
+// same key in stored, recursing into nested objects AND arrays (mirroring
+// redactMap/redactAny, which mask secrets nested under arrays too). topLevel
+// governs what happens to a masked string with no stored counterpart: at the top
+// level it is deleted (a spurious masked key is dropped, never persisted as a
+// literal mask), but deeper it is LEFT in place so containsMask forces the whole
+// field to be preserved (fail closed) rather than silently editing a nested
+// structure whose secret we cannot restore.
+func unmaskMap(in, stored map[string]any, topLevel bool) {
 	for k, v := range in {
 		switch tv := v.(type) {
 		case string:
 			if tv == secretMask {
 				if sv, ok := stored[k]; ok {
 					in[k] = sv
-				} else {
+				} else if topLevel {
 					delete(in, k)
 				}
+				// deeper: leave the mask → containsMask preserves the whole field
 			}
 		case map[string]any:
 			var sub map[string]any
 			if sv, ok := stored[k].(map[string]any); ok {
 				sub = sv
 			}
-			unmaskMap(tv, sub)
+			unmaskMap(tv, sub, false)
+		case []any:
+			var sub []any
+			if sv, ok := stored[k].([]any); ok {
+				sub = sv
+			}
+			unmaskSlice(tv, sub)
+		}
+	}
+}
+
+// unmaskSlice restores masked values inside an array by aligning with the stored
+// array by index, mirroring redactAny's array recursion. A masked string element
+// is restored from the stored element at the same index when present; map and
+// nested-array elements are recursed. Anything a mask cannot be resolved from
+// (a shorter/absent stored array, a type mismatch) is left as the mask, so
+// containsMask forces the whole field to be preserved — never a silent drop that
+// would shift array indices.
+func unmaskSlice(in, stored []any) {
+	for i, v := range in {
+		var s any
+		if i < len(stored) {
+			s = stored[i]
+		}
+		switch tv := v.(type) {
+		case string:
+			if tv == secretMask && s != nil {
+				in[i] = s
+			}
+			// else leave the mask → containsMask fails closed
+		case map[string]any:
+			var sub map[string]any
+			if sm, ok := s.(map[string]any); ok {
+				sub = sm
+			}
+			unmaskMap(tv, sub, false)
+		case []any:
+			var sub []any
+			if ss, ok := s.([]any); ok {
+				sub = ss
+			}
+			unmaskSlice(tv, sub)
 		}
 	}
 }

--- a/internal/api/ui_connections.go
+++ b/internal/api/ui_connections.go
@@ -3,12 +3,20 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/neochaotic/leoflow/internal/domain"
 )
+
+// secretMask is the placeholder a read API returns in place of a secret
+// (a connection password/extra value, a sensitive-keyed variable). On write it
+// is treated as "unchanged": a field equal to it preserves the stored value
+// rather than overwriting it, so a round-tripped GET (Admin UI re-submitting a
+// connection it read) never persists the mask over the real secret (#874, #887).
+const secretMask = "***"
 
 // redactExtra masks secret-bearing values in a connection's free-form `extra`
 // before it is returned by the read API (#11). The extra is where provider
@@ -20,32 +28,32 @@ import (
 // Keys are matched by name via isSensitiveKey, which also covers Airflow's
 // prefixed form (extra__<type>__client_secret). If the extra is not a JSON
 // object (unexpected), it is redacted wholesale — fail closed rather than risk
-// echoing a secret. NOTE: a masked read that is written straight back would
-// persist "***"; the write path should treat "***" as "unchanged" (tracked as a
-// follow-up) — the same round-trip caveat the variable mask already carries.
+// echoing a secret. A masked value written straight back is treated as
+// "unchanged" by the write path (unmaskExtra restores it from the stored blob),
+// so a round-tripped GET never persists the mask over the real secret (#874).
 func redactExtra(extra string) string {
 	if extra == "" {
 		return extra
 	}
 	var m map[string]any
 	if err := json.Unmarshal([]byte(extra), &m); err != nil {
-		return "***" // not a JSON object → fail closed rather than echo a possible secret
+		return secretMask // not a JSON object → fail closed rather than echo a possible secret
 	}
 	redactMap(m)
 	b, err := json.Marshal(m)
 	if err != nil {
-		return "***"
+		return secretMask
 	}
 	return string(b)
 }
 
-// redactMap masks, to "***", every value whose key is sensitive, recursing into
-// nested objects and arrays so a secret nested under a non-sensitive key (extra
-// is free-form) is still caught, not just top-level ones.
+// redactMap masks, to secretMask, every value whose key is sensitive, recursing
+// into nested objects and arrays so a secret nested under a non-sensitive key
+// (extra is free-form) is still caught, not just top-level ones.
 func redactMap(m map[string]any) {
 	for k, v := range m {
 		if isSensitiveKey(k) {
-			m[k] = "***"
+			m[k] = secretMask
 			continue
 		}
 		redactAny(v)
@@ -68,7 +76,7 @@ func redactAny(v any) {
 type ConnectionStore interface {
 	ListConnections(ctx context.Context, tenant string, limit, offset int) ([]domain.Connection, int, error)
 	GetConnection(ctx context.Context, tenant, connID string) (domain.Connection, error)
-	SetConnection(ctx context.Context, tenant string, c domain.Connection) error
+	SetConnectionPatch(ctx context.Context, tenant string, p domain.ConnectionPatch) error
 	DeleteConnection(ctx context.Context, tenant, connID string) error
 }
 
@@ -104,23 +112,148 @@ func toConnectionDTO(c domain.Connection) connectionDTO {
 }
 
 // connectionBody is the POST/PATCH payload; password is accepted (write-only).
+// Every optional field is a pointer so the write path is tri-state (#887): a key
+// omitted from the JSON is nil (preserve the stored value), a key present with
+// "" clears the field, and a value sets it. ConnType is required on every write.
 type connectionBody struct {
-	ConnectionID string `json:"connection_id"`
-	ConnType     string `json:"conn_type"`
-	Description  string `json:"description"`
-	Host         string `json:"host"`
-	Login        string `json:"login"`
-	Password     string `json:"password"`
-	Schema       string `json:"schema"`
-	Port         *int   `json:"port"`
-	Extra        string `json:"extra"`
+	ConnectionID string  `json:"connection_id"`
+	ConnType     string  `json:"conn_type"`
+	Description  *string `json:"description"`
+	Host         *string `json:"host"`
+	Login        *string `json:"login"`
+	Password     *string `json:"password"`
+	Schema       *string `json:"schema"`
+	Port         *int    `json:"port"`
+	Extra        *string `json:"extra"`
 }
 
+// toDomain flattens the tri-state body to a plain domain.Connection (absent
+// fields become ""). It is used only by the non-persisting "test" probe, which
+// validates the posted connection's structure and has no stored value to merge.
 func (b connectionBody) toDomain(connID string) domain.Connection {
 	return domain.Connection{
-		ConnID: connID, ConnType: b.ConnType, Host: b.Host, Schema: b.Schema,
-		Login: b.Login, Password: b.Password, Port: b.Port, Extra: b.Extra, Description: b.Description,
+		ConnID: connID, ConnType: b.ConnType, Host: strVal(b.Host), Schema: strVal(b.Schema),
+		Login: strVal(b.Login), Password: strVal(b.Password), Port: b.Port,
+		Extra: strVal(b.Extra), Description: strVal(b.Description),
 	}
+}
+
+// toPatch builds a tri-state ConnectionPatch from the body, applying the
+// secret-mask rule (#874): a password equal to the mask is treated as absent
+// (preserve), and each masked value inside extra is restored from the stored
+// blob rather than overwriting the real secret. stored is the current connection
+// (extra decrypted) on update, or the zero value on create. Non-secret fields
+// pass through unchanged, so an omitted key preserves and an explicit "" clears.
+func (b connectionBody) toPatch(connID string, stored domain.Connection) domain.ConnectionPatch {
+	p := domain.ConnectionPatch{
+		ConnID: connID, ConnType: b.ConnType,
+		Host: b.Host, Login: b.Login, Schema: b.Schema,
+		Port: b.Port, Description: b.Description,
+	}
+	// Password: absent preserves; the mask means "unchanged" → also preserve.
+	if b.Password != nil && *b.Password != secretMask {
+		p.Password = b.Password
+	}
+	// Extra: absent preserves; present is unmasked against the stored extra so a
+	// round-tripped GET (secrets shown as the mask) never persists the mask. If
+	// the unmask cannot cleanly resolve every mask, the whole field is preserved
+	// (fail closed) rather than risking a literal mask overwriting a real secret.
+	if b.Extra != nil {
+		if merged, preserve := unmaskExtra(*b.Extra, stored.Extra); !preserve {
+			p.Extra = &merged
+		}
+	}
+	return p
+}
+
+// unmaskExtra reconciles an incoming extra against the stored extra for the
+// masked round-trip (#874). It returns the extra to persist and whether the
+// whole field should instead be preserved (left NULL):
+//   - incoming exactly the mask → the GET redacted the whole blob (extra was not
+//     a JSON object); preserve.
+//   - incoming a JSON object → every value (recursively) equal to the mask is
+//     replaced by the stored value at the same key; a masked key with no stored
+//     counterpart is dropped. If any mask survives (e.g. a mask buried in an
+//     array the stored side cannot supply), preserve the whole field — fail
+//     closed rather than persist a literal mask.
+//   - otherwise (not the mask, not an object; includes "") → persist as-is, so
+//     an explicit "" still clears the field.
+func unmaskExtra(incoming, stored string) (result string, preserve bool) {
+	if incoming == secretMask {
+		return "", true
+	}
+	var in map[string]any
+	if err := json.Unmarshal([]byte(incoming), &in); err != nil {
+		return incoming, false
+	}
+	var st map[string]any
+	if err := json.Unmarshal([]byte(stored), &st); err != nil {
+		st = nil // stored may be "" or a non-object → merge against an empty map
+	}
+	unmaskMap(in, st)
+	if containsMask(in) {
+		return "", true // a mask we could not resolve remains → preserve, fail closed
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		return "", true // cannot re-encode → preserve rather than risk a bad write
+	}
+	return string(b), false
+}
+
+// unmaskMap replaces, in place, every masked value in in with the value at the
+// same key in stored, recursing into nested objects (mirroring redactMap). A
+// masked key absent from stored is deleted — never persisted as a literal mask.
+func unmaskMap(in, stored map[string]any) {
+	for k, v := range in {
+		switch tv := v.(type) {
+		case string:
+			if tv == secretMask {
+				if sv, ok := stored[k]; ok {
+					in[k] = sv
+				} else {
+					delete(in, k)
+				}
+			}
+		case map[string]any:
+			var sub map[string]any
+			if sv, ok := stored[k].(map[string]any); ok {
+				sub = sv
+			}
+			unmaskMap(tv, sub)
+		}
+	}
+}
+
+// containsMask reports whether the mask survives anywhere in v (as a value in a
+// map, an element of an array, or a bare string), so unmaskExtra can fail closed
+// on anything it could not resolve.
+func containsMask(v any) bool {
+	switch t := v.(type) {
+	case string:
+		return t == secretMask
+	case map[string]any:
+		for _, e := range t {
+			if containsMask(e) {
+				return true
+			}
+		}
+	case []any:
+		for _, e := range t {
+			if containsMask(e) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// strVal dereferences an optional string, returning "" for nil.
+func strVal(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
 }
 
 func listConnectionsHandler(store ConnectionStore) gin.HandlerFunc {
@@ -161,20 +294,36 @@ func createConnectionHandler(store ConnectionStore) gin.HandlerFunc {
 			AbortProblem(c, http.StatusBadRequest, "bad request", "connection_id and conn_type are required")
 			return
 		}
-		conn := body.toDomain(body.ConnectionID)
-		if err := store.SetConnection(c.Request.Context(), tenantOf(c), conn); err != nil {
+		// POST is an upsert (`leoflow connections set`), so merge against any
+		// existing connection: a masked field then preserves the stored secret,
+		// exactly as on PATCH. When the connection does not exist yet, stored is
+		// the zero value and a masked field has nothing to preserve, so toPatch
+		// drops it (fail closed) rather than persisting the literal mask.
+		stored, gerr := store.GetConnection(c.Request.Context(), tenantOf(c), body.ConnectionID)
+		if gerr != nil && !errors.Is(gerr, ErrNotFound) {
+			handleRepoError(c, gerr)
+			return
+		}
+		patch := body.toPatch(body.ConnectionID, stored)
+		if err := store.SetConnectionPatch(c.Request.Context(), tenantOf(c), patch); err != nil {
 			handleConnWriteError(c, err)
 			return
 		}
-		c.JSON(http.StatusCreated, toConnectionDTO(conn))
+		dto, err := effectiveConnectionDTO(c, store, body.ConnectionID)
+		if err != nil {
+			handleRepoError(c, err)
+			return
+		}
+		c.JSON(http.StatusCreated, dto)
 	}
 }
 
 func updateConnectionHandler(store ConnectionStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		connID := c.Param("connection_id")
-		if _, err := store.GetConnection(c.Request.Context(), tenantOf(c), connID); err != nil {
-			handleRepoError(c, err)
+		stored, gerr := store.GetConnection(c.Request.Context(), tenantOf(c), connID)
+		if gerr != nil {
+			handleRepoError(c, gerr)
 			return
 		}
 		var body connectionBody
@@ -182,17 +331,36 @@ func updateConnectionHandler(store ConnectionStore) gin.HandlerFunc {
 			AbortProblem(c, http.StatusBadRequest, "bad request", err.Error())
 			return
 		}
-		conn := body.toDomain(connID)
-		if conn.ConnType == "" {
+		if body.ConnType == "" {
 			AbortProblem(c, http.StatusBadRequest, "bad request", "conn_type is required")
 			return
 		}
-		if err := store.SetConnection(c.Request.Context(), tenantOf(c), conn); err != nil {
+		// Merge the tri-state body over the stored connection so an omitted field
+		// preserves, an explicit "" clears, and a masked secret is left unchanged.
+		patch := body.toPatch(connID, stored)
+		if err := store.SetConnectionPatch(c.Request.Context(), tenantOf(c), patch); err != nil {
 			handleConnWriteError(c, err)
 			return
 		}
-		c.JSON(http.StatusOK, toConnectionDTO(conn))
+		dto, err := effectiveConnectionDTO(c, store, connID)
+		if err != nil {
+			handleRepoError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, dto)
 	}
+}
+
+// effectiveConnectionDTO re-reads the connection after a write so the response
+// reflects the merged result (preserved + cleared + set fields), with secrets
+// masked — never an echo of the request body, which would show empty for every
+// field the caller left the store to preserve.
+func effectiveConnectionDTO(c *gin.Context, store ConnectionStore, connID string) (connectionDTO, error) {
+	got, err := store.GetConnection(c.Request.Context(), tenantOf(c), connID)
+	if err != nil {
+		return connectionDTO{}, err
+	}
+	return toConnectionDTO(got), nil
 }
 
 func deleteConnectionHandler(store ConnectionStore) gin.HandlerFunc {

--- a/internal/api/ui_connections_test.go
+++ b/internal/api/ui_connections_test.go
@@ -35,14 +35,41 @@ func (f *fakeConnStore) GetConnection(_ context.Context, _, id string) (domain.C
 	return domain.Connection{}, ErrNotFound
 }
 
-func (f *fakeConnStore) SetConnection(_ context.Context, _ string, c domain.Connection) error {
+// SetConnectionPatch applies the tri-state patch to the in-memory store,
+// mirroring the repository's COALESCE upsert: a nil field preserves the stored
+// value, a non-nil field overwrites it (an empty string clears).
+func (f *fakeConnStore) SetConnectionPatch(_ context.Context, _ string, p domain.ConnectionPatch) error {
 	if f.writeErr != nil {
 		return f.writeErr
 	}
 	if f.conns == nil {
 		f.conns = map[string]domain.Connection{}
 	}
-	f.conns[c.ConnID] = c
+	cur := f.conns[p.ConnID]
+	cur.ConnID = p.ConnID
+	cur.ConnType = p.ConnType
+	if p.Host != nil {
+		cur.Host = *p.Host
+	}
+	if p.Login != nil {
+		cur.Login = *p.Login
+	}
+	if p.Schema != nil {
+		cur.Schema = *p.Schema
+	}
+	if p.Password != nil {
+		cur.Password = *p.Password
+	}
+	if p.Port != nil {
+		cur.Port = p.Port
+	}
+	if p.Extra != nil {
+		cur.Extra = *p.Extra
+	}
+	if p.Description != nil {
+		cur.Description = *p.Description
+	}
+	f.conns[p.ConnID] = cur
 	return nil
 }
 
@@ -171,6 +198,223 @@ func TestConnectionWriteWithoutKeyReturns503(t *testing.T) {
 		`{"connection_id":"pg","conn_type":"postgres","password":"x"}`)
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Errorf("write without key = %d, want 503", rec.Code)
+	}
+}
+
+// TestConnectionUpdateTriState locks the #887 write semantics on the PATCH path:
+// an omitted field preserves the stored value, an explicit "" clears it, and a
+// masked password ("***") is treated as unchanged so a round-tripped GET never
+// overwrites the real secret with the mask (#874).
+func TestConnectionUpdateTriState(t *testing.T) {
+	newStore := func() *fakeConnStore {
+		return &fakeConnStore{conns: map[string]domain.Connection{
+			"pg": {
+				ConnID: "pg", ConnType: "postgres", Host: "db", Login: "analytics",
+				Password: "s3cr3t", Schema: "public", Extra: `{"sslmode":"require"}`,
+			},
+		}}
+	}
+
+	t.Run("omitted field preserves", func(t *testing.T) {
+		store := newStore()
+		srv := connServer(store)
+		rec := authGet(srv, http.MethodPatch, "/api/v2/connections/pg",
+			`{"conn_type":"postgres","host":"db2"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("patch = %d (%s)", rec.Code, rec.Body.String())
+		}
+		got := store.conns["pg"]
+		if got.Host != "db2" {
+			t.Errorf("host not updated: %q", got.Host)
+		}
+		if got.Login != "analytics" || got.Password != "s3cr3t" || got.Extra != `{"sslmode":"require"}` {
+			t.Errorf("omitted fields were clobbered: %+v", got)
+		}
+	})
+
+	t.Run("explicit empty clears a non-secret field", func(t *testing.T) {
+		store := newStore()
+		srv := connServer(store)
+		rec := authGet(srv, http.MethodPatch, "/api/v2/connections/pg",
+			`{"conn_type":"postgres","login":""}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("patch = %d (%s)", rec.Code, rec.Body.String())
+		}
+		if got := store.conns["pg"]; got.Login != "" {
+			t.Errorf("login was not cleared: %q", got.Login)
+		}
+		if got := store.conns["pg"]; got.Password != "s3cr3t" {
+			t.Errorf("clearing login must not touch the password: %q", got.Password)
+		}
+	})
+
+	t.Run("masked password preserves the real secret", func(t *testing.T) {
+		store := newStore()
+		srv := connServer(store)
+		rec := authGet(srv, http.MethodPatch, "/api/v2/connections/pg",
+			`{"conn_type":"postgres","password":"***","host":"db3"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("patch = %d (%s)", rec.Code, rec.Body.String())
+		}
+		got := store.conns["pg"]
+		if got.Password != "s3cr3t" {
+			t.Errorf("masked password overwrote the real secret: %q", got.Password)
+		}
+		if got.Host != "db3" {
+			t.Errorf("the co-submitted host edit did not land: %q", got.Host)
+		}
+	})
+
+	t.Run("explicit empty password clears it", func(t *testing.T) {
+		store := newStore()
+		srv := connServer(store)
+		rec := authGet(srv, http.MethodPatch, "/api/v2/connections/pg",
+			`{"conn_type":"postgres","password":""}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("patch = %d (%s)", rec.Code, rec.Body.String())
+		}
+		if got := store.conns["pg"]; got.Password != "" {
+			t.Errorf("explicit empty password did not clear: %q", got.Password)
+		}
+	})
+}
+
+// TestConnectionUpdateExtraUnmask locks that a round-tripped `extra` (secrets
+// shown as the mask by GET) is merged back against the stored blob rather than
+// persisting the mask over the real secret (#874), while a co-edited plain key
+// still lands. It also covers the wholesale-mask case and an explicit clear.
+func TestConnectionUpdateExtraUnmask(t *testing.T) {
+	seed := func() *fakeConnStore {
+		return &fakeConnStore{conns: map[string]domain.Connection{
+			"wh": {
+				ConnID: "wh", ConnType: "databricks",
+				Extra: `{"token":"tok-REAL","http_path":"/sql/1.0/x","account":"acme"}`,
+			},
+		}}
+	}
+
+	t.Run("masked secret key is restored, plain edit lands", func(t *testing.T) {
+		store := seed()
+		srv := connServer(store)
+		// The UI GET'd the connection (token shown as ***) and the user changed
+		// http_path, then re-submitted the whole extra.
+		rec := authGet(srv, http.MethodPatch, "/api/v2/connections/wh",
+			`{"conn_type":"databricks","extra":"{\"token\":\"***\",\"http_path\":\"/sql/2.0/y\",\"account\":\"acme\"}"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("patch = %d (%s)", rec.Code, rec.Body.String())
+		}
+		var ex map[string]any
+		if err := json.Unmarshal([]byte(store.conns["wh"].Extra), &ex); err != nil {
+			t.Fatalf("stored extra not json: %v (%q)", err, store.conns["wh"].Extra)
+		}
+		if ex["token"] != "tok-REAL" {
+			t.Errorf("masked token overwrote the real secret: %v", ex["token"])
+		}
+		if ex["http_path"] != "/sql/2.0/y" {
+			t.Errorf("the plain edit did not land: %v", ex["http_path"])
+		}
+	})
+
+	t.Run("wholesale mask preserves the stored extra", func(t *testing.T) {
+		store := seed()
+		srv := connServer(store)
+		rec := authGet(srv, http.MethodPatch, "/api/v2/connections/wh",
+			`{"conn_type":"databricks","extra":"***"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("patch = %d (%s)", rec.Code, rec.Body.String())
+		}
+		if got := store.conns["wh"].Extra; got != `{"token":"tok-REAL","http_path":"/sql/1.0/x","account":"acme"}` {
+			t.Errorf("wholesale mask did not preserve the stored extra: %q", got)
+		}
+	})
+
+	t.Run("explicit empty extra clears it", func(t *testing.T) {
+		store := seed()
+		srv := connServer(store)
+		rec := authGet(srv, http.MethodPatch, "/api/v2/connections/wh",
+			`{"conn_type":"databricks","extra":""}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("patch = %d (%s)", rec.Code, rec.Body.String())
+		}
+		if got := store.conns["wh"].Extra; got != "" {
+			t.Errorf("explicit empty extra did not clear: %q", got)
+		}
+	})
+}
+
+// TestConnectionUpsertPOSTMaskedRoundTrip locks that the POST upsert path (what
+// `leoflow connections set` uses) merges a masked field against the EXISTING
+// connection, not an empty one. A regression here silently wiped a round-tripped
+// secret extra to "{}" even though PATCH was correct (caught by the e2e).
+func TestConnectionUpsertPOSTMaskedRoundTrip(t *testing.T) {
+	store := &fakeConnStore{conns: map[string]domain.Connection{
+		"pg": {
+			ConnID: "pg", ConnType: "postgres", Host: "db",
+			Password: "s3cr3t", Extra: `{"token":"tok-REAL"}`,
+		},
+	}}
+	srv := connServer(store)
+	// Re-POST the same connection with a masked password and masked extra.
+	rec := authGet(srv, http.MethodPost, "/api/v2/connections",
+		`{"connection_id":"pg","conn_type":"postgres","password":"***","extra":"{\"token\":\"***\"}"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("post = %d (%s)", rec.Code, rec.Body.String())
+	}
+	got := store.conns["pg"]
+	if got.Password != "s3cr3t" {
+		t.Errorf("POST upsert overwrote the real password with the mask: %q", got.Password)
+	}
+	if got.Extra != `{"token":"tok-REAL"}` {
+		t.Errorf("POST upsert wiped/masked the real extra token: %q", got.Extra)
+	}
+}
+
+// TestUnmaskExtra unit-tests the fail-closed merge helper directly.
+func TestUnmaskExtra(t *testing.T) {
+	stored := `{"token":"real","cfg":{"secret":"deep"},"opts":["a"]}`
+
+	// A masked key is restored from stored; a plain key passes through.
+	got, preserve := unmaskExtra(`{"token":"***","region":"eu"}`, stored)
+	if preserve {
+		t.Fatal("a resolvable object must not preserve wholesale")
+	}
+	var m map[string]any
+	_ = json.Unmarshal([]byte(got), &m)
+	if m["token"] != "real" || m["region"] != "eu" {
+		t.Errorf("unmask/merge wrong: %v", m)
+	}
+
+	// Nested masked key restored from the stored nested object.
+	got, _ = unmaskExtra(`{"cfg":{"secret":"***"}}`, stored)
+	_ = json.Unmarshal([]byte(got), &m)
+	cfg, _ := m["cfg"].(map[string]any)
+	if cfg["secret"] != "deep" {
+		t.Errorf("nested unmask wrong: %v", m)
+	}
+
+	// Wholesale mask preserves.
+	if _, preserve = unmaskExtra("***", stored); !preserve {
+		t.Error("wholesale mask must preserve")
+	}
+
+	// A mask with no stored counterpart is dropped (never persisted literally).
+	got, preserve = unmaskExtra(`{"ghost":"***","keep":"v"}`, stored)
+	if preserve {
+		t.Fatal("a droppable mask should not force wholesale preserve")
+	}
+	_ = json.Unmarshal([]byte(got), &m)
+	if _, ok := m["ghost"]; ok {
+		t.Errorf("unresolvable mask must be dropped, not persisted: %v", m)
+	}
+
+	// A mask buried in an array (stored cannot supply it) fails closed to preserve.
+	if _, preserve = unmaskExtra(`{"opts":["***"]}`, stored); !preserve {
+		t.Error("an unresolvable array mask must fail closed to preserve")
+	}
+
+	// An explicit empty extra clears (not the mask, not an object).
+	if got, preserve := unmaskExtra("", stored); preserve || got != "" {
+		t.Errorf(`empty extra must clear: got %q preserve=%v`, got, preserve)
 	}
 }
 

--- a/internal/api/ui_connections_test.go
+++ b/internal/api/ui_connections_test.go
@@ -340,6 +340,38 @@ func TestConnectionUpdateExtraUnmask(t *testing.T) {
 			t.Errorf("explicit empty extra did not clear: %q", got)
 		}
 	})
+
+	t.Run("secret nested in an array is restored, top-level edit lands", func(t *testing.T) {
+		store := &fakeConnStore{conns: map[string]domain.Connection{
+			"wh": {
+				ConnID: "wh", ConnType: "databricks",
+				// A secret buried in an array-of-objects (redactExtra masks these too).
+				Extra: `{"account":"acme","hosts":[{"password":"arr-REAL"}]}`,
+			},
+		}}
+		srv := connServer(store)
+		// UI GET'd it (array password shown as ***) and edited the top-level account.
+		rec := authGet(srv, http.MethodPatch, "/api/v2/connections/wh",
+			`{"conn_type":"databricks","extra":"{\"account\":\"beta\",\"hosts\":[{\"password\":\"***\"}]}"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("patch = %d (%s)", rec.Code, rec.Body.String())
+		}
+		var ex map[string]any
+		if err := json.Unmarshal([]byte(store.conns["wh"].Extra), &ex); err != nil {
+			t.Fatalf("stored extra not json: %v (%q)", err, store.conns["wh"].Extra)
+		}
+		if ex["account"] != "beta" {
+			t.Errorf("top-level edit was dropped (whole field force-preserved?): %v", ex["account"])
+		}
+		hosts, _ := ex["hosts"].([]any)
+		if len(hosts) != 1 {
+			t.Fatalf("array shape changed: %v", ex)
+		}
+		first, _ := hosts[0].(map[string]any)
+		if first["password"] != "arr-REAL" {
+			t.Errorf("array-nested secret overwritten by the mask: %v", first)
+		}
+	})
 }
 
 // TestConnectionUpsertPOSTMaskedRoundTrip locks that the POST upsert path (what
@@ -407,9 +439,32 @@ func TestUnmaskExtra(t *testing.T) {
 		t.Errorf("unresolvable mask must be dropped, not persisted: %v", m)
 	}
 
-	// A mask buried in an array (stored cannot supply it) fails closed to preserve.
-	if _, preserve = unmaskExtra(`{"opts":["***"]}`, stored); !preserve {
-		t.Error("an unresolvable array mask must fail closed to preserve")
+	// A secret nested inside an array-of-objects is restored from the stored array
+	// (aligned by index), and a co-edited plain key at the top level still lands —
+	// the whole field must NOT be force-preserved.
+	arrStored := `{"region":"us-east","items":[{"token":"real-arr","note":"n"}]}`
+	got, preserve = unmaskExtra(`{"region":"eu-west","items":[{"token":"***","note":"n"}]}`, arrStored)
+	if preserve {
+		t.Fatal("a restorable array-nested mask must not force wholesale preserve")
+	}
+	_ = json.Unmarshal([]byte(got), &m)
+	if m["region"] != "eu-west" {
+		t.Errorf("top-level co-edit lost when a mask sat in an array: %v", m)
+	}
+	if items, _ := m["items"].([]any); len(items) != 1 {
+		t.Fatalf("array shape changed: %v", m)
+	} else if first, _ := items[0].(map[string]any); first["token"] != "real-arr" {
+		t.Errorf("array-nested secret not restored from stored: %v", m)
+	}
+
+	// A masked array element the stored side cannot supply (shorter/empty array)
+	// fails closed to preserve — never a silent drop that shifts indices.
+	if _, preserve = unmaskExtra(`{"items":[{"token":"***"}]}`, `{"items":[]}`); !preserve {
+		t.Error("an unresolvable array-nested mask must fail closed to preserve")
+	}
+	// A bare masked string in an array with no stored counterpart also fails closed.
+	if _, preserve = unmaskExtra(`{"opts":["***"]}`, `{"opts":[]}`); !preserve {
+		t.Error("an unresolvable bare array mask must fail closed to preserve")
 	}
 
 	// An explicit empty extra clears (not the mask, not an object).

--- a/internal/api/ui_connections_tristate_integration_test.go
+++ b/internal/api/ui_connections_tristate_integration_test.go
@@ -1,0 +1,191 @@
+//go:build integration
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/config"
+	"github.com/neochaotic/leoflow/internal/secrets"
+	"github.com/neochaotic/leoflow/internal/storage"
+)
+
+// tristateServer wires the real Repository (over the test DB, with a cipher) as
+// the connection/variable store behind the actual HTTP handlers, plus a handle
+// to the repo for out-of-band assertions on the delivered secret.
+func tristateServer(t *testing.T) (srv *gin.Engine, repo *storage.Repository, ctx context.Context) {
+	t.Helper()
+	url := os.Getenv("DATABASE_URL")
+	if url == "" {
+		t.Skip("DATABASE_URL must point at a migrated database for integration tests")
+	}
+	ctx = context.Background()
+	pg, err := storage.NewPostgres(ctx, config.DatabaseSection{URL: url})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pg.Close)
+	repo = storage.NewRepository(pg)
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 23)
+	}
+	cipher, err := secrets.NewAESGCM(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo.SetCipher(cipher)
+	return NewServer(Dependencies{
+		Logger:        discardLogger(),
+		Authenticator: &fakeAuthn{user: &auth.User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}},
+		RateLimiter:   auth.NewRateLimiter(1000, time.Minute),
+		CORSOrigins:   []string{"*"},
+		TokenTTLSecs:  3600,
+		Connections:   repo,
+		Variables:     repo,
+	}), repo, ctx
+}
+
+// TestConnectionMaskedRoundTripFullStack is the #874 end-to-end regression lock:
+// it drives the real HTTP handlers against a real Repository and proves that
+// GETting a connection (secrets shown as "***") and PATCHing it straight back —
+// exactly what the embedded Admin UI does — does NOT overwrite the stored
+// password or the secret inside `extra` with the mask. The password survives is
+// proven through the delivered AIRFLOW_CONN_<id> URI; the extra secret through
+// GetConnection (which returns the decrypted, unredacted extra).
+func TestConnectionMaskedRoundTripFullStack(t *testing.T) {
+	srv, repo, ctx := tristateServer(t)
+	connID := fmt.Sprintf("api_tristate_%d", time.Now().UnixNano())
+	t.Cleanup(func() { _ = repo.DeleteConnection(ctx, "default", connID) })
+
+	// Create with a real password and a secret token inside extra.
+	create := fmt.Sprintf(
+		`{"connection_id":%q,"conn_type":"databricks","host":"h","password":"PW-REAL","extra":"{\"token\":\"TOK-REAL\",\"http_path\":\"/sql/1.0/x\"}"}`,
+		connID)
+	if rec := authGet(srv, http.MethodPost, "/api/v2/connections", create); rec.Code != http.StatusCreated {
+		t.Fatalf("create = %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	// GET as the UI would: the password is absent, the extra token is masked.
+	rec := authGet(srv, http.MethodGet, "/api/v2/connections/"+connID, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("get = %d (%s)", rec.Code, rec.Body.String())
+	}
+	var dto connectionDTO
+	if err := json.Unmarshal(rec.Body.Bytes(), &dto); err != nil {
+		t.Fatal(err)
+	}
+	if dto.Extra == nil || !strings.Contains(*dto.Extra, secretMask) {
+		t.Fatalf("GET should mask the extra token: %+v", dto.Extra)
+	}
+
+	// The UI edits a plain field (http_path) and re-submits the masked extra plus
+	// a masked password — the round-trip that #874 is about.
+	maskedExtra := *dto.Extra
+	maskedExtra = strings.Replace(maskedExtra, "/sql/1.0/x", "/sql/2.0/y", 1)
+	patch := map[string]any{"conn_type": "databricks", "password": secretMask, "extra": maskedExtra}
+	pb, _ := json.Marshal(patch)
+	if rec := authGet(srv, http.MethodPatch, "/api/v2/connections/"+connID, string(pb)); rec.Code != http.StatusOK {
+		t.Fatalf("patch = %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	// Password must still be the real one (proven via the delivered URI).
+	tenantUUID, err := repo.TenantUUID(ctx, "default")
+	if err != nil {
+		t.Fatalf("TenantUUID: %v", err)
+	}
+	uris, err := repo.SecretConnectionURIs(ctx, tenantUUID)
+	if err != nil {
+		t.Fatalf("SecretConnectionURIs: %v", err)
+	}
+	if uri := uris[connID]; !strings.Contains(uri, "PW-REAL") {
+		t.Errorf("masked password round-trip overwrote the real secret: %q", uri)
+	}
+
+	// Extra token must still be the real one, and the plain edit must have landed.
+	got, err := repo.GetConnection(ctx, "default", connID)
+	if err != nil {
+		t.Fatalf("GetConnection: %v", err)
+	}
+	var ex map[string]any
+	if err := json.Unmarshal([]byte(got.Extra), &ex); err != nil {
+		t.Fatalf("stored extra not json: %v (%q)", err, got.Extra)
+	}
+	if ex["token"] != "TOK-REAL" {
+		t.Errorf("masked extra token overwrote the real secret: %v", ex["token"])
+	}
+	if ex["http_path"] != "/sql/2.0/y" {
+		t.Errorf("the plain extra edit did not land: %v", ex["http_path"])
+	}
+}
+
+// TestConnectionExplicitClearFullStack proves the other half of the tri-state
+// contract end to end: an explicit empty value clears a non-secret field, while
+// the omitted (unreadable) password is preserved.
+func TestConnectionExplicitClearFullStack(t *testing.T) {
+	srv, repo, ctx := tristateServer(t)
+	connID := fmt.Sprintf("api_clear_%d", time.Now().UnixNano())
+	t.Cleanup(func() { _ = repo.DeleteConnection(ctx, "default", connID) })
+
+	create := fmt.Sprintf(
+		`{"connection_id":%q,"conn_type":"postgres","host":"h","login":"analytics","password":"PW-REAL"}`,
+		connID)
+	if rec := authGet(srv, http.MethodPost, "/api/v2/connections", create); rec.Code != http.StatusCreated {
+		t.Fatalf("create = %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	// Blank the login and save (Airflow-UI clear semantics), password omitted.
+	if rec := authGet(srv, http.MethodPatch, "/api/v2/connections/"+connID,
+		`{"conn_type":"postgres","login":""}`); rec.Code != http.StatusOK {
+		t.Fatalf("patch = %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	got, err := repo.GetConnection(ctx, "default", connID)
+	if err != nil {
+		t.Fatalf("GetConnection: %v", err)
+	}
+	if got.Login != "" {
+		t.Errorf("explicit empty login did not clear: %q", got.Login)
+	}
+	tenantUUID, _ := repo.TenantUUID(ctx, "default")
+	uris, _ := repo.SecretConnectionURIs(ctx, tenantUUID)
+	if uri := uris[connID]; !strings.Contains(uri, "PW-REAL") {
+		t.Errorf("clearing login must preserve the omitted password: %q", uri)
+	}
+}
+
+// TestVariableMaskedRoundTripFullStack is the variable analog of the #874
+// lock: a GET of a sensitive-keyed variable masks the value, and writing it
+// straight back must not persist the mask over the real value.
+func TestVariableMaskedRoundTripFullStack(t *testing.T) {
+	srv, repo, ctx := tristateServer(t)
+	key := fmt.Sprintf("api_token_%d", time.Now().UnixNano())
+	t.Cleanup(func() { _ = repo.DeleteVariable(ctx, "default", key) })
+
+	create := fmt.Sprintf(`{"key":%q,"value":"TOK-REAL"}`, key)
+	if rec := authGet(srv, http.MethodPost, "/api/v2/variables", create); rec.Code != http.StatusCreated {
+		t.Fatalf("create = %d (%s)", rec.Code, rec.Body.String())
+	}
+	// Write back the masked value the UI GET returns.
+	if rec := authGet(srv, http.MethodPatch, "/api/v2/variables/"+key,
+		fmt.Sprintf(`{"value":%q}`, secretMask)); rec.Code != http.StatusOK {
+		t.Fatalf("patch = %d (%s)", rec.Code, rec.Body.String())
+	}
+	got, err := repo.GetVariable(ctx, "default", key)
+	if err != nil {
+		t.Fatalf("GetVariable: %v", err)
+	}
+	if got.Value != "TOK-REAL" {
+		t.Errorf("masked variable round-trip overwrote the real value: %q", got.Value)
+	}
+}

--- a/internal/api/ui_variables.go
+++ b/internal/api/ui_variables.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -14,7 +15,7 @@ import (
 type VariableStore interface {
 	ListVariables(ctx context.Context, tenant string, limit, offset int) ([]domain.Variable, int, error)
 	GetVariable(ctx context.Context, tenant, key string) (domain.Variable, error)
-	SetVariable(ctx context.Context, tenant string, v domain.Variable) error
+	SetVariablePatch(ctx context.Context, tenant string, p domain.VariablePatch) error
 	DeleteVariable(ctx context.Context, tenant, key string) error
 }
 
@@ -39,12 +40,35 @@ func isSensitiveKey(key string) bool {
 	return false
 }
 
-// maskedValue returns "***" when the key looks sensitive, else the value.
+// maskedValue returns the mask when the key looks sensitive, else the value.
 func maskedValue(key, value string) string {
 	if isSensitiveKey(key) {
-		return "***"
+		return secretMask
 	}
 	return value
+}
+
+// buildVariablePatch maps the tri-state variable body to a VariablePatch (#887),
+// applying the masked round-trip rule: a value equal to the mask for a
+// sensitive-looking key is treated as "unchanged". Because the `value` column is
+// NOT NULL it cannot be preserved at the SQL layer, so "preserve" is resolved
+// here to the stored value (available on update). On create there is nothing to
+// preserve, so an absent or masked value becomes an explicit empty string (fail
+// closed — never persist a literal mask as the real value). An explicit "" for a
+// non-mask value always clears.
+func buildVariablePatch(key string, value, desc *string, stored domain.Variable, isCreate bool) domain.VariablePatch {
+	p := domain.VariablePatch{Key: key, Description: desc}
+	switch {
+	case value != nil && (!isSensitiveKey(key) || *value != secretMask):
+		p.Value = value // explicit set (including "" to clear)
+	case isCreate:
+		empty := ""
+		p.Value = &empty // nothing to preserve on create → empty
+	default:
+		v := stored.Value // update: absent or masked → preserve the stored value
+		p.Value = &v
+	}
+	return p
 }
 
 // variableDTO is the Airflow 3.2.1 VariableResponse. Leoflow stores variables in
@@ -105,9 +129,9 @@ func getVariableHandler(store VariableStore) gin.HandlerFunc {
 func createVariableHandler(store VariableStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var body struct {
-			Key         string `json:"key"`
-			Value       string `json:"value"`
-			Description string `json:"description"`
+			Key         string  `json:"key"`
+			Value       *string `json:"value"`
+			Description *string `json:"description"`
 		}
 		if err := c.ShouldBindJSON(&body); err != nil {
 			AbortProblem(c, http.StatusBadRequest, "bad request", err.Error())
@@ -117,12 +141,27 @@ func createVariableHandler(store VariableStore) gin.HandlerFunc {
 			AbortProblem(c, http.StatusBadRequest, "bad request", "key is required")
 			return
 		}
-		v := domain.Variable{Key: body.Key, Value: body.Value, Description: body.Description}
-		if err := store.SetVariable(c.Request.Context(), tenantOf(c), v); err != nil {
+		// POST is an upsert (`leoflow variables set`), so merge against any existing
+		// variable: a masked value for an existing sensitive key then preserves the
+		// stored value, exactly as on PATCH. A genuinely new key (not found) is a
+		// create, where a masked value has nothing to preserve → empty (fail closed).
+		stored, gerr := store.GetVariable(c.Request.Context(), tenantOf(c), body.Key)
+		isCreate := errors.Is(gerr, ErrNotFound)
+		if gerr != nil && !isCreate {
+			handleRepoError(c, gerr)
+			return
+		}
+		patch := buildVariablePatch(body.Key, body.Value, body.Description, stored, isCreate)
+		if err := store.SetVariablePatch(c.Request.Context(), tenantOf(c), patch); err != nil {
 			handleRepoError(c, err)
 			return
 		}
-		c.JSON(http.StatusCreated, toVariableDTO(v))
+		dto, err := effectiveVariableDTO(c, store, body.Key)
+		if err != nil {
+			handleRepoError(c, err)
+			return
+		}
+		c.JSON(http.StatusCreated, dto)
 	}
 }
 
@@ -130,25 +169,42 @@ func createVariableHandler(store VariableStore) gin.HandlerFunc {
 func updateVariableHandler(store VariableStore) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		key := c.Param("variable_key")
-		if _, err := store.GetVariable(c.Request.Context(), tenantOf(c), key); err != nil {
-			handleRepoError(c, err)
+		stored, gerr := store.GetVariable(c.Request.Context(), tenantOf(c), key)
+		if gerr != nil {
+			handleRepoError(c, gerr)
 			return
 		}
 		var body struct {
-			Value       string `json:"value"`
-			Description string `json:"description"`
+			Value       *string `json:"value"`
+			Description *string `json:"description"`
 		}
 		if err := c.ShouldBindJSON(&body); err != nil {
 			AbortProblem(c, http.StatusBadRequest, "bad request", err.Error())
 			return
 		}
-		v := domain.Variable{Key: key, Value: body.Value, Description: body.Description}
-		if err := store.SetVariable(c.Request.Context(), tenantOf(c), v); err != nil {
+		patch := buildVariablePatch(key, body.Value, body.Description, stored, false)
+		if err := store.SetVariablePatch(c.Request.Context(), tenantOf(c), patch); err != nil {
 			handleRepoError(c, err)
 			return
 		}
-		c.JSON(http.StatusOK, toVariableDTO(v))
+		dto, err := effectiveVariableDTO(c, store, key)
+		if err != nil {
+			handleRepoError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, dto)
 	}
+}
+
+// effectiveVariableDTO re-reads the variable after a write so the response
+// reflects the merged result (preserved + cleared + set fields), with a
+// sensitive-keyed value masked — never an echo of the request body.
+func effectiveVariableDTO(c *gin.Context, store VariableStore, key string) (variableDTO, error) {
+	v, err := store.GetVariable(c.Request.Context(), tenantOf(c), key)
+	if err != nil {
+		return variableDTO{}, err
+	}
+	return toVariableDTO(v), nil
 }
 
 // deleteVariableHandler implements DELETE /api/v2/variables/{variable_key}.

--- a/internal/api/ui_variables_test.go
+++ b/internal/api/ui_variables_test.go
@@ -33,12 +33,23 @@ func (f *fakeVariableStore) GetVariable(_ context.Context, _, key string) (domai
 	return domain.Variable{}, ErrNotFound
 }
 
-func (f *fakeVariableStore) SetVariable(_ context.Context, _ string, v domain.Variable) error {
+// SetVariablePatch applies the tri-state patch to the in-memory store, mirroring
+// the repository's COALESCE upsert: a nil field preserves the stored value, a
+// non-nil field overwrites it (an empty string clears).
+func (f *fakeVariableStore) SetVariablePatch(_ context.Context, _ string, p domain.VariablePatch) error {
 	if f.vars == nil {
 		f.vars = map[string]domain.Variable{}
 	}
-	f.vars[v.Key] = v
-	f.setCalls = append(f.setCalls, v)
+	cur := f.vars[p.Key]
+	cur.Key = p.Key
+	if p.Value != nil {
+		cur.Value = *p.Value
+	}
+	if p.Description != nil {
+		cur.Description = *p.Description
+	}
+	f.vars[p.Key] = cur
+	f.setCalls = append(f.setCalls, cur)
 	return nil
 }
 
@@ -124,6 +135,106 @@ func TestVariableSecretMasking(t *testing.T) {
 	_ = json.Unmarshal(rec.Body.Bytes(), &v)
 	if v.Value != "us-east" {
 		t.Errorf("plain value should not be masked, got %q", v.Value)
+	}
+}
+
+// TestVariableUpdateTriState locks the #887 write semantics on the variable
+// PATCH path: a masked value ("***") for a sensitive key is treated as unchanged
+// (the #874 rule for variables), an omitted value preserves, and an explicit ""
+// clears.
+func TestVariableUpdateTriState(t *testing.T) {
+	newStore := func() *fakeVariableStore {
+		return &fakeVariableStore{vars: map[string]domain.Variable{
+			"api_token": {Key: "api_token", Value: "tok-REAL", Description: "prod"},
+			"region":    {Key: "region", Value: "us-east"},
+		}}
+	}
+
+	t.Run("masked sensitive value preserves the real value", func(t *testing.T) {
+		store := newStore()
+		srv := variablesServer(store)
+		// The UI GET'd api_token (value shown as ***) and re-submitted it verbatim.
+		rec := authGet(srv, http.MethodPatch, "/api/v2/variables/api_token", `{"value":"***"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("patch = %d (%s)", rec.Code, rec.Body.String())
+		}
+		if got := store.vars["api_token"].Value; got != "tok-REAL" {
+			t.Errorf("masked value overwrote the real secret: %q", got)
+		}
+	})
+
+	t.Run("masked value for a NON-sensitive key is a literal set", func(t *testing.T) {
+		store := newStore()
+		srv := variablesServer(store)
+		// "region" is not sensitive, so "***" is a real value the user chose.
+		rec := authGet(srv, http.MethodPatch, "/api/v2/variables/region", `{"value":"***"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("patch = %d (%s)", rec.Code, rec.Body.String())
+		}
+		if got := store.vars["region"].Value; got != "***" {
+			t.Errorf("a non-sensitive key must set the literal value: %q", got)
+		}
+	})
+
+	t.Run("omitted value preserves, description updates", func(t *testing.T) {
+		store := newStore()
+		srv := variablesServer(store)
+		rec := authGet(srv, http.MethodPatch, "/api/v2/variables/api_token", `{"description":"staging"}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("patch = %d (%s)", rec.Code, rec.Body.String())
+		}
+		got := store.vars["api_token"]
+		if got.Value != "tok-REAL" {
+			t.Errorf("omitted value was clobbered: %q", got.Value)
+		}
+		if got.Description != "staging" {
+			t.Errorf("description not updated: %q", got.Description)
+		}
+	})
+
+	t.Run("explicit empty value clears", func(t *testing.T) {
+		store := newStore()
+		srv := variablesServer(store)
+		rec := authGet(srv, http.MethodPatch, "/api/v2/variables/region", `{"value":""}`)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("patch = %d (%s)", rec.Code, rec.Body.String())
+		}
+		if got := store.vars["region"].Value; got != "" {
+			t.Errorf("explicit empty value did not clear: %q", got)
+		}
+	})
+}
+
+// TestVariableCreateMaskedFailsClosed: creating a sensitive-keyed variable whose
+// value is the mask has nothing to preserve, so it stores an empty value rather
+// than persisting a literal "***" as the real secret.
+func TestVariableCreateMaskedFailsClosed(t *testing.T) {
+	store := &fakeVariableStore{vars: map[string]domain.Variable{}}
+	srv := variablesServer(store)
+	rec := authGet(srv, http.MethodPost, "/api/v2/variables", `{"key":"api_token","value":"***"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create = %d (%s)", rec.Code, rec.Body.String())
+	}
+	if got := store.vars["api_token"].Value; got != "" {
+		t.Errorf("masked create must not persist the literal mask: %q", got)
+	}
+}
+
+// TestVariableUpsertPOSTMaskedRoundTrip locks that the POST upsert path (what
+// `leoflow variables set` uses) preserves an existing sensitive value when the
+// masked value is written back, rather than treating it as a fresh create and
+// clearing it.
+func TestVariableUpsertPOSTMaskedRoundTrip(t *testing.T) {
+	store := &fakeVariableStore{vars: map[string]domain.Variable{
+		"api_token": {Key: "api_token", Value: "tok-REAL"},
+	}}
+	srv := variablesServer(store)
+	rec := authGet(srv, http.MethodPost, "/api/v2/variables", `{"key":"api_token","value":"***"}`)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("post = %d (%s)", rec.Code, rec.Body.String())
+	}
+	if got := store.vars["api_token"].Value; got != "tok-REAL" {
+		t.Errorf("POST upsert overwrote the real value with the mask: %q", got)
 	}
 }
 

--- a/internal/cli/connections.go
+++ b/internal/cli/connections.go
@@ -50,8 +50,8 @@ func newConnectionsSetCommand() *cobra.Command {
 			"--conn-type is required.\n\n" +
 			"Only the fields you pass are changed; any field you omit keeps its " +
 			"current value. So you can change just --host without re-supplying the " +
-			"password (which cannot be read back anyway). To clear a field, delete " +
-			"and recreate the connection.\n\n" +
+			"password (which cannot be read back anyway). To clear a field, pass it " +
+			"as an empty string, e.g. --login '' or --schema ''.\n\n" +
 			"The password and extra are sent to the control plane but never printed " +
 			"back; read commands show masked values. Prefer --password-stdin / " +
 			"--extra-file over --password / --extra so a secret never lands in your " +

--- a/internal/cli/connections.go
+++ b/internal/cli/connections.go
@@ -132,7 +132,12 @@ func connectionBodyFromFlags(cmd *cobra.Command, connID string, f connectionSetF
 	if cmd.Flags().Changed("login") {
 		body.Login = &f.login
 	}
-	if password != "" {
+	// Send the password only when it was actually supplied — via --password
+	// (including an explicit empty string, which clears it) or --password-stdin.
+	// Omitting both leaves it absent (nil), so the control plane preserves the
+	// stored, unreadable password. Gating on non-empty would make --password ''
+	// a silent no-op, inconsistent with --login '' clearing.
+	if cmd.Flags().Changed("password") || cmd.Flags().Changed("password-stdin") {
 		body.Password = &password
 	}
 	if cmd.Flags().Changed("schema") {

--- a/internal/cli/connections_test.go
+++ b/internal/cli/connections_test.go
@@ -129,6 +129,53 @@ func TestSetConnectionCommandPasswordStdin(t *testing.T) {
 	}
 }
 
+// TestSetConnectionCommandPasswordClearVsOmit locks the tri-state password flag
+// (#887): an explicit empty --password sends an empty string (clear), while
+// omitting --password sends no password field at all (nil, so the control plane
+// preserves the stored, unreadable password). Gating on non-empty would make an
+// empty --password a silent no-op, inconsistent with an empty --login clearing.
+func TestSetConnectionCommandPasswordClearVsOmit(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"connection_id":"pg","conn_type":"postgres"}`)
+	}))
+	defer srv.Close()
+	cfg := seedSessionConfig(t, srv.URL, "tok")
+
+	// --password '' → an empty (clearing) password is sent.
+	if _, _, err := run(t, "connections", "set", "pg",
+		"--config", cfg, "--conn-type", "postgres", "--password", ""); err != nil {
+		t.Fatalf("connections set --password '': %v", err)
+	}
+	var sent apiclient.ConnectionBody
+	if uerr := json.Unmarshal([]byte(gotBody), &sent); uerr != nil {
+		t.Fatalf("request body not JSON: %v (%s)", uerr, gotBody)
+	}
+	if sent.Password == nil {
+		t.Errorf("--password '' must send an (empty) password to clear it: %s", gotBody)
+	} else if *sent.Password != "" {
+		t.Errorf("--password '' should send an empty string, got %q", *sent.Password)
+	}
+
+	// Omitting --password → no password field is sent (preserve).
+	gotBody = ""
+	if _, _, err := run(t, "connections", "set", "pg",
+		"--config", cfg, "--conn-type", "postgres", "--host", "db2"); err != nil {
+		t.Fatalf("connections set (no --password): %v", err)
+	}
+	sent = apiclient.ConnectionBody{}
+	if uerr := json.Unmarshal([]byte(gotBody), &sent); uerr != nil {
+		t.Fatalf("request body not JSON: %v (%s)", uerr, gotBody)
+	}
+	if sent.Password != nil {
+		t.Errorf("omitting --password must not send a password field: %s", gotBody)
+	}
+}
+
 func TestSetConnectionCommandRequiresConnType(t *testing.T) {
 	cfg := seedSessionConfig(t, "http://127.0.0.1:0", "tok")
 	if _, _, err := run(t, "connections", "set", "pg", "--config", cfg); err == nil {

--- a/internal/domain/connection.go
+++ b/internal/domain/connection.go
@@ -14,3 +14,28 @@ type Connection struct {
 	Extra       string
 	Description string
 }
+
+// ConnectionPatch is a tri-state write to a Connection (#887). Each nullable
+// field is one of three states the write path must keep distinct:
+//   - nil pointer   -> absent: preserve the stored value (the upsert passes NULL
+//     and COALESCE keeps the current column).
+//   - non-nil ""    -> present and empty: clear the field to empty.
+//   - non-nil value -> present: set the field.
+//
+// A plain string cannot carry "absent" vs "present and empty", which is why the
+// safe-merge upsert alone (v0.4.4) could neither clear a field nor stop a
+// round-tripped mask from overwriting a secret. ConnType is always written
+// (required on every upsert). Secret-mask handling (the mask means "unchanged")
+// is resolved by the caller before it builds the patch, so the repository only
+// ever sees the three states above.
+type ConnectionPatch struct {
+	ConnID      string
+	ConnType    string
+	Host        *string
+	Schema      *string
+	Login       *string
+	Password    *string
+	Port        *int
+	Extra       *string
+	Description *string
+}

--- a/internal/domain/variable.go
+++ b/internal/domain/variable.go
@@ -8,3 +8,15 @@ type Variable struct {
 	Value       string
 	Description string
 }
+
+// VariablePatch is a tri-state write to a Variable (#887). Description mirrors
+// domain.ConnectionPatch: nil preserves the stored value (COALESCE), non-nil ""
+// clears, and a value sets. Value is subtly different because the `value` column
+// is NOT NULL: the caller resolves an omitted or masked ("***" for a sensitive
+// key) value to the stored value BEFORE building the patch, so Value is expected
+// non-nil here — a non-nil "" still clears. Key is always written.
+type VariablePatch struct {
+	Key         string
+	Value       *string
+	Description *string
+}

--- a/internal/storage/connection_tristate_integration_test.go
+++ b/internal/storage/connection_tristate_integration_test.go
@@ -1,0 +1,166 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/secrets"
+)
+
+// ptr is a tiny helper for building tri-state patch fields in these tests.
+func ptr(s string) *string { return &s }
+
+// tristateCipher installs a deterministic AES-GCM cipher on the repo so the
+// connection write/read paths encrypt and decrypt the password/extra at rest.
+func tristateCipher(t *testing.T) secrets.Cipher {
+	t.Helper()
+	key := make([]byte, 32)
+	for i := range key {
+		key[i] = byte(i + 11)
+	}
+	c, err := secrets.NewAESGCM(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+// TestConnectionPatchTriState locks the #887 storage primitive that the API
+// write path rests on: SetConnectionPatch treats a nil field as "preserve"
+// (NULL param → COALESCE), a non-nil "" as "clear", and a value as "set". The
+// password is write-only, so its preservation is proven through the delivered
+// AIRFLOW_CONN_<id> URI (the credential a task actually receives), not through
+// GetConnection. This is the mechanism a masked ("***") password relies on — the
+// handler maps the mask to a nil Password, exercised here as the nil case.
+func TestConnectionPatchTriState(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+	repo.SetCipher(tristateCipher(t))
+
+	connID := fmt.Sprintf("tristate_%d", time.Now().UnixNano())
+	port := 5432
+	// Seed a full connection through the patch path (every field present).
+	if err := repo.SetConnectionPatch(ctx, "default", domain.ConnectionPatch{
+		ConnID: connID, ConnType: "postgres",
+		Host: ptr("db"), Login: ptr("analytics"), Password: ptr("s3cr3t"),
+		Schema: ptr("public"), Port: &port, Extra: ptr(`{"sslmode":"require"}`),
+		Description: ptr("primary warehouse"),
+	}); err != nil {
+		t.Fatalf("seed SetConnectionPatch: %v", err)
+	}
+
+	tenantUUID, terr := repo.TenantUUID(ctx, "default")
+	if terr != nil {
+		t.Fatalf("TenantUUID: %v", terr)
+	}
+	uriHas := func(want string) {
+		t.Helper()
+		uris, uerr := repo.SecretConnectionURIs(ctx, tenantUUID)
+		if uerr != nil {
+			t.Fatalf("SecretConnectionURIs: %v", uerr)
+		}
+		if uri := uris[connID]; !strings.Contains(uri, want) {
+			t.Errorf("delivered URI %q does not carry %q", uri, want)
+		}
+	}
+
+	// (1) Absent field preserves — including the write-only password. This is the
+	// #881 lock re-expressed on the patch path: only the host is present.
+	if err := repo.SetConnectionPatch(ctx, "default", domain.ConnectionPatch{
+		ConnID: connID, ConnType: "postgres", Host: ptr("db2"),
+	}); err != nil {
+		t.Fatalf("partial patch: %v", err)
+	}
+	got, err := repo.GetConnection(ctx, "default", connID)
+	if err != nil {
+		t.Fatalf("GetConnection: %v", err)
+	}
+	if got.Host != "db2" {
+		t.Errorf("host not updated: %q", got.Host)
+	}
+	if got.Login != "analytics" || got.Extra != `{"sslmode":"require"}` ||
+		got.Port == nil || *got.Port != 5432 || got.Description != "primary warehouse" {
+		t.Errorf("omitted fields were clobbered: %+v", got)
+	}
+	uriHas("s3cr3t") // password preserved across the partial write
+	uriHas("db2")    // host edit reflected
+
+	// (2) A masked password (nil Password, as the handler maps "***") preserves
+	// the stored secret, while a co-submitted host edit still lands (#874).
+	if err := repo.SetConnectionPatch(ctx, "default", domain.ConnectionPatch{
+		ConnID: connID, ConnType: "postgres", Host: ptr("db3"), Password: nil,
+	}); err != nil {
+		t.Fatalf("masked-password patch: %v", err)
+	}
+	uriHas("s3cr3t")
+	uriHas("db3")
+
+	// (3) Explicit "" clears a non-secret field (login), leaving the password.
+	if err := repo.SetConnectionPatch(ctx, "default", domain.ConnectionPatch{
+		ConnID: connID, ConnType: "postgres", Login: ptr(""),
+	}); err != nil {
+		t.Fatalf("clear-login patch: %v", err)
+	}
+	if got, _ := repo.GetConnection(ctx, "default", connID); got.Login != "" {
+		t.Errorf("explicit empty login did not clear: %q", got.Login)
+	}
+	uriHas("s3cr3t") // clearing login must not disturb the password
+
+	// (4) A write that DOES carry a new password rotates it.
+	if err := repo.SetConnectionPatch(ctx, "default", domain.ConnectionPatch{
+		ConnID: connID, ConnType: "postgres", Password: ptr("rotated"),
+	}); err != nil {
+		t.Fatalf("rotate-password patch: %v", err)
+	}
+	uris, _ := repo.SecretConnectionURIs(ctx, tenantUUID)
+	if u := uris[connID]; strings.Contains(u, "s3cr3t") || !strings.Contains(u, "rotated") {
+		t.Errorf("password not rotated: %q", u)
+	}
+
+	_ = repo.DeleteConnection(ctx, "default", connID)
+}
+
+// TestVariablePatchTriState locks the #887 storage primitives for variables that
+// live at the SQL layer: SetVariablePatch overwrites value with the resolved
+// value (the API handler resolves an omitted/masked value to the stored value,
+// since the NOT NULL `value` column cannot preserve via COALESCE), an explicit
+// "" clears it, and a nil Description preserves the stored description. The
+// masked-value round-trip (handler-resolved preserve) is proven end to end in
+// the api package's TestVariableMaskedRoundTripFullStack.
+func TestVariablePatchTriState(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+
+	key := fmt.Sprintf("tristate_var_%d", time.Now().UnixNano())
+	if err := repo.SetVariable(ctx, "default", domain.Variable{Key: key, Value: "real", Description: "prod"}); err != nil {
+		t.Fatalf("seed SetVariable: %v", err)
+	}
+
+	// A resolved value overwrites; a nil Description preserves the stored one.
+	if err := repo.SetVariablePatch(ctx, "default", domain.VariablePatch{Key: key, Value: ptr("real"), Description: nil}); err != nil {
+		t.Fatalf("preserve-description patch: %v", err)
+	}
+	got, err := repo.GetVariable(ctx, "default", key)
+	if err != nil {
+		t.Fatalf("GetVariable: %v", err)
+	}
+	if got.Value != "real" {
+		t.Errorf("value not written: %q", got.Value)
+	}
+	if got.Description != "prod" {
+		t.Errorf("nil description overwrote the stored description: %q", got.Description)
+	}
+
+	// Explicit "" clears the value.
+	if err := repo.SetVariablePatch(ctx, "default", domain.VariablePatch{Key: key, Value: ptr("")}); err != nil {
+		t.Fatalf("clear-value patch: %v", err)
+	}
+	if got, _ := repo.GetVariable(ctx, "default", key); got.Value != "" {
+		t.Errorf("explicit empty value did not clear: %q", got.Value)
+	}
+
+	_ = repo.DeleteVariable(ctx, "default", key)
+}

--- a/internal/storage/queries/connections.sql
+++ b/internal/storage/queries/connections.sql
@@ -42,12 +42,14 @@ SELECT conn_id FROM connections
 WHERE tenant_id = $1 AND conn_id = ANY(sqlc.arg(conn_ids)::text[]);
 
 -- name: UpsertConnection :exec
--- A write preserves any nullable field the caller left NULL, rather than
--- clobbering it: COALESCE(EXCLUDED.col, connections.col) keeps the stored value
--- when the request omits that field. This is what makes a partial `set` safe —
--- e.g. changing only --host must not wipe the (unreadable) password. conn_type is
--- required on every write, so it is a plain overwrite. To clear a field, delete
--- and recreate the connection.
+-- Tri-state write (#887): COALESCE(EXCLUDED.col, connections.col) preserves the
+-- stored value when the param is NULL, overwrites it when the param is a value,
+-- and clears it when the param is a non-NULL empty string. A NULL param is how a
+-- partial `set` stays safe — changing only --host must not wipe the (unreadable)
+-- password — while an explicit empty string now clears a field, and a masked
+-- secret ("***") is mapped to NULL by the caller so it preserves rather than
+-- overwrites (#874). conn_type is required on every write, so it is a plain
+-- overwrite.
 INSERT INTO connections (tenant_id, conn_id, conn_type, host, conn_schema, login, password, port, extra, description)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 ON CONFLICT (tenant_id, conn_id) DO UPDATE SET

--- a/internal/storage/queries/connections.sql.go
+++ b/internal/storage/queries/connections.sql.go
@@ -302,12 +302,14 @@ type UpsertConnectionParams struct {
 	Description *string     `json:"description"`
 }
 
-// A write preserves any nullable field the caller left NULL, rather than
-// clobbering it: COALESCE(EXCLUDED.col, connections.col) keeps the stored value
-// when the request omits that field. This is what makes a partial `set` safe —
-// e.g. changing only --host must not wipe the (unreadable) password. conn_type is
-// required on every write, so it is a plain overwrite. To clear a field, delete
-// and recreate the connection.
+// Tri-state write (#887): COALESCE(EXCLUDED.col, connections.col) preserves the
+// stored value when the param is NULL, overwrites it when the param is a value,
+// and clears it when the param is a non-NULL empty string. A NULL param is how a
+// partial `set` stays safe — changing only --host must not wipe the (unreadable)
+// password — while an explicit empty string now clears a field, and a masked
+// secret ("***") is mapped to NULL by the caller so it preserves rather than
+// overwrites (#874). conn_type is required on every write, so it is a plain
+// overwrite.
 func (q *Queries) UpsertConnection(ctx context.Context, arg UpsertConnectionParams) error {
 	_, err := q.db.Exec(ctx, upsertConnection,
 		arg.TenantID,

--- a/internal/storage/queries/querier.go
+++ b/internal/storage/queries/querier.go
@@ -522,19 +522,25 @@ type Querier interface {
 	// self-referential, so an already-stamped row is never re-stamped.
 	UpdateTaskInstanceStatesByRunTasks(ctx context.Context, arg UpdateTaskInstanceStatesByRunTasksParams) error
 	UpdateUserPassword(ctx context.Context, arg UpdateUserPasswordParams) (int64, error)
-	// A write preserves any nullable field the caller left NULL, rather than
-	// clobbering it: COALESCE(EXCLUDED.col, connections.col) keeps the stored value
-	// when the request omits that field. This is what makes a partial `set` safe —
-	// e.g. changing only --host must not wipe the (unreadable) password. conn_type is
-	// required on every write, so it is a plain overwrite. To clear a field, delete
-	// and recreate the connection.
+	// Tri-state write (#887): COALESCE(EXCLUDED.col, connections.col) preserves the
+	// stored value when the param is NULL, overwrites it when the param is a value,
+	// and clears it when the param is a non-NULL empty string. A NULL param is how a
+	// partial `set` stays safe — changing only --host must not wipe the (unreadable)
+	// password — while an explicit empty string now clears a field, and a masked
+	// secret ("***") is mapped to NULL by the caller so it preserves rather than
+	// overwrites (#874). conn_type is required on every write, so it is a plain
+	// overwrite.
 	UpsertConnection(ctx context.Context, arg UpsertConnectionParams) error
 	UpsertDag(ctx context.Context, arg UpsertDagParams) (Dag, error)
 	UpsertImportError(ctx context.Context, arg UpsertImportErrorParams) error
 	UpsertPool(ctx context.Context, arg UpsertPoolParams) error
-	// value is always supplied (a variable is its value), so it is overwritten;
-	// description is preserved when the request omits it (NULL) rather than being
-	// wiped — see the COALESCE rationale on UpsertConnection.
+	// value is always supplied (the variable IS its value, and the `value` column is
+	// NOT NULL, so a NULL param cannot reach the COALESCE — Postgres rejects it on
+	// the INSERT arm). The tri-state write (#887) therefore resolves value in the
+	// handler: an omitted or masked ("***") value on update is replaced with the
+	// stored value before it reaches here, so this always overwrites value.
+	// description is nullable, so it keeps the COALESCE preserve semantics: a NULL
+	// param keeps the stored description rather than wiping it.
 	UpsertVariable(ctx context.Context, arg UpsertVariableParams) error
 }
 

--- a/internal/storage/queries/variables.sql
+++ b/internal/storage/queries/variables.sql
@@ -32,9 +32,13 @@ SELECT key FROM variables
 WHERE tenant_id = $1 AND key = ANY(sqlc.arg(keys)::text[]);
 
 -- name: UpsertVariable :exec
--- value is always supplied (a variable is its value), so it is overwritten;
--- description is preserved when the request omits it (NULL) rather than being
--- wiped — see the COALESCE rationale on UpsertConnection.
+-- value is always supplied (the variable IS its value, and the `value` column is
+-- NOT NULL, so a NULL param cannot reach the COALESCE — Postgres rejects it on
+-- the INSERT arm). The tri-state write (#887) therefore resolves value in the
+-- handler: an omitted or masked ("***") value on update is replaced with the
+-- stored value before it reaches here, so this always overwrites value.
+-- description is nullable, so it keeps the COALESCE preserve semantics: a NULL
+-- param keeps the stored description rather than wiping it.
 INSERT INTO variables (tenant_id, key, value, description)
 VALUES ($1, $2, $3, $4)
 ON CONFLICT (tenant_id, key) DO UPDATE SET

--- a/internal/storage/queries/variables.sql.go
+++ b/internal/storage/queries/variables.sql.go
@@ -195,9 +195,13 @@ type UpsertVariableParams struct {
 	Description *string     `json:"description"`
 }
 
-// value is always supplied (a variable is its value), so it is overwritten;
-// description is preserved when the request omits it (NULL) rather than being
-// wiped — see the COALESCE rationale on UpsertConnection.
+// value is always supplied (the variable IS its value, and the `value` column is
+// NOT NULL, so a NULL param cannot reach the COALESCE — Postgres rejects it on
+// the INSERT arm). The tri-state write (#887) therefore resolves value in the
+// handler: an omitted or masked ("***") value on update is replaced with the
+// stored value before it reaches here, so this always overwrites value.
+// description is nullable, so it keeps the COALESCE preserve semantics: a NULL
+// param keeps the stored description rather than wiping it.
 func (q *Queries) UpsertVariable(ctx context.Context, arg UpsertVariableParams) error {
 	_, err := q.db.Exec(ctx, upsertVariable,
 		arg.TenantID,

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -1635,7 +1635,10 @@ func (r *Repository) GetVariable(ctx context.Context, tenant, key string) (domai
 	return domain.Variable{Key: v.Key, Value: v.Value, Description: strOrEmpty(v.Description)}, nil
 }
 
-// SetVariable creates or updates a variable.
+// SetVariable creates or updates a variable, always overwriting the value and
+// preserving description when empty. It is the full-write convenience the
+// storage tests and internal callers use; the tri-state API write path goes
+// through SetVariablePatch.
 func (r *Repository) SetVariable(ctx context.Context, tenant string, v domain.Variable) error {
 	tid, err := r.tenantID(ctx, tenant)
 	if err != nil {
@@ -1643,6 +1646,30 @@ func (r *Repository) SetVariable(ctx context.Context, tenant string, v domain.Va
 	}
 	if err := r.q.UpsertVariable(ctx, queries.UpsertVariableParams{
 		TenantID: tid, Key: v.Key, Value: v.Value, Description: strPtr(v.Description),
+	}); err != nil {
+		return fmt.Errorf("upserting variable: %w", err)
+	}
+	return nil
+}
+
+// SetVariablePatch upserts a variable with tri-state semantics on description
+// (#887): a nil Description is preserved (NULL param → COALESCE), a non-nil one
+// is written ("" clears it). The `value` column is NOT NULL, so value cannot be
+// preserved at the SQL layer (a NULL param is rejected on the INSERT arm before
+// COALESCE); the API handler therefore resolves an omitted/masked value to the
+// stored value before calling here, and Value is expected non-nil (a nil Value
+// defensively clears to empty rather than panicking).
+func (r *Repository) SetVariablePatch(ctx context.Context, tenant string, p domain.VariablePatch) error {
+	tid, err := r.tenantID(ctx, tenant)
+	if err != nil {
+		return err
+	}
+	value := ""
+	if p.Value != nil {
+		value = *p.Value
+	}
+	if err := r.q.UpsertVariable(ctx, queries.UpsertVariableParams{
+		TenantID: tid, Key: p.Key, Value: value, Description: p.Description,
 	}); err != nil {
 		return fmt.Errorf("upserting variable: %w", err)
 	}
@@ -1705,6 +1732,64 @@ func (r *Repository) SetConnection(ctx context.Context, tenant string, c domain.
 		TenantID: tid, ConnID: c.ConnID, ConnType: c.ConnType,
 		Host: strPtr(c.Host), ConnSchema: strPtr(c.Schema), Login: strPtr(c.Login),
 		Password: encPass, Port: port, Extra: encExtra, Description: strPtr(c.Description),
+	})
+}
+
+// encPatch encrypts a tri-state secret param (#887): a nil pointer preserves the
+// stored column (NULL), a non-empty value is encrypted, and an explicit empty
+// string clears the column to empty (stored as-is — an empty value is not a
+// secret, so there is nothing to encrypt, and decryptExtra returns "" for it).
+// This differs from encOrEmpty, which collapses "" to NULL (preserve) and so
+// cannot express a clear.
+func (r *Repository) encPatch(p *string) (*string, error) {
+	if p == nil {
+		return nil, nil //nolint:nilnil // nil param preserves the stored value via COALESCE
+	}
+	if *p == "" {
+		empty := ""
+		return &empty, nil // explicit clear: overwrite with empty, not preserve
+	}
+	enc, err := r.cipher.Encrypt(*p)
+	if err != nil {
+		return nil, err
+	}
+	return &enc, nil
+}
+
+// SetConnectionPatch upserts a connection with tri-state field semantics (#887):
+// a nil field is preserved (NULL param → COALESCE keeps the stored value), a
+// non-nil field is written exactly ("" clears it). Password and extra are
+// encrypted when set. It is how the API write path distinguishes an omitted
+// field from an explicit empty one without reintroducing the password-wipe, and
+// where a masked secret round-trip is preserved (the handler maps a masked
+// password to a nil field, and unmasks extra, before calling here). It fails if
+// no encryption cipher is configured (never stores a credential in plaintext —
+// ADR 0019).
+func (r *Repository) SetConnectionPatch(ctx context.Context, tenant string, p domain.ConnectionPatch) error {
+	if r.cipher == nil {
+		return secrets.ErrNoKey
+	}
+	tid, err := r.tenantID(ctx, tenant)
+	if err != nil {
+		return err
+	}
+	encPass, err := r.encPatch(p.Password)
+	if err != nil {
+		return fmt.Errorf("encrypting password: %w", err)
+	}
+	encExtra, err := r.encPatch(p.Extra)
+	if err != nil {
+		return fmt.Errorf("encrypting extra: %w", err)
+	}
+	var port *int32
+	if p.Port != nil {
+		pp := toInt32(*p.Port)
+		port = &pp
+	}
+	return r.q.UpsertConnection(ctx, queries.UpsertConnectionParams{
+		TenantID: tid, ConnID: p.ConnID, ConnType: p.ConnType,
+		Host: p.Host, ConnSchema: p.Schema, Login: p.Login,
+		Password: encPass, Port: port, Extra: encExtra, Description: p.Description,
 	})
 }
 

--- a/pkg/client/client.gen.go
+++ b/pkg/client/client.gen.go
@@ -157,7 +157,7 @@ type Connection struct {
 	Schema       *string `json:"schema,omitempty"`
 }
 
-// ConnectionBody Connection create/replace payload. connection_id is required on POST (taken from the path on PATCH). password and extra are write-only.
+// ConnectionBody Connection create/replace payload. connection_id is required on POST (taken from the path on PATCH). password and extra are write-only. Every optional field is tri-state: omit the key to preserve the stored value (a partial write never wipes a field it does not mention, so the unreadable password survives a `--host`-only edit), send an empty string to clear the field, or send a value to set it. A password equal to the mask `***`, and any key inside `extra` whose value is exactly `***`, is treated as "unchanged" — so re-submitting a connection read back from GET (whose secrets are masked) never overwrites the real secret with the mask.
 type ConnectionBody struct {
 	ConnType     string  `json:"conn_type"`
 	ConnectionId *string `json:"connection_id,omitempty"`
@@ -388,7 +388,7 @@ type Variable struct {
 	Value       string  `json:"value"`
 }
 
-// VariableBody defines model for VariableBody.
+// VariableBody Variable create/replace payload. value and description are tri-state: omit the key to preserve the stored value, send an empty string to clear it, or send a value to set it. A value equal to the mask `***` for a sensitive-looking key (secret/password/token/...) is treated as "unchanged", so re-submitting a variable read back from GET (whose sensitive value is masked) never overwrites the real value with the mask.
 type VariableBody struct {
 	Description *string `json:"description,omitempty"`
 	Key         string  `json:"key"`

--- a/test/e2e/lite-connections.sh
+++ b/test/e2e/lite-connections.sh
@@ -140,6 +140,37 @@ python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if d.get
 grep -q '\*\*\*' "$TMP/ui2.json" || fail "partial set WIPED the omitted extra (no masked value remains)" "$TMP/ui2.json"
 pass "partial set changed the host and preserved the omitted extra (safe merge)"
 
+echo "==> explicit clear: set --login '' blanks the login but preserves the rest (#887)"
+"${CLI[@]}" connections set "$CONN_ID" "${srv[@]}" \
+  --conn-type postgres --login "" >"$TMP/clear.out" 2>&1 \
+  || fail "explicit-clear connections set failed" "$TMP/clear.out"
+curl -fsS "${BASE}/api/v2/connections/${CONN_ID}" >"$TMP/ui3.json" \
+  || fail "curl after explicit clear failed" "$TMP/lite.log"
+# login was "analytics"; an explicit "" must clear it (rendered as null/absent).
+python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); v=d.get("login"); sys.exit(0 if (v is None or v=="") else 1)' "$TMP/ui3.json" \
+  || fail "explicit --login \"\" did not clear the login" "$TMP/ui3.json"
+# Clearing login must not disturb the omitted extra (still masked-present).
+grep -q '\*\*\*' "$TMP/ui3.json" || fail "explicit clear WIPED the omitted extra" "$TMP/ui3.json"
+pass "explicit --login '' cleared the login and preserved the omitted extra"
+
+echo "==> masked write-back: extra token as *** must PRESERVE the real secret (#874)"
+# Simulate the Admin UI GETting the connection (extra token shown as ***) and
+# saving it straight back. The mask must be treated as "unchanged", not persisted
+# over the real secret.
+"${CLI[@]}" connections set "$CONN_ID" "${srv[@]}" \
+  --conn-type postgres --extra '{"token":"***"}' >"$TMP/mask.out" 2>&1 \
+  || fail "masked-extra connections set failed" "$TMP/mask.out"
+curl -fsS "${BASE}/api/v2/connections/${CONN_ID}" >"$TMP/ui4.json" \
+  || fail "curl after masked write-back failed" "$TMP/lite.log"
+# The extra must still be present and masked — not cleared, and never the literal
+# mask leaked as a real value. The value-level proof (that the stored secret is
+# still EXTRA_SENTINEL rather than "***") lives in the Go integration tests
+# (internal/storage + internal/api full-stack), which the delivery path cannot
+# expose over HTTP; here we prove the write did not wipe or leak.
+grep -q '\*\*\*' "$TMP/ui4.json" || fail "masked write-back WIPED the extra" "$TMP/ui4.json"
+grep -q "$EXTRA_SENTINEL" "$TMP/ui4.json" && fail "masked write-back leaked the real secret" "$TMP/ui4.json"
+pass "masked extra write-back preserved a masked extra (no wipe, no leak)"
+
 # ---------------------------------------------------------------------------
 echo "==> variables set (plain + a secret-keyed one) via positional and --value-stdin"
 "${CLI[@]}" variables set "$VAR_PLAIN" us-east-1 "${srv[@]}" --description "default region" >"$TMP/vset.out" 2>&1 \

--- a/website/content/reference/cli/leoflow_connections_set.md
+++ b/website/content/reference/cli/leoflow_connections_set.md
@@ -14,7 +14,7 @@ Create or update a connection (upsert).
 
 Creates a connection, or updates an existing one with the same id. --conn-type is required.
 
-Only the fields you pass are changed; any field you omit keeps its current value. So you can change just --host without re-supplying the password (which cannot be read back anyway). To clear a field, delete and recreate the connection.
+Only the fields you pass are changed; any field you omit keeps its current value. So you can change just --host without re-supplying the password (which cannot be read back anyway). To clear a field, pass it as an empty string, e.g. --login '' or --schema ''.
 
 The password and extra are sent to the control plane but never printed back; read commands show masked values. Prefer --password-stdin / --extra-file over --password / --extra so a secret never lands in your shell history or the process table.
 


### PR DESCRIPTION
Closes #887, closes #874.

Completes the v0.4.4 safe-merge with true tri-state write semantics for connections & variables:
- **absent** (JSON key omitted) → preserve stored value (as v0.4.4)
- **`""`** (present, empty) → clear the field
- **secret == `"***"`** (the read mask) → treat as unchanged → preserve (this is #874)

## Design
Dedicated `domain.ConnectionPatch`/`VariablePatch` (pointer fields) threaded handler→repository, rather than pointer-ising `domain.Connection` (which is built with plain strings in 50+ call sites incl. secret delivery + the #881 storage locks). Blast radius: the two API store interfaces + fakes.

- Connections: columns are nullable, so the existing `COALESCE(EXCLUDED,table)` upsert already does tri-state at SQL; new `SetConnectionPatch` threads pointer-ness without `strPtr`'s `""`→nil collapse.
- Variables: `value` is NOT NULL (a NULL param fails the INSERT arm before COALESCE), so value-preserve is resolved in the handler; description keeps COALESCE.
- Mask handled in the API layer, **fail-closed**: a `"***"` it can't resolve preserves the whole field rather than persist a literal mask. `extra` is unmasked key-by-key (recursive) against the stored decrypted blob.
- POST is an upsert (`connections set` uses POST), so the create handlers now merge against an existing row too — a masked re-POST no longer wipes the stored secret (caught by e2e).

## Tests
Unit (api), storage integration (tri-state incl. password-preserve via delivered URI; the #881 lock still passes), full-stack integration closing the #874 chain end-to-end, and e2e (explicit-clear + masked-write-preserves). CHANGELOG entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)