### PR TITLE
test: scan what the 409 body composed, not the dag id it echoes back

### DIFF
--- a/internal/api/leakscan_scrub_test.go
+++ b/internal/api/leakscan_scrub_test.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"strings"
+	"testing"
+)
+
+// pgLeaks are the database internals no error body may carry to a client.
+var pgLeaks = []string{"23505", "dag_versions_unique", "SQLSTATE"}
+
+func TestLeakScanTargetIgnoresTheEchoedIdentifier(t *testing.T) {
+	// The dag id and body from the observed failure, where the timestamp
+	// itself contained 23505 and the response was correct.
+	const dagID = "api_dup_1788792423505739498"
+	body := `{"type":"about:blank","title":"conflict","status":409,` +
+		`"detail":"inserting version: resource already exists",` +
+		`"instance":"/api/v2/dags/` + dagID + `/versions"}`
+
+	for _, leak := range pgLeaks {
+		if strings.Contains(leakScanTarget(body, dagID), leak) {
+			t.Errorf("scrubbed body still trips on %q, so a correct 409 fails the scan: %s",
+				leak, leakScanTarget(body, dagID))
+		}
+	}
+}
+
+func TestLeakScanTargetStillSeesARealLeak(t *testing.T) {
+	// Scrubbing must not blind the scan: the same id, but the server composed
+	// the constraint name and SQLSTATE into the detail.
+	const dagID = "api_dup_1788792423505739498"
+	body := `{"title":"internal","status":500,` +
+		`"detail":"inserting version: ERROR: duplicate key value violates ` +
+		`unique constraint \"dag_versions_unique\" (SQLSTATE 23505)",` +
+		`"instance":"/api/v2/dags/` + dagID + `/versions"}`
+
+	scrubbed := leakScanTarget(body, dagID)
+	for _, leak := range pgLeaks {
+		if !strings.Contains(scrubbed, leak) {
+			t.Errorf("scrubbing hid a real leak (%q) from the scan: %s", leak, scrubbed)
+		}
+	}
+}

--- a/internal/api/leakscan_scrub_test.go
+++ b/internal/api/leakscan_scrub_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"slices"
 	"strings"
 	"testing"
 )
@@ -33,10 +34,25 @@ func TestLeakScanTargetStillSeesARealLeak(t *testing.T) {
 		`unique constraint \"dag_versions_unique\" (SQLSTATE 23505)",` +
 		`"instance":"/api/v2/dags/` + dagID + `/versions"}`
 
+	// Assert against the tokens THIS fixture carries, not pgLeaks: iterating
+	// the shared list would require every future addition to it to appear in
+	// this hand-written body, so hardening the scan would turn the fast suite
+	// red and the obvious "fix" would be to un-harden it.
 	scrubbed := leakScanTarget(body, dagID)
-	for _, leak := range pgLeaks {
+	for _, leak := range []string{"23505", "dag_versions_unique", "SQLSTATE"} {
 		if !strings.Contains(scrubbed, leak) {
 			t.Errorf("scrubbing hid a real leak (%q) from the scan: %s", leak, scrubbed)
+		}
+	}
+}
+
+// TestPgLeaksCoversTheKnownPgInternals guards the other direction. Deleting a
+// token from pgLeaks makes every test above easier and silently weakens the
+// integration assertion that consumes it, so the floor is pinned here.
+func TestPgLeaksCoversTheKnownPgInternals(t *testing.T) {
+	for _, want := range []string{"23505", "dag_versions_unique", "SQLSTATE"} {
+		if !slices.Contains(pgLeaks, want) {
+			t.Errorf("pgLeaks no longer covers %q; the 409 leak scan is weaker than it was", want)
 		}
 	}
 }

--- a/internal/api/leakscan_test.go
+++ b/internal/api/leakscan_test.go
@@ -1,0 +1,23 @@
+package api
+
+import "strings"
+
+// leakScanTarget returns body with every occurrence of an identifier the test
+// itself chose replaced by a placeholder, so a scan for leaked database
+// internals cannot be tripped by the handler echoing that identifier back.
+//
+// The identifiers these tests generate are nanosecond timestamps, and a
+// 19-digit timestamp readily contains a 5-digit SQLSTATE by chance: the dag id
+// api_dup_1788792423505739498 embeds 23505, which failed the scan in
+// TestRegisterVersionDuplicateReturns409 on a response body that was entirely
+// correct. Echoing back a caller-supplied path segment is not a leak, so it
+// must not be scanned; everything the server composed itself still is.
+func leakScanTarget(body string, echoed ...string) string {
+	for _, e := range echoed {
+		if e == "" {
+			continue
+		}
+		body = strings.ReplaceAll(body, e, "<echoed>")
+	}
+	return body
+}

--- a/internal/api/leakscan_test.go
+++ b/internal/api/leakscan_test.go
@@ -10,8 +10,20 @@ import "strings"
 // 19-digit timestamp readily contains a 5-digit SQLSTATE by chance: the dag id
 // api_dup_1788792423505739498 embeds 23505, which failed the scan in
 // TestRegisterVersionDuplicateReturns409 on a response body that was entirely
-// correct. Echoing back a caller-supplied path segment is not a leak, so it
-// must not be scanned; everything the server composed itself still is.
+// correct. Echoing back a caller-supplied path segment is not a leak (problem.go
+// sets Instance to c.Request.URL.Path verbatim), so it must not be scanned;
+// everything the server composed itself still is.
+//
+// Scrubbing rather than decoding the body and scanning Problem.Title/Detail:
+// a decode-based scan fails OPEN. If the response ever arrives as something
+// other than a well-formed Problem — a middleware-written body, a truncated
+// one — unmarshalling succeeds with empty fields and the scan passes on a body
+// nobody looked at. This fails closed.
+//
+// The placeholder must be non-empty and must contain characters that appear in
+// no scan token. An empty placeholder would splice the surrounding bytes
+// together and could MANUFACTURE a match: "pg 235<id>05" would become
+// "pg 23505". That is a correctness constraint, not cosmetics.
 func leakScanTarget(body string, echoed ...string) string {
 	for _, e := range echoed {
 		if e == "" {

--- a/internal/api/versions_conflict_integration_test.go
+++ b/internal/api/versions_conflict_integration_test.go
@@ -57,8 +57,10 @@ func TestRegisterVersionDuplicateReturns409(t *testing.T) {
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("duplicate version push = %d, want 409 (%s)", rec.Code, rec.Body.String())
 	}
-	body := rec.Body.String()
-	for _, leak := range []string{"23505", "dag_versions_unique", "SQLSTATE"} {
+	// Scan what the server composed, not the dag id it echoes back — see
+	// leakScanTarget.
+	body := leakScanTarget(rec.Body.String(), dagID)
+	for _, leak := range pgLeaks {
 		if strings.Contains(body, leak) {
 			t.Errorf("409 body leaks raw pg internals (%q): %s", leak, body)
 		}


### PR DESCRIPTION
## What broke

`TestRegisterVersionDuplicateReturns409` turned **main** red ([run 34134312144](https://github.com/neochaotic/leoflow/actions/runs/34134312144)) on a response body that was completely correct:

```
--- FAIL: TestRegisterVersionDuplicateReturns409 (0.08s)
    versions_conflict_integration_test.go:63: 409 body leaks raw pg internals ("23505"):
    {"type":"about:blank","title":"conflict","status":409,
     "detail":"inserting version: resource already exists",
     "instance":"/api/v2/dags/api_dup_1788792423505739498/versions"}
```

Read the instance URL: `api_dup_1788792**423505**739498`. The dag id is `fmt.Sprintf("api_dup_%d", time.Now().UnixNano())`, the handler echoes it back in the problem document, and the leak scan ran over the **whole body** — so the timestamp itself matched the scan for pg SQLSTATE `23505`.

No leak. No product defect. A 19-digit timestamp offers ~15 positions for any given 5-digit run, so this fires roughly once every few thousand runs, on any branch, at random. It is not a flake to rerun past: the assertion is malformed and will keep firing.

## The fix

Echoing back a caller-supplied path segment is not a leak, so it must not be scanned. `leakScanTarget` scrubs the identifiers the test itself chose and leaves everything the server composed.

## Verification

- Two unit tests in the **default** build (the integration test is behind `//go:build integration`, so its assertion logic was previously unreachable to the fast suite): the observed body with the observed id must pass the scan, and the same id with a genuinely leaky `detail` (`unique constraint "dag_versions_unique" (SQLSTATE 23505)`) must still fail it — scrubbing must not blind the scan.
- **Mutation**: with `leakScanTarget` turned into a no-op, `TestLeakScanTargetIgnoresTheEchoedIdentifier` fails on exactly the string main failed on. Restored, green.
- `go vet -tags integration ./internal/api/` clean.

## Same class elsewhere

Checked. `internal/storage/register_version_conflict_integration_test.go:56` scans `rerr.Error()` for the same three tokens, but `RegisterDagVersion`'s conflict error is `inserting version: resource already exists` — it carries neither the generated dag id nor the spec hash, so nothing generated reaches the scan. Left alone.

Only `internal/api` scans a whole serialized body.