### PR TITLE
docs(agents): the lessons this cut paid for, and leoflow.yaml as the standard

### DIFF
--- a/.github/CLAUDE.md.template
+++ b/.github/CLAUDE.md.template
@@ -21,6 +21,15 @@ The core insight: the **pod-per-task** execution model is correct (Airflow prove
 9. **Enterprise architecture, MVP features.** Schemas, interfaces, and middleware are enterprise-ready from day one. Implementations start simple.
 10. **Observability is not optional.** Prometheus metrics, OpenTelemetry tracing, and structured logs ship from the first commit.
 11. **Supply chain security is built-in.** govulncheck + gosec + Trivy + CodeQL run on every PR. See ADR 0014.
+12. **`leoflow.yaml` is the authoring standard.** A DAG is described by its
+    `leoflow.yaml`; the compiler generates the Dockerfile. A hand-written
+    Dockerfile is a supported escape hatch (ADR 0003's "Intermediate" tier), never
+    the default — not in examples, not in docs, and above all not in tests. When a
+    fixture reaches for `--dockerfile`, it stops exercising the path almost every
+    user takes. Measured on 2026-09-08: 8 of 11 end-to-end scripts took that
+    shortcut, all three dbt ones among them, so the generated Dockerfile's dbt arm
+    had **zero** coverage — which is how four separate defects (#17, #20, #993,
+    #994) shipped green in a single fixture.
 
 ## Architectural Overview
 
@@ -123,6 +132,31 @@ leoflow/
 8. **Never use Python outside of `parser/` and inside user task containers.**
 9. **When in doubt about an architectural choice, stop and ask.** Don't guess on irreversible decisions.
 10. **Agent context files (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, etc.) are gitignored.** They are never committed. The template at `.github/CLAUDE.md.template` is the source of truth for the canonical context; copy from it.
+11. **A test that bypasses the documented path proves nothing.** Before trusting
+    a green suite, ask which path it exercised. The mixed-mode e2e hand-wrote a
+    Dockerfile (hiding a missing COPY), overrode `DBT_PROFILES_DIR` (hiding an
+    unreachable profile), `chown`ed the project (hiding that the read-only posture
+    was fiction), and wired Bash tasks (so nothing ever imported `dag.py`). Four
+    defects, one fixture, all invisible. The shape we recommend must be the shape
+    CI runs.
+12. **Mutation-test every new assertion, and prove the mutant applied.** Break the
+    fix, watch the test go red, restore. A test that stays green with the fix fully
+    reverted is not a regression test. Assert the edit landed (`assert
+    s.count(old) == 1`) — a mutation run whose mutant silently failed to apply is
+    indistinguishable from a passing one, and reads as rigor while providing none.
+13. **Lock the wiring, not the leaf.** Bugs cluster where a correct helper is
+    called with a wrong input. `dbtProjectDir` computed a correct absolute path
+    from a wrong flag; `decorateCommands` appended a correct argument it was never
+    given. Both leaf tests passed with both fixes reverted. Drive the real entry
+    point and assert on its output.
+14. **A comment that asserts what the code does not do is a bug.** It outlives any
+    defect, because nothing tests it. Repeatedly the code here was right and its
+    comment was wrong — an ownership claim about `COPY`, an invented ADR citation,
+    a release note describing the opposite of the commit above it. When you change
+    behavior, grep for the sentences that described the old one.
+15. **Read the exit code you think you read.** `cmd | head` reports `head`'s
+    status; a background job's log tail is not its verdict; an empty filter output
+    is not a pass. Re-measure without the pipe before concluding anything.
 
 ## Domain Vocabulary
 


### PR DESCRIPTION
Five defects in one release traced back to the same root, and none of them was hard code. They were hidden behind tests that went around the path we document.

## The principle

**`leoflow.yaml` is the authoring standard.** The compiler generates the Dockerfile. A hand-written one stays supported — ADR 0003's "Intermediate" tier — but it is never the default, and above all not in tests.

Measured while closing #20:

| Path | e2e scripts |
|---|---|
| Generated Dockerfile | 3 of 11 |
| Hand-written | **8 of 11**, including all three dbt ones |

So `generatedDockerfile`'s dbt arm had **zero** end-to-end coverage. #17, #20, #993 and #994 all shipped green inside a single fixture that COPYed the whole context (hiding the missing `dbt_groups` COPY), overrode `DBT_PROFILES_DIR` (hiding the unreachable `profiles.yml`), `chown`ed the project (so the read-only posture of #852 was never exercised), and wired `BashOperator`s (so nothing ever imported `dag.py`).

## The rules

- **A test that bypasses the documented path proves nothing.** Ask which path a green suite exercised before trusting it.
- **Mutation-test every new assertion, and prove the mutant applied.** Three times this cut I reported a mutation test whose substitution silently failed to match — "0 failures" then reads as the test surviving when nothing ran.
- **Lock the wiring, not the leaf.** #993 and #994 were correct helpers called with wrong inputs; the leaf tests stayed green with both fixes fully reverted.
- **A comment asserting what the code does not do is a bug.** It outlives any defect because nothing tests it. This cut shipped an ownership claim about `COPY` that a real build disproved, an invented ADR citation in four places, and a release note describing the opposite of the commit above it.
- **Read the exit code you think you read.** `cmd | head` reports `head`'s status; an empty filter output is not a pass.

## Also

Rule 10 pointed at `docs/agent-templates/CLAUDE.md.template`, which does not exist. The template is `.github/CLAUDE.md.template` — this file.

Docs only; no code, no test changes.