### PR TITLE
ci(ui-smoke): cap and cache the browser install, and make the smoke exit symmetrically

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -467,6 +467,7 @@ jobs:
     timeout-minutes: 15
     env:
       PYTHONPATH: parser
+      PLAYWRIGHT_VERSION: "1.63.0"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -489,16 +490,31 @@ jobs:
       # why. That is what happened on the v0.4.5-rc.2 cut: this step took 539s
       # against its usual 24s, leaving the smoke below it only 209s of the
       # job's 900s for work that needs 213-221s. It was over before it started.
+      # The key carries the Playwright version, and the version is pinned. A
+      # constant key would freeze on today's chromium revision: actions/cache
+      # never overwrites an existing key, so the next Playwright bump would
+      # restore the wrong browser, download the right one at full cost, and
+      # then refuse to save it — the cache degrades to a pure restore cost and
+      # never self-heals until a human edits the key.
+      #
+      # Pinning also closes an inconsistency: every action here is SHA-pinned
+      # and the repo runs govulncheck, CodeQL, gitleaks and Trivy, while this
+      # step installed whatever `latest` resolved to — a package whose
+      # postinstall downloads a browser binary.
       - name: Cache the Playwright browser
+        id: pw-cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cache/ms-playwright
-          key: ms-playwright-${{ runner.os }}-chromium-v1
+          key: ms-playwright-${{ runner.os }}-${{ env.PLAYWRIGHT_VERSION }}
+      # The install still runs on a cache hit: --with-deps installs OS packages
+      # the cache does not carry, and the browser download is the only part the
+      # cache shortcuts.
       - name: Install Playwright + Chromium
         timeout-minutes: 6
         run: |
           npm init -y >/dev/null 2>&1
-          npm i --no-save playwright-core playwright
+          npm i --no-save playwright-core@"$PLAYWRIGHT_VERSION" playwright@"$PLAYWRIGHT_VERSION"
           npx playwright install --with-deps chromium
       - name: Boot Lite and run the UI smoke
         run: |
@@ -528,18 +544,21 @@ jobs:
           # exit 124 naming the command, rather than running the job out of
           # budget into a `cancelled` that says nothing.
           #
-          # 600s, not a tighter number: the node run has never been measured.
-          # The step emits nothing between its start and the report, so its
-          # 211-221s cannot be split between the Lite boot and node from the
-          # log. The script's own hard-coded waits alone are ~30s and it does
-          # ~15 networkidle navigations, so a realistic run is a quarter to a
-          # half of the step. 600s cannot false-kill (the job wall arrives
-          # first) while still catching a true hang. The line below prints the
-          # duration, so the next person can set this from data.
-          t0=$SECONDS
+          # 180s is 4x the measured node run. An earlier draft used 600s on the
+          # reasoning that it "cannot false-kill because the job wall arrives
+          # first" — which is exactly why it could never fire either: those are
+          # the same property. This step's own instrumentation settled it on the
+          # first run: node takes 45s, and it starts around t+334s of a 900s
+          # job, so anything above ~560s is unreachable.
+          #
+          # The duration prints on BOTH paths. Under `set -e` a bare invocation
+          # would skip the echo precisely when the timeout tripped, which is the
+          # one case it was added for.
+          t0=$SECONDS; rc=0
           LEOFLOW_URL=http://localhost:18080 LEOFLOW_USER=admin@leoflow.local LEOFLOW_PASS="$PW" \
-            timeout --kill-after=30 600 node test/e2e/ui-smoke.js
-          echo "ui-smoke node run: $((SECONDS - t0))s"
+            timeout --kill-after=30 180 node test/e2e/ui-smoke.js || rc=$?
+          echo "ui-smoke node run: $((SECONDS - t0))s (rc=$rc)"
+          exit $rc
 
   # ─────────────────────────────────────────────────────────────────────
   # Full pod-per-task e2e on a real k3d cluster (test/e2e/e2e.sh): builds the

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -481,7 +481,21 @@ jobs:
           node-version: "20"
       - name: Build binaries
         run: make build
+      # Cache the browser so the common path stops depending on a download at
+      # all, and give the step its own ceiling. A STEP timeout marks the step
+      # and the job `failure`; the job-level timeout-minutes marks them
+      # `cancelled`, and since #975 a cancelled run is not a green run — so an
+      # over-budget job silently stops a release cut while saying nothing about
+      # why. That is what happened on the v0.4.5-rc.2 cut: this step took 539s
+      # against its usual 24s, leaving the smoke below it only 209s of the
+      # job's 900s for work that needs 213-221s. It was over before it started.
+      - name: Cache the Playwright browser
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.cache/ms-playwright
+          key: ms-playwright-${{ runner.os }}-chromium-v1
       - name: Install Playwright + Chromium
+        timeout-minutes: 6
         run: |
           npm init -y >/dev/null 2>&1
           npm i --no-save playwright-core playwright
@@ -510,8 +524,22 @@ jobs:
           # Wait for the typed-params fixture DAG to register too (the trigger-form step needs it).
           for _ in $(seq 1 40); do curl -fsS -H "Authorization: Bearer $TOK" http://localhost:18080/api/v2/dags/params_demo >/dev/null 2>&1 && break; sleep 3; done
           sleep 10
+          # A `timeout` here so a hang in the smoke itself fails loudly, as
+          # exit 124 naming the command, rather than running the job out of
+          # budget into a `cancelled` that says nothing.
+          #
+          # 600s, not a tighter number: the node run has never been measured.
+          # The step emits nothing between its start and the report, so its
+          # 211-221s cannot be split between the Lite boot and node from the
+          # log. The script's own hard-coded waits alone are ~30s and it does
+          # ~15 networkidle navigations, so a realistic run is a quarter to a
+          # half of the step. 600s cannot false-kill (the job wall arrives
+          # first) while still catching a true hang. The line below prints the
+          # duration, so the next person can set this from data.
+          t0=$SECONDS
           LEOFLOW_URL=http://localhost:18080 LEOFLOW_USER=admin@leoflow.local LEOFLOW_PASS="$PW" \
-            node test/e2e/ui-smoke.js
+            timeout --kill-after=30 600 node test/e2e/ui-smoke.js
+          echo "ui-smoke node run: $((SECONDS - t0))s"
 
   # ─────────────────────────────────────────────────────────────────────
   # Full pod-per-task e2e on a real k3d cluster (test/e2e/e2e.sh): builds the

--- a/test/e2e/ui-smoke.js
+++ b/test/e2e/ui-smoke.js
@@ -47,6 +47,31 @@ function cachedChromium() {
 
 const CRASH_RE = /Cannot read properties|is not a function|client-side exception|Something went wrong|Minified React error #\d/i;
 
+// finish writes the report and exits explicitly, rather than letting the
+// process end when the event loop happens to drain.
+//
+// The reason is symmetry, not a known leak. Both failure paths call
+// process.exit, so they can never linger; the pass path fell off the end of
+// the async IIFE and depended on nothing else holding the loop open. A test
+// runner whose two outcomes exit by different mechanisms will eventually
+// differ in behaviour, and the one that can hang is the one that succeeded —
+// which is the hardest case to read from CI, because the log says it passed.
+// (Searched for an actual leak first: one launch, one context, one page, all
+// closed by browser.close(); every API call goes through page.request, which
+// the context owns. Nothing is left open. This is insurance, not a workaround.)
+//
+// Flushing is the part that needs care. console.log to a pipe — which is what
+// CI gives us — is asynchronous, and a bare process.exit() drops whatever has
+// not reached the OS. That would truncate the result line, the one thing a
+// reader needs. So the exit happens in the write callback, with an unref'd 5s
+// timer as a backstop for a stdout that never drains; unref'd so the timer
+// itself cannot hold the process open.
+function finish(code, text, stream = process.stdout) {
+  process.exitCode = code;
+  setTimeout(() => process.exit(code), 5000).unref();
+  stream.write(text, () => process.exit(code));
+}
+
 (async () => {
   const browser = await chromium.launch({ headless: true, executablePath: cachedChromium() });
   const page = await (await browser.newContext()).newPage();
@@ -232,14 +257,15 @@ const CRASH_RE = /Cannot read properties|is not a function|client-side exception
   await browser.close();
 
   const failed = results.filter((r) => r.bad);
-  console.log('\n===== UI SMOKE =====');
+  const report = ['', '===== UI SMOKE ====='];
   for (const r of results) {
-    console.log(`${r.bad ? 'FAIL' : 'ok  '}  ${r.name}`);
-    r.errs.forEach((e) => console.log('        ' + e.slice(0, 200)));
+    report.push(`${r.bad ? 'FAIL' : 'ok  '}  ${r.name}`);
+    r.errs.forEach((e) => report.push('        ' + e.slice(0, 200)));
   }
-  if (failed.length) {
-    console.error(`\nUI SMOKE FAILED: ${failed.length} screen(s) threw an uncaught error.`);
-    process.exit(1);
-  }
-  console.log(`\nUI SMOKE PASSED: ${results.length} screens/interactions, no crashes.`);
-})().catch((e) => { console.error('FATAL', e.message); process.exit(1); });
+  report.push(
+    failed.length
+      ? `\nUI SMOKE FAILED: ${failed.length} screen(s) threw an uncaught error.`
+      : `\nUI SMOKE PASSED: ${results.length} screens/interactions, no crashes.`,
+  );
+  finish(failed.length ? 1 : 0, report.join('\n') + '\n');
+})().catch((e) => finish(1, `FATAL ${(e && e.stack) || String(e)}\n`, process.stderr));


### PR DESCRIPTION
Closes the cancellation class that blocked the v0.4.5-rc.2 cut.

The job was not hung by the smoke. Step timings:

    Build binaries                    107-137s
    Install Playwright + Chromium     539s   <- 23-45s on eight other runs
    Boot Lite and run the UI smoke    214s   <- 211-221s on those same runs

The budget is timeout-minutes: 15. The steps above the smoke consumed 691s, so
it started with 209s left for work that needs 213-221s: over before it began.
It ran its normal duration, printed UI SMOKE PASSED, and the cancellation
arrived 23ms later. One dependency download running 22x long ate the wall.

That matters beyond the incident, because a job killed by timeout-minutes is
marked `cancelled`, and since #975 a cancelled run is not a green run — so an
over-budget job silently stops a release cut while saying nothing about why. It
stopped the v0.4.5-rc.2 cut, and the tag had to be made by hand.

So the fix is where the time went. The browser is cached and the install step
gets timeout-minutes: 6. A STEP timeout marks the step and job `failure`, which
is diagnosable and rerun-eligible; only the job-level timeout produces the
`cancelled` that says nothing. 6 minutes catches the 539s case and does newly
fail an install between 360s and ~540s — that band used to pass by seconds, and
red-and-loud beats green-by-eight-seconds when the signal gates a release.

The cache key carries a pinned Playwright version. A constant key would freeze
on today's chromium revision: actions/cache never overwrites an existing key,
so the next Playwright bump would restore the wrong browser, download the right
one at full cost, and refuse to save it — degrading to a pure restore cost that
never self-heals. Pinning also closes an inconsistency, since every action here
is SHA-pinned while this step installed whatever `latest` resolved to, a
package whose postinstall downloads a browser.

The smoke's own exit is still worth making symmetric, on its own merit and not
as the cause: both failure paths called process.exit, the pass path fell off
the end of the async IIFE. A runner whose two outcomes end by different
mechanisms will eventually differ, and the one that can hang is the one that
succeeded — the hardest case to read, because the log says it passed. I looked
for a leak first and there is none: one launch, one context, one page, all
closed, and every API call goes through page.request, which the context owns.

finish() flushes before exiting, because console.log to a pipe is asynchronous
and a bare process.exit() would truncate the result line. Verified against a
held handle: exits in 0s with all bytes delivered.

The node run is wrapped in `timeout --kill-after=30 180`. An earlier draft used
600s on the reasoning that it could not false-kill because the job wall arrives
first — which is exactly why it could never fire either; those are the same
property. This step's own instrumentation settled it on the first run: node
takes 45s and starts around t+334s of a 900s job, so anything above ~560s is
unreachable. 180s is 4x the measurement. The duration now prints on both paths;
under `set -e` a bare invocation skipped the echo precisely when the timeout
tripped, which is the case it exists for.

Also: the fatal path printed `FATAL undefined` for a thrown non-Error.



## Measured, not assumed

| | main (n=8) | this PR |
|---|---|---|
| `Install Playwright + Chromium` | 23-45s (bad run **539s**) | 25s, cache miss |
| `Boot Lite and run the UI smoke` | 211-221s | 218s |
| **node run** | never measured | **45s** |
| job wall | 900s | 900s |

The node figure comes from this branch's own instrumentation, on its first run — and it refuted the 600s ceiling the earlier draft argued for.

## Verification

`finish()` tested against a deliberately held handle: exits in 0s, all 200027 bytes delivered, final line intact; the same handle without it keeps node alive indefinitely. `actions/cache` SHA verified against the real `v4.2.3` object (an earlier draft carried an invented one). `actionlint` clean.