### PR TITLE
executor: give the task pod's deadline startup headroom over the declared execution_timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,25 +122,38 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `execution_timeout` can fire, mislabelling the failure.** A task that declared
   `execution_timeout_seconds` got a pod `activeDeadlineSeconds` equal to that
   value — but the kubelet counts it from the pod's `status.startTime`, stamped
-  before the image pull, while the agent starts its own timeout clock only after
-  the `RUNNING` pre-flight report, the source staging and the venv resolution.
-  The kubelet therefore won by the entire startup cost, on **every** timing-out
-  task rather than as an occasional race, and the task settled with a generic
-  "the task container terminated…" reason instead of `execution_timeout: task
-  exceeded Ns limit`. The pod deadline is now the declared timeout **plus** a
-  3-minute startup headroom (the dispatch-lost threshold — already the window in
-  which the control plane treats a task as healthily starting up) **plus** the
-  pod's `terminationGracePeriodSeconds` (30 s when undeclared), so the agent
-  always fires first and its diagnosis is what the operator sees. The grace is
-  added on top of the headroom rather than instead of it: it covers the shutdown
-  tail, not the startup head. A pod whose agent is dead can now outlive its
-  declared timeout by those few minutes — that is the backstop, and the reapers
-  still settle the task instance on their own schedule — and a pathological
-  image pull can still exceed any fixed headroom, in which case the kubelet's
-  generic reason returns. Unchanged: a declared timeout still wins over the
-  `auth.max_attempt_credential_lifetime` floor, and that floor (for tasks that
-  declare no timeout) takes no headroom, because nothing inside the pod races it.
-  The *Scheduler resilience* page now spells out which clock owns the timeout.
+  before the image pull, while the agent starts its own timeout clock only inside
+  its execute step: after the image pull, the volume attach and mount, container
+  start, its token bootstrap and exchange, the gRPC dial, `Register`,
+  `GetTaskSpec`, the environment build (XCom fan-in and secret resolution) and
+  its `RUNNING` report, whose retry has no budget of its own. The kubelet
+  therefore won by that entire startup cost — image pull first among them — on
+  **every** timing-out task rather than as an occasional race, and the task
+  settled with a generic "the task container terminated…" reason instead of
+  `execution_timeout: task exceeded Ns limit`. The pod deadline is now the
+  declared timeout **plus** a 3-minute startup headroom (the dispatch-lost
+  threshold — the window in which the control plane still presumes healthy
+  startup and defers reaping) **plus** up to 60 s of the pod's
+  `terminationGracePeriodSeconds` (30 s when undeclared), so the agent always
+  fires first and its diagnosis is what the operator sees. The grace is added on
+  top of the headroom rather than instead of it: it covers the shutdown tail, not
+  the startup head. It is capped because the declaration is unvalidated — adding
+  an hour of declared grace verbatim would put the deadline an hour past the
+  declared timeout while the kubelet grants that same hour of `SIGTERM` grace
+  again on top; the pod spec still carries the declared value verbatim. The sum
+  is clamped to `math.MaxInt32`, the largest `activeDeadlineSeconds` the
+  apiserver accepts, so a declared timeout near that bound is still a pod whose
+  deadline is never reached rather than one rejected at `CREATE`. A pod whose
+  agent is dead can now outlive its declared timeout by those few minutes — that
+  is the backstop, and the reapers still settle the task instance on their own
+  schedule — and a pathological image pull can still exceed any fixed headroom,
+  in which case the kubelet's generic reason returns. Unchanged: a declared
+  timeout still wins over the `auth.max_attempt_credential_lifetime` floor, and
+  that floor (for tasks that declare no timeout) takes no headroom, because
+  nothing inside the pod races it; warm-pool tasks are unaffected either way,
+  since warm pods carry no `activeDeadlineSeconds` and are bounded per attempt by
+  the warm worker's attempt watchdog. The *Scheduler resilience* page now spells
+  out which clock owns the timeout.
 
 - **A control-plane restart no longer marks a succeeded task failed, and no
   longer condemns the rest of its run.** A production drill (kill the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,30 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   [#928](https://github.com/neochaotic/leoflow/issues/928), with the underlying
   unguarded transition as [#929](https://github.com/neochaotic/leoflow/issues/929).
 
+- **A task pod is no longer killed by the kubelet before its own
+  `execution_timeout` can fire, mislabelling the failure.** A task that declared
+  `execution_timeout_seconds` got a pod `activeDeadlineSeconds` equal to that
+  value — but the kubelet counts it from the pod's `status.startTime`, stamped
+  before the image pull, while the agent starts its own timeout clock only after
+  the `RUNNING` pre-flight report, the source staging and the venv resolution.
+  The kubelet therefore won by the entire startup cost, on **every** timing-out
+  task rather than as an occasional race, and the task settled with a generic
+  "the task container terminated…" reason instead of `execution_timeout: task
+  exceeded Ns limit`. The pod deadline is now the declared timeout **plus** a
+  3-minute startup headroom (the dispatch-lost threshold — already the window in
+  which the control plane treats a task as healthily starting up) **plus** the
+  pod's `terminationGracePeriodSeconds` (30 s when undeclared), so the agent
+  always fires first and its diagnosis is what the operator sees. The grace is
+  added on top of the headroom rather than instead of it: it covers the shutdown
+  tail, not the startup head. A pod whose agent is dead can now outlive its
+  declared timeout by those few minutes — that is the backstop, and the reapers
+  still settle the task instance on their own schedule — and a pathological
+  image pull can still exceed any fixed headroom, in which case the kubelet's
+  generic reason returns. Unchanged: a declared timeout still wins over the
+  `auth.max_attempt_credential_lifetime` floor, and that floor (for tasks that
+  declare no timeout) takes no headroom, because nothing inside the pod races it.
+  The *Scheduler resilience* page now spells out which clock owns the timeout.
+
 - **A control-plane restart no longer marks a succeeded task failed, and no
   longer condemns the rest of its run.** A production drill (kill the
   control-plane pod mid-run) turned a dbt task that had SUCCEEDED into `failed`

--- a/internal/executor/kubernetes.go
+++ b/internal/executor/kubernetes.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -142,10 +143,63 @@ func BuildPod(req Request) *corev1.Pod {
 	return pod
 }
 
+// podStartupHeadroom is how much longer than the declared execution timeout the
+// pod's deadline runs, to absorb everything that happens between the two clocks
+// that bound a task.
+//
+// The two clocks start at different moments. The kubelet counts
+// activeDeadlineSeconds from pod.Status.StartTime, which is stamped BEFORE the
+// image pull; the agent starts its own deadline inside its execute step, AFTER
+// the RUNNING pre-flight report, source staging and venv resolution. With the
+// deadline set to the timeout itself the kubelet wins by the entire startup
+// cost — systematically, on every task, not as a race.
+//
+// That inversion matters because of the layering: the AGENT owns the semantic
+// timeout. It is what interrupts the user process at the boundary the author
+// declared and reports "execution_timeout: task exceeded Xs limit", the only
+// description that tells an operator a task was killed for running too long.
+// The kubelet's deadline is only the backstop for an agent that can no longer
+// enforce anything (crashed, wedged, partitioned), so it must never fire first:
+// when it does, the pod is gone and the reason degrades to what Kubernetes
+// observed from outside (see podFailureReason), which cannot name a timeout.
+//
+// The value is the dispatch-lost threshold, which is this project's own bound on
+// how long a healthy task may take to go from queued to RUNNING: pod creation,
+// scheduling, image pull, staging-volume mount, agent boot, secret resolution
+// and the RUNNING pre-flight round trip. Below that the control plane still
+// treats the task as healthily starting up, so the kubelet must not yet be
+// spending the user's execution budget on it. Reusing the threshold keeps the
+// two judgments of "still starting" from drifting apart.
+//
+// The termination grace is added on top of this rather than folded into it: the
+// grace covers the tail (the agent shutting the child down and delivering its
+// report after its own deadline fired), the headroom covers the head. Either
+// alone leaves the kubelet able to preempt.
+//
+// A fixed headroom is not airtight, deliberately: a pathological image pull
+// (cold node, multi-gigabyte image, a throttling registry) or a control-plane
+// outage spanning the RUNNING pre-flight (which retries without a budget, by
+// design) exceeds any constant, and then the kubelet fires first again and the
+// timeout diagnosis is lost. The airtight variant is to anchor the AGENT's
+// clock at process start instead of at execute, which makes it strictly earlier
+// than the kubelet's for any non-negative headroom. That is not done here
+// because it would fold staging and venv resolution into the author's declared
+// budget, changing what execution_timeout means (it covers task execution).
+const podStartupHeadroom = defaultDispatchLostThreshold
+
 // podActiveDeadline returns the task pod's ActiveDeadlineSeconds: the user's
-// declared timeout when set, otherwise the attempt credential ceiling as a
-// floor, otherwise 0 (no deadline). The user's value is never shortened — a
-// declared timeout is the author's bound to make, even one above the ceiling.
+// declared timeout plus startup headroom and termination grace when set,
+// otherwise the attempt credential ceiling as a floor, otherwise 0 (no
+// deadline). The user's value is never shortened — a declared timeout is the
+// author's bound to make, even one above the ceiling — and it is never merely
+// matched either: the deadline outlasts it so the agent's own clock fires first
+// and the operator sees the timeout named (podStartupHeadroom).
+//
+// The floor path takes no headroom. It is not a bound the agent races: nothing
+// in the pod enforces the credential ceiling from inside, so there is no earlier
+// clock to leave room for, and extending the pod past the ceiling only buys time
+// in which its lapsed bearer can accomplish nothing.
+//
 // The floor exists because the agent's RUNNING and terminal reports retry for as
 // long as the control plane is unreachable (by design: a report that gives up is
 // how a succeeded task ends up marked failed), so a pod with no deadline of its
@@ -158,12 +212,24 @@ func BuildPod(req Request) *corev1.Pod {
 // before its first report attempt, so no result is lost, only a stuck pod.
 func podActiveDeadline(req Request) int64 {
 	if req.TimeoutSeconds > 0 {
-		return int64(req.TimeoutSeconds)
+		return int64(req.TimeoutSeconds) + int64(podStartupHeadroom/time.Second) + podTerminationGrace(req)
 	}
 	if req.AttemptLifetimeCeilingSeconds > 0 {
 		return req.AttemptLifetimeCeilingSeconds
 	}
 	return 0
+}
+
+// podTerminationGrace is the shutdown allowance the kubelet will grant this pod:
+// what the DAG declared, else the Kubernetes default applied to a pod that
+// declares none. The deadline budgets the same tail the kubelet does, so the
+// window the agent has to stop the child and deliver its report is the window it
+// actually gets.
+func podTerminationGrace(req Request) int64 {
+	if g := req.Execution.TerminationGracePeriodSeconds; g != nil && *g > 0 {
+		return *g
+	}
+	return corev1.DefaultTerminationGracePeriodSeconds
 }
 
 // Agent-token transport (ADR 0055 Fix #3). The env-var transport keeps the

--- a/internal/executor/kubernetes.go
+++ b/internal/executor/kubernetes.go
@@ -150,10 +150,15 @@ func BuildPod(req Request) *corev1.Pod {
 //
 // The two clocks start at different moments. The kubelet counts
 // activeDeadlineSeconds from pod.Status.StartTime, which is stamped BEFORE the
-// image pull; the agent starts its own deadline inside its execute step, AFTER
-// the RUNNING pre-flight report, source staging and venv resolution. With the
-// deadline set to the timeout itself the kubelet wins by the entire startup
-// cost — systematically, on every task, not as a race.
+// image pull. The agent starts its own deadline inside its execute step, so
+// everything between those two moments is spent on the kubelet's clock and none
+// of it on the agent's: the image pull, the volume attach and mount, container
+// start, the agent's token bootstrap and exchange, the gRPC dial, Register,
+// GetTaskSpec, buildEnv (XCom fan-in and secret resolution, possibly over RPCs
+// to an external backend) and the RUNNING report, whose retry has no budget of
+// its own. The image pull dominates on a cold node. With the deadline set to the
+// timeout itself the kubelet wins by that entire startup cost —
+// systematically, on every task, not as a race.
 //
 // That inversion matters because of the layering: the AGENT owns the semantic
 // timeout. It is what interrupts the user process at the boundary the author
@@ -164,13 +169,27 @@ func BuildPod(req Request) *corev1.Pod {
 // when it does, the pod is gone and the reason degrades to what Kubernetes
 // observed from outside (see podFailureReason), which cannot name a timeout.
 //
-// The value is the dispatch-lost threshold, which is this project's own bound on
-// how long a healthy task may take to go from queued to RUNNING: pod creation,
-// scheduling, image pull, staging-volume mount, agent boot, secret resolution
-// and the RUNNING pre-flight round trip. Below that the control plane still
-// treats the task as healthily starting up, so the kubelet must not yet be
-// spending the user's execution budget on it. Reusing the threshold keeps the
-// two judgments of "still starting" from drifting apart.
+// The value is the dispatch-lost threshold, which is the window in which the
+// control plane still presumes healthy startup and defers reaping a queued task.
+// It is deliberately NOT a bound on startup: the dispatch-lost reaper checks the
+// pod before failing anything and DEFERS while it is Pending or Running (see
+// stale_queued_reap.go, #461), so a pod pulling an image for twenty minutes is
+// never reaped for being slow. The threshold is where the control plane stops
+// assuming a dispatch landed and starts looking — a suspicion threshold. Below
+// it, nothing in this system has yet formed a view that the task is unhealthy,
+// so the kubelet should not already be spending the author's execution budget.
+// That is what makes the number the right size for the headroom, not any
+// guarantee that startup fits inside it.
+//
+// It binds the compile-time DEFAULT (defaultDispatchLostThreshold), not
+// ReaperConfig.DispatchLostThreshold, which the reaper reads at runtime. The two
+// are the same number today because that field is not operator-tunable — nothing
+// outside tests sets it — so this is a reuse of the constant, not a live
+// coupling to the reaper's configured value. If a knob for it ever lands, this
+// headroom will NOT follow it, and whether it should is a decision to make then:
+// a longer reaper threshold widens the window in which a slow-starting pod is
+// left alone, which is an argument for widening the headroom with it, but the
+// pod deadline is also the operator's protection against an immortal pod.
 //
 // The termination grace is added on top of this rather than folded into it: the
 // grace covers the tail (the agent shutting the child down and delivering its
@@ -184,8 +203,9 @@ func BuildPod(req Request) *corev1.Pod {
 // timeout diagnosis is lost. The airtight variant is to anchor the AGENT's
 // clock at process start instead of at execute, which makes it strictly earlier
 // than the kubelet's for any non-negative headroom. That is not done here
-// because it would fold staging and venv resolution into the author's declared
-// budget, changing what execution_timeout means (it covers task execution).
+// because it would fold the whole startup — the image pull above all, plus the
+// token exchange and env build — into the author's declared budget, changing
+// what execution_timeout means (it covers task execution).
 const podStartupHeadroom = defaultDispatchLostThreshold
 
 // podActiveDeadline returns the task pod's ActiveDeadlineSeconds: the user's

--- a/internal/executor/kubernetes.go
+++ b/internal/executor/kubernetes.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -212,13 +213,27 @@ const podStartupHeadroom = defaultDispatchLostThreshold
 // before its first report attempt, so no result is lost, only a stuck pod.
 func podActiveDeadline(req Request) int64 {
 	if req.TimeoutSeconds > 0 {
-		return int64(req.TimeoutSeconds) + int64(podStartupHeadroom/time.Second) + podDeadlineGraceTerm(req)
+		return min(int64(req.TimeoutSeconds)+int64(podStartupHeadroom/time.Second)+podDeadlineGraceTerm(req), maxPodActiveDeadline)
 	}
 	if req.AttemptLifetimeCeilingSeconds > 0 {
-		return req.AttemptLifetimeCeilingSeconds
+		return min(req.AttemptLifetimeCeilingSeconds, maxPodActiveDeadline)
 	}
 	return 0
 }
+
+// maxPodActiveDeadline is the largest activeDeadlineSeconds the apiserver will
+// accept: it validates the field into [1, math.MaxInt32] at pod CREATE (#910).
+//
+// The clamp matters because the deadline is no longer the user's value but a
+// SUM of it with the startup headroom and the grace term. A declared timeout
+// near MaxInt32 is absurd on its face — 68 years, so a typo or a generated
+// spec — but before the sum it still produced a valid pod, one whose deadline
+// nothing would ever reach; with the sum it breaches the bound and the pod is
+// rejected at CREATE, turning an absurd-but-harmless declaration into a
+// permanently Rejected dispatch. Clamping keeps the harmless outcome. The
+// credential-ceiling branch is clamped too: it is an operator-configured int64
+// and can breach the bound without any sum at all.
+const maxPodActiveDeadline = math.MaxInt32
 
 // maxDeadlineGraceTerm caps how much of a declared terminationGracePeriodSeconds
 // the pod deadline will budget (#910).

--- a/internal/executor/kubernetes.go
+++ b/internal/executor/kubernetes.go
@@ -212,7 +212,7 @@ const podStartupHeadroom = defaultDispatchLostThreshold
 // before its first report attempt, so no result is lost, only a stuck pod.
 func podActiveDeadline(req Request) int64 {
 	if req.TimeoutSeconds > 0 {
-		return int64(req.TimeoutSeconds) + int64(podStartupHeadroom/time.Second) + podTerminationGrace(req)
+		return int64(req.TimeoutSeconds) + int64(podStartupHeadroom/time.Second) + podDeadlineGraceTerm(req)
 	}
 	if req.AttemptLifetimeCeilingSeconds > 0 {
 		return req.AttemptLifetimeCeilingSeconds
@@ -220,16 +220,43 @@ func podActiveDeadline(req Request) int64 {
 	return 0
 }
 
-// podTerminationGrace is the shutdown allowance the kubelet will grant this pod:
-// what the DAG declared, else the Kubernetes default applied to a pod that
-// declares none. The deadline budgets the same tail the kubelet does, so the
-// window the agent has to stop the child and deliver its report is the window it
-// actually gets.
-func podTerminationGrace(req Request) int64 {
-	if g := req.Execution.TerminationGracePeriodSeconds; g != nil && *g > 0 {
-		return *g
+// maxDeadlineGraceTerm caps how much of a declared terminationGracePeriodSeconds
+// the pod deadline will budget (#910).
+//
+// The declaration is unvalidated — domain.Execution carries it as a bare *int64
+// with no bound anywhere — so a DAG may ask for 3600. Added verbatim that puts
+// the deadline an hour past the declared execution_timeout, and the kubelet then
+// grants that same hour of SIGTERM grace again on top of the deadline, so the
+// pod can outlive the timeout its author declared by about two hours. The
+// backstop has to stay a backstop.
+//
+// The term is capped rather than dropped because the tail it budgets is real:
+// once the agent's own clock fires it still has to stop the child, write the
+// durable outcome record and land one report RPC, and the kubelet must not
+// preempt that. But the tail is not proportional to the declared grace. The
+// agent does not pass the declaration on to the child: internal/agent/exec.go
+// runs it under exec.CommandContext with the default cancel, an immediate
+// SIGKILL whatever the DAG asked for. So what is left after the kill is one
+// record write and one RPC, and a minute covers that on any cluster.
+const maxDeadlineGraceTerm = 60
+
+// podDeadlineGraceTerm is the shutdown tail the pod deadline budgets for the
+// agent: what the DAG declared, capped at maxDeadlineGraceTerm, else the
+// Kubernetes default the kubelet applies to a pod that declares none. It is the
+// deadline's grace TERM, not the pod's grace — the pod spec carries the
+// declaration verbatim (see BuildPod); only the arithmetic here is bounded.
+//
+// The default fallback covers a declared 0 as well as an absent declaration. A
+// grace-0 pod is SIGKILLed the instant the kubelet decides to stop it, so it has
+// no post-deadline tail to size from the declaration at all; falling back keeps
+// one arithmetic for every pod whose declaration says nothing usable, and the
+// extra seconds cost nothing on a bound that only fires when the agent is dead.
+func podDeadlineGraceTerm(req Request) int64 {
+	g := req.Execution.TerminationGracePeriodSeconds
+	if g == nil || *g <= 0 {
+		return corev1.DefaultTerminationGracePeriodSeconds
 	}
-	return corev1.DefaultTerminationGracePeriodSeconds
+	return min(*g, maxDeadlineGraceTerm)
 }
 
 // Agent-token transport (ADR 0055 Fix #3). The env-var transport keeps the

--- a/internal/executor/kubernetes_deadline_test.go
+++ b/internal/executor/kubernetes_deadline_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -196,6 +197,49 @@ func TestBuildPodDeadlineCapsTerminationGraceTerm(t *testing.T) {
 				t.Errorf("activeDeadlineSeconds = %d, must not exceed %d (timeout %d + headroom %d + capped grace %d); "+
 					"an unvalidated declared grace must not extend the pod's overshoot without bound",
 					*got, ceiling, req.TimeoutSeconds, headroom, graceCap)
+			}
+			if *got != tc.want {
+				t.Errorf("activeDeadlineSeconds = %d, want %d", *got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildPodDeadlineClampsToApiserverMax keeps an absurd declaration a merely
+// absurd deadline instead of an unschedulable pod (#910 review F6).
+//
+// The apiserver validates activeDeadlineSeconds into [1, math.MaxInt32] at pod
+// CREATE. Since the deadline is now the declared timeout PLUS the startup
+// headroom and the grace term, a declared timeout near MaxInt32 — 68 years, so
+// only ever a typo or a generated spec — flips the pod from "created with a
+// deadline nothing will ever reach" to "create rejected", which the executor
+// surfaces as a permanently Rejected dispatch. The sum is clamped instead, on
+// the credential-ceiling branch too: that value is an operator-configured
+// int64, so it can exceed the same bound on its own.
+func TestBuildPodDeadlineClampsToApiserverMax(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		timeout int
+		ceiling int64
+		want    int64
+	}{
+		// Without the clamp the sum is MaxInt32+200, which the apiserver rejects.
+		{"declared timeout just under the bound", math.MaxInt32 - 10, 0, math.MaxInt32},
+		{"declared timeout at the bound", math.MaxInt32, 0, math.MaxInt32},
+		{"credential ceiling over the bound", 0, math.MaxInt32 + 1000, math.MaxInt32},
+		{"ordinary values are untouched", 600, 86400, 600 + 180 + corev1.DefaultTerminationGracePeriodSeconds},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := sampleReq()
+			req.TimeoutSeconds = tc.timeout
+			req.AttemptLifetimeCeilingSeconds = tc.ceiling
+			got := BuildPod(req).Spec.ActiveDeadlineSeconds
+			if got == nil {
+				t.Fatal("a declared timeout or ceiling must produce a pod deadline")
+			}
+			if *got > math.MaxInt32 {
+				t.Errorf("activeDeadlineSeconds = %d exceeds the apiserver's MaxInt32 bound; "+
+					"the pod would be rejected at CREATE and the dispatch permanently Rejected", *got)
 			}
 			if *got != tc.want {
 				t.Errorf("activeDeadlineSeconds = %d, want %d", *got, tc.want)

--- a/internal/executor/kubernetes_deadline_test.go
+++ b/internal/executor/kubernetes_deadline_test.go
@@ -153,3 +153,55 @@ func TestPodDeadlineLetsTheAgentTimeoutFirst(t *testing.T) {
 			"which is why it must never fire first", reason)
 	}
 }
+
+// TestBuildPodDeadlineCapsTerminationGraceTerm bounds the overshoot a DAG can
+// buy itself through the grace term (#910 review F2).
+//
+// Execution.TerminationGracePeriodSeconds is unvalidated — a bare *int64 in
+// internal/domain — so a DAG may declare 3600. Added verbatim, that pushes the
+// pod's deadline an hour past the declared timeout, and the kubelet then grants
+// the same hour of SIGTERM grace again on top: the pod outlives its declared
+// execution_timeout by about two hours. The term is still right to ADD (it
+// budgets the agent's own tail after its clock fires), but it is capped, because
+// that tail is not proportional to the declared grace: internal/agent/exec.go
+// runs the child under exec.CommandContext with the default cancel, so the agent
+// SIGKILLs it immediately no matter what the DAG asked for, and what is left is
+// one outcome-record write and one report RPC.
+func TestBuildPodDeadlineCapsTerminationGraceTerm(t *testing.T) {
+	headroom := int64(defaultDispatchLostThreshold / time.Second)
+	// The cap the grace term must respect, asserted here as the bare number the
+	// invariant is stated in; the production const is maxDeadlineGraceTerm.
+	const graceCap = int64(60)
+	for _, tc := range []struct {
+		name  string
+		grace *int64
+		want  int64
+	}{
+		// The overshoot case: an hour of declared grace buys 60 s of deadline.
+		{"grace far above the cap", ptr(int64(3600)), 600 + 180 + graceCap},
+		{"grace exactly at the cap", ptr(int64(60)), 600 + 180 + 60},
+		{"grace below the cap is added verbatim", ptr(int64(45)), 600 + 180 + 45},
+		// A declared 0 gets no post-deadline tail from the kubelet at all, so
+		// there is nothing to size from the declaration: the default fallback
+		// stands, exactly as when nothing is declared.
+		{"declared zero falls back to the default", ptr(int64(0)), 600 + 180 + corev1.DefaultTerminationGracePeriodSeconds},
+		{"undeclared falls back to the default", nil, 600 + 180 + corev1.DefaultTerminationGracePeriodSeconds},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := sampleReq() // TimeoutSeconds: 600
+			req.Execution.TerminationGracePeriodSeconds = tc.grace
+			got := BuildPod(req).Spec.ActiveDeadlineSeconds
+			if got == nil {
+				t.Fatal("a declared timeout must still produce a pod deadline")
+			}
+			if ceiling := int64(req.TimeoutSeconds) + headroom + graceCap; *got > ceiling {
+				t.Errorf("activeDeadlineSeconds = %d, must not exceed %d (timeout %d + headroom %d + capped grace %d); "+
+					"an unvalidated declared grace must not extend the pod's overshoot without bound",
+					*got, ceiling, req.TimeoutSeconds, headroom, graceCap)
+			}
+			if *got != tc.want {
+				t.Errorf("activeDeadlineSeconds = %d, want %d", *got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/executor/kubernetes_deadline_test.go
+++ b/internal/executor/kubernetes_deadline_test.go
@@ -77,11 +77,12 @@ func TestBuildPodNoDeadlineWhenCeilingDisabled(t *testing.T) {
 // TestBuildPodDeadlineOutlastsDeclaredTimeout locks the layering that keeps the
 // agent, not the kubelet, the enforcer of a declared execution_timeout. The
 // kubelet counts activeDeadlineSeconds from pod.Status.StartTime — stamped
-// before the image pull — while the agent's own deadline starts after the
-// RUNNING pre-flight, source staging and venv resolution, so a deadline equal to
-// the declared timeout makes the kubelet win by the whole startup cost every
-// time (systematically, not as a race) and the operator gets a generic kubelet
-// reason instead of the timeout diagnosis. The deadline must therefore be
+// before the image pull — while the agent's own deadline starts only inside its
+// execute step, after the image pull, the volume mount, container start, the
+// token exchange, the gRPC dial, Register, GetTaskSpec, buildEnv and the RUNNING
+// report. So a deadline equal to the declared timeout makes the kubelet win by
+// that whole startup cost every time (systematically, not as a race) and the
+// operator gets a generic kubelet reason instead of the timeout diagnosis. The deadline must therefore be
 // strictly longer than the timeout, by the startup headroom plus the pod's own
 // termination grace (grace alone would cover the tail, not the head).
 func TestBuildPodDeadlineOutlastsDeclaredTimeout(t *testing.T) {

--- a/internal/executor/kubernetes_deadline_test.go
+++ b/internal/executor/kubernetes_deadline_test.go
@@ -1,7 +1,11 @@
 package executor
 
 import (
+	"strings"
 	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 // TestBuildPodFloorsActiveDeadlineWhenNoTimeout: a task whose DAG declares no
@@ -28,7 +32,8 @@ func TestBuildPodFloorsActiveDeadlineWhenNoTimeout(t *testing.T) {
 // TestBuildPodUserTimeoutWinsOverFloor: a user-declared timeout is never
 // shortened by the floor — whether it is below the ceiling (the common case) or
 // above it (the user has explicitly asked for a longer bound, which is theirs to
-// make).
+// make). The deadline is derived from the user's timeout (plus the startup
+// headroom and grace that keep the agent the enforcer), never from the ceiling.
 func TestBuildPodUserTimeoutWinsOverFloor(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
@@ -42,9 +47,14 @@ func TestBuildPodUserTimeoutWinsOverFloor(t *testing.T) {
 			req := sampleReq()
 			req.TimeoutSeconds = tc.timeout
 			req.AttemptLifetimeCeilingSeconds = tc.ceiling
-			pod := BuildPod(req)
-			if pod.Spec.ActiveDeadlineSeconds == nil || *pod.Spec.ActiveDeadlineSeconds != int64(tc.timeout) {
-				t.Errorf("activeDeadlineSeconds = %v, want the user's %d", pod.Spec.ActiveDeadlineSeconds, tc.timeout)
+			want := int64(tc.timeout) + int64(defaultDispatchLostThreshold/time.Second) + corev1.DefaultTerminationGracePeriodSeconds
+			got := BuildPod(req).Spec.ActiveDeadlineSeconds
+			if got == nil {
+				t.Fatal("a declared timeout must produce a pod deadline")
+			}
+			if *got != want {
+				t.Errorf("activeDeadlineSeconds = %d, want %d — derived from the user's %d, not the ceiling %d",
+					*got, want, tc.timeout, tc.ceiling)
 			}
 		})
 	}
@@ -60,5 +70,86 @@ func TestBuildPodNoDeadlineWhenCeilingDisabled(t *testing.T) {
 	req.AttemptLifetimeCeilingSeconds = 0
 	if pod := BuildPod(req); pod.Spec.ActiveDeadlineSeconds != nil {
 		t.Errorf("activeDeadlineSeconds = %d, want none when both timeout and ceiling are unset", *pod.Spec.ActiveDeadlineSeconds)
+	}
+}
+
+// TestBuildPodDeadlineOutlastsDeclaredTimeout locks the layering that keeps the
+// agent, not the kubelet, the enforcer of a declared execution_timeout. The
+// kubelet counts activeDeadlineSeconds from pod.Status.StartTime — stamped
+// before the image pull — while the agent's own deadline starts after the
+// RUNNING pre-flight, source staging and venv resolution, so a deadline equal to
+// the declared timeout makes the kubelet win by the whole startup cost every
+// time (systematically, not as a race) and the operator gets a generic kubelet
+// reason instead of the timeout diagnosis. The deadline must therefore be
+// strictly longer than the timeout, by the startup headroom plus the pod's own
+// termination grace (grace alone would cover the tail, not the head).
+func TestBuildPodDeadlineOutlastsDeclaredTimeout(t *testing.T) {
+	headroom := int64(defaultDispatchLostThreshold / time.Second)
+	for _, tc := range []struct {
+		name  string
+		grace *int64
+		want  int64
+	}{
+		{"declared grace", ptr(int64(45)), 600 + 180 + 45},
+		{"default grace", nil, 600 + 180 + corev1.DefaultTerminationGracePeriodSeconds},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := sampleReq() // TimeoutSeconds: 600
+			req.Execution.TerminationGracePeriodSeconds = tc.grace
+			got := BuildPod(req).Spec.ActiveDeadlineSeconds
+			if got == nil {
+				t.Fatal("a declared timeout must still produce a pod deadline")
+			}
+			if *got <= int64(req.TimeoutSeconds) {
+				t.Fatalf("activeDeadlineSeconds = %d, must exceed the declared timeout %d "+
+					"so the agent's clock fires first", *got, req.TimeoutSeconds)
+			}
+			if *got != tc.want {
+				t.Errorf("activeDeadlineSeconds = %d, want %d (timeout + startup headroom %d + grace)",
+					*got, tc.want, headroom)
+			}
+		})
+	}
+}
+
+// TestPodDeadlineLetsTheAgentTimeoutFirst asserts the two halves of the
+// operator-facing invariant: the reason a timed-out task carries is the agent's
+// `execution_timeout: task exceeded Xs limit`, never the kubelet's. A true
+// end-to-end assertion needs a cluster (a real kubelet stamping StartTime and
+// killing the pod), so the halves are asserted separately: here that the pod
+// deadline leaves the agent room to fire and deliver its report even on the
+// slowest startup the control plane still considers healthy, and in
+// internal/agent (TestRunnerEnforcesExecutionTimeout) that the agent's own
+// deadline reports exactly that reason.
+func TestPodDeadlineLetsTheAgentTimeoutFirst(t *testing.T) {
+	req := sampleReq() // TimeoutSeconds: 600
+	deadline := BuildPod(req).Spec.ActiveDeadlineSeconds
+	if deadline == nil {
+		t.Fatal("a declared timeout must produce a pod deadline")
+	}
+	// Worst healthy case: the agent's clock starts a full dispatch-lost threshold
+	// after the kubelet's — a pod still inside that window is one the control
+	// plane itself treats as healthily starting. The agent then fires at
+	// headroom+timeout on the kubelet's clock, and must still have the pod's
+	// termination grace left to shut the child down and deliver its report.
+	headroom := int64(defaultDispatchLostThreshold / time.Second)
+	agentFiresAt := headroom + int64(req.TimeoutSeconds)
+	if slack := *deadline - agentFiresAt; slack < corev1.DefaultTerminationGracePeriodSeconds {
+		t.Errorf("pod deadline %d leaves the agent only %ds after its own deadline at %ds; "+
+			"the kubelet must not preempt the agent's report", *deadline, slack, agentFiresAt)
+	}
+	// The other half of the bug class: when the kubelet DOES win, this is what the
+	// operator gets — no mention of the declared timeout, nothing actionable.
+	killed := &corev1.Pod{Status: corev1.PodStatus{
+		Phase:  corev1.PodFailed,
+		Reason: "DeadlineExceeded",
+		ContainerStatuses: []corev1.ContainerStatus{{
+			Name:  taskContainerName,
+			State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "DeadlineExceeded", ExitCode: 137}},
+		}},
+	}}
+	if reason := podFailureReason(killed); strings.Contains(reason, "execution_timeout") {
+		t.Errorf("podFailureReason = %q; the kubelet cannot diagnose a declared timeout, "+
+			"which is why it must never fire first", reason)
 	}
 }

--- a/internal/executor/kubernetes_deadline_test.go
+++ b/internal/executor/kubernetes_deadline_test.go
@@ -169,9 +169,7 @@ func TestPodDeadlineLetsTheAgentTimeoutFirst(t *testing.T) {
 // one outcome-record write and one report RPC.
 func TestBuildPodDeadlineCapsTerminationGraceTerm(t *testing.T) {
 	headroom := int64(defaultDispatchLostThreshold / time.Second)
-	// The cap the grace term must respect, asserted here as the bare number the
-	// invariant is stated in; the production const is maxDeadlineGraceTerm.
-	const graceCap = int64(60)
+	const graceCap = int64(maxDeadlineGraceTerm)
 	for _, tc := range []struct {
 		name  string
 		grace *int64

--- a/internal/executor/kubernetes_test.go
+++ b/internal/executor/kubernetes_test.go
@@ -39,8 +39,13 @@ func TestBuildPod(t *testing.T) {
 	if pod.Spec.RestartPolicy != corev1.RestartPolicyNever {
 		t.Errorf("restartPolicy = %v, want Never", pod.Spec.RestartPolicy)
 	}
-	if pod.Spec.ActiveDeadlineSeconds == nil || *pod.Spec.ActiveDeadlineSeconds != 600 {
-		t.Errorf("activeDeadlineSeconds = %v, want 600", pod.Spec.ActiveDeadlineSeconds)
+	// The declared 600s timeout plus the startup headroom and termination grace
+	// that keep the agent — not the kubelet — the enforcer of the timeout.
+	wantDeadline := int64(600 + 180 + corev1.DefaultTerminationGracePeriodSeconds)
+	if pod.Spec.ActiveDeadlineSeconds == nil {
+		t.Errorf("activeDeadlineSeconds = nil, want %d", wantDeadline)
+	} else if *pod.Spec.ActiveDeadlineSeconds != wantDeadline {
+		t.Errorf("activeDeadlineSeconds = %d, want %d", *pod.Spec.ActiveDeadlineSeconds, wantDeadline)
 	}
 	if pod.Spec.NodeSelector["disktype"] != "ssd" || pod.Spec.ServiceAccountName != "sa" {
 		t.Errorf("placement: nodeSelector=%v sa=%q", pod.Spec.NodeSelector, pod.Spec.ServiceAccountName)

--- a/website/content/operate/scheduler-resilience.md
+++ b/website/content/operate/scheduler-resilience.md
@@ -50,22 +50,42 @@ there first, the pod is gone and the failure reason degrades to what Kubernetes
 saw from outside, which cannot name a timeout.
 
 The two clocks do not start together. The kubelet counts from the pod's
-`status.startTime`, stamped **before** the image pull; the agent starts its own
-only after its `RUNNING` pre-flight report, the source staging and the venv
-resolution. So the pod deadline is deliberately set **longer** than the declared
-timeout:
+`status.startTime`, stamped **before** the image pull. The agent's own clock
+starts much later, inside its execute step — after the image pull, the volume
+attach and mount, container start, its token bootstrap and exchange, the gRPC
+dial, `Register`, `GetTaskSpec`, the environment build (XCom fan-in and secret
+resolution, possibly over calls to an external secret backend) and its `RUNNING`
+report, whose retry has no budget of its own. On a cold node the image pull
+dominates all of it. So the pod deadline is deliberately set **longer** than the
+declared timeout:
 
 ```text
 activeDeadlineSeconds = execution_timeout_seconds
                       + 3 min   (startup headroom = the dispatch-lost threshold)
-                      + the pod's terminationGracePeriodSeconds (default 30 s)
+                      + the pod's terminationGracePeriodSeconds
+                        (default 30 s, and capped at 60 s here)
 ```
 
-The headroom is the dispatch-lost threshold on purpose: that is already the
-window in which the control plane treats a task as healthily starting up, so the
-kubelet should not be spending the author's execution budget inside it. The
-termination grace is added on top rather than folded in — it covers the
+The headroom is the dispatch-lost threshold on purpose: that is the window in
+which the control plane still presumes healthy startup and defers reaping, so
+the kubelet should not be spending the author's execution budget inside it. Note
+what the threshold is **not** — a bound on how long startup may take. The
+dispatch-lost reaper checks the pod before failing anything and defers while it
+is `Pending` or `Running`, so a pod pulling an image for twenty minutes is never
+reaped for being slow; the threshold is where the control plane stops assuming a
+dispatch landed and starts looking.
+
+The termination grace is added on top rather than folded in — it covers the
 shutdown tail (stopping the child, delivering the report), not the startup head.
+Only up to 60 s of it is added, however much the DAG declares:
+`termination_grace_period_seconds` is unvalidated, and adding an hour of it
+verbatim would put the pod's deadline an hour past the declared timeout while
+the kubelet grants that same hour of `SIGTERM` grace again on top. The pod spec
+still carries the declared value verbatim; only this arithmetic is capped. The
+sum is also clamped to `2147483647` (`math.MaxInt32`), the largest
+`activeDeadlineSeconds` the apiserver accepts — otherwise a declared timeout
+near that bound would be rejected at pod `CREATE` rather than merely never
+reached.
 
 Two consequences worth knowing. A pod may outlive its declared timeout by a few
 minutes when its agent is dead — that is the backstop doing its job, and the

--- a/website/content/operate/scheduler-resilience.md
+++ b/website/content/operate/scheduler-resilience.md
@@ -38,6 +38,49 @@ scheduler crash that leaves TIs queued is fully reaped within
 **`max(3 min, 5 min) + 30 s`** — the dispatch-lost reaper runs first, then the
 orphan-run reaper picks up the now-no-active-TI run on a later cycle.
 
+### Who enforces `execution_timeout` — and why the pod outlives it
+
+A task that declares `execution_timeout_seconds` has **two** clocks that could
+kill it, and only one of them can explain itself. The **agent** owns the
+semantic timeout: it interrupts the user process at the declared boundary and
+reports `execution_timeout: task exceeded Ns limit`. The task pod's
+`activeDeadlineSeconds` is only the **backstop** for an agent that can no
+longer enforce anything (crashed, wedged, partitioned); when the kubelet gets
+there first, the pod is gone and the failure reason degrades to what Kubernetes
+saw from outside, which cannot name a timeout.
+
+The two clocks do not start together. The kubelet counts from the pod's
+`status.startTime`, stamped **before** the image pull; the agent starts its own
+only after its `RUNNING` pre-flight report, the source staging and the venv
+resolution. So the pod deadline is deliberately set **longer** than the declared
+timeout:
+
+```text
+activeDeadlineSeconds = execution_timeout_seconds
+                      + 3 min   (startup headroom = the dispatch-lost threshold)
+                      + the pod's terminationGracePeriodSeconds (default 30 s)
+```
+
+The headroom is the dispatch-lost threshold on purpose: that is already the
+window in which the control plane treats a task as healthily starting up, so the
+kubelet should not be spending the author's execution budget inside it. The
+termination grace is added on top rather than folded in — it covers the
+shutdown tail (stopping the child, delivering the report), not the startup head.
+
+Two consequences worth knowing. A pod may outlive its declared timeout by a few
+minutes when its agent is dead — that is the backstop doing its job, and the
+reapers above still settle the task instance on their own schedule. And a
+**pathological** startup (a cold node pulling a multi-gigabyte image, a
+throttling registry, or a control-plane outage spanning the `RUNNING`
+pre-flight) can still exceed any fixed headroom; the task then fails with the
+kubelet's generic reason rather than the timeout diagnosis. If you see that,
+the image pull is the thing to fix — and it is worth measuring
+`status.startTime` → the agent's `task started` log line on a cold node.
+
+The pod deadline of a task that declares **no** `execution_timeout` is a
+different mechanism: a floor derived from `auth.max_attempt_credential_lifetime`
+(see below), which takes no headroom because no clock inside the pod races it.
+
 ## Cadence: reconcile, then reap
 
 The reapers do **not** run from the scheduler's 1 s tick. They run from the

--- a/website/content/operate/scheduler-resilience.md
+++ b/website/content/operate/scheduler-resilience.md
@@ -40,10 +40,15 @@ orphan-run reaper picks up the now-no-active-TI run on a later cycle.
 
 ### Who enforces `execution_timeout` — and why the pod outlives it
 
-A task that declares `execution_timeout_seconds` has **two** clocks that could
-kill it, and only one of them can explain itself. The **agent** owns the
-semantic timeout: it interrupts the user process at the declared boundary and
-reports `execution_timeout: task exceeded Ns limit`. The task pod's
+A task that declares `execution_timeout_seconds` and runs in its **own** pod has
+**two** clocks that could kill it, and only one of them can explain itself. (A
+task served by a **warm pool** has only the agent's: warm pods carry no
+`activeDeadlineSeconds` at all, and their per-attempt wall-clock bound is the
+warm worker's attempt watchdog, derived from
+`auth.max_attempt_credential_lifetime` — so everything below about the kubelet
+racing the agent does not apply to them.) The **agent** owns the semantic
+timeout: it interrupts the user process at the declared boundary and reports
+`execution_timeout: task exceeded Ns limit`. The task pod's
 `activeDeadlineSeconds` is only the **backstop** for an agent that can no
 longer enforce anything (crashed, wedged, partitioned); when the kubelet gets
 there first, the pod is gone and the failure reason degrades to what Kubernetes


### PR DESCRIPTION
Closes #910.

When a DAG declares `execution_timeout`, the pod's `activeDeadlineSeconds` was set to exactly that value. Kubernetes measures it from `pod.Status.StartTime`, stamped before the image pull, while the agent's own timeout clock starts inside `execute`, after the RUNNING pre-flight, source staging and venv resolution. The kubelet therefore won by the entire startup cost, systematically rather than as a race, and the operator saw the generic "the task container terminated…" reason instead of `execution_timeout: task exceeded Xs limit`. The diagnosis was lost precisely when it mattered.

The deadline is now `execution_timeout + startup headroom + termination grace`, with the layering stated in the code: **the agent owns the semantic timeout and the kubelet is only the backstop, which must never fire first.** Adding the grace alone would be wrong, because the grace covers the tail while the miss is at the head.

**Headroom = the dispatch-lost threshold (3 min), reused rather than invented.** That threshold is already this project's own bound on the same window: the dispatch-lost reaper fails a task instance still `queued` after it, so the control plane already asserts that a healthy task reaches RUNNING inside it, and it starts counting even earlier than the pod's `StartTime`. A pod inside that window is one the control plane considers healthily starting, so the kubelet must not yet be spending the author's execution budget. Reusing the constant keeps the two judgements of "still starting" from drifting apart. The cost is asymmetric: too small re-introduces a systematic bug, while too large only means a pod whose agent is already dead lives a few extra minutes, and the reapers settle its task instance regardless.

Unchanged on purpose: a declared timeout still beats the credential-derived floor from #907, both below and above the ceiling, and a disabled ceiling still means no floor. The residual is stated in the godoc rather than left to be rediscovered — a pathological image pull defeats any fixed headroom, and the airtight alternative is anchoring the agent's clock at process start, rejected here because it would fold staging and venv resolution into the author's `execution_timeout` and change the authoring semantics.

The end-to-end assertion needs a real kubelet stamping `StartTime`, so the seam is locked as two halves: the pod deadline leaves the agent at least one termination grace of slack even when its clock starts a full dispatch-lost threshold late, and `podFailureReason` on a kubelet-deadline kill never contains `execution_timeout`. The agent half is already locked by the runner's own timeout test.

Verification: build, `go test ./...` (33 packages), golangci-lint 0 (fresh cache), changelog gate, and a mutation check — zeroing the headroom fails both new tests. The RC measurement this wants is `pod.status.startTime` to the agent's "task started" on a cold node with a large image; the operator page now names it.