### PR TITLE
auth: token renewal reloads the user, so a revoked principal stops getting fresh tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -309,6 +309,16 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   would let renewal traffic burn the password-login budget for the address (and
   for everyone behind a proxy when `server.trusted_proxies` is unset); a renewal
   limiter needs its own instance and is tracked separately.
+- **Three registered settings that were written down nowhere, plus a guard for
+  the next one (#801).** `auth.jwt.max_lifetime_seconds` — the ceiling that
+  bounds a transparently renewed session, i.e. the control that makes renewal
+  acceptable — and `secrets.backend` / `secrets.backend_kwargs` bound from the
+  environment but appeared in no settings table in the configuration reference,
+  so an operator had no documented way to reach them. All three now have rows
+  (`secrets.*` gets its own section). `TestDocumentedEnvVarsBind` could not catch
+  this: it only runs doc → binding. The new reverse guard runs binding → doc, so
+  registering a key without documenting it now fails the build (same class as
+  #725 / #733 / #743).
 - **The pod-lost reaper no longer reaps a task whose pod is still there,
   finished.** Its liveness question returned one bool for two different states —
   "no pod for this attempt at all" and "a pod that exists in a terminal phase" —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,26 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   large share of installs is a worse posture than an opt-in one that is honestly
   labelled ([#804](https://github.com/neochaotic/leoflow/issues/804)).
 
+- **Token renewal now re-proves the user, not just the token (#801).**
+  `POST /api/v2/auth/token/renew` validated the incoming bearer, checked the
+  session ceiling, and then re-minted the principal purely from the token's
+  claims — it never reloaded the user, unlike every other auth path. A user
+  deactivated or deleted mid-session therefore kept getting `200` and a fresh
+  token from the renew endpoint until `auth.jwt.max_lifetime_seconds` elapsed.
+  Renewal now reloads the user and answers `401` when the account is inactive or
+  its row is gone. **Severity, precisely:** this was a broken invariant and a
+  false changelog claim, not an access path. The renewed token was inert — both
+  consumers of a user token authenticate through the store-backed reload, so it
+  was rejected on use — and no product path deactivates a user today (the users
+  API exposes only list and create), so reaching the precondition required
+  editing the database by hand. The two carve-outs the request path already makes
+  are preserved exactly: no bound data plane (in-process `leoflow dev`) and the
+  dev-token subject, which has no user row by design; any other store error
+  refuses the renewal. The renew route remains without a rate limiter — the
+  existing login limiter counts failures toward an IP lockout, so sharing it
+  would let renewal traffic burn the password-login budget for the address (and
+  for everyone behind a proxy when `server.trusted_proxies` is unset); a renewal
+  limiter needs its own instance and is tracked separately.
 - **The pod-lost reaper no longer reaps a task whose pod is still there,
   finished.** Its liveness question returned one bool for two different states —
   "no pod for this attempt at all" and "a pod that exists in a terminal phase" —
@@ -992,8 +1012,11 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   longer hit `401 missing bearer token` every hour. Backed by a new
   `POST /api/v2/auth/token/renew` that re-mints the same identity with a fresh
   short TTL, bounded by `auth.jwt.max_lifetime_seconds` (default 24h). The
-  access-token TTL is unchanged and revocation is still enforced per request, so a
-  renewed token dies the moment its user is deactivated.
+  access-token TTL is unchanged and revocation is enforced per request, so a
+  renewed token is rejected the moment its user is deactivated. (Corrected: as
+  shipped, revocation was enforced on *use* but not on *issuance* — the renew
+  endpoint itself kept answering `200` for a deactivated user until the ceiling
+  elapsed. Fixed in a later release; see the Unreleased entry.)
 - **`leoflow runs list` (#747).** The common `runs` verb now lists DAG runs
   (`--state`/`--dag`/`--older-than`) alongside `trigger` and `status`, reusing the
   same lister as `leoflow admin runs list`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1026,7 +1026,7 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   renewed token is rejected the moment its user is deactivated. (Corrected: as
   shipped, revocation was enforced on *use* but not on *issuance* — the renew
   endpoint itself kept answering `200` for a deactivated user until the ceiling
-  elapsed. Fixed in a later release; see the Unreleased entry.)
+  elapsed. Fixed later; see the token-renewal entry under Fixed above.)
 - **`leoflow runs list` (#747).** The common `runs` verb now lists DAG runs
   (`--state`/`--dag`/`--older-than`) alongside `trigger` and `status`, reusing the
   same lister as `leoflow admin runs list`.

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strings"
@@ -14,9 +15,11 @@ import (
 // TokenRenewer re-mints a still-valid user bearer with a fresh short TTL, bounded
 // by max_lifetime since first login. *auth.JWTAuthenticator implements it via
 // RenewUserToken; the handler depends on this narrow interface so the renew route
-// can be tested without a real signing key.
+// can be tested without a real signing key. It takes a context because renewal
+// re-proves the principal against the user store, so it must be canceled with
+// the request.
 type TokenRenewer interface {
-	RenewUserToken(token string, ttl, maxLifetime time.Duration) (renewed string, ok bool, err error)
+	RenewUserToken(ctx context.Context, token string, ttl, maxLifetime time.Duration) (renewed string, ok bool, err error)
 }
 
 // breakGlass gates the credential path when the provider is OIDC (D8): only the
@@ -153,11 +156,12 @@ func authTokenHandler(authn auth.Authenticator, limiter *auth.RateLimiter, ttlSe
 //
 // The route sits under the public /api/v2/auth/ prefix (like login/logout), so the
 // handler is self-gating: it re-mints ONLY from a cryptographically valid,
-// unexpired, correct-audience bearer (the renewer enforces all of that), and
-// answers 401 both when the token is invalid/expired and when it is past
-// max_lifetime, so the CLI falls back to login in either case. You cannot renew
-// without already holding a valid token. The response mirrors /auth/token so the
-// same client decoder handles both.
+// unexpired, correct-audience bearer whose user is still active in the store (the
+// renewer enforces all of that), and answers 401 when the token is
+// invalid/expired, when its user has been deactivated or deleted, and when it is
+// past max_lifetime, so the CLI falls back to login in every case. You cannot
+// renew without already holding a valid token for a live account. The response
+// mirrors /auth/token so the same client decoder handles both.
 func renewTokenHandler(renewer TokenRenewer, ttlSeconds, maxLifetimeSeconds int) gin.HandlerFunc {
 	ttl := time.Duration(ttlSeconds) * time.Second
 	maxLifetime := time.Duration(maxLifetimeSeconds) * time.Second
@@ -167,7 +171,7 @@ func renewTokenHandler(renewer TokenRenewer, ttlSeconds, maxLifetimeSeconds int)
 			AbortProblem(c, http.StatusUnauthorized, "unauthorized", "missing bearer token")
 			return
 		}
-		renewed, ok, err := renewer.RenewUserToken(token, ttl, maxLifetime)
+		renewed, ok, err := renewer.RenewUserToken(c.Request.Context(), token, ttl, maxLifetime)
 		if err != nil {
 			AbortProblem(c, http.StatusUnauthorized, "unauthorized", "token cannot be renewed; log in again")
 			return

--- a/internal/api/auth_renew_test.go
+++ b/internal/api/auth_renew_test.go
@@ -20,13 +20,14 @@ type fakeRenewer struct {
 	ok      bool
 	err     error
 
+	gotCtx   context.Context
 	gotToken string
 	gotTTL   time.Duration
 	gotMax   time.Duration
 }
 
-func (f *fakeRenewer) RenewUserToken(token string, ttl, maxLifetime time.Duration) (renewed string, ok bool, err error) {
-	f.gotToken, f.gotTTL, f.gotMax = token, ttl, maxLifetime
+func (f *fakeRenewer) RenewUserToken(ctx context.Context, token string, ttl, maxLifetime time.Duration) (renewed string, ok bool, err error) {
+	f.gotCtx, f.gotToken, f.gotTTL, f.gotMax = ctx, token, ttl, maxLifetime
 	return f.renewed, f.ok, f.err
 }
 
@@ -77,6 +78,11 @@ func TestRenewTokenReturnsFreshToken(t *testing.T) {
 	}
 	if r.gotMax != 24*time.Hour {
 		t.Errorf("renewer max_lifetime = %v, want 24h (TokenMaxLifetimeSecs)", r.gotMax)
+	}
+	// The renewer reloads the user from the store, so it must run under the
+	// request's context rather than a detached one (#801).
+	if r.gotCtx == nil {
+		t.Error("renewer got a nil context; the store reload must be canceled with the request")
 	}
 }
 

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -179,10 +179,21 @@ func (a *JWTAuthenticator) mintUserToken(user *User, ttl time.Duration, origin t
 // maxLifetime disables the ceiling. exp is always now+ttl — never accumulated.
 //
 // An invalid incoming token (bad signature, wrong audience, expired) returns an
-// error and is never re-minted. Roles are copied from the incoming token, exactly
-// as they were signed; Authenticate still reloads authorization from the store on
-// every request, so a renewed token confers no more than the original did.
-func (a *JWTAuthenticator) RenewUserToken(token string, ttl, maxLifetime time.Duration) (renewed string, ok bool, err error) {
+// error and is never re-minted.
+//
+// Renewal RE-PROVES the principal: after the claims check and the ceiling check
+// it reloads the user from the store, exactly as Authenticate does, and refuses
+// (ErrInvalidToken) when the account is inactive or its row is gone. Issuing a
+// credential is not weaker than using one, so a deactivated user must stop
+// receiving fresh tokens, not merely stop being able to spend them. The same two
+// carve-outs Authenticate makes apply verbatim: a nil store (no data plane bound
+// — the trusted in-process minting context) and the dev-token subject, which has
+// no backing row by design. Any other store failure fails closed; that adds no
+// failure mode, because a database blip that refuses this renewal would refuse
+// the following request anyway, and the client's refresh is best-effort. Roles on
+// the re-minted token come from the reload, so a role revoked mid-session is
+// reflected at once rather than carried forward from the old claims.
+func (a *JWTAuthenticator) RenewUserToken(ctx context.Context, token string, ttl, maxLifetime time.Duration) (renewed string, ok bool, err error) {
 	var c jwtClaims
 	parsed, err := jwt.ParseWithClaims(token, &c, func(*jwt.Token) (any, error) {
 		return a.secret, nil
@@ -201,10 +212,37 @@ func (a *JWTAuthenticator) RenewUserToken(token string, ttl, maxLifetime time.Du
 	if maxLifetime > 0 && !origin.IsZero() && a.clock().Sub(origin) > maxLifetime {
 		return "", false, nil // past the ceiling: let the credential lapse
 	}
-	user := &User{ID: c.Subject, TenantID: c.TenantID, Email: c.Email, Roles: c.Roles}
+	user, err := a.reloadForRenewal(ctx, &c)
+	if err != nil {
+		return "", false, err
+	}
 	renewed, err = a.mintUserToken(user, ttl, origin)
 	if err != nil {
 		return "", false, err
 	}
 	return renewed, true, nil
+}
+
+// reloadForRenewal resolves the principal a renewal will re-mint, preferring the
+// store over the incoming token's claims. It is the read side that makes renewal
+// obey the same revocation rule as request authentication, and it mirrors
+// Authenticate's branches one for one — nil store and the dev-token subject fall
+// back to the signed claims, an inactive or otherwise-missing user is refused,
+// and any other store error fails closed.
+func (a *JWTAuthenticator) reloadForRenewal(ctx context.Context, c *jwtClaims) (*User, error) {
+	claimed := &User{ID: c.Subject, TenantID: c.TenantID, Email: c.Email, Roles: c.Roles}
+	if a.store == nil {
+		return claimed, nil
+	}
+	user, active, err := a.store.FindUserByID(ctx, c.Subject)
+	if err != nil {
+		if errors.Is(err, ErrUserNotFound) && c.Subject == DevTokenSubject {
+			return claimed, nil
+		}
+		return nil, errors.Join(ErrInvalidToken, err)
+	}
+	if !active {
+		return nil, ErrInvalidToken
+	}
+	return user, nil
 }

--- a/internal/auth/user_token_renewal_test.go
+++ b/internal/auth/user_token_renewal_test.go
@@ -181,3 +181,103 @@ func TestIssueTokenStampsOrigin(t *testing.T) {
 		t.Errorf("issued origin = %v, want issue instant %v", c.OriginIssuedAt, t0)
 	}
 }
+
+// TestRenewUserTokenRefusesDeactivatedUser pins the invariant this whole file
+// had missed: renewal must RE-PROVE the principal against the store, exactly as
+// Authenticate does, instead of rebuilding it from the incoming token's claims.
+// Every other renewal test above builds the authenticator with a nil store, so
+// nothing here exercised the reload at all — a deactivated user kept collecting
+// fresh tokens from /auth/token/renew until the session ceiling elapsed (#801).
+func TestRenewUserTokenRefusesDeactivatedUser(t *testing.T) {
+	store := &fakeStore{user: &User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}, inactive: true}
+	a := NewJWTAuthenticator(store, "secret", time.Hour)
+	t0 := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return t0 }
+	issued, err := a.mintUserToken(&User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}, time.Hour, t0)
+	if err != nil {
+		t.Fatalf("mintUserToken: %v", err)
+	}
+	renewed, ok, err := a.RenewUserToken(issued, time.Hour, 24*time.Hour)
+	if err == nil || ok || renewed != "" {
+		t.Fatalf("a deactivated user must be refused and minted nothing; got ok=%v renewed=%q err=%v", ok, renewed, err)
+	}
+	if !errors.Is(err, ErrInvalidToken) {
+		t.Errorf("deactivated renewal error = %v, want ErrInvalidToken", err)
+	}
+}
+
+// TestRenewUserTokenRefusesMissingNonDevSubject mirrors
+// TestAuthenticateRejectsMissingNonDevSubject onto the renewal path: a subject
+// with no user row (a hard-deleted user) is refused rather than trusted from the
+// roles baked into its signed claims.
+func TestRenewUserTokenRefusesMissingNonDevSubject(t *testing.T) {
+	a := NewJWTAuthenticator(&fakeStore{byIDErr: ErrUserNotFound}, "secret", time.Hour)
+	t0 := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return t0 }
+	issued, err := a.mintUserToken(&User{ID: "deleted-user-id", TenantID: "default", Roles: []string{"admin"}}, time.Hour, t0)
+	if err != nil {
+		t.Fatalf("mintUserToken: %v", err)
+	}
+	renewed, ok, err := a.RenewUserToken(issued, time.Hour, 24*time.Hour)
+	if err == nil || ok || renewed != "" {
+		t.Fatalf("a non-dev subject with no user row must be refused; got ok=%v renewed=%q err=%v", ok, renewed, err)
+	}
+}
+
+// TestRenewUserTokenFailsClosedOnStoreError: a store failure during the reload
+// refuses the renewal instead of falling through to the token's claims, which
+// would let a flaky database silently restore the old claims-only behavior. It
+// adds no new failure mode — a blip that refuses the renewal would refuse the
+// following request too, and the client's refresh is best-effort by construction.
+func TestRenewUserTokenFailsClosedOnStoreError(t *testing.T) {
+	a := NewJWTAuthenticator(&fakeStore{byIDErr: errors.New("connection refused")}, "secret", time.Hour)
+	t0 := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return t0 }
+	issued, err := a.mintUserToken(&User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}, time.Hour, t0)
+	if err != nil {
+		t.Fatalf("mintUserToken: %v", err)
+	}
+	if renewed, ok, rerr := a.RenewUserToken(issued, time.Hour, 24*time.Hour); rerr == nil || ok || renewed != "" {
+		t.Fatalf("a store error must fail closed; got ok=%v renewed=%q err=%v", ok, renewed, rerr)
+	}
+}
+
+// TestRenewUserTokenAllowsDevSubjectWithNoUserRow preserves the first of
+// Authenticate's two carve-outs on the renewal path: the in-process `leoflow dev`
+// token intentionally has no user row, so its signed claims stay the source of
+// truth and its session keeps renewing.
+func TestRenewUserTokenAllowsDevSubjectWithNoUserRow(t *testing.T) {
+	a := NewJWTAuthenticator(&fakeStore{byIDErr: ErrUserNotFound}, "secret", time.Hour)
+	t0 := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return t0 }
+	issued, err := a.mintUserToken(
+		&User{ID: DevTokenSubject, TenantID: "default", Email: "dev@leoflow.local", Roles: []string{"admin"}},
+		time.Hour, t0)
+	if err != nil {
+		t.Fatalf("mintUserToken: %v", err)
+	}
+	renewed, ok, err := a.RenewUserToken(issued, time.Hour, 24*time.Hour)
+	if err != nil || !ok {
+		t.Fatalf("the dev subject must keep renewing without a user row; got ok=%v err=%v", ok, err)
+	}
+	got := userClaimsOf(t, a, renewed)
+	if got.Subject != DevTokenSubject || len(got.Roles) != 1 || got.Roles[0] != "admin" {
+		t.Errorf("renewed dev claims = %+v, want the signed claims preserved", got)
+	}
+}
+
+// TestRenewUserTokenAllowsNilStore preserves Authenticate's other carve-out: with
+// no data plane bound (the trusted in-process minting context — `leoflow dev`,
+// tests) there is nothing to reload, so renewal proceeds on the signed claims.
+func TestRenewUserTokenAllowsNilStore(t *testing.T) {
+	a := NewJWTAuthenticator(nil, "secret", time.Hour)
+	t0 := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return t0 }
+	issued, err := a.mintUserToken(&User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}, time.Hour, t0)
+	if err != nil {
+		t.Fatalf("mintUserToken: %v", err)
+	}
+	if _, ok, rerr := a.RenewUserToken(issued, time.Hour, 24*time.Hour); rerr != nil || !ok {
+		t.Fatalf("a nil store must still renew; got ok=%v err=%v", ok, rerr)
+	}
+}

--- a/internal/auth/user_token_renewal_test.go
+++ b/internal/auth/user_token_renewal_test.go
@@ -188,6 +188,37 @@ func TestIssueTokenStampsOrigin(t *testing.T) {
 // Every other renewal test above builds the authenticator with a nil store, so
 // nothing here exercised the reload at all — a deactivated user kept collecting
 // fresh tokens from /auth/token/renew until the session ceiling elapsed (#801).
+// TestRenewUserTokenTakesRolesFromStore is the success-path lock the refusal
+// tests do not provide. Every other new case here pins a branch that REFUSES,
+// so all of them keep passing if the reload's result is discarded and the
+// claimed principal is re-minted instead — which is the one behaviour change a
+// user can observe on the happy path, and the whole point of reloading. Mint a
+// token claiming a role the store no longer grants, renew, and read the roles
+// back off the re-minted token: they must be the store's.
+func TestRenewUserTokenTakesRolesFromStore(t *testing.T) {
+	const secret = "renew-roles-secret"
+	issued, err := MintUserToken(secret, time.Hour, User{
+		ID: "u-stale", TenantID: "default", Email: "s@x.y", Roles: []string{"admin"},
+	})
+	if err != nil {
+		t.Fatalf("MintUserToken: %v", err)
+	}
+	store := &fakeStore{byIDUser: &User{
+		ID: "u-stale", TenantID: "default", Email: "s@x.y", Roles: []string{"viewer"},
+	}}
+	a := NewJWTAuthenticator(store, secret, time.Hour)
+
+	renewed, ok, err := a.RenewUserToken(context.Background(), issued, time.Hour, 24*time.Hour)
+	if err != nil || !ok {
+		t.Fatalf("RenewUserToken: ok=%v err=%v", ok, err)
+	}
+	got := userClaimsOf(t, a, renewed).Roles
+	if len(got) != 1 || got[0] != "viewer" {
+		t.Errorf("re-minted roles = %v, want the store's [viewer] — a renewal that re-mints the "+
+			"claimed roles carries a grant the store has already withdrawn", got)
+	}
+}
+
 func TestRenewUserTokenRefusesDeactivatedUser(t *testing.T) {
 	store := &fakeStore{user: &User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}, inactive: true}
 	a := NewJWTAuthenticator(store, "secret", time.Hour)

--- a/internal/auth/user_token_renewal_test.go
+++ b/internal/auth/user_token_renewal_test.go
@@ -191,7 +191,7 @@ func TestIssueTokenStampsOrigin(t *testing.T) {
 // TestRenewUserTokenTakesRolesFromStore is the success-path lock the refusal
 // tests do not provide. Every other new case here pins a branch that REFUSES,
 // so all of them keep passing if the reload's result is discarded and the
-// claimed principal is re-minted instead — which is the one behaviour change a
+// claimed principal is re-minted instead — which is the one behavior change a
 // user can observe on the happy path, and the whole point of reloading. Mint a
 // token claiming a role the store no longer grants, renew, and read the roles
 // back off the re-minted token: they must be the store's.

--- a/internal/auth/user_token_renewal_test.go
+++ b/internal/auth/user_token_renewal_test.go
@@ -46,7 +46,7 @@ func TestRenewUserTokenShortTTLAndPreservedOrigin(t *testing.T) {
 	// 55 minutes later, near expiry, the CLI silently renews.
 	t1 := t0.Add(55 * time.Minute)
 	a.now = func() time.Time { return t1 }
-	renewed, ok, err := a.RenewUserToken(issued, time.Hour, 24*time.Hour)
+	renewed, ok, err := a.RenewUserToken(context.Background(), issued, time.Hour, 24*time.Hour)
 	if err != nil {
 		t.Fatalf("RenewUserToken: %v", err)
 	}
@@ -94,7 +94,7 @@ func TestRenewUserTokenRejectsExpired(t *testing.T) {
 		t.Fatalf("mintUserToken: %v", err)
 	}
 	a.now = func() time.Time { return t0.Add(2 * time.Minute) }
-	renewed, ok, err := a.RenewUserToken(expired, time.Hour, 24*time.Hour)
+	renewed, ok, err := a.RenewUserToken(context.Background(), expired, time.Hour, 24*time.Hour)
 	if err == nil || ok || renewed != "" {
 		t.Errorf("renewing an expired token must error and mint nothing; got ok=%v renewed=%q err=%v", ok, renewed, err)
 	}
@@ -116,7 +116,7 @@ func TestRenewUserTokenCeilingStopsRenewal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mintUserToken: %v", err)
 	}
-	renewed, ok, err := a.RenewUserToken(aged, time.Hour, 24*time.Hour)
+	renewed, ok, err := a.RenewUserToken(context.Background(), aged, time.Hour, 24*time.Hour)
 	if err != nil {
 		t.Fatalf("RenewUserToken must not error past the ceiling: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestRenewUserTokenNoCeiling(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mintUserToken: %v", err)
 	}
-	if _, ok, err := a.RenewUserToken(aged, time.Hour, 0); err != nil || !ok {
+	if _, ok, err := a.RenewUserToken(context.Background(), aged, time.Hour, 0); err != nil || !ok {
 		t.Errorf("a non-positive ceiling must never refuse renewal; got ok=%v err=%v", ok, err)
 	}
 }
@@ -151,7 +151,7 @@ func TestRenewUserTokenRejectsForeignAndAgentTokens(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mintUserToken: %v", err)
 	}
-	if _, ok, ferr := a.RenewUserToken(foreign, time.Hour, 24*time.Hour); ferr == nil || ok {
+	if _, ok, ferr := a.RenewUserToken(context.Background(), foreign, time.Hour, 24*time.Hour); ferr == nil || ok {
 		t.Errorf("renewing a foreign-signed token must fail; got ok=%v err=%v", ok, ferr)
 	}
 
@@ -159,7 +159,7 @@ func TestRenewUserTokenRejectsForeignAndAgentTokens(t *testing.T) {
 	if err != nil {
 		t.Fatalf("IssueAgentToken: %v", err)
 	}
-	if _, ok, aerr := a.RenewUserToken(agentTok, time.Hour, 24*time.Hour); aerr == nil || ok {
+	if _, ok, aerr := a.RenewUserToken(context.Background(), agentTok, time.Hour, 24*time.Hour); aerr == nil || ok {
 		t.Errorf("an agent-audience token must not be renewable on the user path; got ok=%v err=%v", ok, aerr)
 	}
 }
@@ -197,7 +197,7 @@ func TestRenewUserTokenRefusesDeactivatedUser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mintUserToken: %v", err)
 	}
-	renewed, ok, err := a.RenewUserToken(issued, time.Hour, 24*time.Hour)
+	renewed, ok, err := a.RenewUserToken(context.Background(), issued, time.Hour, 24*time.Hour)
 	if err == nil || ok || renewed != "" {
 		t.Fatalf("a deactivated user must be refused and minted nothing; got ok=%v renewed=%q err=%v", ok, renewed, err)
 	}
@@ -218,7 +218,7 @@ func TestRenewUserTokenRefusesMissingNonDevSubject(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mintUserToken: %v", err)
 	}
-	renewed, ok, err := a.RenewUserToken(issued, time.Hour, 24*time.Hour)
+	renewed, ok, err := a.RenewUserToken(context.Background(), issued, time.Hour, 24*time.Hour)
 	if err == nil || ok || renewed != "" {
 		t.Fatalf("a non-dev subject with no user row must be refused; got ok=%v renewed=%q err=%v", ok, renewed, err)
 	}
@@ -237,7 +237,7 @@ func TestRenewUserTokenFailsClosedOnStoreError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mintUserToken: %v", err)
 	}
-	if renewed, ok, rerr := a.RenewUserToken(issued, time.Hour, 24*time.Hour); rerr == nil || ok || renewed != "" {
+	if renewed, ok, rerr := a.RenewUserToken(context.Background(), issued, time.Hour, 24*time.Hour); rerr == nil || ok || renewed != "" {
 		t.Fatalf("a store error must fail closed; got ok=%v renewed=%q err=%v", ok, renewed, rerr)
 	}
 }
@@ -256,7 +256,7 @@ func TestRenewUserTokenAllowsDevSubjectWithNoUserRow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mintUserToken: %v", err)
 	}
-	renewed, ok, err := a.RenewUserToken(issued, time.Hour, 24*time.Hour)
+	renewed, ok, err := a.RenewUserToken(context.Background(), issued, time.Hour, 24*time.Hour)
 	if err != nil || !ok {
 		t.Fatalf("the dev subject must keep renewing without a user row; got ok=%v err=%v", ok, err)
 	}
@@ -277,7 +277,7 @@ func TestRenewUserTokenAllowsNilStore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mintUserToken: %v", err)
 	}
-	if _, ok, rerr := a.RenewUserToken(issued, time.Hour, 24*time.Hour); rerr != nil || !ok {
+	if _, ok, rerr := a.RenewUserToken(context.Background(), issued, time.Hour, 24*time.Hour); rerr != nil || !ok {
 		t.Fatalf("a nil store must still renew; got ok=%v err=%v", ok, rerr)
 	}
 }

--- a/internal/config/env_binding_test.go
+++ b/internal/config/env_binding_test.go
@@ -191,10 +191,25 @@ func TestLoadServerBindsRedisCAFile(t *testing.T) {
 // row is part of shipping it. There is deliberately no exception list: an
 // operator-only key still gets a row, marked as such.
 func TestRegisteredKeysAreDocumented(t *testing.T) {
-	cols := strings.Join(docSettingFirstColumns(t), "\n")
+	// Match on WHOLE names, not substrings. A substring test lets a key that is
+	// a prefix of another documented key pass for free — secrets.backend is a
+	// prefix of secrets.backend_kwargs, so deleting the former's row used to
+	// leave this green, shadowed by the latter. That is the one way a guard
+	// like this fails silently rather than loudly.
+	cols := docSettingFirstColumns(t)
+	documented := make(map[string]struct{}, len(cols)*2)
+	tokens := regexp.MustCompile(`[A-Za-z0-9_.]+`)
+	for _, col := range cols {
+		for _, tok := range tokens.FindAllString(col, -1) {
+			documented[tok] = struct{}{}
+		}
+	}
 	for key := range serverDefaults {
 		env := "LEOFLOW_" + strings.ToUpper(strings.ReplaceAll(key, ".", "_"))
-		if strings.Contains(cols, env) || strings.Contains(cols, key) {
+		if _, ok := documented[env]; ok {
+			continue
+		}
+		if _, ok := documented[key]; ok {
 			continue
 		}
 		t.Errorf("%s (%s) is registered in serverDefaults but is named in no "+

--- a/internal/config/env_binding_test.go
+++ b/internal/config/env_binding_test.go
@@ -32,6 +32,30 @@ func bindableEnvVars() map[string]struct{} {
 // credential) are not treated as server settings.
 func docEnvVarsFromReference(t *testing.T) []string {
 	t.Helper()
+	envRe := regexp.MustCompile(`LEOFLOW_[A-Z0-9_]+`)
+	seen := map[string]struct{}{}
+	var vars []string
+	for _, firstCol := range docSettingFirstColumns(t) {
+		for _, v := range envRe.FindAllString(firstCol, -1) {
+			if _, dup := seen[v]; dup {
+				continue
+			}
+			seen[v] = struct{}{}
+			vars = append(vars, v)
+		}
+	}
+	if len(vars) == 0 {
+		t.Fatal("no LEOFLOW_* variables parsed from the configuration reference")
+	}
+	return vars
+}
+
+// docSettingFirstColumns returns the first column of every table row in the
+// configuration reference — the cell that names the setting, either as its
+// LEOFLOW_* env var or, for a config-file/Helm-values-only key, in dotted form.
+// It is the shared read side of both directions of the doc/binding guard.
+func docSettingFirstColumns(t *testing.T) []string {
+	t.Helper()
 	_, thisFile, _, ok := runtime.Caller(0)
 	if !ok {
 		t.Fatal("runtime.Caller failed")
@@ -42,9 +66,7 @@ func docEnvVarsFromReference(t *testing.T) []string {
 	if err != nil {
 		t.Fatalf("read %s: %v", docPath, err)
 	}
-	envRe := regexp.MustCompile(`LEOFLOW_[A-Z0-9_]+`)
-	seen := map[string]struct{}{}
-	var vars []string
+	var cols []string
 	for _, line := range strings.Split(string(raw), "\n") {
 		if !strings.HasPrefix(strings.TrimSpace(line), "|") {
 			continue
@@ -54,18 +76,12 @@ func docEnvVarsFromReference(t *testing.T) []string {
 		if i := strings.Index(line[1:], "|"); i >= 0 {
 			firstCol = line[:i+1]
 		}
-		for _, v := range envRe.FindAllString(firstCol, -1) {
-			if _, dup := seen[v]; dup {
-				continue
-			}
-			seen[v] = struct{}{}
-			vars = append(vars, v)
-		}
+		cols = append(cols, firstCol)
 	}
-	if len(vars) == 0 {
-		t.Fatalf("no LEOFLOW_* variables parsed from %s", docPath)
+	if len(cols) == 0 {
+		t.Fatalf("no table rows parsed from %s", docPath)
 	}
-	return vars
+	return cols
 }
 
 // TestDocumentedEnvVarsBind is the class-level guard: every LEOFLOW_* variable
@@ -158,5 +174,31 @@ func TestLoadServerBindsRedisCAFile(t *testing.T) {
 	}
 	if c.Redis.CAFile != "/etc/leoflow/redis-ca/ca.crt" {
 		t.Errorf("Redis.CAFile = %q, want %q", c.Redis.CAFile, "/etc/leoflow/redis-ca/ca.crt")
+	}
+}
+
+// TestRegisteredKeysAreDocumented is the reverse of TestDocumentedEnvVarsBind:
+// every key registered in serverDefaults must be named in the configuration
+// reference, either as its LEOFLOW_* env var or — for a config-file/Helm-values
+// key — in dotted form. The forward guard only runs doc → binding, so a setting
+// that binds but is written down nowhere is invisible to it. That is exactly how
+// auth.jwt.max_lifetime_seconds shipped as the ceiling bounding transparently
+// renewed sessions — the control that makes the feature acceptable — with no
+// reference row and no chart value, reachable only through extraEnv (#801, same
+// class as #725 / #733 / #743).
+//
+// Registering a key is a promise that an operator can set it, so the reference
+// row is part of shipping it. There is deliberately no exception list: an
+// operator-only key still gets a row, marked as such.
+func TestRegisteredKeysAreDocumented(t *testing.T) {
+	cols := strings.Join(docSettingFirstColumns(t), "\n")
+	for key := range serverDefaults {
+		env := "LEOFLOW_" + strings.ToUpper(strings.ReplaceAll(key, ".", "_"))
+		if strings.Contains(cols, env) || strings.Contains(cols, key) {
+			continue
+		}
+		t.Errorf("%s (%s) is registered in serverDefaults but is named in no "+
+			"settings table in website/content/reference/configuration.md, so "+
+			"an operator has no documented way to reach it", key, env)
 	}
 }

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -127,6 +127,7 @@ var — viper does not split one env var into a map or list.
 | `LEOFLOW_AUTH_PROVIDER` | `jwt` | both | Credential authenticator: `jwt` (default — username/password issues an HS256 token) or `oidc` (adds the OIDC/SSO login flow on top; the JWT authenticator stays the request-path verifier in both modes). `oidc` is Pro-gated and fails boot closed unless its prerequisites are met (see [OIDC / SSO](#oidc--sso-authoidc)). |
 | `LEOFLOW_AUTH_JWT_SECRET` | — *(required)* | both | Signs API/agent tokens. Required for both `jwt` and `oidc` (both mint the app's own HS256 token). |
 | `LEOFLOW_AUTH_JWT_TOKEN_TTL_SECONDS` | `3600` | both | Lifetime, in seconds, of an issued API token. |
+| `LEOFLOW_AUTH_JWT_MAX_LIFETIME_SECONDS` | `86400` | both | Ceiling, in seconds, on the **total** age of a transparently renewed session, measured from first login and preserved across every renewal. Past it, `POST /api/v2/auth/token/renew` refuses and the user must log in again; the short `TOKEN_TTL_SECONDS` is what bounds a stolen token, this only caps how long a live session may keep refreshing. A non-positive value disables the ceiling. Renewal also re-checks that the account is still active, so a deactivated user stops being issued tokens as well as being refused on use. The chart has no value for this yet — set it through `extraEnv`. |
 | `LEOFLOW_AUTH_LOGIN_RATE_LIMIT_PER_MINUTE` | `5` | both | Cap on **failed** `/auth/token` attempts per client IP per minute (anti-brute-force). A successful login consumes no budget. `leoflow lite` raises this well above the default (local single-user tool). |
 | `LEOFLOW_SECRET_KEY` | — | both | 32-byte key encrypting connection secrets at rest ([ADR 0019](/project/adrs/0019-secret-encryption-at-rest/)). Raw 32 chars, 64-char hex, or base64. Empty disables connection writes. |
 | `LEOFLOW_AUTH_SECRET_SCOPING` | `permissive` | both | Scope-by-declaration policy ([ADR 0055](/project/adrs/0055-secret-scoping-and-token-liveness/)): `permissive` (delivers the whole tenant vault; warns when a DAG declares a narrower set), `enforce` (delivers only the declared subset — empty declaration ⇒ nothing), or `off` (no scoping). Operator-scoped, never author-settable. Helm: `auth.secretScoping`. |
@@ -229,6 +230,21 @@ dedicated pod per task attempt.
 | `LEOFLOW_LOGS_SINK_FORCE_PATH_STYLE` | `false` | Pro | **s3-only.** Use path-style addressing (bucket in the path, not the host). Required by MinIO and some S3-compatible stores. |
 | `LEOFLOW_LOGS_SINK_ACCESS_KEY_ID` / `LEOFLOW_LOGS_SINK_SECRET_ACCESS_KEY` | _(empty)_ | Pro | **s3-only.** Static credentials — **discouraged**. Leave empty (recommended) to use the keyless chain (IRSA / instance profile), per [ADR 0035](/project/adrs/0035-cloud-connector-auth-keyless-first/). |
 | `LEOFLOW_LOGS_SINK_CREDENTIALS_FILE` | _(empty)_ | Pro | **gcs-only.** Path to a service-account JSON key — **discouraged**. Leave empty (recommended) to use Application Default Credentials (GKE Workload Identity). |
+
+### External secrets (`secrets.*`)
+
+Operator-only ([ADR 0060](/project/adrs/0060-external-secrets-resolution/)):
+delivered to the task pod as `LEOFLOW_SECRETS_*`, which an author's task env can
+never set. Empty `backend` keeps the Leoflow vault as the only source —
+byte-identical to having no external secrets at all. See
+[External secrets](/operate/external-secrets/) and run the
+[cluster validation runbook](/operate/external-secrets-cluster-validation/)
+before enabling it in production.
+
+| Variable | Default | Edition | Purpose |
+|---|---|---|---|
+| `LEOFLOW_SECRETS_BACKEND` | _(empty — disabled)_ | Pro (K8s) | Provider secrets-backend class the in-pod resolver drives (e.g. `airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend`). When set, a Connection/Variable a DAG declares can be resolved pod-side from the provider store under the pod's keyless identity. Helm: `secrets.backend`. |
+| `LEOFLOW_SECRETS_BACKEND_KWARGS` | _(empty — treated as `{}`)_ | Pro (K8s) | Provider kwargs as a JSON **object string** (`connections_prefix`, `variables_prefix`, `region_name`, …), delivered to the pod verbatim. A kind is served only if its `*_prefix` kwarg is present. A JSON string rather than a map so a single env var sets it, matching the env-only control-plane chart. Keyless auth (IRSA / Workload Identity) uses the task pod's ServiceAccount — set `executor.task_service_account` accordingly. Helm: `secrets.backendKwargs`. |
 
 ### Observability (`observability.*`)
 


### PR DESCRIPTION
Closes the before-the-cut half of #801, as scoped by the specialist.

Renewal validated the token, checked the session ceiling, then rebuilt the principal purely from claims and re-minted. It never consulted the user store, unlike the authentication path in the same file. So a deactivated or deleted user kept receiving a fresh token from the renew endpoint until the session ceiling elapsed.

**Severity, stated accurately rather than dramatically.** The renewed token was inert: both consumers of a user token go through the store-backed authentication path, which rejects it. And there is no product path to deactivate a user at all — the users API registers only list and create — so reaching the precondition today needs a hand-edited row. This was a broken invariant and a false documentation claim, not an access path.

**The argument for fixing it anyway is the project's own rule.** The agent-side renewal already runs only on the branch that has just proven the attempt live, and declines to renew on a store blip. Renewal re-proving the principal is the house rule here; the user path was the one place it was broken. Roles on the re-minted token now come from the reload too, so a mid-session role revocation takes effect immediately rather than at the next login.

**Both carve-outs are preserved, each with its own test**, because breaking either would break local development and the lite path: a nil store returns the claimed principal before any store call, and a not-found user whose subject is the development subject is still accepted. Any other store error fails closed, which adds no new failure mode, since a database blip that refuses the renewal would refuse the following request anyway and the client's refresh is best-effort.

**The rate limiter is deliberately not wired in.** The issue suggests reusing the existing one, and that would be a new bug: it counts login failures toward an address lockout, so renewal traffic would burn the password-login budget for that address, and behind a load balancer with trusted proxies unset, for everyone. This repository already solved that exact problem once with a separate instance, with a comment saying the two kinds of traffic must never contaminate each other's budget. A renewal limiter belongs in a follow-up with its own instance.

**Two false claims corrected, both saying the same wrong thing.** The changelog line that says revocation is enforced per request so a renewed token dies the moment its user is deactivated — true of use, false of issuance — is corrected in place, in the already-published section where it lives rather than moved. And the renewal function's own godoc carried the same conflation.

Cost, for the record: the client renews only past the halfway point of a token's life and the default life is an hour, so this is roughly one store call per half hour per session, against an authentication path that already reloads the user on every request. No caching, deliberately.

**One extra guard, and it earned its scope.** The repository asserted that every documented environment variable binds, but nothing asserted the reverse. The new guard has no exception list, because registering a key is a promise an operator can set it — and it immediately found three registered keys documented nowhere, including the session ceiling this issue mentions. All three are now documented, with the ceiling's row stating outright that the chart has no value for it and that extra environment is the only path, which documents the gap rather than papering over it. The chart value is the other half of the issue and is not in this change.

Verified: build, the full Go suite, golangci-lint 0 on a clean cache, the changelog gate, storage and API integration tests against Postgres, and a mutation — removing the reload fails exactly the three refusal tests while both carve-out tests keep passing.