### PR TITLE
executor/server: one leader-settling gate over every reaper + reconcile-then-reap maintenance loop (closes the restart-race class)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ bin/
 dist/
 /leoflow-mcp
 /leoflow
+/leoflow-server
+/leoflow-agent
 *.exe
 *.exe~
 *.dll

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,31 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   The shipped default stays `replicaCount: 1`: flipping it would
   Multi-Attach-break every existing install on upgrade.
 
+### Changed
+
+- **The reapers now run from a 30 s leader maintenance loop, ordered after the
+  pod reconciler, behind one leader-settling gate.** The five reapers
+  (orphan-run, agent-lost, dispatch-lost, pod-lost, warm-worker-lost) no longer
+  run from the scheduler's 1 s tick. They run once per maintenance cycle, and
+  every cycle reconciles first — recovering each finished pod's durable outcome —
+  then reaps, so a reaper always judges post-reconcile state. The two clocks
+  whose independence let a restart mark a succeeded task failed are now one.
+  The per-reaper post-leadership graces (agent-lost, pod-lost) are replaced by a
+  single **settling gate** at the entry of the reaper pass: after a
+  (re-)election no reaper fires until the settling grace (180 s) has elapsed,
+  the pod informer has synced, and a reconciler sweep has completed under this
+  leadership. A **liveness valve** opens the gate after 2 × grace with a `WARN`
+  and a `reap_settling_valve_open` decision if the sweep never completes, so a
+  broken reconciler cannot silently disable reaping. New decisions
+  `reap_settling_skip` / `reap_settling_valve_open`; `agent_lost_grace_skip` and
+  `pod_lost_grace_skip` are gone. The boot-time ladder check now enforces
+  `heartbeat < agent-lost threshold < settling grace < token TTL` and two
+  maintenance cycles inside the grace. **Detection latency note:** a stuck
+  run/TI is now noticed up to 30 s after its threshold elapses instead of
+  within 1 s — against thresholds of 60 s–5 min, and reaping being a backstop
+  rather than the primary path. Lite (no pods) is unchanged: no maintenance loop,
+  no reaping.
+
 ### Fixed
 
 - **A control-plane restart no longer marks a succeeded task failed, and no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,10 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `reap_settling_skip` / `reap_settling_valve_open`; `agent_lost_grace_skip` and
   `pod_lost_grace_skip` are gone. The boot-time ladder check now enforces
   `heartbeat < agent-lost threshold < settling grace < token TTL` and two
-  maintenance cycles inside the grace. **Detection latency note:** a stuck
+  maintenance cycles inside the grace. Each phase of a cycle runs under its own
+  one-interval budget, so a sweep hung on a slow apiserver cannot starve the
+  reap and a slow reap cannot starve the sweep it depends on (an overrun logs a
+  `WARN`). **Detection latency note:** a stuck
   run/TI is now noticed up to 30 s after its threshold elapses instead of
   within 1 s — against thresholds of 60 s–5 min, and reaping being a backstop
   rather than the primary path. Lite (no pods) is unchanged: no maintenance loop,

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -1095,18 +1095,43 @@ func buildPodInformer(ctx context.Context, cfg *config.ServerConfig, cs kubernet
 	return pi
 }
 
-func startReconciler(ctx context.Context, cs kubernetes.Interface, namespace string, reporter executor.OutcomeReporter, leading func() bool, logger *slog.Logger, snapshotter executor.PodSnapshotter) {
+// startMaintenance runs the leader's periodic recovery work — the pod
+// reconciler's sweep and the execution reapers — as ONE ordered cycle on one
+// leader-gated ticker, every reconcileInterval: reconcile, then reap. The
+// reapers used to run from the scheduler's 1s tick while the reconciler swept on
+// its own 30s timer; two independent clocks gave no ordering, so a reaper could
+// judge a task pod "gone" at 1s that the reconciler would have recovered as
+// succeeded at its next sweep. In one cycle the reap always sees post-reconcile
+// state, and the reaper's settling gate reads the reconciler's sweep record to
+// know a sweep has completed under this leadership. The cost is detection
+// latency: a stuck run/TI is now noticed up to one interval (30s) later than at
+// the 1s tick — negligible against 60s–5m thresholds, and reaping is a backstop,
+// never the primary path. Lite/subprocess never calls this: no pods, no reaping.
+func startMaintenance(ctx context.Context, cs kubernetes.Interface, namespace string, reporter executor.OutcomeReporter, reaper *executor.Reaper, leading func() bool, logger *slog.Logger, snapshotter executor.PodSnapshotter) {
 	rec := executor.NewReconciler(cs, namespace, reporter)
 	// Read task pods from the shared informer cache instead of a live LIST every
 	// tick when the informer is wired (PR-10); nil keeps the live LIST.
 	if snapshotter != nil {
 		rec.SetPodSnapshotter(snapshotter)
 	}
-	startGatedTicker(ctx, "pod-reconcile", reconcileInterval, leading, logger, func() {
-		if err := rec.Reconcile(ctx); err != nil {
-			logger.Error("pod reconcile", "error", err)
-		}
+	reaper.SetLastSweepCompleted(rec.LastSweepCompletedAt)
+	startGatedTicker(ctx, "maintenance", reconcileInterval, leading, logger, func() {
+		maintenanceCycle(ctx, rec.Reconcile, reaper.ReapOnce, logger)
 	})
+}
+
+// maintenanceCycle is one pass of the maintenance loop: reconcile, then reap,
+// in that order, always. A reconcile error (the LIST failed) is logged and the
+// reapers still run — they are independent backstops with their own fail-closed
+// liveness reads, and whether a leader that has never completed a sweep may reap
+// is the reaper's settling gate's decision, not this loop's.
+func maintenanceCycle(ctx context.Context, reconcile, reap func(context.Context) error, logger *slog.Logger) {
+	if err := reconcile(ctx); err != nil {
+		logger.Error("pod reconcile", "error", err)
+	}
+	if err := reap(ctx); err != nil {
+		logger.Error("execution reaper", "error", err)
+	}
 }
 
 // startWarmPoolReconciler runs the leader-gated warm-pool reconciler (ADR 0058
@@ -1552,7 +1577,7 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 	// The execution reaper (#120/#128/#202/#527) fails stuck runs and TIs; it
 	// tears down a reaped task's pod and gates the dispatch-lost decision on real
 	// pod liveness (#474, #461), so it is wired only on the pod path. Lite/
-	// subprocess leaves the scheduler's reaper unset and does no reaping.
+	// subprocess starts no maintenance loop and does no reaping.
 	reaper := executor.NewReaper(store, podExec, cache, warmLister, metrics, logger, executor.DefaultReaperConfig(), sched.SteppingDown)
 	// Give the reaper an append-aware marker sink so a reaped attempt's log ends
 	// with a "killed: agent_lost" marker instead of a silent truncation (#861).
@@ -1562,19 +1587,22 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 	if ms, ok := logSink.(logs.MarkerSink); ok {
 		reaper.SetLogSink(ms)
 	}
-	// Suppress agent-lost AND pod-lost reaping for a grace window after this
-	// instance acquires leadership, so a control-plane restart doesn't mass-reap
-	// in-flight tasks whose heartbeats went stale during the outage (#858), nor
-	// fail a task whose pod finished during the outage before the reconciler has
-	// recovered its durable outcome record.
+	// Leader-settling gate: no reaper fires until this instance has led for the
+	// settling grace, the pod informer has synced, and the reconciler has
+	// completed a sweep under this leadership (wired in startMaintenance). A
+	// control-plane restart makes heartbeats look stale and finished task pods
+	// look lost; the gate holds every reaper until the true outcomes have been
+	// recovered, with a liveness valve so a broken sweep cannot disable reaping.
 	reaper.SetLeaderSince(sched.LeaderSince)
+	if podInformer != nil {
+		reaper.SetInformerSynced(podInformer.HasSynced)
+	}
 	// Close the reaper's destructive gate the moment this instance stops leading:
 	// together with the step-down flag and the run-context cancel, this keeps a
 	// draining or stepping-down leader from marking TIs failed or deleting pods
-	// on its way out — the successor redoes the reap under its own grace.
+	// on its way out — the successor redoes the reap under its own settling gate.
 	reaper.SetLeading(sched.IsLeading)
-	sched.SetExecutionReaper(reaper)
-	startReconciler(ctx, cs, cfg.Executor.TaskNamespace, execStore, sched.IsLeading, logger, snapshotter)
+	startMaintenance(ctx, cs, cfg.Executor.TaskNamespace, execStore, reaper, sched.IsLeading, logger, snapshotter)
 	startStagingGC(ctx, cs, cfg.Executor.TaskNamespace, store, sched.IsLeading, logger)
 	// Warm-pool reconciler (ADR 0058 N1b2b, model A2): keeps min_idle warm workers
 	// ready per active dag_version. Started ONLY when warm pools are enabled — with

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -1040,8 +1040,6 @@ func startXComSweep(ctx context.Context, backend *xcom.PostgresBackend, logger *
 	}()
 }
 
-// startReconciler runs a periodic pod reconciler that marks task instances
-// failed when their pod failed without the agent reporting (feeding retries).
 // startGatedTicker runs fn every interval on a background goroutine, but only
 // while leading() reports this instance holds leadership. It stops when ctx is
 // done. The pod reconciler and staging GC mutate cluster state, so at
@@ -1106,7 +1104,9 @@ func buildPodInformer(ctx context.Context, cfg *config.ServerConfig, cs kubernet
 // know a sweep has completed under this leadership. The cost is detection
 // latency: a stuck run/TI is now noticed up to one interval (30s) later than at
 // the 1s tick — negligible against 60s–5m thresholds, and reaping is a backstop,
-// never the primary path. Lite/subprocess never calls this: no pods, no reaping.
+// never the primary path. Each phase runs under its own one-interval budget
+// (maintenancePhaseTimeout). Lite/subprocess never calls this: no pods, no
+// reaping.
 func startMaintenance(ctx context.Context, cs kubernetes.Interface, namespace string, reporter executor.OutcomeReporter, reaper *executor.Reaper, leading func() bool, logger *slog.Logger, snapshotter executor.PodSnapshotter) {
 	rec := executor.NewReconciler(cs, namespace, reporter)
 	// Read task pods from the shared informer cache instead of a live LIST every
@@ -1116,21 +1116,51 @@ func startMaintenance(ctx context.Context, cs kubernetes.Interface, namespace st
 	}
 	reaper.SetLastSweepCompleted(rec.LastSweepCompletedAt)
 	startGatedTicker(ctx, "maintenance", reconcileInterval, leading, logger, func() {
-		maintenanceCycle(ctx, rec.Reconcile, reaper.ReapOnce, logger)
+		maintenanceCycle(ctx, maintenancePhaseTimeout, rec.Reconcile, reaper.ReapOnce, logger)
 	})
 }
 
+// maintenancePhaseTimeout bounds each phase of a maintenance cycle — the
+// reconciler's sweep and the reaper pass — separately, at one interval. The
+// reapers used to run inside the scheduler tick under its step timeout; sharing
+// one goroutine with the reconciler must not lose that bound: a sweep hung on a
+// slow apiserver would otherwise starve the reap indefinitely, and a reap that
+// issues one live LIST per running task instance (plus lock-blocked UPDATEs)
+// would starve the very sweep it depends on. Each phase gets its own FRESH
+// budget, so a reconcile that spends all of its own still hands the reap a live
+// context — the reaper's destructive gate reads ctx.Err() and a dead context
+// would silently disable reaping rather than fail loudly. A cycle can therefore
+// take up to two intervals; the ticker coalesces the ticks it overruns, and the
+// settling gate's "two cycles inside the grace" still holds by construction.
+const maintenancePhaseTimeout = reconcileInterval
+
 // maintenanceCycle is one pass of the maintenance loop: reconcile, then reap,
-// in that order, always. A reconcile error (the LIST failed) is logged and the
-// reapers still run — they are independent backstops with their own fail-closed
-// liveness reads, and whether a leader that has never completed a sweep may reap
-// is the reaper's settling gate's decision, not this loop's.
-func maintenanceCycle(ctx context.Context, reconcile, reap func(context.Context) error, logger *slog.Logger) {
-	if err := reconcile(ctx); err != nil {
-		logger.Error("pod reconcile", "error", err)
-	}
-	if err := reap(ctx); err != nil {
-		logger.Error("execution reaper", "error", err)
+// in that order, always, each under its own phaseTimeout. A reconcile error
+// (the LIST failed) is logged and the reapers still run — they are independent
+// backstops with their own fail-closed liveness reads, and whether a leader that
+// has never completed a sweep may reap is the reaper's settling gate's decision,
+// not this loop's.
+func maintenanceCycle(ctx context.Context, phaseTimeout time.Duration, reconcile, reap func(context.Context) error, logger *slog.Logger) {
+	runMaintenancePhase(ctx, "pod reconcile", phaseTimeout, reconcile, logger)
+	runMaintenancePhase(ctx, "execution reaper", phaseTimeout, reap, logger)
+}
+
+// runMaintenancePhase runs one phase under its own deadline. Overrunning the
+// budget is a load signal (a large namespace, a slow apiserver), not a bug, so
+// it logs at WARN with the budget; any other error logs at ERROR. Nothing is
+// logged once the parent context is done — that cancel fan-out at shutdown is
+// expected, not a finding.
+func runMaintenancePhase(ctx context.Context, name string, timeout time.Duration, fn func(context.Context) error, logger *slog.Logger) {
+	pctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	err := fn(pctx)
+	switch {
+	case ctx.Err() != nil:
+		return
+	case errors.Is(pctx.Err(), context.DeadlineExceeded):
+		logger.Warn(name+" exceeded its maintenance budget", "budget", timeout, "error", err)
+	case err != nil:
+		logger.Error(name, "error", err)
 	}
 }
 

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -364,8 +364,7 @@ func resilienceLadder(cfg *config.ServerConfig) executor.ResilienceLadder {
 	return executor.ResilienceLadder{
 		HeartbeatInterval:            agent.DefaultHeartbeatInterval,
 		AgentLostThreshold:           rc.AgentLostThreshold,
-		AgentLostGrace:               rc.AgentLostGrace,
-		PodLostLeaderGrace:           rc.PodLostLeaderGrace,
+		SettlingGrace:                rc.SettlingGrace,
 		AttemptTokenTTL:              attemptTokenTTL,
 		ReconcileInterval:            reconcileInterval,
 		OrphanThreshold:              rc.OrphanThreshold,

--- a/cmd/leoflow-server/maintenance_test.go
+++ b/cmd/leoflow-server/maintenance_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestMaintenanceCycleReconcilesBeforeReaping: one maintenance cycle runs the
+// reconciler's sweep and THEN the reapers, in that order, every time. The
+// ordering is the structural fix for the drill race — a reaper that judged a
+// task pod "gone" before the reconciler had recovered the pod's durable outcome
+// — and it holds by construction rather than by two independent timers lining
+// up.
+func TestMaintenanceCycleReconcilesBeforeReaping(t *testing.T) {
+	var order []string
+	reconcile := func(context.Context) error { order = append(order, "reconcile"); return nil }
+	reap := func(context.Context) error { order = append(order, "reap"); return nil }
+
+	for i := 0; i < 3; i++ {
+		maintenanceCycle(context.Background(), reconcile, reap, discardLog())
+	}
+	want := []string{"reconcile", "reap", "reconcile", "reap", "reconcile", "reap"}
+	if len(order) != len(want) {
+		t.Fatalf("order = %v, want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("order = %v, want %v", order, want)
+		}
+	}
+}
+
+// TestMaintenanceCycleReapsWhenReconcileFails: a reconcile error (the apiserver
+// LIST failed) is logged, not fatal to the cycle — the reapers still run. They
+// are independent backstops with their own fail-closed liveness reads, and the
+// reaper's settling gate, not this loop, decides whether a leader that has never
+// completed a sweep may act.
+func TestMaintenanceCycleReapsWhenReconcileFails(t *testing.T) {
+	reaped := false
+	reconcile := func(context.Context) error { return errors.New("apiserver down") }
+	reap := func(context.Context) error { reaped = true; return nil }
+
+	maintenanceCycle(context.Background(), reconcile, reap, discardLog())
+	if !reaped {
+		t.Fatal("the reapers must run even when the reconcile sweep failed")
+	}
+}
+
+// TestMaintenanceLoopHonorsLeaderGate: the maintenance cycle runs on the
+// leader-gated ticker, so a follower tick neither reconciles nor reaps —
+// reaping writes state and must stay single-writer across the fleet — and a
+// leader tick does both. Same stable-gate construction as the gated-ticker
+// tests: two sends on an unbuffered channel prove the first tick was fully
+// processed.
+func TestMaintenanceLoopHonorsLeaderGate(t *testing.T) {
+	newLoop := func(leading *atomic.Bool) (ticks chan time.Time, ran chan string, stop func()) {
+		ticks = make(chan time.Time)
+		ran = make(chan string, 8)
+		ctx, cancel := context.WithCancel(context.Background())
+		go runGatedTicker(ctx, "maintenance", ticks, leading.Load, discardLog(), func() {
+			maintenanceCycle(ctx,
+				func(context.Context) error { ran <- "reconcile"; return nil },
+				func(context.Context) error { ran <- "reap"; return nil },
+				discardLog())
+		})
+		return ticks, ran, cancel
+	}
+
+	t.Run("follower", func(t *testing.T) {
+		var leading atomic.Bool // stays false
+		ticks, ran, stop := newLoop(&leading)
+		defer stop()
+		ticks <- time.Now()
+		ticks <- time.Now()
+		select {
+		case got := <-ran:
+			t.Errorf("a follower tick ran %q; the maintenance cycle must be leader-only", got)
+		default:
+		}
+	})
+	t.Run("leader", func(t *testing.T) {
+		var leading atomic.Bool
+		leading.Store(true)
+		ticks, ran, stop := newLoop(&leading)
+		defer stop()
+		ticks <- time.Now()
+		var got []string
+		for len(got) < 2 {
+			select {
+			case s := <-ran:
+				got = append(got, s)
+			case <-time.After(2 * time.Second):
+				t.Fatalf("leader tick did not run the whole cycle, got %v", got)
+			}
+		}
+		if got[0] != "reconcile" || got[1] != "reap" {
+			t.Errorf("cycle order = %v, want [reconcile reap]", got)
+		}
+	})
+}

--- a/cmd/leoflow-server/maintenance_test.go
+++ b/cmd/leoflow-server/maintenance_test.go
@@ -20,7 +20,7 @@ func TestMaintenanceCycleReconcilesBeforeReaping(t *testing.T) {
 	reap := func(context.Context) error { order = append(order, "reap"); return nil }
 
 	for i := 0; i < 3; i++ {
-		maintenanceCycle(context.Background(), reconcile, reap, discardLog())
+		maintenanceCycle(context.Background(), time.Second, reconcile, reap, discardLog())
 	}
 	want := []string{"reconcile", "reap", "reconcile", "reap", "reconcile", "reap"}
 	if len(order) != len(want) {
@@ -43,7 +43,7 @@ func TestMaintenanceCycleReapsWhenReconcileFails(t *testing.T) {
 	reconcile := func(context.Context) error { return errors.New("apiserver down") }
 	reap := func(context.Context) error { reaped = true; return nil }
 
-	maintenanceCycle(context.Background(), reconcile, reap, discardLog())
+	maintenanceCycle(context.Background(), time.Second, reconcile, reap, discardLog())
 	if !reaped {
 		t.Fatal("the reapers must run even when the reconcile sweep failed")
 	}
@@ -61,7 +61,7 @@ func TestMaintenanceLoopHonorsLeaderGate(t *testing.T) {
 		ran = make(chan string, 8)
 		ctx, cancel := context.WithCancel(context.Background())
 		go runGatedTicker(ctx, "maintenance", ticks, leading.Load, discardLog(), func() {
-			maintenanceCycle(ctx,
+			maintenanceCycle(ctx, time.Second,
 				func(context.Context) error { ran <- "reconcile"; return nil },
 				func(context.Context) error { ran <- "reap"; return nil },
 				discardLog())
@@ -98,6 +98,54 @@ func TestMaintenanceLoopHonorsLeaderGate(t *testing.T) {
 		}
 		if got[0] != "reconcile" || got[1] != "reap" {
 			t.Errorf("cycle order = %v, want [reconcile reap]", got)
+		}
+	})
+}
+
+// TestMaintenanceCycleBoundsEachPhase: each phase of a maintenance cycle runs
+// under its own time budget. The reapers used to run inside the scheduler tick,
+// which is bounded by the step timeout; moving them into this loop must not
+// lose that bound. The two phases share one goroutine, so an unbounded reconcile
+// (a LIST that hangs on a slow apiserver) would starve the reap indefinitely
+// and an unbounded reap (one live LIST per running task instance, lock-blocked
+// UPDATEs) would starve the very reconcile it depends on. Each phase gets a
+// fresh budget: a reconcile that spends all of its own must still leave the
+// reap running with a LIVE context — the reaper's destructive gate reads
+// ctx.Err() and a canceled context would silently disable reaping.
+func TestMaintenanceCycleBoundsEachPhase(t *testing.T) {
+	const budget = 50 * time.Millisecond
+	block := func(ctx context.Context) error { <-ctx.Done(); return ctx.Err() }
+
+	t.Run("hung reconcile still leaves the reap a live context", func(t *testing.T) {
+		var reapCtxErr error
+		reaped := false
+		reap := func(ctx context.Context) error { reaped = true; reapCtxErr = ctx.Err(); return nil }
+		start := time.Now()
+		maintenanceCycle(context.Background(), budget, block, reap, discardLog())
+		if d := time.Since(start); d > 10*budget {
+			t.Fatalf("cycle took %v with a hung reconcile; the phase budget (%v) must bound it", d, budget)
+		}
+		if !reaped {
+			t.Fatal("the reap must run after a reconcile that exhausted its budget")
+		}
+		if reapCtxErr != nil {
+			t.Fatalf("the reap started with a dead context (%v); each phase needs its own budget", reapCtxErr)
+		}
+	})
+	t.Run("hung reap is bounded too", func(t *testing.T) {
+		start := time.Now()
+		maintenanceCycle(context.Background(), budget, func(context.Context) error { return nil }, block, discardLog())
+		if d := time.Since(start); d > 10*budget {
+			t.Fatalf("cycle took %v with a hung reap; the phase budget (%v) must bound it", d, budget)
+		}
+	})
+	t.Run("a phase within budget sees no deadline", func(t *testing.T) {
+		var gotErr error
+		maintenanceCycle(context.Background(), time.Second,
+			func(ctx context.Context) error { gotErr = ctx.Err(); return nil },
+			func(context.Context) error { return nil }, discardLog())
+		if gotErr != nil {
+			t.Fatalf("reconcile saw %v on a fresh budget", gotErr)
 		}
 	})
 }

--- a/internal/executor/heartbeat_reap.go
+++ b/internal/executor/heartbeat_reap.go
@@ -89,16 +89,6 @@ type agentLostReaper struct {
 	// log stream so a killed task's log does not end in a silent truncation
 	// (#861). Nil disables the marker; the reap itself is unaffected.
 	sink logSink
-	// grace suppresses reaping for this long after leadership is (re-)acquired
-	// (#858). A control-plane restart makes every in-flight TI's heartbeat look
-	// stale — the silence was manufactured by the outage, not a dead agent — so
-	// the new leader must wait for the fleet to re-heartbeat before reaping.
-	// Zero disables the grace (with a nil leaderSince). See DefaultReaperConfig.
-	grace time.Duration
-	// leaderSince reports when this instance last acquired scheduler leadership,
-	// so the grace is measured from recovery, not wall-clock. Nil (Lite/tests
-	// without leadership) disables the grace check.
-	leaderSince func() time.Time
 	// gate is re-checked before every destructive call (see destructiveGate).
 	gate destructiveGate
 }
@@ -118,16 +108,11 @@ func (r *agentLostReaper) run(ctx context.Context) error {
 		}
 	}()
 	now := time.Now().UTC()
-	// Post-leadership grace: a control-plane restart manufactures the very
-	// silence this reaper punishes — every in-flight TI's last heartbeat elapses
-	// during the outage, and the heartbeat receiver is the same process that just
-	// came back. Suppress reaping until the fleet has had a full grace window to
-	// re-heartbeat under the recovered leader (see inLeaderGrace for the shared
-	// gate semantics). Checked before the list so a grace tick does no query.
-	if inLeaderGrace(r.leaderSince, r.grace, now) {
-		r.record("agent_lost_grace_skip")
-		return nil
-	}
+	// A control-plane restart manufactures the very silence this reaper punishes:
+	// every in-flight TI's last heartbeat elapses during the outage, and the
+	// heartbeat receiver is the process that just came back. Reaper.settling holds
+	// the whole tick until the fleet has had a grace to re-heartbeat, so by the
+	// time run is reached a stale heartbeat is a real one.
 	candidates, err := r.store.ListAgentLostCandidates(ctx)
 	if err != nil {
 		return err

--- a/internal/executor/heartbeat_reap_test.go
+++ b/internal/executor/heartbeat_reap_test.go
@@ -219,49 +219,6 @@ func TestReapAgentLost_MarkerErrorDoesNotBlockReap(t *testing.T) {
 	}
 }
 
-// TestReapAgentLost_GraceAfterLeadership: after a control-plane restart, the new
-// leader must NOT immediately reap TIs whose heartbeats went stale DURING the
-// outage — the silence was manufactured by the control plane being down, not by
-// a dead agent (#858). A post-leadership grace window suppresses reaping until
-// the fleet has had time to re-heartbeat; past the grace, a still-silent TI is
-// reaped normally.
-func TestReapAgentLost_GraceAfterLeadership(t *testing.T) {
-	now := time.Now().UTC()
-	newStore := func() *fakeHeartbeatStore {
-		return &fakeHeartbeatStore{candidates: []AgentLostCandidate{
-			{TaskInstanceID: "stale", DagRunID: "r", TaskID: "t", TryNumber: 1, LastHeartbeat: now.Add(-2 * time.Minute)},
-		}}
-	}
-
-	// Just became leader (10s ago) — within the 180s grace — must NOT reap.
-	within := newStore()
-	rec := &capturingRecorder{}
-	r := newAgentLostReaper(within, reapTestLogger(), 90*time.Second, rec)
-	r.grace = 180 * time.Second
-	r.leaderSince = func() time.Time { return now.Add(-10 * time.Second) }
-	if err := r.run(context.Background()); err != nil {
-		t.Fatalf("run: %v", err)
-	}
-	if len(within.failed) != 0 {
-		t.Errorf("must not reap within the post-leadership grace, failed=%v", within.failed)
-	}
-	if rec.count("agent_lost_grace_skip") != 1 {
-		t.Errorf("agent_lost_grace_skip = %d, want 1", rec.count("agent_lost_grace_skip"))
-	}
-
-	// Leader well past the grace — a still-stale TI is reaped.
-	past := newStore()
-	r2 := newAgentLostReaper(past, reapTestLogger(), 90*time.Second, &capturingRecorder{})
-	r2.grace = 180 * time.Second
-	r2.leaderSince = func() time.Time { return now.Add(-10 * time.Minute) }
-	if err := r2.run(context.Background()); err != nil {
-		t.Fatalf("run: %v", err)
-	}
-	if len(past.failed) != 1 || past.failed[0] != "stale" {
-		t.Errorf("must reap after the grace elapses, failed=%v", past.failed)
-	}
-}
-
 // TestReapAgentLost_ListErrorSurfaces: a list failure is returned so the
 // caller can log it (the scheduler's reapHeartbeatLossesIfLeader treats this
 // as a "next tick will try again" condition). It must NEVER panic.

--- a/internal/executor/pod_informer.go
+++ b/internal/executor/pod_informer.go
@@ -102,6 +102,15 @@ func (p *PodInformer) WaitForCacheSync(ctx context.Context) bool {
 	return cache.WaitForCacheSync(ctx.Done(), p.informer.HasSynced)
 }
 
+// HasSynced reports whether the initial LIST has populated the cache. It is the
+// live form of WaitForCacheSync's one-shot answer, for a caller that must keep
+// asking — the reaper's leader-settling gate — so a cache that synced late (a
+// watch recovered after an RBAC fix) is seen, and one that never synced is not
+// mistaken for an empty cluster.
+func (p *PodInformer) HasSynced() bool {
+	return p.informer.HasSynced()
+}
+
 // Shutdown stops the watch and waits for the informer goroutines to exit. Safe to
 // call more than once (Start's ctx-cancel path and an explicit caller may race).
 func (p *PodInformer) Shutdown() {

--- a/internal/executor/pod_informer_test.go
+++ b/internal/executor/pod_informer_test.go
@@ -127,3 +127,25 @@ func TestPodInformer_SnapshotTaskPods(t *testing.T) {
 		t.Errorf("snapshot should hold both managed pods, got %d", len(pods))
 	}
 }
+
+// TestPodInformer_HasSynced exposes the cache's sync state as a predicate the
+// reaper's leader-settling gate can poll: false until the initial LIST has
+// populated the cache, true after. A gate that read a one-shot boot-time value
+// would never see a late sync (a watch that recovered after RBAC drift was fixed).
+func TestPodInformer_HasSynced(t *testing.T) {
+	cs := fake.NewClientset()
+	pi := NewPodInformer(cs, "leoflow")
+	if pi.HasSynced() {
+		t.Fatal("HasSynced must be false before the informer starts")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	pi.Start(ctx)
+	defer pi.Shutdown()
+	if !pi.WaitForCacheSync(ctx) {
+		t.Fatal("cache did not sync")
+	}
+	if !pi.HasSynced() {
+		t.Error("HasSynced must be true once the cache synced")
+	}
+}

--- a/internal/executor/pod_lost_reap.go
+++ b/internal/executor/pod_lost_reap.go
@@ -86,19 +86,6 @@ type podLostReaper struct {
 	// TaskPodActive read below, so cache lag can only delay a reap, never cause a
 	// false-positive one (#461). Nil keeps every candidate on the live path.
 	cache PodPresenceCache
-	// leaderGrace suppresses reaping for this long after leadership is
-	// (re-)acquired, ADDITIVE to the per-task grace above. A control-plane
-	// restart makes a task pod that finished during the outage look lost (its
-	// container exited; its TI is still `running` because the terminal report
-	// found no server), while the pod's durable outcome record is still waiting
-	// for the reconciler's slower sweep. Without this window the pod-lost mark
-	// wins that race and a succeeded task is recorded failed. Zero disables it.
-	leaderGrace time.Duration
-	// leaderSince reports when this instance last acquired scheduler leadership,
-	// so leaderGrace is measured from recovery, not wall-clock. Nil (Lite/tests
-	// without leadership) disables the leadership grace; the per-task grace and
-	// the liveness read are unchanged.
-	leaderSince func() time.Time
 	// gate is re-checked before every destructive call (see destructiveGate).
 	gate destructiveGate
 }
@@ -123,13 +110,12 @@ func (r *podLostReaper) run(ctx context.Context) error {
 		return nil
 	}
 	now := time.Now().UTC()
-	// Post-leadership grace: let the reconciler recover durable outcomes of pods
-	// that finished during the outage before declaring any of them lost. Checked
-	// before the list so a grace tick does no query at all.
-	if inLeaderGrace(r.leaderSince, r.leaderGrace, now) {
-		r.record("pod_lost_grace_skip")
-		return nil
-	}
+	// A control-plane restart makes a task pod that finished during the outage
+	// look lost: its container exited, yet its TI is still `running` because the
+	// terminal report found no server. Only the reconciler's sweep can recover
+	// that pod's durable outcome; Reaper.settling holds the whole tick until one
+	// has completed under this leadership, so by the time run is reached a
+	// `running` TI with no live pod is genuinely lost.
 	candidates, err := r.store.ListRunningTasks(ctx)
 	if err != nil {
 		return err

--- a/internal/executor/pod_lost_reap.go
+++ b/internal/executor/pod_lost_reap.go
@@ -66,12 +66,13 @@ type PodLostReapStore interface {
 //
 // Warm-pool attempts are out of this reaper's scope: a warm attempt has no
 // per-task pod, so it never appears live here; the warm-worker-lost reaper
-// recovers those from the warm pod's own liveness. That reaper carries no
-// leadership grace because its liveness signal is not one a control-plane
-// restart can manufacture: ListWarmPods is a live apiserver LIST (not an
-// informer-backed cache that could be cold or stale after a restart), and a
-// LIST error aborts its tick with zero marks, so a fresh leader either sees the
-// real warm fleet or marks nothing.
+// recovers those from the warm pod's own liveness. That signal is one a
+// control-plane restart cannot manufacture — ListWarmPods is a live apiserver
+// LIST (not an informer-backed cache that could be cold or stale after a
+// restart), and a LIST error aborts its tick with zero marks, so a fresh leader
+// either sees the real warm fleet or marks nothing — yet the reaper is held by
+// the same leader-settling gate as every other one: the delay is harmless and
+// one uniform gate is the point.
 type podLostReaper struct {
 	store    PodLostReapStore
 	logger   *slog.Logger

--- a/internal/executor/pod_lost_reap_test.go
+++ b/internal/executor/pod_lost_reap_test.go
@@ -150,67 +150,6 @@ func TestPodLostReaper(t *testing.T) {
 		}
 	})
 
-	t.Run("post-leadership grace defers, then reaps once it elapses", func(t *testing.T) {
-		// A control-plane restart manufactures the very signal this reaper acts
-		// on: a task pod that finished DURING the outage is no longer live, yet
-		// its TI is still `running` because its terminal report never landed.
-		// The pod's durable outcome record is recovered by the reconciler on its
-		// slower sweep — so the new leader must hold off pod-lost reaping until
-		// the reconciler has had time to settle the true outcome. Within the
-		// grace: NO MarkTaskPodLost, a recorded skip. Past it: reap as usual.
-		newStore := func() *fakePodLostStore {
-			return &fakePodLostStore{candidates: []PodLostCandidate{
-				{TaskInstanceID: "finished-during-outage", DagRunID: "run-a", TaskID: "work", TryNumber: 1, RunningSince: past},
-			}}
-		}
-		within := newStore()
-		rec := &capturingRecorder{}
-		pods := &fakePodManager{active: map[string]bool{}} // pod gone (Succeeded, not Pending/Running)
-		r := newPodLostReaper(within, reapTestLogger(), grace, rec)
-		r.pods = pods
-		r.leaderGrace = 180 * time.Second
-		r.leaderSince = func() time.Time { return now.Add(-10 * time.Second) } // just became leader
-		if err := r.run(context.Background()); err != nil {
-			t.Fatalf("run: %v", err)
-		}
-		if len(within.marked) != 0 {
-			t.Fatalf("must not mark pod_lost within the post-leadership grace, got %v", within.marked)
-		}
-		if len(pods.deletedTasks) != 0 {
-			t.Fatalf("must not tear down a pod within the post-leadership grace, got %v", pods.deletedTasks)
-		}
-		if got := rec.count("pod_lost_grace_skip"); got != 1 {
-			t.Errorf("pod_lost_grace_skip = %d, want 1", got)
-		}
-
-		pastGrace := newStore()
-		r2 := newPodLostReaper(pastGrace, reapTestLogger(), grace, &capturingRecorder{})
-		r2.pods = &fakePodManager{active: map[string]bool{}}
-		r2.leaderGrace = 180 * time.Second
-		r2.leaderSince = func() time.Time { return now.Add(-10 * time.Minute) } // leader long enough
-		if err := r2.run(context.Background()); err != nil {
-			t.Fatalf("run: %v", err)
-		}
-		if len(pastGrace.marked) != 1 || pastGrace.marked[0] != "finished-during-outage" {
-			t.Fatalf("must reap once the post-leadership grace elapsed, got %v", pastGrace.marked)
-		}
-	})
-
-	t.Run("nil leaderSince (Lite / no leadership) leaves the grace off", func(t *testing.T) {
-		store := &fakePodLostStore{candidates: []PodLostCandidate{
-			{TaskInstanceID: "lost", DagRunID: "run-a", TaskID: "work", TryNumber: 1, RunningSince: past},
-		}}
-		r := newPodLostReaper(store, reapTestLogger(), grace, nil)
-		r.pods = &fakePodManager{active: map[string]bool{}}
-		r.leaderGrace = 180 * time.Second // configured, but no leadership accessor
-		if err := r.run(context.Background()); err != nil {
-			t.Fatalf("run: %v", err)
-		}
-		if len(store.marked) != 1 {
-			t.Fatalf("without a leaderSince accessor the reaper must behave as before, got %v", store.marked)
-		}
-	})
-
 	t.Run("a list error surfaces and reaps nothing", func(t *testing.T) {
 		store := &fakePodLostStore{listErr: errors.New("db down")}
 		pods := &fakePodManager{active: map[string]bool{}}

--- a/internal/executor/reaper.go
+++ b/internal/executor/reaper.go
@@ -15,9 +15,9 @@ type DecisionRecorder interface {
 	RecordSchedulerDecision(decisionType string)
 }
 
-// ReaperStore is the full store surface the four reapers need, composed from
+// ReaperStore is the full store surface the five reapers need, composed from
 // each reaper's own slice. The metadatabase-backed SchedulerStore satisfies all
-// four, so production wires through one type; a unit test fakes just the slice
+// five, so production wires through one type; a unit test fakes just the slice
 // its reaper touches.
 type ReaperStore interface {
 	ReapStore
@@ -44,40 +44,32 @@ const (
 	defaultAgentLostThreshold    = 90 * time.Second
 	defaultDispatchLostThreshold = 3 * time.Minute
 	defaultPodLostGrace          = 60 * time.Second
-	// defaultAgentLostGrace is the post-leadership window during which the
-	// agent-lost reaper does not fire (#858). Set to 2× the agent-lost threshold
-	// so a single control-plane restart + re-election (whose recorded silence can
-	// approach the threshold) cannot trip a mass false reap, while staying well
-	// under the 10-minute agent token TTL so a re-heartbeat still authenticates.
-	// Ladder: heartbeat(15s) < threshold(90s) < grace(180s) < tokenTTL(600s).
-	defaultAgentLostGrace = 2 * defaultAgentLostThreshold
-	// defaultPodLostLeaderGrace is the post-leadership window during which the
-	// pod-lost reaper does not fire. The same control-plane restart that makes
-	// heartbeats look stale also makes a task pod that FINISHED during the outage
-	// look lost: its container exited, so it is no longer Pending/Running, yet its
-	// TI is still `running` because the terminal report never reached a server.
-	// The pod's durable outcome record (termination log) is recovered by the
-	// reconciler on its own, slower sweep; if the pod-lost reaper fires first it
-	// marks a succeeded task failed and the reconciler then finds a settled row.
-	// Reusing the agent-lost grace keeps one ladder value for "one restart fault"
-	// and leaves the reconciler (30s sweep) several passes to recover the true
-	// outcome before this reaper may act. It is additive to PodLostGrace, which
-	// is a per-task liveness floor measured from the TI's running transition.
-	defaultPodLostLeaderGrace = defaultAgentLostGrace
+	// defaultSettlingGrace is the post-leadership window during which NO reaper
+	// fires (see Reaper.settling). Set to 2× the agent-lost threshold so a single
+	// control-plane restart + re-election (whose recorded silence can approach
+	// the threshold) cannot trip a mass false reap, while staying well under the
+	// 10-minute agent token TTL so a re-heartbeat still authenticates.
+	// Ladder: heartbeat(15s) < threshold(90s) < grace(180s) < tokenTTL(600s);
+	// 2 × maintenance interval (60s) < grace, so at least two reconcile sweeps
+	// complete before the gate can open.
+	defaultSettlingGrace = 2 * defaultAgentLostThreshold
 )
 
-// ReaperConfig holds the idle thresholds and post-leadership graces the reapers
-// apply. Zero values are legal but reap aggressively; callers pass
+// ReaperConfig holds the idle thresholds and the post-leadership settling grace
+// the reapers apply. Zero values are legal but reap aggressively; callers pass
 // DefaultReaperConfig unless a test or load harness deliberately overrides them.
 type ReaperConfig struct {
 	OrphanThreshold       time.Duration
 	AgentLostThreshold    time.Duration
-	AgentLostGrace        time.Duration
 	DispatchLostThreshold time.Duration
-	PodLostGrace          time.Duration
-	// PodLostLeaderGrace suppresses pod-lost reaping for this long after this
-	// instance acquires leadership. See defaultPodLostLeaderGrace.
-	PodLostLeaderGrace time.Duration
+	// PodLostGrace is the per-task liveness floor measured from the TI's running
+	// transition, below which the pod-lost reaper does not consult pod liveness.
+	PodLostGrace time.Duration
+	// SettlingGrace is the minimum time after this instance acquires leadership
+	// before ANY reaper may act — one rung of the leader-settling gate, which
+	// also requires a synced pod informer and a completed reconciler sweep. See
+	// defaultSettlingGrace and Reaper.settling. Zero disables the whole gate.
+	SettlingGrace time.Duration
 }
 
 // DefaultReaperConfig returns the production thresholds — the exact values the
@@ -86,33 +78,10 @@ func DefaultReaperConfig() ReaperConfig {
 	return ReaperConfig{
 		OrphanThreshold:       defaultOrphanThreshold,
 		AgentLostThreshold:    defaultAgentLostThreshold,
-		AgentLostGrace:        defaultAgentLostGrace,
 		DispatchLostThreshold: defaultDispatchLostThreshold,
 		PodLostGrace:          defaultPodLostGrace,
-		PodLostLeaderGrace:    defaultPodLostLeaderGrace,
+		SettlingGrace:         defaultSettlingGrace,
 	}
-}
-
-// inLeaderGrace reports whether now falls within the post-leadership grace: a
-// leaderSince accessor is wired, the grace is positive, leadership is currently
-// held (non-zero stamp), and less than grace has elapsed since it was acquired.
-// A nil accessor (Lite / no leadership) or a zero grace disables the check.
-//
-// It is the single definition of the leader-settling gate the reapers share. A
-// control-plane restart manufactures the signals several reapers act on (a stale
-// heartbeat, a task pod that exited during the outage), so a freshly elected
-// leader must let the fleet re-heartbeat and the reconciler recover durable
-// outcomes before any of them fires; a genuinely lost task stays stale past the
-// grace and is reaped on a later tick. Measured from leadership acquisition, not
-// process start, so a re-election also resets it. If leadership flaps with a
-// period shorter than the grace the stamp keeps moving and the gated reapers
-// never fire — the orphan-run reaper is the backstop for that pathological case.
-func inLeaderGrace(leaderSince func() time.Time, grace time.Duration, now time.Time) bool {
-	if leaderSince == nil || grace <= 0 {
-		return false
-	}
-	ls := leaderSince()
-	return !ls.IsZero() && now.Sub(ls) < grace
 }
 
 // destructiveGate reports whether a reaper may take a destructive action — mark
@@ -123,9 +92,9 @@ func inLeaderGrace(leaderSince func() time.Time, grace time.Duration, now time.T
 //
 // The invariant: a leader that is terminating or stepping down must not mark or
 // delete. Its context is being canceled, its view of the fleet is about to go
-// stale, and the successor redoes every reap under its own post-leadership
-// grace — so a destructive write on the way out is at best redundant and at
-// worst the false reap the grace exists to prevent.
+// stale, and the successor redoes every reap under its own settling gate — so
+// a destructive write on the way out is at best redundant and at worst the
+// false reap the gate exists to prevent.
 type destructiveGate func(ctx context.Context) bool
 
 // gateOpen evaluates a possibly-nil destructiveGate.
@@ -135,9 +104,9 @@ func gateOpen(g destructiveGate, ctx context.Context) bool {
 
 // Reaper is the execution-side backstop that fails stuck runs and task instances
 // the scheduler dispatched but that then went dark. It bundles the five
-// independent reapers behind one ReapOnce entrypoint the scheduler drives once
-// per leader tick, so the scheduler depends on a single capability rather than
-// wiring each reaper itself.
+// independent reapers behind one ReapOnce entrypoint the leader's maintenance
+// loop drives once per cycle, after the pod reconciler's sweep, so the caller
+// depends on a single capability rather than wiring each reaper itself.
 type Reaper struct {
 	orphan         *orphanReaper
 	agentLost      *agentLostReaper
@@ -148,14 +117,25 @@ type Reaper struct {
 	rec            DecisionRecorder
 	// inStepDown reports whether the scheduler is in a graceful leader step-down.
 	// It downgrades an expected context-cancel fanout of the run-context to WARN
-	// (#311) and, with ctx and leading, closes the destructive gate: a leader
-	// stepping down must not mark or delete. Nil is tolerated ("not stepping
-	// down").
+	// and, with ctx and leading, closes the destructive gate: a leader stepping
+	// down must not mark or delete. Nil is tolerated ("not stepping down").
 	inStepDown func() bool
 	// leading reports whether this instance currently holds scheduler leadership;
 	// part of the destructive gate. Nil is tolerated ("leading") so Lite and
 	// tests without an election are unaffected.
 	leading func() bool
+	// now is the clock the settling gate reads; time.Now in production, injected
+	// by tests so the gate's three conditions can be driven deterministically.
+	now func() time.Time
+	// settlingGrace is ReaperConfig.SettlingGrace.
+	settlingGrace time.Duration
+	// leaderSince, informerSynced and lastSweepCompleted are the three inputs of
+	// the leader-settling gate (see settling). Each is nil when its subsystem is
+	// not wired — Lite has no leadership, informer or reconciler — and a nil
+	// input is "satisfied", so an unwired reaper is never held.
+	leaderSince        func() time.Time
+	informerSynced     func() bool
+	lastSweepCompleted func() time.Time
 }
 
 // NewReaper constructs the reapers and wires their pod-teardown / liveness
@@ -177,7 +157,6 @@ func NewReaper(store ReaperStore, pods PodManager, cache PodPresenceCache, warmP
 
 	agentLost := newAgentLostReaper(store, logger, cfg.AgentLostThreshold, rec)
 	agentLost.pods = pods
-	agentLost.grace = cfg.AgentLostGrace
 
 	dispatchLost := newDispatchLostReaper(store, logger, cfg.DispatchLostThreshold, rec)
 	dispatchLost.pods = pods
@@ -187,7 +166,6 @@ func NewReaper(store ReaperStore, pods PodManager, cache PodPresenceCache, warmP
 	podLost := newPodLostReaper(store, logger, cfg.PodLostGrace, rec)
 	podLost.pods = pods
 	podLost.cache = cache
-	podLost.leaderGrace = cfg.PodLostLeaderGrace
 
 	warmWorkerLost := newWarmWorkerLostReaper(store, logger, rec)
 	warmWorkerLost.warmPods = warmPods
@@ -201,6 +179,8 @@ func NewReaper(store ReaperStore, pods PodManager, cache PodPresenceCache, warmP
 		logger:         logger,
 		rec:            rec,
 		inStepDown:     inStepDown,
+		now:            time.Now,
+		settlingGrace:  cfg.SettlingGrace,
 	}
 	// One destructive gate, shared by every reaper: each re-checks it right before
 	// a mark or delete, so a cancel/step-down that lands mid-tick still stops the
@@ -216,9 +196,9 @@ func NewReaper(store ReaperStore, pods PodManager, cache PodPresenceCache, warmP
 
 // SetLeading wires the leadership predicate into the destructive gate, so a
 // reaper tick on an instance that no longer holds leadership marks and deletes
-// nothing. The scheduler already drives ReapOnce only while leading; this is the
-// defensive re-check at the point of the write. Nil leaves the gate on ctx and
-// step-down alone.
+// nothing. The maintenance loop already drives ReapOnce only while leading;
+// this is the defensive re-check at the point of the write. Nil leaves the gate
+// on ctx and step-down alone.
 func (r *Reaper) SetLeading(fn func() bool) {
 	r.leading = fn
 }
@@ -239,30 +219,124 @@ func (r *Reaper) mayReap(ctx context.Context) bool {
 }
 
 // SetLogSink wires the sink the agent-lost reaper uses to append a final
-// "killed: agent_lost" marker to a reaped attempt's log stream (#861), so a
-// killed task's log ends with the reason instead of a silent truncation. Any
-// logs.Sink satisfies the parameter; nil (Lite / unwired) leaves markers off.
+// "killed: agent_lost" marker to a reaped attempt's log stream, so a killed
+// task's log ends with the reason instead of a silent truncation. Any logs.Sink
+// satisfies the parameter; nil (Lite / unwired) leaves markers off.
 func (r *Reaper) SetLogSink(s logSink) {
 	r.agentLost.sink = s
 }
 
-// SetLeaderSince wires the accessor the leadership-gated reapers use to measure
-// their post-leadership grace — the window after a (re-)election during which a
-// stale heartbeat or a vanished task pod is assumed to be the outage's doing, not
-// a dead agent or a lost pod, and is not reaped (see inLeaderGrace). It reaches
-// every reaper that acts on a restart-manufactured signal: agent-lost and
-// pod-lost. Nil (Lite / no leadership) leaves the grace off. The warm-worker-lost
-// reaper is deliberately not gated: its signal is the warm pod's own liveness
-// read by a live apiserver LIST (ListWarmPods, not an informer cache that a
-// restart could leave cold), and a LIST error aborts its tick with zero marks —
-// so a fresh leader either sees the real warm fleet or marks nothing, and there
-// is no restart-manufactured false signal for a grace to absorb.
+// SetLeaderSince wires the accessor the settling gate measures its grace from:
+// when this instance last acquired scheduler leadership (zero while not
+// leading). Measured from leadership acquisition, not process start, so a
+// re-election also resets the gate. Nil (Lite / no leadership) disables the
+// gate entirely — the other two inputs are only meaningful under a leader.
 func (r *Reaper) SetLeaderSince(fn func() time.Time) {
-	r.agentLost.leaderSince = fn
-	r.podLost.leaderSince = fn
+	r.leaderSince = fn
 }
 
-// ReapOnce runs the five reapers once, in the same order the scheduler drove
+// SetInformerSynced wires the pod informer's sync predicate into the settling
+// gate. Until the cache has synced, the reapers' presence reads fall back to
+// live LISTs (safe, but the fleet view a fresh leader is about to judge from is
+// still being assembled), so the gate waits. Nil (no informer: Lite, or a
+// non-Kubernetes executor) leaves this condition satisfied.
+func (r *Reaper) SetInformerSynced(fn func() bool) {
+	r.informerSynced = fn
+}
+
+// SetLastSweepCompleted wires the reconciler's last-completed-sweep record into
+// the settling gate: the gate holds until a sweep has COMPLETED at or after
+// leadership was acquired, because that sweep is what recovers the durable
+// outcome of a task pod that finished during the outage; before it, "no live
+// pod" and "no recent heartbeat" are indistinguishable from a lost task. Nil
+// (no reconciler: Lite) leaves this condition satisfied.
+func (r *Reaper) SetLastSweepCompleted(fn func() time.Time) {
+	r.lastSweepCompleted = fn
+}
+
+// settlingVerdict is the settling gate's answer for one tick.
+type settlingVerdict struct {
+	// hold is true while the leader has not settled and the valve is shut: the
+	// tick must do nothing.
+	hold bool
+	// valve is true when the leader has not settled but the liveness valve has
+	// opened: the tick proceeds, loudly.
+	valve bool
+	// pending names the unsatisfied condition (grace, informer, sweep), for logs.
+	pending string
+	// elapsed is how long this instance has led.
+	elapsed time.Duration
+}
+
+// settling is the uniform leader-settling gate: after a (re-)election NO reaper
+// may act until the leader has settled, meaning all of
+//
+//	elapsed since leadership >= SettlingGrace
+//	pod informer cache synced          (when wired)
+//	a reconciler sweep completed at or after leadership was acquired (when wired)
+//
+// A control-plane restart manufactures the very signals the reapers act on: a
+// stale heartbeat (the receiver was down), a task pod that exited during the
+// outage (its terminal report found no server), a run with no recent activity.
+// Each reaper used to carry its own post-leadership grace; that closes the race
+// per reaper and leaves the class open — the reaper cadence and the reconciler
+// cadence were independent clocks, so a grace tuned against one sweep interval
+// still allowed zero completed sweeps. One gate over the observable facts (the
+// sweep DID complete; the cache IS synced; the fleet HAD a grace to re-heartbeat)
+// closes the class for every present and future reaper.
+//
+// Liveness valve: if the leader has not settled after 2 × SettlingGrace (the
+// reconciler cannot list pods, the informer never syncs) the gate opens anyway,
+// warning and metering reap_settling_valve_open on every cycle it stays open.
+// A permanently held gate would trade "reap wrong" for "never reap": stuck runs
+// and lost tasks would accumulate silently, which is the failure the reapers
+// exist to prevent. By then the reconciler has had at least four cycles, so the
+// diagnosis "the sweep is broken" is real, not a scheduling artifact.
+//
+// The warm-worker-lost reaper is gated too although its signal (a warm pod's
+// own liveness, read by a live LIST that fails closed) is not one a restart
+// manufactures: delaying it by the grace is harmless — a dead worker's attempts
+// are recovered a little later, and warm-pool REFILL is a separate loop that
+// is not gated — and one uniform gate is the point.
+//
+// Nil inputs are satisfied conditions: Lite wires none of them and must behave
+// exactly as before. A zero leadership stamp (not leading) also opens the gate
+// here — the destructive gate mayReap owns the not-leading case.
+func (r *Reaper) settling(now time.Time) settlingVerdict {
+	if r.leaderSince == nil || r.settlingGrace <= 0 {
+		return settlingVerdict{}
+	}
+	since := r.leaderSince()
+	if since.IsZero() {
+		return settlingVerdict{}
+	}
+	elapsed := now.Sub(since)
+	pending := r.settlingPending(since, elapsed)
+	if pending == "" {
+		return settlingVerdict{elapsed: elapsed}
+	}
+	if elapsed >= 2*r.settlingGrace {
+		return settlingVerdict{valve: true, pending: pending, elapsed: elapsed}
+	}
+	return settlingVerdict{hold: true, pending: pending, elapsed: elapsed}
+}
+
+// settlingPending names the first unsatisfied settling condition, or "" when
+// the leader has settled. Order is cheapest-first; only the name differs.
+func (r *Reaper) settlingPending(since time.Time, elapsed time.Duration) string {
+	if elapsed < r.settlingGrace {
+		return "grace"
+	}
+	if r.informerSynced != nil && !r.informerSynced() {
+		return "informer_unsynced"
+	}
+	if r.lastSweepCompleted != nil && r.lastSweepCompleted().Before(since) {
+		return "no_sweep_since_leadership"
+	}
+	return ""
+}
+
+// ReapOnce runs the five reapers once, in the order the scheduler used to drive
 // them: orphan-run, then agent-lost, then dispatch-lost, then pod-lost, then
 // warm-worker-lost. The dispatch-lost reaper runs AFTER the orphan-run reaper so
 // a clean stuck-queued -> failed -> orphan-run-failed chain can complete in a
@@ -270,20 +344,32 @@ func (r *Reaper) SetLeaderSince(fn func() time.Time) {
 //
 // The whole tick is skipped — and the skip metered as reap_gate_skip — when the
 // destructive gate is closed on entry: a canceled context (SIGTERM drain, the
-// step-down cancel fan-out), a scheduler in step-down, or a lost leadership. The
-// reapers also re-check the gate before each individual write, so this early
-// return is the cheap common case, not the only defense.
+// step-down cancel fan-out), a scheduler in step-down, or a lost leadership. It
+// is likewise skipped, metered as reap_settling_skip, while the leader has not
+// settled (see settling); once settling has lasted 2× the grace the liveness
+// valve opens and the tick proceeds with a WARN and reap_settling_valve_open.
+// The reapers also re-check the destructive gate before each individual write,
+// so the early return is the cheap common case, not the only defense.
 //
 // Each reaper's infra-level list error is logged and metered but never returned:
 // the reapers are independent backstops, so one's failure must not block the
-// others, and a list error must not stall the scheduler tick. Per-candidate
+// others, and a list error must not stall the caller's cycle. Per-candidate
 // failures are already isolated inside each reaper's run. ReapOnce therefore
 // always returns nil today; the error return is kept for the seam so a future
-// hard-failure mode need not change the scheduler.
+// hard-failure mode need not change the caller.
 func (r *Reaper) ReapOnce(ctx context.Context) error {
 	if !r.mayReap(ctx) {
 		r.record("reap_gate_skip")
 		return nil
+	}
+	if v := r.settling(r.now()); v.hold {
+		r.record("reap_settling_skip")
+		r.logger.Info("reapers holding until the leader settles", "pending", v.pending, "since_leadership", v.elapsed, "grace", r.settlingGrace)
+		return nil
+	} else if v.valve {
+		r.record("reap_settling_valve_open")
+		r.logger.Warn("reaper settling valve open: leader never settled, reaping anyway",
+			"pending", v.pending, "since_leadership", v.elapsed, "valve_after", 2*r.settlingGrace)
 	}
 	if err := r.orphan.run(ctx); err != nil {
 		r.logError("orphan reaper", err)
@@ -312,7 +398,7 @@ func (r *Reaper) ReapOnce(ctx context.Context) error {
 // to WARN only when it wraps context.Canceled AND the scheduler is currently in a
 // graceful leader step-down (the run-context is canceled as the leader releases
 // the advisory lock, and every in-flight reaper returns "context canceled"
-// milliseconds later — a non-event, #311). Any other error, or a cancel outside a
+// milliseconds later — a non-event). Any other error, or a cancel outside a
 // known step-down, stays ERROR: the tripwire that catches an unexpected cancel.
 func (r *Reaper) logError(msg string, err error) {
 	if r.inStepDown != nil && r.inStepDown() && errors.Is(err, context.Canceled) {

--- a/internal/executor/reaper_settling_test.go
+++ b/internal/executor/reaper_settling_test.go
@@ -1,0 +1,321 @@
+package executor
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// settlingHarness builds a Reaper over a stale-everything store with every
+// settling input injected: a fixed clock, the leadership stamp, the informer
+// sync flag and the reconciler's last completed sweep. Each test flips exactly
+// the input it is about, so the settling predicate is exercised one condition
+// at a time with no wall-clock dependence.
+type settlingHarness struct {
+	store  *fakeReaperStore
+	pods   *fakePodManager
+	rec    *capturingRecorder
+	logs   *bytes.Buffer
+	reaper *Reaper
+	now    time.Time
+	since  time.Time // leadership acquired
+	synced bool
+	sweep  time.Time // reconciler's last completed sweep; zero = never
+}
+
+func newSettlingHarness(t *testing.T) *settlingHarness {
+	t.Helper()
+	h := &settlingHarness{
+		store: staleEverythingStore(),
+		pods:  &fakePodManager{active: map[string]bool{}},
+		rec:   &capturingRecorder{},
+		logs:  &bytes.Buffer{},
+		now:   time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+	}
+	logger := slog.New(slog.NewTextHandler(h.logs, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	h.reaper = NewReaper(h.store, h.pods, nil, &fakeWarmLister{}, h.rec, logger, DefaultReaperConfig(), nil)
+	h.reaper.now = func() time.Time { return h.now }
+	h.reaper.SetLeaderSince(func() time.Time { return h.since })
+	h.reaper.SetInformerSynced(func() bool { return h.synced })
+	h.reaper.SetLastSweepCompleted(func() time.Time { return h.sweep })
+	return h
+}
+
+// settle puts every settling input into its "satisfied" state: leadership
+// acquired a full grace ago, informer synced, one sweep completed since.
+func (h *settlingHarness) settle() {
+	grace := DefaultReaperConfig().SettlingGrace
+	h.since = h.now.Add(-grace)
+	h.synced = true
+	h.sweep = h.now.Add(-time.Second)
+}
+
+func (h *settlingHarness) reap(t *testing.T) {
+	t.Helper()
+	if err := h.reaper.ReapOnce(context.Background()); err != nil {
+		t.Fatalf("ReapOnce: %v", err)
+	}
+}
+
+// assertEverythingReaped is the positive control: with the gate open every one
+// of the five reapers acts on its stale candidate.
+func assertEverythingReaped(t *testing.T, store *fakeReaperStore) {
+	t.Helper()
+	if len(store.reapedRuns) != 1 || len(store.agentMarked) != 1 || len(store.queuedMarked) != 1 || len(store.podMarked) != 2 {
+		t.Errorf("an open gate must let every reaper act: reapedRuns=%v agentMarked=%v queuedMarked=%v podMarked=%v",
+			store.reapedRuns, store.agentMarked, store.queuedMarked, store.podMarked)
+	}
+}
+
+// TestReapOnceSkipsWhileSettling: after a (re-)election the whole reaper tick is
+// a no-op until the leader has SETTLED — the grace has elapsed, the pod informer
+// has synced, and the reconciler has completed a sweep under this leadership.
+// Each condition alone must hold the tick: a control-plane restart manufactures
+// the signals several reapers act on (stale heartbeats, exited task pods, quiet
+// runs), and only a completed post-leadership sweep separates "finished during
+// the outage" from "lost". The skip is metered so operators can see it.
+func TestReapOnceSkipsWhileSettling(t *testing.T) {
+	grace := DefaultReaperConfig().SettlingGrace
+	cases := map[string]func(h *settlingHarness){
+		"grace not elapsed":          func(h *settlingHarness) { h.since = h.now.Add(-grace + time.Second) },
+		"informer not synced":        func(h *settlingHarness) { h.synced = false },
+		"no sweep since leadership":  func(h *settlingHarness) { h.sweep = time.Time{} },
+		"last sweep predates leader": func(h *settlingHarness) { h.sweep = h.since.Add(-time.Second) },
+	}
+	for name, unsettle := range cases {
+		t.Run(name, func(t *testing.T) {
+			h := newSettlingHarness(t)
+			h.settle()
+			unsettle(h)
+			h.reap(t)
+			assertNothingDestroyed(t, h.store, h.pods)
+			if got := h.rec.count("reap_settling_skip"); got != 1 {
+				t.Errorf("reap_settling_skip = %d, want 1", got)
+			}
+			if got := h.rec.count("reap_settling_valve_open"); got != 0 {
+				t.Errorf("the valve must stay shut inside 2×grace, reap_settling_valve_open = %d", got)
+			}
+		})
+	}
+}
+
+// TestReapOnceActiveOnceSettled: with all three conditions satisfied the tick
+// runs every reaper normally and records no settling decision.
+func TestReapOnceActiveOnceSettled(t *testing.T) {
+	h := newSettlingHarness(t)
+	h.settle()
+	h.reap(t)
+	assertEverythingReaped(t, h.store)
+	if got := h.rec.count("reap_settling_skip") + h.rec.count("reap_settling_valve_open"); got != 0 {
+		t.Errorf("a settled leader must record no settling decision, got %d", got)
+	}
+}
+
+// TestReapOnceSettlingValveOpens is the liveness valve: a reconciler that never
+// completes a sweep (or an informer that never syncs) must not turn "reap wrong"
+// into "never reap". Once settling has lasted 2×grace the tick proceeds anyway,
+// with a WARN and a reap_settling_valve_open decision on every cycle it stays
+// open, so the broken sweep is loud rather than silently disabling recovery.
+func TestReapOnceSettlingValveOpens(t *testing.T) {
+	grace := DefaultReaperConfig().SettlingGrace
+	t.Run("no sweep", func(t *testing.T) {
+		h := newSettlingHarness(t)
+		h.settle()
+		h.sweep = time.Time{}
+		h.since = h.now.Add(-2 * grace)
+		h.reap(t)
+		assertEverythingReaped(t, h.store)
+		if got := h.rec.count("reap_settling_valve_open"); got != 1 {
+			t.Errorf("reap_settling_valve_open = %d, want 1", got)
+		}
+		if got := h.rec.count("reap_settling_skip"); got != 0 {
+			t.Errorf("an open valve is not a skip, reap_settling_skip = %d", got)
+		}
+		if !strings.Contains(h.logs.String(), "level=WARN") || !strings.Contains(h.logs.String(), "valve") {
+			t.Errorf("the open valve must be logged at WARN naming the valve, got %q", h.logs.String())
+		}
+	})
+	t.Run("informer never synced", func(t *testing.T) {
+		h := newSettlingHarness(t)
+		h.settle()
+		h.synced = false
+		h.since = h.now.Add(-2 * grace)
+		h.reap(t)
+		assertEverythingReaped(t, h.store)
+		if got := h.rec.count("reap_settling_valve_open"); got != 1 {
+			t.Errorf("reap_settling_valve_open = %d, want 1", got)
+		}
+	})
+	t.Run("just under 2×grace stays shut", func(t *testing.T) {
+		h := newSettlingHarness(t)
+		h.settle()
+		h.sweep = time.Time{}
+		h.since = h.now.Add(-2*grace + time.Second)
+		h.reap(t)
+		assertNothingDestroyed(t, h.store, h.pods)
+		if got := h.rec.count("reap_settling_valve_open"); got != 0 {
+			t.Errorf("reap_settling_valve_open = %d, want 0", got)
+		}
+	})
+}
+
+// TestReapOnceDrillRaceHoldsPodLostUntilSweep replays the production drill: a
+// task pod finished while the control plane was down, so its TI is still
+// `running` and no live pod exists; leadership was acquired just now. The
+// pod-lost reaper must NOT mark it — not while the grace runs, and not even
+// after the grace if no reconciler sweep has completed under this leadership,
+// because only that sweep can recover the pod's durable success record. Once a
+// sweep has completed the still-unsettled TI is reaped normally.
+func TestReapOnceDrillRaceHoldsPodLostUntilSweep(t *testing.T) {
+	grace := DefaultReaperConfig().SettlingGrace
+	h := newSettlingHarness(t)
+	h.store = &fakeReaperStore{runningCands: []PodLostCandidate{
+		{TaskInstanceID: "finished-during-outage", DagRunID: "run-a", TaskID: "work", TryNumber: 1, RunningSince: h.now.Add(-10 * time.Minute)},
+	}}
+	h.reaper = NewReaper(h.store, h.pods, nil, nil, h.rec, reapTestLogger(), DefaultReaperConfig(), nil)
+	h.reaper.now = func() time.Time { return h.now }
+	h.reaper.SetLeaderSince(func() time.Time { return h.since })
+	h.reaper.SetInformerSynced(func() bool { return h.synced })
+	h.reaper.SetLastSweepCompleted(func() time.Time { return h.sweep })
+	h.since = h.now // leadership acquired this instant
+	h.synced = true
+
+	h.reap(t)
+	if len(h.store.podMarked) != 0 {
+		t.Fatalf("no pod-lost mark while the grace runs, got %v", h.store.podMarked)
+	}
+
+	h.now = h.now.Add(grace) // grace elapsed, still no sweep
+	h.reap(t)
+	if len(h.store.podMarked) != 0 {
+		t.Fatalf("no pod-lost mark before a post-leadership sweep completed, got %v", h.store.podMarked)
+	}
+	if got := h.rec.count("reap_settling_skip"); got != 2 {
+		t.Errorf("reap_settling_skip = %d, want 2", got)
+	}
+
+	h.sweep = h.now // the reconciler completed a sweep; the TI is still unsettled
+	h.reap(t)
+	if len(h.store.podMarked) != 1 || h.store.podMarked[0] != "finished-during-outage" {
+		t.Errorf("a TI still unsettled after a completed sweep is genuinely lost, got %v", h.store.podMarked)
+	}
+}
+
+// TestReapOnceSettlingCoversAgentLost carries the agent-lost half of the old
+// per-reaper grace up to the single gate: a TI whose heartbeat went stale during
+// a control-plane outage is not failed agent_lost by a leader that has not
+// settled; once settled, a still-silent TI is reaped. The invariant is the same
+// as before; it is now enforced in one place for every reaper.
+func TestReapOnceSettlingCoversAgentLost(t *testing.T) {
+	h := newSettlingHarness(t)
+	h.store = &fakeReaperStore{agentCands: []AgentLostCandidate{
+		{TaskInstanceID: "stale", DagRunID: "r", TaskID: "t", TryNumber: 1, LastHeartbeat: h.now.Add(-2 * time.Minute)},
+	}}
+	h.reaper = NewReaper(h.store, h.pods, nil, nil, h.rec, reapTestLogger(), DefaultReaperConfig(), nil)
+	h.reaper.now = func() time.Time { return h.now }
+	h.reaper.SetLeaderSince(func() time.Time { return h.since })
+	h.reaper.SetInformerSynced(func() bool { return h.synced })
+	h.reaper.SetLastSweepCompleted(func() time.Time { return h.sweep })
+	h.settle()
+	h.since = h.now.Add(-10 * time.Second) // just became leader
+
+	h.reap(t)
+	if len(h.store.agentMarked) != 0 {
+		t.Fatalf("must not reap agent_lost before the leader settled, got %v", h.store.agentMarked)
+	}
+	h.settle()
+	h.reap(t)
+	if len(h.store.agentMarked) != 1 || h.store.agentMarked[0] != "stale" {
+		t.Errorf("must reap agent_lost once settled, got %v", h.store.agentMarked)
+	}
+}
+
+// TestReapOnceNilSettlingPredicatesAreOpen: Lite wires no leadership, no
+// informer and no reconciler, so every settling input is nil — and nil means
+// "open", exactly as the nil destructive-gate inputs do. Nothing changes on the
+// subprocess path. A partially wired reaper (leadership but no informer or
+// sweep record) likewise gates only on what it was given.
+func TestReapOnceNilSettlingPredicatesAreOpen(t *testing.T) {
+	t.Run("nothing wired", func(t *testing.T) {
+		store := staleEverythingStore()
+		rec := &capturingRecorder{}
+		r := NewReaper(store, &fakePodManager{active: map[string]bool{}}, nil, &fakeWarmLister{}, rec, reapTestLogger(), DefaultReaperConfig(), nil)
+		if err := r.ReapOnce(context.Background()); err != nil {
+			t.Fatalf("ReapOnce: %v", err)
+		}
+		assertEverythingReaped(t, store)
+		if got := rec.count("reap_settling_skip") + rec.count("reap_settling_valve_open"); got != 0 {
+			t.Errorf("nil predicates must record no settling decision, got %d", got)
+		}
+	})
+	t.Run("leadership only, grace elapsed", func(t *testing.T) {
+		store := staleEverythingStore()
+		r := NewReaper(store, &fakePodManager{active: map[string]bool{}}, nil, &fakeWarmLister{}, nil, reapTestLogger(), DefaultReaperConfig(), nil)
+		r.SetLeaderSince(func() time.Time { return time.Now().Add(-time.Hour) })
+		if err := r.ReapOnce(context.Background()); err != nil {
+			t.Fatalf("ReapOnce: %v", err)
+		}
+		assertEverythingReaped(t, store)
+	})
+	t.Run("not leading (zero stamp) leaves the settling gate open", func(t *testing.T) {
+		// mayReap owns the not-leading case; a zero leadership stamp must not be
+		// read as "settling forever".
+		store := staleEverythingStore()
+		r := NewReaper(store, &fakePodManager{active: map[string]bool{}}, nil, &fakeWarmLister{}, nil, reapTestLogger(), DefaultReaperConfig(), nil)
+		r.SetLeaderSince(func() time.Time { return time.Time{} })
+		r.SetLastSweepCompleted(func() time.Time { return time.Time{} })
+		if err := r.ReapOnce(context.Background()); err != nil {
+			t.Fatalf("ReapOnce: %v", err)
+		}
+		assertEverythingReaped(t, store)
+	})
+}
+
+// TestReapOnceSettlesAfterFirstReconcileSweep wires the real reconciler's sweep
+// record into the reaper: before the reconciler has swept under this leadership
+// the tick is held; the moment one Reconcile completes, the gate opens. This is
+// the seam the maintenance loop relies on — reconcile, then reap — expressed
+// without the loop.
+func TestReapOnceSettlesAfterFirstReconcileSweep(t *testing.T) {
+	grace := DefaultReaperConfig().SettlingGrace
+	rec := NewReconciler(fake.NewClientset(), "leoflow", &fakeReporter{})
+	store := staleEverythingStore()
+	r := NewReaper(store, &fakePodManager{active: map[string]bool{}}, nil, &fakeWarmLister{}, nil, reapTestLogger(), DefaultReaperConfig(), nil)
+	r.SetLeaderSince(func() time.Time { return time.Now().Add(-grace - time.Second) })
+	r.SetInformerSynced(func() bool { return true })
+	r.SetLastSweepCompleted(rec.LastSweepCompletedAt)
+
+	if err := r.ReapOnce(context.Background()); err != nil {
+		t.Fatalf("ReapOnce: %v", err)
+	}
+	if len(store.reapedRuns)+len(store.agentMarked)+len(store.queuedMarked)+len(store.podMarked) != 0 {
+		t.Fatal("the tick must be held until the reconciler has swept under this leadership")
+	}
+	if err := rec.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if err := r.ReapOnce(context.Background()); err != nil {
+		t.Fatalf("ReapOnce: %v", err)
+	}
+	assertEverythingReaped(t, store)
+}
+
+// TestDefaultReaperConfigSettlingGrace pins the ladder position of the one
+// post-leadership grace: twice the agent-lost threshold, so a restart plus
+// re-election (whose recorded silence can approach the threshold) cannot trip a
+// mass false reap, and well above two 30s maintenance cycles so a settle that
+// failed transiently on the first sweep is retried before the gate can open.
+func TestDefaultReaperConfigSettlingGrace(t *testing.T) {
+	cfg := DefaultReaperConfig()
+	if cfg.SettlingGrace != 2*cfg.AgentLostThreshold {
+		t.Errorf("SettlingGrace = %v, want 2 × AgentLostThreshold (%v)", cfg.SettlingGrace, 2*cfg.AgentLostThreshold)
+	}
+	if cfg.SettlingGrace <= 2*30*time.Second {
+		t.Errorf("SettlingGrace = %v must exceed two 30s maintenance cycles", cfg.SettlingGrace)
+	}
+}

--- a/internal/executor/reaper_test.go
+++ b/internal/executor/reaper_test.go
@@ -274,61 +274,6 @@ func TestReapersHonorGateMidTick(t *testing.T) {
 	})
 }
 
-// TestReaperSetLeaderSinceGatesPodLost: the post-leadership grace must reach the
-// pod-lost reaper, not only the agent-lost one. Both reapers act on a signal a
-// control-plane restart manufactures (a stale heartbeat; a task pod that finished
-// during the outage and is no longer live), so both must let the fleet
-// re-heartbeat and the reconciler recover durable outcomes before firing. A
-// `running` TI whose pod is gone, past its own liveness grace, is NOT marked
-// through ReapOnce while leadership is fresh; it is once the grace elapsed.
-func TestReaperSetLeaderSinceGatesPodLost(t *testing.T) {
-	now := time.Now().UTC()
-	newStore := func() *fakeReaperStore {
-		return &fakeReaperStore{runningCands: []PodLostCandidate{
-			{TaskInstanceID: "finished-during-outage", DagRunID: "run-a", TaskID: "work", TryNumber: 1, RunningSince: now.Add(-10 * time.Minute)},
-		}}
-	}
-
-	fresh := newStore()
-	rec := &capturingRecorder{}
-	r := NewReaper(fresh, &fakePodManager{active: map[string]bool{}}, nil, nil, rec, reapTestLogger(), DefaultReaperConfig(), nil)
-	r.SetLeaderSince(func() time.Time { return now.Add(-5 * time.Second) })
-	if err := r.ReapOnce(context.Background()); err != nil {
-		t.Fatalf("ReapOnce: %v", err)
-	}
-	if len(fresh.podMarked) != 0 {
-		t.Errorf("pod-lost must defer within the post-leadership grace, marked %v", fresh.podMarked)
-	}
-	if got := rec.count("pod_lost_grace_skip"); got != 1 {
-		t.Errorf("pod_lost_grace_skip = %d, want 1", got)
-	}
-
-	settled := newStore()
-	r2 := NewReaper(settled, &fakePodManager{active: map[string]bool{}}, nil, nil, nil, reapTestLogger(), DefaultReaperConfig(), nil)
-	r2.SetLeaderSince(func() time.Time { return now.Add(-time.Hour) })
-	if err := r2.ReapOnce(context.Background()); err != nil {
-		t.Fatalf("ReapOnce: %v", err)
-	}
-	if len(settled.podMarked) != 1 {
-		t.Errorf("pod-lost must reap once the post-leadership grace elapsed, marked %v", settled.podMarked)
-	}
-}
-
-// TestDefaultReaperConfigPodLostLeaderGrace pins the ladder position of the
-// pod-lost leadership grace: it equals the agent-lost grace (the same restart
-// fault manufactures both signals) and sits well above the 30s reconciler sweep,
-// so the reconciler gets several sweeps to recover a durable outcome before the
-// pod-lost reaper may fire on the same pod.
-func TestDefaultReaperConfigPodLostLeaderGrace(t *testing.T) {
-	cfg := DefaultReaperConfig()
-	if cfg.PodLostLeaderGrace != cfg.AgentLostGrace {
-		t.Errorf("PodLostLeaderGrace = %v, want AgentLostGrace (%v)", cfg.PodLostLeaderGrace, cfg.AgentLostGrace)
-	}
-	if cfg.PodLostLeaderGrace < 2*30*time.Second {
-		t.Errorf("PodLostLeaderGrace = %v must leave margin over the 30s reconcile interval", cfg.PodLostLeaderGrace)
-	}
-}
-
 // TestReaperThreadsPresenceCacheToDispatchLost is the wiring check re-homed from
 // the scheduler's TestStepThreadsPresenceCacheToReapers: a presence cache passed
 // to NewReaper must reach the dispatch-lost reaper. A stale queued TI whose pod

--- a/internal/executor/reconcile.go
+++ b/internal/executor/reconcile.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -268,6 +269,11 @@ type Reconciler struct {
 	// (PR-10). Nil keeps the live LIST (Lite/subprocess, or before the informer
 	// is wired). GC deletes still go straight to the apiserver.
 	snapshot PodSnapshotter
+	// lastSweepCompleted is the unix-nano stamp of the last sweep that listed
+	// the task-pod set and visited every pod; 0 = none yet. Read by the reaper's
+	// leader-settling gate (see LastSweepCompletedAt) from another goroutine
+	// than the one that writes it at the end of Reconcile, hence atomic.
+	lastSweepCompleted atomic.Int64
 }
 
 // NewReconciler builds a Reconciler over the given cluster and outcome reporter.
@@ -280,9 +286,29 @@ func NewReconciler(clientset kubernetes.Interface, namespace string, reporter Ou
 // (PR-10). Left unset, the reconciler keeps the live LIST — today's behavior.
 func (r *Reconciler) SetPodSnapshotter(s PodSnapshotter) { r.snapshot = s }
 
+// LastSweepCompletedAt reports when the last COMPLETED sweep finished: the
+// task-pod set was listed and every pod visited, so every terminal pod present
+// at that moment had its chance to settle its task instance. Zero means no
+// sweep has completed yet. It is the record the reaper's leader-settling gate
+// compares against the leadership stamp — the reapers act on signals a
+// control-plane restart manufactures (a task pod that exited during the outage
+// looks lost), and only a sweep completed under the new leader separates
+// "finished during the outage, outcome recoverable" from "genuinely lost".
+//
+// A sweep that could not list pods records nothing. A sweep whose individual
+// settle failed on a DB error still counts: that pod is retried next sweep, and
+// the gate's grace leaves room for the retry before any reaper may act.
+func (r *Reconciler) LastSweepCompletedAt() time.Time {
+	ns := r.lastSweepCompleted.Load()
+	if ns == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns)
+}
+
 // Reconcile lists managed task pods, records each terminal one's outcome against
 // its task instance, and garbage-collects finished pods older than the grace
-// period.
+// period. A completed sweep is stamped for LastSweepCompletedAt.
 func (r *Reconciler) Reconcile(ctx context.Context) error {
 	pods, err := r.listTaskPods(ctx)
 	if err != nil {
@@ -318,6 +344,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error {
 			r.collect(ctx, pod)
 		}
 	}
+	r.lastSweepCompleted.Store(r.now().UnixNano())
 	return nil
 }
 

--- a/internal/executor/reconcile_test.go
+++ b/internal/executor/reconcile_test.go
@@ -2,13 +2,16 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
 
 	"github.com/neochaotic/leoflow/internal/taskoutcome"
 )
@@ -416,5 +419,36 @@ func TestClassifyPodConfigErrorWithoutNonRoot(t *testing.T) {
 	}
 	if strings.Contains(got.reason, "runAsNonRoot") {
 		t.Errorf("reason = %q, must not attribute an unrelated config error to non-root", got.reason)
+	}
+}
+
+// TestReconcileRecordsCompletedSweep: the reconciler stamps the time of its last
+// COMPLETED sweep — the task-pod set was listed and every pod visited — and only
+// then. A sweep that could not list pods records nothing. The stamp is what the
+// reaper's leader-settling gate reads to know a post-leadership sweep has had
+// its chance to recover durable outcomes before anything is declared lost.
+func TestReconcileRecordsCompletedSweep(t *testing.T) {
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	r := NewReconciler(fake.NewClientset(managedPod("p-ok", "ti-ok", corev1.PodSucceeded)), "leoflow", &fakeReporter{})
+	r.now = func() time.Time { return now }
+	if !r.LastSweepCompletedAt().IsZero() {
+		t.Fatalf("no sweep yet, got %v", r.LastSweepCompletedAt())
+	}
+	if err := r.Reconcile(context.Background()); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if got := r.LastSweepCompletedAt(); !got.Equal(now) {
+		t.Errorf("LastSweepCompletedAt = %v, want %v", got, now)
+	}
+
+	failing := NewReconciler(fake.NewClientset(), "leoflow", &fakeReporter{})
+	failing.clientset.(*fake.Clientset).PrependReactor("list", "pods", func(ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("apiserver down")
+	})
+	if err := failing.Reconcile(context.Background()); err == nil {
+		t.Fatal("a failed LIST must surface")
+	}
+	if !failing.LastSweepCompletedAt().IsZero() {
+		t.Errorf("a sweep that could not list pods must record nothing, got %v", failing.LastSweepCompletedAt())
 	}
 }

--- a/internal/executor/resilience_ladder.go
+++ b/internal/executor/resilience_ladder.go
@@ -11,27 +11,30 @@ import (
 // for its own reason, so nothing but this type states that they must line up.
 // The invariants:
 //
-//	heartbeat interval  <  agent-lost threshold  <  agent-lost grace  <  attempt token TTL
-//	2 × reconcile interval  <  agent-lost grace
-//	2 × reconcile interval  <  pod-lost leader grace
+//	heartbeat interval  <  agent-lost threshold  <  settling grace  <  attempt token TTL
+//	2 × maintenance interval  <  settling grace
 //	longest infra re-place delay  <  orphan threshold
 //	attempt token TTL  <  max attempt credential lifetime   (when the ceiling is enabled)
 //
 // Why each rung matters:
 //   - heartbeat < threshold: a healthy agent must beat well inside the silence
 //     window or the agent-lost reaper fails live tasks.
-//   - threshold < agent-lost grace: after a (re-)election the reaper waits
-//     longer than the silence it punishes, so the whole fleet can re-heartbeat.
-//   - agent-lost grace < token TTL: the grace ends while a re-heartbeat can still
+//   - threshold < settling grace: after a (re-)election the reapers wait longer
+//     than the silence they punish, so the whole fleet can re-heartbeat.
+//   - settling grace < token TTL: the grace ends while a re-heartbeat can still
 //     authenticate and renew the bearer; otherwise the fleet is unreapable AND
 //     unable to report — every in-flight task is lost.
-//   - 2×reconcile < agent-lost grace, 2×reconcile < pod-lost leader grace: the
-//     reconciler gets at least two full sweeps under the new leader before any
-//     reaper may fail a task whose pod finished during the outage, so the
-//     durable outcome record is recovered as the truth before a reaper guesses.
-//     A single sweep is not enough: the first tick under a new leader may land
-//     anywhere in the interval, so "one interval below the grace" can mean zero
-//     completed sweeps.
+//   - 2×maintenance < settling grace: the leader's maintenance loop runs the
+//     reconciler's sweep and then the reapers as ONE ordered cycle, so a reap
+//     structurally follows a completed sweep — the settling gate additionally
+//     requires that a sweep completed under the new leader. This rung is what
+//     makes the grace meaningful on top of that ordering: at least two whole
+//     cycles fit inside it, so a settle that failed transiently on the first
+//     sweep (a DB hiccup) is retried before the gate can open, and the liveness
+//     valve at 2×grace has seen at least four cycles before it declares the
+//     sweep broken. A single cycle is not enough: the first tick under a new
+//     leader may land anywhere in the interval, so "one interval below the
+//     grace" can mean zero completed cycles.
 //   - infra re-place delay < orphan threshold: a run whose only live task is
 //     parked in its longest infra re-place backoff has no activity to show the
 //     orphan-run reaper; the threshold must outlast that parking or the reaper
@@ -49,10 +52,13 @@ import (
 type ResilienceLadder struct {
 	HeartbeatInterval  time.Duration
 	AgentLostThreshold time.Duration
-	AgentLostGrace     time.Duration
-	PodLostLeaderGrace time.Duration
-	AttemptTokenTTL    time.Duration
-	ReconcileInterval  time.Duration
+	// SettlingGrace is the post-leadership window during which no reaper fires
+	// (ReaperConfig.SettlingGrace); the one grace every reaper shares.
+	SettlingGrace   time.Duration
+	AttemptTokenTTL time.Duration
+	// ReconcileInterval is the period of the leader's maintenance loop: one
+	// reconciler sweep followed by one reaper pass per cycle.
+	ReconcileInterval time.Duration
 	// OrphanThreshold is how long a running dag run may sit with no activity
 	// before the orphan-run reaper fails it (ReaperConfig.OrphanThreshold).
 	OrphanThreshold time.Duration
@@ -100,25 +106,23 @@ type ladderRelation struct {
 func ValidateResilienceLadder(l ResilienceLadder) error {
 	hb := ladderRung{"heartbeat interval", l.HeartbeatInterval}
 	thr := ladderRung{"agent-lost threshold", l.AgentLostThreshold}
-	agrace := ladderRung{"agent-lost grace", l.AgentLostGrace}
-	pgrace := ladderRung{"pod-lost leader grace", l.PodLostLeaderGrace}
+	grace := ladderRung{"settling grace", l.SettlingGrace}
 	ttl := ladderRung{"attempt token TTL", l.AttemptTokenTTL}
-	rec := ladderRung{"reconcile interval", l.ReconcileInterval}
+	rec := ladderRung{"maintenance interval", l.ReconcileInterval}
 	orphan := ladderRung{"orphan threshold", l.OrphanThreshold}
 	replace := ladderRung{"longest infra re-place delay", l.InfraReplaceMaxDelay}
 
-	for _, r := range []ladderRung{hb, thr, agrace, pgrace, ttl, rec, orphan, replace} {
+	for _, r := range []ladderRung{hb, thr, grace, ttl, rec, orphan, replace} {
 		if r.d <= 0 {
 			return fmt.Errorf("resilience ladder: %s (%v) must be positive", r.name, r.d)
 		}
 	}
-	twoRec := ladderRung{"2 × reconcile interval", 2 * l.ReconcileInterval}
+	twoRec := ladderRung{"2 × maintenance interval", 2 * l.ReconcileInterval}
 	relations := []ladderRelation{
 		{lo: hb, hi: thr, why: "a live agent must heartbeat well inside the agent-lost silence window"},
-		{lo: thr, hi: agrace, why: "the post-leadership grace must outlast the silence it forgives so the fleet can re-heartbeat"},
-		{lo: agrace, hi: ttl, why: "a re-heartbeat must still authenticate and renew the bearer when the grace ends"},
-		{lo: twoRec, hi: agrace, why: "the reconciler must complete at least two sweeps under a new leader before agent-lost may reap"},
-		{lo: twoRec, hi: pgrace, why: "the reconciler must complete at least two sweeps to recover durable pod outcomes before pod-lost may reap"},
+		{lo: thr, hi: grace, why: "the post-leadership settling grace must outlast the silence it forgives so the fleet can re-heartbeat"},
+		{lo: grace, hi: ttl, why: "a re-heartbeat must still authenticate and renew the bearer when the grace ends"},
+		{lo: twoRec, hi: grace, why: "at least two reconcile-then-reap cycles must complete under a new leader before the settling gate may open, so a transiently failed settle is retried before any reaper acts"},
 		{lo: replace, hi: orphan, why: "a run parked in its longest infra re-place backoff must not be reaped as orphaned while it is still recovering"},
 	}
 	if l.MaxAttemptCredentialLifetime > 0 {

--- a/internal/executor/resilience_ladder_test.go
+++ b/internal/executor/resilience_ladder_test.go
@@ -15,8 +15,7 @@ func defaultLadder() ResilienceLadder {
 	return ResilienceLadder{
 		HeartbeatInterval:            15 * time.Second,
 		AgentLostThreshold:           cfg.AgentLostThreshold,
-		AgentLostGrace:               cfg.AgentLostGrace,
-		PodLostLeaderGrace:           cfg.PodLostLeaderGrace,
+		SettlingGrace:                cfg.SettlingGrace,
 		AttemptTokenTTL:              10 * time.Minute,
 		ReconcileInterval:            30 * time.Second,
 		OrphanThreshold:              cfg.OrphanThreshold,
@@ -45,22 +44,21 @@ func TestValidateResilienceLadderDisabledCredentialCeilingPasses(t *testing.T) {
 	}
 }
 
-// TestValidateResilienceLadderRequiresTwoSweepsUnderGrace: the reconciler must
-// get at least TWO full sweeps under a new leader before either grace ends. A
-// reconcile interval just under the grace (179s vs 180s) satisfies a plain
-// "reconcile < grace" ordering yet guarantees zero completed sweeps in the
+// TestValidateResilienceLadderRequiresTwoSweepsUnderGrace: at least TWO whole
+// maintenance cycles (reconcile sweep, then reap) must fit under the settling
+// grace. A maintenance interval just under the grace (179s vs 180s) satisfies a
+// plain "interval < grace" ordering yet guarantees zero completed cycles in the
 // window, so the validator must reject it.
 func TestValidateResilienceLadderRequiresTwoSweepsUnderGrace(t *testing.T) {
 	l := defaultLadder()
 	l.ReconcileInterval = 179 * time.Second
-	l.AgentLostGrace = 180 * time.Second
-	l.PodLostLeaderGrace = 180 * time.Second
+	l.SettlingGrace = 180 * time.Second
 	l.AttemptTokenTTL = 10 * time.Minute
 	err := ValidateResilienceLadder(l)
 	if err == nil {
-		t.Fatal("reconcile=179s under grace=180s must be rejected")
+		t.Fatal("maintenance interval=179s under grace=180s must be rejected")
 	}
-	for _, w := range []string{"reconcile interval", "grace", "build-time invariant violated"} {
+	for _, w := range []string{"maintenance interval", "settling grace", "build-time invariant violated"} {
 		if !strings.Contains(err.Error(), w) {
 			t.Errorf("error %q must name %q", err, w)
 		}
@@ -88,27 +86,21 @@ func TestValidateResilienceLadderRejectsEachViolation(t *testing.T) {
 			notWant: []string{key},
 		},
 		{
-			name:    "agent-lost threshold not below agent-lost grace",
-			mutate:  func(l *ResilienceLadder) { l.AgentLostGrace = l.AgentLostThreshold },
-			want:    []string{"agent-lost threshold", "agent-lost grace", bug},
+			name:    "agent-lost threshold not below settling grace",
+			mutate:  func(l *ResilienceLadder) { l.SettlingGrace = l.AgentLostThreshold },
+			want:    []string{"agent-lost threshold", "settling grace", bug},
 			notWant: []string{key},
 		},
 		{
-			name:    "agent-lost grace not below attempt token TTL",
-			mutate:  func(l *ResilienceLadder) { l.AttemptTokenTTL = l.AgentLostGrace },
-			want:    []string{"agent-lost grace", "attempt token TTL", bug},
+			name:    "settling grace not below attempt token TTL",
+			mutate:  func(l *ResilienceLadder) { l.AttemptTokenTTL = l.SettlingGrace },
+			want:    []string{"settling grace", "attempt token TTL", bug},
 			notWant: []string{key},
 		},
 		{
-			name:    "two reconcile intervals not below agent-lost grace",
-			mutate:  func(l *ResilienceLadder) { l.ReconcileInterval = l.AgentLostGrace / 2 },
-			want:    []string{"reconcile interval", "agent-lost grace", bug},
-			notWant: []string{key},
-		},
-		{
-			name:    "two reconcile intervals not below pod-lost leader grace",
-			mutate:  func(l *ResilienceLadder) { l.PodLostLeaderGrace = 2 * l.ReconcileInterval },
-			want:    []string{"reconcile interval", "pod-lost leader grace", bug},
+			name:    "two maintenance intervals not below settling grace",
+			mutate:  func(l *ResilienceLadder) { l.ReconcileInterval = l.SettlingGrace / 2 },
+			want:    []string{"maintenance interval", "settling grace", bug},
 			notWant: []string{key},
 		},
 		{

--- a/internal/scheduler/reaper_seam_test.go
+++ b/internal/scheduler/reaper_seam_test.go
@@ -2,77 +2,40 @@ package scheduler
 
 import (
 	"context"
+	"reflect"
 	"testing"
-	"time"
 )
 
-// spyExecutionReaper records how many times the scheduler drove it, so the seam
-// tests can assert the leader-gating contract without depending on the executor
-// package. The reaper's own marking behavior is covered by the executor-package
-// reaper tests; here we only prove the scheduler invokes it at the right time.
-type spyExecutionReaper struct {
-	calls int
+// reapOncer is the shape of the execution reaper's entrypoint. The scheduler
+// used to expose a seam of this shape and drive it from every 1s leader tick.
+type reapOncer interface {
+	ReapOnce(context.Context) error
 }
 
-func (s *spyExecutionReaper) ReapOnce(context.Context) error {
-	s.calls++
-	return nil
-}
-
-// TestStepDrivesExecutionReaperOnLeader is the leader half of the reap-gate
-// contract (#120/#208), re-expressed at the new seam: a leader tick drives the
-// execution reaper exactly once. It replaces the pre-refactor
-// TestStepReapsOrphanRunsOnLeader / TestStepRunsDispatchLostReaperOnLeader,
-// whose end-to-end marking behavior now lives in the executor package.
-func TestStepDrivesExecutionReaperOnLeader(t *testing.T) {
-	s := newScheduler(newFakeStore())
-	s.SetLeading(true)
-	reaper := &spyExecutionReaper{}
-	s.SetExecutionReaper(reaper)
-
-	if err := s.Step(context.Background()); err != nil {
-		t.Fatal(err)
+// TestSchedulerTickHasNoReaperHook pins that the scheduling tick cannot drive
+// the execution reaper: the Scheduler carries no field that satisfies the
+// reaper's ReapOnce shape and no method that accepts one. The reapers run from
+// the leader's maintenance loop, ordered after the pod reconciler's sweep, at
+// that loop's cadence — not at 1s from the tick. Re-adding a seam here would
+// re-open the class of race this closes (a reaper judging state the reconciler
+// has not yet recovered), so its absence is asserted rather than assumed.
+func TestSchedulerTickHasNoReaperHook(t *testing.T) {
+	reaperType := reflect.TypeOf((*reapOncer)(nil)).Elem()
+	st := reflect.TypeOf(Scheduler{})
+	for i := 0; i < st.NumField(); i++ {
+		f := st.Field(i)
+		if f.Type.Kind() == reflect.Interface && f.Type.Implements(reaperType) {
+			t.Errorf("Scheduler.%s holds a ReapOnce-shaped value; the tick must not be able to reap", f.Name)
+		}
 	}
-	if reaper.calls != 1 {
-		t.Errorf("a leader tick must drive the execution reaper once, got %d", reaper.calls)
-	}
-}
-
-// TestStepDrivesExecutionReaperEvenIfCreateDueRunsFails preserves the backstop
-// guard from the pre-refactor TestStepReapsEvenIfCreateDueRunsFails: the reaper
-// runs even when the rest of the tick is degraded (a DB hiccup on
-// createScheduledRun), because a sick DB hiding orphans exactly when you want to
-// see them would be a silent failure mode.
-func TestStepDrivesExecutionReaperEvenIfCreateDueRunsFails(t *testing.T) {
-	store := newFakeStore()
-	last := time.Now().UTC().Add(-2 * time.Hour)
-	store.scheduled = []ScheduledDAG{{DagID: "etl", Schedule: "@hourly", LastLogical: &last}}
-	store.createErr = true
-	s := newScheduler(store)
-	s.SetLeading(true)
-	reaper := &spyExecutionReaper{}
-	s.SetExecutionReaper(reaper)
-
-	_ = s.Step(context.Background())
-	if reaper.calls != 1 {
-		t.Errorf("the reaper must run even when createScheduledRun fails, got %d calls", reaper.calls)
-	}
-}
-
-// TestStepSkipsExecutionReaperOnFollower is the follower half: reaping writes
-// state and must be single-writer across the fleet, so a follower tick never
-// drives the reaper. Replaces the pre-refactor TestStepDoesNotReapOnFollower /
-// TestStepSkipsDispatchLostReaperOnFollower.
-func TestStepSkipsExecutionReaperOnFollower(t *testing.T) {
-	s := newScheduler(newFakeStore())
-	s.SetLeading(false) // newScheduler defaults to leader; opt out for follower-mode test.
-	reaper := &spyExecutionReaper{}
-	s.SetExecutionReaper(reaper)
-
-	if err := s.Step(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-	if reaper.calls != 0 {
-		t.Errorf("a follower must not drive the execution reaper, got %d calls", reaper.calls)
+	pt := reflect.TypeOf(&Scheduler{})
+	for i := 0; i < pt.NumMethod(); i++ {
+		m := pt.Method(i)
+		for j := 1; j < m.Type.NumIn(); j++ { // 0 is the receiver
+			in := m.Type.In(j)
+			if in.Kind() == reflect.Interface && in.Implements(reaperType) {
+				t.Errorf("Scheduler.%s accepts a ReapOnce-shaped value; the tick must not be able to reap", m.Name)
+			}
+		}
 	}
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -277,16 +277,15 @@ type Scheduler struct {
 	// buffered channel used as a counting semaphore; a saturated slot drops the
 	// alert (best-effort) rather than blocking the tick.
 	alertSem chan struct{}
-	// executionReaper is the execution-side backstop that fails stuck runs and
-	// task instances (the four reapers, #120/#128/#202/#527). It lives in the
-	// executor package because reaping tears down pods and gates on pod liveness;
-	// the scheduler only drives it once per leader tick through this seam. Nil
-	// leaves the tick with no reaping (e.g. a load harness that opts out).
-	executionReaper ExecutionReaper
-	lastTick        atomic.Int64 // unix-nano of the last loop iteration; 0 = not yet ticked
-	leading         atomic.Bool  // true only while this instance holds leadership and ticks
-	leaderSince     atomic.Int64 // unix-nano when leadership was last acquired; 0 = not leading. Drives the agent-lost reaper's post-recovery grace (#858)
-	steppingDown    atomic.Bool  // true only during a leader step-down — the campaign loop sets it before canceling the run-context so the expected cancel-fanout logs at WARN, not ERROR (#311 tripwire preserved when it's false)
+	// The execution reapers are NOT driven from the tick. They run from the
+	// leader's maintenance loop, after the pod reconciler's sweep, at that loop's
+	// cadence: a reaper judging state at 1s that a 30s reconciler had not yet
+	// recovered was the race a restart turned into a false failure. The
+	// scheduler exposes LeaderSince/IsLeading/SteppingDown for that loop's gate.
+	lastTick     atomic.Int64 // unix-nano of the last loop iteration; 0 = not yet ticked
+	leading      atomic.Bool  // true only while this instance holds leadership and ticks
+	leaderSince  atomic.Int64 // unix-nano when leadership was last acquired; 0 = not leading. Drives the execution reaper's leader-settling gate
+	steppingDown atomic.Bool  // true only during a leader step-down — the campaign loop sets it before canceling the run-context so the expected cancel-fanout logs at WARN, not ERROR (#311 tripwire preserved when it's false)
 	// warnedSchedules dedupes the "unparseable schedule" warning per DAG (keyed by
 	// the offending expression) so a bad cron logs once, not every tick. Accessed
 	// only from the single-threaded tick (createDueRuns), so it needs no lock.
@@ -312,22 +311,6 @@ func NewScheduler(store Store, logger *slog.Logger, interval time.Duration) *Sch
 	}
 }
 
-// ExecutionReaper is the execution-side backstop the scheduler drives once per
-// leader tick to fail stuck runs and task instances. It is the seam between the
-// scheduler (which owns the leader gate and the tick) and the executor package
-// (which owns pod teardown and pod-liveness). executor.Reaper satisfies it.
-type ExecutionReaper interface {
-	// ReapOnce runs every reaper once. Implementations isolate per-reaper and
-	// per-candidate failures internally and log/meter list errors, so the
-	// scheduler ignores the return today; the error is kept for the seam.
-	ReapOnce(ctx context.Context) error
-}
-
-// SetExecutionReaper wires the execution-side reaper the scheduler drives on the
-// leader tick. Left unset (e.g. a load harness, or a Lite path that opts out of
-// reaping), the tick simply reaps nothing.
-func (s *Scheduler) SetExecutionReaper(r ExecutionReaper) { s.executionReaper = r }
-
 // defaultStepTimeout bounds how long one scheduling tick may run before it is
 // canceled so the loop can recover, rather than hang forever on a stuck query.
 // It is generous (well above a healthy tick) to avoid aborting legitimate work.
@@ -349,9 +332,9 @@ func (s *Scheduler) SetStepTimeout(d time.Duration) { s.stepTimeout = d }
 func (s *Scheduler) SetLeading(on bool) {
 	if on {
 		s.lastTick.Store(0)
-		// Stamp when leadership was acquired so the agent-lost reaper measures its
-		// post-recovery grace from now, not from wall-clock (#858). Clear it on
-		// loss so a non-leader reports no leadership window.
+		// Stamp when leadership was acquired so the execution reaper's settling
+		// gate measures from now, not from wall-clock. Clear it on loss so a
+		// non-leader reports no leadership window.
 		s.leaderSince.Store(time.Now().UnixNano())
 	} else {
 		s.leaderSince.Store(0)
@@ -568,31 +551,7 @@ func (s *Scheduler) Step(ctx context.Context) error {
 			poolOccupied[k] += n
 		}
 	}
-	createErr := s.createDueRuns(ctx, activeByDAG)
-	s.reapOrphansIfLeader(ctx)
-	return createErr
-}
-
-// reapOrphansIfLeader drives the execution-side reaper exactly once per tick,
-// only on the leader: reaping writes state and we want one writer at a time
-// across the fleet. The reaper (executor.Reaper) isolates per-reaper and
-// per-candidate failures internally and logs/meters its own list errors, so the
-// tick neither returns nor stalls on a reap error — the reapers are backstops,
-// not on the critical path. Nil executionReaper (a harness that opts out, or a
-// role that does no reaping) makes this a no-op.
-func (s *Scheduler) reapOrphansIfLeader(ctx context.Context) {
-	if !s.leading.Load() {
-		return
-	}
-	if s.executionReaper == nil {
-		return
-	}
-	// ReapOnce isolates and logs its own per-reaper failures and returns nil
-	// today; the guarded log keeps the scheduler honest if the seam ever grows a
-	// hard-failure return, matching how the tick logs (never returns) reap errors.
-	if err := s.executionReaper.ReapOnce(ctx); err != nil {
-		logSchedulerError(s.logger, "execution reaper", err, s.steppingDown.Load())
-	}
+	return s.createDueRuns(ctx, activeByDAG)
 }
 
 // activeTaskCounts tallies, per DAG, the task instances that already occupy a

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -510,7 +510,7 @@ func (s *Scheduler) Step(ctx context.Context) error {
 	// read or write scheduler state. The lastTick.Store above keeps the
 	// follower's heartbeat live so the orchestrator can prove the instance
 	// is alive without granting it the writer role. Lifting the gate here
-	// (instead of only inside reapOrphansIfLeader) removes the wasted reads,
+	// (instead of only around individual phases) removes the wasted reads,
 	// the duplicate ApplyTransition / CreateScheduledRun attempts that ON
 	// CONFLICT used to swallow, and the "what does a follower's count drift
 	// mean?" puzzle.

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -457,8 +457,6 @@ func TestStepFollowerSkipsAllWrites(t *testing.T) {
 	store.scheduled = []ScheduledDAG{{DagID: "etl", Schedule: "@hourly"}}
 	s := newScheduler(store)
 	s.SetLeading(false) // newScheduler defaults to leader; opt out for this follower-mode test.
-	reaper := &spyExecutionReaper{}
-	s.SetExecutionReaper(reaper)
 
 	if err := s.Step(context.Background()); err != nil {
 		t.Fatalf("Step on follower must not return infra-level error: %v", err)
@@ -471,9 +469,6 @@ func TestStepFollowerSkipsAllWrites(t *testing.T) {
 	}
 	if len(store.createdRuns) != 0 {
 		t.Errorf("follower must not create scheduled runs; got %v", store.createdRuns)
-	}
-	if reaper.calls != 0 {
-		t.Errorf("follower must not drive the execution reaper; got %d calls", reaper.calls)
 	}
 	// Heartbeat MUST still fire — the leadership check sits AFTER lastTick.Store
 	// so the orchestrator can prove the instance is alive without granting it

--- a/internal/storage/chaos_integration_test.go
+++ b/internal/storage/chaos_integration_test.go
@@ -27,9 +27,9 @@ import (
 //     run up and fails it with `orphaned`.
 //
 // Wall-clock dogfood would wait 3 min + 5 min for the production thresholds;
-// here we shrink them to a couple hundred ms in the ReaperConfig wired to the
-// scheduler's execution-reaper seam so the test stays fast. We are validating
-// the contract SHAPE, not the production tuning.
+// here we shrink them to a couple hundred ms in the ReaperConfig of a reaper the
+// test drives directly, the way the server's maintenance loop does, so the test
+// stays fast. We are validating the contract SHAPE, not the production tuning.
 //
 // Skips when DATABASE_URL is absent (no PG available).
 func TestChaosMidTickCrashRecoveryIntegration(t *testing.T) {
@@ -64,36 +64,47 @@ func TestChaosMidTickCrashRecoveryIntegration(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	s := scheduler.NewScheduler(sched, logger, time.Millisecond)
 	s.SetLeading(true)
-	// The reapers now live behind the execution-reaper seam. Wire one over the
-	// same store (Lite path: nil pods/cache/recorder) with thresholds tight
-	// enough for a fast test but well above the ~ms in-process Step() latency.
-	// AgentLostThreshold is a minute — irrelevant here, kept high so it can't fire
-	// on unrelated rows; PodLostGrace is a no-op with nil pods.
-	s.SetExecutionReaper(executor.NewReaper(sched, nil, nil, nil, nil, logger, executor.ReaperConfig{
+	// The reapers run from the server's leader maintenance loop, not from the
+	// scheduler tick; here the test plays that loop, driving ReapOnce after each
+	// Step exactly as the loop orders reconcile -> reap (no pods, so no
+	// reconciler on this Lite-shaped path). Wire one over the same store (nil
+	// pods/cache/recorder) with thresholds tight enough for a fast test but well
+	// above the ~ms in-process latency. AgentLostThreshold is a minute —
+	// irrelevant here, kept high so it can't fire on unrelated rows; PodLostGrace
+	// is a no-op with nil pods; no leadership stamp is wired, so the settling
+	// gate is open, as it is in Lite.
+	reaper := executor.NewReaper(sched, nil, nil, nil, nil, logger, executor.ReaperConfig{
 		OrphanThreshold:       400 * time.Millisecond,
 		AgentLostThreshold:    time.Minute,
 		DispatchLostThreshold: 200 * time.Millisecond,
 		PodLostGrace:          time.Minute,
-	}, s.SteppingDown))
+	}, s.SteppingDown)
+	reaper.SetLeading(s.IsLeading)
 
-	// 3. Wait past the dispatch-lost threshold, then tick. The reaper must
-	//    flip our queued TI to failed/dispatch_lost.
+	// 3. Wait past the dispatch-lost threshold, then tick and reap. The reaper
+	//    must flip our queued TI to failed/dispatch_lost.
 	time.Sleep(250 * time.Millisecond)
 	if err := s.Step(ctx); err != nil {
 		t.Fatalf("dispatch-lost tick: %v", err)
 	}
+	if err := reaper.ReapOnce(ctx); err != nil {
+		t.Fatalf("dispatch-lost reap: %v", err)
+	}
 	tiState := taskInstanceState(t, sched, ctx, runUUID, "t")
 	if tiState != domain.TaskStateFailed {
-		t.Fatalf("TI state after dispatch-lost tick = %q, want failed", tiState)
+		t.Fatalf("TI state after dispatch-lost reap = %q, want failed", tiState)
 	}
 
 	// 4. Wait past the orphan threshold (relative to the run's last
 	//    activity, which our queued TI's transition just bumped), then
-	//    tick again. The orphan-run reaper should flip the run to failed
-	//    now that no active TI remains on it.
+	//    tick and reap again. The orphan-run reaper should flip the run to
+	//    failed now that no active TI remains on it.
 	time.Sleep(450 * time.Millisecond)
 	if err := s.Step(ctx); err != nil {
 		t.Fatalf("orphan-run tick: %v", err)
+	}
+	if err := reaper.ReapOnce(ctx); err != nil {
+		t.Fatalf("orphan-run reap: %v", err)
 	}
 	runState := dagRunState(t, sched, ctx, runUUID)
 	if runState != domain.DagRunStateFailed {

--- a/test/load/scheduler_ceiling/main.go
+++ b/test/load/scheduler_ceiling/main.go
@@ -93,9 +93,9 @@ func run() error {
 	sched := scheduler.NewScheduler(store, logger, time.Second)
 	sched.SetRecorder(metrics) // captures step-downs; scraped per N below
 	sched.SetLeading(true)     // Step is a no-op for a follower
-	// No execution reaper is wired, so no reaper ever touches our synthetic runs
-	// and the active set stays fixed at N for the measurement window (reaping now
-	// lives behind the scheduler's ExecutionReaper seam, off by default).
+	// No maintenance loop runs here, so no reaper ever touches our synthetic runs
+	// and the active set stays fixed at N for the measurement window (reaping
+	// lives in the server's leader maintenance loop, not in the scheduler tick).
 	// No dispatcher is wired: a `running` task is never re-dispatched, so the
 	// scheduler advances state only and launches nothing.
 

--- a/website/content/operate/control-plane-ha.md
+++ b/website/content/operate/control-plane-ha.md
@@ -21,13 +21,14 @@ When the single control-plane pod is evicted, the replacement has to:
 2. **Boot**: connect to Postgres and Redis, start the API, gRPC and metrics
    listeners, pass readiness.
 3. **Take leadership**: acquire the scheduler's advisory lock
-   ([ADR 0009](/project/adrs/0009-leader-election/)) and start the loop. For the
-   **post-leadership grace** (180 s by default) the two reapers that judge a
-   task by its pod — **agent-lost** and **pod-lost** — hold their verdicts, so a
-   task that merely lost its control plane for the duration of the restart is
-   not failed before the reconciler has recovered its durable outcome. The other
-   reapers (dispatch-lost, orphan-run, warm-worker-lost) carry no such grace
-   ([scheduler resilience](/operate/scheduler-resilience/)).
+   ([ADR 0009](/project/adrs/0009-leader-election/)) and start the loop. Until
+   the new leader has **settled** — the settling grace (180 s by default) has
+   elapsed, the pod informer has synced, and the pod reconciler has completed a
+   sweep under this leadership — **no reaper** fires, so a task that merely lost
+   its control plane for the duration of the restart is not failed before the
+   reconciler has recovered its durable outcome. One gate covers all five
+   reapers; a liveness valve opens it after 2 × grace if the sweep never
+   completes ([scheduler resilience](/operate/scheduler-resilience/)).
 
 Measured on a production drill (EKS Auto Mode), that window is **48–80 seconds**,
 dominated by the image pull. During it:
@@ -35,10 +36,10 @@ dominated by the image pull. During it:
 - **Nothing dispatches.** Queued task instances wait; scheduled runs slip.
 - **In-flight tasks lose their control plane.** Agents keep running the task and
   retry their heartbeats and outcome reports until the server returns. The
-  post-leadership grace on agent-lost and pod-lost is what keeps that from
-  becoming a false `agent_lost` / `pod_lost` failure; the server also validates
-  at boot that the timing ladder this depends on holds (heartbeat < agent-lost
-  threshold < grace < token TTL, and the reconcile interval below both graces),
+  leader-settling gate on the reapers is what keeps that from becoming a false
+  `agent_lost` / `pod_lost` failure; the server also validates at boot that the
+  timing ladder this depends on holds (heartbeat < agent-lost threshold <
+  settling grace < token TTL, and two maintenance cycles inside the grace),
   refusing to start if a knob was moved out of order. These bound the damage;
   they do not remove the window.
 - **The API and UI are down.** Every replica is the same binary, so one replica
@@ -359,10 +360,11 @@ No PDB, annotation or grace period prevents:
 
 Each of those is the 48–80 second restart window with no warning. The only
 thing that shrinks it is a replica that is already running somewhere else — and
-the scheduler's own resilience — the post-leadership grace on the agent-lost and
-pod-lost reapers, the destructive gate that holds every reaper during a step-down,
-the reconciler that recovers a pod's durable outcome, and the boot-time check of
-the timing ladder they depend on, described in
+the scheduler's own resilience — the leader-settling gate that holds every reaper
+until the reconciler has swept under the new leader, the destructive gate that
+holds every reaper during a step-down, the reconciler that recovers a pod's
+durable outcome (now run in the same cycle as, and before, the reapers), and the
+boot-time check of the timing ladder they depend on, described in
 [scheduler resilience](/operate/scheduler-resilience/) — is what keeps the tasks
 that were in flight during the window from being falsely failed. HA shortens the
 window; the resilience mechanisms make the remaining window survivable. Run both.

--- a/website/content/operate/scheduler-resilience.md
+++ b/website/content/operate/scheduler-resilience.md
@@ -49,6 +49,12 @@ leader's maintenance loop, which every 30 s performs **one ordered cycle**:
    and garbage-collects old finished pods;
 2. **then** the five reapers run.
 
+Each phase runs under its own budget of one interval (30 s): a sweep hung on a
+slow apiserver cannot starve the reap, and a reap pass over a large namespace
+cannot starve the sweep it depends on. Overrunning a budget is a load signal,
+logged at `WARN` with the budget, not an error; a cycle can take up to two
+intervals and the ticker coalesces the ticks it overruns.
+
 The order is structural, not a matter of timers lining up. Before this, the
 reapers ticked at 1 s and the reconciler at 30 s on an independent clock, so a
 pod-lost verdict could land on a pod the reconciler would have recovered as

--- a/website/content/operate/scheduler-resilience.md
+++ b/website/content/operate/scheduler-resilience.md
@@ -10,14 +10,16 @@ description: "How the scheduler survives restarts, leader loss and partial failu
 
 How Leoflow keeps the scheduler honest when something goes wrong: a process
 dies, an agent goes silent, a dispatch is lost in flight. The control plane
-ships **three reapers** — small, single-purpose loops that turn stuck state
+ships **five reapers** — small, single-purpose backstops that turn stuck state
 back into observable terminal state, so the dashboard never lies about what's
 actually running.
 
 This applies to **both editions**: Lite (single-process) and Pro
 (multi-replica with [leader election](/project/adrs/0009-leader-election/)). The
 reapers run only on the leader — reaping writes state, and we want one writer
-across the fleet.
+across the fleet. On Kubernetes they run from the leader's **maintenance loop**
+(every 30 s, after the pod reconciler's sweep — see below); in Lite there are no
+pods, so no pod-based reaper applies and the loop is not started.
 
 ## Recovery SLAs
 
@@ -25,28 +27,80 @@ across the fleet.
 |---|---|---|---|
 | **Task code wedged past its declared `execution_timeout_seconds`** | **Agent itself** ([#194](https://github.com/neochaotic/leoflow/issues/194)) | **`execution_timeout_seconds`** (per-task) | **TI failed with `execution_timeout: task exceeded N`. Retries kick in if budget remains.** |
 | Agent process crashed mid-task (TI in `running`, no heartbeat) | TI heartbeat reaper ([#128](https://github.com/neochaotic/leoflow/issues/128)) | **90 s** | TI failed with `agent_lost`; the TI's pod is deleted so a partitioned-but-alive container stops. Retries kick in if budget remains. |
-| Scheduler crashed before dispatching (TI stuck in `queued`) | Dispatch-lost reaper ([#202](https://github.com/neochaotic/leoflow/issues/202)) | **3 min** | TI failed with `dispatch_lost` — but only if no live pod for it exists (see below); the pod is torn down. Frees the run for the orphan reaper on the next tick. |
+| Scheduler crashed before dispatching (TI stuck in `queued`) | Dispatch-lost reaper ([#202](https://github.com/neochaotic/leoflow/issues/202)) | **3 min** | TI failed with `dispatch_lost` — but only if no live pod for it exists (see below); the pod is torn down. Frees the run for the orphan reaper on the next maintenance cycle. |
+| Task pod vanished (TI in `running`, no Pending/Running pod for its attempt) | Pod-lost reaper | **60 s** after the running transition, then a live pod read | TI failed with `pod_lost`. Only after the reconciler has had its chance to recover the pod's durable outcome (see the settling gate below). |
+| Warm worker died holding attempts (warm pools only) | Warm-worker-lost reaper | next maintenance cycle | Each attempt bound to the dead worker is failed `pod_lost`; refill of the pool is the warm-pool reconciler's job, not the reaper's. |
 | Run stuck `running` with no active TIs (post-crash limbo) | Orphan-run reaper ([#120](https://github.com/neochaotic/leoflow/issues/120)) | **5 min** | Run failed with `orphaned`; any remaining active TIs flipped to `failed` and every pod of the run is deleted. |
 
-Worst case end-to-end: a mid-tick scheduler crash that leaves TIs queued is
-fully reaped within **`max(3 min, 5 min) = 5 min`** — the dispatch-lost reaper
-runs first, then the orphan-run reaper picks up the now-no-active-TI run on
-the next tick.
+Every SLA above is a floor: the reapers run every **30 s**, so detection lands
+up to one cycle after the threshold elapses. Worst case end-to-end: a mid-tick
+scheduler crash that leaves TIs queued is fully reaped within
+**`max(3 min, 5 min) + 30 s`** — the dispatch-lost reaper runs first, then the
+orphan-run reaper picks up the now-no-active-TI run on a later cycle.
+
+## Cadence: reconcile, then reap
+
+The reapers do **not** run from the scheduler's 1 s tick. They run from the
+leader's maintenance loop, which every 30 s performs **one ordered cycle**:
+
+1. the **pod reconciler** sweeps the task pods, recovers each finished pod's
+   durable outcome record (a success whose report was lost during an outage is
+   recorded as a success — [ADR 0052](/project/adrs/0052-durable-task-outcome/)),
+   and garbage-collects old finished pods;
+2. **then** the five reapers run.
+
+The order is structural, not a matter of timers lining up. Before this, the
+reapers ticked at 1 s and the reconciler at 30 s on an independent clock, so a
+pod-lost verdict could land on a pod the reconciler would have recovered as
+succeeded at its next sweep. The cost is up to 30 s of extra detection latency
+on top of thresholds of 60 s–5 min; reaping is a backstop, never the primary
+path, so that trade is the right one.
+
+### The leader-settling gate
+
+A control-plane restart manufactures the very signals the reapers act on:
+every in-flight heartbeat looks stale (the receiver was down), a task pod that
+finished during the outage looks lost (its terminal report found no server), a
+run looks quiet. So after this instance acquires leadership **no reaper fires**
+until the leader has **settled** — all three of:
+
+- the **settling grace** (180 s, twice the agent-lost threshold) has elapsed
+  since leadership, giving the whole fleet time to re-heartbeat;
+- the **pod informer cache has synced**, so the fleet view is complete;
+- **a reconciler sweep has completed under this leadership**, so every finished
+  pod's true outcome has been recovered before anything is declared lost.
+
+One gate, at the entry of the reaper pass, covers all five reapers (the
+warm-worker-lost reaper too: delaying it by the grace only postpones recovering
+a dead worker's attempts; pool refill is a separate loop and is not held).
+Measured from leadership acquisition, so a re-election resets it. While it
+holds, every cycle records `reap_settling_skip`.
+
+**Liveness valve.** A gate that could hold forever would trade "reap wrong" for
+"never reap". If the leader has not settled after **2 × grace (360 s)** — the
+reconciler cannot list pods, the informer never syncs — the reapers proceed
+anyway, with a `WARN` log and a `reap_settling_valve_open` decision on every
+cycle the valve stays open. By then the reconciler has had at least four cycles,
+so a valve that opens means the sweep really is broken; treat it as an alert.
+
+The server validates the timing ladder these depend on at boot and refuses to
+start if a constant was moved out of order:
+`heartbeat (15 s) < agent-lost threshold (90 s) < settling grace (180 s) < attempt token TTL (10 min)`,
+and `2 × maintenance interval (60 s) < settling grace`, so at least two whole
+reconcile-then-reap cycles complete inside the grace.
 
 ## Tuning the thresholds
 
-Defaults are conservative. For tighter recovery on a fast-failing workload,
-override via the scheduler interfaces:
+The thresholds and the settling grace are **build-time constants**
+(`executor.DefaultReaperConfig`), not operator knobs: they sit on the ladder
+above, and the boot-time validator exists precisely because moving one out of
+order turns a restart into a false reap. The one operator-tunable rung is
+`auth.max_attempt_credential_lifetime`, which must stay above the attempt token
+TTL; boot fails naming the key if it does not.
 
-```go
-sched.SetAgentLostThreshold(30 * time.Second)
-sched.SetDispatchLostThreshold(1 * time.Minute)
-sched.SetOrphanThreshold(2 * time.Minute)
-```
-
-For most users the defaults are correct: too-tight thresholds risk reaping a
-legitimately slow dispatch (Kubernetes pod-pull latency under contention) or
-a busy agent.
+The defaults are conservative on purpose: too-tight thresholds risk reaping a
+legitimately slow dispatch (Kubernetes pod-pull latency under contention) or a
+busy agent.
 
 ## The "do no harm" rule
 
@@ -63,10 +117,19 @@ anything:
   positive, [#461](https://github.com/neochaotic/leoflow/issues/461)) — the
   reaper defers. If pod liveness can't be determined (K8s API error), it also
   defers. A TI without a `queued_at` stamp is too poorly observed to reap.
+- **Pod-lost reaper** — requires a `running` TI past its 60 s liveness floor
+  AND a live read confirming no Pending/Running pod exists for exactly that
+  attempt. A cached "pod present" defers without an API call; a cache miss is
+  never trusted and falls through to the live read; a read error defers. And,
+  like every reaper, it waits for the leader-settling gate — so a pod that
+  finished during an outage is recovered by the reconciler, not failed.
+- **Warm-worker-lost reaper** — requires a live LIST of the warm pods (not the
+  cache) showing the bound worker gone; a LIST error aborts the pass with zero
+  marks. It never deletes a pod: a warm worker outlives its attempts.
 - **Orphan-run reaper** — requires `state = 'running'` AND no active TI on
   the run. A run with any TI in `scheduled`/`queued`/`running` is left alone
   (the dispatch-lost reaper unblocks this case by failing the stuck queued
-  TIs first, so the next tick sees no active TIs).
+  TIs first, so a later cycle sees no active TIs).
 
 ## Tearing down the reaped task's pod
 
@@ -120,10 +183,15 @@ your Prometheus dashboard:
 | `agent_lost` | TI failed by the heartbeat reaper |
 | `dispatch_lost` | TI failed by the dispatch-lost reaper |
 | `dispatch_lost_deferred` | Dispatch-lost skipped because the TI's pod is live (slow start, [#461](https://github.com/neochaotic/leoflow/issues/461)) — a healthy signal, not a fault |
+| `pod_lost` | TI failed by the pod-lost reaper (no live pod for the attempt) |
+| `warm_worker_lost` | TI failed by the warm-worker-lost reaper (its warm worker is gone) |
 | `orphan_reaped` | Run failed by the orphan-run reaper |
-| `agent_lost_list_error`, `dispatch_lost_list_error`, `orphan_list_error` | Reaper's list query failed; next tick will retry |
-| `dispatch_lost_pod_query_error` | Pod liveness could not be read (K8s API error); the reaper deferred rather than risk a false positive |
-| `agent_lost_pod_delete_error`, `dispatch_lost_pod_delete_error`, `orphan_pod_delete_error` | Pod teardown after a reap failed; the DB reap stands and the pod's `activeDeadlineSeconds`/GC are backstops |
+| `reap_settling_skip` | The whole reaper pass was held because the leader has not settled yet (grace, informer sync, or a post-leadership reconciler sweep still pending) — expected for ~3 min after every (re-)election |
+| `reap_settling_valve_open` | The leader never settled within 2 × grace and the reapers ran anyway; the reconciler sweep or the pod informer is broken — **alert on this** |
+| `reap_gate_skip` | The pass was skipped because this instance is stepping down, no longer leads, or is shutting down — a healthy signal during rollouts |
+| `agent_lost_list_error`, `dispatch_lost_list_error`, `orphan_list_error`, `pod_lost_list_error`, `warm_worker_lost_list_error` | Reaper's list query failed; the next cycle will retry |
+| `dispatch_lost_pod_query_error`, `pod_lost_pod_query_error` | Pod liveness could not be read (K8s API error); the reaper deferred rather than risk a false positive |
+| `agent_lost_pod_delete_error`, `dispatch_lost_pod_delete_error`, `orphan_pod_delete_error`, `pod_lost_pod_delete_error` | Pod teardown after a reap failed; the DB reap stands and the pod's `activeDeadlineSeconds`/GC are backstops |
 
 A sustained non-zero rate on any of these is worth investigating — reapers
 are backstops, not the primary path; if they fire often, something upstream


### PR DESCRIPTION
Part of #896 (structural follow-ups D2 + D3). Closes the CLASS behind the drill's race instead of patching reapers one by one.

## D3 — one leader-settling gate
A new leader may not take any destructive reaper action until it has **settled**: `elapsed ≥ SettlingGrace (180s) && informerSynced && lastSweepCompleted ≥ leaderSince`. Gated at `ReapOnce` entry; the per-write `mayReap` checks are unchanged. The per-reaper graces (`AgentLostGrace`, `PodLostLeaderGrace`, `inLeaderGrace`, the two `*_grace_skip` decisions) are **removed** — they read the same `leaderSince` with the same value, so the uniform gate is a strict superset; two knobs that must be kept equal by hand invite drift, and a per-reaper grace that stayed shut past the valve would silently defeat the valve.
**Liveness valve:** at `elapsed ≥ 2×grace` with any condition still pending (no completed sweep, or an informer that never synced), reaping proceeds with a WARN and a `reap_settling_valve_open` decision every cycle it stays open — "reap wrong" is never traded for "never reap". Nil predicates are satisfied (Lite wires no reaper and is unchanged); a zero leadership stamp is open (`mayReap` owns not-leading).

## D2 — reconcile then reap, in one maintenance loop
The reapers no longer run from the scheduler's 1s tick. A leader-gated maintenance ticker (the existing 30s `reconcileInterval`) runs `Reconcile` **then** `ReapOnce`, so reapers always see post-reconcile state and never act at 1s cadence on a stale view. A reconcile error is logged and reaping still runs — the settling gate, not the loop, decides whether a never-swept leader may reap. Detection latency for agent-lost grows by ≤30s against 60s–5min thresholds. `dispatchBackoff`/jitter untouched. The scheduler's reaper seam (`ExecutionReaper`, `SetExecutionReaper`, `reapOrphansIfLeader`) is removed entirely; `TestSchedulerTickHasNoReaperHook` (reflection) fails if a tick-driven reaper is ever re-added.

## Supporting changes
- Reconciler records `lastSweepCompleted` (atomic) at the end of a sweep that listed and visited every pod; a failed LIST records nothing.
- `PodInformer.HasSynced()` — a live predicate wired via `reaper.SetInformerSynced` (replaces the one-shot boot boolean).
- Ladder: `heartbeat < threshold < settling grace < token TTL`; `2×maintenance interval < settling grace` (≥2 whole reconcile→reap cycles inside the grace, ≥4 before the valve); infra re-place < orphan; TTL < credential ceiling.
- Docs: `operate/scheduler-resilience.md` (three → five reapers, stale API removed, new cadence + settling section, decision-label table) and `operate/control-plane-ha.md`; CHANGELOG `### Changed`.
- The chaos integration test drove the reaper through the removed seam; it now drives it the way the maintenance loop does.

## Verification
`go build ./...`, `go test ./...` (34 ok), `go vet -tags integration` and `-tags e2e`, `go test -tags integration ./internal/storage/ ./internal/api/` against Postgres (incl. the updated chaos test), `golangci-lint` 0 issues (fresh cache), gofmt clean, changelog gate OK. Operational timing (two full cycles inside the grace on a real apiserver; the valve never opening in a healthy cluster) is on the RC validation matrix in #896. `website/content/reference/go/*` (godoc mirror) deliberately not regenerated here — CI regenerates it before the Hugo build.