### PR TITLE
docs(release): point the RC runbook at v0.4.5, and stop it certifying the wrong cloud

### DIFF
--- a/test/release/rc-cluster-validation.md
+++ b/test/release/rc-cluster-validation.md
@@ -180,7 +180,8 @@ kubectl run img-probe -n <taskNamespace> --rm -i --restart=Never \
 
   ```bash
   API=<control-plane base URL>          # e.g. http://localhost:8080 via port-forward
-  TOKEN=$(leoflow auth token)           # or the JWT from §2's login
+  TOKEN=$(leoflow auth create-token --server "$API" \
+                  --username <u> --password <p>)
   DAG=<the hybrid DAG from #17>         # NOT the §2 smoke DAG — it has no dbt tasks,
                                         # so it passes this vacuously
   curl -fsS -H "Authorization: Bearer $TOKEN" "$API/api/v2/dags/$DAG/spec" \
@@ -205,7 +206,7 @@ kubectl run img-probe -n <taskNamespace> --rm -i --restart=Never \
   succeeding. `decorateCommands` appends `--profiles-dir` only in the
   no-connection branch, so the fix sits one `switch` arm from the managed-secret
   path — the arm that also crosses ADR 0060 external secrets. Run one.
-- **#852 read-only project, for real ★** — the half no test covers.
+- **#852 read-only project, for real** — the half no test covers.
 
   ```bash
   kubectl label ns <taskNamespace> pod-security.kubernetes.io/enforce=restricted
@@ -222,15 +223,20 @@ kubectl run img-probe -n <taskNamespace> --rm -i --restart=Never \
   must resolve the image's numeric USER. That half is **already green three ways**
   (every k3d e2e pod, plus the image-level UID assertion in the e2e); it is not
   what makes this row cluster-only.
-  Run the PSA-`restricted` admission and the `LimitRange` ephemeral-storage
-  default here too — but note **k3d enforces both** (PodSecurity admission is
-  built in and on since 1.25; LimitRange is core), so a green there is not cloud
-  evidence and these belong in a k3d e2e rather than on cluster minutes.
-  What is genuinely cloud-only: **GKE Autopilot** mutating securityContext and
-  injecting resource requests, and **node-level ephemeral-storage eviction** under
-  a real kubelet with real disk pressure — the executor creates that emptyDir with
-  **no `sizeLimit`**, so nothing in our code bounds `/tmp/leoflow/dbt/target` on a
-  large manifest and the node is the only thing that will.
+  **This row has no cloud-only half, and three review rounds failed to find one.**
+  Each proposed anchor collapsed on inspection: the kubelet resolving the image's
+  numeric USER is already green three ways; PSA `restricted` admission and
+  `LimitRange` are in-tree apiserver features k3d enforces identically; node-level
+  ephemeral-storage eviction runs on a real kubelet on k3d too. GKE Autopilot
+  would be a genuine delta but the RC target is EKS, where it does not exist.
+  So: **run it on whatever cluster you have and record the result, but do not
+  spend cluster time you would not otherwise spend on it.** The right home for
+  this is a k3d e2e setting
+  `LEOFLOW_EXECUTOR_DEFAULTS_READ_ONLY_TASK_ROOT_FILESYSTEM=true` against a
+  `restricted`-labelled namespace, filed as #1016. One thing worth noting while
+  you are here, because nothing in our code bounds it: the executor creates that
+  emptyDir with **no `sizeLimit`**, so a namespace `LimitRange` or the node's own
+  eviction threshold is the only limit on `/tmp/leoflow/dbt/target`.
 - **#1005 does a task pod reuse the build-time parse?** — **run this locally, not
   on the cluster.** 
 
@@ -239,11 +245,16 @@ kubectl run img-probe -n <taskNamespace> --rm -i --restart=Never \
     --project-dir <project> --profiles-dir <project>
   ```
 
-  Read whether it reports a full parse or a partial one. Both flags are
-  required: the image's `WORKDIR` is `/home/leoflow` while the project sits at
-  `/home/leoflow/<project>`, so a bare `parse` dies with "Not a dbt project", and
-  `DBT_PROFILES_DIR` points at a `/tmp` path that does not exist in a fresh
-  container. The base image points
+  `--project-dir` is always required — the image's `WORKDIR` is `/home/leoflow`
+  while the project sits at `/home/leoflow/<project>`, so a bare `parse` dies
+  with "Not a dbt project". `--profiles-dir` is required only for a project that
+  **bakes its own `profiles.yml`** (the #994 shape); a `connection:` group has no
+  baked profile, since the managed one is written at runtime under `/tmp`.
+
+  **Expect "full parse", and treat a partial one as the surprise.**
+  `DBT_TARGET_PATH` is `/tmp/leoflow/dbt/target`, empty in a fresh container, so
+  `partial_parse.msgpack` cannot be there. This is a question, not a gate — if it
+  answers as expected, close #1005 and leave the claim out of the docs. The base image points
   `DBT_TARGET_PATH` at `/tmp/leoflow/dbt/target` while the project (with any
   baked `target/`) is copied to `/home/leoflow/<project>`, and nothing copies one
   to the other — so a full parse per task is the expected answer. Two files and a
@@ -410,33 +421,40 @@ automatically whenever the guaranteed replica floor is `> 1` — every
 (`minReplicas` default 2). A budget that appears unannounced is what hangs node
 drains and stalls auto-upgrades.
 
+`--set split.enabled=true` alone **will not render** on §1's baseline: the chart
+refuses more than one control-plane pod against a ReadWriteOnce logs PVC. Turn
+the PVC off (and ship logs to object storage), or layer the HA profile over your
+own values — never apply `values-ha.yaml` alone, it carries `CHANGEME`
+placeholders for the database, Redis and secrets that would repoint the control
+plane at a nonexistent Postgres:
+
 ```bash
-helm upgrade leoflow ... --set split.enabled=true
-kubectl get pdb -n <ns>                 # it should now exist, unasked
+helm upgrade leoflow ... -f <your-values>.yaml -f helm/leoflow/examples/values-ha.yaml
+kubectl get pdb -n <ns> -l app.kubernetes.io/instance=leoflow
+```
+
+**PASS:** a PDB now exists that you never asked for. That object's existence is
+the whole observation — it is what flips if the change is reverted.
+
+**The drain is a separate, weaker check.** A drain completes with no PDB at all,
+and faster, so "the drain completed" does not discriminate. It is worth running
+only to catch the budget *blocking* one, and it needs a precondition or it reads
+FAIL on a correct install — the chart ships no default anti-affinity, and
+`values-ha.yaml` spreads with `whenUnsatisfiable: ScheduleAnyway`, which is
+best-effort and can still bin-pack both replicas onto one node:
+
+```bash
+kubectl get pods -n <ns> -l app.kubernetes.io/instance=leoflow -o wide   # two distinct NODEs
 kubectl drain <node> --ignore-daemonsets --delete-emptydir-data
 ```
 
-**PASS:** the PDB renders, and the drain **completes** rather than hanging.
-
-**First put the two replicas on different nodes**, or this row reads FAIL on a
-correct install: the chart ships no default anti-affinity, so both api pods can
-land on one node and the drain will legitimately block on `minAvailable: 1`.
-Installing from the shipped HA profile is the better shape here, since it is also
-the artifact we advertise and nothing else validates it:
-`helm upgrade leoflow ... -f helm/leoflow/examples/values-ha.yaml`.
-
-**Then check the field survived.** `unhealthyPodEvictionPolicy: AlwaysAllow` is
-already the chart default, so *setting* it proves nothing. The cluster-only
-observation is that the apiserver kept it:
-
-```bash
-kubectl get pdb -n <ns> -o jsonpath='{.items[0].spec.unhealthyPodEvictionPolicy}'
-```
-
-**PASS:** prints `AlwaysAllow`. An apiserver older than 1.27 **prunes the field
-silently** — you get a PDB with the Kubernetes default `IfHealthyBudget`, under
-which two unready replicas cannot be evicted at all and a drain hangs on an
-already-down control plane. That silent loss is the thing worth a cluster.
+**Not worth running: the `unhealthyPodEvictionPolicy` field check.**
+`AlwaysAllow` is the chart default and only an apiserver older than 1.27 prunes
+it — neither EKS nor GKE will sell you one, so the check prints `AlwaysAllow`
+unconditionally. The observation that *would* flip is the behavior: break **both**
+replicas (bad DB credential or a bogus image), then drain. Under `AlwaysAllow`
+the eviction succeeds; under `IfHealthyBudget` it blocks on an already-down
+control plane. Stage that if you want the row, and skip it otherwise.
 
 The chart **fails the render** if `minAvailable` and `maxUnavailable` are both
 set — worth one deliberate attempt, since the point of that guard is to fail at
@@ -456,8 +474,21 @@ fired. Run it rather than improvising:
 LEOFLOW_CHAOS_ONLY=CD test/e2e/chaos-runtime.sh
 ```
 
-**PASS:** scenarios C and D both pass. Note this script is **not** in CI — it is
-opt-in, so an RC is the moment it actually gets run.
+**PASS:** scenarios C and D both pass. Two caveats worth stating, because they
+bound what a green here means:
+
+- The script is **not in any workflow** — only `make chaos-runtime`, which
+  nothing invokes. An RC is the moment it actually gets run, which is why it is
+  named here at all.
+- It runs the control plane as **host processes** from `bin/leoflow-server` on a
+  k3d cluster it creates and deletes. So it validates **the tree at the RC tag**,
+  not `ghcr.io/neochaotic/leoflow-server:<rc>`. Check out the tag and build
+  before running it, and record that the published image is not what was
+  exercised.
+
+Prerequisites beyond §0: a Linux docker host (a Lima VM on macOS), `k3d`, `jq`,
+a migrated external Postgres, and **`bin/leoflow` + `bin/leoflow-server` already
+built** — the script builds the base image but not those two.
 
 ---
 
@@ -517,8 +548,8 @@ cloud reads as proof, and that is the failure §5 exists to prevent.
 | #993 | bare compile + /spec: no host path in any entrypoint (§3a) | | |
 | #994 | no-connection group succeeds AND carries --profiles-dir (§3a) | | |
 | #994 | second arm: a group **with** `connection:` still succeeds (§3a) | | |
-| #852 | PSA `restricted` admits the pod + dbt tasks succeed read-only (§3a) | | |
-| #1005 | `docker run --entrypoint dbt --debug parse`: full or partial? (local, §3a) | | |
+| #852 | read-only rootfs: pod admitted, dbt tasks succeed (§3a; no cloud delta) | | |
+| #1005 | `docker run … dbt --debug parse`: full or partial? (local, §3a — a question, not a gate) | | |
 | #15 | stray top-level key fails validate AND compile; Lite discovery unaffected (§3a) | | |
 | #800 | zero-declaration: no scope_warning, task gets every connection (§3b) | | |
 | #800 | stale-declaration: deleted conn → no warning; enforce → nothing (§3b) | | |
@@ -533,8 +564,8 @@ cloud reads as proof, and that is the failure §5 exists to prevent.
 | #728 | warm TMPDIR fresh (§4.2) | | |
 | #729 | managed-PG re-extract (Lite host) | | |
 | — | task pods non-root by default | | |
-| HA | `split.enabled` install: PDB renders, `kubectl drain` completes (§4.5) | | |
-| ADR 0052 | control-plane restart mid-task: succeeded task stays succeeded (§4.5) | | |
+| HA | HA-profile upgrade: a PDB exists that nobody asked for (§4.5) | | |
+| ADR 0052 | `LEOFLOW_CHAOS_ONLY=CD chaos-runtime.sh` — C and D pass (§4.5) | | |
 
 For each FAIL: open an issue on `neochaotic/leoflow` with the root cause and, where
 possible, the file:line (the #722–#729 batch is the quality bar). A red RC →

--- a/test/release/rc-cluster-validation.md
+++ b/test/release/rc-cluster-validation.md
@@ -47,7 +47,7 @@ install page <https://neochaotic.github.io/leoflow/get-started/installation/>.
   The control-plane image comes from `ghcr.io/neochaotic/leoflow-server:<rc>`.
 - **Cloud identity** for keyless auth, to annotate the ServiceAccounts: EKS
   **IRSA** (`eks.amazonaws.com/role-arn`) or GKE **Workload Identity**
-  (`iam.gke.io/gcp-service-account`) — see §4.3/#725 and §5.
+  (`iam.gke.io/gcp-service-account`) — see §4.2/#728 and §5.
 - The `leoflow` CLI locally (client):
   `LEOFLOW_VERSION=<tag> curl -fsSL https://raw.githubusercontent.com/neochaotic/leoflow/main/install.sh | sh`
   (explicit tag — "latest" skips pre-releases).
@@ -130,10 +130,6 @@ forward across RCs. Deleting a §3b row is a decision, not a refresh.
 
 ✔ = also unit/e2e-verified; ★ = **only a real cluster proves it well**.
 
-> These ✔ marks rest on `dbt-mixing-e2e.sh` exercising the generated Dockerfile
-> path, which lands in #1008. **If #1008 has not merged, treat every ✔ below as
-> unbacked** and run the row anyway.
-
 Every item below is one of the five GA blockers this release closed, and they
 share a root: the hybrid DAG — a `dag.py` with dbt projects as task groups — was
 never exercised end to end by CI, so four defects shipped green inside one e2e
@@ -172,7 +168,7 @@ kubectl run img-probe -n <taskNamespace> --rm -i --restart=Never \
   the only production site setting it is `dev.go` (Lite subprocess) — `compile`,
   `deploy` and `deploy --skip-build` all leave it false. So one machine's output
   either carries a host path or it does not.
-  **PASS (local, and what the e2e asserts):**
+  **PASS (local; `internal/cli/dbt_projectdir_test.go` asserts the same shape as a unit test):**
 
   ```bash
   leoflow compile <dag-dir> -o /tmp/spec.json   # no --build
@@ -183,7 +179,11 @@ kubectl run img-probe -n <taskNamespace> --rm -i --restart=Never \
   pod fetches over gRPC:**
 
   ```bash
-  curl -fsS -H "Authorization: Bearer $TOKEN" "$API/api/v2/dags/<dag>/spec" \
+  API=<control-plane base URL>          # e.g. http://localhost:8080 via port-forward
+  TOKEN=$(leoflow auth token)           # or the JWT from §2's login
+  DAG=<the hybrid DAG from #17>         # NOT the §2 smoke DAG — it has no dbt tasks,
+                                        # so it passes this vacuously
+  curl -fsS -H "Authorization: Bearer $TOKEN" "$API/api/v2/dags/$DAG/spec" \
     | jq -e '[.tasks[] | .entrypoint // "" | test("--(project|profiles)-dir /") | not] | all'
   ```
 
@@ -222,13 +222,28 @@ kubectl run img-probe -n <taskNamespace> --rm -i --restart=Never \
   must resolve the image's numeric USER. That half is **already green three ways**
   (every k3d e2e pod, plus the image-level UID assertion in the e2e); it is not
   what makes this row cluster-only.
-  What *is* cluster-only: apiserver admission under PSA `restricted`, and a
-  namespace `LimitRange` with a default `ephemeral-storage` limit truncating
-  `/tmp/leoflow/dbt/target` on a large manifest — the executor creates that
-  emptyDir with **no `sizeLimit`**, so cluster policy is the only bound.
+  Run the PSA-`restricted` admission and the `LimitRange` ephemeral-storage
+  default here too — but note **k3d enforces both** (PodSecurity admission is
+  built in and on since 1.25; LimitRange is core), so a green there is not cloud
+  evidence and these belong in a k3d e2e rather than on cluster minutes.
+  What is genuinely cloud-only: **GKE Autopilot** mutating securityContext and
+  injecting resource requests, and **node-level ephemeral-storage eviction** under
+  a real kubelet with real disk pressure — the executor creates that emptyDir with
+  **no `sizeLimit`**, so nothing in our code bounds `/tmp/leoflow/dbt/target` on a
+  large manifest and the node is the only thing that will.
 - **#1005 does a task pod reuse the build-time parse?** — **run this locally, not
-  on the cluster.** `docker run --entrypoint dbt <dag-image> --debug parse` and
-  read whether it reports a full parse or a partial one. The base image points
+  on the cluster.** 
+
+  ```bash
+  docker run --rm --entrypoint dbt <dag-image> --debug parse \
+    --project-dir <project> --profiles-dir <project>
+  ```
+
+  Read whether it reports a full parse or a partial one. Both flags are
+  required: the image's `WORKDIR` is `/home/leoflow` while the project sits at
+  `/home/leoflow/<project>`, so a bare `parse` dies with "Not a dbt project", and
+  `DBT_PROFILES_DIR` points at a `/tmp` path that does not exist in a fresh
+  container. The base image points
   `DBT_TARGET_PATH` at `/tmp/leoflow/dbt/target` while the project (with any
   baked `target/`) is copied to `/home/leoflow/<project>`, and nothing copies one
   to the other — so a full parse per task is the expected answer. Two files and a
@@ -245,7 +260,9 @@ kubectl run img-probe -n <taskNamespace> --rm -i --restart=Never \
   With `secretScoping=permissive` (default), run a DAG declaring **no** variables
   and **no** connections against a tenant that has several connections defined.
   **PASS (today's behavior, and the blind spot made executable):** the task
-  receives **every** connection in the vault, and `GET /api/v2/eventLogs` shows
+  receives **every** connection in the vault — observe this with a probe task that
+  prints the `AIRFLOW_CONN_*` **names** it was handed, never their values — and
+  `GET /api/v2/eventLogs` shows
   **no** `secret.scope_warning` row for that run. That silence is exactly what an
   operator would read as "safe to flip to `enforce`", while this same DAG would
   receive **nothing** after the flip. Until #800's code half lands, this row is
@@ -399,19 +416,48 @@ kubectl get pdb -n <ns>                 # it should now exist, unasked
 kubectl drain <node> --ignore-daemonsets --delete-emptydir-data
 ```
 
-**PASS:** the PDB renders, and the drain **completes** rather than hanging. If
-you want the mitigation for an unhealthy pair, set
-`podDisruptionBudget.unhealthyPodEvictionPolicy=AlwaysAllow` (needs apiserver
-≥ 1.27) and confirm it renders. Note the chart **fails the render** if
-`minAvailable` and `maxUnavailable` are both set — worth one deliberate attempt,
-since the point of that guard is to fail at render rather than at install.
+**PASS:** the PDB renders, and the drain **completes** rather than hanging.
 
-**Restart recovery (ADR 0052).** Kill the control plane while a task is running
-and confirm a task that *succeeded* is not marked failed on recovery. The
-reconciler reads the outcome from the pod's `terminationMessage`, which needs a
-real pod status — k3d can stage the pod but not the eviction class of failure.
-**PASS:** after the control plane returns, the task's final state matches what
-the pod actually did.
+**First put the two replicas on different nodes**, or this row reads FAIL on a
+correct install: the chart ships no default anti-affinity, so both api pods can
+land on one node and the drain will legitimately block on `minAvailable: 1`.
+Installing from the shipped HA profile is the better shape here, since it is also
+the artifact we advertise and nothing else validates it:
+`helm upgrade leoflow ... -f helm/leoflow/examples/values-ha.yaml`.
+
+**Then check the field survived.** `unhealthyPodEvictionPolicy: AlwaysAllow` is
+already the chart default, so *setting* it proves nothing. The cluster-only
+observation is that the apiserver kept it:
+
+```bash
+kubectl get pdb -n <ns> -o jsonpath='{.items[0].spec.unhealthyPodEvictionPolicy}'
+```
+
+**PASS:** prints `AlwaysAllow`. An apiserver older than 1.27 **prunes the field
+silently** — you get a PDB with the Kubernetes default `IfHealthyBudget`, under
+which two unready replicas cannot be evicted at all and a drain hangs on an
+already-down control plane. That silent loss is the thing worth a cluster.
+
+The chart **fails the render** if `minAvailable` and `maxUnavailable` are both
+set — worth one deliberate attempt, since the point of that guard is to fail at
+render rather than at install.
+
+**Restart recovery (ADR 0052) — do NOT hand-roll this.** Killing the control
+plane mid-task and watching the task settle to `success` proves nothing: the
+agent's terminal report retries for as long as the control plane is unreachable,
+so the ordinary report path produces the same green without the recovery path
+ever running. `test/e2e/chaos-runtime.sh` already covers it on k3d, and refuses
+that exact false green — it bakes `LEOFLOW_CHAOS_DIE_BEFORE_REPORT` into the DAG
+image (dispatch strips author-declared `LEOFLOW_`-prefixed keys, #828/#829) and
+fails loudly if the pod ends `Completed`, because that means the fault seam never
+fired. Run it rather than improvising:
+
+```bash
+LEOFLOW_CHAOS_ONLY=CD test/e2e/chaos-runtime.sh
+```
+
+**PASS:** scenarios C and D both pass. Note this script is **not** in CI — it is
+opt-in, so an RC is the moment it actually gets run.
 
 ---
 
@@ -466,8 +512,8 @@ cloud reads as proof, and that is the failure §5 exists to prevent.
 | # | Check | PASS/FAIL | Notes / evidence |
 |---|---|---|---|
 | §2 | smoke: task→success | | |
-| #17 | hybrid: python tasks succeed (§3) | | |
-| #20 | dbt_project.yml present in the task pod (§3) | | |
+| #17 | hybrid: python tasks succeed (§3a) | | |
+| #20 | dbt_groups project present in the image, both shapes (§3a) | | |
 | #993 | bare compile + /spec: no host path in any entrypoint (§3a) | | |
 | #994 | no-connection group succeeds AND carries --profiles-dir (§3a) | | |
 | #994 | second arm: a group **with** `connection:` still succeeds (§3a) | | |
@@ -481,7 +527,7 @@ cloud reads as proof, and that is the failure §5 exists to prevent.
 | #724 | validation → 400 | | |
 | #725 | QoS Guaranteed + ClientIP (§4.3) | | |
 | #802 | partial resource pair → Burstable + boot WARN + compile error (§4.3) | | |
-| #804 | control-plane policy on, task policy off → 0 netpols in taskNamespace (§4.4) | | |
+| #804 | control-plane policy on, task policy off → no policy **selects** a task pod (§4.4) | | |
 | #726 | api has no tls.key (§4.1) | | |
 | #727 | migrate job no SA token | | |
 | #728 | warm TMPDIR fresh (§4.2) | | |

--- a/test/release/rc-cluster-validation.md
+++ b/test/release/rc-cluster-validation.md
@@ -20,14 +20,14 @@ release notes.
 
 | Field | Value |
 |---|---|
-| RC under test | `v0.4.0-rc.3` |
-| Cloud / cluster | AWS **EKS** (context: `<kubectl-context>`) |
-| CNI | AWS VPC CNI (note if using Calico/Cilium overlay) |
-| Node provisioning | (managed node group / Karpenter?) |
-| Server image | `ghcr.io/neochaotic/leoflow-server:v0.4.0-rc.3` |
+| RC under test | `<tag>` |
+| Cloud / cluster | `<AWS EKS / GCP GKE>` (context: `<kubectl-context>`) |
+| CNI | `<AWS VPC CNI / GKE Dataplane V2 / Calico>` — note it, §5 depends on it |
+| Node provisioning | (managed node group / Karpenter / GKE node pool?) |
+| Server image | `ghcr.io/neochaotic/leoflow-server:<tag>` |
 | Date / operator | `<date>` / `<who>` |
 
-Links: release <https://github.com/neochaotic/leoflow/releases/tag/v0.4.0-rc.3> ·
+Links: release <https://github.com/neochaotic/leoflow/releases/tag/TAG> ·
 Helm guide <https://neochaotic.github.io/leoflow/operate/helm-chart/> ·
 chart README (full values) <https://github.com/neochaotic/leoflow/blob/main/helm/leoflow/README.md> ·
 install page <https://neochaotic.github.io/leoflow/get-started/installation/>.
@@ -45,7 +45,7 @@ install page <https://neochaotic.github.io/leoflow/get-started/installation/>.
 - **Cloud identity** for keyless auth: an **IRSA** role (`eks.amazonaws.com/role-arn`)
   to annotate the ServiceAccounts (see §3/#725, §5).
 - The `leoflow` CLI locally (client):
-  `LEOFLOW_VERSION=v0.4.0-rc.3 curl -fsSL https://raw.githubusercontent.com/neochaotic/leoflow/main/install.sh | sh`
+  `LEOFLOW_VERSION=<tag> curl -fsSL https://raw.githubusercontent.com/neochaotic/leoflow/main/install.sh | sh`
   (explicit tag — "latest" skips pre-releases).
 
 ---
@@ -116,53 +116,66 @@ Record: does the control plane reach `Ready`? Is `/api/v2/` + the UI reachable
 
 ---
 
-## §3 rc.3 feature validation (refresh this section per RC)
+## §3 v0.4.5 feature validation (refresh this section per RC)
 
-The rc.3 tranche (#722–#729). ✔ = also unit/helm-verified; ★ = **only a real cluster proves it well**.
+The v0.4.5 tranche. ✔ = also unit/e2e-verified; ★ = **only a real cluster proves it well**.
 
-- **#722 secret-audit ✔** — with `secretLivenessMode=observe`, run a DAG that
-  declares fewer secrets than the vault. **PASS:** `GET /api/v2/eventLogs` shows a
-  `secret.scope_warning` row (not just a log line). Flip a scenario to `enforce`
-  and confirm a `secret.liveness_denied` row is written too.
-- **#800 zero-declaration blind spot** — the row above validates the population
-  that *does* warn, so a green RC has been certifying past the one that does not.
-  With `secretScoping=permissive` (default), run a DAG declaring **no** variables
-  and **no** connections against a tenant that has several connections defined.
-  **PASS (today's behavior, and the blind spot made executable):** the task
-  receives **every** connection in the vault, and `GET /api/v2/eventLogs` shows
-  **no** `secret.scope_warning` row for that run. That silence is exactly what an
-  operator would read as "safe to flip to `enforce`", while this same DAG would
-  receive **nothing** after the flip. Until #800's code half lands, this row is
-  the reminder that a clean trail is not evidence; when it lands, this row
-  inverts — the run must then produce a warning naming zero declarations.
-- **#800 stale-declaration blind spot** — the second population the trail never
-  shows, and the likelier one in practice, since secret rotation produces it. The
-  warning counts only declared names that actually *resolve*, so a DAG whose
-  declarations all point at names since deleted from the vault collapses to zero
-  declared and never warns — registration-time validation (#724) guards the
-  moment of registration, not later deletion. With `secretScoping=permissive`,
-  register a DAG declaring `conn_a`, run it, then delete `conn_a` from the vault
-  and run it again. **PASS (today's behavior):** the second run receives **every**
-  connection in the vault and `GET /api/v2/eventLogs` shows **no**
-  `secret.scope_warning` row for it. Flip that same DAG to `enforce` and confirm
-  it receives **nothing** — and that no audit row explains why.
-- **#723 reaper try-number ★** — see §4.2.
-- **#724 validation 400 ✔** — register a DAG version declaring an unknown
-  connection. **PASS:** API returns **400** (not 500); message points at
-  `leoflow connections set`.
-- **#725 config-bind + QoS ★** — see §4.3.
-- **#726 gRPC key off api ★** — see §4.1 (split mode only).
-- **#727 migration-job SA token ✔** — `kubectl get job <migrate> -o yaml`.
-  **PASS:** `spec.template.spec.automountServiceAccountToken: false`.
-- **#728 warm TMPDIR ★** — see §4.2 (warm pools).
-- **#729 managed-PG idempotent** — Lite/local, not EKS. Run the opt-in E2E
-  `test/e2e/lite-managed-pg-reextract.sh` on a networked host with managed-PG.
+Every item below is one of the five GA blockers this release closed, and they
+share a root: the hybrid DAG — a `dag.py` with dbt projects as task groups — was
+never exercised end to end by CI, so four defects shipped green inside one e2e
+fixture that hand-wrote its Dockerfile and used Bash tasks. `dbt-mixing-e2e.sh`
+now exercises the generated path, which is why most rows are ✔. What remains is
+what a pod does that a container on a laptop does not.
 
-Also confirm the **rc.2 behavior change** still holds: **task pods run as non-root
-by default** — `kubectl get pod <task> -o jsonpath='{.spec.securityContext}'`;
-root-assuming DAG images now fail (expected).
+- **#17 authoring package in the task image ✔★** — deploy a hybrid DAG whose
+  `dag.py` starts `from leoflow import dbt_group` and whose Python tasks sit
+  either side of the group. **PASS:** the `python` tasks reach `success`. The
+  runtime re-imports `dag.py` per task, so a missing package fails every one of
+  them with `ModuleNotFoundError`. ★ because the e2e proves the image; only a pod
+  proves the agent's own import path under `PYTHONPATH=/home/leoflow` and UID
+  65532.
+- **#20 dbt_groups project baked into the image ✔** — same DAG. **PASS:** the
+  `transform__*` tasks reach `success` rather than exiting within seconds.
+  `kubectl exec` into a task pod and confirm `/home/leoflow/<project>/dbt_project.yml`
+  exists.
+- **#993 absolute host path in the entrypoint ★** — the one the e2e structurally
+  cannot reach, because it needs two machines. Compile on machine A, then
+  `leoflow deploy --skip-build` from a CI runner or a second machine where that
+  path does not exist. **PASS:** `kubectl get pod <task> -o jsonpath='{.spec.containers[0].args}'`
+  contains no `/Users/` or `/home/<someone>/` prefix. **FAIL** is a dbt task
+  exiting seconds after start with "project directory does not exist".
+- **#994 project-baked profiles.yml ✔★** — a group with **no** `connection:`
+  whose project ships its own `profiles.yml`. **PASS:** the dbt tasks succeed.
+  ★ because the base image points `DBT_PROFILES_DIR` at `/tmp`, and only a pod
+  with a real `/tmp` emptyDir shows whether the read path and the write path
+  agree.
+- **#852 read-only project, for real ★** — the half no test covers.
+  `taskPodSecurity.readOnlyRootFilesystem=true` with a `/tmp` emptyDir, and
+  `runAsNonRoot=true` with **no** `runAsUser`. **PASS:** the pod reaches `Running`
+  (the kubelet resolves the image's numeric USER — a different code path from
+  `docker run`, and a symbolic `USER nonroot` fails here where it passes locally),
+  the dbt tasks succeed, and nothing is written under `/home/leoflow/<project>`.
+  Watch for a namespace-default emptyDir `sizeLimit` truncating
+  `/tmp/leoflow/dbt/target` on a large manifest — every parse artifact lands there
+  now.
+- **#1005 does a task pod reuse the build-time parse? ★** — twenty minutes, and it
+  settles a claim removed from the docs rather than left standing. Run one dbt
+  task with `dbt --debug` and read whether it reports a full parse or a partial
+  one. Nothing in the tree copies the baked `target/` to `DBT_TARGET_PATH`, so a
+  full parse per task is the expected answer; if so, close #1005 and leave the
+  claim out.
+- **#15 strict `leoflow.yaml` keys ✔** — unit-covered, no cluster needed. Worth
+  one smoke: `leoflow validate` against a project carrying a stray top-level key
+  must fail and name it.
 
----
+### Not provable on GKE
+
+The four §5 deltas. Record them as **not verified on this cloud** rather than
+PASS — a GKE run that reports them green is the false confidence §5 exists to
+prevent. Specifically for this tranche: nothing above depends on IRSA, RWX or
+ingress, but **NetworkPolicy enforcement does differ**, so any netpol-dependent
+row is GKE-shaped evidence only.
+
 
 ## §4 Deep cluster-only checks (k3d cannot show these)
 
@@ -283,9 +296,19 @@ helm upgrade leoflow ... --set networkPolicy.enabled=true
 
 ## §6 Results + reporting
 
+Record **NOT VERIFIED (cloud)** rather than PASS for anything §5 says this cloud
+cannot settle. A row left blank reads as "not run"; a row marked PASS on the wrong
+cloud reads as proof, and that is the failure §5 exists to prevent.
+
 | # | Check | PASS/FAIL | Notes / evidence |
 |---|---|---|---|
 | §2 | smoke: task→success | | |
+| #17 | hybrid: python tasks succeed (§3) | | |
+| #20 | dbt_project.yml present in the task pod (§3) | | |
+| #993 | deploy --skip-build: no host path in pod args (§3) | | |
+| #994 | group with no connection: dbt tasks succeed (§3) | | |
+| #852 | readOnlyRootFilesystem + numeric non-root: pod Running, project unwritten (§3) | | |
+| #1005 | task pod: full parse or partial? (§3) | | |
 | #722 | audit rows written | | |
 | #723 | retry not wedged (§4.2) | | |
 | #724 | validation → 400 | | |

--- a/test/release/rc-cluster-validation.md
+++ b/test/release/rc-cluster-validation.md
@@ -514,9 +514,11 @@ built** — the script builds the base image but not those two.
 
 ## §5b What a GKE run cannot settle
 
-§3a touches none of the §5 deltas — image content, entrypoint strings, container
-security context and YAML strictness have no cloud delta. The rows that **do**
-depend on them are all in §4, and a GKE pass on these is not an EKS pass:
+No §3a row **depends** on a §5 delta — image content, entrypoint strings,
+container security context and YAML strictness have no cloud delta. (#852 names
+Autopilot only to rule it out as a justification; it does not rest on it.) The
+rows that do depend on a delta are all in §4, and a GKE pass on these is not an
+EKS pass:
 
 - **§4.2 / #728 — IRSA credential cache.** "creds cached to `~/.aws/cli/cache`"
   has no Workload Identity equivalent; that half is unrunnable on GKE. The

--- a/test/release/rc-cluster-validation.md
+++ b/test/release/rc-cluster-validation.md
@@ -10,9 +10,10 @@ validate") — this file is that checklist.
 
 **How to use:** fill in the run header, follow §0→§6, record PASS/FAIL in §6, and
 open one issue per FAIL (root-caused, file:line if known — same bar as the
-#722–#729 batch). For the **next** RC, keep §0/§2/§4/§5 as-is and only refresh §3
-(the "features this RC shipped") from that release's CHANGELOG `[Unreleased]` /
-release notes.
+#722–#729 batch). For the **next** RC, keep §0/§2/§4/§5 as-is and refresh only
+**§3a** (the "features this RC shipped") from that release's CHANGELOG
+`[Unreleased]` / release notes. **§3b carries forward** — those rows stand until
+the issue they name closes.
 
 ---
 
@@ -24,6 +25,7 @@ release notes.
 | Cloud / cluster | `<AWS EKS / GCP GKE>` (context: `<kubectl-context>`) |
 | CNI | `<AWS VPC CNI / GKE Dataplane V2 / Calico>` — note it, §5 depends on it |
 | Node provisioning | (managed node group / Karpenter / GKE node pool?) |
+| GKE mode | `<Standard / Autopilot>` — Autopilot mutates pod specs; see §5 |
 | Server image | `ghcr.io/neochaotic/leoflow-server:<tag>` |
 | Date / operator | `<date>` / `<who>` |
 
@@ -36,14 +38,16 @@ install page <https://neochaotic.github.io/leoflow/get-started/installation/>.
 
 ## §0 Prerequisites
 
-- `kubectl` pointed at the target EKS cluster; `helm` v3.
+- `kubectl` pointed at the target cluster (EKS / GKE Standard / other); `helm` v3.
 - **External Postgres + Redis** reachable from the cluster (the chart runs on any
   cluster with external datastores — see the chart README "datastore
   compatibility" for the exact secret/URL value keys; do not guess them).
-- A container registry the cluster can pull from for **your DAG images** (ECR).
+- A container registry the cluster can pull from for **your DAG images**
+  (ECR / Artifact Registry).
   The control-plane image comes from `ghcr.io/neochaotic/leoflow-server:<rc>`.
-- **Cloud identity** for keyless auth: an **IRSA** role (`eks.amazonaws.com/role-arn`)
-  to annotate the ServiceAccounts (see §3/#725, §5).
+- **Cloud identity** for keyless auth, to annotate the ServiceAccounts: EKS
+  **IRSA** (`eks.amazonaws.com/role-arn`) or GKE **Workload Identity**
+  (`iam.gke.io/gcp-service-account`) — see §4.3/#725 and §5.
 - The `leoflow` CLI locally (client):
   `LEOFLOW_VERSION=<tag> curl -fsSL https://raw.githubusercontent.com/neochaotic/leoflow/main/install.sh | sh`
   (explicit tag — "latest" skips pre-releases).
@@ -97,7 +101,7 @@ Baseline install (single-replica, dedicated pod-per-task, defaults):
 helm install leoflow oci-or-repo/leoflow \
   --version <chart-version-for-rc> \
   -n leoflow --create-namespace \
-  -f values.eks.yaml
+  -f <your-values>.yaml   # e.g. values.eks.yaml / values.gke.yaml
 ```
 
 Record: does the control plane reach `Ready`? Is `/api/v2/` + the UI reachable
@@ -116,9 +120,19 @@ Record: does the control plane reach `Ready`? Is `/api/v2/` + the UI reachable
 
 ---
 
-## §3 v0.4.5 feature validation (refresh this section per RC)
+## §3 v0.4.5 feature validation
 
-The v0.4.5 tranche. ✔ = also unit/e2e-verified; ★ = **only a real cluster proves it well**.
+**§3a is refreshed per RC** from that release's CHANGELOG `[Unreleased]`.
+**§3b is not** — those rows stand until the issue they name closes, and carry
+forward across RCs. Deleting a §3b row is a decision, not a refresh.
+
+### §3a — the v0.4.5 tranche
+
+✔ = also unit/e2e-verified; ★ = **only a real cluster proves it well**.
+
+> These ✔ marks rest on `dbt-mixing-e2e.sh` exercising the generated Dockerfile
+> path, which lands in #1008. **If #1008 has not merged, treat every ✔ below as
+> unbacked** and run the row anyway.
 
 Every item below is one of the five GA blockers this release closed, and they
 share a root: the hybrid DAG — a `dag.py` with dbt projects as task groups — was
@@ -127,56 +141,145 @@ fixture that hand-wrote its Dockerfile and used Bash tasks. `dbt-mixing-e2e.sh`
 now exercises the generated path, which is why most rows are ✔. What remains is
 what a pod does that a container on a laptop does not.
 
-- **#17 authoring package in the task image ✔★** — deploy a hybrid DAG whose
+**Task pods are `restartPolicy: Never` and live seconds.** `kubectl exec` into
+one is not runnable — the container is gone before you can attach. Where a row
+needs to look inside the image *as the cluster pulled it*, use a throwaway pod:
+
+```bash
+kubectl run img-probe -n <taskNamespace> --rm -i --restart=Never \
+  --image=<dag-image> --command -- sh -c '<command>'
+```
+
+- **#17 authoring package in the task image ✔** — deploy a hybrid DAG whose
   `dag.py` starts `from leoflow import dbt_group` and whose Python tasks sit
   either side of the group. **PASS:** the `python` tasks reach `success`. The
   runtime re-imports `dag.py` per task, so a missing package fails every one of
-  them with `ModuleNotFoundError`. ★ because the e2e proves the image; only a pod
-  proves the agent's own import path under `PYTHONPATH=/home/leoflow` and UID
-  65532.
+  them with `ModuleNotFoundError`. No ★: `leoflow` ships **in the wheel**
+  (`runtime/python/pyproject.toml` `packages = ["leoflow_runtime", "leoflow"]`,
+  installed to site-packages by `runtime/Dockerfile`), so it resolves
+  independently of `PYTHONPATH` and of UID. `PYTHONPATH=/home/leoflow` is what
+  makes *`dag.py`* importable, not `leoflow`. The e2e already runs this with
+  `-e PYTHONPATH=` empty, which is stricter than a pod.
 - **#20 dbt_groups project baked into the image ✔** — same DAG. **PASS:** the
-  `transform__*` tasks reach `success` rather than exiting within seconds.
-  `kubectl exec` into a task pod and confirm `/home/leoflow/<project>/dbt_project.yml`
-  exists.
-- **#993 absolute host path in the entrypoint ★** — the one the e2e structurally
-  cannot reach, because it needs two machines. Compile on machine A, then
-  `leoflow deploy --skip-build` from a CI runner or a second machine where that
-  path does not exist. **PASS:** `kubectl get pod <task> -o jsonpath='{.spec.containers[0].args}'`
-  contains no `/Users/` or `/home/<someone>/` prefix. **FAIL** is a dbt task
-  exiting seconds after start with "project directory does not exist".
-- **#994 project-baked profiles.yml ✔★** — a group with **no** `connection:`
-  whose project ships its own `profiles.yml`. **PASS:** the dbt tasks succeed.
-  ★ because the base image points `DBT_PROFILES_DIR` at `/tmp`, and only a pod
-  with a real `/tmp` emptyDir shows whether the read path and the write path
-  agree.
+  `transform__*` tasks reach `success` rather than exiting within seconds. To
+  see the image content, use the `img-probe` pod above with
+  `ls -l /home/leoflow/<project>/dbt_project.yml`.
+  **Second shape, not covered by the e2e:** a group whose `project` is `"."`
+  (the DAG dir itself) takes a different `COPY . /home/leoflow/` branch in
+  `compile_build.go` and omits `--project-dir` entirely. Run one.
+- **#993 absolute host path in the entrypoint ✔★** — **single machine; a second
+  one adds nothing.** `dbtProjectDir` only absolutizes when `local` is true, and
+  the only production site setting it is `dev.go` (Lite subprocess) — `compile`,
+  `deploy` and `deploy --skip-build` all leave it false. So one machine's output
+  either carries a host path or it does not.
+  **PASS (local, and what the e2e asserts):**
+
+  ```bash
+  leoflow compile <dag-dir> -o /tmp/spec.json   # no --build
+  jq -e '[.tasks[] | .entrypoint // "" | test("--(project|profiles)-dir /") | not] | all' /tmp/spec.json
+  ```
+
+  **PASS (cluster) — read the entrypoint the *server* holds, which is what the
+  pod fetches over gRPC:**
+
+  ```bash
+  curl -fsS -H "Authorization: Bearer $TOKEN" "$API/api/v2/dags/<dag>/spec" \
+    | jq -e '[.tasks[] | .entrypoint // "" | test("--(project|profiles)-dir /") | not] | all'
+  ```
+
+  **Do NOT** read `kubectl get pod <task> -o jsonpath='{.spec.containers[0].args}'`.
+  `BuildPod` sets neither `command` nor `args` — the entrypoint never reaches the
+  pod spec — so that jsonpath returns empty on a fixed build *and* on a broken
+  one. It is a row that cannot fail.
+  **FAIL** is a dbt task exiting seconds after start with "project directory does
+  not exist".
+- **#994 project-baked profiles.yml ✔** — a group with **no** `connection:` whose
+  project ships its own `profiles.yml`. **PASS:** the dbt tasks succeed **and**
+  the `/spec` entrypoint for every `transform__*` task carries
+  `--profiles-dir <project>`; without the positive assertion you cannot tell the
+  fix from a project that never needed it. No ★: the `/tmp` emptyDir is created
+  by `mountWritableTmp` **only** when `readOnlyRootFilesystem` is on, which is
+  off by default — `/tmp` here is the container's writable layer, identical on
+  k3d and GKE.
+  **Second arm, not covered anywhere:** a group **with** `connection:` still
+  succeeding. `decorateCommands` appends `--profiles-dir` only in the
+  no-connection branch, so the fix sits one `switch` arm from the managed-secret
+  path — the arm that also crosses ADR 0060 external secrets. Run one.
 - **#852 read-only project, for real ★** — the half no test covers.
-  `taskPodSecurity.readOnlyRootFilesystem=true` with a `/tmp` emptyDir, and
-  `runAsNonRoot=true` with **no** `runAsUser`. **PASS:** the pod reaches `Running`
-  (the kubelet resolves the image's numeric USER — a different code path from
-  `docker run`, and a symbolic `USER nonroot` fails here where it passes locally),
-  the dbt tasks succeed, and nothing is written under `/home/leoflow/<project>`.
-  Watch for a namespace-default emptyDir `sizeLimit` truncating
-  `/tmp/leoflow/dbt/target` on a large manifest — every parse artifact lands there
-  now.
-- **#1005 does a task pod reuse the build-time parse? ★** — twenty minutes, and it
-  settles a claim removed from the docs rather than left standing. Run one dbt
-  task with `dbt --debug` and read whether it reports a full parse or a partial
-  one. Nothing in the tree copies the baked `target/` to `DBT_TARGET_PATH`, so a
-  full parse per task is the expected answer; if so, close #1005 and leave the
-  claim out.
+
+  ```bash
+  kubectl label ns <taskNamespace> pod-security.kubernetes.io/enforce=restricted
+  helm upgrade leoflow ... --set taskPodSecurity.readOnlyRootFilesystem=true
+  ```
+
+  **PASS:** the pod is **admitted** by a `restricted`-enforcing namespace and
+  reaches `Running` (not `CreateContainerConfigError`), and the dbt tasks succeed
+  — which is the observable form of "every write landed in the `/tmp` emptyDir".
+  Do not try to observe "nothing was written under `/home/leoflow/<project>`":
+  with a read-only rootfs the kernel makes it impossible, and the pod is gone
+  before you could look.
+  Note the executor never sets `runAsUser` — only `runAsNonRoot` — so the kubelet
+  must resolve the image's numeric USER. That half is **already green three ways**
+  (every k3d e2e pod, plus the image-level UID assertion in the e2e); it is not
+  what makes this row cluster-only.
+  What *is* cluster-only: apiserver admission under PSA `restricted`, and a
+  namespace `LimitRange` with a default `ephemeral-storage` limit truncating
+  `/tmp/leoflow/dbt/target` on a large manifest — the executor creates that
+  emptyDir with **no `sizeLimit`**, so cluster policy is the only bound.
+- **#1005 does a task pod reuse the build-time parse?** — **run this locally, not
+  on the cluster.** `docker run --entrypoint dbt <dag-image> --debug parse` and
+  read whether it reports a full parse or a partial one. The base image points
+  `DBT_TARGET_PATH` at `/tmp/leoflow/dbt/target` while the project (with any
+  baked `target/`) is copied to `/home/leoflow/<project>`, and nothing copies one
+  to the other — so a full parse per task is the expected answer. Two files and a
+  `docker run` settle it; it does not deserve cluster minutes.
 - **#15 strict `leoflow.yaml` keys ✔** — unit-covered, no cluster needed. Worth
-  one smoke: `leoflow validate` against a project carrying a stray top-level key
-  must fail and name it.
+  one smoke: a project carrying a stray top-level key must fail **both**
+  `leoflow validate` and `leoflow compile`, naming the key — and must **not**
+  break Lite discovery, which decodes leniently on purpose.
 
-### Not provable on GKE
+### §3b — standing assertions (carry forward until the issue closes)
 
-The four §5 deltas. Record them as **not verified on this cloud** rather than
-PASS — a GKE run that reports them green is the false confidence §5 exists to
-prevent. Specifically for this tranche: nothing above depends on IRSA, RWX or
-ingress, but **NetworkPolicy enforcement does differ**, so any netpol-dependent
-row is GKE-shaped evidence only.
+- **#800 zero-declaration blind spot** — the row above validates the population
+  that *does* warn, so a green RC has been certifying past the one that does not.
+  With `secretScoping=permissive` (default), run a DAG declaring **no** variables
+  and **no** connections against a tenant that has several connections defined.
+  **PASS (today's behavior, and the blind spot made executable):** the task
+  receives **every** connection in the vault, and `GET /api/v2/eventLogs` shows
+  **no** `secret.scope_warning` row for that run. That silence is exactly what an
+  operator would read as "safe to flip to `enforce`", while this same DAG would
+  receive **nothing** after the flip. Until #800's code half lands, this row is
+  the reminder that a clean trail is not evidence; when it lands, this row
+  inverts — the run must then produce a warning naming zero declarations.
+- **#800 stale-declaration blind spot** — the second population the trail never
+  shows, and the likelier one in practice, since secret rotation produces it. The
+  warning counts only declared names that actually *resolve*, so a DAG whose
+  declarations all point at names since deleted from the vault collapses to zero
+  declared and never warns — registration-time validation (#724) guards the
+  moment of registration, not later deletion. With `secretScoping=permissive`,
+  register a DAG declaring `conn_a`, run it, then delete `conn_a` from the vault
+  and run it again. **PASS (today's behavior):** the second run receives **every**
+  connection in the vault and `GET /api/v2/eventLogs` shows **no**
+  `secret.scope_warning` row for it. Flip that same DAG to `enforce` and confirm
+  it receives **nothing** — and that no audit row explains why.
+- **#722 secret-audit ✔** — with `secretLivenessMode=observe`, run a DAG that
+  declares fewer secrets than the vault. **PASS:** `GET /api/v2/eventLogs` shows a
+  `secret.scope_warning` row (not just a log line). Flip a scenario to `enforce`
+  and confirm a `secret.liveness_denied` row is written too. (This is the row the
+  two #800 rows above exist to qualify: it validates the population that *does*
+  warn.)
+- **#724 validation 400 ✔** — register a DAG version declaring an unknown
+  connection. **PASS:** API returns **400** (not 500); message points at
+  `leoflow connections set`.
+- **#727 migration-job SA token ✔** — `kubectl get job <migrate> -o yaml`.
+  **PASS:** `spec.template.spec.automountServiceAccountToken: false`.
+- **#729 managed-PG idempotent** — Lite/local, not a cloud cluster. Run the opt-in
+  E2E `test/e2e/lite-managed-pg-reextract.sh` on a networked host with managed-PG.
+- **task pods non-root by default** — the rc.2 behavior change, still standing.
+  `kubectl get pod <task> -o jsonpath='{.spec.securityContext}'`. Root-assuming
+  DAG images fail (expected).
 
-
+---
 ## §4 Deep cluster-only checks (k3d cannot show these)
 
 ### §4.1 — #726: api role never receives the gRPC TLS private key (split mode)
@@ -280,6 +383,38 @@ helm upgrade leoflow ... --set networkPolicy.enabled=true
 
 ---
 
+### §4.5 — HA posture: the PDB that appears on `helm upgrade`, and restart recovery
+
+Two `[Unreleased]` changes with no other executable statement in this file.
+
+**PDB (changes existing installs on upgrade).** The budget now renders
+automatically whenever the guaranteed replica floor is `> 1` — every
+`split.enabled` install (api default 2) and every `autoscaling.enabled` install
+(`minReplicas` default 2). A budget that appears unannounced is what hangs node
+drains and stalls auto-upgrades.
+
+```bash
+helm upgrade leoflow ... --set split.enabled=true
+kubectl get pdb -n <ns>                 # it should now exist, unasked
+kubectl drain <node> --ignore-daemonsets --delete-emptydir-data
+```
+
+**PASS:** the PDB renders, and the drain **completes** rather than hanging. If
+you want the mitigation for an unhealthy pair, set
+`podDisruptionBudget.unhealthyPodEvictionPolicy=AlwaysAllow` (needs apiserver
+≥ 1.27) and confirm it renders. Note the chart **fails the render** if
+`minAvailable` and `maxUnavailable` are both set — worth one deliberate attempt,
+since the point of that guard is to fail at render rather than at install.
+
+**Restart recovery (ADR 0052).** Kill the control plane while a task is running
+and confirm a task that *succeeded* is not marked failed on recovery. The
+reconciler reads the outcome from the pod's `terminationMessage`, which needs a
+real pod status — k3d can stage the pod but not the eviction class of failure.
+**PASS:** after the control plane returns, the task's final state matches what
+the pod actually did.
+
+---
+
 ## §5 EKS ↔ GKE deltas (so a GKE pass doesn't give false confidence)
 
 - **Identity:** EKS **IRSA** (`eks.amazonaws.com/role-arn`) vs GKE **Workload
@@ -291,6 +426,34 @@ helm upgrade leoflow ... --set networkPolicy.enabled=true
   `logs.persistence.accessMode=ReadWriteMany`). GKE uses PD / Filestore.
 - **Ingress:** ALB (IP vs instance target mode) / NLB (proxy-protocol) change what
   `ClientIP` sees → the §4.3 `trustedProxies` CIDR is cloud-specific.
+- **GKE Autopilot vs Standard:** Autopilot mutates pod specs, injects resource
+  requests and constrains securityContext / ephemeral storage — which lands
+  directly on §3a/#852 (read-only rootfs + an unsized emptyDir) and on §4.3's QoS
+  row. This runbook assumes **Standard**; record the mode in the run header.
+  *Confirm this against your own cluster before trusting it — it is the one delta
+  here not verified against the code.*
+
+---
+
+## §5b What a GKE run cannot settle
+
+§3a touches none of the §5 deltas — image content, entrypoint strings, container
+security context and YAML strictness have no cloud delta. The rows that **do**
+depend on them are all in §4, and a GKE pass on these is not an EKS pass:
+
+- **§4.2 / #728 — IRSA credential cache.** "creds cached to `~/.aws/cli/cache`"
+  has no Workload Identity equivalent; that half is unrunnable on GKE. The
+  `$TMPDIR` sentinel half does transfer. Split the row: **NOT VERIFIED (cloud)**
+  for the cache.
+- **§4.3 / #725 — ClientIP.** GCLB's `X-Forwarded-For` shape differs from
+  ALB/NLB, and the `trustedProxies` CIDR does not transfer. Run it for the code
+  path; record **NOT VERIFIED (cloud)** for the EKS claim.
+- **§4.4 / #804 — containment.** This is the **most misleading row to pass on
+  GKE**, because the delta runs the wrong way: Dataplane V2 enforces
+  NetworkPolicy natively, so the metadata-egress test passes almost by default,
+  while the AWS VPC CNI enforces *nothing* unless its network-policy agent is on.
+  A green here is the weakest evidence in the file. Record **NOT VERIFIED
+  (cloud)** for EKS and re-run on the EKS RC with the addon flag in the header.
 
 ---
 
@@ -305,10 +468,14 @@ cloud reads as proof, and that is the failure §5 exists to prevent.
 | §2 | smoke: task→success | | |
 | #17 | hybrid: python tasks succeed (§3) | | |
 | #20 | dbt_project.yml present in the task pod (§3) | | |
-| #993 | deploy --skip-build: no host path in pod args (§3) | | |
-| #994 | group with no connection: dbt tasks succeed (§3) | | |
-| #852 | readOnlyRootFilesystem + numeric non-root: pod Running, project unwritten (§3) | | |
-| #1005 | task pod: full parse or partial? (§3) | | |
+| #993 | bare compile + /spec: no host path in any entrypoint (§3a) | | |
+| #994 | no-connection group succeeds AND carries --profiles-dir (§3a) | | |
+| #994 | second arm: a group **with** `connection:` still succeeds (§3a) | | |
+| #852 | PSA `restricted` admits the pod + dbt tasks succeed read-only (§3a) | | |
+| #1005 | `docker run --entrypoint dbt --debug parse`: full or partial? (local, §3a) | | |
+| #15 | stray top-level key fails validate AND compile; Lite discovery unaffected (§3a) | | |
+| #800 | zero-declaration: no scope_warning, task gets every connection (§3b) | | |
+| #800 | stale-declaration: deleted conn → no warning; enforce → nothing (§3b) | | |
 | #722 | audit rows written | | |
 | #723 | retry not wedged (§4.2) | | |
 | #724 | validation → 400 | | |
@@ -320,6 +487,8 @@ cloud reads as proof, and that is the failure §5 exists to prevent.
 | #728 | warm TMPDIR fresh (§4.2) | | |
 | #729 | managed-PG re-extract (Lite host) | | |
 | — | task pods non-root by default | | |
+| HA | `split.enabled` install: PDB renders, `kubectl drain` completes (§4.5) | | |
+| ADR 0052 | control-plane restart mid-task: succeeded task stays succeeded (§4.5) | | |
 
 For each FAIL: open an issue on `neochaotic/leoflow` with the root cause and, where
 possible, the file:line (the #722–#729 batch is the quality bar). A red RC →


### PR DESCRIPTION
`test/release/rc-cluster-validation.md` says to refresh §3 per RC and to be reusable "per RC and per cloud". It was neither: §3 still described the rc.3 tranche (#722–#729), and the run header hardcoded **AWS EKS** and `v0.4.0-rc.3`. Run as written against this release, it would have validated the previous one's features.

## §3 → v0.4.5

The five GA blockers this release closed, in the file's own notation — ✔ for what unit or e2e already proves, ★ for what only a pod shows.

That split carries more weight than usual here, because #1008 makes `dbt-mixing-e2e.sh` exercise the generated path end to end. Most rows are now ✔, and the cluster's remaining job is narrow and specific:

| | why a cluster |
|---|---|
| **#993** | needs two machines — compile on one, `deploy --skip-build` from another, then read the pod's args for a host path. The e2e structurally cannot reach it |
| **#852** | `readOnlyRootFilesystem` with a real `/tmp` emptyDir, and `runAsNonRoot` with no `runAsUser` so the **kubelet** resolves the image's numeric USER — a different code path from `docker run`, where a symbolic `USER nonroot` passes and in a pod does not |
| **#1005** | one `dbt --debug` in a task pod settles whether the build-time parse is reused. Twenty minutes, and it decides whether a claim returns to the docs or stays out |

## The cloud half

§5 already lists four EKS↔GKE deltas "so a GKE pass doesn't give false confidence" — but §6 offered only PASS/FAIL, leaving an operator nowhere to put *"this cloud cannot settle it"*. §6 now says to record **NOT VERIFIED (cloud)** for those rows, and §3 ends with which of this tranche's rows that applies to (NetworkPolicy enforcement; nothing here depends on IRSA, RWX or ingress).

A blank row reads as "not run". A PASS on the wrong cloud reads as proof. That second one is the failure §5 exists to prevent, and the results table was quietly inviting it.

## Header

Tag and cloud are placeholders now, and the CNI row says to note it because §5 depends on it.

The one surviving `v0.4.0-rc.3` reference is a historical note about that release shipping with a stale `Chart.yaml`. It is about the past and stays.

Docs only — no code, no test changes.