### PR TITLE
fix: bake a hybrid DAG's dbt projects into the image (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,17 +146,24 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `leoflow dev` cluster path had the identical gap and gets the identical fix.
   Paths under `dbt_groups` are validated the same way `dbt.project` already was:
   the guard for escaping and absolute paths returned early whenever the
-  top-level `dbt:` block was absent — which is every hybrid DAG — so a
-  `../shared` that happened to exist built **green** against a directory nobody
-  named, while Lite resolved the real sibling. Two paths still fail after this,
+  top-level `dbt:` block was absent — which is every hybrid DAG. Measured against
+  real builds: an **absolute** `project:` is the silent one — Docker resolves the
+  source against the context root, so `/opt/dbt` builds **green** against
+  `<context>/opt/dbt`, a directory nobody named. An escaping `../shared` is loud
+  but misleading: the classic builder refuses outright, and BuildKit clamps to
+  `<context>/shared` and bakes *that* if it exists — never the sibling Lite
+  resolves. Either way the message never mentions `leoflow.yaml`. Two paths still fail after this,
   and are tracked separately: `compile` without `--build` (and `deploy
   --skip-build`) bakes an absolute host path into the dbt entrypoint, and a
   group with no `connection:` cannot resolve a project-baked `profiles.yml`.
   Also corrected while in the file: the `#852` comment claimed the source COPY
   had to sit above the `USER` drop to land root-owned. Measured against a real
-  build, `COPY` lands `uid=0 gid=0` whatever `USER` is active; what the ordering
-  actually buys is that the **final** `USER` is non-root, which is what
-  PodSecurity's `runAsNonRoot` admits on.
+  build under both BuildKit and the classic builder, `COPY` lands `uid=0 gid=0`
+  whatever `USER` is active; what the ordering
+  actually buys is that the **final** `USER` is a **numeric** non-root UID, which
+  is what the kubelet resolves at container creation when a task pod sets
+  `runAsNonRoot` with no `runAsUser` — the pair `buildSecurityContext` sets.
+  PodSecurity admission never reads the image; it checks the PodSpec.
 
 - **HA chart posture: five render refusals for combinations that used to fail
   later, and the ServiceAccount / warm-pool docs the profile was missing.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,27 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **A hybrid DAG's dbt projects are baked into the image, so its dbt tasks can
+  run (#20).** `generatedDockerfile` branched on the top-level `dbt:` block and
+  had no reference to `dbt_groups` at all: for a `dag.py` with dbt task groups —
+  the authoring shape ADR 0043 defines — it COPYed only the DAG source. The
+  group's tasks then ran `dbt --project-dir <project>` from WORKDIR
+  `/home/leoflow` against a directory that was never in the image, so every dbt
+  task exited within seconds of pod start. Compile was green and so was Lite,
+  because Lite's subprocess executor reads from disk and never needs an image —
+  the gap only appeared once something built. Both the DAG source and every
+  group's project are COPYed now, deduplicated and **sorted**: `dbt_groups` is a
+  map and Go randomizes map iteration, so emitting in range order would give a
+  different Dockerfile per compile and break the byte-for-byte reproducibility
+  of ADR 0003. `project: "."` collapses to a single `COPY . /home/leoflow/`,
+  matching the fact that no `--project-dir` is emitted for that value. The
+  `leoflow dev` cluster path had the identical gap and gets the identical fix.
+  Also corrected while in the file: the `#852` comment claimed the source COPY
+  had to sit above the `USER` drop to land root-owned. Measured against a real
+  build, `COPY` lands `uid=0 gid=0` whatever `USER` is active; what the ordering
+  actually buys is that the **final** `USER` is non-root, which is what
+  PodSecurity's `runAsNonRoot` admits on.
+
 - **HA chart posture: five render refusals for combinations that used to fail
   later, and the ServiceAccount / warm-pool docs the profile was missing.**
   `podDisruptionBudget.enabled` keyed on a real boolean, so the string spellings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,8 +130,7 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- **A hybrid DAG's dbt projects are baked into the image, so its dbt tasks can
-  run (#20).** `generatedDockerfile` branched on the top-level `dbt:` block and
+- **A hybrid DAG's dbt projects are baked into the image (#20).** `generatedDockerfile` branched on the top-level `dbt:` block and
   had no reference to `dbt_groups` at all: for a `dag.py` with dbt task groups —
   the authoring shape ADR 0043 defines — it COPYed only the DAG source. The
   group's tasks then ran `dbt --project-dir <project>` from WORKDIR
@@ -141,10 +140,18 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the gap only appeared once something built. Both the DAG source and every
   group's project are COPYed now, deduplicated and **sorted**: `dbt_groups` is a
   map and Go randomizes map iteration, so emitting in range order would give a
-  different Dockerfile per compile and break the byte-for-byte reproducibility
-  of ADR 0003. `project: "."` collapses to a single `COPY . /home/leoflow/`,
+  different image digest from an unchanged project, and a cold layer cache every
+  time. `project: "."` collapses to a single `COPY . /home/leoflow/`,
   matching the fact that no `--project-dir` is emitted for that value. The
   `leoflow dev` cluster path had the identical gap and gets the identical fix.
+  Paths under `dbt_groups` are validated the same way `dbt.project` already was:
+  the guard for escaping and absolute paths returned early whenever the
+  top-level `dbt:` block was absent — which is every hybrid DAG — so a
+  `../shared` that happened to exist built **green** against a directory nobody
+  named, while Lite resolved the real sibling. Two paths still fail after this,
+  and are tracked separately: `compile` without `--build` (and `deploy
+  --skip-build`) bakes an absolute host path into the dbt entrypoint, and a
+  group with no `connection:` cannot resolve a project-baked `profiles.yml`.
   Also corrected while in the file: the `#852` comment claimed the source COPY
   had to sit above the `USER` drop to land root-owned. Measured against a real
   build, `COPY` lands `uid=0 gid=0` whatever `USER` is active; what the ordering

--- a/internal/cli/compile_build.go
+++ b/internal/cli/compile_build.go
@@ -17,8 +17,10 @@ import (
 //
 // Sorted rather than ranged: DbtGroups is a map and Go randomizes map
 // iteration, so emitting in range order would give a different Dockerfile on
-// every compile — thrashing the layer cache and breaking the byte-for-byte
-// reproducibility ADR 0003 promises. Deduplicated because two groups may cover
+// every compile — a different image digest from an unchanged project, and a
+// cold layer cache every time. (ADR 0003 argues for per-DAG images; it says
+// nothing about reproducibility, so this is the engineering reason, not a
+// citation.) Deduplicated because two groups may cover
 // one project with different granularity or selectors, and a repeated COPY is a
 // wasted layer that reads like a bug in a diff.
 //
@@ -138,8 +140,12 @@ func generatedDockerfile(cfg *domain.LeoflowConfig, dagSource string) (string, e
 	// `--user` install whose console scripts (e.g. `dbt`) land in ~/.local/bin, which
 	// is not on PATH — so a synthesized dbt image would fail `dbt: command not found`.
 	// Install as root (system site → /usr/local/bin on PATH), then drop back to the
-	// non-root runtime USER as the LAST instruction, so PodSecurity's runAsNonRoot
-	// admits the pod (#852).
+	// non-root runtime USER as the LAST instruction, so the image's final USER is a
+	// numeric non-root UID (#852). That is what the KUBELET resolves at container
+	// creation when a task pod sets runAsNonRoot with no runAsUser — buildSecurityContext
+	// sets exactly that pair — and a root image fails CreateContainerConfigError,
+	// which reconcile.go matches by name. PodSecurity admission never reads the
+	// image; it only checks the PodSpec.
 	//
 	// The drop being last is not what makes the copied source read-only to the
 	// task. COPY without --chown lands uid=0 gid=0 whatever USER is active —

--- a/internal/cli/compile_build.go
+++ b/internal/cli/compile_build.go
@@ -5,11 +5,44 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/neochaotic/leoflow/internal/domain"
 	"github.com/neochaotic/leoflow/internal/version"
 )
+
+// dbtGroupProjectDirs returns the distinct project directories the dbt_groups
+// of a dag.py DAG need baked into the image, cleaned and in a stable order.
+//
+// Sorted rather than ranged: DbtGroups is a map and Go randomizes map
+// iteration, so emitting in range order would give a different Dockerfile on
+// every compile — thrashing the layer cache and breaking the byte-for-byte
+// reproducibility ADR 0003 promises. Deduplicated because two groups may cover
+// one project with different granularity or selectors, and a repeated COPY is a
+// wasted layer that reads like a bug in a diff.
+//
+// The cleaned form is what the baked flag resolves against: dbtProjectDir
+// returns the value verbatim, so `--project-dir ./transform` from WORKDIR
+// /home/leoflow lands on /home/leoflow/transform — which is where
+// filepath.Clean puts the COPY destination.
+func dbtGroupProjectDirs(cfg *domain.LeoflowConfig) []string {
+	seen := make(map[string]bool, len(cfg.DbtGroups))
+	dirs := make([]string, 0, len(cfg.DbtGroups))
+	for _, group := range cfg.DbtGroups {
+		if group == nil || group.Project == "" {
+			continue
+		}
+		project := filepath.Clean(group.Project)
+		if seen[project] {
+			continue
+		}
+		seen[project] = true
+		dirs = append(dirs, project)
+	}
+	slices.Sort(dirs)
+	return dirs
+}
 
 // generatedDockerfileName is the file a yaml-driven build writes its synthesized
 // Dockerfile to when the project ships none. The leading dot keeps it out of the
@@ -105,7 +138,13 @@ func generatedDockerfile(cfg *domain.LeoflowConfig, dagSource string) (string, e
 	// `--user` install whose console scripts (e.g. `dbt`) land in ~/.local/bin, which
 	// is not on PATH — so a synthesized dbt image would fail `dbt: command not found`.
 	// Install as root (system site → /usr/local/bin on PATH), then drop back to the
-	// non-root runtime USER before the source COPY (#852).
+	// non-root runtime USER as the LAST instruction, so PodSecurity's runAsNonRoot
+	// admits the pod (#852).
+	//
+	// The drop being last is not what makes the copied source read-only to the
+	// task. COPY without --chown lands uid=0 gid=0 whatever USER is active —
+	// measured against a real build, both before and after a USER instruction —
+	// so the ownership holds regardless of where the drop sits.
 	rootForInstall := len(cfg.SystemPackages) > 0 || len(deps) > 0
 	if rootForInstall {
 		b.WriteString("USER root\n")
@@ -126,8 +165,9 @@ func generatedDockerfile(cfg *domain.LeoflowConfig, dagSource string) (string, e
 		// + models/ + baked manifest.json) to the workdir and set no PYTHONPATH. The
 		// task runs `dbt --project-dir <project>` from WORKDIR /home/leoflow, so the
 		// project must land at /home/leoflow/<project> matching the baked --project-dir.
-		// COPYed while still root, so the project is read-only to the task: dbt writes
-		// target/, logs/, and profiles.yml to /tmp (base ENV), never the project (#852).
+		// The project is read-only to the task because COPY lands it root-owned, not
+		// because of where it sits relative to the USER drop: dbt writes target/,
+		// logs/, and profiles.yml to /tmp (base ENV), never the project (#852).
 		project := filepath.Clean(cfg.Dbt.Project)
 		fmt.Fprintf(&b, "COPY %s /home/leoflow/%s\n", project, project)
 		if rootForInstall {
@@ -135,8 +175,27 @@ func generatedDockerfile(cfg *domain.LeoflowConfig, dagSource string) (string, e
 		}
 		return b.String(), nil
 	}
+	// A dag.py DAG, with or without dbt task groups (ADR 0043). Both the DAG
+	// source and every group's project have to be in the image: a group's tasks
+	// run `dbt --project-dir <project>` from WORKDIR /home/leoflow, so a project
+	// that was never COPYed makes every dbt task exit within seconds of pod
+	// start — after a green compile and a green Lite run, because Lite's
+	// subprocess executor reads from disk and never needs the image (#20).
 	base := filepath.Base(dagSource)
-	fmt.Fprintf(&b, "COPY %s /home/leoflow/%s\nENV PYTHONPATH=/home/leoflow\n", base, base)
+	groups := dbtGroupProjectDirs(cfg)
+	if slices.Contains(groups, ".") {
+		// project: "." means the dbt project IS the DAG directory. render.go
+		// omits --project-dir for that value, so dbt runs from WORKDIR and the
+		// whole context must land at /home/leoflow — one COPY that already
+		// carries dag.py and subsumes every other group directory.
+		b.WriteString("COPY . /home/leoflow/\n")
+	} else {
+		fmt.Fprintf(&b, "COPY %s /home/leoflow/%s\n", base, base)
+		for _, project := range groups {
+			fmt.Fprintf(&b, "COPY %s /home/leoflow/%s\n", project, project)
+		}
+	}
+	b.WriteString("ENV PYTHONPATH=/home/leoflow\n")
 	if rootForInstall {
 		b.WriteString("USER 65532:65532\n")
 	}

--- a/internal/cli/compile_build_test.go
+++ b/internal/cli/compile_build_test.go
@@ -285,9 +285,11 @@ func TestGeneratedDockerfileMixedCopiesDagSourceAndEveryGroupProject(t *testing.
 			t.Errorf("generatedDockerfile() missing %q, got:\n%s", want, df)
 		}
 	}
-	// The USER drop must stay last, because PodSecurity's runAsNonRoot admits the
-	// pod on the final USER (#852). Ownership is not the reason — COPY lands
-	// uid=0 gid=0 whatever USER is active, measured against a real build — but
+	// The USER drop must stay last, because the kubelet resolves the image's
+	// final USER when a task pod sets runAsNonRoot with no runAsUser, and a root
+	// image fails CreateContainerConfigError (#852). Ownership is not the reason
+	// — COPY lands uid=0 gid=0 whatever USER is active, measured on a real build
+	// under both BuildKit and the classic builder — but
 	// the structure is still worth locking: a COPY emitted below the drop would
 	// mean the drop is no longer last.
 	drop := strings.LastIndex(df, "USER 65532:65532")

--- a/internal/cli/compile_build_test.go
+++ b/internal/cli/compile_build_test.go
@@ -252,3 +252,123 @@ func TestGeneratedDockerfileNoDepsNoRootSwitch(t *testing.T) {
 		t.Errorf("no deps → no root switch needed; got:\n%s", df)
 	}
 }
+
+// TestGeneratedDockerfileMixedCopiesDagSourceAndEveryGroupProject pins the fix
+// for #20. A hybrid DAG — a dag.py with dbt projects as task groups (ADR 0043),
+// which is the authoring shape leoflow targets — must bake BOTH the DAG source
+// and every group's project. generatedDockerfile branched on cfg.Dbt only and
+// had no reference to DbtGroups at all, so a group's tasks ran
+// `dbt --project-dir <project>` from WORKDIR /home/leoflow against a directory
+// that was not in the image: every dbt task exited within seconds of pod start,
+// after a green compile and a green Lite run (Lite reads from disk, so the gap
+// only appears once there is an image).
+func TestGeneratedDockerfileMixedCopiesDagSourceAndEveryGroupProject(t *testing.T) {
+	cfg := &domain.LeoflowConfig{
+		PythonVersion: "3.11",
+		Dependencies:  []string{"dbt-postgres==1.9.0"},
+		DbtGroups: map[string]*domain.DbtConfig{
+			"transform": {Project: "./transform"},
+			"marketing": {Project: "marketing"},
+		},
+	}
+	df, err := generatedDockerfile(cfg, "dag.py")
+	if err != nil {
+		t.Fatalf("generatedDockerfile() error = %v", err)
+	}
+	for _, want := range []string{
+		"COPY dag.py /home/leoflow/dag.py",
+		"ENV PYTHONPATH=/home/leoflow",
+		"COPY transform /home/leoflow/transform",
+		"COPY marketing /home/leoflow/marketing",
+	} {
+		if !strings.Contains(df, want) {
+			t.Errorf("generatedDockerfile() missing %q, got:\n%s", want, df)
+		}
+	}
+	// The USER drop must stay last, because PodSecurity's runAsNonRoot admits the
+	// pod on the final USER (#852). Ownership is not the reason — COPY lands
+	// uid=0 gid=0 whatever USER is active, measured against a real build — but
+	// the structure is still worth locking: a COPY emitted below the drop would
+	// mean the drop is no longer last.
+	drop := strings.LastIndex(df, "USER 65532:65532")
+	if drop < 0 {
+		t.Fatalf("generatedDockerfile() never drops back to the non-root user:\n%s", df)
+	}
+	for _, copyLine := range []string{"COPY dag.py", "COPY transform", "COPY marketing"} {
+		if strings.Index(df, copyLine) > drop {
+			t.Errorf("%q is emitted after the USER drop, so it would land task-owned:\n%s", copyLine, df)
+		}
+	}
+}
+
+// TestGeneratedDockerfileMixedGroupCopiesAreDeterministic guards ADR 0003's
+// byte-for-byte reproducibility. DbtGroups is a map and Go randomizes map
+// iteration, so emitting COPY lines in range order would produce a different
+// Dockerfile per compile — a cache-thrashing, unreproducible image.
+func TestGeneratedDockerfileMixedGroupCopiesAreDeterministic(t *testing.T) {
+	cfg := &domain.LeoflowConfig{
+		PythonVersion: "3.11",
+		DbtGroups: map[string]*domain.DbtConfig{
+			"zulu": {Project: "zulu"}, "alpha": {Project: "alpha"},
+			"mike": {Project: "mike"}, "bravo": {Project: "bravo"},
+		},
+	}
+	first, err := generatedDockerfile(cfg, "dag.py")
+	if err != nil {
+		t.Fatalf("generatedDockerfile() error = %v", err)
+	}
+	for i := range 100 {
+		got, gerr := generatedDockerfile(cfg, "dag.py")
+		if gerr != nil {
+			t.Fatalf("generatedDockerfile() error = %v", gerr)
+		}
+		if got != first {
+			t.Fatalf("generatedDockerfile() is not deterministic (run %d differs):\n%s\n---\n%s", i, first, got)
+		}
+	}
+}
+
+// TestGeneratedDockerfileMixedGroupProjectDotEmitsOneCopy covers project: ".".
+// filepath.Clean(".") is ".", and internal/dbt/render.go omits --project-dir for
+// that value, so dbt runs from WORKDIR and the project must land at
+// /home/leoflow itself. That single COPY already carries dag.py, so emitting a
+// separate one would be redundant.
+func TestGeneratedDockerfileMixedGroupProjectDotEmitsOneCopy(t *testing.T) {
+	cfg := &domain.LeoflowConfig{
+		PythonVersion: "3.11",
+		DbtGroups:     map[string]*domain.DbtConfig{"transform": {Project: "."}},
+	}
+	df, err := generatedDockerfile(cfg, "dag.py")
+	if err != nil {
+		t.Fatalf("generatedDockerfile() error = %v", err)
+	}
+	if n := strings.Count(df, "COPY "); n != 1 {
+		t.Errorf("generatedDockerfile() emitted %d COPY lines, want exactly 1 for project \".\":\n%s", n, df)
+	}
+	if !strings.Contains(df, "COPY . /home/leoflow/") {
+		t.Errorf("generatedDockerfile() should COPY the whole context for project \".\":\n%s", df)
+	}
+	if !strings.Contains(df, "ENV PYTHONPATH=/home/leoflow") {
+		t.Errorf("generatedDockerfile() must still set PYTHONPATH — dag.py is imported per task:\n%s", df)
+	}
+}
+
+// TestGeneratedDockerfileMixedDeduplicatesSharedProjectDir: two groups may point
+// at the same directory (different granularity or selectors over one project).
+// A duplicate COPY is a wasted layer and a diff that looks like a bug.
+func TestGeneratedDockerfileMixedDeduplicatesSharedProjectDir(t *testing.T) {
+	cfg := &domain.LeoflowConfig{
+		PythonVersion: "3.11",
+		DbtGroups: map[string]*domain.DbtConfig{
+			"staging": {Project: "./warehouse"},
+			"marts":   {Project: "warehouse"},
+		},
+	}
+	df, err := generatedDockerfile(cfg, "dag.py")
+	if err != nil {
+		t.Fatalf("generatedDockerfile() error = %v", err)
+	}
+	if n := strings.Count(df, "COPY warehouse /home/leoflow/warehouse"); n != 1 {
+		t.Errorf("generatedDockerfile() emitted the shared project COPY %d times, want 1:\n%s", n, df)
+	}
+}

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -19,6 +19,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -508,7 +509,12 @@ func kubectlNamespaceArgs(kubeconfig string) []string {
 // devDockerfile is the Dockerfile generated for a project that does not ship its
 // own: it layers the DAG source onto the task base image so the agent can import
 // it (matching runtime/Dockerfile's PYTHONPATH convention).
-func devDockerfile(baseImage, dagSource string, deps []string) string {
+//
+// dbtGroups carries the cleaned, sorted project directories of a hybrid DAG's
+// dbt task groups — see dbtGroupProjectDirs. They belong in the image for the
+// same reason the DAG source does: a group's tasks run `dbt --project-dir
+// <project>` from WORKDIR /home/leoflow (#20).
+func devDockerfile(baseImage, dagSource string, deps []string, dbtGroups []string) string {
 	base := filepath.Base(dagSource)
 	df := "FROM " + baseImage + "\n"
 	// Install the DAG's declared dependencies before COPY so the (rarely-changing)
@@ -516,7 +522,16 @@ func devDockerfile(baseImage, dagSource string, deps []string) string {
 	if len(deps) > 0 {
 		df += "RUN pip install --no-cache-dir " + strings.Join(deps, " ") + "\n"
 	}
-	df += fmt.Sprintf("COPY %s /home/leoflow/%s\nENV PYTHONPATH=/home/leoflow\n", base, base)
+	if slices.Contains(dbtGroups, ".") {
+		// project: "." — the project is the DAG directory; one COPY covers both.
+		df += "COPY . /home/leoflow/\n"
+	} else {
+		df += fmt.Sprintf("COPY %s /home/leoflow/%s\n", base, base)
+		for _, project := range dbtGroups {
+			df += fmt.Sprintf("COPY %s /home/leoflow/%s\n", project, project)
+		}
+	}
+	df += "ENV PYTHONPATH=/home/leoflow\n"
 	return df
 }
 
@@ -1317,7 +1332,7 @@ func ensureProjectDockerfile(cmd *cobra.Command, dir string, cfg *domain.Leoflow
 		return fmt.Errorf("resolving dependencies: %w", derr)
 	}
 	devPrintln(cmd.OutOrStdout(), "▸ generating a default Dockerfile (none found) …")
-	if werr := os.WriteFile(df, []byte(devDockerfile(devBaseImage, src, deps)), 0o600); werr != nil {
+	if werr := os.WriteFile(df, []byte(devDockerfile(devBaseImage, src, deps, dbtGroupProjectDirs(cfg))), 0o600); werr != nil {
 		return fmt.Errorf("writing Dockerfile: %w", werr)
 	}
 	return nil

--- a/internal/cli/dev_test.go
+++ b/internal/cli/dev_test.go
@@ -282,7 +282,7 @@ func TestDevDagImageRef(t *testing.T) {
 }
 
 func TestDevDockerfile(t *testing.T) {
-	df := devDockerfile("leoflow-base:py3.11", "dag.py", nil)
+	df := devDockerfile("leoflow-base:py3.11", "dag.py", nil, nil)
 	for _, must := range []string{"FROM leoflow-base:py3.11", "COPY dag.py", "PYTHONPATH"} {
 		if !strings.Contains(df, must) {
 			t.Errorf("generated Dockerfile missing %q:\n%s", must, df)
@@ -292,7 +292,7 @@ func TestDevDockerfile(t *testing.T) {
 		t.Errorf("no deps -> no pip install line:\n%s", df)
 	}
 	// Declared dependencies are pip-installed before COPY (cached layer).
-	withDeps := devDockerfile("leoflow-base:py3.11", "dag.py", []string{"duckdb==1.1.3", "pandas"})
+	withDeps := devDockerfile("leoflow-base:py3.11", "dag.py", []string{"duckdb==1.1.3", "pandas"}, nil)
 	if !strings.Contains(withDeps, "RUN pip install --no-cache-dir duckdb==1.1.3 pandas") {
 		t.Errorf("deps not installed in Dockerfile:\n%s", withDeps)
 	}
@@ -703,5 +703,32 @@ func writeFakeBinary(t *testing.T, path string) {
 	t.Helper()
 	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestDevDockerfileCopiesDbtGroupProjects: the `leoflow dev` cluster path had
+// the same #20 gap as the compile path — it layered only the DAG source, so a
+// hybrid DAG's dbt task groups ran against project directories that were not in
+// the image. The Lite subprocess loop reads from disk and never notices, which
+// is exactly why this went unseen: the gap only appears once something builds.
+func TestDevDockerfileCopiesDbtGroupProjects(t *testing.T) {
+	cfg := &domain.LeoflowConfig{DbtGroups: map[string]*domain.DbtConfig{
+		"transform": {Project: "./transform"},
+		"marketing": {Project: "marketing"},
+	}}
+	df := devDockerfile("leoflow-base:py3.11", "dag.py", nil, dbtGroupProjectDirs(cfg))
+	for _, want := range []string{
+		"COPY dag.py /home/leoflow/dag.py",
+		"COPY marketing /home/leoflow/marketing",
+		"COPY transform /home/leoflow/transform",
+		"ENV PYTHONPATH=/home/leoflow",
+	} {
+		if !strings.Contains(df, want) {
+			t.Errorf("devDockerfile() missing %q, got:\n%s", want, df)
+		}
+	}
+	// Sorted, for the same reproducibility reason as the compile path.
+	if strings.Index(df, "COPY marketing") > strings.Index(df, "COPY transform") {
+		t.Errorf("devDockerfile() emits group COPYs out of sorted order:\n%s", df)
 	}
 }

--- a/internal/domain/dbt_project_path.go
+++ b/internal/domain/dbt_project_path.go
@@ -3,7 +3,9 @@ package domain
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -26,16 +28,33 @@ var ErrInvalidDbtProject = errors.New("invalid dbt.project")
 // inside a pod, where it surfaces as "project directory does not exist" with no
 // indication that leoflow.yaml was the cause.
 func (c *LeoflowConfig) validateDbtProject() error {
-	if c.Dbt == nil {
-		return nil
-	}
 	// Both fields feed the same filepath.Join chain: project is joined onto the
 	// DAG directory, then manifest is joined onto that result. Validating only
 	// project would leave half the defect in place.
-	for _, f := range []struct{ field, value string }{
-		{"dbt.project", c.Dbt.Project},
-		{"dbt.manifest", c.Dbt.Manifest},
-	} {
+	fields := make([]struct{ field, value string }, 0, 2+2*len(c.DbtGroups))
+	if c.Dbt != nil {
+		fields = append(fields,
+			struct{ field, value string }{"dbt.project", c.Dbt.Project},
+			struct{ field, value string }{"dbt.manifest", c.Dbt.Manifest},
+		)
+	}
+	// dbt_groups (ADR 0043) reach the same Join chain and the same build
+	// context, and this guard used to return early whenever cfg.Dbt was nil —
+	// which is every hybrid DAG, the mode leoflow actually targets. Sorted
+	// rather than ranged so a config with several bad groups always names the
+	// same one: DbtGroups is a map, and an error message that changes between
+	// identical compiles is its own bug.
+	for _, name := range slices.Sorted(maps.Keys(c.DbtGroups)) {
+		group := c.DbtGroups[name]
+		if group == nil {
+			continue
+		}
+		fields = append(fields,
+			struct{ field, value string }{"dbt_groups." + name + ".project", group.Project},
+			struct{ field, value string }{"dbt_groups." + name + ".manifest", group.Manifest},
+		)
+	}
+	for _, f := range fields {
 		if err := containedRelativePath(f.field, f.value); err != nil {
 			return err
 		}

--- a/internal/domain/dbt_project_path_test.go
+++ b/internal/domain/dbt_project_path_test.go
@@ -116,11 +116,18 @@ func TestValidateAcceptsUsableDbtManifest(t *testing.T) {
 // early when that was nil — which is every hybrid DAG — so dbt_groups paths fed
 // the same filepath.Join chain and the same Docker build context unguarded.
 //
-// The one that is not merely confusing: "../shared" clamps to a sibling of the
-// DAG directory in the build context and normalizes to /home/shared in the
-// image, so when that directory happens to exist the build goes GREEN and bakes
-// a directory nobody named — while Lite resolves the real sibling. Lite and Pro
-// then run the same DAG against different data, silently.
+// Measured against real builds, the silent one is the ABSOLUTE path, not the
+// escaping one: Docker resolves a COPY source against the context root, so
+// "/opt/dbt" builds GREEN against <context>/opt/dbt and bakes a directory nobody
+// named. Go does the mirror thing on the host — filepath.Join swallows the
+// leading slash — which is what the file comment above already describes.
+//
+// "../shared" is loud but misleading rather than silent: the classic builder
+// refuses with "forbidden path outside the build context", and BuildKit clamps
+// to <context>/shared, so it is green only when the DAG dir has its own shared/
+// and then bakes THAT. Neither ever reaches the sibling — while Lite, which
+// resolves filepath.Abs on the host, does. Lite and Pro diverge on which
+// directory they read, and no message mentions leoflow.yaml.
 func TestValidateDbtGroupsProjectRejectsEscapingAndAbsolutePaths(t *testing.T) {
 	for _, tc := range []struct {
 		name  string

--- a/internal/domain/dbt_project_path_test.go
+++ b/internal/domain/dbt_project_path_test.go
@@ -110,3 +110,76 @@ func TestValidateAcceptsUsableDbtManifest(t *testing.T) {
 		}
 	}
 }
+
+// TestValidateDbtGroupsProjectRejectsEscapingAndAbsolutePaths extends the ADR
+// 0042 guard to ADR 0043's task groups. It covered cfg.Dbt only and returned
+// early when that was nil — which is every hybrid DAG — so dbt_groups paths fed
+// the same filepath.Join chain and the same Docker build context unguarded.
+//
+// The one that is not merely confusing: "../shared" clamps to a sibling of the
+// DAG directory in the build context and normalizes to /home/shared in the
+// image, so when that directory happens to exist the build goes GREEN and bakes
+// a directory nobody named — while Lite resolves the real sibling. Lite and Pro
+// then run the same DAG against different data, silently.
+func TestValidateDbtGroupsProjectRejectsEscapingAndAbsolutePaths(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		group *DbtConfig
+		field string
+	}{
+		{"escaping project", &DbtConfig{Project: "../shared"}, "dbt_groups.transform.project"},
+		{"absolute project", &DbtConfig{Project: "/opt/dbt"}, "dbt_groups.transform.project"},
+		{"escaping manifest", &DbtConfig{Project: "t", Manifest: "../x/manifest.json"}, "dbt_groups.transform.manifest"},
+		{"absolute manifest", &DbtConfig{Project: "t", Manifest: "/tmp/manifest.json"}, "dbt_groups.transform.manifest"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &LeoflowConfig{DbtGroups: map[string]*DbtConfig{"transform": tc.group}}
+			err := cfg.validateDbtProject()
+			if !errors.Is(err, ErrInvalidDbtProject) {
+				t.Fatalf("validateDbtProject() = %v, want ErrInvalidDbtProject", err)
+			}
+			// The message must name the key, not just the value: a config with
+			// several groups is otherwise a hunt.
+			if !strings.Contains(err.Error(), tc.field) {
+				t.Errorf("error %q does not name %q", err, tc.field)
+			}
+		})
+	}
+}
+
+// TestValidateDbtGroupsErrorIsDeterministic: DbtGroups is a map, so reporting
+// the first offender found by range order would name a different group on
+// different runs — an error message that changes between identical compiles.
+func TestValidateDbtGroupsErrorIsDeterministic(t *testing.T) {
+	cfg := &LeoflowConfig{DbtGroups: map[string]*DbtConfig{
+		"zulu": {Project: "../z"}, "alpha": {Project: "../a"},
+		"mike": {Project: "../m"}, "bravo": {Project: "../b"},
+	}}
+	first := cfg.validateDbtProject()
+	if first == nil {
+		t.Fatal("validateDbtProject() = nil, want an error")
+	}
+	for range 50 {
+		if got := cfg.validateDbtProject(); got.Error() != first.Error() {
+			t.Fatalf("error text is not stable: %q then %q", first, got)
+		}
+	}
+	if !strings.Contains(first.Error(), "dbt_groups.alpha.project") {
+		t.Errorf("want the lowest-sorted group reported first, got %q", first)
+	}
+}
+
+// TestValidateDbtGroupsAcceptsContainedPaths is the bidirectional half: the
+// guard must not start refusing the shapes the docs teach.
+func TestValidateDbtGroupsAcceptsContainedPaths(t *testing.T) {
+	cfg := &LeoflowConfig{DbtGroups: map[string]*DbtConfig{
+		"transform": {Project: "./transform"},
+		"marketing": {Project: "marketing", Manifest: "target/manifest.json"},
+		"root":      {Project: "."},
+		"empty":     {},
+		"nil":       nil,
+	}}
+	if err := cfg.validateDbtProject(); err != nil {
+		t.Errorf("validateDbtProject() = %v, want nil for contained paths", err)
+	}
+}


### PR DESCRIPTION
`generatedDockerfile` branched on the top-level `dbt:` block and had **zero** references to `DbtGroups`. For a `dag.py` with dbt task groups — the shape ADR 0043 defines and the one leoflow targets — it COPYed only the DAG source, so a group's tasks ran `dbt --project-dir <project>` from WORKDIR `/home/leoflow` against a directory that was not in the image, and exited within seconds of pod start.

Compile was green and so was Lite. Lite's subprocess executor reads the project from disk and never needs an image, so the gap could only appear once something built — which is why a mode reported from the field as "much of it does not work" passed every gate we have.

## The fix

Both the DAG source and every group's project are COPYed, deduplicated (two groups may cover one project with different granularity) and **sorted**. Sorting is not tidiness: `DbtGroups` is a map, Go randomizes map iteration, and emitting in range order gives a different Dockerfile on every compile — thrashing the layer cache and breaking the byte-for-byte reproducibility ADR 0003 promises. There is a test that renders the same config 100 times.

`project: "."` collapses to one `COPY . /home/leoflow/`: `render.go` emits no `--project-dir` for that value, so dbt runs from WORKDIR and the project must land there, and that COPY already carries `dag.py`.

The `leoflow dev` cluster path had the identical gap — `devDockerfile` also layered only the DAG source — and gets the identical fix from the same helper.

## A comment I corrected rather than inherit

The `#852` comment said the source COPY had to sit above the `USER` drop so it lands root-owned. Measured against a real docker build:

```
/home/f-after-user.txt uid=0 gid=0
/home/f-as-root.txt    uid=0 gid=0
```

`COPY` lands `uid=0 gid=0` whatever `USER` is active. The ordering buys something real but different — the **final** `USER` is non-root, which is what PodSecurity's `runAsNonRoot` admits on — and the read-only property comes from COPY's default ownership, not the position. A test I was adding would have inherited the wrong reasoning, so both are restated.

## Not in this PR

The mixed-mode e2e still hand-writes its own Dockerfile and wires `BashOperator`s around the group, which is why neither this nor #17 was caught. Removing the BYO Dockerfile and putting two `PythonOperator`s in that fixture is the next change, and it needs #991 (#17) to land first.

## Verification

- Every new assertion mutation-tested: dropping the group COPYs fails two tests, dropping the sort fails the determinism test.
- The `COPY`-ownership claim measured against a real `docker build`, not assumed.
- `go vet`, full `go test ./internal/cli/`, and every `scripts/check-*.sh` green.

Fixes #20