### PR TITLE
resilience: alertable attributes on the credential-ceiling WARN, correct cap arithmetic, hermetic tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,7 +200,10 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     never returns: if it comes back after the token has lapsed, the rejected
     bearer already makes the agent exit promptly. It makes explicit a bound
     that held in practice before — the ceiling was a de-facto attempt-lifetime
-    cap of roughly ceiling + token TTL + the agent-lost threshold.
+    cap of ceiling + token TTL + the agent-lost threshold + up to one
+    maintenance cycle (30s, since the reapers run from that loop and not from
+    the scheduler tick), and the settling grace on top when a leader
+    re-election intervenes.
   - The pod-lost reaper (every scheduler tick) raced the reconciler (every 30s)
     for a pod that finished during the outage, and won — marking it `pod_lost`
     before the reconciler could recover the pod's durable outcome record. It now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,10 +200,12 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     never returns: if it comes back after the token has lapsed, the rejected
     bearer already makes the agent exit promptly. It makes explicit a bound
     that held in practice before — the ceiling was a de-facto attempt-lifetime
-    cap of ceiling + token TTL + the agent-lost threshold + up to one
+    cap of about ceiling + token TTL + the agent-lost threshold + one
     maintenance cycle (30s, since the reapers run from that loop and not from
-    the scheduler tick), and the settling grace on top when a leader
-    re-election intervenes.
+    the scheduler tick, and up to two intervals when a cycle overruns its
+    phase budgets), and the settling grace on top when a leader re-election
+    intervenes — up to twice that grace if the new leader never settles and
+    the liveness valve has to open.
   - The pod-lost reaper (every scheduler tick) raced the reconciler (every 30s)
     for a pod that finished during the outage, and won — marking it `pod_lost`
     before the reconciler could recover the pod's durable outcome record. It now

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -373,7 +373,10 @@ func validateStartup(cfg *config.ServerConfig) error {
 // off the warm-pool attempt watchdog. They are documented settings, not errors,
 // so boot proceeds; the WARN is the only operator-visible signal that those
 // guarantees are off. It runs after the logger exists, right after validation
-// has passed. Only a process that serves the scheduler warns: token renewal
+// has passed. Each warning is logged with the config key and the offending
+// value as attributes, so the JSON record an alert rule reads carries
+// config_key/value fields instead of only a prose message (#924).
+// Only a process that serves the scheduler warns: token renewal
 // lives in the agent gRPC server and the pod deadline floor in the dispatcher,
 // both scheduler-side, so an api-only replica in a split install would be
 // warning about behavior it does not implement — and a WARN operators learn to
@@ -383,7 +386,7 @@ func warnStartup(cfg *config.ServerConfig, logger *slog.Logger) {
 		return
 	}
 	for _, w := range executor.ResilienceLadderWarnings(resilienceLadder(cfg)) {
-		logger.Warn(w)
+		logger.Warn(w.Msg, "config_key", w.Key, "value", w.Value)
 	}
 }
 

--- a/cmd/leoflow-server/resilience_ladder_wiring_test.go
+++ b/cmd/leoflow-server/resilience_ladder_wiring_test.go
@@ -67,7 +67,9 @@ func TestResilienceLadderWiringFailsOnShortCredentialCeiling(t *testing.T) {
 // renewal and no activeDeadlineSeconds floor on task pods without a declared
 // execution_timeout. The boot WARN is the operator's only signal, so the boot
 // path must emit exactly one WARN naming the key when the ceiling is disabled,
-// and none when it is set.
+// and none when it is set. The record must carry the key and the offending
+// value as ATTRIBUTES so a JSON log can be alerted on (#924); a pre-formatted
+// message alone is only greppable by a human.
 func TestResilienceLadderWiringWarnsWhenCredentialCeilingDisabled(t *testing.T) {
 	warn := func(d time.Duration) string {
 		var buf bytes.Buffer
@@ -83,6 +85,12 @@ func TestResilienceLadderWiringWarnsWhenCredentialCeilingDisabled(t *testing.T) 
 		}
 		if !strings.Contains(out, "auth.max_attempt_credential_lifetime") || !strings.Contains(out, "activeDeadlineSeconds") {
 			t.Errorf("ceiling %v: WARN must name the key and the lost pod deadline floor, got %q", d, out)
+		}
+		if !strings.Contains(out, `config_key=auth.max_attempt_credential_lifetime`) {
+			t.Errorf("ceiling %v: WARN must carry the config key as an attribute, got %q", d, out)
+		}
+		if !strings.Contains(out, "value="+d.String()) {
+			t.Errorf("ceiling %v: WARN must carry the offending value as an attribute, got %q", d, out)
 		}
 	}
 	if out := warn(24 * time.Hour); out != "" {

--- a/cmd/leoflow-server/resilience_ladder_wiring_test.go
+++ b/cmd/leoflow-server/resilience_ladder_wiring_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"log/slog"
 	"os"
 	"strings"
@@ -15,8 +16,14 @@ import (
 
 // ceilingEnv is the env var viper's AutomaticEnv binds to
 // auth.max_attempt_credential_lifetime, the one ladder rung an operator can
-// move. It is the ONLY non-hermetic input to the wired ladder: every other rung
-// is a build-time constant, and LoadServer("", nil) reads no config file.
+// move. It is the only non-hermetic input to the wired ladder's VALUES: every
+// other rung is a build-time constant, and LoadServer("", nil) reads no config
+// file. It is not the only environment this test touches — LoadServer itself
+// still surfaces a malformed LEOFLOW_* duration — but that fails with its own
+// message naming the key, which is the opposite of the misleading failure this
+// unset exists to prevent. The unset is explicit rather than an empty string
+// because viper only treats an empty env var as unset while AllowEmptyEnv is
+// false, and this should not depend on that flag.
 const ceilingEnv = "LEOFLOW_AUTH_MAX_ATTEMPT_CREDENTIAL_LIFETIME"
 
 // TestResilienceLadderWiringValidates pins that the ladder the server actually
@@ -113,6 +120,21 @@ func TestResilienceLadderWiringWarnsWhenCredentialCeilingDisabled(t *testing.T) 
 		}
 		if !strings.Contains(out, "value="+d.String()) {
 			t.Errorf("ceiling %v: WARN must carry the offending value as an attribute, got %q", d, out)
+		}
+		// The text handler renders a duration the same whether the attribute is
+		// the time.Duration or its String(), so it cannot see the difference
+		// that matters to whoever writes the alert: under the JSON handler the
+		// production one, per observability.log_format's default — a duration
+		// is a number of nanoseconds, while a string would be "0s". The godoc
+		// on LadderWarning.Value promises the numeric shape, so pin it here or
+		// a one-token change flips it invisibly.
+		var jbuf bytes.Buffer
+		cfgJSON := &config.ServerConfig{}
+		cfgJSON.Auth.MaxAttemptCredentialLifetime = d
+		warnStartup(cfgJSON, slog.New(slog.NewJSONHandler(&jbuf, nil)))
+		if got := jbuf.String(); !strings.Contains(got, `"config_key":"auth.max_attempt_credential_lifetime"`) ||
+			!strings.Contains(got, fmt.Sprintf(`"value":%d`, d.Nanoseconds())) {
+			t.Errorf("ceiling %v: the JSON WARN must carry config_key and a numeric nanosecond value, got %s", d, got)
 		}
 	}
 	if out := warn(24 * time.Hour); out != "" {

--- a/cmd/leoflow-server/resilience_ladder_wiring_test.go
+++ b/cmd/leoflow-server/resilience_ladder_wiring_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"log/slog"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +13,12 @@ import (
 	"github.com/neochaotic/leoflow/internal/scheduler"
 )
 
+// ceilingEnv is the env var viper's AutomaticEnv binds to
+// auth.max_attempt_credential_lifetime, the one ladder rung an operator can
+// move. It is the ONLY non-hermetic input to the wired ladder: every other rung
+// is a build-time constant, and LoadServer("", nil) reads no config file.
+const ceilingEnv = "LEOFLOW_AUTH_MAX_ATTEMPT_CREDENTIAL_LIFETIME"
+
 // TestResilienceLadderWiringValidates pins that the ladder the server actually
 // boots with — agent heartbeat/TTL, default reaper config, reconcile interval,
 // the scheduler's infra re-place ceiling and the SHIPPED default
@@ -19,7 +26,22 @@ import (
 // depends on. The ceiling is read from the config defaults rather than
 // hardcoded, so a change to the shipped default that breaks the order fails
 // this test too, not only a change to a build-time constant.
+//
+// LoadServer resolves that ceiling through viper's AutomaticEnv, so the test
+// unsets ceilingEnv for its own duration to reach the config package's own
+// defaults map and nothing else (#924). Without that, a developer with a short
+// ceiling exported — exactly the developer most likely to be exercising this
+// knob — saw this test fail complaining about the SHIPPED defaults, which are
+// not what it was reading. A too-short ceiling has its own test below, where it
+// is set explicitly rather than inherited from the shell.
 func TestResilienceLadderWiringValidates(t *testing.T) {
+	// t.Setenv registers the restore and bars t.Parallel; there is no
+	// t.Unsetenv, so remove the variable by hand afterwards.
+	t.Setenv(ceilingEnv, "")
+	if err := os.Unsetenv(ceilingEnv); err != nil {
+		t.Fatalf("unsetting %s: %v", ceilingEnv, err)
+	}
+
 	cfg, err := config.LoadServer("", nil)
 	if err != nil {
 		t.Fatalf("LoadServer with shipped defaults: %v", err)

--- a/internal/executor/reaper_test.go
+++ b/internal/executor/reaper_test.go
@@ -109,6 +109,12 @@ func TestReaperReapOnceDrivesReapers(t *testing.T) {
 
 // staleEverythingStore serves one long-stale candidate to EVERY reaper, so a
 // test can prove that a gate stops all five destructive paths at once.
+//
+// If you grow this fixture, note that gateWiringStore exists precisely so the
+// "exactly one gate skip per reaper" assertion does not read these counts: that
+// test is about the wiring, and a second candidate here would have made it fail
+// while blaming the wiring instead. Add candidates freely; add them there only
+// deliberately.
 func staleEverythingStore() *fakeReaperStore {
 	past := time.Now().UTC().Add(-1 * time.Hour)
 	return &fakeReaperStore{

--- a/internal/executor/reaper_test.go
+++ b/internal/executor/reaper_test.go
@@ -429,8 +429,13 @@ func leadingOpenThenClosed(n int) func() bool {
 // reaper must meter its own gate skip exactly once — a reaper whose gate was
 // not wired would write instead. The settling gate is open (no leadership
 // stamp), so it does not stand between the entry check and the reapers.
+//
+// It uses its own gateWiringStore rather than the shared staleEverythingStore:
+// the "exactly once" assertion is a statement about the candidate count, so a
+// second candidate added to the shared fixture for another test's sake would
+// fail this one with a message accusing the wiring (#924).
 func TestNewReaperWiresGateIntoEveryReaper(t *testing.T) {
-	store := staleEverythingStore()
+	store := gateWiringStore()
 	pods := &fakePodManager{active: map[string]bool{}}
 	rec := &capturingRecorder{}
 	r := NewReaper(store, pods, nil, &fakeWarmLister{}, rec, reapTestLogger(), DefaultReaperConfig(), nil)
@@ -448,7 +453,7 @@ func TestNewReaperWiresGateIntoEveryReaper(t *testing.T) {
 	// the message would blame the wiring. Nil predicates and no leadership stamp
 	// must keep settling open in this test.
 	if got := rec.count("reap_settling_skip"); got != 0 {
-		t.Fatalf("settling must not stand between the entry check and the reapers in this test (candidates come from staleEverythingStore, one per reaper), reap_settling_skip = %d", got)
+		t.Fatalf("settling must not stand between the entry check and the reapers in this test (candidates come from gateWiringStore, one per reaper), reap_settling_skip = %d", got)
 	}
 	for _, skip := range []string{
 		"orphan_gate_skip",
@@ -458,7 +463,25 @@ func TestNewReaperWiresGateIntoEveryReaper(t *testing.T) {
 		"warm_worker_lost_gate_skip",
 	} {
 		if got := rec.count(skip); got != 1 {
-			t.Errorf("%s = %d, want exactly 1 (is that reaper's gate wired in NewReaper?)", skip, got)
+			t.Errorf("%s = %d, want exactly 1 — gateWiringStore serves exactly one candidate per reaper, so is that reaper's gate wired in NewReaper?", skip, got)
 		}
+	}
+}
+
+// gateWiringStore serves exactly ONE long-stale candidate to each of the five
+// destructive reapers, and exists solely for TestNewReaperWiresGateIntoEveryReaper:
+// that test counts one gate skip per reaper, so its assertion is only as stable
+// as the candidate count of the store behind it. The shared staleEverythingStore
+// has four other callers; growing it to serve a second candidate for one of them
+// would have failed the wiring test for a reason that has nothing to do with
+// wiring (#924).
+func gateWiringStore() *fakeReaperStore {
+	past := time.Now().UTC().Add(-1 * time.Hour)
+	return &fakeReaperStore{
+		orphanCands:  []ReapCandidate{{RunID: "stuck-run", DagID: "etl", LastActivity: past}},
+		agentCands:   []AgentLostCandidate{{TaskInstanceID: "silent", DagRunID: "r1", TaskID: "t", TryNumber: 1, LastHeartbeat: past}},
+		queuedCands:  []StaleQueuedCandidate{{TaskInstanceID: "stuck-ti", DagRunID: "r2", TaskID: "t", TryNumber: 1, QueuedAt: past}},
+		runningCands: []PodLostCandidate{{TaskInstanceID: "gone", DagRunID: "r3", TaskID: "t", TryNumber: 1, RunningSince: past}},
+		warmBound:    []WarmBoundTI{{TaskInstanceID: "warm-orphan", DagRunID: "r4", TaskID: "t", TryNumber: 1, WarmWorkerID: "dead-worker"}},
 	}
 }

--- a/internal/executor/resilience_ladder.go
+++ b/internal/executor/resilience_ladder.go
@@ -161,11 +161,37 @@ func ValidateResilienceLadder(l ResilienceLadder) error {
 // task instance and agent-lost never fires on a live agent. None of these
 // losses is an error; all are invisible without this signal. Pure, like the
 // validator: the server calls it once at boot after the logger exists.
-func ResilienceLadderWarnings(l ResilienceLadder) []string {
-	var warnings []string
+func ResilienceLadderWarnings(l ResilienceLadder) []LadderWarning {
+	var warnings []LadderWarning
 	if l.MaxAttemptCredentialLifetime <= 0 {
-		warnings = append(warnings, fmt.Sprintf("%s is disabled (%v): heartbeat renewal of an attempt's credential is unbounded, task pods with no declared execution_timeout get no activeDeadlineSeconds floor, and with warm pools enabled the per-attempt watchdog is off — a wedged or partitioned task pod has no wall-clock bound of its own",
-			maxAttemptCredentialLifetimeKey, l.MaxAttemptCredentialLifetime))
+		warnings = append(warnings, LadderWarning{
+			Msg: fmt.Sprintf("%s is disabled (%v): heartbeat renewal of an attempt's credential is unbounded, task pods with no declared execution_timeout get no activeDeadlineSeconds floor, and with warm pools enabled the per-attempt watchdog is off — a wedged or partitioned task pod has no wall-clock bound of its own",
+				maxAttemptCredentialLifetimeKey, l.MaxAttemptCredentialLifetime),
+			Key:   maxAttemptCredentialLifetimeKey,
+			Value: l.MaxAttemptCredentialLifetime,
+		})
 	}
 	return warnings
+}
+
+// LadderWarning is one boot WARN about a ladder setting that is valid but
+// removes a resilience backstop: the operator-readable sentence plus the two
+// things a monitoring rule needs as FIELDS. Logging only a pre-formatted string
+// leaves the JSON record with nothing but msg, so the single alert an operator
+// would actually want — "some instance booted with the credential ceiling
+// disabled" — can only be written as a substring match on prose that a later
+// reword silently breaks (#924). Msg stays self-contained (it names the key and
+// the value too) so a plain-text log needs no field expansion to be read.
+// Every rung of the ladder is a duration, so Value is one.
+type LadderWarning struct {
+	// Msg is the human-readable sentence: what is off and what it costs.
+	Msg string
+	// Key is the config key an operator would set to restore the backstop —
+	// the attribute an alert rule matches on.
+	Key string
+	// Value is the offending setting as configured. slog's JSON handler renders
+	// a duration as an integer nanosecond count, so an alert rule matches it
+	// numerically (value <= 0 for a disabled ceiling), not as "0s" — that
+	// spelling is the text handler's.
+	Value time.Duration
 }

--- a/internal/executor/resilience_ladder_test.go
+++ b/internal/executor/resilience_ladder_test.go
@@ -159,22 +159,31 @@ func TestValidateResilienceLadderRejectsEachViolation(t *testing.T) {
 // and a task pod with no declared execution timeout gets no ActiveDeadlineSeconds
 // floor. The operator's only signal is the boot WARN, so the warnings must name
 // the key and both consequences for zero and for negative values, and must be
-// empty when the ceiling is set.
+// empty when the ceiling is set. The key and the offending value are carried as
+// FIELDS, not only inside the prose: a pre-formatted string logs a JSON record
+// with nothing to alert on (#924).
 func TestResilienceLadderWarningsDisabledCredentialCeiling(t *testing.T) {
 	for _, d := range []time.Duration{0, -time.Second} {
 		l := defaultLadder()
 		l.MaxAttemptCredentialLifetime = d
 		got := ResilienceLadderWarnings(l)
 		if len(got) != 1 {
-			t.Fatalf("ceiling %v: want exactly one warning, got %q", d, got)
+			t.Fatalf("ceiling %v: want exactly one warning, got %+v", d, got)
+		}
+		w := got[0]
+		if w.Key != maxAttemptCredentialLifetimeKey {
+			t.Errorf("ceiling %v: warning key = %q, want %q — an alert rule matches on the field, not the prose", d, w.Key, maxAttemptCredentialLifetimeKey)
+		}
+		if w.Value != d {
+			t.Errorf("ceiling %v: warning value = %v, want the offending value", d, w.Value)
 		}
 		for _, want := range []string{"auth.max_attempt_credential_lifetime", "disabled", "renewal", "activeDeadlineSeconds", "watchdog", "wedged"} {
-			if !strings.Contains(got[0], want) {
-				t.Errorf("ceiling %v: warning %q must mention %q", d, got[0], want)
+			if !strings.Contains(w.Msg, want) {
+				t.Errorf("ceiling %v: warning %q must mention %q", d, w.Msg, want)
 			}
 		}
 	}
 	if got := ResilienceLadderWarnings(defaultLadder()); len(got) != 0 {
-		t.Errorf("a set ceiling must produce no warning, got %q", got)
+		t.Errorf("a set ceiling must produce no warning, got %+v", got)
 	}
 }

--- a/website/content/reference/go/internal-agentrpc.md
+++ b/website/content/reference/go/internal-agentrpc.md
@@ -19,6 +19,11 @@ Package agentrpc implements the control\-plane side of the agent gRPC protocol: 
 - [type AgentTokenMinter](<#AgentTokenMinter>)
 - [type AgentTokenRenewer](<#AgentTokenRenewer>)
 - [type Authenticator](<#Authenticator>)
+- [type InflightHandlers](<#InflightHandlers>)
+  - [func NewInflightHandlers\(\) \*InflightHandlers](<#NewInflightHandlers>)
+  - [func \(c \*InflightHandlers\) Count\(\) int](<#InflightHandlers.Count>)
+  - [func \(c \*InflightHandlers\) StreamInterceptor\(\) grpc.StreamServerInterceptor](<#InflightHandlers.StreamInterceptor>)
+  - [func \(c \*InflightHandlers\) UnaryInterceptor\(\) grpc.UnaryServerInterceptor](<#InflightHandlers.UnaryInterceptor>)
 - [type LogPublisher](<#LogPublisher>)
 - [type LogSink](<#LogSink>)
 - [type PodTaskResolver](<#PodTaskResolver>)
@@ -161,6 +166,55 @@ type Authenticator interface {
 }
 ```
 
+<a name="InflightHandlers"></a>
+## type [InflightHandlers](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/inflight.go#L21-L23>)
+
+InflightHandlers counts the agent RPC handlers currently executing. gRPC exposes no such number, and the bounded graceful stop needs it: past its bound the process force\-closes the transports and waits only briefly for the handlers to return, while a log writer's final Put is bounded far longer, so the process can legitimately exit with handlers still running. Abandoning one is safe — a log object is written by a single atomic Put, so the stored object stays at its previous flush rather than being truncated — but silent, and this count is what makes it visible.
+
+The zero value is not usable; build one with NewInflightHandlers. It is safe for concurrent use.
+
+```go
+type InflightHandlers struct {
+    // contains filtered or unexported fields
+}
+```
+
+<a name="NewInflightHandlers"></a>
+### func [NewInflightHandlers](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/inflight.go#L27>)
+
+```go
+func NewInflightHandlers() *InflightHandlers
+```
+
+NewInflightHandlers returns a zeroed counter to install on a gRPC server via UnaryInterceptor and StreamInterceptor and to read with Count.
+
+<a name="InflightHandlers.Count"></a>
+### func \(\*InflightHandlers\) [Count](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/inflight.go#L30>)
+
+```go
+func (c *InflightHandlers) Count() int
+```
+
+Count reports how many handlers are executing right now.
+
+<a name="InflightHandlers.StreamInterceptor"></a>
+### func \(\*InflightHandlers\) [StreamInterceptor](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/inflight.go#L49>)
+
+```go
+func (c *InflightHandlers) StreamInterceptor() grpc.StreamServerInterceptor
+```
+
+StreamInterceptor counts a streaming handler for the duration of its stream. These are the handlers the shutdown log is about: StreamLogs lives as long as its task and an idle warm worker's AwaitAssignment lives indefinitely, so they are what is still open when the bounded stop gives up.
+
+<a name="InflightHandlers.UnaryInterceptor"></a>
+### func \(\*InflightHandlers\) [UnaryInterceptor](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/inflight.go#L33>)
+
+```go
+func (c *InflightHandlers) UnaryInterceptor() grpc.UnaryServerInterceptor
+```
+
+UnaryInterceptor counts a unary handler for the duration of its call.
+
 <a name="LogPublisher"></a>
 ## type [LogPublisher](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L140-L142>)
 
@@ -295,7 +349,7 @@ type SecretsStore interface {
 ```
 
 <a name="Server"></a>
-## type [Server](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L145-L190>)
+## type [Server](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L145-L195>)
 
 Server implements agentv1.AgentServiceServer over a Store and Authenticator.
 
@@ -307,7 +361,7 @@ type Server struct {
 ```
 
 <a name="NewServer"></a>
-### func [NewServer](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L194>)
+### func [NewServer](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L199>)
 
 ```go
 func NewServer(authn Authenticator, store Store, xcomSvc XComService) *Server
@@ -316,7 +370,7 @@ func NewServer(authn Authenticator, store Store, xcomSvc XComService) *Server
 NewServer builds an AgentService server backed by the given authenticator, store, and XCom service.
 
 <a name="Server.AwaitAssignment"></a>
-### func \(\*Server\) [AwaitAssignment](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/await_assignment.go#L57>)
+### func \(\*Server\) [AwaitAssignment](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/await_assignment.go#L58>)
 
 ```go
 func (s *Server) AwaitAssignment(stream agentv1.AgentService_AwaitAssignmentServer) error
@@ -328,7 +382,7 @@ Inert\-when\-off: if warm pools are not wired the handler refuses immediately wi
 
 Identity: the registry key is the worker's AUTHENTICATED identity from the stream's bearer token \(via identify\), NOT the dag\_version\_id in the register payload — a worker cannot claim an arbitrary identity through the message. The payload's dag\_version\_id only names which pool the worker serves and must be non\-empty.
 
-After registration two flows run concurrently: the receive loop drains WorkerMessages \(acks feed the H1 lease machine, slot\-free frees the worker\) while the main select pumps assignments from the worker's outbound channel down the stream. The handler exits — deregistering the worker \(defer\) — on context cancellation, a stream Send error, or the receive loop ending \(clean EOF or a transport error\).
+After registration two flows run concurrently: the receive loop drains WorkerMessages \(acks feed the H1 lease machine, slot\-free frees the worker\) while the main select pumps assignments from the worker's outbound channel down the stream. The handler exits — deregistering the worker \(defer\) — on context cancellation, the control plane's shutdown signal \(SetShutdown\), a stream Send error, or the receive loop ending \(clean EOF or a transport error\).
 
 <a name="Server.EnableWarmPools"></a>
 ### func \(\*Server\) [EnableWarmPools](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/await_assignment.go#L33>)
@@ -351,7 +405,7 @@ ExchangeToken validates the agent's projected ServiceAccount token \(bootstrap b
 It fails closed at every step: Unimplemented when the exchange is not wired, PermissionDenied on an insecure channel, Unauthenticated on a missing or rejected projected token, and Internal when the reviewed pod cannot be resolved to an attempt \(never mint an unscoped or misattributed token\). The minted token and the presented projected token are never logged.
 
 <a name="Server.FetchXCom"></a>
-### func \(\*Server\) [FetchXCom](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L428>)
+### func \(\*Server\) [FetchXCom](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L439>)
 
 ```go
 func (s *Server) FetchXCom(ctx context.Context, req *agentv1.FetchXComRequest) (*agentv1.FetchXComResponse, error)
@@ -369,7 +423,7 @@ func (s *Server) GetConnections(ctx context.Context, _ *agentv1.GetConnectionsRe
 GetConnections returns the calling task's tenant Connections as Airflow URIs for the agent to export as AIRFLOW\_CONN\_\<CONN\_ID\>.
 
 <a name="Server.GetTaskSpec"></a>
-### func \(\*Server\) [GetTaskSpec](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L237>)
+### func \(\*Server\) [GetTaskSpec](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L248>)
 
 ```go
 func (s *Server) GetTaskSpec(ctx context.Context, _ *agentv1.GetTaskSpecRequest) (*agentv1.TaskSpec, error)
@@ -387,7 +441,7 @@ func (s *Server) GetVariables(ctx context.Context, _ *agentv1.GetVariablesReques
 GetVariables returns the calling task's tenant Variables for the agent to export as AIRFLOW\_VAR\_\<KEY\>.
 
 <a name="Server.Heartbeat"></a>
-### func \(\*Server\) [Heartbeat](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L328>)
+### func \(\*Server\) [Heartbeat](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L339>)
 
 ```go
 func (s *Server) Heartbeat(ctx context.Context, _ *agentv1.HeartbeatRequest) (*agentv1.HeartbeatResponse, error)
@@ -396,7 +450,7 @@ func (s *Server) Heartbeat(ctx context.Context, _ *agentv1.HeartbeatRequest) (*a
 Heartbeat stamps the per\-TI liveness signal \(\#128\) and returns the server clock so the agent can detect skew. A storage error stamping the heartbeat is logged but does not fail the RPC — failing the call would risk the agent terminating itself unnecessarily on a transient DB blip. The scheduler reaper would, in the worst case, fail the TI as agent\_lost on the next tick; correct under "do no harm" \(ADR 0031\).
 
 <a name="Server.PushXCom"></a>
-### func \(\*Server\) [PushXCom](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L400>)
+### func \(\*Server\) [PushXCom](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L411>)
 
 ```go
 func (s *Server) PushXCom(ctx context.Context, req *agentv1.PushXComRequest) (*agentv1.PushXComResponse, error)
@@ -405,7 +459,7 @@ func (s *Server) PushXCom(ctx context.Context, req *agentv1.PushXComRequest) (*a
 PushXCom stores a value the task produced, keyed by the caller's identity. Size/schema violations are returned as a rejection, not a transport error, so the agent can fail the task with a clear reason.
 
 <a name="Server.Register"></a>
-### func \(\*Server\) [Register](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L225>)
+### func \(\*Server\) [Register](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L236>)
 
 ```go
 func (s *Server) Register(ctx context.Context, _ *agentv1.RegisterRequest) (*agentv1.RegisterResponse, error)
@@ -414,7 +468,7 @@ func (s *Server) Register(ctx context.Context, _ *agentv1.RegisterRequest) (*age
 Register acknowledges an agent's startup and returns the server clock.
 
 <a name="Server.ReportState"></a>
-### func \(\*Server\) [ReportState](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L278>)
+### func \(\*Server\) [ReportState](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L289>)
 
 ```go
 func (s *Server) ReportState(ctx context.Context, req *agentv1.ReportStateRequest) (*agentv1.ReportStateResponse, error)
@@ -441,7 +495,7 @@ func (s *Server) SetLivenessGate(checker TaskLivenessChecker, mode string)
 SetLivenessGate attaches the read\-only task\-instance liveness predicate the secret path consults, in the given mode \("observe" | "enforce", ADR 0055 E2\). An unrecognized mode falls back to observe — the safe, non\-denying default. A nil checker leaves the gate off \(delivery unchanged\), so the gate is opt\-in.
 
 <a name="Server.SetLogPublisher"></a>
-### func \(\*Server\) [SetLogPublisher](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L222>)
+### func \(\*Server\) [SetLogPublisher](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L233>)
 
 ```go
 func (s *Server) SetLogPublisher(p LogPublisher)
@@ -450,7 +504,7 @@ func (s *Server) SetLogPublisher(p LogPublisher)
 SetLogPublisher attaches the live\-tail publisher \(optional\). When set, StreamLogs publishes each line for the UI's live tail.
 
 <a name="Server.SetLogSink"></a>
-### func \(\*Server\) [SetLogSink](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L218>)
+### func \(\*Server\) [SetLogSink](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L229>)
 
 ```go
 func (s *Server) SetLogSink(sink LogSink)
@@ -495,13 +549,13 @@ func (s *Server) SetSecrets(store SecretsStore, allowInsecure bool)
 SetSecrets attaches the secrets store. allowInsecure permits serving secrets over a non\-TLS channel — for local/dev only; production must use TLS \(the handlers fail closed otherwise\). See ADR 0021 / issue \#58.
 
 <a name="Server.SetShutdown"></a>
-### func \(\*Server\) [SetShutdown](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L214>)
+### func \(\*Server\) [SetShutdown](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L225>)
 
 ```go
 func (s *Server) SetShutdown(ctx context.Context)
 ```
 
-SetShutdown wires the control plane's shutdown context: once ctx ends, every open StreamLogs returns Unavailable after closing \(flushing\) its log writer, so the gRPC graceful stop that follows completes instead of waiting for the tasks themselves to finish. The agent treats the closed stream as best\-effort log delivery and keeps running its task.
+SetShutdown wires the control plane's shutdown context: once ctx ends, every long\-lived stream returns Unavailable, so the gRPC graceful stop that follows completes instead of waiting for the tasks themselves to finish. An open StreamLogs first closes \(flushes\) its log writer; the agent treats the closed stream as best\-effort log delivery and keeps running its task. A StreamLogs that arrives AFTER the signal is refused before its writer is opened — the listener keeps accepting for the rest of the shutdown, and an opened\-then\- abandoned writer Puts an empty object over an attempt that is logging elsewhere. An open AwaitAssignment ends too — an idle warm worker holds one open indefinitely, so leaving it out would make the forced stop the normal shutdown path.
 
 <a name="Server.SetTokenExchange"></a>
 ### func \(\*Server\) [SetTokenExchange](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/exchange.go#L69>)
@@ -513,7 +567,7 @@ func (s *Server) SetTokenExchange(reviewer TokenReviewer, resolver PodTaskResolv
 SetTokenExchange wires the projected\-SA\-token exchange \(ADR 0055 Fix \#3\): the TokenReview client, the pod→task\-instance resolver, the JWT minter, and the TTL of the minted task\-scoped token. allowInsecure permits running the exchange over a non\-TLS channel \(dev only\); production must use TLS \(ExchangeToken fails closed otherwise, like the secret path\). A nil reviewer leaves the exchange OFF — ExchangeToken then reports Unimplemented — which is the default \(env\-var\) transport, so a deployment that does not opt in is byte\-identical to today.
 
 <a name="Server.SetTokenRenewal"></a>
-### func \(\*Server\) [SetTokenRenewal](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L205>)
+### func \(\*Server\) [SetTokenRenewal](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L210>)
 
 ```go
 func (s *Server) SetTokenRenewal(renewer AgentTokenRenewer, renewalTTL, maxAttemptLifetime time.Duration)
@@ -531,13 +585,13 @@ func (s *Server) SetWarmPools(reg *WorkerRegistry)
 SetWarmPools wires a prebuilt warm\-worker assignment registry \(ADR 0058 N1b\). A nil registry \(the default\) leaves AwaitAssignment inert — it returns FailedPrecondition — so with execution.warm\_pools\_enabled off the transport is completely dormant and no running path changes. Used by tests to inject a registry with a deterministic lease; callers wire it via EnableWarmPools.
 
 <a name="Server.StreamLogs"></a>
-### func \(\*Server\) [StreamLogs](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L466>)
+### func \(\*Server\) [StreamLogs](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L479>)
 
 ```go
 func (s *Server) StreamLogs(stream agentv1.AgentService_StreamLogsServer) (err error)
 ```
 
-StreamLogs receives the task's log lines and writes them through the sink, flushing on stream end so the logs survive the pod. The stream also ends when the control plane shuts down \(SetShutdown\), so the flush runs before exit.
+StreamLogs receives the task's log lines and writes them through the sink, flushing on stream end so the logs survive the pod. The stream also ends when the control plane shuts down \(SetShutdown\), so the flush runs before exit — and a stream that ARRIVES after that signal is refused before any writer is opened, so it leaves no empty object behind.
 
 <a name="Store"></a>
 ## type [Store](<https://github.com/neochaotic/leoflow/blob/main/internal/agentrpc/server.go#L107-L126>)

--- a/website/content/reference/go/internal-executor.md
+++ b/website/content/reference/go/internal-executor.md
@@ -19,7 +19,6 @@ Package executor runs task instances via Kubernetes, Docker, or a subprocess.
 - [func IsDispatchLost\(c StaleQueuedCandidate, threshold time.Duration, now time.Time\) bool](<#IsDispatchLost>)
 - [func IsOrphaned\(c ReapCandidate, threshold time.Duration, now time.Time\) bool](<#IsOrphaned>)
 - [func IsPodLostCandidate\(c PodLostCandidate, grace time.Duration, now time.Time\) bool](<#IsPodLostCandidate>)
-- [func ResilienceLadderWarnings\(l ResilienceLadder\) \[\]string](<#ResilienceLadderWarnings>)
 - [func StagingClaimName\(dagID, runID string\) string](<#StagingClaimName>)
 - [func ValidateResilienceLadder\(l ResilienceLadder\) error](<#ValidateResilienceLadder>)
 - [type AgentLostCandidate](<#AgentLostCandidate>)
@@ -45,6 +44,8 @@ Package executor runs task instances via Kubernetes, Docker, or a subprocess.
   - [func \(k \*KubernetesWarmPods\) DeleteWarmPod\(ctx context.Context, name string\) error](<#KubernetesWarmPods.DeleteWarmPod>)
   - [func \(k \*KubernetesWarmPods\) EnsureWarmAnchor\(ctx context.Context, dagVersionID string\) \(string, error\)](<#KubernetesWarmPods.EnsureWarmAnchor>)
   - [func \(k \*KubernetesWarmPods\) ListWarmPods\(ctx context.Context\) \(\[\]WarmPodInfo, error\)](<#KubernetesWarmPods.ListWarmPods>)
+- [type LadderWarning](<#LadderWarning>)
+  - [func ResilienceLadderWarnings\(l ResilienceLadder\) \[\]LadderWarning](<#ResilienceLadderWarnings>)
 - [type OutcomeReporter](<#OutcomeReporter>)
 - [type PodIdentity](<#PodIdentity>)
   - [func ParseAgentIdentity\(raw string\) \(PodIdentity, error\)](<#ParseAgentIdentity>)
@@ -143,7 +144,7 @@ const (
 ```
 
 <a name="BuildPod"></a>
-## func [BuildPod](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L70>)
+## func [BuildPod](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L72>)
 
 ```go
 func BuildPod(req Request) *corev1.Pod
@@ -201,15 +202,6 @@ func IsPodLostCandidate(c PodLostCandidate, grace time.Duration, now time.Time) 
 ```
 
 IsPodLostCandidate reports whether a running TI has been running long enough to warrant a pod\-liveness check. A zero RunningSince is treated as alive \(too poorly observed to reap — the "do no harm" rule of ADR 0031\), and a future RunningSince \(clock skew\) is treated as alive. This gate is purely about elapsed time; the actual lost\-vs\-alive decision is the pod\-liveness check.
-
-<a name="ResilienceLadderWarnings"></a>
-## func [ResilienceLadderWarnings](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/resilience_ladder.go#L164>)
-
-```go
-func ResilienceLadderWarnings(l ResilienceLadder) []string
-```
-
-ResilienceLadderWarnings reports the ladder settings that are valid but remove a resilience backstop, so the server can surface them as boot WARNs. ValidateResilienceLadder deliberately accepts a non\-positive credential ceiling — it is the operator's documented "no ceiling" setting — but that one value disables every wall\-clock bound the ceiling carries: heartbeat renewal of an attempt's bearer becomes unbounded; a dedicated task pod whose DAG declares no execution timeout gets no ActiveDeadlineSeconds floor; and, with warm pools enabled, the per\-attempt watchdog that keeps a wedged attempt from pinning a warm slot is off too \(a warm pod has no pod\-level deadline at all, and the worker lifetime cap drains between attempts, never mid\-attempt\). A task that wedges while still heartbeating then has no bound of its own even with a healthy control plane: the orphan\-run reaper skips a run with a live task instance and agent\-lost never fires on a live agent. None of these losses is an error; all are invisible without this signal. Pure, like the validator: the server calls it once at boot after the logger exists.
 
 <a name="StagingClaimName"></a>
 ## func [StagingClaimName](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/staging.go#L45>)
@@ -369,7 +361,7 @@ type HeartbeatReapStore interface {
 ```
 
 <a name="KubernetesExecutor"></a>
-## type [KubernetesExecutor](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L21-L25>)
+## type [KubernetesExecutor](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L23-L27>)
 
 KubernetesExecutor runs each task as an ephemeral pod \(ADR 0002\).
 
@@ -380,7 +372,7 @@ type KubernetesExecutor struct {
 ```
 
 <a name="NewKubernetesExecutor"></a>
-### func [NewKubernetesExecutor](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L32>)
+### func [NewKubernetesExecutor](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L34>)
 
 ```go
 func NewKubernetesExecutor(clientset kubernetes.Interface, namespace string) *KubernetesExecutor
@@ -389,25 +381,25 @@ func NewKubernetesExecutor(clientset kubernetes.Interface, namespace string) *Ku
 NewKubernetesExecutor builds an executor creating pods in the given namespace.
 
 <a name="KubernetesExecutor.DeleteRunPods"></a>
-### func \(\*KubernetesExecutor\) [DeleteRunPods](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_terminate.go#L43>)
+### func \(\*KubernetesExecutor\) [DeleteRunPods](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_terminate.go#L64>)
 
 ```go
 func (e *KubernetesExecutor) DeleteRunPods(ctx context.Context, runID string) error
 ```
 
-DeleteRunPods deletes every task pod belonging to a single reaped run. The orphan\-run reaper abandons a whole run \(failing all its still\-active TIs\), so every pod of that run must be torn down. The run\-id is a unique per\-run UUID, so this selector can only ever match pods of the one abandoned run — never a different run's live pod. Tolerates NotFound.
+DeleteRunPods deletes every task pod belonging to a single reaped run. The orphan\-run reaper abandons a whole run \(failing all its still\-active TIs\), so every pod of that run must be torn down. The run\-id is a unique per\-run UUID, so this selector can only ever match pods of the one abandoned run — never a different run's live pod. The terminal\-phase skip applies per pod inside the run, not just to the per\-attempt delete above \(\#928\): this reaper reads no presence at all, so a run abandoned at the 5\-minute threshold would otherwise take every finished task's outcome record with it. A mixed set is safe because each settle is guarded on the pod's own try\-number, ReapRun has already flipped the run and every still\-active task instance in one transaction before this runs, and pod names carry a random suffix so a preserved pod can never collide with a redispatch. The subtlest cell is a reschedule poke pod, which the reconciler collects immediately rather than on age because a reschedule reuses the same try\-number: preserving one delays that collect by up to a cycle, which is harmless because up\_for\_reschedule is not an active state for any reaper, so a reaper only ever preserves a poke pod for an attempt it has just made terminal. Tolerates NotFound.
 
 <a name="KubernetesExecutor.DeleteTaskPod"></a>
-### func \(\*KubernetesExecutor\) [DeleteTaskPod](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_terminate.go#L32>)
+### func \(\*KubernetesExecutor\) [DeleteTaskPod](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_terminate.go#L41>)
 
 ```go
 func (e *KubernetesExecutor) DeleteTaskPod(ctx context.Context, runID, taskID string, tryNumber int) error
 ```
 
-DeleteTaskPod deletes the pod\(s\) for exactly one reaped task instance: the \(run, task, try\) tuple. Pinning try\-number is the invariant guard — a retry bumps try\_number in place and dispatches a new pod with a new try\-number label, so a newer live attempt can never match this selector and is never deleted. Tolerates NotFound.
+DeleteTaskPod deletes the pod\(s\) for exactly one reaped task instance: the \(run, task, try\) tuple. Pinning try\-number is the invariant guard — a retry bumps try\_number in place and dispatches a new pod with a new try\-number label, so a newer live attempt can never match this selector and is never deleted. A pod already in a terminal phase is left for the reconciler \(\#928\). Tolerates NotFound.
 
 <a name="KubernetesExecutor.Execute"></a>
-### func \(\*KubernetesExecutor\) [Execute](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L45>)
+### func \(\*KubernetesExecutor\) [Execute](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L47>)
 
 ```go
 func (e *KubernetesExecutor) Execute(ctx context.Context, req Request) (Disposition, error)
@@ -425,7 +417,7 @@ func (e *KubernetesExecutor) GCStagingClaims(ctx context.Context, ttl time.Durat
 GCStagingClaims reclaims per\-run staging PVCs from the metadatabase\-tracked lifecycle \(ADR 0022\): a successful run frees its volume immediately; a failed run keeps it until ttl elapses after the run's terminal time \(clear\+re\-run safety\); an orphaned volume \(run row gone\) is reclaimed. Each deletion is recorded with its reason. A no\-op when no StagingStore is wired.
 
 <a name="KubernetesExecutor.SetStagingStore"></a>
-### func \(\*KubernetesExecutor\) [SetStagingStore](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L29>)
+### func \(\*KubernetesExecutor\) [SetStagingStore](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L31>)
 
 ```go
 func (e *KubernetesExecutor) SetStagingStore(s StagingStore)
@@ -434,7 +426,7 @@ func (e *KubernetesExecutor) SetStagingStore(s StagingStore)
 SetStagingStore wires the metadatabase\-backed staging\-volume lifecycle store \(ADR 0022\). With no store set, provisioning is not recorded and GC is a no\-op.
 
 <a name="KubernetesExecutor.TaskPodPresence"></a>
-### func \(\*KubernetesExecutor\) [TaskPodPresence](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_terminate.go#L91>)
+### func \(\*KubernetesExecutor\) [TaskPodPresence](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_terminate.go#L171>)
 
 ```go
 func (e *KubernetesExecutor) TaskPodPresence(ctx context.Context, runID, taskID string, tryNumber int) (PodPresence, error)
@@ -511,6 +503,35 @@ func (k *KubernetesWarmPods) ListWarmPods(ctx context.Context) ([]WarmPodInfo, e
 
 ListWarmPods returns every warm\-worker pod in the namespace, tagged with the dag\_version it serves \(from its label\).
 
+<a name="LadderWarning"></a>
+## type [LadderWarning](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/resilience_ladder.go#L186-L197>)
+
+LadderWarning is one boot WARN about a ladder setting that is valid but removes a resilience backstop: the operator\-readable sentence plus the two things a monitoring rule needs as FIELDS. Logging only a pre\-formatted string leaves the JSON record with nothing but msg, so the single alert an operator would actually want — "some instance booted with the credential ceiling disabled" — can only be written as a substring match on prose that a later reword silently breaks \(\#924\). Msg stays self\-contained \(it names the key and the value too\) so a plain\-text log needs no field expansion to be read. Every rung of the ladder is a duration, so Value is one.
+
+```go
+type LadderWarning struct {
+    // Msg is the human-readable sentence: what is off and what it costs.
+    Msg string
+    // Key is the config key an operator would set to restore the backstop —
+    // the attribute an alert rule matches on.
+    Key string
+    // Value is the offending setting as configured. slog's JSON handler renders
+    // a duration as an integer nanosecond count, so an alert rule matches it
+    // numerically (value <= 0 for a disabled ceiling), not as "0s" — that
+    // spelling is the text handler's.
+    Value time.Duration
+}
+```
+
+<a name="ResilienceLadderWarnings"></a>
+### func [ResilienceLadderWarnings](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/resilience_ladder.go#L164>)
+
+```go
+func ResilienceLadderWarnings(l ResilienceLadder) []LadderWarning
+```
+
+ResilienceLadderWarnings reports the ladder settings that are valid but remove a resilience backstop, so the server can surface them as boot WARNs. ValidateResilienceLadder deliberately accepts a non\-positive credential ceiling — it is the operator's documented "no ceiling" setting — but that one value disables every wall\-clock bound the ceiling carries: heartbeat renewal of an attempt's bearer becomes unbounded; a dedicated task pod whose DAG declares no execution timeout gets no ActiveDeadlineSeconds floor; and, with warm pools enabled, the per\-attempt watchdog that keeps a wedged attempt from pinning a warm slot is off too \(a warm pod has no pod\-level deadline at all, and the worker lifetime cap drains between attempts, never mid\-attempt\). A task that wedges while still heartbeating then has no bound of its own even with a healthy control plane: the orphan\-run reaper skips a run with a live task instance and agent\-lost never fires on a live agent. None of these losses is an error; all are invisible without this signal. Pure, like the validator: the server calls it once at boot after the logger exists.
+
 <a name="OutcomeReporter"></a>
 ## type [OutcomeReporter](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L227-L231>)
 
@@ -525,7 +546,7 @@ type OutcomeReporter interface {
 ```
 
 <a name="PodIdentity"></a>
-## type [PodIdentity](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L198-L205>)
+## type [PodIdentity](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L326-L333>)
 
 PodIdentity is the JSON payload of AgentIdentityAnnotation: the full task\-instance identity the control plane mints the exchanged JWT for.
 
@@ -541,7 +562,7 @@ type PodIdentity struct {
 ```
 
 <a name="ParseAgentIdentity"></a>
-### func [ParseAgentIdentity](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L210>)
+### func [ParseAgentIdentity](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L338>)
 
 ```go
 func ParseAgentIdentity(raw string) (PodIdentity, error)
@@ -666,7 +687,7 @@ type PodLostReapStore interface {
 ```
 
 <a name="PodManager"></a>
-## type [PodManager](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_manager.go#L19-L36>)
+## type [PodManager](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_manager.go#L19-L45>)
 
 PodManager is the slice of the Kubernetes executor the reapers use to \(1\) tear down a reaped task's pod and \(2\) check whether a queued TI's pod is actually live before declaring its dispatch lost \(\#474, \#461\).
 
@@ -682,10 +703,19 @@ type PodManager interface {
     // the (run, task, try) tuple. Pinning try-number guarantees a newer live
     // attempt (dispatched with a new try-number) is never deleted. Tolerates
     // a missing pod.
+    //
+    // A pod already in a terminal phase is SKIPPED, not deleted (#928): the
+    // teardown exists to stop a running container, a terminal pod has none, and
+    // its termination message is the outcome record the reconciler settles the
+    // attempt from (ADR 0052). That is why a reaper may call this unconditionally
+    // after its mark without reading presence first — the guard is at the delete
+    // site, so it holds for every reaper including the ones (agent-lost,
+    // orphan-run) that read no presence at all.
     DeleteTaskPod(ctx context.Context, runID, taskID string, tryNumber int) error
     // DeleteRunPods deletes every task pod of one reaped run. Used by the
     // orphan-run reaper, which abandons the whole run. The run-id is unique
-    // per run, so no other run's pod can match. Tolerates missing pods.
+    // per run, so no other run's pod can match. Tolerates missing pods. The
+    // terminal-phase skip above applies per pod within the run (#928).
     DeleteRunPods(ctx context.Context, runID string) error
     // TaskPodPresence reports what the apiserver holds for exactly the
     // (run, task, try) attempt: a live pod, a present-but-finished pod, or
@@ -698,7 +728,7 @@ type PodManager interface {
 ```
 
 <a name="PodPresence"></a>
-## type [PodPresence](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_manager.go#L49>)
+## type [PodPresence](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_manager.go#L58>)
 
 PodPresence is the three\-way answer to "what does the apiserver hold for this attempt's pod?".
 
@@ -721,7 +751,17 @@ const (
     // Pending or Running. Whatever happened to that attempt is recorded on the
     // pod object, so settling it belongs to the reconciler and no reaper may
     // delete it. Phase Unknown counts here as well: the pod object is still
-    // there, the reconciler still watches it, and it is not an absence.
+    // there and it is not an absence. Note the backstop for a pod stuck in
+    // Unknown is NOT the reconciler — classifyPod groups Unknown with
+    // Pending/Running, so the reconciler neither settles nor collects it — but
+    // the agent-lost reaper (heartbeats stop when a node goes unreachable) and
+    // the orphan-run reaper. The phase has not been set by kubelet since 2015
+    // and is deprecated upstream, so the practical exposure is nil; classifying
+    // it as presence is the conservative direction. Note this is deliberately
+    // WIDER than terminalForTeardown, which the pod teardown uses: presence asks
+    // "is this an absence?" (Unknown is not), teardown asks "is there a container
+    // to stop, and will anything else collect this?" (for Unknown, possibly yes
+    // and no) — so Unknown defers a reap here and is still deleted there (#928).
     PodPresenceTerminal
     // PodPresenceAbsent means the apiserver holds no pod for the attempt at all
     // — the attempt's pod is genuinely gone (deleted, evicted, lost with its
@@ -732,7 +772,7 @@ const (
 ```
 
 <a name="PodPresence.String"></a>
-### func \(PodPresence\) [String](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_manager.go#L71>)
+### func \(PodPresence\) [String](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_manager.go#L90>)
 
 ```go
 func (p PodPresence) String() string
@@ -741,7 +781,7 @@ func (p PodPresence) String() string
 String names the presence for logs.
 
 <a name="PodPresenceCache"></a>
-## type [PodPresenceCache](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_manager.go#L100-L107>)
+## type [PodPresenceCache](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/pod_manager.go#L119-L126>)
 
 PodPresenceCache is an optional read\-through cache of pod presence — backed by a shared informer \(PR\-10\) — that the pod\-lost and dispatch\-lost reapers consult ONLY to DEFER a reap, never to authorize one. Its trust is asymmetric \(\#461\):
 
@@ -857,7 +897,7 @@ NewReaper constructs the reapers and wires their pod\-teardown / liveness capabi
 warmPods is the live warm\-pod seam \(ADR 0058 N1d\-a2\), threaded to the two warm consumers exactly the way pods/cache are threaded: the warm\-worker\-lost reaper \(which recovers a dead worker's attempts\) and the dispatch\-lost reaper's H3 defer. Nil \(warm pools off / not wired\) makes the warm reaper a no\-op and the dispatch\-lost warm defer inert — with the flag off no TI ever carries a warm\_worker\_id either, so both warm paths are doubly inert, byte\-for\-byte today.
 
 <a name="Reaper.ReapOnce"></a>
-### func \(\*Reaper\) [ReapOnce](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reaper.go#L378>)
+### func \(\*Reaper\) [ReapOnce](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reaper.go#L389>)
 
 ```go
 func (r *Reaper) ReapOnce(ctx context.Context) error


### PR DESCRIPTION
Closes #924, the nits from the review of #923. One of them ships in the release, which is why they are going in before the cut.

**The boot WARN is now alertable.** It logged a pre-formatted string, so the JSON log carried nothing to match on. `ResilienceLadderWarnings` returns a warning carrying the message, the config key and the offending value, and the server logs them as attributes. The message text is byte-identical and the scheduler-role guard is untouched, so nothing about when it fires changed. Worth knowing for whoever writes the alert: the JSON handler renders the duration numerically in nanoseconds, not as `0s`, and that is stated on the field.

**The cap arithmetic was stale and the release publishes it.** The entry said the de-facto attempt-lifetime cap is roughly the ceiling plus the token TTL plus the agent-lost threshold. Since the reapers moved to the 30-second maintenance loop behind the leader-settling gate, that undercounts: it needs up to one maintenance cycle, and the settling grace on top when a re-election intervenes. A grep across the docs, the godoc and the operator pages found the additive form in exactly one place, the changelog entry, because everywhere else states the ordering ladder rather than a sum.

**The ladder wiring test was not hermetic, and it misled exactly the developer most likely to hit it.** It loads config through viper with automatic environment binding, so anyone with `LEOFLOW_AUTH_MAX_ATTEMPT_CREDENTIAL_LIFETIME` exported below ten minutes saw it fail locally with a message about shipped defaults. It now clears that one variable for its own duration, so the ceiling resolves from the config package's defaults through the shipped load path. Proven both ways: with the variable exported at five minutes this branch passes and `main` fails.

**The gate-wiring test no longer borrows a shared fixture.** It asserts exactly one skip per reaper, which is a statement about the candidate count, so it got its own store rather than one with four other callers. Proven by perturbing the shared fixture with a second candidate: the old assertion failed with a message blaming the wiring, which was wired correctly, and the new one is immune.

Verified: build, `go test ./...` (33 packages), golangci-lint 0 on a clean cache, changelog gate, plus a mutation check — dropping the attributes from the log call fails the wiring test.