### PR TITLE
fix(resilience): a control-plane restart no longer fails succeeded tasks or strands the run (drill #896)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **A control-plane restart no longer marks a succeeded task failed, and no
+  longer condemns the rest of its run.** A production drill (kill the
+  control-plane pod mid-run) turned a dbt task that had SUCCEEDED into `failed`
+  and failed the whole run. Four compounding causes, each now fixed:
+  - The agent abandoned a terminal report after 6 attempts (~31s) — shorter than
+    a control-plane restart — while its heartbeat loop kept going indefinitely.
+    The report now retries until its context ends (SIGTERM, pod delete, execution
+    timeout), with the pause between attempts capped at the heartbeat interval so
+    it reconnects within about one heartbeat of the server returning.
+    Credential rejections are still returned at once.
+  - The pod-lost reaper (every scheduler tick) raced the reconciler (every 30s)
+    for a pod that finished during the outage, and won — marking it `pod_lost`
+    before the reconciler could recover the pod's durable outcome record. It now
+    honors the same post-leadership grace as the agent-lost reaper, so the
+    durable outcome is recovered first.
+  - A downstream task was persisted `upstream_failed` — a terminal state nothing
+    reverts — while its upstream was infra-failed but still re-placeable (parked
+    in its re-place backoff). Downstream tasks now wait until an upstream is
+    TERMINALLY failed (retries and infra re-place exhausted).
+  - Reapers could mark or delete during the SIGTERM drain or a leader step-down.
+    Every destructive reaper action is now gated on a live context, no step-down
+    in progress, and (when wired) current leadership; the successor redoes the
+    reap under its own grace.
+  - The timing ladder the recovery depends on (`heartbeat < agent-lost threshold
+    < agent-lost grace < token TTL`, and `reconcile interval` below both
+    graces) is validated at server boot; a knob moved out of order fails startup
+    naming the violated relation.
+
 - **Connection/variable writes are now tri-state, restoring explicit-clear and
   fixing the masked write-back overwrite (#887, subsumes #874).** The safe-merge
   upsert (v0.4.4) preserved any omitted field, but because the API request body

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -1479,6 +1479,11 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 	// fail a task whose pod finished during the outage before the reconciler has
 	// recovered its durable outcome record.
 	reaper.SetLeaderSince(sched.LeaderSince)
+	// Close the reaper's destructive gate the moment this instance stops leading:
+	// together with the step-down flag and the run-context cancel, this keeps a
+	// draining or stepping-down leader from marking TIs failed or deleting pods
+	// on its way out — the successor redoes the reap under its own grace.
+	reaper.SetLeading(sched.IsLeading)
 	sched.SetExecutionReaper(reaper)
 	startReconciler(ctx, cs, cfg.Executor.TaskNamespace, execStore, sched.IsLeading, logger, snapshotter)
 	startStagingGC(ctx, cs, cfg.Executor.TaskNamespace, store, sched.IsLeading, logger)

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -106,7 +106,7 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
 	}
-	if verr := cfg.Validate(); verr != nil {
+	if verr := validateStartup(cfg); verr != nil {
 		return verr
 	}
 
@@ -341,6 +341,33 @@ func bootstrapAdmin(ctx context.Context, repo *storage.Repository, logger *slog.
 // TTL at the dispatch site; the total renewed lifetime is separately capped by
 // auth.max_attempt_credential_lifetime.
 var attemptTokenTTL = agent.AttemptTokenTTL(agent.DefaultHeartbeatInterval)
+
+// validateStartup runs every boot-time invariant check before any subsystem
+// starts: the operator's configuration, then the resilience timing ladder the
+// restart recovery depends on. A violation fails boot with the offending
+// relation named, instead of surfacing as a false reap after the next restart.
+func validateStartup(cfg *config.ServerConfig) error {
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+	return executor.ValidateResilienceLadder(resilienceLadder())
+}
+
+// resilienceLadder assembles the effective timing knobs the control-plane
+// restart recovery depends on, exactly as this binary wires them: the agent's
+// heartbeat interval and derived token TTL, the reaper thresholds/graces, and
+// the reconciler sweep. validateStartup checks it before anything starts.
+func resilienceLadder() executor.ResilienceLadder {
+	rc := executor.DefaultReaperConfig()
+	return executor.ResilienceLadder{
+		HeartbeatInterval:  agent.DefaultHeartbeatInterval,
+		AgentLostThreshold: rc.AgentLostThreshold,
+		AgentLostGrace:     rc.AgentLostGrace,
+		PodLostLeaderGrace: rc.PodLostLeaderGrace,
+		AttemptTokenTTL:    attemptTokenTTL,
+		ReconcileInterval:  reconcileInterval,
+	}
+}
 
 // loginRateLimit returns the per-minute failed-login cap with a safe floor: a
 // missing or nonsensical (<=0) config value falls back to the conservative

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -1473,9 +1473,11 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 	if ms, ok := logSink.(logs.MarkerSink); ok {
 		reaper.SetLogSink(ms)
 	}
-	// Suppress agent-lost reaping for a grace window after this instance acquires
-	// leadership, so a control-plane restart doesn't mass-reap in-flight tasks
-	// whose heartbeats went stale during the outage (#858).
+	// Suppress agent-lost AND pod-lost reaping for a grace window after this
+	// instance acquires leadership, so a control-plane restart doesn't mass-reap
+	// in-flight tasks whose heartbeats went stale during the outage (#858), nor
+	// fail a task whose pod finished during the outage before the reconciler has
+	// recovered its durable outcome record.
 	reaper.SetLeaderSince(sched.LeaderSince)
 	sched.SetExecutionReaper(reaper)
 	startReconciler(ctx, cs, cfg.Executor.TaskNamespace, execStore, sched.IsLeading, logger, snapshotter)

--- a/cmd/leoflow-server/resilience_ladder_wiring_test.go
+++ b/cmd/leoflow-server/resilience_ladder_wiring_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/executor"
+)
+
+// TestResilienceLadderWiringValidates pins that the ladder the server actually
+// boots with — agent heartbeat/TTL, default reaper config, reconcile interval —
+// satisfies every ordering the restart recovery depends on. A change to any one
+// of those constants that breaks the order fails this test before it fails a
+// deployment at boot.
+func TestResilienceLadderWiringValidates(t *testing.T) {
+	l := resilienceLadder()
+	if err := executor.ValidateResilienceLadder(l); err != nil {
+		t.Fatalf("server ladder %+v must validate: %v", l, err)
+	}
+	if l.ReconcileInterval != reconcileInterval || l.AttemptTokenTTL != attemptTokenTTL {
+		t.Errorf("ladder must carry the wired values: %+v", l)
+	}
+}

--- a/internal/agent/report_retry_test.go
+++ b/internal/agent/report_retry_test.go
@@ -43,21 +43,95 @@ func TestReportRetriesTransientThenSucceeds(t *testing.T) {
 	}
 }
 
-// TestReportGivesUpAfterMaxAttempts: a report that never recovers stops after
-// the bounded number of attempts and returns an error — it must not loop
-// forever holding the task.
-func TestReportGivesUpAfterMaxAttempts(t *testing.T) {
-	client := &fakeClient{reportFailCode: codes.Unavailable, reportFailTimes: 1000}
+// TestReportOutlastsControlPlaneRestart: a terminal report must keep retrying
+// for as long as the control plane is down — it is never abandoned on an attempt
+// count. The previous policy gave up after 6 attempts (~31s of backoff), shorter
+// than a control-plane pod restart (48-80s observed), so a SUCCEEDED task's
+// report was dropped and a reaper later marked it failed. The heartbeat loop
+// already tolerates the outage indefinitely and renews the token when the
+// server returns; the report must not give up earlier than the heartbeat.
+// Here the server is Unavailable for twice the old attempt budget, then
+// recovers — the report lands.
+func TestReportOutlastsControlPlaneRestart(t *testing.T) {
+	const outageAttempts = 12 // > the retired 6-attempt budget
+	client := &fakeClient{reportFailCode: codes.Unavailable, reportFailTimes: outageAttempts}
+	r := instantRunner(client)
+
+	if err := r.report(context.Background(), agentv1.TaskState_TASK_STATE_SUCCESS, 0, ""); err != nil {
+		t.Fatalf("report must succeed once the control plane returns, got %v", err)
+	}
+	if want := outageAttempts + 1; client.reportAttempts != want {
+		t.Errorf("expected %d attempts (%d failed + 1 success), got %d", want, outageAttempts, client.reportAttempts)
+	}
+	if len(client.reports) != 1 || client.reports[0].GetState() != agentv1.TaskState_TASK_STATE_SUCCESS {
+		t.Errorf("exactly one successful SUCCESS report expected, got %+v", client.reports)
+	}
+}
+
+// TestReportBackoffRampsThenHoldsAtHeartbeatInterval pins the per-attempt delay
+// policy: an exponential ramp (1s, 2s, 4s, 8s) that is CAPPED at the heartbeat
+// interval and then holds there for every further attempt — never longer. Capping
+// the delay rather than the duration means the agent reconnects within about one
+// heartbeat of the server returning, however long the outage lasted.
+func TestReportBackoffRampsThenHoldsAtHeartbeatInterval(t *testing.T) {
+	want := []time.Duration{
+		time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second,
+		DefaultHeartbeatInterval, DefaultHeartbeatInterval, DefaultHeartbeatInterval, DefaultHeartbeatInterval,
+	}
+	for i, w := range want {
+		if got := reportBackoff(i + 1); got != w {
+			t.Errorf("reportBackoff(%d) = %v, want %v", i+1, got, w)
+		}
+	}
+	for _, n := range []int{0, -3, 100, 1 << 20} {
+		if got := reportBackoff(n); got <= 0 || got > DefaultHeartbeatInterval {
+			t.Errorf("reportBackoff(%d) = %v, want a positive delay no longer than the heartbeat interval", n, got)
+		}
+	}
+
+	// The loop uses exactly that schedule: capture the delays it sleeps for.
+	var delays []time.Duration
+	client := &fakeClient{reportFailCode: codes.Unavailable, reportFailTimes: len(want)}
+	r := &Runner{
+		Client:   client,
+		Hostname: "pod-1",
+		Version:  "test",
+		afterFunc: func(d time.Duration) <-chan time.Time {
+			delays = append(delays, d)
+			ch := make(chan time.Time, 1)
+			ch <- time.Time{}
+			return ch
+		},
+	}
+	if err := r.report(context.Background(), agentv1.TaskState_TASK_STATE_SUCCESS, 0, ""); err != nil {
+		t.Fatalf("report: %v", err)
+	}
+	if len(delays) != len(want) {
+		t.Fatalf("slept %d times, want %d", len(delays), len(want))
+	}
+	for i, d := range delays {
+		if d != want[i] {
+			t.Errorf("sleep %d = %v, want %v", i+1, d, want[i])
+		}
+		if d > DefaultHeartbeatInterval {
+			t.Errorf("sleep %d = %v exceeds the heartbeat-interval cap", i+1, d)
+		}
+	}
+}
+
+// TestReportDoesNotRetryUnauthenticated: a credential rejection is not a
+// transient outage — retrying it can never succeed and would only hold the pod.
+// It is returned at once, and the durable outcome record (written before the
+// report) is what the reconciler recovers from.
+func TestReportDoesNotRetryUnauthenticated(t *testing.T) {
+	client := &fakeClient{reportFailCode: codes.Unauthenticated, reportFailTimes: 1000}
 	r := instantRunner(client)
 
 	if err := r.report(context.Background(), agentv1.TaskState_TASK_STATE_SUCCESS, 0, ""); err == nil {
-		t.Fatal("report should fail after exhausting attempts")
+		t.Fatal("an Unauthenticated report error must be returned, not retried")
 	}
-	// One initial attempt plus maxRetryAttempts retries (Backoff yields a delay
-	// for attempts 1..maxRetryAttempts, then exhausts on the next), bounding the
-	// total at maxRetryAttempts+1 calls / ~31s of backoff.
-	if want := maxRetryAttempts + 1; client.reportAttempts != want {
-		t.Errorf("expected exactly %d attempts, got %d", want, client.reportAttempts)
+	if client.reportAttempts != 1 {
+		t.Errorf("Unauthenticated must not be retried, got %d attempts", client.reportAttempts)
 	}
 }
 

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -850,15 +850,57 @@ func (r *Runner) writeOutcome(rec taskoutcome.Record) {
 	}
 }
 
+// reportRetryMaxDelay caps the pause between two attempts to deliver a report.
+// It equals the heartbeat interval on purpose: the heartbeat is the agent's
+// other channel to the control plane, and once the server is back a report
+// retry lands within about one heartbeat of it — the same posture the kubelet's
+// status manager takes toward an unreachable apiserver (keep trying at a bounded
+// cadence, never abandon the status).
+const reportRetryMaxDelay = DefaultHeartbeatInterval
+
+// reportBackoff returns the delay before report retry attempt n (1-based): an
+// exponential ramp from 1s that is clipped at reportRetryMaxDelay and then holds
+// there — 1s, 2s, 4s, 8s, then the cap for every further attempt. It caps the
+// per-attempt DELAY and never the DURATION: there is no attempt budget, so the
+// policy alone never ends a retry loop; only the caller's context does. Out-of-
+// range attempts (n < 1) are treated as the first.
+func reportBackoff(attempt int) time.Duration {
+	d := time.Second
+	for i := 1; i < attempt && d < reportRetryMaxDelay; i++ {
+		d *= 2
+	}
+	if d > reportRetryMaxDelay {
+		d = reportRetryMaxDelay
+	}
+	return d
+}
+
 // reportRequest sends a ReportState request and translates the response's
 // should_terminate signal into an error. A transient RPC failure (the api pod
-// momentarily Unavailable, a deadline) is retried with exponential backoff so a
-// task's terminal result is not lost to a network blip — which would otherwise
-// leave the TI to be failed as agent_lost by a reaper even though it succeeded.
-// The server's ReportState is idempotent (a report that already applied comes
-// back as a stale ack, not a double-apply), so retrying is safe. A logical
-// rejection is returned immediately, and a canceled context (parent shutdown,
-// SIGTERM) aborts the backoff at once.
+// Unavailable, a deadline) is retried until it lands, with the delay between
+// attempts following reportBackoff. Retrying is safe: the server's ReportState
+// is idempotent (a report that already applied comes back as a stale ack, not a
+// double-apply). A logical rejection or a credential rejection (Unauthenticated,
+// PermissionDenied) is returned immediately, and a canceled context (parent
+// shutdown, SIGTERM, pod deletion, execution timeout) aborts the loop at once
+// with the context error.
+//
+// The loop deliberately has NO attempt budget. A control-plane restart lasts
+// longer than any handful of attempts, and a terminal report that gives up while
+// the server is down is how a SUCCEEDED task ends up marked failed by a reaper.
+// The heartbeat loop already tolerates the outage indefinitely and renews the
+// bearer on the first heartbeat the recovered server answers, so the report has
+// no reason to give up earlier than the heartbeat does. The true outcome is
+// durably recorded (recordOutcome) before this is called, so a report that never
+// lands — the pod is deleted or times out first — is recovered by the reconciler
+// from that record; the retry loop only shortens the path to the same result.
+//
+// Warm-pool workers share this path (the per-attempt Runner is built by
+// WarmRunner.attemptRunner). A warm worker retrying a report stays busy only
+// while the control plane is down, which is exactly the window in which no new
+// work can be assigned to it anyway; and the warm-worker-lost reaper is keyed
+// on the warm pod's own liveness, so a live worker retrying is never falsely
+// reaped for it.
 func (r *Runner) reportRequest(ctx context.Context, req *agentv1.ReportStateRequest) error {
 	for attempt := 1; ; attempt++ {
 		resp, err := r.Client.ReportState(ctx, req)
@@ -878,10 +920,7 @@ func (r *Runner) reportRequest(ctx context.Context, req *agentv1.ReportStateRequ
 		if !retryableReportErr(err) {
 			return fmt.Errorf("reporting state %v: %w", req.GetState(), err)
 		}
-		delay, ok := Backoff(attempt)
-		if !ok {
-			return fmt.Errorf("reporting state %v after %d attempts: %w", req.GetState(), attempt, err)
-		}
+		delay := reportBackoff(attempt)
 		slog.Warn("report failed; retrying after backoff",
 			"state", req.GetState(), "attempt", attempt, "delay", delay, "error", err)
 		select {

--- a/internal/executor/heartbeat_reap.go
+++ b/internal/executor/heartbeat_reap.go
@@ -99,6 +99,8 @@ type agentLostReaper struct {
 	// so the grace is measured from recovery, not wall-clock. Nil (Lite/tests
 	// without leadership) disables the grace check.
 	leaderSince func() time.Time
+	// gate is re-checked before every destructive call (see destructiveGate).
+	gate destructiveGate
 }
 
 func newAgentLostReaper(store HeartbeatReapStore, logger *slog.Logger, threshold time.Duration, rec DecisionRecorder) *agentLostReaper {
@@ -134,41 +136,56 @@ func (r *agentLostReaper) run(ctx context.Context) error {
 		if !IsAgentLost(c, r.threshold, now) {
 			continue
 		}
-		applied, ferr := r.store.MarkTaskAgentLost(ctx, c.TaskInstanceID)
-		if ferr != nil {
-			r.logger.Error("marking task agent-lost",
-				"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID, "error", ferr)
-			r.record("agent_lost_error")
-			continue
-		}
-		if !applied {
-			// A late terminal report transitioned the TI between our list and our
-			// write (WHERE state='running' matched 0 rows). It is no longer ours
-			// to reap — do not log a false reap or delete a pod for a settled TI.
-			r.record("agent_lost_noop")
-			continue
-		}
-		r.logger.Warn("task agent silent past threshold; failing as agent_lost",
-			"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID,
-			"last_heartbeat", c.LastHeartbeat)
-		r.record("agent_lost")
-		// Append a final marker to the attempt's log BEFORE deleting the pod, so a
-		// killed task's log ends with the reason instead of a silent truncation
-		// (#861) — the log stream stops the moment the pod is gone.
-		r.writeAgentLostMarker(c, now)
-		// The TI is now durably failed; delete its pod so a partitioned-but-alive
-		// container stops (#474). Pinned to (run, task, try) so a retry's newer
-		// pod is never touched. Only reached after the DB mark, so we never delete
-		// a pod for a TI we did not settle. Best-effort: a delete error is logged.
-		if r.pods != nil {
-			if derr := r.pods.DeleteTaskPod(ctx, c.DagRunID, c.TaskID, c.TryNumber); derr != nil {
-				r.logger.Error("deleting agent-lost task pod",
-					"ti", c.TaskInstanceID, "run", c.DagRunID, "task", c.TaskID, "try", c.TryNumber, "error", derr)
-				r.record("agent_lost_pod_delete_error")
-			}
-		}
+		r.reapOne(ctx, c, now)
 	}
 	return nil
+}
+
+// reapOne fails one silent TI, writes its log marker and tears down its pod,
+// re-checking the destructive gate immediately before each write.
+func (r *agentLostReaper) reapOne(ctx context.Context, c AgentLostCandidate, now time.Time) {
+	if !gateOpen(r.gate, ctx) {
+		r.record("agent_lost_gate_skip")
+		return
+	}
+	applied, ferr := r.store.MarkTaskAgentLost(ctx, c.TaskInstanceID)
+	if ferr != nil {
+		r.logger.Error("marking task agent-lost",
+			"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID, "error", ferr)
+		r.record("agent_lost_error")
+		return
+	}
+	if !applied {
+		// A late terminal report transitioned the TI between our list and our
+		// write (WHERE state='running' matched 0 rows). It is no longer ours
+		// to reap — do not log a false reap or delete a pod for a settled TI.
+		r.record("agent_lost_noop")
+		return
+	}
+	r.logger.Warn("task agent silent past threshold; failing as agent_lost",
+		"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID,
+		"last_heartbeat", c.LastHeartbeat)
+	r.record("agent_lost")
+	// Append a final marker to the attempt's log BEFORE deleting the pod, so a
+	// killed task's log ends with the reason instead of a silent truncation
+	// (#861) — the log stream stops the moment the pod is gone.
+	r.writeAgentLostMarker(c, now)
+	// The TI is now durably failed; delete its pod so a partitioned-but-alive
+	// container stops (#474). Pinned to (run, task, try) so a retry's newer
+	// pod is never touched. Only reached after the DB mark, so we never delete
+	// a pod for a TI we did not settle. Best-effort: a delete error is logged.
+	if r.pods == nil {
+		return
+	}
+	if !gateOpen(r.gate, ctx) {
+		r.record("agent_lost_teardown_gate_skip")
+		return
+	}
+	if derr := r.pods.DeleteTaskPod(ctx, c.DagRunID, c.TaskID, c.TryNumber); derr != nil {
+		r.logger.Error("deleting agent-lost task pod",
+			"ti", c.TaskInstanceID, "run", c.DagRunID, "task", c.TaskID, "try", c.TryNumber, "error", derr)
+		r.record("agent_lost_pod_delete_error")
+	}
 }
 
 // writeAgentLostMarker appends one terminal line to the reaped attempt's log

--- a/internal/executor/heartbeat_reap.go
+++ b/internal/executor/heartbeat_reap.go
@@ -116,22 +116,15 @@ func (r *agentLostReaper) run(ctx context.Context) error {
 		}
 	}()
 	now := time.Now().UTC()
-	// Post-leadership grace (#858): a control-plane restart manufactures the very
+	// Post-leadership grace: a control-plane restart manufactures the very
 	// silence this reaper punishes — every in-flight TI's last heartbeat elapses
 	// during the outage, and the heartbeat receiver is the same process that just
 	// came back. Suppress reaping until the fleet has had a full grace window to
-	// re-heartbeat under the recovered leader; a genuinely lost agent stays stale
-	// past the grace and is reaped on a later tick. The window is measured from
-	// leadership acquisition, not startup, so a re-election also resets it.
-	// Checked before the list so a grace tick does no query at all. NOTE: if
-	// leadership flaps with a period shorter than the grace, leaderSince keeps
-	// restamping and this reaper never fires — the orphan-run reaper (5m) is the
-	// backstop for that pathological case; steady-state leadership is the norm.
-	if r.leaderSince != nil && r.grace > 0 {
-		if ls := r.leaderSince(); !ls.IsZero() && now.Sub(ls) < r.grace {
-			r.record("agent_lost_grace_skip")
-			return nil
-		}
+	// re-heartbeat under the recovered leader (see inLeaderGrace for the shared
+	// gate semantics). Checked before the list so a grace tick does no query.
+	if inLeaderGrace(r.leaderSince, r.grace, now) {
+		r.record("agent_lost_grace_skip")
+		return nil
 	}
 	candidates, err := r.store.ListAgentLostCandidates(ctx)
 	if err != nil {

--- a/internal/executor/pod_lost_reap.go
+++ b/internal/executor/pod_lost_reap.go
@@ -95,6 +95,8 @@ type podLostReaper struct {
 	// without leadership) disables the leadership grace; the per-task grace and
 	// the liveness read are unchanged.
 	leaderSince func() time.Time
+	// gate is re-checked before every destructive call (see destructiveGate).
+	gate destructiveGate
 }
 
 func newPodLostReaper(store PodLostReapStore, logger *slog.Logger, grace time.Duration, rec DecisionRecorder) *podLostReaper {
@@ -154,33 +156,47 @@ func (r *podLostReaper) run(ctx context.Context) error {
 		if active {
 			continue
 		}
-		applied, ferr := r.store.MarkTaskPodLost(ctx, c.TaskInstanceID)
-		if ferr != nil {
-			r.logger.Error("marking task pod-lost",
-				"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID, "error", ferr)
-			r.record("pod_lost_error")
-			continue
-		}
-		if !applied {
-			// A late terminal report transitioned the TI between our list and our
-			// write (WHERE state='running' matched 0 rows) — it settled on its own,
-			// so do not log a false reap or run the teardown.
-			r.record("pod_lost_noop")
-			continue
-		}
-		r.logger.Warn("running task has no live pod past grace; failing as pod_lost",
-			"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID, "running_since", c.RunningSince)
-		r.record("pod_lost")
-		// Best-effort teardown pinned to (run, task, try). TaskPodActive said no
-		// live pod, so this only sweeps a lingering terminal pod at most; a
-		// retry's newer pod has a different try-number label and is never touched.
-		if derr := r.pods.DeleteTaskPod(ctx, c.DagRunID, c.TaskID, c.TryNumber); derr != nil {
-			r.logger.Error("deleting pod-lost task pod",
-				"ti", c.TaskInstanceID, "run", c.DagRunID, "task", c.TaskID, "try", c.TryNumber, "error", derr)
-			r.record("pod_lost_pod_delete_error")
-		}
+		r.reapOne(ctx, c)
 	}
 	return nil
+}
+
+// reapOne fails one TI whose pod is gone and sweeps any lingering pod,
+// re-checking the destructive gate immediately before each write.
+func (r *podLostReaper) reapOne(ctx context.Context, c PodLostCandidate) {
+	if !gateOpen(r.gate, ctx) {
+		r.record("pod_lost_gate_skip")
+		return
+	}
+	applied, ferr := r.store.MarkTaskPodLost(ctx, c.TaskInstanceID)
+	if ferr != nil {
+		r.logger.Error("marking task pod-lost",
+			"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID, "error", ferr)
+		r.record("pod_lost_error")
+		return
+	}
+	if !applied {
+		// A late terminal report transitioned the TI between our list and our
+		// write (WHERE state='running' matched 0 rows) — it settled on its own,
+		// so do not log a false reap or run the teardown.
+		r.record("pod_lost_noop")
+		return
+	}
+	r.logger.Warn("running task has no live pod past grace; failing as pod_lost",
+		"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID, "running_since", c.RunningSince)
+	r.record("pod_lost")
+	// Best-effort teardown pinned to (run, task, try). TaskPodActive said no
+	// live pod, so this only sweeps a lingering terminal pod at most; a
+	// retry's newer pod has a different try-number label and is never touched.
+	if !gateOpen(r.gate, ctx) {
+		r.record("pod_lost_teardown_gate_skip")
+		return
+	}
+	if derr := r.pods.DeleteTaskPod(ctx, c.DagRunID, c.TaskID, c.TryNumber); derr != nil {
+		r.logger.Error("deleting pod-lost task pod",
+			"ti", c.TaskInstanceID, "run", c.DagRunID, "task", c.TaskID, "try", c.TryNumber, "error", derr)
+		r.record("pod_lost_pod_delete_error")
+	}
 }
 
 func (r *podLostReaper) record(decision string) {

--- a/internal/executor/pod_lost_reap.go
+++ b/internal/executor/pod_lost_reap.go
@@ -63,6 +63,11 @@ type PodLostReapStore interface {
 // It is Kubernetes-ONLY. With no PodManager (Lite/subprocess) there is no pod to
 // lose and a subprocess task legitimately has none, so the reaper is a no-op —
 // it must never reap live subprocess work on a "no pod" signal.
+//
+// Warm-pool attempts are out of this reaper's scope: a warm attempt has no
+// per-task pod, so it never appears live here; the warm-worker-lost reaper
+// recovers those from the warm pod's own liveness, which a control-plane restart
+// does not disturb — hence that reaper carries no leadership grace.
 type podLostReaper struct {
 	store    PodLostReapStore
 	logger   *slog.Logger
@@ -77,6 +82,19 @@ type podLostReaper struct {
 	// TaskPodActive read below, so cache lag can only delay a reap, never cause a
 	// false-positive one (#461). Nil keeps every candidate on the live path.
 	cache PodPresenceCache
+	// leaderGrace suppresses reaping for this long after leadership is
+	// (re-)acquired, ADDITIVE to the per-task grace above. A control-plane
+	// restart makes a task pod that finished during the outage look lost (its
+	// container exited; its TI is still `running` because the terminal report
+	// found no server), while the pod's durable outcome record is still waiting
+	// for the reconciler's slower sweep. Without this window the pod-lost mark
+	// wins that race and a succeeded task is recorded failed. Zero disables it.
+	leaderGrace time.Duration
+	// leaderSince reports when this instance last acquired scheduler leadership,
+	// so leaderGrace is measured from recovery, not wall-clock. Nil (Lite/tests
+	// without leadership) disables the leadership grace; the per-task grace and
+	// the liveness read are unchanged.
+	leaderSince func() time.Time
 }
 
 func newPodLostReaper(store PodLostReapStore, logger *slog.Logger, grace time.Duration, rec DecisionRecorder) *podLostReaper {
@@ -98,11 +116,18 @@ func (r *podLostReaper) run(ctx context.Context) error {
 	if r.pods == nil {
 		return nil
 	}
+	now := time.Now().UTC()
+	// Post-leadership grace: let the reconciler recover durable outcomes of pods
+	// that finished during the outage before declaring any of them lost. Checked
+	// before the list so a grace tick does no query at all.
+	if inLeaderGrace(r.leaderSince, r.leaderGrace, now) {
+		r.record("pod_lost_grace_skip")
+		return nil
+	}
 	candidates, err := r.store.ListRunningTasks(ctx)
 	if err != nil {
 		return err
 	}
-	now := time.Now().UTC()
 	for _, c := range candidates {
 		if !IsPodLostCandidate(c, r.grace, now) {
 			continue

--- a/internal/executor/pod_lost_reap_test.go
+++ b/internal/executor/pod_lost_reap_test.go
@@ -150,6 +150,67 @@ func TestPodLostReaper(t *testing.T) {
 		}
 	})
 
+	t.Run("post-leadership grace defers, then reaps once it elapses", func(t *testing.T) {
+		// A control-plane restart manufactures the very signal this reaper acts
+		// on: a task pod that finished DURING the outage is no longer live, yet
+		// its TI is still `running` because its terminal report never landed.
+		// The pod's durable outcome record is recovered by the reconciler on its
+		// slower sweep — so the new leader must hold off pod-lost reaping until
+		// the reconciler has had time to settle the true outcome. Within the
+		// grace: NO MarkTaskPodLost, a recorded skip. Past it: reap as usual.
+		newStore := func() *fakePodLostStore {
+			return &fakePodLostStore{candidates: []PodLostCandidate{
+				{TaskInstanceID: "finished-during-outage", DagRunID: "run-a", TaskID: "work", TryNumber: 1, RunningSince: past},
+			}}
+		}
+		within := newStore()
+		rec := &capturingRecorder{}
+		pods := &fakePodManager{active: map[string]bool{}} // pod gone (Succeeded, not Pending/Running)
+		r := newPodLostReaper(within, reapTestLogger(), grace, rec)
+		r.pods = pods
+		r.leaderGrace = 180 * time.Second
+		r.leaderSince = func() time.Time { return now.Add(-10 * time.Second) } // just became leader
+		if err := r.run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if len(within.marked) != 0 {
+			t.Fatalf("must not mark pod_lost within the post-leadership grace, got %v", within.marked)
+		}
+		if len(pods.deletedTasks) != 0 {
+			t.Fatalf("must not tear down a pod within the post-leadership grace, got %v", pods.deletedTasks)
+		}
+		if got := rec.count("pod_lost_grace_skip"); got != 1 {
+			t.Errorf("pod_lost_grace_skip = %d, want 1", got)
+		}
+
+		pastGrace := newStore()
+		r2 := newPodLostReaper(pastGrace, reapTestLogger(), grace, &capturingRecorder{})
+		r2.pods = &fakePodManager{active: map[string]bool{}}
+		r2.leaderGrace = 180 * time.Second
+		r2.leaderSince = func() time.Time { return now.Add(-10 * time.Minute) } // leader long enough
+		if err := r2.run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if len(pastGrace.marked) != 1 || pastGrace.marked[0] != "finished-during-outage" {
+			t.Fatalf("must reap once the post-leadership grace elapsed, got %v", pastGrace.marked)
+		}
+	})
+
+	t.Run("nil leaderSince (Lite / no leadership) leaves the grace off", func(t *testing.T) {
+		store := &fakePodLostStore{candidates: []PodLostCandidate{
+			{TaskInstanceID: "lost", DagRunID: "run-a", TaskID: "work", TryNumber: 1, RunningSince: past},
+		}}
+		r := newPodLostReaper(store, reapTestLogger(), grace, nil)
+		r.pods = &fakePodManager{active: map[string]bool{}}
+		r.leaderGrace = 180 * time.Second // configured, but no leadership accessor
+		if err := r.run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if len(store.marked) != 1 {
+			t.Fatalf("without a leaderSince accessor the reaper must behave as before, got %v", store.marked)
+		}
+	})
+
 	t.Run("a list error surfaces and reaps nothing", func(t *testing.T) {
 		store := &fakePodLostStore{listErr: errors.New("db down")}
 		pods := &fakePodManager{active: map[string]bool{}}

--- a/internal/executor/reap.go
+++ b/internal/executor/reap.go
@@ -57,6 +57,8 @@ type orphanReaper struct {
 	// pods tears down the reaped run's pods after the DB transition (#474).
 	// Nil in Lite (no pods); the delete is skipped.
 	pods PodManager
+	// gate is re-checked before every destructive call (see destructiveGate).
+	gate destructiveGate
 }
 
 func newOrphanReaper(store ReapStore, logger *slog.Logger, threshold time.Duration, rec DecisionRecorder) *orphanReaper {
@@ -83,26 +85,41 @@ func (r *orphanReaper) run(ctx context.Context) error {
 		if !IsOrphaned(c, r.threshold, now) {
 			continue
 		}
-		if rerr := r.store.ReapRun(ctx, c.RunID); rerr != nil {
-			r.logger.Error("reaping orphan run", "run", c.RunID, "dag", c.DagID, "error", rerr)
-			r.record("orphan_reap_error")
-			continue
-		}
-		r.logger.Warn("reaped orphan run", "run", c.RunID, "dag", c.DagID, "last_activity", c.LastActivity)
-		r.record("orphan_reaped")
-		// The run is now durably failed; tear down its pods so any still-running
-		// task containers stop instead of finishing abandoned work (#474). The
-		// run-id is unique, so this can only ever hit this run's pods. Best-effort:
-		// a delete failure is logged but does not undo the DB reap — the pod's own
-		// ActiveDeadline and the reconciler's GC remain backstops.
-		if r.pods != nil {
-			if derr := r.pods.DeleteRunPods(ctx, c.RunID); derr != nil {
-				r.logger.Error("deleting orphaned run pods", "run", c.RunID, "dag", c.DagID, "error", derr)
-				r.record("orphan_pod_delete_error")
-			}
-		}
+		r.reapOne(ctx, c)
 	}
 	return nil
+}
+
+// reapOne fails one orphaned run and tears down its pods, re-checking the
+// destructive gate immediately before each write.
+func (r *orphanReaper) reapOne(ctx context.Context, c ReapCandidate) {
+	if !gateOpen(r.gate, ctx) {
+		r.record("orphan_gate_skip")
+		return
+	}
+	if rerr := r.store.ReapRun(ctx, c.RunID); rerr != nil {
+		r.logger.Error("reaping orphan run", "run", c.RunID, "dag", c.DagID, "error", rerr)
+		r.record("orphan_reap_error")
+		return
+	}
+	r.logger.Warn("reaped orphan run", "run", c.RunID, "dag", c.DagID, "last_activity", c.LastActivity)
+	r.record("orphan_reaped")
+	// The run is now durably failed; tear down its pods so any still-running
+	// task containers stop instead of finishing abandoned work (#474). The
+	// run-id is unique, so this can only ever hit this run's pods. Best-effort:
+	// a delete failure is logged but does not undo the DB reap — the pod's own
+	// ActiveDeadline and the reconciler's GC remain backstops.
+	if r.pods == nil {
+		return
+	}
+	if !gateOpen(r.gate, ctx) {
+		r.record("orphan_teardown_gate_skip")
+		return
+	}
+	if derr := r.pods.DeleteRunPods(ctx, c.RunID); derr != nil {
+		r.logger.Error("deleting orphaned run pods", "run", c.RunID, "dag", c.DagID, "error", derr)
+		r.record("orphan_pod_delete_error")
+	}
 }
 
 func (r *orphanReaper) record(decision string) {

--- a/internal/executor/reaper.go
+++ b/internal/executor/reaper.go
@@ -115,8 +115,26 @@ func inLeaderGrace(leaderSince func() time.Time, grace time.Duration, now time.T
 	return !ls.IsZero() && now.Sub(ls) < grace
 }
 
+// destructiveGate reports whether a reaper may take a destructive action — mark
+// a TI or run failed, delete a pod — right now. Every reaper consults it
+// immediately before each such call (not only at the top of the tick), so a
+// shutdown or leader step-down that lands after the candidate list was read
+// still stops the write that would follow. A nil gate is open (Lite / tests).
+//
+// The invariant: a leader that is terminating or stepping down must not mark or
+// delete. Its context is being canceled, its view of the fleet is about to go
+// stale, and the successor redoes every reap under its own post-leadership
+// grace — so a destructive write on the way out is at best redundant and at
+// worst the false reap the grace exists to prevent.
+type destructiveGate func(ctx context.Context) bool
+
+// gateOpen evaluates a possibly-nil destructiveGate.
+func gateOpen(g destructiveGate, ctx context.Context) bool {
+	return g == nil || g(ctx)
+}
+
 // Reaper is the execution-side backstop that fails stuck runs and task instances
-// the scheduler dispatched but that then went dark. It bundles the four
+// the scheduler dispatched but that then went dark. It bundles the five
 // independent reapers behind one ReapOnce entrypoint the scheduler drives once
 // per leader tick, so the scheduler depends on a single capability rather than
 // wiring each reaper itself.
@@ -128,10 +146,16 @@ type Reaper struct {
 	warmWorkerLost *warmWorkerLostReaper
 	logger         *slog.Logger
 	rec            DecisionRecorder
-	// inStepDown reports whether the scheduler is in a graceful leader step-down,
-	// so an expected context-cancel fanout of the run-context logs at WARN, not
-	// ERROR (#311). Nil is tolerated (treated as "not stepping down").
+	// inStepDown reports whether the scheduler is in a graceful leader step-down.
+	// It downgrades an expected context-cancel fanout of the run-context to WARN
+	// (#311) and, with ctx and leading, closes the destructive gate: a leader
+	// stepping down must not mark or delete. Nil is tolerated ("not stepping
+	// down").
 	inStepDown func() bool
+	// leading reports whether this instance currently holds scheduler leadership;
+	// part of the destructive gate. Nil is tolerated ("leading") so Lite and
+	// tests without an election are unaffected.
+	leading func() bool
 }
 
 // NewReaper constructs the reapers and wires their pod-teardown / liveness
@@ -168,7 +192,7 @@ func NewReaper(store ReaperStore, pods PodManager, cache PodPresenceCache, warmP
 	warmWorkerLost := newWarmWorkerLostReaper(store, logger, rec)
 	warmWorkerLost.warmPods = warmPods
 
-	return &Reaper{
+	r := &Reaper{
 		orphan:         orphan,
 		agentLost:      agentLost,
 		dispatchLost:   dispatchLost,
@@ -178,6 +202,40 @@ func NewReaper(store ReaperStore, pods PodManager, cache PodPresenceCache, warmP
 		rec:            rec,
 		inStepDown:     inStepDown,
 	}
+	// One destructive gate, shared by every reaper: each re-checks it right before
+	// a mark or delete, so a cancel/step-down that lands mid-tick still stops the
+	// write. The closure reads r's predicates at call time, so SetLeading may be
+	// wired after construction.
+	orphan.gate = r.mayReap
+	agentLost.gate = r.mayReap
+	dispatchLost.gate = r.mayReap
+	podLost.gate = r.mayReap
+	warmWorkerLost.gate = r.mayReap
+	return r
+}
+
+// SetLeading wires the leadership predicate into the destructive gate, so a
+// reaper tick on an instance that no longer holds leadership marks and deletes
+// nothing. The scheduler already drives ReapOnce only while leading; this is the
+// defensive re-check at the point of the write. Nil leaves the gate on ctx and
+// step-down alone.
+func (r *Reaper) SetLeading(fn func() bool) {
+	r.leading = fn
+}
+
+// mayReap is the destructive gate: open only while the tick's context is live,
+// the scheduler is not stepping down, and (when wired) this instance leads.
+func (r *Reaper) mayReap(ctx context.Context) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	if r.inStepDown != nil && r.inStepDown() {
+		return false
+	}
+	if r.leading != nil && !r.leading() {
+		return false
+	}
+	return true
 }
 
 // SetLogSink wires the sink the agent-lost reaper uses to append a final
@@ -201,11 +259,17 @@ func (r *Reaper) SetLeaderSince(fn func() time.Time) {
 	r.podLost.leaderSince = fn
 }
 
-// ReapOnce runs the four reapers once, in the same order the scheduler drove
-// them: orphan-run, then agent-lost, then dispatch-lost, then pod-lost. The
-// dispatch-lost reaper runs AFTER the orphan-run reaper so a clean
-// stuck-queued -> failed -> orphan-run-failed chain can complete in a single
-// tick once the thresholds elapse.
+// ReapOnce runs the five reapers once, in the same order the scheduler drove
+// them: orphan-run, then agent-lost, then dispatch-lost, then pod-lost, then
+// warm-worker-lost. The dispatch-lost reaper runs AFTER the orphan-run reaper so
+// a clean stuck-queued -> failed -> orphan-run-failed chain can complete in a
+// single tick once the thresholds elapse.
+//
+// The whole tick is skipped — and the skip metered as reap_gate_skip — when the
+// destructive gate is closed on entry: a canceled context (SIGTERM drain, the
+// step-down cancel fan-out), a scheduler in step-down, or a lost leadership. The
+// reapers also re-check the gate before each individual write, so this early
+// return is the cheap common case, not the only defense.
 //
 // Each reaper's infra-level list error is logged and metered but never returned:
 // the reapers are independent backstops, so one's failure must not block the
@@ -214,6 +278,10 @@ func (r *Reaper) SetLeaderSince(fn func() time.Time) {
 // always returns nil today; the error return is kept for the seam so a future
 // hard-failure mode need not change the scheduler.
 func (r *Reaper) ReapOnce(ctx context.Context) error {
+	if !r.mayReap(ctx) {
+		r.record("reap_gate_skip")
+		return nil
+	}
 	if err := r.orphan.run(ctx); err != nil {
 		r.logError("orphan reaper", err)
 		r.record("orphan_list_error")

--- a/internal/executor/reaper.go
+++ b/internal/executor/reaper.go
@@ -51,17 +51,33 @@ const (
 	// under the 10-minute agent token TTL so a re-heartbeat still authenticates.
 	// Ladder: heartbeat(15s) < threshold(90s) < grace(180s) < tokenTTL(600s).
 	defaultAgentLostGrace = 2 * defaultAgentLostThreshold
+	// defaultPodLostLeaderGrace is the post-leadership window during which the
+	// pod-lost reaper does not fire. The same control-plane restart that makes
+	// heartbeats look stale also makes a task pod that FINISHED during the outage
+	// look lost: its container exited, so it is no longer Pending/Running, yet its
+	// TI is still `running` because the terminal report never reached a server.
+	// The pod's durable outcome record (termination log) is recovered by the
+	// reconciler on its own, slower sweep; if the pod-lost reaper fires first it
+	// marks a succeeded task failed and the reconciler then finds a settled row.
+	// Reusing the agent-lost grace keeps one ladder value for "one restart fault"
+	// and leaves the reconciler (30s sweep) several passes to recover the true
+	// outcome before this reaper may act. It is additive to PodLostGrace, which
+	// is a per-task liveness floor measured from the TI's running transition.
+	defaultPodLostLeaderGrace = defaultAgentLostGrace
 )
 
-// ReaperConfig holds the four idle thresholds the reapers apply. Zero values are
-// legal but reap aggressively; callers pass DefaultReaperConfig unless a test or
-// load harness deliberately overrides them.
+// ReaperConfig holds the idle thresholds and post-leadership graces the reapers
+// apply. Zero values are legal but reap aggressively; callers pass
+// DefaultReaperConfig unless a test or load harness deliberately overrides them.
 type ReaperConfig struct {
 	OrphanThreshold       time.Duration
 	AgentLostThreshold    time.Duration
 	AgentLostGrace        time.Duration
 	DispatchLostThreshold time.Duration
 	PodLostGrace          time.Duration
+	// PodLostLeaderGrace suppresses pod-lost reaping for this long after this
+	// instance acquires leadership. See defaultPodLostLeaderGrace.
+	PodLostLeaderGrace time.Duration
 }
 
 // DefaultReaperConfig returns the production thresholds — the exact values the
@@ -73,7 +89,30 @@ func DefaultReaperConfig() ReaperConfig {
 		AgentLostGrace:        defaultAgentLostGrace,
 		DispatchLostThreshold: defaultDispatchLostThreshold,
 		PodLostGrace:          defaultPodLostGrace,
+		PodLostLeaderGrace:    defaultPodLostLeaderGrace,
 	}
+}
+
+// inLeaderGrace reports whether now falls within the post-leadership grace: a
+// leaderSince accessor is wired, the grace is positive, leadership is currently
+// held (non-zero stamp), and less than grace has elapsed since it was acquired.
+// A nil accessor (Lite / no leadership) or a zero grace disables the check.
+//
+// It is the single definition of the leader-settling gate the reapers share. A
+// control-plane restart manufactures the signals several reapers act on (a stale
+// heartbeat, a task pod that exited during the outage), so a freshly elected
+// leader must let the fleet re-heartbeat and the reconciler recover durable
+// outcomes before any of them fires; a genuinely lost task stays stale past the
+// grace and is reaped on a later tick. Measured from leadership acquisition, not
+// process start, so a re-election also resets it. If leadership flaps with a
+// period shorter than the grace the stamp keeps moving and the gated reapers
+// never fire — the orphan-run reaper is the backstop for that pathological case.
+func inLeaderGrace(leaderSince func() time.Time, grace time.Duration, now time.Time) bool {
+	if leaderSince == nil || grace <= 0 {
+		return false
+	}
+	ls := leaderSince()
+	return !ls.IsZero() && now.Sub(ls) < grace
 }
 
 // Reaper is the execution-side backstop that fails stuck runs and task instances
@@ -124,6 +163,7 @@ func NewReaper(store ReaperStore, pods PodManager, cache PodPresenceCache, warmP
 	podLost := newPodLostReaper(store, logger, cfg.PodLostGrace, rec)
 	podLost.pods = pods
 	podLost.cache = cache
+	podLost.leaderGrace = cfg.PodLostLeaderGrace
 
 	warmWorkerLost := newWarmWorkerLostReaper(store, logger, rec)
 	warmWorkerLost.warmPods = warmPods
@@ -148,12 +188,17 @@ func (r *Reaper) SetLogSink(s logSink) {
 	r.agentLost.sink = s
 }
 
-// SetLeaderSince wires the accessor the agent-lost reaper uses to measure its
-// post-leadership grace (#858) — the window after a (re-)election during which a
-// stale heartbeat is assumed to be the outage's doing, not a dead agent, and is
-// not reaped. Nil (Lite / no leadership) leaves the grace off.
+// SetLeaderSince wires the accessor the leadership-gated reapers use to measure
+// their post-leadership grace — the window after a (re-)election during which a
+// stale heartbeat or a vanished task pod is assumed to be the outage's doing, not
+// a dead agent or a lost pod, and is not reaped (see inLeaderGrace). It reaches
+// every reaper that acts on a restart-manufactured signal: agent-lost and
+// pod-lost. Nil (Lite / no leadership) leaves the grace off. The warm-worker-lost
+// reaper is deliberately not gated: its signal is the warm pod's own liveness,
+// which a control-plane restart does not disturb.
 func (r *Reaper) SetLeaderSince(fn func() time.Time) {
 	r.agentLost.leaderSince = fn
+	r.podLost.leaderSince = fn
 }
 
 // ReapOnce runs the four reapers once, in the same order the scheduler drove

--- a/internal/executor/reaper_test.go
+++ b/internal/executor/reaper_test.go
@@ -107,6 +107,61 @@ func TestReaperReapOnceDrivesReapers(t *testing.T) {
 	}
 }
 
+// TestReaperSetLeaderSinceGatesPodLost: the post-leadership grace must reach the
+// pod-lost reaper, not only the agent-lost one. Both reapers act on a signal a
+// control-plane restart manufactures (a stale heartbeat; a task pod that finished
+// during the outage and is no longer live), so both must let the fleet
+// re-heartbeat and the reconciler recover durable outcomes before firing. A
+// `running` TI whose pod is gone, past its own liveness grace, is NOT marked
+// through ReapOnce while leadership is fresh; it is once the grace elapsed.
+func TestReaperSetLeaderSinceGatesPodLost(t *testing.T) {
+	now := time.Now().UTC()
+	newStore := func() *fakeReaperStore {
+		return &fakeReaperStore{runningCands: []PodLostCandidate{
+			{TaskInstanceID: "finished-during-outage", DagRunID: "run-a", TaskID: "work", TryNumber: 1, RunningSince: now.Add(-10 * time.Minute)},
+		}}
+	}
+
+	fresh := newStore()
+	rec := &capturingRecorder{}
+	r := NewReaper(fresh, &fakePodManager{active: map[string]bool{}}, nil, nil, rec, reapTestLogger(), DefaultReaperConfig(), nil)
+	r.SetLeaderSince(func() time.Time { return now.Add(-5 * time.Second) })
+	if err := r.ReapOnce(context.Background()); err != nil {
+		t.Fatalf("ReapOnce: %v", err)
+	}
+	if len(fresh.podMarked) != 0 {
+		t.Errorf("pod-lost must defer within the post-leadership grace, marked %v", fresh.podMarked)
+	}
+	if got := rec.count("pod_lost_grace_skip"); got != 1 {
+		t.Errorf("pod_lost_grace_skip = %d, want 1", got)
+	}
+
+	settled := newStore()
+	r2 := NewReaper(settled, &fakePodManager{active: map[string]bool{}}, nil, nil, nil, reapTestLogger(), DefaultReaperConfig(), nil)
+	r2.SetLeaderSince(func() time.Time { return now.Add(-time.Hour) })
+	if err := r2.ReapOnce(context.Background()); err != nil {
+		t.Fatalf("ReapOnce: %v", err)
+	}
+	if len(settled.podMarked) != 1 {
+		t.Errorf("pod-lost must reap once the post-leadership grace elapsed, marked %v", settled.podMarked)
+	}
+}
+
+// TestDefaultReaperConfigPodLostLeaderGrace pins the ladder position of the
+// pod-lost leadership grace: it equals the agent-lost grace (the same restart
+// fault manufactures both signals) and sits well above the 30s reconciler sweep,
+// so the reconciler gets several sweeps to recover a durable outcome before the
+// pod-lost reaper may fire on the same pod.
+func TestDefaultReaperConfigPodLostLeaderGrace(t *testing.T) {
+	cfg := DefaultReaperConfig()
+	if cfg.PodLostLeaderGrace != cfg.AgentLostGrace {
+		t.Errorf("PodLostLeaderGrace = %v, want AgentLostGrace (%v)", cfg.PodLostLeaderGrace, cfg.AgentLostGrace)
+	}
+	if cfg.PodLostLeaderGrace < 2*30*time.Second {
+		t.Errorf("PodLostLeaderGrace = %v must leave margin over the 30s reconcile interval", cfg.PodLostLeaderGrace)
+	}
+}
+
 // TestReaperThreadsPresenceCacheToDispatchLost is the wiring check re-homed from
 // the scheduler's TestStepThreadsPresenceCacheToReapers: a presence cache passed
 // to NewReaper must reach the dispatch-lost reaper. A stale queued TI whose pod

--- a/internal/executor/reaper_test.go
+++ b/internal/executor/reaper_test.go
@@ -107,6 +107,173 @@ func TestReaperReapOnceDrivesReapers(t *testing.T) {
 	}
 }
 
+// staleEverythingStore serves one long-stale candidate to EVERY reaper, so a
+// test can prove that a gate stops all five destructive paths at once.
+func staleEverythingStore() *fakeReaperStore {
+	past := time.Now().UTC().Add(-1 * time.Hour)
+	return &fakeReaperStore{
+		orphanCands:  []ReapCandidate{{RunID: "stuck-run", DagID: "etl", LastActivity: past}},
+		agentCands:   []AgentLostCandidate{{TaskInstanceID: "silent", DagRunID: "r1", TaskID: "t", TryNumber: 1, LastHeartbeat: past}},
+		queuedCands:  []StaleQueuedCandidate{{TaskInstanceID: "stuck-ti", DagRunID: "r2", TaskID: "t", TryNumber: 1, QueuedAt: past}},
+		runningCands: []PodLostCandidate{{TaskInstanceID: "gone", DagRunID: "r3", TaskID: "t", TryNumber: 1, RunningSince: past}},
+		warmBound:    []WarmBoundTI{{TaskInstanceID: "warm-orphan", DagRunID: "r4", TaskID: "t", TryNumber: 1, WarmWorkerID: "dead-worker"}},
+	}
+}
+
+// assertNothingDestroyed fails the test if any reaper marked, reaped or deleted.
+func assertNothingDestroyed(t *testing.T, store *fakeReaperStore, pods *fakePodManager) {
+	t.Helper()
+	if len(store.reapedRuns)+len(store.agentMarked)+len(store.queuedMarked)+len(store.podMarked) != 0 {
+		t.Errorf("no store write may happen: reapedRuns=%v agentMarked=%v queuedMarked=%v podMarked=%v",
+			store.reapedRuns, store.agentMarked, store.queuedMarked, store.podMarked)
+	}
+	if len(pods.deletedTasks)+len(pods.deletedRuns) != 0 {
+		t.Errorf("no pod delete may happen: tasks=%v runs=%v", pods.deletedTasks, pods.deletedRuns)
+	}
+}
+
+// TestReaperReapOnceSkipsOnCanceledContext: a reaper tick that starts under an
+// already-canceled context — the SIGTERM drain, or the run-context fan-out of a
+// leader step-down — must not mark or delete anything. The successor leader
+// redoes the reap under its own post-leadership grace; a terminating leader
+// marking a TI failed on its way out is the same fault class as reaping before
+// the fleet has settled. The skip is recorded so operators can see it.
+func TestReaperReapOnceSkipsOnCanceledContext(t *testing.T) {
+	store := staleEverythingStore()
+	pods := &fakePodManager{active: map[string]bool{}}
+	rec := &capturingRecorder{}
+	r := NewReaper(store, pods, nil, &fakeWarmLister{}, rec, reapTestLogger(), DefaultReaperConfig(), nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := r.ReapOnce(ctx); err != nil {
+		t.Fatalf("ReapOnce: %v", err)
+	}
+	assertNothingDestroyed(t, store, pods)
+	if got := rec.count("reap_gate_skip"); got != 1 {
+		t.Errorf("reap_gate_skip = %d, want 1", got)
+	}
+}
+
+// TestReaperReapOnceSkipsDuringStepDown: while the scheduler reports a graceful
+// leader step-down, the tick is not destructive even if its context has not been
+// canceled yet (MarkSteppingDown runs BEFORE the cancel).
+func TestReaperReapOnceSkipsDuringStepDown(t *testing.T) {
+	store := staleEverythingStore()
+	pods := &fakePodManager{active: map[string]bool{}}
+	rec := &capturingRecorder{}
+	steppingDown := func() bool { return true }
+	r := NewReaper(store, pods, nil, &fakeWarmLister{}, rec, reapTestLogger(), DefaultReaperConfig(), steppingDown)
+
+	if err := r.ReapOnce(context.Background()); err != nil {
+		t.Fatalf("ReapOnce: %v", err)
+	}
+	assertNothingDestroyed(t, store, pods)
+	if got := rec.count("reap_gate_skip"); got != 1 {
+		t.Errorf("reap_gate_skip = %d, want 1", got)
+	}
+}
+
+// TestReaperReapOnceSkipsWhenNotLeading: a wired leadership predicate that
+// reports "not leading" stops the tick; the same predicate reporting "leading"
+// leaves the normal path unchanged (everything stale is reaped).
+func TestReaperReapOnceSkipsWhenNotLeading(t *testing.T) {
+	follower := staleEverythingStore()
+	pods := &fakePodManager{active: map[string]bool{}}
+	r := NewReaper(follower, pods, nil, &fakeWarmLister{}, nil, reapTestLogger(), DefaultReaperConfig(), nil)
+	r.SetLeading(func() bool { return false })
+	if err := r.ReapOnce(context.Background()); err != nil {
+		t.Fatalf("ReapOnce: %v", err)
+	}
+	assertNothingDestroyed(t, follower, pods)
+
+	leader := staleEverythingStore()
+	r2 := NewReaper(leader, &fakePodManager{active: map[string]bool{}}, nil, &fakeWarmLister{}, nil, reapTestLogger(), DefaultReaperConfig(), func() bool { return false })
+	r2.SetLeading(func() bool { return true })
+	if err := r2.ReapOnce(context.Background()); err != nil {
+		t.Fatalf("ReapOnce: %v", err)
+	}
+	if len(leader.reapedRuns) != 1 || len(leader.agentMarked) != 1 || len(leader.queuedMarked) != 1 || len(leader.podMarked) != 2 {
+		t.Errorf("a leading, non-stepping-down reaper must reap normally: reapedRuns=%v agentMarked=%v queuedMarked=%v podMarked=%v",
+			leader.reapedRuns, leader.agentMarked, leader.queuedMarked, leader.podMarked)
+	}
+}
+
+// TestReapersHonorGateMidTick: the gate is re-checked immediately before EVERY
+// destructive call inside each reaper, not only at the top of the tick — a
+// cancel or step-down that lands after the candidate list was read must still
+// stop the mark/delete that follows. Each reaper is driven directly with a gate
+// that is already closed, so the list succeeds and the write is what gets
+// refused; the per-reaper skip decision is recorded.
+func TestReapersHonorGateMidTick(t *testing.T) {
+	closed := func(context.Context) bool { return false }
+	past := time.Now().UTC().Add(-1 * time.Hour)
+
+	t.Run("orphan", func(t *testing.T) {
+		store := &fakeReaperStore{orphanCands: []ReapCandidate{{RunID: "stuck", LastActivity: past}}}
+		rec := &capturingRecorder{}
+		r := newOrphanReaper(store, reapTestLogger(), time.Minute, rec)
+		r.gate = closed
+		if err := r.run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if len(store.reapedRuns) != 0 || rec.count("orphan_gate_skip") != 1 {
+			t.Errorf("reapedRuns=%v orphan_gate_skip=%d, want none / 1", store.reapedRuns, rec.count("orphan_gate_skip"))
+		}
+	})
+	t.Run("agent-lost", func(t *testing.T) {
+		store := &fakeHeartbeatStore{candidates: []AgentLostCandidate{{TaskInstanceID: "silent", LastHeartbeat: past}}}
+		rec := &capturingRecorder{}
+		r := newAgentLostReaper(store, reapTestLogger(), time.Minute, rec)
+		r.gate = closed
+		if err := r.run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if len(store.failed) != 0 || rec.count("agent_lost_gate_skip") != 1 {
+			t.Errorf("failed=%v agent_lost_gate_skip=%d, want none / 1", store.failed, rec.count("agent_lost_gate_skip"))
+		}
+	})
+	t.Run("dispatch-lost", func(t *testing.T) {
+		store := &fakeReaperStore{queuedCands: []StaleQueuedCandidate{{TaskInstanceID: "stuck", QueuedAt: past}}}
+		rec := &capturingRecorder{}
+		r := newDispatchLostReaper(store, reapTestLogger(), time.Minute, rec)
+		r.gate = closed
+		if err := r.run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if len(store.queuedMarked) != 0 || rec.count("dispatch_lost_gate_skip") != 1 {
+			t.Errorf("queuedMarked=%v dispatch_lost_gate_skip=%d, want none / 1", store.queuedMarked, rec.count("dispatch_lost_gate_skip"))
+		}
+	})
+	t.Run("pod-lost", func(t *testing.T) {
+		store := &fakePodLostStore{candidates: []PodLostCandidate{{TaskInstanceID: "gone", DagRunID: "r", TaskID: "t", TryNumber: 1, RunningSince: past}}}
+		rec := &capturingRecorder{}
+		pods := &fakePodManager{active: map[string]bool{}}
+		r := newPodLostReaper(store, reapTestLogger(), time.Minute, rec)
+		r.pods = pods
+		r.gate = closed
+		if err := r.run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if len(store.marked) != 0 || len(pods.deletedTasks) != 0 || rec.count("pod_lost_gate_skip") != 1 {
+			t.Errorf("marked=%v deleted=%v pod_lost_gate_skip=%d, want none / none / 1", store.marked, pods.deletedTasks, rec.count("pod_lost_gate_skip"))
+		}
+	})
+	t.Run("warm-worker-lost", func(t *testing.T) {
+		store := &fakeWarmBoundStore{bound: []WarmBoundTI{{TaskInstanceID: "warm-orphan", WarmWorkerID: "dead"}}}
+		rec := &capturingRecorder{}
+		r := newWarmWorkerLostReaper(store, reapTestLogger(), rec)
+		r.warmPods = &fakeWarmLister{}
+		r.gate = closed
+		if err := r.run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if len(store.marked) != 0 || rec.count("warm_worker_lost_gate_skip") != 1 {
+			t.Errorf("marked=%v warm_worker_lost_gate_skip=%d, want none / 1", store.marked, rec.count("warm_worker_lost_gate_skip"))
+		}
+	})
+}
+
 // TestReaperSetLeaderSinceGatesPodLost: the post-leadership grace must reach the
 // pod-lost reaper, not only the agent-lost one. Both reapers act on a signal a
 // control-plane restart manufactures (a stale heartbeat; a task pod that finished

--- a/internal/executor/resilience_ladder.go
+++ b/internal/executor/resilience_ladder.go
@@ -1,0 +1,80 @@
+package executor
+
+import (
+	"fmt"
+	"time"
+)
+
+// ResilienceLadder is the set of timing knobs whose relative ORDER the
+// control-plane-restart recovery depends on. Each is owned by a different
+// package (agent, executor, server main) and tuned for its own reason, so
+// nothing but this type states that they must line up. The invariants:
+//
+//	heartbeat interval  <  agent-lost threshold  <  agent-lost grace  <  attempt token TTL
+//	reconcile interval  <  agent-lost grace
+//	reconcile interval  <  pod-lost leader grace
+//
+// Why each rung matters:
+//   - heartbeat < threshold: a healthy agent must beat well inside the silence
+//     window or the agent-lost reaper fails live tasks.
+//   - threshold < agent-lost grace: after a (re-)election the reaper waits
+//     longer than the silence it punishes, so the whole fleet can re-heartbeat.
+//   - agent-lost grace < token TTL: the grace ends while a re-heartbeat can still
+//     authenticate and renew the bearer; otherwise the fleet is unreapable AND
+//     unable to report — every in-flight task is lost.
+//   - reconcile < agent-lost grace, reconcile < pod-lost leader grace: the
+//     reconciler gets at least one full sweep under the new leader before any
+//     reaper may fail a task whose pod finished during the outage, so the
+//     durable outcome record is recovered as the truth before a reaper guesses.
+type ResilienceLadder struct {
+	HeartbeatInterval  time.Duration
+	AgentLostThreshold time.Duration
+	AgentLostGrace     time.Duration
+	PodLostLeaderGrace time.Duration
+	AttemptTokenTTL    time.Duration
+	ReconcileInterval  time.Duration
+}
+
+// ladderRung names one knob for error messages.
+type ladderRung struct {
+	name string
+	d    time.Duration
+}
+
+// ValidateResilienceLadder checks the orderings the restart recovery depends on
+// (see ResilienceLadder) and reports the first violated relation, naming both
+// sides with their values so the operator knows which knob moved. All rungs
+// must be positive. It is pure — the server calls it once at boot and refuses
+// to start on an error, turning what used to be a comment-level convention into
+// an enforced invariant.
+func ValidateResilienceLadder(l ResilienceLadder) error {
+	hb := ladderRung{"heartbeat interval", l.HeartbeatInterval}
+	thr := ladderRung{"agent-lost threshold", l.AgentLostThreshold}
+	agrace := ladderRung{"agent-lost grace", l.AgentLostGrace}
+	pgrace := ladderRung{"pod-lost leader grace", l.PodLostLeaderGrace}
+	ttl := ladderRung{"attempt token TTL", l.AttemptTokenTTL}
+	rec := ladderRung{"reconcile interval", l.ReconcileInterval}
+
+	for _, r := range []ladderRung{hb, thr, agrace, pgrace, ttl, rec} {
+		if r.d <= 0 {
+			return fmt.Errorf("resilience ladder: %s (%v) must be positive", r.name, r.d)
+		}
+	}
+	relations := []struct {
+		lo, hi ladderRung
+		why    string
+	}{
+		{hb, thr, "a live agent must heartbeat well inside the agent-lost silence window"},
+		{thr, agrace, "the post-leadership grace must outlast the silence it forgives so the fleet can re-heartbeat"},
+		{agrace, ttl, "a re-heartbeat must still authenticate and renew the bearer when the grace ends"},
+		{rec, agrace, "the reconciler must sweep at least once under a new leader before agent-lost may reap"},
+		{rec, pgrace, "the reconciler must recover durable pod outcomes before pod-lost may reap"},
+	}
+	for _, rel := range relations {
+		if rel.lo.d >= rel.hi.d {
+			return fmt.Errorf("resilience ladder: %s (%v) must be < %s (%v): %s",
+				rel.lo.name, rel.lo.d, rel.hi.name, rel.hi.d, rel.why)
+		}
+	}
+	return nil
+}

--- a/internal/executor/resilience_ladder_test.go
+++ b/internal/executor/resilience_ladder_test.go
@@ -1,0 +1,87 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// defaultLadder is the production ladder as the server wires it: the agent's
+// heartbeat interval and token TTL, the default reaper thresholds/graces, and
+// the reconciler's sweep interval.
+func defaultLadder() ResilienceLadder {
+	cfg := DefaultReaperConfig()
+	return ResilienceLadder{
+		HeartbeatInterval:  15 * time.Second,
+		AgentLostThreshold: cfg.AgentLostThreshold,
+		AgentLostGrace:     cfg.AgentLostGrace,
+		PodLostLeaderGrace: cfg.PodLostLeaderGrace,
+		AttemptTokenTTL:    10 * time.Minute,
+		ReconcileInterval:  30 * time.Second,
+	}
+}
+
+// TestValidateResilienceLadderDefaultsPass: the shipped defaults satisfy every
+// ordering the control-plane-restart recovery depends on.
+func TestValidateResilienceLadderDefaultsPass(t *testing.T) {
+	if err := ValidateResilienceLadder(defaultLadder()); err != nil {
+		t.Fatalf("default ladder must validate, got %v", err)
+	}
+}
+
+// TestValidateResilienceLadderRejectsEachViolation: each single inverted (or
+// equal — the relations are strict) rung fails, and the error names BOTH sides
+// of the violated relation so an operator can tell which knob to move.
+func TestValidateResilienceLadderRejectsEachViolation(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*ResilienceLadder)
+		want   []string // substrings the error must carry
+	}{
+		{
+			name:   "heartbeat interval not below agent-lost threshold",
+			mutate: func(l *ResilienceLadder) { l.HeartbeatInterval = l.AgentLostThreshold },
+			want:   []string{"heartbeat interval", "agent-lost threshold"},
+		},
+		{
+			name:   "agent-lost threshold not below agent-lost grace",
+			mutate: func(l *ResilienceLadder) { l.AgentLostGrace = l.AgentLostThreshold },
+			want:   []string{"agent-lost threshold", "agent-lost grace"},
+		},
+		{
+			name:   "agent-lost grace not below attempt token TTL",
+			mutate: func(l *ResilienceLadder) { l.AttemptTokenTTL = l.AgentLostGrace },
+			want:   []string{"agent-lost grace", "attempt token TTL"},
+		},
+		{
+			name:   "reconcile interval not below agent-lost grace",
+			mutate: func(l *ResilienceLadder) { l.ReconcileInterval = l.AgentLostGrace },
+			want:   []string{"reconcile interval", "agent-lost grace"},
+		},
+		{
+			name:   "reconcile interval not below pod-lost leader grace",
+			mutate: func(l *ResilienceLadder) { l.PodLostLeaderGrace = l.ReconcileInterval },
+			want:   []string{"reconcile interval", "pod-lost leader grace"},
+		},
+		{
+			name:   "a non-positive rung",
+			mutate: func(l *ResilienceLadder) { l.HeartbeatInterval = 0 },
+			want:   []string{"heartbeat interval", "positive"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			l := defaultLadder()
+			tc.mutate(&l)
+			err := ValidateResilienceLadder(l)
+			if err == nil {
+				t.Fatalf("ladder %+v must be rejected", l)
+			}
+			for _, w := range tc.want {
+				if !strings.Contains(err.Error(), w) {
+					t.Errorf("error %q must name %q", err, w)
+				}
+			}
+		})
+	}
+}

--- a/internal/executor/stale_queued_reap.go
+++ b/internal/executor/stale_queued_reap.go
@@ -90,6 +90,8 @@ type dispatchLostReaper struct {
 	// off / not wired) yields an empty live set, so the warm check never defers
 	// and the dedicated pod-liveness path is byte-for-byte unchanged.
 	warmPods WarmPodLister
+	// gate is re-checked before every destructive call (see destructiveGate).
+	gate destructiveGate
 }
 
 func newDispatchLostReaper(store DispatchLostReapStore, logger *slog.Logger, threshold time.Duration, rec DecisionRecorder) *dispatchLostReaper {
@@ -163,28 +165,43 @@ func (r *dispatchLostReaper) run(ctx context.Context) error {
 				continue
 			}
 		}
-		if ferr := r.store.MarkTaskDispatchLost(ctx, c.TaskInstanceID); ferr != nil {
-			r.logger.Error("marking task dispatch-lost",
-				"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID, "error", ferr)
-			r.record("dispatch_lost_error")
-			continue
-		}
-		r.logger.Warn("task queued past dispatch threshold; failing as dispatch_lost",
-			"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID,
-			"queued_at", c.QueuedAt)
-		r.record("dispatch_lost")
-		// Best-effort teardown of any lingering pod for this attempt (#474). By
-		// here TaskPodActive said no live pod exists (or pods is nil), so this
-		// only cleans up a terminal/failed pod; pinned to (run, task, try).
-		if r.pods != nil {
-			if derr := r.pods.DeleteTaskPod(ctx, c.DagRunID, c.TaskID, c.TryNumber); derr != nil {
-				r.logger.Error("deleting dispatch-lost task pod",
-					"ti", c.TaskInstanceID, "run", c.DagRunID, "task", c.TaskID, "try", c.TryNumber, "error", derr)
-				r.record("dispatch_lost_pod_delete_error")
-			}
-		}
+		r.reapOne(ctx, c)
 	}
 	return nil
+}
+
+// reapOne fails one dispatch-lost TI and tears down any lingering pod,
+// re-checking the destructive gate immediately before each write.
+func (r *dispatchLostReaper) reapOne(ctx context.Context, c StaleQueuedCandidate) {
+	if !gateOpen(r.gate, ctx) {
+		r.record("dispatch_lost_gate_skip")
+		return
+	}
+	if ferr := r.store.MarkTaskDispatchLost(ctx, c.TaskInstanceID); ferr != nil {
+		r.logger.Error("marking task dispatch-lost",
+			"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID, "error", ferr)
+		r.record("dispatch_lost_error")
+		return
+	}
+	r.logger.Warn("task queued past dispatch threshold; failing as dispatch_lost",
+		"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID,
+		"queued_at", c.QueuedAt)
+	r.record("dispatch_lost")
+	// Best-effort teardown of any lingering pod for this attempt (#474). By
+	// here TaskPodActive said no live pod exists (or pods is nil), so this
+	// only cleans up a terminal/failed pod; pinned to (run, task, try).
+	if r.pods == nil {
+		return
+	}
+	if !gateOpen(r.gate, ctx) {
+		r.record("dispatch_lost_teardown_gate_skip")
+		return
+	}
+	if derr := r.pods.DeleteTaskPod(ctx, c.DagRunID, c.TaskID, c.TryNumber); derr != nil {
+		r.logger.Error("deleting dispatch-lost task pod",
+			"ti", c.TaskInstanceID, "run", c.DagRunID, "task", c.TaskID, "try", c.TryNumber, "error", derr)
+		r.record("dispatch_lost_pod_delete_error")
+	}
 }
 
 func (r *dispatchLostReaper) record(decision string) {

--- a/internal/executor/warm_worker_lost_reap.go
+++ b/internal/executor/warm_worker_lost_reap.go
@@ -96,6 +96,8 @@ type warmWorkerLostReaper struct {
 	// warmPods is the live warm-pod seam. Nil (warm off / not wired) makes run a
 	// no-op via the empty live set.
 	warmPods WarmPodLister
+	// gate is re-checked before every destructive call (see destructiveGate).
+	gate destructiveGate
 }
 
 func newWarmWorkerLostReaper(store WarmWorkerLostReapStore, logger *slog.Logger, rec DecisionRecorder) *warmWorkerLostReaper {
@@ -153,6 +155,10 @@ func (r *warmWorkerLostReaper) run(ctx context.Context) error {
 	for _, ti := range bound {
 		if live[ti.WarmWorkerID] {
 			// The serving warm worker is still alive; the attempt is healthy.
+			continue
+		}
+		if !gateOpen(r.gate, ctx) {
+			r.record("warm_worker_lost_gate_skip")
 			continue
 		}
 		applied, ferr := r.store.MarkTaskPodLost(ctx, ti.TaskInstanceID)

--- a/internal/scheduler/plan.go
+++ b/internal/scheduler/plan.go
@@ -18,9 +18,12 @@ type PlannedTransition struct {
 // retries — a failed task with retry budget moves to up_for_retry, and an
 // up_for_retry task resets (none, try_number+1) — then plans the rest off the
 // resulting effective states: none -> scheduled (or skipped / upstream_failed
-// per the trigger rule) and scheduled -> queued. A retriable failed task is
-// treated as still active, so downstream tasks wait rather than seeing a
-// failure. The result is deterministic: identical inputs yield identical output.
+// per the trigger rule) and scheduled -> queued. A failed task that can still
+// recover — app-retriable, or infra-failed with re-place budget left (even while
+// parked in its re-place backoff) — is treated as still active, so downstream
+// tasks wait rather than seeing a failure; a downstream is condemned to
+// upstream_failed only once its upstream is terminally failed. The result is
+// deterministic: identical inputs yield identical output.
 func PlanRun(run RunState) []PlannedTransition {
 	upstreams := make(map[string][]string, len(run.Tasks))
 	for _, t := range run.Tasks {
@@ -172,9 +175,21 @@ func planRetryTransitions(run RunState, effective map[string]domain.TaskState, d
 				// infra-attempt limit so a poison placement can't loop forever;
 				// exhausted → terminal (no fallback to the app-retry budget). The
 				// store bumps infra_attempts (not try_number) when applying failed→none.
-				if infraReplaceable(run, t.TaskID) && readyToInfraReplace(run, t.TaskID) {
-					out = append(out, PlannedTransition{TaskID: t.TaskID, To: domain.TaskStateNone})
-					effective[t.TaskID] = domain.TaskStateNone
+				//
+				// The effective state downstream planning sees is decoupled from the
+				// transition emitted this tick. A re-placeable task is ACTIVE for its
+				// downstream from the moment it is re-placeable — not only once its
+				// backoff elapses — mirroring the app-retry branch below. Otherwise a
+				// downstream would be persisted upstream_failed (terminal; nothing
+				// reverts it) during the backoff, condemning the run even though the
+				// upstream goes on to re-run and succeed. A downstream may only see
+				// `failed` once the upstream is terminally failed (budget exhausted).
+				if infraReplaceable(run, t.TaskID) {
+					effective[t.TaskID] = domain.TaskStateUpForRetry
+					if readyToInfraReplace(run, t.TaskID) {
+						out = append(out, PlannedTransition{TaskID: t.TaskID, To: domain.TaskStateNone})
+						effective[t.TaskID] = domain.TaskStateNone
+					}
 				}
 				decided[t.TaskID] = true
 			case retriable(run, t.TaskID):

--- a/internal/scheduler/plan_test.go
+++ b/internal/scheduler/plan_test.go
@@ -216,6 +216,87 @@ func TestInfraReplaceJitterSpreadsSiblings(t *testing.T) {
 	}
 }
 
+// TestPlanRunInfraReplaceInBackoffDoesNotCondemnDownstream pins the lazy
+// upstream_failed invariant: a downstream must see its upstream as failed ONLY
+// once the upstream is terminally failed. An infra-failed upstream that is still
+// re-placeable but parked in its re-place backoff is an ACTIVE upstream — the
+// downstream waits, exactly as it does for an app-retriable upstream. Before the
+// fix the infra branch left the effective state as `failed` during the backoff,
+// so the downstream was persisted `upstream_failed` (a terminal state nothing
+// ever reverts) while its upstream went on to re-run and succeed — condemning
+// the run on a control-plane restart that the upstream itself survived.
+func TestPlanRunInfraReplaceInBackoffDoesNotCondemnDownstream(t *testing.T) {
+	now := time.Now().UTC()
+	ended := now.Add(-2 * time.Second) // < 5s base backoff: replaceable, not yet ready
+	run := RunState{
+		RunID:         "run-1",
+		Tasks:         linear(),
+		States:        map[string]domain.TaskState{"a": domain.TaskStateFailed, "b": domain.TaskStateNone},
+		Tries:         map[string]int{"a": 0},
+		MaxTries:      map[string]int{"a": 3},
+		InfraFailed:   map[string]bool{"a": true},
+		InfraAttempts: map[string]int{"a": 0},
+		EndedAt:       map[string]*time.Time{"a": &ended},
+		Now:           now,
+	}
+	got := planMap(run)
+	if _, ok := got["a"]; ok {
+		t.Errorf("a within the infra backoff must stay parked (no transition), got %q", got["a"])
+	}
+	if to, ok := got["b"]; ok {
+		t.Errorf("b must WAIT while its upstream is still infra-replaceable, got planned to %q", to)
+	}
+
+	// Past the backoff the upstream re-places to none; the downstream still waits
+	// (none is an active state) rather than being condemned or scheduled.
+	run.Now = ended.Add(dispatchBackoffBase + infraReplaceJitterWindow)
+	got = planMap(run)
+	if got["a"] != domain.TaskStateNone {
+		t.Errorf("a past the backoff must re-place (none), got %q", got["a"])
+	}
+	if to, ok := got["b"]; ok {
+		t.Errorf("b must still wait while a re-places, got planned to %q", to)
+	}
+}
+
+// TestPlanRunDownstreamSchedulesAfterInfraReplaceSucceeds: once the re-placed
+// upstream runs again and succeeds, the downstream — which was never condemned —
+// plans none→scheduled. The InfraFailed marker of a task that has since
+// succeeded is irrelevant to downstream planning.
+func TestPlanRunDownstreamSchedulesAfterInfraReplaceSucceeds(t *testing.T) {
+	run := RunState{
+		Tasks:         linear(),
+		States:        map[string]domain.TaskState{"a": domain.TaskStateSuccess, "b": domain.TaskStateNone},
+		InfraFailed:   map[string]bool{"a": true},
+		InfraAttempts: map[string]int{"a": 1},
+	}
+	if got := planMap(run); got["b"] != domain.TaskStateScheduled {
+		t.Errorf("b = %q, want scheduled once the re-placed upstream succeeded", got["b"])
+	}
+}
+
+// TestPlanRunInfraExhaustedCondemnsDownstream is the regression guard for the
+// lazy marking: once the upstream is TERMINALLY failed — infra budget spent, and
+// infra faults never fall back to the app-retry budget — the downstream DOES get
+// upstream_failed. Lazy must not mean never.
+func TestPlanRunInfraExhaustedCondemnsDownstream(t *testing.T) {
+	run := RunState{
+		Tasks:         linear(),
+		States:        map[string]domain.TaskState{"a": domain.TaskStateFailed, "b": domain.TaskStateNone},
+		Tries:         map[string]int{"a": 0}, // app budget available, but infra routes exclusively
+		MaxTries:      map[string]int{"a": 3},
+		InfraFailed:   map[string]bool{"a": true},
+		InfraAttempts: map[string]int{"a": infraMaxAttempts},
+	}
+	got := planMap(run)
+	if _, ok := got["a"]; ok {
+		t.Errorf("infra-exhausted a must be terminal (no transition), got %q", got["a"])
+	}
+	if got["b"] != domain.TaskStateUpstreamFailed {
+		t.Errorf("b = %q, want upstream_failed once a is terminally failed", got["b"])
+	}
+}
+
 func TestPlanRunResetsUpForRetry(t *testing.T) {
 	run := RunState{
 		Tasks:    linear(),


### PR DESCRIPTION
Closes #871. Addresses the GA-gate checklist in #896 (structural follow-ups remain tracked there).

Production drill on EKS (v0.4.4): killing the control plane mid-run turned a SUCCEEDED dbt task into `failed` and left the run unrecoverable (`success=16 upstream_failed=10`, nothing that ran actually failed). Root cause was a **race**: the agent's durable outcome (termination-log, ADR 0052) *should* have been recovered by the reconciler, but the pod-lost reaper (1s cadence, no post-leadership grace) marked it failed first; the agent's 31s report budget was the trigger. Five fixes, one commit each, each locked by an invariant test:

1. **scheduler: lazy-mark `upstream_failed`** — a downstream sees its upstream as failed only once the upstream is *terminally* failed (retries + infra-replace exhausted); while `infraReplaceable`, the effective state stays active (mirrors the app-retry branch). First slice toward deriving downstream state every tick.
2. **executor: post-leadership grace on the pod-lost reaper** (`PodLostLeaderGrace` = `AgentLostGrace` 180s, 6× the 30s reconcile) via a shared `inLeaderGrace` gate — the reconciler recovers the durable SUCCESS before pod-lost can convert `running→failed`. First step toward a uniform leader-settling gate.
3. **agent: terminal report never gives up on attempt count** — `reportBackoff` ramps `1,2,4,8` then holds at the heartbeat interval (15s); retries until ctx-cancel or a non-retryable code. The heartbeat already survives the outage and renews the token every beat (sliding); the report must not be more fragile than it (kubelet status-manager posture). Applies uniformly to warm workers.
4. **executor: no destructive reaping during shutdown / step-down** — `destructiveGate` (`ctx live && !inStepDown && leading`) checked at `ReapOnce` and before every mark/delete in all five reapers; the successor redoes it under its own grace.
5. **boot: validate the resilience timing ladder** — `ValidateResilienceLadder` fails startup unless `heartbeat < agentLostThreshold < agentLostGrace < tokenTTL` and `reconcile < every destructive-reaper leadership grace`. The *ordering* is the guarantee, not the numbers.

Decisions kept: mediated agent→control-plane write topology; no DB creds in task pods. Not adopting Airflow's direct-DB-write — "you don't fix a race by changing the medium."

**Verification:** `go build`, `go test ./...` (32 pkgs), `go test -tags integration ./internal/storage/ ./internal/api/` (run against Postgres), `golangci-lint` 0 issues, gofmt clean, changelog gate OK. **Not run on a real cluster** — the pod-lost/reconciler ordering is asserted via fake stores + the ladder check; the cluster drill matrix in #896 is the operational confirmation.

Reviewer note: the generic `Backoff` helper is now unreferenced by production code (kept per brief) — removal candidate.
