### PR TITLE
executor: a terminal-but-present task pod is the reconciler's to settle, not the pod-lost reaper's to delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,8 +111,12 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `pod_lost_pod_query_error`, which is also the reason the valve is safe to open
   (the reconciler's pod LIST and the reaper's own hit the same apiserver, so
   whatever stops the sweep also denies the reaper its authorization). The
-  dispatch-lost reaper's behavior is unchanged: a queued attempt never ran, so
-  its finished pod carries no outcome to preserve.
+  dispatch-lost reaper's behavior is unchanged in this fix, and that reaper can
+  still delete a terminal pod's outcome record: a queued attempt's finished pod
+  CAN carry an outcome (the settle statements admit `queued`, and a dispatch can
+  stamp a row that already reached `running` back to `queued`). Tracked as
+  [#928](https://github.com/neochaotic/leoflow/issues/928), with the underlying
+  unguarded transition as [#929](https://github.com/neochaotic/leoflow/issues/929).
 
 - **A control-plane restart no longer marks a succeeded task failed, and no
   longer condemns the rest of its run.** A production drill (kill the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,27 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **The pod-lost reaper no longer reaps a task whose pod is still there,
+  finished.** Its liveness question returned one bool for two different states —
+  "no pod for this attempt at all" and "a pod that exists in a terminal phase" —
+  and it read either as authorization to reap: it marked the task instance
+  `pod_lost` and then deleted the pod, destroying the termination log the
+  reconciler recovers the attempt's durable outcome from (so a task that had
+  SUCCEEDED read as failed, and its run with it). Pod liveness is now
+  three-valued and pod-lost defers on a present-but-finished pod, metering a
+  `pod_lost_terminal_pod_defer` decision, reaping only when the apiserver holds
+  no pod for the attempt. This holds independently of the leader-settling gate,
+  its grace and the reconciler cadence: an absence is a state no timing can
+  manufacture, so the settling gate's liveness valve — which opens after 2 ×
+  grace precisely so a broken reconciler sweep cannot wedge the reapers — can no
+  longer surface the reap it was narrowing. Behavior on an unreadable apiserver
+  is unchanged and now locked by a test: pod-lost defers with
+  `pod_lost_pod_query_error`, which is also the reason the valve is safe to open
+  (the reconciler's pod LIST and the reaper's own hit the same apiserver, so
+  whatever stops the sweep also denies the reaper its authorization). The
+  dispatch-lost reaper's behavior is unchanged: a queued attempt never ran, so
+  its finished pod carries no outcome to preserve.
+
 - **A control-plane restart no longer marks a succeeded task failed, and no
   longer condemns the rest of its run.** A production drill (kill the
   control-plane pod mid-run) turned a dbt task that had SUCCEEDED into `failed`

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -1601,7 +1601,7 @@ func setupK8sDispatch(ctx context.Context, cfg *config.ServerConfig, sched *sche
 	sched.SetDispatcher(disp)
 	// Shared informer read-path (PR-10): one long-lived watch replaces the
 	// reapers' per-running-TI LIST storm and the reconciler's 30s LIST. Consulted
-	// only to DEFER a reap; the live TaskPodActive kill path is unchanged (#461).
+	// only to DEFER a reap; the live TaskPodPresence kill path is unchanged (#461).
 	// A typed-nil pointer would defeat the reconciler's / reaper's nil check, so
 	// the interfaces are only populated when the informer actually built.
 	podInformer := buildPodInformer(ctx, cfg, cs, logger)

--- a/internal/executor/pod_cache_reap_test.go
+++ b/internal/executor/pod_cache_reap_test.go
@@ -10,7 +10,7 @@ import (
 // fakePresenceCache is a PodPresenceCache whose readings a test controls. It is
 // the safe-direction seam (#461): a true reading may DEFER a reap; a false
 // reading is never authoritative and the reaper must fall through to the live
-// TaskPodActive read.
+// TaskPodPresence read.
 type fakePresenceCache struct {
 	active map[string]bool // "runID/taskID/try" -> cached Pending/Running
 }
@@ -23,7 +23,7 @@ func (c *fakePresenceCache) CachedPodActive(runID, taskID string, try int) bool 
 
 // TestPodLostReaper_CacheAbsentButLiveRunning_DoesNotReap is the #461 regression
 // lock, mechanized. The cache says the pod is ABSENT (a lagged/cold read), but the
-// live TaskPodActive read says it is Running. The reaper MUST fall through to the
+// live TaskPodPresence read says it is Running. The reaper MUST fall through to the
 // live read and DEFER — cache absence is never authoritative, so cache lag can
 // only delay a reap, never cause a false-positive one. Reaping here would kill a
 // live task.
@@ -53,7 +53,7 @@ func TestPodLostReaper_CacheAbsentButLiveRunning_DoesNotReap(t *testing.T) {
 
 // TestPodLostReaper_CacheActive_SkipsLiveList: a cache-present Pending/Running pod
 // defers the reap without touching the apiserver — the whole point of PR-10. The
-// live TaskPodActive read must not be called.
+// live TaskPodPresence read must not be called.
 func TestPodLostReaper_CacheActive_SkipsLiveList(t *testing.T) {
 	past := time.Now().UTC().Add(-2 * time.Minute)
 	store := &fakePodLostStore{candidates: []PodLostCandidate{

--- a/internal/executor/pod_informer.go
+++ b/internal/executor/pod_informer.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Pod label keys the informer selects and filters on. They mirror exactly the
-// keys BuildPod stamps and TaskPodActive selects, sanitizeLabel-transformed —
+// keys BuildPod stamps and TaskPodPresence selects, sanitizeLabel-transformed —
 // reusing the same transform is load-bearing: a lookup built from a different key
 // would silently miss every pod and quietly return the storm PR-10 removes.
 const (
@@ -39,7 +39,7 @@ var errCacheNotSynced = errors.New("pod informer cache not synced")
 // Its readings are trusted only in the safe direction (#461): CachedPodActive is
 // consulted ONLY to DEFER a reap when a pod is present and Pending/Running — a
 // cache "absent" reading is never authoritative and callers MUST fall through to
-// the live TaskPodActive (quorum) read before any destructive action. Cache lag
+// the live TaskPodPresence (quorum) read before any destructive action. Cache lag
 // can therefore only ever delay a reap by a tick, never cause a false-positive
 // one. SnapshotTaskPods is safe for the reconciler because presence of a terminal
 // pod is monotonic and every settle is attempt/state-guarded (ADR 0052).
@@ -120,7 +120,7 @@ func (p *PodInformer) Shutdown() {
 
 // CachedPodActive reports whether the cache holds a pod for exactly the
 // (run, task, try) attempt that is Pending or Running — the exact predicate
-// TaskPodActive uses, pinned to the same attempt (#723). It is the safe
+// TaskPodPresence uses, pinned to the same attempt (#723). It is the safe
 // direction of the asymmetric-trust contract: a true return may DEFER a reap; a
 // false return is NEVER authoritative and the caller must fall through to the live
 // read. Before the cache has synced it returns false, so a cold cache degrades to

--- a/internal/executor/pod_informer_test.go
+++ b/internal/executor/pod_informer_test.go
@@ -45,9 +45,9 @@ func waitFor(t *testing.T, cond func() bool) bool {
 
 // TestPodInformer_SeesAddAndDelete verifies the cache reflects the live pod set
 // through the initial LIST and subsequent watch events, applies the same
-// sanitizeLabel transform BuildPod/TaskPodActive use (so a raw run-id lookup hits
+// sanitizeLabel transform BuildPod/TaskPodPresence use (so a raw run-id lookup hits
 // the sanitized label), and treats only Pending/Running as active — the identical
-// predicate to TaskPodActive. A Succeeded pod is not active.
+// predicate to TaskPodPresence. A Succeeded pod is not active.
 func TestPodInformer_SeesAddAndDelete(t *testing.T) {
 	// Uppercase/underscore run-id proves the lookup sanitizes before matching.
 	cs := fake.NewClientset(
@@ -91,7 +91,7 @@ func TestPodInformer_SeesAddAndDelete(t *testing.T) {
 
 // TestPodInformer_BeforeSync_ReturnsFalse locks the safety gate: until the cache
 // has synced, CachedPodActive returns false so every candidate falls through to
-// the live TaskPodActive read (today's behavior). A cold cache is never wrong,
+// the live TaskPodPresence read (today's behavior). A cold cache is never wrong,
 // only "no speedup yet" — leader-failover safe.
 func TestPodInformer_BeforeSync_ReturnsFalse(t *testing.T) {
 	cs := fake.NewClientset(informerPod("p-run", "r1", "t1", corev1.PodRunning))

--- a/internal/executor/pod_lost_reap.go
+++ b/internal/executor/pod_lost_reap.go
@@ -84,7 +84,7 @@ type podLostReaper struct {
 	// cache is an optional informer-backed presence cache (PR-10) consulted ONLY
 	// to DEFER a reap: a cached Pending/Running pod skips the live LIST. A cache
 	// miss is never authoritative — the reaper falls through to the live
-	// TaskPodActive read below, so cache lag can only delay a reap, never cause a
+	// TaskPodPresence read below, so cache lag can only delay a reap, never cause a
 	// false-positive one (#461). Nil keeps every candidate on the live path.
 	cache PodPresenceCache
 	// gate is re-checked before every destructive call (see destructiveGate).
@@ -137,14 +137,14 @@ func (r *podLostReaper) run(ctx context.Context) error {
 		//   * pod Pending/Running -> a pod exists; not lost. Silence, if any, is
 		//                            the agent-lost reaper's job.
 		//   * no live pod       -> the pod is genuinely gone; fail as pod_lost.
-		active, perr := r.pods.TaskPodActive(ctx, c.DagRunID, c.TaskID, c.TryNumber)
+		presence, perr := r.pods.TaskPodPresence(ctx, c.DagRunID, c.TaskID, c.TryNumber)
 		if perr != nil {
 			r.logger.Warn("pod-lost: pod liveness unknown; deferring",
 				"ti", c.TaskInstanceID, "run", c.DagRunID, "task", c.TaskID, "error", perr)
 			r.record("pod_lost_pod_query_error")
 			continue
 		}
-		if active {
+		if presence == PodPresenceLive {
 			continue
 		}
 		r.reapOne(ctx, c)
@@ -176,7 +176,7 @@ func (r *podLostReaper) reapOne(ctx context.Context, c PodLostCandidate) {
 	r.logger.Warn("running task has no live pod past grace; failing as pod_lost",
 		"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID, "running_since", c.RunningSince)
 	r.record("pod_lost")
-	// Best-effort teardown pinned to (run, task, try). TaskPodActive said no
+	// Best-effort teardown pinned to (run, task, try). TaskPodPresence said no
 	// live pod, so this only sweeps a lingering terminal pod at most; a
 	// retry's newer pod has a different try-number label and is never touched.
 	if !gateOpen(r.gate, ctx) {

--- a/internal/executor/pod_lost_reap.go
+++ b/internal/executor/pod_lost_reap.go
@@ -95,9 +95,11 @@ func newPodLostReaper(store PodLostReapStore, logger *slog.Logger, grace time.Du
 	return &podLostReaper{store: store, logger: logger, grace: grace, recorder: rec}
 }
 
-// run lists every running TI, checks pod liveness for the ones past the grace
-// period, and fails those with no live pod as pod_lost. Per-TI failures are
-// isolated; a panic anywhere is recovered so the scheduler tick stays alive.
+// run lists every running TI, checks pod presence for the ones past the grace
+// period, and fails as pod_lost only those whose attempt has no pod at all. A
+// pod that is present — live or finished — is somebody else's to resolve.
+// Per-TI failures are isolated; a panic anywhere is recovered so the scheduler
+// tick stays alive.
 func (r *podLostReaper) run(ctx context.Context) error {
 	defer func() {
 		if rec := recover(); rec != nil {
@@ -115,8 +117,14 @@ func (r *podLostReaper) run(ctx context.Context) error {
 	// look lost: its container exited, yet its TI is still `running` because the
 	// terminal report found no server. Only the reconciler's sweep can recover
 	// that pod's durable outcome; Reaper.settling holds the whole tick until one
-	// has completed under this leadership, so by the time run is reached a
-	// `running` TI with no live pod is genuinely lost.
+	// has completed under this leadership.
+	//
+	// That gate is a timing argument, so it cannot be the only defense: it holds
+	// on facts about the leader, and its liveness valve deliberately opens after
+	// 2 × grace when those facts never arrive. The reap authorization below is
+	// therefore narrowed to a state no timing can fake — no pod object for the
+	// attempt at all. A finished pod is still a present pod, and stays the
+	// reconciler's, valve open or shut.
 	candidates, err := r.store.ListRunningTasks(ctx)
 	if err != nil {
 		return err
@@ -133,10 +141,15 @@ func (r *podLostReaper) run(ctx context.Context) error {
 			continue
 		}
 		// Consult the pod before failing:
-		//   * query failed     -> liveness unknown; DEFER ("do no harm").
+		//   * query failed        -> liveness unknown; DEFER ("do no harm"). The
+		//                            live read is the only authorization there is,
+		//                            so an unreachable or forbidden apiserver
+		//                            fails this reaper closed (see Reaper.settling).
 		//   * pod Pending/Running -> a pod exists; not lost. Silence, if any, is
 		//                            the agent-lost reaper's job.
-		//   * no live pod       -> the pod is genuinely gone; fail as pod_lost.
+		//   * pod present but done -> the attempt's outcome is on that pod object;
+		//                            settling it is the reconciler's job. DEFER.
+		//   * no pod at all       -> the pod is genuinely gone; fail as pod_lost.
 		presence, perr := r.pods.TaskPodPresence(ctx, c.DagRunID, c.TaskID, c.TryNumber)
 		if perr != nil {
 			r.logger.Warn("pod-lost: pod liveness unknown; deferring",
@@ -144,16 +157,30 @@ func (r *podLostReaper) run(ctx context.Context) error {
 			r.record("pod_lost_pod_query_error")
 			continue
 		}
-		if presence == PodPresenceLive {
+		switch presence {
+		case PodPresenceLive:
 			continue
+		case PodPresenceTerminal:
+			// A terminal-but-present pod is NOT a lost pod, and treating it as one
+			// is destructive twice over: the mark makes a finished attempt read as
+			// pod_lost, and the teardown then deletes the pod whose termination log
+			// is the durable evidence of what the attempt actually did. Only the
+			// reconciler may settle it. Deferring costs at most one reconcile
+			// interval; reaping costs the outcome permanently.
+			r.logger.Info("pod-lost: pod is present in a terminal phase; leaving it for the reconciler",
+				"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID, "try", c.TryNumber)
+			r.record("pod_lost_terminal_pod_defer")
+			continue
+		case PodPresenceAbsent:
+			r.reapOne(ctx, c)
 		}
-		r.reapOne(ctx, c)
 	}
 	return nil
 }
 
-// reapOne fails one TI whose pod is gone and sweeps any lingering pod,
-// re-checking the destructive gate immediately before each write.
+// reapOne fails one TI whose pod is gone and sweeps any pod that appears for the
+// attempt after all, re-checking the destructive gate immediately before each
+// write. It must only ever be called for PodPresenceAbsent.
 func (r *podLostReaper) reapOne(ctx context.Context, c PodLostCandidate) {
 	if !gateOpen(r.gate, ctx) {
 		r.record("pod_lost_gate_skip")
@@ -176,8 +203,9 @@ func (r *podLostReaper) reapOne(ctx context.Context, c PodLostCandidate) {
 	r.logger.Warn("running task has no live pod past grace; failing as pod_lost",
 		"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID, "running_since", c.RunningSince)
 	r.record("pod_lost")
-	// Best-effort teardown pinned to (run, task, try). TaskPodPresence said no
-	// live pod, so this only sweeps a lingering terminal pod at most; a
+	// Best-effort teardown pinned to (run, task, try). The presence read said
+	// there is no pod for this attempt at all, so this normally deletes nothing
+	// and exists to catch a pod that materialized between the read and here; a
 	// retry's newer pod has a different try-number label and is never touched.
 	if !gateOpen(r.gate, ctx) {
 		r.record("pod_lost_teardown_gate_skip")

--- a/internal/executor/pod_lost_reap_test.go
+++ b/internal/executor/pod_lost_reap_test.go
@@ -233,3 +233,56 @@ func TestPodLostReaper_TerminalPodIsTheReconcilersToSettle(t *testing.T) {
 		})
 	}
 }
+
+// TestPodLostReaper_UnreadableApiserverFailsClosed locks the safety argument the
+// leader-settling gate's liveness valve rests on (see Reaper.settling): the
+// reconciler's broad pod LIST and this reaper's narrow one talk to the same
+// apiserver, so whatever stops the sweep from completing — unreachable,
+// unauthorized, throttled — also denies pod-lost its only authorization to reap.
+// The valve may therefore open on a broken sweep without pod-lost turning that
+// into a false reap. If this reaper ever reaps on a query error, the valve stops
+// being safe and this test must fail.
+//
+// The cache is wired with a MISS in the second case: a fall-through from a cold
+// or lagged cache lands on the same failing live read, so it authorizes nothing
+// either.
+func TestPodLostReaper_UnreadableApiserverFailsClosed(t *testing.T) {
+	const grace = 60 * time.Second
+	past := time.Now().UTC().Add(-2 * time.Minute)
+
+	cases := []struct {
+		name  string
+		cache PodPresenceCache
+	}{
+		{"no cache wired: the live read is the only authorization", nil},
+		{"cache miss falls through to the same failing read", &fakePresenceCache{active: map[string]bool{}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakePodLostStore{candidates: []PodLostCandidate{
+				{TaskInstanceID: "unreadable", DagRunID: "run-a", TaskID: "work", TryNumber: 1, RunningSince: past},
+			}}
+			pods := &fakePodManager{activeErr: errors.New("Get \"https://10.0.0.1:443/api/v1/pods\": dial tcp: i/o timeout")}
+			rec := &capturingRecorder{}
+			r := newPodLostReaper(store, reapTestLogger(), grace, rec)
+			r.pods = pods
+			r.cache = tc.cache
+
+			if err := r.run(context.Background()); err != nil {
+				t.Fatalf("run: %v", err)
+			}
+			if len(store.marked) != 0 {
+				t.Errorf("reaped on an unreadable apiserver: %v", store.marked)
+			}
+			if len(pods.deletedTasks) != 0 {
+				t.Errorf("deleted a pod on an unreadable apiserver: %v", pods.deletedTasks)
+			}
+			if got := rec.count("pod_lost_pod_query_error"); got != 1 {
+				t.Errorf("pod_lost_pod_query_error metered %d times, want 1", got)
+			}
+			if got := rec.count("pod_lost"); got != 0 {
+				t.Errorf("pod_lost metered %d times, want 0", got)
+			}
+		})
+	}
+}

--- a/internal/executor/pod_lost_reap_test.go
+++ b/internal/executor/pod_lost_reap_test.go
@@ -234,10 +234,13 @@ func TestPodLostReaper_TerminalPodIsTheReconcilersToSettle(t *testing.T) {
 	}
 }
 
-// TestPodLostReaper_UnreadableApiserverFailsClosed locks the safety argument the
-// leader-settling gate's liveness valve rests on (see Reaper.settling): the
-// reconciler's broad pod LIST and this reaper's narrow one talk to the same
-// apiserver, so whatever stops the sweep from completing — unreachable,
+// TestPodLostReaper_UnreadableApiserverFailsClosed locks the CONSEQUENCE the
+// leader-settling gate's liveness valve leans on (see Reaper.settling), not its
+// premise: this reaper never reaps on a failed pod read. The premise — that
+// whatever stops the reconciler's broad sweep also denies this narrow read — is
+// usually but not always true (see Reaper.settling for how the two diverge), so
+// what a test can pin is the fail-closed behavior on an apiserver that is
+// unreachable,
 // unauthorized, throttled — also denies pod-lost its only authorization to reap.
 // The valve may therefore open on a broken sweep without pod-lost turning that
 // into a false reap. If this reaper ever reaps on a query error, the valve stops

--- a/internal/executor/pod_lost_reap_test.go
+++ b/internal/executor/pod_lost_reap_test.go
@@ -161,3 +161,75 @@ func TestPodLostReaper(t *testing.T) {
 		}
 	})
 }
+
+// TestPodLostReaper_TerminalPodIsTheReconcilersToSettle is the load-bearing
+// separation between "the pod is gone" and "the pod is finished but still
+// there". Pod-lost used to see one bool for both and reap on either: it marked
+// the task instance pod_lost and then DELETED the pod, destroying the
+// termination log the reconciler recovers the attempt's durable outcome from —
+// so a task that had SUCCEEDED read as failed, and its run with it. A pod that
+// is present in a terminal phase must therefore produce no state write, no pod
+// delete, and one metered defer; only a genuine absence authorizes the reap.
+func TestPodLostReaper_TerminalPodIsTheReconcilersToSettle(t *testing.T) {
+	const grace = 60 * time.Second
+	past := time.Now().UTC().Add(-2 * time.Minute) // comfortably past the grace
+
+	cases := []struct {
+		name string
+		// pods is the pod-manager fixture for the one candidate below.
+		pods *fakePodManager
+		// wantMarked is whether the TI is transitioned to pod_lost.
+		wantMarked bool
+		// wantDeleted is whether the attempt's pod is torn down.
+		wantDeleted bool
+		// wantDecisions is the exact count expected for each decision named.
+		wantDecisions map[string]int
+	}{
+		{
+			name:          "present terminal pod defers to the reconciler",
+			pods:          &fakePodManager{terminal: map[string]bool{"run-a/work/1": true}},
+			wantMarked:    false,
+			wantDeleted:   false,
+			wantDecisions: map[string]int{"pod_lost_terminal_pod_defer": 1, "pod_lost": 0},
+		},
+		{
+			name:          "genuine absence still reaps",
+			pods:          &fakePodManager{}, // neither live nor terminal: no pod at all
+			wantMarked:    true,
+			wantDeleted:   true,
+			wantDecisions: map[string]int{"pod_lost_terminal_pod_defer": 0, "pod_lost": 1},
+		},
+		{
+			name:          "live pod defers without a terminal decision",
+			pods:          &fakePodManager{active: map[string]bool{"run-a/work/1": true}},
+			wantMarked:    false,
+			wantDeleted:   false,
+			wantDecisions: map[string]int{"pod_lost_terminal_pod_defer": 0, "pod_lost": 0},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := &fakePodLostStore{candidates: []PodLostCandidate{
+				{TaskInstanceID: "ti", DagRunID: "run-a", TaskID: "work", TryNumber: 1, RunningSince: past},
+			}}
+			rec := &capturingRecorder{}
+			r := newPodLostReaper(store, reapTestLogger(), grace, rec)
+			r.pods = tc.pods
+
+			if err := r.run(context.Background()); err != nil {
+				t.Fatalf("run: %v", err)
+			}
+			if marked := len(store.marked) > 0; marked != tc.wantMarked {
+				t.Errorf("marked pod_lost = %v (%v), want %v", marked, store.marked, tc.wantMarked)
+			}
+			if deleted := len(tc.pods.deletedTasks) > 0; deleted != tc.wantDeleted {
+				t.Errorf("pod deleted = %v (%v), want %v", deleted, tc.pods.deletedTasks, tc.wantDeleted)
+			}
+			for decision, want := range tc.wantDecisions {
+				if got := rec.count(decision); got != want {
+					t.Errorf("decision %q metered %d times, want %d", decision, got, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/executor/pod_manager.go
+++ b/internal/executor/pod_manager.go
@@ -58,7 +58,13 @@ const (
 	// Pending or Running. Whatever happened to that attempt is recorded on the
 	// pod object, so settling it belongs to the reconciler and no reaper may
 	// delete it. Phase Unknown counts here as well: the pod object is still
-	// there, the reconciler still watches it, and it is not an absence.
+	// there and it is not an absence. Note the backstop for a pod stuck in
+	// Unknown is NOT the reconciler — classifyPod groups Unknown with
+	// Pending/Running, so the reconciler neither settles nor collects it — but
+	// the agent-lost reaper (heartbeats stop when a node goes unreachable) and
+	// the orphan-run reaper. The phase has not been set by kubelet since 2015
+	// and is deprecated upstream, so the practical exposure is nil; classifying
+	// it as presence is the conservative direction.
 	PodPresenceTerminal
 	// PodPresenceAbsent means the apiserver holds no pod for the attempt at all
 	// — the attempt's pod is genuinely gone (deleted, evicted, lost with its

--- a/internal/executor/pod_manager.go
+++ b/internal/executor/pod_manager.go
@@ -26,12 +26,59 @@ type PodManager interface {
 	// orphan-run reaper, which abandons the whole run. The run-id is unique
 	// per run, so no other run's pod can match. Tolerates missing pods.
 	DeleteRunPods(ctx context.Context, runID string) error
-	// TaskPodActive reports whether a pod for exactly the (run, task, try)
-	// attempt exists and is Pending or Running. The reaper defers when it is
-	// true — the dispatch landed, the node is merely slow (#461). Try-number is
-	// pinned so a retried TI's liveness gate asks about the attempt it is about
-	// to fail, not any older attempt whose pod may still linger (#723).
-	TaskPodActive(ctx context.Context, runID, taskID string, tryNumber int) (bool, error)
+	// TaskPodPresence reports what the apiserver holds for exactly the
+	// (run, task, try) attempt: a live pod, a present-but-finished pod, or
+	// nothing. A reaper defers on a live pod — the dispatch landed, the node is
+	// merely slow (#461). Try-number is pinned so a retried TI's liveness gate
+	// asks about the attempt it is about to fail, not any older attempt whose
+	// pod may still linger (#723).
+	TaskPodPresence(ctx context.Context, runID, taskID string, tryNumber int) (PodPresence, error)
+}
+
+// PodPresence is the three-way answer to "what does the apiserver hold for this
+// attempt's pod?".
+//
+// The distinction is load-bearing, not cosmetic. A bare bool collapsed the last
+// two states, and the pod-lost reaper read that collapse as authorization to
+// reap: for a task pod that had already finished it marked the task instance
+// pod_lost and then DELETED the pod — destroying the termination-log evidence
+// the reconciler recovers the task's durable outcome from. A finished task then
+// reads as failed, and its run with it. Presence must be three-valued so a
+// reaper can defer on "present but finished" while still reaping on a genuine
+// absence, which is the state pod-lost exists for.
+type PodPresence int
+
+const (
+	// PodPresenceLive means a pod for the attempt exists and is Pending or
+	// Running: work may still be happening, so every reaper must defer. It is
+	// deliberately the zero value — an unset or error-path presence then
+	// authorizes nothing destructive.
+	PodPresenceLive PodPresence = iota
+	// PodPresenceTerminal means a pod for the attempt exists but none of them is
+	// Pending or Running. Whatever happened to that attempt is recorded on the
+	// pod object, so settling it belongs to the reconciler and no reaper may
+	// delete it. Phase Unknown counts here as well: the pod object is still
+	// there, the reconciler still watches it, and it is not an absence.
+	PodPresenceTerminal
+	// PodPresenceAbsent means the apiserver holds no pod for the attempt at all
+	// — the attempt's pod is genuinely gone (deleted, evicted, lost with its
+	// node) and there is nothing left to settle from. This is the only presence
+	// that authorizes a pod-lost reap.
+	PodPresenceAbsent
+)
+
+// String names the presence for logs.
+func (p PodPresence) String() string {
+	switch p {
+	case PodPresenceLive:
+		return "live"
+	case PodPresenceTerminal:
+		return "terminal"
+	case PodPresenceAbsent:
+		return "absent"
+	default:
+		return "invalid"
+	}
 }
 
 // PodPresenceCache is an optional read-through cache of pod presence — backed by
@@ -43,7 +90,7 @@ type PodManager interface {
 //     cache lag (a pod the cache still shows as live cannot have been gone longer
 //     than the lag, and deferring one tick is harmless).
 //   - CachedPodActive == false => NOT authoritative. The reaper MUST fall through
-//     to the live TaskPodActive (quorum) read before any destructive action, so a
+//     to the live TaskPodPresence (quorum) read before any destructive action, so a
 //     lagged/cold cache can only ever delay a reap by a tick, never cause a
 //     false-positive one.
 //

--- a/internal/executor/pod_terminate.go
+++ b/internal/executor/pod_terminate.go
@@ -68,12 +68,18 @@ func (e *KubernetesExecutor) deletePodsBySelector(ctx context.Context, selector 
 	return errors.Join(errs...)
 }
 
-// TaskPodActive reports whether a pod for exactly the (run, task, try) attempt
-// exists and is still Pending or Running. The dispatch-lost and pod-lost reapers
-// consult this before failing a TI: a live pod means the dispatch actually landed
-// and the node is merely slow to pull the image (#461), so the reaper must DEFER.
-// No pod, or only terminal (Failed/Succeeded/Unknown) pods, means the attempt is
-// genuinely lost and the reaper may proceed.
+// TaskPodPresence reports what the apiserver holds for exactly the
+// (run, task, try) attempt: a live pod (Pending/Running), a present-but-finished
+// pod, or no pod at all. The dispatch-lost and pod-lost reapers consult this
+// before failing a TI: a live pod means the dispatch actually landed and the node
+// is merely slow to pull the image (#461), so the reaper must DEFER.
+//
+// A present-but-finished pod is reported apart from an absence on purpose. The
+// pod object still carries the attempt's outcome (the termination log the
+// reconciler recovers a durable result from), so it is the reconciler's to settle
+// and no reaper may delete it; only a genuine absence means the attempt is lost
+// with nothing left to recover. Any live pod for the attempt wins over a
+// lingering finished sibling, since work may still be running.
 //
 // Try-number is pinned — the same invariant guard as DeleteTaskPod above. The
 // retry rail resets up_for_retry -> none with try_number+1 and the planner
@@ -82,17 +88,22 @@ func (e *KubernetesExecutor) deletePodsBySelector(ctx context.Context, selector 
 // delete. Selecting on (run, task) alone would match that stale older pod and
 // false-defer the reap of the current attempt forever (#723). Asking about the
 // attempt the reaper is about to fail is the correct liveness question.
-func (e *KubernetesExecutor) TaskPodActive(ctx context.Context, runID, taskID string, tryNumber int) (bool, error) {
+func (e *KubernetesExecutor) TaskPodPresence(ctx context.Context, runID, taskID string, tryNumber int) (PodPresence, error) {
 	selector := fmt.Sprintf("leoflow.io/run-id=%s,leoflow.io/task-id=%s,leoflow.io/try-number=%s",
 		sanitizeLabel(runID), sanitizeLabel(taskID), strconv.Itoa(tryNumber))
 	pods, err := e.clientset.CoreV1().Pods(e.namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
-		return false, fmt.Errorf("listing pods for liveness (%s): %w", selector, err)
+		// PodPresenceLive is the zero value on purpose: a caller that drops the
+		// error still holds the presence that authorizes nothing.
+		return PodPresenceLive, fmt.Errorf("listing pods for liveness (%s): %w", selector, err)
+	}
+	if len(pods.Items) == 0 {
+		return PodPresenceAbsent, nil
 	}
 	for i := range pods.Items {
 		if phase := pods.Items[i].Status.Phase; phase == corev1.PodPending || phase == corev1.PodRunning {
-			return true, nil
+			return PodPresenceLive, nil
 		}
 	}
-	return false, nil
+	return PodPresenceTerminal, nil
 }

--- a/internal/executor/pod_terminate_test.go
+++ b/internal/executor/pod_terminate_test.go
@@ -110,71 +110,95 @@ func TestDeleteRunPods_DeletesAllOfTheRunOnly(t *testing.T) {
 	}
 }
 
-// TestTaskPodActive covers the dispatch-lost deferral signal (#461): a pod that
-// exists and is Pending/Running means the dispatch landed and the node is just
-// slow, so the reaper must DEFER. A gone/failed/absent pod means the dispatch is
-// truly lost and the reaper may proceed.
-func TestTaskPodActive(t *testing.T) {
+// TestTaskPodPresence covers the three-way liveness answer the reapers act on.
+// A Pending/Running pod means the dispatch landed and the node is just slow
+// (#461), so every reaper DEFERS. A pod that is present but no longer running is
+// the reconciler's to settle from its termination log, so it must be
+// distinguishable from a genuine absence — collapsing those two into one "not
+// active" bool is what let the pod-lost reaper delete a finished pod and destroy
+// the evidence of its outcome.
+func TestTaskPodPresence(t *testing.T) {
 	tests := []struct {
 		name  string
 		phase corev1.PodPhase
-		want  bool
+		want  PodPresence
 	}{
-		{"pending pod is active (defer)", corev1.PodPending, true},
-		{"running pod is active (defer)", corev1.PodRunning, true},
-		{"failed pod is not active (reap)", corev1.PodFailed, false},
-		{"succeeded pod is not active (reap)", corev1.PodSucceeded, false},
+		{"pending pod is live (defer)", corev1.PodPending, PodPresenceLive},
+		{"running pod is live (defer)", corev1.PodRunning, PodPresenceLive},
+		{"failed pod is present-but-terminal", corev1.PodFailed, PodPresenceTerminal},
+		{"succeeded pod is present-but-terminal", corev1.PodSucceeded, PodPresenceTerminal},
+		{"unknown-phase pod is present, so not absent", corev1.PodUnknown, PodPresenceTerminal},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cs := fake.NewSimpleClientset(taskPod("p", "run-a", "extract", 1, tc.phase))
 			e := NewKubernetesExecutor(cs, "leoflow")
-			active, err := e.TaskPodActive(context.Background(), "run-a", "extract", 1)
+			got, err := e.TaskPodPresence(context.Background(), "run-a", "extract", 1)
 			if err != nil {
-				t.Fatalf("TaskPodActive: %v", err)
+				t.Fatalf("TaskPodPresence: %v", err)
 			}
-			if active != tc.want {
-				t.Errorf("TaskPodActive(phase=%s) = %v, want %v", tc.phase, active, tc.want)
+			if got != tc.want {
+				t.Errorf("TaskPodPresence(phase=%s) = %v, want %v", tc.phase, got, tc.want)
 			}
 		})
 	}
 }
 
-// TestTaskPodActive_PinsTryNumber is the #723 selector lock: a try-1 pod lingers
-// Pending, but a liveness query for try 2 must NOT match it. Asking whether the
-// attempt the reaper is about to fail (try 2) is live must return false, so the
-// reaper does not false-defer on a stale older attempt's pod.
-func TestTaskPodActive_PinsTryNumber(t *testing.T) {
-	cs := fake.NewSimpleClientset(taskPod("try1", "run-a", "extract", 1, corev1.PodPending))
+// TestTaskPodPresence_LiveWinsOverTerminalSibling: a lingering terminal pod must
+// never mask a live one for the same attempt — presence answers about the
+// attempt, and any live pod for it means work may still be running.
+func TestTaskPodPresence_LiveWinsOverTerminalSibling(t *testing.T) {
+	cs := fake.NewSimpleClientset(
+		taskPod("dead", "run-a", "extract", 1, corev1.PodFailed),
+		taskPod("live", "run-a", "extract", 1, corev1.PodRunning),
+	)
 	e := NewKubernetesExecutor(cs, "leoflow")
-
-	active, err := e.TaskPodActive(context.Background(), "run-a", "extract", 2)
+	got, err := e.TaskPodPresence(context.Background(), "run-a", "extract", 1)
 	if err != nil {
-		t.Fatalf("TaskPodActive: %v", err)
+		t.Fatalf("TaskPodPresence: %v", err)
 	}
-	if active {
-		t.Errorf("#723: a try-2 liveness query matched a lingering try-1 pod; try-number must be pinned")
-	}
-	// Sanity: the same query for the attempt that DOES have a Pending pod is active.
-	active, err = e.TaskPodActive(context.Background(), "run-a", "extract", 1)
-	if err != nil {
-		t.Fatalf("TaskPodActive(try1): %v", err)
-	}
-	if !active {
-		t.Errorf("try-1's own Pending pod must read as active")
+	if got != PodPresenceLive {
+		t.Errorf("TaskPodPresence = %v, want %v", got, PodPresenceLive)
 	}
 }
 
-// TestTaskPodActive_AbsentIsNotActive: no pod at all means the dispatch never
-// landed — not active, so the reaper proceeds.
-func TestTaskPodActive_AbsentIsNotActive(t *testing.T) {
+// TestTaskPodPresence_PinsTryNumber is the #723 selector lock: a try-1 pod
+// lingers Pending, but a liveness query for try 2 must NOT match it. Asking
+// about the attempt the reaper is about to fail (try 2) must report an absence,
+// so the reaper neither false-defers on a stale older attempt's pod nor mistakes
+// it for that attempt's own outcome.
+func TestTaskPodPresence_PinsTryNumber(t *testing.T) {
+	cs := fake.NewSimpleClientset(taskPod("try1", "run-a", "extract", 1, corev1.PodPending))
+	e := NewKubernetesExecutor(cs, "leoflow")
+
+	got, err := e.TaskPodPresence(context.Background(), "run-a", "extract", 2)
+	if err != nil {
+		t.Fatalf("TaskPodPresence: %v", err)
+	}
+	if got != PodPresenceAbsent {
+		t.Errorf("#723: a try-2 liveness query saw %v; try-number must be pinned so try 1's pod is invisible", got)
+	}
+	// Sanity: the same query for the attempt that DOES have a Pending pod is live.
+	got, err = e.TaskPodPresence(context.Background(), "run-a", "extract", 1)
+	if err != nil {
+		t.Fatalf("TaskPodPresence(try1): %v", err)
+	}
+	if got != PodPresenceLive {
+		t.Errorf("try-1's own Pending pod read as %v, want %v", got, PodPresenceLive)
+	}
+}
+
+// TestTaskPodPresence_AbsentIsNotTerminal: no pod at all is a genuine absence —
+// the state that authorizes a pod-lost reap — and must not be reported as a
+// present-but-terminal pod.
+func TestTaskPodPresence_AbsentIsNotTerminal(t *testing.T) {
 	cs := fake.NewSimpleClientset()
 	e := NewKubernetesExecutor(cs, "leoflow")
-	active, err := e.TaskPodActive(context.Background(), "run-a", "extract", 1)
+	got, err := e.TaskPodPresence(context.Background(), "run-a", "extract", 1)
 	if err != nil {
-		t.Fatalf("TaskPodActive: %v", err)
+		t.Fatalf("TaskPodPresence: %v", err)
 	}
-	if active {
-		t.Errorf("TaskPodActive with no pods = true, want false")
+	if got != PodPresenceAbsent {
+		t.Errorf("TaskPodPresence with no pods = %v, want %v", got, PodPresenceAbsent)
 	}
 }

--- a/internal/executor/reap_pod_teardown_test.go
+++ b/internal/executor/reap_pod_teardown_test.go
@@ -52,6 +52,10 @@ func (f *fakePodManager) DeleteRunPods(_ context.Context, runID string) error {
 	return nil
 }
 
+// TaskPodPresence reports absence for a key in neither map, because most
+// fixtures here are about a pod that is gone. Absence is the one presence that
+// AUTHORIZES a reap, so a test about deferral must populate `active` or
+// `terminal` explicitly rather than rely on the zero-configuration default.
 func (f *fakePodManager) TaskPodPresence(_ context.Context, runID, taskID string, try int) (PodPresence, error) {
 	f.activeCalls++
 	if f.activeErr != nil {

--- a/internal/executor/reap_pod_teardown_test.go
+++ b/internal/executor/reap_pod_teardown_test.go
@@ -18,7 +18,11 @@ type fakePodManager struct {
 	// that attempt; absent key is false. Keying by try mirrors the real
 	// executor's try-pinned selector (#723).
 	active map[string]bool
-	// activeCalls counts TaskPodActive invocations, so a test can assert the live
+	// terminal maps "runID/taskID/try" -> whether a present-but-finished pod
+	// exists for that attempt. A key in neither map is a genuine absence, which
+	// is what most tests want, so they need not mention this one.
+	terminal map[string]bool
+	// activeCalls counts TaskPodPresence invocations, so a test can assert the live
 	// (quorum) read was skipped when the presence cache already deferred.
 	activeCalls int
 	activeErr   error
@@ -48,12 +52,20 @@ func (f *fakePodManager) DeleteRunPods(_ context.Context, runID string) error {
 	return nil
 }
 
-func (f *fakePodManager) TaskPodActive(_ context.Context, runID, taskID string, try int) (bool, error) {
+func (f *fakePodManager) TaskPodPresence(_ context.Context, runID, taskID string, try int) (PodPresence, error) {
 	f.activeCalls++
 	if f.activeErr != nil {
-		return false, f.activeErr
+		return PodPresenceLive, f.activeErr
 	}
-	return f.active[fmt.Sprintf("%s/%s/%d", runID, taskID, try)], nil
+	key := fmt.Sprintf("%s/%s/%d", runID, taskID, try)
+	switch {
+	case f.active[key]:
+		return PodPresenceLive, nil
+	case f.terminal[key]:
+		return PodPresenceTerminal, nil
+	default:
+		return PodPresenceAbsent, nil
+	}
 }
 
 // --- Dispatch-lost reaper: K8s-aware deferral (part C) ---------------------

--- a/internal/executor/reap_try_number_test.go
+++ b/internal/executor/reap_try_number_test.go
@@ -25,7 +25,7 @@ import (
 // than a hand-rolled fake predicate.
 
 // TestDispatchLostReaper_TryNumberPinned_LiveRead is the #723 lock on the
-// dispatch-lost/queued path via the live TaskPodActive read: a try-1 pod lingers
+// dispatch-lost/queued path via the live TaskPodPresence read: a try-1 pod lingers
 // Pending, but the dispatch-lost candidate is on try 2. Try 2's dispatch is
 // genuinely lost, so the reaper MUST fail it as dispatch_lost — it must not defer
 // on the stale try-1 pod.

--- a/internal/executor/reaper.go
+++ b/internal/executor/reaper.go
@@ -296,13 +296,24 @@ type settlingVerdict struct {
 // Why opening it is safe — the argument the valve rests on. The dominant reason
 // a sweep never completes is that the apiserver cannot be read: unreachable,
 // unauthorized, throttled. The reconciler's pod LIST and the reapers' own
-// pod-presence LIST hit that same apiserver, so the failure that shuts the gate
-// also denies every pod-dependent reaper its authorization: pod-lost and
-// dispatch-lost defer on a query error, and the warm-worker-lost reaper aborts
-// its tick with zero marks. They fail closed on their own, without the gate.
+// pod-presence LIST hit that same apiserver, so that failure usually denies
+// every pod-dependent reaper its authorization too: pod-lost and dispatch-lost
+// defer on a query error, and the warm-worker-lost reaper aborts its tick with
+// zero marks. They fail closed on their own, without the gate.
+//
+// But the two reads CAN diverge, and pretending otherwise is how this gate
+// would grow a false reputation. RBAC cannot split them (one rule, one verb,
+// one resource, and Kubernetes RBAC has no field or label granularity), yet a
+// broad namespace-wide LIST can time out where a narrow server-side-filtered
+// one succeeds — which is exactly the trigger this whole class was reported
+// under — an informer that never syncs needs `watch` where the reapers need
+// only `list`, and API Priority and Fairness can starve the heavy request while
+// the cheap one gets through. That divergence is precisely why the valve must
+// not be the only guard, and why pod-lost reaps on absence alone.
+//
 // The gate covers the remaining case — the apiserver answers but no sweep has
-// yet run under this leadership — and the valve trades that narrow window for
-// not wedging the reapers forever.
+// yet run under this leadership — and the valve trades that window for not
+// wedging the reapers forever.
 //
 // The valve must therefore never be the only thing standing between a
 // recoverable pod and a destructive reap, because it is designed to open. That

--- a/internal/executor/reaper.go
+++ b/internal/executor/reaper.go
@@ -293,6 +293,24 @@ type settlingVerdict struct {
 // exist to prevent. By then the reconciler has had at least four cycles, so the
 // diagnosis "the sweep is broken" is real, not a scheduling artifact.
 //
+// Why opening it is safe — the argument the valve rests on. The dominant reason
+// a sweep never completes is that the apiserver cannot be read: unreachable,
+// unauthorized, throttled. The reconciler's pod LIST and the reapers' own
+// pod-presence LIST hit that same apiserver, so the failure that shuts the gate
+// also denies every pod-dependent reaper its authorization: pod-lost and
+// dispatch-lost defer on a query error, and the warm-worker-lost reaper aborts
+// its tick with zero marks. They fail closed on their own, without the gate.
+// The gate covers the remaining case — the apiserver answers but no sweep has
+// yet run under this leadership — and the valve trades that narrow window for
+// not wedging the reapers forever.
+//
+// The valve must therefore never be the only thing standing between a
+// recoverable pod and a destructive reap, because it is designed to open. That
+// is why the pod-lost reaper reaps only when the attempt has NO pod object at
+// all: a pod that is present but finished stays the reconciler's to settle from
+// its termination log, valve open or shut. A reap authorized by presence alone
+// cannot be manufactured by any grace, cadence or election timing.
+//
 // The warm-worker-lost reaper is gated too although its signal (a warm pod's
 // own liveness, read by a live LIST that fails closed) is not one a restart
 // manufactures: delaying it by the grace is harmless — a dead worker's attempts

--- a/internal/executor/stale_queued_reap.go
+++ b/internal/executor/stale_queued_reap.go
@@ -29,7 +29,7 @@ type StaleQueuedCandidate struct {
 	// set AND the worker is in the live warm-pod set, the dispatch-lost reaper
 	// DEFERS: the warm worker holds this attempt and is merely slow to transition
 	// queued->running, so failing it would double-run the task (review finding
-	// H3). A warm attempt has no task pod, so the existing TaskPodActive gate
+	// H3). A warm attempt has no task pod, so the existing pod-presence gate
 	// cannot protect it — this warm check is what does.
 	WarmWorkerID string
 }
@@ -78,12 +78,12 @@ type dispatchLostReaper struct {
 	// cache is an optional informer-backed presence cache (PR-10) consulted ONLY
 	// to DEFER a reap: a cached Pending/Running pod skips the live LIST. A cache
 	// miss is never authoritative — the reaper falls through to the live
-	// TaskPodActive read, so cache lag can only delay a reap, never cause a
+	// TaskPodPresence read, so cache lag can only delay a reap, never cause a
 	// false-positive one (#461, the queued path). Nil keeps the live path.
 	cache PodPresenceCache
 	// warmPods is the live warm-pod seam (ADR 0058 N1d-a2), consulted ONLY to
 	// DEFER a reap of a warm-bound queued TI: a warm attempt has no task pod, so
-	// TaskPodActive cannot tell a slow queued->running transition from a lost
+	// TaskPodPresence cannot tell a slow queued->running transition from a lost
 	// dispatch. Before failing a candidate whose WarmWorkerID is set, the reaper
 	// checks whether that worker is still live; if so it defers (the worker holds
 	// the attempt — failing it would double-run, review finding H3). Nil (warm
@@ -124,7 +124,7 @@ func (r *dispatchLostReaper) run(ctx context.Context) error {
 		// Warm-liveness gate (ADR 0058 N1d-a2, review finding H3): a warm attempt
 		// can sit in `queued` past the threshold while its serving warm worker is
 		// alive and merely slow to transition queued->running. A warm attempt has
-		// no task pod, so the TaskPodActive gate below cannot protect it; failing
+		// no task pod, so the pod-presence gate below cannot protect it; failing
 		// it would double-run the task once the live worker does transition it.
 		// If this candidate is bound to a warm worker that is still live, DEFER.
 		if c.WarmWorkerID != "" && liveWarm[c.WarmWorkerID] {
@@ -151,14 +151,18 @@ func (r *dispatchLostReaper) run(ctx context.Context) error {
 			continue
 		}
 		if r.pods != nil {
-			active, perr := r.pods.TaskPodActive(ctx, c.DagRunID, c.TaskID, c.TryNumber)
+			presence, perr := r.pods.TaskPodPresence(ctx, c.DagRunID, c.TaskID, c.TryNumber)
 			if perr != nil {
 				r.logger.Warn("dispatch-lost: pod liveness unknown; deferring",
 					"ti", c.TaskInstanceID, "run", c.DagRunID, "task", c.TaskID, "error", perr)
 				r.record("dispatch_lost_pod_query_error")
 				continue
 			}
-			if active {
+			// Only a LIVE pod defers here. A queued TI whose pod already finished
+			// never transitioned to `running`, so there is no outcome the
+			// reconciler could settle from that pod — the dispatch is lost either
+			// way and this reaper proceeds.
+			if presence == PodPresenceLive {
 				r.logger.Info("dispatch-lost: pod is live (slow start); deferring",
 					"ti", c.TaskInstanceID, "run", c.DagRunID, "task", c.TaskID)
 				r.record("dispatch_lost_deferred")
@@ -188,7 +192,7 @@ func (r *dispatchLostReaper) reapOne(ctx context.Context, c StaleQueuedCandidate
 		"queued_at", c.QueuedAt)
 	r.record("dispatch_lost")
 	// Best-effort teardown of any lingering pod for this attempt (#474). By
-	// here TaskPodActive said no live pod exists (or pods is nil), so this
+	// here the pod presence said no live pod exists (or pods is nil), so this
 	// only cleans up a terminal/failed pod; pinned to (run, task, try).
 	if r.pods == nil {
 		return

--- a/internal/executor/stale_queued_reap.go
+++ b/internal/executor/stale_queued_reap.go
@@ -158,10 +158,14 @@ func (r *dispatchLostReaper) run(ctx context.Context) error {
 				r.record("dispatch_lost_pod_query_error")
 				continue
 			}
-			// Only a LIVE pod defers here. A queued TI whose pod already finished
-			// never transitioned to `running`, so there is no outcome the
-			// reconciler could settle from that pod — the dispatch is lost either
-			// way and this reaper proceeds.
+			// Only a LIVE pod defers here, which is NOT because a finished pod is
+			// worthless: SucceedTaskInstanceIfActive and its siblings admit
+			// `queued`, so the reconciler settles queued attempts by design, and
+			// ApplyTransition can stamp a row that already reached `running` back
+			// to `queued` (#929), so "a queued attempt never ran" is unsound. This
+			// reaper therefore still deletes an outcome record it should preserve;
+			// the fix belongs at the teardown site, where deleting a terminal pod
+			// accomplishes nothing but destroying evidence (#928).
 			if presence == PodPresenceLive {
 				r.logger.Info("dispatch-lost: pod is live (slow start); deferring",
 					"ti", c.TaskInstanceID, "run", c.DagRunID, "task", c.TaskID)

--- a/internal/executor/stale_queued_reap_test.go
+++ b/internal/executor/stale_queued_reap_test.go
@@ -118,7 +118,7 @@ func TestReapDispatchLost_PerTIErrorIsolated(t *testing.T) {
 // N1d-a2, review finding H3). A warm attempt can sit in `queued` past the
 // dispatch threshold while its serving warm worker is alive and merely slow to
 // transition queued->running. A warm attempt has NO task pod, so the existing
-// TaskPodActive gate cannot protect it — the pure time threshold would fail it,
+// TaskPodPresence gate cannot protect it — the pure time threshold would fail it,
 // and once the live worker DOES transition the attempt, the task runs twice.
 //
 // The fix: if the candidate's WarmWorkerID is in the live warm-pod set, DEFER.

--- a/website/content/operate/scheduler-resilience.md
+++ b/website/content/operate/scheduler-resilience.md
@@ -28,7 +28,7 @@ pods, so no pod-based reaper applies and the loop is not started.
 | **Task code wedged past its declared `execution_timeout_seconds`** | **Agent itself** ([#194](https://github.com/neochaotic/leoflow/issues/194)) | **`execution_timeout_seconds`** (per-task) | **TI failed with `execution_timeout: task exceeded N`. Retries kick in if budget remains.** |
 | Agent process crashed mid-task (TI in `running`, no heartbeat) | TI heartbeat reaper ([#128](https://github.com/neochaotic/leoflow/issues/128)) | **90 s** | TI failed with `agent_lost`; the TI's pod is deleted so a partitioned-but-alive container stops. Retries kick in if budget remains. |
 | Scheduler crashed before dispatching (TI stuck in `queued`) | Dispatch-lost reaper ([#202](https://github.com/neochaotic/leoflow/issues/202)) | **3 min** | TI failed with `dispatch_lost` — but only if no live pod for it exists (see below); the pod is torn down. Frees the run for the orphan reaper on the next maintenance cycle. |
-| Task pod vanished (TI in `running`, no Pending/Running pod for its attempt) | Pod-lost reaper | **60 s** after the running transition, then a live pod read | TI failed with `pod_lost`. Only after the reconciler has had its chance to recover the pod's durable outcome (see the settling gate below). |
+| Task pod vanished (TI in `running`, no pod at all for its attempt) | Pod-lost reaper | **60 s** after the running transition, then a live pod read | TI failed with `pod_lost`. Only when the apiserver holds no pod for the attempt: a pod that is still there in a terminal phase is left for the reconciler to settle from its termination log (`pod_lost_terminal_pod_defer`). |
 | Warm worker died holding attempts (warm pools only) | Warm-worker-lost reaper | next maintenance cycle | Each attempt bound to the dead worker is failed `pod_lost`; refill of the pool is the warm-pool reconciler's job, not the reaper's. |
 | Run stuck `running` with no active TIs (post-crash limbo) | Orphan-run reaper ([#120](https://github.com/neochaotic/leoflow/issues/120)) | **5 min** | Run failed with `orphaned`; any remaining active TIs flipped to `failed` and every pod of the run is deleted. |
 
@@ -88,6 +88,18 @@ reconciler cannot list pods, the informer never syncs — the reapers proceed
 anyway, with a `WARN` log and a `reap_settling_valve_open` decision on every
 cycle the valve stays open. By then the reconciler has had at least four cycles,
 so a valve that opens means the sweep really is broken; treat it as an alert.
+
+**Why opening it is safe.** The usual reason a sweep never completes is an
+apiserver that cannot be read — unreachable, unauthorized, throttled. The
+reconciler's pod LIST and each reaper's own pod-presence LIST hit that same
+apiserver, so the failure that shuts the gate also denies every pod-dependent
+reaper its authorization: pod-lost and dispatch-lost defer
+(`pod_lost_pod_query_error`, `dispatch_lost_pod_query_error`) and the
+warm-worker-lost reaper aborts its cycle with zero marks. They fail closed on
+their own, valve or no valve. And because the valve is *designed* to open, it is
+never the only guard: the pod-lost reaper fails a task only when the attempt has
+**no pod object at all**, a state no grace, cadence or election timing can
+manufacture. A finished pod is a present pod, and stays the reconciler's.
 
 The server validates the timing ladder these depend on at boot and refuses to
 start if a constant was moved out of order:
@@ -192,7 +204,8 @@ your Prometheus dashboard:
 | `agent_lost` | TI failed by the heartbeat reaper |
 | `dispatch_lost` | TI failed by the dispatch-lost reaper |
 | `dispatch_lost_deferred` | Dispatch-lost skipped because the TI's pod is live (slow start, [#461](https://github.com/neochaotic/leoflow/issues/461)) — a healthy signal, not a fault |
-| `pod_lost` | TI failed by the pod-lost reaper (no live pod for the attempt) |
+| `pod_lost` | TI failed by the pod-lost reaper (no pod at all for the attempt) |
+| `pod_lost_terminal_pod_defer` | Pod-lost skipped because the attempt's pod is still there in a terminal phase — the reconciler settles it from its termination log; reaping would delete that evidence. A healthy signal, not a fault |
 | `warm_worker_lost` | TI failed by the warm-worker-lost reaper (its warm worker is gone) |
 | `orphan_reaped` | Run failed by the orphan-run reaper |
 | `reap_settling_skip` | The whole reaper pass was held because the leader has not settled yet (grace, informer sync, or a post-leadership reconciler sweep still pending) — expected for ~3 min after every (re-)election |

--- a/website/content/operate/scheduler-resilience.md
+++ b/website/content/operate/scheduler-resilience.md
@@ -92,11 +92,15 @@ so a valve that opens means the sweep really is broken; treat it as an alert.
 **Why opening it is safe.** The usual reason a sweep never completes is an
 apiserver that cannot be read — unreachable, unauthorized, throttled. The
 reconciler's pod LIST and each reaper's own pod-presence LIST hit that same
-apiserver, so the failure that shuts the gate also denies every pod-dependent
-reaper its authorization: pod-lost and dispatch-lost defer
+apiserver, so that failure usually denies every pod-dependent
+reaper its authorization too: pod-lost and dispatch-lost defer
 (`pod_lost_pod_query_error`, `dispatch_lost_pod_query_error`) and the
 warm-worker-lost reaper aborts its cycle with zero marks. They fail closed on
-their own, valve or no valve. And because the valve is *designed* to open, it is
+their own, valve or no valve. The two reads can still diverge, though — a broad
+namespace-wide LIST can time out where a narrow, server-side-filtered one
+succeeds, an informer that never syncs needs `watch` where the reapers need only
+`list`, and API Priority and Fairness can starve the heavy request while the
+cheap one gets through. And because the valve is *designed* to open, it is
 never the only guard: the pod-lost reaper fails a task only when the attempt has
 **no pod object at all**, a state no grace, cadence or election timing can
 manufacture. A finished pod is a present pod, and stays the reconciler's.
@@ -205,7 +209,7 @@ your Prometheus dashboard:
 | `dispatch_lost` | TI failed by the dispatch-lost reaper |
 | `dispatch_lost_deferred` | Dispatch-lost skipped because the TI's pod is live (slow start, [#461](https://github.com/neochaotic/leoflow/issues/461)) — a healthy signal, not a fault |
 | `pod_lost` | TI failed by the pod-lost reaper (no pod at all for the attempt) |
-| `pod_lost_terminal_pod_defer` | Pod-lost skipped because the attempt's pod is still there in a terminal phase — the reconciler settles it from its termination log; reaping would delete that evidence. A healthy signal, not a fault |
+| `pod_lost_terminal_pod_defer` | Pod-lost skipped because the attempt's pod is still there in a terminal phase — the reconciler settles it from its termination log; reaping would delete that evidence. Healthy as a *transient*. Sustained past two maintenance cycles means the reconciler is not settling and those task instances are stranded `running`, not about to settle: correlate with `reap_settling_valve_open` and `pod_lost_pod_query_error` |
 | `warm_worker_lost` | TI failed by the warm-worker-lost reaper (its warm worker is gone) |
 | `orphan_reaped` | Run failed by the orphan-run reaper |
 | `reap_settling_skip` | The whole reaper pass was held because the leader has not settled yet (grace, informer sync, or a post-leadership reconciler sweep still pending) — expected for ~3 min after every (re-)election |

--- a/website/content/reference/go/internal-executor.md
+++ b/website/content/reference/go/internal-executor.md
@@ -37,7 +37,7 @@ Package executor runs task instances via Kubernetes, Docker, or a subprocess.
   - [func \(e \*KubernetesExecutor\) Execute\(ctx context.Context, req Request\) \(Disposition, error\)](<#KubernetesExecutor.Execute>)
   - [func \(e \*KubernetesExecutor\) GCStagingClaims\(ctx context.Context, ttl time.Duration\) error](<#KubernetesExecutor.GCStagingClaims>)
   - [func \(e \*KubernetesExecutor\) SetStagingStore\(s StagingStore\)](<#KubernetesExecutor.SetStagingStore>)
-  - [func \(e \*KubernetesExecutor\) TaskPodActive\(ctx context.Context, runID, taskID string, tryNumber int\) \(bool, error\)](<#KubernetesExecutor.TaskPodActive>)
+  - [func \(e \*KubernetesExecutor\) TaskPodPresence\(ctx context.Context, runID, taskID string, tryNumber int\) \(PodPresence, error\)](<#KubernetesExecutor.TaskPodPresence>)
 - [type KubernetesWarmPods](<#KubernetesWarmPods>)
   - [func NewKubernetesWarmPods\(cs kubernetes.Interface, namespace string, newSpec WarmPodSpecFunc\) \*KubernetesWarmPods](<#NewKubernetesWarmPods>)
   - [func \(k \*KubernetesWarmPods\) CreateWarmPod\(ctx context.Context, t WarmTarget, anchorName, anchorUID string\) error](<#KubernetesWarmPods.CreateWarmPod>)
@@ -59,6 +59,8 @@ Package executor runs task instances via Kubernetes, Docker, or a subprocess.
 - [type PodLostCandidate](<#PodLostCandidate>)
 - [type PodLostReapStore](<#PodLostReapStore>)
 - [type PodManager](<#PodManager>)
+- [type PodPresence](<#PodPresence>)
+  - [func \(p PodPresence\) String\(\) string](<#PodPresence.String>)
 - [type PodPresenceCache](<#PodPresenceCache>)
 - [type PodSecurity](<#PodSecurity>)
 - [type PodSnapshotter](<#PodSnapshotter>)
@@ -431,14 +433,16 @@ func (e *KubernetesExecutor) SetStagingStore(s StagingStore)
 
 SetStagingStore wires the metadatabase\-backed staging\-volume lifecycle store \(ADR 0022\). With no store set, provisioning is not recorded and GC is a no\-op.
 
-<a name="KubernetesExecutor.TaskPodActive"></a>
-### func \(\*KubernetesExecutor\) [TaskPodActive](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_terminate.go#L85>)
+<a name="KubernetesExecutor.TaskPodPresence"></a>
+### func \(\*KubernetesExecutor\) [TaskPodPresence](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_terminate.go#L91>)
 
 ```go
-func (e *KubernetesExecutor) TaskPodActive(ctx context.Context, runID, taskID string, tryNumber int) (bool, error)
+func (e *KubernetesExecutor) TaskPodPresence(ctx context.Context, runID, taskID string, tryNumber int) (PodPresence, error)
 ```
 
-TaskPodActive reports whether a pod for exactly the \(run, task, try\) attempt exists and is still Pending or Running. The dispatch\-lost and pod\-lost reapers consult this before failing a TI: a live pod means the dispatch actually landed and the node is merely slow to pull the image \(\#461\), so the reaper must DEFER. No pod, or only terminal \(Failed/Succeeded/Unknown\) pods, means the attempt is genuinely lost and the reaper may proceed.
+TaskPodPresence reports what the apiserver holds for exactly the \(run, task, try\) attempt: a live pod \(Pending/Running\), a present\-but\-finished pod, or no pod at all. The dispatch\-lost and pod\-lost reapers consult this before failing a TI: a live pod means the dispatch actually landed and the node is merely slow to pull the image \(\#461\), so the reaper must DEFER.
+
+A present\-but\-finished pod is reported apart from an absence on purpose. The pod object still carries the attempt's outcome \(the termination log the reconciler recovers a durable result from\), so it is the reconciler's to settle and no reaper may delete it; only a genuine absence means the attempt is lost with nothing left to recover. Any live pod for the attempt wins over a lingering finished sibling, since work may still be running.
 
 Try\-number is pinned — the same invariant guard as DeleteTaskPod above. The retry rail resets up\_for\_retry \-\> none with try\_number\+1 and the planner re\-queues the TI \(storage/queries/runs.sql\), so a \`queued\`/\`running\` TI can be on try 2 while try 1's pod still lingers Pending after a failed best\-effort delete. Selecting on \(run, task\) alone would match that stale older pod and false\-defer the reap of the current attempt forever \(\#723\). Asking about the attempt the reaper is about to fail is the correct liveness question.
 
@@ -550,7 +554,7 @@ ParseAgentIdentity decodes the AgentIdentityAnnotation payload. It is the read s
 
 PodInformer is a shared\-informer read\-path over task pods, scoped by namespace and the leoflow.io/run\-id label \(ADR 0002 pods\). It replaces the reapers' per\-running\-TI\-per\-second apiserver LIST storm and the reconciler's 30s LIST with one long\-lived watch feeding a local cache.
 
-Its readings are trusted only in the safe direction \(\#461\): CachedPodActive is consulted ONLY to DEFER a reap when a pod is present and Pending/Running — a cache "absent" reading is never authoritative and callers MUST fall through to the live TaskPodActive \(quorum\) read before any destructive action. Cache lag can therefore only ever delay a reap by a tick, never cause a false\-positive one. SnapshotTaskPods is safe for the reconciler because presence of a terminal pod is monotonic and every settle is attempt/state\-guarded \(ADR 0052\).
+Its readings are trusted only in the safe direction \(\#461\): CachedPodActive is consulted ONLY to DEFER a reap when a pod is present and Pending/Running — a cache "absent" reading is never authoritative and callers MUST fall through to the live TaskPodPresence \(quorum\) read before any destructive action. Cache lag can therefore only ever delay a reap by a tick, never cause a false\-positive one. SnapshotTaskPods is safe for the reconciler because presence of a terminal pod is monotonic and every settle is attempt/state\-guarded \(ADR 0052\).
 
 It is constructed only in the scheduler/all role \(ADR 0049\), never api\-only, and is nil in Lite/subprocess \(no pods\), where consumers keep their live paths.
 
@@ -576,7 +580,7 @@ NewPodInformer builds a shared pod informer over the given cluster, scoped to na
 func (p *PodInformer) CachedPodActive(runID, taskID string, tryNumber int) bool
 ```
 
-CachedPodActive reports whether the cache holds a pod for exactly the \(run, task, try\) attempt that is Pending or Running — the exact predicate TaskPodActive uses, pinned to the same attempt \(\#723\). It is the safe direction of the asymmetric\-trust contract: a true return may DEFER a reap; a false return is NEVER authoritative and the caller must fall through to the live read. Before the cache has synced it returns false, so a cold cache degrades to the live path rather than misreporting absence.
+CachedPodActive reports whether the cache holds a pod for exactly the \(run, task, try\) attempt that is Pending or Running — the exact predicate TaskPodPresence uses, pinned to the same attempt \(\#723\). It is the safe direction of the asymmetric\-trust contract: a true return may DEFER a reap; a false return is NEVER authoritative and the caller must fall through to the live read. Before the cache has synced it returns false, so a cold cache degrades to the live path rather than misreporting absence.
 
 <a name="PodInformer.HasSynced"></a>
 ### func \(\*PodInformer\) [HasSynced](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_informer.go#L110>)
@@ -662,7 +666,7 @@ type PodLostReapStore interface {
 ```
 
 <a name="PodManager"></a>
-## type [PodManager](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_manager.go#L19-L35>)
+## type [PodManager](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_manager.go#L19-L36>)
 
 PodManager is the slice of the Kubernetes executor the reapers use to \(1\) tear down a reaped task's pod and \(2\) check whether a queued TI's pod is actually live before declaring its dispatch lost \(\#474, \#461\).
 
@@ -683,22 +687,66 @@ type PodManager interface {
     // orphan-run reaper, which abandons the whole run. The run-id is unique
     // per run, so no other run's pod can match. Tolerates missing pods.
     DeleteRunPods(ctx context.Context, runID string) error
-    // TaskPodActive reports whether a pod for exactly the (run, task, try)
-    // attempt exists and is Pending or Running. The reaper defers when it is
-    // true — the dispatch landed, the node is merely slow (#461). Try-number is
-    // pinned so a retried TI's liveness gate asks about the attempt it is about
-    // to fail, not any older attempt whose pod may still linger (#723).
-    TaskPodActive(ctx context.Context, runID, taskID string, tryNumber int) (bool, error)
+    // TaskPodPresence reports what the apiserver holds for exactly the
+    // (run, task, try) attempt: a live pod, a present-but-finished pod, or
+    // nothing. A reaper defers on a live pod — the dispatch landed, the node is
+    // merely slow (#461). Try-number is pinned so a retried TI's liveness gate
+    // asks about the attempt it is about to fail, not any older attempt whose
+    // pod may still linger (#723).
+    TaskPodPresence(ctx context.Context, runID, taskID string, tryNumber int) (PodPresence, error)
 }
 ```
 
+<a name="PodPresence"></a>
+## type [PodPresence](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_manager.go#L49>)
+
+PodPresence is the three\-way answer to "what does the apiserver hold for this attempt's pod?".
+
+The distinction is load\-bearing, not cosmetic. A bare bool collapsed the last two states, and the pod\-lost reaper read that collapse as authorization to reap: for a task pod that had already finished it marked the task instance pod\_lost and then DELETED the pod — destroying the termination\-log evidence the reconciler recovers the task's durable outcome from. A finished task then reads as failed, and its run with it. Presence must be three\-valued so a reaper can defer on "present but finished" while still reaping on a genuine absence, which is the state pod\-lost exists for.
+
+```go
+type PodPresence int
+```
+
+<a name="PodPresenceLive"></a>
+
+```go
+const (
+    // PodPresenceLive means a pod for the attempt exists and is Pending or
+    // Running: work may still be happening, so every reaper must defer. It is
+    // deliberately the zero value — an unset or error-path presence then
+    // authorizes nothing destructive.
+    PodPresenceLive PodPresence = iota
+    // PodPresenceTerminal means a pod for the attempt exists but none of them is
+    // Pending or Running. Whatever happened to that attempt is recorded on the
+    // pod object, so settling it belongs to the reconciler and no reaper may
+    // delete it. Phase Unknown counts here as well: the pod object is still
+    // there, the reconciler still watches it, and it is not an absence.
+    PodPresenceTerminal
+    // PodPresenceAbsent means the apiserver holds no pod for the attempt at all
+    // — the attempt's pod is genuinely gone (deleted, evicted, lost with its
+    // node) and there is nothing left to settle from. This is the only presence
+    // that authorizes a pod-lost reap.
+    PodPresenceAbsent
+)
+```
+
+<a name="PodPresence.String"></a>
+### func \(PodPresence\) [String](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_manager.go#L71>)
+
+```go
+func (p PodPresence) String() string
+```
+
+String names the presence for logs.
+
 <a name="PodPresenceCache"></a>
-## type [PodPresenceCache](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_manager.go#L53-L60>)
+## type [PodPresenceCache](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_manager.go#L100-L107>)
 
 PodPresenceCache is an optional read\-through cache of pod presence — backed by a shared informer \(PR\-10\) — that the pod\-lost and dispatch\-lost reapers consult ONLY to DEFER a reap, never to authorize one. Its trust is asymmetric \(\#461\):
 
 - CachedPodActive == true =\> a pod is present and Pending/Running; the reaper may skip the live LIST and defer, because presence is monotonic\-safe against cache lag \(a pod the cache still shows as live cannot have been gone longer than the lag, and deferring one tick is harmless\).
-- CachedPodActive == false =\> NOT authoritative. The reaper MUST fall through to the live TaskPodActive \(quorum\) read before any destructive action, so a lagged/cold cache can only ever delay a reap by a tick, never cause a false\-positive one.
+- CachedPodActive == false =\> NOT authoritative. The reaper MUST fall through to the live TaskPodPresence \(quorum\) read before any destructive action, so a lagged/cold cache can only ever delay a reap by a tick, never cause a false\-positive one.
 
 It exists to remove the O\(running\-TIs\)/sec apiserver LIST storm from the read path while keeping the kill decision on the live read. Nil in Lite/subprocess and before the informer warms: every candidate then uses the live path.
 
@@ -809,7 +857,7 @@ NewReaper constructs the reapers and wires their pod\-teardown / liveness capabi
 warmPods is the live warm\-pod seam \(ADR 0058 N1d\-a2\), threaded to the two warm consumers exactly the way pods/cache are threaded: the warm\-worker\-lost reaper \(which recovers a dead worker's attempts\) and the dispatch\-lost reaper's H3 defer. Nil \(warm pools off / not wired\) makes the warm reaper a no\-op and the dispatch\-lost warm defer inert — with the flag off no TI ever carries a warm\_worker\_id either, so both warm paths are doubly inert, byte\-for\-byte today.
 
 <a name="Reaper.ReapOnce"></a>
-### func \(\*Reaper\) [ReapOnce](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reaper.go#L360>)
+### func \(\*Reaper\) [ReapOnce](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reaper.go#L378>)
 
 ```go
 func (r *Reaper) ReapOnce(ctx context.Context) error
@@ -1155,7 +1203,7 @@ type StaleQueuedCandidate struct {
     // set AND the worker is in the live warm-pod set, the dispatch-lost reaper
     // DEFERS: the warm worker holds this attempt and is merely slow to transition
     // queued->running, so failing it would double-run the task (review finding
-    // H3). A warm attempt has no task pod, so the existing TaskPodActive gate
+    // H3). A warm attempt has no task pod, so the existing pod-presence gate
     // cannot protect it — this warm check is what does.
     WarmWorkerID string
 }


### PR DESCRIPTION
Closes #915, the residual path by which the leader-settling gate's liveness valve could still destroy the reconciler's evidence.

Pod-lost authorized a reap from a single `false`, but that bool collapsed two different worlds: **no pod at all**, and **a pod that exists in a terminal phase**. The second is the reconciler's to settle, because whatever happened to that attempt is recorded on the pod object (ADR 0052). Pod-lost instead marked the task instance `pod_lost` and deleted the pod, destroying exactly the record the reconciler would have read. #914 narrowed the window, from an unconditional 180s to 360s only when the sweep is broken, but the valve is designed to open, so the window never closed.

Liveness is now a three-way `PodPresence` (live / terminal / absent). Pod-lost skips on live, defers on terminal with a `pod_lost_terminal_pod_defer` decision, and reaps only on genuine absence — a state no timing can fake. `PodPresenceLive` is deliberately the zero value, so an error path or an uninitialized fake authorizes nothing destructive. The `pod_lost_pod_query_error` defer is unchanged and still precedes the switch, and the informer cache fast-path stays defer-only: a miss falls through to the live read, which is now the sole authorization for a reap, locked by its own subtest.

Phase `Unknown` counts as terminal, so pod-lost defers there too. That is wider than the issue's literal Succeeded/Failed, in the safe direction, and it matches the reconciler, which treats `Unknown` as still-watched. Deferring costs at most a reconcile interval, and a node-lost pod is garbage-collected into a genuine absence, which still reaps.

Dispatch-lost keeps its semantics on purpose: it defers only on live, so a terminal or absent pod reaps exactly as before, with the reasoning recorded at the call site.

The valve's safety argument is now written down in the settling gate's doc comment and locked by a test, because it was load-bearing and stated nowhere: whatever makes the reconciler's broad LIST fail also denies the reapers their narrow one, so pod-lost independently fails closed. The gate only ever covers "the apiserver answers but no sweep has run yet".

Verification: build, `go test ./...` (33 packages), `-race` on the executor, golangci-lint 0 (fresh cache), changelog gate, plus two mutation checks — reaping on terminal fails the new reaper test, and classifying terminal as absent fails the presence tests.