### PR TITLE
fix(cli): refuse a dbt: block alongside a dag.py instead of dropping the Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,18 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **A `dbt:` block alongside a `dag.py` is now refused instead of silently
+  discarding the Python (#1001).** `compile` routes on the `dbt:` block before
+  the parser is ever invoked, so the Python was never read and nothing said so:
+  `validate`, `compile` and `deploy` all reported success while shipping a DAG
+  missing every non-dbt task. This is also the state a migration passes through,
+  because writing the `dag.py` before deleting `dbt:` is the order a person
+  naturally works in — and the dbt authoring page now recommends that migration.
+  `compile` and `validate` both refuse the pair and name which block to delete.
+  Refusing rather than merging keeps "which one wins, and how would they
+  compose?" out of the decision: no author means both at once. A genuine
+  dbt-only project is untouched — the check keys on the DAG source existing.
+
 - **`leoflow.yaml` rejects keys the schema does not define, and `leoflow validate`
   finally works on a pure-dbt project (#15, #996).** The authoring schema declares
   `additionalProperties: false` and that guard was **unreachable**: the loader used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,11 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Refusing rather than merging keeps "which one wins, and how would they
   compose?" out of the decision: no author means both at once. A genuine
   dbt-only project is untouched — the check keys on the DAG source existing.
+  **Upgrade note:** a dbt-only project carrying a *leftover* `dag.py` now fails
+  to compile until you delete the file. If you added an empty one to work around
+  #769 — `deploy --build` failed on `COPY dag.py` for pure-dbt projects between
+  v0.3.0 and v0.4.0 — that workaround has been unnecessary since v0.4.0 and the
+  file can go.
 
 - **`leoflow.yaml` rejects keys the schema does not define, and `leoflow validate`
   finally works on a pure-dbt project (#15, #996).** The authoring schema declares

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -83,13 +83,13 @@ func runCompile(cmd *cobra.Command, dir string, o compileOptions) error {
 	if verr := cfg.Validate(); verr != nil {
 		return fmt.Errorf("invalid %s: %w", projectConfigPath(dir), verr)
 	}
+	if derr := errDbtBlockWithDagSource(dir, cfg); derr != nil {
+		return derr
+	}
 	// Self-heal the extracted parser sources before running the parser, so a binary
 	// upgrade (new features like dbt vs a stale ~/.leoflow/pysrc) never surfaces as
 	// a confusing "not supported" error (#239).
 	ensurePysrc(cmd)
-	if derr := errDbtBlockWithDagSource(dir, cfg); derr != nil {
-		return derr
-	}
 	if cfg.Dbt != nil {
 		return runDbtCompile(cmd, dir, o, cfg)
 	}

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -87,6 +87,9 @@ func runCompile(cmd *cobra.Command, dir string, o compileOptions) error {
 	// upgrade (new features like dbt vs a stale ~/.leoflow/pysrc) never surfaces as
 	// a confusing "not supported" error (#239).
 	ensurePysrc(cmd)
+	if derr := errDbtBlockWithDagSource(dir, cfg); derr != nil {
+		return derr
+	}
 	if cfg.Dbt != nil {
 		return runDbtCompile(cmd, dir, o, cfg)
 	}

--- a/internal/cli/compile_dbt_dagpy_test.go
+++ b/internal/cli/compile_dbt_dagpy_test.go
@@ -3,12 +3,15 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/neochaotic/leoflow/internal/domain"
 )
 
 // dbtPlusDagPyProject writes a project carrying BOTH a top-level dbt: block and
@@ -118,9 +121,97 @@ func TestCompileDbtOnlyStillWorks(t *testing.T) {
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 
+	spec := filepath.Join(dir, "dag.json")
 	if err := runCompile(cmd, dir, compileOptions{
-		output: filepath.Join(dir, "dag.json"), image: "reg/sales:v1", dagVersion: "v1",
+		output: spec, image: "reg/sales:v1", dagVersion: "v1",
 	}); err != nil {
 		t.Fatalf("dbt-only project no longer compiles: %v\noutput:\n%s", err, out.String())
+	}
+	// A nil error is not the contract — the artifact is. Its sibling asserts the
+	// refusal wrote nothing; without the mirror image here, a change that returns
+	// nil while producing no dag.json keeps this "guard on the guard" green.
+	data, rerr := os.ReadFile(spec)
+	if rerr != nil {
+		t.Fatalf("compile returned nil but wrote no dag.json: %v", rerr)
+	}
+	var got domain.DAGSpec
+	if uerr := json.Unmarshal(data, &got); uerr != nil {
+		t.Fatalf("dag.json is not a DAGSpec: %v", uerr)
+	}
+	if len(got.Tasks) == 0 {
+		t.Fatalf("dbt-only compile produced a spec with no tasks: %s", data)
+	}
+}
+
+// TestErrDbtBlockWithDagSourceTable drives the predicate directly. The
+// round-trip tests above all use the DEFAULT dag.py, so replacing
+// dagSourcePath(dir, cfg) with a hardcoded "dag.py" left every one of them
+// green — and that is the likeliest mutation to actually get written, because
+// discovery deliberately hardcodes the name (discover.go dagSourceFile) and a
+// future "make these consistent" pass would silently un-protect every project
+// with a custom dag_source.
+func TestErrDbtBlockWithDagSourceTable(t *testing.T) {
+	write := func(t *testing.T, dir, name string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x = 1\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cases := []struct {
+		name    string
+		source  string // cfg.DagSource
+		create  string // file to create, "" for none
+		mkdir   string // directory to create, "" for none
+		dbt     bool
+		wantErr bool
+	}{
+		{name: "no config", dbt: false, wantErr: false},
+		{name: "dbt only, no source", source: "dag.py", dbt: true, wantErr: false},
+		{name: "dbt plus default source", source: "dag.py", create: "dag.py", dbt: true, wantErr: true},
+		// The mutation guard: a hardcoded "dag.py" makes this case pass silently.
+		{name: "dbt plus custom source", source: "pipeline.py", create: "pipeline.py", dbt: true, wantErr: true},
+		// A custom source that is absent must not be caught by a stray dag.py.
+		{name: "custom source absent, stray dag.py", source: "pipeline.py", create: "dag.py", dbt: true, wantErr: false},
+		// dag_source has no pattern in the schema, so "." is legal and stats as
+		// the project dir. A plain existence check refuses every dbt-only project.
+		{name: "dag_source is a directory", source: ".", dbt: true, wantErr: false},
+		{name: "directory named like the source", source: "dag.py", mkdir: "dag.py", dbt: true, wantErr: false},
+		{name: "source present but no dbt block", source: "dag.py", create: "dag.py", dbt: false, wantErr: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tc.create != "" {
+				write(t, dir, tc.create)
+			}
+			if tc.mkdir != "" {
+				if err := os.Mkdir(filepath.Join(dir, tc.mkdir), 0o750); err != nil {
+					t.Fatal(err)
+				}
+			}
+			var cfg *domain.LeoflowConfig
+			if tc.name != "no config" {
+				cfg = &domain.LeoflowConfig{DagSource: tc.source}
+				if tc.dbt {
+					cfg.Dbt = &domain.DbtConfig{Project: "."}
+				}
+			}
+			err := errDbtBlockWithDagSource(dir, cfg)
+			if tc.wantErr && err == nil {
+				t.Fatalf("want a refusal, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("want nil, got: %v", err)
+			}
+			if tc.wantErr {
+				// The message is the whole deliverable here, so pin the two
+				// escape routes rather than only that something failed.
+				for _, want := range []string{"dbt_groups.<name>:", `dbt_group("<name>")`, tc.create} {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("message is missing %q: %v", want, err)
+					}
+				}
+			}
+		})
 	}
 }

--- a/internal/cli/compile_dbt_dagpy_test.go
+++ b/internal/cli/compile_dbt_dagpy_test.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// dbtPlusDagPyProject writes a project carrying BOTH a top-level dbt: block and
+// a dag.py. Compiling it used to route on cfg.Dbt before the parser was ever
+// consulted, so the Python was discarded with no diagnostic (#1001).
+func dbtPlusDagPyProject(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	yaml := `schema_version: "1.0"
+dag_id: sales
+owner: data-team
+dbt:
+  project: .
+  manifest: manifest.json
+  granularity: folder
+  schedule: "@daily"
+`
+	if err := os.WriteFile(filepath.Join(dir, "leoflow.yaml"), []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := os.ReadFile(filepath.Join("..", "dbt", "testdata", "manifest_wide.json"))
+	if err != nil {
+		t.Fatalf("reading fixture manifest: %v", err)
+	}
+	if werr := os.WriteFile(filepath.Join(dir, "manifest.json"), manifest, 0o600); werr != nil {
+		t.Fatal(werr)
+	}
+	dbtProj := "name: sales\nversion: \"1.0\"\nprofile: sales\n"
+	if werr := os.WriteFile(filepath.Join(dir, "dbt_project.yml"), []byte(dbtProj), 0o600); werr != nil {
+		t.Fatal(werr)
+	}
+	dagPy := "from airflow import DAG\n" +
+		"from airflow.providers.standard.operators.python import PythonOperator\n"
+	if werr := os.WriteFile(filepath.Join(dir, "dag.py"), []byte(dagPy), 0o600); werr != nil {
+		t.Fatal(werr)
+	}
+	return dir
+}
+
+// TestCompileRefusesDbtBlockWithDagPy pins the refusal. The failure this locks
+// is not a crash: without it `compile` SUCCEEDS and writes a dag.json holding
+// only the dbt nodes, so the author ships a DAG missing every Python task with
+// a green exit code.
+func TestCompileRefusesDbtBlockWithDagPy(t *testing.T) {
+	dir := dbtPlusDagPyProject(t)
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	out2 := filepath.Join(dir, "dag.json")
+	err := runCompile(cmd, dir, compileOptions{output: out2, image: "reg/sales:v1", dagVersion: "v1"})
+	if err == nil {
+		t.Fatalf("compile accepted a dbt: block alongside dag.py and silently dropped the Python (#1001)\noutput:\n%s", out.String())
+	}
+	for _, want := range []string{"dbt:", "dag.py", "dbt_groups"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error does not mention %q, so it does not tell the author what to do: %v", want, err)
+		}
+	}
+	// A refusal that still emitted the truncated artifact would be worse than
+	// none: a later step could pick it up.
+	if _, serr := os.Stat(out2); serr == nil {
+		t.Errorf("refused but still wrote %s", out2)
+	}
+}
+
+// TestValidateRefusesDbtBlockWithDagPy pins the same refusal in `validate`,
+// which is the command whose whole job is to answer "is this project sane".
+// It reported "is valid" for this shape.
+func TestValidateRefusesDbtBlockWithDagPy(t *testing.T) {
+	dir := dbtPlusDagPyProject(t)
+	cmd := newValidateCommand()
+	cmd.SetContext(context.Background())
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{dir})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("validate called a dbt: block alongside dag.py valid (#1001)\noutput:\n%s", out.String())
+	}
+	// Assert on the message. An earlier draft of this test passed with no
+	// implementation at all, because the fixture was missing dbt_project.yml and
+	// validate errored on THAT — a green that observed nothing.
+	for _, want := range []string{"dbt:", "dag.py"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("validate errored for some other reason, not the #1001 conflict (missing %q): %v", want, err)
+		}
+	}
+}
+
+// TestCompileDbtOnlyStillWorks is the guard on the guard: the refusal keys on
+// the dag.py EXISTING, so a genuine dbt-only project must stay compilable.
+// Without this a stricter-than-intended check would take the whole mode down,
+// which is how #996 happened.
+func TestCompileDbtOnlyStillWorks(t *testing.T) {
+	dir := dbtPlusDagPyProject(t)
+	if err := os.Remove(filepath.Join(dir, "dag.py")); err != nil {
+		t.Fatal(err)
+	}
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	if err := runCompile(cmd, dir, compileOptions{
+		output: filepath.Join(dir, "dag.json"), image: "reg/sales:v1", dagVersion: "v1",
+	}); err != nil {
+		t.Fatalf("dbt-only project no longer compiles: %v\noutput:\n%s", err, out.String())
+	}
+}

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -202,12 +202,16 @@ func dagSourcePath(dir string, cfg *domain.LeoflowConfig) string {
 	return filepath.Join(dir, cfg.DagSource)
 }
 
-// regularFileExists reports whether path names something that is present and
-// readable. An unreadable path answers false: absence and inaccessibility are
-// both "no evidence this file participates", which is what every caller wants.
+// regularFileExists reports whether path names an existing regular file.
+//
+// The regularity test is load-bearing, not defensive. `dag_source` has no
+// pattern in the authoring schema, so `dag_source: "."` is legal and stats
+// successfully as the project directory — a plain existence check refuses every
+// dbt-only project with "delete .". A directory literally named dag.py stats
+// the same way.
 func regularFileExists(path string) bool {
-	_, err := os.Stat(path)
-	return err == nil
+	st, err := os.Stat(path)
+	return err == nil && st.Mode().IsRegular()
 }
 
 // errDbtBlockWithDagSource refuses a project carrying BOTH a top-level dbt:
@@ -236,10 +240,12 @@ func errDbtBlockWithDagSource(dir string, cfg *domain.LeoflowConfig) error {
 		return nil
 	}
 	return fmt.Errorf(
-		"%s declares a top-level dbt: block and %s also exists: the dbt: block wins and the Python in %s would be silently ignored (#1001). "+
-			"Delete one. To keep the Python, remove the dbt: block and declare the project under dbt_groups: in your dag.py; "+
-			"to keep the dbt-only DAG, delete %s",
-		projectConfigPath(dir), src, cfg.DagSource, cfg.DagSource)
+		"%s declares a top-level dbt: block and %s also exists; refusing, because the two describe different DAGs.\n"+
+			"  To keep the Python: delete the dbt: block, move the project under dbt_groups.<name>: in %s,\n"+
+			"                      and call dbt_group(\"<name>\") in %s.\n"+
+			"  To keep the dbt-only DAG: delete %s.\n"+
+			"(Compiling the pair used to succeed and drop the Python silently.)",
+		projectConfigPath(dir), src, projectConfigPath(dir), src, src)
 }
 
 // configFilePath returns the config file to load: the --config flag when set,

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -202,6 +202,46 @@ func dagSourcePath(dir string, cfg *domain.LeoflowConfig) string {
 	return filepath.Join(dir, cfg.DagSource)
 }
 
+// regularFileExists reports whether path names something that is present and
+// readable. An unreadable path answers false: absence and inaccessibility are
+// both "no evidence this file participates", which is what every caller wants.
+func regularFileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// errDbtBlockWithDagSource refuses a project carrying BOTH a top-level dbt:
+// block and a DAG source, because the two describe different DAGs and only one
+// of them can win.
+//
+// It used to be the dbt: block, silently: compile routes on cfg.Dbt before the
+// parser is ever invoked, so the Python was never read and nothing said so. The
+// author's whole feedback loop — validate, compile, deploy — reported success
+// while shipping a DAG missing every non-dbt task (#1001). This is also the
+// state a migration passes through, since writing the dag.py before deleting
+// dbt: is the order a person naturally works in.
+//
+// Refusing rather than merging keeps the semantics question ("which wins?
+// how would they compose?") out of the decision: there is no reading of both
+// blocks at once that the author could have intended.
+func errDbtBlockWithDagSource(dir string, cfg *domain.LeoflowConfig) error {
+	if cfg == nil || cfg.Dbt == nil {
+		return nil
+	}
+	src := dagSourcePath(dir, cfg)
+	// Absence is the ordinary case — a genuine dbt-only project has no DAG
+	// source — so it is not an error to report, and an unreadable path is not
+	// evidence of a conflict either.
+	if !regularFileExists(src) {
+		return nil
+	}
+	return fmt.Errorf(
+		"%s declares a top-level dbt: block and %s also exists: the dbt: block wins and the Python in %s would be silently ignored (#1001). "+
+			"Delete one. To keep the Python, remove the dbt: block and declare the project under dbt_groups: in your dag.py; "+
+			"to keep the dbt-only DAG, delete %s",
+		projectConfigPath(dir), src, cfg.DagSource, cfg.DagSource)
+}
+
 // configFilePath returns the config file to load: the --config flag when set,
 // otherwise the default path when it exists, otherwise empty (defaults + env).
 func configFilePath(cmd *cobra.Command) string {

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -32,6 +32,9 @@ func newValidateCommand() *cobra.Command {
 			// mode unvalidatable — the command that exists to say "this is
 			// fine" always said it was not (#996). The check is scoped, not
 			// removed: a dag.py DAG with a missing source still fails here.
+			if derr := errDbtBlockWithDagSource(dir, cfg); derr != nil {
+				return derr
+			}
 			if cfg.Dbt != nil {
 				// Scoping the dag.py check to a dag.py DAG left the dbt lane with
 				// NOTHING checked, so `validate` answered "is valid" for a dbt:

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -80,17 +80,24 @@ func (w *WorkspaceSpec) WatchedPaths() []string {
 	if w == nil {
 		return nil
 	}
-	paths := make([]string, 0, len(w.Projects)*2)
+	paths := make([]string, 0, len(w.Projects)*3)
 	for _, p := range w.Projects {
 		if p.HasYAML {
 			paths = append(paths, p.ConfigPath)
 		}
+		// Always watch the DAG source, even for a project whose config says dbt.
+		// projectAt keys on the source EXISTING while this used to key on
+		// Dbt != nil, and the two disagree in exactly one shape: a project
+		// carrying both, which compile now refuses. Watching only dbt_project.yml
+		// there meant the user read "delete dag.py", deleted it, and nothing
+		// reloaded — no watched path's mtime moved and the import-error banner is
+		// only cleared by a successful reload. Watching a normally-absent path is
+		// already safe: projectMtimes skips what it cannot stat.
+		paths = append(paths, filepath.Join(p.Path, p.Config.DagSource))
 		if p.Config.Dbt != nil {
 			// A pure dbt project has no dag.py; watch its dbt project file so a
 			// model/config edit still triggers a reload.
 			paths = append(paths, filepath.Join(p.Path, p.Config.Dbt.Project, "dbt_project.yml"))
-		} else {
-			paths = append(paths, filepath.Join(p.Path, p.Config.DagSource))
 		}
 	}
 	return paths

--- a/internal/cli/workspace_test.go
+++ b/internal/cli/workspace_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -299,5 +300,47 @@ func TestResolveWorkspace_WatchedPathsCoverEveryProject(t *testing.T) {
 	}
 	for missing := range want {
 		t.Errorf("missing watched path %q", missing)
+	}
+}
+
+// TestWatchedPathsCoverTheRefusedShape pins the watcher for a project carrying
+// BOTH a dbt: block and a dag.py — the shape compile refuses (#1001).
+//
+// This used to branch on Config.Dbt != nil while projectAt branches on the DAG
+// source existing, and the two disagree in exactly this shape. The consequence
+// was not abstract: `leoflow dev` printed "delete dag.py", the user deleted it,
+// and nothing reloaded — no watched path's mtime moved, and the import-error
+// banner is only cleared by a successful reload, so the UI stayed red while the
+// project was already fixed.
+func TestWatchedPathsCoverTheRefusedShape(t *testing.T) {
+	ws := t.TempDir()
+	mixed := filepath.Join(ws, "mixed")
+	if err := os.MkdirAll(mixed, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	yaml := "dag_id: mixed\ndbt:\n  project: .\n  manifest: manifest.json\n"
+	for name, body := range map[string]string{
+		"leoflow.yaml":    yaml,
+		"dag.py":          "x=1\n",
+		"dbt_project.yml": "name: mixed\n",
+	} {
+		if err := os.WriteFile(filepath.Join(mixed, name), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := ResolveWorkspace(ws)
+	if err != nil {
+		t.Fatalf("ResolveWorkspace: %v", err)
+	}
+	paths := got.WatchedPaths()
+	for _, want := range []string{
+		filepath.Join(mixed, "leoflow.yaml"),
+		filepath.Join(mixed, "dag.py"),
+		filepath.Join(mixed, "dbt_project.yml"),
+	} {
+		if !slices.Contains(paths, want) {
+			t.Errorf("watcher does not cover %q, so the fix the error message asks for triggers no reload; watching %v", want, paths)
+		}
 	}
 }

--- a/website/content/author-dags/dbt.md
+++ b/website/content/author-dags/dbt.md
@@ -319,7 +319,8 @@ live-query coverage needs real accounts and CI secrets.
 
 ## If your DAG is only models
 
-A DAG whose tasks are *only* dbt models can skip the `dag.py`: declare the project
+A DAG whose tasks are *only* dbt models has no `dag.py` — and **must not carry
+one**, even an empty placeholder: `compile` refuses the pair. Declare the project
 under a top-level `dbt:` block and the shape comes from dbt's `ref()`/`source()`
 graph. It is one file fewer to start with.
 

--- a/website/content/author-dags/dbt.md
+++ b/website/content/author-dags/dbt.md
@@ -339,9 +339,10 @@ DAG-wide — all four come from `leoflow.yaml` and apply to both shapes.
 
 **Adding one Python task means rewriting the DAG.** Delete `dbt:`, add
 `dbt_groups:`, write a `dag.py`, and move the schedule from `dbt.schedule` to
-`DAG(schedule=…)`. **Delete `dbt:` first.** A project that has both a top-level
-`dbt:` block and a `dag.py` compiles green and silently ignores the Python —
-the `dbt:` block wins before the parser is consulted
+`DAG(schedule=…)`. **Delete `dbt:` in the same change.** A project carrying both
+a top-level `dbt:` block and a `dag.py` is refused by `compile` and `validate`,
+naming which block to remove — the two describe different DAGs and there is no
+reading of both at once
 ([#1001](https://github.com/neochaotic/leoflow/issues/1001)).
 
 **Every `task_id` changes**: the shortcut emits bare node ids


### PR DESCRIPTION
Closes #1001.

## The bug

`runCompile` routes on `cfg.Dbt` **before the parser is ever invoked** (`internal/cli/compile.go`), so a project carrying both a top-level `dbt:` block and a `dag.py` never had its Python read — and `runDbtCompile` says nothing about it (grepping its body for `dag.py`/`warn`/`ignor`/`discard` returns zero).

`validate` did not catch it either: when `cfg.Dbt != nil` it checks `dbt_project.yml` and **skips the DAG-source branch entirely**. I measured this — with a valid dbt project plus a `dag.py`, `validate` reported the project fine.

So `validate` → `compile` → `deploy` all report success while shipping a DAG missing every non-dbt task.

## Why now

This is the state a **migration passes through**. Writing the `dag.py` before deleting `dbt:` is the order a person naturally works in — and #1009 (merged today) now recommends exactly that migration. The release steers more people into the trap in the same cut that documents it.

## Why refuse rather than merge

There is no reading of "both blocks at once" an author could have intended, so "which wins? how do they compose?" does not need an answer — only a message naming which block to delete. That keeps a semantics decision out of a patch release.

`compile` and `validate` both refuse. `deploy` and `dev` inherit it through `runCompile`; `dev` degrades correctly because `devCompileAndRegisterAll` already prints `✗ <dag>: <err>`, reports an import error to the UI, and continues — so one bad project does not take the workspace down.

**Known cost:** a project with a *vestigial* `dag.py` and a `dbt:` block compiles today and will now fail. I think that trade is clearly right — the error names the fix and takes a minute, versus silently shipping a DAG missing every Python task behind three green checkmarks — but it is a real behavior change and worth seeing before merge.

## Tests

Three, and the third is the one that matters most:

- `TestCompileRefusesDbtBlockWithDagPy` — also asserts the refusal did **not** write the truncated `dag.json`.
- `TestValidateRefusesDbtBlockWithDagPy`
- `TestCompileDbtOnlyStillWorks` — the guard on the guard. An over-strict check keyed on `cfg.Dbt` rather than on the DAG source existing takes the whole dbt-only mode down, which is how #996 happened.

Mutation-tested: removing the existence check reddens **only** `TestCompileDbtOnlyStillWorks` while both refusal tests stay green — the discrimination the design needs. The mutant was asserted applied before running.

**A miss worth recording:** the validate test initially passed *with no implementation at all*. My fixture had no `dbt_project.yml`, so `validate` errored on that instead and my `err != nil` assertion was satisfied by the wrong error. Fixed the fixture, and both cases now assert the message names the conflict rather than merely that something failed.

## Docs

`website/content/author-dags/dbt.md` described the silent-discard behavior (added in #1009 hours ago). This makes that text false, so it is updated in the same change.