### PR TITLE
docs(changelog): one Changed section under Unreleased, not two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,16 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   rather than the primary path. Lite (no pods) is unchanged: no maintenance loop,
   no reaping.
 
+- **Dependency refresh, with the generated protobuf code regenerated to match.**
+  The AWS SDK (including S3), the Google Cloud Storage client, the OpenTelemetry
+  SDK, go-oidc and gRPC move to their current minor and patch releases; the S3
+  and GCS clients are the object log sink's own transport, so the release
+  validates them rather than shipping them unexercised. `google.golang.org/protobuf`
+  moves from a pseudo-version to the `v1.36.12` release, which changes the
+  generator the committed code must match, so `proto/agent/v1` is regenerated in
+  the same change — the proto-sync gate pins `protoc-gen-go` to the module version
+  precisely so this cannot drift silently.
+
 ### Fixed
 
 - **HA chart posture: five render refusals for combinations that used to fail
@@ -558,18 +568,6 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   advisories published on 2026-09-03 (GO-2026-6354, GO-2026-6355). `govulncheck`
   finds no reachable call path from leoflow into the affected symbols; the bump
   keeps the dependency scan clean and the fix in place regardless.
-
-### Changed
-
-- **Dependency refresh, with the generated protobuf code regenerated to match.**
-  The AWS SDK (including S3), the Google Cloud Storage client, the OpenTelemetry
-  SDK, go-oidc and gRPC move to their current minor and patch releases; the S3
-  and GCS clients are the object log sink's own transport, so the release
-  validates them rather than shipping them unexercised. `google.golang.org/protobuf`
-  moves from a pseudo-version to the `v1.36.12` release, which changes the
-  generator the committed code must match, so `proto/agent/v1` is regenerated in
-  the same change — the proto-sync gate pins `protoc-gen-go` to the module version
-  precisely so this cannot drift silently.
 
 ## [0.4.4] - 2026-09-03
 


### PR DESCRIPTION
## Found while pre-flighting the RC

`[Unreleased]` carried **two** `### Changed` headers:

```
line  93: ### Changed      <- reaper maintenance loop
line 121: ### Fixed
line 555: ### Security
line 562: ### Changed      <- dependency refresh, appended after Security
```

Keep-a-Changelog has one subsection per category per version, and `date_the_changelog` in `cut-release.sh` moves the section **verbatim** — so a GA cut would ship a dated version with two separate Changed lists, which reads as an editing mistake rather than a release note. An `rc` keeps `[Unreleased]`, so this does not block the RC; it is cheaper to fix now than at GA.

## Not a content change

Merged the second into the first, restoring Added / Changed / Fixed / Security order. No prose was edited:

- 19 top-level entries under `[Unreleased]` before and after.
- Verified present after the move: the dependency-refresh entry, the reaper maintenance-loop entry, and the `golang.org/x/crypto` Security entry that bordered the change.
- `+10 -12` lines, all of it the header move and blank-line normalisation.