### PR TITLE
test(e2e): make the mixed-mode e2e prove the path instead of bypassing it

### DIFF
--- a/test/e2e/dbt-mixing-e2e.sh
+++ b/test/e2e/dbt-mixing-e2e.sh
@@ -198,10 +198,14 @@ jq -e '.tasks[] | select(.task_id=="post") | .depends_on | index("transform__mar
 # The image the COMPILER produced, asserted directly. A red run only says "a task
 # failed"; these name the property.
 #
-# The write probe below is the one the cluster run cannot stand in for. dbt's only
-# write into the project is its .user.yml tracking cookie, dropped in the profiles
-# dir — and dbt swallows the EACCES — so a writable project produces an identical
-# green run. Only this block can tell the two apart.
+# The write probe below is the one the cluster run cannot stand in for. Nothing dbt
+# does in the pod touches the project: the base image aims DBT_TARGET_PATH /
+# DBT_LOG_PATH / DBT_PROFILES_DIR at /tmp (#852), and the one file dbt would drop in
+# the profiles dir — its .user.yml tracking cookie — is already baked in by the host
+# `dbt parse` above, so it is read, not written. Where no cookie is baked, dbt
+# swallows the EACCES (tracking.py initialize_from_flags) and stops tracking. Either
+# way a writable project produces an identical green run, so only this block can tell
+# the two apart.
 log "Asserting the generated image"
 docker run --rm --entrypoint sh "$DAG_IMAGE" -c 'test -f /home/leoflow/dag.py' \
   || fail "the generated Dockerfile did not COPY the DAG source"
@@ -229,11 +233,12 @@ docker run --rm --entrypoint python "$DAG_IMAGE" -c 'import dbt.adapters.postgre
 # assertion above is a canary, not a proof. The defect needs a bare compile —
 # which is also the door a CI or prebuilt-image workflow actually walks through.
 "$ROOT/bin/leoflow" compile "$PROJ" ${PARSER_CMD[@]+"${PARSER_CMD[@]}"} --image "$DAG_IMAGE" -o "$PROJ/nobuild.json"
-# Anchor first: `all` over an empty array is true, so without this the check
-# below would go green measuring nothing if the group ever stopped expanding —
-# the same shape it was added to remove, one level down.
+# Anchor first. The #993 check below iterates ALL tasks, so if the group ever
+# stopped expanding it would not go green on an empty array — it would go green
+# measuring `pre`/`post`, which carry no --project-dir at all. Same shape it was
+# added to remove, one level down. 3 = 1 seed + 2 models, the five nodes named above.
 jq -e '[.tasks[] | select(.task_id | startswith("transform__"))] | length == 3' "$PROJ/nobuild.json" >/dev/null \
-  || fail "the bare compile did not expand the dbt_group — the #993 check below would pass on nothing"
+  || fail "the bare compile expanded $(jq '[.tasks[]|select(.task_id|startswith("transform__"))]|length' "$PROJ/nobuild.json") transform__ tasks, want 3 — the #993 check below would pass without measuring the dbt tasks"
 jq -e '[.tasks[] | .entrypoint // "" | test("--(project|profiles)-dir /") | not] | all' "$PROJ/nobuild.json" >/dev/null \
   || fail "a bare compile baked an absolute host path into a pod-bound dag.json (#993)"
 

--- a/test/e2e/dbt-mixing-e2e.sh
+++ b/test/e2e/dbt-mixing-e2e.sh
@@ -33,6 +33,9 @@ WAREHOUSE="leoflow-dbt-mix-wh"
 API="http://localhost:${HTTP_PORT}"
 WORKDIR="$(mktemp -d)"
 # shellcheck disable=SC2206
+# Expanded below as ${PARSER_CMD[@]+...}: on bash 3.2 — macOS, where releases are
+# cut from — "${arr[@]}" over an EMPTY array is an error under set -u, so this
+# script aborted before its first useful step and could only ever run in CI.
 PARSER_CMD=(${LEOFLOW_E2E_PARSER_CMD:+--parser-cmd "$LEOFLOW_E2E_PARSER_CMD"})
 
 # dump_pods prints the task pods, a describe tail for those not Running, and
@@ -79,20 +82,37 @@ for _ in $(seq 1 30); do docker exec "$WAREHOUSE" pg_isready -U postgres >/dev/n
 # The DAG = a dbt project at the root + a dag.py that wires operators around it.
 PROJ="$WORKDIR/$DAG_ID"
 mkdir -p "$PROJ/transform/models" "$PROJ/transform/seeds"
+# PythonOperators, not Bash. A bash task never imports dag.py, so this fixture
+# used to execute the group without ever executing the DAG module — which is
+# exactly why #17 (`from leoflow import dbt_group` unresolvable in the task
+# image) shipped green. The runtime re-imports this file for every python task.
 cat >"$PROJ/dag.py" <<'PY'
 from leoflow import dbt_group
-from airflow.providers.standard.operators.bash import BashOperator
+from airflow.providers.standard.operators.python import PythonOperator
 from airflow.sdk import DAG
 
+
+def pre():
+    print("pre")
+
+
+def post():
+    print("post")
+
+
 with DAG("mix", schedule="@daily"):
-    pre = BashOperator(task_id="pre", bash_command="echo pre")
+    before = PythonOperator(task_id="pre", python_callable=pre)
     models = dbt_group("transform")
-    post = BashOperator(task_id="post", bash_command="echo post")
-    pre >> models >> post
+    after = PythonOperator(task_id="post", python_callable=post)
+    before >> models >> after
 PY
 cat >"$PROJ/leoflow.yaml" <<'YAML'
 schema_version: "1.0"
 dag_id: mix
+# The adapter is declared, not installed by a hand-written Dockerfile: the
+# generated one has to carry it, and that is half of what this test now proves.
+dependencies:
+  - dbt-postgres==1.9.*
 dbt_groups:
   transform:
     project: ./transform
@@ -103,6 +123,13 @@ YAML
 # linux/amd64, which fails FROM an arm64 base on a Lima/dev host → ErrImagePull.
 case "$(uname -m)" in arm64|aarch64) HOST_PLATFORM="linux/arm64" ;; *) HOST_PLATFORM="linux/amd64" ;; esac
 cat >>"$PROJ/leoflow.yaml" <<YAML
+# base_image: the base THIS checkout just built. Without it the generated
+# Dockerfile resolves to the published base, which only gains a fix in the next
+# release — so the test would measure the last release's image instead of the code
+# under review, going green precisely when it can no longer detect a regression.
+# The hand-written Dockerfile this fixture used to ship made the FROM explicit, so
+# the question never arose.
+base_image: ${BASE_IMAGE}
 build:
   platforms:
     - ${HOST_PLATFORM}
@@ -128,18 +155,13 @@ echo "select id, sum(v) as total from {{ ref('stg') }} group by id" >"$PROJ/tran
 log "Generating the manifest"
 ( cd "$PROJ/transform" && DBT_PROFILES_DIR="$PROJ/transform" dbt parse >/dev/null 2>&1 ) || fail "dbt parse failed"
 
-cat >"$PROJ/Dockerfile" <<DOCKER
-FROM ${BASE_IMAGE}
-USER root
-RUN pip install --no-cache-dir "dbt-postgres==1.9.*"
-COPY . /home/leoflow/
-ENV DBT_PROFILES_DIR=/home/leoflow/transform
-RUN chown -R 65532:65532 /home/leoflow
-# Numeric UID so PodSecurity runAsNonRoot (on by default) admits the pod: the
-# kubelet cannot verify a login NAME. Matches the base image's USER 65532:65532.
-USER 65532:65532
-WORKDIR /home/leoflow
-DOCKER
+# No hand-written Dockerfile. This fixture used to ship one, and it was an
+# escape hatch that hid three defects at once: it COPYed the whole context (so
+# #20's missing dbt_groups COPY never bit), it set DBT_PROFILES_DIR at the
+# project (so #994's unreachable profiles.yml never bit), and it chown'd
+# /home/leoflow to the task user (so the read-only-project posture #852 claims
+# was never actually exercised). The generated Dockerfile has to do all three
+# correctly now, or this test fails.
 
 log "Building the leoflow base image"
 docker build --provenance=false -q -f "$ROOT/runtime/Dockerfile" --build-arg "PYTHON_VERSION=${PY_VERSION}" -t "$BASE_IMAGE" "$ROOT" >/dev/null
@@ -161,7 +183,7 @@ SERVER_PID=$!
 sleep 5
 
 log "Compiling (parser merges the operators with the dbt_group) + building the image"
-"$ROOT/bin/leoflow" compile "$PROJ" "${PARSER_CMD[@]}" --image "$DAG_IMAGE" --build --dockerfile Dockerfile -o "$PROJ/dag.json"
+"$ROOT/bin/leoflow" compile "$PROJ" ${PARSER_CMD[@]+"${PARSER_CMD[@]}"} --image "$DAG_IMAGE" --build -o "$PROJ/dag.json"
 log "Asserting the merge: operators + namespaced dbt tasks wired together"
 for want in pre post transform__raw transform__stg transform__mart; do
   jq -e --arg t "$want" '.tasks[] | select(.task_id==$t)' "$PROJ/dag.json" >/dev/null || fail "missing task $want"
@@ -170,6 +192,25 @@ jq -e '.tasks[] | select(.task_id=="transform__raw") | .depends_on | index("pre"
   || fail "group root transform__raw is not wired to the upstream operator 'pre'"
 jq -e '.tasks[] | select(.task_id=="post") | .depends_on | index("transform__mart")' "$PROJ/dag.json" >/dev/null \
   || fail "downstream operator 'post' is not wired to the group leaf"
+# The image the COMPILER produced, asserted directly. The run below proves these
+# transitively, but a red run says "a task failed" — these say which property
+# broke, and each one is a defect this release actually shipped.
+log "Asserting the generated image"
+docker run --rm --entrypoint sh "$DAG_IMAGE" -c 'test -f /home/leoflow/dag.py' \
+  || fail "the generated Dockerfile did not COPY the DAG source"
+docker run --rm --entrypoint sh "$DAG_IMAGE" -c 'test -f /home/leoflow/transform/dbt_project.yml' \
+  || fail "the generated Dockerfile did not COPY the dbt_groups project (#20)"
+docker run --rm --entrypoint python "$DAG_IMAGE" -c 'import leoflow, leoflow_runtime' \
+  || fail "the authoring package is not importable in the task image (#17)"
+docker run --rm --entrypoint sh "$DAG_IMAGE" -c 'id -u | grep -qx 65532' \
+  || fail "the image does not end on the numeric non-root UID the kubelet checks"
+docker run --rm --entrypoint sh "$DAG_IMAGE" -c '! touch /home/leoflow/transform/WRITE_PROBE 2>/dev/null' \
+  || fail "the dbt project is writable by the task user — the read-only posture (#852) is not real"
+jq -e '[.tasks[] | select(.task_id | startswith("transform__")) | .entrypoint | test("--profiles-dir")] | all' "$PROJ/dag.json" >/dev/null \
+  || fail "no --profiles-dir baked: the project ships profiles.yml and the base image points DBT_PROFILES_DIR at /tmp (#994)"
+jq -e '[.tasks[] | .entrypoint // "" | test("--project-dir /") | not] | all' "$PROJ/dag.json" >/dev/null \
+  || fail "an absolute host path was baked into a task entrypoint (#993)"
+
 k3d_import "$CLUSTER" "$BASE_IMAGE" "$DAG_IMAGE"
 
 log "Pushing + triggering"

--- a/test/e2e/dbt-mixing-e2e.sh
+++ b/test/e2e/dbt-mixing-e2e.sh
@@ -196,8 +196,12 @@ jq -e '.tasks[] | select(.task_id=="transform__raw") | .depends_on | index("pre"
 jq -e '.tasks[] | select(.task_id=="post") | .depends_on | index("transform__mart")' "$PROJ/dag.json" >/dev/null \
   || fail "downstream operator 'post' is not wired to the group leaf"
 # The image the COMPILER produced, asserted directly. A red run only says "a task
-# failed"; these name the property. Note the run does NOT prove all of them: it
-# never writes into the project, so A5 is a property only this block checks.
+# failed"; these name the property.
+#
+# The write probe below is the one the cluster run cannot stand in for. dbt's only
+# write into the project is its .user.yml tracking cookie, dropped in the profiles
+# dir — and dbt swallows the EACCES — so a writable project produces an identical
+# green run. Only this block can tell the two apart.
 log "Asserting the generated image"
 docker run --rm --entrypoint sh "$DAG_IMAGE" -c 'test -f /home/leoflow/dag.py' \
   || fail "the generated Dockerfile did not COPY the DAG source"
@@ -214,16 +218,22 @@ jq -e '[.tasks[] | select(.task_id | startswith("transform__")) | .entrypoint | 
 jq -e '[.tasks[] | .entrypoint // "" | test("--(project|profiles)-dir /") | not] | all' "$PROJ/dag.json" >/dev/null \
   || fail "an absolute host path was baked into a task entrypoint (#993)"
 
-# F9: the adapter must come from dependencies:, since no hand-written Dockerfile
+# The adapter must come from dependencies:, since no hand-written Dockerfile
 # installs it any more. Without this, deleting the pip layer from the generated
-# Dockerfile leaves all the assertions above green.
-docker run --rm --entrypoint sh "$DAG_IMAGE" -c 'command -v dbt >/dev/null' \
-  || fail "the declared adapter (dependencies:) is not installed in the generated image"
+# Dockerfile leaves every assertion above green. Import the adapter rather than
+# probing for the dbt binary, so the check and its message are one statement.
+docker run --rm --entrypoint python "$DAG_IMAGE" -c 'import dbt.adapters.postgres' \
+  || fail "the adapter declared in dependencies: is not installed in the generated image"
 
 # #993 CANNOT manifest under --build: `local` is false either way there, so the
 # assertion above is a canary, not a proof. The defect needs a bare compile —
 # which is also the door a CI or prebuilt-image workflow actually walks through.
 "$ROOT/bin/leoflow" compile "$PROJ" ${PARSER_CMD[@]+"${PARSER_CMD[@]}"} --image "$DAG_IMAGE" -o "$PROJ/nobuild.json"
+# Anchor first: `all` over an empty array is true, so without this the check
+# below would go green measuring nothing if the group ever stopped expanding —
+# the same shape it was added to remove, one level down.
+jq -e '[.tasks[] | select(.task_id | startswith("transform__"))] | length == 3' "$PROJ/nobuild.json" >/dev/null \
+  || fail "the bare compile did not expand the dbt_group — the #993 check below would pass on nothing"
 jq -e '[.tasks[] | .entrypoint // "" | test("--(project|profiles)-dir /") | not] | all' "$PROJ/nobuild.json" >/dev/null \
   || fail "a bare compile baked an absolute host path into a pod-bound dag.json (#993)"
 

--- a/test/e2e/dbt-mixing-e2e.sh
+++ b/test/e2e/dbt-mixing-e2e.sh
@@ -34,8 +34,10 @@ API="http://localhost:${HTTP_PORT}"
 WORKDIR="$(mktemp -d)"
 # shellcheck disable=SC2206
 # Expanded below as ${PARSER_CMD[@]+...}: on bash 3.2 — macOS, where releases are
-# cut from — "${arr[@]}" over an EMPTY array is an error under set -u, so this
-# script aborted before its first useful step and could only ever run in CI.
+# cut from — "${arr[@]}" over an EMPTY array is an error under set -u. The
+# assignment here is fine; only the expansion at the compile step is not, so the
+# script died AFTER the warehouse, the dbt parse, the base image build and the
+# k3d cluster create. Five minutes in, which is why nobody ran it locally twice.
 PARSER_CMD=(${LEOFLOW_E2E_PARSER_CMD:+--parser-cmd "$LEOFLOW_E2E_PARSER_CMD"})
 
 # dump_pods prints the task pods, a describe tail for those not Running, and
@@ -124,11 +126,11 @@ YAML
 case "$(uname -m)" in arm64|aarch64) HOST_PLATFORM="linux/arm64" ;; *) HOST_PLATFORM="linux/amd64" ;; esac
 cat >>"$PROJ/leoflow.yaml" <<YAML
 # base_image: the base THIS checkout just built. Without it the generated
-# Dockerfile resolves to the published base, which only gains a fix in the next
-# release — so the test would measure the last release's image instead of the code
-# under review, going green precisely when it can no longer detect a regression.
-# The hand-written Dockerfile this fixture used to ship made the FROM explicit, so
-# the question never arose.
+# Dockerfile resolves to the published moving tag, so the test would measure the
+# last release's image instead of the code under review — wrong in either
+# direction, and today it happens to fail rather than pass, because the published
+# py3.11 tag predates #991 and has no leoflow package. The hand-written Dockerfile
+# this fixture used to ship made the FROM explicit, so the question never arose.
 base_image: ${BASE_IMAGE}
 build:
   platforms:
@@ -159,9 +161,10 @@ log "Generating the manifest"
 # escape hatch that hid three defects at once: it COPYed the whole context (so
 # #20's missing dbt_groups COPY never bit), it set DBT_PROFILES_DIR at the
 # project (so #994's unreachable profiles.yml never bit), and it chown'd
-# /home/leoflow to the task user (so the read-only-project posture #852 claims
-# was never actually exercised). The generated Dockerfile has to do all three
-# correctly now, or this test fails.
+# /home/leoflow to the task user (so #852's root-owned project was never actually
+# exercised). Two of those are the generated Dockerfile's job; the third is not —
+# --profiles-dir is decorated onto the entrypoint by dbtProfilesDir, and the
+# Dockerfile carries no profiles logic at all.
 
 log "Building the leoflow base image"
 docker build --provenance=false -q -f "$ROOT/runtime/Dockerfile" --build-arg "PYTHON_VERSION=${PY_VERSION}" -t "$BASE_IMAGE" "$ROOT" >/dev/null
@@ -192,24 +195,37 @@ jq -e '.tasks[] | select(.task_id=="transform__raw") | .depends_on | index("pre"
   || fail "group root transform__raw is not wired to the upstream operator 'pre'"
 jq -e '.tasks[] | select(.task_id=="post") | .depends_on | index("transform__mart")' "$PROJ/dag.json" >/dev/null \
   || fail "downstream operator 'post' is not wired to the group leaf"
-# The image the COMPILER produced, asserted directly. The run below proves these
-# transitively, but a red run says "a task failed" — these say which property
-# broke, and each one is a defect this release actually shipped.
+# The image the COMPILER produced, asserted directly. A red run only says "a task
+# failed"; these name the property. Note the run does NOT prove all of them: it
+# never writes into the project, so A5 is a property only this block checks.
 log "Asserting the generated image"
 docker run --rm --entrypoint sh "$DAG_IMAGE" -c 'test -f /home/leoflow/dag.py' \
   || fail "the generated Dockerfile did not COPY the DAG source"
 docker run --rm --entrypoint sh "$DAG_IMAGE" -c 'test -f /home/leoflow/transform/dbt_project.yml' \
   || fail "the generated Dockerfile did not COPY the dbt_groups project (#20)"
-docker run --rm --entrypoint python "$DAG_IMAGE" -c 'import leoflow, leoflow_runtime' \
+docker run --rm -w / -e PYTHONPATH= --entrypoint python "$DAG_IMAGE" -c 'from leoflow import dbt_group; import leoflow_runtime' \
   || fail "the authoring package is not importable in the task image (#17)"
 docker run --rm --entrypoint sh "$DAG_IMAGE" -c 'id -u | grep -qx 65532' \
   || fail "the image does not end on the numeric non-root UID the kubelet checks"
-docker run --rm --entrypoint sh "$DAG_IMAGE" -c '! touch /home/leoflow/transform/WRITE_PROBE 2>/dev/null' \
-  || fail "the dbt project is writable by the task user — the read-only posture (#852) is not real"
+docker run --rm --entrypoint sh "$DAG_IMAGE" -c 'test -d /home/leoflow/transform && ! touch /home/leoflow/transform/WRITE_PROBE 2>/dev/null' \
+  || fail "the dbt project is writable by the task user — #852's root-owned COPY is not holding"
 jq -e '[.tasks[] | select(.task_id | startswith("transform__")) | .entrypoint | test("--profiles-dir")] | all' "$PROJ/dag.json" >/dev/null \
   || fail "no --profiles-dir baked: the project ships profiles.yml and the base image points DBT_PROFILES_DIR at /tmp (#994)"
-jq -e '[.tasks[] | .entrypoint // "" | test("--project-dir /") | not] | all' "$PROJ/dag.json" >/dev/null \
+jq -e '[.tasks[] | .entrypoint // "" | test("--(project|profiles)-dir /") | not] | all' "$PROJ/dag.json" >/dev/null \
   || fail "an absolute host path was baked into a task entrypoint (#993)"
+
+# F9: the adapter must come from dependencies:, since no hand-written Dockerfile
+# installs it any more. Without this, deleting the pip layer from the generated
+# Dockerfile leaves all the assertions above green.
+docker run --rm --entrypoint sh "$DAG_IMAGE" -c 'command -v dbt >/dev/null' \
+  || fail "the declared adapter (dependencies:) is not installed in the generated image"
+
+# #993 CANNOT manifest under --build: `local` is false either way there, so the
+# assertion above is a canary, not a proof. The defect needs a bare compile —
+# which is also the door a CI or prebuilt-image workflow actually walks through.
+"$ROOT/bin/leoflow" compile "$PROJ" ${PARSER_CMD[@]+"${PARSER_CMD[@]}"} --image "$DAG_IMAGE" -o "$PROJ/nobuild.json"
+jq -e '[.tasks[] | .entrypoint // "" | test("--(project|profiles)-dir /") | not] | all' "$PROJ/nobuild.json" >/dev/null \
+  || fail "a bare compile baked an absolute host path into a pod-bound dag.json (#993)"
 
 k3d_import "$CLUSTER" "$BASE_IMAGE" "$DAG_IMAGE"
 


### PR DESCRIPTION
The only end-to-end coverage the hybrid DAG had went around every part of itself that was broken:

| the fixture did this | so this defect was invisible |
|---|---|
| hand-wrote a `Dockerfile` | #20 — the generated one had no `dbt_groups` COPY |
| set `DBT_PROFILES_DIR` at the project | #994 — the project's `profiles.yml` was unreachable |
| `chown`ed `/home/leoflow` to the task user | #852's read-only-project posture was never exercised |
| wired `BashOperator`s | #17 — a bash task never imports `dag.py` |

Four defects, one fixture. This is the structural reason a mode reported from the field as "much of it does not work" passed every gate we have.

## What changed

The fixture uses the **generated** Dockerfile, declares its adapter through `dependencies:`, and runs `PythonOperator`s either side of the group. Seven assertions read the built image directly, and each names the defect it would catch — because "a task failed" is not a diagnosis:

```
the DAG source is COPYed        the group project is COPYed     (#20)
leoflow imports in the image                                    (#17)
the final USER is numeric 65532
the project is NOT writable by the task user                    (#852)
--profiles-dir is baked on every dbt task                       (#994)
no absolute host path in any entrypoint                         (#993)
```

## Two things found by running it

**`PARSER_CMD[@]` made this script unrunnable on macOS.** bash 3.2 errors on an empty array under `set -u`, so it aborted before its first useful step — it could never be run locally before a push, on the platform releases are cut from. Fixed with the guarded expansion, with a note, since the next optional array will hit it too.

**`base_image` is pinned to the locally built base.** Removing the BYO Dockerfile removed the explicit `FROM`, so the generated one resolved to the **published** base — the test would have measured the last release's image instead of the code under review, going green precisely when it could no longer detect a regression. That one is subtle and it is the reason I ran this rather than shipping it.

## Verification

Run locally, not asserted: `EXIT=0`, `dbt + operators mixed e2e passed` — after three failed attempts that each found one of the above. `bash -n` and `shellcheck -S warning` clean.