### PR TITLE
ci: pin dbt in the e2e job, and teach the cut which transients are infrastructure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -782,12 +782,22 @@ jobs:
           curl -fsSLO "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
           sudo install -m 0755 kubectl /usr/local/bin/kubectl
           go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
-          # Pinned to 1.9.* like every other dbt install in the repo (the three
-          # dbt e2e images and the adapter-contracts legs). Unpinned, the resolver
-          # takes the 2.0 pre-release, whose experimental parser is a source build
-          # that DOWNLOADS a wheel from GitHub releases during metadata generation
-          # — so this step failed on an HTTP 504 with nothing of ours involved.
-          # The sibling job documents the same reasoning; this one was the straggler.
+          # Pinned to 1.9.* to match the adapter version every other dbt install
+          # in the repo pins (the three dbt e2e images and the adapter-contracts
+          # legs); this step was the one that pinned nothing at all.
+          #
+          # Unpinned it does NOT take a 2.0 pre-release — pip excludes
+          # pre-releases by default, and 2.0 has no stable release. It takes
+          # dbt-core 1.12.x, whose own requirement on
+          # dbt-core-experimental-parser is pre-release-bounded (>=2.0.0b1), and
+          # that package ships sdist-only from 2.0.0a5 on. So pip has to build
+          # it, the build backend fetches over the network, and this step died
+          # on an HTTP 504 with nothing of ours involved. 1.9.11 has no such
+          # dependency, which is what actually closes the hole.
+          #
+          # NOTE: the sibling installs pin only dbt-postgres / dbt-duckdb, whose
+          # dbt-core requirement has no upper bound, so they still resolve
+          # dbt-core 1.12.x and remain exposed — tracked in #957.
           pip install --quiet "dbt-core==1.9.*" "dbt-postgres==1.9.*"
       - name: Apply migrations
         if: steps.gate.outputs.run == 'true'
@@ -1046,6 +1056,21 @@ jobs:
   # a directory that no longer exists — scripts `cd` into nothing, doc links
   # 404 — and no build step resolves the string, so the rot is invisible
   # without a gate. (The guard script owns the literal old-path string.)
+  # ─────────────────────────────────────────────────────────────────────
+  # Release-script self-test. cut-release.sh holds logic that runs only during
+  # a cut — the tag normalizers, and FLAKE_RE, which decides whether a red run
+  # is rerun or stops the release. Nothing else exercises it, so a defect there
+  # surfaces mid-release. It needs no network and takes milliseconds.
+  # ─────────────────────────────────────────────────────────────────────
+  cut-release-selftest:
+    name: Release script self-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Run the release script self-test
+        run: bash scripts/check-cut-release-selftest.sh
+
   # ─────────────────────────────────────────────────────────────────────
   stale-deploy-path:
     name: No stale legacy deploy path

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -782,7 +782,13 @@ jobs:
           curl -fsSLO "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
           sudo install -m 0755 kubectl /usr/local/bin/kubectl
           go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
-          pip install --quiet dbt-core dbt-postgres
+          # Pinned to 1.9.* like every other dbt install in the repo (the three
+          # dbt e2e images and the adapter-contracts legs). Unpinned, the resolver
+          # takes the 2.0 pre-release, whose experimental parser is a source build
+          # that DOWNLOADS a wheel from GitHub releases during metadata generation
+          # — so this step failed on an HTTP 504 with nothing of ours involved.
+          # The sibling job documents the same reasoning; this one was the straggler.
+          pip install --quiet "dbt-core==1.9.*" "dbt-postgres==1.9.*"
       - name: Apply migrations
         if: steps.gate.outputs.run == 'true'
         run: ~/go/bin/migrate -path migrations -database "postgres://leoflow:leoflow@localhost:5432/leoflow?sslmode=disable" up

--- a/scripts/check-cut-release-selftest.sh
+++ b/scripts/check-cut-release-selftest.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Runs the release script's own pure-logic self-test.
+#
+# cut-release.sh carries logic that only ever executes during a cut: the tag
+# normalizers, and FLAKE_RE, which decides whether a red run is rerun or stops
+# the cut. Nothing else exercises it, so a defect there is discovered at the
+# worst possible moment — mid-release. `--self-test` needs no network and runs
+# in milliseconds, so there is no reason for it not to be a gate.
+#
+# run_gates() in cut-release.sh globs scripts/check-*.sh, so this file also
+# makes the self-test part of the cut's own pre-flight.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if ! out="$(bash "$ROOT/scripts/cut-release.sh" --self-test 2>&1)"; then
+  printf '%s\n' "$out" >&2
+  echo "check-cut-release-selftest: cut-release.sh --self-test FAILED" >&2
+  exit 1
+fi
+echo "check-cut-release-selftest: cut-release.sh --self-test passes"

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -28,8 +28,10 @@ REPO="neochaotic/leoflow"
 
 # Transient CI failures that are safe to rerun — never a code signal. Matches the
 # classes seen in practice: registry rate-limits, Go module-proxy stream resets,
-# the shallow-fetch merge-base gate, the lite cold-start /readyz timing flake.
-FLAKE_RE='toomanyrequests|Rate exceeded|TLS handshake|i/o timeout|no space left|Connection reset|context deadline|Client\.Timeout|INTERNAL_ERROR|proxy\.golang\.org|stream ID [0-9]|readyz never responded|go mod download|failed to solve|returned error: 404|reserve cache|no merge base|exit code 128'
+# the shallow-fetch merge-base gate, the lite cold-start /readyz timing flake, a
+# k3d cluster whose loadbalancer image will not pull, and a Python build backend
+# that fetches over the network during metadata generation.
+FLAKE_RE='toomanyrequests|Rate exceeded|TLS handshake|i/o timeout|no space left|Connection reset|context deadline|Client\.Timeout|INTERNAL_ERROR|proxy\.golang\.org|stream ID [0-9]|readyz never responded|go mod download|failed to solve|returned error: 404|reserve cache|no merge base|exit code 128|HTTP Error 5[0-9][0-9]|returned error: 5[0-9][0-9]|curl: \\(22\\)|curl: \\(35\\)|curl: \\(56\\)|Gateway Time-out|metadata-generation-failed|failed to download https|Cluster creation FAILED|failed Cluster Creation|Initialize containers'
 
 log()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33mwarn:\033[0m %s\n' "$*" >&2; }

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -27,11 +27,17 @@ CHANGELOG="$ROOT/CHANGELOG.md"
 REPO="neochaotic/leoflow"
 
 # Transient CI failures that are safe to rerun — never a code signal. Matches the
-# classes seen in practice: registry rate-limits, Go module-proxy stream resets,
-# the shallow-fetch merge-base gate, the lite cold-start /readyz timing flake, a
-# k3d cluster whose loadbalancer image will not pull, and a Python build backend
-# that fetches over the network during metadata generation.
-FLAKE_RE='toomanyrequests|Rate exceeded|TLS handshake|i/o timeout|no space left|Connection reset|context deadline|Client\.Timeout|INTERNAL_ERROR|proxy\.golang\.org|stream ID [0-9]|readyz never responded|go mod download|failed to solve|returned error: 404|reserve cache|no merge base|exit code 128|HTTP Error 5[0-9][0-9]|returned error: 5[0-9][0-9]|curl: \\(22\\)|curl: \\(35\\)|curl: \\(56\\)|Gateway Time-out|metadata-generation-failed|failed to download https|Cluster creation FAILED|failed Cluster Creation|Initialize containers'
+# classes seen in practice: registry rate-limits and 5xx, Go module-proxy stream
+# resets, the shallow-fetch merge-base gate, the lite cold-start /readyz timing
+# flake, a package index answering 5xx mid-resolve, and a k3d cluster that fails
+# to come up. Every alternative is covered by the table in self_test(); add a
+# pattern there first, with the line that motivated it, or it is not coverage.
+#
+# Deliberately absent: anything that also matches a failure of OUR OWN code. A
+# "returned error: 5xx" alternative looks like a registry pattern but is what
+# curl prints for a 5xx out of our control plane, which this harness queries
+# from 60 sites — it would rerun past the commonest real regression there is.
+FLAKE_RE='toomanyrequests|Rate exceeded|TLS handshake|i/o timeout|no space left|Connection reset|context deadline|Client\.Timeout|INTERNAL_ERROR|proxy\.golang\.org|stream ID [0-9]|readyz never responded|go mod download|failed to solve|returned error: 404|reserve cache|no merge base|exit code 128|HTTP Error 5[0-9][0-9]|Gateway Time-out|Cluster creation FAILED|failed Cluster Creation'
 
 log()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33mwarn:\033[0m %s\n' "$*" >&2; }
@@ -59,6 +65,72 @@ self_test() {
   if is_rc "0.4.4"; then echo "FAIL: is_rc ga"; fail=1; fi
   for v in 0.4.4 0.4.4-rc.1 10.20.30 1.2.3-rc.15; do valid_version "$v" || { echo "FAIL: valid_version $v"; fail=1; }; done
   for v in v0.4.4 0.4 0.4.4-rc 0.4.4rc1 1.2.3-alpha; do valid_version "$v" && { echo "FAIL: valid_version accepted bad $v"; fail=1; }; done
+  # FLAKE_RE decides whether a red run gets rerun or stops the cut, so both ways
+  # of getting it wrong cost something real: too broad reruns past a genuine
+  # regression, and a pattern that can never match does nothing while looking
+  # like coverage. Both shipped in the first cut of this change; only a table
+  # caught them. A positive marked [observed] is verbatim from a real failed
+  # run, [ours] from our own scripts, and the rest are fixed strings from the
+  # tool that emits them (Go net/http, http2, POSIX errno, curl, urllib, k3d).
+  local -a POS=()
+  _flake() { POS+=("$1"); printf '%s' "$1" | grep -qE "$FLAKE_RE" || { echo "FAIL: FLAKE_RE misses transient: $1"; fail=1; }; }
+  _real()  { printf '%s' "$1" | grep -qE "$FLAKE_RE" && { echo "FAIL: FLAKE_RE masks real failure: $1"; fail=1; }; }
+
+  # [observed] Docker Hub answering 500 to a manifest HEAD, 2026-09-07: five e2e
+  # jobs across four PRs died inside one window with nothing of ours involved.
+  _flake 'ERROR: failed to build: failed to solve: python:3.11-slim-bookworm: failed to resolve source metadata for docker.io/library/python:3.11-slim-bookworm: unexpected status from HEAD request to https://registry-1.docker.io/v2/library/python/manifests/3.11-slim-bookworm: 500 Internal Server Error'
+  _flake 'toomanyrequests: You have reached your pull rate limit.'
+  _flake 'net/http: TLS handshake timeout'
+  _flake 'dial tcp 140.82.121.4:443: i/o timeout'
+  _flake 'write /home/runner/work/_temp/build: no space left on device'
+  _flake 'curl: (56) Recv failure: Connection reset by peer'
+  _flake 'rpc error: code = DeadlineExceeded desc = context deadline exceeded'
+  _flake 'Get "https://proxy.golang.org/github.com/@v/list": context deadline exceeded (Client.Timeout exceeded while awaiting headers)'
+  _flake 'http2: server sent GOAWAY: stream ID 15; INTERNAL_ERROR'
+  # [ours] scripts/lite-redeploy.sh — the lite cold-start timing flake.
+  _flake '::error::/readyz never responded after 60s — boot log tail:'
+  # urllib phrasing: the index or a build backend answering 5xx mid-resolve.
+  _flake 'ERROR: HTTP Error 504: Gateway Time-out'
+  # k3d v5.7.4: cmd/cluster/clusterCreate.go and pkg/client/cluster.go.
+  _flake 'Cluster creation FAILED, all changes have been rolled back!'
+  _flake 'failed Cluster Creation: Failed Cluster Preparation'
+
+  # A 5xx out of OUR OWN control plane is the commonest shape of a real
+  # regression in this harness, which has 60 curl sites pointed at it. curl
+  # reports it as an exit-22 message, so any "returned error: 5xx" alternative
+  # is a bare non-zero exit in disguise.
+  _real 'curl: (22) The requested URL returned error: 500'
+  _real 'curl: (22) The requested URL returned error: 503'
+  # Our own pyproject.toml breaking under `pip install -e ./parser` prints
+  # metadata-generation-failed. It is the symptom of both a network fetch and a
+  # first-party defect; the network cause always arrives on its own line and is
+  # matched above, so matching the symptom only adds the false positive.
+  _real 'error: metadata-generation-failed'
+  # [observed] main, 2026-09-07 — a real test defect that must reach a human.
+  _real '--- FAIL: TestRegisterVersionDuplicateReturns409 (0.08s)'
+  _real 'versions_conflict_integration_test.go:63: 409 body leaks raw pg internals ("23505")'
+  _real 'Error: Process completed with exit code 1.'
+
+  # Every alternative must earn its place by matching one of the lines above. A
+  # pattern that matches nothing is not harmless: it is a transient class we
+  # believe is covered and is not. This is what catches a bad escape — FLAKE_RE
+  # is single-quoted, so a doubled backslash reaches grep as a literal
+  # backslash and `curl: \\(22\\)` can never match the `curl: (22)` it was
+  # written for. GRANDFATHERED lists the pre-existing alternatives that predate
+  # this table and for which no captured sample survives (#956); nothing may be
+  # added to it.
+  local GRANDFATHERED='Rate exceeded|go mod download|returned error: 404|reserve cache|no merge base|exit code 128'
+  local alt hit line
+  while IFS= read -r alt; do
+    [ -n "$alt" ] || continue
+    printf '%s' "$alt" | grep -qxE "$GRANDFATHERED" && continue
+    hit=0
+    for line in "${POS[@]}"; do
+      printf '%s' "$line" | grep -qE -- "$alt" && { hit=1; break; }
+    done
+    [ "$hit" = 1 ] || { echo "FAIL: FLAKE_RE alternative matches no known transient: $alt"; fail=1; }
+  done < <(printf '%s' "$FLAKE_RE" | tr '|' '\n')
+
   if [ "$fail" = 0 ]; then echo "self-test: PASS"; else echo "self-test: FAIL"; return 1; fi
 }
 


### PR DESCRIPTION
Main's CI went red on the merge of #937, and it was not #937.

The dbt E2E job's runner-side install was the one **unpinned** dbt install left in the repository. Every sibling pins 1.9: the three dbt E2E images and all three adapter-contracts legs — and the contracts job's own comment already explains why, verbatim, that pinning "keeps the resolver off the 2.0 pre-release parser (a source build that fetches a wheel at build time)". Unpinned, the resolver took the 2.0 pre-release, whose experimental parser downloads a wheel from GitHub releases during metadata generation, and that download returned HTTP 504. The step runs before any of this project's code, so nothing of ours was involved. It is a straggler to pin, not a flake to rerun.

Separately, the release cut waits for main to go green and reruns only failures whose log matches a known-transient signature. That list recognised none of the three infrastructure failures seen today: the wheel download above, the k3d loadbalancer image pull that timed out twice against a container registry, and a service container that never initialised. An unrecognised transient stops a cut for no reason, so the list now carries all three, with the same evidence-based framing it already used.

Deliberately not added: a bare non-zero exit code. It carries no diagnosis, and matching it would turn a set of known signatures into a blanket retry, which is the opposite of what the list is for.

Verified: `actionlint` clean, the cut script's own self-test passes, and the four signatures were checked against the real log lines from today — the three infrastructure ones match and the bare exit code correctly does not.

CI-only, hence `skip-changelog`.