### PR TITLE
resilience: boot WARN when the attempt credential ceiling is disabled; honest docs for its two roles; ladder/gate wiring tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,15 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   The shipped default stays `replicaCount: 1`: flipping it would
   Multi-Attach-break every existing install on upgrade.
 
+- **Boot `WARN` when `auth.max_attempt_credential_lifetime` is disabled.** A
+  non-positive value is a documented setting the boot-time ladder check
+  accepts, but it now removes two backstops at once: heartbeat renewal of an
+  attempt's credential becomes unbounded, and task pods with no declared
+  `execution_timeout` get no `activeDeadlineSeconds` floor. The server logs one
+  `WARN` naming the key and both consequences; boot proceeds. The field's godoc
+  and the agent-credential-transport operator page now state both roles of the
+  knob.
+
 ### Changed
 
 - **The reapers now run from a 30 s leader maintenance loop, ordered after the
@@ -98,8 +107,13 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     pod also gets an `activeDeadlineSeconds` floor when its DAG declares no
     execution timeout — derived from `auth.max_attempt_credential_lifetime`,
     past which the pod cannot renew its credential — so no task pod is left
-    Running forever after a total control-plane outage. A user-declared timeout
-    is never shortened.
+    Running forever after a total control-plane outage (unless the ceiling is
+    disabled, which also disables this floor). A user-declared timeout is
+    never shortened. The floor is load-bearing only when the control plane
+    never returns: if it comes back after the token has lapsed, the rejected
+    bearer already makes the agent exit promptly. It makes explicit a bound
+    that held in practice before — the ceiling was a de-facto attempt-lifetime
+    cap of roughly ceiling + token TTL + the agent-lost threshold.
   - The pod-lost reaper (every scheduler tick) raced the reconciler (every 30s)
     for a pod that finished during the outage, and won — marking it `pod_lost`
     before the reconciler could recover the pod's durable outcome record. It now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,12 +54,14 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **Boot `WARN` when `auth.max_attempt_credential_lifetime` is disabled.** A
   non-positive value is a documented setting the boot-time ladder check
-  accepts, but it now removes two backstops at once: heartbeat renewal of an
-  attempt's credential becomes unbounded, and task pods with no declared
-  `execution_timeout` get no `activeDeadlineSeconds` floor. The server logs one
-  `WARN` naming the key and both consequences; boot proceeds. The field's godoc
-  and the agent-credential-transport operator page now state both roles of the
-  knob.
+  accepts, but it removes every wall-clock bound the ceiling carries: heartbeat
+  renewal of an attempt's credential becomes unbounded, task pods with no
+  declared `execution_timeout` get no `activeDeadlineSeconds` floor, and with
+  warm pools enabled the per-attempt watchdog is off — a wedged task then has no
+  bound of its own even with a healthy control plane. The server logs one
+  `WARN` naming the key and the consequences; boot proceeds. The field's godoc
+  and the agent-credential-transport and warm-pools operator pages now state
+  every role of the knob.
 
 ### Changed
 

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -121,6 +121,7 @@ func run() error {
 		return fmt.Errorf("observability setup: %w", err)
 	}
 	defer shutdownTel()
+	warnStartup(cfg, tel.Logger)
 
 	pg, err := openVerifiedPostgres(ctx, cfg.Database)
 	if err != nil {
@@ -351,6 +352,18 @@ func validateStartup(cfg *config.ServerConfig) error {
 		return err
 	}
 	return executor.ValidateResilienceLadder(resilienceLadder(cfg))
+}
+
+// warnStartup surfaces the boot-time settings validateStartup accepts but that
+// remove a resilience backstop — today the disabled credential ceiling, which
+// unbounds heartbeat renewal AND drops the task pod deadline floor. They are
+// documented settings, not errors, so boot proceeds; the WARN is the only
+// operator-visible signal that both guarantees are off. It runs after the
+// logger exists, right after validation has passed.
+func warnStartup(cfg *config.ServerConfig, logger *slog.Logger) {
+	for _, w := range executor.ResilienceLadderWarnings(resilienceLadder(cfg)) {
+		logger.Warn(w)
+	}
 }
 
 // resilienceLadder assembles the effective timing knobs the control-plane

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -356,11 +356,19 @@ func validateStartup(cfg *config.ServerConfig) error {
 
 // warnStartup surfaces the boot-time settings validateStartup accepts but that
 // remove a resilience backstop — today the disabled credential ceiling, which
-// unbounds heartbeat renewal AND drops the task pod deadline floor. They are
-// documented settings, not errors, so boot proceeds; the WARN is the only
-// operator-visible signal that both guarantees are off. It runs after the
-// logger exists, right after validation has passed.
+// unbounds heartbeat renewal, drops the task pod deadline floor and switches
+// off the warm-pool attempt watchdog. They are documented settings, not errors,
+// so boot proceeds; the WARN is the only operator-visible signal that those
+// guarantees are off. It runs after the logger exists, right after validation
+// has passed. Only a process that serves the scheduler warns: token renewal
+// lives in the agent gRPC server and the pod deadline floor in the dispatcher,
+// both scheduler-side, so an api-only replica in a split install would be
+// warning about behavior it does not implement — and a WARN operators learn to
+// ignore is worse than none.
 func warnStartup(cfg *config.ServerConfig, logger *slog.Logger) {
+	if !cfg.Server.ServesScheduler() {
+		return
+	}
 	for _, w := range executor.ResilienceLadderWarnings(resilienceLadder(cfg)) {
 		logger.Warn(w)
 	}

--- a/cmd/leoflow-server/resilience_ladder_wiring_test.go
+++ b/cmd/leoflow-server/resilience_ladder_wiring_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -50,5 +52,34 @@ func TestResilienceLadderWiringFailsOnShortCredentialCeiling(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "auth.max_attempt_credential_lifetime") {
 		t.Errorf("error %q must name the config key the operator has to move", err)
+	}
+}
+
+// TestResilienceLadderWiringWarnsWhenCredentialCeilingDisabled: a non-positive
+// auth.max_attempt_credential_lifetime passes validation (it is the documented
+// "no ceiling" setting) yet silently removes two backstops — unbounded heartbeat
+// renewal and no activeDeadlineSeconds floor on task pods without a declared
+// execution_timeout. The boot WARN is the operator's only signal, so the boot
+// path must emit exactly one WARN naming the key when the ceiling is disabled,
+// and none when it is set.
+func TestResilienceLadderWiringWarnsWhenCredentialCeilingDisabled(t *testing.T) {
+	warn := func(d time.Duration) string {
+		var buf bytes.Buffer
+		cfg := &config.ServerConfig{}
+		cfg.Auth.MaxAttemptCredentialLifetime = d
+		warnStartup(cfg, slog.New(slog.NewTextHandler(&buf, nil)))
+		return buf.String()
+	}
+	for _, d := range []time.Duration{0, -time.Minute} {
+		out := warn(d)
+		if strings.Count(out, "level=WARN") != 1 {
+			t.Errorf("ceiling %v: want exactly one WARN, got %q", d, out)
+		}
+		if !strings.Contains(out, "auth.max_attempt_credential_lifetime") || !strings.Contains(out, "activeDeadlineSeconds") {
+			t.Errorf("ceiling %v: WARN must name the key and the lost pod deadline floor, got %q", d, out)
+		}
+	}
+	if out := warn(24 * time.Hour); out != "" {
+		t.Errorf("a set ceiling must log nothing at boot, got %q", out)
 	}
 }

--- a/cmd/leoflow-server/resilience_ladder_wiring_test.go
+++ b/cmd/leoflow-server/resilience_ladder_wiring_test.go
@@ -88,4 +88,15 @@ func TestResilienceLadderWiringWarnsWhenCredentialCeilingDisabled(t *testing.T) 
 	if out := warn(24 * time.Hour); out != "" {
 		t.Errorf("a set ceiling must log nothing at boot, got %q", out)
 	}
+	// Both guarantees live on the scheduler side (token renewal in the agent
+	// gRPC server, the pod deadline floor in the dispatcher), so an api-only
+	// process in a split install must not warn about behavior it does not
+	// implement — a WARN operators learn to ignore is worse than none.
+	var buf bytes.Buffer
+	cfg := &config.ServerConfig{}
+	cfg.Server.Role = "api"
+	warnStartup(cfg, slog.New(slog.NewTextHandler(&buf, nil)))
+	if buf.Len() != 0 {
+		t.Errorf("an api-only role must not emit the credential-ceiling WARN, got %q", buf.String())
+	}
 }

--- a/cmd/leoflow-server/resilience_ladder_wiring_test.go
+++ b/cmd/leoflow-server/resilience_ladder_wiring_test.go
@@ -14,13 +14,19 @@ import (
 
 // TestResilienceLadderWiringValidates pins that the ladder the server actually
 // boots with — agent heartbeat/TTL, default reaper config, reconcile interval,
-// the scheduler's infra re-place ceiling and the default credential-lifetime
-// ceiling — satisfies every ordering the restart recovery depends on. A change
-// to any one of those constants that breaks the order fails this test before it
-// fails a deployment at boot.
+// the scheduler's infra re-place ceiling and the SHIPPED default
+// credential-lifetime ceiling — satisfies every ordering the restart recovery
+// depends on. The ceiling is read from the config defaults rather than
+// hardcoded, so a change to the shipped default that breaks the order fails
+// this test too, not only a change to a build-time constant.
 func TestResilienceLadderWiringValidates(t *testing.T) {
-	cfg := &config.ServerConfig{}
-	cfg.Auth.MaxAttemptCredentialLifetime = 24 * time.Hour
+	cfg, err := config.LoadServer("", nil)
+	if err != nil {
+		t.Fatalf("LoadServer with shipped defaults: %v", err)
+	}
+	if cfg.Auth.MaxAttemptCredentialLifetime <= 0 {
+		t.Fatalf("the shipped default credential ceiling must be set, got %v", cfg.Auth.MaxAttemptCredentialLifetime)
+	}
 	l := resilienceLadder(cfg)
 	if err := executor.ValidateResilienceLadder(l); err != nil {
 		t.Fatalf("server ladder %+v must validate: %v", l, err)
@@ -34,8 +40,8 @@ func TestResilienceLadderWiringValidates(t *testing.T) {
 	if l.OrphanThreshold != executor.DefaultReaperConfig().OrphanThreshold {
 		t.Errorf("ladder must carry the orphan threshold, got %v", l.OrphanThreshold)
 	}
-	if l.MaxAttemptCredentialLifetime != 24*time.Hour {
-		t.Errorf("ladder must carry the configured credential ceiling, got %v", l.MaxAttemptCredentialLifetime)
+	if l.MaxAttemptCredentialLifetime != cfg.Auth.MaxAttemptCredentialLifetime {
+		t.Errorf("ladder must carry the shipped default credential ceiling %v, got %v", cfg.Auth.MaxAttemptCredentialLifetime, l.MaxAttemptCredentialLifetime)
 	}
 }
 

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -418,8 +418,12 @@ type AuthSection struct {
 	// forever (a declared timeout is never shortened). Generous by default (24h)
 	// so no normal task regresses. Bind via
 	// LEOFLOW_AUTH_MAX_ATTEMPT_CREDENTIAL_LIFETIME as a duration (e.g. "24h",
-	// "90m"). A non-positive value disables BOTH the renewal ceiling and the pod
-	// deadline floor; boot logs a WARN so the loss is visible.
+	// "90m"). With warm pools enabled it is also the per-attempt watchdog that
+	// keeps a wedged attempt from pinning a warm slot (a warm pod has no pod-level
+	// deadline; the worker lifetime cap drains between attempts, never
+	// mid-attempt). A non-positive value disables the renewal ceiling, the pod
+	// deadline floor and that watchdog together — a wedged task then has no
+	// wall-clock bound of its own — so boot logs a WARN naming the key.
 	MaxAttemptCredentialLifetime time.Duration `mapstructure:"max_attempt_credential_lifetime"`
 	// AgentTokenTransport selects how the in-pod agent obtains its control-plane
 	// bearer credential (ADR 0055 Fix #3): "envvar" (the default) sets the token as
@@ -614,8 +618,9 @@ var serverDefaults = map[string]any{
 	// flip to it is a separate operator decision after real-cluster e2e.
 	"auth.agent_token_transport": "envvar",
 	// Hard ceiling on an attempt's total renewed credential lifetime (ADR 0055
-	// Fix #4) and the activeDeadlineSeconds floor of a task pod with no declared
-	// execution_timeout. Generous by default so nothing regresses; the short
+	// Fix #4), the activeDeadlineSeconds floor of a task pod with no declared
+	// execution_timeout, and the warm-pool per-attempt watchdog. Generous by
+	// default so nothing regresses; the short
 	// per-attempt TTL is what bounds a stolen token. Parsed as a duration by
 	// viper's decode hook.
 	"auth.max_attempt_credential_lifetime": "24h",

--- a/internal/config/server.go
+++ b/internal/config/server.go
@@ -411,9 +411,15 @@ type AuthSection struct {
 	// Fix #4). Past this age since first dispatch, the control plane stops renewing
 	// the token on heartbeat and lets it lapse, bounding a runaway attempt. The
 	// short per-attempt TTL still bounds a stolen/finished token independently;
-	// this only caps the total renewed lifetime. Generous by default (24h) so no
-	// normal task regresses. Bind via LEOFLOW_AUTH_MAX_ATTEMPT_CREDENTIAL_LIFETIME
-	// as a duration (e.g. "24h", "90m"); a non-positive value disables the ceiling.
+	// this caps the total renewed lifetime. It governs a second guarantee too: the
+	// Kubernetes executor floors a task pod's activeDeadlineSeconds with it when
+	// the DAG declares no execution_timeout, so a pod whose agent keeps retrying
+	// its report through a total control-plane outage is not left Running
+	// forever (a declared timeout is never shortened). Generous by default (24h)
+	// so no normal task regresses. Bind via
+	// LEOFLOW_AUTH_MAX_ATTEMPT_CREDENTIAL_LIFETIME as a duration (e.g. "24h",
+	// "90m"). A non-positive value disables BOTH the renewal ceiling and the pod
+	// deadline floor; boot logs a WARN so the loss is visible.
 	MaxAttemptCredentialLifetime time.Duration `mapstructure:"max_attempt_credential_lifetime"`
 	// AgentTokenTransport selects how the in-pod agent obtains its control-plane
 	// bearer credential (ADR 0055 Fix #3): "envvar" (the default) sets the token as
@@ -608,8 +614,10 @@ var serverDefaults = map[string]any{
 	// flip to it is a separate operator decision after real-cluster e2e.
 	"auth.agent_token_transport": "envvar",
 	// Hard ceiling on an attempt's total renewed credential lifetime (ADR 0055
-	// Fix #4). Generous by default so nothing regresses; the short per-attempt TTL
-	// is what bounds a stolen token. Parsed as a duration by viper's decode hook.
+	// Fix #4) and the activeDeadlineSeconds floor of a task pod with no declared
+	// execution_timeout. Generous by default so nothing regresses; the short
+	// per-attempt TTL is what bounds a stolen token. Parsed as a duration by
+	// viper's decode hook.
 	"auth.max_attempt_credential_lifetime": "24h",
 	// OIDC leaves. Every leaf is registered so viper's AutomaticEnv binds the
 	// scalar LEOFLOW_AUTH_OIDC_* env vars (notably the client secret). The slice

--- a/internal/executor/reaper_test.go
+++ b/internal/executor/reaper_test.go
@@ -406,3 +406,52 @@ func TestReapersHonorGateAtTeardown(t *testing.T) {
 		}
 	})
 }
+
+// leadingOpenThenClosed returns a leadership predicate (the SetLeading shape)
+// that reports leading for the first n consultations and not-leading after. It
+// models a leadership loss that lands after ReapOnce's entry check and before
+// the reapers reach their writes.
+func leadingOpenThenClosed(n int) func() bool {
+	calls := 0
+	return func() bool {
+		calls++
+		return calls <= n
+	}
+}
+
+// TestNewReaperWiresGateIntoEveryReaper: the destructive gate is only a
+// guarantee if NewReaper hands it to all five reapers. TestReapersHonorGateMidTick
+// drives each reaper with its own gate, so it cannot notice a dropped
+// assignment in NewReaper — a reaper with a nil gate is unconditionally open.
+// Here the whole Reaper is driven through ReapOnce with a leadership predicate
+// that is open exactly once: the entry check consumes that one, so every
+// reaper's own pre-write check finds it closed. Nothing may be destroyed and each
+// reaper must meter its own gate skip exactly once — a reaper whose gate was
+// not wired would write instead. The settling gate is open (no leadership
+// stamp), so it does not stand between the entry check and the reapers.
+func TestNewReaperWiresGateIntoEveryReaper(t *testing.T) {
+	store := staleEverythingStore()
+	pods := &fakePodManager{active: map[string]bool{}}
+	rec := &capturingRecorder{}
+	r := NewReaper(store, pods, nil, &fakeWarmLister{}, rec, reapTestLogger(), DefaultReaperConfig(), nil)
+	r.SetLeading(leadingOpenThenClosed(1))
+
+	if err := r.ReapOnce(context.Background()); err != nil {
+		t.Fatalf("ReapOnce: %v", err)
+	}
+	assertNothingDestroyed(t, store, pods)
+	if got := rec.count("reap_gate_skip"); got != 0 {
+		t.Errorf("the entry check must pass (it consumed the open consultation), reap_gate_skip = %d", got)
+	}
+	for _, skip := range []string{
+		"orphan_gate_skip",
+		"agent_lost_gate_skip",
+		"dispatch_lost_gate_skip",
+		"pod_lost_gate_skip",
+		"warm_worker_lost_gate_skip",
+	} {
+		if got := rec.count(skip); got != 1 {
+			t.Errorf("%s = %d, want exactly 1 (is that reaper's gate wired in NewReaper?)", skip, got)
+		}
+	}
+}

--- a/internal/executor/reaper_test.go
+++ b/internal/executor/reaper_test.go
@@ -443,6 +443,13 @@ func TestNewReaperWiresGateIntoEveryReaper(t *testing.T) {
 	if got := rec.count("reap_gate_skip"); got != 0 {
 		t.Errorf("the entry check must pass (it consumed the open consultation), reap_gate_skip = %d", got)
 	}
+	// Guard against a false accusation: if the settling gate ever stood between
+	// the entry check and the reapers here, every count below would read 0 and
+	// the message would blame the wiring. Nil predicates and no leadership stamp
+	// must keep settling open in this test.
+	if got := rec.count("reap_settling_skip"); got != 0 {
+		t.Fatalf("settling must not stand between the entry check and the reapers in this test (candidates come from staleEverythingStore, one per reaper), reap_settling_skip = %d", got)
+	}
 	for _, skip := range []string{
 		"orphan_gate_skip",
 		"agent_lost_gate_skip",

--- a/internal/executor/resilience_ladder.go
+++ b/internal/executor/resilience_ladder.go
@@ -150,16 +150,21 @@ func ValidateResilienceLadder(l ResilienceLadder) error {
 // remove a resilience backstop, so the server can surface them as boot WARNs.
 // ValidateResilienceLadder deliberately accepts a non-positive credential
 // ceiling — it is the operator's documented "no ceiling" setting — but that one
-// value disables two guarantees at once: heartbeat renewal of an attempt's
-// bearer becomes unbounded, and a task pod whose DAG declares no execution
-// timeout gets no ActiveDeadlineSeconds floor, so a total control-plane outage
-// can leave it Running indefinitely. Neither loss is an error; both are
-// invisible without this signal. Pure, like the validator: the server calls it
-// once at boot after the logger exists.
+// value disables every wall-clock bound the ceiling carries: heartbeat renewal
+// of an attempt's bearer becomes unbounded; a dedicated task pod whose DAG
+// declares no execution timeout gets no ActiveDeadlineSeconds floor; and, with
+// warm pools enabled, the per-attempt watchdog that keeps a wedged attempt from
+// pinning a warm slot is off too (a warm pod has no pod-level deadline at all,
+// and the worker lifetime cap drains between attempts, never mid-attempt). A
+// task that wedges while still heartbeating then has no bound of its own even
+// with a healthy control plane: the orphan-run reaper skips a run with a live
+// task instance and agent-lost never fires on a live agent. None of these
+// losses is an error; all are invisible without this signal. Pure, like the
+// validator: the server calls it once at boot after the logger exists.
 func ResilienceLadderWarnings(l ResilienceLadder) []string {
 	var warnings []string
 	if l.MaxAttemptCredentialLifetime <= 0 {
-		warnings = append(warnings, fmt.Sprintf("%s is disabled (%v): heartbeat renewal of an attempt's credential is unbounded AND task pods with no declared execution_timeout get no activeDeadlineSeconds floor, so a total control-plane outage can leave them Running indefinitely",
+		warnings = append(warnings, fmt.Sprintf("%s is disabled (%v): heartbeat renewal of an attempt's credential is unbounded, task pods with no declared execution_timeout get no activeDeadlineSeconds floor, and with warm pools enabled the per-attempt watchdog is off — a wedged or partitioned task pod has no wall-clock bound of its own",
 			maxAttemptCredentialLifetimeKey, l.MaxAttemptCredentialLifetime))
 	}
 	return warnings

--- a/internal/executor/resilience_ladder.go
+++ b/internal/executor/resilience_ladder.go
@@ -145,3 +145,22 @@ func ValidateResilienceLadder(l ResilienceLadder) error {
 	}
 	return nil
 }
+
+// ResilienceLadderWarnings reports the ladder settings that are valid but
+// remove a resilience backstop, so the server can surface them as boot WARNs.
+// ValidateResilienceLadder deliberately accepts a non-positive credential
+// ceiling — it is the operator's documented "no ceiling" setting — but that one
+// value disables two guarantees at once: heartbeat renewal of an attempt's
+// bearer becomes unbounded, and a task pod whose DAG declares no execution
+// timeout gets no ActiveDeadlineSeconds floor, so a total control-plane outage
+// can leave it Running indefinitely. Neither loss is an error; both are
+// invisible without this signal. Pure, like the validator: the server calls it
+// once at boot after the logger exists.
+func ResilienceLadderWarnings(l ResilienceLadder) []string {
+	var warnings []string
+	if l.MaxAttemptCredentialLifetime <= 0 {
+		warnings = append(warnings, fmt.Sprintf("%s is disabled (%v): heartbeat renewal of an attempt's credential is unbounded AND task pods with no declared execution_timeout get no activeDeadlineSeconds floor, so a total control-plane outage can leave them Running indefinitely",
+			maxAttemptCredentialLifetimeKey, l.MaxAttemptCredentialLifetime))
+	}
+	return warnings
+}

--- a/internal/executor/resilience_ladder_test.go
+++ b/internal/executor/resilience_ladder_test.go
@@ -168,7 +168,7 @@ func TestResilienceLadderWarningsDisabledCredentialCeiling(t *testing.T) {
 		if len(got) != 1 {
 			t.Fatalf("ceiling %v: want exactly one warning, got %q", d, got)
 		}
-		for _, want := range []string{"auth.max_attempt_credential_lifetime", "disabled", "renewal", "activeDeadlineSeconds"} {
+		for _, want := range []string{"auth.max_attempt_credential_lifetime", "disabled", "renewal", "activeDeadlineSeconds", "watchdog", "wedged"} {
 			if !strings.Contains(got[0], want) {
 				t.Errorf("ceiling %v: warning %q must mention %q", d, got[0], want)
 			}

--- a/internal/executor/resilience_ladder_test.go
+++ b/internal/executor/resilience_ladder_test.go
@@ -152,3 +152,29 @@ func TestValidateResilienceLadderRejectsEachViolation(t *testing.T) {
 		})
 	}
 }
+
+// TestResilienceLadderWarningsDisabledCredentialCeiling: a non-positive
+// credential ceiling is a documented setting the validator tolerates, but it
+// silently removes TWO backstops at once — heartbeat renewal becomes unbounded
+// and a task pod with no declared execution timeout gets no ActiveDeadlineSeconds
+// floor. The operator's only signal is the boot WARN, so the warnings must name
+// the key and both consequences for zero and for negative values, and must be
+// empty when the ceiling is set.
+func TestResilienceLadderWarningsDisabledCredentialCeiling(t *testing.T) {
+	for _, d := range []time.Duration{0, -time.Second} {
+		l := defaultLadder()
+		l.MaxAttemptCredentialLifetime = d
+		got := ResilienceLadderWarnings(l)
+		if len(got) != 1 {
+			t.Fatalf("ceiling %v: want exactly one warning, got %q", d, got)
+		}
+		for _, want := range []string{"auth.max_attempt_credential_lifetime", "disabled", "renewal", "activeDeadlineSeconds"} {
+			if !strings.Contains(got[0], want) {
+				t.Errorf("ceiling %v: warning %q must mention %q", d, got[0], want)
+			}
+		}
+	}
+	if got := ResilienceLadderWarnings(defaultLadder()); len(got) != 0 {
+		t.Errorf("a set ceiling must produce no warning, got %q", got)
+	}
+}

--- a/website/content/operate/agent-credential-transport.md
+++ b/website/content/operate/agent-credential-transport.md
@@ -157,7 +157,7 @@ dimensions of the same credential and are configured independently:
 | `agent_token_transport` | **how** the credential reaches the pod | `envvar` | `exchange` keeps it off the plaintext pod spec and enables per-attempt identity. |
 | `secret_liveness_mode` | **when** a token stops resolving secrets | `observe` | `enforce` denies a not-live token's secret reads. Always-on liveness renewal underlies both modes. |
 | `secret_scoping` | **what** a task may fetch | `permissive` | `enforce` delivers only the DAG's declared subset; `off` disables scoping. |
-| `max_attempt_credential_lifetime` | **how long** an attempt's renewed credential may live — and the `activeDeadlineSeconds` floor of a task pod with no declared `execution_timeout` | `24h` | A runaway-task backstop for both the credential and the pod; the short per-attempt TTL is what bounds a stolen token. Non-positive disables both (boot logs a `WARN`). |
+| `max_attempt_credential_lifetime` | **how long** an attempt's renewed credential may live — also the `activeDeadlineSeconds` floor of a task pod with no declared `execution_timeout`, and the warm-pool per-attempt watchdog | `24h` | A runaway-task backstop for the credential, the pod and the warm slot; the short per-attempt TTL is what bounds a stolen token. Non-positive disables all three — a wedged task then has no wall-clock bound of its own — and boot logs a `WARN`. |
 
 Warm pools require `agent_token_transport=exchange` **and**
 `secret_liveness_mode=enforce`. `secret_scoping` and

--- a/website/content/operate/agent-credential-transport.md
+++ b/website/content/operate/agent-credential-transport.md
@@ -157,7 +157,7 @@ dimensions of the same credential and are configured independently:
 | `agent_token_transport` | **how** the credential reaches the pod | `envvar` | `exchange` keeps it off the plaintext pod spec and enables per-attempt identity. |
 | `secret_liveness_mode` | **when** a token stops resolving secrets | `observe` | `enforce` denies a not-live token's secret reads. Always-on liveness renewal underlies both modes. |
 | `secret_scoping` | **what** a task may fetch | `permissive` | `enforce` delivers only the DAG's declared subset; `off` disables scoping. |
-| `max_attempt_credential_lifetime` | **how long** an attempt's renewed credential may live | `24h` | A runaway-task backstop; the short per-attempt TTL is what bounds a stolen token. |
+| `max_attempt_credential_lifetime` | **how long** an attempt's renewed credential may live — and the `activeDeadlineSeconds` floor of a task pod with no declared `execution_timeout` | `24h` | A runaway-task backstop for both the credential and the pod; the short per-attempt TTL is what bounds a stolen token. Non-positive disables both (boot logs a `WARN`). |
 
 Warm pools require `agent_token_transport=exchange` **and**
 `secret_liveness_mode=enforce`. `secret_scoping` and

--- a/website/content/operate/scheduler-resilience.md
+++ b/website/content/operate/scheduler-resilience.md
@@ -103,8 +103,9 @@ above, and the boot-time validator exists precisely because moving one out of
 order turns a restart into a false reap. The one operator-tunable rung is
 `auth.max_attempt_credential_lifetime`, which must stay above the attempt token
 TTL; boot fails naming the key if it does not. Setting it non-positive is
-accepted but disables both the renewal ceiling and the task-pod
-`activeDeadlineSeconds` floor, so boot logs a `WARN` naming the key.
+accepted but disables the renewal ceiling, the task-pod `activeDeadlineSeconds`
+floor and the warm-pool attempt watchdog together, so boot logs a `WARN` naming
+the key.
 
 The defaults are conservative on purpose: too-tight thresholds risk reaping a
 legitimately slow dispatch (Kubernetes pod-pull latency under contention) or a

--- a/website/content/operate/scheduler-resilience.md
+++ b/website/content/operate/scheduler-resilience.md
@@ -102,7 +102,9 @@ The thresholds and the settling grace are **build-time constants**
 above, and the boot-time validator exists precisely because moving one out of
 order turns a restart into a false reap. The one operator-tunable rung is
 `auth.max_attempt_credential_lifetime`, which must stay above the attempt token
-TTL; boot fails naming the key if it does not.
+TTL; boot fails naming the key if it does not. Setting it non-positive is
+accepted but disables both the renewal ceiling and the task-pod
+`activeDeadlineSeconds` floor, so boot logs a `WARN` naming the key.
 
 The defaults are conservative on purpose: too-tight thresholds risk reaping a
 legitimately slow dispatch (Kubernetes pod-pull latency under contention) or a

--- a/website/content/operate/warm-pools.md
+++ b/website/content/operate/warm-pools.md
@@ -321,7 +321,8 @@ in-flight attempt on its own renewed credential before recycling. (There is
 therefore **no** `max_worker_lifetime ≥ max_attempt_credential_lifetime` boot guard —
 the real "credential lapses mid-attempt" bound is per-attempt, enforced on the
 execution path via the attempt watchdog, not by an ordering rule between these two
-knobs.)
+knobs. The watchdog is derived from `max_attempt_credential_lifetime`, so a
+non-positive ceiling disables it too — boot logs a `WARN`.)
 
 ### Losing a worker
 

--- a/website/content/reference/go/internal-agent.md
+++ b/website/content/reference/go/internal-agent.md
@@ -1,8 +1,4 @@
 ---
-# --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
-aliases:
-  - /go/internal/agent.html
-# --- end AUTO redirect aliases ---
 title: "internal/agent"
 linkTitle: "internal/agent"
 weight: 5
@@ -26,6 +22,7 @@ Package agent contains the worker\-side logic that runs inside the task containe
 - [func ReadReturnValue\(path string\) \(value \[\]byte, ok bool, err error\)](<#ReadReturnValue>)
 - [func ReadTokenFile\(path string\) \(string, error\)](<#ReadTokenFile>)
 - [func ReportBootstrapFailure\(path string, stage BootstrapStage, err error\)](<#ReportBootstrapFailure>)
+- [func ResolverFromEnv\(getenv func\(string\) string\) \(secretsource.SecretResolver, secretsource.Backend, error\)](<#ResolverFromEnv>)
 - [func XComEnvVar\(name string, value \[\]byte\) string](<#XComEnvVar>)
 - [type BootstrapStage](<#BootstrapStage>)
 - [type CommandRunner](<#CommandRunner>)
@@ -141,6 +138,15 @@ ReportBootstrapFailure records a classified pre\-registration failure on the con
 
 It is best\-effort and never fails the caller: the agent is already exiting, and a lost diagnostic must not change the exit path. An empty path \(outside a pod\) is a no\-op.
 
+<a name="ResolverFromEnv"></a>
+## func [ResolverFromEnv](<https://github.com/neochaotic/leoflow/blob/main/internal/agent/secret_resolver.go#L67>)
+
+```go
+func ResolverFromEnv(getenv func(string) string) (secretsource.SecretResolver, secretsource.Backend, error)
+```
+
+ResolverFromEnv builds the external\-secrets resolver \+ its routing Backend from the operator\-injected LEOFLOW\_SECRETS\_\* pod env \(operator\-only: the dispatch filter, \#828, keeps an author's task env from setting LEOFLOW\_ keys\). It returns a nil resolver when no backend is configured — the chain then stays vault\-only, byte\-identical to the pre\-0060 env\-export. A malformed config fails closed \(returned error\) rather than silently disabling external secrets.
+
 <a name="XComEnvVar"></a>
 ## func [XComEnvVar](<https://github.com/neochaotic/leoflow/blob/main/internal/agent/command.go#L86>)
 
@@ -173,7 +179,7 @@ const (
 ```
 
 <a name="CommandRunner"></a>
-## type [CommandRunner](<https://github.com/neochaotic/leoflow/blob/main/internal/agent/runner.go#L27-L29>)
+## type [CommandRunner](<https://github.com/neochaotic/leoflow/blob/main/internal/agent/runner.go#L28-L30>)
 
 CommandRunner executes the user task process, writing its stdout and stderr to the supplied writers and returning the process exit code.
 
@@ -193,7 +199,7 @@ func NewExecRunner() CommandRunner
 NewExecRunner returns a CommandRunner that executes tasks as child processes.
 
 <a name="LogSink"></a>
-## type [LogSink](<https://github.com/neochaotic/leoflow/blob/main/internal/agent/runner.go#L38-L41>)
+## type [LogSink](<https://github.com/neochaotic/leoflow/blob/main/internal/agent/runner.go#L39-L42>)
 
 LogSink receives log lines produced by the user task. Sends are best\-effort.
 
@@ -214,7 +220,7 @@ func OpenLogSink(ctx context.Context, client agentv1.AgentServiceClient) (LogSin
 OpenLogSink starts the StreamLogs RPC and returns a sink that forwards lines to it. It is the agent's first RPC, so it uses WaitForReady: with the lazy connection of grpc.NewClient the channel may not be established yet, and without this the stream would fail fast on a cold connection \(the "opening log stream" EOF in \#36\) rather than waiting for the control plane to be reachable.
 
 <a name="NoopLogSink"></a>
-## type [NoopLogSink](<https://github.com/neochaotic/leoflow/blob/main/internal/agent/runner.go#L46>)
+## type [NoopLogSink](<https://github.com/neochaotic/leoflow/blob/main/internal/agent/runner.go#L47>)
 
 NoopLogSink discards log lines. The agent falls back to it when the control plane log stream is unavailable \(e.g. StreamLogs not yet implemented\), so a task still runs even though its logs are not shipped this run.
 
@@ -223,7 +229,7 @@ type NoopLogSink struct{}
 ```
 
 <a name="NoopLogSink.Close"></a>
-### func \(NoopLogSink\) [Close](<https://github.com/neochaotic/leoflow/blob/main/internal/agent/runner.go#L52>)
+### func \(NoopLogSink\) [Close](<https://github.com/neochaotic/leoflow/blob/main/internal/agent/runner.go#L53>)
 
 ```go
 func (NoopLogSink) Close() error
@@ -232,7 +238,7 @@ func (NoopLogSink) Close() error
 Close is a no\-op.
 
 <a name="NoopLogSink.Send"></a>
-### func \(NoopLogSink\) [Send](<https://github.com/neochaotic/leoflow/blob/main/internal/agent/runner.go#L49>)
+### func \(NoopLogSink\) [Send](<https://github.com/neochaotic/leoflow/blob/main/internal/agent/runner.go#L50>)
 
 ```go
 func (NoopLogSink) Send(*agentv1.LogLine) error
@@ -241,7 +247,7 @@ func (NoopLogSink) Send(*agentv1.LogLine) error
 Send discards the line.
 
 <a name="Runner"></a>
-## type [Runner](<https://github.com/neochaotic/leoflow/blob/main/internal/agent/runner.go#L58-L95>)
+## type [Runner](<https://github.com/neochaotic/leoflow/blob/main/internal/agent/runner.go#L59-L111>)
 
 Runner orchestrates a single task execution inside the worker container: it registers with the control plane, fetches the task spec and XCom inputs, runs the user process while streaming logs, pushes the return value, and reports the terminal state.
 
@@ -259,6 +265,14 @@ type Runner struct {
     // ReschedulePath is the file a reschedule-mode sensor writes its next-poke time
     // to before exiting with rescheduleExitCode; empty disables reschedule (#380).
     ReschedulePath string
+    // TmpDir, when set, is exported to the task as TMPDIR so the child's temp files
+    // land in a per-attempt directory the caller wipes between attempts, instead of
+    // the pod's real /tmp. The warm worker points this at a subdir of its scratch
+    // (reset before every attempt) so no attempt observes another attempt's temp
+    // files — a token cache, a dbt profile, ~/.aws-style credentials (#728). Empty
+    // leaves TMPDIR untouched: a single-shot pod is already destroyed per task, so
+    // its /tmp needs no in-process reset.
+    TmpDir string
     // TerminationLogPath is where the agent writes its durable outcome record just
     // before delivering the report, so a pod killed mid-report still leaves the
     // task's true result behind for the reconciler to recover (ADR 0052). Empty
@@ -280,12 +294,20 @@ type Runner struct {
     // binary wires it, from an env var, to exit the process, simulating a pod
     // killed mid-report with the record already on disk. Nil in production.
     BeforeReport func(agentv1.TaskState)
+
+    // Resolver resolves a declared secret name from an external backend, pod-side
+    // (ADR 0060). Nil = no external backend configured: the resolution chain is the
+    // vault only, byte-identical to the pre-0060 env-export. SecretBackend is the
+    // operator-configured routing (which kinds/names are externally sourced); its
+    // zero value covers nothing, so a nil-or-zero pair never calls the resolver.
+    Resolver      secretsource.SecretResolver
+    SecretBackend secretsource.Backend
     // contains filtered or unexported fields
 }
 ```
 
 <a name="Runner.Run"></a>
-### func \(\*Runner\) [Run](<https://github.com/neochaotic/leoflow/blob/main/internal/agent/runner.go#L110>)
+### func \(\*Runner\) [Run](<https://github.com/neochaotic/leoflow/blob/main/internal/agent/runner.go#L126>)
 
 ```go
 func (r *Runner) Run(ctx context.Context) error

--- a/website/content/reference/go/internal-agentrpc.md
+++ b/website/content/reference/go/internal-agentrpc.md
@@ -1,8 +1,4 @@
 ---
-# --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
-aliases:
-  - /go/internal/agentrpc.html
-# --- end AUTO redirect aliases ---
 title: "internal/agentrpc"
 linkTitle: "internal/agentrpc"
 weight: 6
@@ -53,6 +49,7 @@ Package agentrpc implements the control\-plane side of the agent gRPC protocol: 
   - [func \(s \*Server\) SetSecretScopeAuditor\(a SecretScopeAuditor\)](<#Server.SetSecretScopeAuditor>)
   - [func \(s \*Server\) SetSecretScoping\(policy string\)](<#Server.SetSecretScoping>)
   - [func \(s \*Server\) SetSecrets\(store SecretsStore, allowInsecure bool\)](<#Server.SetSecrets>)
+  - [func \(s \*Server\) SetShutdown\(ctx context.Context\)](<#Server.SetShutdown>)
   - [func \(s \*Server\) SetTokenExchange\(reviewer TokenReviewer, resolver PodTaskResolver, minter AgentTokenMinter, ttl time.Duration, allowInsecure bool\)](<#Server.SetTokenExchange>)
   - [func \(s \*Server\) SetTokenRenewal\(renewer AgentTokenRenewer, renewalTTL, maxAttemptLifetime time.Duration\)](<#Server.SetTokenRenewal>)
   - [func \(s \*Server\) SetWarmPools\(reg \*WorkerRegistry\)](<#Server.SetWarmPools>)
@@ -256,24 +253,28 @@ type ReviewedPod struct {
 ```
 
 <a name="SecretLivenessAuditor"></a>
-## type [SecretLivenessAuditor](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/secrets.go#L83-L85>)
+## type [SecretLivenessAuditor](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/secrets.go#L85-L89>)
 
 SecretLivenessAuditor records a structured audit event when the secret\-path liveness gate fires: a would\-have\-denied in observe mode, or a denial in enforce mode \(ADR 0055\). It carries identity \+ kind \+ mode only, never secret names or values. Optional and best\-effort: a nil auditor or a write error only skips the row; it never changes the gate's decision.
 
 ```go
 type SecretLivenessAuditor interface {
-    RecordSecretLivenessDenial(ctx context.Context, tenant, dagID, runID, taskID string, tryNumber int, kind, mode string) error
+    // tenantID is the tenant UUID the agent token carries (AgentIdentity.TenantID),
+    // not the tenant name.
+    RecordSecretLivenessDenial(ctx context.Context, tenantID, dagID, runID, taskID string, tryNumber int, kind, mode string) error
 }
 ```
 
 <a name="SecretScopeAuditor"></a>
-## type [SecretScopeAuditor](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/secrets.go#L51-L53>)
+## type [SecretScopeAuditor](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/secrets.go#L51-L55>)
 
 SecretScopeAuditor records a structured audit event when a task receives the full tenant secret set despite declaring only a subset of it — the visibility half of the warn\-before\-enforce arc \(ADR 0045 §Settled \#3, ADR 0055\). It carries counts only, never secret names or values. It is optional and best\-effort: a nil auditor or a write error only skips the audit row; it never changes what is delivered.
 
 ```go
 type SecretScopeAuditor interface {
-    RecordSecretScopeWarning(ctx context.Context, tenant, dagID, runID, taskID, kind string, declared, total int) error
+    // tenantID is the tenant UUID the agent token carries (AgentIdentity.TenantID),
+    // not the tenant name.
+    RecordSecretScopeWarning(ctx context.Context, tenantID, dagID, runID, taskID, kind string, declared, total int) error
 }
 ```
 
@@ -294,7 +295,7 @@ type SecretsStore interface {
 ```
 
 <a name="Server"></a>
-## type [Server](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L145-L184>)
+## type [Server](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L145-L190>)
 
 Server implements agentv1.AgentServiceServer over a Store and Authenticator.
 
@@ -306,7 +307,7 @@ type Server struct {
 ```
 
 <a name="NewServer"></a>
-### func [NewServer](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L188>)
+### func [NewServer](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L194>)
 
 ```go
 func NewServer(authn Authenticator, store Store, xcomSvc XComService) *Server
@@ -350,7 +351,7 @@ ExchangeToken validates the agent's projected ServiceAccount token \(bootstrap b
 It fails closed at every step: Unimplemented when the exchange is not wired, PermissionDenied on an insecure channel, Unauthenticated on a missing or rejected projected token, and Internal when the reviewed pod cannot be resolved to an attempt \(never mint an unscoped or misattributed token\). The minted token and the presented projected token are never logged.
 
 <a name="Server.FetchXCom"></a>
-### func \(\*Server\) [FetchXCom](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L413>)
+### func \(\*Server\) [FetchXCom](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L428>)
 
 ```go
 func (s *Server) FetchXCom(ctx context.Context, req *agentv1.FetchXComRequest) (*agentv1.FetchXComResponse, error)
@@ -359,7 +360,7 @@ func (s *Server) FetchXCom(ctx context.Context, req *agentv1.FetchXComRequest) (
 FetchXCom returns an upstream task's value, but only from a task the caller declared as an XCom input within the same run \(and, by construction, the same tenant\), enforcing cross\-tenant and cross\-run isolation.
 
 <a name="Server.GetConnections"></a>
-### func \(\*Server\) [GetConnections](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/secrets.go#L254>)
+### func \(\*Server\) [GetConnections](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/secrets.go#L258>)
 
 ```go
 func (s *Server) GetConnections(ctx context.Context, _ *agentv1.GetConnectionsRequest) (*agentv1.GetConnectionsResponse, error)
@@ -368,7 +369,7 @@ func (s *Server) GetConnections(ctx context.Context, _ *agentv1.GetConnectionsRe
 GetConnections returns the calling task's tenant Connections as Airflow URIs for the agent to export as AIRFLOW\_CONN\_\<CONN\_ID\>.
 
 <a name="Server.GetTaskSpec"></a>
-### func \(\*Server\) [GetTaskSpec](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L224>)
+### func \(\*Server\) [GetTaskSpec](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L237>)
 
 ```go
 func (s *Server) GetTaskSpec(ctx context.Context, _ *agentv1.GetTaskSpecRequest) (*agentv1.TaskSpec, error)
@@ -377,7 +378,7 @@ func (s *Server) GetTaskSpec(ctx context.Context, _ *agentv1.GetTaskSpecRequest)
 GetTaskSpec returns the execution spec for the calling task instance.
 
 <a name="Server.GetVariables"></a>
-### func \(\*Server\) [GetVariables](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/secrets.go#L216>)
+### func \(\*Server\) [GetVariables](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/secrets.go#L220>)
 
 ```go
 func (s *Server) GetVariables(ctx context.Context, _ *agentv1.GetVariablesRequest) (*agentv1.GetVariablesResponse, error)
@@ -386,7 +387,7 @@ func (s *Server) GetVariables(ctx context.Context, _ *agentv1.GetVariablesReques
 GetVariables returns the calling task's tenant Variables for the agent to export as AIRFLOW\_VAR\_\<KEY\>.
 
 <a name="Server.Heartbeat"></a>
-### func \(\*Server\) [Heartbeat](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L313>)
+### func \(\*Server\) [Heartbeat](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L328>)
 
 ```go
 func (s *Server) Heartbeat(ctx context.Context, _ *agentv1.HeartbeatRequest) (*agentv1.HeartbeatResponse, error)
@@ -395,7 +396,7 @@ func (s *Server) Heartbeat(ctx context.Context, _ *agentv1.HeartbeatRequest) (*a
 Heartbeat stamps the per\-TI liveness signal \(\#128\) and returns the server clock so the agent can detect skew. A storage error stamping the heartbeat is logged but does not fail the RPC — failing the call would risk the agent terminating itself unnecessarily on a transient DB blip. The scheduler reaper would, in the worst case, fail the TI as agent\_lost on the next tick; correct under "do no harm" \(ADR 0031\).
 
 <a name="Server.PushXCom"></a>
-### func \(\*Server\) [PushXCom](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L385>)
+### func \(\*Server\) [PushXCom](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L400>)
 
 ```go
 func (s *Server) PushXCom(ctx context.Context, req *agentv1.PushXComRequest) (*agentv1.PushXComResponse, error)
@@ -404,7 +405,7 @@ func (s *Server) PushXCom(ctx context.Context, req *agentv1.PushXComRequest) (*a
 PushXCom stores a value the task produced, keyed by the caller's identity. Size/schema violations are returned as a rejection, not a transport error, so the agent can fail the task with a clear reason.
 
 <a name="Server.Register"></a>
-### func \(\*Server\) [Register](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L212>)
+### func \(\*Server\) [Register](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L225>)
 
 ```go
 func (s *Server) Register(ctx context.Context, _ *agentv1.RegisterRequest) (*agentv1.RegisterResponse, error)
@@ -413,7 +414,7 @@ func (s *Server) Register(ctx context.Context, _ *agentv1.RegisterRequest) (*age
 Register acknowledges an agent's startup and returns the server clock.
 
 <a name="Server.ReportState"></a>
-### func \(\*Server\) [ReportState](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L263>)
+### func \(\*Server\) [ReportState](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L278>)
 
 ```go
 func (s *Server) ReportState(ctx context.Context, req *agentv1.ReportStateRequest) (*agentv1.ReportStateResponse, error)
@@ -431,7 +432,7 @@ func (s *Server) SetLeaderCheck(fn func() bool)
 SetLeaderCheck gates AwaitAssignment to the scheduler leader \(warm\-pool Hole B\). Each scheduler replica wires its OWN leadership predicate, so a follower refuses the stream \(FailedPrecondition\) and only the leader — whose leader\-only placer consults the same in\-memory registry the worker registers into — serves it. A nil predicate \(the default\) leaves the handler unchecked, so a single\-node or unwired deployment serves exactly as before.
 
 <a name="Server.SetLivenessGate"></a>
-### func \(\*Server\) [SetLivenessGate](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/secrets.go#L103>)
+### func \(\*Server\) [SetLivenessGate](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/secrets.go#L107>)
 
 ```go
 func (s *Server) SetLivenessGate(checker TaskLivenessChecker, mode string)
@@ -440,7 +441,7 @@ func (s *Server) SetLivenessGate(checker TaskLivenessChecker, mode string)
 SetLivenessGate attaches the read\-only task\-instance liveness predicate the secret path consults, in the given mode \("observe" | "enforce", ADR 0055 E2\). An unrecognized mode falls back to observe — the safe, non\-denying default. A nil checker leaves the gate off \(delivery unchanged\), so the gate is opt\-in.
 
 <a name="Server.SetLogPublisher"></a>
-### func \(\*Server\) [SetLogPublisher](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L209>)
+### func \(\*Server\) [SetLogPublisher](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L222>)
 
 ```go
 func (s *Server) SetLogPublisher(p LogPublisher)
@@ -449,7 +450,7 @@ func (s *Server) SetLogPublisher(p LogPublisher)
 SetLogPublisher attaches the live\-tail publisher \(optional\). When set, StreamLogs publishes each line for the UI's live tail.
 
 <a name="Server.SetLogSink"></a>
-### func \(\*Server\) [SetLogSink](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L205>)
+### func \(\*Server\) [SetLogSink](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L218>)
 
 ```go
 func (s *Server) SetLogSink(sink LogSink)
@@ -458,7 +459,7 @@ func (s *Server) SetLogSink(sink LogSink)
 SetLogSink attaches the log sink that StreamLogs writes to. Without it, StreamLogs reports Unimplemented.
 
 <a name="Server.SetSecretLivenessAuditor"></a>
-### func \(\*Server\) [SetSecretLivenessAuditor](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/secrets.go#L115>)
+### func \(\*Server\) [SetSecretLivenessAuditor](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/secrets.go#L119>)
 
 ```go
 func (s *Server) SetSecretLivenessAuditor(a SecretLivenessAuditor)
@@ -467,7 +468,7 @@ func (s *Server) SetSecretLivenessAuditor(a SecretLivenessAuditor)
 SetSecretLivenessAuditor attaches the sink for secret\-path liveness events \(optional\). Without it, a would\-have\-denied / denial still produces the WARN log but no audit row.
 
 <a name="Server.SetSecretScopeAuditor"></a>
-### func \(\*Server\) [SetSecretScopeAuditor](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/secrets.go#L97>)
+### func \(\*Server\) [SetSecretScopeAuditor](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/secrets.go#L101>)
 
 ```go
 func (s *Server) SetSecretScopeAuditor(a SecretScopeAuditor)
@@ -476,7 +477,7 @@ func (s *Server) SetSecretScopeAuditor(a SecretScopeAuditor)
 SetSecretScopeAuditor attaches the sink for secret\-scope warning events \(optional\). Without it, a narrowing declaration still produces the WARN log but no audit row.
 
 <a name="Server.SetSecretScoping"></a>
-### func \(\*Server\) [SetSecretScoping](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/secrets.go#L121>)
+### func \(\*Server\) [SetSecretScoping](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/secrets.go#L125>)
 
 ```go
 func (s *Server) SetSecretScoping(policy string)
@@ -485,13 +486,22 @@ func (s *Server) SetSecretScoping(policy string)
 SetSecretScoping sets the operator scope\-by\-declaration policy \(ADR 0055 D9\): "enforce" | "permissive" | "off". An unrecognized value falls back to permissive — the safe, non\-denying default — so a misconfiguration never silently denies. The policy is operator\-scoped, never author\-settable.
 
 <a name="Server.SetSecrets"></a>
-### func \(\*Server\) [SetSecrets](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/secrets.go#L90>)
+### func \(\*Server\) [SetSecrets](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/secrets.go#L94>)
 
 ```go
 func (s *Server) SetSecrets(store SecretsStore, allowInsecure bool)
 ```
 
 SetSecrets attaches the secrets store. allowInsecure permits serving secrets over a non\-TLS channel — for local/dev only; production must use TLS \(the handlers fail closed otherwise\). See ADR 0021 / issue \#58.
+
+<a name="Server.SetShutdown"></a>
+### func \(\*Server\) [SetShutdown](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L214>)
+
+```go
+func (s *Server) SetShutdown(ctx context.Context)
+```
+
+SetShutdown wires the control plane's shutdown context: once ctx ends, every open StreamLogs returns Unavailable after closing \(flushing\) its log writer, so the gRPC graceful stop that follows completes instead of waiting for the tasks themselves to finish. The agent treats the closed stream as best\-effort log delivery and keeps running its task.
 
 <a name="Server.SetTokenExchange"></a>
 ### func \(\*Server\) [SetTokenExchange](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/exchange.go#L69>)
@@ -503,7 +513,7 @@ func (s *Server) SetTokenExchange(reviewer TokenReviewer, resolver PodTaskResolv
 SetTokenExchange wires the projected\-SA\-token exchange \(ADR 0055 Fix \#3\): the TokenReview client, the pod→task\-instance resolver, the JWT minter, and the TTL of the minted task\-scoped token. allowInsecure permits running the exchange over a non\-TLS channel \(dev only\); production must use TLS \(ExchangeToken fails closed otherwise, like the secret path\). A nil reviewer leaves the exchange OFF — ExchangeToken then reports Unimplemented — which is the default \(env\-var\) transport, so a deployment that does not opt in is byte\-identical to today.
 
 <a name="Server.SetTokenRenewal"></a>
-### func \(\*Server\) [SetTokenRenewal](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L199>)
+### func \(\*Server\) [SetTokenRenewal](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L205>)
 
 ```go
 func (s *Server) SetTokenRenewal(renewer AgentTokenRenewer, renewalTTL, maxAttemptLifetime time.Duration)
@@ -521,13 +531,13 @@ func (s *Server) SetWarmPools(reg *WorkerRegistry)
 SetWarmPools wires a prebuilt warm\-worker assignment registry \(ADR 0058 N1b\). A nil registry \(the default\) leaves AwaitAssignment inert — it returns FailedPrecondition — so with execution.warm\_pools\_enabled off the transport is completely dormant and no running path changes. Used by tests to inject a registry with a deterministic lease; callers wire it via EnableWarmPools.
 
 <a name="Server.StreamLogs"></a>
-### func \(\*Server\) [StreamLogs](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L450>)
+### func \(\*Server\) [StreamLogs](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L466>)
 
 ```go
 func (s *Server) StreamLogs(stream agentv1.AgentService_StreamLogsServer) (err error)
 ```
 
-StreamLogs receives the task's log lines and writes them through the sink, flushing on stream end so the logs survive the pod.
+StreamLogs receives the task's log lines and writes them through the sink, flushing on stream end so the logs survive the pod. The stream also ends when the control plane shuts down \(SetShutdown\), so the flush runs before exit.
 
 <a name="Store"></a>
 ## type [Store](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L107-L126>)
@@ -558,7 +568,7 @@ type Store interface {
 ```
 
 <a name="TaskLivenessChecker"></a>
-## type [TaskLivenessChecker](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/secrets.go#L74-L76>)
+## type [TaskLivenessChecker](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/secrets.go#L76-L78>)
 
 TaskLivenessChecker reports whether a task\-instance attempt is still live — present and in an active \(non\-terminal\) state for the given \(run, task, try\). It is the read\-only revocation signal the secret path consults \(ADR 0055 D3\): a terminal, superseded, or reaped attempt is not live, so its token stops resolving secrets. The predicate derives ONLY from \(run, task, try\) \+ active state — never run recency — so a clear\-and\-rerun of an old run stays live.
 

--- a/website/content/reference/go/internal-api.md
+++ b/website/content/reference/go/internal-api.md
@@ -1,8 +1,4 @@
 ---
-# --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
-aliases:
-  - /go/internal/api.html
-# --- end AUTO redirect aliases ---
 title: "internal/api"
 linkTitle: "internal/api"
 weight: 11
@@ -55,6 +51,7 @@ Package api implements the Airflow\-compatible HTTP control plane \(ADR 0007\).
 - [type Problem](<#Problem>)
 - [type TaskInstanceRepository](<#TaskInstanceRepository>)
 - [type TaskSummaryReader](<#TaskSummaryReader>)
+- [type TokenRenewer](<#TokenRenewer>)
 - [type UIServer](<#UIServer>)
 - [type UserAuditWriter](<#UserAuditWriter>)
 - [type UserStore](<#UserStore>)
@@ -116,7 +113,7 @@ func JWTAuth(authn auth.Authenticator) gin.HandlerFunc
 JWTAuth validates the bearer token on protected routes and stores the user.
 
 <a name="NewServer"></a>
-## func [NewServer](<https://github.com/neochaotic/leoflow/blob/main/internal/api/server.go#L127>)
+## func [NewServer](<https://github.com/neochaotic/leoflow/blob/main/internal/api/server.go#L140>)
 
 ```go
 func NewServer(deps Dependencies) *gin.Engine
@@ -209,7 +206,7 @@ type AuditLogReader interface {
 ```
 
 <a name="AuditWriter"></a>
-## type [AuditWriter](<https://github.com/neochaotic/leoflow/blob/main/internal/api/resources.go#L55-L57>)
+## type [AuditWriter](<https://github.com/neochaotic/leoflow/blob/main/internal/api/resources.go#L57-L59>)
 
 AuditWriter records task\-level actions \(clear, mark state\) for the Audit Log view, with the acting user and the run/task in the entry.
 
@@ -231,7 +228,7 @@ type AuthAuditWriter interface {
 ```
 
 <a name="ConnectionStore"></a>
-## type [ConnectionStore](<https://github.com/neochaotic/leoflow/blob/main/internal/api/ui_connections.go#L14-L19>)
+## type [ConnectionStore](<https://github.com/neochaotic/leoflow/blob/main/internal/api/ui_connections.go#L76-L81>)
 
 ConnectionStore reads and writes Airflow\-style Connections for the Admin UI. Password is encrypted at rest by the store \(ADR 0019\) and never returned.
 
@@ -239,7 +236,7 @@ ConnectionStore reads and writes Airflow\-style Connections for the Admin UI. Pa
 type ConnectionStore interface {
     ListConnections(ctx context.Context, tenant string, limit, offset int) ([]domain.Connection, int, error)
     GetConnection(ctx context.Context, tenant, connID string) (domain.Connection, error)
-    SetConnection(ctx context.Context, tenant string, c domain.Connection) error
+    SetConnectionPatch(ctx context.Context, tenant string, p domain.ConnectionPatch) error
     DeleteConnection(ctx context.Context, tenant, connID string) error
 }
 ```
@@ -267,7 +264,7 @@ type DagLatestRunsReader interface {
 ```
 
 <a name="DagRepository"></a>
-## type [DagRepository](<https://github.com/neochaotic/leoflow/blob/main/internal/api/resources.go#L23-L30>)
+## type [DagRepository](<https://github.com/neochaotic/leoflow/blob/main/internal/api/resources.go#L25-L32>)
 
 DagRepository reads, updates, and deletes registered DAGs.
 
@@ -283,7 +280,7 @@ type DagRepository interface {
 ```
 
 <a name="DagRunRepository"></a>
-## type [DagRunRepository](<https://github.com/neochaotic/leoflow/blob/main/internal/api/resources.go#L33-L39>)
+## type [DagRunRepository](<https://github.com/neochaotic/leoflow/blob/main/internal/api/resources.go#L35-L41>)
 
 DagRunRepository reads and creates DAG runs.
 
@@ -346,7 +343,7 @@ type DashboardStatsReader interface {
 ```
 
 <a name="Dependencies"></a>
-## type [Dependencies](<https://github.com/neochaotic/leoflow/blob/main/internal/api/server.go#L29-L123>)
+## type [Dependencies](<https://github.com/neochaotic/leoflow/blob/main/internal/api/server.go#L29-L136>)
 
 Dependencies bundles everything the HTTP server needs.
 
@@ -367,6 +364,15 @@ type Dependencies struct {
     // CIDR so per-client rate-limiting and audit see the real client.
     TrustedProxies []string
     TokenTTLSecs   int
+    // TokenRenewer re-mints a still-valid user bearer with a fresh short TTL so a
+    // long CLI/dev session need not re-login every TokenTTLSecs (aresta #5). Nil
+    // leaves the renew route unregistered (renewal simply unavailable). In practice
+    // it is the same *auth.JWTAuthenticator as Authenticator.
+    TokenRenewer TokenRenewer
+    // TokenMaxLifetimeSecs is the hard ceiling on a renewed session's total age
+    // since first login; past it, renewal is refused and the user must
+    // re-authenticate. Non-positive disables the ceiling.
+    TokenMaxLifetimeSecs int
     // InstanceName is shown in the UI navbar (Airflow's instance_name). Empty
     // falls back to "Leoflow"; `leoflow dev` sets it to mark the DEV environment.
     InstanceName string
@@ -435,6 +441,10 @@ type Dependencies struct {
     // OIDCFlow is the discovered Authorization Code + PKCE flow; nil in JWT mode,
     // in which case the /api/v2/auth/oidc/* routes are not registered.
     OIDCFlow *oidc.Flow
+    // OIDCEnabled is true when auth.provider is "oidc". It makes the credential
+    // path break-glass-only: with OIDC on, an empty break-glass allowlist means
+    // SSO-only (every password login rejected), NOT ungated — the secure default.
+    OIDCEnabled bool
     // OIDCSettings carries the role mappings, JIT policy, default_role, and
     // break-glass allowlist the login flow and the credential gate read.
     OIDCSettings config.OIDCSection
@@ -586,7 +596,7 @@ type Problem struct {
 ```
 
 <a name="TaskInstanceRepository"></a>
-## type [TaskInstanceRepository](<https://github.com/neochaotic/leoflow/blob/main/internal/api/resources.go#L43-L51>)
+## type [TaskInstanceRepository](<https://github.com/neochaotic/leoflow/blob/main/internal/api/resources.go#L45-L53>)
 
 TaskInstanceRepository reads task instances, clears them for re\-run, and sets their state directly \(the UI's mark\-success/failed actions\).
 
@@ -610,6 +620,17 @@ TaskSummaryReader fetches task instances across a set of runs of a DAG, the sour
 ```go
 type TaskSummaryReader interface {
     TaskInstancesForRuns(ctx context.Context, tenant, dagID string, runIDs []string) ([]domain.TaskInstance, error)
+}
+```
+
+<a name="TokenRenewer"></a>
+## type [TokenRenewer](<https://github.com/neochaotic/leoflow/blob/main/internal/api/auth_handler.go#L18-L20>)
+
+TokenRenewer re\-mints a still\-valid user bearer with a fresh short TTL, bounded by max\_lifetime since first login. \*auth.JWTAuthenticator implements it via RenewUserToken; the handler depends on this narrow interface so the renew route can be tested without a real signing key.
+
+```go
+type TokenRenewer interface {
+    RenewUserToken(token string, ttl, maxLifetime time.Duration) (renewed string, ok bool, err error)
 }
 ```
 
@@ -649,7 +670,7 @@ type UserStore interface {
 ```
 
 <a name="VariableStore"></a>
-## type [VariableStore](<https://github.com/neochaotic/leoflow/blob/main/internal/api/ui_variables.go#L14-L19>)
+## type [VariableStore](<https://github.com/neochaotic/leoflow/blob/main/internal/api/ui_variables.go#L15-L20>)
 
 VariableStore reads and writes Airflow\-style Variables for the Admin UI.
 
@@ -657,7 +678,7 @@ VariableStore reads and writes Airflow\-style Variables for the Admin UI.
 type VariableStore interface {
     ListVariables(ctx context.Context, tenant string, limit, offset int) ([]domain.Variable, int, error)
     GetVariable(ctx context.Context, tenant, key string) (domain.Variable, error)
-    SetVariable(ctx context.Context, tenant string, v domain.Variable) error
+    SetVariablePatch(ctx context.Context, tenant string, p domain.VariablePatch) error
     DeleteVariable(ctx context.Context, tenant, key string) error
 }
 ```

--- a/website/content/reference/go/internal-auth.md
+++ b/website/content/reference/go/internal-auth.md
@@ -1,8 +1,4 @@
 ---
-# --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
-aliases:
-  - /go/internal/auth.html
-# --- end AUTO redirect aliases ---
 title: "internal/auth"
 linkTitle: "internal/auth"
 weight: 8
@@ -31,6 +27,7 @@ Package auth provides JWT authentication, password hashing, the RBAC permission 
   - [func \(a \*JWTAuthenticator\) IssueAgentToken\(id AgentIdentity, ttl time.Duration\) \(string, error\)](<#JWTAuthenticator.IssueAgentToken>)
   - [func \(a \*JWTAuthenticator\) IssueToken\(ctx context.Context, creds Credentials\) \(string, error\)](<#JWTAuthenticator.IssueToken>)
   - [func \(a \*JWTAuthenticator\) RenewAgentToken\(token string, ttl, maxLifetime time.Duration\) \(renewed string, ok bool, err error\)](<#JWTAuthenticator.RenewAgentToken>)
+  - [func \(a \*JWTAuthenticator\) RenewUserToken\(token string, ttl, maxLifetime time.Duration\) \(renewed string, ok bool, err error\)](<#JWTAuthenticator.RenewUserToken>)
 - [type Permission](<#Permission>)
 - [type RateLimiter](<#RateLimiter>)
   - [func NewRateLimiter\(limit int, window time.Duration\) \*RateLimiter](<#NewRateLimiter>)
@@ -85,7 +82,7 @@ func HashPassword(password string) (string, error)
 HashPassword hashes a plaintext password with bcrypt.
 
 <a name="MintUserToken"></a>
-## func [MintUserToken](<https://github.com/neochaotic/leoflow/blob/main/internal/auth/jwt.go#L62>)
+## func [MintUserToken](<https://github.com/neochaotic/leoflow/blob/main/internal/auth/jwt.go#L69>)
 
 ```go
 func MintUserToken(secret string, ttl time.Duration, user User) (string, error)
@@ -155,7 +152,7 @@ type Credentials struct {
 ```
 
 <a name="JWTAuthenticator"></a>
-## type [JWTAuthenticator](<https://github.com/neochaotic/leoflow/blob/main/internal/auth/jwt.go#L32-L40>)
+## type [JWTAuthenticator](<https://github.com/neochaotic/leoflow/blob/main/internal/auth/jwt.go#L39-L47>)
 
 JWTAuthenticator issues and validates HS256 JWTs against a UserStore.
 
@@ -166,7 +163,7 @@ type JWTAuthenticator struct {
 ```
 
 <a name="NewJWTAuthenticator"></a>
-### func [NewJWTAuthenticator](<https://github.com/neochaotic/leoflow/blob/main/internal/auth/jwt.go#L44>)
+### func [NewJWTAuthenticator](<https://github.com/neochaotic/leoflow/blob/main/internal/auth/jwt.go#L51>)
 
 ```go
 func NewJWTAuthenticator(store UserStore, secret string, ttl time.Duration) *JWTAuthenticator
@@ -175,7 +172,7 @@ func NewJWTAuthenticator(store UserStore, secret string, ttl time.Duration) *JWT
 NewJWTAuthenticator builds a JWTAuthenticator with the given user store, HS256 secret, and token lifetime.
 
 <a name="JWTAuthenticator.Authenticate"></a>
-### func \(\*JWTAuthenticator\) [Authenticate](<https://github.com/neochaotic/leoflow/blob/main/internal/auth/jwt.go#L92>)
+### func \(\*JWTAuthenticator\) [Authenticate](<https://github.com/neochaotic/leoflow/blob/main/internal/auth/jwt.go#L103>)
 
 ```go
 func (a *JWTAuthenticator) Authenticate(ctx context.Context, token string) (*User, error)
@@ -206,7 +203,7 @@ IssueAgentToken mints a signed token that identifies a single task instance, val
 The token's origin \(oiat\) is set to the mint time — this is a fresh dispatch. Renewal \(RenewAgentToken\) preserves that origin instead of resetting it.
 
 <a name="JWTAuthenticator.IssueToken"></a>
-### func \(\*JWTAuthenticator\) [IssueToken](<https://github.com/neochaotic/leoflow/blob/main/internal/auth/jwt.go#L68>)
+### func \(\*JWTAuthenticator\) [IssueToken](<https://github.com/neochaotic/leoflow/blob/main/internal/auth/jwt.go#L75>)
 
 ```go
 func (a *JWTAuthenticator) IssueToken(ctx context.Context, creds Credentials) (string, error)
@@ -226,6 +223,19 @@ RenewAgentToken validates an in\-flight agent bearer token and re\-mints it for 
 The attempt's original dispatch time is preserved across every renewal \(the oiat claim\). maxLifetime is a hard ceiling on that total age: once the attempt has been alive longer than maxLifetime since first dispatch, renewal is refused \(ok=false, empty token\) so a runaway attempt's credential lapses instead of being kept alive forever. A non\-positive maxLifetime disables the ceiling. exp is always now\+ttl — never accumulated onto the previous exp.
 
 An invalid incoming token \(bad signature, wrong audience, expired\) returns an error and is never re\-minted.
+
+<a name="JWTAuthenticator.RenewUserToken"></a>
+### func \(\*JWTAuthenticator\) [RenewUserToken](<https://github.com/neochaotic/leoflow/blob/main/internal/auth/jwt.go#L185>)
+
+```go
+func (a *JWTAuthenticator) RenewUserToken(token string, ttl, maxLifetime time.Duration) (renewed string, ok bool, err error)
+```
+
+RenewUserToken validates a still\-valid user bearer token and re\-mints it for the SAME principal \(subject, tenant, email, roles\) with a fresh short TTL, without ever changing what Authenticate verifies \(signature, issuer, leoflow\-user audience, HS256\). It is the server half of transparent CLI token renewal \(EKS validation aresta \#5\): the short access\-token TTL still bounds a stolen token, while renewal keeps a genuinely live session working so a long dev session never has to \`leoflow auth login\` again on the hour. It is modeled directly on RenewAgentToken.
+
+The session's original login time is preserved across every renewal \(the oiat claim, falling back to iat for a token minted before that claim existed\). maxLifetime is a hard ceiling on that total age: once the session has been alive longer than maxLifetime since first login, renewal is refused \(ok=false, empty token, no error\) so the user must re\-authenticate. A non\-positive maxLifetime disables the ceiling. exp is always now\+ttl — never accumulated.
+
+An invalid incoming token \(bad signature, wrong audience, expired\) returns an error and is never re\-minted. Roles are copied from the incoming token, exactly as they were signed; Authenticate still reloads authorization from the store on every request, so a renewed token confers no more than the original did.
 
 <a name="Permission"></a>
 ## type [Permission](<https://github.com/neochaotic/leoflow/blob/main/internal/auth/auth.go#L23-L26>)

--- a/website/content/reference/go/internal-cli.md
+++ b/website/content/reference/go/internal-cli.md
@@ -1,8 +1,4 @@
 ---
-# --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
-aliases:
-  - /go/internal/cli.html
-# --- end AUTO redirect aliases ---
 title: "internal/cli"
 linkTitle: "internal/cli"
 weight: 10

--- a/website/content/reference/go/internal-config.md
+++ b/website/content/reference/go/internal-config.md
@@ -1,8 +1,4 @@
 ---
-# --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
-aliases:
-  - /go/internal/config.html
-# --- end AUTO redirect aliases ---
 title: "internal/config"
 linkTitle: "internal/config"
 weight: 9
@@ -38,6 +34,7 @@ Package config loads Leoflow configuration from defaults, an optional config fil
 - [type PlatformDefaultsSection](<#PlatformDefaultsSection>)
 - [type RedisSection](<#RedisSection>)
 - [type SchedulerSection](<#SchedulerSection>)
+- [type SecretsSection](<#SecretsSection>)
 - [type ServerConfig](<#ServerConfig>)
   - [func LoadServer\(configFile string, flags \*pflag.FlagSet\) \(\*ServerConfig, error\)](<#LoadServer>)
   - [func \(c \*ServerConfig\) Validate\(\) error](<#ServerConfig.Validate>)
@@ -119,7 +116,7 @@ func PersistSession(path, serverURL, token string) error
 PersistSession writes the control\-plane server URL and auth token into the config file at path, preserving any other keys already there \(e.g. the Lite settings written by \`leoflow setup\`\). It creates the file and its parent directory when absent, and keeps the file at 0600 because the token is a secret. An empty path is an error: the caller must resolve the target first.
 
 <a name="AuthSection"></a>
-## type [AuthSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L350-L399>)
+## type [AuthSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L379-L438>)
 
 AuthSection configures authentication.
 
@@ -159,9 +156,19 @@ type AuthSection struct {
     // Fix #4). Past this age since first dispatch, the control plane stops renewing
     // the token on heartbeat and lets it lapse, bounding a runaway attempt. The
     // short per-attempt TTL still bounds a stolen/finished token independently;
-    // this only caps the total renewed lifetime. Generous by default (24h) so no
-    // normal task regresses. Bind via LEOFLOW_AUTH_MAX_ATTEMPT_CREDENTIAL_LIFETIME
-    // as a duration (e.g. "24h", "90m"); a non-positive value disables the ceiling.
+    // this caps the total renewed lifetime. It governs a second guarantee too: the
+    // Kubernetes executor floors a task pod's activeDeadlineSeconds with it when
+    // the DAG declares no execution_timeout, so a pod whose agent keeps retrying
+    // its report through a total control-plane outage is not left Running
+    // forever (a declared timeout is never shortened). Generous by default (24h)
+    // so no normal task regresses. Bind via
+    // LEOFLOW_AUTH_MAX_ATTEMPT_CREDENTIAL_LIFETIME as a duration (e.g. "24h",
+    // "90m"). With warm pools enabled it is also the per-attempt watchdog that
+    // keeps a wedged attempt from pinning a warm slot (a warm pod has no pod-level
+    // deadline; the worker lifetime cap drains between attempts, never
+    // mid-attempt). A non-positive value disables the renewal ceiling, the pod
+    // deadline floor and that watchdog together — a wedged task then has no
+    // wall-clock bound of its own — so boot logs a WARN naming the key.
     MaxAttemptCredentialLifetime time.Duration `mapstructure:"max_attempt_credential_lifetime"`
     // AgentTokenTransport selects how the in-pod agent obtains its control-plane
     // bearer credential (ADR 0055 Fix #3): "envvar" (the default) sets the token as
@@ -177,7 +184,7 @@ type AuthSection struct {
 ```
 
 <a name="CORSSection"></a>
-## type [CORSSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L324-L326>)
+## type [CORSSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L353-L355>)
 
 CORSSection configures cross\-origin access.
 
@@ -239,7 +246,7 @@ func Load(configFile string, flags *pflag.FlagSet) (*Config, error)
 Load assembles configuration from defaults, the given file \(when non\-empty\), LEOFLOW\_\* environment variables, and the provided flag set, in increasing order of precedence. A nil flag set or empty file path is ignored.
 
 <a name="DatabaseSection"></a>
-## type [DatabaseSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L329-L333>)
+## type [DatabaseSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L358-L362>)
 
 DatabaseSection configures the Postgres connection pool.
 
@@ -252,7 +259,7 @@ type DatabaseSection struct {
 ```
 
 <a name="DispatchSection"></a>
-## type [DispatchSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L487-L495>)
+## type [DispatchSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L547-L555>)
 
 DispatchSection sizes the BufferedDispatcher \(\#127\). BufferSize=0 keeps the scheduler tick synchronous with the inner dispatcher — the right shape for Lite \(subprocess fork is microseconds\). BufferSize\>0 enables the worker pool — the right shape for Pro \(Kubernetes API calls add real latency\). The defaults are set per\-edition by configsetup so the user does not have to think about this; an operator can still tune the knobs.
 
@@ -269,7 +276,7 @@ type DispatchSection struct {
 ```
 
 <a name="ExecutionSection"></a>
-## type [ExecutionSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L165-L205>)
+## type [ExecutionSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L194-L234>)
 
 ExecutionSection configures warm worker pools — Pro\-gated N:1 pod reuse \(ADR 0058\). Every field is operator\-set \(never DAG\-author\-set\), consistent with the secret\-scoping stance: whether a pod may be reused across attempts is an operator's security decision, not a DAG author's. All fields default to a byte\-for\-byte no\-op — warm pools OFF means dedicated pod\-per\-task, today's behavior — and are read for runtime behavior only in a later brick; N1a introduces the knobs plus the fail\-closed boot guard \(validateExecution\).
 
@@ -318,7 +325,7 @@ type ExecutionSection struct {
 ```
 
 <a name="ExecutionSection.EffectiveMinIdle"></a>
-### func \(ExecutionSection\) [EffectiveMinIdle](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L219>)
+### func \(ExecutionSection\) [EffectiveMinIdle](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L248>)
 
 ```go
 func (e ExecutionSection) EffectiveMinIdle(dagMinIdle int) int
@@ -331,7 +338,7 @@ EffectiveMinIdle resolves the warm\-worker target for one dag\_version under mod
 - The resolved value is clamped to \[0, max\_pool\_size\] so an author can never provision more warmth than the operator's per\-version cap allows, and a nonsensical negative never underflows.
 
 <a name="ExecutorSection"></a>
-## type [ExecutorSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L85-L122>)
+## type [ExecutorSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L108-L151>)
 
 ExecutorSection configures how tasks are executed.
 
@@ -361,6 +368,12 @@ type ExecutorSection struct {
     // the agent verifies the control plane's gRPC TLS cert (issue #58). Empty =
     // agents use the insecure channel (dev).
     AgentTLSCAConfigMap string `mapstructure:"agent_tls_ca_configmap"`
+    // TaskServiceAccount is the ServiceAccount task pods run as when a DAG's task
+    // does not set execution.service_account. The chart wires its taskServiceAccount
+    // here, so creating that SA makes keyless work without every DAG opting in.
+    // Empty keeps pods on the namespace default SA (an explicit per-task value
+    // always wins).
+    TaskServiceAccount string `mapstructure:"task_service_account"`
     // TaskSecretName names a Kubernetes Secret mounted (read-only) into every task
     // pod at TaskSecretMountPath. It lets a task read a credential that lives in
     // the cluster's secret store (e.g. a GCP service-account key) referenced by a
@@ -377,7 +390,7 @@ type ExecutorSection struct {
 ```
 
 <a name="HTTPExecutorSection"></a>
-## type [HTTPExecutorSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L262-L266>)
+## type [HTTPExecutorSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L291-L295>)
 
 HTTPExecutorSection configures HTTP\-related executor knobs.
 
@@ -390,7 +403,7 @@ type HTTPExecutorSection struct {
 ```
 
 <a name="JWTSection"></a>
-## type [JWTSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L402-L405>)
+## type [JWTSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L441-L454>)
 
 JWTSection configures JWT issuance and validation.
 
@@ -398,11 +411,21 @@ JWTSection configures JWT issuance and validation.
 type JWTSection struct {
     Secret          string `mapstructure:"secret"`
     TokenTTLSeconds int    `mapstructure:"token_ttl_seconds"`
+    // MaxLifetimeSeconds is the hard ceiling on how long a user session may be kept
+    // alive by transparent token renewal (aresta #5), measured since first login
+    // (the token's oiat claim). Past it, POST /api/v2/auth/token/renew is refused
+    // and the user must `leoflow auth login` again. The short TokenTTLSeconds still
+    // bounds a stolen token independently; this only caps the total renewed
+    // lifetime, mirroring auth.max_attempt_credential_lifetime for agent tokens.
+    // Generous by default (24h) so a normal dev day never re-logs in mid-session; a
+    // non-positive value disables the ceiling (renewal never expires the session).
+    // Bind via LEOFLOW_AUTH_JWT_MAX_LIFETIME_SECONDS.
+    MaxLifetimeSeconds int `mapstructure:"max_lifetime_seconds"`
 }
 ```
 
 <a name="LogsSection"></a>
-## type [LogsSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L35-L47>)
+## type [LogsSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L58-L70>)
 
 LogsSection configures task log shipping.
 
@@ -423,7 +446,7 @@ type LogsSection struct {
 ```
 
 <a name="OIDCSection"></a>
-## type [OIDCSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L416-L472>)
+## type [OIDCSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L465-L532>)
 
 OIDCSection configures the OIDC/SSO login flow \(Authorization Code \+ PKCE\). It is read only when auth.provider is "oidc", which is Pro\-gated and fails boot closed unless Issuer, ClientID, and RedirectURL are all set.
 
@@ -452,7 +475,12 @@ type OIDCSection struct {
     // RoleMappings maps an IdP group value to an existing Leoflow role name.
     // Default-DENY: a group with no mapping grants no role. Configure via the
     // config file / Helm values (maps do not bind from a single env var).
-    RoleMappings map[string]string `mapstructure:"role_mappings"`
+    //
+    // Decoded OUT-OF-BAND (mapstructure:"-"), not by viper: viper's "." key
+    // delimiter splits a dotted MAP KEY (a dotted IdP group like "app.admins")
+    // into nested maps and fails to decode. LoadServer parses this map straight
+    // from the raw YAML instead (#826). Env-var binding never applied to maps.
+    RoleMappings map[string]string `mapstructure:"-"`
     // DefaultRole softens the default-deny WITHOUT weakening the secure default:
     // when an authenticated user resolves to zero mapped roles and DefaultRole is
     // set, they are granted this single role (operators are advised to use a
@@ -465,7 +493,13 @@ type OIDCSection struct {
     TenantClaim string `mapstructure:"tenant_claim"`
     // TenantClaims maps a TenantClaim value to a Leoflow tenant name. A value not
     // present here is rejected (403) — the login never falls back to "default".
-    TenantClaims map[string]string `mapstructure:"tenant_claims"`
+    //
+    // Decoded OUT-OF-BAND (mapstructure:"-"), not by viper: a Google Workspace
+    // `hd` value is a domain (always dotted, e.g. "example.com" or
+    // "sub.example.co.uk"), which viper's "." delimiter would split into nested
+    // maps and fail to decode — the #826 crash. LoadServer parses this map from
+    // the raw YAML instead.
+    TenantClaims map[string]string `mapstructure:"-"`
     // AllowedEmailDomains is an install-time, login-level allowlist layered on TOP
     // of the tid/hd tenant pin — it is NOT the pin itself (that stays issuer +
     // tid/hd + email_verified per D6). The check runs only AFTER the pin and
@@ -490,7 +524,7 @@ type OIDCSection struct {
 ```
 
 <a name="OTelSection"></a>
-## type [OTelSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L505-L508>)
+## type [OTelSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L565-L568>)
 
 OTelSection configures OpenTelemetry export.
 
@@ -502,7 +536,7 @@ type OTelSection struct {
 ```
 
 <a name="ObjectLogSection"></a>
-## type [ObjectLogSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L58-L82>)
+## type [ObjectLogSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L81-L105>)
 
 ObjectLogSection configures the object\-store log backend for both the "s3" and "gcs" providers. Auth is keyless\-first \(ADR 0035\): leave the credential fields empty to use the ambient chain — IRSA / instance profile for S3, GKE Workload Identity \(ADC\) for GCS. Static keys and credential files are a discouraged escape hatch for dev and clusters without an identity broker.
 
@@ -537,7 +571,7 @@ type ObjectLogSection struct {
 ```
 
 <a name="ObservabilitySection"></a>
-## type [ObservabilitySection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L498-L502>)
+## type [ObservabilitySection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L558-L562>)
 
 ObservabilitySection configures logging, metrics, and tracing.
 
@@ -550,7 +584,7 @@ type ObservabilitySection struct {
 ```
 
 <a name="PlatformDefaultsSection"></a>
-## type [PlatformDefaultsSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L126-L156>)
+## type [PlatformDefaultsSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L155-L185>)
 
 PlatformDefaultsSection configures the lowest\-precedence \(L0\) task defaults, applied at dispatch to fill gaps the DAG left empty \(ADR 0023\).
 
@@ -589,7 +623,7 @@ type PlatformDefaultsSection struct {
 ```
 
 <a name="RedisSection"></a>
-## type [RedisSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L336-L347>)
+## type [RedisSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L365-L376>)
 
 RedisSection configures the Redis connection.
 
@@ -609,7 +643,7 @@ type RedisSection struct {
 ```
 
 <a name="SchedulerSection"></a>
-## type [SchedulerSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L475-L479>)
+## type [SchedulerSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L535-L539>)
 
 SchedulerSection configures the scheduler loop.
 
@@ -621,8 +655,27 @@ type SchedulerSection struct {
 }
 ```
 
+<a name="SecretsSection"></a>
+## type [SecretsSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L45-L55>)
+
+SecretsSection configures the external secrets backend \(ADR 0060\). When Backend is set, a Connection/Variable a DAG declares can be resolved pod\-side from the provider store under the pod's keyless identity instead of the leoflow vault. Empty \(the default\) keeps the vault as the only source — byte\-identical to pre\-0060. This is operator\-only config: it is delivered to the pod as LEOFLOW\_SECRETS\_\* env, which an author's task env can never set \(\#828\).
+
+```go
+type SecretsSection struct {
+    // Backend is the provider secrets-backend class the in-pod resolver drives
+    // (e.g. the Airflow AWS SecretsManagerBackend). Empty disables external secrets.
+    Backend string `mapstructure:"backend"`
+    // BackendKwargs is the provider kwargs as a JSON object string (connections_prefix,
+    // variables_prefix, region_name, …); a kind is served iff its `*_prefix` kwarg is
+    // present. A JSON string (not a map) so it is settable via a single
+    // LEOFLOW_SECRETS_BACKEND_KWARGS env var, matching the env-only control-plane
+    // chart. Empty is treated as `{}`. Delivered verbatim to the pod.
+    BackendKwargs string `mapstructure:"backend_kwargs"`
+}
+```
+
 <a name="ServerConfig"></a>
-## type [ServerConfig](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L17-L32>)
+## type [ServerConfig](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L21-L37>)
 
 ServerConfig is the full configuration for the leoflow\-server control plane. It mirrors the nested YAML described in the Phase 2 prompt.
 
@@ -638,6 +691,7 @@ type ServerConfig struct {
     Logs          LogsSection          `mapstructure:"logs"`
     Observability ObservabilitySection `mapstructure:"observability"`
     UI            UISection            `mapstructure:"ui"`
+    Secrets       SecretsSection       `mapstructure:"secrets"`
     // SecretKey (LEOFLOW_SECRET_KEY) is the 32-byte key encrypting connection
     // secrets at rest (ADR 0019). Raw 32 chars, 64-char hex, or base64. Empty
     // disables connection writes.
@@ -646,7 +700,7 @@ type ServerConfig struct {
 ```
 
 <a name="LoadServer"></a>
-### func [LoadServer](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L629>)
+### func [LoadServer](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L727>)
 
 ```go
 func LoadServer(configFile string, flags *pflag.FlagSet) (*ServerConfig, error)
@@ -655,7 +709,7 @@ func LoadServer(configFile string, flags *pflag.FlagSet) (*ServerConfig, error)
 LoadServer assembles the server configuration from defaults, the given file, LEOFLOW\_\* environment variables, and flags, in increasing precedence.
 
 <a name="ServerConfig.Validate"></a>
-### func \(\*ServerConfig\) [Validate](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L693>)
+### func \(\*ServerConfig\) [Validate](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L835>)
 
 ```go
 func (c *ServerConfig) Validate() error
@@ -664,7 +718,7 @@ func (c *ServerConfig) Validate() error
 Validate reports configuration errors that must abort startup.
 
 <a name="ServerSection"></a>
-## type [ServerSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L269-L289>)
+## type [ServerSection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L298-L318>)
 
 ServerSection configures the HTTP, metrics, and agent gRPC listeners.
 
@@ -693,7 +747,7 @@ type ServerSection struct {
 ```
 
 <a name="ServerSection.EffectiveRole"></a>
-### func \(ServerSection\) [EffectiveRole](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L303>)
+### func \(ServerSection\) [EffectiveRole](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L332>)
 
 ```go
 func (s ServerSection) EffectiveRole() string
@@ -702,7 +756,7 @@ func (s ServerSection) EffectiveRole() string
 EffectiveRole returns the configured role, defaulting empty to RoleAll so an unset role \(Lite, and every pre\-0049 deployment\) keeps the monolith behavior.
 
 <a name="ServerSection.ServesAPI"></a>
-### func \(ServerSection\) [ServesAPI](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L311>)
+### func \(ServerSection\) [ServesAPI](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L340>)
 
 ```go
 func (s ServerSection) ServesAPI() bool
@@ -711,7 +765,7 @@ func (s ServerSection) ServesAPI() bool
 ServesAPI reports whether this process runs the HTTP API \+ UI.
 
 <a name="ServerSection.ServesScheduler"></a>
-### func \(ServerSection\) [ServesScheduler](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L318>)
+### func \(ServerSection\) [ServesScheduler](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L347>)
 
 ```go
 func (s ServerSection) ServesScheduler() bool
@@ -720,7 +774,7 @@ func (s ServerSection) ServesScheduler() bool
 ServesScheduler reports whether this process runs the scheduler, dispatch, and the agent gRPC endpoint.
 
 <a name="UISection"></a>
-## type [UISection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L238-L259>)
+## type [UISection](<https://github.com/neochaotic/leoflow/blob/main/internal/config/server.go#L267-L288>)
 
 UISection configures the embedded Airflow UI.
 

--- a/website/content/reference/go/internal-dispatch.md
+++ b/website/content/reference/go/internal-dispatch.md
@@ -1,8 +1,4 @@
 ---
-# --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
-aliases:
-  - /go/internal/dispatch.html
-# --- end AUTO redirect aliases ---
 title: "internal/dispatch"
 linkTitle: "internal/dispatch"
 weight: 4
@@ -27,7 +23,10 @@ Package dispatch launches pod\-path task instances: it resolves a task's executi
   - [func \(d \*Dispatcher\) Dispatch\(ctx context.Context, runID, dagID, dagVersionID string, task domain.TaskSpec\) \(executor.Disposition, error\)](<#Dispatcher.Dispatch>)
   - [func \(d \*Dispatcher\) SetAgentTLSCAConfigMap\(name string\)](<#Dispatcher.SetAgentTLSCAConfigMap>)
   - [func \(d \*Dispatcher\) SetAgentTokenTransport\(transport, audience string, expirationSeconds int64\)](<#Dispatcher.SetAgentTokenTransport>)
+  - [func \(d \*Dispatcher\) SetAttemptLifetimeCeiling\(ceiling time.Duration\)](<#Dispatcher.SetAttemptLifetimeCeiling>)
+  - [func \(d \*Dispatcher\) SetDefaultTaskServiceAccount\(name string\)](<#Dispatcher.SetDefaultTaskServiceAccount>)
   - [func \(d \*Dispatcher\) SetPlatformDefaults\(p PlatformDefaults\)](<#Dispatcher.SetPlatformDefaults>)
+  - [func \(d \*Dispatcher\) SetSecretsBackend\(class, kwargs string\)](<#Dispatcher.SetSecretsBackend>)
   - [func \(d \*Dispatcher\) SetTaskSecret\(name, mountPath string\)](<#Dispatcher.SetTaskSecret>)
   - [func \(d \*Dispatcher\) SetWarmPlacer\(p WarmPlacer\)](<#Dispatcher.SetWarmPlacer>)
 - [type FailureSink](<#FailureSink>)
@@ -112,7 +111,7 @@ func (b *BufferedDispatcher) Dispatch(ctx context.Context, runID, dagID, dagVers
 Dispatch hands a task off to the inner dispatcher. In passthrough mode the inner call happens inline. In buffered mode the request is enqueued non\- blockingly: success returns \(Dispatched, nil\) immediately \(the scheduler then records the TI as \`queued\`\); a full or closed channel returns \(Rejected, ErrAtCapacity\). Rejected preserves today's behavior exactly: ErrAtCapacity is a plain error, which the old scheduler classified as permanent — the bounded path that leaves the TI scheduled for the next tick.
 
 <a name="Dispatcher"></a>
-## type [Dispatcher](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L86-L108>)
+## type [Dispatcher](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L114-L151>)
 
 Dispatcher builds executor requests for queued pod\-path tasks and runs them.
 
@@ -123,7 +122,7 @@ type Dispatcher struct {
 ```
 
 <a name="NewDispatcher"></a>
-### func [NewDispatcher](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L113>)
+### func [NewDispatcher](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L202>)
 
 ```go
 func NewDispatcher(exec executor.Executor, resolver Resolver, issuer TokenIssuer, controlAddr string, tokenTTL time.Duration) *Dispatcher
@@ -132,7 +131,7 @@ func NewDispatcher(exec executor.Executor, resolver Resolver, issuer TokenIssuer
 NewDispatcher builds a Dispatcher that launches tasks via exec, resolves their context with resolver, mints tokens with issuer \(valid for tokenTTL\), and tells the agent to reach the control plane at controlAddr.
 
 <a name="Dispatcher.Dispatch"></a>
-### func \(\*Dispatcher\) [Dispatch](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L156>)
+### func \(\*Dispatcher\) [Dispatch](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L245>)
 
 ```go
 func (d *Dispatcher) Dispatch(ctx context.Context, runID, dagID, dagVersionID string, task domain.TaskSpec) (executor.Disposition, error)
@@ -141,7 +140,7 @@ func (d *Dispatcher) Dispatch(ctx context.Context, runID, dagID, dagVersionID st
 Dispatch resolves the task, mints its agent token, and executes it. The executor classifies its own dispatch outcome and returns it as an executor.Disposition \(ADR 0051 Phase 4\). A dispatcher\-INTERNAL failure that happens BEFORE Execute \(task resolve, token mint\) is permanent and so returns executor.Rejected — those bare errors classified as permanent before this change, so Rejected preserves the behavior exactly.
 
 <a name="Dispatcher.SetAgentTLSCAConfigMap"></a>
-### func \(\*Dispatcher\) [SetAgentTLSCAConfigMap](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L126>)
+### func \(\*Dispatcher\) [SetAgentTLSCAConfigMap](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L215>)
 
 ```go
 func (d *Dispatcher) SetAgentTLSCAConfigMap(name string)
@@ -150,7 +149,7 @@ func (d *Dispatcher) SetAgentTLSCAConfigMap(name string)
 SetAgentTLSCAConfigMap configures the CA ConfigMap mounted into task pods so agents verify the control plane's gRPC TLS cert \(issue \#58\). Empty = the agent stays on the insecure channel \(dev\).
 
 <a name="Dispatcher.SetAgentTokenTransport"></a>
-### func \(\*Dispatcher\) [SetAgentTokenTransport](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L146>)
+### func \(\*Dispatcher\) [SetAgentTokenTransport](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L235>)
 
 ```go
 func (d *Dispatcher) SetAgentTokenTransport(transport, audience string, expirationSeconds int64)
@@ -158,8 +157,26 @@ func (d *Dispatcher) SetAgentTokenTransport(transport, audience string, expirati
 
 SetAgentTokenTransport selects how the agent's bearer credential reaches the task pod \(ADR 0055 Fix \#3\). transport is "" / "envvar" \(the plaintext env\-var default\) or "exchange" \(project a ServiceAccount token the agent exchanges for a task\-scoped JWT\). audience and expirationSeconds configure the projected token and are read only under the exchange transport. Ignored by the subprocess \(Lite\) executor, which has no pod.
 
+<a name="Dispatcher.SetAttemptLifetimeCeiling"></a>
+### func \(\*Dispatcher\) [SetAttemptLifetimeCeiling](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L158>)
+
+```go
+func (d *Dispatcher) SetAttemptLifetimeCeiling(ceiling time.Duration)
+```
+
+SetAttemptLifetimeCeiling wires the operator's attempt credential ceiling \(auth.max\_attempt\_credential\_lifetime\) into every dispatched request, where the Kubernetes executor floors the pod's ActiveDeadlineSeconds with it when the task declares no execution timeout. A non\-positive value is "no ceiling" and applies no floor; the subprocess executor ignores it.
+
+<a name="Dispatcher.SetDefaultTaskServiceAccount"></a>
+### func \(\*Dispatcher\) [SetDefaultTaskServiceAccount](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L197>)
+
+```go
+func (d *Dispatcher) SetDefaultTaskServiceAccount(name string)
+```
+
+SetDefaultTaskServiceAccount sets the ServiceAccount task pods run as when a DAG's task does not specify execution.service\_account. Empty leaves pods on the namespace default SA \(today's behavior\). Wiring the chart's task ServiceAccount here closes the trap where creating the SA silently had no effect until every DAG also set execution.service\_account.
+
 <a name="Dispatcher.SetPlatformDefaults"></a>
-### func \(\*Dispatcher\) [SetPlatformDefaults](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L138>)
+### func \(\*Dispatcher\) [SetPlatformDefaults](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L227>)
 
 ```go
 func (d *Dispatcher) SetPlatformDefaults(p PlatformDefaults)
@@ -167,8 +184,17 @@ func (d *Dispatcher) SetPlatformDefaults(p PlatformDefaults)
 
 SetPlatformDefaults configures the per\-cluster task defaults applied at dispatch to fill gaps the DAG artifact left empty \(ADR 0023, layer L0\).
 
+<a name="Dispatcher.SetSecretsBackend"></a>
+### func \(\*Dispatcher\) [SetSecretsBackend](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L176>)
+
+```go
+func (d *Dispatcher) SetSecretsBackend(class, kwargs string)
+```
+
+SetSecretsBackend configures the operator's external secrets backend \(ADR 0060\): the provider class the in\-pod resolver drives and its raw kwargs JSON, delivered to the pod as operator\-owned LEOFLOW\_SECRETS\_\* env. Empty leaves external secrets off \(the chain stays vault\-only\).
+
 <a name="Dispatcher.SetTaskSecret"></a>
-### func \(\*Dispatcher\) [SetTaskSecret](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L132>)
+### func \(\*Dispatcher\) [SetTaskSecret](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L221>)
 
 ```go
 func (d *Dispatcher) SetTaskSecret(name, mountPath string)
@@ -177,7 +203,7 @@ func (d *Dispatcher) SetTaskSecret(name, mountPath string)
 SetTaskSecret configures a Kubernetes Secret mounted read\-only into every task pod at mountPath, so tasks can read a credential \(e.g. a GCP service\-account key referenced by a connection's key\_path\) from the cluster's secret store rather than from Leoflow \(ADR 0035\). Empty name = nothing mounted.
 
 <a name="Dispatcher.SetWarmPlacer"></a>
-### func \(\*Dispatcher\) [SetWarmPlacer](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L121>)
+### func \(\*Dispatcher\) [SetWarmPlacer](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L210>)
 
 ```go
 func (d *Dispatcher) SetWarmPlacer(p WarmPlacer)
@@ -222,7 +248,7 @@ type MetricsRecorder interface {
 ```
 
 <a name="PlatformDefaults"></a>
-## type [PlatformDefaults](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L65-L83>)
+## type [PlatformDefaults](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L93-L111>)
 
 PlatformDefaults are per\-cluster task defaults applied at dispatch to fill gaps the DAG artifact left empty \(ADR 0023, layer L0\). They are the lowest precedence \(task override \> DAG default \> platform default\) and never replace a value baked into dag.json, so the artifact stays portable across clusters.
 
@@ -249,7 +275,7 @@ type PlatformDefaults struct {
 ```
 
 <a name="Resolved"></a>
-## type [Resolved](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L35-L49>)
+## type [Resolved](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L63-L77>)
 
 Resolved is the execution context the dispatcher needs to launch a task.
 
@@ -272,7 +298,7 @@ type Resolved struct {
 ```
 
 <a name="Resolver"></a>
-## type [Resolver](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L52-L54>)
+## type [Resolver](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L80-L82>)
 
 Resolver loads a task instance's execution context from storage.
 
@@ -283,7 +309,7 @@ type Resolver interface {
 ```
 
 <a name="TokenIssuer"></a>
-## type [TokenIssuer](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L57-L59>)
+## type [TokenIssuer](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L85-L87>)
 
 TokenIssuer mints a per\-task\-instance agent token.
 
@@ -294,7 +320,7 @@ type TokenIssuer interface {
 ```
 
 <a name="WarmPlacer"></a>
-## type [WarmPlacer](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L30-L32>)
+## type [WarmPlacer](<https://github.com/neochaotic/leoflow/blob/main/internal/dispatch/dispatch.go#L58-L60>)
 
 WarmPlacer hands a per\-attempt WorkAssignment to a free warm worker of a dag\_version, returning false when none is free \(ADR 0058 N1b1\-place\). It is a narrow structural view of the agentrpc worker registry: the executor package must not import agentrpc, so the seam lives here and main.go passes the registry, which satisfies it. A nil WarmPlacer on the Dispatcher means warm pools are off — every task takes the dedicated pod path, today's behavior.
 

--- a/website/content/reference/go/internal-domain.md
+++ b/website/content/reference/go/internal-domain.md
@@ -1,8 +1,4 @@
 ---
-# --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
-aliases:
-  - /go/internal/domain.html
-# --- end AUTO redirect aliases ---
 title: "internal/domain"
 linkTitle: "internal/domain"
 weight: 1
@@ -27,6 +23,7 @@ Package domain defines the core Leoflow types \(DAG, Task, project config\) and 
 - [type BuildConfig](<#BuildConfig>)
 - [type ConfigDefaults](<#ConfigDefaults>)
 - [type Connection](<#Connection>)
+- [type ConnectionPatch](<#ConnectionPatch>)
 - [type DAG](<#DAG>)
 - [type DAGSpec](<#DAGSpec>)
   - [func \(d \*DAGSpec\) CanonicalHash\(\) \(string, error\)](<#DAGSpec.CanonicalHash>)
@@ -40,6 +37,7 @@ Package domain defines the core Leoflow types \(DAG, Task, project config\) and 
 - [type DbtConfig](<#DbtConfig>)
 - [type DefaultArgs](<#DefaultArgs>)
 - [type DefaultResources](<#DefaultResources>)
+  - [func \(d \*DefaultResources\) AsResources\(\) \*Resources](<#DefaultResources.AsResources>)
 - [type Execution](<#Execution>)
 - [type ExecutionMode](<#ExecutionMode>)
 - [type HistoricalMetrics](<#HistoricalMetrics>)
@@ -48,6 +46,7 @@ Package domain defines the core Leoflow types \(DAG, Task, project config\) and 
   - [func \(c \*LeoflowConfig\) ApplyDefaults\(\)](<#LeoflowConfig.ApplyDefaults>)
   - [func \(c \*LeoflowConfig\) EffectiveDependencies\(\) \(\[\]string, error\)](<#LeoflowConfig.EffectiveDependencies>)
   - [func \(c \*LeoflowConfig\) Validate\(\) error](<#LeoflowConfig.Validate>)
+- [type ParamSpec](<#ParamSpec>)
 - [type Pool](<#Pool>)
 - [type PoolUsage](<#PoolUsage>)
 - [type RegistryConfig](<#RegistryConfig>)
@@ -65,6 +64,7 @@ Package domain defines the core Leoflow types \(DAG, Task, project config\) and 
 - [type TriggerRule](<#TriggerRule>)
 - [type User](<#User>)
 - [type Variable](<#Variable>)
+- [type VariablePatch](<#VariablePatch>)
 - [type XComEntryMeta](<#XComEntryMeta>)
 
 
@@ -222,7 +222,7 @@ type BuildConfig struct {
 ```
 
 <a name="ConfigDefaults"></a>
-## type [ConfigDefaults](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/config.go#L143-L148>)
+## type [ConfigDefaults](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/config.go#L143-L153>)
 
 ConfigDefaults holds task defaults applied to every task generated from the project at compile time.
 
@@ -232,6 +232,11 @@ type ConfigDefaults struct {
     RetryDelaySeconds       int               `json:"retry_delay_seconds,omitempty" yaml:"retry_delay_seconds,omitempty"`
     ExecutionTimeoutSeconds int               `json:"execution_timeout_seconds,omitempty" yaml:"execution_timeout_seconds,omitempty"`
     Resources               *DefaultResources `json:"resources,omitempty" yaml:"resources,omitempty"`
+    // NodeSelector is the DAG-wide pod placement fallback applied to every task
+    // that declares no execution.node_selector of its own. Like Resources it is a
+    // default, so the most-specific per-task value always wins. Consumed at
+    // compile time by the overlay, which bakes it onto each task in dag.json.
+    NodeSelector map[string]string `json:"node_selector,omitempty" yaml:"node_selector,omitempty"`
 }
 ```
 
@@ -254,8 +259,33 @@ type Connection struct {
 }
 ```
 
+<a name="ConnectionPatch"></a>
+## type [ConnectionPatch](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/connection.go#L31-L41>)
+
+ConnectionPatch is a tri\-state write to a Connection \(\#887\). Each nullable field is one of three states the write path must keep distinct:
+
+- nil pointer \-\> absent: preserve the stored value \(the upsert passes NULL and COALESCE keeps the current column\).
+- non\-nil "" \-\> present and empty: clear the field to empty.
+- non\-nil value \-\> present: set the field.
+
+A plain string cannot carry "absent" vs "present and empty", which is why the safe\-merge upsert alone \(v0.4.4\) could neither clear a field nor stop a round\-tripped mask from overwriting a secret. ConnType is always written \(required on every upsert\). Secret\-mask handling \(the mask means "unchanged"\) is resolved by the caller before it builds the patch, so the repository only ever sees the three states above.
+
+```go
+type ConnectionPatch struct {
+    ConnID      string
+    ConnType    string
+    Host        *string
+    Schema      *string
+    Login       *string
+    Password    *string
+    Port        *int
+    Extra       *string
+    Description *string
+}
+```
+
 <a name="DAG"></a>
-## type [DAG](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/run.go#L7-L20>)
+## type [DAG](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/run.go#L10-L23>)
 
 DAG is a registered DAG with its scheduling metadata \(distinct from DAGSpec, which is the compiled artifact\).
 
@@ -277,7 +307,7 @@ type DAG struct {
 ```
 
 <a name="DAGSpec"></a>
-## type [DAGSpec](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L60-L113>)
+## type [DAGSpec](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L61-L128>)
 
 DAGSpec is the canonical serialized representation of a DAG consumed by the control plane. It mirrors docs/api/dag\-schema.json.
 
@@ -302,16 +332,22 @@ type DAGSpec struct {
     // exactly as before. The scheduler enforces it in PlanRun's scheduled→queued
     // admission gate.
     MaxActiveTasks int `json:"max_active_tasks,omitempty"`
-    // MinIdleWorkers is the number of warm workers the DAG AUTHOR wants kept ready
-    // for this DAG version so its tasks skip cold-pod startup (ADR 0058 N1b2b,
-    // warm pools model A2). It mirrors MaxActiveTasks as a per-DAG author-declared
-    // spec field: zero (the default) means no warmth, and a DAG that never sets it
-    // — and all of Lite — behaves exactly as before. It is only a REQUEST: the
-    // operator caps it at execution.max_pool_size, floors an unset value at
-    // execution.min_idle_workers, and the whole thing is inert unless the operator
-    // enabled execution.warm_pools_enabled (see config.ExecutionSection.
-    // EffectiveMinIdle). Whether a pod may be reused across attempts stays the
-    // operator's security decision; this field only tunes how many.
+    // MinIdleWorkers is a DORMANT seam for per-DAG author-declared warmth: the
+    // number of warm workers an author would want kept ready for this DAG version
+    // so its tasks skip cold-pod startup (ADR 0058, warm pools model A2). It is NOT
+    // author-settable today. There is no author entry point: the field is absent
+    // from the authoring schema (leoflow-yaml-schema.json, which is
+    // additionalProperties:false) and the parser never emits it, so after the
+    // parse→compile path this value is ALWAYS 0. The intended split is that the
+    // operator gates IF warmth happens at all (execution.warm_pools_enabled) while
+    // the author would only tune HOW MANY, with the operator clamping the request;
+    // whether a pod may be reused across attempts stays the operator's security
+    // decision. The downstream is intentionally pre-wired around this field —
+    // config.ExecutionSection.EffectiveMinIdle already clamps it and the scheduler
+    // store already reads it — so exposing it to authors later is a schema+parser
+    // change only (add the key to the authoring schema and have the parser emit
+    // it), with no domain/scheduler rework. Until then it stays 0 and every DAG,
+    // and all of Lite, behaves exactly as before.
     MinIdleWorkers int          `json:"min_idle_workers,omitempty"`
     Catchup        bool         `json:"catchup,omitempty"`
     DefaultArgs    *DefaultArgs `json:"default_args,omitempty"`
@@ -328,9 +364,17 @@ type DAGSpec struct {
     // valid and means the DAG declares nothing — the additive, back-compatible
     // default. These carry the declaration only; secret delivery still ships the
     // whole tenant vault until enforcement lands on a later increment.
-    Variables   []string   `json:"variables,omitempty"`
-    Connections []string   `json:"connections,omitempty"`
-    Tasks       []TaskSpec `json:"tasks"`
+    Variables   []string `json:"variables,omitempty"`
+    Connections []string `json:"connections,omitempty"`
+    // Params are the DAG's author-declared run parameters (Airflow's params=),
+    // keyed by name. Each carries a Default (materialized into a run's conf when
+    // the trigger omits that key) and an optional JSON Schema the trigger-time
+    // conf value is validated against. Absent (empty) means the DAG declares no
+    // params — the additive, back-compatible default, so the compiled shape of a
+    // param-free DAG is unchanged. Part of the immutable spec (CanonicalHash), so
+    // changing a default or schema produces a new DAG version.
+    Params map[string]ParamSpec `json:"params,omitempty"`
+    Tasks  []TaskSpec           `json:"tasks"`
     // Source is the original dag.py text, captured at compile time so the UI's
     // Code tab can show the Python a human wrote (not the compiled spec). It is
     // part of the artifact: changing it produces a new version.
@@ -348,7 +392,7 @@ func (d *DAGSpec) CanonicalHash() (string, error)
 CanonicalHash returns the SHA\-256 of the spec's canonical JSON encoding. Go's struct marshaling is deterministic \(fixed field order, sorted map keys\), so identical specs hash identically — used to deduplicate DAG versions.
 
 <a name="DAGSpec.Validate"></a>
-### func \(\*DAGSpec\) [Validate](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L259>)
+### func \(\*DAGSpec\) [Validate](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L287>)
 
 ```go
 func (d *DAGSpec) Validate() error
@@ -366,7 +410,7 @@ func (d *DAGSpec) ValidateSchedule() error
 ValidateSchedule checks that a DAG's cron schedule is parseable. An empty or absent schedule \(manual\-only\) and the recognized non\-cron Airflow schedules \(@once, @continuous\) are valid. A malformed cron expression — a 4\-field cron, a typo — is rejected here so it fails loudly at compile time; otherwise the scheduler silently can't parse it and the DAG simply never runs, with no error surfaced anywhere \(the worst failure mode\). The parser is robfig/cron's ParseStandard, the same one the scheduler uses, so what validates here is exactly what the scheduler can run \(see scheduler/cron.go\).
 
 <a name="DagRun"></a>
-## type [DagRun](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/run.go#L35-L45>)
+## type [DagRun](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/run.go#L38-L52>)
 
 DagRun is an execution of a DAG, identified by dag\_id \+ run\_id.
 
@@ -381,6 +425,10 @@ type DagRun struct {
     StartedAt   *time.Time
     EndedAt     *time.Time
     Note        string
+    // Conf is the run's configuration as a JSON object, supplied at trigger time
+    // and exposed to tasks as params. Empty means no configuration; storage
+    // persists the empty-object default so downstream readers never see NULL.
+    Conf json.RawMessage
 }
 ```
 
@@ -432,7 +480,7 @@ type DagStats struct {
 ```
 
 <a name="DagVersion"></a>
-## type [DagVersion](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/run.go#L24-L32>)
+## type [DagVersion](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/run.go#L27-L35>)
 
 DagVersion is a registered version of a DAG. VersionNumber is the 1\-based ordinal the UI uses \(the stored version label is free\-form\).
 
@@ -478,7 +526,7 @@ type DbtConfig struct {
 ```
 
 <a name="DefaultArgs"></a>
-## type [DefaultArgs](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L125-L129>)
+## type [DefaultArgs](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L153-L157>)
 
 DefaultArgs holds retry and timeout defaults applied to every task in a DAG.
 
@@ -491,7 +539,7 @@ type DefaultArgs struct {
 ```
 
 <a name="DefaultResources"></a>
-## type [DefaultResources](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/config.go#L151-L154>)
+## type [DefaultResources](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/config.go#L156-L159>)
 
 DefaultResources expresses default CPU and memory for generated tasks.
 
@@ -502,8 +550,19 @@ type DefaultResources struct {
 }
 ```
 
+<a name="DefaultResources.AsResources"></a>
+### func \(\*DefaultResources\) [AsResources](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/config.go#L171>)
+
+```go
+func (d *DefaultResources) AsResources() *Resources
+```
+
+AsResources expands the simplified default cpu/memory into a full Resources with requests == limits \(the QoS story of \#725\). This mirrors how the per\-cluster platform default is built at dispatch. Returns nil when the receiver is nil or declares no quantity, so callers can treat a missing default as "leave the task untouched".
+
+Guaranteed QoS is reached only when BOTH cpu and memory are set \(and thus equal across requests and limits\). A partial default — only cpu, or only memory — leaves the other dimension unset, so Kubernetes classifies the pod as Burstable, not Guaranteed.
+
 <a name="Execution"></a>
-## type [Execution](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L209-L246>)
+## type [Execution](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L237-L274>)
 
 Execution carries executor\-specific placement and scheduling hints for a task. Every field beyond NodeSelector/Tolerations/ServiceAccount is applied only by the Kubernetes executor; Lite \(subprocess, no pods\) ignores them.
 
@@ -549,7 +608,7 @@ type Execution struct {
 ```
 
 <a name="ExecutionMode"></a>
-## type [ExecutionMode](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L33>)
+## type [ExecutionMode](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L34>)
 
 ExecutionMode selects how a task runs. Every task runs inside a worker pod; the field is retained for forward compatibility and defaults to pod.
 
@@ -652,7 +711,7 @@ type LeoflowConfig struct {
 ```
 
 <a name="LeoflowConfig.ApplyDefaults"></a>
-### func \(\*LeoflowConfig\) [ApplyDefaults](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/config.go#L166>)
+### func \(\*LeoflowConfig\) [ApplyDefaults](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/config.go#L191>)
 
 ```go
 func (c *LeoflowConfig) ApplyDefaults()
@@ -663,7 +722,7 @@ ApplyDefaults fills zero\-valued fields with the defaults declared in the canoni
 Centralizing defaults here \(instead of scattered \`if x == ""\` fallbacks at each consumer\) is what lets the multi\-DAG workspace synthesize a working config when a subdir ships no leoflow.yaml, while keeping the resolved values debuggable from one place.
 
 <a name="LeoflowConfig.EffectiveDependencies"></a>
-### func \(\*LeoflowConfig\) [EffectiveDependencies](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/config.go#L212>)
+### func \(\*LeoflowConfig\) [EffectiveDependencies](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/config.go#L237>)
 
 ```go
 func (c *LeoflowConfig) EffectiveDependencies() ([]string, error)
@@ -674,13 +733,28 @@ EffectiveDependencies resolves the full pip install list the image/venv needs: t
 An unknown connector name is a compile error, not a silent drop: a typo that slipped through would otherwise surface as a ModuleNotFoundError inside the task pod, far from its cause. The message names the offender, lists the known types, and points at the dependencies: escape hatch.
 
 <a name="LeoflowConfig.Validate"></a>
-### func \(\*LeoflowConfig\) [Validate](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/config.go#L233>)
+### func \(\*LeoflowConfig\) [Validate](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/config.go#L258>)
 
 ```go
 func (c *LeoflowConfig) Validate() error
 ```
 
 Validate checks the LeoflowConfig against the canonical leoflow.yaml schema and returns a joined error describing every violation, or nil when valid.
+
+<a name="ParamSpec"></a>
+## type [ParamSpec](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L135-L141>)
+
+ParamSpec is one author\-declared DAG\-run parameter: a default value and the JSON Schema its trigger\-time conf value is validated against. Both are carried as raw JSON so an arbitrary default and an arbitrary schema round\-trip verbatim. Schema is \{\} \(or absent\) when the author declared a bare default with no constraints, in which case any conf value for that key is accepted.
+
+```go
+type ParamSpec struct {
+    // Default is the value merged into a run's conf when the trigger omits this
+    // key. Absent (omitempty, len 0) means the param is REQUIRED — the trigger
+    // must supply it — as distinct from an explicit JSON null default.
+    Default json.RawMessage `json:"default,omitempty"`
+    Schema  json.RawMessage `json:"schema,omitempty"`
+}
+```
 
 <a name="Pool"></a>
 ## type [Pool](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/pool.go#L8-L13>)
@@ -725,7 +799,7 @@ type RegistryConfig struct {
 ```
 
 <a name="ResourceQuantity"></a>
-## type [ResourceQuantity](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L196-L204>)
+## type [ResourceQuantity](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L224-L232>)
 
 ResourceQuantity expresses CPU, memory, and ephemeral\-storage in Kubernetes notation.
 
@@ -742,7 +816,7 @@ type ResourceQuantity struct {
 ```
 
 <a name="Resources"></a>
-## type [Resources](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L182-L192>)
+## type [Resources](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L210-L220>)
 
 Resources holds Kubernetes\-style resource requests and limits for a task.
 
@@ -761,7 +835,7 @@ type Resources struct {
 ```
 
 <a name="StagingConfig"></a>
-## type [StagingConfig](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L118-L122>)
+## type [StagingConfig](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L146-L150>)
 
 StagingConfig is the opt\-in per\-DAG\-run shared staging volume \(ADR 0022\). Size is a Kubernetes quantity \(e.g. "5Gi"\); StorageClass empty uses the cluster default RWX class.
 
@@ -816,7 +890,7 @@ type TaskConfig struct {
 ```
 
 <a name="TaskInstance"></a>
-## type [TaskInstance](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/run.go#L48-L80>)
+## type [TaskInstance](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/run.go#L55-L87>)
 
 TaskInstance is an execution of a task within a DagRun.
 
@@ -857,7 +931,7 @@ type TaskInstance struct {
 ```
 
 <a name="TaskSpec"></a>
-## type [TaskSpec](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L132-L179>)
+## type [TaskSpec](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L160-L207>)
 
 TaskSpec describes a single unit of work within a DAG.
 
@@ -913,7 +987,7 @@ type TaskSpec struct {
 ```
 
 <a name="TaskSpec.EffectiveExecutionMode"></a>
-### func \(TaskSpec\) [EffectiveExecutionMode](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L250>)
+### func \(TaskSpec\) [EffectiveExecutionMode](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L278>)
 
 ```go
 func (t TaskSpec) EffectiveExecutionMode() ExecutionMode
@@ -969,7 +1043,7 @@ func (s TaskState) IsTerminal() bool
 IsTerminal reports whether the task state is final \(no further automatic transitions occur from it\).
 
 <a name="TaskType"></a>
-## type [TaskType](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L12>)
+## type [TaskType](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L13>)
 
 TaskType enumerates the kinds of work a task can perform.
 
@@ -998,7 +1072,7 @@ const (
 ```
 
 <a name="TriggerRule"></a>
-## type [TriggerRule](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L42>)
+## type [TriggerRule](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/dag.go#L43>)
 
 TriggerRule decides whether a task runs based on its upstreams' states.
 
@@ -1048,6 +1122,19 @@ type Variable struct {
     Key         string
     Value       string
     Description string
+}
+```
+
+<a name="VariablePatch"></a>
+## type [VariablePatch](<https://github.com/neochaotic/leoflow/blob/main/internal/domain/variable.go#L18-L22>)
+
+VariablePatch is a tri\-state write to a Variable \(\#887\). Description mirrors domain.ConnectionPatch: nil preserves the stored value \(COALESCE\), non\-nil "" clears, and a value sets. Value is subtly different because the \`value\` column is NOT NULL: the caller resolves an omitted or masked \("\*\*\*" for a sensitive key\) value to the stored value BEFORE building the patch, so Value is expected non\-nil here — a non\-nil "" still clears. Key is always written.
+
+```go
+type VariablePatch struct {
+    Key         string
+    Value       *string
+    Description *string
 }
 ```
 

--- a/website/content/reference/go/internal-executor.md
+++ b/website/content/reference/go/internal-executor.md
@@ -1,8 +1,4 @@
 ---
-# --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
-aliases:
-  - /go/internal/executor.html
-# --- end AUTO redirect aliases ---
 title: "internal/executor"
 linkTitle: "internal/executor"
 weight: 3
@@ -23,7 +19,9 @@ Package executor runs task instances via Kubernetes, Docker, or a subprocess.
 - [func IsDispatchLost\(c StaleQueuedCandidate, threshold time.Duration, now time.Time\) bool](<#IsDispatchLost>)
 - [func IsOrphaned\(c ReapCandidate, threshold time.Duration, now time.Time\) bool](<#IsOrphaned>)
 - [func IsPodLostCandidate\(c PodLostCandidate, grace time.Duration, now time.Time\) bool](<#IsPodLostCandidate>)
+- [func ResilienceLadderWarnings\(l ResilienceLadder\) \[\]string](<#ResilienceLadderWarnings>)
 - [func StagingClaimName\(dagID, runID string\) string](<#StagingClaimName>)
+- [func ValidateResilienceLadder\(l ResilienceLadder\) error](<#ValidateResilienceLadder>)
 - [type AgentLostCandidate](<#AgentLostCandidate>)
 - [type BusyWarmWorkerSource](<#BusyWarmWorkerSource>)
 - [type DecisionRecorder](<#DecisionRecorder>)
@@ -39,7 +37,7 @@ Package executor runs task instances via Kubernetes, Docker, or a subprocess.
   - [func \(e \*KubernetesExecutor\) Execute\(ctx context.Context, req Request\) \(Disposition, error\)](<#KubernetesExecutor.Execute>)
   - [func \(e \*KubernetesExecutor\) GCStagingClaims\(ctx context.Context, ttl time.Duration\) error](<#KubernetesExecutor.GCStagingClaims>)
   - [func \(e \*KubernetesExecutor\) SetStagingStore\(s StagingStore\)](<#KubernetesExecutor.SetStagingStore>)
-  - [func \(e \*KubernetesExecutor\) TaskPodActive\(ctx context.Context, runID, taskID string\) \(bool, error\)](<#KubernetesExecutor.TaskPodActive>)
+  - [func \(e \*KubernetesExecutor\) TaskPodActive\(ctx context.Context, runID, taskID string, tryNumber int\) \(bool, error\)](<#KubernetesExecutor.TaskPodActive>)
 - [type KubernetesWarmPods](<#KubernetesWarmPods>)
   - [func NewKubernetesWarmPods\(cs kubernetes.Interface, namespace string, newSpec WarmPodSpecFunc\) \*KubernetesWarmPods](<#NewKubernetesWarmPods>)
   - [func \(k \*KubernetesWarmPods\) CreateWarmPod\(ctx context.Context, t WarmTarget, anchorName, anchorUID string\) error](<#KubernetesWarmPods.CreateWarmPod>)
@@ -52,7 +50,8 @@ Package executor runs task instances via Kubernetes, Docker, or a subprocess.
   - [func ParseAgentIdentity\(raw string\) \(PodIdentity, error\)](<#ParseAgentIdentity>)
 - [type PodInformer](<#PodInformer>)
   - [func NewPodInformer\(clientset kubernetes.Interface, namespace string\) \*PodInformer](<#NewPodInformer>)
-  - [func \(p \*PodInformer\) CachedPodActive\(runID, taskID string\) bool](<#PodInformer.CachedPodActive>)
+  - [func \(p \*PodInformer\) CachedPodActive\(runID, taskID string, tryNumber int\) bool](<#PodInformer.CachedPodActive>)
+  - [func \(p \*PodInformer\) HasSynced\(\) bool](<#PodInformer.HasSynced>)
   - [func \(p \*PodInformer\) Shutdown\(\)](<#PodInformer.Shutdown>)
   - [func \(p \*PodInformer\) SnapshotTaskPods\(\) \(\[\]\*corev1.Pod, error\)](<#PodInformer.SnapshotTaskPods>)
   - [func \(p \*PodInformer\) Start\(ctx context.Context\)](<#PodInformer.Start>)
@@ -68,14 +67,21 @@ Package executor runs task instances via Kubernetes, Docker, or a subprocess.
 - [type Reaper](<#Reaper>)
   - [func NewReaper\(store ReaperStore, pods PodManager, cache PodPresenceCache, warmPods WarmPodLister, rec DecisionRecorder, logger \*slog.Logger, cfg ReaperConfig, inStepDown func\(\) bool\) \*Reaper](<#NewReaper>)
   - [func \(r \*Reaper\) ReapOnce\(ctx context.Context\) error](<#Reaper.ReapOnce>)
+  - [func \(r \*Reaper\) SetInformerSynced\(fn func\(\) bool\)](<#Reaper.SetInformerSynced>)
+  - [func \(r \*Reaper\) SetLastSweepCompleted\(fn func\(\) time.Time\)](<#Reaper.SetLastSweepCompleted>)
+  - [func \(r \*Reaper\) SetLeaderSince\(fn func\(\) time.Time\)](<#Reaper.SetLeaderSince>)
+  - [func \(r \*Reaper\) SetLeading\(fn func\(\) bool\)](<#Reaper.SetLeading>)
+  - [func \(r \*Reaper\) SetLogSink\(s logSink\)](<#Reaper.SetLogSink>)
 - [type ReaperConfig](<#ReaperConfig>)
   - [func DefaultReaperConfig\(\) ReaperConfig](<#DefaultReaperConfig>)
 - [type ReaperStore](<#ReaperStore>)
 - [type Reconciler](<#Reconciler>)
   - [func NewReconciler\(clientset kubernetes.Interface, namespace string, reporter OutcomeReporter\) \*Reconciler](<#NewReconciler>)
+  - [func \(r \*Reconciler\) LastSweepCompletedAt\(\) time.Time](<#Reconciler.LastSweepCompletedAt>)
   - [func \(r \*Reconciler\) Reconcile\(ctx context.Context\) error](<#Reconciler.Reconcile>)
   - [func \(r \*Reconciler\) SetPodSnapshotter\(s PodSnapshotter\)](<#Reconciler.SetPodSnapshotter>)
 - [type Request](<#Request>)
+- [type ResilienceLadder](<#ResilienceLadder>)
 - [type StagingStore](<#StagingStore>)
 - [type StaleQueuedCandidate](<#StaleQueuedCandidate>)
 - [type SubprocessExecutor](<#SubprocessExecutor>)
@@ -144,7 +150,7 @@ func BuildPod(req Request) *corev1.Pod
 BuildPod constructs the pod spec for a task instance. It is pure \(modulo the random name suffix\) and unit\-tested independently of any cluster.
 
 <a name="BuildWarmPod"></a>
-## func [BuildWarmPod](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/warmpod.go#L148>)
+## func [BuildWarmPod](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/warmpod.go#L156>)
 
 ```go
 func BuildWarmPod(spec WarmPodSpec) *corev1.Pod
@@ -159,7 +165,7 @@ BuildWarmPod constructs the pod spec for one warm worker. It reuses BuildPod's m
 It is pure \(modulo the random name suffix\) and unit\-tested independently of any cluster. It bakes NO task token in. When the spec carries a GC anchor \(D11\) it stamps an ownerReference to that anchor ConfigMap so the pod is cascade\-GC'd on external teardown; without an anchor it builds a bare pod, unchanged.
 
 <a name="IsAgentLost"></a>
-## func [IsAgentLost](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/heartbeat_reap.go#L35>)
+## func [IsAgentLost](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/heartbeat_reap.go#L51>)
 
 ```go
 func IsAgentLost(c AgentLostCandidate, threshold time.Duration, now time.Time) bool
@@ -194,6 +200,15 @@ func IsPodLostCandidate(c PodLostCandidate, grace time.Duration, now time.Time) 
 
 IsPodLostCandidate reports whether a running TI has been running long enough to warrant a pod\-liveness check. A zero RunningSince is treated as alive \(too poorly observed to reap — the "do no harm" rule of ADR 0031\), and a future RunningSince \(clock skew\) is treated as alive. This gate is purely about elapsed time; the actual lost\-vs\-alive decision is the pod\-liveness check.
 
+<a name="ResilienceLadderWarnings"></a>
+## func [ResilienceLadderWarnings](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/resilience_ladder.go#L164>)
+
+```go
+func ResilienceLadderWarnings(l ResilienceLadder) []string
+```
+
+ResilienceLadderWarnings reports the ladder settings that are valid but remove a resilience backstop, so the server can surface them as boot WARNs. ValidateResilienceLadder deliberately accepts a non\-positive credential ceiling — it is the operator's documented "no ceiling" setting — but that one value disables every wall\-clock bound the ceiling carries: heartbeat renewal of an attempt's bearer becomes unbounded; a dedicated task pod whose DAG declares no execution timeout gets no ActiveDeadlineSeconds floor; and, with warm pools enabled, the per\-attempt watchdog that keeps a wedged attempt from pinning a warm slot is off too \(a warm pod has no pod\-level deadline at all, and the worker lifetime cap drains between attempts, never mid\-attempt\). A task that wedges while still heartbeating then has no bound of its own even with a healthy control plane: the orphan\-run reaper skips a run with a live task instance and agent\-lost never fires on a live agent. None of these losses is an error; all are invisible without this signal. Pure, like the validator: the server calls it once at boot after the logger exists.
+
 <a name="StagingClaimName"></a>
 ## func [StagingClaimName](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/staging.go#L45>)
 
@@ -203,14 +218,24 @@ func StagingClaimName(dagID, runID string) string
 
 StagingClaimName is the deterministic PVC name for a run's staging volume. It must be stable across retries and clear\+re\-run so the same PVC is re\-attached \(ADR 0022\), and DNS\-safe.
 
+<a name="ValidateResilienceLadder"></a>
+## func [ValidateResilienceLadder](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/resilience_ladder.go#L106>)
+
+```go
+func ValidateResilienceLadder(l ResilienceLadder) error
+```
+
+ValidateResilienceLadder checks the orderings the restart recovery depends on \(see ResilienceLadder\) and reports the first violated relation, naming both sides with their values. A relation between build\-time constants can only be broken by a code change, so its error says so and asks for a bug report; the one relation involving an operator knob names the config key. All build\-time rungs must be positive. It is pure — the server calls it once at boot and refuses to start on an error, turning what used to be a comment\-level convention into an enforced invariant.
+
 <a name="AgentLostCandidate"></a>
-## type [AgentLostCandidate](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/heartbeat_reap.go#L15-L27>)
+## type [AgentLostCandidate](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/heartbeat_reap.go#L30-L43>)
 
 AgentLostCandidate is one task instance in \`running\` whose agent may have gone silent, with the timestamp of its most recent heartbeat. The reaper compares the gap from this stamp to "now" against a stall threshold; a non\-zero gap larger than the threshold means the agent is presumed gone and the TI is failed with reason "agent\_lost".
 
 ```go
 type AgentLostCandidate struct {
     TaskInstanceID string
+    TenantID       string
     DagRunID       string
     DagID          string
     TaskID         string
@@ -310,7 +335,7 @@ func (d Disposition) String() string
 String renders the disposition for logs and error notes.
 
 <a name="Executor"></a>
-## type [Executor](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/executor.go#L124-L126>)
+## type [Executor](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/executor.go#L145-L147>)
 
 Executor runs or dispatches a task. For asynchronous executors \(Kubernetes/Docker/subprocess\) the return reflects dispatch only, and the agent reports the final state over gRPC. The Disposition tells the scheduler WHY a dispatch failed — transient cluster Backpressure vs a permanent Rejected — so the orchestration layer never has to inspect runtime\-specific error types itself \(ADR 0051 Phase 4\). A successful dispatch returns \(Dispatched, nil\); a failure returns the classified disposition alongside the non\-nil cause \(its text feeds the scheduler's note/log\).
 
@@ -321,7 +346,7 @@ type Executor interface {
 ```
 
 <a name="HeartbeatReapStore"></a>
-## type [HeartbeatReapStore](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/heartbeat_reap.go#L45-L57>)
+## type [HeartbeatReapStore](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/heartbeat_reap.go#L61-L73>)
 
 HeartbeatReapStore is the slice of scheduler.Store the TI heartbeat reaper needs. The full scheduler.Store embeds this interface so production wires through one type; unit tests fake just this surface.
 
@@ -407,13 +432,15 @@ func (e *KubernetesExecutor) SetStagingStore(s StagingStore)
 SetStagingStore wires the metadatabase\-backed staging\-volume lifecycle store \(ADR 0022\). With no store set, provisioning is not recorded and GC is a no\-op.
 
 <a name="KubernetesExecutor.TaskPodActive"></a>
-### func \(\*KubernetesExecutor\) [TaskPodActive](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_terminate.go#L80>)
+### func \(\*KubernetesExecutor\) [TaskPodActive](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_terminate.go#L85>)
 
 ```go
-func (e *KubernetesExecutor) TaskPodActive(ctx context.Context, runID, taskID string) (bool, error)
+func (e *KubernetesExecutor) TaskPodActive(ctx context.Context, runID, taskID string, tryNumber int) (bool, error)
 ```
 
-TaskPodActive reports whether a pod for the given \(run, task\) exists and is still Pending or Running. The dispatch\-lost reaper consults this before failing a \`queued\` TI: a live pod means the dispatch actually landed and the node is merely slow to pull the image \(\#461\), so the reaper must DEFER. No pod, or only terminal \(Failed/Succeeded/Unknown\) pods, means the dispatch is genuinely lost and the reaper may proceed. Try\-number is deliberately NOT pinned here: a \`queued\` TI has not been retried, so run\-id\+task\-id already identifies its single pod, and matching any live pod for the task is the safer \(more deferring\) choice.
+TaskPodActive reports whether a pod for exactly the \(run, task, try\) attempt exists and is still Pending or Running. The dispatch\-lost and pod\-lost reapers consult this before failing a TI: a live pod means the dispatch actually landed and the node is merely slow to pull the image \(\#461\), so the reaper must DEFER. No pod, or only terminal \(Failed/Succeeded/Unknown\) pods, means the attempt is genuinely lost and the reaper may proceed.
+
+Try\-number is pinned — the same invariant guard as DeleteTaskPod above. The retry rail resets up\_for\_retry \-\> none with try\_number\+1 and the planner re\-queues the TI \(storage/queries/runs.sql\), so a \`queued\`/\`running\` TI can be on try 2 while try 1's pod still lingers Pending after a failed best\-effort delete. Selecting on \(run, task\) alone would match that stale older pod and false\-defer the reap of the current attempt forever \(\#723\). Asking about the attempt the reaper is about to fail is the correct liveness question.
 
 <a name="KubernetesWarmPods"></a>
 ## type [KubernetesWarmPods](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/warmpool_k8s.go#L25-L29>)
@@ -481,7 +508,7 @@ func (k *KubernetesWarmPods) ListWarmPods(ctx context.Context) ([]WarmPodInfo, e
 ListWarmPods returns every warm\-worker pod in the namespace, tagged with the dag\_version it serves \(from its label\).
 
 <a name="OutcomeReporter"></a>
-## type [OutcomeReporter](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L208-L212>)
+## type [OutcomeReporter](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L227-L231>)
 
 OutcomeReporter records a terminal task\-instance outcome the reconciler recovered from a pod \(its durable outcome record, or its phase\). Every method is guarded by the attempt \(try\_number\) so a stale reconciler acting on a previous attempt's pod never clobbers a live retry, and is idempotent: a settle on an already\-terminal instance is a no\-op, not an error.
 
@@ -494,7 +521,7 @@ type OutcomeReporter interface {
 ```
 
 <a name="PodIdentity"></a>
-## type [PodIdentity](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L174-L181>)
+## type [PodIdentity](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L198-L205>)
 
 PodIdentity is the JSON payload of AgentIdentityAnnotation: the full task\-instance identity the control plane mints the exchanged JWT for.
 
@@ -510,7 +537,7 @@ type PodIdentity struct {
 ```
 
 <a name="ParseAgentIdentity"></a>
-### func [ParseAgentIdentity](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L186>)
+### func [ParseAgentIdentity](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L210>)
 
 ```go
 func ParseAgentIdentity(raw string) (PodIdentity, error)
@@ -519,7 +546,7 @@ func ParseAgentIdentity(raw string) (PodIdentity, error)
 ParseAgentIdentity decodes the AgentIdentityAnnotation payload. It is the read side of the identity contract mountAgentToken writes, used by the pod → task\-instance resolver on the exchange path.
 
 <a name="PodInformer"></a>
-## type [PodInformer](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_informer.go#L47-L54>)
+## type [PodInformer](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_informer.go#L49-L56>)
 
 PodInformer is a shared\-informer read\-path over task pods, scoped by namespace and the leoflow.io/run\-id label \(ADR 0002 pods\). It replaces the reapers' per\-running\-TI\-per\-second apiserver LIST storm and the reconciler's 30s LIST with one long\-lived watch feeding a local cache.
 
@@ -534,7 +561,7 @@ type PodInformer struct {
 ```
 
 <a name="NewPodInformer"></a>
-### func [NewPodInformer](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_informer.go#L60>)
+### func [NewPodInformer](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_informer.go#L62>)
 
 ```go
 func NewPodInformer(clientset kubernetes.Interface, namespace string) *PodInformer
@@ -543,16 +570,25 @@ func NewPodInformer(clientset kubernetes.Interface, namespace string) *PodInform
 NewPodInformer builds a shared pod informer over the given cluster, scoped to namespace and to pods carrying the leoflow.io/run\-id label \(managed task pods\). Resync is 0: reads are level\-triggered on demand, so there are no logic\-bearing handlers to re\-fire. It does not start watching until Start is called.
 
 <a name="PodInformer.CachedPodActive"></a>
-### func \(\*PodInformer\) [CachedPodActive](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_informer.go#L116>)
+### func \(\*PodInformer\) [CachedPodActive](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_informer.go#L128>)
 
 ```go
-func (p *PodInformer) CachedPodActive(runID, taskID string) bool
+func (p *PodInformer) CachedPodActive(runID, taskID string, tryNumber int) bool
 ```
 
-CachedPodActive reports whether the cache holds a pod for \(run, task\) that is Pending or Running — the exact predicate TaskPodActive uses. It is the safe direction of the asymmetric\-trust contract: a true return may DEFER a reap; a false return is NEVER authoritative and the caller must fall through to the live read. Before the cache has synced it returns false, so a cold cache degrades to the live path rather than misreporting absence.
+CachedPodActive reports whether the cache holds a pod for exactly the \(run, task, try\) attempt that is Pending or Running — the exact predicate TaskPodActive uses, pinned to the same attempt \(\#723\). It is the safe direction of the asymmetric\-trust contract: a true return may DEFER a reap; a false return is NEVER authoritative and the caller must fall through to the live read. Before the cache has synced it returns false, so a cold cache degrades to the live path rather than misreporting absence.
+
+<a name="PodInformer.HasSynced"></a>
+### func \(\*PodInformer\) [HasSynced](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_informer.go#L110>)
+
+```go
+func (p *PodInformer) HasSynced() bool
+```
+
+HasSynced reports whether the initial LIST has populated the cache. It is the live form of WaitForCacheSync's one\-shot answer, for a caller that must keep asking — the reaper's leader\-settling gate — so a cache that synced late \(a watch recovered after an RBAC fix\) is seen, and one that never synced is not mistaken for an empty cluster.
 
 <a name="PodInformer.Shutdown"></a>
-### func \(\*PodInformer\) [Shutdown](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_informer.go#L105>)
+### func \(\*PodInformer\) [Shutdown](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_informer.go#L116>)
 
 ```go
 func (p *PodInformer) Shutdown()
@@ -561,7 +597,7 @@ func (p *PodInformer) Shutdown()
 Shutdown stops the watch and waits for the informer goroutines to exit. Safe to call more than once \(Start's ctx\-cancel path and an explicit caller may race\).
 
 <a name="PodInformer.SnapshotTaskPods"></a>
-### func \(\*PodInformer\) [SnapshotTaskPods](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_informer.go#L140>)
+### func \(\*PodInformer\) [SnapshotTaskPods](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_informer.go#L153>)
 
 ```go
 func (p *PodInformer) SnapshotTaskPods() ([]*corev1.Pod, error)
@@ -570,7 +606,7 @@ func (p *PodInformer) SnapshotTaskPods() ([]*corev1.Pod, error)
 SnapshotTaskPods returns the managed task pods currently in the cache — the reconciler's read replacement for its 30s LIST. It errors \(errCacheNotSynced\) before the initial sync so the reconciler retries next tick instead of acting on a cold cache that looks empty.
 
 <a name="PodInformer.Start"></a>
-### func \(\*PodInformer\) [Start](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_informer.go#L87>)
+### func \(\*PodInformer\) [Start](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_informer.go#L89>)
 
 ```go
 func (p *PodInformer) Start(ctx context.Context)
@@ -579,7 +615,7 @@ func (p *PodInformer) Start(ctx context.Context)
 Start begins the watch in the background and stops it when ctx is canceled, so the informer is always\-on for the process lifetime \(warming the cache before leadership\). It is idempotent\-safe to call once per informer.
 
 <a name="PodInformer.WaitForCacheSync"></a>
-### func \(\*PodInformer\) [WaitForCacheSync](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_informer.go#L99>)
+### func \(\*PodInformer\) [WaitForCacheSync](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_informer.go#L101>)
 
 ```go
 func (p *PodInformer) WaitForCacheSync(ctx context.Context) bool
@@ -626,7 +662,7 @@ type PodLostReapStore interface {
 ```
 
 <a name="PodManager"></a>
-## type [PodManager](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_manager.go#L19-L33>)
+## type [PodManager](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_manager.go#L19-L35>)
 
 PodManager is the slice of the Kubernetes executor the reapers use to \(1\) tear down a reaped task's pod and \(2\) check whether a queued TI's pod is actually live before declaring its dispatch lost \(\#474, \#461\).
 
@@ -647,15 +683,17 @@ type PodManager interface {
     // orphan-run reaper, which abandons the whole run. The run-id is unique
     // per run, so no other run's pod can match. Tolerates missing pods.
     DeleteRunPods(ctx context.Context, runID string) error
-    // TaskPodActive reports whether a pod for (run, task) exists and is
-    // Pending or Running. The dispatch-lost reaper defers when it is true —
-    // the dispatch landed, the node is merely slow (#461).
-    TaskPodActive(ctx context.Context, runID, taskID string) (bool, error)
+    // TaskPodActive reports whether a pod for exactly the (run, task, try)
+    // attempt exists and is Pending or Running. The reaper defers when it is
+    // true — the dispatch landed, the node is merely slow (#461). Try-number is
+    // pinned so a retried TI's liveness gate asks about the attempt it is about
+    // to fail, not any older attempt whose pod may still linger (#723).
+    TaskPodActive(ctx context.Context, runID, taskID string, tryNumber int) (bool, error)
 }
 ```
 
 <a name="PodPresenceCache"></a>
-## type [PodPresenceCache](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_manager.go#L51-L56>)
+## type [PodPresenceCache](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_manager.go#L53-L60>)
 
 PodPresenceCache is an optional read\-through cache of pod presence — backed by a shared informer \(PR\-10\) — that the pod\-lost and dispatch\-lost reapers consult ONLY to DEFER a reap, never to authorize one. Its trust is asymmetric \(\#461\):
 
@@ -667,9 +705,11 @@ It exists to remove the O\(running\-TIs\)/sec apiserver LIST storm from the read
 ```go
 type PodPresenceCache interface {
     // CachedPodActive reports whether the cache holds a Pending/Running pod for
-    // (run, task). Only a true return is trusted (to defer); false is a "no
-    // speedup" signal that must not drive a reap.
-    CachedPodActive(runID, taskID string) bool
+    // exactly the (run, task, try) attempt. Only a true return is trusted (to
+    // defer); false is a "no speedup" signal that must not drive a reap.
+    // Try-number is pinned so the cache gate cannot defer on an older attempt's
+    // lingering pod (#723).
+    CachedPodActive(runID, taskID string, tryNumber int) bool
 }
 ```
 
@@ -701,7 +741,7 @@ type PodSecurity struct {
 ```
 
 <a name="PodSnapshotter"></a>
-## type [PodSnapshotter](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L220-L225>)
+## type [PodSnapshotter](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L239-L244>)
 
 PodSnapshotter supplies the reconciler's task\-pod set from a local cache instead of a live LIST every tick \(PR\-10\). It is safe here without a live confirm: the signal the reconciler acts on is presence of a terminal pod, which is monotonic \(a pod that reached Failed/Succeeded stays terminal\), and every settle is attempt\- and state\-guarded \(ADR 0052\), so at worst cache lag delays a settle by a tick. A nil snapshotter \(Lite/subprocess, or a cold start\) keeps the live LIST.
 
@@ -747,9 +787,9 @@ type ReapStore interface {
 ```
 
 <a name="Reaper"></a>
-## type [Reaper](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reaper.go#L75-L87>)
+## type [Reaper](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reaper.go#L110-L139>)
 
-Reaper is the execution\-side backstop that fails stuck runs and task instances the scheduler dispatched but that then went dark. It bundles the four independent reapers behind one ReapOnce entrypoint the scheduler drives once per leader tick, so the scheduler depends on a single capability rather than wiring each reaper itself.
+Reaper is the execution\-side backstop that fails stuck runs and task instances the scheduler dispatched but that then went dark. It bundles the five independent reapers behind one ReapOnce entrypoint the leader's maintenance loop drives once per cycle, after the pod reconciler's sweep, so the caller depends on a single capability rather than wiring each reaper itself.
 
 ```go
 type Reaper struct {
@@ -758,7 +798,7 @@ type Reaper struct {
 ```
 
 <a name="NewReaper"></a>
-### func [NewReaper](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reaper.go#L102>)
+### func [NewReaper](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reaper.go#L154>)
 
 ```go
 func NewReaper(store ReaperStore, pods PodManager, cache PodPresenceCache, warmPods WarmPodLister, rec DecisionRecorder, logger *slog.Logger, cfg ReaperConfig, inStepDown func() bool) *Reaper
@@ -769,32 +809,86 @@ NewReaper constructs the reapers and wires their pod\-teardown / liveness capabi
 warmPods is the live warm\-pod seam \(ADR 0058 N1d\-a2\), threaded to the two warm consumers exactly the way pods/cache are threaded: the warm\-worker\-lost reaper \(which recovers a dead worker's attempts\) and the dispatch\-lost reaper's H3 defer. Nil \(warm pools off / not wired\) makes the warm reaper a no\-op and the dispatch\-lost warm defer inert — with the flag off no TI ever carries a warm\_worker\_id either, so both warm paths are doubly inert, byte\-for\-byte today.
 
 <a name="Reaper.ReapOnce"></a>
-### func \(\*Reaper\) [ReapOnce](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reaper.go#L145>)
+### func \(\*Reaper\) [ReapOnce](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reaper.go#L360>)
 
 ```go
 func (r *Reaper) ReapOnce(ctx context.Context) error
 ```
 
-ReapOnce runs the four reapers once, in the same order the scheduler drove them: orphan\-run, then agent\-lost, then dispatch\-lost, then pod\-lost. The dispatch\-lost reaper runs AFTER the orphan\-run reaper so a clean stuck\-queued \-\> failed \-\> orphan\-run\-failed chain can complete in a single tick once the thresholds elapse.
+ReapOnce runs the five reapers once, in the order the scheduler used to drive them: orphan\-run, then agent\-lost, then dispatch\-lost, then pod\-lost, then warm\-worker\-lost. The dispatch\-lost reaper runs AFTER the orphan\-run reaper so a clean stuck\-queued \-\> failed \-\> orphan\-run\-failed chain can complete in a single tick once the thresholds elapse.
 
-Each reaper's infra\-level list error is logged and metered but never returned: the reapers are independent backstops, so one's failure must not block the others, and a list error must not stall the scheduler tick. Per\-candidate failures are already isolated inside each reaper's run. ReapOnce therefore always returns nil today; the error return is kept for the seam so a future hard\-failure mode need not change the scheduler.
+The whole tick is skipped — and the skip metered as reap\_gate\_skip — when the destructive gate is closed on entry: a canceled context \(SIGTERM drain, the step\-down cancel fan\-out\), a scheduler in step\-down, or a lost leadership. It is likewise skipped, metered as reap\_settling\_skip, while the leader has not settled \(see settling\); once settling has lasted 2× the grace the liveness valve opens and the tick proceeds with a WARN and reap\_settling\_valve\_open. The reapers also re\-check the destructive gate before each individual write, so the early return is the cheap common case, not the only defense.
+
+Each reaper's infra\-level list error is logged and metered but never returned: the reapers are independent backstops, so one's failure must not block the others, and a list error must not stall the caller's cycle. Per\-candidate failures are already isolated inside each reaper's run. ReapOnce therefore always returns nil today; the error return is kept for the seam so a future hard\-failure mode need not change the caller.
+
+<a name="Reaper.SetInformerSynced"></a>
+### func \(\*Reaper\) [SetInformerSynced](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reaper.go#L243>)
+
+```go
+func (r *Reaper) SetInformerSynced(fn func() bool)
+```
+
+SetInformerSynced wires the pod informer's sync predicate into the settling gate. Until the cache has synced, the reapers' presence reads fall back to live LISTs \(safe, but the fleet view a fresh leader is about to judge from is still being assembled\), so the gate waits. Nil \(no informer: Lite, or a non\-Kubernetes executor\) leaves this condition satisfied.
+
+<a name="Reaper.SetLastSweepCompleted"></a>
+### func \(\*Reaper\) [SetLastSweepCompleted](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reaper.go#L253>)
+
+```go
+func (r *Reaper) SetLastSweepCompleted(fn func() time.Time)
+```
+
+SetLastSweepCompleted wires the reconciler's last\-completed\-sweep record into the settling gate: the gate holds until a sweep has COMPLETED at or after leadership was acquired, because that sweep is what recovers the durable outcome of a task pod that finished during the outage; before it, "no live pod" and "no recent heartbeat" are indistinguishable from a lost task. Nil \(no reconciler: Lite\) leaves this condition satisfied.
+
+<a name="Reaper.SetLeaderSince"></a>
+### func \(\*Reaper\) [SetLeaderSince](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reaper.go#L234>)
+
+```go
+func (r *Reaper) SetLeaderSince(fn func() time.Time)
+```
+
+SetLeaderSince wires the accessor the settling gate measures its grace from: when this instance last acquired scheduler leadership \(zero while not leading\). Measured from leadership acquisition, not process start, so a re\-election also resets the gate. Nil \(Lite / no leadership\) disables the gate entirely — the other two inputs are only meaningful under a leader.
+
+<a name="Reaper.SetLeading"></a>
+### func \(\*Reaper\) [SetLeading](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reaper.go#L202>)
+
+```go
+func (r *Reaper) SetLeading(fn func() bool)
+```
+
+SetLeading wires the leadership predicate into the destructive gate, so a reaper tick on an instance that no longer holds leadership marks and deletes nothing. The maintenance loop already drives ReapOnce only while leading; this is the defensive re\-check at the point of the write. Nil leaves the gate on ctx and step\-down alone.
+
+<a name="Reaper.SetLogSink"></a>
+### func \(\*Reaper\) [SetLogSink](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reaper.go#L225>)
+
+```go
+func (r *Reaper) SetLogSink(s logSink)
+```
+
+SetLogSink wires the sink the agent\-lost reaper uses to append a final "killed: agent\_lost" marker to a reaped attempt's log stream, so a killed task's log ends with the reason instead of a silent truncation. Any logs.Sink satisfies the parameter; nil \(Lite / unwired\) leaves markers off.
 
 <a name="ReaperConfig"></a>
-## type [ReaperConfig](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reaper.go#L52-L57>)
+## type [ReaperConfig](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reaper.go#L61-L73>)
 
-ReaperConfig holds the four idle thresholds the reapers apply. Zero values are legal but reap aggressively; callers pass DefaultReaperConfig unless a test or load harness deliberately overrides them.
+ReaperConfig holds the idle thresholds and the post\-leadership settling grace the reapers apply. Zero values are legal but reap aggressively; callers pass DefaultReaperConfig unless a test or load harness deliberately overrides them.
 
 ```go
 type ReaperConfig struct {
     OrphanThreshold       time.Duration
     AgentLostThreshold    time.Duration
     DispatchLostThreshold time.Duration
-    PodLostGrace          time.Duration
+    // PodLostGrace is the per-task liveness floor measured from the TI's running
+    // transition, below which the pod-lost reaper does not consult pod liveness.
+    PodLostGrace time.Duration
+    // SettlingGrace is the minimum time after this instance acquires leadership
+    // before ANY reaper may act — one rung of the leader-settling gate, which
+    // also requires a synced pod informer and a completed reconciler sweep. See
+    // defaultSettlingGrace and Reaper.settling. Zero disables the whole gate.
+    SettlingGrace time.Duration
 }
 ```
 
 <a name="DefaultReaperConfig"></a>
-### func [DefaultReaperConfig](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reaper.go#L61>)
+### func [DefaultReaperConfig](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reaper.go#L77>)
 
 ```go
 func DefaultReaperConfig() ReaperConfig
@@ -805,7 +899,7 @@ DefaultReaperConfig returns the production thresholds — the exact values the s
 <a name="ReaperStore"></a>
 ## type [ReaperStore](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reaper.go#L22-L28>)
 
-ReaperStore is the full store surface the four reapers need, composed from each reaper's own slice. The metadatabase\-backed SchedulerStore satisfies all four, so production wires through one type; a unit test fakes just the slice its reaper touches.
+ReaperStore is the full store surface the five reapers need, composed from each reaper's own slice. The metadatabase\-backed SchedulerStore satisfies all five, so production wires through one type; a unit test fakes just the slice its reaper touches.
 
 ```go
 type ReaperStore interface {
@@ -818,7 +912,7 @@ type ReaperStore interface {
 ```
 
 <a name="Reconciler"></a>
-## type [Reconciler](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L243-L253>)
+## type [Reconciler](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L262-L277>)
 
 Reconciler detects task pods whose task instance was never settled by the agent \(a pod killed before or during its report\) and records the true outcome — from the pod's durable outcome record where present, else its phase — so retries and run finalization proceed instead of stranding the task. It also garbage\-collects finished pods once they age out.
 
@@ -831,7 +925,7 @@ type Reconciler struct {
 ```
 
 <a name="NewReconciler"></a>
-### func [NewReconciler](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L256>)
+### func [NewReconciler](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L280>)
 
 ```go
 func NewReconciler(clientset kubernetes.Interface, namespace string, reporter OutcomeReporter) *Reconciler
@@ -839,17 +933,28 @@ func NewReconciler(clientset kubernetes.Interface, namespace string, reporter Ou
 
 NewReconciler builds a Reconciler over the given cluster and outcome reporter.
 
+<a name="Reconciler.LastSweepCompletedAt"></a>
+### func \(\*Reconciler\) [LastSweepCompletedAt](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L301>)
+
+```go
+func (r *Reconciler) LastSweepCompletedAt() time.Time
+```
+
+LastSweepCompletedAt reports when the last COMPLETED sweep finished: the task\-pod set was listed and every pod visited, so every terminal pod present at that moment had its chance to settle its task instance. Zero means no sweep has completed yet. It is the record the reaper's leader\-settling gate compares against the leadership stamp — the reapers act on signals a control\-plane restart manufactures \(a task pod that exited during the outage looks lost\), and only a sweep completed under the new leader separates "finished during the outage, outcome recoverable" from "genuinely lost".
+
+A sweep that could not list pods records nothing. A sweep whose individual settle failed on a DB error still counts: that pod is retried next sweep, and the gate's grace leaves room for the retry before any reaper may act.
+
 <a name="Reconciler.Reconcile"></a>
-### func \(\*Reconciler\) [Reconcile](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L268>)
+### func \(\*Reconciler\) [Reconcile](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L312>)
 
 ```go
 func (r *Reconciler) Reconcile(ctx context.Context) error
 ```
 
-Reconcile lists managed task pods, records each terminal one's outcome against its task instance, and garbage\-collects finished pods older than the grace period.
+Reconcile lists managed task pods, records each terminal one's outcome against its task instance, and garbage\-collects finished pods older than the grace period. A completed sweep is stamped for LastSweepCompletedAt.
 
 <a name="Reconciler.SetPodSnapshotter"></a>
-### func \(\*Reconciler\) [SetPodSnapshotter](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L263>)
+### func \(\*Reconciler\) [SetPodSnapshotter](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L287>)
 
 ```go
 func (r *Reconciler) SetPodSnapshotter(s PodSnapshotter)
@@ -858,7 +963,7 @@ func (r *Reconciler) SetPodSnapshotter(s PodSnapshotter)
 SetPodSnapshotter wires a cache\-backed pod source so Reconcile reads its task\-pod set from the shared informer instead of a live LIST every tick \(PR\-10\). Left unset, the reconciler keeps the live LIST — today's behavior.
 
 <a name="Request"></a>
-## type [Request](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/executor.go#L35-L114>)
+## type [Request](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/executor.go#L35-L135>)
 
 Request bundles everything an executor needs to run a single task instance.
 
@@ -879,6 +984,19 @@ type Request struct {
     Resources       domain.Resources
     Execution       domain.Execution
     TimeoutSeconds  int
+    // AttemptLifetimeCeilingSeconds is the operator's attempt credential ceiling
+    // (auth.max_attempt_credential_lifetime) in whole seconds. The Kubernetes
+    // executor floors the task pod's ActiveDeadlineSeconds with it when the task
+    // declares no TimeoutSeconds, so no task pod is immortal: the agent's reports
+    // retry for as long as the control plane is unreachable, and without a floor
+    // a total control-plane outage would leave every such pod Running forever,
+    // holding its requests and blocking node scale-down. Past the ceiling the pod
+    // can do nothing useful — heartbeat renewal stops and its bearer lapses. A
+    // user-declared TimeoutSeconds always wins, even when longer. Non-positive
+    // means "no ceiling" (the same convention as the warm worker's attempt
+    // watchdog for the same knob) and applies no floor. Ignored by the subprocess
+    // executor, which has no pod.
+    AttemptLifetimeCeilingSeconds int64
 
     // PodSecurity carries the two hardening choices that can change how a task
     // runs. Everything else BuildPod applies is unconditional, because dropping
@@ -942,6 +1060,65 @@ type Request struct {
     // the key in the cluster's secret store rather than in Leoflow (ADR 0035).
     TaskSecretName      string
     TaskSecretMountPath string
+
+    // SecretsBackend / SecretsBackendKwargs, when set, are the operator's external
+    // secrets backend (ADR 0060): the provider class the in-pod resolver drives and
+    // its raw kwargs JSON. Injected as LEOFLOW_SECRETS_BACKEND[_KWARGS] pod env, in
+    // the leoflow-owned group (operator-sourced — an author's task env cannot set
+    // LEOFLOW_ keys, #828). Empty = no external backend (chain stays vault-only).
+    SecretsBackend       string
+    SecretsBackendKwargs string
+}
+```
+
+<a name="ResilienceLadder"></a>
+## type [ResilienceLadder](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/resilience_ladder.go#L52-L76>)
+
+ResilienceLadder is the set of timing knobs whose relative ORDER the control\-plane\-restart recovery depends on. Each is owned by a different package \(agent, executor, scheduler, server main, operator config\) and tuned for its own reason, so nothing but this type states that they must line up. The invariants:
+
+```
+heartbeat interval  <  agent-lost threshold  <  settling grace  <  attempt token TTL
+2 × maintenance interval  <  settling grace
+longest infra re-place delay  <  orphan threshold
+attempt token TTL  <  max attempt credential lifetime   (when the ceiling is enabled)
+```
+
+Why each rung matters:
+
+- heartbeat \< threshold: a healthy agent must beat well inside the silence window or the agent\-lost reaper fails live tasks.
+- threshold \< settling grace: after a \(re\-\)election the reapers wait longer than the silence they punish, so the whole fleet can re\-heartbeat.
+- settling grace \< token TTL: the grace ends while a re\-heartbeat can still authenticate and renew the bearer; otherwise the fleet is unreapable AND unable to report — every in\-flight task is lost.
+- 2×maintenance \< settling grace: the leader's maintenance loop runs the reconciler's sweep and then the reapers as ONE ordered cycle, so a reap structurally follows a completed sweep — the settling gate additionally requires that a sweep completed under the new leader. This rung is what makes the grace meaningful on top of that ordering: at least two whole cycles fit inside it, so a settle that failed transiently on the first sweep \(a DB hiccup\) is retried before the gate can open, and the liveness valve at 2×grace has seen at least four cycles before it declares the sweep broken. A single cycle is not enough: the first tick under a new leader may land anywhere in the interval, so "one interval below the grace" can mean zero completed cycles.
+- infra re\-place delay \< orphan threshold: a run whose only live task is parked in its longest infra re\-place backoff has no activity to show the orphan\-run reaper; the threshold must outlast that parking or the reaper eats a run that is still recovering from the very fault being retried.
+- token TTL \< credential lifetime: heartbeat renewal keeps an attempt's bearer alive only while the attempt is younger than the ceiling. A ceiling below the TTL means the first renewal is already refused, the bearer lapses at the TTL, and every task longer than one TTL is unreapable AND unable to report — the restart recovery is silently disabled. This is the ONLY operator\-tunable rung; every other value is a build\-time constant.
+
+Warm pools share the same ladder: a warm worker's per\-attempt bearer is renewed by the same heartbeat under the same ceiling, and the warm\-worker\-lost reaper reuses the pod\-lost mark, so no warm\-specific rung exists.
+
+```go
+type ResilienceLadder struct {
+    HeartbeatInterval  time.Duration
+    AgentLostThreshold time.Duration
+    // SettlingGrace is the post-leadership window during which no reaper fires
+    // (ReaperConfig.SettlingGrace); the one grace every reaper shares.
+    SettlingGrace   time.Duration
+    AttemptTokenTTL time.Duration
+    // ReconcileInterval is the period of the leader's maintenance loop: one
+    // reconciler sweep followed by one reaper pass per cycle.
+    ReconcileInterval time.Duration
+    // OrphanThreshold is how long a running dag run may sit with no activity
+    // before the orphan-run reaper fails it (ReaperConfig.OrphanThreshold).
+    OrphanThreshold time.Duration
+    // InfraReplaceMaxDelay is the longest the scheduler may park an infra-failed
+    // task before re-placing it: the backoff before the final permitted re-place
+    // plus the whole de-synchronizing jitter window. The scheduler owns and
+    // computes it; it is passed in because the scheduler package depends on this
+    // one, so the validator cannot read it directly.
+    InfraReplaceMaxDelay time.Duration
+    // MaxAttemptCredentialLifetime is the operator's auth.max_attempt_credential_lifetime:
+    // the ceiling on how long heartbeat renewal keeps an attempt's bearer alive.
+    // A non-positive value is the documented "no ceiling" setting; the rung that
+    // depends on it is then trivially satisfied and skipped.
+    MaxAttemptCredentialLifetime time.Duration
 }
 ```
 
@@ -1005,7 +1182,7 @@ func NewSubprocessExecutor(agentPath string, logger *slog.Logger) *SubprocessExe
 NewSubprocessExecutor builds a SubprocessExecutor running the given agent binary. It warns that user code runs unsandboxed. The per\-DAG venv root is read from LEOFLOW\_LITE\_VENVS\_ROOT at construction time so the executor can pick the right Python for each task without a follow\-up call.
 
 <a name="SubprocessExecutor.Execute"></a>
-### func \(\*SubprocessExecutor\) [Execute](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/subprocess.go#L141>)
+### func \(\*SubprocessExecutor\) [Execute](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/subprocess.go#L154>)
 
 ```go
 func (e *SubprocessExecutor) Execute(ctx context.Context, req Request) (Disposition, error)
@@ -1084,7 +1261,7 @@ type WarmPodLister interface {
 ```
 
 <a name="WarmPodSpec"></a>
-## type [WarmPodSpec](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/warmpod.go#L60-L124>)
+## type [WarmPodSpec](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/warmpod.go#L60-L132>)
 
 WarmPodSpec is everything BuildWarmPod needs to build one long\-lived warm\-worker pod: which dag\_version pool it serves, the image \(the DAG's image — a warm worker runs the agent in warm mode and forks a child per attempt\), the control\-plane connection, and how its BOOTSTRAP credential reaches it \(the same transport a task pod uses\). It carries NO task instance: the per\-attempt token and task identity arrive in\-band over AwaitAssignment, never on this spec.
 
@@ -1106,6 +1283,14 @@ type WarmPodSpec struct {
     // cert against. Reused verbatim so a warm worker connects exactly as a task pod.
     ControlPlaneAddr    string
     AgentTLSCAConfigMap string
+
+    // ServiceAccount is the ServiceAccount the warm pod runs as — the operator's
+    // default task ServiceAccount (executor.task_service_account). A warm worker is
+    // pre-created and generic, so it can only carry the operator-wide default, not a
+    // per-DAG execution.service_account; empty leaves it on the namespace default SA.
+    // Without this a task placed on a warm worker runs as the default SA and keyless
+    // secret resolution breaks (#2, warm-pool path).
+    ServiceAccount string
 
     // Bootstrap-credential transport (ADR 0055 Fix #3), mirroring Request's token
     // fields: BootstrapToken rides plaintext on the env-var default; the exchange

--- a/website/content/reference/go/internal-scheduler.md
+++ b/website/content/reference/go/internal-scheduler.md
@@ -1,8 +1,4 @@
 ---
-# --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
-aliases:
-  - /go/internal/scheduler.html
-# --- end AUTO redirect aliases ---
 title: "internal/scheduler"
 linkTitle: "internal/scheduler"
 weight: 2
@@ -20,10 +16,10 @@ Package scheduler implements the Leoflow scheduling state machine and loop.
 - [func CanTransition\(from, to domain.TaskState\) bool](<#CanTransition>)
 - [func CanTransitionDagRun\(from, to domain.DagRunState\) bool](<#CanTransitionDagRun>)
 - [func FinalizeRun\(run RunState\) \(domain.DagRunState, bool\)](<#FinalizeRun>)
+- [func InfraReplaceMaxDelay\(\) time.Duration](<#InfraReplaceMaxDelay>)
 - [func PoolKey\(tenant, pool string\) string](<#PoolKey>)
 - [type Alerter](<#Alerter>)
 - [type Dispatcher](<#Dispatcher>)
-- [type ExecutionReaper](<#ExecutionReaper>)
 - [type Leader](<#Leader>)
   - [func NewLeader\(pool \*pgxpool.Pool\) \*Leader](<#NewLeader>)
   - [func \(l \*Leader\) HoldsLock\(ctx context.Context\) \(bool, error\)](<#Leader.HoldsLock>)
@@ -43,13 +39,13 @@ Package scheduler implements the Leoflow scheduling state machine and loop.
   - [func \(s \*Scheduler\) EnablePools\(\)](<#Scheduler.EnablePools>)
   - [func \(s \*Scheduler\) Heartbeat\(\) \(bool, time.Time\)](<#Scheduler.Heartbeat>)
   - [func \(s \*Scheduler\) IsLeading\(\) bool](<#Scheduler.IsLeading>)
+  - [func \(s \*Scheduler\) LeaderSince\(\) time.Time](<#Scheduler.LeaderSince>)
   - [func \(s \*Scheduler\) MarkSteppingDown\(reason string\)](<#Scheduler.MarkSteppingDown>)
   - [func \(s \*Scheduler\) RecordReacquireSince\(stepDownAt time.Time\)](<#Scheduler.RecordReacquireSince>)
   - [func \(s \*Scheduler\) Run\(ctx context.Context\) error](<#Scheduler.Run>)
   - [func \(s \*Scheduler\) SetAlertConcurrency\(n int\)](<#Scheduler.SetAlertConcurrency>)
   - [func \(s \*Scheduler\) SetAlerter\(a Alerter\)](<#Scheduler.SetAlerter>)
   - [func \(s \*Scheduler\) SetDispatcher\(d Dispatcher\)](<#Scheduler.SetDispatcher>)
-  - [func \(s \*Scheduler\) SetExecutionReaper\(r ExecutionReaper\)](<#Scheduler.SetExecutionReaper>)
   - [func \(s \*Scheduler\) SetLeading\(on bool\)](<#Scheduler.SetLeading>)
   - [func \(s \*Scheduler\) SetRecorder\(r Recorder\)](<#Scheduler.SetRecorder>)
   - [func \(s \*Scheduler\) SetStepTimeout\(d time.Duration\)](<#Scheduler.SetStepTimeout>)
@@ -87,7 +83,7 @@ func CanTransitionDagRun(from, to domain.DagRunState) bool
 CanTransitionDagRun reports whether a dag run may move from one state to another.
 
 <a name="FinalizeRun"></a>
-## func [FinalizeRun](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/plan.go#L315>)
+## func [FinalizeRun](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/plan.go#L367>)
 
 ```go
 func FinalizeRun(run RunState) (domain.DagRunState, bool)
@@ -95,8 +91,17 @@ func FinalizeRun(run RunState) (domain.DagRunState, bool)
 
 FinalizeRun reports the terminal dag\-run state once every task is terminal. A failed task that still has retry budget \(or an infra re\-place budget\) counts as non\-terminal, so the run keeps running until it resolves. The boolean is false while any task is still non\-terminal.
 
+<a name="InfraReplaceMaxDelay"></a>
+## func [InfraReplaceMaxDelay](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/dispatch_backoff.go#L52>)
+
+```go
+func InfraReplaceMaxDelay() time.Duration
+```
+
+InfraReplaceMaxDelay is the longest the planner may park an infra\-failed task before re\-placing it: the backoff before the last permitted re\-place \(attempt infraMaxAttempts\) plus the full de\-synchronizing jitter window. It is the upper bound on how long a run whose only live task is infra\-parked shows no activity, so the executor's orphan\-run threshold must sit above it or the orphan reaper fails a run that is still recovering. The two values live in packages that depend in one direction only \(the scheduler imports the executor\), so this is exported for the server to hand to the executor's boot\-time resilience ladder rather than read from there.
+
 <a name="PoolKey"></a>
-## func [PoolKey](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/plan.go#L99>)
+## func [PoolKey](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/plan.go#L103>)
 
 ```go
 func PoolKey(tenant, pool string) string
@@ -105,7 +110,7 @@ func PoolKey(tenant, pool string) string
 PoolKey composes the cross\-DAG admission\-budget key for a \(tenant, pool\) pair. Pools are tenant\-scoped, so a pool name is only meaningful within its tenant; the key namespaces the pool budget and occupancy maps by tenant. The NUL separator cannot occur in a tenant UUID or an Airflow pool name, so the join is unambiguous. The scheduler store builds its budget map with the same key.
 
 <a name="Alerter"></a>
-## type [Alerter](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L433-L438>)
+## type [Alerter](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L434-L439>)
 
 Alerter dispatches a DAG's on\-failure alert rules for a run that finalized in the failed state. Implementations resolve each rule's managed connection to an endpoint and send \(Slack/webhook\). The scheduler calls it from a detached goroutine, so an implementation may block on network I/O without stalling the tick; it MUST treat every send as best\-effort — a delivery failure is logged, never propagated, so alerting can never fail a run.
 
@@ -126,20 +131,6 @@ Dispatcher launches a task instance for execution. The scheduler dispatches a ta
 ```go
 type Dispatcher interface {
     Dispatch(ctx context.Context, runID, dagID, dagVersionID string, task domain.TaskSpec) (executor.Disposition, error)
-}
-```
-
-<a name="ExecutionReaper"></a>
-## type [ExecutionReaper](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L318-L323>)
-
-ExecutionReaper is the execution\-side backstop the scheduler drives once per leader tick to fail stuck runs and task instances. It is the seam between the scheduler \(which owns the leader gate and the tick\) and the executor package \(which owns pod teardown and pod\-liveness\). executor.Reaper satisfies it.
-
-```go
-type ExecutionReaper interface {
-    // ReapOnce runs every reaper once. Implementations isolate per-reaper and
-    // per-candidate failures internally and log/meter list errors, so the
-    // scheduler ignores the return today; the error is kept for the seam.
-    ReapOnce(ctx context.Context) error
 }
 ```
 
@@ -222,7 +213,7 @@ func (r *LeaderHealthReader) Heartbeat() (healthy bool, last time.Time)
 Heartbeat implements api.Heartbeater. healthy is true iff some live session holds the scheduler leadership lock. The timestamp is best\-effort "now" when healthy \(the reader has no cross\-process tick time\); it is unused by the handler when the status is unhealthy.
 
 <a name="PlannedTransition"></a>
-## type [PlannedTransition](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/plan.go#L11-L14>)
+## type [PlannedTransition](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/plan.go#L12-L15>)
 
 PlannedTransition is a decided state change for a task instance within a run.
 
@@ -234,13 +225,13 @@ type PlannedTransition struct {
 ```
 
 <a name="PlanRun"></a>
-### func [PlanRun](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/plan.go#L23>)
+### func [PlanRun](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/plan.go#L27>)
 
 ```go
 func PlanRun(run RunState) []PlannedTransition
 ```
 
-PlanRun computes the task transitions for one dag run. It first handles retries — a failed task with retry budget moves to up\_for\_retry, and an up\_for\_retry task resets \(none, try\_number\+1\) — then plans the rest off the resulting effective states: none \-\> scheduled \(or skipped / upstream\_failed per the trigger rule\) and scheduled \-\> queued. A retriable failed task is treated as still active, so downstream tasks wait rather than seeing a failure. The result is deterministic: identical inputs yield identical output.
+PlanRun computes the task transitions for one dag run. It first handles retries — a failed task with retry budget moves to up\_for\_retry, and an up\_for\_retry task resets \(none, try\_number\+1\) — then plans the rest off the resulting effective states: none \-\> scheduled \(or skipped / upstream\_failed per the trigger rule\) and scheduled \-\> queued. A failed task that can still recover — app\-retriable, or infra\-failed with re\-place budget left \(even while parked in its re\-place backoff\) — is treated as still active, so downstream tasks wait rather than seeing a failure; a downstream is condemned to upstream\_failed only once its upstream is terminally failed. The result is deterministic: identical inputs yield identical output.
 
 <a name="Recorder"></a>
 ## type [Recorder](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L226-L243>)
@@ -415,7 +406,7 @@ func NewScheduler(store Store, logger *slog.Logger, interval time.Duration) *Sch
 NewScheduler builds a Scheduler over the given store, ticking every interval.
 
 <a name="Scheduler.ClearSteppingDown"></a>
-### func \(\*Scheduler\) [ClearSteppingDown](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L380>)
+### func \(\*Scheduler\) [ClearSteppingDown](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L381>)
 
 ```go
 func (s *Scheduler) ClearSteppingDown()
@@ -424,7 +415,7 @@ func (s *Scheduler) ClearSteppingDown()
 ClearSteppingDown ends the step\-down window opened by MarkSteppingDown. Idempotent — calling it when no step\-down is active is a no\-op.
 
 <a name="Scheduler.EnablePools"></a>
-### func \(\*Scheduler\) [EnablePools](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L411>)
+### func \(\*Scheduler\) [EnablePools](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L412>)
 
 ```go
 func (s *Scheduler) EnablePools()
@@ -433,7 +424,7 @@ func (s *Scheduler) EnablePools()
 EnablePools turns on the cross\-DAG named\-pool admission gate \(ADR 0053 Stage 3\). It is Pro\-only: main calls it exactly when the edition is "pro". Left unset in Lite/non\-Pro, where the pool gate stays a no\-op and the tick never queries pool budgets, so Lite plans byte\-identically. Call once before the scheduler starts ticking.
 
 <a name="Scheduler.Heartbeat"></a>
-### func \(\*Scheduler\) [Heartbeat](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L486>)
+### func \(\*Scheduler\) [Heartbeat](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L487>)
 
 ```go
 func (s *Scheduler) Heartbeat() (bool, time.Time)
@@ -442,7 +433,7 @@ func (s *Scheduler) Heartbeat() (bool, time.Time)
 Heartbeat reports whether the scheduling loop is live and when it last ticked. Only a leader is expected to tick, so a non\-leader \(a follower, or an instance that stepped down after losing the lock\) reports healthy without ticking — it is correctly idle, not stalled. A leader is healthy during the startup grace \(before its first tick\) and while ticks stay within a small multiple of the loop interval; a stalled leader goes unhealthy so the UI/monitor surfaces it.
 
 <a name="Scheduler.IsLeading"></a>
-### func \(\*Scheduler\) [IsLeading](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L359>)
+### func \(\*Scheduler\) [IsLeading](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L360>)
 
 ```go
 func (s *Scheduler) IsLeading() bool
@@ -450,8 +441,17 @@ func (s *Scheduler) IsLeading() bool
 
 IsLeading reports whether this instance currently holds scheduler leadership. Background sweeps that mutate cluster state — the pod reconciler and the staging\-volume GC — gate on this so that at replicaCount\>1 only the leader sweeps; otherwise every replica would reconcile and delete the same pods.
 
+<a name="Scheduler.LeaderSince"></a>
+### func \(\*Scheduler\) [LeaderSince](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L348>)
+
+```go
+func (s *Scheduler) LeaderSince() time.Time
+```
+
+LeaderSince reports when this instance last acquired scheduler leadership, or the zero time if it is not currently leading. The agent\-lost reaper uses it to suppress reaping within a grace window after a \(re\-\)election \(\#858\).
+
 <a name="Scheduler.MarkSteppingDown"></a>
-### func \(\*Scheduler\) [MarkSteppingDown](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L371>)
+### func \(\*Scheduler\) [MarkSteppingDown](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L372>)
 
 ```go
 func (s *Scheduler) MarkSteppingDown(reason string)
@@ -460,7 +460,7 @@ func (s *Scheduler) MarkSteppingDown(reason string)
 MarkSteppingDown records that a graceful step\-down has begun. The campaign loop calls this BEFORE canceling the scheduler's run\-context, so any in\-flight reaper/Step that returns "context canceled" inside the window logs at WARN \(expected\) instead of ERROR. It also increments the step\-down counter labeled by reason, so operators can alert on the \*rate\* of churn \(rate\(...\[5m\]\)\) instead of grep'ing log content. ClearSteppingDown closes the window; outside it, context.Canceled stays ERROR — the tripwire that catches an unexpected cancel a flat downgrade would silently swallow.
 
 <a name="Scheduler.RecordReacquireSince"></a>
-### func \(\*Scheduler\) [RecordReacquireSince](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L386>)
+### func \(\*Scheduler\) [RecordReacquireSince](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L387>)
 
 ```go
 func (s *Scheduler) RecordReacquireSince(stepDownAt time.Time)
@@ -469,7 +469,7 @@ func (s *Scheduler) RecordReacquireSince(stepDownAt time.Time)
 RecordReacquireSince records the time spent stepped down \(\#311\). It is called by the campaign loop immediately after a successful re\-acquire, with the timestamp captured at the moment of step\-down. A zero stepDownAt \(no prior step\-down — first acquisition at boot\) is ignored.
 
 <a name="Scheduler.Run"></a>
-### func \(\*Scheduler\) [Run](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L443>)
+### func \(\*Scheduler\) [Run](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L444>)
 
 ```go
 func (s *Scheduler) Run(ctx context.Context) error
@@ -478,7 +478,7 @@ func (s *Scheduler) Run(ctx context.Context) error
 Run drives the scheduling loop until ctx is canceled. The loop is crash\-proof: a panic or error in a tick is recovered and logged, so the scheduler keeps ticking — it may fall behind, but it never dies \(the critical invariant\).
 
 <a name="Scheduler.SetAlertConcurrency"></a>
-### func \(\*Scheduler\) [SetAlertConcurrency](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L420>)
+### func \(\*Scheduler\) [SetAlertConcurrency](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L421>)
 
 ```go
 func (s *Scheduler) SetAlertConcurrency(n int)
@@ -487,7 +487,7 @@ func (s *Scheduler) SetAlertConcurrency(n int)
 SetAlertConcurrency caps how many on\-failure alert dispatches may run at once \(\#424\). n \< 1 is treated as 1. Mainly a config/test seam; the default is defaultAlertConcurrency.
 
 <a name="Scheduler.SetAlerter"></a>
-### func \(\*Scheduler\) [SetAlerter](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L415>)
+### func \(\*Scheduler\) [SetAlerter](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L416>)
 
 ```go
 func (s *Scheduler) SetAlerter(a Alerter)
@@ -496,7 +496,7 @@ func (s *Scheduler) SetAlerter(a Alerter)
 SetAlerter attaches the on\-failure alerter \(optional; \#424\). Without it, or for a DAG with no alert rules, the scheduler finalizes failures silently.
 
 <a name="Scheduler.SetDispatcher"></a>
-### func \(\*Scheduler\) [SetDispatcher](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L404>)
+### func \(\*Scheduler\) [SetDispatcher](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L405>)
 
 ```go
 func (s *Scheduler) SetDispatcher(d Dispatcher)
@@ -504,17 +504,8 @@ func (s *Scheduler) SetDispatcher(d Dispatcher)
 
 SetDispatcher attaches the executor dispatcher \(optional; without it the scheduler advances state only and launches nothing\).
 
-<a name="Scheduler.SetExecutionReaper"></a>
-### func \(\*Scheduler\) [SetExecutionReaper](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L328>)
-
-```go
-func (s *Scheduler) SetExecutionReaper(r ExecutionReaper)
-```
-
-SetExecutionReaper wires the execution\-side reaper the scheduler drives on the leader tick. Left unset \(e.g. a load harness, or a Lite path that opts out of reaping\), the tick simply reaps nothing.
-
 <a name="Scheduler.SetLeading"></a>
-### func \(\*Scheduler\) [SetLeading](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L348>)
+### func \(\*Scheduler\) [SetLeading](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L332>)
 
 ```go
 func (s *Scheduler) SetLeading(on bool)
@@ -523,7 +514,7 @@ func (s *Scheduler) SetLeading(on bool)
 SetLeading marks whether this instance currently holds scheduler leadership. The leadership manager sets it true while the loop runs and false when it steps down \(lost lock\) or stops. Becoming leader resets the tick clock so the startup grace applies afresh and a stale pre\-step\-down heartbeat is not mistaken for a stall. It governs Heartbeat: only a leader is expected to tick.
 
 <a name="Scheduler.SetRecorder"></a>
-### func \(\*Scheduler\) [SetRecorder](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L400>)
+### func \(\*Scheduler\) [SetRecorder](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L401>)
 
 ```go
 func (s *Scheduler) SetRecorder(r Recorder)
@@ -532,7 +523,7 @@ func (s *Scheduler) SetRecorder(r Recorder)
 SetRecorder attaches a metrics recorder \(optional\).
 
 <a name="Scheduler.SetStepTimeout"></a>
-### func \(\*Scheduler\) [SetStepTimeout](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L341>)
+### func \(\*Scheduler\) [SetStepTimeout](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L325>)
 
 ```go
 func (s *Scheduler) SetStepTimeout(d time.Duration)
@@ -541,7 +532,7 @@ func (s *Scheduler) SetStepTimeout(d time.Duration)
 SetStepTimeout overrides the per\-tick timeout \(optional; mainly for tests\).
 
 <a name="Scheduler.Step"></a>
-### func \(\*Scheduler\) [Step](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L506>)
+### func \(\*Scheduler\) [Step](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L507>)
 
 ```go
 func (s *Scheduler) Step(ctx context.Context) error
@@ -550,7 +541,7 @@ func (s *Scheduler) Step(ctx context.Context) error
 Step runs one deterministic scheduling iteration over every active run. Each run is advanced in isolation \(see advanceSafely\): a panic or error in one run is contained, so it never blocks the other runs or new\-run creation. The reaper runs independently of createDueRuns success — they share no dependency, and silencing the reaper when scheduling has a hiccup would let orphans accumulate exactly when the operator is most likely to notice the counter is wrong. The first non\-nil infra\-level error is returned \(logged by the caller\); the later phases still execute.
 
 <a name="Scheduler.SteppingDown"></a>
-### func \(\*Scheduler\) [SteppingDown](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L397>)
+### func \(\*Scheduler\) [SteppingDown](<https://github.com/neochaotic/leoflow/blob/main/internal/scheduler/scheduler.go#L398>)
 
 ```go
 func (s *Scheduler) SteppingDown() bool

--- a/website/content/reference/go/internal-storage.md
+++ b/website/content/reference/go/internal-storage.md
@@ -1,8 +1,4 @@
 ---
-# --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
-aliases:
-  - /go/internal/storage.html
-# --- end AUTO redirect aliases ---
 title: "internal/storage"
 linkTitle: "internal/storage"
 weight: 7
@@ -37,8 +33,10 @@ Package storage wraps the Postgres and Redis connections used by the control pla
   - [func \(r \*LogReader\) Tail\(ctx context.Context, tenant, dagID, runID, taskID string, tryNumber int\) \(lines \<\-chan string, cancel func\(\), err error\)](<#LogReader.Tail>)
 - [type Postgres](<#Postgres>)
   - [func NewPostgres\(ctx context.Context, cfg config.DatabaseSection\) \(\*Postgres, error\)](<#NewPostgres>)
+  - [func \(p \*Postgres\) CheckSchemaCurrent\(ctx context.Context\) error](<#Postgres.CheckSchemaCurrent>)
   - [func \(p \*Postgres\) Close\(\)](<#Postgres.Close>)
   - [func \(p \*Postgres\) Ping\(ctx context.Context\) error](<#Postgres.Ping>)
+  - [func \(p \*Postgres\) SchemaVersion\(ctx context.Context\) \(version uint, dirty, exists bool, err error\)](<#Postgres.SchemaVersion>)
 - [type Redis](<#Redis>)
   - [func NewRedis\(ctx context.Context, cfg config.RedisSection\) \(\*Redis, error\)](<#NewRedis>)
   - [func \(r \*Redis\) Close\(\) error](<#Redis.Close>)
@@ -89,8 +87,8 @@ Package storage wraps the Postgres and Redis connections used by the control pla
   - [func \(r \*Repository\) PoolSlotUsage\(ctx context.Context, tenant string\) \(map\[string\]domain.PoolUsage, error\)](<#Repository.PoolSlotUsage>)
   - [func \(r \*Repository\) ReconcileUserRoles\(ctx context.Context, userID string, roleNames \[\]string\) error](<#Repository.ReconcileUserRoles>)
   - [func \(r \*Repository\) RecordAuthEvent\(ctx context.Context, tenant, actorUserID, action, email, outcome string, extra map\[string\]string\) error](<#Repository.RecordAuthEvent>)
-  - [func \(r \*Repository\) RecordSecretLivenessDenial\(ctx context.Context, tenant, dagID, runID, taskID string, tryNumber int, kind, mode string\) error](<#Repository.RecordSecretLivenessDenial>)
-  - [func \(r \*Repository\) RecordSecretScopeWarning\(ctx context.Context, tenant, dagID, runID, taskID, kind string, declared, total int\) error](<#Repository.RecordSecretScopeWarning>)
+  - [func \(r \*Repository\) RecordSecretLivenessDenial\(ctx context.Context, tenantID, dagID, runID, taskID string, tryNumber int, kind, mode string\) error](<#Repository.RecordSecretLivenessDenial>)
+  - [func \(r \*Repository\) RecordSecretScopeWarning\(ctx context.Context, tenantID, dagID, runID, taskID, kind string, declared, total int\) error](<#Repository.RecordSecretScopeWarning>)
   - [func \(r \*Repository\) RecordTaskActionAudit\(ctx context.Context, tenant, userID, action, dagID, runID, taskID string, tryNumber int\) error](<#Repository.RecordTaskActionAudit>)
   - [func \(r \*Repository\) RecordUserCreatedAudit\(ctx context.Context, tenant, actorUserID, createdUserID, email, roles string\) error](<#Repository.RecordUserCreatedAudit>)
   - [func \(r \*Repository\) RegisterDagVersion\(ctx context.Context, tenant string, spec domain.DAGSpec, specHash string\) \(bool, error\)](<#Repository.RegisterDagVersion>)
@@ -102,13 +100,16 @@ Package storage wraps the Postgres and Redis connections used by the control pla
   - [func \(r \*Repository\) SecretVariablesScoped\(ctx context.Context, tenantID string, names \[\]string\) \(map\[string\]string, error\)](<#Repository.SecretVariablesScoped>)
   - [func \(r \*Repository\) SetCipher\(c secrets.Cipher\)](<#Repository.SetCipher>)
   - [func \(r \*Repository\) SetConnection\(ctx context.Context, tenant string, c domain.Connection\) error](<#Repository.SetConnection>)
+  - [func \(r \*Repository\) SetConnectionPatch\(ctx context.Context, tenant string, p domain.ConnectionPatch\) error](<#Repository.SetConnectionPatch>)
   - [func \(r \*Repository\) SetDagRunState\(ctx context.Context, tenant, dagID, runID, state string\) error](<#Repository.SetDagRunState>)
+  - [func \(r \*Repository\) SetExternalSecretCoverage\(c externalSecretCoverage\)](<#Repository.SetExternalSecretCoverage>)
   - [func \(r \*Repository\) SetImportError\(ctx context.Context, tenant string, e domain.ImportError\) error](<#Repository.SetImportError>)
   - [func \(r \*Repository\) SetPaused\(ctx context.Context, tenant, dagID string, paused bool\) \(domain.DAG, error\)](<#Repository.SetPaused>)
   - [func \(r \*Repository\) SetPool\(ctx context.Context, tenant string, p domain.Pool\) error](<#Repository.SetPool>)
   - [func \(r \*Repository\) SetTaskInstanceState\(ctx context.Context, tenant, dagID, runID, taskID, state string\) error](<#Repository.SetTaskInstanceState>)
   - [func \(r \*Repository\) SetUserPassword\(ctx context.Context, tenant, email, hash string\) \(bool, error\)](<#Repository.SetUserPassword>)
   - [func \(r \*Repository\) SetVariable\(ctx context.Context, tenant string, v domain.Variable\) error](<#Repository.SetVariable>)
+  - [func \(r \*Repository\) SetVariablePatch\(ctx context.Context, tenant string, p domain.VariablePatch\) error](<#Repository.SetVariablePatch>)
   - [func \(r \*Repository\) TaskInstancesForRuns\(ctx context.Context, tenant, dagID string, runIDs \[\]string\) \(\[\]domain.TaskInstance, error\)](<#Repository.TaskInstancesForRuns>)
   - [func \(r \*Repository\) TenantUUID\(ctx context.Context, name string\) \(string, error\)](<#Repository.TenantUUID>)
 - [type SchedulerStore](<#SchedulerStore>)
@@ -359,6 +360,15 @@ func NewPostgres(ctx context.Context, cfg config.DatabaseSection) (*Postgres, er
 
 NewPostgres opens a connection pool and verifies connectivity, retrying transient failures during boot for up to pgStartupBudget. Pre\-2026\-06, the first failed ping fatal\-ed the server, so a docker compose race or any Pro failover blip became a hard crash. The retry loop keeps Lite boot ergonomic and Pro startup resilient under realistic upstream\-PG dynamics. A truly broken setup \(wrong DSN, bad auth\) still surfaces quickly because the underlying error is wrapped into the final error.
 
+<a name="Postgres.CheckSchemaCurrent"></a>
+### func \(\*Postgres\) [CheckSchemaCurrent](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/schema_check.go#L69>)
+
+```go
+func (p *Postgres) CheckSchemaCurrent(ctx context.Context) error
+```
+
+CheckSchemaCurrent reads the DB schema version and compares it to the binary's embedded latest, failing fast on a mismatch. Called at boot after the pool is open, before the server serves.
+
 <a name="Postgres.Close"></a>
 ### func \(\*Postgres\) [Close](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/postgres.go#L137>)
 
@@ -376,6 +386,15 @@ func (p *Postgres) Ping(ctx context.Context) error
 ```
 
 Ping checks database connectivity \(used by /readyz\).
+
+<a name="Postgres.SchemaVersion"></a>
+### func \(\*Postgres\) [SchemaVersion](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/schema_check.go#L21>)
+
+```go
+func (p *Postgres) SchemaVersion(ctx context.Context) (version uint, dirty, exists bool, err error)
+```
+
+SchemaVersion reads the applied migration version from golang\-migrate's schema\_migrations table. exists is false when the table is absent \(migrations never ran\). It issues only a SELECT, so it is compatible with the read\-only role:api DB identity \(ADR 0049\), which skips migrations by design.
 
 <a name="Redis"></a>
 ## type [Redis](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/redis.go#L17-L19>)
@@ -431,7 +450,7 @@ type RedisMetrics interface {
 ```
 
 <a name="Repository"></a>
-## type [Repository](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L33-L37>)
+## type [Repository](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L33-L38>)
 
 Repository implements the API resource and auth user\-store interfaces over Postgres using the sqlc\-generated query set.
 
@@ -442,7 +461,7 @@ type Repository struct {
 ```
 
 <a name="NewRepository"></a>
-### func [NewRepository](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L40>)
+### func [NewRepository](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L51>)
 
 ```go
 func NewRepository(pg *Postgres) *Repository
@@ -451,7 +470,7 @@ func NewRepository(pg *Postgres) *Repository
 NewRepository builds a Repository backed by the given Postgres connection.
 
 <a name="Repository.AddFavorite"></a>
-### func \(\*Repository\) [AddFavorite](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1519>)
+### func \(\*Repository\) [AddFavorite](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1597>)
 
 ```go
 func (r *Repository) AddFavorite(ctx context.Context, tenant, userID, dagID string) error
@@ -460,7 +479,7 @@ func (r *Repository) AddFavorite(ctx context.Context, tenant, userID, dagID stri
 AddFavorite marks a DAG as a favorite for the user \(idempotent\).
 
 <a name="Repository.AlertEndpoint"></a>
-### func \(\*Repository\) [AlertEndpoint](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1467>)
+### func \(\*Repository\) [AlertEndpoint](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1545>)
 
 ```go
 func (r *Repository) AlertEndpoint(ctx context.Context, tenantID, connID string) (endpointURL string, headers map[string]string, err error)
@@ -469,7 +488,7 @@ func (r *Repository) AlertEndpoint(ctx context.Context, tenantID, connID string)
 AlertEndpoint resolves an alert channel connection \(\#424\) to its endpoint for a tenant UUID: the decrypted password is the channel URL \(the full webhook URL, kept encrypted at rest\), and an optional \`headers\` object in the connection's extra becomes request headers \(e.g. an Authorization header for an endpoint whose token is not in the URL\). An absent/empty URL is an error — a misconfigured alert connection must fail loud. Never expose these in UI/API.
 
 <a name="Repository.BootstrapAdmin"></a>
-### func \(\*Repository\) [BootstrapAdmin](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1047>)
+### func \(\*Repository\) [BootstrapAdmin](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1125>)
 
 ```go
 func (r *Repository) BootstrapAdmin(ctx context.Context, tenant, email, password string) (bool, error)
@@ -478,7 +497,7 @@ func (r *Repository) BootstrapAdmin(ctx context.Context, tenant, email, password
 BootstrapAdmin creates a default admin user with the given password when the tenant has no users yet, assigning the seeded admin role. It returns whether a user was created \(false when users already exist\).
 
 <a name="Repository.BootstrapAdminHash"></a>
-### func \(\*Repository\) [BootstrapAdminHash](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1172>)
+### func \(\*Repository\) [BootstrapAdminHash](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1250>)
 
 ```go
 func (r *Repository) BootstrapAdminHash(ctx context.Context, tenant, email, hash string) (bool, error)
@@ -487,7 +506,7 @@ func (r *Repository) BootstrapAdminHash(ctx context.Context, tenant, email, hash
 BootstrapAdminHash provisions the Lite admin from a precomputed bcrypt hash \(so the plaintext never reaches the control plane\). It RECONCILES: if the admin already exists, its password is reset to this hash. The Lite config \(admin\_password\_hash\) is the source of truth, so the password the setup printed always logs in — even against a pre\-existing or stale database — without anyone having to wipe Docker volumes. The only sanctioned way to change the password, \`reset\-password\`, also writes the config, so the two never drift. Returns true only when the admin was newly created \(false when an existing one was reconciled\). See cmd/leoflow\-server bootstrapAdmin.
 
 <a name="Repository.ClearDagHistory"></a>
-### func \(\*Repository\) [ClearDagHistory](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1725>)
+### func \(\*Repository\) [ClearDagHistory](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1888>)
 
 ```go
 func (r *Repository) ClearDagHistory(ctx context.Context, tenant, dagID string) error
@@ -496,7 +515,7 @@ func (r *Repository) ClearDagHistory(ctx context.Context, tenant, dagID string) 
 ClearDagHistory deletes a DAG's runs \(cascading task instances and XCom index rows\) while keeping the DAG and its versions registered — the safe "clear" the UI trash maps to \(ADR 0020\). Returns ErrNotFound when the DAG is absent.
 
 <a name="Repository.ClearImportError"></a>
-### func \(\*Repository\) [ClearImportError](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1770>)
+### func \(\*Repository\) [ClearImportError](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1933>)
 
 ```go
 func (r *Repository) ClearImportError(ctx context.Context, tenant, filename string) error
@@ -505,7 +524,7 @@ func (r *Repository) ClearImportError(ctx context.Context, tenant, filename stri
 ClearImportError removes any recorded error for a file \(a good re\-import\).
 
 <a name="Repository.ClearTaskInstances"></a>
-### func \(\*Repository\) [ClearTaskInstances](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L518>)
+### func \(\*Repository\) [ClearTaskInstances](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L549>)
 
 ```go
 func (r *Repository) ClearTaskInstances(ctx context.Context, tenant, dagID, runID string, taskIDs []string, onlyFailed, resetDagRun bool) (int, error)
@@ -514,7 +533,7 @@ func (r *Repository) ClearTaskInstances(ctx context.Context, tenant, dagID, runI
 ClearTaskInstances resets tasks to none for re\-run, optionally resetting the parent run to queued. When onlyFailed is true, only tasks currently in a failed\-ish state \(failed, upstream\_failed, up\_for\_retry\) are reset; with an empty taskIDs and onlyFailed, every failed task in the run is cleared. It returns the number of task instances actually reset.
 
 <a name="Repository.CreateDagRun"></a>
-### func \(\*Repository\) [CreateDagRun](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L413>)
+### func \(\*Repository\) [CreateDagRun](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L436>)
 
 ```go
 func (r *Repository) CreateDagRun(ctx context.Context, tenant, dagID string, run domain.DagRun) (domain.DagRun, error)
@@ -523,7 +542,7 @@ func (r *Repository) CreateDagRun(ctx context.Context, tenant, dagID string, run
 CreateDagRun inserts a new run for a DAG at its current version. The per\-DAG max\_active\_runs cap \(\#200\) is enforced here for any caller that goes through the repository — manual triggers via the API, scripted backfills, and any future programmatic trigger path — so the contract is honored in one place. A cap of zero is treated as "unlimited" to match the scheduler path \(see \`Scheduler.hasHeadroom\`\). The check races with concurrent inserts, but the small overshoot window is bounded by the number of concurrent writers and lets us avoid an advisory lock on the hot path.
 
 <a name="Repository.CreateOIDCUser"></a>
-### func \(\*Repository\) [CreateOIDCUser](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L187>)
+### func \(\*Repository\) [CreateOIDCUser](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L210>)
 
 ```go
 func (r *Repository) CreateOIDCUser(ctx context.Context, tenant, email, provider, subject string, roles []string) (*auth.User, error)
@@ -532,7 +551,7 @@ func (r *Repository) CreateOIDCUser(ctx context.Context, tenant, email, provider
 CreateOIDCUser just\-in\-time provisions an OIDC\-only account \(NULL password\), linked by \(oidc\_provider, oidc\_subject\), and grants it the given roles. It mirrors CreateUser's atomicity: every role is resolved BEFORE the insert so an unknown role fails cleanly as domain.ErrValidation without leaving an orphaned account, and the insert plus the grants run in one transaction so a failed grant rolls the account back. An empty role set grants none \(default\-deny\). A concurrent double\-provision surfaces as domain.ErrConflict via the unique \(oidc\_provider, oidc\_subject\) constraint. The returned user carries the granted role names so the caller can mint a token without a reload.
 
 <a name="Repository.CreateUser"></a>
-### func \(\*Repository\) [CreateUser](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1071>)
+### func \(\*Repository\) [CreateUser](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1149>)
 
 ```go
 func (r *Repository) CreateUser(ctx context.Context, tenant, email, password string, roles []string) (domain.User, error)
@@ -554,7 +573,7 @@ func (r *Repository) DagStats(ctx context.Context, tenant string) (domain.DagSta
 DagStats returns the home dashboard's DAG counters: the total active DAG count plus how many DAGs have a latest run in the failed/running/queued state.
 
 <a name="Repository.DeleteConnection"></a>
-### func \(\*Repository\) [DeleteConnection](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1698>)
+### func \(\*Repository\) [DeleteConnection](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1861>)
 
 ```go
 func (r *Repository) DeleteConnection(ctx context.Context, tenant, connID string) error
@@ -563,7 +582,7 @@ func (r *Repository) DeleteConnection(ctx context.Context, tenant, connID string
 DeleteConnection removes a connection, returning ErrNotFound when none matched.
 
 <a name="Repository.DeleteDag"></a>
-### func \(\*Repository\) [DeleteDag](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1258>)
+### func \(\*Repository\) [DeleteDag](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1336>)
 
 ```go
 func (r *Repository) DeleteDag(ctx context.Context, tenant, dagID string) error
@@ -572,7 +591,7 @@ func (r *Repository) DeleteDag(ctx context.Context, tenant, dagID string) error
 DeleteDag removes a DAG and \(via ON DELETE CASCADE\) its versions, runs, task instances, and XCom index rows. It returns ErrNotFound when no DAG matched.
 
 <a name="Repository.DeleteDagRun"></a>
-### func \(\*Repository\) [DeleteDagRun](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L389>)
+### func \(\*Repository\) [DeleteDagRun](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L412>)
 
 ```go
 func (r *Repository) DeleteDagRun(ctx context.Context, tenant, dagID, runID string) error
@@ -590,7 +609,7 @@ func (r *Repository) DeletePool(ctx context.Context, tenant, name string) error
 DeletePool removes a pool. It returns domain.ErrNotFound when none matched and domain.ErrConflict when the target is the implicit default pool — Airflow parity: the fallback pool the gate resolves to must never be deleted.
 
 <a name="Repository.DeleteVariable"></a>
-### func \(\*Repository\) [DeleteVariable](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1575>)
+### func \(\*Repository\) [DeleteVariable](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1680>)
 
 ```go
 func (r *Repository) DeleteVariable(ctx context.Context, tenant, key string) error
@@ -599,7 +618,7 @@ func (r *Repository) DeleteVariable(ctx context.Context, tenant, key string) err
 DeleteVariable removes a variable, returning ErrNotFound when none matched.
 
 <a name="Repository.FavoriteDagIDs"></a>
-### func \(\*Repository\) [FavoriteDagIDs](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1535>)
+### func \(\*Repository\) [FavoriteDagIDs](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1613>)
 
 ```go
 func (r *Repository) FavoriteDagIDs(ctx context.Context, tenant, userID string) (map[string]bool, error)
@@ -608,7 +627,7 @@ func (r *Repository) FavoriteDagIDs(ctx context.Context, tenant, userID string) 
 FavoriteDagIDs returns the set of DAG ids the user has favorited.
 
 <a name="Repository.FindUserByID"></a>
-### func \(\*Repository\) [FindUserByID](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L119>)
+### func \(\*Repository\) [FindUserByID](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L142>)
 
 ```go
 func (r *Repository) FindUserByID(ctx context.Context, id string) (*auth.User, bool, error)
@@ -617,7 +636,7 @@ func (r *Repository) FindUserByID(ctx context.Context, id string) (*auth.User, b
 FindUserByID reloads a user's current authorization state by id: its tenant, roles, and permissions, plus whether the account is active. It is the per\- request source of truth the authenticator uses on token validation. A subject that is not a valid uuid, or that matches no row, yields auth.ErrUserNotFound \(the trusted in\-process minting path has no backing user\); any other failure is returned as\-is so the caller can fail closed.
 
 <a name="Repository.FindUserByLogin"></a>
-### func \(\*Repository\) [FindUserByLogin](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L90>)
+### func \(\*Repository\) [FindUserByLogin](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L107>)
 
 ```go
 func (r *Repository) FindUserByLogin(ctx context.Context, tenant, username string) (*auth.User, string, error)
@@ -626,7 +645,7 @@ func (r *Repository) FindUserByLogin(ctx context.Context, tenant, username strin
 FindUserByLogin loads a user and its bcrypt hash for authentication.
 
 <a name="Repository.FindUserByOIDCSubject"></a>
-### func \(\*Repository\) [FindUserByOIDCSubject](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L153>)
+### func \(\*Repository\) [FindUserByOIDCSubject](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L176>)
 
 ```go
 func (r *Repository) FindUserByOIDCSubject(ctx context.Context, provider, subject string) (*auth.User, bool, error)
@@ -635,7 +654,7 @@ func (r *Repository) FindUserByOIDCSubject(ctx context.Context, provider, subjec
 FindUserByOIDCSubject resolves an OIDC identity to a Leoflow user by its immutable \(provider, subject\) pair — the trusted link key for a returning SSO login. Like FindUserByID it loads the current tenant, roles, and permissions plus the active flag, so the caller reconstructs the same principal the credential path would. A pair matching no row yields auth.ErrUserNotFound \(the signal to consider just\-in\-time provisioning\); any other failure is returned as\-is so the caller can fail closed.
 
 <a name="Repository.GetConnection"></a>
-### func \(\*Repository\) [GetConnection](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1635>)
+### func \(\*Repository\) [GetConnection](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1798>)
 
 ```go
 func (r *Repository) GetConnection(ctx context.Context, tenant, connID string) (domain.Connection, error)
@@ -644,7 +663,7 @@ func (r *Repository) GetConnection(ctx context.Context, tenant, connID string) (
 GetConnection returns a connection with extra decrypted; the password is not returned \(write\-only\). Returns ErrNotFound when absent.
 
 <a name="Repository.GetCurrentSpec"></a>
-### func \(\*Repository\) [GetCurrentSpec](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L885>)
+### func \(\*Repository\) [GetCurrentSpec](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L926>)
 
 ```go
 func (r *Repository) GetCurrentSpec(ctx context.Context, tenant, dagID string) (domain.DAGSpec, error)
@@ -653,7 +672,7 @@ func (r *Repository) GetCurrentSpec(ctx context.Context, tenant, dagID string) (
 GetCurrentSpec returns the parsed spec of the DAG's current version, or domain.ErrNotFound if the DAG or its current version does not exist.
 
 <a name="Repository.GetDag"></a>
-### func \(\*Repository\) [GetDag](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L315>)
+### func \(\*Repository\) [GetDag](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L338>)
 
 ```go
 func (r *Repository) GetDag(ctx context.Context, tenant, dagID string) (domain.DAG, error)
@@ -662,7 +681,7 @@ func (r *Repository) GetDag(ctx context.Context, tenant, dagID string) (domain.D
 GetDag returns a single DAG by its user\-facing id.
 
 <a name="Repository.GetDagRun"></a>
-### func \(\*Repository\) [GetDagRun](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L374>)
+### func \(\*Repository\) [GetDagRun](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L397>)
 
 ```go
 func (r *Repository) GetDagRun(ctx context.Context, tenant, dagID, runID string) (domain.DagRun, error)
@@ -680,7 +699,7 @@ func (r *Repository) GetPool(ctx context.Context, tenant, name string) (domain.P
 GetPool returns one pool by name, or domain.ErrNotFound.
 
 <a name="Repository.GetVariable"></a>
-### func \(\*Repository\) [GetVariable](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1548>)
+### func \(\*Repository\) [GetVariable](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1626>)
 
 ```go
 func (r *Repository) GetVariable(ctx context.Context, tenant, key string) (domain.Variable, error)
@@ -698,7 +717,7 @@ func (r *Repository) HistoricalMetrics(ctx context.Context, tenant string, since
 HistoricalMetrics returns run\- and task\-instance state counts for runs whose logical date falls within \[since, until\], keyed by Leoflow state name.
 
 <a name="Repository.LatestRunsForDags"></a>
-### func \(\*Repository\) [LatestRunsForDags](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L799>)
+### func \(\*Repository\) [LatestRunsForDags](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L840>)
 
 ```go
 func (r *Repository) LatestRunsForDags(ctx context.Context, tenant string, dagIDs []string, perDag int) (map[string][]domain.DagRun, error)
@@ -707,7 +726,7 @@ func (r *Repository) LatestRunsForDags(ctx context.Context, tenant string, dagID
 LatestRunsForDags returns up to perDag most\-recent runs for each named DAG, keyed by dag\_id, in a single windowed query \(no per\-DAG round trips\).
 
 <a name="Repository.ListAuditLogs"></a>
-### func \(\*Repository\) [ListAuditLogs](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1222>)
+### func \(\*Repository\) [ListAuditLogs](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1300>)
 
 ```go
 func (r *Repository) ListAuditLogs(ctx context.Context, tenant, dagID string, limit, offset int) ([]domain.AuditLogEntry, int, error)
@@ -716,7 +735,7 @@ func (r *Repository) ListAuditLogs(ctx context.Context, tenant, dagID string, li
 ListAuditLogs returns a page of audit\-log entries for the tenant, newest first, optionally filtered to a single DAG \(dagID == "" means no filter\).
 
 <a name="Repository.ListConnections"></a>
-### func \(\*Repository\) [ListConnections](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1656>)
+### func \(\*Repository\) [ListConnections](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1819>)
 
 ```go
 func (r *Repository) ListConnections(ctx context.Context, tenant string, limit, offset int) ([]domain.Connection, int, error)
@@ -725,7 +744,7 @@ func (r *Repository) ListConnections(ctx context.Context, tenant string, limit, 
 ListConnections returns a page of connections \(no passwords\) and the total.
 
 <a name="Repository.ListDagRuns"></a>
-### func \(\*Repository\) [ListDagRuns](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L353>)
+### func \(\*Repository\) [ListDagRuns](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L376>)
 
 ```go
 func (r *Repository) ListDagRuns(ctx context.Context, tenant, dagID string, limit, offset int) ([]domain.DagRun, int, error)
@@ -734,7 +753,7 @@ func (r *Repository) ListDagRuns(ctx context.Context, tenant, dagID string, limi
 ListDagRuns returns a page of runs for a DAG and the total count.
 
 <a name="Repository.ListDagVersions"></a>
-### func \(\*Repository\) [ListDagVersions](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L862>)
+### func \(\*Repository\) [ListDagVersions](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L903>)
 
 ```go
 func (r *Repository) ListDagVersions(ctx context.Context, tenant, dagID string) ([]domain.DagVersion, error)
@@ -743,7 +762,7 @@ func (r *Repository) ListDagVersions(ctx context.Context, tenant, dagID string) 
 ListDagVersions returns the DAG's versions, newest first, with a 1\-based version\_number the UI uses to query version\-scoped structure.
 
 <a name="Repository.ListDags"></a>
-### func \(\*Repository\) [ListDags](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L294>)
+### func \(\*Repository\) [ListDags](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L317>)
 
 ```go
 func (r *Repository) ListDags(ctx context.Context, tenant string, limit, offset int) ([]domain.DAG, int, error)
@@ -752,7 +771,7 @@ func (r *Repository) ListDags(ctx context.Context, tenant string, limit, offset 
 ListDags returns a page of DAGs for the tenant and the total count.
 
 <a name="Repository.ListDagsFiltered"></a>
-### func \(\*Repository\) [ListDagsFiltered](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1276>)
+### func \(\*Repository\) [ListDagsFiltered](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1354>)
 
 ```go
 func (r *Repository) ListDagsFiltered(ctx context.Context, tenant, runState string, paused *bool, limit, offset int) ([]domain.DAG, int, error)
@@ -761,7 +780,7 @@ func (r *Repository) ListDagsFiltered(ctx context.Context, tenant, runState stri
 ListDagsFiltered returns a page of active DAGs for the tenant, optionally filtered by paused state and/or latest\-run state, with the matching total. An empty runState or nil paused disables that filter.
 
 <a name="Repository.ListImportErrors"></a>
-### func \(\*Repository\) [ListImportErrors](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1737>)
+### func \(\*Repository\) [ListImportErrors](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1900>)
 
 ```go
 func (r *Repository) ListImportErrors(ctx context.Context, tenant string) ([]domain.ImportError, error)
@@ -779,7 +798,7 @@ func (r *Repository) ListPools(ctx context.Context, tenant string, limit, offset
 ListPools returns a page of the tenant's named pools and the total count.
 
 <a name="Repository.ListTaskInstanceAttempts"></a>
-### func \(\*Repository\) [ListTaskInstanceAttempts](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L450>)
+### func \(\*Repository\) [ListTaskInstanceAttempts](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L481>)
 
 ```go
 func (r *Repository) ListTaskInstanceAttempts(ctx context.Context, tenant, dagID, runID, taskID string) ([]domain.TaskInstance, error)
@@ -788,7 +807,7 @@ func (r *Repository) ListTaskInstanceAttempts(ctx context.Context, tenant, dagID
 ListTaskInstanceAttempts returns every attempt for \(run, task\), oldest first — the current task\_instances row UNIONed with all archived task\_instance\_history rows. The UI's /tries endpoint needs this to render one navigable tab per attempt; without history, a cleared task shows only the latest attempt and the user cannot inspect prior failures \(Lima bug \#241\).
 
 <a name="Repository.ListTaskInstances"></a>
-### func \(\*Repository\) [ListTaskInstances](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L493>)
+### func \(\*Repository\) [ListTaskInstances](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L524>)
 
 ```go
 func (r *Repository) ListTaskInstances(ctx context.Context, tenant, dagID, runID string, _, _ int) ([]domain.TaskInstance, int, error)
@@ -797,7 +816,7 @@ func (r *Repository) ListTaskInstances(ctx context.Context, tenant, dagID, runID
 ListTaskInstances returns the task instances of a run.
 
 <a name="Repository.ListUsers"></a>
-### func \(\*Repository\) [ListUsers](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1124>)
+### func \(\*Repository\) [ListUsers](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1202>)
 
 ```go
 func (r *Repository) ListUsers(ctx context.Context, tenant string, limit, offset int) ([]domain.User, int, error)
@@ -806,7 +825,7 @@ func (r *Repository) ListUsers(ctx context.Context, tenant string, limit, offset
 ListUsers returns a page of the tenant's accounts, newest first, each with the full set of role names it holds. It never reads or returns password\_hash — the list must not expose secrets. The second result is the unpaged total, so the caller can render total\_entries independent of the page size.
 
 <a name="Repository.ListVariables"></a>
-### func \(\*Repository\) [ListVariables](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1304>)
+### func \(\*Repository\) [ListVariables](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1382>)
 
 ```go
 func (r *Repository) ListVariables(ctx context.Context, tenant string, limit, offset int) ([]domain.Variable, int, error)
@@ -824,7 +843,7 @@ func (r *Repository) PoolSlotUsage(ctx context.Context, tenant string) (map[stri
 PoolSlotUsage returns per\-pool occupancy for the tenant, keyed by pool name \(a task instance with no pool is counted under the implicit default\_pool\). It feeds the Airflow PoolResponse occupancy fields.
 
 <a name="Repository.ReconcileUserRoles"></a>
-### func \(\*Repository\) [ReconcileUserRoles](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L256>)
+### func \(\*Repository\) [ReconcileUserRoles](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L279>)
 
 ```go
 func (r *Repository) ReconcileUserRoles(ctx context.Context, userID string, roleNames []string) error
@@ -835,7 +854,7 @@ ReconcileUserRoles makes the user's granted roles exactly roleNames, atomically:
 Every name is resolved to a role id in the user's OWN tenant BEFORE any write, so a name that is not a role in that tenant fails closed as domain.ErrValidation with the prior grants untouched — the login path turns that into a rejected, audited login rather than silently wiping the user's roles. The delete and the inserts run in one transaction, making the operation idempotent \(reconciling the same set yields the same rows\) and an empty roleNames a full clear \(default\-deny\).
 
 <a name="Repository.RecordAuthEvent"></a>
-### func \(\*Repository\) [RecordAuthEvent](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L676>)
+### func \(\*Repository\) [RecordAuthEvent](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L707>)
 
 ```go
 func (r *Repository) RecordAuthEvent(ctx context.Context, tenant, actorUserID, action, email, outcome string, extra map[string]string) error
@@ -846,25 +865,29 @@ RecordAuthEvent records an authentication event to the audit log \(H5\): OIDC lo
 The event is scoped to the resolved tenant when known; events that never resolved a tenant \(a login failure, a tenant\-pin rejection\) fall back to the "default" tenant so the row still lands, with the attempted values in the metadata. resourceID carries the email so account\-scoped auth activity is filterable alongside user.create.
 
 <a name="Repository.RecordSecretLivenessDenial"></a>
-### func \(\*Repository\) [RecordSecretLivenessDenial](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L751>)
+### func \(\*Repository\) [RecordSecretLivenessDenial](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L792>)
 
 ```go
-func (r *Repository) RecordSecretLivenessDenial(ctx context.Context, tenant, dagID, runID, taskID string, tryNumber int, kind, mode string) error
+func (r *Repository) RecordSecretLivenessDenial(ctx context.Context, tenantID, dagID, runID, taskID string, tryNumber int, kind, mode string) error
 ```
 
 RecordSecretLivenessDenial records that the secret\-path liveness gate fired for a task instance whose attempt is no longer live \(ADR 0055\): a would\-have\-denied in observe mode, or a denial in enforce mode. It is scoped to the DAG resource so the event surfaces on the DAG's Audit Log tab, with the kind \("variables" or "connections"\), the run, task, attempt, and the gate mode in metadata. It records identity \+ kind \+ mode only — never secret names or values.
 
+tenantID is the tenant UUID the agent token carries \(not the tenant name\): the caller is the agent RPC path, which passes AgentIdentity.TenantID. Resolving it by name silently dropped every row \(\#722\) — including enforce\-mode security denials — so mirror the secret\-delivery path and parse it as a UUID.
+
 <a name="Repository.RecordSecretScopeWarning"></a>
-### func \(\*Repository\) [RecordSecretScopeWarning](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L723>)
+### func \(\*Repository\) [RecordSecretScopeWarning](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L759>)
 
 ```go
-func (r *Repository) RecordSecretScopeWarning(ctx context.Context, tenant, dagID, runID, taskID, kind string, declared, total int) error
+func (r *Repository) RecordSecretScopeWarning(ctx context.Context, tenantID, dagID, runID, taskID, kind string, declared, total int) error
 ```
 
 RecordSecretScopeWarning records that a task received the full tenant secret set while it declared only a narrower subset \(ADR 0045, ADR 0055\): under secret\_scoping: enforce it would receive only its declared set. It is scoped to the DAG resource so the event surfaces on the DAG's Audit Log tab, with the kind \("variables" or "connections"\), the run and task, and the declared/total counts in metadata. It records counts only — never secret names or values.
 
+tenantID is the tenant UUID the agent token carries \(not the tenant name\): the caller is the agent RPC path, which passes AgentIdentity.TenantID. Resolving it by name silently dropped every row \(\#722\), so mirror the secret\-delivery path and parse it as a UUID.
+
 <a name="Repository.RecordTaskActionAudit"></a>
-### func \(\*Repository\) [RecordTaskActionAudit](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L605>)
+### func \(\*Repository\) [RecordTaskActionAudit](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L636>)
 
 ```go
 func (r *Repository) RecordTaskActionAudit(ctx context.Context, tenant, userID, action, dagID, runID, taskID string, tryNumber int) error
@@ -873,7 +896,7 @@ func (r *Repository) RecordTaskActionAudit(ctx context.Context, tenant, userID, 
 RecordTaskActionAudit logs a task\-level action \(clear, mark state\) with the acting user and the run/task/try in metadata, so the Audit Log view shows the owner and the task columns. Scoped to the DAG \(resource\_id = dag\_id\) so it appears on the DAG's Audit Log tab.
 
 <a name="Repository.RecordUserCreatedAudit"></a>
-### func \(\*Repository\) [RecordUserCreatedAudit](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L636>)
+### func \(\*Repository\) [RecordUserCreatedAudit](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L667>)
 
 ```go
 func (r *Repository) RecordUserCreatedAudit(ctx context.Context, tenant, actorUserID, createdUserID, email, roles string) error
@@ -882,7 +905,7 @@ func (r *Repository) RecordUserCreatedAudit(ctx context.Context, tenant, actorUs
 RecordUserCreatedAudit logs an account creation with the acting admin as the owner and the new account's email and granted roles in metadata, scoped to the "user" resource so account\-management actions are visible in the Audit Log. The roles arrive as a single comma\-joined string \(empty when none were granted\).
 
 <a name="Repository.RegisterDagVersion"></a>
-### func \(\*Repository\) [RegisterDagVersion](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L903>)
+### func \(\*Repository\) [RegisterDagVersion](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L944>)
 
 ```go
 func (r *Repository) RegisterDagVersion(ctx context.Context, tenant string, spec domain.DAGSpec, specHash string) (bool, error)
@@ -891,7 +914,7 @@ func (r *Repository) RegisterDagVersion(ctx context.Context, tenant string, spec
 RegisterDagVersion upserts the DAG and inserts a version keyed by specHash, setting it as current. It is idempotent: an existing hash yields created=false.
 
 <a name="Repository.RemoveFavorite"></a>
-### func \(\*Repository\) [RemoveFavorite](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1527>)
+### func \(\*Repository\) [RemoveFavorite](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1605>)
 
 ```go
 func (r *Repository) RemoveFavorite(ctx context.Context, tenant, userID, dagID string) error
@@ -900,7 +923,7 @@ func (r *Repository) RemoveFavorite(ctx context.Context, tenant, userID, dagID s
 RemoveFavorite clears a DAG's favorite mark for the user \(idempotent\).
 
 <a name="Repository.RoleExists"></a>
-### func \(\*Repository\) [RoleExists](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L229>)
+### func \(\*Repository\) [RoleExists](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L252>)
 
 ```go
 func (r *Repository) RoleExists(ctx context.Context, tenant, role string) (bool, error)
@@ -909,7 +932,7 @@ func (r *Repository) RoleExists(ctx context.Context, tenant, role string) (bool,
 RoleExists reports whether a role name exists for the tenant. The OIDC login path uses it to fail closed on a misconfigured default\_role before minting a token for a returning user \(the JIT path validates roles inside CreateOIDCUser\).
 
 <a name="Repository.SecretConnectionURIs"></a>
-### func \(\*Repository\) [SecretConnectionURIs](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1358>)
+### func \(\*Repository\) [SecretConnectionURIs](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1436>)
 
 ```go
 func (r *Repository) SecretConnectionURIs(ctx context.Context, tenantID string) (map[string]string, error)
@@ -918,7 +941,7 @@ func (r *Repository) SecretConnectionURIs(ctx context.Context, tenantID string) 
 SecretConnectionURIs returns the tenant's connections as conn\_id→Airflow URI \(password decrypted\), for delivering to task pods \(ADR 0021\). The agent exports them as AIRFLOW\_CONN\_\<CONN\_ID\>. tenantID is the tenant UUID carried by the agent token. Never expose these in UI/API responses.
 
 <a name="Repository.SecretConnectionURIsScoped"></a>
-### func \(\*Repository\) [SecretConnectionURIsScoped](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1426>)
+### func \(\*Repository\) [SecretConnectionURIsScoped](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1504>)
 
 ```go
 func (r *Repository) SecretConnectionURIsScoped(ctx context.Context, tenantID string, names []string) (map[string]string, error)
@@ -927,7 +950,7 @@ func (r *Repository) SecretConnectionURIsScoped(ctx context.Context, tenantID st
 SecretConnectionURIsScoped returns only the named subset of the tenant's connections as Airflow URIs \(password decrypted\), filtered in the query \(ADR 0055 D1\). It backs secret\_scoping: enforce. An empty name set returns nothing without a query. Never expose these in UI/API responses. It shares the per\-connection decrypt\-and\-skip\-on\-failure semantics of SecretConnectionURIs: one undecryptable connection is skipped with a warning, never blinding the rest of the declared set.
 
 <a name="Repository.SecretVariables"></a>
-### func \(\*Repository\) [SecretVariables](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1337>)
+### func \(\*Repository\) [SecretVariables](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1415>)
 
 ```go
 func (r *Repository) SecretVariables(ctx context.Context, tenantID string) (map[string]string, error)
@@ -936,7 +959,7 @@ func (r *Repository) SecretVariables(ctx context.Context, tenantID string) (map[
 SecretVariables returns the tenant's variables as key→value, for delivering to task pods \(ADR 0021\). The agent exports them as AIRFLOW\_VAR\_\<KEY\>. tenantID is the tenant UUID carried by the agent token \(not the tenant name\).
 
 <a name="Repository.SecretVariablesScoped"></a>
-### func \(\*Repository\) [SecretVariablesScoped](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1400>)
+### func \(\*Repository\) [SecretVariablesScoped](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1478>)
 
 ```go
 func (r *Repository) SecretVariablesScoped(ctx context.Context, tenantID string, names []string) (map[string]string, error)
@@ -945,7 +968,7 @@ func (r *Repository) SecretVariablesScoped(ctx context.Context, tenantID string,
 SecretVariablesScoped returns only the named subset of the tenant's variables, filtered in the query \(ADR 0055 D1: scope in the SQL, never post\-filter the decrypted whole vault in the handler\). It backs secret\_scoping: enforce, where a task receives only the Variables it declared. An empty name set returns nothing without a query — enforce's load\-bearing \[\] case. tenantID is the tenant UUID carried by the agent token.
 
 <a name="Repository.SetCipher"></a>
-### func \(\*Repository\) [SetCipher](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L46>)
+### func \(\*Repository\) [SetCipher](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L57>)
 
 ```go
 func (r *Repository) SetCipher(c secrets.Cipher)
@@ -954,7 +977,7 @@ func (r *Repository) SetCipher(c secrets.Cipher)
 SetCipher attaches the encryption cipher used for connection secrets \(ADR 0019\). Without it, connection writes fail rather than storing plaintext.
 
 <a name="Repository.SetConnection"></a>
-### func \(\*Repository\) [SetConnection](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1605>)
+### func \(\*Repository\) [SetConnection](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1710>)
 
 ```go
 func (r *Repository) SetConnection(ctx context.Context, tenant string, c domain.Connection) error
@@ -962,8 +985,17 @@ func (r *Repository) SetConnection(ctx context.Context, tenant string, c domain.
 
 SetConnection creates or updates a connection, encrypting password and extra at rest. It fails if no encryption cipher is configured \(never stores a credential in plaintext — ADR 0019\).
 
+<a name="Repository.SetConnectionPatch"></a>
+### func \(\*Repository\) [SetConnectionPatch](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1768>)
+
+```go
+func (r *Repository) SetConnectionPatch(ctx context.Context, tenant string, p domain.ConnectionPatch) error
+```
+
+SetConnectionPatch upserts a connection with tri\-state field semantics \(\#887\): a nil field is preserved \(NULL param → COALESCE keeps the stored value\), a non\-nil field is written exactly \("" clears it\). Password and extra are encrypted when set. It is how the API write path distinguishes an omitted field from an explicit empty one without reintroducing the password\-wipe, and where a masked secret round\-trip is preserved \(the handler maps a masked password to a nil field, and unmasks extra, before calling here\). It fails if no encryption cipher is configured \(never stores a credential in plaintext — ADR 0019\).
+
 <a name="Repository.SetDagRunState"></a>
-### func \(\*Repository\) [SetDagRunState](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L580>)
+### func \(\*Repository\) [SetDagRunState](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L611>)
 
 ```go
 func (r *Repository) SetDagRunState(ctx context.Context, tenant, dagID, runID, state string) error
@@ -971,8 +1003,17 @@ func (r *Repository) SetDagRunState(ctx context.Context, tenant, dagID, runID, s
 
 SetDagRunState sets a DAG run's state directly, backing the UI's mark run success/failed actions. Terminal states stamp ended\_at; re\-opening to a non\-terminal state clears it. started\_at is preserved.
 
+<a name="Repository.SetExternalSecretCoverage"></a>
+### func \(\*Repository\) [SetExternalSecretCoverage](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L63>)
+
+```go
+func (r *Repository) SetExternalSecretCoverage(c externalSecretCoverage)
+```
+
+SetExternalSecretCoverage attaches the operator\-configured external\-backend coverage used by the D6 registration check \(ADR 0060 B1\). Without it, the check is the pre\-0060 vault\-existence check \(a declared name must exist in the vault\). It must be wired from operator/Helm config, never from a DAG.
+
 <a name="Repository.SetImportError"></a>
-### func \(\*Repository\) [SetImportError](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1756>)
+### func \(\*Repository\) [SetImportError](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1919>)
 
 ```go
 func (r *Repository) SetImportError(ctx context.Context, tenant string, e domain.ImportError) error
@@ -981,7 +1022,7 @@ func (r *Repository) SetImportError(ctx context.Context, tenant string, e domain
 SetImportError records \(or replaces\) the parse/compile error for a file.
 
 <a name="Repository.SetPaused"></a>
-### func \(\*Repository\) [SetPaused](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L328>)
+### func \(\*Repository\) [SetPaused](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L351>)
 
 ```go
 func (r *Repository) SetPaused(ctx context.Context, tenant, dagID string, paused bool) (domain.DAG, error)
@@ -999,7 +1040,7 @@ func (r *Repository) SetPool(ctx context.Context, tenant string, p domain.Pool) 
 SetPool creates or updates a pool \(its slot cap and description\). The is\_default flag is not writable through this path — only the seed migration marks the implicit default pool.
 
 <a name="Repository.SetTaskInstanceState"></a>
-### func \(\*Repository\) [SetTaskInstanceState](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L780>)
+### func \(\*Repository\) [SetTaskInstanceState](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L821>)
 
 ```go
 func (r *Repository) SetTaskInstanceState(ctx context.Context, tenant, dagID, runID, taskID, state string) error
@@ -1008,7 +1049,7 @@ func (r *Repository) SetTaskInstanceState(ctx context.Context, tenant, dagID, ru
 SetTaskInstanceState sets a task instance's state directly, backing the UI's "mark success"/"mark failed" actions. It does not run the task.
 
 <a name="Repository.SetUserPassword"></a>
-### func \(\*Repository\) [SetUserPassword](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1153>)
+### func \(\*Repository\) [SetUserPassword](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1231>)
 
 ```go
 func (r *Repository) SetUserPassword(ctx context.Context, tenant, email, hash string) (bool, error)
@@ -1017,16 +1058,25 @@ func (r *Repository) SetUserPassword(ctx context.Context, tenant, email, hash st
 SetUserPassword sets a user's bcrypt hash by email, returning whether a user was updated \(false when no such user exists\). Used by \`leoflow lite reset\-password\`.
 
 <a name="Repository.SetVariable"></a>
-### func \(\*Repository\) [SetVariable](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1561>)
+### func \(\*Repository\) [SetVariable](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1642>)
 
 ```go
 func (r *Repository) SetVariable(ctx context.Context, tenant string, v domain.Variable) error
 ```
 
-SetVariable creates or updates a variable.
+SetVariable creates or updates a variable, always overwriting the value and preserving description when empty. It is the full\-write convenience the storage tests and internal callers use; the tri\-state API write path goes through SetVariablePatch.
+
+<a name="Repository.SetVariablePatch"></a>
+### func \(\*Repository\) [SetVariablePatch](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1662>)
+
+```go
+func (r *Repository) SetVariablePatch(ctx context.Context, tenant string, p domain.VariablePatch) error
+```
+
+SetVariablePatch upserts a variable with tri\-state semantics on description \(\#887\): a nil Description is preserved \(NULL param → COALESCE\), a non\-nil one is written \("" clears it\). The \`value\` column is NOT NULL, so value cannot be preserved at the SQL layer \(a NULL param is rejected on the INSERT arm before COALESCE\); the API handler therefore resolves an omitted/masked value to the stored value before calling here, and Value is expected non\-nil \(a nil Value defensively clears to empty rather than panicking\).
 
 <a name="Repository.TaskInstancesForRuns"></a>
-### func \(\*Repository\) [TaskInstancesForRuns](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L831>)
+### func \(\*Repository\) [TaskInstancesForRuns](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L872>)
 
 ```go
 func (r *Repository) TaskInstancesForRuns(ctx context.Context, tenant, dagID string, runIDs []string) ([]domain.TaskInstance, error)
@@ -1035,7 +1085,7 @@ func (r *Repository) TaskInstancesForRuns(ctx context.Context, tenant, dagID str
 TaskInstancesForRuns returns the task instances of the given runs of a DAG in one query, ordered by run\_id, task\_id, try\_number, for the grid summaries.
 
 <a name="Repository.TenantUUID"></a>
-### func \(\*Repository\) [TenantUUID](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1326>)
+### func \(\*Repository\) [TenantUUID](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/repository.go#L1404>)
 
 ```go
 func (r *Repository) TenantUUID(ctx context.Context, name string) (string, error)
@@ -1073,7 +1123,7 @@ func (s *SchedulerStore) ActiveRuns(ctx context.Context) ([]scheduler.RunState, 
 ActiveRuns loads every active dag run and projects it into the scheduler's RunState \(topology \+ per\-task state\), the read side of a scheduler tick.
 
 <a name="SchedulerStore.ActiveWarmTargets"></a>
-### func \(\*SchedulerStore\) [ActiveWarmTargets](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L227>)
+### func \(\*SchedulerStore\) [ActiveWarmTargets](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L236>)
 
 ```go
 func (s *SchedulerStore) ActiveWarmTargets(ctx context.Context) ([]executor.WarmTarget, error)
@@ -1082,7 +1132,7 @@ func (s *SchedulerStore) ActiveWarmTargets(ctx context.Context) ([]executor.Warm
 ActiveWarmTargets returns one warm target per distinct active dag\_version with its effective warm\-worker count \(ADR 0058 N1b2b\), the read side of a warm\-pool reconcile tick. It reuses the same active\-runs \+ cached\-spec path as ActiveRuns: the spec is immutable per dag\_version\_id, so N active runs sharing a version decode it once and the effective target is derived from the DAG author's min\_idle\_workers under the operator's clamp/fallback. It implements executor.WarmTargetSource without the executor importing storage.
 
 <a name="SchedulerStore.ApplyTransition"></a>
-### func \(\*SchedulerStore\) [ApplyTransition](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L324>)
+### func \(\*SchedulerStore\) [ApplyTransition](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L336>)
 
 ```go
 func (s *SchedulerStore) ApplyTransition(ctx context.Context, runID, taskID string, to domain.TaskState) error
@@ -1091,7 +1141,7 @@ func (s *SchedulerStore) ApplyTransition(ctx context.Context, runID, taskID stri
 ApplyTransition moves a task instance to a new state.
 
 <a name="SchedulerStore.ApplyTransitions"></a>
-### func \(\*SchedulerStore\) [ApplyTransitions](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L342>)
+### func \(\*SchedulerStore\) [ApplyTransitions](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L354>)
 
 ```go
 func (s *SchedulerStore) ApplyTransitions(ctx context.Context, runID string, taskIDs []string, to domain.TaskState) error
@@ -1100,7 +1150,7 @@ func (s *SchedulerStore) ApplyTransitions(ctx context.Context, runID string, tas
 ApplyTransitions moves every listed task of a run to the SAME target state in one UPDATE, the batched equivalent of calling ApplyTransition once per task. The scheduler groups a tick's plain state\-set transitions by target state and flushes each group here, collapsing R updates into one per distinct state. The per\-row stamping is identical to the single\-row query, so the result is byte\-identical — only the statement count drops. An empty list is a no\-op.
 
 <a name="SchedulerStore.ClaimAlertAttempt"></a>
-### func \(\*SchedulerStore\) [ClaimAlertAttempt](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L496>)
+### func \(\*SchedulerStore\) [ClaimAlertAttempt](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L508>)
 
 ```go
 func (s *SchedulerStore) ClaimAlertAttempt(ctx context.Context, runID string, maxAttempts int, backoff time.Duration) (int, error)
@@ -1111,7 +1161,7 @@ ClaimAlertAttempt atomically claims one on\-failure send attempt for a run \(\#4
 Claiming an attempt is NOT the same as recording delivery; that is MarkRunAlertDelivered. Conflating the two is what made a failed send a permanently lost page. Returns the attempt number won \(0 when the claim was refused\), which the caller passes back to MarkRunAlertDelivered so a superseded send cannot stamp.
 
 <a name="SchedulerStore.CreateScheduledRun"></a>
-### func \(\*SchedulerStore\) [CreateScheduledRun](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L552>)
+### func \(\*SchedulerStore\) [CreateScheduledRun](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L564>)
 
 ```go
 func (s *SchedulerStore) CreateScheduledRun(ctx context.Context, dagID string, logical time.Time) error
@@ -1120,7 +1170,7 @@ func (s *SchedulerStore) CreateScheduledRun(ctx context.Context, dagID string, l
 CreateScheduledRun inserts a scheduled run for a DAG \(idempotent on run\_id\).
 
 <a name="SchedulerStore.FailDispatchExhausted"></a>
-### func \(\*SchedulerStore\) [FailDispatchExhausted](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L448>)
+### func \(\*SchedulerStore\) [FailDispatchExhausted](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L460>)
 
 ```go
 func (s *SchedulerStore) FailDispatchExhausted(ctx context.Context, runID, taskID, reason string) error
@@ -1129,7 +1179,7 @@ func (s *SchedulerStore) FailDispatchExhausted(ctx context.Context, runID, taskI
 FailDispatchExhausted fails a scheduled task as dispatch\_failed once its dispatch\-attempt budget is spent \(ADR 0031 Amendment A\).
 
 <a name="SchedulerStore.ListActiveStagingVolumes"></a>
-### func \(\*SchedulerStore\) [ListActiveStagingVolumes](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L864>)
+### func \(\*SchedulerStore\) [ListActiveStagingVolumes](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L877>)
 
 ```go
 func (s *SchedulerStore) ListActiveStagingVolumes(ctx context.Context) ([]domain.StagingVolumeState, error)
@@ -1138,7 +1188,7 @@ func (s *SchedulerStore) ListActiveStagingVolumes(ctx context.Context) ([]domain
 ListActiveStagingVolumes returns active staging volumes joined with their DAG run's state \(empty when the run row is gone\), for the GC \(ADR 0022\).
 
 <a name="SchedulerStore.ListAgentLostCandidates"></a>
-### func \(\*SchedulerStore\) [ListAgentLostCandidates](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L678>)
+### func \(\*SchedulerStore\) [ListAgentLostCandidates](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L690>)
 
 ```go
 func (s *SchedulerStore) ListAgentLostCandidates(ctx context.Context) ([]executor.AgentLostCandidate, error)
@@ -1147,7 +1197,7 @@ func (s *SchedulerStore) ListAgentLostCandidates(ctx context.Context) ([]executo
 ListAgentLostCandidates returns every \`running\` TI with a non\-null last\_heartbeat\_at, for the scheduler's TI heartbeat reaper \(\#128\). The reaper applies the threshold per row so the SQL stays simple.
 
 <a name="SchedulerStore.ListBusyWarmWorkerPods"></a>
-### func \(\*SchedulerStore\) [ListBusyWarmWorkerPods](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L793>)
+### func \(\*SchedulerStore\) [ListBusyWarmWorkerPods](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L806>)
 
 ```go
 func (s *SchedulerStore) ListBusyWarmWorkerPods(ctx context.Context) (map[string]bool, error)
@@ -1156,7 +1206,7 @@ func (s *SchedulerStore) ListBusyWarmWorkerPods(ctx context.Context) (map[string
 ListBusyWarmWorkerPods returns the set of warm\-worker pod names currently serving a \`running\` attempt \(ADR 0058 N1d\-b\): a warm worker is BUSY iff some \`running\` task\_instance is durably bound to it \(warm\_worker\_id = the pod's own name\). The busy\-aware warm\-pool reconciler reads this once per tick to classify each live warm pod as busy or idle, so scale\-down/drain deletes only IDLE workers and never kills an in\-flight attempt \(review findings M1/M2\). With warm pools off no TI is ever bound, so the set is always empty and every worker classifies as idle — byte\-for\-byte today. Implements executor.BusyWarmWorkerSource without the executor importing storage.
 
 <a name="SchedulerStore.ListReapCandidates"></a>
-### func \(\*SchedulerStore\) [ListReapCandidates](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L612>)
+### func \(\*SchedulerStore\) [ListReapCandidates](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L624>)
 
 ```go
 func (s *SchedulerStore) ListReapCandidates(ctx context.Context) ([]executor.ReapCandidate, error)
@@ -1165,7 +1215,7 @@ func (s *SchedulerStore) ListReapCandidates(ctx context.Context) ([]executor.Rea
 ListReapCandidates returns every dag\_run currently in 'running' state with the timestamp of its most recent activity, for the scheduler's orphan reaper. The query \(sqlc.runs.ListOrphanCandidates\) is the authority on how to compute the timestamp; the reaper only decides whether each one is past its threshold.
 
 <a name="SchedulerStore.ListRunningTasks"></a>
-### func \(\*SchedulerStore\) [ListRunningTasks](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L824>)
+### func \(\*SchedulerStore\) [ListRunningTasks](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L837>)
 
 ```go
 func (s *SchedulerStore) ListRunningTasks(ctx context.Context) ([]executor.PodLostCandidate, error)
@@ -1174,7 +1224,7 @@ func (s *SchedulerStore) ListRunningTasks(ctx context.Context) ([]executor.PodLo
 ListRunningTasks returns every \`running\` TI with the timestamp it entered running, for the pod\-lost reaper \(\#527\). The reaper applies the grace period and the pod\-liveness check per row, so the SQL stays simple.
 
 <a name="SchedulerStore.ListStaleQueuedCandidates"></a>
-### func \(\*SchedulerStore\) [ListStaleQueuedCandidates](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L738>)
+### func \(\*SchedulerStore\) [ListStaleQueuedCandidates](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L751>)
 
 ```go
 func (s *SchedulerStore) ListStaleQueuedCandidates(ctx context.Context) ([]executor.StaleQueuedCandidate, error)
@@ -1183,7 +1233,7 @@ func (s *SchedulerStore) ListStaleQueuedCandidates(ctx context.Context) ([]execu
 ListStaleQueuedCandidates returns every \`queued\` TI with its queued\_at, for the dispatch\-lost reaper \(\#202\). The reaper applies the threshold per row so the SQL stays simple.
 
 <a name="SchedulerStore.ListWarmBoundRunningTIs"></a>
-### func \(\*SchedulerStore\) [ListWarmBoundRunningTIs](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L766>)
+### func \(\*SchedulerStore\) [ListWarmBoundRunningTIs](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L779>)
 
 ```go
 func (s *SchedulerStore) ListWarmBoundRunningTIs(ctx context.Context) ([]executor.WarmBoundTI, error)
@@ -1192,7 +1242,7 @@ func (s *SchedulerStore) ListWarmBoundRunningTIs(ctx context.Context) ([]executo
 ListWarmBoundRunningTIs returns every \`running\` TI durably bound to a warm worker \(warm\_worker\_id IS NOT NULL\), for the warm\-worker\-lost reaper \(ADR 0058 N1d\-a2\). With warm pools off no TI is ever bound, so this is always empty and the reaper is inert.
 
 <a name="SchedulerStore.MarkRunAlertDelivered"></a>
-### func \(\*SchedulerStore\) [MarkRunAlertDelivered](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L519>)
+### func \(\*SchedulerStore\) [MarkRunAlertDelivered](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L531>)
 
 ```go
 func (s *SchedulerStore) MarkRunAlertDelivered(ctx context.Context, runID string, attempt int) error
@@ -1201,7 +1251,7 @@ func (s *SchedulerStore) MarkRunAlertDelivered(ctx context.Context, runID string
 MarkRunAlertDelivered stamps a run's on\-failure alert as delivered, for the attempt the caller won. The attempt is part of the predicate so a stamp from a send that an operator clear has since superseded matches no row — see the query.
 
 <a name="SchedulerStore.MarkStagingDeleted"></a>
-### func \(\*SchedulerStore\) [MarkStagingDeleted](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L597>)
+### func \(\*SchedulerStore\) [MarkStagingDeleted](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L609>)
 
 ```go
 func (s *SchedulerStore) MarkStagingDeleted(ctx context.Context, pvcName, reason string) error
@@ -1210,7 +1260,7 @@ func (s *SchedulerStore) MarkStagingDeleted(ctx context.Context, pvcName, reason
 MarkStagingDeleted records that a staging volume's PVC was deleted and why \(run\_succeeded | ttl\_expired | orphaned\).
 
 <a name="SchedulerStore.MarkTaskAgentLost"></a>
-### func \(\*SchedulerStore\) [MarkTaskAgentLost](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L723>)
+### func \(\*SchedulerStore\) [MarkTaskAgentLost](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L736>)
 
 ```go
 func (s *SchedulerStore) MarkTaskAgentLost(ctx context.Context, taskInstanceID string) (bool, error)
@@ -1219,7 +1269,7 @@ func (s *SchedulerStore) MarkTaskAgentLost(ctx context.Context, taskInstanceID s
 MarkTaskAgentLost transitions one TI to \`failed\` with the agent\_lost reason. The WHERE state='running' guard makes this idempotent and prevents a late terminal report being overwritten — if the row already moved, we touch zero rows and return nil.
 
 <a name="SchedulerStore.MarkTaskDispatchFailed"></a>
-### func \(\*SchedulerStore\) [MarkTaskDispatchFailed](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L707>)
+### func \(\*SchedulerStore\) [MarkTaskDispatchFailed](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L720>)
 
 ```go
 func (s *SchedulerStore) MarkTaskDispatchFailed(ctx context.Context, runID, taskID, reason string) error
@@ -1228,7 +1278,7 @@ func (s *SchedulerStore) MarkTaskDispatchFailed(ctx context.Context, runID, task
 MarkTaskDispatchFailed transitions a TI to \`failed\` after its asynchronous dispatch failed inside the BufferedDispatcher worker \(\#127\). The SQL guard only targets scheduled/queued rows, so a TI that already moved to running or terminal between the worker accepting the request and the dispatch failing is left alone \(defense in depth — the agent's late progress report wins over the dispatcher's "I failed" claim\).
 
 <a name="SchedulerStore.MarkTaskDispatchLost"></a>
-### func \(\*SchedulerStore\) [MarkTaskDispatchLost](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L810>)
+### func \(\*SchedulerStore\) [MarkTaskDispatchLost](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L823>)
 
 ```go
 func (s *SchedulerStore) MarkTaskDispatchLost(ctx context.Context, taskInstanceID string) error
@@ -1237,7 +1287,7 @@ func (s *SchedulerStore) MarkTaskDispatchLost(ctx context.Context, taskInstanceI
 MarkTaskDispatchLost transitions one TI to \`failed\` with the dispatch\_lost reason. The WHERE state='queued' guard makes this idempotent: a TI that has since been dispatched \(real progress landed\) is left alone.
 
 <a name="SchedulerStore.MarkTaskPodLost"></a>
-### func \(\*SchedulerStore\) [MarkTaskPodLost](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L850>)
+### func \(\*SchedulerStore\) [MarkTaskPodLost](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L863>)
 
 ```go
 func (s *SchedulerStore) MarkTaskPodLost(ctx context.Context, taskInstanceID string) (bool, error)
@@ -1246,7 +1296,7 @@ func (s *SchedulerStore) MarkTaskPodLost(ctx context.Context, taskInstanceID str
 MarkTaskPodLost transitions one TI to \`failed\` with the pod\_lost reason. The WHERE state='running' guard makes it idempotent: a TI that has since moved on \(a late terminal report landed\) is left alone.
 
 <a name="SchedulerStore.MaterializeTasks"></a>
-### func \(\*SchedulerStore\) [MaterializeTasks](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L258>)
+### func \(\*SchedulerStore\) [MaterializeTasks](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L270>)
 
 ```go
 func (s *SchedulerStore) MaterializeTasks(ctx context.Context, runID string, tasks []domain.TaskSpec) error
@@ -1255,7 +1305,7 @@ func (s *SchedulerStore) MaterializeTasks(ctx context.Context, runID string, tas
 MaterializeTasks creates a none\-state task instance for each task in the run, in one batched COPY rather than T INSERT round\-trips. The rows are identical to the per\-task loop this replaced: try\_number pinned to 1, state none, and max\_tries derived from the task's retries \(default 1\). An empty task set is a no\-op \(a DAG with no tasks materializes nothing\).
 
 <a name="SchedulerStore.PoolBudgets"></a>
-### func \(\*SchedulerStore\) [PoolBudgets](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L311>)
+### func \(\*SchedulerStore\) [PoolBudgets](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L323>)
 
 ```go
 func (s *SchedulerStore) PoolBudgets(ctx context.Context) (map[string]int, error)
@@ -1264,7 +1314,7 @@ func (s *SchedulerStore) PoolBudgets(ctx context.Context) (map[string]int, error
 PoolBudgets returns every named pool's slot cap keyed by scheduler.PoolKey\(tenantID, name\) — the cross\-DAG admission budget the pool gate enforces \(ADR 0053 Stage 3\). The scheduler calls it once per tick, and only on the Pro path; Lite never loads pool budgets.
 
 <a name="SchedulerStore.ReapRun"></a>
-### func \(\*SchedulerStore\) [ReapRun](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L639>)
+### func \(\*SchedulerStore\) [ReapRun](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L651>)
 
 ```go
 func (s *SchedulerStore) ReapRun(ctx context.Context, runID string) error
@@ -1273,7 +1323,7 @@ func (s *SchedulerStore) ReapRun(ctx context.Context, runID string) error
 ReapRun fails an orphaned dag run, then any of its still\-active task instances, inside a single transaction. The run UPDATE comes first and is guarded by \`state = 'running'\`: if zero rows are touched, the run was no longer running \(a competing finalizer beat us\) and we abort with a clean rollback — the TI table is never touched. This guarantees we cannot leave a run as \`success\`/\`failed\` while flipping its TIs to \`failed \(orphaned\)\`. Idempotent: a second call on an already\-failed run no\-ops.
 
 <a name="SchedulerStore.RecordDispatchBackpressure"></a>
-### func \(\*SchedulerStore\) [RecordDispatchBackpressure](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L434>)
+### func \(\*SchedulerStore\) [RecordDispatchBackpressure](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L446>)
 
 ```go
 func (s *SchedulerStore) RecordDispatchBackpressure(ctx context.Context, runID, taskID string, nextAt time.Time) error
@@ -1282,7 +1332,7 @@ func (s *SchedulerStore) RecordDispatchBackpressure(ctx context.Context, runID, 
 RecordDispatchBackpressure backs off a scheduled task after a retriable\-forever cluster\-backpressure dispatch failure \(quota 403 / APF 429\), setting nextAt WITHOUT incrementing dispatch\_attempts so it never accumulates toward the dispatch\_failed cap \(ADR 0053\).
 
 <a name="SchedulerStore.RecordDispatchFailure"></a>
-### func \(\*SchedulerStore\) [RecordDispatchFailure](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L418>)
+### func \(\*SchedulerStore\) [RecordDispatchFailure](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L430>)
 
 ```go
 func (s *SchedulerStore) RecordDispatchFailure(ctx context.Context, runID, taskID string, nextAt time.Time) error
@@ -1291,7 +1341,7 @@ func (s *SchedulerStore) RecordDispatchFailure(ctx context.Context, runID, taskI
 RecordDispatchFailure increments a scheduled task's dispatch\-failure counter and backs off its next attempt to nextAt \(ADR 0031 Amendment A\).
 
 <a name="SchedulerStore.RecordStagingVolume"></a>
-### func \(\*SchedulerStore\) [RecordStagingVolume](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L582>)
+### func \(\*SchedulerStore\) [RecordStagingVolume](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L594>)
 
 ```go
 func (s *SchedulerStore) RecordStagingVolume(ctx context.Context, tenantID, dagID, runID, pvcName, size string) error
@@ -1300,7 +1350,7 @@ func (s *SchedulerStore) RecordStagingVolume(ctx context.Context, tenantID, dagI
 RecordStagingVolume records a per\-run staging volume as active, keyed by PVC name \(idempotent — called per task as the PVC is ensured\). ADR 0022.
 
 <a name="SchedulerStore.RedispatchReschedule"></a>
-### func \(\*SchedulerStore\) [RedispatchReschedule](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L462>)
+### func \(\*SchedulerStore\) [RedispatchReschedule](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L474>)
 
 ```go
 func (s *SchedulerStore) RedispatchReschedule(ctx context.Context, runID, taskID string) error
@@ -1309,7 +1359,7 @@ func (s *SchedulerStore) RedispatchReschedule(ctx context.Context, runID, taskID
 RedispatchReschedule returns a task parked in up\_for\_reschedule to 'none' for re\-dispatch, preserving try\_number \(reschedule is not a retry; \#380\).
 
 <a name="SchedulerStore.ResetForInfraReplace"></a>
-### func \(\*SchedulerStore\) [ResetForInfraReplace](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L401>)
+### func \(\*SchedulerStore\) [ResetForInfraReplace](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L413>)
 
 ```go
 func (s *SchedulerStore) ResetForInfraReplace(ctx context.Context, runID, taskID string) (bool, error)
@@ -1318,7 +1368,7 @@ func (s *SchedulerStore) ResetForInfraReplace(ctx context.Context, runID, taskID
 ResetForInfraReplace returns a task instance failed by a reaper as infra \(last\_failure\_kind='infra'\) to 'none' so the scheduler re\-runs it, bumping infra\_attempts instead of try\_number — an infrastructure fault must not consume the user's retry budget \(ADR 0051 Phase 1\). It uses the failed\+infra\-guarded query so a late terminal report or a non\-infra failure at state='failed' cannot be re\-placed off\-budget. The bool reports whether the guarded update fired \(exactly one row\): a false means the TI was no longer a failed\-infra candidate, so the caller must not record a re\-placement it did not perform.
 
 <a name="SchedulerStore.ResetForRetry"></a>
-### func \(\*SchedulerStore\) [ResetForRetry](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L377>)
+### func \(\*SchedulerStore\) [ResetForRetry](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L389>)
 
 ```go
 func (s *SchedulerStore) ResetForRetry(ctx context.Context, runID, taskID string) (bool, error)
@@ -1327,7 +1377,7 @@ func (s *SchedulerStore) ResetForRetry(ctx context.Context, runID, taskID string
 ResetForRetry returns a task instance to 'none', clears its timestamps, and increments its try number so the scheduler re\-evaluates and re\-runs it. It uses the up\_for\_retry\-guarded query so a stale retry decision cannot reset a TI that has since been re\-dispatched \(audit follow\-up; see the query doc\). The bool reports whether the guarded update actually fired \(exactly one row\): a false means the TI was no longer up\_for\_retry and nothing was reset, so the caller must not record a retry it did not perform.
 
 <a name="SchedulerStore.ScheduledDAGs"></a>
-### func \(\*SchedulerStore\) [ScheduledDAGs](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L532>)
+### func \(\*SchedulerStore\) [ScheduledDAGs](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L544>)
 
 ```go
 func (s *SchedulerStore) ScheduledDAGs(ctx context.Context) ([]scheduler.ScheduledDAG, error)
@@ -1336,7 +1386,7 @@ func (s *SchedulerStore) ScheduledDAGs(ctx context.Context) ([]scheduler.Schedul
 ScheduledDAGs returns active, unpaused, cron\-scheduled DAGs with the logical date of their most recent run.
 
 <a name="SchedulerStore.SetRunState"></a>
-### func \(\*SchedulerStore\) [SetRunState](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L474>)
+### func \(\*SchedulerStore\) [SetRunState](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L486>)
 
 ```go
 func (s *SchedulerStore) SetRunState(ctx context.Context, runID string, state domain.DagRunState) error
@@ -1345,7 +1395,7 @@ func (s *SchedulerStore) SetRunState(ctx context.Context, runID string, state do
 SetRunState updates a run's state.
 
 <a name="SchedulerStore.SetTaskNote"></a>
-### func \(\*SchedulerStore\) [SetTaskNote](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L358>)
+### func \(\*SchedulerStore\) [SetTaskNote](<https://github.com/neochaotic/leoflow/blob/main/internal/storage/scheduler_store.go#L370>)
 
 ```go
 func (s *SchedulerStore) SetTaskNote(ctx context.Context, runID, taskID, note string) error

--- a/website/content/reference/go/pkg-client.md
+++ b/website/content/reference/go/pkg-client.md
@@ -1,8 +1,4 @@
 ---
-# --- AUTO redirect aliases (build_redirects.py) — do not edit by hand ---
-aliases:
-  - /go/pkg/client.html
-# --- end AUTO redirect aliases ---
 title: "pkg/client"
 linkTitle: "pkg/client"
 weight: 12
@@ -24,8 +20,15 @@ client.gen.go is generated from docs/api/openapi.yaml. Do not edit it by hand; r
 
 - [func NewClearTaskInstancesRequest\(server string, dagId DagID, body ClearTaskInstancesJSONRequestBody\) \(\*http.Request, error\)](<#NewClearTaskInstancesRequest>)
 - [func NewClearTaskInstancesRequestWithBody\(server string, dagId DagID, contentType string, body io.Reader\) \(\*http.Request, error\)](<#NewClearTaskInstancesRequestWithBody>)
+- [func NewCreateConnectionRequest\(server string, body CreateConnectionJSONRequestBody\) \(\*http.Request, error\)](<#NewCreateConnectionRequest>)
+- [func NewCreateConnectionRequestWithBody\(server string, contentType string, body io.Reader\) \(\*http.Request, error\)](<#NewCreateConnectionRequestWithBody>)
 - [func NewCreateUserRequest\(server string, body CreateUserJSONRequestBody\) \(\*http.Request, error\)](<#NewCreateUserRequest>)
 - [func NewCreateUserRequestWithBody\(server string, contentType string, body io.Reader\) \(\*http.Request, error\)](<#NewCreateUserRequestWithBody>)
+- [func NewCreateVariableRequest\(server string, body CreateVariableJSONRequestBody\) \(\*http.Request, error\)](<#NewCreateVariableRequest>)
+- [func NewCreateVariableRequestWithBody\(server string, contentType string, body io.Reader\) \(\*http.Request, error\)](<#NewCreateVariableRequestWithBody>)
+- [func NewDeleteConnectionRequest\(server string, connectionId ConnectionID\) \(\*http.Request, error\)](<#NewDeleteConnectionRequest>)
+- [func NewDeleteVariableRequest\(server string, variableKey VariableKey\) \(\*http.Request, error\)](<#NewDeleteVariableRequest>)
+- [func NewGetConnectionRequest\(server string, connectionId ConnectionID\) \(\*http.Request, error\)](<#NewGetConnectionRequest>)
 - [func NewGetDagRequest\(server string, dagId DagID\) \(\*http.Request, error\)](<#NewGetDagRequest>)
 - [func NewGetDagRunRequest\(server string, dagId DagID, dagRunId DagRunID\) \(\*http.Request, error\)](<#NewGetDagRunRequest>)
 - [func NewGetDagSourceRequest\(server string, dagId DagID\) \(\*http.Request, error\)](<#NewGetDagSourceRequest>)
@@ -37,17 +40,23 @@ client.gen.go is generated from docs/api/openapi.yaml. Do not edit it by hand; r
 - [func NewGetReadyzRequest\(server string\) \(\*http.Request, error\)](<#NewGetReadyzRequest>)
 - [func NewGetTaskInstanceRequest\(server string, dagId DagID, dagRunId DagRunID, taskId TaskID\) \(\*http.Request, error\)](<#NewGetTaskInstanceRequest>)
 - [func NewGetTaskLogsRequest\(server string, dagId DagID, dagRunId DagRunID, taskId TaskID, tryNumber int\) \(\*http.Request, error\)](<#NewGetTaskLogsRequest>)
+- [func NewGetVariableRequest\(server string, variableKey VariableKey\) \(\*http.Request, error\)](<#NewGetVariableRequest>)
 - [func NewGetVersionRequest\(server string\) \(\*http.Request, error\)](<#NewGetVersionRequest>)
 - [func NewGetXcomEntryRequest\(server string, dagId DagID, dagRunId DagRunID, taskId TaskID, key string\) \(\*http.Request, error\)](<#NewGetXcomEntryRequest>)
 - [func NewIssueTokenRequest\(server string, body IssueTokenJSONRequestBody\) \(\*http.Request, error\)](<#NewIssueTokenRequest>)
 - [func NewIssueTokenRequestWithBody\(server string, contentType string, body io.Reader\) \(\*http.Request, error\)](<#NewIssueTokenRequestWithBody>)
+- [func NewListConnectionsRequest\(server string, params \*ListConnectionsParams\) \(\*http.Request, error\)](<#NewListConnectionsRequest>)
 - [func NewListDagRunsRequest\(server string, dagId DagID, params \*ListDagRunsParams\) \(\*http.Request, error\)](<#NewListDagRunsRequest>)
 - [func NewListDagVersionsRequest\(server string, dagId DagID\) \(\*http.Request, error\)](<#NewListDagVersionsRequest>)
 - [func NewListDagsRequest\(server string, params \*ListDagsParams\) \(\*http.Request, error\)](<#NewListDagsRequest>)
 - [func NewListTaskInstancesRequest\(server string, dagId DagID, dagRunId DagRunID\) \(\*http.Request, error\)](<#NewListTaskInstancesRequest>)
 - [func NewListUsersRequest\(server string, params \*ListUsersParams\) \(\*http.Request, error\)](<#NewListUsersRequest>)
+- [func NewListVariablesRequest\(server string, params \*ListVariablesParams\) \(\*http.Request, error\)](<#NewListVariablesRequest>)
+- [func NewRenewTokenRequest\(server string\) \(\*http.Request, error\)](<#NewRenewTokenRequest>)
 - [func NewTriggerDagRunRequest\(server string, dagId DagID, body TriggerDagRunJSONRequestBody\) \(\*http.Request, error\)](<#NewTriggerDagRunRequest>)
 - [func NewTriggerDagRunRequestWithBody\(server string, dagId DagID, contentType string, body io.Reader\) \(\*http.Request, error\)](<#NewTriggerDagRunRequestWithBody>)
+- [func NewUpdateConnectionRequest\(server string, connectionId ConnectionID, body UpdateConnectionJSONRequestBody\) \(\*http.Request, error\)](<#NewUpdateConnectionRequest>)
+- [func NewUpdateConnectionRequestWithBody\(server string, connectionId ConnectionID, contentType string, body io.Reader\) \(\*http.Request, error\)](<#NewUpdateConnectionRequestWithBody>)
 - [func NewUpdateDagRequest\(server string, dagId DagID, body UpdateDagJSONRequestBody\) \(\*http.Request, error\)](<#NewUpdateDagRequest>)
 - [func NewUpdateDagRequestWithBody\(server string, dagId DagID, contentType string, body io.Reader\) \(\*http.Request, error\)](<#NewUpdateDagRequestWithBody>)
 - [type ClearTaskInstancesJSONRequestBody](<#ClearTaskInstancesJSONRequestBody>)
@@ -63,8 +72,15 @@ client.gen.go is generated from docs/api/openapi.yaml. Do not edit it by hand; r
   - [func NewClient\(server string, opts ...ClientOption\) \(\*Client, error\)](<#NewClient>)
   - [func \(c \*Client\) ClearTaskInstances\(ctx context.Context, dagId DagID, body ClearTaskInstancesJSONRequestBody, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.ClearTaskInstances>)
   - [func \(c \*Client\) ClearTaskInstancesWithBody\(ctx context.Context, dagId DagID, contentType string, body io.Reader, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.ClearTaskInstancesWithBody>)
+  - [func \(c \*Client\) CreateConnection\(ctx context.Context, body CreateConnectionJSONRequestBody, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.CreateConnection>)
+  - [func \(c \*Client\) CreateConnectionWithBody\(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.CreateConnectionWithBody>)
   - [func \(c \*Client\) CreateUser\(ctx context.Context, body CreateUserJSONRequestBody, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.CreateUser>)
   - [func \(c \*Client\) CreateUserWithBody\(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.CreateUserWithBody>)
+  - [func \(c \*Client\) CreateVariable\(ctx context.Context, body CreateVariableJSONRequestBody, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.CreateVariable>)
+  - [func \(c \*Client\) CreateVariableWithBody\(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.CreateVariableWithBody>)
+  - [func \(c \*Client\) DeleteConnection\(ctx context.Context, connectionId ConnectionID, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.DeleteConnection>)
+  - [func \(c \*Client\) DeleteVariable\(ctx context.Context, variableKey VariableKey, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.DeleteVariable>)
+  - [func \(c \*Client\) GetConnection\(ctx context.Context, connectionId ConnectionID, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.GetConnection>)
   - [func \(c \*Client\) GetDag\(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.GetDag>)
   - [func \(c \*Client\) GetDagRun\(ctx context.Context, dagId DagID, dagRunId DagRunID, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.GetDagRun>)
   - [func \(c \*Client\) GetDagSource\(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.GetDagSource>)
@@ -76,17 +92,23 @@ client.gen.go is generated from docs/api/openapi.yaml. Do not edit it by hand; r
   - [func \(c \*Client\) GetReadyz\(ctx context.Context, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.GetReadyz>)
   - [func \(c \*Client\) GetTaskInstance\(ctx context.Context, dagId DagID, dagRunId DagRunID, taskId TaskID, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.GetTaskInstance>)
   - [func \(c \*Client\) GetTaskLogs\(ctx context.Context, dagId DagID, dagRunId DagRunID, taskId TaskID, tryNumber int, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.GetTaskLogs>)
+  - [func \(c \*Client\) GetVariable\(ctx context.Context, variableKey VariableKey, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.GetVariable>)
   - [func \(c \*Client\) GetVersion\(ctx context.Context, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.GetVersion>)
   - [func \(c \*Client\) GetXcomEntry\(ctx context.Context, dagId DagID, dagRunId DagRunID, taskId TaskID, key string, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.GetXcomEntry>)
   - [func \(c \*Client\) IssueToken\(ctx context.Context, body IssueTokenJSONRequestBody, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.IssueToken>)
   - [func \(c \*Client\) IssueTokenWithBody\(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.IssueTokenWithBody>)
+  - [func \(c \*Client\) ListConnections\(ctx context.Context, params \*ListConnectionsParams, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.ListConnections>)
   - [func \(c \*Client\) ListDagRuns\(ctx context.Context, dagId DagID, params \*ListDagRunsParams, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.ListDagRuns>)
   - [func \(c \*Client\) ListDagVersions\(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.ListDagVersions>)
   - [func \(c \*Client\) ListDags\(ctx context.Context, params \*ListDagsParams, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.ListDags>)
   - [func \(c \*Client\) ListTaskInstances\(ctx context.Context, dagId DagID, dagRunId DagRunID, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.ListTaskInstances>)
   - [func \(c \*Client\) ListUsers\(ctx context.Context, params \*ListUsersParams, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.ListUsers>)
+  - [func \(c \*Client\) ListVariables\(ctx context.Context, params \*ListVariablesParams, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.ListVariables>)
+  - [func \(c \*Client\) RenewToken\(ctx context.Context, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.RenewToken>)
   - [func \(c \*Client\) TriggerDagRun\(ctx context.Context, dagId DagID, body TriggerDagRunJSONRequestBody, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.TriggerDagRun>)
   - [func \(c \*Client\) TriggerDagRunWithBody\(ctx context.Context, dagId DagID, contentType string, body io.Reader, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.TriggerDagRunWithBody>)
+  - [func \(c \*Client\) UpdateConnection\(ctx context.Context, connectionId ConnectionID, body UpdateConnectionJSONRequestBody, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.UpdateConnection>)
+  - [func \(c \*Client\) UpdateConnectionWithBody\(ctx context.Context, connectionId ConnectionID, contentType string, body io.Reader, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.UpdateConnectionWithBody>)
   - [func \(c \*Client\) UpdateDag\(ctx context.Context, dagId DagID, body UpdateDagJSONRequestBody, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.UpdateDag>)
   - [func \(c \*Client\) UpdateDagWithBody\(ctx context.Context, dagId DagID, contentType string, body io.Reader, reqEditors ...RequestEditorFn\) \(\*http.Response, error\)](<#Client.UpdateDagWithBody>)
 - [type ClientInterface](<#ClientInterface>)
@@ -99,8 +121,15 @@ client.gen.go is generated from docs/api/openapi.yaml. Do not edit it by hand; r
   - [func NewClientWithResponses\(server string, opts ...ClientOption\) \(\*ClientWithResponses, error\)](<#NewClientWithResponses>)
   - [func \(c \*ClientWithResponses\) ClearTaskInstancesWithBodyWithResponse\(ctx context.Context, dagId DagID, contentType string, body io.Reader, reqEditors ...RequestEditorFn\) \(\*ClearTaskInstancesResponse, error\)](<#ClientWithResponses.ClearTaskInstancesWithBodyWithResponse>)
   - [func \(c \*ClientWithResponses\) ClearTaskInstancesWithResponse\(ctx context.Context, dagId DagID, body ClearTaskInstancesJSONRequestBody, reqEditors ...RequestEditorFn\) \(\*ClearTaskInstancesResponse, error\)](<#ClientWithResponses.ClearTaskInstancesWithResponse>)
+  - [func \(c \*ClientWithResponses\) CreateConnectionWithBodyWithResponse\(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn\) \(\*CreateConnectionResponse, error\)](<#ClientWithResponses.CreateConnectionWithBodyWithResponse>)
+  - [func \(c \*ClientWithResponses\) CreateConnectionWithResponse\(ctx context.Context, body CreateConnectionJSONRequestBody, reqEditors ...RequestEditorFn\) \(\*CreateConnectionResponse, error\)](<#ClientWithResponses.CreateConnectionWithResponse>)
   - [func \(c \*ClientWithResponses\) CreateUserWithBodyWithResponse\(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn\) \(\*CreateUserResponse, error\)](<#ClientWithResponses.CreateUserWithBodyWithResponse>)
   - [func \(c \*ClientWithResponses\) CreateUserWithResponse\(ctx context.Context, body CreateUserJSONRequestBody, reqEditors ...RequestEditorFn\) \(\*CreateUserResponse, error\)](<#ClientWithResponses.CreateUserWithResponse>)
+  - [func \(c \*ClientWithResponses\) CreateVariableWithBodyWithResponse\(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn\) \(\*CreateVariableResponse, error\)](<#ClientWithResponses.CreateVariableWithBodyWithResponse>)
+  - [func \(c \*ClientWithResponses\) CreateVariableWithResponse\(ctx context.Context, body CreateVariableJSONRequestBody, reqEditors ...RequestEditorFn\) \(\*CreateVariableResponse, error\)](<#ClientWithResponses.CreateVariableWithResponse>)
+  - [func \(c \*ClientWithResponses\) DeleteConnectionWithResponse\(ctx context.Context, connectionId ConnectionID, reqEditors ...RequestEditorFn\) \(\*DeleteConnectionResponse, error\)](<#ClientWithResponses.DeleteConnectionWithResponse>)
+  - [func \(c \*ClientWithResponses\) DeleteVariableWithResponse\(ctx context.Context, variableKey VariableKey, reqEditors ...RequestEditorFn\) \(\*DeleteVariableResponse, error\)](<#ClientWithResponses.DeleteVariableWithResponse>)
+  - [func \(c \*ClientWithResponses\) GetConnectionWithResponse\(ctx context.Context, connectionId ConnectionID, reqEditors ...RequestEditorFn\) \(\*GetConnectionResponse, error\)](<#ClientWithResponses.GetConnectionWithResponse>)
   - [func \(c \*ClientWithResponses\) GetDagRunWithResponse\(ctx context.Context, dagId DagID, dagRunId DagRunID, reqEditors ...RequestEditorFn\) \(\*GetDagRunResponse, error\)](<#ClientWithResponses.GetDagRunWithResponse>)
   - [func \(c \*ClientWithResponses\) GetDagSourceWithResponse\(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn\) \(\*GetDagSourceResponse, error\)](<#ClientWithResponses.GetDagSourceWithResponse>)
   - [func \(c \*ClientWithResponses\) GetDagSpecWithResponse\(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn\) \(\*GetDagSpecResponse, error\)](<#ClientWithResponses.GetDagSpecWithResponse>)
@@ -112,21 +141,42 @@ client.gen.go is generated from docs/api/openapi.yaml. Do not edit it by hand; r
   - [func \(c \*ClientWithResponses\) GetReadyzWithResponse\(ctx context.Context, reqEditors ...RequestEditorFn\) \(\*GetReadyzResponse, error\)](<#ClientWithResponses.GetReadyzWithResponse>)
   - [func \(c \*ClientWithResponses\) GetTaskInstanceWithResponse\(ctx context.Context, dagId DagID, dagRunId DagRunID, taskId TaskID, reqEditors ...RequestEditorFn\) \(\*GetTaskInstanceResponse, error\)](<#ClientWithResponses.GetTaskInstanceWithResponse>)
   - [func \(c \*ClientWithResponses\) GetTaskLogsWithResponse\(ctx context.Context, dagId DagID, dagRunId DagRunID, taskId TaskID, tryNumber int, reqEditors ...RequestEditorFn\) \(\*GetTaskLogsResponse, error\)](<#ClientWithResponses.GetTaskLogsWithResponse>)
+  - [func \(c \*ClientWithResponses\) GetVariableWithResponse\(ctx context.Context, variableKey VariableKey, reqEditors ...RequestEditorFn\) \(\*GetVariableResponse, error\)](<#ClientWithResponses.GetVariableWithResponse>)
   - [func \(c \*ClientWithResponses\) GetVersionWithResponse\(ctx context.Context, reqEditors ...RequestEditorFn\) \(\*GetVersionResponse, error\)](<#ClientWithResponses.GetVersionWithResponse>)
   - [func \(c \*ClientWithResponses\) GetXcomEntryWithResponse\(ctx context.Context, dagId DagID, dagRunId DagRunID, taskId TaskID, key string, reqEditors ...RequestEditorFn\) \(\*GetXcomEntryResponse, error\)](<#ClientWithResponses.GetXcomEntryWithResponse>)
   - [func \(c \*ClientWithResponses\) IssueTokenWithBodyWithResponse\(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn\) \(\*IssueTokenResponse, error\)](<#ClientWithResponses.IssueTokenWithBodyWithResponse>)
   - [func \(c \*ClientWithResponses\) IssueTokenWithResponse\(ctx context.Context, body IssueTokenJSONRequestBody, reqEditors ...RequestEditorFn\) \(\*IssueTokenResponse, error\)](<#ClientWithResponses.IssueTokenWithResponse>)
+  - [func \(c \*ClientWithResponses\) ListConnectionsWithResponse\(ctx context.Context, params \*ListConnectionsParams, reqEditors ...RequestEditorFn\) \(\*ListConnectionsResponse, error\)](<#ClientWithResponses.ListConnectionsWithResponse>)
   - [func \(c \*ClientWithResponses\) ListDagRunsWithResponse\(ctx context.Context, dagId DagID, params \*ListDagRunsParams, reqEditors ...RequestEditorFn\) \(\*ListDagRunsResponse, error\)](<#ClientWithResponses.ListDagRunsWithResponse>)
   - [func \(c \*ClientWithResponses\) ListDagVersionsWithResponse\(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn\) \(\*ListDagVersionsResponse, error\)](<#ClientWithResponses.ListDagVersionsWithResponse>)
   - [func \(c \*ClientWithResponses\) ListDagsWithResponse\(ctx context.Context, params \*ListDagsParams, reqEditors ...RequestEditorFn\) \(\*ListDagsResponse, error\)](<#ClientWithResponses.ListDagsWithResponse>)
   - [func \(c \*ClientWithResponses\) ListTaskInstancesWithResponse\(ctx context.Context, dagId DagID, dagRunId DagRunID, reqEditors ...RequestEditorFn\) \(\*ListTaskInstancesResponse, error\)](<#ClientWithResponses.ListTaskInstancesWithResponse>)
   - [func \(c \*ClientWithResponses\) ListUsersWithResponse\(ctx context.Context, params \*ListUsersParams, reqEditors ...RequestEditorFn\) \(\*ListUsersResponse, error\)](<#ClientWithResponses.ListUsersWithResponse>)
+  - [func \(c \*ClientWithResponses\) ListVariablesWithResponse\(ctx context.Context, params \*ListVariablesParams, reqEditors ...RequestEditorFn\) \(\*ListVariablesResponse, error\)](<#ClientWithResponses.ListVariablesWithResponse>)
+  - [func \(c \*ClientWithResponses\) RenewTokenWithResponse\(ctx context.Context, reqEditors ...RequestEditorFn\) \(\*RenewTokenResponse, error\)](<#ClientWithResponses.RenewTokenWithResponse>)
   - [func \(c \*ClientWithResponses\) TriggerDagRunWithBodyWithResponse\(ctx context.Context, dagId DagID, contentType string, body io.Reader, reqEditors ...RequestEditorFn\) \(\*TriggerDagRunResponse, error\)](<#ClientWithResponses.TriggerDagRunWithBodyWithResponse>)
   - [func \(c \*ClientWithResponses\) TriggerDagRunWithResponse\(ctx context.Context, dagId DagID, body TriggerDagRunJSONRequestBody, reqEditors ...RequestEditorFn\) \(\*TriggerDagRunResponse, error\)](<#ClientWithResponses.TriggerDagRunWithResponse>)
+  - [func \(c \*ClientWithResponses\) UpdateConnectionWithBodyWithResponse\(ctx context.Context, connectionId ConnectionID, contentType string, body io.Reader, reqEditors ...RequestEditorFn\) \(\*UpdateConnectionResponse, error\)](<#ClientWithResponses.UpdateConnectionWithBodyWithResponse>)
+  - [func \(c \*ClientWithResponses\) UpdateConnectionWithResponse\(ctx context.Context, connectionId ConnectionID, body UpdateConnectionJSONRequestBody, reqEditors ...RequestEditorFn\) \(\*UpdateConnectionResponse, error\)](<#ClientWithResponses.UpdateConnectionWithResponse>)
   - [func \(c \*ClientWithResponses\) UpdateDagWithBodyWithResponse\(ctx context.Context, dagId DagID, contentType string, body io.Reader, reqEditors ...RequestEditorFn\) \(\*UpdateDagResponse, error\)](<#ClientWithResponses.UpdateDagWithBodyWithResponse>)
   - [func \(c \*ClientWithResponses\) UpdateDagWithResponse\(ctx context.Context, dagId DagID, body UpdateDagJSONRequestBody, reqEditors ...RequestEditorFn\) \(\*UpdateDagResponse, error\)](<#ClientWithResponses.UpdateDagWithResponse>)
 - [type ClientWithResponsesInterface](<#ClientWithResponsesInterface>)
 - [type ComponentHealth](<#ComponentHealth>)
+- [type Connection](<#Connection>)
+- [type ConnectionBody](<#ConnectionBody>)
+- [type ConnectionCollection](<#ConnectionCollection>)
+- [type ConnectionID](<#ConnectionID>)
+- [type CreateConnectionJSONRequestBody](<#CreateConnectionJSONRequestBody>)
+- [type CreateConnectionResponse](<#CreateConnectionResponse>)
+  - [func ParseCreateConnectionResponse\(rsp \*http.Response\) \(\*CreateConnectionResponse, error\)](<#ParseCreateConnectionResponse>)
+  - [func \(r CreateConnectionResponse\) ContentType\(\) string](<#CreateConnectionResponse.ContentType>)
+  - [func \(r CreateConnectionResponse\) GetBody\(\) \[\]byte](<#CreateConnectionResponse.GetBody>)
+  - [func \(r CreateConnectionResponse\) GetJSON201\(\) \*Connection](<#CreateConnectionResponse.GetJSON201>)
+  - [func \(r CreateConnectionResponse\) GetJSON400\(\) \*Error](<#CreateConnectionResponse.GetJSON400>)
+  - [func \(r CreateConnectionResponse\) GetJSON401\(\) \*Unauthorized](<#CreateConnectionResponse.GetJSON401>)
+  - [func \(r CreateConnectionResponse\) GetJSON503\(\) \*EncryptionUnavailable](<#CreateConnectionResponse.GetJSON503>)
+  - [func \(r CreateConnectionResponse\) Status\(\) string](<#CreateConnectionResponse.Status>)
+  - [func \(r CreateConnectionResponse\) StatusCode\(\) int](<#CreateConnectionResponse.StatusCode>)
 - [type CreateUserJSONRequestBody](<#CreateUserJSONRequestBody>)
 - [type CreateUserRequest](<#CreateUserRequest>)
 - [type CreateUserResponse](<#CreateUserResponse>)
@@ -139,6 +189,16 @@ client.gen.go is generated from docs/api/openapi.yaml. Do not edit it by hand; r
   - [func \(r CreateUserResponse\) GetJSON409\(\) \*Error](<#CreateUserResponse.GetJSON409>)
   - [func \(r CreateUserResponse\) Status\(\) string](<#CreateUserResponse.Status>)
   - [func \(r CreateUserResponse\) StatusCode\(\) int](<#CreateUserResponse.StatusCode>)
+- [type CreateVariableJSONRequestBody](<#CreateVariableJSONRequestBody>)
+- [type CreateVariableResponse](<#CreateVariableResponse>)
+  - [func ParseCreateVariableResponse\(rsp \*http.Response\) \(\*CreateVariableResponse, error\)](<#ParseCreateVariableResponse>)
+  - [func \(r CreateVariableResponse\) ContentType\(\) string](<#CreateVariableResponse.ContentType>)
+  - [func \(r CreateVariableResponse\) GetBody\(\) \[\]byte](<#CreateVariableResponse.GetBody>)
+  - [func \(r CreateVariableResponse\) GetJSON201\(\) \*Variable](<#CreateVariableResponse.GetJSON201>)
+  - [func \(r CreateVariableResponse\) GetJSON400\(\) \*Error](<#CreateVariableResponse.GetJSON400>)
+  - [func \(r CreateVariableResponse\) GetJSON401\(\) \*Unauthorized](<#CreateVariableResponse.GetJSON401>)
+  - [func \(r CreateVariableResponse\) Status\(\) string](<#CreateVariableResponse.Status>)
+  - [func \(r CreateVariableResponse\) StatusCode\(\) int](<#CreateVariableResponse.StatusCode>)
 - [type DAG](<#DAG>)
 - [type DAGCollection](<#DAGCollection>)
 - [type DAGRun](<#DAGRun>)
@@ -154,8 +214,34 @@ client.gen.go is generated from docs/api/openapi.yaml. Do not edit it by hand; r
 - [type DagSource](<#DagSource>)
 - [type DagVersion](<#DagVersion>)
 - [type DagVersionCollection](<#DagVersionCollection>)
+- [type DeleteConnectionResponse](<#DeleteConnectionResponse>)
+  - [func ParseDeleteConnectionResponse\(rsp \*http.Response\) \(\*DeleteConnectionResponse, error\)](<#ParseDeleteConnectionResponse>)
+  - [func \(r DeleteConnectionResponse\) ContentType\(\) string](<#DeleteConnectionResponse.ContentType>)
+  - [func \(r DeleteConnectionResponse\) GetBody\(\) \[\]byte](<#DeleteConnectionResponse.GetBody>)
+  - [func \(r DeleteConnectionResponse\) GetJSON401\(\) \*Unauthorized](<#DeleteConnectionResponse.GetJSON401>)
+  - [func \(r DeleteConnectionResponse\) GetJSON404\(\) \*NotFound](<#DeleteConnectionResponse.GetJSON404>)
+  - [func \(r DeleteConnectionResponse\) Status\(\) string](<#DeleteConnectionResponse.Status>)
+  - [func \(r DeleteConnectionResponse\) StatusCode\(\) int](<#DeleteConnectionResponse.StatusCode>)
+- [type DeleteVariableResponse](<#DeleteVariableResponse>)
+  - [func ParseDeleteVariableResponse\(rsp \*http.Response\) \(\*DeleteVariableResponse, error\)](<#ParseDeleteVariableResponse>)
+  - [func \(r DeleteVariableResponse\) ContentType\(\) string](<#DeleteVariableResponse.ContentType>)
+  - [func \(r DeleteVariableResponse\) GetBody\(\) \[\]byte](<#DeleteVariableResponse.GetBody>)
+  - [func \(r DeleteVariableResponse\) GetJSON401\(\) \*Unauthorized](<#DeleteVariableResponse.GetJSON401>)
+  - [func \(r DeleteVariableResponse\) GetJSON404\(\) \*NotFound](<#DeleteVariableResponse.GetJSON404>)
+  - [func \(r DeleteVariableResponse\) Status\(\) string](<#DeleteVariableResponse.Status>)
+  - [func \(r DeleteVariableResponse\) StatusCode\(\) int](<#DeleteVariableResponse.StatusCode>)
+- [type EncryptionUnavailable](<#EncryptionUnavailable>)
 - [type Error](<#Error>)
 - [type ExecutorInfo](<#ExecutorInfo>)
+- [type GetConnectionResponse](<#GetConnectionResponse>)
+  - [func ParseGetConnectionResponse\(rsp \*http.Response\) \(\*GetConnectionResponse, error\)](<#ParseGetConnectionResponse>)
+  - [func \(r GetConnectionResponse\) ContentType\(\) string](<#GetConnectionResponse.ContentType>)
+  - [func \(r GetConnectionResponse\) GetBody\(\) \[\]byte](<#GetConnectionResponse.GetBody>)
+  - [func \(r GetConnectionResponse\) GetJSON200\(\) \*Connection](<#GetConnectionResponse.GetJSON200>)
+  - [func \(r GetConnectionResponse\) GetJSON401\(\) \*Unauthorized](<#GetConnectionResponse.GetJSON401>)
+  - [func \(r GetConnectionResponse\) GetJSON404\(\) \*NotFound](<#GetConnectionResponse.GetJSON404>)
+  - [func \(r GetConnectionResponse\) Status\(\) string](<#GetConnectionResponse.Status>)
+  - [func \(r GetConnectionResponse\) StatusCode\(\) int](<#GetConnectionResponse.StatusCode>)
 - [type GetDagResponse](<#GetDagResponse>)
   - [func ParseGetDagResponse\(rsp \*http.Response\) \(\*GetDagResponse, error\)](<#ParseGetDagResponse>)
   - [func \(r GetDagResponse\) ContentType\(\) string](<#GetDagResponse.ContentType>)
@@ -235,6 +321,15 @@ client.gen.go is generated from docs/api/openapi.yaml. Do not edit it by hand; r
   - [func \(r GetTaskLogsResponse\) GetBody\(\) \[\]byte](<#GetTaskLogsResponse.GetBody>)
   - [func \(r GetTaskLogsResponse\) Status\(\) string](<#GetTaskLogsResponse.Status>)
   - [func \(r GetTaskLogsResponse\) StatusCode\(\) int](<#GetTaskLogsResponse.StatusCode>)
+- [type GetVariableResponse](<#GetVariableResponse>)
+  - [func ParseGetVariableResponse\(rsp \*http.Response\) \(\*GetVariableResponse, error\)](<#ParseGetVariableResponse>)
+  - [func \(r GetVariableResponse\) ContentType\(\) string](<#GetVariableResponse.ContentType>)
+  - [func \(r GetVariableResponse\) GetBody\(\) \[\]byte](<#GetVariableResponse.GetBody>)
+  - [func \(r GetVariableResponse\) GetJSON200\(\) \*Variable](<#GetVariableResponse.GetJSON200>)
+  - [func \(r GetVariableResponse\) GetJSON401\(\) \*Unauthorized](<#GetVariableResponse.GetJSON401>)
+  - [func \(r GetVariableResponse\) GetJSON404\(\) \*NotFound](<#GetVariableResponse.GetJSON404>)
+  - [func \(r GetVariableResponse\) Status\(\) string](<#GetVariableResponse.Status>)
+  - [func \(r GetVariableResponse\) StatusCode\(\) int](<#GetVariableResponse.StatusCode>)
 - [type GetVersionResponse](<#GetVersionResponse>)
   - [func ParseGetVersionResponse\(rsp \*http.Response\) \(\*GetVersionResponse, error\)](<#ParseGetVersionResponse>)
   - [func \(r GetVersionResponse\) ContentType\(\) string](<#GetVersionResponse.ContentType>)
@@ -262,6 +357,15 @@ client.gen.go is generated from docs/api/openapi.yaml. Do not edit it by hand; r
   - [func \(r IssueTokenResponse\) Status\(\) string](<#IssueTokenResponse.Status>)
   - [func \(r IssueTokenResponse\) StatusCode\(\) int](<#IssueTokenResponse.StatusCode>)
 - [type Limit](<#Limit>)
+- [type ListConnectionsParams](<#ListConnectionsParams>)
+- [type ListConnectionsResponse](<#ListConnectionsResponse>)
+  - [func ParseListConnectionsResponse\(rsp \*http.Response\) \(\*ListConnectionsResponse, error\)](<#ParseListConnectionsResponse>)
+  - [func \(r ListConnectionsResponse\) ContentType\(\) string](<#ListConnectionsResponse.ContentType>)
+  - [func \(r ListConnectionsResponse\) GetBody\(\) \[\]byte](<#ListConnectionsResponse.GetBody>)
+  - [func \(r ListConnectionsResponse\) GetJSON200\(\) \*ConnectionCollection](<#ListConnectionsResponse.GetJSON200>)
+  - [func \(r ListConnectionsResponse\) GetJSON401\(\) \*Unauthorized](<#ListConnectionsResponse.GetJSON401>)
+  - [func \(r ListConnectionsResponse\) Status\(\) string](<#ListConnectionsResponse.Status>)
+  - [func \(r ListConnectionsResponse\) StatusCode\(\) int](<#ListConnectionsResponse.StatusCode>)
 - [type ListDagRunsParams](<#ListDagRunsParams>)
 - [type ListDagRunsParamsState](<#ListDagRunsParamsState>)
   - [func \(e ListDagRunsParamsState\) Valid\(\) bool](<#ListDagRunsParamsState.Valid>)
@@ -303,8 +407,25 @@ client.gen.go is generated from docs/api/openapi.yaml. Do not edit it by hand; r
   - [func \(r ListUsersResponse\) GetJSON401\(\) \*Unauthorized](<#ListUsersResponse.GetJSON401>)
   - [func \(r ListUsersResponse\) Status\(\) string](<#ListUsersResponse.Status>)
   - [func \(r ListUsersResponse\) StatusCode\(\) int](<#ListUsersResponse.StatusCode>)
+- [type ListVariablesParams](<#ListVariablesParams>)
+- [type ListVariablesResponse](<#ListVariablesResponse>)
+  - [func ParseListVariablesResponse\(rsp \*http.Response\) \(\*ListVariablesResponse, error\)](<#ParseListVariablesResponse>)
+  - [func \(r ListVariablesResponse\) ContentType\(\) string](<#ListVariablesResponse.ContentType>)
+  - [func \(r ListVariablesResponse\) GetBody\(\) \[\]byte](<#ListVariablesResponse.GetBody>)
+  - [func \(r ListVariablesResponse\) GetJSON200\(\) \*VariableCollection](<#ListVariablesResponse.GetJSON200>)
+  - [func \(r ListVariablesResponse\) GetJSON401\(\) \*Unauthorized](<#ListVariablesResponse.GetJSON401>)
+  - [func \(r ListVariablesResponse\) Status\(\) string](<#ListVariablesResponse.Status>)
+  - [func \(r ListVariablesResponse\) StatusCode\(\) int](<#ListVariablesResponse.StatusCode>)
 - [type NotFound](<#NotFound>)
 - [type Offset](<#Offset>)
+- [type RenewTokenResponse](<#RenewTokenResponse>)
+  - [func ParseRenewTokenResponse\(rsp \*http.Response\) \(\*RenewTokenResponse, error\)](<#ParseRenewTokenResponse>)
+  - [func \(r RenewTokenResponse\) ContentType\(\) string](<#RenewTokenResponse.ContentType>)
+  - [func \(r RenewTokenResponse\) GetBody\(\) \[\]byte](<#RenewTokenResponse.GetBody>)
+  - [func \(r RenewTokenResponse\) GetJSON200\(\) \*TokenResponse](<#RenewTokenResponse.GetJSON200>)
+  - [func \(r RenewTokenResponse\) GetJSON401\(\) \*Unauthorized](<#RenewTokenResponse.GetJSON401>)
+  - [func \(r RenewTokenResponse\) Status\(\) string](<#RenewTokenResponse.Status>)
+  - [func \(r RenewTokenResponse\) StatusCode\(\) int](<#RenewTokenResponse.StatusCode>)
 - [type RequestEditorFn](<#RequestEditorFn>)
 - [type TaskID](<#TaskID>)
 - [type TaskInstance](<#TaskInstance>)
@@ -322,6 +443,18 @@ client.gen.go is generated from docs/api/openapi.yaml. Do not edit it by hand; r
   - [func \(r TriggerDagRunResponse\) Status\(\) string](<#TriggerDagRunResponse.Status>)
   - [func \(r TriggerDagRunResponse\) StatusCode\(\) int](<#TriggerDagRunResponse.StatusCode>)
 - [type Unauthorized](<#Unauthorized>)
+- [type UpdateConnectionJSONRequestBody](<#UpdateConnectionJSONRequestBody>)
+- [type UpdateConnectionResponse](<#UpdateConnectionResponse>)
+  - [func ParseUpdateConnectionResponse\(rsp \*http.Response\) \(\*UpdateConnectionResponse, error\)](<#ParseUpdateConnectionResponse>)
+  - [func \(r UpdateConnectionResponse\) ContentType\(\) string](<#UpdateConnectionResponse.ContentType>)
+  - [func \(r UpdateConnectionResponse\) GetBody\(\) \[\]byte](<#UpdateConnectionResponse.GetBody>)
+  - [func \(r UpdateConnectionResponse\) GetJSON200\(\) \*Connection](<#UpdateConnectionResponse.GetJSON200>)
+  - [func \(r UpdateConnectionResponse\) GetJSON400\(\) \*Error](<#UpdateConnectionResponse.GetJSON400>)
+  - [func \(r UpdateConnectionResponse\) GetJSON401\(\) \*Unauthorized](<#UpdateConnectionResponse.GetJSON401>)
+  - [func \(r UpdateConnectionResponse\) GetJSON404\(\) \*NotFound](<#UpdateConnectionResponse.GetJSON404>)
+  - [func \(r UpdateConnectionResponse\) GetJSON503\(\) \*EncryptionUnavailable](<#UpdateConnectionResponse.GetJSON503>)
+  - [func \(r UpdateConnectionResponse\) Status\(\) string](<#UpdateConnectionResponse.Status>)
+  - [func \(r UpdateConnectionResponse\) StatusCode\(\) int](<#UpdateConnectionResponse.StatusCode>)
 - [type UpdateDagJSONRequestBody](<#UpdateDagJSONRequestBody>)
 - [type UpdateDagResponse](<#UpdateDagResponse>)
   - [func ParseUpdateDagResponse\(rsp \*http.Response\) \(\*UpdateDagResponse, error\)](<#ParseUpdateDagResponse>)
@@ -333,12 +466,16 @@ client.gen.go is generated from docs/api/openapi.yaml. Do not edit it by hand; r
 - [type User](<#User>)
 - [type UserCollection](<#UserCollection>)
 - [type UserListItem](<#UserListItem>)
+- [type Variable](<#Variable>)
+- [type VariableBody](<#VariableBody>)
+- [type VariableCollection](<#VariableCollection>)
+- [type VariableKey](<#VariableKey>)
 - [type VersionInfo](<#VersionInfo>)
 - [type XComEntry](<#XComEntry>)
 
 
 <a name="NewClearTaskInstancesRequest"></a>
-## func [NewClearTaskInstancesRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1345>)
+## func [NewClearTaskInstancesRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2006>)
 
 ```go
 func NewClearTaskInstancesRequest(server string, dagId DagID, body ClearTaskInstancesJSONRequestBody) (*http.Request, error)
@@ -347,7 +484,7 @@ func NewClearTaskInstancesRequest(server string, dagId DagID, body ClearTaskInst
 NewClearTaskInstancesRequest calls the generic ClearTaskInstances builder with application/json body
 
 <a name="NewClearTaskInstancesRequestWithBody"></a>
-## func [NewClearTaskInstancesRequestWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1356>)
+## func [NewClearTaskInstancesRequestWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2017>)
 
 ```go
 func NewClearTaskInstancesRequestWithBody(server string, dagId DagID, contentType string, body io.Reader) (*http.Request, error)
@@ -355,8 +492,26 @@ func NewClearTaskInstancesRequestWithBody(server string, dagId DagID, contentTyp
 
 NewClearTaskInstancesRequestWithBody constructs an http.Request for the ClearTaskInstances method, with any body, and a specified content type
 
+<a name="NewCreateConnectionRequest"></a>
+## func [NewCreateConnectionRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1634>)
+
+```go
+func NewCreateConnectionRequest(server string, body CreateConnectionJSONRequestBody) (*http.Request, error)
+```
+
+NewCreateConnectionRequest calls the generic CreateConnection builder with application/json body
+
+<a name="NewCreateConnectionRequestWithBody"></a>
+## func [NewCreateConnectionRequestWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1645>)
+
+```go
+func NewCreateConnectionRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error)
+```
+
+NewCreateConnectionRequestWithBody constructs an http.Request for the CreateConnection method, with any body, and a specified content type
+
 <a name="NewCreateUserRequest"></a>
-## func [NewCreateUserRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1938>)
+## func [NewCreateUserRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2599>)
 
 ```go
 func NewCreateUserRequest(server string, body CreateUserJSONRequestBody) (*http.Request, error)
@@ -365,7 +520,7 @@ func NewCreateUserRequest(server string, body CreateUserJSONRequestBody) (*http.
 NewCreateUserRequest calls the generic CreateUser builder with application/json body
 
 <a name="NewCreateUserRequestWithBody"></a>
-## func [NewCreateUserRequestWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1949>)
+## func [NewCreateUserRequestWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2610>)
 
 ```go
 func NewCreateUserRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error)
@@ -373,8 +528,53 @@ func NewCreateUserRequestWithBody(server string, contentType string, body io.Rea
 
 NewCreateUserRequestWithBody constructs an http.Request for the CreateUser method, with any body, and a specified content type
 
+<a name="NewCreateVariableRequest"></a>
+## func [NewCreateVariableRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2705>)
+
+```go
+func NewCreateVariableRequest(server string, body CreateVariableJSONRequestBody) (*http.Request, error)
+```
+
+NewCreateVariableRequest calls the generic CreateVariable builder with application/json body
+
+<a name="NewCreateVariableRequestWithBody"></a>
+## func [NewCreateVariableRequestWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2716>)
+
+```go
+func NewCreateVariableRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error)
+```
+
+NewCreateVariableRequestWithBody constructs an http.Request for the CreateVariable method, with any body, and a specified content type
+
+<a name="NewDeleteConnectionRequest"></a>
+## func [NewDeleteConnectionRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1674>)
+
+```go
+func NewDeleteConnectionRequest(server string, connectionId ConnectionID) (*http.Request, error)
+```
+
+NewDeleteConnectionRequest constructs an http.Request for the DeleteConnection method
+
+<a name="NewDeleteVariableRequest"></a>
+## func [NewDeleteVariableRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2745>)
+
+```go
+func NewDeleteVariableRequest(server string, variableKey VariableKey) (*http.Request, error)
+```
+
+NewDeleteVariableRequest constructs an http.Request for the DeleteVariable method
+
+<a name="NewGetConnectionRequest"></a>
+## func [NewGetConnectionRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1708>)
+
+```go
+func NewGetConnectionRequest(server string, connectionId ConnectionID) (*http.Request, error)
+```
+
+NewGetConnectionRequest constructs an http.Request for the GetConnection method
+
 <a name="NewGetDagRequest"></a>
-## func [NewGetDagRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1264>)
+## func [NewGetDagRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1925>)
 
 ```go
 func NewGetDagRequest(server string, dagId DagID) (*http.Request, error)
@@ -383,7 +583,7 @@ func NewGetDagRequest(server string, dagId DagID) (*http.Request, error)
 NewGetDagRequest constructs an http.Request for the GetDag method
 
 <a name="NewGetDagRunRequest"></a>
-## func [NewGetDagRunRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1524>)
+## func [NewGetDagRunRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2185>)
 
 ```go
 func NewGetDagRunRequest(server string, dagId DagID, dagRunId DagRunID) (*http.Request, error)
@@ -392,7 +592,7 @@ func NewGetDagRunRequest(server string, dagId DagID, dagRunId DagRunID) (*http.R
 NewGetDagRunRequest constructs an http.Request for the GetDagRun method
 
 <a name="NewGetDagSourceRequest"></a>
-## func [NewGetDagSourceRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1128>)
+## func [NewGetDagSourceRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1789>)
 
 ```go
 func NewGetDagSourceRequest(server string, dagId DagID) (*http.Request, error)
@@ -401,7 +601,7 @@ func NewGetDagSourceRequest(server string, dagId DagID) (*http.Request, error)
 NewGetDagSourceRequest constructs an http.Request for the GetDagSource method
 
 <a name="NewGetDagSpecRequest"></a>
-## func [NewGetDagSpecRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1784>)
+## func [NewGetDagSpecRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2445>)
 
 ```go
 func NewGetDagSpecRequest(server string, dagId DagID) (*http.Request, error)
@@ -410,7 +610,7 @@ func NewGetDagSpecRequest(server string, dagId DagID) (*http.Request, error)
 NewGetDagSpecRequest constructs an http.Request for the GetDagSpec method
 
 <a name="NewGetDagVersionRequest"></a>
-## func [NewGetDagVersionRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1743>)
+## func [NewGetDagVersionRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2404>)
 
 ```go
 func NewGetDagVersionRequest(server string, dagId DagID, versionNumber int) (*http.Request, error)
@@ -419,7 +619,7 @@ func NewGetDagVersionRequest(server string, dagId DagID, versionNumber int) (*ht
 NewGetDagVersionRequest constructs an http.Request for the GetDagVersion method
 
 <a name="NewGetHealthzRequest"></a>
-## func [NewGetHealthzRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2100>)
+## func [NewGetHealthzRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2935>)
 
 ```go
 func NewGetHealthzRequest(server string) (*http.Request, error)
@@ -428,7 +628,7 @@ func NewGetHealthzRequest(server string) (*http.Request, error)
 NewGetHealthzRequest constructs an http.Request for the GetHealthz method
 
 <a name="NewGetMonitorExecutorRequest"></a>
-## func [NewGetMonitorExecutorRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1818>)
+## func [NewGetMonitorExecutorRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2479>)
 
 ```go
 func NewGetMonitorExecutorRequest(server string) (*http.Request, error)
@@ -437,7 +637,7 @@ func NewGetMonitorExecutorRequest(server string) (*http.Request, error)
 NewGetMonitorExecutorRequest constructs an http.Request for the GetMonitorExecutor method
 
 <a name="NewGetMonitorHealthRequest"></a>
-## func [NewGetMonitorHealthRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1845>)
+## func [NewGetMonitorHealthRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2506>)
 
 ```go
 func NewGetMonitorHealthRequest(server string) (*http.Request, error)
@@ -446,7 +646,7 @@ func NewGetMonitorHealthRequest(server string) (*http.Request, error)
 NewGetMonitorHealthRequest constructs an http.Request for the GetMonitorHealth method
 
 <a name="NewGetReadyzRequest"></a>
-## func [NewGetReadyzRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2127>)
+## func [NewGetReadyzRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2962>)
 
 ```go
 func NewGetReadyzRequest(server string) (*http.Request, error)
@@ -455,7 +655,7 @@ func NewGetReadyzRequest(server string) (*http.Request, error)
 NewGetReadyzRequest constructs an http.Request for the GetReadyz method
 
 <a name="NewGetTaskInstanceRequest"></a>
-## func [NewGetTaskInstanceRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1606>)
+## func [NewGetTaskInstanceRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2267>)
 
 ```go
 func NewGetTaskInstanceRequest(server string, dagId DagID, dagRunId DagRunID, taskId TaskID) (*http.Request, error)
@@ -464,7 +664,7 @@ func NewGetTaskInstanceRequest(server string, dagId DagID, dagRunId DagRunID, ta
 NewGetTaskInstanceRequest constructs an http.Request for the GetTaskInstance method
 
 <a name="NewGetTaskLogsRequest"></a>
-## func [NewGetTaskLogsRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1654>)
+## func [NewGetTaskLogsRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2315>)
 
 ```go
 func NewGetTaskLogsRequest(server string, dagId DagID, dagRunId DagRunID, taskId TaskID, tryNumber int) (*http.Request, error)
@@ -472,8 +672,17 @@ func NewGetTaskLogsRequest(server string, dagId DagID, dagRunId DagRunID, taskId
 
 NewGetTaskLogsRequest constructs an http.Request for the GetTaskLogs method
 
+<a name="NewGetVariableRequest"></a>
+## func [NewGetVariableRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2779>)
+
+```go
+func NewGetVariableRequest(server string, variableKey VariableKey) (*http.Request, error)
+```
+
+NewGetVariableRequest constructs an http.Request for the GetVariable method
+
 <a name="NewGetVersionRequest"></a>
-## func [NewGetVersionRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1978>)
+## func [NewGetVersionRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2813>)
 
 ```go
 func NewGetVersionRequest(server string) (*http.Request, error)
@@ -482,7 +691,7 @@ func NewGetVersionRequest(server string) (*http.Request, error)
 NewGetVersionRequest constructs an http.Request for the GetVersion method
 
 <a name="NewGetXcomEntryRequest"></a>
-## func [NewGetXcomEntryRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2005>)
+## func [NewGetXcomEntryRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2840>)
 
 ```go
 func NewGetXcomEntryRequest(server string, dagId DagID, dagRunId DagRunID, taskId TaskID, key string) (*http.Request, error)
@@ -491,7 +700,7 @@ func NewGetXcomEntryRequest(server string, dagId DagID, dagRunId DagRunID, taskI
 NewGetXcomEntryRequest constructs an http.Request for the GetXcomEntry method
 
 <a name="NewIssueTokenRequest"></a>
-## func [NewIssueTokenRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2060>)
+## func [NewIssueTokenRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2895>)
 
 ```go
 func NewIssueTokenRequest(server string, body IssueTokenJSONRequestBody) (*http.Request, error)
@@ -500,7 +709,7 @@ func NewIssueTokenRequest(server string, body IssueTokenJSONRequestBody) (*http.
 NewIssueTokenRequest calls the generic IssueToken builder with application/json body
 
 <a name="NewIssueTokenRequestWithBody"></a>
-## func [NewIssueTokenRequestWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2071>)
+## func [NewIssueTokenRequestWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2906>)
 
 ```go
 func NewIssueTokenRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error)
@@ -508,8 +717,17 @@ func NewIssueTokenRequestWithBody(server string, contentType string, body io.Rea
 
 NewIssueTokenRequestWithBody constructs an http.Request for the IssueToken method, with any body, and a specified content type
 
+<a name="NewListConnectionsRequest"></a>
+## func [NewListConnectionsRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1568>)
+
+```go
+func NewListConnectionsRequest(server string, params *ListConnectionsParams) (*http.Request, error)
+```
+
+NewListConnectionsRequest constructs an http.Request for the ListConnections method
+
 <a name="NewListDagRunsRequest"></a>
-## func [NewListDagRunsRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1392>)
+## func [NewListDagRunsRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2053>)
 
 ```go
 func NewListDagRunsRequest(server string, dagId DagID, params *ListDagRunsParams) (*http.Request, error)
@@ -518,7 +736,7 @@ func NewListDagRunsRequest(server string, dagId DagID, params *ListDagRunsParams
 NewListDagRunsRequest constructs an http.Request for the ListDagRuns method
 
 <a name="NewListDagVersionsRequest"></a>
-## func [NewListDagVersionsRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1709>)
+## func [NewListDagVersionsRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2370>)
 
 ```go
 func NewListDagVersionsRequest(server string, dagId DagID) (*http.Request, error)
@@ -527,7 +745,7 @@ func NewListDagVersionsRequest(server string, dagId DagID) (*http.Request, error
 NewListDagVersionsRequest constructs an http.Request for the ListDagVersions method
 
 <a name="NewListDagsRequest"></a>
-## func [NewListDagsRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1162>)
+## func [NewListDagsRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1823>)
 
 ```go
 func NewListDagsRequest(server string, params *ListDagsParams) (*http.Request, error)
@@ -536,7 +754,7 @@ func NewListDagsRequest(server string, params *ListDagsParams) (*http.Request, e
 NewListDagsRequest constructs an http.Request for the ListDags method
 
 <a name="NewListTaskInstancesRequest"></a>
-## func [NewListTaskInstancesRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1565>)
+## func [NewListTaskInstancesRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2226>)
 
 ```go
 func NewListTaskInstancesRequest(server string, dagId DagID, dagRunId DagRunID) (*http.Request, error)
@@ -545,7 +763,7 @@ func NewListTaskInstancesRequest(server string, dagId DagID, dagRunId DagRunID) 
 NewListTaskInstancesRequest constructs an http.Request for the ListTaskInstances method
 
 <a name="NewListUsersRequest"></a>
-## func [NewListUsersRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1872>)
+## func [NewListUsersRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2533>)
 
 ```go
 func NewListUsersRequest(server string, params *ListUsersParams) (*http.Request, error)
@@ -553,8 +771,26 @@ func NewListUsersRequest(server string, params *ListUsersParams) (*http.Request,
 
 NewListUsersRequest constructs an http.Request for the ListUsers method
 
+<a name="NewListVariablesRequest"></a>
+## func [NewListVariablesRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2639>)
+
+```go
+func NewListVariablesRequest(server string, params *ListVariablesParams) (*http.Request, error)
+```
+
+NewListVariablesRequest constructs an http.Request for the ListVariables method
+
+<a name="NewRenewTokenRequest"></a>
+## func [NewRenewTokenRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1541>)
+
+```go
+func NewRenewTokenRequest(server string) (*http.Request, error)
+```
+
+NewRenewTokenRequest constructs an http.Request for the RenewToken method
+
 <a name="NewTriggerDagRunRequest"></a>
-## func [NewTriggerDagRunRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1477>)
+## func [NewTriggerDagRunRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2138>)
 
 ```go
 func NewTriggerDagRunRequest(server string, dagId DagID, body TriggerDagRunJSONRequestBody) (*http.Request, error)
@@ -563,7 +799,7 @@ func NewTriggerDagRunRequest(server string, dagId DagID, body TriggerDagRunJSONR
 NewTriggerDagRunRequest calls the generic TriggerDagRun builder with application/json body
 
 <a name="NewTriggerDagRunRequestWithBody"></a>
-## func [NewTriggerDagRunRequestWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1488>)
+## func [NewTriggerDagRunRequestWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2149>)
 
 ```go
 func NewTriggerDagRunRequestWithBody(server string, dagId DagID, contentType string, body io.Reader) (*http.Request, error)
@@ -571,8 +807,26 @@ func NewTriggerDagRunRequestWithBody(server string, dagId DagID, contentType str
 
 NewTriggerDagRunRequestWithBody constructs an http.Request for the TriggerDagRun method, with any body, and a specified content type
 
+<a name="NewUpdateConnectionRequest"></a>
+## func [NewUpdateConnectionRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1742>)
+
+```go
+func NewUpdateConnectionRequest(server string, connectionId ConnectionID, body UpdateConnectionJSONRequestBody) (*http.Request, error)
+```
+
+NewUpdateConnectionRequest calls the generic UpdateConnection builder with application/json body
+
+<a name="NewUpdateConnectionRequestWithBody"></a>
+## func [NewUpdateConnectionRequestWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1753>)
+
+```go
+func NewUpdateConnectionRequestWithBody(server string, connectionId ConnectionID, contentType string, body io.Reader) (*http.Request, error)
+```
+
+NewUpdateConnectionRequestWithBody constructs an http.Request for the UpdateConnection method, with any body, and a specified content type
+
 <a name="NewUpdateDagRequest"></a>
-## func [NewUpdateDagRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1298>)
+## func [NewUpdateDagRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1959>)
 
 ```go
 func NewUpdateDagRequest(server string, dagId DagID, body UpdateDagJSONRequestBody) (*http.Request, error)
@@ -581,7 +835,7 @@ func NewUpdateDagRequest(server string, dagId DagID, body UpdateDagJSONRequestBo
 NewUpdateDagRequest calls the generic UpdateDag builder with application/json body
 
 <a name="NewUpdateDagRequestWithBody"></a>
-## func [NewUpdateDagRequestWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1309>)
+## func [NewUpdateDagRequestWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1970>)
 
 ```go
 func NewUpdateDagRequestWithBody(server string, dagId DagID, contentType string, body io.Reader) (*http.Request, error)
@@ -590,7 +844,7 @@ func NewUpdateDagRequestWithBody(server string, dagId DagID, contentType string,
 NewUpdateDagRequestWithBody constructs an http.Request for the UpdateDag method, with any body, and a specified content type
 
 <a name="ClearTaskInstancesJSONRequestBody"></a>
-## type [ClearTaskInstancesJSONRequestBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L417>)
+## type [ClearTaskInstancesJSONRequestBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L497>)
 
 ClearTaskInstancesJSONRequestBody defines body for ClearTaskInstances for application/json ContentType.
 
@@ -614,7 +868,7 @@ type ClearTaskInstancesRequest struct {
 ```
 
 <a name="ClearTaskInstancesResponse"></a>
-## type [ClearTaskInstancesResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2584-L2589>)
+## type [ClearTaskInstancesResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3863-L3868>)
 
 
 
@@ -628,7 +882,7 @@ type ClearTaskInstancesResponse struct {
 ```
 
 <a name="ParseClearTaskInstancesResponse"></a>
-### func [ParseClearTaskInstancesResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3900>)
+### func [ParseClearTaskInstancesResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5820>)
 
 ```go
 func ParseClearTaskInstancesResponse(rsp *http.Response) (*ClearTaskInstancesResponse, error)
@@ -637,7 +891,7 @@ func ParseClearTaskInstancesResponse(rsp *http.Response) (*ClearTaskInstancesRes
 ParseClearTaskInstancesResponse parses an HTTP response from a ClearTaskInstancesWithResponse call
 
 <a name="ClearTaskInstancesResponse.ContentType"></a>
-### func \(ClearTaskInstancesResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2618>)
+### func \(ClearTaskInstancesResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3897>)
 
 ```go
 func (r ClearTaskInstancesResponse) ContentType() string
@@ -646,7 +900,7 @@ func (r ClearTaskInstancesResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="ClearTaskInstancesResponse.GetBody"></a>
-### func \(ClearTaskInstancesResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2597>)
+### func \(ClearTaskInstancesResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3876>)
 
 ```go
 func (r ClearTaskInstancesResponse) GetBody() []byte
@@ -655,7 +909,7 @@ func (r ClearTaskInstancesResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="ClearTaskInstancesResponse.GetJSON200"></a>
-### func \(ClearTaskInstancesResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2592>)
+### func \(ClearTaskInstancesResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3871>)
 
 ```go
 func (r ClearTaskInstancesResponse) GetJSON200() *TaskInstanceCollection
@@ -664,7 +918,7 @@ func (r ClearTaskInstancesResponse) GetJSON200() *TaskInstanceCollection
 GetJSON200 returns the response for an HTTP 200 \`application/json\` response
 
 <a name="ClearTaskInstancesResponse.Status"></a>
-### func \(ClearTaskInstancesResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2602>)
+### func \(ClearTaskInstancesResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3881>)
 
 ```go
 func (r ClearTaskInstancesResponse) Status() string
@@ -673,7 +927,7 @@ func (r ClearTaskInstancesResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="ClearTaskInstancesResponse.StatusCode"></a>
-### func \(ClearTaskInstancesResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2610>)
+### func \(ClearTaskInstancesResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3889>)
 
 ```go
 func (r ClearTaskInstancesResponse) StatusCode() int
@@ -682,7 +936,7 @@ func (r ClearTaskInstancesResponse) StatusCode() int
 StatusCode returns HTTPResponse.StatusCode
 
 <a name="Client"></a>
-## type [Client](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L439-L453>)
+## type [Client](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L522-L536>)
 
 Client which conforms to the OpenAPI3 specification for this service.
 
@@ -705,7 +959,7 @@ type Client struct {
 ```
 
 <a name="NewClient"></a>
-### func [NewClient](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L459>)
+### func [NewClient](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L542>)
 
 ```go
 func NewClient(server string, opts ...ClientOption) (*Client, error)
@@ -714,7 +968,7 @@ func NewClient(server string, opts ...ClientOption) (*Client, error)
 Creates a new Client, with reasonable defaults
 
 <a name="Client.ClearTaskInstances"></a>
-### func \(\*Client\) [ClearTaskInstances](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L776>)
+### func \(\*Client\) [ClearTaskInstances](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1101>)
 
 ```go
 func (c *Client) ClearTaskInstances(ctx context.Context, dagId DagID, body ClearTaskInstancesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -727,7 +981,7 @@ Takes a body of the \`application/json\` content type.
 Corresponds with POST /api/v2/dags/\{dag\_id\}/clearTaskInstances \(the \`ClearTaskInstances\` operationId\).
 
 <a name="Client.ClearTaskInstancesWithBody"></a>
-### func \(\*Client\) [ClearTaskInstancesWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L759>)
+### func \(\*Client\) [ClearTaskInstancesWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1084>)
 
 ```go
 func (c *Client) ClearTaskInstancesWithBody(ctx context.Context, dagId DagID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -739,8 +993,38 @@ Takes any type of body and a specified content type.
 
 Corresponds with POST /api/v2/dags/\{dag\_id\}/clearTaskInstances \(the \`ClearTaskInstances\` operationId\).
 
+<a name="Client.CreateConnection"></a>
+### func \(\*Client\) [CreateConnection](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L924>)
+
+```go
+func (c *Client) CreateConnection(ctx context.Context, body CreateConnectionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+```
+
+CreateConnection Create or replace a connection \(upsert\)
+
+Upserts a connection: creates it, or replaces an existing one with the same connection\_id. The password is write\-only and never returned. Requires the write:connection permission and a configured encryption key.
+
+Takes a body of the \`application/json\` content type.
+
+Corresponds with POST /api/v2/connections \(the \`CreateConnection\` operationId\).
+
+<a name="Client.CreateConnectionWithBody"></a>
+### func \(\*Client\) [CreateConnectionWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L903>)
+
+```go
+func (c *Client) CreateConnectionWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+```
+
+CreateConnectionWithBody Create or replace a connection \(upsert\)
+
+Upserts a connection: creates it, or replaces an existing one with the same connection\_id. The password is write\-only and never returned. Requires the write:connection permission and a configured encryption key.
+
+Takes any type of body and a specified content type.
+
+Corresponds with POST /api/v2/connections \(the \`CreateConnection\` operationId\).
+
 <a name="Client.CreateUser"></a>
-### func \(\*Client\) [CreateUser](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1021>)
+### func \(\*Client\) [CreateUser](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1346>)
 
 ```go
 func (c *Client) CreateUser(ctx context.Context, body CreateUserJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -755,7 +1039,7 @@ Takes a body of the \`application/json\` content type.
 Corresponds with POST /api/v2/users \(the \`CreateUser\` operationId\).
 
 <a name="Client.CreateUserWithBody"></a>
-### func \(\*Client\) [CreateUserWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1000>)
+### func \(\*Client\) [CreateUserWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1325>)
 
 ```go
 func (c *Client) CreateUserWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -769,8 +1053,71 @@ Takes any type of body and a specified content type.
 
 Corresponds with POST /api/v2/users \(the \`CreateUser\` operationId\).
 
+<a name="Client.CreateVariable"></a>
+### func \(\*Client\) [CreateVariable](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1404>)
+
+```go
+func (c *Client) CreateVariable(ctx context.Context, body CreateVariableJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+```
+
+CreateVariable Create or replace a variable \(upsert\)
+
+Upserts a variable: creates it, or replaces an existing one with the same key. Requires the write:variable permission.
+
+Takes a body of the \`application/json\` content type.
+
+Corresponds with POST /api/v2/variables \(the \`CreateVariable\` operationId\).
+
+<a name="Client.CreateVariableWithBody"></a>
+### func \(\*Client\) [CreateVariableWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1384>)
+
+```go
+func (c *Client) CreateVariableWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+```
+
+CreateVariableWithBody Create or replace a variable \(upsert\)
+
+Upserts a variable: creates it, or replaces an existing one with the same key. Requires the write:variable permission.
+
+Takes any type of body and a specified content type.
+
+Corresponds with POST /api/v2/variables \(the \`CreateVariable\` operationId\).
+
+<a name="Client.DeleteConnection"></a>
+### func \(\*Client\) [DeleteConnection](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L939>)
+
+```go
+func (c *Client) DeleteConnection(ctx context.Context, connectionId ConnectionID, reqEditors ...RequestEditorFn) (*http.Response, error)
+```
+
+DeleteConnection Delete a connection
+
+Corresponds with DELETE /api/v2/connections/\{connection\_id\} \(the \`DeleteConnection\` operationId\).
+
+<a name="Client.DeleteVariable"></a>
+### func \(\*Client\) [DeleteVariable](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1419>)
+
+```go
+func (c *Client) DeleteVariable(ctx context.Context, variableKey VariableKey, reqEditors ...RequestEditorFn) (*http.Response, error)
+```
+
+DeleteVariable Delete a variable
+
+Corresponds with DELETE /api/v2/variables/\{variable\_key\} \(the \`DeleteVariable\` operationId\).
+
+<a name="Client.GetConnection"></a>
+### func \(\*Client\) [GetConnection](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L954>)
+
+```go
+func (c *Client) GetConnection(ctx context.Context, connectionId ConnectionID, reqEditors ...RequestEditorFn) (*http.Response, error)
+```
+
+GetConnection Get a connection
+
+Corresponds with GET /api/v2/connections/\{connection\_id\} \(the \`GetConnection\` operationId\).
+
 <a name="Client.GetDag"></a>
-### func \(\*Client\) [GetDag](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L708>)
+### func \(\*Client\) [GetDag](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1033>)
 
 ```go
 func (c *Client) GetDag(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -781,7 +1128,7 @@ GetDag Get a DAG
 Corresponds with GET /api/v2/dags/\{dag\_id\} \(the \`GetDag\` operationId\).
 
 <a name="Client.GetDagRun"></a>
-### func \(\*Client\) [GetDagRun](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L840>)
+### func \(\*Client\) [GetDagRun](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1165>)
 
 ```go
 func (c *Client) GetDagRun(ctx context.Context, dagId DagID, dagRunId DagRunID, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -792,7 +1139,7 @@ GetDagRun Get a DAG run
 Corresponds with GET /api/v2/dags/\{dag\_id\}/dagRuns/\{dag\_run\_id\} \(the \`GetDagRun\` operationId\).
 
 <a name="Client.GetDagSource"></a>
-### func \(\*Client\) [GetDagSource](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L678>)
+### func \(\*Client\) [GetDagSource](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1003>)
 
 ```go
 func (c *Client) GetDagSource(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -803,7 +1150,7 @@ GetDagSource Get a DAG's source \(the dag.py text\)
 Corresponds with GET /api/v2/dagSources/\{dag\_id\} \(the \`GetDagSource\` operationId\).
 
 <a name="Client.GetDagSpec"></a>
-### func \(\*Client\) [GetDagSpec](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L930>)
+### func \(\*Client\) [GetDagSpec](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1255>)
 
 ```go
 func (c *Client) GetDagSpec(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -814,7 +1161,7 @@ GetDagSpec Get a DAG's compiled spec \(the dag.json artifact\)
 Corresponds with GET /api/v2/dags/\{dag\_id\}/spec \(the \`GetDagSpec\` operationId\).
 
 <a name="Client.GetDagVersion"></a>
-### func \(\*Client\) [GetDagVersion](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L915>)
+### func \(\*Client\) [GetDagVersion](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1240>)
 
 ```go
 func (c *Client) GetDagVersion(ctx context.Context, dagId DagID, versionNumber int, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -825,7 +1172,7 @@ GetDagVersion Get a specific registered DAG version
 Corresponds with GET /api/v2/dags/\{dag\_id\}/dagVersions/\{version\_number\} \(the \`GetDagVersion\` operationId\).
 
 <a name="Client.GetHealthz"></a>
-### func \(\*Client\) [GetHealthz](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1100>)
+### func \(\*Client\) [GetHealthz](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1513>)
 
 ```go
 func (c *Client) GetHealthz(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -836,7 +1183,7 @@ GetHealthz Liveness probe
 Corresponds with GET /healthz \(the \`GetHealthz\` operationId\).
 
 <a name="Client.GetMonitorExecutor"></a>
-### func \(\*Client\) [GetMonitorExecutor](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L945>)
+### func \(\*Client\) [GetMonitorExecutor](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1270>)
 
 ```go
 func (c *Client) GetMonitorExecutor(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -847,7 +1194,7 @@ GetMonitorExecutor Executor capability and configuration
 Corresponds with GET /api/v2/monitor/executor \(the \`GetMonitorExecutor\` operationId\).
 
 <a name="Client.GetMonitorHealth"></a>
-### func \(\*Client\) [GetMonitorHealth](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L960>)
+### func \(\*Client\) [GetMonitorHealth](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1285>)
 
 ```go
 func (c *Client) GetMonitorHealth(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -858,7 +1205,7 @@ GetMonitorHealth Control\-plane health \(Airflow HealthInfoResponse shape\)
 Corresponds with GET /api/v2/monitor/health \(the \`GetMonitorHealth\` operationId\).
 
 <a name="Client.GetReadyz"></a>
-### func \(\*Client\) [GetReadyz](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1115>)
+### func \(\*Client\) [GetReadyz](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1528>)
 
 ```go
 func (c *Client) GetReadyz(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -869,7 +1216,7 @@ GetReadyz Readiness probe
 Corresponds with GET /readyz \(the \`GetReadyz\` operationId\).
 
 <a name="Client.GetTaskInstance"></a>
-### func \(\*Client\) [GetTaskInstance](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L870>)
+### func \(\*Client\) [GetTaskInstance](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1195>)
 
 ```go
 func (c *Client) GetTaskInstance(ctx context.Context, dagId DagID, dagRunId DagRunID, taskId TaskID, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -880,7 +1227,7 @@ GetTaskInstance Get a task instance
 Corresponds with GET /api/v2/dags/\{dag\_id\}/dagRuns/\{dag\_run\_id\}/taskInstances/\{task\_id\} \(the \`GetTaskInstance\` operationId\).
 
 <a name="Client.GetTaskLogs"></a>
-### func \(\*Client\) [GetTaskLogs](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L885>)
+### func \(\*Client\) [GetTaskLogs](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1210>)
 
 ```go
 func (c *Client) GetTaskLogs(ctx context.Context, dagId DagID, dagRunId DagRunID, taskId TaskID, tryNumber int, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -890,8 +1237,19 @@ GetTaskLogs Get task logs
 
 Corresponds with GET /api/v2/dags/\{dag\_id\}/dagRuns/\{dag\_run\_id\}/taskInstances/\{task\_id\}/logs/\{try\_number\} \(the \`GetTaskLogs\` operationId\).
 
+<a name="Client.GetVariable"></a>
+### func \(\*Client\) [GetVariable](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1434>)
+
+```go
+func (c *Client) GetVariable(ctx context.Context, variableKey VariableKey, reqEditors ...RequestEditorFn) (*http.Response, error)
+```
+
+GetVariable Get a variable
+
+Corresponds with GET /api/v2/variables/\{variable\_key\} \(the \`GetVariable\` operationId\).
+
 <a name="Client.GetVersion"></a>
-### func \(\*Client\) [GetVersion](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1036>)
+### func \(\*Client\) [GetVersion](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1449>)
 
 ```go
 func (c *Client) GetVersion(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -902,7 +1260,7 @@ GetVersion Control\-plane version \(Airflow VersionInfo shape\)
 Corresponds with GET /api/v2/version \(the \`GetVersion\` operationId\).
 
 <a name="Client.GetXcomEntry"></a>
-### func \(\*Client\) [GetXcomEntry](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1051>)
+### func \(\*Client\) [GetXcomEntry](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1464>)
 
 ```go
 func (c *Client) GetXcomEntry(ctx context.Context, dagId DagID, dagRunId DagRunID, taskId TaskID, key string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -913,7 +1271,7 @@ GetXcomEntry Read XCom value \(read\-only proxy for the Redis backend\)
 Corresponds with GET /api/v2/xcoms/\{dag\_id\}/\{dag\_run\_id\}/\{task\_id\}/\{key\} \(the \`GetXcomEntry\` operationId\).
 
 <a name="Client.IssueToken"></a>
-### func \(\*Client\) [IssueToken](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1085>)
+### func \(\*Client\) [IssueToken](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1498>)
 
 ```go
 func (c *Client) IssueToken(ctx context.Context, body IssueTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -926,7 +1284,7 @@ Takes a body of the \`application/json\` content type.
 Corresponds with POST /auth/token \(the \`IssueToken\` operationId\).
 
 <a name="Client.IssueTokenWithBody"></a>
-### func \(\*Client\) [IssueTokenWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1068>)
+### func \(\*Client\) [IssueTokenWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1481>)
 
 ```go
 func (c *Client) IssueTokenWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -938,8 +1296,21 @@ Takes any type of body and a specified content type.
 
 Corresponds with POST /auth/token \(the \`IssueToken\` operationId\).
 
+<a name="Client.ListConnections"></a>
+### func \(\*Client\) [ListConnections](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L882>)
+
+```go
+func (c *Client) ListConnections(ctx context.Context, params *ListConnectionsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+```
+
+ListConnections List connections
+
+Lists the tenant's Airflow\-style connections. Passwords are write\-only and never returned; secret\-bearing keys inside \`extra\` are masked server\-side. Requires the read:connection permission.
+
+Corresponds with GET /api/v2/connections \(the \`ListConnections\` operationId\).
+
 <a name="Client.ListDagRuns"></a>
-### func \(\*Client\) [ListDagRuns](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L791>)
+### func \(\*Client\) [ListDagRuns](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1116>)
 
 ```go
 func (c *Client) ListDagRuns(ctx context.Context, dagId DagID, params *ListDagRunsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -950,7 +1321,7 @@ ListDagRuns List DAG runs
 Corresponds with GET /api/v2/dags/\{dag\_id\}/dagRuns \(the \`ListDagRuns\` operationId\).
 
 <a name="Client.ListDagVersions"></a>
-### func \(\*Client\) [ListDagVersions](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L900>)
+### func \(\*Client\) [ListDagVersions](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1225>)
 
 ```go
 func (c *Client) ListDagVersions(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -961,7 +1332,7 @@ ListDagVersions List a DAG's registered versions
 Corresponds with GET /api/v2/dags/\{dag\_id\}/dagVersions \(the \`ListDagVersions\` operationId\).
 
 <a name="Client.ListDags"></a>
-### func \(\*Client\) [ListDags](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L693>)
+### func \(\*Client\) [ListDags](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1018>)
 
 ```go
 func (c *Client) ListDags(ctx context.Context, params *ListDagsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -972,7 +1343,7 @@ ListDags List DAGs
 Corresponds with GET /api/v2/dags \(the \`ListDags\` operationId\).
 
 <a name="Client.ListTaskInstances"></a>
-### func \(\*Client\) [ListTaskInstances](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L855>)
+### func \(\*Client\) [ListTaskInstances](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1180>)
 
 ```go
 func (c *Client) ListTaskInstances(ctx context.Context, dagId DagID, dagRunId DagRunID, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -983,7 +1354,7 @@ ListTaskInstances List task instances of a DAG run
 Corresponds with GET /api/v2/dags/\{dag\_id\}/dagRuns/\{dag\_run\_id\}/taskInstances \(the \`ListTaskInstances\` operationId\).
 
 <a name="Client.ListUsers"></a>
-### func \(\*Client\) [ListUsers](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L979>)
+### func \(\*Client\) [ListUsers](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1304>)
 
 ```go
 func (c *Client) ListUsers(ctx context.Context, params *ListUsersParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -995,8 +1366,34 @@ Lists the tenant's control\-plane accounts, newest first. Each entry carries the
 
 Corresponds with GET /api/v2/users \(the \`ListUsers\` operationId\).
 
+<a name="Client.ListVariables"></a>
+### func \(\*Client\) [ListVariables](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1364>)
+
+```go
+func (c *Client) ListVariables(ctx context.Context, params *ListVariablesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+```
+
+ListVariables List variables
+
+Lists the tenant's Airflow\-style variables. Values of secret\-ish keys are masked server\-side. Requires the read:variable permission.
+
+Corresponds with GET /api/v2/variables \(the \`ListVariables\` operationId\).
+
+<a name="Client.RenewToken"></a>
+### func \(\*Client\) [RenewToken](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L863>)
+
+```go
+func (c *Client) RenewToken(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+```
+
+RenewToken Renew a still\-valid JWT into a fresh short\-lived token
+
+Transparent renewal: given a still\-valid user bearer, re\-mints the same identity with a fresh short TTL, bounded by a server\-side max\_lifetime measured from first login. Lets a long CLI/dev session avoid re\-logging in every token TTL while keeping the access token short\-lived. Returns 401 when the presented token is invalid, expired, or past max\_lifetime, in which case the client must log in again.
+
+Corresponds with POST /api/v2/auth/token/renew \(the \`RenewToken\` operationId\).
+
 <a name="Client.TriggerDagRun"></a>
-### func \(\*Client\) [TriggerDagRun](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L825>)
+### func \(\*Client\) [TriggerDagRun](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1150>)
 
 ```go
 func (c *Client) TriggerDagRun(ctx context.Context, dagId DagID, body TriggerDagRunJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1009,7 +1406,7 @@ Takes a body of the \`application/json\` content type.
 Corresponds with POST /api/v2/dags/\{dag\_id\}/dagRuns \(the \`TriggerDagRun\` operationId\).
 
 <a name="Client.TriggerDagRunWithBody"></a>
-### func \(\*Client\) [TriggerDagRunWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L808>)
+### func \(\*Client\) [TriggerDagRunWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1133>)
 
 ```go
 func (c *Client) TriggerDagRunWithBody(ctx context.Context, dagId DagID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1021,8 +1418,34 @@ Takes any type of body and a specified content type.
 
 Corresponds with POST /api/v2/dags/\{dag\_id\}/dagRuns \(the \`TriggerDagRun\` operationId\).
 
+<a name="Client.UpdateConnection"></a>
+### func \(\*Client\) [UpdateConnection](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L988>)
+
+```go
+func (c *Client) UpdateConnection(ctx context.Context, connectionId ConnectionID, body UpdateConnectionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+```
+
+UpdateConnection Update a connection
+
+Takes a body of the \`application/json\` content type.
+
+Corresponds with PATCH /api/v2/connections/\{connection\_id\} \(the \`UpdateConnection\` operationId\).
+
+<a name="Client.UpdateConnectionWithBody"></a>
+### func \(\*Client\) [UpdateConnectionWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L971>)
+
+```go
+func (c *Client) UpdateConnectionWithBody(ctx context.Context, connectionId ConnectionID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+```
+
+UpdateConnectionWithBody Update a connection
+
+Takes any type of body and a specified content type.
+
+Corresponds with PATCH /api/v2/connections/\{connection\_id\} \(the \`UpdateConnection\` operationId\).
+
 <a name="Client.UpdateDag"></a>
-### func \(\*Client\) [UpdateDag](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L742>)
+### func \(\*Client\) [UpdateDag](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1067>)
 
 ```go
 func (c *Client) UpdateDag(ctx context.Context, dagId DagID, body UpdateDagJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1035,7 +1458,7 @@ Takes a body of the \`application/json\` content type.
 Corresponds with PATCH /api/v2/dags/\{dag\_id\} \(the \`UpdateDag\` operationId\).
 
 <a name="Client.UpdateDagWithBody"></a>
-### func \(\*Client\) [UpdateDagWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L725>)
+### func \(\*Client\) [UpdateDagWithBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L1050>)
 
 ```go
 func (c *Client) UpdateDagWithBody(ctx context.Context, dagId DagID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -1048,12 +1471,74 @@ Takes any type of body and a specified content type.
 Corresponds with PATCH /api/v2/dags/\{dag\_id\} \(the \`UpdateDag\` operationId\).
 
 <a name="ClientInterface"></a>
-## type [ClientInterface](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L500-L673>)
+## type [ClientInterface](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L583-L856>)
 
 The interface specification for the client above.
 
 ```go
 type ClientInterface interface {
+
+    // RenewToken Renew a still-valid JWT into a fresh short-lived token
+    //
+    // Transparent renewal: given a still-valid user bearer, re-mints the same identity with a fresh short TTL, bounded by a server-side max_lifetime measured from first login. Lets a long CLI/dev session avoid re-logging in every token TTL while keeping the access token short-lived. Returns 401 when the presented token is invalid, expired, or past max_lifetime, in which case the client must log in again.
+    //
+    // Corresponds with POST /api/v2/auth/token/renew (the `RenewToken` operationId).
+    RenewToken(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+    // ListConnections List connections
+    //
+    // Lists the tenant's Airflow-style connections. Passwords are write-only and
+    // never returned; secret-bearing keys inside `extra` are masked server-side.
+    // Requires the read:connection permission.
+    //
+    // Corresponds with GET /api/v2/connections (the `ListConnections` operationId).
+    ListConnections(ctx context.Context, params *ListConnectionsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+    // CreateConnectionWithBody Create or replace a connection (upsert)
+    //
+    // Upserts a connection: creates it, or replaces an existing one with the same
+    // connection_id. The password is write-only and never returned. Requires the
+    // write:connection permission and a configured encryption key.
+    //
+    // Takes any type of body and a specified content type.
+    //
+    // Corresponds with POST /api/v2/connections (the `CreateConnection` operationId).
+    CreateConnectionWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+    // CreateConnection Create or replace a connection (upsert)
+    //
+    // Upserts a connection: creates it, or replaces an existing one with the same
+    // connection_id. The password is write-only and never returned. Requires the
+    // write:connection permission and a configured encryption key.
+    //
+    // Takes a body of the `application/json` content type.
+    //
+    // Corresponds with POST /api/v2/connections (the `CreateConnection` operationId).
+    CreateConnection(ctx context.Context, body CreateConnectionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+    // DeleteConnection Delete a connection
+    //
+    // Corresponds with DELETE /api/v2/connections/{connection_id} (the `DeleteConnection` operationId).
+    DeleteConnection(ctx context.Context, connectionId ConnectionID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+    // GetConnection Get a connection
+    //
+    // Corresponds with GET /api/v2/connections/{connection_id} (the `GetConnection` operationId).
+    GetConnection(ctx context.Context, connectionId ConnectionID, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+    // UpdateConnectionWithBody Update a connection
+    //
+    // Takes any type of body and a specified content type.
+    //
+    // Corresponds with PATCH /api/v2/connections/{connection_id} (the `UpdateConnection` operationId).
+    UpdateConnectionWithBody(ctx context.Context, connectionId ConnectionID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+    // UpdateConnection Update a connection
+    //
+    // Takes a body of the `application/json` content type.
+    //
+    // Corresponds with PATCH /api/v2/connections/{connection_id} (the `UpdateConnection` operationId).
+    UpdateConnection(ctx context.Context, connectionId ConnectionID, body UpdateConnectionJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
     // GetDagSource Get a DAG's source (the dag.py text)
     //
@@ -1193,6 +1678,44 @@ type ClientInterface interface {
     // Corresponds with POST /api/v2/users (the `CreateUser` operationId).
     CreateUser(ctx context.Context, body CreateUserJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+    // ListVariables List variables
+    //
+    // Lists the tenant's Airflow-style variables. Values of secret-ish keys are
+    // masked server-side. Requires the read:variable permission.
+    //
+    // Corresponds with GET /api/v2/variables (the `ListVariables` operationId).
+    ListVariables(ctx context.Context, params *ListVariablesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+    // CreateVariableWithBody Create or replace a variable (upsert)
+    //
+    // Upserts a variable: creates it, or replaces an existing one with the same
+    // key. Requires the write:variable permission.
+    //
+    // Takes any type of body and a specified content type.
+    //
+    // Corresponds with POST /api/v2/variables (the `CreateVariable` operationId).
+    CreateVariableWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+    // CreateVariable Create or replace a variable (upsert)
+    //
+    // Upserts a variable: creates it, or replaces an existing one with the same
+    // key. Requires the write:variable permission.
+    //
+    // Takes a body of the `application/json` content type.
+    //
+    // Corresponds with POST /api/v2/variables (the `CreateVariable` operationId).
+    CreateVariable(ctx context.Context, body CreateVariableJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+    // DeleteVariable Delete a variable
+    //
+    // Corresponds with DELETE /api/v2/variables/{variable_key} (the `DeleteVariable` operationId).
+    DeleteVariable(ctx context.Context, variableKey VariableKey, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+    // GetVariable Get a variable
+    //
+    // Corresponds with GET /api/v2/variables/{variable_key} (the `GetVariable` operationId).
+    GetVariable(ctx context.Context, variableKey VariableKey, reqEditors ...RequestEditorFn) (*http.Response, error)
+
     // GetVersion Control-plane version (Airflow VersionInfo shape)
     //
     // Corresponds with GET /api/v2/version (the `GetVersion` operationId).
@@ -1230,7 +1753,7 @@ type ClientInterface interface {
 ```
 
 <a name="ClientOption"></a>
-## type [ClientOption](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L456>)
+## type [ClientOption](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L539>)
 
 ClientOption allows setting custom parameters during construction
 
@@ -1239,7 +1762,7 @@ type ClientOption func(*Client) error
 ```
 
 <a name="WithBaseURL"></a>
-### func [WithBaseURL](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2183>)
+### func [WithBaseURL](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3018>)
 
 ```go
 func WithBaseURL(baseURL string) ClientOption
@@ -1248,7 +1771,7 @@ func WithBaseURL(baseURL string) ClientOption
 WithBaseURL overrides the baseURL.
 
 <a name="WithHTTPClient"></a>
-### func [WithHTTPClient](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L483>)
+### func [WithHTTPClient](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L566>)
 
 ```go
 func WithHTTPClient(doer HttpRequestDoer) ClientOption
@@ -1257,7 +1780,7 @@ func WithHTTPClient(doer HttpRequestDoer) ClientOption
 WithHTTPClient allows overriding the default Doer, which is automatically created using http.Client. This is useful for tests.
 
 <a name="WithRequestEditorFn"></a>
-### func [WithRequestEditorFn](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L492>)
+### func [WithRequestEditorFn](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L575>)
 
 ```go
 func WithRequestEditorFn(fn RequestEditorFn) ClientOption
@@ -1266,7 +1789,7 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption
 WithRequestEditorFn allows setting up a callback function, which will be called right before sending the request. This can be used to mutate the request.
 
 <a name="ClientWithResponses"></a>
-## type [ClientWithResponses](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2168-L2170>)
+## type [ClientWithResponses](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3003-L3005>)
 
 ClientWithResponses builds on ClientInterface to offer response payloads
 
@@ -1286,7 +1809,7 @@ func New(baseURL, token string, opts ...ClientOption) (*ClientWithResponses, err
 New builds a typed /api/v2 client for the control plane at baseURL \(an origin such as "http://localhost:8080", with or without a trailing slash\). When token is non\-empty every request carries "Authorization: Bearer \<token\>"; the MCP and CLI pass the caller's JWT through unchanged and never mint one \(ADR 0050 D9\). An empty token leaves requests unauthenticated, for dev/loopback use. Extra ClientOptions \(e.g. WithHTTPClient\) are applied after the auth editor.
 
 <a name="NewClientWithResponses"></a>
-### func [NewClientWithResponses](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2174>)
+### func [NewClientWithResponses](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3009>)
 
 ```go
 func NewClientWithResponses(server string, opts ...ClientOption) (*ClientWithResponses, error)
@@ -1295,7 +1818,7 @@ func NewClientWithResponses(server string, opts ...ClientOption) (*ClientWithRes
 NewClientWithResponses creates a new ClientWithResponses, which wraps Client with return type handling
 
 <a name="ClientWithResponses.ClearTaskInstancesWithBodyWithResponse"></a>
-### func \(\*ClientWithResponses\) [ClearTaskInstancesWithBodyWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3475>)
+### func \(\*ClientWithResponses\) [ClearTaskInstancesWithBodyWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5078>)
 
 ```go
 func (c *ClientWithResponses) ClearTaskInstancesWithBodyWithResponse(ctx context.Context, dagId DagID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*ClearTaskInstancesResponse, error)
@@ -1308,7 +1831,7 @@ Takes any type of body and a specified content type, and returns a wrapper objec
 Corresponds with POST /api/v2/dags/\{dag\_id\}/clearTaskInstances \(the \`ClearTaskInstances\` operationId\).
 
 <a name="ClientWithResponses.ClearTaskInstancesWithResponse"></a>
-### func \(\*ClientWithResponses\) [ClearTaskInstancesWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3488>)
+### func \(\*ClientWithResponses\) [ClearTaskInstancesWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5091>)
 
 ```go
 func (c *ClientWithResponses) ClearTaskInstancesWithResponse(ctx context.Context, dagId DagID, body ClearTaskInstancesJSONRequestBody, reqEditors ...RequestEditorFn) (*ClearTaskInstancesResponse, error)
@@ -1320,8 +1843,38 @@ Takes a body of the \`application/json\` content type, and returns a wrapper obj
 
 Corresponds with POST /api/v2/dags/\{dag\_id\}/clearTaskInstances \(the \`ClearTaskInstances\` operationId\).
 
+<a name="ClientWithResponses.CreateConnectionWithBodyWithResponse"></a>
+### func \(\*ClientWithResponses\) [CreateConnectionWithBodyWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4931>)
+
+```go
+func (c *ClientWithResponses) CreateConnectionWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateConnectionResponse, error)
+```
+
+CreateConnectionWithBodyWithResponse Create or replace a connection \(upsert\)
+
+Upserts a connection: creates it, or replaces an existing one with the same connection\_id. The password is write\-only and never returned. Requires the write:connection permission and a configured encryption key.
+
+Takes any type of body and a specified content type, and returns a wrapper object for the known response body format\(s\).
+
+Corresponds with POST /api/v2/connections \(the \`CreateConnection\` operationId\).
+
+<a name="ClientWithResponses.CreateConnectionWithResponse"></a>
+### func \(\*ClientWithResponses\) [CreateConnectionWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4948>)
+
+```go
+func (c *ClientWithResponses) CreateConnectionWithResponse(ctx context.Context, body CreateConnectionJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateConnectionResponse, error)
+```
+
+CreateConnectionWithResponse Create or replace a connection \(upsert\)
+
+Upserts a connection: creates it, or replaces an existing one with the same connection\_id. The password is write\-only and never returned. Requires the write:connection permission and a configured encryption key.
+
+Takes a body of the \`application/json\` content type, and returns a wrapper object for the known response body format\(s\).
+
+Corresponds with POST /api/v2/connections \(the \`CreateConnection\` operationId\).
+
 <a name="ClientWithResponses.CreateUserWithBodyWithResponse"></a>
-### func \(\*ClientWithResponses\) [CreateUserWithBodyWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3678>)
+### func \(\*ClientWithResponses\) [CreateUserWithBodyWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5281>)
 
 ```go
 func (c *ClientWithResponses) CreateUserWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateUserResponse, error)
@@ -1336,7 +1889,7 @@ Takes any type of body and a specified content type, and returns a wrapper objec
 Corresponds with POST /api/v2/users \(the \`CreateUser\` operationId\).
 
 <a name="ClientWithResponses.CreateUserWithResponse"></a>
-### func \(\*ClientWithResponses\) [CreateUserWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3695>)
+### func \(\*ClientWithResponses\) [CreateUserWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5298>)
 
 ```go
 func (c *ClientWithResponses) CreateUserWithResponse(ctx context.Context, body CreateUserJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateUserResponse, error)
@@ -1350,8 +1903,77 @@ Takes a body of the \`application/json\` content type, and returns a wrapper obj
 
 Corresponds with POST /api/v2/users \(the \`CreateUser\` operationId\).
 
+<a name="ClientWithResponses.CreateVariableWithBodyWithResponse"></a>
+### func \(\*ClientWithResponses\) [CreateVariableWithBodyWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5330>)
+
+```go
+func (c *ClientWithResponses) CreateVariableWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateVariableResponse, error)
+```
+
+CreateVariableWithBodyWithResponse Create or replace a variable \(upsert\)
+
+Upserts a variable: creates it, or replaces an existing one with the same key. Requires the write:variable permission.
+
+Takes any type of body and a specified content type, and returns a wrapper object for the known response body format\(s\).
+
+Corresponds with POST /api/v2/variables \(the \`CreateVariable\` operationId\).
+
+<a name="ClientWithResponses.CreateVariableWithResponse"></a>
+### func \(\*ClientWithResponses\) [CreateVariableWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5346>)
+
+```go
+func (c *ClientWithResponses) CreateVariableWithResponse(ctx context.Context, body CreateVariableJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateVariableResponse, error)
+```
+
+CreateVariableWithResponse Create or replace a variable \(upsert\)
+
+Upserts a variable: creates it, or replaces an existing one with the same key. Requires the write:variable permission.
+
+Takes a body of the \`application/json\` content type, and returns a wrapper object for the known response body format\(s\).
+
+Corresponds with POST /api/v2/variables \(the \`CreateVariable\` operationId\).
+
+<a name="ClientWithResponses.DeleteConnectionWithResponse"></a>
+### func \(\*ClientWithResponses\) [DeleteConnectionWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4961>)
+
+```go
+func (c *ClientWithResponses) DeleteConnectionWithResponse(ctx context.Context, connectionId ConnectionID, reqEditors ...RequestEditorFn) (*DeleteConnectionResponse, error)
+```
+
+DeleteConnectionWithResponse Delete a connection
+
+Returns a wrapper object for the known response body format\(s\).
+
+Corresponds with DELETE /api/v2/connections/\{connection\_id\} \(the \`DeleteConnection\` operationId\).
+
+<a name="ClientWithResponses.DeleteVariableWithResponse"></a>
+### func \(\*ClientWithResponses\) [DeleteVariableWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5359>)
+
+```go
+func (c *ClientWithResponses) DeleteVariableWithResponse(ctx context.Context, variableKey VariableKey, reqEditors ...RequestEditorFn) (*DeleteVariableResponse, error)
+```
+
+DeleteVariableWithResponse Delete a variable
+
+Returns a wrapper object for the known response body format\(s\).
+
+Corresponds with DELETE /api/v2/variables/\{variable\_key\} \(the \`DeleteVariable\` operationId\).
+
+<a name="ClientWithResponses.GetConnectionWithResponse"></a>
+### func \(\*ClientWithResponses\) [GetConnectionWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4974>)
+
+```go
+func (c *ClientWithResponses) GetConnectionWithResponse(ctx context.Context, connectionId ConnectionID, reqEditors ...RequestEditorFn) (*GetConnectionResponse, error)
+```
+
+GetConnectionWithResponse Get a connection
+
+Returns a wrapper object for the known response body format\(s\).
+
+Corresponds with GET /api/v2/connections/\{connection\_id\} \(the \`GetConnection\` operationId\).
+
 <a name="ClientWithResponses.GetDagRunWithResponse"></a>
-### func \(\*ClientWithResponses\) [GetDagRunWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3540>)
+### func \(\*ClientWithResponses\) [GetDagRunWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5143>)
 
 ```go
 func (c *ClientWithResponses) GetDagRunWithResponse(ctx context.Context, dagId DagID, dagRunId DagRunID, reqEditors ...RequestEditorFn) (*GetDagRunResponse, error)
@@ -1364,7 +1986,7 @@ Returns a wrapper object for the known response body format\(s\).
 Corresponds with GET /api/v2/dags/\{dag\_id\}/dagRuns/\{dag\_run\_id\} \(the \`GetDagRun\` operationId\).
 
 <a name="ClientWithResponses.GetDagSourceWithResponse"></a>
-### func \(\*ClientWithResponses\) [GetDagSourceWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3410>)
+### func \(\*ClientWithResponses\) [GetDagSourceWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5013>)
 
 ```go
 func (c *ClientWithResponses) GetDagSourceWithResponse(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn) (*GetDagSourceResponse, error)
@@ -1377,7 +1999,7 @@ Returns a wrapper object for the known response body format\(s\).
 Corresponds with GET /api/v2/dagSources/\{dag\_id\} \(the \`GetDagSource\` operationId\).
 
 <a name="ClientWithResponses.GetDagSpecWithResponse"></a>
-### func \(\*ClientWithResponses\) [GetDagSpecWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3618>)
+### func \(\*ClientWithResponses\) [GetDagSpecWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5221>)
 
 ```go
 func (c *ClientWithResponses) GetDagSpecWithResponse(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn) (*GetDagSpecResponse, error)
@@ -1390,7 +2012,7 @@ Returns a wrapper object for the known response body format\(s\).
 Corresponds with GET /api/v2/dags/\{dag\_id\}/spec \(the \`GetDagSpec\` operationId\).
 
 <a name="ClientWithResponses.GetDagVersionWithResponse"></a>
-### func \(\*ClientWithResponses\) [GetDagVersionWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3605>)
+### func \(\*ClientWithResponses\) [GetDagVersionWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5208>)
 
 ```go
 func (c *ClientWithResponses) GetDagVersionWithResponse(ctx context.Context, dagId DagID, versionNumber int, reqEditors ...RequestEditorFn) (*GetDagVersionResponse, error)
@@ -1403,7 +2025,7 @@ Returns a wrapper object for the known response body format\(s\).
 Corresponds with GET /api/v2/dags/\{dag\_id\}/dagVersions/\{version\_number\} \(the \`GetDagVersion\` operationId\).
 
 <a name="ClientWithResponses.GetDagWithResponse"></a>
-### func \(\*ClientWithResponses\) [GetDagWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3436>)
+### func \(\*ClientWithResponses\) [GetDagWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5039>)
 
 ```go
 func (c *ClientWithResponses) GetDagWithResponse(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn) (*GetDagResponse, error)
@@ -1416,7 +2038,7 @@ Returns a wrapper object for the known response body format\(s\).
 Corresponds with GET /api/v2/dags/\{dag\_id\} \(the \`GetDag\` operationId\).
 
 <a name="ClientWithResponses.GetHealthzWithResponse"></a>
-### func \(\*ClientWithResponses\) [GetHealthzWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3760>)
+### func \(\*ClientWithResponses\) [GetHealthzWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5437>)
 
 ```go
 func (c *ClientWithResponses) GetHealthzWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetHealthzResponse, error)
@@ -1429,7 +2051,7 @@ Returns a wrapper object for the known response body format\(s\).
 Corresponds with GET /healthz \(the \`GetHealthz\` operationId\).
 
 <a name="ClientWithResponses.GetMonitorExecutorWithResponse"></a>
-### func \(\*ClientWithResponses\) [GetMonitorExecutorWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3631>)
+### func \(\*ClientWithResponses\) [GetMonitorExecutorWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5234>)
 
 ```go
 func (c *ClientWithResponses) GetMonitorExecutorWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetMonitorExecutorResponse, error)
@@ -1442,7 +2064,7 @@ Returns a wrapper object for the known response body format\(s\).
 Corresponds with GET /api/v2/monitor/executor \(the \`GetMonitorExecutor\` operationId\).
 
 <a name="ClientWithResponses.GetMonitorHealthWithResponse"></a>
-### func \(\*ClientWithResponses\) [GetMonitorHealthWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3644>)
+### func \(\*ClientWithResponses\) [GetMonitorHealthWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5247>)
 
 ```go
 func (c *ClientWithResponses) GetMonitorHealthWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetMonitorHealthResponse, error)
@@ -1455,7 +2077,7 @@ Returns a wrapper object for the known response body format\(s\).
 Corresponds with GET /api/v2/monitor/health \(the \`GetMonitorHealth\` operationId\).
 
 <a name="ClientWithResponses.GetReadyzWithResponse"></a>
-### func \(\*ClientWithResponses\) [GetReadyzWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3773>)
+### func \(\*ClientWithResponses\) [GetReadyzWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5450>)
 
 ```go
 func (c *ClientWithResponses) GetReadyzWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetReadyzResponse, error)
@@ -1468,7 +2090,7 @@ Returns a wrapper object for the known response body format\(s\).
 Corresponds with GET /readyz \(the \`GetReadyz\` operationId\).
 
 <a name="ClientWithResponses.GetTaskInstanceWithResponse"></a>
-### func \(\*ClientWithResponses\) [GetTaskInstanceWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3566>)
+### func \(\*ClientWithResponses\) [GetTaskInstanceWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5169>)
 
 ```go
 func (c *ClientWithResponses) GetTaskInstanceWithResponse(ctx context.Context, dagId DagID, dagRunId DagRunID, taskId TaskID, reqEditors ...RequestEditorFn) (*GetTaskInstanceResponse, error)
@@ -1481,7 +2103,7 @@ Returns a wrapper object for the known response body format\(s\).
 Corresponds with GET /api/v2/dags/\{dag\_id\}/dagRuns/\{dag\_run\_id\}/taskInstances/\{task\_id\} \(the \`GetTaskInstance\` operationId\).
 
 <a name="ClientWithResponses.GetTaskLogsWithResponse"></a>
-### func \(\*ClientWithResponses\) [GetTaskLogsWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3579>)
+### func \(\*ClientWithResponses\) [GetTaskLogsWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5182>)
 
 ```go
 func (c *ClientWithResponses) GetTaskLogsWithResponse(ctx context.Context, dagId DagID, dagRunId DagRunID, taskId TaskID, tryNumber int, reqEditors ...RequestEditorFn) (*GetTaskLogsResponse, error)
@@ -1493,8 +2115,21 @@ Returns a wrapper object for the known response body format\(s\).
 
 Corresponds with GET /api/v2/dags/\{dag\_id\}/dagRuns/\{dag\_run\_id\}/taskInstances/\{task\_id\}/logs/\{try\_number\} \(the \`GetTaskLogs\` operationId\).
 
+<a name="ClientWithResponses.GetVariableWithResponse"></a>
+### func \(\*ClientWithResponses\) [GetVariableWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5372>)
+
+```go
+func (c *ClientWithResponses) GetVariableWithResponse(ctx context.Context, variableKey VariableKey, reqEditors ...RequestEditorFn) (*GetVariableResponse, error)
+```
+
+GetVariableWithResponse Get a variable
+
+Returns a wrapper object for the known response body format\(s\).
+
+Corresponds with GET /api/v2/variables/\{variable\_key\} \(the \`GetVariable\` operationId\).
+
 <a name="ClientWithResponses.GetVersionWithResponse"></a>
-### func \(\*ClientWithResponses\) [GetVersionWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3708>)
+### func \(\*ClientWithResponses\) [GetVersionWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5385>)
 
 ```go
 func (c *ClientWithResponses) GetVersionWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetVersionResponse, error)
@@ -1507,7 +2142,7 @@ Returns a wrapper object for the known response body format\(s\).
 Corresponds with GET /api/v2/version \(the \`GetVersion\` operationId\).
 
 <a name="ClientWithResponses.GetXcomEntryWithResponse"></a>
-### func \(\*ClientWithResponses\) [GetXcomEntryWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3721>)
+### func \(\*ClientWithResponses\) [GetXcomEntryWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5398>)
 
 ```go
 func (c *ClientWithResponses) GetXcomEntryWithResponse(ctx context.Context, dagId DagID, dagRunId DagRunID, taskId TaskID, key string, reqEditors ...RequestEditorFn) (*GetXcomEntryResponse, error)
@@ -1520,7 +2155,7 @@ Returns a wrapper object for the known response body format\(s\).
 Corresponds with GET /api/v2/xcoms/\{dag\_id\}/\{dag\_run\_id\}/\{task\_id\}/\{key\} \(the \`GetXcomEntry\` operationId\).
 
 <a name="ClientWithResponses.IssueTokenWithBodyWithResponse"></a>
-### func \(\*ClientWithResponses\) [IssueTokenWithBodyWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3734>)
+### func \(\*ClientWithResponses\) [IssueTokenWithBodyWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5411>)
 
 ```go
 func (c *ClientWithResponses) IssueTokenWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*IssueTokenResponse, error)
@@ -1533,7 +2168,7 @@ Takes any type of body and a specified content type, and returns a wrapper objec
 Corresponds with POST /auth/token \(the \`IssueToken\` operationId\).
 
 <a name="ClientWithResponses.IssueTokenWithResponse"></a>
-### func \(\*ClientWithResponses\) [IssueTokenWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3747>)
+### func \(\*ClientWithResponses\) [IssueTokenWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5424>)
 
 ```go
 func (c *ClientWithResponses) IssueTokenWithResponse(ctx context.Context, body IssueTokenJSONRequestBody, reqEditors ...RequestEditorFn) (*IssueTokenResponse, error)
@@ -1545,8 +2180,23 @@ Takes a body of the \`application/json\` content type, and returns a wrapper obj
 
 Corresponds with POST /auth/token \(the \`IssueToken\` operationId\).
 
+<a name="ClientWithResponses.ListConnectionsWithResponse"></a>
+### func \(\*ClientWithResponses\) [ListConnectionsWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4914>)
+
+```go
+func (c *ClientWithResponses) ListConnectionsWithResponse(ctx context.Context, params *ListConnectionsParams, reqEditors ...RequestEditorFn) (*ListConnectionsResponse, error)
+```
+
+ListConnectionsWithResponse List connections
+
+Lists the tenant's Airflow\-style connections. Passwords are write\-only and never returned; secret\-bearing keys inside \`extra\` are masked server\-side. Requires the read:connection permission.
+
+Returns a wrapper object for the known response body format\(s\).
+
+Corresponds with GET /api/v2/connections \(the \`ListConnections\` operationId\).
+
 <a name="ClientWithResponses.ListDagRunsWithResponse"></a>
-### func \(\*ClientWithResponses\) [ListDagRunsWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3501>)
+### func \(\*ClientWithResponses\) [ListDagRunsWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5104>)
 
 ```go
 func (c *ClientWithResponses) ListDagRunsWithResponse(ctx context.Context, dagId DagID, params *ListDagRunsParams, reqEditors ...RequestEditorFn) (*ListDagRunsResponse, error)
@@ -1559,7 +2209,7 @@ Returns a wrapper object for the known response body format\(s\).
 Corresponds with GET /api/v2/dags/\{dag\_id\}/dagRuns \(the \`ListDagRuns\` operationId\).
 
 <a name="ClientWithResponses.ListDagVersionsWithResponse"></a>
-### func \(\*ClientWithResponses\) [ListDagVersionsWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3592>)
+### func \(\*ClientWithResponses\) [ListDagVersionsWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5195>)
 
 ```go
 func (c *ClientWithResponses) ListDagVersionsWithResponse(ctx context.Context, dagId DagID, reqEditors ...RequestEditorFn) (*ListDagVersionsResponse, error)
@@ -1572,7 +2222,7 @@ Returns a wrapper object for the known response body format\(s\).
 Corresponds with GET /api/v2/dags/\{dag\_id\}/dagVersions \(the \`ListDagVersions\` operationId\).
 
 <a name="ClientWithResponses.ListDagsWithResponse"></a>
-### func \(\*ClientWithResponses\) [ListDagsWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3423>)
+### func \(\*ClientWithResponses\) [ListDagsWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5026>)
 
 ```go
 func (c *ClientWithResponses) ListDagsWithResponse(ctx context.Context, params *ListDagsParams, reqEditors ...RequestEditorFn) (*ListDagsResponse, error)
@@ -1585,7 +2235,7 @@ Returns a wrapper object for the known response body format\(s\).
 Corresponds with GET /api/v2/dags \(the \`ListDags\` operationId\).
 
 <a name="ClientWithResponses.ListTaskInstancesWithResponse"></a>
-### func \(\*ClientWithResponses\) [ListTaskInstancesWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3553>)
+### func \(\*ClientWithResponses\) [ListTaskInstancesWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5156>)
 
 ```go
 func (c *ClientWithResponses) ListTaskInstancesWithResponse(ctx context.Context, dagId DagID, dagRunId DagRunID, reqEditors ...RequestEditorFn) (*ListTaskInstancesResponse, error)
@@ -1598,7 +2248,7 @@ Returns a wrapper object for the known response body format\(s\).
 Corresponds with GET /api/v2/dags/\{dag\_id\}/dagRuns/\{dag\_run\_id\}/taskInstances \(the \`ListTaskInstances\` operationId\).
 
 <a name="ClientWithResponses.ListUsersWithResponse"></a>
-### func \(\*ClientWithResponses\) [ListUsersWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3661>)
+### func \(\*ClientWithResponses\) [ListUsersWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5264>)
 
 ```go
 func (c *ClientWithResponses) ListUsersWithResponse(ctx context.Context, params *ListUsersParams, reqEditors ...RequestEditorFn) (*ListUsersResponse, error)
@@ -1612,8 +2262,38 @@ Returns a wrapper object for the known response body format\(s\).
 
 Corresponds with GET /api/v2/users \(the \`ListUsers\` operationId\).
 
+<a name="ClientWithResponses.ListVariablesWithResponse"></a>
+### func \(\*ClientWithResponses\) [ListVariablesWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5314>)
+
+```go
+func (c *ClientWithResponses) ListVariablesWithResponse(ctx context.Context, params *ListVariablesParams, reqEditors ...RequestEditorFn) (*ListVariablesResponse, error)
+```
+
+ListVariablesWithResponse List variables
+
+Lists the tenant's Airflow\-style variables. Values of secret\-ish keys are masked server\-side. Requires the read:variable permission.
+
+Returns a wrapper object for the known response body format\(s\).
+
+Corresponds with GET /api/v2/variables \(the \`ListVariables\` operationId\).
+
+<a name="ClientWithResponses.RenewTokenWithResponse"></a>
+### func \(\*ClientWithResponses\) [RenewTokenWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4897>)
+
+```go
+func (c *ClientWithResponses) RenewTokenWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*RenewTokenResponse, error)
+```
+
+RenewTokenWithResponse Renew a still\-valid JWT into a fresh short\-lived token
+
+Transparent renewal: given a still\-valid user bearer, re\-mints the same identity with a fresh short TTL, bounded by a server\-side max\_lifetime measured from first login. Lets a long CLI/dev session avoid re\-logging in every token TTL while keeping the access token short\-lived. Returns 401 when the presented token is invalid, expired, or past max\_lifetime, in which case the client must log in again.
+
+Returns a wrapper object for the known response body format\(s\).
+
+Corresponds with POST /api/v2/auth/token/renew \(the \`RenewToken\` operationId\).
+
 <a name="ClientWithResponses.TriggerDagRunWithBodyWithResponse"></a>
-### func \(\*ClientWithResponses\) [TriggerDagRunWithBodyWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3514>)
+### func \(\*ClientWithResponses\) [TriggerDagRunWithBodyWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5117>)
 
 ```go
 func (c *ClientWithResponses) TriggerDagRunWithBodyWithResponse(ctx context.Context, dagId DagID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*TriggerDagRunResponse, error)
@@ -1626,7 +2306,7 @@ Takes any type of body and a specified content type, and returns a wrapper objec
 Corresponds with POST /api/v2/dags/\{dag\_id\}/dagRuns \(the \`TriggerDagRun\` operationId\).
 
 <a name="ClientWithResponses.TriggerDagRunWithResponse"></a>
-### func \(\*ClientWithResponses\) [TriggerDagRunWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3527>)
+### func \(\*ClientWithResponses\) [TriggerDagRunWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5130>)
 
 ```go
 func (c *ClientWithResponses) TriggerDagRunWithResponse(ctx context.Context, dagId DagID, body TriggerDagRunJSONRequestBody, reqEditors ...RequestEditorFn) (*TriggerDagRunResponse, error)
@@ -1638,8 +2318,34 @@ Takes a body of the \`application/json\` content type, and returns a wrapper obj
 
 Corresponds with POST /api/v2/dags/\{dag\_id\}/dagRuns \(the \`TriggerDagRun\` operationId\).
 
+<a name="ClientWithResponses.UpdateConnectionWithBodyWithResponse"></a>
+### func \(\*ClientWithResponses\) [UpdateConnectionWithBodyWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4987>)
+
+```go
+func (c *ClientWithResponses) UpdateConnectionWithBodyWithResponse(ctx context.Context, connectionId ConnectionID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateConnectionResponse, error)
+```
+
+UpdateConnectionWithBodyWithResponse Update a connection
+
+Takes any type of body and a specified content type, and returns a wrapper object for the known response body format\(s\).
+
+Corresponds with PATCH /api/v2/connections/\{connection\_id\} \(the \`UpdateConnection\` operationId\).
+
+<a name="ClientWithResponses.UpdateConnectionWithResponse"></a>
+### func \(\*ClientWithResponses\) [UpdateConnectionWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5000>)
+
+```go
+func (c *ClientWithResponses) UpdateConnectionWithResponse(ctx context.Context, connectionId ConnectionID, body UpdateConnectionJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateConnectionResponse, error)
+```
+
+UpdateConnectionWithResponse Update a connection
+
+Takes a body of the \`application/json\` content type, and returns a wrapper object for the known response body format\(s\).
+
+Corresponds with PATCH /api/v2/connections/\{connection\_id\} \(the \`UpdateConnection\` operationId\).
+
 <a name="ClientWithResponses.UpdateDagWithBodyWithResponse"></a>
-### func \(\*ClientWithResponses\) [UpdateDagWithBodyWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3449>)
+### func \(\*ClientWithResponses\) [UpdateDagWithBodyWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5052>)
 
 ```go
 func (c *ClientWithResponses) UpdateDagWithBodyWithResponse(ctx context.Context, dagId DagID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateDagResponse, error)
@@ -1652,7 +2358,7 @@ Takes any type of body and a specified content type, and returns a wrapper objec
 Corresponds with PATCH /api/v2/dags/\{dag\_id\} \(the \`UpdateDag\` operationId\).
 
 <a name="ClientWithResponses.UpdateDagWithResponse"></a>
-### func \(\*ClientWithResponses\) [UpdateDagWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3462>)
+### func \(\*ClientWithResponses\) [UpdateDagWithResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5065>)
 
 ```go
 func (c *ClientWithResponses) UpdateDagWithResponse(ctx context.Context, dagId DagID, body UpdateDagJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateDagResponse, error)
@@ -1665,12 +2371,82 @@ Takes a body of the \`application/json\` content type, and returns a wrapper obj
 Corresponds with PATCH /api/v2/dags/\{dag\_id\} \(the \`UpdateDag\` operationId\).
 
 <a name="ClientWithResponsesInterface"></a>
-## type [ClientWithResponsesInterface](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2195-L2404>)
+## type [ClientWithResponsesInterface](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3030-L3353>)
 
 ClientWithResponsesInterface is the interface specification for the client with responses above.
 
 ```go
 type ClientWithResponsesInterface interface {
+
+    // RenewTokenWithResponse Renew a still-valid JWT into a fresh short-lived token
+    //
+    // Transparent renewal: given a still-valid user bearer, re-mints the same identity with a fresh short TTL, bounded by a server-side max_lifetime measured from first login. Lets a long CLI/dev session avoid re-logging in every token TTL while keeping the access token short-lived. Returns 401 when the presented token is invalid, expired, or past max_lifetime, in which case the client must log in again.
+    //
+    // Returns a wrapper object for the known response body format(s).
+    //
+    // Corresponds with POST /api/v2/auth/token/renew (the `RenewToken` operationId).
+    RenewTokenWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*RenewTokenResponse, error)
+
+    // ListConnectionsWithResponse List connections
+    //
+    // Lists the tenant's Airflow-style connections. Passwords are write-only and
+    // never returned; secret-bearing keys inside `extra` are masked server-side.
+    // Requires the read:connection permission.
+    //
+    // Returns a wrapper object for the known response body format(s).
+    //
+    // Corresponds with GET /api/v2/connections (the `ListConnections` operationId).
+    ListConnectionsWithResponse(ctx context.Context, params *ListConnectionsParams, reqEditors ...RequestEditorFn) (*ListConnectionsResponse, error)
+
+    // CreateConnectionWithBodyWithResponse Create or replace a connection (upsert)
+    //
+    // Upserts a connection: creates it, or replaces an existing one with the same
+    // connection_id. The password is write-only and never returned. Requires the
+    // write:connection permission and a configured encryption key.
+    //
+    // Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
+    //
+    // Corresponds with POST /api/v2/connections (the `CreateConnection` operationId).
+    CreateConnectionWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateConnectionResponse, error)
+
+    // CreateConnectionWithResponse Create or replace a connection (upsert)
+    //
+    // Upserts a connection: creates it, or replaces an existing one with the same
+    // connection_id. The password is write-only and never returned. Requires the
+    // write:connection permission and a configured encryption key.
+    //
+    // Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+    //
+    // Corresponds with POST /api/v2/connections (the `CreateConnection` operationId).
+    CreateConnectionWithResponse(ctx context.Context, body CreateConnectionJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateConnectionResponse, error)
+
+    // DeleteConnectionWithResponse Delete a connection
+    //
+    // Returns a wrapper object for the known response body format(s).
+    //
+    // Corresponds with DELETE /api/v2/connections/{connection_id} (the `DeleteConnection` operationId).
+    DeleteConnectionWithResponse(ctx context.Context, connectionId ConnectionID, reqEditors ...RequestEditorFn) (*DeleteConnectionResponse, error)
+
+    // GetConnectionWithResponse Get a connection
+    //
+    // Returns a wrapper object for the known response body format(s).
+    //
+    // Corresponds with GET /api/v2/connections/{connection_id} (the `GetConnection` operationId).
+    GetConnectionWithResponse(ctx context.Context, connectionId ConnectionID, reqEditors ...RequestEditorFn) (*GetConnectionResponse, error)
+
+    // UpdateConnectionWithBodyWithResponse Update a connection
+    //
+    // Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
+    //
+    // Corresponds with PATCH /api/v2/connections/{connection_id} (the `UpdateConnection` operationId).
+    UpdateConnectionWithBodyWithResponse(ctx context.Context, connectionId ConnectionID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateConnectionResponse, error)
+
+    // UpdateConnectionWithResponse Update a connection
+    //
+    // Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+    //
+    // Corresponds with PATCH /api/v2/connections/{connection_id} (the `UpdateConnection` operationId).
+    UpdateConnectionWithResponse(ctx context.Context, connectionId ConnectionID, body UpdateConnectionJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateConnectionResponse, error)
 
     // GetDagSourceWithResponse Get a DAG's source (the dag.py text)
     //
@@ -1838,6 +2614,50 @@ type ClientWithResponsesInterface interface {
     // Corresponds with POST /api/v2/users (the `CreateUser` operationId).
     CreateUserWithResponse(ctx context.Context, body CreateUserJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateUserResponse, error)
 
+    // ListVariablesWithResponse List variables
+    //
+    // Lists the tenant's Airflow-style variables. Values of secret-ish keys are
+    // masked server-side. Requires the read:variable permission.
+    //
+    // Returns a wrapper object for the known response body format(s).
+    //
+    // Corresponds with GET /api/v2/variables (the `ListVariables` operationId).
+    ListVariablesWithResponse(ctx context.Context, params *ListVariablesParams, reqEditors ...RequestEditorFn) (*ListVariablesResponse, error)
+
+    // CreateVariableWithBodyWithResponse Create or replace a variable (upsert)
+    //
+    // Upserts a variable: creates it, or replaces an existing one with the same
+    // key. Requires the write:variable permission.
+    //
+    // Takes any type of body and a specified content type, and returns a wrapper object for the known response body format(s).
+    //
+    // Corresponds with POST /api/v2/variables (the `CreateVariable` operationId).
+    CreateVariableWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateVariableResponse, error)
+
+    // CreateVariableWithResponse Create or replace a variable (upsert)
+    //
+    // Upserts a variable: creates it, or replaces an existing one with the same
+    // key. Requires the write:variable permission.
+    //
+    // Takes a body of the `application/json` content type, and returns a wrapper object for the known response body format(s).
+    //
+    // Corresponds with POST /api/v2/variables (the `CreateVariable` operationId).
+    CreateVariableWithResponse(ctx context.Context, body CreateVariableJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateVariableResponse, error)
+
+    // DeleteVariableWithResponse Delete a variable
+    //
+    // Returns a wrapper object for the known response body format(s).
+    //
+    // Corresponds with DELETE /api/v2/variables/{variable_key} (the `DeleteVariable` operationId).
+    DeleteVariableWithResponse(ctx context.Context, variableKey VariableKey, reqEditors ...RequestEditorFn) (*DeleteVariableResponse, error)
+
+    // GetVariableWithResponse Get a variable
+    //
+    // Returns a wrapper object for the known response body format(s).
+    //
+    // Corresponds with GET /api/v2/variables/{variable_key} (the `GetVariable` operationId).
+    GetVariableWithResponse(ctx context.Context, variableKey VariableKey, reqEditors ...RequestEditorFn) (*GetVariableResponse, error)
+
     // GetVersionWithResponse Control-plane version (Airflow VersionInfo shape)
     //
     // Returns a wrapper object for the known response body format(s).
@@ -1896,8 +2716,176 @@ type ComponentHealth struct {
 }
 ```
 
+<a name="Connection"></a>
+## type [Connection](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L149-L158>)
+
+Connection An Airflow\-style connection. The password is write\-only and never returned; secret\-bearing keys inside \`extra\` are masked server\-side.
+
+```go
+type Connection struct {
+    ConnType     string  `json:"conn_type"`
+    ConnectionId string  `json:"connection_id"`
+    Description  *string `json:"description,omitempty"`
+    Extra        *string `json:"extra,omitempty"`
+    Host         *string `json:"host,omitempty"`
+    Login        *string `json:"login,omitempty"`
+    Port         *int    `json:"port,omitempty"`
+    Schema       *string `json:"schema,omitempty"`
+}
+```
+
+<a name="ConnectionBody"></a>
+## type [ConnectionBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L161-L171>)
+
+ConnectionBody Connection create/replace payload. connection\_id is required on POST \(taken from the path on PATCH\). password and extra are write\-only. Every optional field is tri\-state: omit the key to preserve the stored value \(a partial write never wipes a field it does not mention, so the unreadable password survives a \`\-\-host\`\-only edit\), send an empty string to clear the field, or send a value to set it. A password equal to the mask \`\*\*\*\`, and any key inside \`extra\` whose value is exactly \`\*\*\*\`, is treated as "unchanged" — so re\-submitting a connection read back from GET \(whose secrets are masked\) never overwrites the real secret with the mask.
+
+```go
+type ConnectionBody struct {
+    ConnType     string  `json:"conn_type"`
+    ConnectionId *string `json:"connection_id,omitempty"`
+    Description  *string `json:"description,omitempty"`
+    Extra        *string `json:"extra,omitempty"`
+    Host         *string `json:"host,omitempty"`
+    Login        *string `json:"login,omitempty"`
+    Password     *string `json:"password,omitempty"`
+    Port         *int    `json:"port,omitempty"`
+    Schema       *string `json:"schema,omitempty"`
+}
+```
+
+<a name="ConnectionCollection"></a>
+## type [ConnectionCollection](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L174-L177>)
+
+ConnectionCollection defines model for ConnectionCollection.
+
+```go
+type ConnectionCollection struct {
+    Connections  *[]Connection `json:"connections,omitempty"`
+    TotalEntries *int          `json:"total_entries,omitempty"`
+}
+```
+
+<a name="ConnectionID"></a>
+## type [ConnectionID](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L421>)
+
+ConnectionID defines model for ConnectionID.
+
+```go
+type ConnectionID = string
+```
+
+<a name="CreateConnectionJSONRequestBody"></a>
+## type [CreateConnectionJSONRequestBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L488>)
+
+CreateConnectionJSONRequestBody defines body for CreateConnection for application/json ContentType.
+
+```go
+type CreateConnectionJSONRequestBody = ConnectionBody
+```
+
+<a name="CreateConnectionResponse"></a>
+## type [CreateConnectionResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3451-L3462>)
+
+
+
+```go
+type CreateConnectionResponse struct {
+    Body         []byte
+    HTTPResponse *http.Response
+    // JSON201 the response for an HTTP 201 `application/json` response
+    JSON201 *Connection
+    // JSON400 the response for an HTTP 400 `application/json` response
+    JSON400 *Error
+    // JSON401 the response for an HTTP 401 `application/json` response
+    JSON401 *Unauthorized
+    // JSON503 the response for an HTTP 503 `application/json` response
+    JSON503 *EncryptionUnavailable
+}
+```
+
+<a name="ParseCreateConnectionResponse"></a>
+### func [ParseCreateConnectionResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5525>)
+
+```go
+func ParseCreateConnectionResponse(rsp *http.Response) (*CreateConnectionResponse, error)
+```
+
+ParseCreateConnectionResponse parses an HTTP response from a CreateConnectionWithResponse call
+
+<a name="CreateConnectionResponse.ContentType"></a>
+### func \(CreateConnectionResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3506>)
+
+```go
+func (r CreateConnectionResponse) ContentType() string
+```
+
+ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
+
+<a name="CreateConnectionResponse.GetBody"></a>
+### func \(CreateConnectionResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3485>)
+
+```go
+func (r CreateConnectionResponse) GetBody() []byte
+```
+
+GetBody returns the raw response body bytes
+
+<a name="CreateConnectionResponse.GetJSON201"></a>
+### func \(CreateConnectionResponse\) [GetJSON201](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3465>)
+
+```go
+func (r CreateConnectionResponse) GetJSON201() *Connection
+```
+
+GetJSON201 returns the response for an HTTP 201 \`application/json\` response
+
+<a name="CreateConnectionResponse.GetJSON400"></a>
+### func \(CreateConnectionResponse\) [GetJSON400](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3470>)
+
+```go
+func (r CreateConnectionResponse) GetJSON400() *Error
+```
+
+GetJSON400 returns the response for an HTTP 400 \`application/json\` response
+
+<a name="CreateConnectionResponse.GetJSON401"></a>
+### func \(CreateConnectionResponse\) [GetJSON401](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3475>)
+
+```go
+func (r CreateConnectionResponse) GetJSON401() *Unauthorized
+```
+
+GetJSON401 returns the response for an HTTP 401 \`application/json\` response
+
+<a name="CreateConnectionResponse.GetJSON503"></a>
+### func \(CreateConnectionResponse\) [GetJSON503](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3480>)
+
+```go
+func (r CreateConnectionResponse) GetJSON503() *EncryptionUnavailable
+```
+
+GetJSON503 returns the response for an HTTP 503 \`application/json\` response
+
+<a name="CreateConnectionResponse.Status"></a>
+### func \(CreateConnectionResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3490>)
+
+```go
+func (r CreateConnectionResponse) Status() string
+```
+
+Status returns HTTPResponse.Status
+
+<a name="CreateConnectionResponse.StatusCode"></a>
+### func \(CreateConnectionResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3498>)
+
+```go
+func (r CreateConnectionResponse) StatusCode() int
+```
+
+StatusCode returns HTTPResponse.StatusCode
+
 <a name="CreateUserJSONRequestBody"></a>
-## type [CreateUserJSONRequestBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L423>)
+## type [CreateUserJSONRequestBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L503>)
 
 CreateUserJSONRequestBody defines body for CreateUser for application/json ContentType.
 
@@ -1906,7 +2894,7 @@ type CreateUserJSONRequestBody = CreateUserRequest
 ```
 
 <a name="CreateUserRequest"></a>
-## type [CreateUserRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L149-L158>)
+## type [CreateUserRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L180-L189>)
 
 CreateUserRequest defines model for CreateUserRequest.
 
@@ -1924,7 +2912,7 @@ type CreateUserRequest struct {
 ```
 
 <a name="CreateUserResponse"></a>
-## type [CreateUserResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3138-L3149>)
+## type [CreateUserResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4417-L4428>)
 
 
 
@@ -1944,7 +2932,7 @@ type CreateUserResponse struct {
 ```
 
 <a name="ParseCreateUserResponse"></a>
-### func [ParseCreateUserResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4256>)
+### func [ParseCreateUserResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L6176>)
 
 ```go
 func ParseCreateUserResponse(rsp *http.Response) (*CreateUserResponse, error)
@@ -1953,7 +2941,7 @@ func ParseCreateUserResponse(rsp *http.Response) (*CreateUserResponse, error)
 ParseCreateUserResponse parses an HTTP response from a CreateUserWithResponse call
 
 <a name="CreateUserResponse.ContentType"></a>
-### func \(CreateUserResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3193>)
+### func \(CreateUserResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4472>)
 
 ```go
 func (r CreateUserResponse) ContentType() string
@@ -1962,7 +2950,7 @@ func (r CreateUserResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="CreateUserResponse.GetBody"></a>
-### func \(CreateUserResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3172>)
+### func \(CreateUserResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4451>)
 
 ```go
 func (r CreateUserResponse) GetBody() []byte
@@ -1971,7 +2959,7 @@ func (r CreateUserResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="CreateUserResponse.GetJSON201"></a>
-### func \(CreateUserResponse\) [GetJSON201](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3152>)
+### func \(CreateUserResponse\) [GetJSON201](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4431>)
 
 ```go
 func (r CreateUserResponse) GetJSON201() *User
@@ -1980,7 +2968,7 @@ func (r CreateUserResponse) GetJSON201() *User
 GetJSON201 returns the response for an HTTP 201 \`application/json\` response
 
 <a name="CreateUserResponse.GetJSON400"></a>
-### func \(CreateUserResponse\) [GetJSON400](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3157>)
+### func \(CreateUserResponse\) [GetJSON400](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4436>)
 
 ```go
 func (r CreateUserResponse) GetJSON400() *Error
@@ -1989,7 +2977,7 @@ func (r CreateUserResponse) GetJSON400() *Error
 GetJSON400 returns the response for an HTTP 400 \`application/json\` response
 
 <a name="CreateUserResponse.GetJSON401"></a>
-### func \(CreateUserResponse\) [GetJSON401](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3162>)
+### func \(CreateUserResponse\) [GetJSON401](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4441>)
 
 ```go
 func (r CreateUserResponse) GetJSON401() *Unauthorized
@@ -1998,7 +2986,7 @@ func (r CreateUserResponse) GetJSON401() *Unauthorized
 GetJSON401 returns the response for an HTTP 401 \`application/json\` response
 
 <a name="CreateUserResponse.GetJSON409"></a>
-### func \(CreateUserResponse\) [GetJSON409](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3167>)
+### func \(CreateUserResponse\) [GetJSON409](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4446>)
 
 ```go
 func (r CreateUserResponse) GetJSON409() *Error
@@ -2007,7 +2995,7 @@ func (r CreateUserResponse) GetJSON409() *Error
 GetJSON409 returns the response for an HTTP 409 \`application/json\` response
 
 <a name="CreateUserResponse.Status"></a>
-### func \(CreateUserResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3177>)
+### func \(CreateUserResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4456>)
 
 ```go
 func (r CreateUserResponse) Status() string
@@ -2016,7 +3004,7 @@ func (r CreateUserResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="CreateUserResponse.StatusCode"></a>
-### func \(CreateUserResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3185>)
+### func \(CreateUserResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4464>)
 
 ```go
 func (r CreateUserResponse) StatusCode() int
@@ -2024,8 +3012,107 @@ func (r CreateUserResponse) StatusCode() int
 
 StatusCode returns HTTPResponse.StatusCode
 
+<a name="CreateVariableJSONRequestBody"></a>
+## type [CreateVariableJSONRequestBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L506>)
+
+CreateVariableJSONRequestBody defines body for CreateVariable for application/json ContentType.
+
+```go
+type CreateVariableJSONRequestBody = VariableBody
+```
+
+<a name="CreateVariableResponse"></a>
+## type [CreateVariableResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4527-L4536>)
+
+
+
+```go
+type CreateVariableResponse struct {
+    Body         []byte
+    HTTPResponse *http.Response
+    // JSON201 the response for an HTTP 201 `application/json` response
+    JSON201 *Variable
+    // JSON400 the response for an HTTP 400 `application/json` response
+    JSON400 *Error
+    // JSON401 the response for an HTTP 401 `application/json` response
+    JSON401 *Unauthorized
+}
+```
+
+<a name="ParseCreateVariableResponse"></a>
+### func [ParseCreateVariableResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L6256>)
+
+```go
+func ParseCreateVariableResponse(rsp *http.Response) (*CreateVariableResponse, error)
+```
+
+ParseCreateVariableResponse parses an HTTP response from a CreateVariableWithResponse call
+
+<a name="CreateVariableResponse.ContentType"></a>
+### func \(CreateVariableResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4575>)
+
+```go
+func (r CreateVariableResponse) ContentType() string
+```
+
+ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
+
+<a name="CreateVariableResponse.GetBody"></a>
+### func \(CreateVariableResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4554>)
+
+```go
+func (r CreateVariableResponse) GetBody() []byte
+```
+
+GetBody returns the raw response body bytes
+
+<a name="CreateVariableResponse.GetJSON201"></a>
+### func \(CreateVariableResponse\) [GetJSON201](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4539>)
+
+```go
+func (r CreateVariableResponse) GetJSON201() *Variable
+```
+
+GetJSON201 returns the response for an HTTP 201 \`application/json\` response
+
+<a name="CreateVariableResponse.GetJSON400"></a>
+### func \(CreateVariableResponse\) [GetJSON400](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4544>)
+
+```go
+func (r CreateVariableResponse) GetJSON400() *Error
+```
+
+GetJSON400 returns the response for an HTTP 400 \`application/json\` response
+
+<a name="CreateVariableResponse.GetJSON401"></a>
+### func \(CreateVariableResponse\) [GetJSON401](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4549>)
+
+```go
+func (r CreateVariableResponse) GetJSON401() *Unauthorized
+```
+
+GetJSON401 returns the response for an HTTP 401 \`application/json\` response
+
+<a name="CreateVariableResponse.Status"></a>
+### func \(CreateVariableResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4559>)
+
+```go
+func (r CreateVariableResponse) Status() string
+```
+
+Status returns HTTPResponse.Status
+
+<a name="CreateVariableResponse.StatusCode"></a>
+### func \(CreateVariableResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4567>)
+
+```go
+func (r CreateVariableResponse) StatusCode() int
+```
+
+StatusCode returns HTTPResponse.StatusCode
+
 <a name="DAG"></a>
-## type [DAG](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L161-L178>)
+## type [DAG](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L192-L209>)
 
 DAG defines model for DAG.
 
@@ -2051,7 +3138,7 @@ type DAG struct {
 ```
 
 <a name="DAGCollection"></a>
-## type [DAGCollection](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L181-L184>)
+## type [DAGCollection](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L212-L215>)
 
 DAGCollection defines model for DAGCollection.
 
@@ -2063,7 +3150,7 @@ type DAGCollection struct {
 ```
 
 <a name="DAGRun"></a>
-## type [DAGRun](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L187-L200>)
+## type [DAGRun](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L218-L231>)
 
 DAGRun defines model for DAGRun.
 
@@ -2085,7 +3172,7 @@ type DAGRun struct {
 ```
 
 <a name="DAGRunCollection"></a>
-## type [DAGRunCollection](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L209-L212>)
+## type [DAGRunCollection](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L240-L243>)
 
 DAGRunCollection defines model for DAGRunCollection.
 
@@ -2097,7 +3184,7 @@ type DAGRunCollection struct {
 ```
 
 <a name="DAGRunCreate"></a>
-## type [DAGRunCreate](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L215-L220>)
+## type [DAGRunCreate](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L246-L251>)
 
 DAGRunCreate defines model for DAGRunCreate.
 
@@ -2111,7 +3198,7 @@ type DAGRunCreate struct {
 ```
 
 <a name="DAGRunRunType"></a>
-## type [DAGRunRunType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L203>)
+## type [DAGRunRunType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L234>)
 
 DAGRunRunType defines model for DAGRun.RunType.
 
@@ -2140,7 +3227,7 @@ func (e DAGRunRunType) Valid() bool
 Valid indicates whether the value is a known member of the DAGRunRunType enum.
 
 <a name="DAGRunState"></a>
-## type [DAGRunState](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L206>)
+## type [DAGRunState](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L237>)
 
 DAGRunState defines model for DAGRun.State.
 
@@ -2169,7 +3256,7 @@ func (e DAGRunState) Valid() bool
 Valid indicates whether the value is a known member of the DAGRunState enum.
 
 <a name="DAGUpdate"></a>
-## type [DAGUpdate](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L223-L225>)
+## type [DAGUpdate](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L254-L256>)
 
 DAGUpdate defines model for DAGUpdate.
 
@@ -2180,7 +3267,7 @@ type DAGUpdate struct {
 ```
 
 <a name="DagID"></a>
-## type [DagID](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L368>)
+## type [DagID](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L424>)
 
 DagID defines model for DagID.
 
@@ -2189,7 +3276,7 @@ type DagID = string
 ```
 
 <a name="DagRunID"></a>
-## type [DagRunID](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L371>)
+## type [DagRunID](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L427>)
 
 DagRunID defines model for DagRunID.
 
@@ -2198,7 +3285,7 @@ type DagRunID = string
 ```
 
 <a name="DagSource"></a>
-## type [DagSource](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L228-L234>)
+## type [DagSource](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L259-L265>)
 
 DagSource defines model for DagSource.
 
@@ -2213,7 +3300,7 @@ type DagSource struct {
 ```
 
 <a name="DagVersion"></a>
-## type [DagVersion](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L237-L246>)
+## type [DagVersion](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L268-L277>)
 
 DagVersion defines model for DagVersion.
 
@@ -2231,7 +3318,7 @@ type DagVersion struct {
 ```
 
 <a name="DagVersionCollection"></a>
-## type [DagVersionCollection](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L249-L252>)
+## type [DagVersionCollection](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L280-L283>)
 
 DagVersionCollection defines model for DagVersionCollection.
 
@@ -2242,8 +3329,175 @@ type DagVersionCollection struct {
 }
 ```
 
+<a name="DeleteConnectionResponse"></a>
+## type [DeleteConnectionResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3513-L3520>)
+
+
+
+```go
+type DeleteConnectionResponse struct {
+    Body         []byte
+    HTTPResponse *http.Response
+    // JSON401 the response for an HTTP 401 `application/json` response
+    JSON401 *Unauthorized
+    // JSON404 the response for an HTTP 404 `application/json` response
+    JSON404 *NotFound
+}
+```
+
+<a name="ParseDeleteConnectionResponse"></a>
+### func [ParseDeleteConnectionResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5572>)
+
+```go
+func ParseDeleteConnectionResponse(rsp *http.Response) (*DeleteConnectionResponse, error)
+```
+
+ParseDeleteConnectionResponse parses an HTTP response from a DeleteConnectionWithResponse call
+
+<a name="DeleteConnectionResponse.ContentType"></a>
+### func \(DeleteConnectionResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3554>)
+
+```go
+func (r DeleteConnectionResponse) ContentType() string
+```
+
+ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
+
+<a name="DeleteConnectionResponse.GetBody"></a>
+### func \(DeleteConnectionResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3533>)
+
+```go
+func (r DeleteConnectionResponse) GetBody() []byte
+```
+
+GetBody returns the raw response body bytes
+
+<a name="DeleteConnectionResponse.GetJSON401"></a>
+### func \(DeleteConnectionResponse\) [GetJSON401](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3523>)
+
+```go
+func (r DeleteConnectionResponse) GetJSON401() *Unauthorized
+```
+
+GetJSON401 returns the response for an HTTP 401 \`application/json\` response
+
+<a name="DeleteConnectionResponse.GetJSON404"></a>
+### func \(DeleteConnectionResponse\) [GetJSON404](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3528>)
+
+```go
+func (r DeleteConnectionResponse) GetJSON404() *NotFound
+```
+
+GetJSON404 returns the response for an HTTP 404 \`application/json\` response
+
+<a name="DeleteConnectionResponse.Status"></a>
+### func \(DeleteConnectionResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3538>)
+
+```go
+func (r DeleteConnectionResponse) Status() string
+```
+
+Status returns HTTPResponse.Status
+
+<a name="DeleteConnectionResponse.StatusCode"></a>
+### func \(DeleteConnectionResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3546>)
+
+```go
+func (r DeleteConnectionResponse) StatusCode() int
+```
+
+StatusCode returns HTTPResponse.StatusCode
+
+<a name="DeleteVariableResponse"></a>
+## type [DeleteVariableResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4582-L4589>)
+
+
+
+```go
+type DeleteVariableResponse struct {
+    Body         []byte
+    HTTPResponse *http.Response
+    // JSON401 the response for an HTTP 401 `application/json` response
+    JSON401 *Unauthorized
+    // JSON404 the response for an HTTP 404 `application/json` response
+    JSON404 *NotFound
+}
+```
+
+<a name="ParseDeleteVariableResponse"></a>
+### func [ParseDeleteVariableResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L6296>)
+
+```go
+func ParseDeleteVariableResponse(rsp *http.Response) (*DeleteVariableResponse, error)
+```
+
+ParseDeleteVariableResponse parses an HTTP response from a DeleteVariableWithResponse call
+
+<a name="DeleteVariableResponse.ContentType"></a>
+### func \(DeleteVariableResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4623>)
+
+```go
+func (r DeleteVariableResponse) ContentType() string
+```
+
+ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
+
+<a name="DeleteVariableResponse.GetBody"></a>
+### func \(DeleteVariableResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4602>)
+
+```go
+func (r DeleteVariableResponse) GetBody() []byte
+```
+
+GetBody returns the raw response body bytes
+
+<a name="DeleteVariableResponse.GetJSON401"></a>
+### func \(DeleteVariableResponse\) [GetJSON401](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4592>)
+
+```go
+func (r DeleteVariableResponse) GetJSON401() *Unauthorized
+```
+
+GetJSON401 returns the response for an HTTP 401 \`application/json\` response
+
+<a name="DeleteVariableResponse.GetJSON404"></a>
+### func \(DeleteVariableResponse\) [GetJSON404](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4597>)
+
+```go
+func (r DeleteVariableResponse) GetJSON404() *NotFound
+```
+
+GetJSON404 returns the response for an HTTP 404 \`application/json\` response
+
+<a name="DeleteVariableResponse.Status"></a>
+### func \(DeleteVariableResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4607>)
+
+```go
+func (r DeleteVariableResponse) Status() string
+```
+
+Status returns HTTPResponse.Status
+
+<a name="DeleteVariableResponse.StatusCode"></a>
+### func \(DeleteVariableResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4615>)
+
+```go
+func (r DeleteVariableResponse) StatusCode() int
+```
+
+StatusCode returns HTTPResponse.StatusCode
+
+<a name="EncryptionUnavailable"></a>
+## type [EncryptionUnavailable](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L442>)
+
+EncryptionUnavailable defines model for EncryptionUnavailable.
+
+```go
+type EncryptionUnavailable = Error
+```
+
 <a name="Error"></a>
-## type [Error](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L255-L261>)
+## type [Error](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L286-L292>)
 
 Error defines model for Error.
 
@@ -2258,7 +3512,7 @@ type Error struct {
 ```
 
 <a name="ExecutorInfo"></a>
-## type [ExecutorInfo](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L264-L269>)
+## type [ExecutorInfo](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L295-L300>)
 
 ExecutorInfo defines model for ExecutorInfo.
 
@@ -2271,8 +3525,98 @@ type ExecutorInfo struct {
 }
 ```
 
+<a name="GetConnectionResponse"></a>
+## type [GetConnectionResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3561-L3570>)
+
+
+
+```go
+type GetConnectionResponse struct {
+    Body         []byte
+    HTTPResponse *http.Response
+    // JSON200 the response for an HTTP 200 `application/json` response
+    JSON200 *Connection
+    // JSON401 the response for an HTTP 401 `application/json` response
+    JSON401 *Unauthorized
+    // JSON404 the response for an HTTP 404 `application/json` response
+    JSON404 *NotFound
+}
+```
+
+<a name="ParseGetConnectionResponse"></a>
+### func [ParseGetConnectionResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5608>)
+
+```go
+func ParseGetConnectionResponse(rsp *http.Response) (*GetConnectionResponse, error)
+```
+
+ParseGetConnectionResponse parses an HTTP response from a GetConnectionWithResponse call
+
+<a name="GetConnectionResponse.ContentType"></a>
+### func \(GetConnectionResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3609>)
+
+```go
+func (r GetConnectionResponse) ContentType() string
+```
+
+ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
+
+<a name="GetConnectionResponse.GetBody"></a>
+### func \(GetConnectionResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3588>)
+
+```go
+func (r GetConnectionResponse) GetBody() []byte
+```
+
+GetBody returns the raw response body bytes
+
+<a name="GetConnectionResponse.GetJSON200"></a>
+### func \(GetConnectionResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3573>)
+
+```go
+func (r GetConnectionResponse) GetJSON200() *Connection
+```
+
+GetJSON200 returns the response for an HTTP 200 \`application/json\` response
+
+<a name="GetConnectionResponse.GetJSON401"></a>
+### func \(GetConnectionResponse\) [GetJSON401](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3578>)
+
+```go
+func (r GetConnectionResponse) GetJSON401() *Unauthorized
+```
+
+GetJSON401 returns the response for an HTTP 401 \`application/json\` response
+
+<a name="GetConnectionResponse.GetJSON404"></a>
+### func \(GetConnectionResponse\) [GetJSON404](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3583>)
+
+```go
+func (r GetConnectionResponse) GetJSON404() *NotFound
+```
+
+GetJSON404 returns the response for an HTTP 404 \`application/json\` response
+
+<a name="GetConnectionResponse.Status"></a>
+### func \(GetConnectionResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3593>)
+
+```go
+func (r GetConnectionResponse) Status() string
+```
+
+Status returns HTTPResponse.Status
+
+<a name="GetConnectionResponse.StatusCode"></a>
+### func \(GetConnectionResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3601>)
+
+```go
+func (r GetConnectionResponse) StatusCode() int
+```
+
+StatusCode returns HTTPResponse.StatusCode
+
 <a name="GetDagResponse"></a>
-## type [GetDagResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2495-L2502>)
+## type [GetDagResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3774-L3781>)
 
 
 
@@ -2288,7 +3632,7 @@ type GetDagResponse struct {
 ```
 
 <a name="ParseGetDagResponse"></a>
-### func [ParseGetDagResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3841>)
+### func [ParseGetDagResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5761>)
 
 ```go
 func ParseGetDagResponse(rsp *http.Response) (*GetDagResponse, error)
@@ -2297,7 +3641,7 @@ func ParseGetDagResponse(rsp *http.Response) (*GetDagResponse, error)
 ParseGetDagResponse parses an HTTP response from a GetDagWithResponse call
 
 <a name="GetDagResponse.ContentType"></a>
-### func \(GetDagResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2536>)
+### func \(GetDagResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3815>)
 
 ```go
 func (r GetDagResponse) ContentType() string
@@ -2306,7 +3650,7 @@ func (r GetDagResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="GetDagResponse.GetBody"></a>
-### func \(GetDagResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2515>)
+### func \(GetDagResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3794>)
 
 ```go
 func (r GetDagResponse) GetBody() []byte
@@ -2315,7 +3659,7 @@ func (r GetDagResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="GetDagResponse.GetJSON200"></a>
-### func \(GetDagResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2505>)
+### func \(GetDagResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3784>)
 
 ```go
 func (r GetDagResponse) GetJSON200() *DAG
@@ -2324,7 +3668,7 @@ func (r GetDagResponse) GetJSON200() *DAG
 GetJSON200 returns the response for an HTTP 200 \`application/json\` response
 
 <a name="GetDagResponse.GetJSON404"></a>
-### func \(GetDagResponse\) [GetJSON404](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2510>)
+### func \(GetDagResponse\) [GetJSON404](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3789>)
 
 ```go
 func (r GetDagResponse) GetJSON404() *NotFound
@@ -2333,7 +3677,7 @@ func (r GetDagResponse) GetJSON404() *NotFound
 GetJSON404 returns the response for an HTTP 404 \`application/json\` response
 
 <a name="GetDagResponse.Status"></a>
-### func \(GetDagResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2520>)
+### func \(GetDagResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3799>)
 
 ```go
 func (r GetDagResponse) Status() string
@@ -2342,7 +3686,7 @@ func (r GetDagResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="GetDagResponse.StatusCode"></a>
-### func \(GetDagResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2528>)
+### func \(GetDagResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3807>)
 
 ```go
 func (r GetDagResponse) StatusCode() int
@@ -2351,7 +3695,7 @@ func (r GetDagResponse) StatusCode() int
 StatusCode returns HTTPResponse.StatusCode
 
 <a name="GetDagRunResponse"></a>
-## type [GetDagRunResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2707-L2714>)
+## type [GetDagRunResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3986-L3993>)
 
 
 
@@ -2367,7 +3711,7 @@ type GetDagRunResponse struct {
 ```
 
 <a name="ParseGetDagRunResponse"></a>
-### func [ParseGetDagRunResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3978>)
+### func [ParseGetDagRunResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5898>)
 
 ```go
 func ParseGetDagRunResponse(rsp *http.Response) (*GetDagRunResponse, error)
@@ -2376,7 +3720,7 @@ func ParseGetDagRunResponse(rsp *http.Response) (*GetDagRunResponse, error)
 ParseGetDagRunResponse parses an HTTP response from a GetDagRunWithResponse call
 
 <a name="GetDagRunResponse.ContentType"></a>
-### func \(GetDagRunResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2748>)
+### func \(GetDagRunResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4027>)
 
 ```go
 func (r GetDagRunResponse) ContentType() string
@@ -2385,7 +3729,7 @@ func (r GetDagRunResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="GetDagRunResponse.GetBody"></a>
-### func \(GetDagRunResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2727>)
+### func \(GetDagRunResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4006>)
 
 ```go
 func (r GetDagRunResponse) GetBody() []byte
@@ -2394,7 +3738,7 @@ func (r GetDagRunResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="GetDagRunResponse.GetJSON200"></a>
-### func \(GetDagRunResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2717>)
+### func \(GetDagRunResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3996>)
 
 ```go
 func (r GetDagRunResponse) GetJSON200() *DAGRun
@@ -2403,7 +3747,7 @@ func (r GetDagRunResponse) GetJSON200() *DAGRun
 GetJSON200 returns the response for an HTTP 200 \`application/json\` response
 
 <a name="GetDagRunResponse.GetJSON404"></a>
-### func \(GetDagRunResponse\) [GetJSON404](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2722>)
+### func \(GetDagRunResponse\) [GetJSON404](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4001>)
 
 ```go
 func (r GetDagRunResponse) GetJSON404() *NotFound
@@ -2412,7 +3756,7 @@ func (r GetDagRunResponse) GetJSON404() *NotFound
 GetJSON404 returns the response for an HTTP 404 \`application/json\` response
 
 <a name="GetDagRunResponse.Status"></a>
-### func \(GetDagRunResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2732>)
+### func \(GetDagRunResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4011>)
 
 ```go
 func (r GetDagRunResponse) Status() string
@@ -2421,7 +3765,7 @@ func (r GetDagRunResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="GetDagRunResponse.StatusCode"></a>
-### func \(GetDagRunResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2740>)
+### func \(GetDagRunResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4019>)
 
 ```go
 func (r GetDagRunResponse) StatusCode() int
@@ -2430,7 +3774,7 @@ func (r GetDagRunResponse) StatusCode() int
 StatusCode returns HTTPResponse.StatusCode
 
 <a name="GetDagSourceResponse"></a>
-## type [GetDagSourceResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2406-L2413>)
+## type [GetDagSourceResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3685-L3692>)
 
 
 
@@ -2446,7 +3790,7 @@ type GetDagSourceResponse struct {
 ```
 
 <a name="ParseGetDagSourceResponse"></a>
-### func [ParseGetDagSourceResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3782>)
+### func [ParseGetDagSourceResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5702>)
 
 ```go
 func ParseGetDagSourceResponse(rsp *http.Response) (*GetDagSourceResponse, error)
@@ -2455,7 +3799,7 @@ func ParseGetDagSourceResponse(rsp *http.Response) (*GetDagSourceResponse, error
 ParseGetDagSourceResponse parses an HTTP response from a GetDagSourceWithResponse call
 
 <a name="GetDagSourceResponse.ContentType"></a>
-### func \(GetDagSourceResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2447>)
+### func \(GetDagSourceResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3726>)
 
 ```go
 func (r GetDagSourceResponse) ContentType() string
@@ -2464,7 +3808,7 @@ func (r GetDagSourceResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="GetDagSourceResponse.GetBody"></a>
-### func \(GetDagSourceResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2426>)
+### func \(GetDagSourceResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3705>)
 
 ```go
 func (r GetDagSourceResponse) GetBody() []byte
@@ -2473,7 +3817,7 @@ func (r GetDagSourceResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="GetDagSourceResponse.GetJSON200"></a>
-### func \(GetDagSourceResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2416>)
+### func \(GetDagSourceResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3695>)
 
 ```go
 func (r GetDagSourceResponse) GetJSON200() *DagSource
@@ -2482,7 +3826,7 @@ func (r GetDagSourceResponse) GetJSON200() *DagSource
 GetJSON200 returns the response for an HTTP 200 \`application/json\` response
 
 <a name="GetDagSourceResponse.GetJSON404"></a>
-### func \(GetDagSourceResponse\) [GetJSON404](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2421>)
+### func \(GetDagSourceResponse\) [GetJSON404](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3700>)
 
 ```go
 func (r GetDagSourceResponse) GetJSON404() *NotFound
@@ -2491,7 +3835,7 @@ func (r GetDagSourceResponse) GetJSON404() *NotFound
 GetJSON404 returns the response for an HTTP 404 \`application/json\` response
 
 <a name="GetDagSourceResponse.Status"></a>
-### func \(GetDagSourceResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2431>)
+### func \(GetDagSourceResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3710>)
 
 ```go
 func (r GetDagSourceResponse) Status() string
@@ -2500,7 +3844,7 @@ func (r GetDagSourceResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="GetDagSourceResponse.StatusCode"></a>
-### func \(GetDagSourceResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2439>)
+### func \(GetDagSourceResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3718>)
 
 ```go
 func (r GetDagSourceResponse) StatusCode() int
@@ -2509,7 +3853,7 @@ func (r GetDagSourceResponse) StatusCode() int
 StatusCode returns HTTPResponse.StatusCode
 
 <a name="GetDagSpecResponse"></a>
-## type [GetDagSpecResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2960-L2967>)
+## type [GetDagSpecResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4239-L4246>)
 
 
 
@@ -2525,7 +3869,7 @@ type GetDagSpecResponse struct {
 ```
 
 <a name="ParseGetDagSpecResponse"></a>
-### func [ParseGetDagSpecResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4138>)
+### func [ParseGetDagSpecResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L6058>)
 
 ```go
 func ParseGetDagSpecResponse(rsp *http.Response) (*GetDagSpecResponse, error)
@@ -2534,7 +3878,7 @@ func ParseGetDagSpecResponse(rsp *http.Response) (*GetDagSpecResponse, error)
 ParseGetDagSpecResponse parses an HTTP response from a GetDagSpecWithResponse call
 
 <a name="GetDagSpecResponse.ContentType"></a>
-### func \(GetDagSpecResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3001>)
+### func \(GetDagSpecResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4280>)
 
 ```go
 func (r GetDagSpecResponse) ContentType() string
@@ -2543,7 +3887,7 @@ func (r GetDagSpecResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="GetDagSpecResponse.GetBody"></a>
-### func \(GetDagSpecResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2980>)
+### func \(GetDagSpecResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4259>)
 
 ```go
 func (r GetDagSpecResponse) GetBody() []byte
@@ -2552,7 +3896,7 @@ func (r GetDagSpecResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="GetDagSpecResponse.GetJSON200"></a>
-### func \(GetDagSpecResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2970>)
+### func \(GetDagSpecResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4249>)
 
 ```go
 func (r GetDagSpecResponse) GetJSON200() *map[string]interface{}
@@ -2561,7 +3905,7 @@ func (r GetDagSpecResponse) GetJSON200() *map[string]interface{}
 GetJSON200 returns the response for an HTTP 200 \`application/json\` response
 
 <a name="GetDagSpecResponse.GetJSON404"></a>
-### func \(GetDagSpecResponse\) [GetJSON404](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2975>)
+### func \(GetDagSpecResponse\) [GetJSON404](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4254>)
 
 ```go
 func (r GetDagSpecResponse) GetJSON404() *NotFound
@@ -2570,7 +3914,7 @@ func (r GetDagSpecResponse) GetJSON404() *NotFound
 GetJSON404 returns the response for an HTTP 404 \`application/json\` response
 
 <a name="GetDagSpecResponse.Status"></a>
-### func \(GetDagSpecResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2985>)
+### func \(GetDagSpecResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4264>)
 
 ```go
 func (r GetDagSpecResponse) Status() string
@@ -2579,7 +3923,7 @@ func (r GetDagSpecResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="GetDagSpecResponse.StatusCode"></a>
-### func \(GetDagSpecResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2993>)
+### func \(GetDagSpecResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4272>)
 
 ```go
 func (r GetDagSpecResponse) StatusCode() int
@@ -2588,7 +3932,7 @@ func (r GetDagSpecResponse) StatusCode() int
 StatusCode returns HTTPResponse.StatusCode
 
 <a name="GetDagVersionResponse"></a>
-## type [GetDagVersionResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2912-L2919>)
+## type [GetDagVersionResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4191-L4198>)
 
 
 
@@ -2604,7 +3948,7 @@ type GetDagVersionResponse struct {
 ```
 
 <a name="ParseGetDagVersionResponse"></a>
-### func [ParseGetDagVersionResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4105>)
+### func [ParseGetDagVersionResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L6025>)
 
 ```go
 func ParseGetDagVersionResponse(rsp *http.Response) (*GetDagVersionResponse, error)
@@ -2613,7 +3957,7 @@ func ParseGetDagVersionResponse(rsp *http.Response) (*GetDagVersionResponse, err
 ParseGetDagVersionResponse parses an HTTP response from a GetDagVersionWithResponse call
 
 <a name="GetDagVersionResponse.ContentType"></a>
-### func \(GetDagVersionResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2953>)
+### func \(GetDagVersionResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4232>)
 
 ```go
 func (r GetDagVersionResponse) ContentType() string
@@ -2622,7 +3966,7 @@ func (r GetDagVersionResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="GetDagVersionResponse.GetBody"></a>
-### func \(GetDagVersionResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2932>)
+### func \(GetDagVersionResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4211>)
 
 ```go
 func (r GetDagVersionResponse) GetBody() []byte
@@ -2631,7 +3975,7 @@ func (r GetDagVersionResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="GetDagVersionResponse.GetJSON200"></a>
-### func \(GetDagVersionResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2922>)
+### func \(GetDagVersionResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4201>)
 
 ```go
 func (r GetDagVersionResponse) GetJSON200() *DagVersion
@@ -2640,7 +3984,7 @@ func (r GetDagVersionResponse) GetJSON200() *DagVersion
 GetJSON200 returns the response for an HTTP 200 \`application/json\` response
 
 <a name="GetDagVersionResponse.GetJSON404"></a>
-### func \(GetDagVersionResponse\) [GetJSON404](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2927>)
+### func \(GetDagVersionResponse\) [GetJSON404](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4206>)
 
 ```go
 func (r GetDagVersionResponse) GetJSON404() *NotFound
@@ -2649,7 +3993,7 @@ func (r GetDagVersionResponse) GetJSON404() *NotFound
 GetJSON404 returns the response for an HTTP 404 \`application/json\` response
 
 <a name="GetDagVersionResponse.Status"></a>
-### func \(GetDagVersionResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2937>)
+### func \(GetDagVersionResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4216>)
 
 ```go
 func (r GetDagVersionResponse) Status() string
@@ -2658,7 +4002,7 @@ func (r GetDagVersionResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="GetDagVersionResponse.StatusCode"></a>
-### func \(GetDagVersionResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2945>)
+### func \(GetDagVersionResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4224>)
 
 ```go
 func (r GetDagVersionResponse) StatusCode() int
@@ -2667,7 +4011,7 @@ func (r GetDagVersionResponse) StatusCode() int
 StatusCode returns HTTPResponse.StatusCode
 
 <a name="GetHealthzResponse"></a>
-## type [GetHealthzResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3337-L3340>)
+## type [GetHealthzResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4822-L4825>)
 
 
 
@@ -2679,7 +4023,7 @@ type GetHealthzResponse struct {
 ```
 
 <a name="ParseGetHealthzResponse"></a>
-### func [ParseGetHealthzResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4395>)
+### func [ParseGetHealthzResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L6464>)
 
 ```go
 func ParseGetHealthzResponse(rsp *http.Response) (*GetHealthzResponse, error)
@@ -2688,7 +4032,7 @@ func ParseGetHealthzResponse(rsp *http.Response) (*GetHealthzResponse, error)
 ParseGetHealthzResponse parses an HTTP response from a GetHealthzWithResponse call
 
 <a name="GetHealthzResponse.ContentType"></a>
-### func \(GetHealthzResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3364>)
+### func \(GetHealthzResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4849>)
 
 ```go
 func (r GetHealthzResponse) ContentType() string
@@ -2697,7 +4041,7 @@ func (r GetHealthzResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="GetHealthzResponse.GetBody"></a>
-### func \(GetHealthzResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3343>)
+### func \(GetHealthzResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4828>)
 
 ```go
 func (r GetHealthzResponse) GetBody() []byte
@@ -2706,7 +4050,7 @@ func (r GetHealthzResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="GetHealthzResponse.Status"></a>
-### func \(GetHealthzResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3348>)
+### func \(GetHealthzResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4833>)
 
 ```go
 func (r GetHealthzResponse) Status() string
@@ -2715,7 +4059,7 @@ func (r GetHealthzResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="GetHealthzResponse.StatusCode"></a>
-### func \(GetHealthzResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3356>)
+### func \(GetHealthzResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4841>)
 
 ```go
 func (r GetHealthzResponse) StatusCode() int
@@ -2724,7 +4068,7 @@ func (r GetHealthzResponse) StatusCode() int
 StatusCode returns HTTPResponse.StatusCode
 
 <a name="GetMonitorExecutorResponse"></a>
-## type [GetMonitorExecutorResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3008-L3013>)
+## type [GetMonitorExecutorResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4287-L4292>)
 
 
 
@@ -2738,7 +4082,7 @@ type GetMonitorExecutorResponse struct {
 ```
 
 <a name="ParseGetMonitorExecutorResponse"></a>
-### func [ParseGetMonitorExecutorResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4171>)
+### func [ParseGetMonitorExecutorResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L6091>)
 
 ```go
 func ParseGetMonitorExecutorResponse(rsp *http.Response) (*GetMonitorExecutorResponse, error)
@@ -2747,7 +4091,7 @@ func ParseGetMonitorExecutorResponse(rsp *http.Response) (*GetMonitorExecutorRes
 ParseGetMonitorExecutorResponse parses an HTTP response from a GetMonitorExecutorWithResponse call
 
 <a name="GetMonitorExecutorResponse.ContentType"></a>
-### func \(GetMonitorExecutorResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3042>)
+### func \(GetMonitorExecutorResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4321>)
 
 ```go
 func (r GetMonitorExecutorResponse) ContentType() string
@@ -2756,7 +4100,7 @@ func (r GetMonitorExecutorResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="GetMonitorExecutorResponse.GetBody"></a>
-### func \(GetMonitorExecutorResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3021>)
+### func \(GetMonitorExecutorResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4300>)
 
 ```go
 func (r GetMonitorExecutorResponse) GetBody() []byte
@@ -2765,7 +4109,7 @@ func (r GetMonitorExecutorResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="GetMonitorExecutorResponse.GetJSON200"></a>
-### func \(GetMonitorExecutorResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3016>)
+### func \(GetMonitorExecutorResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4295>)
 
 ```go
 func (r GetMonitorExecutorResponse) GetJSON200() *ExecutorInfo
@@ -2774,7 +4118,7 @@ func (r GetMonitorExecutorResponse) GetJSON200() *ExecutorInfo
 GetJSON200 returns the response for an HTTP 200 \`application/json\` response
 
 <a name="GetMonitorExecutorResponse.Status"></a>
-### func \(GetMonitorExecutorResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3026>)
+### func \(GetMonitorExecutorResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4305>)
 
 ```go
 func (r GetMonitorExecutorResponse) Status() string
@@ -2783,7 +4127,7 @@ func (r GetMonitorExecutorResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="GetMonitorExecutorResponse.StatusCode"></a>
-### func \(GetMonitorExecutorResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3034>)
+### func \(GetMonitorExecutorResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4313>)
 
 ```go
 func (r GetMonitorExecutorResponse) StatusCode() int
@@ -2792,7 +4136,7 @@ func (r GetMonitorExecutorResponse) StatusCode() int
 StatusCode returns HTTPResponse.StatusCode
 
 <a name="GetMonitorHealthResponse"></a>
-## type [GetMonitorHealthResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3049-L3054>)
+## type [GetMonitorHealthResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4328-L4333>)
 
 
 
@@ -2806,7 +4150,7 @@ type GetMonitorHealthResponse struct {
 ```
 
 <a name="ParseGetMonitorHealthResponse"></a>
-### func [ParseGetMonitorHealthResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4197>)
+### func [ParseGetMonitorHealthResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L6117>)
 
 ```go
 func ParseGetMonitorHealthResponse(rsp *http.Response) (*GetMonitorHealthResponse, error)
@@ -2815,7 +4159,7 @@ func ParseGetMonitorHealthResponse(rsp *http.Response) (*GetMonitorHealthRespons
 ParseGetMonitorHealthResponse parses an HTTP response from a GetMonitorHealthWithResponse call
 
 <a name="GetMonitorHealthResponse.ContentType"></a>
-### func \(GetMonitorHealthResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3083>)
+### func \(GetMonitorHealthResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4362>)
 
 ```go
 func (r GetMonitorHealthResponse) ContentType() string
@@ -2824,7 +4168,7 @@ func (r GetMonitorHealthResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="GetMonitorHealthResponse.GetBody"></a>
-### func \(GetMonitorHealthResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3062>)
+### func \(GetMonitorHealthResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4341>)
 
 ```go
 func (r GetMonitorHealthResponse) GetBody() []byte
@@ -2833,7 +4177,7 @@ func (r GetMonitorHealthResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="GetMonitorHealthResponse.GetJSON200"></a>
-### func \(GetMonitorHealthResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3057>)
+### func \(GetMonitorHealthResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4336>)
 
 ```go
 func (r GetMonitorHealthResponse) GetJSON200() *HealthInfo
@@ -2842,7 +4186,7 @@ func (r GetMonitorHealthResponse) GetJSON200() *HealthInfo
 GetJSON200 returns the response for an HTTP 200 \`application/json\` response
 
 <a name="GetMonitorHealthResponse.Status"></a>
-### func \(GetMonitorHealthResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3067>)
+### func \(GetMonitorHealthResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4346>)
 
 ```go
 func (r GetMonitorHealthResponse) Status() string
@@ -2851,7 +4195,7 @@ func (r GetMonitorHealthResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="GetMonitorHealthResponse.StatusCode"></a>
-### func \(GetMonitorHealthResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3075>)
+### func \(GetMonitorHealthResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4354>)
 
 ```go
 func (r GetMonitorHealthResponse) StatusCode() int
@@ -2860,7 +4204,7 @@ func (r GetMonitorHealthResponse) StatusCode() int
 StatusCode returns HTTPResponse.StatusCode
 
 <a name="GetReadyzResponse"></a>
-## type [GetReadyzResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3371-L3374>)
+## type [GetReadyzResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4856-L4859>)
 
 
 
@@ -2872,7 +4216,7 @@ type GetReadyzResponse struct {
 ```
 
 <a name="ParseGetReadyzResponse"></a>
-### func [ParseGetReadyzResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4411>)
+### func [ParseGetReadyzResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L6480>)
 
 ```go
 func ParseGetReadyzResponse(rsp *http.Response) (*GetReadyzResponse, error)
@@ -2881,7 +4225,7 @@ func ParseGetReadyzResponse(rsp *http.Response) (*GetReadyzResponse, error)
 ParseGetReadyzResponse parses an HTTP response from a GetReadyzWithResponse call
 
 <a name="GetReadyzResponse.ContentType"></a>
-### func \(GetReadyzResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3398>)
+### func \(GetReadyzResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4883>)
 
 ```go
 func (r GetReadyzResponse) ContentType() string
@@ -2890,7 +4234,7 @@ func (r GetReadyzResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="GetReadyzResponse.GetBody"></a>
-### func \(GetReadyzResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3377>)
+### func \(GetReadyzResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4862>)
 
 ```go
 func (r GetReadyzResponse) GetBody() []byte
@@ -2899,7 +4243,7 @@ func (r GetReadyzResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="GetReadyzResponse.Status"></a>
-### func \(GetReadyzResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3382>)
+### func \(GetReadyzResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4867>)
 
 ```go
 func (r GetReadyzResponse) Status() string
@@ -2908,7 +4252,7 @@ func (r GetReadyzResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="GetReadyzResponse.StatusCode"></a>
-### func \(GetReadyzResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3390>)
+### func \(GetReadyzResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4875>)
 
 ```go
 func (r GetReadyzResponse) StatusCode() int
@@ -2917,7 +4261,7 @@ func (r GetReadyzResponse) StatusCode() int
 StatusCode returns HTTPResponse.StatusCode
 
 <a name="GetTaskInstanceResponse"></a>
-## type [GetTaskInstanceResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2796-L2801>)
+## type [GetTaskInstanceResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4075-L4080>)
 
 
 
@@ -2931,7 +4275,7 @@ type GetTaskInstanceResponse struct {
 ```
 
 <a name="ParseGetTaskInstanceResponse"></a>
-### func [ParseGetTaskInstanceResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4037>)
+### func [ParseGetTaskInstanceResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5957>)
 
 ```go
 func ParseGetTaskInstanceResponse(rsp *http.Response) (*GetTaskInstanceResponse, error)
@@ -2940,7 +4284,7 @@ func ParseGetTaskInstanceResponse(rsp *http.Response) (*GetTaskInstanceResponse,
 ParseGetTaskInstanceResponse parses an HTTP response from a GetTaskInstanceWithResponse call
 
 <a name="GetTaskInstanceResponse.ContentType"></a>
-### func \(GetTaskInstanceResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2830>)
+### func \(GetTaskInstanceResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4109>)
 
 ```go
 func (r GetTaskInstanceResponse) ContentType() string
@@ -2949,7 +4293,7 @@ func (r GetTaskInstanceResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="GetTaskInstanceResponse.GetBody"></a>
-### func \(GetTaskInstanceResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2809>)
+### func \(GetTaskInstanceResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4088>)
 
 ```go
 func (r GetTaskInstanceResponse) GetBody() []byte
@@ -2958,7 +4302,7 @@ func (r GetTaskInstanceResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="GetTaskInstanceResponse.GetJSON200"></a>
-### func \(GetTaskInstanceResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2804>)
+### func \(GetTaskInstanceResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4083>)
 
 ```go
 func (r GetTaskInstanceResponse) GetJSON200() *TaskInstance
@@ -2967,7 +4311,7 @@ func (r GetTaskInstanceResponse) GetJSON200() *TaskInstance
 GetJSON200 returns the response for an HTTP 200 \`application/json\` response
 
 <a name="GetTaskInstanceResponse.Status"></a>
-### func \(GetTaskInstanceResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2814>)
+### func \(GetTaskInstanceResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4093>)
 
 ```go
 func (r GetTaskInstanceResponse) Status() string
@@ -2976,7 +4320,7 @@ func (r GetTaskInstanceResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="GetTaskInstanceResponse.StatusCode"></a>
-### func \(GetTaskInstanceResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2822>)
+### func \(GetTaskInstanceResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4101>)
 
 ```go
 func (r GetTaskInstanceResponse) StatusCode() int
@@ -2985,7 +4329,7 @@ func (r GetTaskInstanceResponse) StatusCode() int
 StatusCode returns HTTPResponse.StatusCode
 
 <a name="GetTaskLogsResponse"></a>
-## type [GetTaskLogsResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2837-L2840>)
+## type [GetTaskLogsResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4116-L4119>)
 
 
 
@@ -2997,7 +4341,7 @@ type GetTaskLogsResponse struct {
 ```
 
 <a name="ParseGetTaskLogsResponse"></a>
-### func [ParseGetTaskLogsResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4063>)
+### func [ParseGetTaskLogsResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5983>)
 
 ```go
 func ParseGetTaskLogsResponse(rsp *http.Response) (*GetTaskLogsResponse, error)
@@ -3006,7 +4350,7 @@ func ParseGetTaskLogsResponse(rsp *http.Response) (*GetTaskLogsResponse, error)
 ParseGetTaskLogsResponse parses an HTTP response from a GetTaskLogsWithResponse call
 
 <a name="GetTaskLogsResponse.ContentType"></a>
-### func \(GetTaskLogsResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2864>)
+### func \(GetTaskLogsResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4143>)
 
 ```go
 func (r GetTaskLogsResponse) ContentType() string
@@ -3015,7 +4359,7 @@ func (r GetTaskLogsResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="GetTaskLogsResponse.GetBody"></a>
-### func \(GetTaskLogsResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2843>)
+### func \(GetTaskLogsResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4122>)
 
 ```go
 func (r GetTaskLogsResponse) GetBody() []byte
@@ -3024,7 +4368,7 @@ func (r GetTaskLogsResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="GetTaskLogsResponse.Status"></a>
-### func \(GetTaskLogsResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2848>)
+### func \(GetTaskLogsResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4127>)
 
 ```go
 func (r GetTaskLogsResponse) Status() string
@@ -3033,7 +4377,7 @@ func (r GetTaskLogsResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="GetTaskLogsResponse.StatusCode"></a>
-### func \(GetTaskLogsResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2856>)
+### func \(GetTaskLogsResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4135>)
 
 ```go
 func (r GetTaskLogsResponse) StatusCode() int
@@ -3041,8 +4385,98 @@ func (r GetTaskLogsResponse) StatusCode() int
 
 StatusCode returns HTTPResponse.StatusCode
 
+<a name="GetVariableResponse"></a>
+## type [GetVariableResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4630-L4639>)
+
+
+
+```go
+type GetVariableResponse struct {
+    Body         []byte
+    HTTPResponse *http.Response
+    // JSON200 the response for an HTTP 200 `application/json` response
+    JSON200 *Variable
+    // JSON401 the response for an HTTP 401 `application/json` response
+    JSON401 *Unauthorized
+    // JSON404 the response for an HTTP 404 `application/json` response
+    JSON404 *NotFound
+}
+```
+
+<a name="ParseGetVariableResponse"></a>
+### func [ParseGetVariableResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L6332>)
+
+```go
+func ParseGetVariableResponse(rsp *http.Response) (*GetVariableResponse, error)
+```
+
+ParseGetVariableResponse parses an HTTP response from a GetVariableWithResponse call
+
+<a name="GetVariableResponse.ContentType"></a>
+### func \(GetVariableResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4678>)
+
+```go
+func (r GetVariableResponse) ContentType() string
+```
+
+ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
+
+<a name="GetVariableResponse.GetBody"></a>
+### func \(GetVariableResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4657>)
+
+```go
+func (r GetVariableResponse) GetBody() []byte
+```
+
+GetBody returns the raw response body bytes
+
+<a name="GetVariableResponse.GetJSON200"></a>
+### func \(GetVariableResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4642>)
+
+```go
+func (r GetVariableResponse) GetJSON200() *Variable
+```
+
+GetJSON200 returns the response for an HTTP 200 \`application/json\` response
+
+<a name="GetVariableResponse.GetJSON401"></a>
+### func \(GetVariableResponse\) [GetJSON401](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4647>)
+
+```go
+func (r GetVariableResponse) GetJSON401() *Unauthorized
+```
+
+GetJSON401 returns the response for an HTTP 401 \`application/json\` response
+
+<a name="GetVariableResponse.GetJSON404"></a>
+### func \(GetVariableResponse\) [GetJSON404](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4652>)
+
+```go
+func (r GetVariableResponse) GetJSON404() *NotFound
+```
+
+GetJSON404 returns the response for an HTTP 404 \`application/json\` response
+
+<a name="GetVariableResponse.Status"></a>
+### func \(GetVariableResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4662>)
+
+```go
+func (r GetVariableResponse) Status() string
+```
+
+Status returns HTTPResponse.Status
+
+<a name="GetVariableResponse.StatusCode"></a>
+### func \(GetVariableResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4670>)
+
+```go
+func (r GetVariableResponse) StatusCode() int
+```
+
+StatusCode returns HTTPResponse.StatusCode
+
 <a name="GetVersionResponse"></a>
-## type [GetVersionResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3200-L3205>)
+## type [GetVersionResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4685-L4690>)
 
 
 
@@ -3056,7 +4490,7 @@ type GetVersionResponse struct {
 ```
 
 <a name="ParseGetVersionResponse"></a>
-### func [ParseGetVersionResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4303>)
+### func [ParseGetVersionResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L6372>)
 
 ```go
 func ParseGetVersionResponse(rsp *http.Response) (*GetVersionResponse, error)
@@ -3065,7 +4499,7 @@ func ParseGetVersionResponse(rsp *http.Response) (*GetVersionResponse, error)
 ParseGetVersionResponse parses an HTTP response from a GetVersionWithResponse call
 
 <a name="GetVersionResponse.ContentType"></a>
-### func \(GetVersionResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3234>)
+### func \(GetVersionResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4719>)
 
 ```go
 func (r GetVersionResponse) ContentType() string
@@ -3074,7 +4508,7 @@ func (r GetVersionResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="GetVersionResponse.GetBody"></a>
-### func \(GetVersionResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3213>)
+### func \(GetVersionResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4698>)
 
 ```go
 func (r GetVersionResponse) GetBody() []byte
@@ -3083,7 +4517,7 @@ func (r GetVersionResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="GetVersionResponse.GetJSON200"></a>
-### func \(GetVersionResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3208>)
+### func \(GetVersionResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4693>)
 
 ```go
 func (r GetVersionResponse) GetJSON200() *VersionInfo
@@ -3092,7 +4526,7 @@ func (r GetVersionResponse) GetJSON200() *VersionInfo
 GetJSON200 returns the response for an HTTP 200 \`application/json\` response
 
 <a name="GetVersionResponse.Status"></a>
-### func \(GetVersionResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3218>)
+### func \(GetVersionResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4703>)
 
 ```go
 func (r GetVersionResponse) Status() string
@@ -3101,7 +4535,7 @@ func (r GetVersionResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="GetVersionResponse.StatusCode"></a>
-### func \(GetVersionResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3226>)
+### func \(GetVersionResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4711>)
 
 ```go
 func (r GetVersionResponse) StatusCode() int
@@ -3110,7 +4544,7 @@ func (r GetVersionResponse) StatusCode() int
 StatusCode returns HTTPResponse.StatusCode
 
 <a name="GetXcomEntryResponse"></a>
-## type [GetXcomEntryResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3241-L3248>)
+## type [GetXcomEntryResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4726-L4733>)
 
 
 
@@ -3126,7 +4560,7 @@ type GetXcomEntryResponse struct {
 ```
 
 <a name="ParseGetXcomEntryResponse"></a>
-### func [ParseGetXcomEntryResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4329>)
+### func [ParseGetXcomEntryResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L6398>)
 
 ```go
 func ParseGetXcomEntryResponse(rsp *http.Response) (*GetXcomEntryResponse, error)
@@ -3135,7 +4569,7 @@ func ParseGetXcomEntryResponse(rsp *http.Response) (*GetXcomEntryResponse, error
 ParseGetXcomEntryResponse parses an HTTP response from a GetXcomEntryWithResponse call
 
 <a name="GetXcomEntryResponse.ContentType"></a>
-### func \(GetXcomEntryResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3282>)
+### func \(GetXcomEntryResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4767>)
 
 ```go
 func (r GetXcomEntryResponse) ContentType() string
@@ -3144,7 +4578,7 @@ func (r GetXcomEntryResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="GetXcomEntryResponse.GetBody"></a>
-### func \(GetXcomEntryResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3261>)
+### func \(GetXcomEntryResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4746>)
 
 ```go
 func (r GetXcomEntryResponse) GetBody() []byte
@@ -3153,7 +4587,7 @@ func (r GetXcomEntryResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="GetXcomEntryResponse.GetJSON200"></a>
-### func \(GetXcomEntryResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3251>)
+### func \(GetXcomEntryResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4736>)
 
 ```go
 func (r GetXcomEntryResponse) GetJSON200() *XComEntry
@@ -3162,7 +4596,7 @@ func (r GetXcomEntryResponse) GetJSON200() *XComEntry
 GetJSON200 returns the response for an HTTP 200 \`application/json\` response
 
 <a name="GetXcomEntryResponse.GetJSON404"></a>
-### func \(GetXcomEntryResponse\) [GetJSON404](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3256>)
+### func \(GetXcomEntryResponse\) [GetJSON404](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4741>)
 
 ```go
 func (r GetXcomEntryResponse) GetJSON404() *NotFound
@@ -3171,7 +4605,7 @@ func (r GetXcomEntryResponse) GetJSON404() *NotFound
 GetJSON404 returns the response for an HTTP 404 \`application/json\` response
 
 <a name="GetXcomEntryResponse.Status"></a>
-### func \(GetXcomEntryResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3266>)
+### func \(GetXcomEntryResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4751>)
 
 ```go
 func (r GetXcomEntryResponse) Status() string
@@ -3180,7 +4614,7 @@ func (r GetXcomEntryResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="GetXcomEntryResponse.StatusCode"></a>
-### func \(GetXcomEntryResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3274>)
+### func \(GetXcomEntryResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4759>)
 
 ```go
 func (r GetXcomEntryResponse) StatusCode() int
@@ -3189,7 +4623,7 @@ func (r GetXcomEntryResponse) StatusCode() int
 StatusCode returns HTTPResponse.StatusCode
 
 <a name="HealthInfo"></a>
-## type [HealthInfo](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L272-L277>)
+## type [HealthInfo](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L303-L308>)
 
 HealthInfo defines model for HealthInfo.
 
@@ -3203,7 +4637,7 @@ type HealthInfo struct {
 ```
 
 <a name="HttpRequestDoer"></a>
-## type [HttpRequestDoer](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L434-L436>)
+## type [HttpRequestDoer](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L517-L519>)
 
 Doer performs HTTP requests.
 
@@ -3216,7 +4650,7 @@ type HttpRequestDoer interface {
 ```
 
 <a name="IssueTokenJSONRequestBody"></a>
-## type [IssueTokenJSONRequestBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L426>)
+## type [IssueTokenJSONRequestBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L509>)
 
 IssueTokenJSONRequestBody defines body for IssueToken for application/json ContentType.
 
@@ -3225,7 +4659,7 @@ type IssueTokenJSONRequestBody = TokenRequest
 ```
 
 <a name="IssueTokenResponse"></a>
-## type [IssueTokenResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3289-L3296>)
+## type [IssueTokenResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4774-L4781>)
 
 
 
@@ -3241,7 +4675,7 @@ type IssueTokenResponse struct {
 ```
 
 <a name="ParseIssueTokenResponse"></a>
-### func [ParseIssueTokenResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4362>)
+### func [ParseIssueTokenResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L6431>)
 
 ```go
 func ParseIssueTokenResponse(rsp *http.Response) (*IssueTokenResponse, error)
@@ -3250,7 +4684,7 @@ func ParseIssueTokenResponse(rsp *http.Response) (*IssueTokenResponse, error)
 ParseIssueTokenResponse parses an HTTP response from a IssueTokenWithResponse call
 
 <a name="IssueTokenResponse.ContentType"></a>
-### func \(IssueTokenResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3330>)
+### func \(IssueTokenResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4815>)
 
 ```go
 func (r IssueTokenResponse) ContentType() string
@@ -3259,7 +4693,7 @@ func (r IssueTokenResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="IssueTokenResponse.GetBody"></a>
-### func \(IssueTokenResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3309>)
+### func \(IssueTokenResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4794>)
 
 ```go
 func (r IssueTokenResponse) GetBody() []byte
@@ -3268,7 +4702,7 @@ func (r IssueTokenResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="IssueTokenResponse.GetJSON200"></a>
-### func \(IssueTokenResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3299>)
+### func \(IssueTokenResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4784>)
 
 ```go
 func (r IssueTokenResponse) GetJSON200() *TokenResponse
@@ -3277,7 +4711,7 @@ func (r IssueTokenResponse) GetJSON200() *TokenResponse
 GetJSON200 returns the response for an HTTP 200 \`application/json\` response
 
 <a name="IssueTokenResponse.GetJSON401"></a>
-### func \(IssueTokenResponse\) [GetJSON401](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3304>)
+### func \(IssueTokenResponse\) [GetJSON401](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4789>)
 
 ```go
 func (r IssueTokenResponse) GetJSON401() *Unauthorized
@@ -3286,7 +4720,7 @@ func (r IssueTokenResponse) GetJSON401() *Unauthorized
 GetJSON401 returns the response for an HTTP 401 \`application/json\` response
 
 <a name="IssueTokenResponse.Status"></a>
-### func \(IssueTokenResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3314>)
+### func \(IssueTokenResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4799>)
 
 ```go
 func (r IssueTokenResponse) Status() string
@@ -3295,7 +4729,7 @@ func (r IssueTokenResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="IssueTokenResponse.StatusCode"></a>
-### func \(IssueTokenResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3322>)
+### func \(IssueTokenResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4807>)
 
 ```go
 func (r IssueTokenResponse) StatusCode() int
@@ -3304,7 +4738,7 @@ func (r IssueTokenResponse) StatusCode() int
 StatusCode returns HTTPResponse.StatusCode
 
 <a name="Limit"></a>
-## type [Limit](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L374>)
+## type [Limit](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L430>)
 
 Limit defines model for Limit.
 
@@ -3312,8 +4746,99 @@ Limit defines model for Limit.
 type Limit = int
 ```
 
+<a name="ListConnectionsParams"></a>
+## type [ListConnectionsParams](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L451-L454>)
+
+ListConnectionsParams defines parameters for ListConnections.
+
+```go
+type ListConnectionsParams struct {
+    Limit  *Limit  `form:"limit,omitempty" json:"limit,omitempty"`
+    Offset *Offset `form:"offset,omitempty" json:"offset,omitempty"`
+}
+```
+
+<a name="ListConnectionsResponse"></a>
+## type [ListConnectionsResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3403-L3410>)
+
+
+
+```go
+type ListConnectionsResponse struct {
+    Body         []byte
+    HTTPResponse *http.Response
+    // JSON200 the response for an HTTP 200 `application/json` response
+    JSON200 *ConnectionCollection
+    // JSON401 the response for an HTTP 401 `application/json` response
+    JSON401 *Unauthorized
+}
+```
+
+<a name="ParseListConnectionsResponse"></a>
+### func [ParseListConnectionsResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5492>)
+
+```go
+func ParseListConnectionsResponse(rsp *http.Response) (*ListConnectionsResponse, error)
+```
+
+ParseListConnectionsResponse parses an HTTP response from a ListConnectionsWithResponse call
+
+<a name="ListConnectionsResponse.ContentType"></a>
+### func \(ListConnectionsResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3444>)
+
+```go
+func (r ListConnectionsResponse) ContentType() string
+```
+
+ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
+
+<a name="ListConnectionsResponse.GetBody"></a>
+### func \(ListConnectionsResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3423>)
+
+```go
+func (r ListConnectionsResponse) GetBody() []byte
+```
+
+GetBody returns the raw response body bytes
+
+<a name="ListConnectionsResponse.GetJSON200"></a>
+### func \(ListConnectionsResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3413>)
+
+```go
+func (r ListConnectionsResponse) GetJSON200() *ConnectionCollection
+```
+
+GetJSON200 returns the response for an HTTP 200 \`application/json\` response
+
+<a name="ListConnectionsResponse.GetJSON401"></a>
+### func \(ListConnectionsResponse\) [GetJSON401](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3418>)
+
+```go
+func (r ListConnectionsResponse) GetJSON401() *Unauthorized
+```
+
+GetJSON401 returns the response for an HTTP 401 \`application/json\` response
+
+<a name="ListConnectionsResponse.Status"></a>
+### func \(ListConnectionsResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3428>)
+
+```go
+func (r ListConnectionsResponse) Status() string
+```
+
+Status returns HTTPResponse.Status
+
+<a name="ListConnectionsResponse.StatusCode"></a>
+### func \(ListConnectionsResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3436>)
+
+```go
+func (r ListConnectionsResponse) StatusCode() int
+```
+
+StatusCode returns HTTPResponse.StatusCode
+
 <a name="ListDagRunsParams"></a>
-## type [ListDagRunsParams](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L398-L402>)
+## type [ListDagRunsParams](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L466-L470>)
 
 ListDagRunsParams defines parameters for ListDagRuns.
 
@@ -3326,7 +4851,7 @@ type ListDagRunsParams struct {
 ```
 
 <a name="ListDagRunsParamsState"></a>
-## type [ListDagRunsParamsState](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L405>)
+## type [ListDagRunsParamsState](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L473>)
 
 ListDagRunsParamsState defines parameters for ListDagRuns.
 
@@ -3355,7 +4880,7 @@ func (e ListDagRunsParamsState) Valid() bool
 Valid indicates whether the value is a known member of the ListDagRunsParamsState enum.
 
 <a name="ListDagRunsResponse"></a>
-## type [ListDagRunsResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2625-L2630>)
+## type [ListDagRunsResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3904-L3909>)
 
 
 
@@ -3369,7 +4894,7 @@ type ListDagRunsResponse struct {
 ```
 
 <a name="ParseListDagRunsResponse"></a>
-### func [ParseListDagRunsResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3926>)
+### func [ParseListDagRunsResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5846>)
 
 ```go
 func ParseListDagRunsResponse(rsp *http.Response) (*ListDagRunsResponse, error)
@@ -3378,7 +4903,7 @@ func ParseListDagRunsResponse(rsp *http.Response) (*ListDagRunsResponse, error)
 ParseListDagRunsResponse parses an HTTP response from a ListDagRunsWithResponse call
 
 <a name="ListDagRunsResponse.ContentType"></a>
-### func \(ListDagRunsResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2659>)
+### func \(ListDagRunsResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3938>)
 
 ```go
 func (r ListDagRunsResponse) ContentType() string
@@ -3387,7 +4912,7 @@ func (r ListDagRunsResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="ListDagRunsResponse.GetBody"></a>
-### func \(ListDagRunsResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2638>)
+### func \(ListDagRunsResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3917>)
 
 ```go
 func (r ListDagRunsResponse) GetBody() []byte
@@ -3396,7 +4921,7 @@ func (r ListDagRunsResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="ListDagRunsResponse.GetJSON200"></a>
-### func \(ListDagRunsResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2633>)
+### func \(ListDagRunsResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3912>)
 
 ```go
 func (r ListDagRunsResponse) GetJSON200() *DAGRunCollection
@@ -3405,7 +4930,7 @@ func (r ListDagRunsResponse) GetJSON200() *DAGRunCollection
 GetJSON200 returns the response for an HTTP 200 \`application/json\` response
 
 <a name="ListDagRunsResponse.Status"></a>
-### func \(ListDagRunsResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2643>)
+### func \(ListDagRunsResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3922>)
 
 ```go
 func (r ListDagRunsResponse) Status() string
@@ -3414,7 +4939,7 @@ func (r ListDagRunsResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="ListDagRunsResponse.StatusCode"></a>
-### func \(ListDagRunsResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2651>)
+### func \(ListDagRunsResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3930>)
 
 ```go
 func (r ListDagRunsResponse) StatusCode() int
@@ -3423,7 +4948,7 @@ func (r ListDagRunsResponse) StatusCode() int
 StatusCode returns HTTPResponse.StatusCode
 
 <a name="ListDagVersionsResponse"></a>
-## type [ListDagVersionsResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2871-L2876>)
+## type [ListDagVersionsResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4150-L4155>)
 
 
 
@@ -3437,7 +4962,7 @@ type ListDagVersionsResponse struct {
 ```
 
 <a name="ParseListDagVersionsResponse"></a>
-### func [ParseListDagVersionsResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4079>)
+### func [ParseListDagVersionsResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5999>)
 
 ```go
 func ParseListDagVersionsResponse(rsp *http.Response) (*ListDagVersionsResponse, error)
@@ -3446,7 +4971,7 @@ func ParseListDagVersionsResponse(rsp *http.Response) (*ListDagVersionsResponse,
 ParseListDagVersionsResponse parses an HTTP response from a ListDagVersionsWithResponse call
 
 <a name="ListDagVersionsResponse.ContentType"></a>
-### func \(ListDagVersionsResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2905>)
+### func \(ListDagVersionsResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4184>)
 
 ```go
 func (r ListDagVersionsResponse) ContentType() string
@@ -3455,7 +4980,7 @@ func (r ListDagVersionsResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="ListDagVersionsResponse.GetBody"></a>
-### func \(ListDagVersionsResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2884>)
+### func \(ListDagVersionsResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4163>)
 
 ```go
 func (r ListDagVersionsResponse) GetBody() []byte
@@ -3464,7 +4989,7 @@ func (r ListDagVersionsResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="ListDagVersionsResponse.GetJSON200"></a>
-### func \(ListDagVersionsResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2879>)
+### func \(ListDagVersionsResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4158>)
 
 ```go
 func (r ListDagVersionsResponse) GetJSON200() *DagVersionCollection
@@ -3473,7 +4998,7 @@ func (r ListDagVersionsResponse) GetJSON200() *DagVersionCollection
 GetJSON200 returns the response for an HTTP 200 \`application/json\` response
 
 <a name="ListDagVersionsResponse.Status"></a>
-### func \(ListDagVersionsResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2889>)
+### func \(ListDagVersionsResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4168>)
 
 ```go
 func (r ListDagVersionsResponse) Status() string
@@ -3482,7 +5007,7 @@ func (r ListDagVersionsResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="ListDagVersionsResponse.StatusCode"></a>
-### func \(ListDagVersionsResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2897>)
+### func \(ListDagVersionsResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4176>)
 
 ```go
 func (r ListDagVersionsResponse) StatusCode() int
@@ -3491,7 +5016,7 @@ func (r ListDagVersionsResponse) StatusCode() int
 StatusCode returns HTTPResponse.StatusCode
 
 <a name="ListDagsParams"></a>
-## type [ListDagsParams](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L389-L395>)
+## type [ListDagsParams](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L457-L463>)
 
 ListDagsParams defines parameters for ListDags.
 
@@ -3506,7 +5031,7 @@ type ListDagsParams struct {
 ```
 
 <a name="ListDagsResponse"></a>
-## type [ListDagsResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2454-L2459>)
+## type [ListDagsResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3733-L3738>)
 
 
 
@@ -3520,7 +5045,7 @@ type ListDagsResponse struct {
 ```
 
 <a name="ParseListDagsResponse"></a>
-### func [ParseListDagsResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3815>)
+### func [ParseListDagsResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5735>)
 
 ```go
 func ParseListDagsResponse(rsp *http.Response) (*ListDagsResponse, error)
@@ -3529,7 +5054,7 @@ func ParseListDagsResponse(rsp *http.Response) (*ListDagsResponse, error)
 ParseListDagsResponse parses an HTTP response from a ListDagsWithResponse call
 
 <a name="ListDagsResponse.ContentType"></a>
-### func \(ListDagsResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2488>)
+### func \(ListDagsResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3767>)
 
 ```go
 func (r ListDagsResponse) ContentType() string
@@ -3538,7 +5063,7 @@ func (r ListDagsResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="ListDagsResponse.GetBody"></a>
-### func \(ListDagsResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2467>)
+### func \(ListDagsResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3746>)
 
 ```go
 func (r ListDagsResponse) GetBody() []byte
@@ -3547,7 +5072,7 @@ func (r ListDagsResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="ListDagsResponse.GetJSON200"></a>
-### func \(ListDagsResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2462>)
+### func \(ListDagsResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3741>)
 
 ```go
 func (r ListDagsResponse) GetJSON200() *DAGCollection
@@ -3556,7 +5081,7 @@ func (r ListDagsResponse) GetJSON200() *DAGCollection
 GetJSON200 returns the response for an HTTP 200 \`application/json\` response
 
 <a name="ListDagsResponse.Status"></a>
-### func \(ListDagsResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2472>)
+### func \(ListDagsResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3751>)
 
 ```go
 func (r ListDagsResponse) Status() string
@@ -3565,7 +5090,7 @@ func (r ListDagsResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="ListDagsResponse.StatusCode"></a>
-### func \(ListDagsResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2480>)
+### func \(ListDagsResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3759>)
 
 ```go
 func (r ListDagsResponse) StatusCode() int
@@ -3574,7 +5099,7 @@ func (r ListDagsResponse) StatusCode() int
 StatusCode returns HTTPResponse.StatusCode
 
 <a name="ListTaskInstancesResponse"></a>
-## type [ListTaskInstancesResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2755-L2760>)
+## type [ListTaskInstancesResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4034-L4039>)
 
 
 
@@ -3588,7 +5113,7 @@ type ListTaskInstancesResponse struct {
 ```
 
 <a name="ParseListTaskInstancesResponse"></a>
-### func [ParseListTaskInstancesResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4011>)
+### func [ParseListTaskInstancesResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5931>)
 
 ```go
 func ParseListTaskInstancesResponse(rsp *http.Response) (*ListTaskInstancesResponse, error)
@@ -3597,7 +5122,7 @@ func ParseListTaskInstancesResponse(rsp *http.Response) (*ListTaskInstancesRespo
 ParseListTaskInstancesResponse parses an HTTP response from a ListTaskInstancesWithResponse call
 
 <a name="ListTaskInstancesResponse.ContentType"></a>
-### func \(ListTaskInstancesResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2789>)
+### func \(ListTaskInstancesResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4068>)
 
 ```go
 func (r ListTaskInstancesResponse) ContentType() string
@@ -3606,7 +5131,7 @@ func (r ListTaskInstancesResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="ListTaskInstancesResponse.GetBody"></a>
-### func \(ListTaskInstancesResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2768>)
+### func \(ListTaskInstancesResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4047>)
 
 ```go
 func (r ListTaskInstancesResponse) GetBody() []byte
@@ -3615,7 +5140,7 @@ func (r ListTaskInstancesResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="ListTaskInstancesResponse.GetJSON200"></a>
-### func \(ListTaskInstancesResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2763>)
+### func \(ListTaskInstancesResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4042>)
 
 ```go
 func (r ListTaskInstancesResponse) GetJSON200() *TaskInstanceCollection
@@ -3624,7 +5149,7 @@ func (r ListTaskInstancesResponse) GetJSON200() *TaskInstanceCollection
 GetJSON200 returns the response for an HTTP 200 \`application/json\` response
 
 <a name="ListTaskInstancesResponse.Status"></a>
-### func \(ListTaskInstancesResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2773>)
+### func \(ListTaskInstancesResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4052>)
 
 ```go
 func (r ListTaskInstancesResponse) Status() string
@@ -3633,7 +5158,7 @@ func (r ListTaskInstancesResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="ListTaskInstancesResponse.StatusCode"></a>
-### func \(ListTaskInstancesResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2781>)
+### func \(ListTaskInstancesResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4060>)
 
 ```go
 func (r ListTaskInstancesResponse) StatusCode() int
@@ -3642,7 +5167,7 @@ func (r ListTaskInstancesResponse) StatusCode() int
 StatusCode returns HTTPResponse.StatusCode
 
 <a name="ListUsersParams"></a>
-## type [ListUsersParams](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L408-L411>)
+## type [ListUsersParams](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L476-L479>)
 
 ListUsersParams defines parameters for ListUsers.
 
@@ -3654,7 +5179,7 @@ type ListUsersParams struct {
 ```
 
 <a name="ListUsersResponse"></a>
-## type [ListUsersResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3090-L3097>)
+## type [ListUsersResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4369-L4376>)
 
 
 
@@ -3670,7 +5195,7 @@ type ListUsersResponse struct {
 ```
 
 <a name="ParseListUsersResponse"></a>
-### func [ParseListUsersResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4223>)
+### func [ParseListUsersResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L6143>)
 
 ```go
 func ParseListUsersResponse(rsp *http.Response) (*ListUsersResponse, error)
@@ -3679,7 +5204,7 @@ func ParseListUsersResponse(rsp *http.Response) (*ListUsersResponse, error)
 ParseListUsersResponse parses an HTTP response from a ListUsersWithResponse call
 
 <a name="ListUsersResponse.ContentType"></a>
-### func \(ListUsersResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3131>)
+### func \(ListUsersResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4410>)
 
 ```go
 func (r ListUsersResponse) ContentType() string
@@ -3688,7 +5213,7 @@ func (r ListUsersResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="ListUsersResponse.GetBody"></a>
-### func \(ListUsersResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3110>)
+### func \(ListUsersResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4389>)
 
 ```go
 func (r ListUsersResponse) GetBody() []byte
@@ -3697,7 +5222,7 @@ func (r ListUsersResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="ListUsersResponse.GetJSON200"></a>
-### func \(ListUsersResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3100>)
+### func \(ListUsersResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4379>)
 
 ```go
 func (r ListUsersResponse) GetJSON200() *UserCollection
@@ -3706,7 +5231,7 @@ func (r ListUsersResponse) GetJSON200() *UserCollection
 GetJSON200 returns the response for an HTTP 200 \`application/json\` response
 
 <a name="ListUsersResponse.GetJSON401"></a>
-### func \(ListUsersResponse\) [GetJSON401](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3105>)
+### func \(ListUsersResponse\) [GetJSON401](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4384>)
 
 ```go
 func (r ListUsersResponse) GetJSON401() *Unauthorized
@@ -3715,7 +5240,7 @@ func (r ListUsersResponse) GetJSON401() *Unauthorized
 GetJSON401 returns the response for an HTTP 401 \`application/json\` response
 
 <a name="ListUsersResponse.Status"></a>
-### func \(ListUsersResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3115>)
+### func \(ListUsersResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4394>)
 
 ```go
 func (r ListUsersResponse) Status() string
@@ -3724,7 +5249,7 @@ func (r ListUsersResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="ListUsersResponse.StatusCode"></a>
-### func \(ListUsersResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3123>)
+### func \(ListUsersResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4402>)
 
 ```go
 func (r ListUsersResponse) StatusCode() int
@@ -3732,8 +5257,99 @@ func (r ListUsersResponse) StatusCode() int
 
 StatusCode returns HTTPResponse.StatusCode
 
+<a name="ListVariablesParams"></a>
+## type [ListVariablesParams](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L482-L485>)
+
+ListVariablesParams defines parameters for ListVariables.
+
+```go
+type ListVariablesParams struct {
+    Limit  *Limit  `form:"limit,omitempty" json:"limit,omitempty"`
+    Offset *Offset `form:"offset,omitempty" json:"offset,omitempty"`
+}
+```
+
+<a name="ListVariablesResponse"></a>
+## type [ListVariablesResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4479-L4486>)
+
+
+
+```go
+type ListVariablesResponse struct {
+    Body         []byte
+    HTTPResponse *http.Response
+    // JSON200 the response for an HTTP 200 `application/json` response
+    JSON200 *VariableCollection
+    // JSON401 the response for an HTTP 401 `application/json` response
+    JSON401 *Unauthorized
+}
+```
+
+<a name="ParseListVariablesResponse"></a>
+### func [ParseListVariablesResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L6223>)
+
+```go
+func ParseListVariablesResponse(rsp *http.Response) (*ListVariablesResponse, error)
+```
+
+ParseListVariablesResponse parses an HTTP response from a ListVariablesWithResponse call
+
+<a name="ListVariablesResponse.ContentType"></a>
+### func \(ListVariablesResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4520>)
+
+```go
+func (r ListVariablesResponse) ContentType() string
+```
+
+ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
+
+<a name="ListVariablesResponse.GetBody"></a>
+### func \(ListVariablesResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4499>)
+
+```go
+func (r ListVariablesResponse) GetBody() []byte
+```
+
+GetBody returns the raw response body bytes
+
+<a name="ListVariablesResponse.GetJSON200"></a>
+### func \(ListVariablesResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4489>)
+
+```go
+func (r ListVariablesResponse) GetJSON200() *VariableCollection
+```
+
+GetJSON200 returns the response for an HTTP 200 \`application/json\` response
+
+<a name="ListVariablesResponse.GetJSON401"></a>
+### func \(ListVariablesResponse\) [GetJSON401](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4494>)
+
+```go
+func (r ListVariablesResponse) GetJSON401() *Unauthorized
+```
+
+GetJSON401 returns the response for an HTTP 401 \`application/json\` response
+
+<a name="ListVariablesResponse.Status"></a>
+### func \(ListVariablesResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4504>)
+
+```go
+func (r ListVariablesResponse) Status() string
+```
+
+Status returns HTTPResponse.Status
+
+<a name="ListVariablesResponse.StatusCode"></a>
+### func \(ListVariablesResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L4512>)
+
+```go
+func (r ListVariablesResponse) StatusCode() int
+```
+
+StatusCode returns HTTPResponse.StatusCode
+
 <a name="NotFound"></a>
-## type [NotFound](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L383>)
+## type [NotFound](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L445>)
 
 NotFound defines model for NotFound.
 
@@ -3742,7 +5358,7 @@ type NotFound = Error
 ```
 
 <a name="Offset"></a>
-## type [Offset](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L377>)
+## type [Offset](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L433>)
 
 Offset defines model for Offset.
 
@@ -3750,8 +5366,87 @@ Offset defines model for Offset.
 type Offset = int
 ```
 
+<a name="RenewTokenResponse"></a>
+## type [RenewTokenResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3355-L3362>)
+
+
+
+```go
+type RenewTokenResponse struct {
+    Body         []byte
+    HTTPResponse *http.Response
+    // JSON200 the response for an HTTP 200 `application/json` response
+    JSON200 *TokenResponse
+    // JSON401 the response for an HTTP 401 `application/json` response
+    JSON401 *Unauthorized
+}
+```
+
+<a name="ParseRenewTokenResponse"></a>
+### func [ParseRenewTokenResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5459>)
+
+```go
+func ParseRenewTokenResponse(rsp *http.Response) (*RenewTokenResponse, error)
+```
+
+ParseRenewTokenResponse parses an HTTP response from a RenewTokenWithResponse call
+
+<a name="RenewTokenResponse.ContentType"></a>
+### func \(RenewTokenResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3396>)
+
+```go
+func (r RenewTokenResponse) ContentType() string
+```
+
+ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
+
+<a name="RenewTokenResponse.GetBody"></a>
+### func \(RenewTokenResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3375>)
+
+```go
+func (r RenewTokenResponse) GetBody() []byte
+```
+
+GetBody returns the raw response body bytes
+
+<a name="RenewTokenResponse.GetJSON200"></a>
+### func \(RenewTokenResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3365>)
+
+```go
+func (r RenewTokenResponse) GetJSON200() *TokenResponse
+```
+
+GetJSON200 returns the response for an HTTP 200 \`application/json\` response
+
+<a name="RenewTokenResponse.GetJSON401"></a>
+### func \(RenewTokenResponse\) [GetJSON401](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3370>)
+
+```go
+func (r RenewTokenResponse) GetJSON401() *Unauthorized
+```
+
+GetJSON401 returns the response for an HTTP 401 \`application/json\` response
+
+<a name="RenewTokenResponse.Status"></a>
+### func \(RenewTokenResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3380>)
+
+```go
+func (r RenewTokenResponse) Status() string
+```
+
+Status returns HTTPResponse.Status
+
+<a name="RenewTokenResponse.StatusCode"></a>
+### func \(RenewTokenResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3388>)
+
+```go
+func (r RenewTokenResponse) StatusCode() int
+```
+
+StatusCode returns HTTPResponse.StatusCode
+
 <a name="RequestEditorFn"></a>
-## type [RequestEditorFn](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L429>)
+## type [RequestEditorFn](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L512>)
 
 RequestEditorFn is the function signature for the RequestEditor callback function
 
@@ -3760,7 +5455,7 @@ type RequestEditorFn func(ctx context.Context, req *http.Request) error
 ```
 
 <a name="TaskID"></a>
-## type [TaskID](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L380>)
+## type [TaskID](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L436>)
 
 TaskID defines model for TaskID.
 
@@ -3769,7 +5464,7 @@ type TaskID = string
 ```
 
 <a name="TaskInstance"></a>
-## type [TaskInstance](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L280-L299>)
+## type [TaskInstance](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L311-L330>)
 
 TaskInstance defines model for TaskInstance.
 
@@ -3797,7 +5492,7 @@ type TaskInstance struct {
 ```
 
 <a name="TaskInstanceCollection"></a>
-## type [TaskInstanceCollection](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L305-L308>)
+## type [TaskInstanceCollection](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L336-L339>)
 
 TaskInstanceCollection defines model for TaskInstanceCollection.
 
@@ -3809,7 +5504,7 @@ type TaskInstanceCollection struct {
 ```
 
 <a name="TaskInstanceState"></a>
-## type [TaskInstanceState](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L302>)
+## type [TaskInstanceState](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L333>)
 
 TaskInstanceState defines model for TaskInstance.State.
 
@@ -3843,7 +5538,7 @@ func (e TaskInstanceState) Valid() bool
 Valid indicates whether the value is a known member of the TaskInstanceState enum.
 
 <a name="TokenRequest"></a>
-## type [TokenRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L311-L314>)
+## type [TokenRequest](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L342-L345>)
 
 TokenRequest defines model for TokenRequest.
 
@@ -3855,7 +5550,7 @@ type TokenRequest struct {
 ```
 
 <a name="TokenResponse"></a>
-## type [TokenResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L317-L325>)
+## type [TokenResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L348-L356>)
 
 TokenResponse defines model for TokenResponse.
 
@@ -3872,7 +5567,7 @@ type TokenResponse struct {
 ```
 
 <a name="TriggerDagRunJSONRequestBody"></a>
-## type [TriggerDagRunJSONRequestBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L420>)
+## type [TriggerDagRunJSONRequestBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L500>)
 
 TriggerDagRunJSONRequestBody defines body for TriggerDagRun for application/json ContentType.
 
@@ -3881,7 +5576,7 @@ type TriggerDagRunJSONRequestBody = DAGRunCreate
 ```
 
 <a name="TriggerDagRunResponse"></a>
-## type [TriggerDagRunResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2666-L2671>)
+## type [TriggerDagRunResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3945-L3950>)
 
 
 
@@ -3895,7 +5590,7 @@ type TriggerDagRunResponse struct {
 ```
 
 <a name="ParseTriggerDagRunResponse"></a>
-### func [ParseTriggerDagRunResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3952>)
+### func [ParseTriggerDagRunResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5872>)
 
 ```go
 func ParseTriggerDagRunResponse(rsp *http.Response) (*TriggerDagRunResponse, error)
@@ -3904,7 +5599,7 @@ func ParseTriggerDagRunResponse(rsp *http.Response) (*TriggerDagRunResponse, err
 ParseTriggerDagRunResponse parses an HTTP response from a TriggerDagRunWithResponse call
 
 <a name="TriggerDagRunResponse.ContentType"></a>
-### func \(TriggerDagRunResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2700>)
+### func \(TriggerDagRunResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3979>)
 
 ```go
 func (r TriggerDagRunResponse) ContentType() string
@@ -3913,7 +5608,7 @@ func (r TriggerDagRunResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="TriggerDagRunResponse.GetBody"></a>
-### func \(TriggerDagRunResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2679>)
+### func \(TriggerDagRunResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3958>)
 
 ```go
 func (r TriggerDagRunResponse) GetBody() []byte
@@ -3922,7 +5617,7 @@ func (r TriggerDagRunResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="TriggerDagRunResponse.GetJSON200"></a>
-### func \(TriggerDagRunResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2674>)
+### func \(TriggerDagRunResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3953>)
 
 ```go
 func (r TriggerDagRunResponse) GetJSON200() *DAGRun
@@ -3931,7 +5626,7 @@ func (r TriggerDagRunResponse) GetJSON200() *DAGRun
 GetJSON200 returns the response for an HTTP 200 \`application/json\` response
 
 <a name="TriggerDagRunResponse.Status"></a>
-### func \(TriggerDagRunResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2684>)
+### func \(TriggerDagRunResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3963>)
 
 ```go
 func (r TriggerDagRunResponse) Status() string
@@ -3940,7 +5635,7 @@ func (r TriggerDagRunResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="TriggerDagRunResponse.StatusCode"></a>
-### func \(TriggerDagRunResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2692>)
+### func \(TriggerDagRunResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3971>)
 
 ```go
 func (r TriggerDagRunResponse) StatusCode() int
@@ -3949,7 +5644,7 @@ func (r TriggerDagRunResponse) StatusCode() int
 StatusCode returns HTTPResponse.StatusCode
 
 <a name="Unauthorized"></a>
-## type [Unauthorized](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L386>)
+## type [Unauthorized](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L448>)
 
 Unauthorized defines model for Unauthorized.
 
@@ -3957,8 +5652,129 @@ Unauthorized defines model for Unauthorized.
 type Unauthorized = Error
 ```
 
+<a name="UpdateConnectionJSONRequestBody"></a>
+## type [UpdateConnectionJSONRequestBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L491>)
+
+UpdateConnectionJSONRequestBody defines body for UpdateConnection for application/json ContentType.
+
+```go
+type UpdateConnectionJSONRequestBody = ConnectionBody
+```
+
+<a name="UpdateConnectionResponse"></a>
+## type [UpdateConnectionResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3616-L3629>)
+
+
+
+```go
+type UpdateConnectionResponse struct {
+    Body         []byte
+    HTTPResponse *http.Response
+    // JSON200 the response for an HTTP 200 `application/json` response
+    JSON200 *Connection
+    // JSON400 the response for an HTTP 400 `application/json` response
+    JSON400 *Error
+    // JSON401 the response for an HTTP 401 `application/json` response
+    JSON401 *Unauthorized
+    // JSON404 the response for an HTTP 404 `application/json` response
+    JSON404 *NotFound
+    // JSON503 the response for an HTTP 503 `application/json` response
+    JSON503 *EncryptionUnavailable
+}
+```
+
+<a name="ParseUpdateConnectionResponse"></a>
+### func [ParseUpdateConnectionResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5648>)
+
+```go
+func ParseUpdateConnectionResponse(rsp *http.Response) (*UpdateConnectionResponse, error)
+```
+
+ParseUpdateConnectionResponse parses an HTTP response from a UpdateConnectionWithResponse call
+
+<a name="UpdateConnectionResponse.ContentType"></a>
+### func \(UpdateConnectionResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3678>)
+
+```go
+func (r UpdateConnectionResponse) ContentType() string
+```
+
+ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
+
+<a name="UpdateConnectionResponse.GetBody"></a>
+### func \(UpdateConnectionResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3657>)
+
+```go
+func (r UpdateConnectionResponse) GetBody() []byte
+```
+
+GetBody returns the raw response body bytes
+
+<a name="UpdateConnectionResponse.GetJSON200"></a>
+### func \(UpdateConnectionResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3632>)
+
+```go
+func (r UpdateConnectionResponse) GetJSON200() *Connection
+```
+
+GetJSON200 returns the response for an HTTP 200 \`application/json\` response
+
+<a name="UpdateConnectionResponse.GetJSON400"></a>
+### func \(UpdateConnectionResponse\) [GetJSON400](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3637>)
+
+```go
+func (r UpdateConnectionResponse) GetJSON400() *Error
+```
+
+GetJSON400 returns the response for an HTTP 400 \`application/json\` response
+
+<a name="UpdateConnectionResponse.GetJSON401"></a>
+### func \(UpdateConnectionResponse\) [GetJSON401](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3642>)
+
+```go
+func (r UpdateConnectionResponse) GetJSON401() *Unauthorized
+```
+
+GetJSON401 returns the response for an HTTP 401 \`application/json\` response
+
+<a name="UpdateConnectionResponse.GetJSON404"></a>
+### func \(UpdateConnectionResponse\) [GetJSON404](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3647>)
+
+```go
+func (r UpdateConnectionResponse) GetJSON404() *NotFound
+```
+
+GetJSON404 returns the response for an HTTP 404 \`application/json\` response
+
+<a name="UpdateConnectionResponse.GetJSON503"></a>
+### func \(UpdateConnectionResponse\) [GetJSON503](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3652>)
+
+```go
+func (r UpdateConnectionResponse) GetJSON503() *EncryptionUnavailable
+```
+
+GetJSON503 returns the response for an HTTP 503 \`application/json\` response
+
+<a name="UpdateConnectionResponse.Status"></a>
+### func \(UpdateConnectionResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3662>)
+
+```go
+func (r UpdateConnectionResponse) Status() string
+```
+
+Status returns HTTPResponse.Status
+
+<a name="UpdateConnectionResponse.StatusCode"></a>
+### func \(UpdateConnectionResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3670>)
+
+```go
+func (r UpdateConnectionResponse) StatusCode() int
+```
+
+StatusCode returns HTTPResponse.StatusCode
+
 <a name="UpdateDagJSONRequestBody"></a>
-## type [UpdateDagJSONRequestBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L414>)
+## type [UpdateDagJSONRequestBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L494>)
 
 UpdateDagJSONRequestBody defines body for UpdateDag for application/json ContentType.
 
@@ -3967,7 +5783,7 @@ type UpdateDagJSONRequestBody = DAGUpdate
 ```
 
 <a name="UpdateDagResponse"></a>
-## type [UpdateDagResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2543-L2548>)
+## type [UpdateDagResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3822-L3827>)
 
 
 
@@ -3981,7 +5797,7 @@ type UpdateDagResponse struct {
 ```
 
 <a name="ParseUpdateDagResponse"></a>
-### func [ParseUpdateDagResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3874>)
+### func [ParseUpdateDagResponse](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L5794>)
 
 ```go
 func ParseUpdateDagResponse(rsp *http.Response) (*UpdateDagResponse, error)
@@ -3990,7 +5806,7 @@ func ParseUpdateDagResponse(rsp *http.Response) (*UpdateDagResponse, error)
 ParseUpdateDagResponse parses an HTTP response from a UpdateDagWithResponse call
 
 <a name="UpdateDagResponse.ContentType"></a>
-### func \(UpdateDagResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2577>)
+### func \(UpdateDagResponse\) [ContentType](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3856>)
 
 ```go
 func (r UpdateDagResponse) ContentType() string
@@ -3999,7 +5815,7 @@ func (r UpdateDagResponse) ContentType() string
 ContentType is a convenience method to retrieve the Content\-Type value from the HTTP response headers
 
 <a name="UpdateDagResponse.GetBody"></a>
-### func \(UpdateDagResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2556>)
+### func \(UpdateDagResponse\) [GetBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3835>)
 
 ```go
 func (r UpdateDagResponse) GetBody() []byte
@@ -4008,7 +5824,7 @@ func (r UpdateDagResponse) GetBody() []byte
 GetBody returns the raw response body bytes
 
 <a name="UpdateDagResponse.GetJSON200"></a>
-### func \(UpdateDagResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2551>)
+### func \(UpdateDagResponse\) [GetJSON200](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3830>)
 
 ```go
 func (r UpdateDagResponse) GetJSON200() *DAG
@@ -4017,7 +5833,7 @@ func (r UpdateDagResponse) GetJSON200() *DAG
 GetJSON200 returns the response for an HTTP 200 \`application/json\` response
 
 <a name="UpdateDagResponse.Status"></a>
-### func \(UpdateDagResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2561>)
+### func \(UpdateDagResponse\) [Status](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3840>)
 
 ```go
 func (r UpdateDagResponse) Status() string
@@ -4026,7 +5842,7 @@ func (r UpdateDagResponse) Status() string
 Status returns HTTPResponse.Status
 
 <a name="UpdateDagResponse.StatusCode"></a>
-### func \(UpdateDagResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L2569>)
+### func \(UpdateDagResponse\) [StatusCode](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L3848>)
 
 ```go
 func (r UpdateDagResponse) StatusCode() int
@@ -4035,7 +5851,7 @@ func (r UpdateDagResponse) StatusCode() int
 StatusCode returns HTTPResponse.StatusCode
 
 <a name="User"></a>
-## type [User](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L328-L334>)
+## type [User](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L359-L365>)
 
 User defines model for User.
 
@@ -4050,7 +5866,7 @@ type User struct {
 ```
 
 <a name="UserCollection"></a>
-## type [UserCollection](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L337-L340>)
+## type [UserCollection](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L368-L371>)
 
 UserCollection defines model for UserCollection.
 
@@ -4062,7 +5878,7 @@ type UserCollection struct {
 ```
 
 <a name="UserListItem"></a>
-## type [UserListItem](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L343-L349>)
+## type [UserListItem](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L374-L380>)
 
 UserListItem One account in the user list. Leoflow accounts are email\-keyed and carry a set of RBAC roles, so this diverges from the Airflow FAB users API \(username\-keyed with first\_name/last\_name\).
 
@@ -4076,8 +5892,57 @@ type UserListItem struct {
 }
 ```
 
+<a name="Variable"></a>
+## type [Variable](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L383-L389>)
+
+Variable An Airflow\-style variable. The value is masked server\-side when the key looks sensitive \(secret/password/token/...\).
+
+```go
+type Variable struct {
+    Description *string `json:"description,omitempty"`
+    IsEncrypted bool    `json:"is_encrypted"`
+    Key         string  `json:"key"`
+    TeamName    *string `json:"team_name,omitempty"`
+    Value       string  `json:"value"`
+}
+```
+
+<a name="VariableBody"></a>
+## type [VariableBody](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L392-L396>)
+
+VariableBody Variable create/replace payload. value and description are tri\-state: omit the key to preserve the stored value, send an empty string to clear it, or send a value to set it. A value equal to the mask \`\*\*\*\` for a sensitive\-looking key \(secret/password/token/...\) is treated as "unchanged", so re\-submitting a variable read back from GET \(whose sensitive value is masked\) never overwrites the real value with the mask.
+
+```go
+type VariableBody struct {
+    Description *string `json:"description,omitempty"`
+    Key         string  `json:"key"`
+    Value       *string `json:"value,omitempty"`
+}
+```
+
+<a name="VariableCollection"></a>
+## type [VariableCollection](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L399-L402>)
+
+VariableCollection defines model for VariableCollection.
+
+```go
+type VariableCollection struct {
+    TotalEntries *int        `json:"total_entries,omitempty"`
+    Variables    *[]Variable `json:"variables,omitempty"`
+}
+```
+
+<a name="VariableKey"></a>
+## type [VariableKey](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L439>)
+
+VariableKey defines model for VariableKey.
+
+```go
+type VariableKey = string
+```
+
 <a name="VersionInfo"></a>
-## type [VersionInfo](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L352-L355>)
+## type [VersionInfo](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L405-L408>)
 
 VersionInfo defines model for VersionInfo.
 
@@ -4089,7 +5954,7 @@ type VersionInfo struct {
 ```
 
 <a name="XComEntry"></a>
-## type [XComEntry](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L358-L365>)
+## type [XComEntry](<https://github.com/neochaotic/leoflow/blob/main/pkg/client/client.gen.go#L411-L418>)
 
 XComEntry defines model for XComEntry.
 


### PR DESCRIPTION
Closes #909 — the must-fix-before-the-next-cut items from the review of #907. This PR gates the cut.

- **Boot WARN when `auth.max_attempt_credential_lifetime` is disabled (<= 0).** Since #907 the knob governs two guarantees: the ceiling on heartbeat-driven token renewal and the `activeDeadlineSeconds` floor a task pod gets when its task declares no `execution_timeout`. Setting it to zero silently removed both (the ladder rung is skipped, the floor omitted). `executor.ResilienceLadderWarnings` names the knob and both consequences; `warnStartup` logs it once at WARN right after startup validation passes. Not an error — it is a documented setting.
- **Godoc and docs state both roles.** `internal/config/server.go` (field + defaults comment) no longer says the knob "only caps the total renewed lifetime"; `operate/agent-credential-transport.md` and `operate/scheduler-resilience.md` say the same in the operator's words, including that a declared timeout is never shortened.
- **CHANGELOG qualified.** The "no task pod is left Running forever after a total control-plane outage" claim now carries "(unless the ceiling is disabled, which also disables this floor)" and the honest scope: the floor is load-bearing only when the control plane never returns; when it does, the lapsed bearer already makes the agent exit. Framed as making the pre-existing de-facto cap (ceiling + token TTL + agent-lost threshold) explicit.
- **N2** — the ladder wiring test reads the shipped config default instead of hardcoding 24h, so "the shipped defaults validate" is actually pinned (changing the default to 5m fails it).
- **N3** — `TestNewReaperWiresGateIntoEveryReaper` proves `NewReaper` wires the destructive gate into all five reapers: with the leading predicate open exactly once, the entry check passes and every per-write check fails — nothing destroyed, each reaper's `*_gate_skip` decision metered exactly once. Deleting any one of the five assignments fails it.

Verification: build, `go test ./...` (33 packages), golangci-lint 0 (fresh cache), changelog gate, N3 mutation check.