### PR TITLE
test/e2e: dump task pods, describe and logs when a dbt scenario fails

### DIFF
--- a/test/e2e/dbt-connection-e2e.sh
+++ b/test/e2e/dbt-connection-e2e.sh
@@ -33,7 +33,24 @@ WAREHOUSE="leoflow-dbt-conn-wh"
 API="http://localhost:${HTTP_PORT}"
 WORKDIR="$(mktemp -d)"
 
-fail() { echo "FAIL: $*" >&2; exit 1; }
+# dump_pods prints the task pods, a describe tail for those not Running, and
+# their logs — the evidence for diagnosing a failed task before the cleanup trap
+# deletes the cluster. Without it a failed run leaves only the server log, which
+# says nothing about why a pod exited.
+dump_pods() {
+  printf '\033[1;33m--- task pods (namespace leoflow) ---\033[0m\n' >&2
+  kubectl get pods -n leoflow -o wide >&2 2>&1 || true
+  for p in $(kubectl get pods -n leoflow -o name 2>/dev/null); do
+    phase="$(kubectl get -n leoflow "$p" -o jsonpath='{.status.phase}' 2>/dev/null)"
+    if [ "$phase" != "Running" ]; then
+      printf '\033[1;33m--- describe %s (%s) ---\033[0m\n' "$p" "$phase" >&2
+      kubectl describe -n leoflow "$p" >&2 2>&1 | tail -25 || true
+    fi
+    printf '\033[1;33m--- logs %s ---\033[0m\n' "$p" >&2
+    kubectl logs -n leoflow "$p" --all-containers --tail=80 >&2 2>&1 || true
+  done
+}
+fail() { echo "FAIL: $*" >&2; dump_pods; exit 1; }
 log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
 
 SERVER_PID=""

--- a/test/e2e/dbt-e2e.sh
+++ b/test/e2e/dbt-e2e.sh
@@ -38,7 +38,24 @@ WAREHOUSE="leoflow-dbt-e2e-wh"
 API="http://localhost:${HTTP_PORT}"
 WORKDIR="$(mktemp -d)"
 
-fail() { echo "FAIL: $*" >&2; exit 1; }
+# dump_pods prints the task pods, a describe tail for those not Running, and
+# their logs — the evidence for diagnosing a failed task before the cleanup trap
+# deletes the cluster. Without it a failed run leaves only the server log, which
+# says nothing about why a pod exited.
+dump_pods() {
+  printf '\033[1;33m--- task pods (namespace leoflow) ---\033[0m\n' >&2
+  kubectl get pods -n leoflow -o wide >&2 2>&1 || true
+  for p in $(kubectl get pods -n leoflow -o name 2>/dev/null); do
+    phase="$(kubectl get -n leoflow "$p" -o jsonpath='{.status.phase}' 2>/dev/null)"
+    if [ "$phase" != "Running" ]; then
+      printf '\033[1;33m--- describe %s (%s) ---\033[0m\n' "$p" "$phase" >&2
+      kubectl describe -n leoflow "$p" >&2 2>&1 | tail -25 || true
+    fi
+    printf '\033[1;33m--- logs %s ---\033[0m\n' "$p" >&2
+    kubectl logs -n leoflow "$p" --all-containers --tail=80 >&2 2>&1 || true
+  done
+}
+fail() { echo "FAIL: $*" >&2; dump_pods; exit 1; }
 log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
 
 SERVER_PID=""

--- a/test/e2e/dbt-mixing-e2e.sh
+++ b/test/e2e/dbt-mixing-e2e.sh
@@ -35,7 +35,24 @@ WORKDIR="$(mktemp -d)"
 # shellcheck disable=SC2206
 PARSER_CMD=(${LEOFLOW_E2E_PARSER_CMD:+--parser-cmd "$LEOFLOW_E2E_PARSER_CMD"})
 
-fail() { echo "FAIL: $*" >&2; exit 1; }
+# dump_pods prints the task pods, a describe tail for those not Running, and
+# their logs — the evidence for diagnosing a failed task before the cleanup trap
+# deletes the cluster. Without it a failed run leaves only the server log, which
+# says nothing about why a pod exited.
+dump_pods() {
+  printf '\033[1;33m--- task pods (namespace leoflow) ---\033[0m\n' >&2
+  kubectl get pods -n leoflow -o wide >&2 2>&1 || true
+  for p in $(kubectl get pods -n leoflow -o name 2>/dev/null); do
+    phase="$(kubectl get -n leoflow "$p" -o jsonpath='{.status.phase}' 2>/dev/null)"
+    if [ "$phase" != "Running" ]; then
+      printf '\033[1;33m--- describe %s (%s) ---\033[0m\n' "$p" "$phase" >&2
+      kubectl describe -n leoflow "$p" >&2 2>&1 | tail -25 || true
+    fi
+    printf '\033[1;33m--- logs %s ---\033[0m\n' "$p" >&2
+    kubectl logs -n leoflow "$p" --all-containers --tail=80 >&2 2>&1 || true
+  done
+}
+fail() { echo "FAIL: $*" >&2; dump_pods; exit 1; }
 log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
 
 SERVER_PID=""


### PR DESCRIPTION
Closes the diagnostics half of #919.

The three dbt E2E scripts (`dbt-e2e.sh`, `dbt-mixing-e2e.sh`, `dbt-connection-e2e.sh`) printed only `tail -30 server.log` on a failed task. When the pod fails on its own — a dbt error, an unreachable warehouse, `host.k3d.internal` not yet resolvable in a fresh k3d cluster — the server log says nothing, and by the time anyone looks the cleanup trap has deleted the cluster. That is exactly what made the single failure in #919 undiagnosable.

`fail()` now calls a `dump_pods` that prints `kubectl get pods -o wide`, a `describe` tail for every pod not `Running`, and `--all-containers --tail=80` logs for each pod — the same pattern `e2e.sh`, `deploy-e2e.sh` and `split-two-process.sh` already use. Test-only change; no behavior change in the product.