### PR TITLE
executor: a reaper teardown leaves a task pod that is already in a terminal phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,9 +114,32 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   dispatch-lost reaper's behavior is unchanged in this fix, and that reaper can
   still delete a terminal pod's outcome record: a queued attempt's finished pod
   CAN carry an outcome (the settle statements admit `queued`, and a dispatch can
-  stamp a row that already reached `running` back to `queued`). Tracked as
-  [#928](https://github.com/neochaotic/leoflow/issues/928), with the underlying
-  unguarded transition as [#929](https://github.com/neochaotic/leoflow/issues/929).
+  stamp a row that already reached `running` back to `queued`). Closed one level
+  down by the teardown fix below
+  ([#928](https://github.com/neochaotic/leoflow/issues/928)), with the underlying
+  unguarded transition tracked as
+  [#929](https://github.com/neochaotic/leoflow/issues/929).
+- **A reaper's pod teardown no longer deletes a task pod that already reached a
+  terminal phase.** Deleting one stops no container — there is none — and
+  destroys the durable outcome record on its termination message, the only
+  evidence the reconciler can settle the attempt from (ADR 0052). Three reapers
+  still reached that delete after the pod-lost *decision* was fixed: the
+  agent-lost reaper fires on heartbeat staleness alone at a **90 s** threshold
+  with no pod read at all (and a task that finished and stopped heartbeating is
+  precisely its candidate), the orphan-run reaper deletes every pod of a run at
+  5 minutes with no pod read, and the dispatch-lost reaper defers only on a
+  *live* pod. The guard now sits at the one delete site instead of in four
+  decision paths, so all five reapers are evidence-preserving and **no reaper's
+  mark or decision changes**; the run-scoped delete applies it per pod inside the
+  run, tearing down the run's still-live containers while its finished pods keep
+  their records. Collecting a terminal pod is the reconciler's job — it settles
+  each one and garbage-collects it past the 10-minute grace — and a skip is
+  logged at INFO by pod name and phase, so an operator separates "left for the
+  reconciler" from the `*_pod_delete_error` a failed delete already meters. A pod
+  in phase `Unknown` is still deleted: it may yet be running a container, which
+  is what teardown exists for, and the reconciler treats `Unknown` as
+  non-terminal, so nothing else would collect it.
+  ([#928](https://github.com/neochaotic/leoflow/issues/928))
 
 - **A control-plane restart no longer marks a succeeded task failed, and no
   longer condemns the rest of its run.** A production drill (kill the

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -1287,7 +1287,13 @@ func warmBootstrapTokenTTL(cfg *config.ServerConfig) time.Duration {
 // data). A SUCCEEDED run's volume is freed immediately, regardless of the TTL.
 const (
 	stagingGCInterval = time.Minute // frequent so a succeeded run's volume is freed ~at DAG end
-	stagingTTL        = 24 * time.Hour
+	// stagingTTL must stay well above the reconciler's finished-pod grace. A pod
+	// preserved by a reaper teardown (#928) still holds kubernetes.io/pvc-protection
+	// on the run's staging claim — upstream only skips terminated pods on the newer
+	// unused-since path, not on the deletion path — so if this TTL ever dropped near
+	// that grace, the GC would mark a claim deleted while a pod it cannot see is
+	// still keeping the finalizer on. Today the margin is 24h against 10 minutes.
+	stagingTTL = 24 * time.Hour
 )
 
 // startStagingGC periodically reclaims per-run staging PVCs from the

--- a/internal/executor/heartbeat_reap.go
+++ b/internal/executor/heartbeat_reap.go
@@ -159,6 +159,12 @@ func (r *agentLostReaper) reapOne(ctx context.Context, c AgentLostCandidate, now
 	// container stops (#474). Pinned to (run, task, try) so a retry's newer
 	// pod is never touched. Only reached after the DB mark, so we never delete
 	// a pod for a TI we did not settle. Best-effort: a delete error is logged.
+	//
+	// This reaper reads no pod presence at all — it fires on heartbeat staleness
+	// alone at a 90s threshold, and a task that finished and stopped
+	// heartbeating is precisely its candidate. The evidence guard is therefore in
+	// the teardown, not here: DeleteTaskPod skips a pod in a terminal phase and
+	// leaves its outcome record to the reconciler (#928).
 	if r.pods == nil {
 		return
 	}

--- a/internal/executor/pod_manager.go
+++ b/internal/executor/pod_manager.go
@@ -21,10 +21,19 @@ type PodManager interface {
 	// the (run, task, try) tuple. Pinning try-number guarantees a newer live
 	// attempt (dispatched with a new try-number) is never deleted. Tolerates
 	// a missing pod.
+	//
+	// A pod already in a terminal phase is SKIPPED, not deleted (#928): the
+	// teardown exists to stop a running container, a terminal pod has none, and
+	// its termination message is the outcome record the reconciler settles the
+	// attempt from (ADR 0052). That is why a reaper may call this unconditionally
+	// after its mark without reading presence first — the guard is at the delete
+	// site, so it holds for every reaper including the ones (agent-lost,
+	// orphan-run) that read no presence at all.
 	DeleteTaskPod(ctx context.Context, runID, taskID string, tryNumber int) error
 	// DeleteRunPods deletes every task pod of one reaped run. Used by the
 	// orphan-run reaper, which abandons the whole run. The run-id is unique
-	// per run, so no other run's pod can match. Tolerates missing pods.
+	// per run, so no other run's pod can match. Tolerates missing pods. The
+	// terminal-phase skip above applies per pod within the run (#928).
 	DeleteRunPods(ctx context.Context, runID string) error
 	// TaskPodPresence reports what the apiserver holds for exactly the
 	// (run, task, try) attempt: a live pod, a present-but-finished pod, or
@@ -64,7 +73,11 @@ const (
 	// the agent-lost reaper (heartbeats stop when a node goes unreachable) and
 	// the orphan-run reaper. The phase has not been set by kubelet since 2015
 	// and is deprecated upstream, so the practical exposure is nil; classifying
-	// it as presence is the conservative direction.
+	// it as presence is the conservative direction. Note this is deliberately
+	// WIDER than terminalForTeardown, which the pod teardown uses: presence asks
+	// "is this an absence?" (Unknown is not), teardown asks "is there a container
+	// to stop, and will anything else collect this?" (for Unknown, possibly yes
+	// and no) — so Unknown defers a reap here and is still deleted there (#928).
 	PodPresenceTerminal
 	// PodPresenceAbsent means the apiserver holds no pod for the attempt at all
 	// — the attempt's pod is genuinely gone (deleted, evicted, lost with its

--- a/internal/executor/pod_terminate.go
+++ b/internal/executor/pod_terminate.go
@@ -51,7 +51,16 @@ func (e *KubernetesExecutor) DeleteTaskPod(ctx context.Context, runID, taskID st
 // different run's live pod. The terminal-phase skip applies per pod inside the
 // run, not just to the per-attempt delete above (#928): this reaper reads no
 // presence at all, so a run abandoned at the 5-minute threshold would otherwise
-// take every finished task's outcome record with it. Tolerates NotFound.
+// take every finished task's outcome record with it. A mixed set is safe because
+// each settle is guarded on the pod's own try-number, ReapRun has already flipped
+// the run and every still-active task instance in one transaction before this
+// runs, and pod names carry a random suffix so a preserved pod can never collide
+// with a redispatch. The subtlest cell is a reschedule poke pod, which the
+// reconciler collects immediately rather than on age because a reschedule reuses
+// the same try-number: preserving one delays that collect by up to a cycle, which
+// is harmless because up_for_reschedule is not an active state for any reaper, so
+// a reaper only ever preserves a poke pod for an attempt it has just made
+// terminal. Tolerates NotFound.
 func (e *KubernetesExecutor) DeleteRunPods(ctx context.Context, runID string) error {
 	selector := fmt.Sprintf("leoflow.io/run-id=%s", sanitizeLabel(runID))
 	return e.deletePodsBySelector(ctx, selector)
@@ -82,7 +91,7 @@ func (e *KubernetesExecutor) deletePodsBySelector(ctx context.Context, selector 
 	var errs []error
 	for i := range pods.Items {
 		pod := &pods.Items[i]
-		if terminalForTeardown(pod.Status.Phase) {
+		if terminalForTeardown(pod) {
 			slog.InfoContext(ctx, "reap teardown: task pod is already in a terminal phase; leaving it for the reconciler",
 				"pod", pod.Name, "phase", pod.Status.Phase, "selector", selector)
 			continue
@@ -104,10 +113,27 @@ func (e *KubernetesExecutor) deletePodsBySelector(ctx context.Context, selector 
 // on age, which is the "reconciler-as-deleter" the RBAC comment names
 // (helm/leoflow/templates/rbac.yaml).
 //
-// The phase set here is exactly classifyPod's terminal-by-phase set, and that
-// alignment is the invariant: the teardown skips precisely the pods the
-// reconciler will settle and collect, and deletes precisely the ones it will
-// not. Hence Unknown is deleted, even though TaskPodPresence classifies it as
+// The invariant is ONE-DIRECTIONAL, and stating it as an equality would be
+// false: everything this preserves, classifyPod will settle and collect, so
+// nothing preserved can leak. The converse does not hold and does not need to —
+// classifyPod also treats a Pending or Running pod with an unrecoverable
+// waiting reason (an unpullable image, a missing config) as terminal, and the
+// teardown still deletes those. That costs nothing, because such a container
+// never started and so left no record behind, and it is REQUIRED, because a
+// Pending pod can still start and run the task, which is #474's exact chain.
+//
+// The record test comes first on purpose, and it is not redundant with the
+// phase test. Phase is only a sound proxy for "the record is safe" while a task
+// pod has one container and RestartPolicy Never, which is what makes "the task
+// container terminated" imply "the phase is terminal" — a property of BuildPod,
+// not of this function. Add a second container and the implication breaks: a
+// service mesh injects a sidecar (an author can ask for that through the
+// execution annotations BuildPod merges), the task container terminates and
+// writes its record, the sidecar keeps running, and the phase stays Running for
+// good. That is the one case where the record is the ONLY settle path, so it is
+// the worst possible pod to delete.
+//
+// Hence Unknown is deleted, even though TaskPodPresence classifies it as
 // present-but-terminal — those two answer different questions. Presence asks
 // "is this an absence?", where Unknown is conservatively a presence; teardown
 // asks "is there a container to stop, and will anything else collect this?",
@@ -115,8 +141,11 @@ func (e *KubernetesExecutor) deletePodsBySelector(ctx context.Context, selector 
 // Unknown with Pending/Running, so the reconciler neither settles nor collects
 // it. Skipping it would leave a pod that may still be running the very work
 // #474 exists to stop, with nothing to stop it.
-func terminalForTeardown(phase corev1.PodPhase) bool {
-	return phase == corev1.PodSucceeded || phase == corev1.PodFailed
+func terminalForTeardown(pod *corev1.Pod) bool {
+	if _, ok := outcomeRecord(pod); ok {
+		return true
+	}
+	return pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed
 }
 
 // TaskPodPresence reports what the apiserver holds for exactly the

--- a/internal/executor/pod_terminate.go
+++ b/internal/executor/pod_terminate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
@@ -23,12 +24,20 @@ import (
 // but NOT `deletecollection` (helm/leoflow/templates/rbac.yaml), so a
 // DeleteCollection call would 403 in production. NotFound is always tolerated —
 // a pod may have been garbage-collected between the list and the delete.
+//
+// Both methods skip a pod that has already reached a terminal phase (#928) —
+// see terminalForTeardown. That is enforced HERE, at the one delete site, rather
+// than in each reaper's decision: agent-lost fires on heartbeat staleness alone
+// at 90s and orphan-run abandons a whole run at 5m, neither reading pod presence
+// at all, so a per-reaper guard would have to be written four times and kept
+// right four times. No reaper's mark or decision changes.
 
 // DeleteTaskPod deletes the pod(s) for exactly one reaped task instance: the
 // (run, task, try) tuple. Pinning try-number is the invariant guard — a retry
 // bumps try_number in place and dispatches a new pod with a new try-number
 // label, so a newer live attempt can never match this selector and is never
-// deleted. Tolerates NotFound.
+// deleted. A pod already in a terminal phase is left for the reconciler (#928).
+// Tolerates NotFound.
 func (e *KubernetesExecutor) DeleteTaskPod(ctx context.Context, runID, taskID string, tryNumber int) error {
 	selector := fmt.Sprintf("leoflow.io/run-id=%s,leoflow.io/task-id=%s,leoflow.io/try-number=%s",
 		sanitizeLabel(runID), sanitizeLabel(taskID), strconv.Itoa(tryNumber))
@@ -39,17 +48,29 @@ func (e *KubernetesExecutor) DeleteTaskPod(ctx context.Context, runID, taskID st
 // orphan-run reaper abandons a whole run (failing all its still-active TIs), so
 // every pod of that run must be torn down. The run-id is a unique per-run UUID,
 // so this selector can only ever match pods of the one abandoned run — never a
-// different run's live pod. Tolerates NotFound.
+// different run's live pod. The terminal-phase skip applies per pod inside the
+// run, not just to the per-attempt delete above (#928): this reaper reads no
+// presence at all, so a run abandoned at the 5-minute threshold would otherwise
+// take every finished task's outcome record with it. Tolerates NotFound.
 func (e *KubernetesExecutor) DeleteRunPods(ctx context.Context, runID string) error {
 	selector := fmt.Sprintf("leoflow.io/run-id=%s", sanitizeLabel(runID))
 	return e.deletePodsBySelector(ctx, selector)
 }
 
-// deletePodsBySelector lists the pods matching selector and deletes each by
-// name. It uses only the `list` and `delete` verbs the executor Role grants;
-// a NotFound on either the list target or an individual delete is treated as
-// success (the pod is already gone). Per-pod delete errors are collected so one
-// failure does not skip the rest.
+// deletePodsBySelector lists the pods matching selector and deletes each one
+// that still has a container to stop, skipping those already in a terminal
+// phase (#928). It uses only the `list` and `delete` verbs the executor Role
+// grants; a NotFound on either the list target or an individual delete is
+// treated as success (the pod is already gone). Per-pod delete errors are
+// collected so one failure does not skip the rest.
+//
+// The skip is logged per pod at INFO, by name and phase, so an operator can tell
+// "left for the reconciler" from "failed to delete" — the latter is the
+// *_pod_delete_error the reaper meters at its own call site. It is deliberately
+// NOT metered as a scheduler decision: those labels are recorded by a
+// DecisionRecorder the reapers hold, this layer has none, and a label here could
+// not say which reaper's teardown it came from. The reaper-level defer
+// (pod_lost_terminal_pod_defer) remains the metered signal for the same class.
 func (e *KubernetesExecutor) deletePodsBySelector(ctx context.Context, selector string) error {
 	pods, err := e.clientset.CoreV1().Pods(e.namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
 	if err != nil {
@@ -60,12 +81,42 @@ func (e *KubernetesExecutor) deletePodsBySelector(ctx context.Context, selector 
 	}
 	var errs []error
 	for i := range pods.Items {
-		name := pods.Items[i].Name
-		if derr := e.clientset.CoreV1().Pods(e.namespace).Delete(ctx, name, metav1.DeleteOptions{}); derr != nil && !apierrors.IsNotFound(derr) {
-			errs = append(errs, fmt.Errorf("deleting pod %s: %w", name, derr))
+		pod := &pods.Items[i]
+		if terminalForTeardown(pod.Status.Phase) {
+			slog.InfoContext(ctx, "reap teardown: task pod is already in a terminal phase; leaving it for the reconciler",
+				"pod", pod.Name, "phase", pod.Status.Phase, "selector", selector)
+			continue
+		}
+		if derr := e.clientset.CoreV1().Pods(e.namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{}); derr != nil && !apierrors.IsNotFound(derr) {
+			errs = append(errs, fmt.Errorf("deleting pod %s: %w", pod.Name, derr))
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// terminalForTeardown reports whether a task pod has reached a phase where a
+// reaper's teardown has nothing left to stop and an outcome record to lose
+// (#928). A reap deletes a pod for exactly one reason — to stop a container that
+// is still running user code and would otherwise break at-most-once execution
+// (#474). Succeeded and Failed have no such container, and their pod object
+// carries the attempt's durable outcome record (ADR 0052); the reconciler is the
+// designated deleter of those — it settles each one and then garbage-collects it
+// on age, which is the "reconciler-as-deleter" the RBAC comment names
+// (helm/leoflow/templates/rbac.yaml).
+//
+// The phase set here is exactly classifyPod's terminal-by-phase set, and that
+// alignment is the invariant: the teardown skips precisely the pods the
+// reconciler will settle and collect, and deletes precisely the ones it will
+// not. Hence Unknown is deleted, even though TaskPodPresence classifies it as
+// present-but-terminal — those two answer different questions. Presence asks
+// "is this an absence?", where Unknown is conservatively a presence; teardown
+// asks "is there a container to stop, and will anything else collect this?",
+// and for Unknown the answers are "possibly yes" and "no" — classifyPod groups
+// Unknown with Pending/Running, so the reconciler neither settles nor collects
+// it. Skipping it would leave a pod that may still be running the very work
+// #474 exists to stop, with nothing to stop it.
+func terminalForTeardown(phase corev1.PodPhase) bool {
+	return phase == corev1.PodSucceeded || phase == corev1.PodFailed
 }
 
 // TaskPodPresence reports what the apiserver holds for exactly the

--- a/internal/executor/pod_terminate_test.go
+++ b/internal/executor/pod_terminate_test.go
@@ -243,6 +243,42 @@ func TestDeleteTaskPod_PreservesTerminalPodCarryingOutcomeRecord(t *testing.T) {
 // classifyPod groups Unknown with Pending/Running, so the reconciler neither
 // settles nor collects it — skipping it here would leak it with nothing to stop
 // the container it may still be running.
+// TestDeleteTaskPod_PreservesARecordBearingPodWhateverItsPhase pins the
+// invariant the guard exists for — never destroy an outcome record — rather than
+// the phase that stands in for it. Phase is only a sound proxy while a task pod
+// has one container and RestartPolicy Never, which makes "the task container
+// terminated" imply "the phase is terminal". Add a second container and the
+// implication breaks: a service mesh injects a sidecar (reachable by an author
+// through execution annotations), the task container terminates and writes its
+// record, the sidecar keeps running, and the phase stays Running forever. That
+// is the one case where the record is the ONLY settle path, so it is the worst
+// possible pod to delete.
+func TestDeleteTaskPod_PreservesARecordBearingPodWhateverItsPhase(t *testing.T) {
+	t.Parallel()
+
+	rec, err := taskoutcome.Succeeded().Encode()
+	if err != nil {
+		t.Fatalf("encoding the outcome record: %v", err)
+	}
+	pod := taskPod("sidecar", "sidecar-run", "work", 1, corev1.PodRunning)
+	pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name:  taskContainerName,
+		State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Message: rec}},
+	}, {
+		Name:  "istio-proxy",
+		State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+	}}
+
+	cs := fake.NewSimpleClientset(pod)
+	e := &KubernetesExecutor{clientset: cs, namespace: "leoflow"}
+	if derr := e.DeleteTaskPod(context.Background(), "sidecar-run", "work", 1); derr != nil {
+		t.Fatalf("DeleteTaskPod: %v", derr)
+	}
+	if _, gerr := cs.CoreV1().Pods("leoflow").Get(context.Background(), pod.Name, metav1.GetOptions{}); gerr != nil {
+		t.Fatalf("#928: a pod carrying a decodable outcome record was deleted despite the record being the only settle path: %v", gerr)
+	}
+}
+
 func TestDeleteTaskPod_PhaseDecidesTheTeardown(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/executor/pod_terminate_test.go
+++ b/internal/executor/pod_terminate_test.go
@@ -7,6 +7,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/neochaotic/leoflow/internal/taskoutcome"
 )
 
 // taskPod builds a minimal pod carrying the label scheme the dispatcher stamps
@@ -200,5 +202,106 @@ func TestTaskPodPresence_AbsentIsNotTerminal(t *testing.T) {
 	}
 	if got != PodPresenceAbsent {
 		t.Errorf("TaskPodPresence with no pods = %v, want %v", got, PodPresenceAbsent)
+	}
+}
+
+// --- Teardown preserves a terminal pod's outcome record (#928) --------------
+
+// TestDeleteTaskPod_PreservesTerminalPodCarryingOutcomeRecord is the #928
+// invariant at the delete site: a reaper's teardown exists to stop a container
+// that is still running (#474), and a pod that already reached a terminal phase
+// has none. Deleting it therefore accomplishes exactly one thing — destroying
+// the durable outcome record on its termination message, the only evidence the
+// reconciler could settle the attempt from (ADR 0052). The pod must survive the
+// teardown with its record intact, whatever the reaper's own decision was.
+func TestDeleteTaskPod_PreservesTerminalPodCarryingOutcomeRecord(t *testing.T) {
+	pod := withRecord(taskPod("finished", "run-a", "extract", 1, corev1.PodSucceeded), taskoutcome.Succeeded())
+	cs := fake.NewSimpleClientset(pod)
+	e := NewKubernetesExecutor(cs, "leoflow")
+
+	if err := e.DeleteTaskPod(context.Background(), "run-a", "extract", 1); err != nil {
+		t.Fatalf("DeleteTaskPod: %v", err)
+	}
+	got, err := cs.CoreV1().Pods("leoflow").Get(context.Background(), "finished", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("#928: the terminal pod was deleted, destroying the outcome record the reconciler settles from: %v", err)
+	}
+	rec, ok := outcomeRecord(got)
+	if !ok || rec.Outcome != taskoutcome.Success {
+		t.Errorf("surviving pod lost its outcome record: rec=%+v ok=%v", rec, ok)
+	}
+}
+
+// TestDeleteTaskPod_PhaseDecidesTheTeardown pins which phases a teardown may
+// delete. Pending/Running have a container to stop, so the #474 teardown is the
+// whole point. Succeeded/Failed have none and carry the attempt's outcome, so
+// they are the reconciler's — it both settles and garbage-collects them.
+//
+// Unknown is deliberately on the DELETE side even though pod presence classifies
+// it as present-but-terminal (see PodPresence): a pod in Unknown may still have a
+// running container, which is precisely the case the teardown exists for, and
+// classifyPod groups Unknown with Pending/Running, so the reconciler neither
+// settles nor collects it — skipping it here would leak it with nothing to stop
+// the container it may still be running.
+func TestDeleteTaskPod_PhaseDecidesTheTeardown(t *testing.T) {
+	tests := []struct {
+		name    string
+		phase   corev1.PodPhase
+		deleted bool
+	}{
+		{"pending pod is torn down (a container may yet start)", corev1.PodPending, true},
+		{"running pod is torn down (#474: stop the container)", corev1.PodRunning, true},
+		{"succeeded pod survives (its record is the reconciler's)", corev1.PodSucceeded, false},
+		{"failed pod survives (its record is the reconciler's)", corev1.PodFailed, false},
+		{"unknown pod is torn down (may still be running; nothing else collects it)", corev1.PodUnknown, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cs := fake.NewSimpleClientset(taskPod("p", "run-a", "extract", 1, tc.phase))
+			e := NewKubernetesExecutor(cs, "leoflow")
+			if err := e.DeleteTaskPod(context.Background(), "run-a", "extract", 1); err != nil {
+				t.Fatalf("DeleteTaskPod: %v", err)
+			}
+			survived := podNames(t, cs)["p"]
+			if tc.deleted && survived {
+				t.Errorf("phase %s: pod survived the teardown, want deleted", tc.phase)
+			}
+			if !tc.deleted && !survived {
+				t.Errorf("phase %s: pod was deleted, want preserved for the reconciler", tc.phase)
+			}
+		})
+	}
+}
+
+// TestDeleteRunPods_PreservesTerminalPodsPerPod is the run-scoped half of #928.
+// The orphan-run reaper abandons a whole run at the 5-minute threshold with no
+// presence read at all, so the rule has to apply per pod inside the run and not
+// just to the per-attempt delete: the run's still-running pods are torn down
+// (#474) while its finished ones keep their outcome records for the reconciler.
+func TestDeleteRunPods_PreservesTerminalPodsPerPod(t *testing.T) {
+	cs := fake.NewSimpleClientset(
+		withRecord(taskPod("done-ok", "run-a", "extract", 1, corev1.PodSucceeded), taskoutcome.Succeeded()),
+		withRecord(taskPod("done-bad", "run-a", "load", 1, corev1.PodFailed), taskoutcome.FailedWith(2)),
+		taskPod("still-running", "run-a", "transform", 1, corev1.PodRunning),
+		taskPod("still-pending", "run-a", "publish", 1, corev1.PodPending),
+		taskPod("other-run", "run-b", "extract", 1, corev1.PodRunning),
+	)
+	e := NewKubernetesExecutor(cs, "leoflow")
+	if err := e.DeleteRunPods(context.Background(), "run-a"); err != nil {
+		t.Fatalf("DeleteRunPods: %v", err)
+	}
+	got := podNames(t, cs)
+	for _, keep := range []string{"done-ok", "done-bad"} {
+		if !got[keep] {
+			t.Errorf("#928: terminal pod %q was deleted by the run-scoped teardown, destroying its outcome record: %v", keep, got)
+		}
+	}
+	for _, gone := range []string{"still-running", "still-pending"} {
+		if got[gone] {
+			t.Errorf("live pod %q survived the run teardown; #474 requires its container be stopped: %v", gone, got)
+		}
+	}
+	if !got["other-run"] {
+		t.Errorf("run-b pod wrongly deleted: %v", got)
 	}
 }

--- a/internal/executor/reap.go
+++ b/internal/executor/reap.go
@@ -109,6 +109,11 @@ func (r *orphanReaper) reapOne(ctx context.Context, c ReapCandidate) {
 	// run-id is unique, so this can only ever hit this run's pods. Best-effort:
 	// a delete failure is logged but does not undo the DB reap — the pod's own
 	// ActiveDeadline and the reconciler's GC remain backstops.
+	//
+	// "Its pods" is narrower than every pod of the run: this reaper reads no pod
+	// presence, so DeleteRunPods applies the terminal-phase skip per pod (#928).
+	// A finished task's pod keeps the outcome record the reconciler settles from;
+	// only the run's still-live containers are stopped.
 	if r.pods == nil {
 		return
 	}

--- a/internal/executor/stale_queued_reap.go
+++ b/internal/executor/stale_queued_reap.go
@@ -162,10 +162,10 @@ func (r *dispatchLostReaper) run(ctx context.Context) error {
 			// worthless: SucceedTaskInstanceIfActive and its siblings admit
 			// `queued`, so the reconciler settles queued attempts by design, and
 			// ApplyTransition can stamp a row that already reached `running` back
-			// to `queued` (#929), so "a queued attempt never ran" is unsound. This
-			// reaper therefore still deletes an outcome record it should preserve;
-			// the fix belongs at the teardown site, where deleting a terminal pod
-			// accomplishes nothing but destroying evidence (#928).
+			// to `queued` (#929), so "a queued attempt never ran" is unsound. The
+			// finished pod's outcome record is nonetheless safe: the teardown below
+			// skips a pod in a terminal phase and leaves it to the reconciler
+			// (#928), so this reaper's decision can stay a pure liveness question.
 			if presence == PodPresenceLive {
 				r.logger.Info("dispatch-lost: pod is live (slow start); deferring",
 					"ti", c.TaskInstanceID, "run", c.DagRunID, "task", c.TaskID)
@@ -195,9 +195,11 @@ func (r *dispatchLostReaper) reapOne(ctx context.Context, c StaleQueuedCandidate
 		"ti", c.TaskInstanceID, "run", c.DagRunID, "dag", c.DagID, "task", c.TaskID,
 		"queued_at", c.QueuedAt)
 	r.record("dispatch_lost")
-	// Best-effort teardown of any lingering pod for this attempt (#474). By
-	// here the pod presence said no live pod exists (or pods is nil), so this
-	// only cleans up a terminal/failed pod; pinned to (run, task, try).
+	// Best-effort teardown of any lingering pod for this attempt (#474), pinned
+	// to (run, task, try). By here the presence read said no live pod exists (or
+	// pods is nil), so this normally deletes nothing: a pod that materialized
+	// since the read is stopped, and a pod in a terminal phase is skipped by the
+	// teardown itself and left for the reconciler to settle (#928).
 	if r.pods == nil {
 		return
 	}

--- a/website/content/operate/scheduler-resilience.md
+++ b/website/content/operate/scheduler-resilience.md
@@ -26,11 +26,11 @@ pods, so no pod-based reaper applies and the loop is not started.
 | Failure mode | Detected by | Default SLA | What happens |
 |---|---|---|---|
 | **Task code wedged past its declared `execution_timeout_seconds`** | **Agent itself** ([#194](https://github.com/neochaotic/leoflow/issues/194)) | **`execution_timeout_seconds`** (per-task) | **TI failed with `execution_timeout: task exceeded N`. Retries kick in if budget remains.** |
-| Agent process crashed mid-task (TI in `running`, no heartbeat) | TI heartbeat reaper ([#128](https://github.com/neochaotic/leoflow/issues/128)) | **90 s** | TI failed with `agent_lost`; the TI's pod is deleted so a partitioned-but-alive container stops. Retries kick in if budget remains. |
-| Scheduler crashed before dispatching (TI stuck in `queued`) | Dispatch-lost reaper ([#202](https://github.com/neochaotic/leoflow/issues/202)) | **3 min** | TI failed with `dispatch_lost` — but only if no live pod for it exists (see below); the pod is torn down. Frees the run for the orphan reaper on the next maintenance cycle. |
+| Agent process crashed mid-task (TI in `running`, no heartbeat) | TI heartbeat reaper ([#128](https://github.com/neochaotic/leoflow/issues/128)) | **90 s** | TI failed with `agent_lost`; the TI's pod is deleted so a partitioned-but-alive container stops — unless it has already reached a terminal phase, in which case it is left for the reconciler (see teardown below). Retries kick in if budget remains. |
+| Scheduler crashed before dispatching (TI stuck in `queued`) | Dispatch-lost reaper ([#202](https://github.com/neochaotic/leoflow/issues/202)) | **3 min** | TI failed with `dispatch_lost` — but only if no live pod for it exists (see below); any pod still Pending/Running for the attempt is torn down, a finished one is left for the reconciler. Frees the run for the orphan reaper on the next maintenance cycle. |
 | Task pod vanished (TI in `running`, no pod at all for its attempt) | Pod-lost reaper | **60 s** after the running transition, then a live pod read | TI failed with `pod_lost`. Only when the apiserver holds no pod for the attempt: a pod that is still there in a terminal phase is left for the reconciler to settle from its termination log (`pod_lost_terminal_pod_defer`). |
 | Warm worker died holding attempts (warm pools only) | Warm-worker-lost reaper | next maintenance cycle | Each attempt bound to the dead worker is failed `pod_lost`; refill of the pool is the warm-pool reconciler's job, not the reaper's. |
-| Run stuck `running` with no active TIs (post-crash limbo) | Orphan-run reaper ([#120](https://github.com/neochaotic/leoflow/issues/120)) | **5 min** | Run failed with `orphaned`; any remaining active TIs flipped to `failed` and every pod of the run is deleted. |
+| Run stuck `running` with no active TIs (post-crash limbo) | Orphan-run reaper ([#120](https://github.com/neochaotic/leoflow/issues/120)) | **5 min** | Run failed with `orphaned`; any remaining active TIs flipped to `failed` and every still-live pod of the run is deleted (its finished pods keep their outcome records for the reconciler). |
 
 Every SLA above is a floor: the reapers run every **30 s**, so detection lands
 up to one cycle after the threshold elapses. Worst case end-to-end: a mid-tick
@@ -170,6 +170,24 @@ durable DB transition, each reaper tears the pod down:
   never be the one deleted.
 - The **orphan-run** reaper deletes every pod of the abandoned run (the
   run-id is unique per run, so no other run's pod can match).
+- **A pod that already reached a terminal phase (`Succeeded`/`Failed`) is
+  skipped, not deleted** ([#928](https://github.com/neochaotic/leoflow/issues/928)).
+  It has no container left to stop, so deleting it would buy nothing and cost
+  the durable outcome record on its termination message — the only evidence the
+  reconciler can settle the attempt from
+  ([ADR 0052](/project/adrs/0052-durable-task-outcome/)). Collecting those pods
+  is the reconciler's job: it settles each one, then garbage-collects it once it
+  ages past the 10-minute grace. The skip is enforced once, at the teardown
+  itself, so it holds for every reaper — including the heartbeat reaper, which
+  fires on heartbeat staleness alone at 90 s and reads no pod state, and the
+  orphan-run reaper, which applies it per pod inside the run. No reaper's
+  decision changes: a TI the reaper marked stays marked. Look for
+  `reap teardown: task pod is already in a terminal phase` at INFO to see which
+  pods were left behind; a failed *delete* is the `*_pod_delete_error` decision
+  below, which is a different thing.
+- A pod in phase `Unknown` **is** deleted. It may still be running a container,
+  which is the case teardown exists for, and the reconciler treats `Unknown` as
+  non-terminal — it neither settles nor collects it — so nothing else would.
 - Belt and suspenders: the control plane also answers a **stale** agent
   `ReportState`/`Heartbeat` — one whose attempt no longer matches the live
   row — with `should_terminate`, so a reaped-but-still-alive pod that we
@@ -185,15 +203,28 @@ failure is logged and metered but never undoes the DB reap, and the pod's own
 (subprocess executor) there are no pods, so only the DB transition and the
 `should_terminate` signal apply.
 
+A terminal pod the teardown skips is collected by the reconciler, so a
+reconciler that is not sweeping leaves those pod objects behind. That is not a
+new dependency: every normally-finished task pod has always been the
+reconciler's to collect, and the reap-time delete only ever covered the subset
+belonging to a reaped TI or run. A terminated pod holds no node CPU or memory —
+it costs an API object and a slot against any `count/pods` quota — and
+Kubernetes' own terminated-pod GC (`--terminated-pod-gc-threshold`, 12500 by
+default) is the cluster-level floor under it. A reconciler stuck for longer
+than that shows up first as `reap_settling_valve_open`, which is the label to
+alert on.
+
 ## The load-bearing invariant
 
 Recovery is bounded by the slowest reaper that applies, not the fastest —
 usually fine, sometimes worth tuning
 (ADR [0031](/project/adrs/0031-scheduler-architecture/)). The invariant that governs
 every reap decision is **never fail or tear down the live current attempt —
-only one that is genuinely stale or lost**. It is preserved end-to-end: the DB
+only one that is genuinely stale or lost**, and **never destroy the evidence of
+one that already finished**. It is preserved end-to-end: the DB
 transitions are guarded on source state (`WHERE state IN (...)`), pod deletes
-are pinned to the exact `(run, task, try)` reaped, the dispatch-lost reaper
+are pinned to the exact `(run, task, try)` reaped and skip a pod already in a
+terminal phase, the dispatch-lost reaper
 defers whenever a pod is live or its liveness is unknown, and the
 `should_terminate` signal fires only when the reporting attempt has provably
 moved on. When in doubt, a reaper defers rather than reap.


### PR DESCRIPTION
Closes #928, and closes at the delete site the class #926 only closed in one reaper's decision.

A reaper's teardown exists to stop a container that is still running (#474). A pod already in a terminal phase has no container to stop, so deleting it accomplishes exactly one thing: it destroys the durable outcome record on the pod's termination message, which is the only evidence the reconciler could settle the attempt from (ADR 0052). #926 taught the pod-lost reaper to defer on such a pod, but three others still reached the same delete — agent-lost on heartbeat staleness alone at a **90-second** fuse, shorter than the path #926 fixed; orphan-run across every pod of the run at five minutes; and dispatch-lost, which defers only on a live pod.

The guard therefore sits in the single delete site behind both `DeleteTaskPod` and `DeleteRunPods`, not in three decision paths. All four teardown-calling reapers become evidence-preserving, and no reaper's decision logic moves: their own unit tests did not change, which is the point. The run-scoped half mattered as much as the per-attempt one — the failing test showed the orphan reaper's five-minute teardown taking *both* finished tasks' records with it.

**Phase `Unknown` is deleted, not preserved**, and the two classifications diverge on purpose. `PodPresence` answers "is this an absence?", where `Unknown` is conservatively a presence, so a reaper defers. The teardown answers "is there a container to stop, and will anything else collect this?" — and for `Unknown` the answers are possibly yes and no: `classifyPod` groups it with Pending and Running and returns non-terminal, so the reconciler neither settles nor collects it. Preserving it would leave a pod that may still be running the very work #474 exists to stop, with nothing to stop it. The resulting rule is exact: the teardown's terminal set is `Succeeded` and `Failed`, which is precisely `classifyPod`'s terminal-by-phase set, so the teardown skips what the reconciler will settle and collect, and deletes what it will not.

What this does not do, since the issue scoped the marks out: it preserves the evidence, it does not undo a wrong mark. The reapers still mark, and the settles are guarded on active states, so a task instance a reaper already failed is not re-settled from the surviving record. The value is that the record survives for diagnosis, that any sweep reaching the pod before the mark can still settle it, and that a later fix to the decision paths now has something left to recover from.

The trade is a destroyed record for a possibly lingering pod object, and it is a trade the system already makes: every normally-finished task pod has always been the reconciler's to collect on its ten-minute grace, and the reap-time delete only ever covered the subset belonging to a reaped attempt. A terminated pod holds no node CPU or memory. The self-limiting case is worth noting: if the reconciler is broken because its pod LIST fails, the teardown's own LIST fails too and deletes nothing anyway. A stalled reconciler already has its alert in `reap_settling_valve_open`.

The skip is observable as a per-pod log line naming the pod and the phase, deliberately not a new metric label: the existing labels are recorded through the reapers' decision recorder, which the executor layer does not hold, so a label emitted from there could not say which reaper's teardown it came from. `pod_lost_terminal_pod_defer` from #926 remains the metered signal at the decision level. Note that package-level logging in this layer reaches the configured handler only once #927 lands its `slog.SetDefault`.

Verification: build, `go test ./...` (33 packages), `-race` on the executor, golangci-lint 0 on a clean cache, changelog gate, the storage integration tests covering reaper behaviour, and two mutation checks — never preserving fails all three new tests, and preserving `Unknown` too fails the phase matrix.