### PR TITLE
ci: fetch the PR base fully in the heavy-E2E gate (no merge base after the base advances)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -566,7 +566,13 @@ jobs:
             echo "Not a pull_request event — running heavy k3d E2E."
             exit 0
           fi
-          git fetch --depth=1 origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+          # Full fetch of the base, not --depth=1: the checkout above is fetch-depth 0,
+          # and a depth-1 fetch marks the base's CURRENT tip as a shallow boundary. The
+          # PR merge ref was cut against the base as it was when the run was queued, so
+          # whenever the base advances during the run (a merge landing), the shallow tip
+          # has no path back to the merge ref's parent and `...` fails with "no merge
+          # base" — and a rerun reuses the same merge ref, so it fails again.
+          git fetch origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
           FILES=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
           echo "Changed files:"; echo "$FILES"
           if [ -n "$FILES" ] && ! echo "$FILES" | grep -qvE '^(docs/|spec/|test/load/|website/|.*\.md$)'; then
@@ -653,7 +659,13 @@ jobs:
             echo "Not a pull_request event — running heavy k3d E2E."
             exit 0
           fi
-          git fetch --depth=1 origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+          # Full fetch of the base, not --depth=1: the checkout above is fetch-depth 0,
+          # and a depth-1 fetch marks the base's CURRENT tip as a shallow boundary. The
+          # PR merge ref was cut against the base as it was when the run was queued, so
+          # whenever the base advances during the run (a merge landing), the shallow tip
+          # has no path back to the merge ref's parent and `...` fails with "no merge
+          # base" — and a rerun reuses the same merge ref, so it fails again.
+          git fetch origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
           FILES=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
           echo "Changed files:"; echo "$FILES"
           if [ -n "$FILES" ] && ! echo "$FILES" | grep -qvE '^(docs/|spec/|test/load/|website/|.*\.md$)'; then
@@ -737,7 +749,13 @@ jobs:
             echo "Not a pull_request event — running heavy k3d E2E."
             exit 0
           fi
-          git fetch --depth=1 origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+          # Full fetch of the base, not --depth=1: the checkout above is fetch-depth 0,
+          # and a depth-1 fetch marks the base's CURRENT tip as a shallow boundary. The
+          # PR merge ref was cut against the base as it was when the run was queued, so
+          # whenever the base advances during the run (a merge landing), the shallow tip
+          # has no path back to the merge ref's parent and `...` fails with "no merge
+          # base" — and a rerun reuses the same merge ref, so it fails again.
+          git fetch origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
           FILES=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
           echo "Changed files:"; echo "$FILES"
           if [ -n "$FILES" ] && ! echo "$FILES" | grep -qvE '^(docs/|spec/|test/load/|website/|.*\.md$)'; then
@@ -855,7 +873,13 @@ jobs:
             echo "Not a pull_request event — running heavy k3d E2E."
             exit 0
           fi
-          git fetch --depth=1 origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
+          # Full fetch of the base, not --depth=1: the checkout above is fetch-depth 0,
+          # and a depth-1 fetch marks the base's CURRENT tip as a shallow boundary. The
+          # PR merge ref was cut against the base as it was when the run was queued, so
+          # whenever the base advances during the run (a merge landing), the shallow tip
+          # has no path back to the merge ref's parent and `...` fails with "no merge
+          # base" — and a rerun reuses the same merge ref, so it fails again.
+          git fetch origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
           FILES=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
           echo "Changed files:"; echo "$FILES"
           if [ -n "$FILES" ] && ! echo "$FILES" | grep -qvE '^(docs/|spec/|test/load/|website/|.*\.md$)'; then


### PR DESCRIPTION
Two of PR #914's heavy E2E jobs failed twice in a row in "Gate heavy E2E on code changes" with:

```
fatal: origin/main...HEAD: no merge base
##[error]Process completed with exit code 128.
```

Mechanism: the job checks out with `fetch-depth: 0`, then the gate runs `git fetch --depth=1 origin main:refs/remotes/origin/main`. A depth-1 fetch marks main's **current** tip as a shallow boundary and cuts its parents. The PR merge ref (`refs/pull/N/merge`) was cut against main as it stood when the run was queued; two merges landed on main during #914's run, so the shallow new tip had no path back to the merge ref's base parent and the three-dot diff had no merge base. A rerun reuses the same merge ref, so it fails identically — which is why it looked deterministic.

Fix: fetch the base without `--depth=1` in the four gate steps (operator, split, dbt, deploy E2E). The checkout is already full, so the fetch is incremental. Comment left in the workflow so the flag does not come back. CI-only change, `skip-changelog`.