### PR TITLE
release: give the Lite cold-start a boot budget it can actually meet

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1073,6 +1073,24 @@ jobs:
         run: bash scripts/check-script-selftests.sh
 
   # ─────────────────────────────────────────────────────────────────────
+  # The Lite cold-start release gate pre-pulls the Postgres image by tag, and
+  # that job has no checkout (it installs from the published release), so the
+  # tag is duplicated in release.yaml. Checked here rather than only in the
+  # cut's own pre-flight: a bump to docker-compose.dev.yaml would otherwise go
+  # green through all of CI and surface mid-release.
+  # ─────────────────────────────────────────────────────────────────────
+  lite-prepull-tag:
+    name: Lite pre-pull tag matches the compose
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install PyYAML
+        run: python3 -m pip install --user pyyaml
+      - name: Check the Lite pre-pull tag
+        run: bash scripts/check-lite-prepull-matches-compose.sh
+
+  # ─────────────────────────────────────────────────────────────────────
   stale-deploy-path:
     name: No stale legacy deploy path
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -312,32 +312,98 @@ jobs:
           export PATH="$HOME/.local/bin:$PATH"
           mkdir -p /tmp/ws
           leoflow setup --workspace /tmp/ws </dev/null
+      # Take the image download off the boot clock. `leoflow lite --postgres
+      # docker` brings up the embedded compose (docker-compose.dev.yaml,
+      # materialized under ~/.leoflow on a binary-only install), so on a fresh
+      # runner the pull otherwise happens inside the poll below.
+      #
+      # This step is an OPTIMIZATION and must never be fatal. It is the only
+      # thing this job gained that could retract a signed release on its own,
+      # and a registry outage is not a fact about our code. On failure the pull
+      # simply happens inside the boot budget instead, which is what used to
+      # happen anyway — the budget is now wide enough to absorb it.
+      #
+      # (Three attempts help a 503 or a TLS reset. They do nothing for a Docker
+      # Hub anonymous rate limit, whose window is hours; that is precisely why
+      # this must warn rather than fail.)
+      #
+      # The tag is written out rather than read from the compose on purpose:
+      # this job deliberately has no checkout, because it tests the binary-only
+      # install path. scripts/check-lite-prepull-matches-compose.sh is what
+      # keeps the two from drifting.
+      - name: Pre-pull the Postgres image the Lite compose uses
+        run: |
+          set -u
+          for i in 1 2 3; do
+            docker pull postgres:16 && exit 0
+            echo "pull attempt $i failed; retrying in 10s" >&2
+            sleep 10
+          done
+          echo "::warning::could not pre-pull postgres:16; the pull will happen inside the boot budget instead"
       - name: Boot leoflow lite and wait for /readyz
         run: |
           set -eu
           export PATH="$HOME/.local/bin:$PATH"
+          # This job stays cheap only because `leoflow setup </dev/null` above is
+          # non-interactive and persists lite_executor: subprocess. If that
+          # default ever flips to k8s, `leoflow lite` starts building a k3d
+          # cluster inside the budget below and this job will look flaky.
+          #
           # Background lite; capture stdout+stderr so we can dump on failure.
           leoflow lite --postgres docker --port 8088 --host 127.0.0.1 >/tmp/lite.log 2>&1 &
           LITE_PID=$!
-          # Poll /readyz up to 60s. The Postgres-retry budget is 30s by
-          # itself; budget here is loose enough that a managed-PG cold extract
-          # is not penalized while still catching real hangs.
+          # 240s, not 60. What retracted v0.4.5-rc.1 was NOT the image pull —
+          # the log shows `postgres Pulled` and the container Healthy well
+          # inside the minute. What was still running at the timeout is the
+          # per-DAG venv: `pip install` of the task runtime sdist plus
+          # apache-airflow-task-sdk, an uncached PyPI resolve with a local
+          # hatchling build. First-run boot legitimately contains that.
+          #
+          # ci.yaml's lite UI smoke budgets 180s (60 x sleep 3) for the same
+          # boot on the CHEAPER managed-Postgres path — and the venv install is
+          # on that path too, since ensureWorkspaceDagVenvs runs before
+          # startDevServer. Its own comment says "its venv installs first", so
+          # the repo already knew. This gate had 60s for the heavier path.
+          #
+          # It has bitten twice, not once: v0.4.5-rc.1 attempt 1 at 60s and
+          # v0.4.3 GA attempt 1 at 61s — two of nine first attempts. Across the
+          # seven green releases the step ran 40-50s (mean 45.7, sigma 3.6), so
+          # 60s was ~4 sigma out and the tail is a PyPI download.
+          #
+          # 240s is ~5x the median and 4x under the job's own timeout-minutes:
+          # 15, which is the real hang net.
           ready=0
-          for _ in $(seq 1 60); do
+          started=$SECONDS
+          for _ in $(seq 1 240); do
             if curl -fsS http://127.0.0.1:8088/readyz >/dev/null 2>&1; then
               ready=1
               break
             fi
             sleep 1
           done
+          took=$((SECONDS - started))
           if [ "$ready" -ne 1 ]; then
-            echo "::error::/readyz never responded after 60s"
+            echo "::error::/readyz never responded after 240s"
             echo "--- lite log (tail) ---"
             tail -200 /tmp/lite.log || true
             kill -TERM "$LITE_PID" 2>/dev/null || true
             exit 1
           fi
-          echo "✓ /readyz responded"
+          # Raising the ceiling would otherwise hide a boot that doubled, so the
+          # latency is still reported — as a warning, not a failure.
+          # 75s, derived rather than picked: 1.5x the slowest of the last seven
+          # green releases (40-50s, mean 45.7, sigma 3.6 — and those figures
+          # INCLUDE the image pull the step above now removes, so the new
+          # baseline is lower). The regression this exists to catch is one
+          # heavyweight wheel entering the task-runtime dep tree, worth +20-40s;
+          # a 90s threshold would not have spoken until boot nearly doubled.
+          if [ "$took" -gt 75 ]; then
+            echo "::warning::lite cold-start took ${took}s — the last seven green releases ran 40-50s including an image pull this job no longer does. Investigate before it reaches the 240s ceiling."
+          fi
+          echo "✓ /readyz responded in ${took}s"
+          # Also to the summary, so the trend is readable across releases
+          # without pulling job logs through the API.
+          echo "lite cold-start: /readyz in ${took}s (ceiling 240s, warn 75s)" >>"$GITHUB_STEP_SUMMARY"
           # Graceful shutdown; assert SIGTERM is honored (otherwise the
           # process becomes a CI zombie and future runs leak).
           kill -TERM "$LITE_PID"

--- a/scripts/check-lite-prepull-matches-compose.sh
+++ b/scripts/check-lite-prepull-matches-compose.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# The Lite cold-start release gate pre-pulls the Postgres image by tag, and the
+# tag must equal the one Lite actually starts.
+#
+# That job has no checkout — it installs from the published release, which is
+# the point of it — so it cannot read docker-compose.dev.yaml at runtime and the
+# tag is written into the workflow. Two copies of a version string with nothing
+# between them is how the docs/adr links and the dependabot directories rotted,
+# so this is the gate for it. The tree already carries two Postgres majors
+# (docker-compose.yml runs 17-alpine, docker-compose.dev.yaml runs 16), so
+# "someone bumps the wrong file" is not hypothetical here.
+#
+# If they drift, the pre-pull silently fetches an image nobody starts, the real
+# one is downloaded inside the /readyz budget again, and a slow registry eats
+# the boot margin (#977).
+#
+# Both sides are parsed as YAML rather than grepped. An earlier awk version had
+# a fail-open a reviewer reproduced in one line: commenting out the pull step —
+# the most common way a step gets disabled while debugging — left the gate
+# green, because a `#`-prefixed line still matched. Scoping to the job's parsed
+# steps and dropping comment lines is what closes that, and it is also what
+# allows the pull to be a multi-line retry block.
+#
+# Usage: scripts/check-lite-prepull-matches-compose.sh [--self-test]
+#        scripts/check-lite-prepull-matches-compose.sh <compose> <workflow>
+set -euo pipefail
+
+JOB="lite-cold-start-smoke"
+
+check() { # <compose> <workflow>
+	python3 - "$1" "$2" "$JOB" <<'PY'
+import sys
+
+try:
+	import yaml
+except ImportError:
+	sys.exit("SKIP: PyYAML unavailable; cannot verify the Lite pre-pull tag")
+
+compose_path, workflow_path, job_name = sys.argv[1], sys.argv[2], sys.argv[3]
+
+
+def fail(msg):
+	sys.exit("FAIL: " + msg)
+
+
+with open(compose_path) as fh:
+	compose = yaml.safe_load(fh) or {}
+services = (compose.get("services") or {})
+if "postgres" not in services:
+	fail(f"{compose_path} has no `postgres` service")
+want = (services["postgres"] or {}).get("image")
+if not want:
+	fail(f"{compose_path}'s postgres service declares no image")
+
+with open(workflow_path) as fh:
+	workflow = yaml.safe_load(fh) or {}
+jobs = workflow.get("jobs") or {}
+if job_name not in jobs:
+	fail(f"{workflow_path} has no `{job_name}` job — did it get renamed?")
+
+# Only this job's steps. Another job in the same workflow may legitimately pull
+# something else, and a file-wide scan would read whichever came first.
+pulled = []
+for step in (jobs[job_name].get("steps") or []):
+	run = step.get("run")
+	if not isinstance(run, str):
+		continue
+	for line in run.splitlines():
+		stripped = line.strip()
+		if stripped.startswith("#"):
+			continue  # a commented-out pull is not a pull
+		if "docker pull " not in stripped:
+			continue
+		tail = stripped.split("docker pull ", 1)[1].split("&&")[0].split(";")[0]
+		# Skip flags so `docker pull --quiet postgres:16` still resolves.
+		for tok in tail.split():
+			if not tok.startswith("-"):
+				pulled.append(tok)
+				break
+
+if not pulled:
+	fail(
+		f"{workflow_path}'s `{job_name}` job has no `docker pull <image>` step.\n"
+		"The image must be pulled before the /readyz budget starts; without it the\n"
+		"download happens inside the budget and eats the boot margin (#977)."
+	)
+if len(set(pulled)) > 1:
+	fail(f"`{job_name}` pulls more than one image ({', '.join(sorted(set(pulled)))}); this gate expects one")
+
+got = pulled[0]
+if got != want:
+	fail(
+		"the Lite pre-pull image does not match the compose Lite starts.\n"
+		f"  {compose_path}  postgres image: {want}\n"
+		f"  {workflow_path}  `{job_name}` pulls: {got}\n"
+		"Pulling the wrong tag is the same as not pulling: the real image is then\n"
+		"downloaded inside the /readyz budget."
+	)
+
+print(f"OK: Lite pre-pull matches the compose image ({want})")
+PY
+}
+
+self_test() {
+	local fail=0 tmp out
+	_case() { # <name> <want-rc> <want-substring> <compose-yaml> <workflow-yaml>
+		local name="$1" want_rc="$2" want_msg="$3" cy="$4" wy="$5" rc=0 out
+		printf '%s' "$cy" >"$tmp/compose.yaml"
+		printf '%s' "$wy" >"$tmp/wf.yaml"
+		out="$(check "$tmp/compose.yaml" "$tmp/wf.yaml" 2>&1)" || rc=$?
+		if [ "$rc" != "$want_rc" ]; then
+			printf '  FAIL %s (exit)\n    got:  %s\n    want: %s\n    out: %s\n' "$name" "$rc" "$want_rc" "$out"; fail=1; return
+		fi
+		case "$out" in
+			*"$want_msg"*) printf '  ok   %s\n' "$name" ;;
+			*) printf '  FAIL %s (message)\n    got: %q\n    want to contain: %q\n' "$name" "$out" "$want_msg"; fail=1 ;;
+		esac
+	}
+
+	tmp="$(mktemp -d)"
+	trap 'rm -rf "${tmp:-}"' RETURN
+
+	local ok_compose ok_wf
+	ok_compose=$'services:\n  postgres:\n    image: postgres:16\n  redis:\n    image: redis:7\n'
+	ok_wf=$'jobs:\n  lite-cold-start-smoke:\n    steps:\n      - name: pre-pull\n        run: docker pull postgres:16\n'
+
+	_case "matching tags pass" 0 "matches the compose image (postgres:16)" "$ok_compose" "$ok_wf"
+
+	# The reviewer's one-line defeat of the previous parser.
+	_case "a commented-out pull is not a pull" 1 "has no \`docker pull <image>\` step" "$ok_compose" \
+		$'jobs:\n  lite-cold-start-smoke:\n    steps:\n      - name: pre-pull\n        run: |\n          # docker pull postgres:16\n          true\n'
+
+	# A pull in another job must not be read as this job's.
+	_case "another job's pull does not count" 1 "has no \`docker pull <image>\` step" "$ok_compose" \
+		$'jobs:\n  release:\n    steps:\n      - run: docker pull postgres:16\n  lite-cold-start-smoke:\n    steps:\n      - run: true\n'
+
+	_case "drift is caught" 1 "does not match the compose" \
+		$'services:\n  postgres:\n    image: postgres:17-alpine\n' "$ok_wf"
+
+	# The retry wrapper the pull needs is a multi-line block.
+	_case "a multi-line retry block still resolves" 0 "matches the compose image (postgres:16)" "$ok_compose" \
+		$'jobs:\n  lite-cold-start-smoke:\n    steps:\n      - run: |\n          for i in 1 2 3; do\n            docker pull postgres:16 && exit 0\n            sleep 10\n          done\n          exit 1\n'
+
+	_case "flags are skipped" 0 "matches the compose image (postgres:16)" "$ok_compose" \
+		$'jobs:\n  lite-cold-start-smoke:\n    steps:\n      - run: docker pull --quiet postgres:16\n'
+
+	# Quoting and service order are YAML concerns now, not regex concerns.
+	_case "a quoted image compares by value" 0 "matches the compose image (postgres:16)" \
+		$'services:\n  postgres:\n    image: "postgres:16"\n' "$ok_wf"
+	_case "service order does not matter" 0 "matches the compose image (postgres:16)" \
+		$'services:\n  redis:\n    image: redis:7\n  postgres:\n    image: postgres:16\n' "$ok_wf"
+
+	_case "a renamed job fails loudly" 1 "did it get renamed?" "$ok_compose" \
+		$'jobs:\n  lite-cold-start:\n    steps:\n      - run: docker pull postgres:16\n'
+
+	if [ "$fail" -eq 0 ]; then echo "self-test: PASS"; return 0; else echo "self-test: FAIL"; return 1; fi
+}
+
+[ "${1:-}" = "--self-test" ] && { self_test; exit $?; }
+
+cd "$(dirname "$0")/.."
+check "${1:-docker-compose.dev.yaml}" "${2:-.github/workflows/release.yaml}"

--- a/scripts/check-script-selftests.sh
+++ b/scripts/check-script-selftests.sh
@@ -33,8 +33,8 @@ done
 
 # A rename or a lost self_test() would otherwise shrink this gate to nothing
 # while still exiting 0 — the same silent-shrink hole run_gates guards against.
-if [ "$found" -lt "${MIN_SELFTESTS:-3}" ]; then
-	echo "FAIL: found only $found self-test(s), expected at least ${MIN_SELFTESTS:-3} — did a script lose its self_test()?" >&2
+if [ "$found" -lt "${MIN_SELFTESTS:-4}" ]; then
+	echo "FAIL: found only $found self-test(s), expected at least ${MIN_SELFTESTS:-4} — did a script lose its self_test()?" >&2
 	exit 1
 fi
 [ "$failed" -eq 0 ] || exit 1

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -336,8 +336,8 @@ run_gates() { # <tag>
   shopt -u nullglob
   # A gate renamed out of check-*.sh silently leaves the cut's gate set with no
   # signal at all, so assert the floor.
-  [ "${#gates[@]}" -ge "${MIN_GATES:-6}" ] || {
-    echo "gate set shrank to ${#gates[@]} (expected >= ${MIN_GATES:-6}) — a check-*.sh was renamed or removed" >&2
+  [ "${#gates[@]}" -ge "${MIN_GATES:-7}" ] || {
+    echo "gate set shrank to ${#gates[@]} (expected >= ${MIN_GATES:-7}) — a check-*.sh was renamed or removed" >&2
     return 1
   }
   for s in "${gates[@]}"; do


### PR DESCRIPTION
Closes #977.

## Correction: my first diagnosis was wrong

I wrote that rc.1 timed out with the Postgres image still downloading. I had read the first lines of the dumped log and stopped. The full tail:

```
 postgres Pulled
 Container leoflow-685fd7906f0e-postgres-1  Healthy
▸ creating isolated dev database leoflow_dev …
▸ migrating leoflow_dev (embedded) …
▸ creating isolated dev venv for "hello" …
▸ installing task runtime + Airflow SDK into the "hello" venv (using pip) …
##[error]Process completed with exit code 1.
```

Postgres pulled, started and reported **healthy** well inside the minute. What was still running at the timeout is the per-DAG venv: `pip install` of the task runtime sdist plus `apache-airflow-task-sdk` — an uncached PyPI resolve with a local hatchling build. First-run boot legitimately contains that, and 60 seconds does not.

## The repo already knew this

`ci.yaml`'s Lite UI smoke budgets **180s** (`seq 1 60` × `sleep 3`) for the same boot on the **cheaper** `--postgres managed` path, and its own comment says *"its venv installs first"*.

This gate had **60s** for the heavier docker path — 3× tighter, on the one gate that can retract a signed release. Measured from the Actions API:

| release | boot step | headroom on 60s |
|---|---|---|
| v0.4.4 (GA) | 50s | 10s |
| v0.4.4-rc.2 | 43s | 17s |

Ten to seventeen seconds of margin over a PyPI download is a coin flip with good odds. rc.1 lost it.

## The fix

**Budget → 240s**, which is 4× under the job's own `timeout-minutes: 15` — that timeout is the real hang net. Raising a number is the right fix when the number was never derived from anything; what would be wrong is raising it and calling the problem gone. So the success path now reports the duration and emits a `::warning::` above 90s, otherwise a boot that doubled would simply be absorbed by the new ceiling.

**The pre-pull stays**, because taking the image download off the boot clock is correct on its own terms — and it is **retried**, since under `bash -e` a Docker Hub 503 or an anonymous-pull rate limit would otherwise fail the step outright and retract the release, a failure mode the old 60s timeout happened to absorb.

## The gate, and the fail-open in its first version

The job has **no checkout** — installing from the published release is the point of it — so the tag is duplicated in the workflow. `scripts/check-lite-prepull-matches-compose.sh` keeps the two honest. The tree already carries two Postgres majors (`docker-compose.yml` runs `17-alpine`, `docker-compose.dev.yaml` runs `16`), so "someone bumps the wrong file" is not hypothetical.

My first version grepped with `awk` and had a fail-open that review defeated in one line — commenting out the pull left the gate **green**, because a `#`-prefixed line still matched. Both sides are now parsed as YAML and scoped to the job's own steps, which also closes a second hole (another job's `docker pull` was readable as this one's) and is what makes the multi-line retry block expressible at all.

Nine `self_test()` cases:

| case | expects |
|---|---|
| matching tags | pass |
| **pull commented out** | FAIL — the mutation that beat the old parser |
| pull in another job only | FAIL |
| tag drift | FAIL |
| multi-line retry block | pass |
| `docker pull --quiet <tag>` | pass |
| quoted image in compose | pass |
| `redis` declared before `postgres` | pass |
| job renamed | FAIL, naming the rename |

Verified against the real tree: commenting out the pull line now exits 1.

## Also

- **Wired into `ci.yaml`** as `lite-prepull-tag`, so a `docker-compose.dev.yaml` bump fails at PR time instead of surfacing inside `cut-release.sh --prepare`.
- **`MIN_GATES` 6 → 7, `MIN_SELFTESTS` 3 → 4** — both floors sit at the current count by design, so a new `scripts/check-*.sh` has to move them.
- **Executor assumption commented in the job**: it only stays cheap because `leoflow setup </dev/null` persists `lite_executor: subprocess`. If that default ever flips to k8s, `leoflow lite` starts building a k3d cluster inside the budget.
- `ci.yaml`'s Lite jobs are unaffected by the pre-pull — `--postgres managed` downloads no image.

## Still open, and it prices every remaining risk

**#979** — retracting to draft makes the release assets 404, so the smoke jobs whose green re-run would un-draft can never be green. Verified on rc.1: attempt 2 ran 4 seconds and died on `curl: (22) … 404`. This PR removes the cause of the rc.1 retraction; it does not remove the deadlock, so any retraction on rc.2 still costs a new tag.

Follow-ups filed from the review: a committed gate manifest with set equality instead of the two numeric floors; `~/.leoflow/docker-compose.yaml` never being refreshed on upgrade; retries for `install-smoke`'s non-apt package managers and for `cosign verify`.