### PR TITLE
fix: make additionalProperties:false reachable, and validate a dbt-only project (#15, #996)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,7 +149,13 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   told off by `compile`, rather than silently vanishing from the workspace or being
   renamed after its directory. Separately, `validate` stat'd `dag.py` unconditionally,
   so a project whose DAG *is* the dbt project could never be validated at all; the
-  check is now scoped to a `dag.py` DAG, where a missing source still fails.
+  check is scoped to a `dag.py` DAG, where a missing source still fails, and the
+  dbt lane gets the equivalent check it never had: **`validate` now fails when
+  `dbt.project` names a directory with no `dbt_project.yml`.** That is a new hard
+  failure, breaking for anyone whose project relied on `validate` accepting it —
+  deliberately, because the command exists to say "this is fine" and it was saying
+  it for a project that cannot run. It does not yet cover `dbt_groups[*].project`;
+  that gap is tracked separately.
 - **A hybrid DAG's dbt projects are baked into the image (#20).** `generatedDockerfile` branched on the top-level `dbt:` block and
   had no reference to `dbt_groups` at all: for a `dag.py` with dbt task groups —
   the authoring shape ADR 0043 defines — it COPYed only the DAG source. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,27 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`leoflow.yaml` rejects keys the schema does not define, and `leoflow validate`
+  finally works on a pure-dbt project (#15, #996).** The authoring schema declares
+  `additionalProperties: false` and that guard was **unreachable**: the loader used
+  `yaml.Unmarshal`, which drops an unknown key into the void, and `Validate()` then
+  marshals the *struct* back to JSON and validates that — so by the time the schema
+  saw the document, the offending key had ceased to exist. Every typo, and every key
+  written at the wrong level, was accepted in silence. This is not hypothetical: our
+  own flagship dbt example taught a **top-level `schedule:`**, which is not a schema
+  key (the real one is `dbt.schedule`), so a team following the docs shipped a DAG
+  that never ran and took days to notice — `leoflow validate` said "is valid" the
+  whole time. The three examples that taught it are corrected, and the reference
+  table now says where the key belongs. The refusal names the offending keys and,
+  for `schedule` specifically, points at both right answers. **This is breaking for
+  a project carrying a stray key** — deliberately, and better at a GA than after
+  one. Discovery is unaffected: a Lite workspace loads every subdirectory with a
+  lenient parse, so a DAG with a typo keeps its `dag_id` and its `dbt:` block and is
+  told off by `compile`, rather than silently vanishing from the workspace or being
+  renamed after its directory. Separately, `validate` stat'd `dag.py` unconditionally,
+  so a project whose DAG *is* the dbt project could never be validated at all; the
+  check is now scoped to a `dag.py` DAG, where a missing source still fails.
+
 - **HA chart posture: five render refusals for combinations that used to fail
   later, and the ServiceAccount / warm-pool docs the profile was missing.**
   `podDisruptionBudget.enabled` keyed on a real boolean, so the string spellings

--- a/articles/2026-06-leoflow-dbt-devto.md
+++ b/articles/2026-06-leoflow-dbt-devto.md
@@ -80,9 +80,9 @@ the task pod.
 
 ```yaml
 dag_id: sales
-schedule: "@daily"
 dbt:
   project: .
+  schedule: "@daily"
   granularity: node      # one pod per model
   connection: warehouse_pg
 ```

--- a/internal/cli/discover.go
+++ b/internal/cli/discover.go
@@ -145,7 +145,7 @@ func projectAt(path string) (Project, bool) {
 		return dbtOnlyProjectAt(path, yamlPath)
 	}
 	if _, err := os.Stat(yamlPath); err == nil {
-		cfg, lerr := loadProjectConfig(path)
+		cfg, lerr := loadProjectConfigLenient(path)
 		if lerr != nil {
 			// A yaml that fails to parse is still a discovered project; its
 			// config falls back to defaults + DagID = basename. The compile
@@ -194,7 +194,7 @@ func dbtOnlyProjectAt(path, yamlPath string) (Project, bool) {
 	if _, err := os.Stat(yamlPath); err != nil {
 		return Project{}, false
 	}
-	cfg, lerr := loadProjectConfig(path)
+	cfg, lerr := loadProjectConfigLenient(path)
 	if lerr != nil || cfg.Dbt == nil {
 		return Project{}, false
 	}

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -75,21 +77,37 @@ func loadProjectConfigLenient(dir string) (*domain.LeoflowConfig, error) {
 // already ceased to exist. Every typo, and every key written at the wrong level,
 // was accepted in silence.
 func parseProjectConfig(data []byte) (cfg *domain.LeoflowConfig, unknown, err error) {
-	var strict domain.LeoflowConfig
-	dec := yaml.NewDecoder(bytes.NewReader(data))
-	dec.KnownFields(true)
-	if serr := dec.Decode(&strict); serr != nil && !isUnknownFieldError(serr) {
-		// A real syntax error, not an unknown key: both loaders must fail.
-		return nil, nil, serr
-	} else if serr != nil {
-		unknown = unknownKeyError(serr)
-	}
-
+	// The lenient decode runs FIRST and unconditionally, and its own verdict is
+	// the one that decides whether a config exists at all. That ordering is
+	// deliberate: the classifier below is a string match against a third-party
+	// library's prose, and it used to gate this decode. When it answered "no" for
+	// a file carrying an unknown key AND a type error, discovery lost the config
+	// — and for a dbt-only project that means the DAG is REMOVED from the
+	// registry as "folder gone". A wrong message is an acceptable failure mode
+	// for a prose match; a deleted DAG is not.
 	var lenient domain.LeoflowConfig
 	if lerr := yaml.Unmarshal(data, &lenient); lerr != nil {
 		return nil, nil, lerr
 	}
 	lenient.ApplyDefaults()
+
+	// The strict pass is a REPORTER. It never decides whether the config parses,
+	// only what the strict callers are told about it.
+	var strict domain.LeoflowConfig
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	switch serr := dec.Decode(&strict); {
+	case serr == nil, errors.Is(serr, io.EOF):
+		// io.EOF: an empty or comments-only file. yaml.Unmarshal treats that as
+		// an empty document and so must this, or a mid-edit save in the Lite web
+		// IDE reports a bare "EOF" where it used to report the missing dag_id.
+	case isUnknownFieldError(serr):
+		unknown = unknownKeyError(serr)
+	default:
+		// A genuine decode error the lenient pass tolerated. Report it to the
+		// strict callers, but the config still stands for discovery.
+		unknown = serr
+	}
 	return &lenient, unknown, nil
 }
 
@@ -121,6 +139,7 @@ func unknownKeyError(err error) error {
 	}
 	keys := make([]string, 0, len(te.Errors))
 	seen := map[string]bool{}
+	topLevel := false
 	for _, e := range te.Errors {
 		m := unknownFieldRe.FindStringSubmatch(e)
 		if len(m) < 2 || seen[m[1]] {
@@ -128,20 +147,35 @@ func unknownKeyError(err error) error {
 		}
 		seen[m[1]] = true
 		keys = append(keys, m[1])
+		if strings.Contains(e, "not found in type domain.LeoflowConfig") {
+			topLevel = true
+		}
 	}
 	slices.Sort(keys)
-	msg := fmt.Sprintf("unknown key %q", strings.Join(keys, `", "`))
-	if len(keys) > 1 {
-		msg = fmt.Sprintf("unknown keys %q", strings.Join(keys, `", "`))
+	// Quote each key, then join. Sprintf("%q", ...) over a string that already
+	// carries the join's quotes re-escapes them and renders: unknown keys
+	// "bar\", \"foo".
+	quoted := make([]string, 0, len(keys))
+	for _, k := range keys {
+		quoted = append(quoted, strconv.Quote(k))
 	}
-	if seen["schedule"] {
+	noun := "unknown key "
+	if len(keys) > 1 {
+		noun = "unknown keys "
+	}
+	msg := noun + strings.Join(quoted, ", ")
+	// Only for the top-level key. The hint was keyed off the leaf name, so a
+	// `schedule` nested anywhere — build.schedule, say — got told its DAG takes
+	// its schedule from DAG(schedule=...), which is not that person's problem.
+	// The TypeError entry names the struct the field was missing from.
+	if seen["schedule"] && topLevel {
 		// The one we taught ourselves, in three places, for three releases.
 		msg += ". A dag.py DAG takes its schedule from DAG(schedule=…); a pure-dbt DAG declares it under dbt.schedule. There is no top-level schedule:"
 	}
 	return fmt.Errorf("%s in leoflow.yaml", msg)
 }
 
-var unknownFieldRe = regexp.MustCompile(`field ([^ ]+) not found in type`)
+var unknownFieldRe = regexp.MustCompile(`field (.+) not found in type`)
 
 // dagSourcePath resolves the DAG source file for a project. The caller is
 // expected to have applied schema defaults (cfg.ApplyDefaults), so cfg.DagSource

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -1,9 +1,14 @@
 package cli
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
 
 	"github.com/spf13/cobra"
 	yaml "go.yaml.in/yaml/v3"
@@ -28,13 +33,115 @@ func loadProjectConfig(dir string) (*domain.LeoflowConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", p, err)
 	}
-	var cfg domain.LeoflowConfig
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	cfg, unknown, err := parseProjectConfig(data)
+	if err != nil {
 		return nil, fmt.Errorf("parsing %s: %w", p, err)
 	}
-	cfg.ApplyDefaults()
-	return &cfg, nil
+	if unknown != nil {
+		return nil, fmt.Errorf("%s: %w", p, unknown)
+	}
+	return cfg, nil
 }
+
+// loadProjectConfigLenient is loadProjectConfig without the unknown-key
+// refusal. Discovery uses it: a Lite workspace loads every subdirectory, and a
+// project whose yaml has a stray key still has a dag_id, a dbt block and a
+// source. Refusing here would either rename the DAG after its directory or drop
+// it from the workspace entirely — a typo should be reported by compile, with
+// the file and the key, not by a DAG quietly disappearing. Genuine syntax
+// errors still fail.
+func loadProjectConfigLenient(dir string) (*domain.LeoflowConfig, error) {
+	p := projectConfigPath(dir)
+	data, err := os.ReadFile(p) //nolint:gosec // G304: project path is supplied by the operator on the CLI.
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", p, err)
+	}
+	cfg, _, perr := parseProjectConfig(data) //nolint:errcheck // discarding the unknown-key error is what "lenient" means here.
+	if perr != nil {
+		return nil, fmt.Errorf("parsing %s: %w", p, perr)
+	}
+	return cfg, nil
+}
+
+// parseProjectConfig decodes leoflow.yaml twice, on purpose: once strictly to
+// learn whether the file carries keys the schema does not define, and once
+// leniently to produce the config regardless. Splitting the two lets one caller
+// refuse the file while another keeps working with it.
+//
+// The strict pass is what makes the schema's `additionalProperties: false`
+// reachable at all (#15). It was not: yaml.Unmarshal drops an unknown key into
+// the void, and Validate() then marshals the STRUCT back to JSON and validates
+// that — so by the time the schema sees the document, the offending key has
+// already ceased to exist. Every typo, and every key written at the wrong level,
+// was accepted in silence.
+func parseProjectConfig(data []byte) (cfg *domain.LeoflowConfig, unknown, err error) {
+	var strict domain.LeoflowConfig
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if serr := dec.Decode(&strict); serr != nil && !isUnknownFieldError(serr) {
+		// A real syntax error, not an unknown key: both loaders must fail.
+		return nil, nil, serr
+	} else if serr != nil {
+		unknown = unknownKeyError(serr)
+	}
+
+	var lenient domain.LeoflowConfig
+	if lerr := yaml.Unmarshal(data, &lenient); lerr != nil {
+		return nil, nil, lerr
+	}
+	lenient.ApplyDefaults()
+	return &lenient, unknown, nil
+}
+
+// isUnknownFieldError reports whether a yaml decode error is only about keys the
+// struct does not define. yaml/v3 reports these as a TypeError whose every entry
+// says "field X not found in type Y"; anything else in the list is a real
+// decode failure and must not be downgraded to an unknown-key warning.
+func isUnknownFieldError(err error) bool {
+	te := &yaml.TypeError{}
+	if !errors.As(err, &te) || len(te.Errors) == 0 {
+		return false
+	}
+	for _, e := range te.Errors {
+		if !strings.Contains(e, "not found in type") {
+			return false
+		}
+	}
+	return true
+}
+
+// unknownKeyError turns yaml's per-line "field X not found in type Y" list into
+// one message that names the keys and, for the key our own docs taught, says
+// where it actually belongs. A rejection that only says "unknown key" moves the
+// user from a silent failure to a puzzle; naming the right key is the fix.
+func unknownKeyError(err error) error {
+	te := &yaml.TypeError{}
+	if !errors.As(err, &te) {
+		return err
+	}
+	keys := make([]string, 0, len(te.Errors))
+	seen := map[string]bool{}
+	for _, e := range te.Errors {
+		m := unknownFieldRe.FindStringSubmatch(e)
+		if len(m) < 2 || seen[m[1]] {
+			continue
+		}
+		seen[m[1]] = true
+		keys = append(keys, m[1])
+	}
+	slices.Sort(keys)
+	msg := fmt.Sprintf("unknown key %q", strings.Join(keys, `", "`))
+	if len(keys) > 1 {
+		msg = fmt.Sprintf("unknown keys %q", strings.Join(keys, `", "`))
+	}
+	if seen["schedule"] {
+		// The one we taught ourselves, in three places, for three releases.
+		msg += ". A dag.py DAG takes its schedule from DAG(schedule=…); a pure-dbt DAG declares it under dbt.schedule. There is no top-level schedule:"
+	}
+	return fmt.Errorf("%s in leoflow.yaml", msg)
+}
+
+var unknownFieldRe = regexp.MustCompile(`field ([^ ]+) not found in type`)
 
 // dagSourcePath resolves the DAG source file for a project. The caller is
 // expected to have applied schema defaults (cfg.ApplyDefaults), so cfg.DagSource

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"slices"
 	"strconv"
@@ -79,12 +80,15 @@ func loadProjectConfigLenient(dir string) (*domain.LeoflowConfig, error) {
 func parseProjectConfig(data []byte) (cfg *domain.LeoflowConfig, unknown, err error) {
 	// The lenient decode runs FIRST and unconditionally, and its own verdict is
 	// the one that decides whether a config exists at all. That ordering is
-	// deliberate: the classifier below is a string match against a third-party
-	// library's prose, and it used to gate this decode. When it answered "no" for
-	// a file carrying an unknown key AND a type error, discovery lost the config
-	// — and for a dbt-only project that means the DAG is REMOVED from the
-	// registry as "folder gone". A wrong message is an acceptable failure mode
-	// for a prose match; a deleted DAG is not.
+	// deliberate, but it is forward insurance rather than a fix for a reachable
+	// bug: measured, DiscoverProjects returns byte-identical results with and
+	// without the restructure, because yaml.Unmarshal rejects the same inputs the
+	// classifier mishandles. What it buys is that isUnknownFieldError is a string
+	// match against a third-party library's prose. It used to GATE this decode, so
+	// a yaml/v3 bump that reworded the error would have cost a caller its config —
+	// and for a dbt-only project that means discovery drops it and the DAG is
+	// removed from the registry as "folder gone". Now the same bump costs an ugly
+	// message and nothing else.
 	var lenient domain.LeoflowConfig
 	if lerr := yaml.Unmarshal(data, &lenient); lerr != nil {
 		return nil, nil, lerr
@@ -139,17 +143,26 @@ func unknownKeyError(err error) error {
 	}
 	keys := make([]string, 0, len(te.Errors))
 	seen := map[string]bool{}
-	topLevel := false
+	// Per KEY, not per message. Two independent ORs over the same error list let
+	// any top-level unknown key light the flag while a nested `schedule` lit the
+	// hint, so `build.schedule` next to an unrelated typo got lectured about
+	// DAG(schedule=...).
+	topLevelKeys := map[string]bool{}
 	for _, e := range te.Errors {
 		m := unknownFieldRe.FindStringSubmatch(e)
-		if len(m) < 2 || seen[m[1]] {
+		if len(m) < 2 {
+			continue
+		}
+		// Marked before the dedup: a key reported at two levels must not lose
+		// its top-level mark to an early continue.
+		if strings.Contains(e, "not found in type "+leoflowConfigTypeName) {
+			topLevelKeys[m[1]] = true
+		}
+		if seen[m[1]] {
 			continue
 		}
 		seen[m[1]] = true
 		keys = append(keys, m[1])
-		if strings.Contains(e, "not found in type domain.LeoflowConfig") {
-			topLevel = true
-		}
 	}
 	slices.Sort(keys)
 	// Quote each key, then join. Sprintf("%q", ...) over a string that already
@@ -168,7 +181,7 @@ func unknownKeyError(err error) error {
 	// `schedule` nested anywhere — build.schedule, say — got told its DAG takes
 	// its schedule from DAG(schedule=...), which is not that person's problem.
 	// The TypeError entry names the struct the field was missing from.
-	if seen["schedule"] && topLevel {
+	if topLevelKeys["schedule"] {
 		// The one we taught ourselves, in three places, for three releases.
 		msg += ". A dag.py DAG takes its schedule from DAG(schedule=…); a pure-dbt DAG declares it under dbt.schedule. There is no top-level schedule:"
 	}
@@ -176,6 +189,11 @@ func unknownKeyError(err error) error {
 }
 
 var unknownFieldRe = regexp.MustCompile(`field (.+) not found in type`)
+
+// leoflowConfigTypeName is how yaml/v3 names the root config in its "not found
+// in type X" errors. Derived from the type so renaming the struct cannot quietly
+// unlink the top-level-key detection above.
+var leoflowConfigTypeName = reflect.TypeOf(domain.LeoflowConfig{}).String()
 
 // dagSourcePath resolves the DAG source file for a project. The caller is
 // expected to have applied schema defaults (cfg.ApplyDefaults), so cfg.DagSource

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -155,7 +155,7 @@ func unknownKeyError(err error) error {
 		}
 		// Marked before the dedup: a key reported at two levels must not lose
 		// its top-level mark to an early continue.
-		if strings.Contains(e, "not found in type "+leoflowConfigTypeName) {
+		if strings.HasSuffix(e, "not found in type "+leoflowConfigTypeName) {
 			topLevelKeys[m[1]] = true
 		}
 		if seen[m[1]] {

--- a/internal/cli/helpers_unknown_keys_test.go
+++ b/internal/cli/helpers_unknown_keys_test.go
@@ -178,14 +178,29 @@ func TestScheduleHintDoesNotLeakAcrossKeys(t *testing.T) {
 	if strings.Contains(err.Error(), "DAG(schedule=") {
 		t.Errorf("the top-level hint leaked onto a nested schedule: %v", err)
 	}
+
+	// The other ordering. The top-level mark is set BEFORE the dedup `continue`
+	// precisely so a key reported at two levels does not lose it — move the mark
+	// after the dedup and this case silently stops hinting while the one above
+	// still passes. An invariant a refactor can erase without reddening CI is
+	// not an invariant.
+	_, err = loadProjectConfig(writeProject(t, "schema_version: \"1.0\"\ndag_id: s\nbuild:\n  schedule: x\nschedule: \"@daily\"\n"))
+	if err == nil {
+		t.Fatal("the nested-then-top-level pair was accepted")
+	}
+	if !strings.Contains(err.Error(), "DAG(schedule=") {
+		t.Errorf("a top-level schedule reported after a nested one lost its hint: %v", err)
+	}
 }
 
-// The lenient decode must not depend on the unknown-key classifier. It is a
-// string match against a third-party library's prose, and when it answers "no"
-// for a file that also has a type error, discovery loses the config — which for
-// a dbt-only project means the DAG is REMOVED from the registry as "folder
-// gone". A wrong message is an acceptable failure mode for a prose match; a
-// deleted DAG is not.
+// The lenient decode must not depend on the unknown-key classifier — not
+// because the gate was reachable (measured: yaml.Unmarshal rejects the same
+// inputs the classifier mishandles, so the verdict is identical either way) but
+// because the classifier is a string match against a third-party library's
+// prose. While it gated this decode, a yaml/v3 rewording would have cost a
+// caller its config, and for a dbt-only project that means discovery drops it
+// and the DAG is removed from the registry as "folder gone". Ungated, the same
+// rewording costs an ugly message.
 func TestLenientDecodeIsNotGatedOnTheClassifier(t *testing.T) {
 	// What is observable: the lenient loader keeps the config for a file the
 	// strict loader refuses, and it reaches that answer through yaml.Unmarshal

--- a/internal/cli/helpers_unknown_keys_test.go
+++ b/internal/cli/helpers_unknown_keys_test.go
@@ -135,3 +135,99 @@ func TestValidateStillRequiresTheDagSourceForAPythonDag(t *testing.T) {
 		t.Fatalf("validate accepted a python DAG with no dag.py: %v", err)
 	}
 }
+
+// A message that names several keys must be readable. `%q` over a string that
+// already contains the quotes from the join re-escapes them, so the headline
+// feature of this change rendered as: unknown keys "bar\", \"foo".
+func TestUnknownKeyMessageRendersSeveralKeys(t *testing.T) {
+	_, err := loadProjectConfig(writeProject(t, "schema_version: \"1.0\"\ndag_id: s\nfoo: 1\nbar: 2\n"))
+	if err == nil {
+		t.Fatal("two unknown keys were accepted")
+	}
+	if !strings.Contains(err.Error(), `unknown keys "bar", "foo"`) {
+		t.Errorf("message is not readable: %v", err)
+	}
+	if strings.Contains(err.Error(), `\"`) {
+		t.Errorf("message carries escaped quotes: %v", err)
+	}
+}
+
+// The top-level `schedule:` hint is keyed off the leaf name, so it fired for a
+// `schedule` nested anywhere — telling someone who wrote `build.schedule` that
+// their DAG takes its schedule from DAG(schedule=…), which is not their problem.
+func TestScheduleHintOnlyFiresForTheTopLevelKey(t *testing.T) {
+	_, err := loadProjectConfig(writeProject(t, "schema_version: \"1.0\"\ndag_id: s\nbuild:\n  schedule: x\n"))
+	if err == nil {
+		t.Fatal("a nested unknown key was accepted")
+	}
+	if strings.Contains(err.Error(), "DAG(schedule=") {
+		t.Errorf("the top-level hint fired for a nested schedule: %v", err)
+	}
+}
+
+// The lenient decode must not depend on the unknown-key classifier. It is a
+// string match against a third-party library's prose, and when it answers "no"
+// for a file that also has a type error, discovery loses the config — which for
+// a dbt-only project means the DAG is REMOVED from the registry as "folder
+// gone". A wrong message is an acceptable failure mode for a prose match; a
+// deleted DAG is not.
+func TestLenientDecodeIsNotGatedOnTheClassifier(t *testing.T) {
+	// What is observable: the lenient loader keeps the config for a file the
+	// strict loader refuses, and it reaches that answer through yaml.Unmarshal
+	// alone — the classifier no longer sits between them.
+	dir := writeProject(t, "schema_version: \"1.0\"\ndag_id: sales\nschedule: \"@daily\"\ndbt:\n  project: analytics\n")
+	cfg, err := loadProjectConfigLenient(dir)
+	if err != nil {
+		t.Fatalf("loadProjectConfigLenient refused a file it must still parse: %v", err)
+	}
+	if cfg.DagID != "sales" || cfg.Dbt == nil {
+		t.Errorf("lost the config: DagID=%q Dbt=%v — discovery would drop this DAG", cfg.DagID, cfg.Dbt)
+	}
+	if _, serr := loadProjectConfig(dir); serr == nil {
+		t.Error("the strict loader must still refuse it")
+	}
+
+	// A genuine type error still fails BOTH, and that is not something the
+	// restructure changes: yaml.Unmarshal rejects it too, so there is no config
+	// to hand discovery. Pinning it so nobody reads the case above as a promise
+	// that the lenient loader tolerates everything.
+	bad := writeProject(t, "schema_version: \"1.0\"\ndag_id: sales\ndependencies: 5\n")
+	if _, lerr := loadProjectConfigLenient(bad); lerr == nil {
+		t.Error("the lenient loader accepted a type error")
+	}
+}
+
+// An empty or comments-only file must not become a hard failure. Decoder.Decode
+// returns io.EOF where yaml.Unmarshal treats it as an empty document, so a
+// mid-edit save in the Lite web IDE started reporting a bare "EOF" instead of
+// the missing dag_id.
+func TestEmptyProjectConfigIsNotAnError(t *testing.T) {
+	for _, body := range []string{"", "# nada ainda\n"} {
+		cfg, err := loadProjectConfig(writeProject(t, body))
+		if err != nil {
+			t.Errorf("loadProjectConfig(%q) = %v, want the empty document to parse", body, err)
+			continue
+		}
+		if verr := cfg.Validate(); verr == nil {
+			t.Errorf("an empty config should fail Validate() on the missing dag_id, not at the decoder")
+		}
+	}
+}
+
+// #996 scoped the dag.py check to a dag.py DAG and put nothing in its place, so
+// `validate` answered "is valid" for a dbt: block pointing at a directory that
+// does not exist — the exact shape of #15, reintroduced by #15's own fix.
+func TestValidateRejectsADbtProjectThatIsNotThere(t *testing.T) {
+	dir := writeProject(t, "schema_version: \"1.0\"\ndag_id: sales\ndbt:\n  project: ./nowhere\n")
+	cmd := newValidateCommand()
+	cmd.SetArgs([]string{dir})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("validate accepted a dbt project directory that does not exist")
+	}
+	if !strings.Contains(err.Error(), "dbt_project.yml") {
+		t.Errorf("error %q should name what is missing", err)
+	}
+}

--- a/internal/cli/helpers_unknown_keys_test.go
+++ b/internal/cli/helpers_unknown_keys_test.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The authoring schema declares `additionalProperties: false`, and that guard was
+// unreachable (#15). loadProjectConfig used yaml.Unmarshal, which drops unknown
+// keys into the void; Validate() then marshals the STRUCT back to JSON and
+// validates that, by which point the key no longer exists. A typo, or a key at
+// the wrong level, was accepted in silence.
+//
+// It is not hypothetical: our own flagship dbt example taught a top-level
+// `schedule:`, which is not in the schema — the real key is `dbt.schedule` — so a
+// team following the docs shipped a DAG that never ran and took five days to
+// notice. The failure has no signal at all: `leoflow validate` prints "is valid".
+func writeProject(t *testing.T, yaml string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "leoflow.yaml"), []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestLoadProjectConfigRejectsUnknownKeys(t *testing.T) {
+	t.Run("the key the docs taught", func(t *testing.T) {
+		_, err := loadProjectConfig(writeProject(t, "schema_version: \"1.0\"\ndag_id: sales\nschedule: \"@daily\"\n"))
+		if err == nil {
+			t.Fatal("loadProjectConfig accepted a top-level schedule: — the key that silently unscheduled a real DAG")
+		}
+		// Naming the key is the minimum; pointing at the right one is what turns
+		// a rejection into a fix.
+		for _, want := range []string{"schedule", "dbt.schedule", "DAG(schedule="} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error %q does not mention %q", err, want)
+			}
+		}
+	})
+
+	t.Run("an ordinary typo", func(t *testing.T) {
+		// Built rather than written literally: the point of the case is a
+		// realistic misspelling of a real key, and spelling it out inline just
+		// trips the misspell linter on the fixture.
+		typo := "depend" + "ancies"
+		_, err := loadProjectConfig(writeProject(t, "schema_version: \"1.0\"\ndag_id: sales\n"+typo+": [x]\n"))
+		if err == nil {
+			t.Fatal("loadProjectConfig accepted an unknown key")
+		}
+		if !strings.Contains(err.Error(), typo) {
+			t.Errorf("error %q does not name the offending key", err)
+		}
+	})
+
+	t.Run("a valid config still loads", func(t *testing.T) {
+		cfg, err := loadProjectConfig(writeProject(t, "schema_version: \"1.0\"\ndag_id: sales\nowner: t\ndependencies: [duckdb]\n"))
+		if err != nil {
+			t.Fatalf("loadProjectConfig rejected a valid config: %v", err)
+		}
+		if cfg.DagID != "sales" {
+			t.Errorf("DagID = %q, want sales", cfg.DagID)
+		}
+	})
+}
+
+// Discovery must not lose a DAG to a typo. A Lite workspace loads every
+// subdirectory, and a project whose yaml has a stray key still has a dag_id, a
+// dbt block and a source — the compile step is where the user should be told,
+// with the file and the key, not by the DAG quietly vanishing from the workspace.
+func TestLoadProjectConfigLenientKeepsTheConfigAnUnknownKeyWouldCost(t *testing.T) {
+	dir := writeProject(t, "schema_version: \"1.0\"\ndag_id: sales\nschedule: \"@daily\"\ndbt:\n  project: analytics\n")
+
+	if _, err := loadProjectConfig(dir); err == nil {
+		t.Fatal("the strict loader must still refuse this")
+	}
+	cfg, err := loadProjectConfigLenient(dir)
+	if err != nil {
+		t.Fatalf("loadProjectConfigLenient: %v", err)
+	}
+	if cfg.DagID != "sales" {
+		t.Errorf("DagID = %q, want sales — discovery would name the DAG after its directory", cfg.DagID)
+	}
+	if cfg.Dbt == nil || cfg.Dbt.Project != "analytics" {
+		t.Errorf("Dbt = %+v, want the declared project — a dbt-only project would stop being discovered", cfg.Dbt)
+	}
+}
+
+// Genuine YAML syntax errors must still fail both loaders.
+func TestBothLoadersRejectMalformedYAML(t *testing.T) {
+	dir := writeProject(t, "dag_id: [unclosed\n")
+	if _, err := loadProjectConfig(dir); err == nil {
+		t.Error("the strict loader accepted malformed YAML")
+	}
+	if _, err := loadProjectConfigLenient(dir); err == nil {
+		t.Error("the lenient loader accepted malformed YAML")
+	}
+}
+
+// TestValidateAcceptsADbtOnlyProject pins #996. `leoflow validate` stat'd the
+// DAG source unconditionally, with no cfg.Dbt branch, so a project whose DAG IS
+// the dbt project (ADR 0042) could never be validated:
+//
+//	error: DAG source not found: stat .../dag.py: no such file or directory
+//
+// The command that exists to say "this is fine" always said it was not — which
+// is how the mode's other gaps stayed invisible.
+func TestValidateAcceptsADbtOnlyProject(t *testing.T) {
+	dir := writeProject(t, "schema_version: \"1.0\"\ndag_id: sales\ndbt:\n  project: .\n  schedule: \"@daily\"\n")
+	if err := os.WriteFile(filepath.Join(dir, "dbt_project.yml"), []byte("name: sales\nversion: \"1.0\"\nprofile: sales\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newValidateCommand()
+	cmd.SetArgs([]string{dir})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("validate rejected a dbt-only project: %v", err)
+	}
+}
+
+// And it must still catch a dag.py DAG whose source is missing — the check is
+// scoped, not removed.
+func TestValidateStillRequiresTheDagSourceForAPythonDag(t *testing.T) {
+	dir := writeProject(t, "schema_version: \"1.0\"\ndag_id: sales\n")
+	cmd := newValidateCommand()
+	cmd.SetArgs([]string{dir})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "DAG source not found") {
+		t.Fatalf("validate accepted a python DAG with no dag.py: %v", err)
+	}
+}

--- a/internal/cli/helpers_unknown_keys_test.go
+++ b/internal/cli/helpers_unknown_keys_test.go
@@ -165,6 +165,21 @@ func TestScheduleHintOnlyFiresForTheTopLevelKey(t *testing.T) {
 	}
 }
 
+// ...and the gate must correlate per KEY, not per message. `topLevel` and the
+// seen-`schedule` flag were two independent ORs over the same error list, so any
+// other top-level unknown key lit the first while a nested `schedule` lit the
+// second — and someone who wrote `build.schedule` alongside an unrelated typo got
+// lectured about DAG(schedule=…). The single-key test above cannot see it.
+func TestScheduleHintDoesNotLeakAcrossKeys(t *testing.T) {
+	_, err := loadProjectConfig(writeProject(t, "schema_version: \"1.0\"\ndag_id: s\nzzz: 1\nbuild:\n  schedule: x\n"))
+	if err == nil {
+		t.Fatal("two unknown keys were accepted")
+	}
+	if strings.Contains(err.Error(), "DAG(schedule=") {
+		t.Errorf("the top-level hint leaked onto a nested schedule: %v", err)
+	}
+}
+
 // The lenient decode must not depend on the unknown-key classifier. It is a
 // string match against a third-party library's prose, and when it answers "no"
 // for a file that also has a type error, discovery loses the config — which for

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -31,6 +32,17 @@ func newValidateCommand() *cobra.Command {
 			// mode unvalidatable — the command that exists to say "this is
 			// fine" always said it was not (#996). The check is scoped, not
 			// removed: a dag.py DAG with a missing source still fails here.
+			if cfg.Dbt != nil {
+				// Scoping the dag.py check to a dag.py DAG left the dbt lane with
+				// NOTHING checked, so `validate` answered "is valid" for a dbt:
+				// block pointing at a directory that does not exist — the exact
+				// shape of #15, reintroduced by #15's own fix. The project's
+				// dbt_project.yml is the dbt equivalent of the DAG source.
+				proj := filepath.Join(dir, cfg.Dbt.Project)
+				if _, serr := os.Stat(filepath.Join(proj, "dbt_project.yml")); serr != nil {
+					return fmt.Errorf("dbt project not found: no dbt_project.yml under %s (dbt.project = %q): %w", proj, cfg.Dbt.Project, serr)
+				}
+			}
 			if cfg.Dbt == nil {
 				dagSrc := dagSourcePath(dir, cfg)
 				if _, serr := os.Stat(dagSrc); serr != nil {

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -26,12 +26,19 @@ func newValidateCommand() *cobra.Command {
 			if verr := cfg.Validate(); verr != nil {
 				return fmt.Errorf("invalid %s: %w", projectConfigPath(dir), verr)
 			}
-			dagSrc := dagSourcePath(dir, cfg)
-			if _, serr := os.Stat(dagSrc); serr != nil {
-				return fmt.Errorf("DAG source not found: %w", serr)
-			}
-			if perr := checkDagPythonSyntax(cmd, dagSrc); perr != nil {
-				return perr
+			// A pure-dbt project has no dag.py: the dbt project IS the DAG
+			// (ADR 0042). Stat'ing the source unconditionally made the whole
+			// mode unvalidatable — the command that exists to say "this is
+			// fine" always said it was not (#996). The check is scoped, not
+			// removed: a dag.py DAG with a missing source still fails here.
+			if cfg.Dbt == nil {
+				dagSrc := dagSourcePath(dir, cfg)
+				if _, serr := os.Stat(dagSrc); serr != nil {
+					return fmt.Errorf("DAG source not found: %w", serr)
+				}
+				if perr := checkDagPythonSyntax(cmd, dagSrc); perr != nil {
+					return perr
+				}
 			}
 			if _, werr := fmt.Fprintf(cmd.OutOrStdout(), "%s is valid\n", projectConfigPath(dir)); werr != nil {
 				return werr

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -85,8 +85,9 @@ type AlertRule struct {
 type DbtConfig struct {
 	// Project is the directory containing dbt_project.yml.
 	Project string `json:"project,omitempty" yaml:"project,omitempty"`
-	// Granularity is the task partition strategy: node, level, folder, or tag
-	// (ADR 0042 §5). Empty means node.
+	// Granularity is the task partition strategy: node, level or folder (ADR 0042
+	// §5). Empty means node. Tag and selector grouping are not implemented — the
+	// schema enum is the three above; see #398.
 	Granularity string `json:"granularity,omitempty" yaml:"granularity,omitempty"`
 	// Manifest optionally points to a pre-built manifest.json (the Pro/CI baked
 	// path); empty means run `dbt parse` to generate it at compile time.

--- a/website/content/author-dags/dbt.md
+++ b/website/content/author-dags/dbt.md
@@ -70,11 +70,11 @@ sales/                         # the DAG = a dbt project + leoflow.yaml
 # leoflow.yaml
 schema_version: "1.0"
 dag_id: sales
-schedule: "@daily"             # optional; empty = on-demand (Lite dev loop)
 owner: data-team
 dbt:
   project: .                   # dir containing dbt_project.yml
   granularity: node            # node | level | folder  (see §3)
+  schedule: "@daily"           # optional; empty = on-demand (Lite dev loop)
 ```
 
 Compile it like any DAG:
@@ -175,8 +175,9 @@ with DAG("sales", schedule="@daily"):
 
 ```yaml
 # sales/leoflow.yaml
+# The schedule lives in dag.py's DAG(schedule=…) — there is no top-level
+# schedule: key, and leoflow.yaml rejects one.
 dag_id: sales
-schedule: "@daily"
 dbt_groups:
   transform:                  # the name passed to dbt_group()
     project: ./transform
@@ -478,7 +479,7 @@ confirms the adapter integration works against a real account; it is still a
 | `granularity` | `node` \| `level` \| `folder` (default `node`) |
 | `manifest` | optional pre-built `manifest.json` path (project-relative); empty runs `dbt parse` |
 | `connection` | managed Leoflow connection id; empty = bring-your-own `profiles.yml` |
-| `schedule` | *(whole-DAG `dbt:` only)* cron/preset; empty = on-demand |
+| `schedule` | *(whole-DAG `dbt:` only)* cron/preset; empty = on-demand. Declared **under `dbt:`** — a `dag.py` DAG takes its schedule from `DAG(schedule=…)` instead. There is no top-level `schedule:` key, and `leoflow.yaml` rejects one. |
 
 ## Cosmos at a glance
 

--- a/website/content/connections/google_ads.md
+++ b/website/content/connections/google_ads.md
@@ -80,7 +80,7 @@ google_ads_demo()
 ```yaml
 # leoflow.yaml
 dag_id: google_ads_demo
-python: "3.12"
+python_version: "3.12"
 connectors: [google_ads]
 ```
 

--- a/website/content/project/adrs/0042-dbt-support-native-rendering.md
+++ b/website/content/project/adrs/0042-dbt-support-native-rendering.md
@@ -163,9 +163,16 @@ Two further invariants on the partition:
 
 Config:
 
+> **Design intent, not the shipped schema.** The fence below predates the
+> implementation: `groups:` is not a `dbt:` key and `leoflow.yaml` rejects it,
+> and the shipped `granularity` enum is `node | level | folder` — `resource`,
+> `tag` and `selector` are not implemented (tag/selector grouping is tracked in
+> #398). The status line above says "shipped in v0.1.1", which is true of
+> manifest rendering and not of this block.
+
 ```yaml
 dbt:
-  granularity: folder        # node | level | resource | folder | tag | selector
+  granularity: folder        # shipped enum: node | level | folder
   groups:                    # only for granularity: selector
     - { name: staging, select: "path:models/staging" }
     - { name: core,    select: "tag:core" }

--- a/website/content/project/adrs/0043-taskgroup-split-fused-execution.md
+++ b/website/content/project/adrs/0043-taskgroup-split-fused-execution.md
@@ -70,6 +70,10 @@ Why leoflow.yaml for the mode: it must be able to **vary Lite vs Pro from one DA
 fuse in Lite for a fast dev loop, split in Pro for isolation — which a value baked into
 dag.py could not. Default is `split`.
 
+> **Design intent, not yet implemented.** The `groups:` block and
+> `dbt_groups.<name>.threads` below are not schema keys — `leoflow.yaml` rejects
+> them. Kept here as the shape this ADR argues for.
+
 ```yaml
 # leoflow.yaml
 groups:


### PR DESCRIPTION
The authoring schema declares `additionalProperties: false` and the guard was **unreachable**. `loadProjectConfig` used `yaml.Unmarshal`, which drops an unknown key into the void, and `Validate()` then marshals the *struct* back to JSON and validates that — so by the time the schema saw the document, the offending key had already ceased to exist. Every typo, and every key written at the wrong level, was accepted in silence.

Not hypothetical. Our own flagship dbt example taught a **top-level `schedule:`**, which is not a schema key (the real one is `dbt.schedule`), so a team following the docs shipped a DAG that never ran and took days to notice — with `leoflow validate` printing `is valid` the whole time. Three places taught it (`dbt.md` twice, the dev.to article once); all three are corrected here, and the reference table now says where the key belongs, so the fix and its cause land together.

## Strict for judgement, lenient for discovery

The parse is split. A strict pass with `KnownFields(true)` learns whether the file carries undefined keys; a lenient pass produces the config regardless. `compile`, `deploy` and `validate` refuse; discovery does not.

That distinction is load-bearing. A Lite workspace loads every subdirectory, and refusing there would either rename a DAG after its directory (`discover.go:148`'s fallback) or drop a dbt-only project from the workspace entirely (`dbtOnlyProjectAt`). A typo should be reported by `compile`, naming the file and the key — not by a DAG quietly vanishing. Genuine syntax errors still fail both loaders.

## The message

A rejection that only says "unknown key" trades a silent failure for a puzzle:

```
error: leoflow.yaml: unknown key "schedule". A dag.py DAG takes its schedule
from DAG(schedule=…); a pure-dbt DAG declares it under dbt.schedule.
There is no top-level schedule: in leoflow.yaml
```

## Breaking, deliberately

A project carrying a stray key now fails. That is the point, and a validator that gets stricter *after* a GA is a far worse conversation than one that is strict at it.

Blast radius measured, not assumed: all **30** versioned `leoflow.yaml` files pass, and a scan of every `test/**/*.sh` heredoc that writes a `leoflow.yaml` found no undefined top-level key.

## Folded in: #996

`validate` stat'd `dag.py` unconditionally, so a project whose DAG *is* the dbt project could never be validated. It is what blocked me from proving the corrected mode-1 example above actually passes, which is how it surfaced — so it ships here rather than as a separate PR. The check is scoped to a `dag.py` DAG now; a missing source there still fails, pinned by a test.

## Verification

- Both fixes mutation-tested — neutering either produces failing tests (3 and 1 respectively).
- The corrected mode-1 example driven through the real binary: `leoflow.yaml is valid`.
- Full `go test ./internal/...`, `golangci-lint` (v2.12.2) `0 issues`, `gofmt` clean, `scripts/check-*.sh` green.

Fixes #15
Fixes #996