### PR TITLE
fix: the entry points a newcomer touches first, and two links I broke today

### DIFF
--- a/.github/CLAUDE.md.template
+++ b/.github/CLAUDE.md.template
@@ -116,7 +116,7 @@ leoflow/
 1. **TDD is mandatory and observable.** Every production code change must be preceded by a failing test commit (or a test added in the same commit that initially fails). The workflow is: write test → run test → see it fail → implement → run test → see it pass → refactor. Never claim "this should work" without running the test. Never write production code first and tests after. See ADR 0011.
 2. **Go Report Card A+ is the floor, not the ceiling.** Every commit maintains the grade. Every exported identifier (function, type, method, constant, variable) has a GoDoc comment starting with its name and ending with a period. Cyclomatic complexity ≤ 15 per function. `make lint` must be clean before any commit. See ADR 0012.
 3. **Run `make lint` and `go test ./...` before claiming a task is done.** Show the output. "Tests should pass" is never acceptable; "tests passed (here is the output)" is the bar.
-4. **Never modify `docs/adr/*.md` files without explicit user approval.** ADRs are immutable decisions.
+4. **Never modify `website/content/project/adrs/*.md` files without explicit user approval.** ADRs are immutable decisions.
 5. **Always read relevant ADRs before writing code in a new area.** They explain *why* decisions were made.
 6. **Never introduce new dependencies without checking the tech stack table above.** Every new dep is a supply chain surface; if added, ensure it appears in `govulncheck` clean and Dependabot can track it.
 7. **Never break the `/api/v2/` API surface.** It must remain Airflow 3.2.x compatible.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -55,5 +55,5 @@ body:
       options:
         - label: I searched existing issues and this is not a duplicate.
           required: true
-        - label: I checked the relevant ADRs under `docs/adr/` (behavior may be by design).
+        - label: I checked the relevant [ADRs](https://neochaotic.github.io/leoflow/project/adrs/) (behavior may be by design).
           required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -29,7 +29,7 @@ body:
     attributes:
       label: Does this likely need an ADR?
       description: >
-        Significant or architectural changes require a draft ADR under `docs/adr/`
+        Significant or architectural changes require a draft ADR under `website/content/project/adrs/`
         with status "Proposed" (see CONTRIBUTING.md). Unsure is fine.
       options:
         - "No — small / local change"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,10 +13,10 @@ Closes #
 
 ## Checklist
 
-- [ ] **TDD** — a failing test preceded the production code (red → green → refactor) — [ADR 0011](https://github.com/neochaotic/leoflow/blob/main/docs/adr/0011-tdd-strict.md)
+- [ ] **TDD** — a failing test preceded the production code (red → green → refactor) — [ADR 0011](https://neochaotic.github.io/leoflow/project/adrs/0011-tdd-strict/)
 - [ ] `make lint test` passes locally
-- [ ] GoDocs on every new exported identifier; cyclomatic complexity ≤ 15 — [ADR 0012](https://github.com/neochaotic/leoflow/blob/main/docs/adr/0012-code-quality-standards.md)
-- [ ] No new dependency without justification; `make vuln` clean — [ADR 0014](https://github.com/neochaotic/leoflow/blob/main/docs/adr/0014-supply-chain-security.md)
+- [ ] GoDocs on every new exported identifier; cyclomatic complexity ≤ 15 — [ADR 0012](https://neochaotic.github.io/leoflow/project/adrs/0012-code-quality-standards/)
+- [ ] No new dependency without justification; `make vuln` clean — [ADR 0014](https://neochaotic.github.io/leoflow/project/adrs/0014-supply-chain-security/)
 - [ ] Public `/api/v2/` surface unchanged, or Airflow 3.2.x compatibility preserved
 - [ ] Docs updated if behavior, flags, or config changed
 - [ ] All code, comments, and commit messages are in English

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,7 +246,7 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   still suppresses the platform default wholesale rather than merging per field,
   and the same wholesale suppression is reachable without any `defaults` block at
   all: a task declaring only an `ephemeral_storage` limit (a standalone knob
-  [ADR 0054](https://leoflow.dev/project/adrs/0054-shared-cluster-coexistence/)
+  [ADR 0054](https://neochaotic.github.io/leoflow/project/adrs/0054-shared-cluster-coexistence/)
   promotes) makes the resources object non-nil and therefore drops the platform
   cpu and memory defaults entirely, leaving a pod with an ephemeral-storage limit
   and no cpu or memory request at all. Only cpu and memory are QoS compute
@@ -269,7 +269,7 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   were wrong. Task pods are governed by a *different* value,
   `taskNetworkPolicy.enabled`, which defaults to `false` — so an operator who
   followed the section to the letter believed the network-layer containment
-  [ADR 0048](https://leoflow.dev/project/adrs/0048-no-user-code-in-control-plane/)
+  [ADR 0048](https://neochaotic.github.io/leoflow/project/adrs/0048-no-user-code-in-control-plane/)
   leans on was in place and had none. And the control-plane policy restricts
   **ingress only**: its `networkPolicy.egress` is empty by default and the
   chart then renders a single empty egress *rule* (`- {}`), which matches every

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ rebrand-ui: ## Rewrite the embedded SPA's Docs/GitHub nav links from Airflow to 
 
 .PHONY: e2e-lite
 e2e-lite: ## End-to-end Lite happy path (setup -> control plane -> login); needs local Postgres+Redis (DESTRUCTIVE: resets leoflow_dev)
-	bash scripts/e2e-lite-login.sh
+	bash test/e2e/lite-login.sh
 
 .PHONY: e2e-lite-selfheal
 e2e-lite-selfheal: ## Lite boot self-heal gate (#404); needs local Postgres (DESTRUCTIVE: resets leoflow_dev)


### PR DESCRIPTION
Closes the first two of the pre-GA items (P0-7 and the link half of P0-2).

## `make e2e-lite` was broken

```make
e2e-lite: ## End-to-end Lite happy path …
	bash scripts/e2e-lite-login.sh      # ← does not exist
```

The script is `test/e2e/lite-login.sh`, where `ci.yaml`'s `e2e-lite` job and `test/e2e/README.md` both correctly point. It is the first e2e a contributor runs after `make setup && make build`, `make help` advertises it, and it fails with file-not-found — which reads as "the project does not build on my machine". An audit of every script path in the Makefile found this to be the only broken one.

## Three of eight PR-checklist items linked to 404s

`docs/` has held only `api/` since the MkDocs→Hugo cutover (`253e9d9`) moved the ADRs to `website/content/project/adrs/`. Rewritten to the published site. Both issue templates and `.github/CLAUDE.md.template` carried the same stale path in prose, where no link checker can see it; those now name the real path, matching what `CONTRIBUTING.md` already does.

## And two I introduced today

#953 added CHANGELOG entries citing `leoflow.dev/project/adrs/…`. **That host does not serve the site**:

```
HTTP 200  https://leoflow.dev/
HTTP 404  https://leoflow.dev/project/adrs/0048-no-user-code-in-control-plane/
HTTP 404  https://leoflow.dev/project/adrs/0054-shared-cluster-coexistence/
```

The Hugo `baseURL` is `https://neochaotic.github.io/leoflow/`. Fixed both.

## Verified by fetching, not by pattern

Every rewritten link was requested:

```
HTTP 200  …/project/adrs/0011-tdd-strict/
HTTP 200  …/project/adrs/0012-code-quality-standards/
HTTP 200  …/project/adrs/0014-supply-chain-security/
HTTP 200  …/project/adrs/0048-no-user-code-in-control-plane/
HTTP 200  …/project/adrs/0054-shared-cluster-coexistence/
```

`make -n e2e-lite` now resolves to `bash test/e2e/lite-login.sh`, and that file exists and is executable. All seven `scripts/check-*.sh` pass.

## Not in scope

Widening lychee and adding the stale-path grep gate — the P0 spec's gate half, which can land after the GA. This is the part that is broken in front of a newcomer today.

One observation for that gate's design, from this PR: the two `leoflow.dev` links were **live 404s in valid Markdown**, so a stale-path grep would never have found them and only a link checker would — while the issue templates' prose is the exact opposite. Neither gate covers the other, which is precisely what the P0 spec argues and why it proposes both.