### PR TITLE
fix(resilience): pre-cut gates — ladder rungs that can fail in production, teardown-gate coverage, task-pod deadline floor, wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,13 +57,21 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **A control-plane restart no longer marks a succeeded task failed, and no
   longer condemns the rest of its run.** A production drill (kill the
   control-plane pod mid-run) turned a dbt task that had SUCCEEDED into `failed`
-  and failed the whole run. Four compounding causes, each now fixed:
+  and failed the whole run. Five compounding causes, each now fixed:
   - The agent abandoned a terminal report after 6 attempts (~31s) — shorter than
     a control-plane restart — while its heartbeat loop kept going indefinitely.
     The report now retries until its context ends (SIGTERM, pod delete, execution
     timeout), with the pause between attempts capped at the heartbeat interval so
-    it reconnects within about one heartbeat of the server returning.
-    Credential rejections are still returned at once.
+    it reconnects within about one heartbeat plus the gRPC channel's own
+    reconnect backoff once the server returns. Credential rejections are still
+    returned at once. The RUNNING pre-flight report takes the same path, on
+    purpose: an agent that cannot reach the control plane does not start user
+    code until it can. Because both reports now outlast an outage, every task
+    pod also gets an `activeDeadlineSeconds` floor when its DAG declares no
+    execution timeout — derived from `auth.max_attempt_credential_lifetime`,
+    past which the pod cannot renew its credential — so no task pod is left
+    Running forever after a total control-plane outage. A user-declared timeout
+    is never shortened.
   - The pod-lost reaper (every scheduler tick) raced the reconciler (every 30s)
     for a pod that finished during the outage, and won — marking it `pod_lost`
     before the reconciler could recover the pod's durable outcome record. It now
@@ -77,10 +85,16 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     Every destructive reaper action is now gated on a live context, no step-down
     in progress, and (when wired) current leadership; the successor redoes the
     reap under its own grace.
-  - The timing ladder the recovery depends on (`heartbeat < agent-lost threshold
-    < agent-lost grace < token TTL`, and `reconcile interval` below both
-    graces) is validated at server boot; a knob moved out of order fails startup
-    naming the violated relation.
+  - The timing ladder the recovery depends on is validated at server boot:
+    `heartbeat < agent-lost threshold < agent-lost grace < token TTL`, two
+    `reconcile interval`s below both post-leadership graces (one is not enough
+    to guarantee a completed sweep), the scheduler's longest infra re-place
+    delay below the orphan-run threshold, and the token TTL below
+    `auth.max_attempt_credential_lifetime`. That last rung is the only one an
+    operator can move — hardening the ceiling below the TTL would silently
+    disable heartbeat renewal and with it the whole recovery — so its failure
+    names the config key; every other rung is a build-time constant and its
+    failure asks for a bug report.
 
 - **Connection/variable writes are now tri-state, restoring explicit-clear and
   fixing the masked write-back overwrite (#887, subsumes #874).** The safe-merge

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -350,22 +350,27 @@ func validateStartup(cfg *config.ServerConfig) error {
 	if err := cfg.Validate(); err != nil {
 		return err
 	}
-	return executor.ValidateResilienceLadder(resilienceLadder())
+	return executor.ValidateResilienceLadder(resilienceLadder(cfg))
 }
 
 // resilienceLadder assembles the effective timing knobs the control-plane
 // restart recovery depends on, exactly as this binary wires them: the agent's
-// heartbeat interval and derived token TTL, the reaper thresholds/graces, and
-// the reconciler sweep. validateStartup checks it before anything starts.
-func resilienceLadder() executor.ResilienceLadder {
+// heartbeat interval and derived token TTL, the reaper thresholds/graces, the
+// reconciler sweep, the scheduler's longest infra re-place delay, and the
+// operator's credential-lifetime ceiling — the one rung a deployment can move.
+// validateStartup checks it before anything starts.
+func resilienceLadder(cfg *config.ServerConfig) executor.ResilienceLadder {
 	rc := executor.DefaultReaperConfig()
 	return executor.ResilienceLadder{
-		HeartbeatInterval:  agent.DefaultHeartbeatInterval,
-		AgentLostThreshold: rc.AgentLostThreshold,
-		AgentLostGrace:     rc.AgentLostGrace,
-		PodLostLeaderGrace: rc.PodLostLeaderGrace,
-		AttemptTokenTTL:    attemptTokenTTL,
-		ReconcileInterval:  reconcileInterval,
+		HeartbeatInterval:            agent.DefaultHeartbeatInterval,
+		AgentLostThreshold:           rc.AgentLostThreshold,
+		AgentLostGrace:               rc.AgentLostGrace,
+		PodLostLeaderGrace:           rc.PodLostLeaderGrace,
+		AttemptTokenTTL:              attemptTokenTTL,
+		ReconcileInterval:            reconcileInterval,
+		OrphanThreshold:              rc.OrphanThreshold,
+		InfraReplaceMaxDelay:         scheduler.InfraReplaceMaxDelay(),
+		MaxAttemptCredentialLifetime: cfg.Auth.MaxAttemptCredentialLifetime,
 	}
 }
 

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -1456,6 +1456,12 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 	// BuildPod.
 	dispatcher.SetAgentTokenTransport(cfg.Auth.AgentTokenTransport, executor.DefaultAgentTokenAudience, 0)
 	dispatcher.SetPlatformDefaults(platformDefaults(cfg.Executor.Defaults))
+	// Deadline floor for task pods that declare no execution timeout: the agent's
+	// reports retry for as long as the control plane is unreachable, so a pod
+	// with no deadline of its own would outlive a total outage indefinitely. The
+	// credential ceiling is the natural bound — past it the pod cannot renew its
+	// bearer — and it is the same knob the warm worker's attempt watchdog uses.
+	dispatcher.SetAttemptLifetimeCeiling(cfg.Auth.MaxAttemptCredentialLifetime)
 	// External secrets backend (ADR 0060, Pro pod path): deliver the operator config
 	// to task pods as LEOFLOW_SECRETS_* env. Empty backend → podEnv skips it (chain
 	// stays vault-only). The D6 registration relaxation is wired separately in run()

--- a/cmd/leoflow-server/resilience_ladder_wiring_test.go
+++ b/cmd/leoflow-server/resilience_ladder_wiring_test.go
@@ -1,22 +1,54 @@
 package main
 
 import (
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/neochaotic/leoflow/internal/config"
 	"github.com/neochaotic/leoflow/internal/executor"
+	"github.com/neochaotic/leoflow/internal/scheduler"
 )
 
 // TestResilienceLadderWiringValidates pins that the ladder the server actually
-// boots with — agent heartbeat/TTL, default reaper config, reconcile interval —
-// satisfies every ordering the restart recovery depends on. A change to any one
-// of those constants that breaks the order fails this test before it fails a
-// deployment at boot.
+// boots with — agent heartbeat/TTL, default reaper config, reconcile interval,
+// the scheduler's infra re-place ceiling and the default credential-lifetime
+// ceiling — satisfies every ordering the restart recovery depends on. A change
+// to any one of those constants that breaks the order fails this test before it
+// fails a deployment at boot.
 func TestResilienceLadderWiringValidates(t *testing.T) {
-	l := resilienceLadder()
+	cfg := &config.ServerConfig{}
+	cfg.Auth.MaxAttemptCredentialLifetime = 24 * time.Hour
+	l := resilienceLadder(cfg)
 	if err := executor.ValidateResilienceLadder(l); err != nil {
 		t.Fatalf("server ladder %+v must validate: %v", l, err)
 	}
 	if l.ReconcileInterval != reconcileInterval || l.AttemptTokenTTL != attemptTokenTTL {
 		t.Errorf("ladder must carry the wired values: %+v", l)
+	}
+	if l.InfraReplaceMaxDelay != scheduler.InfraReplaceMaxDelay() {
+		t.Errorf("ladder must carry the scheduler's infra re-place ceiling %v, got %v", scheduler.InfraReplaceMaxDelay(), l.InfraReplaceMaxDelay)
+	}
+	if l.OrphanThreshold != executor.DefaultReaperConfig().OrphanThreshold {
+		t.Errorf("ladder must carry the orphan threshold, got %v", l.OrphanThreshold)
+	}
+	if l.MaxAttemptCredentialLifetime != 24*time.Hour {
+		t.Errorf("ladder must carry the configured credential ceiling, got %v", l.MaxAttemptCredentialLifetime)
+	}
+}
+
+// TestResilienceLadderWiringFailsOnShortCredentialCeiling: the ONLY
+// operator-tunable rung is auth.max_attempt_credential_lifetime. Hardening it
+// below the per-attempt token TTL would silently disable heartbeat renewal — and
+// with it the whole restart recovery — so boot must refuse, naming the key.
+func TestResilienceLadderWiringFailsOnShortCredentialCeiling(t *testing.T) {
+	cfg := &config.ServerConfig{}
+	cfg.Auth.MaxAttemptCredentialLifetime = 5 * time.Minute
+	err := executor.ValidateResilienceLadder(resilienceLadder(cfg))
+	if err == nil {
+		t.Fatal("a 5-minute credential ceiling under a 10-minute token TTL must fail validation")
+	}
+	if !strings.Contains(err.Error(), "auth.max_attempt_credential_lifetime") {
+		t.Errorf("error %q must name the config key the operator has to move", err)
 	}
 }

--- a/internal/agent/report_retry_test.go
+++ b/internal/agent/report_retry_test.go
@@ -72,8 +72,9 @@ func TestReportOutlastsControlPlaneRestart(t *testing.T) {
 // TestReportBackoffRampsThenHoldsAtHeartbeatInterval pins the per-attempt delay
 // policy: an exponential ramp (1s, 2s, 4s, 8s) that is CAPPED at the heartbeat
 // interval and then holds there for every further attempt — never longer. Capping
-// the delay rather than the duration means the agent reconnects within about one
-// heartbeat of the server returning, however long the outage lasted.
+// the delay rather than the duration means the agent's next attempt is at most
+// one heartbeat away once the server returns (plus the gRPC channel's own
+// reconnect backoff), however long the outage lasted.
 func TestReportBackoffRampsThenHoldsAtHeartbeatInterval(t *testing.T) {
 	want := []time.Duration{
 		time.Second, 2 * time.Second, 4 * time.Second, 8 * time.Second,

--- a/internal/agent/report_retry_test.go
+++ b/internal/agent/report_retry_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"io"
 	"testing"
 	"time"
 
@@ -170,5 +171,73 @@ func TestReportRetryAbortsOnContextCancel(t *testing.T) {
 	}
 	if client.reportAttempts != 1 {
 		t.Errorf("expected 1 attempt before the canceled backoff aborted, got %d", client.reportAttempts)
+	}
+}
+
+// holdingCmd is a CommandRunner that records, at the moment user code would
+// start, how many reports the control plane had accepted — so a test can prove
+// user code is held back until the RUNNING pre-flight report has landed.
+type holdingCmd struct {
+	client             *fakeClient
+	acceptedAtStart    int
+	attemptsAtStart    int
+	stateAcceptedFirst agentv1.TaskState
+	ran                bool
+}
+
+func (c *holdingCmd) Run(context.Context, []string, []string, io.Writer, io.Writer) (int, error) {
+	c.ran = true
+	c.acceptedAtStart = len(c.client.reports)
+	c.attemptsAtStart = c.client.reportAttempts
+	if len(c.client.reports) > 0 {
+		c.stateAcceptedFirst = c.client.reports[0].GetState()
+	}
+	return 0, nil
+}
+
+// TestRunningReportOutlastsControlPlaneRestart: the RUNNING pre-flight report
+// shares the terminal report's retry loop and therefore also outlasts a
+// control-plane outage — deliberately. An agent that cannot reach the control
+// plane does not start user code until it can: the pod sits in its pre-flight,
+// not in a half-observed run. Here the control plane is Unavailable for twice
+// the retired 6-attempt budget while the agent tries to report RUNNING; user
+// code must not have started before that report was accepted, and the task
+// then completes normally.
+func TestRunningReportOutlastsControlPlaneRestart(t *testing.T) {
+	const outageAttempts = 12
+	client := &fakeClient{
+		spec:            &agentv1.TaskSpec{Operator: "bash", Entrypoint: "true"},
+		reportFailCode:  codes.Unavailable,
+		reportFailTimes: outageAttempts,
+	}
+	cmd := &holdingCmd{client: client}
+	r := &Runner{
+		Client:   client,
+		Cmd:      cmd,
+		Sink:     &recordingSink{},
+		Hostname: "pod-1",
+		Version:  "test",
+		afterFunc: func(time.Duration) <-chan time.Time {
+			ch := make(chan time.Time, 1)
+			ch <- time.Time{}
+			return ch
+		},
+	}
+
+	if err := r.Run(context.Background()); err != nil {
+		t.Fatalf("the task must complete once the control plane returns, got %v", err)
+	}
+	if !cmd.ran {
+		t.Fatal("user code must run once the RUNNING report landed")
+	}
+	if cmd.acceptedAtStart != 1 || cmd.stateAcceptedFirst != agentv1.TaskState_TASK_STATE_RUNNING {
+		t.Errorf("user code started with %d accepted reports (first %v); want exactly the RUNNING report accepted first",
+			cmd.acceptedAtStart, cmd.stateAcceptedFirst)
+	}
+	if want := outageAttempts + 1; cmd.attemptsAtStart != want {
+		t.Errorf("user code started after %d report attempts, want %d (%d refused + the accepted RUNNING)", cmd.attemptsAtStart, want, outageAttempts)
+	}
+	if n := len(client.reports); n != 2 || client.reports[1].GetState() != agentv1.TaskState_TASK_STATE_SUCCESS {
+		t.Errorf("accepted reports = %d (last %v), want RUNNING then SUCCESS", n, client.reports[n-1].GetState())
 	}
 }

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -895,6 +895,16 @@ func reportBackoff(attempt int) time.Duration {
 // lands — the pod is deleted or times out first — is recovered by the reconciler
 // from that record; the retry loop only shortens the path to the same result.
 //
+// The RUNNING pre-flight report takes this same path, so it too outlasts an
+// outage — intentionally. An agent that cannot reach the control plane does not
+// start user code until it can: the pod waits in its pre-flight rather than
+// running half-observed work whose RUNNING transition the control plane never
+// saw (the dispatch-lost reaper would then fail a task that is actually
+// executing). The cost is a pod that holds its requests for the length of the
+// outage; that is bounded by the pod's ActiveDeadlineSeconds, which the
+// executor floors with the attempt credential ceiling when the task declares
+// no timeout of its own, so no task pod is immortal.
+//
 // Warm-pool workers share this path (the per-attempt Runner is built by
 // WarmRunner.attemptRunner). A warm worker retrying a report stays busy only
 // while the control plane is down, which is exactly the window in which no new

--- a/internal/agent/runner.go
+++ b/internal/agent/runner.go
@@ -853,9 +853,10 @@ func (r *Runner) writeOutcome(rec taskoutcome.Record) {
 // reportRetryMaxDelay caps the pause between two attempts to deliver a report.
 // It equals the heartbeat interval on purpose: the heartbeat is the agent's
 // other channel to the control plane, and once the server is back a report
-// retry lands within about one heartbeat of it — the same posture the kubelet's
-// status manager takes toward an unreachable apiserver (keep trying at a bounded
-// cadence, never abandon the status).
+// retry lands within about one heartbeat plus the gRPC channel's own reconnect
+// backoff (the channel re-dials on its own schedule, independent of this cap) —
+// the same posture the kubelet's status manager takes toward an unreachable
+// apiserver (keep trying at a bounded cadence, never abandon the status).
 const reportRetryMaxDelay = DefaultHeartbeatInterval
 
 // reportBackoff returns the delay before report retry attempt n (1-based): an

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -144,6 +144,29 @@ type Dispatcher struct {
 	// taskServiceAccount here makes keyless work without every DAG having to opt in
 	// (the execution.service_account trap).
 	defaultTaskServiceAccount string
+	// attemptLifetimeCeiling is the operator's auth.max_attempt_credential_lifetime,
+	// handed to the executor so a task pod that declares no timeout still gets a
+	// deadline floor. Zero (unset / disabled) applies no floor.
+	attemptLifetimeCeiling time.Duration
+}
+
+// SetAttemptLifetimeCeiling wires the operator's attempt credential ceiling
+// (auth.max_attempt_credential_lifetime) into every dispatched request, where the
+// Kubernetes executor floors the pod's ActiveDeadlineSeconds with it when the
+// task declares no execution timeout. A non-positive value is "no ceiling" and
+// applies no floor; the subprocess executor ignores it.
+func (d *Dispatcher) SetAttemptLifetimeCeiling(ceiling time.Duration) {
+	d.attemptLifetimeCeiling = ceiling
+}
+
+// wholeSeconds converts a positive duration to whole seconds for the executor
+// request; a non-positive duration ("disabled") maps to 0 so the executor applies
+// no floor.
+func wholeSeconds(d time.Duration) int64 {
+	if d <= 0 {
+		return 0
+	}
+	return int64(d.Seconds())
 }
 
 // SetSecretsBackend configures the operator's external secrets backend (ADR 0060):
@@ -288,7 +311,8 @@ func (d *Dispatcher) Dispatch(ctx context.Context, runID, dagID, dagVersionID st
 		ControlPlaneAddr:     d.controlAddr,
 		AgentToken:           token,
 		// Cluster-operator policy, not a per-task choice — see PlatformDefaults.
-		PodSecurity: d.defaults.PodSecurity,
+		PodSecurity:                   d.defaults.PodSecurity,
+		AttemptLifetimeCeilingSeconds: wholeSeconds(d.attemptLifetimeCeiling),
 	}
 	if task.ExecutionTimeoutSeconds != nil {
 		req.TimeoutSeconds = *task.ExecutionTimeoutSeconds

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -149,3 +149,28 @@ func TestDispatchPropagatesErrors(t *testing.T) {
 		})
 	}
 }
+
+// TestDispatchThreadsAttemptLifetimeCeiling: the operator's credential-lifetime
+// ceiling reaches the executor request as whole seconds, so the pod builder can
+// floor the pod's ActiveDeadlineSeconds with it when the task declares no
+// timeout. Unset (the zero value) is passed through as zero — "no floor".
+func TestDispatchThreadsAttemptLifetimeCeiling(t *testing.T) {
+	res := &fakeResolver{resolved: Resolved{TaskInstanceID: "ti-1", TenantID: "acme", Image: "etl:v1", TryNumber: 1}}
+	exec := &fakeExecutor{}
+	d := newDispatcher(res, &fakeIssuer{token: "t"}, exec)
+
+	if _, err := d.Dispatch(context.Background(), "run-uuid", "etl", "", pythonTask()); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if exec.req.AttemptLifetimeCeilingSeconds != 0 {
+		t.Errorf("unset ceiling must pass through as 0, got %d", exec.req.AttemptLifetimeCeilingSeconds)
+	}
+
+	d.SetAttemptLifetimeCeiling(24 * time.Hour)
+	if _, err := d.Dispatch(context.Background(), "run-uuid", "etl", "", pythonTask()); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if exec.req.AttemptLifetimeCeilingSeconds != 86400 {
+		t.Errorf("ceiling must reach the request as seconds, got %d want 86400", exec.req.AttemptLifetimeCeilingSeconds)
+	}
+}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -48,6 +48,19 @@ type Request struct {
 	Resources       domain.Resources
 	Execution       domain.Execution
 	TimeoutSeconds  int
+	// AttemptLifetimeCeilingSeconds is the operator's attempt credential ceiling
+	// (auth.max_attempt_credential_lifetime) in whole seconds. The Kubernetes
+	// executor floors the task pod's ActiveDeadlineSeconds with it when the task
+	// declares no TimeoutSeconds, so no task pod is immortal: the agent's reports
+	// retry for as long as the control plane is unreachable, and without a floor
+	// a total control-plane outage would leave every such pod Running forever,
+	// holding its requests and blocking node scale-down. Past the ceiling the pod
+	// can do nothing useful — heartbeat renewal stops and its bearer lapses. A
+	// user-declared TimeoutSeconds always wins, even when longer. Non-positive
+	// means "no ceiling" (the same convention as the warm worker's attempt
+	// watchdog for the same knob) and applies no floor. Ignored by the subprocess
+	// executor, which has no pod.
+	AttemptLifetimeCeilingSeconds int64
 
 	// PodSecurity carries the two hardening choices that can change how a task
 	// runs. Everything else BuildPod applies is unconditional, because dropping

--- a/internal/executor/kubernetes.go
+++ b/internal/executor/kubernetes.go
@@ -126,8 +126,7 @@ func BuildPod(req Request) *corev1.Pod {
 			}},
 		},
 	}
-	if req.TimeoutSeconds > 0 {
-		deadline := int64(req.TimeoutSeconds)
+	if deadline := podActiveDeadline(req); deadline > 0 {
 		pod.Spec.ActiveDeadlineSeconds = &deadline
 	}
 	if req.Execution.ServiceAccount != "" {
@@ -141,6 +140,30 @@ func BuildPod(req Request) *corev1.Pod {
 	mountTaskSecret(pod, req)
 	mountAgentToken(pod, agentTokenOf(req))
 	return pod
+}
+
+// podActiveDeadline returns the task pod's ActiveDeadlineSeconds: the user's
+// declared timeout when set, otherwise the attempt credential ceiling as a
+// floor, otherwise 0 (no deadline). The user's value is never shortened — a
+// declared timeout is the author's bound to make, even one above the ceiling.
+// The floor exists because the agent's RUNNING and terminal reports retry for as
+// long as the control plane is unreachable (by design: a report that gives up is
+// how a succeeded task ends up marked failed), so a pod with no deadline of its
+// own would survive a total control-plane outage indefinitely, pinned Running
+// with its requests held and blocking node scale-down. Past the credential
+// ceiling the pod can do nothing useful — its bearer stops renewing and lapses —
+// so that is the natural bound; a non-positive ceiling is the operator's "no
+// ceiling" and applies no floor. When the pod hits the floor the kubelet kills
+// it and the reconciler recovers the durable outcome record the agent wrote
+// before its first report attempt, so no result is lost, only a stuck pod.
+func podActiveDeadline(req Request) int64 {
+	if req.TimeoutSeconds > 0 {
+		return int64(req.TimeoutSeconds)
+	}
+	if req.AttemptLifetimeCeilingSeconds > 0 {
+		return req.AttemptLifetimeCeilingSeconds
+	}
+	return 0
 }
 
 // Agent-token transport (ADR 0055 Fix #3). The env-var transport keeps the

--- a/internal/executor/kubernetes_deadline_test.go
+++ b/internal/executor/kubernetes_deadline_test.go
@@ -1,0 +1,64 @@
+package executor
+
+import (
+	"testing"
+)
+
+// TestBuildPodFloorsActiveDeadlineWhenNoTimeout: a task whose DAG declares no
+// execution timeout still gets an ActiveDeadlineSeconds, derived from the
+// attempt credential ceiling. The agent's reports retry for as long as the
+// control plane is down, so without a floor a total control-plane outage would
+// leave every such pod Running forever, holding its requests and blocking node
+// scale-down. Past the credential ceiling the pod can do nothing useful anyway:
+// heartbeat renewal stops there and its bearer lapses.
+func TestBuildPodFloorsActiveDeadlineWhenNoTimeout(t *testing.T) {
+	req := sampleReq()
+	req.TimeoutSeconds = 0
+	req.AttemptLifetimeCeilingSeconds = 86400
+
+	pod := BuildPod(req)
+	if pod.Spec.ActiveDeadlineSeconds == nil {
+		t.Fatal("a task pod with no declared timeout must still carry a deadline floor")
+	}
+	if got := *pod.Spec.ActiveDeadlineSeconds; got != 86400 {
+		t.Errorf("activeDeadlineSeconds = %d, want the credential ceiling 86400", got)
+	}
+}
+
+// TestBuildPodUserTimeoutWinsOverFloor: a user-declared timeout is never
+// shortened by the floor — whether it is below the ceiling (the common case) or
+// above it (the user has explicitly asked for a longer bound, which is theirs to
+// make).
+func TestBuildPodUserTimeoutWinsOverFloor(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		timeout int
+		ceiling int64
+	}{
+		{"timeout below ceiling", 600, 86400},
+		{"timeout above ceiling", 172800, 86400},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := sampleReq()
+			req.TimeoutSeconds = tc.timeout
+			req.AttemptLifetimeCeilingSeconds = tc.ceiling
+			pod := BuildPod(req)
+			if pod.Spec.ActiveDeadlineSeconds == nil || *pod.Spec.ActiveDeadlineSeconds != int64(tc.timeout) {
+				t.Errorf("activeDeadlineSeconds = %v, want the user's %d", pod.Spec.ActiveDeadlineSeconds, tc.timeout)
+			}
+		})
+	}
+}
+
+// TestBuildPodNoDeadlineWhenCeilingDisabled: with no declared timeout AND the
+// credential ceiling disabled (non-positive, the operator's documented "no
+// ceiling"), the pod carries no deadline — the same zero-means-unbounded
+// convention the warm worker's attempt watchdog follows for the same knob.
+func TestBuildPodNoDeadlineWhenCeilingDisabled(t *testing.T) {
+	req := sampleReq()
+	req.TimeoutSeconds = 0
+	req.AttemptLifetimeCeilingSeconds = 0
+	if pod := BuildPod(req); pod.Spec.ActiveDeadlineSeconds != nil {
+		t.Errorf("activeDeadlineSeconds = %d, want none when both timeout and ceiling are unset", *pod.Spec.ActiveDeadlineSeconds)
+	}
+}

--- a/internal/executor/pod_lost_reap.go
+++ b/internal/executor/pod_lost_reap.go
@@ -66,8 +66,12 @@ type PodLostReapStore interface {
 //
 // Warm-pool attempts are out of this reaper's scope: a warm attempt has no
 // per-task pod, so it never appears live here; the warm-worker-lost reaper
-// recovers those from the warm pod's own liveness, which a control-plane restart
-// does not disturb — hence that reaper carries no leadership grace.
+// recovers those from the warm pod's own liveness. That reaper carries no
+// leadership grace because its liveness signal is not one a control-plane
+// restart can manufacture: ListWarmPods is a live apiserver LIST (not an
+// informer-backed cache that could be cold or stale after a restart), and a
+// LIST error aborts its tick with zero marks, so a fresh leader either sees the
+// real warm fleet or marks nothing.
 type podLostReaper struct {
 	store    PodLostReapStore
 	logger   *slog.Logger

--- a/internal/executor/reaper.go
+++ b/internal/executor/reaper.go
@@ -252,8 +252,11 @@ func (r *Reaper) SetLogSink(s logSink) {
 // a dead agent or a lost pod, and is not reaped (see inLeaderGrace). It reaches
 // every reaper that acts on a restart-manufactured signal: agent-lost and
 // pod-lost. Nil (Lite / no leadership) leaves the grace off. The warm-worker-lost
-// reaper is deliberately not gated: its signal is the warm pod's own liveness,
-// which a control-plane restart does not disturb.
+// reaper is deliberately not gated: its signal is the warm pod's own liveness
+// read by a live apiserver LIST (ListWarmPods, not an informer cache that a
+// restart could leave cold), and a LIST error aborts its tick with zero marks —
+// so a fresh leader either sees the real warm fleet or marks nothing, and there
+// is no restart-manufactured false signal for a grace to absorb.
 func (r *Reaper) SetLeaderSince(fn func() time.Time) {
 	r.agentLost.leaderSince = fn
 	r.podLost.leaderSince = fn

--- a/internal/executor/reaper_test.go
+++ b/internal/executor/reaper_test.go
@@ -354,3 +354,110 @@ func TestReaperThreadsPresenceCacheToDispatchLost(t *testing.T) {
 		t.Errorf("a cache-active defer must skip the live LIST, got %d live calls", pods.activeCalls)
 	}
 }
+
+// gateOpenThenClosed returns a destructiveGate that is open for the first n
+// consultations and closed for every one after. It models a step-down or cancel
+// that lands between two writes of the same reap, so a test can let the mark
+// through and have the teardown that follows refused.
+func gateOpenThenClosed(n int) destructiveGate {
+	calls := 0
+	return func(context.Context) bool {
+		calls++
+		return calls <= n
+	}
+}
+
+// TestReapersHonorGateAtTeardown: the destructive gate is consulted a SECOND time
+// right before the pod teardown that follows a successful mark — not only at the
+// top of reapOne. With a gate that closes after the first consultation the DB
+// mark applies (it was authorized), but the pod delete is refused and metered as
+// <reaper>_teardown_gate_skip. The always-closed gate in
+// TestReapersHonorGateMidTick can never reach this branch because the top check
+// returns first; this test is the proof of the "re-checked before EVERY
+// mark/delete" claim for the four reapers that own a teardown. The
+// warm-worker-lost reaper deletes no pod (a warm worker outlives its attempts),
+// so it has no teardown re-check to cover.
+func TestReapersHonorGateAtTeardown(t *testing.T) {
+	past := time.Now().UTC().Add(-1 * time.Hour)
+
+	t.Run("orphan", func(t *testing.T) {
+		store := &fakeReaperStore{orphanCands: []ReapCandidate{{RunID: "stuck", LastActivity: past}}}
+		rec := &capturingRecorder{}
+		pods := &fakePodManager{active: map[string]bool{}}
+		r := newOrphanReaper(store, reapTestLogger(), time.Minute, rec)
+		r.pods = pods
+		r.gate = gateOpenThenClosed(1)
+		if err := r.run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if len(store.reapedRuns) != 1 {
+			t.Errorf("the authorized mark must apply, reapedRuns=%v", store.reapedRuns)
+		}
+		if len(pods.deletedRuns) != 0 {
+			t.Errorf("the teardown must be refused once the gate closed, deletedRuns=%v", pods.deletedRuns)
+		}
+		if got := rec.count("orphan_teardown_gate_skip"); got != 1 {
+			t.Errorf("orphan_teardown_gate_skip = %d, want 1", got)
+		}
+	})
+	t.Run("agent-lost", func(t *testing.T) {
+		store := &fakeHeartbeatStore{candidates: []AgentLostCandidate{{TaskInstanceID: "silent", DagRunID: "r", TaskID: "t", TryNumber: 1, LastHeartbeat: past}}}
+		rec := &capturingRecorder{}
+		pods := &fakePodManager{active: map[string]bool{}}
+		r := newAgentLostReaper(store, reapTestLogger(), time.Minute, rec)
+		r.pods = pods
+		r.gate = gateOpenThenClosed(1)
+		if err := r.run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if len(store.failed) != 1 {
+			t.Errorf("the authorized mark must apply, failed=%v", store.failed)
+		}
+		if len(pods.deletedTasks) != 0 {
+			t.Errorf("the teardown must be refused once the gate closed, deletedTasks=%v", pods.deletedTasks)
+		}
+		if got := rec.count("agent_lost_teardown_gate_skip"); got != 1 {
+			t.Errorf("agent_lost_teardown_gate_skip = %d, want 1", got)
+		}
+	})
+	t.Run("dispatch-lost", func(t *testing.T) {
+		store := &fakeReaperStore{queuedCands: []StaleQueuedCandidate{{TaskInstanceID: "stuck", DagRunID: "r", TaskID: "t", TryNumber: 1, QueuedAt: past}}}
+		rec := &capturingRecorder{}
+		pods := &fakePodManager{active: map[string]bool{}}
+		r := newDispatchLostReaper(store, reapTestLogger(), time.Minute, rec)
+		r.pods = pods
+		r.gate = gateOpenThenClosed(1)
+		if err := r.run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if len(store.queuedMarked) != 1 {
+			t.Errorf("the authorized mark must apply, queuedMarked=%v", store.queuedMarked)
+		}
+		if len(pods.deletedTasks) != 0 {
+			t.Errorf("the teardown must be refused once the gate closed, deletedTasks=%v", pods.deletedTasks)
+		}
+		if got := rec.count("dispatch_lost_teardown_gate_skip"); got != 1 {
+			t.Errorf("dispatch_lost_teardown_gate_skip = %d, want 1", got)
+		}
+	})
+	t.Run("pod-lost", func(t *testing.T) {
+		store := &fakePodLostStore{candidates: []PodLostCandidate{{TaskInstanceID: "gone", DagRunID: "r", TaskID: "t", TryNumber: 1, RunningSince: past}}}
+		rec := &capturingRecorder{}
+		pods := &fakePodManager{active: map[string]bool{}}
+		r := newPodLostReaper(store, reapTestLogger(), time.Minute, rec)
+		r.pods = pods
+		r.gate = gateOpenThenClosed(1)
+		if err := r.run(context.Background()); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+		if len(store.marked) != 1 {
+			t.Errorf("the authorized mark must apply, marked=%v", store.marked)
+		}
+		if len(pods.deletedTasks) != 0 {
+			t.Errorf("the teardown must be refused once the gate closed, deletedTasks=%v", pods.deletedTasks)
+		}
+		if got := rec.count("pod_lost_teardown_gate_skip"); got != 1 {
+			t.Errorf("pod_lost_teardown_gate_skip = %d, want 1", got)
+		}
+	})
+}

--- a/internal/executor/resilience_ladder.go
+++ b/internal/executor/resilience_ladder.go
@@ -7,12 +7,15 @@ import (
 
 // ResilienceLadder is the set of timing knobs whose relative ORDER the
 // control-plane-restart recovery depends on. Each is owned by a different
-// package (agent, executor, server main) and tuned for its own reason, so
-// nothing but this type states that they must line up. The invariants:
+// package (agent, executor, scheduler, server main, operator config) and tuned
+// for its own reason, so nothing but this type states that they must line up.
+// The invariants:
 //
 //	heartbeat interval  <  agent-lost threshold  <  agent-lost grace  <  attempt token TTL
-//	reconcile interval  <  agent-lost grace
-//	reconcile interval  <  pod-lost leader grace
+//	2 × reconcile interval  <  agent-lost grace
+//	2 × reconcile interval  <  pod-lost leader grace
+//	longest infra re-place delay  <  orphan threshold
+//	attempt token TTL  <  max attempt credential lifetime   (when the ceiling is enabled)
 //
 // Why each rung matters:
 //   - heartbeat < threshold: a healthy agent must beat well inside the silence
@@ -22,10 +25,27 @@ import (
 //   - agent-lost grace < token TTL: the grace ends while a re-heartbeat can still
 //     authenticate and renew the bearer; otherwise the fleet is unreapable AND
 //     unable to report — every in-flight task is lost.
-//   - reconcile < agent-lost grace, reconcile < pod-lost leader grace: the
-//     reconciler gets at least one full sweep under the new leader before any
+//   - 2×reconcile < agent-lost grace, 2×reconcile < pod-lost leader grace: the
+//     reconciler gets at least two full sweeps under the new leader before any
 //     reaper may fail a task whose pod finished during the outage, so the
 //     durable outcome record is recovered as the truth before a reaper guesses.
+//     A single sweep is not enough: the first tick under a new leader may land
+//     anywhere in the interval, so "one interval below the grace" can mean zero
+//     completed sweeps.
+//   - infra re-place delay < orphan threshold: a run whose only live task is
+//     parked in its longest infra re-place backoff has no activity to show the
+//     orphan-run reaper; the threshold must outlast that parking or the reaper
+//     eats a run that is still recovering from the very fault being retried.
+//   - token TTL < credential lifetime: heartbeat renewal keeps an attempt's
+//     bearer alive only while the attempt is younger than the ceiling. A ceiling
+//     below the TTL means the first renewal is already refused, the bearer
+//     lapses at the TTL, and every task longer than one TTL is unreapable AND
+//     unable to report — the restart recovery is silently disabled. This is the
+//     ONLY operator-tunable rung; every other value is a build-time constant.
+//
+// Warm pools share the same ladder: a warm worker's per-attempt bearer is renewed
+// by the same heartbeat under the same ceiling, and the warm-worker-lost reaper
+// reuses the pod-lost mark, so no warm-specific rung exists.
 type ResilienceLadder struct {
 	HeartbeatInterval  time.Duration
 	AgentLostThreshold time.Duration
@@ -33,20 +53,50 @@ type ResilienceLadder struct {
 	PodLostLeaderGrace time.Duration
 	AttemptTokenTTL    time.Duration
 	ReconcileInterval  time.Duration
+	// OrphanThreshold is how long a running dag run may sit with no activity
+	// before the orphan-run reaper fails it (ReaperConfig.OrphanThreshold).
+	OrphanThreshold time.Duration
+	// InfraReplaceMaxDelay is the longest the scheduler may park an infra-failed
+	// task before re-placing it: the backoff before the final permitted re-place
+	// plus the whole de-synchronizing jitter window. The scheduler owns and
+	// computes it; it is passed in because the scheduler package depends on this
+	// one, so the validator cannot read it directly.
+	InfraReplaceMaxDelay time.Duration
+	// MaxAttemptCredentialLifetime is the operator's auth.max_attempt_credential_lifetime:
+	// the ceiling on how long heartbeat renewal keeps an attempt's bearer alive.
+	// A non-positive value is the documented "no ceiling" setting; the rung that
+	// depends on it is then trivially satisfied and skipped.
+	MaxAttemptCredentialLifetime time.Duration
 }
 
-// ladderRung names one knob for error messages.
+// maxAttemptCredentialLifetimeKey is the config key of the one operator-tunable
+// rung, so the boot error points the operator at the knob that has to move.
+const maxAttemptCredentialLifetimeKey = "auth.max_attempt_credential_lifetime"
+
+// ladderRung names one knob (or a fixed multiple of one) for error messages.
 type ladderRung struct {
 	name string
 	d    time.Duration
 }
 
+// ladderRelation is one strict ordering lo < hi. operator marks the relation's
+// hi side as an operator-tunable config value: the error then names the config
+// key; otherwise every value is a build-time constant and the only remedy is a
+// code change, so the error asks for a bug report.
+type ladderRelation struct {
+	lo, hi   ladderRung
+	why      string
+	operator bool
+}
+
 // ValidateResilienceLadder checks the orderings the restart recovery depends on
 // (see ResilienceLadder) and reports the first violated relation, naming both
-// sides with their values so the operator knows which knob moved. All rungs
-// must be positive. It is pure — the server calls it once at boot and refuses
-// to start on an error, turning what used to be a comment-level convention into
-// an enforced invariant.
+// sides with their values. A relation between build-time constants can only be
+// broken by a code change, so its error says so and asks for a bug report; the
+// one relation involving an operator knob names the config key. All build-time
+// rungs must be positive. It is pure — the server calls it once at boot and
+// refuses to start on an error, turning what used to be a comment-level
+// convention into an enforced invariant.
 func ValidateResilienceLadder(l ResilienceLadder) error {
 	hb := ladderRung{"heartbeat interval", l.HeartbeatInterval}
 	thr := ladderRung{"agent-lost threshold", l.AgentLostThreshold}
@@ -54,27 +104,40 @@ func ValidateResilienceLadder(l ResilienceLadder) error {
 	pgrace := ladderRung{"pod-lost leader grace", l.PodLostLeaderGrace}
 	ttl := ladderRung{"attempt token TTL", l.AttemptTokenTTL}
 	rec := ladderRung{"reconcile interval", l.ReconcileInterval}
+	orphan := ladderRung{"orphan threshold", l.OrphanThreshold}
+	replace := ladderRung{"longest infra re-place delay", l.InfraReplaceMaxDelay}
 
-	for _, r := range []ladderRung{hb, thr, agrace, pgrace, ttl, rec} {
+	for _, r := range []ladderRung{hb, thr, agrace, pgrace, ttl, rec, orphan, replace} {
 		if r.d <= 0 {
 			return fmt.Errorf("resilience ladder: %s (%v) must be positive", r.name, r.d)
 		}
 	}
-	relations := []struct {
-		lo, hi ladderRung
-		why    string
-	}{
-		{hb, thr, "a live agent must heartbeat well inside the agent-lost silence window"},
-		{thr, agrace, "the post-leadership grace must outlast the silence it forgives so the fleet can re-heartbeat"},
-		{agrace, ttl, "a re-heartbeat must still authenticate and renew the bearer when the grace ends"},
-		{rec, agrace, "the reconciler must sweep at least once under a new leader before agent-lost may reap"},
-		{rec, pgrace, "the reconciler must recover durable pod outcomes before pod-lost may reap"},
+	twoRec := ladderRung{"2 × reconcile interval", 2 * l.ReconcileInterval}
+	relations := []ladderRelation{
+		{lo: hb, hi: thr, why: "a live agent must heartbeat well inside the agent-lost silence window"},
+		{lo: thr, hi: agrace, why: "the post-leadership grace must outlast the silence it forgives so the fleet can re-heartbeat"},
+		{lo: agrace, hi: ttl, why: "a re-heartbeat must still authenticate and renew the bearer when the grace ends"},
+		{lo: twoRec, hi: agrace, why: "the reconciler must complete at least two sweeps under a new leader before agent-lost may reap"},
+		{lo: twoRec, hi: pgrace, why: "the reconciler must complete at least two sweeps to recover durable pod outcomes before pod-lost may reap"},
+		{lo: replace, hi: orphan, why: "a run parked in its longest infra re-place backoff must not be reaped as orphaned while it is still recovering"},
+	}
+	if l.MaxAttemptCredentialLifetime > 0 {
+		ceiling := ladderRung{maxAttemptCredentialLifetimeKey, l.MaxAttemptCredentialLifetime}
+		relations = append(relations, ladderRelation{
+			lo: ttl, hi: ceiling, operator: true,
+			why: "heartbeat renewal must be able to extend the bearer at least once, or every task longer than one TTL loses its credential and the restart recovery is disabled",
+		})
 	}
 	for _, rel := range relations {
-		if rel.lo.d >= rel.hi.d {
-			return fmt.Errorf("resilience ladder: %s (%v) must be < %s (%v): %s",
-				rel.lo.name, rel.lo.d, rel.hi.name, rel.hi.d, rel.why)
+		if rel.lo.d < rel.hi.d {
+			continue
 		}
+		if rel.operator {
+			return fmt.Errorf("resilience ladder: %s (%v) must be < %s (%v): %s — raise %s",
+				rel.lo.name, rel.lo.d, rel.hi.name, rel.hi.d, rel.why, rel.hi.name)
+		}
+		return fmt.Errorf("resilience ladder: %s (%v) must be < %s (%v): %s — build-time invariant violated, please file a bug",
+			rel.lo.name, rel.lo.d, rel.hi.name, rel.hi.d, rel.why)
 	}
 	return nil
 }

--- a/internal/executor/resilience_ladder_test.go
+++ b/internal/executor/resilience_ladder_test.go
@@ -7,17 +7,21 @@ import (
 )
 
 // defaultLadder is the production ladder as the server wires it: the agent's
-// heartbeat interval and token TTL, the default reaper thresholds/graces, and
-// the reconciler's sweep interval.
+// heartbeat interval and token TTL, the default reaper thresholds/graces, the
+// reconciler's sweep interval, the scheduler's longest infra re-place delay and
+// the default credential-lifetime ceiling.
 func defaultLadder() ResilienceLadder {
 	cfg := DefaultReaperConfig()
 	return ResilienceLadder{
-		HeartbeatInterval:  15 * time.Second,
-		AgentLostThreshold: cfg.AgentLostThreshold,
-		AgentLostGrace:     cfg.AgentLostGrace,
-		PodLostLeaderGrace: cfg.PodLostLeaderGrace,
-		AttemptTokenTTL:    10 * time.Minute,
-		ReconcileInterval:  30 * time.Second,
+		HeartbeatInterval:            15 * time.Second,
+		AgentLostThreshold:           cfg.AgentLostThreshold,
+		AgentLostGrace:               cfg.AgentLostGrace,
+		PodLostLeaderGrace:           cfg.PodLostLeaderGrace,
+		AttemptTokenTTL:              10 * time.Minute,
+		ReconcileInterval:            30 * time.Second,
+		OrphanThreshold:              cfg.OrphanThreshold,
+		InfraReplaceMaxDelay:         190 * time.Second,
+		MaxAttemptCredentialLifetime: 24 * time.Hour,
 	}
 }
 
@@ -29,44 +33,110 @@ func TestValidateResilienceLadderDefaultsPass(t *testing.T) {
 	}
 }
 
+// TestValidateResilienceLadderDisabledCredentialCeilingPasses: a non-positive
+// credential lifetime is the operator's documented "no ceiling" setting, under
+// which a token renews for as long as the attempt lives — so the TTL-below-
+// ceiling rung is trivially satisfied and must not be reported as a violation.
+func TestValidateResilienceLadderDisabledCredentialCeilingPasses(t *testing.T) {
+	l := defaultLadder()
+	l.MaxAttemptCredentialLifetime = 0
+	if err := ValidateResilienceLadder(l); err != nil {
+		t.Fatalf("a disabled credential ceiling must validate, got %v", err)
+	}
+}
+
+// TestValidateResilienceLadderRequiresTwoSweepsUnderGrace: the reconciler must
+// get at least TWO full sweeps under a new leader before either grace ends. A
+// reconcile interval just under the grace (179s vs 180s) satisfies a plain
+// "reconcile < grace" ordering yet guarantees zero completed sweeps in the
+// window, so the validator must reject it.
+func TestValidateResilienceLadderRequiresTwoSweepsUnderGrace(t *testing.T) {
+	l := defaultLadder()
+	l.ReconcileInterval = 179 * time.Second
+	l.AgentLostGrace = 180 * time.Second
+	l.PodLostLeaderGrace = 180 * time.Second
+	l.AttemptTokenTTL = 10 * time.Minute
+	err := ValidateResilienceLadder(l)
+	if err == nil {
+		t.Fatal("reconcile=179s under grace=180s must be rejected")
+	}
+	for _, w := range []string{"reconcile interval", "grace", "build-time invariant violated"} {
+		if !strings.Contains(err.Error(), w) {
+			t.Errorf("error %q must name %q", err, w)
+		}
+	}
+}
+
 // TestValidateResilienceLadderRejectsEachViolation: each single inverted (or
 // equal — the relations are strict) rung fails, and the error names BOTH sides
-// of the violated relation so an operator can tell which knob to move.
+// of the violated relation so an operator can tell which knob moved. Rungs made
+// of build-time constants tell the operator to file a bug; the one operator-
+// tunable rung names its config key instead.
 func TestValidateResilienceLadderRejectsEachViolation(t *testing.T) {
+	const bug = "build-time invariant violated"
+	const key = "auth.max_attempt_credential_lifetime"
 	cases := []struct {
-		name   string
-		mutate func(*ResilienceLadder)
-		want   []string // substrings the error must carry
+		name    string
+		mutate  func(*ResilienceLadder)
+		want    []string // substrings the error must carry
+		notWant []string // substrings the error must NOT carry
 	}{
 		{
-			name:   "heartbeat interval not below agent-lost threshold",
-			mutate: func(l *ResilienceLadder) { l.HeartbeatInterval = l.AgentLostThreshold },
-			want:   []string{"heartbeat interval", "agent-lost threshold"},
+			name:    "heartbeat interval not below agent-lost threshold",
+			mutate:  func(l *ResilienceLadder) { l.HeartbeatInterval = l.AgentLostThreshold },
+			want:    []string{"heartbeat interval", "agent-lost threshold", bug},
+			notWant: []string{key},
 		},
 		{
-			name:   "agent-lost threshold not below agent-lost grace",
-			mutate: func(l *ResilienceLadder) { l.AgentLostGrace = l.AgentLostThreshold },
-			want:   []string{"agent-lost threshold", "agent-lost grace"},
+			name:    "agent-lost threshold not below agent-lost grace",
+			mutate:  func(l *ResilienceLadder) { l.AgentLostGrace = l.AgentLostThreshold },
+			want:    []string{"agent-lost threshold", "agent-lost grace", bug},
+			notWant: []string{key},
 		},
 		{
-			name:   "agent-lost grace not below attempt token TTL",
-			mutate: func(l *ResilienceLadder) { l.AttemptTokenTTL = l.AgentLostGrace },
-			want:   []string{"agent-lost grace", "attempt token TTL"},
+			name:    "agent-lost grace not below attempt token TTL",
+			mutate:  func(l *ResilienceLadder) { l.AttemptTokenTTL = l.AgentLostGrace },
+			want:    []string{"agent-lost grace", "attempt token TTL", bug},
+			notWant: []string{key},
 		},
 		{
-			name:   "reconcile interval not below agent-lost grace",
-			mutate: func(l *ResilienceLadder) { l.ReconcileInterval = l.AgentLostGrace },
-			want:   []string{"reconcile interval", "agent-lost grace"},
+			name:    "two reconcile intervals not below agent-lost grace",
+			mutate:  func(l *ResilienceLadder) { l.ReconcileInterval = l.AgentLostGrace / 2 },
+			want:    []string{"reconcile interval", "agent-lost grace", bug},
+			notWant: []string{key},
 		},
 		{
-			name:   "reconcile interval not below pod-lost leader grace",
-			mutate: func(l *ResilienceLadder) { l.PodLostLeaderGrace = l.ReconcileInterval },
-			want:   []string{"reconcile interval", "pod-lost leader grace"},
+			name:    "two reconcile intervals not below pod-lost leader grace",
+			mutate:  func(l *ResilienceLadder) { l.PodLostLeaderGrace = 2 * l.ReconcileInterval },
+			want:    []string{"reconcile interval", "pod-lost leader grace", bug},
+			notWant: []string{key},
+		},
+		{
+			name:    "infra re-place delay not below orphan threshold",
+			mutate:  func(l *ResilienceLadder) { l.InfraReplaceMaxDelay = l.OrphanThreshold },
+			want:    []string{"infra re-place", "orphan threshold", bug},
+			notWant: []string{key},
+		},
+		{
+			name:    "attempt token TTL not below the credential lifetime ceiling",
+			mutate:  func(l *ResilienceLadder) { l.MaxAttemptCredentialLifetime = 5 * time.Minute },
+			want:    []string{"attempt token TTL", key},
+			notWant: []string{bug, "file a bug"},
 		},
 		{
 			name:   "a non-positive rung",
 			mutate: func(l *ResilienceLadder) { l.HeartbeatInterval = 0 },
 			want:   []string{"heartbeat interval", "positive"},
+		},
+		{
+			name:   "a non-positive orphan threshold",
+			mutate: func(l *ResilienceLadder) { l.OrphanThreshold = 0 },
+			want:   []string{"orphan threshold", "positive"},
+		},
+		{
+			name:   "a non-positive infra re-place delay",
+			mutate: func(l *ResilienceLadder) { l.InfraReplaceMaxDelay = -time.Second },
+			want:   []string{"infra re-place", "positive"},
 		},
 	}
 	for _, tc := range cases {
@@ -80,6 +150,11 @@ func TestValidateResilienceLadderRejectsEachViolation(t *testing.T) {
 			for _, w := range tc.want {
 				if !strings.Contains(err.Error(), w) {
 					t.Errorf("error %q must name %q", err, w)
+				}
+			}
+			for _, nw := range tc.notWant {
+				if strings.Contains(err.Error(), nw) {
+					t.Errorf("error %q must not carry %q", err, nw)
 				}
 			}
 		})

--- a/internal/scheduler/dispatch_backoff.go
+++ b/internal/scheduler/dispatch_backoff.go
@@ -39,3 +39,16 @@ func dispatchBackoff(attempts int) time.Duration {
 	}
 	return d
 }
+
+// InfraReplaceMaxDelay is the longest the planner may park an infra-failed task
+// before re-placing it: the backoff before the last permitted re-place (attempt
+// infraMaxAttempts) plus the full de-synchronizing jitter window. It is the
+// upper bound on how long a run whose only live task is infra-parked shows no
+// activity, so the executor's orphan-run threshold must sit above it or the
+// orphan reaper fails a run that is still recovering. The two values live in
+// packages that depend in one direction only (the scheduler imports the
+// executor), so this is exported for the server to hand to the executor's
+// boot-time resilience ladder rather than read from there.
+func InfraReplaceMaxDelay() time.Duration {
+	return dispatchBackoff(infraMaxAttempts) + infraReplaceJitterWindow
+}

--- a/internal/scheduler/infra_replace_ceiling_test.go
+++ b/internal/scheduler/infra_replace_ceiling_test.go
@@ -1,0 +1,36 @@
+package scheduler
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// TestInfraReplaceMaxDelayBoundsEveryReplace: the exported ceiling is a true
+// upper bound on the delay readyToInfraReplace can impose on any infra-failed
+// task still within its re-place budget — the backoff before the last permitted
+// re-place plus the whole jitter window. The orphan-run reaper's idle threshold
+// (owned by the executor package) must sit above this value, or a run whose only
+// live task is parked in its longest re-place backoff is reaped as orphaned
+// while it is still recovering; the boot-time resilience ladder holds the two
+// values apart, so this test pins what the ladder is told.
+func TestInfraReplaceMaxDelayBoundsEveryReplace(t *testing.T) {
+	ceiling := InfraReplaceMaxDelay()
+	if want := dispatchBackoff(infraMaxAttempts) + infraReplaceJitterWindow; ceiling != want {
+		t.Fatalf("InfraReplaceMaxDelay() = %v, want backoff(infraMaxAttempts)+jitter window = %v", ceiling, want)
+	}
+	if ceiling != 190*time.Second {
+		t.Errorf("InfraReplaceMaxDelay() = %v; the shipped budget is 190s — if this moved on purpose, re-check it against the orphan threshold", ceiling)
+	}
+	// Every re-placeable attempt count (0..infraMaxAttempts-1, so backoff index
+	// 1..infraMaxAttempts) with every sampled jitter stays strictly under it.
+	for attempts := 0; attempts < infraMaxAttempts; attempts++ {
+		for i := 0; i < 64; i++ {
+			runID, taskID := fmt.Sprintf("run-%d", i), fmt.Sprintf("task-%d", i*7)
+			delay := dispatchBackoff(attempts+1) + infraReplaceJitter(runID, taskID)
+			if delay >= ceiling {
+				t.Fatalf("infra_attempts=%d %s/%s: re-place delay %v is not below the ceiling %v", attempts, runID, taskID, delay, ceiling)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #898. The four items the specialist review of #897 marked as must-fix before the next GA cut.

1. **Ladder rungs that can actually fail in production.** `ValidateResilienceLadder` gains `AttemptTokenTTL < auth.max_attempt_credential_lifetime` (the only operator-tunable knob in the ladder — hardening it to a few minutes would otherwise silently disable the restart recovery), `2×reconcile < AgentLostGrace` / `< PodLostLeaderGrace` (the two-sweep margin the reaper test already asserts; 179s/180s now fails), and `InfraReplaceMaxDelay < OrphanThreshold` (190s vs 300s across two packages, previously tied by nothing). `scheduler` exports one computed `InfraReplaceMaxDelay()` so the executor-side validator needs no new import edge. Build-time rungs say "build-time invariant violated — please file a bug"; the config rung names the real key and its remedy.
2. **The four `*_teardown_gate_skip` branches are now covered** (orphan, agent-lost, dispatch-lost, pod-lost) via a `gateOpenThenClosed(n)` fake: mark applied, pod delete did not, skip recorded once. Coverprofile proves each block went from 0 to 1 hit. Warm-worker-lost has no teardown re-check (it never deletes a pod) — stated in the test.
3. **Every task pod gets an `ActiveDeadlineSeconds` floor** derived from the credential ceiling (past it the pod can do nothing useful) when the DAG declares no timeout; a user timeout always wins. With the terminal and pre-flight RUNNING reports now retrying until the control plane returns, no pod is immortal after a total outage. The RUNNING widening is declared intentional (an agent that cannot reach the control plane does not start user code until it can) and locked by a test.
4. **Wording:** "Four" → five causes; "reconnects within about one heartbeat" → "one heartbeat plus the gRPC channel's own reconnect backoff" (the channel backoff cap is #899); the warm-worker-lost comment now cites the real property (live apiserver LIST, LIST error aborts the tick with zero marks).

Pre-existing observation, not changed here: when `TimeoutSeconds` is set, `ActiveDeadlineSeconds == TimeoutSeconds` exactly, so the agent's timeout report races the kubelet kill; the durable outcome record covers it.

**Verification:** `go build`, `go test ./...` (33 ok), `go test -tags integration ./internal/storage/ ./internal/api/` against Postgres, `golangci-lint` 0 issues (fresh cache), gofmt clean, changelog gate OK, all four items TDD (red confirmed before each change).