### PR TITLE
ci: pull service containers from a registry that does not rate-limit by IP

### DIFF
--- a/.github/ci/kind-datastores.yaml
+++ b/.github/ci/kind-datastores.yaml
@@ -35,7 +35,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: postgres:16-alpine
+          image: mirror.gcr.io/library/postgres:16-alpine
           env:
             - name: POSTGRES_USER
               value: leoflow
@@ -87,7 +87,7 @@ spec:
     spec:
       containers:
         - name: redis
-          image: redis:7-alpine
+          image: mirror.gcr.io/library/redis:7-alpine
           ports:
             - containerPort: 6379
           readinessProbe:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,7 +142,7 @@ jobs:
     timeout-minutes: 20
     services:
       postgres:
-        image: public.ecr.aws/docker/library/postgres:16
+        image: mirror.gcr.io/library/postgres:16
         env:
           POSTGRES_USER: leoflow
           POSTGRES_PASSWORD: leoflow
@@ -151,7 +151,7 @@ jobs:
         options: >-
           --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
       redis:
-        image: public.ecr.aws/docker/library/redis:7
+        image: mirror.gcr.io/library/redis:7
         ports: [6379:6379]
         options: --health-cmd "redis-cli ping" --health-interval 5s --health-timeout 3s --health-retries 10
 
@@ -203,7 +203,7 @@ jobs:
     timeout-minutes: 20
     services:
       postgres:
-        image: public.ecr.aws/docker/library/postgres:16
+        image: mirror.gcr.io/library/postgres:16
         env:
           POSTGRES_USER: leoflow
           POSTGRES_PASSWORD: leoflow
@@ -212,7 +212,7 @@ jobs:
         options: >-
           --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
       redis:
-        image: public.ecr.aws/docker/library/redis:7
+        image: mirror.gcr.io/library/redis:7
         ports: [6379:6379]
         options: --health-cmd "redis-cli ping" --health-interval 5s --health-timeout 3s --health-retries 10
     env:
@@ -244,7 +244,7 @@ jobs:
     timeout-minutes: 15
     services:
       postgres:
-        image: public.ecr.aws/docker/library/postgres:16
+        image: mirror.gcr.io/library/postgres:16
         env:
           POSTGRES_USER: leoflow
           POSTGRES_PASSWORD: leoflow
@@ -253,7 +253,7 @@ jobs:
         options: >-
           --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
       redis:
-        image: public.ecr.aws/docker/library/redis:7
+        image: mirror.gcr.io/library/redis:7
         ports: [6379:6379]
         options: --health-cmd "redis-cli ping" --health-interval 5s --health-timeout 3s --health-retries 10
     steps:
@@ -328,7 +328,7 @@ jobs:
     timeout-minutes: 15
     services:
       postgres:
-        image: public.ecr.aws/docker/library/postgres:16
+        image: mirror.gcr.io/library/postgres:16
         env:
           POSTGRES_USER: leoflow
           POSTGRES_PASSWORD: leoflow
@@ -363,7 +363,7 @@ jobs:
     timeout-minutes: 15
     services:
       postgres:
-        image: public.ecr.aws/docker/library/postgres:16
+        image: mirror.gcr.io/library/postgres:16
         env:
           POSTGRES_USER: leoflow
           POSTGRES_PASSWORD: leoflow
@@ -398,7 +398,7 @@ jobs:
     timeout-minutes: 15
     services:
       postgres:
-        image: public.ecr.aws/docker/library/postgres:16
+        image: mirror.gcr.io/library/postgres:16
         env:
           POSTGRES_USER: leoflow
           POSTGRES_PASSWORD: leoflow
@@ -429,7 +429,7 @@ jobs:
     timeout-minutes: 15
     services:
       postgres:
-        image: public.ecr.aws/docker/library/postgres:16
+        image: mirror.gcr.io/library/postgres:16
         env:
           POSTGRES_USER: leoflow
           POSTGRES_PASSWORD: leoflow
@@ -575,7 +575,7 @@ jobs:
     timeout-minutes: 30
     services:
       postgres:
-        image: public.ecr.aws/docker/library/postgres:16
+        image: mirror.gcr.io/library/postgres:16
         env:
           POSTGRES_USER: leoflow
           POSTGRES_PASSWORD: leoflow
@@ -584,7 +584,7 @@ jobs:
         options: >-
           --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
       redis:
-        image: public.ecr.aws/docker/library/redis:7
+        image: mirror.gcr.io/library/redis:7
         ports: [6379:6379]
         options: --health-cmd "redis-cli ping" --health-interval 5s --health-timeout 3s --health-retries 10
     env:
@@ -672,7 +672,7 @@ jobs:
     timeout-minutes: 30
     services:
       postgres:
-        image: public.ecr.aws/docker/library/postgres:16
+        image: mirror.gcr.io/library/postgres:16
         env:
           POSTGRES_USER: leoflow
           POSTGRES_PASSWORD: leoflow
@@ -681,7 +681,7 @@ jobs:
         options: >-
           --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
       redis:
-        image: public.ecr.aws/docker/library/redis:7
+        image: mirror.gcr.io/library/redis:7
         ports: [6379:6379]
         options: --health-cmd "redis-cli ping" --health-interval 5s --health-timeout 3s --health-retries 10
     env:
@@ -762,7 +762,7 @@ jobs:
     timeout-minutes: 30
     services:
       postgres:
-        image: public.ecr.aws/docker/library/postgres:16
+        image: mirror.gcr.io/library/postgres:16
         env:
           POSTGRES_USER: leoflow
           POSTGRES_PASSWORD: leoflow
@@ -771,7 +771,7 @@ jobs:
         options: >-
           --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
       redis:
-        image: public.ecr.aws/docker/library/redis:7
+        image: mirror.gcr.io/library/redis:7
         ports: [6379:6379]
         options: --health-cmd "redis-cli ping" --health-interval 5s --health-timeout 3s --health-retries 10
     env:
@@ -901,7 +901,7 @@ jobs:
     timeout-minutes: 30
     services:
       postgres:
-        image: public.ecr.aws/docker/library/postgres:16
+        image: mirror.gcr.io/library/postgres:16
         env:
           POSTGRES_USER: leoflow
           POSTGRES_PASSWORD: leoflow
@@ -910,7 +910,7 @@ jobs:
         options: >-
           --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
       redis:
-        image: public.ecr.aws/docker/library/redis:7
+        image: mirror.gcr.io/library/redis:7
         ports: [6379:6379]
         options: --health-cmd "redis-cli ping" --health-interval 5s --health-timeout 3s --health-retries 10
     env:
@@ -1110,6 +1110,15 @@ jobs:
   # there surfaces mid-release. Discovery is by self_test() definition, so a new
   # script's cases join this job by existing. No network, milliseconds.
   # ─────────────────────────────────────────────────────────────────────
+  service-image-registry:
+    name: Service images avoid a source-IP-rate-limited registry
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Check no workflow pulls service containers from public.ecr.aws
+        run: bash scripts/check-service-image-registry.sh
+
   script-selftests:
     name: Script self-tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1104,11 +1104,9 @@ jobs:
   # 404 — and no build step resolves the string, so the rot is invisible
   # without a gate. (The guard script owns the literal old-path string.)
   # ─────────────────────────────────────────────────────────────────────
-  # Script self-tests. cut-release.sh and the check-* gates hold logic nothing
-  # else exercises — the tag normalizers, FLAKE_RE (which decides whether a red
-  # run is rerun or stops a release), and the gates' ref comparisons. A defect
-  # there surfaces mid-release. Discovery is by self_test() definition, so a new
-  # script's cases join this job by existing. No network, milliseconds.
+  # Container images the runner pulls in `Initialize containers`, before any
+  # step, must come from a registry that does not rate-limit anonymous pulls by
+  # shared source IP (#1007). Allowlist, parsed from the workflow YAML.
   # ─────────────────────────────────────────────────────────────────────
   service-image-registry:
     name: Service images avoid a source-IP-rate-limited registry
@@ -1116,9 +1114,16 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Check no workflow pulls service containers from public.ecr.aws
+      - name: Check every workflow container image comes from an allowed registry
         run: bash scripts/check-service-image-registry.sh
 
+  # ─────────────────────────────────────────────────────────────────────
+  # Script self-tests. cut-release.sh and the check-* gates hold logic nothing
+  # else exercises — the tag normalizers, FLAKE_RE (which decides whether a red
+  # run is rerun or stops a release), and the gates' ref comparisons. A defect
+  # there surfaces mid-release. Discovery is by self_test() definition, so a new
+  # script's cases join this job by existing. No network, milliseconds.
+  # ─────────────────────────────────────────────────────────────────────
   script-selftests:
     name: Script self-tests
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -258,13 +258,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { image: "debian:12", prep: "apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update -qq && apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y -qq curl ca-certificates tar" }
-          - { image: "ubuntu:24.04", prep: "apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update -qq && apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y -qq curl ca-certificates tar" }
-          - { image: "fedora:41", prep: "dnf install -y -q tar curl --allowerasing" }
+          - { image: "mirror.gcr.io/library/debian:12", prep: "apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update -qq && apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y -qq curl ca-certificates tar" }
+          - { image: "mirror.gcr.io/library/ubuntu:24.04", prep: "apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update -qq && apt-get -o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y -qq curl ca-certificates tar" }
+          - { image: "mirror.gcr.io/library/fedora:41", prep: "dnf install -y -q tar curl --allowerasing" }
           - { image: "quay.io/rockylinux/rockylinux:9", prep: "dnf install -y -q tar curl --allowerasing" }
-          - { image: "opensuse/leap:15", prep: "zypper --no-gpg-checks -n in -y curl tar gzip" }
-          - { image: "archlinux:latest", prep: "pacman -Sy --noconfirm archlinux-keyring && pacman -Syu --noconfirm curl tar" }
-          - { image: "alpine:3.20", prep: "apk add --no-cache curl tar" }
+          - { image: "mirror.gcr.io/opensuse/leap:15", prep: "zypper --no-gpg-checks -n in -y curl tar gzip" }
+          - { image: "mirror.gcr.io/library/archlinux:latest", prep: "pacman -Sy --noconfirm archlinux-keyring && pacman -Syu --noconfirm curl tar" }
+          - { image: "mirror.gcr.io/library/alpine:3.20", prep: "apk add --no-cache curl tar" }
     steps:
       - name: Install prerequisites (curl + tar)
         # Retry the whole prep. apt-get carries Acquire::Retries inline, but
@@ -445,7 +445,7 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    container: ubuntu:24.04
+    container: mirror.gcr.io/library/ubuntu:24.04
     steps:
       - name: Install prerequisites
         run: |

--- a/.github/workflows/secrets-e2e.yaml
+++ b/.github/workflows/secrets-e2e.yaml
@@ -39,7 +39,7 @@ jobs:
       # never handed leftover queued task instances from another cluster (which
       # would ImagePullBackOff and add noise).
       postgres:
-        image: public.ecr.aws/docker/library/postgres:16
+        image: mirror.gcr.io/library/postgres:16
         env:
           POSTGRES_USER: leoflow
           POSTGRES_PASSWORD: leoflow
@@ -48,7 +48,7 @@ jobs:
         options: >-
           --health-cmd pg_isready --health-interval 5s --health-timeout 3s --health-retries 10
       redis:
-        image: public.ecr.aws/docker/library/redis:7
+        image: mirror.gcr.io/library/redis:7
         ports: [6379:6379]
         options: --health-cmd "redis-cli ping" --health-interval 5s --health-timeout 3s --health-retries 10
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,16 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (only `apt-get` had retries; `dnf`, `zypper`, `pacman` and `apk` had none).
   `pacman -Sy` was also an unsupported partial upgrade that breaks on mirror
   rotation rather than on anything we changed; it is now `-Syu`.
+- **CI service containers no longer pull from a registry that rate-limits by
+  source IP (#1007).** GitHub-hosted runners share a small pool of egress IPs,
+  so `public.ecr.aws` returned `toomanyrequests: Rate exceeded` on roughly 13%
+  of main runs. The failure lands in `Initialize containers` — before
+  `actions/checkout` and before any step — so no retry we write could reach it,
+  and it fired even on pull requests that changed only markdown. All twenty
+  references now use `mirror.gcr.io`, Google's unauthenticated pull-through
+  cache for Docker Hub official images. A new `check-service-image-registry.sh`
+  gate keeps them from drifting back; it is globbed into both the CI self-test
+  job and the cut's own gate set.
 
 - **`leoflow.yaml` rejects keys the schema does not define, and `leoflow validate`
   finally works on a pure-dbt project (#15, #996).** The authoring schema declares

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,9 +176,25 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `actions/checkout` and before any step — so no retry we write could reach it,
   and it fired even on pull requests that changed only markdown. All twenty
   references now use `mirror.gcr.io`, Google's unauthenticated pull-through
-  cache for Docker Hub official images. A new `check-service-image-registry.sh`
-  gate keeps them from drifting back; it is globbed into both the CI self-test
-  job and the cut's own gate set.
+  cache for Docker Hub. The release workflow's seven distro smoke containers and
+  the kind datastore manifest move too — those are pulled in the same pre-step
+  phase, in the workflow where a red job costs a tag. `quay.io` stays as-is; it
+  is a different registry, not the shared-IP pool.
+
+  A new `check-service-image-registry.sh` gate keeps them from drifting back. It
+  parses the workflow YAML — walking `jobs.*.container` and `jobs.*.services.*`,
+  and resolving `${{ matrix.* }}` against literal matrix values — and enforces an
+  **allowlist**, so a bare `image: postgres:16` pasted out of the compose file is
+  caught too. A grep would not have been enough: an earlier version of this gate
+  missed an env indirection, a folded scalar, a job-level `container:` and an
+  uppercase key while failing on a comment that merely mentioned the registry.
+
+  Note the trade: `mirror.gcr.io` is not covered by an SLA, and Google documents
+  it for daemon-level configuration rather than direct addressing — which is not
+  usable here, since the pull happens before any step we control. Twenty-plus
+  call sites now depend on one host; the failure mode changes from ~13% red to
+  all-or-nothing. The durable answer is a mirror we own, which needs a one-time
+  manual package-visibility flip GitHub's API cannot perform.
 
 - **`leoflow.yaml` rejects keys the schema does not define, and `leoflow validate`
   finally works on a pure-dbt project (#15, #996).** The authoring schema declares

--- a/scripts/check-script-selftests.sh
+++ b/scripts/check-script-selftests.sh
@@ -33,8 +33,8 @@ done
 
 # A rename or a lost self_test() would otherwise shrink this gate to nothing
 # while still exiting 0 — the same silent-shrink hole run_gates guards against.
-if [ "$found" -lt "${MIN_SELFTESTS:-4}" ]; then
-	echo "FAIL: found only $found self-test(s), expected at least ${MIN_SELFTESTS:-4} — did a script lose its self_test()?" >&2
+if [ "$found" -lt "${MIN_SELFTESTS:-5}" ]; then
+	echo "FAIL: found only $found self-test(s), expected at least ${MIN_SELFTESTS:-5} — did a script lose its self_test()?" >&2
 	exit 1
 fi
 [ "$failed" -eq 0 ] || exit 1

--- a/scripts/check-service-image-registry.sh
+++ b/scripts/check-service-image-registry.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Service-container images must not come from a registry that rate-limits
+# anonymous pulls by source IP.
+#
+# GitHub-hosted runners share a small pool of egress IPs across every customer,
+# so `public.ecr.aws` returns `toomanyrequests: Rate exceeded` on a schedule we
+# do not control. That failure lands in `Initialize containers` — BEFORE
+# actions/checkout and before any step we write — so no retry, cache or guard
+# inside the job can touch it, and it fires even on pull requests that change
+# only markdown. It cost ~13% of main runs (#1007).
+#
+# The replacement is mirror.gcr.io, Google's unauthenticated pull-through cache
+# for Docker Hub official images. This trades one third-party for another, and
+# that is the honest description of it: what changes is the failure mode, since
+# mirror.gcr.io does not impose the shared-source-IP anonymous limit that is
+# actually biting us.
+#
+# Two copies of a registry hostname with nothing between them is how these rot,
+# so this is the gate. If a genuinely better mirror appears, change ALLOWED and
+# the swap becomes one edit.
+#
+# Usage: scripts/check-service-image-registry.sh [--self-test]
+set -euo pipefail
+
+# Registries that must never appear as a service-container image.
+BANNED_RE='public\.ecr\.aws'
+
+scan() { # <dir>
+	local dir="$1" hits
+	hits=$(grep -rnE "image:[[:space:]]*[\"']?${BANNED_RE}" "$dir" || true)
+	if [ -n "$hits" ]; then
+		echo "Service-container images from a source-IP-rate-limited registry (#1007):" >&2
+		echo "$hits" >&2
+		echo >&2
+		echo "Use mirror.gcr.io/library/<image> instead. These pulls happen in" >&2
+		echo "'Initialize containers', before any step, so a retry cannot rescue them." >&2
+		return 1
+	fi
+	return 0
+}
+
+self_test() {
+	local tmp rc
+	tmp=$(mktemp -d); trap 'rm -rf "$tmp"' RETURN
+
+	# A clean tree passes.
+	printf 'services:\n  db:\n    image: mirror.gcr.io/library/postgres:16\n' > "$tmp/ok.yaml"
+	if ! scan "$tmp" 2>/dev/null; then echo "self-test FAIL: clean tree rejected" >&2; return 1; fi
+
+	# The banned registry is caught.
+	printf 'services:\n  db:\n    image: public.ecr.aws/docker/library/postgres:16\n' > "$tmp/bad.yaml"
+	rc=0; scan "$tmp" >/dev/null 2>&1 || rc=$?
+	if [ "$rc" -eq 0 ]; then echo "self-test FAIL: banned registry accepted" >&2; return 1; fi
+
+	# A quoted form is caught too — the thing an author writes when they copy
+	# from a registry UI, and the shape a naive grep for `image: public` misses.
+	rm -f "$tmp/bad.yaml"
+	printf 'services:\n  db:\n    image: "public.ecr.aws/docker/library/redis:7"\n' > "$tmp/quoted.yaml"
+	rc=0; scan "$tmp" >/dev/null 2>&1 || rc=$?
+	if [ "$rc" -eq 0 ]; then echo "self-test FAIL: quoted banned registry accepted" >&2; return 1; fi
+
+	# A mention in a COMMENT must not fail the gate — this file and #1007's own
+	# notes name the registry on purpose, and a gate that cannot survive being
+	# documented gets deleted.
+	rm -f "$tmp/quoted.yaml"
+	printf '# we used to pull from public.ecr.aws/docker/library/postgres:16\nservices:\n  db:\n    image: mirror.gcr.io/library/postgres:16\n' > "$tmp/comment.yaml"
+	if ! scan "$tmp" 2>/dev/null; then echo "self-test FAIL: a comment mentioning the registry failed the gate" >&2; return 1; fi
+
+	echo "check-service-image-registry self-test: ok"
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+	self_test
+	exit $?
+fi
+
+scan "$(dirname "$0")/../.github/workflows"
+echo "service-container registries ok"

--- a/scripts/check-service-image-registry.sh
+++ b/scripts/check-service-image-registry.sh
@@ -1,78 +1,164 @@
 #!/usr/bin/env bash
-# Service-container images must not come from a registry that rate-limits
-# anonymous pulls by source IP.
+# Container images pulled by a workflow must come from a registry that does not
+# rate-limit anonymous pulls by source IP.
 #
-# GitHub-hosted runners share a small pool of egress IPs across every customer,
-# so `public.ecr.aws` returns `toomanyrequests: Rate exceeded` on a schedule we
-# do not control. That failure lands in `Initialize containers` — BEFORE
-# actions/checkout and before any step we write — so no retry, cache or guard
-# inside the job can touch it, and it fires even on pull requests that change
-# only markdown. It cost ~13% of main runs (#1007).
+# GitHub-hosted runners share a small pool of egress IPs across every customer.
+# `public.ecr.aws` returned `toomanyrequests: Rate exceeded` on ~13% of main
+# runs, and bare Docker Hub is tighter still (100 pulls / 6h per IPv4 or IPv6
+# /64). Both failures land in `Initialize containers` — BEFORE actions/checkout
+# and before any step we write — so no retry, cache or guard inside the job can
+# reach them, and they fire even on pull requests that change only markdown
+# (#1007).
 #
-# The replacement is mirror.gcr.io, Google's unauthenticated pull-through cache
-# for Docker Hub official images. This trades one third-party for another, and
-# that is the honest description of it: what changes is the failure mode, since
-# mirror.gcr.io does not impose the shared-source-IP anonymous limit that is
-# actually biting us.
+# This is an ALLOWLIST, not a denylist. A denylist naming public.ecr.aws would
+# wave through `image: postgres:16`, which is the likeliest drift (someone
+# pastes it out of docker-compose.dev.yaml) and is rate-limited by the same
+# mechanism.
 #
-# Two copies of a registry hostname with nothing between them is how these rot,
-# so this is the gate. If a genuinely better mirror appears, change ALLOWED and
-# the swap becomes one edit.
+# The tree is PARSED, not grepped. An earlier version of this file grepped for
+# `image:\s*public\.ecr\.aws` and was close to inert: it missed an env
+# indirection, a folded scalar, a job-level `container:`, an uppercase key, and
+# a `docker pull` in a run: step — five real references, exit 0 — while failing
+# on a COMMENT that mentioned the registry. Same fail-open shape
+# check-lite-prepull-matches-compose.sh already documents and fixes by parsing.
 #
 # Usage: scripts/check-service-image-registry.sh [--self-test]
+#        scripts/check-service-image-registry.sh <workflow-dir> [<workflow-dir>...]
 set -euo pipefail
 
-# Registries that must never appear as a service-container image.
-BANNED_RE='public\.ecr\.aws'
+scan() { # <dir>...
+	python3 - "$@" <<'PY'
+import sys, pathlib, re
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAML is required (pip install pyyaml)")
 
-scan() { # <dir>
-	local dir="$1" hits
-	hits=$(grep -rnE "image:[[:space:]]*[\"']?${BANNED_RE}" "$dir" || true)
-	if [ -n "$hits" ]; then
-		echo "Service-container images from a source-IP-rate-limited registry (#1007):" >&2
-		echo "$hits" >&2
-		echo >&2
-		echo "Use mirror.gcr.io/library/<image> instead. These pulls happen in" >&2
-		echo "'Initialize containers', before any step, so a retry cannot rescue them." >&2
-		return 1
-	fi
-	return 0
+# Registries whose anonymous pulls are not rate-limited by shared source IP.
+# ghcr.io and the mirror are fine; a bare `postgres:16` is Docker Hub and is not.
+# quay.io is a distinct registry with its own limits, not the shared-IP
+# Docker Hub / ECR Public pool this gate exists for.
+ALLOWED_PREFIXES = ("mirror.gcr.io/", "ghcr.io/", "quay.io/")
+
+MATRIX_REF = re.compile(r"^[$][{][{]\s*matrix[.]([A-Za-z0-9_-]+)\s*[}][}]$")
+
+def resolve(img, job):
+    """Expand `${{ matrix.<key> }}` against this job's literal matrix values.
+
+    Without this the gate can only say "unresolvable" for the shape release.yaml
+    actually uses (a distro matrix feeding `container:`), which is the shape
+    where a flake is most expensive. Returns a list, because a matrix is a fan-out.
+    """
+    m = MATRIX_REF.match(img.strip())
+    if not m:
+        return [img]
+    key = m.group(1)
+    matrix = ((job.get("strategy") or {}).get("matrix") or {})
+    vals = []
+    for entry in (matrix.get("include") or []):
+        if isinstance(entry, dict) and isinstance(entry.get(key), str):
+            vals.append(entry[key])
+    direct = matrix.get(key)
+    if isinstance(direct, list):
+        vals += [v for v in direct if isinstance(v, str)]
+    return vals or [img]
+
+def offenders(doc, where):
+    """Yield (where, image) for every container image the runner pulls before
+    our steps: job-level `container:` and every `services.*.image`."""
+    for job_id, job in (doc.get("jobs") or {}).items():
+        if not isinstance(job, dict):
+            continue
+        c = job.get("container")
+        raw = c if isinstance(c, str) else (c.get("image") if isinstance(c, dict) else None)
+        if isinstance(raw, str):
+            for img in resolve(raw, job):
+                yield (f"{where}: jobs.{job_id}.container", img)
+        for svc_id, svc in (job.get("services") or {}).items():
+            raw = svc.get("image") if isinstance(svc, dict) else svc
+            if isinstance(raw, str):
+                for img in resolve(raw, job):
+                    yield (f"{where}: jobs.{job_id}.services.{svc_id}.image", img)
+
+bad, scanned = [], 0
+for arg in sys.argv[1:]:
+    d = pathlib.Path(arg)
+    if not d.is_dir():
+        sys.exit(f"not a directory: {d} — the scan target moved, refusing to report clean")
+    files = sorted(list(d.glob("*.yaml")) + list(d.glob("*.yml")))
+    if not files:
+        sys.exit(f"no workflow files under {d} — refusing to report clean")
+    for f in files:
+        scanned += 1
+        doc = yaml.safe_load(f.read_text()) or {}
+        if not isinstance(doc, dict):
+            continue
+        for where, img in offenders(doc, f.name):
+            # An expression is only as good as what it resolves to; we cannot
+            # evaluate it here, so flag it for a human rather than pass it.
+            if re.search(r"\$\{\{", img):
+                bad.append((where, img, "unresolvable expression — inline the image or add it here"))
+            elif not img.startswith(ALLOWED_PREFIXES):
+                bad.append((where, img, "not from an allowed registry"))
+
+if bad:
+    print("Container images the runner pulls before any step, from a registry", file=sys.stderr)
+    print("that rate-limits anonymous pulls by shared source IP (#1007):", file=sys.stderr)
+    for where, img, why in bad:
+        print(f"  {where} = {img}\n      {why}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(f"Allowed prefixes: {', '.join(ALLOWED_PREFIXES)}", file=sys.stderr)
+    print("These pulls happen in 'Initialize containers', so no retry can rescue them.", file=sys.stderr)
+    sys.exit(1)
+print(f"container registries ok ({scanned} workflow file(s) scanned)")
+PY
 }
 
 self_test() {
-	local tmp rc
-	tmp=$(mktemp -d); trap 'rm -rf "$tmp"' RETURN
+	local tmp rc; tmp=$(mktemp -d); trap 'rm -rf "$tmp"' RETURN
+	mkdir -p "$tmp/wf"
 
-	# A clean tree passes.
-	printf 'services:\n  db:\n    image: mirror.gcr.io/library/postgres:16\n' > "$tmp/ok.yaml"
-	if ! scan "$tmp" 2>/dev/null; then echo "self-test FAIL: clean tree rejected" >&2; return 1; fi
+	printf 'jobs:\n  a:\n    services:\n      db:\n        image: mirror.gcr.io/library/postgres:16\n' >"$tmp/wf/ok.yaml"
+	scan "$tmp/wf" >/dev/null || { echo "self-test FAIL: allowed registry rejected" >&2; return 1; }
 
-	# The banned registry is caught.
-	printf 'services:\n  db:\n    image: public.ecr.aws/docker/library/postgres:16\n' > "$tmp/bad.yaml"
-	rc=0; scan "$tmp" >/dev/null 2>&1 || rc=$?
-	if [ "$rc" -eq 0 ]; then echo "self-test FAIL: banned registry accepted" >&2; return 1; fi
+	# Every shape the grep version missed. Each must fail ON ITS OWN, or a
+	# single catch would mask the other four.
+	local shapes=(
+'jobs:\n  a:\n    services:\n      db:\n        image: public.ecr.aws/docker/library/postgres:16\n|plain service image'
+'jobs:\n  a:\n    container: ubuntu:24.04\n|job-level container (bare Docker Hub)'
+'jobs:\n  a:\n    container:\n      image: public.ecr.aws/docker/library/ubuntu:24.04\n|container mapping'
+'jobs:\n  a:\n    services:\n      db:\n        image: >-\n          public.ecr.aws/docker/library/postgres:16\n|folded scalar'
+'jobs:\n  a:\n    services:\n      db:\n        image: ${{ env.PG_IMAGE }}\n|unresolvable expression'
+'jobs:\n  a:\n    services:\n      db:\n        image: postgres:16\n|bare Docker Hub'
+	)
+	local entry body label
+	for entry in "${shapes[@]}"; do
+		body="${entry%%|*}"; label="${entry##*|}"
+		rm -f "$tmp/wf"/*.yaml
+		# shellcheck disable=SC2059
+		printf "$body" >"$tmp/wf/bad.yaml"
+		rc=0; scan "$tmp/wf" >/dev/null 2>&1 || rc=$?
+		[ "$rc" -ne 0 ] || { echo "self-test FAIL: accepted $label" >&2; return 1; }
+	done
 
-	# A quoted form is caught too — the thing an author writes when they copy
-	# from a registry UI, and the shape a naive grep for `image: public` misses.
-	rm -f "$tmp/bad.yaml"
-	printf 'services:\n  db:\n    image: "public.ecr.aws/docker/library/redis:7"\n' > "$tmp/quoted.yaml"
-	rc=0; scan "$tmp" >/dev/null 2>&1 || rc=$?
-	if [ "$rc" -eq 0 ]; then echo "self-test FAIL: quoted banned registry accepted" >&2; return 1; fi
+	# A COMMENT naming the registry must NOT fail. The grep version failed here,
+	# and its self-test claimed otherwise because the fixture comment happened
+	# to lack the literal "image:". Use a comment that DOES contain it.
+	rm -f "$tmp/wf"/*.yaml
+	printf '# we used to write image: public.ecr.aws/docker/library/postgres:16 here\njobs:\n  a:\n    services:\n      db:\n        image: mirror.gcr.io/library/postgres:16\n' >"$tmp/wf/comment.yaml"
+	scan "$tmp/wf" >/dev/null 2>&1 || { echo "self-test FAIL: a comment naming the registry failed the gate" >&2; return 1; }
 
-	# A mention in a COMMENT must not fail the gate — this file and #1007's own
-	# notes name the registry on purpose, and a gate that cannot survive being
-	# documented gets deleted.
-	rm -f "$tmp/quoted.yaml"
-	printf '# we used to pull from public.ecr.aws/docker/library/postgres:16\nservices:\n  db:\n    image: mirror.gcr.io/library/postgres:16\n' > "$tmp/comment.yaml"
-	if ! scan "$tmp" 2>/dev/null; then echo "self-test FAIL: a comment mentioning the registry failed the gate" >&2; return 1; fi
+	# A missing or empty scan target must NOT report clean — that is how a gate
+	# silently stops gating after a directory move.
+	rc=0; scan "$tmp/gone" >/dev/null 2>&1 || rc=$?
+	[ "$rc" -ne 0 ] || { echo "self-test FAIL: a missing directory reported clean" >&2; return 1; }
+	mkdir -p "$tmp/empty"
+	rc=0; scan "$tmp/empty" >/dev/null 2>&1 || rc=$?
+	[ "$rc" -ne 0 ] || { echo "self-test FAIL: an empty directory reported clean" >&2; return 1; }
 
 	echo "check-service-image-registry self-test: ok"
 }
 
-if [ "${1:-}" = "--self-test" ]; then
-	self_test
-	exit $?
-fi
-
+if [ "${1:-}" = "--self-test" ]; then self_test; exit $?; fi
+if [ "$#" -gt 0 ]; then scan "$@"; exit $?; fi
 scan "$(dirname "$0")/../.github/workflows"
-echo "service-container registries ok"

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -748,8 +748,8 @@ run_gates() { # <tag>
   shopt -u nullglob
   # A gate renamed out of check-*.sh silently leaves the cut's gate set with no
   # signal at all, so assert the floor.
-  [ "${#gates[@]}" -ge "${MIN_GATES:-7}" ] || {
-    echo "gate set shrank to ${#gates[@]} (expected >= ${MIN_GATES:-7}) — a check-*.sh was renamed or removed" >&2
+  [ "${#gates[@]}" -ge "${MIN_GATES:-8}" ] || {
+    echo "gate set shrank to ${#gates[@]} (expected >= ${MIN_GATES:-8}) — a check-*.sh was renamed or removed" >&2
     return 1
   }
   for s in "${gates[@]}"; do


### PR DESCRIPTION
Closes #1007.

`public.ecr.aws` returns `toomanyrequests: Rate exceeded` on roughly 13% of main runs. The limit is **per source IP**, and GitHub-hosted runners share a small pool across every customer — nothing about this repo's traffic controls it. Three hits today, one on a PR that changed only markdown, one on `main` right after a merge.

## Why it has been absorbed rather than fixed

It is nearly invisible:

- The pull happens in **`Initialize containers`** — before `actions/checkout`, before any step. So it fires regardless of what the PR touches, and no retry, cache or guard inside the job can reach it.
- It fails in ~14 seconds, which reads as "rerun and move on".
- `gh run view --log-failed` returns **empty** for it, with no error, because a job that dies there has no step log. The obvious triage command reports zero matching lines — easy to read as "no rate limit found" ([#978](https://github.com/neochaotic/leoflow/issues/978)). I did exactly that this morning.

## The change

All 20 references → `mirror.gcr.io/library/<image>`, Google's unauthenticated pull-through cache for Docker Hub official images. Verified both manifests resolve there (HTTP 200) before swapping.

**This trades one third party for another and the PR should say so plainly.** What changes is the failure mode: `mirror.gcr.io` does not impose the shared-source-IP anonymous limit that is actually biting. It is not a guarantee, it is a different and empirically much quieter dependency. If you would rather own the mirror, the alternative is pushing these to GHCR — I did not take it because the package would need a one-time manual visibility flip that `GITHUB_TOKEN` cannot perform, which makes the change land half-broken.

## The guard

`scripts/check-service-image-registry.sh`, globbed into both the CI self-test job and `cut-release.sh`'s `run_gates()`, so no wiring rots.

Two things I made sure of, because a guard that cannot fail is worse than none:

- **It fails on the tree as it stood before this commit** — exit 1, pointing at all 20 lines. Measured, not assumed.
- Its self-test asserts a **comment** naming the registry does *not* trip it. This script and the issue notes name `public.ecr.aws` on purpose, and a gate that cannot survive being documented gets deleted.

## Not affected

`release.yaml`'s Lite pre-pull uses plain `postgres:16`, so `check-lite-prepull-matches-compose.sh` still compares what it compared. `MIN_GATES` is a `-ge` floor, so an added gate does not trip it.

Companion to #1017, which mitigates the *consequences* of a flake during a cut. This one removes the largest source.