### PR TITLE
fix: two dbt entrypoint defects — host path baked in, and an unreachable profiles.yml (#993, #994)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,12 +165,14 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   uses. The executor is chosen by server configuration
   (`LEOFLOW_EXECUTOR_TYPE`), not by anything in the `dag.json`, so compile cannot
   infer it; it is now an explicit option that only Lite's subprocess run mode
-  sets. **Behavior change, in two places:** a bare `leoflow compile` now emits the
-  in-image relative path, and it no longer reaches for the per-DAG Lite venv's
-  `dbt` or generates a parse-time duckdb profile — that flag carried the same
-  conflation and moved with it, so a bare compile on a Lite host now needs `dbt`
-  on `PATH` and a resolvable profile, where it previously borrowed the venv's.
-  Lite itself is unaffected: `leoflow dev` sets the flag.
+  sets. **Behavior change:** a bare `leoflow compile` now emits the in-image
+  relative path, and no longer writes a parse-time duckdb profile — so a project
+  with no managed connection and no `profiles.yml` of its own fails the parse
+  instead of compiling against a stub for the wrong warehouse. Which `dbt`
+  parses the manifest is *not* part of this: that question does not depend on
+  where the DAG will run, so the per-DAG venv's `dbt` is preferred whenever the
+  host has one, image-bound compiles included. Lite itself is unaffected:
+  `leoflow dev` sets the flag.
 - **A hybrid DAG's dbt projects are baked into the image (#20).** `generatedDockerfile` branched on the top-level `dbt:` block and
   had no reference to `dbt_groups` at all: for a `dag.py` with dbt task groups —
   the authoring shape ADR 0043 defines — it COPYed only the DAG source. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,8 +167,9 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   infer it; it is now an explicit option that only Lite's subprocess run mode
   sets. **Behavior change:** a bare `leoflow compile` now emits the in-image
   relative path, and no longer writes a parse-time duckdb profile — so a project
-  with no managed connection and no `profiles.yml` of its own fails the parse
-  instead of compiling against a stub for the wrong warehouse. Which `dbt`
+  with no managed connection and no `profiles.yml` of its own has no profile for
+  `dbt parse` to resolve, and fails unless one is reachable through `~/.dbt` or
+  `DBT_PROFILES_DIR`, instead of compiling against a stub for the wrong warehouse. Which `dbt`
   parses the manifest is *not* part of this: that question does not depend on
   where the DAG will run, so the per-DAG venv's `dbt` is preferred whenever the
   host has one, image-bound compiles included. Lite itself is unaffected:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,7 +144,11 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   connection still wins — it generates a profile from the operator's credentials
   into `DBT_PROFILES_DIR`, and letting a file checked into the repository
   override that would be a downgrade, so that case is pinned by a test. Applies
-  to the top-level `dbt:` block and to `dbt_groups` alike.
+  to the top-level `dbt:` block and to `dbt_groups` alike — **and to Lite**,
+  where the same path was equally dead: the subprocess executor points
+  `DBT_PROFILES_DIR` at an empty per-task scratch dir, so a Lite project shipping
+  its own `profiles.yml` failed the same way. The Lite dbt e2e fixture asserts it
+  ships none, which is why nobody noticed.
 
 - **`compile` and `deploy --skip-build` no longer bake the operator's own
   absolute path into dbt tasks (#993).** Whether dbt's `--project-dir` is baked
@@ -161,10 +165,12 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   uses. The executor is chosen by server configuration
   (`LEOFLOW_EXECUTOR_TYPE`), not by anything in the `dag.json`, so compile cannot
   infer it; it is now an explicit option that only Lite's subprocess run mode
-  sets. **Behavior change:** a bare `leoflow compile` now emits the in-image
-  relative path. Lite is unaffected — `leoflow dev` sets the flag itself — but a
-  `dag.json` hand-compiled for a subprocess executor must now come from
-  `leoflow dev`.
+  sets. **Behavior change, in two places:** a bare `leoflow compile` now emits the
+  in-image relative path, and it no longer reaches for the per-DAG Lite venv's
+  `dbt` or generates a parse-time duckdb profile — that flag carried the same
+  conflation and moved with it, so a bare compile on a Lite host now needs `dbt`
+  on `PATH` and a resolvable profile, where it previously borrowed the venv's.
+  Lite itself is unaffected: `leoflow dev` sets the flag.
 
 - **HA chart posture: five render refusals for combinations that used to fail
   later, and the ServiceAccount / warm-pool docs the profile was missing.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,26 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`compile` and `deploy --skip-build` no longer bake the operator's own
+  absolute path into dbt tasks (#993).** Whether dbt's `--project-dir` is baked
+  as an absolute host path or as the relative path inside the image was derived
+  from `!--build` — but "we did not build an image this invocation" is a
+  different question from "this DAG will run as a subprocess on this host".
+  `leoflow compile` without `--build`, and `leoflow deploy --skip-build` (whose
+  whole purpose is reusing an image built elsewhere), were both classified local,
+  so every dbt task in the resulting `dag.json` carried something like
+  `--project-dir /Users/<someone>/work/sales/analytics`. That `dag.json` is what
+  gets registered and executed in pods, so the task exits seconds after start
+  with "project directory does not exist" and nothing points at the cause — the
+  same class as #20, through the door a CI or prebuilt-image workflow actually
+  uses. The executor is chosen by server configuration
+  (`LEOFLOW_EXECUTOR_TYPE`), not by anything in the `dag.json`, so compile cannot
+  infer it; it is now an explicit option that only Lite's subprocess run mode
+  sets. **Behavior change:** a bare `leoflow compile` now emits the in-image
+  relative path. Lite is unaffected — `leoflow dev` sets the flag itself — but a
+  `dag.json` hand-compiled for a subprocess executor must now come from
+  `leoflow dev`.
+
 - **HA chart posture: five render refusals for combinations that used to fail
   later, and the ServiceAccount / warm-pool docs the profile was missing.**
   `podDisruptionBudget.enabled` keyed on a real boolean, so the string spellings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,22 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **A dbt task with no managed connection can find its project's own
+  `profiles.yml` (#994).** The base image points `DBT_PROFILES_DIR` at an
+  ephemeral `/tmp` dir so dbt's writes stay off the read-only project (#852) —
+  and the side effect was that dbt never looked inside the project at all, so a
+  project that ships its own `profiles.yml` failed in the pod with
+  `Invalid value for '--profiles-dir': Path '/tmp/leoflow/dbt' does not exist`,
+  while the code comment claimed it was using "the image's baked profiles.yml".
+  `--profiles-dir` is now baked at the project when the project ships one and no
+  managed connection is configured. Only reads go through it: measured in a real
+  image against real dbt, the parse succeeds and `perf_info.json` still lands in
+  `/tmp/leoflow/dbt/target`, so `readOnlyRootFilesystem` is unaffected. A managed
+  connection still wins — it generates a profile from the operator's credentials
+  into `DBT_PROFILES_DIR`, and letting a file checked into the repository
+  override that would be a downgrade, so that case is pinned by a test. Applies
+  to the top-level `dbt:` block and to `dbt_groups` alike.
+
 - **`compile` and `deploy --skip-build` no longer bake the operator's own
   absolute path into dbt tasks (#993).** Whether dbt's `--project-dir` is baked
   as an absolute host path or as the relative path inside the image was derived

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -322,9 +322,6 @@ func liteDbtBinAt(home, dagID string) string {
 	return ""
 }
 
-// liteDbtBin resolves liteDbtBinAt against the user's home, so a Lite compile parses
-// the manifest with the same dbt the task runs — not a system dbt the user may not
-// have (L1).
 // dbtParseBinAt picks the dbt that parses the manifest: the DAG's own per-DAG
 // venv dbt when this host has one, else whatever is on PATH.
 //

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -325,12 +325,28 @@ func liteDbtBinAt(home, dagID string) string {
 // liteDbtBin resolves liteDbtBinAt against the user's home, so a Lite compile parses
 // the manifest with the same dbt the task runs — not a system dbt the user may not
 // have (L1).
-func liteDbtBin(dagID string) string {
+// dbtParseBinAt picks the dbt that parses the manifest: the DAG's own per-DAG
+// venv dbt when this host has one, else whatever is on PATH.
+//
+// Deliberately NOT a function of where the DAG will run. Tying it to that was
+// the #993 conflation one layer down — a venv dbt is that DAG's own, pinned to
+// the adapter its leoflow.yaml declares, while PATH's is whatever the operator
+// happens to have. When both exist the venv one is strictly the better parser,
+// whichever executor the artifact ends up on.
+func dbtParseBinAt(home, dagID string) string {
+	if v := liteDbtBinAt(home, dagID); v != "" {
+		return v
+	}
+	return "dbt"
+}
+
+// dbtParseBin is dbtParseBinAt against the real home.
+func dbtParseBin(dagID string) string {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return ""
+		return "dbt"
 	}
-	return liteDbtBinAt(home, dagID)
+	return dbtParseBinAt(home, dagID)
 }
 
 // writeParseDuckdbProfile writes a temporary default-duckdb profiles.yml for

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -157,10 +157,12 @@ func runDbtCompile(cmd *cobra.Command, dir string, o compileOptions, cfg *domain
 	if perr != nil {
 		return perr
 	}
-	// A non-build compile is a Lite/host build (subprocess executor), same as the
-	// dbt_group path. On Lite: --project-dir must be absolute (the task runs from a
-	// temp workdir), and with no managed connection each task gets the zero-config
-	// duckdb profile step — unless the project ships its own profiles.yml (#575).
+	// Lite (subprocess executor): --project-dir must be absolute, because the task
+	// does not run from the project — it runs from the workspace root — and with no
+	// managed connection each task gets the zero-config duckdb profile step, unless
+	// the project ships its own profiles.yml (#575). o.local is set by `leoflow
+	// dev`'s subprocess mode and by nothing else; deriving it from !o.build is what
+	// #993 was.
 	local := o.local
 	spec, err := dbt.Compile(manifest, dbt.Meta{
 		DagID:       cfg.DagID,

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -175,6 +175,7 @@ func runDbtCompile(cmd *cobra.Command, dir string, o compileOptions, cfg *domain
 		Profile:     profile,
 		Schema:      cfg.Dbt.Schema,
 		ProjectDir:  dbtProjectDir(dir, cfg.Dbt.Project, local),
+		ProfilesDir: dbtProfilesDir(dir, cfg.Dbt.Project, local),
 		Local:       local && !dbtProjectHasProfiles(filepath.Join(dir, cfg.Dbt.Project)),
 	})
 	if err != nil {
@@ -253,6 +254,7 @@ func expandDbtGroupsInFile(cmd *cobra.Command, dir, output string, cfg *domain.L
 			Profile:     profile,
 			Schema:      gc.Schema,
 			ProjectDir:  dbtProjectDir(dir, gc.Project, local),
+			ProfilesDir: dbtProfilesDir(dir, gc.Project, local),
 			// Auto-default duckdb (L4) only when the project has no profiles.yml of its
 			// own — never override a warehouse the user configured.
 			Local: local && !dbtProjectHasProfiles(filepath.Join(dir, gc.Project)),
@@ -336,6 +338,23 @@ func liteDbtBin(dagID string) string {
 // profiles.yml (respected) or its profile name can't be read.
 // dbtProjectHasProfiles reports whether a dbt project ships its own profiles.yml —
 // which the zero-config default duckdb (L4) must never override.
+// dbtProfilesDir returns the --profiles-dir to bake, or "" to leave dbt to
+// DBT_PROFILES_DIR. A project that ships its own profiles.yml has to be pointed
+// at explicitly: the base image aims DBT_PROFILES_DIR at an ephemeral /tmp dir
+// so dbt's writes stay off the read-only project (#852), which also means dbt
+// never looks inside the project (#994). Same absolute-vs-relative rule as
+// dbtProjectDir — the profiles live in the project directory, so it is the same
+// path.
+func dbtProfilesDir(dagDir, project string, local bool) string {
+	if !dbtProjectHasProfiles(filepath.Join(dagDir, project)) {
+		return ""
+	}
+	if d := dbtProjectDir(dagDir, project, local); d != "" {
+		return d
+	}
+	return "."
+}
+
 func dbtProjectHasProfiles(projectDir string) bool {
 	_, err := os.Stat(filepath.Join(projectDir, "profiles.yml"))
 	return err == nil

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -32,6 +32,20 @@ type compileOptions struct {
 	dockerfile string
 	build      bool
 	push       bool
+	// local says the compiled DAG will run under a SUBPROCESS executor on this
+	// host — Lite — rather than in a pod. It decides whether dbt's --project-dir
+	// is baked as an absolute workspace path or as the relative path inside the
+	// image, and which dbt binary parses the manifest.
+	//
+	// It is set explicitly rather than derived from `build`, which was the #993
+	// bug: "we did not build an image this invocation" is a different question.
+	// `compile` without --build and `deploy --skip-build` both target an image
+	// that exists or will be built elsewhere, and both used to bake the
+	// operator's own absolute path into every dbt task of a dag.json destined
+	// for a cluster. The executor is chosen by server configuration
+	// (LEOFLOW_EXECUTOR_TYPE), not by anything in the dag.json, so compile
+	// cannot infer this — only Lite's subprocess mode knows.
+	local bool
 }
 
 func newCompileCommand() *cobra.Command {
@@ -101,7 +115,7 @@ func runCompile(cmd *cobra.Command, dir string, o compileOptions) error {
 	}); rerr != nil {
 		return rerr
 	}
-	if eerr := expandDbtGroupsInFile(cmd, dir, o.output, cfg, !o.build); eerr != nil {
+	if eerr := expandDbtGroupsInFile(cmd, dir, o.output, cfg, o.local); eerr != nil {
 		return eerr
 	}
 	if oerr := overlayProject(o.output, cfg); oerr != nil {
@@ -135,7 +149,7 @@ func runDbtCompile(cmd *cobra.Command, dir string, o compileOptions, cfg *domain
 	if ierr := checkImageFlags(cmd, o.build, o.push, image); ierr != nil {
 		return ierr
 	}
-	manifest, err := loadDbtManifest(cmd, dir, cfg.Dbt, !o.build, cfg.DagID)
+	manifest, err := loadDbtManifest(cmd, dir, cfg.Dbt, o.local, cfg.DagID)
 	if err != nil {
 		return err
 	}
@@ -147,7 +161,7 @@ func runDbtCompile(cmd *cobra.Command, dir string, o compileOptions, cfg *domain
 	// dbt_group path. On Lite: --project-dir must be absolute (the task runs from a
 	// temp workdir), and with no managed connection each task gets the zero-config
 	// duckdb profile step — unless the project ships its own profiles.yml (#575).
-	local := !o.build
+	local := o.local
 	spec, err := dbt.Compile(manifest, dbt.Meta{
 		DagID:       cfg.DagID,
 		DagVersion:  o.dagVersion,

--- a/internal/cli/dbt_manifest.go
+++ b/internal/cli/dbt_manifest.go
@@ -23,7 +23,16 @@ import (
 // excluded from the unit-coverage floor (ADR 0011), like the other external-binary
 // orchestrators (managed_postgres.go, …). The pure branches (a pinned manifest, the
 // dbt-not-found error, the venv/profile resolution) are unit-tested via their helpers.
-func loadDbtManifest(cmd *cobra.Command, dir string, c *domain.DbtConfig, local bool, dagID string) ([]byte, error) {
+// localWarehouse is NOT "where the DAG will run" in general — the dbt binary
+// above is chosen without reference to it (#993). It says specifically that this
+// compile targets Lite's zero-config duckdb warehouse, which genuinely is a
+// property of the runtime target: that warehouse exists only for the subprocess
+// executor, and `dbt parse` needs the same profile the task will get. Writing a
+// duckdb stub for an image-bound compile would let a DAG destined for Snowflake
+// parse against duckdb and produce a manifest for the wrong adapter — a green
+// compile with a silently wrong artifact, which is the class this file has spent
+// the release removing.
+func loadDbtManifest(cmd *cobra.Command, dir string, c *domain.DbtConfig, localWarehouse bool, dagID string) ([]byte, error) {
 	projectDir := filepath.Join(dir, c.Project)
 	if c.Manifest != "" {
 		path := filepath.Join(projectDir, c.Manifest)
@@ -33,12 +42,7 @@ func loadDbtManifest(cmd *cobra.Command, dir string, c *domain.DbtConfig, local 
 		}
 		return data, nil
 	}
-	dbtBin := "dbt"
-	if local {
-		if v := liteDbtBin(dagID); v != "" {
-			dbtBin = v
-		}
-	}
+	dbtBin := dbtParseBin(dagID)
 	if dbtBin == "dbt" {
 		if _, lerr := exec.LookPath("dbt"); lerr != nil {
 			return nil, fmt.Errorf("dbt is not on PATH: install dbt-core and your adapter (e.g. `pip install dbt-postgres`), or set dbt.manifest in leoflow.yaml to a pre-built manifest.json")
@@ -50,7 +54,7 @@ func loadDbtManifest(cmd *cobra.Command, dir string, c *domain.DbtConfig, local 
 	// Zero-config local warehouse: `dbt parse` needs a profile too, so give it a
 	// default duckdb one when the Lite project has no connection and no profiles.yml
 	// — the compile-time half of L4 (the runtime writes the same at task time).
-	if local && c.Connection == "" {
+	if localWarehouse && c.Connection == "" {
 		if pdir := writeParseDuckdbProfile(dir, c); pdir != "" {
 			defer func() { _ = os.RemoveAll(pdir) }() //nolint:errcheck // best-effort cleanup of a temp dir
 			pc.Env = append(pc.Env, "DBT_PROFILES_DIR="+pdir)

--- a/internal/cli/dbt_projectdir_test.go
+++ b/internal/cli/dbt_projectdir_test.go
@@ -148,3 +148,36 @@ func TestCompiledEntrypointsAreWiredForTheRightTarget(t *testing.T) {
 		})
 	}
 }
+
+// TestDbtParseBinDoesNotDependOnTheRuntimeTarget separates the last piece of the
+// #993 conflation. Which dbt parses the manifest was gated on `local` — "the DAG
+// will run on this host" — but that is a different question from "which dbt on
+// this host is the better parser". A per-DAG venv dbt is that DAG's own, pinned
+// to the adapter its leoflow.yaml declares; PATH's is whatever the operator
+// happens to have installed. When both exist the venv one is strictly better,
+// whether the compiled artifact ends up in a pod or in a subprocess — and after
+// #993 a bare `leoflow compile` stopped being "local", so it silently lost
+// access to the venv dbt it had been using.
+func TestDbtParseBinDoesNotDependOnTheRuntimeTarget(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, ".leoflow", "dev", "venvs", "sales", "bin")
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	venvDbt := filepath.Join(binDir, "dbt")
+	if err := os.WriteFile(venvDbt, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { //nolint:gosec // test stub must be executable
+		t.Fatal(err)
+	}
+
+	if got := dbtParseBinAt(home, "sales"); got != venvDbt {
+		t.Errorf("dbtParseBinAt = %q, want the DAG's own venv dbt %q", got, venvDbt)
+	}
+	// No venv for this DAG: fall back to PATH, which is what the not-found error
+	// downstream is written about.
+	if got := dbtParseBinAt(home, "other"); got != "dbt" {
+		t.Errorf("dbtParseBinAt with no venv = %q, want \"dbt\"", got)
+	}
+	if got := dbtParseBinAt("", "sales"); got != "dbt" {
+		t.Errorf("dbtParseBinAt with no home = %q, want \"dbt\"", got)
+	}
+}

--- a/internal/cli/dbt_projectdir_test.go
+++ b/internal/cli/dbt_projectdir_test.go
@@ -181,3 +181,59 @@ func TestDbtParseBinDoesNotDependOnTheRuntimeTarget(t *testing.T) {
 		t.Errorf("dbtParseBinAt with no home = %q, want \"dbt\"", got)
 	}
 }
+
+// TestManifestParseUsesTheVenvDbtEvenForAnImageBoundCompile locks the WIRING of
+// the parse-binary split, not the leaf. dbtParseBinAt has a table test above;
+// re-gating loadDbtManifest's call to it on the runtime target leaves that table
+// green, which is round one's lesson repeating one layer down: the leaf was
+// never wrong, the wiring was.
+//
+// It also cannot be reached through TestCompiledEntrypointsAreWiredForTheRightTarget,
+// because every case there pins `manifest:` and loadDbtManifest short-circuits
+// before choosing a binary. This one deliberately leaves the manifest unpinned.
+func TestManifestParseUsesTheVenvDbtEvenForAnImageBoundCompile(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, ".leoflow", "dev", "venvs", "sales", "bin")
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	// Exits 3 so the error is unmistakably THIS binary and not PATH's.
+	if err := os.WriteFile(filepath.Join(binDir, "dbt"), []byte("#!/bin/sh\nexit 3\n"), 0o755); err != nil { //nolint:gosec // a test stub must be executable
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir()) // no dbt on PATH at all
+
+	dir := t.TempDir()
+	project := filepath.Join(dir, "analytics")
+	if err := os.MkdirAll(project, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(project, "dbt_project.yml"), []byte("name: a\nversion: \"1.0\"\nprofile: a\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// No `manifest:` — this is the path that actually runs `dbt parse`.
+	yaml := "schema_version: \"1.0\"\ndag_id: sales\nowner: t\ndbt:\n  project: analytics\n  schedule: \"@daily\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "leoflow.yaml"), []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	// local:false — an IMAGE-bound compile. It must still prefer the venv dbt:
+	// that is the DAG's own, pinned to the adapter its leoflow.yaml declares.
+	err := runCompile(cmd, dir, compileOptions{output: filepath.Join(dir, "dag.json"), image: "reg/s:v1", dagVersion: "v1"})
+	if err == nil {
+		t.Fatal("expected the stub dbt to fail the parse")
+	}
+	if strings.Contains(err.Error(), "not on PATH") {
+		t.Fatalf("an image-bound compile fell back to PATH instead of the DAG's own venv dbt: %v", err)
+	}
+	if !strings.Contains(err.Error(), "exit status 3") {
+		t.Errorf("error %q does not show the venv stub ran", err)
+	}
+}

--- a/internal/cli/dbt_projectdir_test.go
+++ b/internal/cli/dbt_projectdir_test.go
@@ -29,3 +29,54 @@ func TestDbtProjectDir(t *testing.T) {
 		})
 	}
 }
+
+// TestCompileOptionsLocalIsNotDerivedFromBuild pins the fix for #993.
+//
+// `local` selects between two incompatible meanings of --project-dir: an
+// absolute host path for a subprocess executor running from a per-task temp
+// workdir (Lite), and the relative path inside the image for a pod (Pro). It
+// used to be derived as `!o.build`, which reads as "we did not build an image
+// this invocation" — a different question. `leoflow compile` without --build
+// and `leoflow deploy --skip-build` both mean "the image already exists or will
+// be built elsewhere", and both were classified local, so every dbt task in the
+// produced dag.json carried the operator's own absolute path:
+//
+//	dbt run --select mart --project-dir /Users/<someone>/work/sales/analytics
+//
+// That dag.json is what gets registered and executed in pods, so the task exits
+// seconds after start with "project directory does not exist" and nothing points
+// at the real cause. Same class as #20, through a different door — and the more
+// likely one for a CI or prebuilt-image workflow.
+//
+// The executor is chosen by SERVER configuration (LEOFLOW_EXECUTOR_TYPE), not by
+// anything in the dag.json, so compile cannot infer it. It has to be told, and
+// only Lite's subprocess mode knows the answer is yes.
+func TestCompileOptionsLocalIsNotDerivedFromBuild(t *testing.T) {
+	for _, c := range []struct {
+		name  string
+		opts  compileOptions
+		local bool
+	}{
+		{"bare compile targets an image", compileOptions{}, false},
+		{"compile --build targets an image", compileOptions{build: true}, false},
+		{"deploy targets an image", compileOptions{build: true, push: true}, false},
+		{"deploy --skip-build still targets an image", compileOptions{}, false},
+		{"only Lite's subprocess mode is local", compileOptions{local: true}, true},
+		{"Lite's cluster mode is not", compileOptions{build: true, builder: "docker"}, false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if c.opts.local != c.local {
+				t.Errorf("compileOptions%+v local = %v, want %v", c.opts, c.opts.local, c.local)
+			}
+			// And the value must reach the baked flag unchanged: deriving it
+			// from build is what produced the host path.
+			got := dbtProjectDir("/work/sales", "analytics", c.opts.local)
+			if c.local && got != "/work/sales/analytics" {
+				t.Errorf("local build baked %q, want the absolute workspace path", got)
+			}
+			if !c.local && got != "analytics" {
+				t.Errorf("image build baked %q, want the relative in-image path", got)
+			}
+		})
+	}
+}

--- a/internal/cli/dbt_projectdir_test.go
+++ b/internal/cli/dbt_projectdir_test.go
@@ -1,8 +1,15 @@
 package cli
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 // TestDbtProjectDir: for an image build (Pro) the dbt --project-dir stays
@@ -30,52 +37,113 @@ func TestDbtProjectDir(t *testing.T) {
 	}
 }
 
-// TestCompileOptionsLocalIsNotDerivedFromBuild pins the fix for #993.
+// TestCompiledEntrypointsAreWiredForTheRightTarget locks the WIRING of #993 and
+// #994, through runCompile, because that is where both bugs lived.
 //
-// `local` selects between two incompatible meanings of --project-dir: an
-// absolute host path for a subprocess executor running from a per-task temp
-// workdir (Lite), and the relative path inside the image for a pod (Pro). It
-// used to be derived as `!o.build`, which reads as "we did not build an image
-// this invocation" — a different question. `leoflow compile` without --build
-// and `leoflow deploy --skip-build` both mean "the image already exists or will
-// be built elsewhere", and both were classified local, so every dbt task in the
-// produced dag.json carried the operator's own absolute path:
+// The leaf helpers were never wrong: dbtProjectDir computed a correct absolute
+// path from a wrong input, and decorateCommands appended a correct flag it was
+// never given. So a test of either passes with both bugs fully restored —
+// measured, both packages green with `local := !o.build` back. A regression test
+// that cannot fail on the actual defect is not one.
 //
-//	dbt run --select mart --project-dir /Users/<someone>/work/sales/analytics
+// #993: `local` decided between an absolute host path for a subprocess executor
+// and the relative in-image path for a pod, and it was derived from `!o.build` —
+// "we did not build an image this invocation", a different question. A bare
+// compile and `deploy --skip-build` both baked the operator's own path into a
+// dag.json destined for pods.
 //
-// That dag.json is what gets registered and executed in pods, so the task exits
-// seconds after start with "project directory does not exist" and nothing points
-// at the real cause. Same class as #20, through a different door — and the more
-// likely one for a CI or prebuilt-image workflow.
-//
-// The executor is chosen by SERVER configuration (LEOFLOW_EXECUTOR_TYPE), not by
-// anything in the dag.json, so compile cannot infer it. It has to be told, and
-// only Lite's subprocess mode knows the answer is yes.
-func TestCompileOptionsLocalIsNotDerivedFromBuild(t *testing.T) {
+// #994: the base image aims DBT_PROFILES_DIR at /tmp so dbt's writes stay off
+// the read-only project (#852), so dbt never looks inside the project and a
+// project shipping its own profiles.yml was unreachable.
+func TestCompiledEntrypointsAreWiredForTheRightTarget(t *testing.T) {
+	manifest, merr := os.ReadFile(filepath.Join("..", "dbt", "testdata", "manifest_wide.json"))
+	if merr != nil {
+		t.Fatalf("reading fixture manifest: %v", merr)
+	}
+
 	for _, c := range []struct {
-		name  string
-		opts  compileOptions
-		local bool
+		name        string
+		local       bool
+		hasProfiles bool
+		want        []string
+		deny        []string
 	}{
-		{"bare compile targets an image", compileOptions{}, false},
-		{"compile --build targets an image", compileOptions{build: true}, false},
-		{"deploy targets an image", compileOptions{build: true, push: true}, false},
-		{"deploy --skip-build still targets an image", compileOptions{}, false},
-		{"only Lite's subprocess mode is local", compileOptions{local: true}, true},
-		{"Lite's cluster mode is not", compileOptions{build: true, builder: "docker"}, false},
+		{
+			name: "an image-bound compile bakes in-image relative paths",
+			want: []string{"--project-dir analytics"},
+			// The absolute form is the #993 defect; any leading slash after the
+			// flag means a host path rode into an artifact destined for a pod.
+			deny: []string{"--project-dir /", "--profiles-dir"},
+		},
+		{
+			name:  "a Lite compile bakes the absolute workspace path",
+			local: true,
+			want:  []string{"--project-dir /"},
+		},
+		{
+			name:        "a project shipping profiles.yml is pointed at it",
+			hasProfiles: true,
+			want:        []string{"--project-dir analytics", "--profiles-dir analytics"},
+		},
 	} {
 		t.Run(c.name, func(t *testing.T) {
-			if c.opts.local != c.local {
-				t.Errorf("compileOptions%+v local = %v, want %v", c.opts, c.opts.local, c.local)
+			dir := t.TempDir()
+			project := filepath.Join(dir, "analytics")
+			if err := os.MkdirAll(project, 0o750); err != nil {
+				t.Fatal(err)
 			}
-			// And the value must reach the baked flag unchanged: deriving it
-			// from build is what produced the host path.
-			got := dbtProjectDir("/work/sales", "analytics", c.opts.local)
-			if c.local && got != "/work/sales/analytics" {
-				t.Errorf("local build baked %q, want the absolute workspace path", got)
+			if err := os.WriteFile(filepath.Join(project, "manifest.json"), manifest, 0o600); err != nil {
+				t.Fatal(err)
 			}
-			if !c.local && got != "analytics" {
-				t.Errorf("image build baked %q, want the relative in-image path", got)
+			if c.hasProfiles {
+				if err := os.WriteFile(filepath.Join(project, "profiles.yml"), []byte("analytics:\n  target: dev\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			yaml := "schema_version: \"1.0\"\ndag_id: sales\nowner: t\ndbt:\n  project: analytics\n  manifest: manifest.json\n  schedule: \"@daily\"\n"
+			if err := os.WriteFile(filepath.Join(dir, "leoflow.yaml"), []byte(yaml), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			cmd := &cobra.Command{}
+			cmd.SetContext(context.Background())
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+
+			opts := compileOptions{output: filepath.Join(dir, "dag.json"), image: "reg/sales:v1", dagVersion: "v1", local: c.local}
+			if rerr := runCompile(cmd, dir, opts); rerr != nil {
+				t.Fatalf("runCompile: %v\noutput:\n%s", rerr, out.String())
+			}
+			data, rerr := os.ReadFile(filepath.Join(dir, "dag.json"))
+			if rerr != nil {
+				t.Fatal(rerr)
+			}
+			var spec struct {
+				Tasks []struct {
+					TaskID     string `json:"task_id"`
+					Entrypoint string `json:"entrypoint"`
+				} `json:"tasks"`
+			}
+			if uerr := json.Unmarshal(data, &spec); uerr != nil {
+				t.Fatal(uerr)
+			}
+			if len(spec.Tasks) == 0 {
+				t.Fatal("compiled no tasks — the fixture stopped exercising the dbt path")
+			}
+			// Every task, not the first: the flags are appended per task and a
+			// partial application is exactly the shape that would slip through.
+			for _, task := range spec.Tasks {
+				for _, w := range c.want {
+					if !strings.Contains(task.Entrypoint, w) {
+						t.Errorf("task %q entrypoint %q is missing %q", task.TaskID, task.Entrypoint, w)
+					}
+				}
+				for _, d := range c.deny {
+					if strings.Contains(task.Entrypoint, d) {
+						t.Errorf("task %q entrypoint %q must not contain %q", task.TaskID, task.Entrypoint, d)
+					}
+				}
 			}
 		})
 	}

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -734,7 +734,9 @@ func devSubprocessSetup(ctx context.Context, cmd *cobra.Command, ws *WorkspaceSp
 			if _, perr := ensureWorkspaceDagVenvs(ctx, cmd, curWs, home, runtimeSrc); perr != nil {
 				return perr
 			}
-			return devCompileAndRegisterAll(ctx, cmd, curWs, compileOptions{image: o.image}, token, nil, devURL(o.port))
+			// local: this is the subprocess run mode, so tasks execute on this
+			// host and dbt needs the absolute workspace path (#993).
+			return devCompileAndRegisterAll(ctx, cmd, curWs, compileOptions{image: o.image, local: true}, token, nil, devURL(o.port))
 		}
 	}
 	return env, makeReload, nil

--- a/internal/dbt/compile.go
+++ b/internal/dbt/compile.go
@@ -26,6 +26,15 @@ type Meta struct {
 	Schema string
 	// ProjectDir scopes the dbt commands with --project-dir for a subdir project.
 	ProjectDir string
+	// ProfilesDir, when set, is passed as --profiles-dir. It is how a project
+	// that ships its own profiles.yml gets honored: the base image points
+	// DBT_PROFILES_DIR at an ephemeral /tmp dir so dbt's WRITES stay off the
+	// read-only project (#852), and the side effect is that dbt never looks
+	// inside the project at all (#994). Only reads happen through this — target
+	// and log paths keep their own env and still land in /tmp. Ignored when a
+	// managed connection is set: that path generates a profile into
+	// DBT_PROFILES_DIR and must win over a checked-in file.
+	ProfilesDir string
 	// Local marks a Lite/host build: with no Connection, each task is prefixed with
 	// the step that writes a default duckdb profiles.yml (the zero-config local
 	// warehouse). Ignored on the Pro/image path. See Options.Local.
@@ -45,6 +54,7 @@ func Compile(manifestJSON []byte, meta Meta) (domain.DAGSpec, error) {
 		Profile:     meta.Profile,
 		Schema:      meta.Schema,
 		ProjectDir:  meta.ProjectDir,
+		ProfilesDir: meta.ProfilesDir,
 		Local:       meta.Local,
 	})
 	if err != nil {

--- a/internal/dbt/render.go
+++ b/internal/dbt/render.go
@@ -47,6 +47,15 @@ type Options struct {
 	// ProjectDir scopes each command with --project-dir so dbt finds dbt_project.yml
 	// when the project is a subdirectory of the DAG (#401). "." or empty adds nothing.
 	ProjectDir string
+	// ProfilesDir, when set, is passed as --profiles-dir. It is how a project that
+	// ships its own profiles.yml gets honored: the base image points
+	// DBT_PROFILES_DIR at an ephemeral /tmp dir so dbt's WRITES stay off the
+	// read-only project (#852), and the side effect is that dbt never looks inside
+	// the project at all (#994). Only reads go through this — DBT_TARGET_PATH and
+	// DBT_LOG_PATH still carry the writes to /tmp. Ignored when Connection is set:
+	// that path generates a profile into DBT_PROFILES_DIR and must win over a
+	// file checked into the project.
+	ProfilesDir string
 	// Local marks a Lite/host build: with no Connection, each task is prefixed with a
 	// step that writes a default duckdb profiles.yml — a zero-config local warehouse,
 	// no server and no connection needed (L4). Ignored on the Pro/image path.
@@ -194,7 +203,15 @@ func decorateCommands(tasks []domain.TaskSpec, opts Options) {
 		}
 		prefix = fmt.Sprintf("python -m leoflow_runtime --dbt-default-duckdb %s %s && ", opts.Profile, db)
 	default:
-		return // Pro/non-local without a connection: the image's baked profiles.yml
+		// No managed connection: the profile comes from the project's own
+		// profiles.yml, which dbt cannot find on its own because the base image
+		// points DBT_PROFILES_DIR at /tmp (#852, #994).
+		if opts.ProfilesDir != "" {
+			for i := range tasks {
+				tasks[i].Entrypoint += " --profiles-dir " + opts.ProfilesDir
+			}
+		}
+		return
 	}
 	for i := range tasks {
 		tasks[i].Entrypoint = prefix + tasks[i].Entrypoint

--- a/internal/dbt/render_test.go
+++ b/internal/dbt/render_test.go
@@ -245,3 +245,62 @@ func TestRenderGroupedDeclaresManagedConnection(t *testing.T) {
 		}
 	}
 }
+
+// TestDecorateCommandsHonorsAProjectBakedProfilesYml pins #994.
+//
+// The base image sets DBT_PROFILES_DIR=/tmp/leoflow/dbt so dbt's writes land on
+// an ephemeral dir instead of the read-only project (#852). The side effect is
+// that dbt never looks inside the project — so a dbt task with no managed
+// connection, whose project ships its own profiles.yml, failed in the pod:
+//
+//	Invalid value for '--profiles-dir': Path '/tmp/leoflow/dbt' does not exist
+//	(and once created) Could not find profile named 'transform'
+//
+// while the default branch's comment claimed it was using "the image's baked
+// profiles.yml". Reading a profiles.yml out of the project is safe against the
+// read-only posture — only dbt's writes needed redirecting, and DBT_TARGET_PATH
+// and DBT_LOG_PATH still carry them to /tmp.
+func TestDecorateCommandsHonorsAProjectBakedProfilesYml(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		opts Options
+		want string
+		deny string
+	}{
+		{
+			name: "no connection, project ships profiles.yml",
+			opts: Options{ProjectDir: "analytics", ProfilesDir: "analytics"},
+			want: "--profiles-dir analytics",
+		},
+		{
+			name: "project is the DAG dir",
+			opts: Options{ProfilesDir: "."},
+			want: "--profiles-dir .",
+		},
+		{
+			name: "no profiles.yml — nothing is added, DBT_PROFILES_DIR still governs",
+			opts: Options{ProjectDir: "analytics"},
+			deny: "--profiles-dir",
+		},
+		{
+			// A managed connection writes its generated profile to
+			// DBT_PROFILES_DIR; overriding that would send dbt to the project's
+			// checked-in file instead of the operator's credentials.
+			name: "a managed connection wins over a baked profiles.yml",
+			opts: Options{ProjectDir: "analytics", ProfilesDir: "analytics", Connection: "warehouse", Profile: "analytics"},
+			deny: "--profiles-dir",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			tasks := []domain.TaskSpec{{TaskID: "mart", Entrypoint: "dbt run --select mart"}}
+			decorateCommands(tasks, c.opts)
+			got := tasks[0].Entrypoint
+			if c.want != "" && !strings.Contains(got, c.want) {
+				t.Errorf("entrypoint %q does not contain %q", got, c.want)
+			}
+			if c.deny != "" && strings.Contains(got, c.deny) {
+				t.Errorf("entrypoint %q must not contain %q", got, c.deny)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Two defects in what gets baked into a dbt task's entrypoint. Both are GA gates, both surfaced while reviewing #20, and both share the same wiring in `compile.go`, so they ride together.

## #993 — `compile` and `deploy --skip-build` bake the operator's own absolute path

dbt's `--project-dir` is baked one of two incompatible ways: an absolute workspace path for a subprocess executor running from a per-task temp workdir, or the relative path inside the image for a pod. Which one was decided by `!o.build` — and *"we did not build an image this invocation"* is a different question from *"this DAG will run on this host"*.

So `leoflow compile` without `--build`, and `leoflow deploy --skip-build` whose entire purpose is reusing an image built elsewhere, were both classified local. Measured against the release binary, on a project whose `leoflow.yaml` says `project: analytics`:

```
before   --project-dir /var/folders/.../T/tmp.2fxBvspSK3/analytics
after    --project-dir analytics
```

That `dag.json` is what gets registered and executed in pods, so the task exits seconds after start with "project directory does not exist" and nothing points at `leoflow.yaml`. Same class as #20, through the door a CI or prebuilt-image workflow actually walks.

**Why it has to be explicit:** the executor is chosen by server configuration (`LEOFLOW_EXECUTOR_TYPE`, set by Lite's subprocess mode at `dev.go:1608`), not by anything in the `dag.json`. Compile cannot infer it from the artifact it produces. `local` is now a field on `compileOptions`, set in exactly one place — Lite's subprocess run mode. Lite's cluster mode already builds an image and is unchanged. Which `dbt` parses the manifest is deliberately *not* on this flag: that question does not depend on where the DAG will run, so the per-DAG venv's `dbt` is preferred whenever the host has one, image-bound compiles included.

**Behavior change:** a bare `leoflow compile` emits the in-image relative path now. Lite is unaffected because `leoflow dev` sets the flag itself, but a `dag.json` hand-compiled for a subprocess executor has to come from `leoflow dev`. I deliberately did not add a `--local` escape hatch — the env var is documented but no workflow registers a hand-compiled `dag.json` against a subprocess server, so it would be surface for a workflow I cannot point at. Say the word if that judgement is wrong.

## #994 — a project's own `profiles.yml` was unreachable

The base image points `DBT_PROFILES_DIR` at `/tmp/leoflow/dbt` so dbt's writes stay off the read-only project. That part is right and it is what lets a task pod run with `readOnlyRootFilesystem` (#852). The side effect is that dbt then never looks inside the project at all — so a project shipping its own `profiles.yml`, with no managed connection, died in the pod while the code comment claimed it was using "the image's baked profiles.yml".

Proven against **real dbt in a real image**, not asserted from a string:

```
without --profiles-dir   Error: Invalid value for '--profiles-dir':
                         Path '/tmp/leoflow/dbt' does not exist.
with --profiles-dir      Registered adapter: duckdb=1.9.6
                         ...parse completes
                         Performance info: /tmp/leoflow/dbt/target/perf_info.json
```

That last line is the important one: the read-only posture survives, because only the profile **read** goes through the new flag while `DBT_TARGET_PATH` and `DBT_LOG_PATH` still carry every write to `/tmp`.

A managed connection still wins — it generates a profile from the operator's credentials into `DBT_PROFILES_DIR`, and letting a file checked into the repository override that would be a silent downgrade. Pinned by a test, as is the no-`profiles.yml` case where nothing is added.

Both apply to the top-level `dbt:` block and to `dbt_groups` alike.

## Verification

- Both before/after pairs measured against real binaries and a real image build.
- The regression test drives `runCompile` and reads the entrypoints back out of the produced `dag.json`, because that is where both bugs lived — the leaf helpers were never wrong, and a first pass of this PR shipped tests that stayed green with both fixes fully reverted. Now measured: restoring `local := !o.build` fails it, and deleting the `ProfilesDir` wiring fails it.
- `--profiles-dir` proven read-only under `--read-only` + `--tmpfs /tmp` as UID 65532, for `parse` and `run`: nothing is written into the project.
- Full `go test ./internal/...`, `golangci-lint` (v2.12.2, the CI pin) `0 issues`, `gofmt` clean, `scripts/check-*.sh` green.

Fixes #993
Fixes #994

