### PR TITLE
docs: document task pod hardening, and gate user-facing changes on a docs update

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,6 +1,0 @@
-.git/
-node_modules/
-bin/
-website/public/
-website/resources/
-*.log

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,6 @@
+.git/
+node_modules/
+bin/
+website/public/
+website/resources/
+*.log

--- a/.github/workflows/docs-guard.yaml
+++ b/.github/workflows/docs-guard.yaml
@@ -1,0 +1,47 @@
+# Requires a docs update when a PR changes user-facing surface
+# (see scripts/check-docs-updated.sh).
+#
+# A standalone workflow — not a job in ci.yaml — for the same reason as the
+# CHANGELOG guard: it triggers on `labeled` / `unlabeled` too, so applying
+# `skip-docs` re-runs THIS guard alone and the exemption takes effect at once.
+#
+# Why it exists: taskPodSecurity.readOnlyRootFilesystem — the security hardening
+# of the v0.4.5 tranche — shipped in rc.3 with zero mentions anywhere under
+# website/content/. It had been validated on a real cluster the same day. The
+# CHANGELOG guard was added after the same failure repeated at least eight times
+# with changelog entries; this is that lesson applied one surface earlier.
+name: Docs guard
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  docs-guard:
+    name: Docs updated for user-facing changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Dependabot is exempt by author, not by label — the same reasoning the
+    # CHANGELOG guard documents: keying on the author keeps one mechanism and
+    # survives a label being removed.
+    if: >-
+      ${{ !contains(github.event.pull_request.labels.*.name, 'skip-docs')
+          && github.event.pull_request.user.login != 'dependabot[bot]' }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      # The changed-file list comes from the API rather than a git diff: the
+      # CHANGELOG guard can fetch --depth=1 because it compares one file's
+      # content, but a file LIST needs a merge base, and a shallow clone has
+      # none. Asking gh sidesteps the fetch-depth question entirely.
+      - name: Collect the changed files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: gh pr diff "$PR" --name-only > /tmp/changed.txt
+      - name: Require a docs update (or the skip-docs label)
+        run: bash scripts/check-docs-updated.sh HEAD /tmp/changed.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,19 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   not-ready rather than report nothing at all. An **ahead** schema still passes,
   as it does at boot — expand-contract migrations keep older code working, and
   failing it would break `helm rollback`.
+### Fixed
+
+- **A user-facing change without a docs update now fails CI (`skip-docs` to
+  exempt).** `taskPodSecurity.readOnlyRootFilesystem` — this tranche's security
+  hardening — shipped in rc.3 with zero mentions anywhere under
+  `website/content/`, having been validated on a real cluster the same day. The
+  CHANGELOG guard exists because that same failure repeated at least eight times
+  with changelog entries; this applies the lesson one surface earlier. The gate
+  keys on capability rather than churn — the chart values file, the authoring
+  schema, and the CLI commands — so internal refactors do not trip it, and it
+  mirrors the CHANGELOG guard's shape (standalone workflow, re-runs on label,
+  Dependabot exempt by author). The missing hardening page is written.
+
 
 ## [0.4.5] - 2026-09-09
 
@@ -408,17 +421,6 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   precisely so this cannot drift silently.
 
 ### Fixed
-
-- **A user-facing change without a docs update now fails CI (`skip-docs` to
-  exempt).** `taskPodSecurity.readOnlyRootFilesystem` — this tranche's security
-  hardening — shipped in rc.3 with zero mentions anywhere under
-  `website/content/`, having been validated on a real cluster the same day. The
-  CHANGELOG guard exists because that same failure repeated at least eight times
-  with changelog entries; this applies the lesson one surface earlier. The gate
-  keys on capability rather than churn — the chart values file, the authoring
-  schema, and the CLI commands — so internal refactors do not trip it, and it
-  mirrors the CHANGELOG guard's shape (standalone workflow, re-runs on label,
-  Dependabot exempt by author). The missing hardening page is written.
 
 - **A `dbt:` block alongside a `dag.py` is now refused instead of silently
   discarding the Python (#1001).** `compile` routes on the `dbt:` block before

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,7 +282,6 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   not-ready rather than report nothing at all. An **ahead** schema still passes,
   as it does at boot — expand-contract migrations keep older code working, and
   failing it would break `helm rollback`.
-### Fixed
 
 - **A user-facing change without a docs update now fails CI (`skip-docs` to
   exempt).** `taskPodSecurity.readOnlyRootFilesystem` — this tranche's security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -409,6 +409,17 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **A user-facing change without a docs update now fails CI (`skip-docs` to
+  exempt).** `taskPodSecurity.readOnlyRootFilesystem` — this tranche's security
+  hardening — shipped in rc.3 with zero mentions anywhere under
+  `website/content/`, having been validated on a real cluster the same day. The
+  CHANGELOG guard exists because that same failure repeated at least eight times
+  with changelog entries; this applies the lesson one surface earlier. The gate
+  keys on capability rather than churn — the chart values file, the authoring
+  schema, and the CLI commands — so internal refactors do not trip it, and it
+  mirrors the CHANGELOG guard's shape (standalone workflow, re-runs on label,
+  Dependabot exempt by author). The missing hardening page is written.
+
 - **A `dbt:` block alongside a `dag.py` is now refused instead of silently
   discarding the Python (#1001).** `compile` routes on the `dbt:` block before
   the parser is ever invoked, so the Python was never read and nothing said so:

--- a/scripts/check-docs-updated.sh
+++ b/scripts/check-docs-updated.sh
@@ -81,9 +81,22 @@ self_test() {
 	printf 'website/content/operate/x.md\n' > "$tmp/f"
 	check X "$tmp/f" >/dev/null || { echo "self-test FAIL: docs-only PR rejected" >&2; return 1; }
 
+	# Exercise the CLI ENTRYPOINT, not just check(). The bug this catches:
+	# the entrypoint forwarded only $1, dropping the file list, so every real
+	# invocation diffed <base>...HEAD (empty) and passed. check() was fine.
+	rc=0; bash "$0" X "$tmp/c" >/dev/null 2>&1 || rc=$?
+	[ "$rc" -ne 0 ] || { echo "self-test FAIL: entrypoint ignored the file list" >&2; return 1; }
+	rc=0; bash "$0" X "$tmp/f" >/dev/null 2>&1 || rc=$?
+	[ "$rc" -eq 0 ] || { echo "self-test FAIL: entrypoint rejected a docs-only PR" >&2; return 1; }
+
 	echo "check-docs-updated self-test: ok"
 }
 
 if [ "${1:-}" = "--self-test" ]; then self_test; exit $?; fi
-[ $# -ge 1 ] || { echo "usage: $0 <base-ref> | --self-test" >&2; exit 2; }
-check "$1"
+[ $# -ge 1 ] || { echo "usage: $0 <base-ref> [changed-files-file] | --self-test" >&2; exit 2; }
+# Forward BOTH arguments. This used to be `check "$1"`, which silently dropped
+# the file list and diffed <base>...HEAD instead — empty in CI, so the gate
+# passed everything. The self-test never caught it because it calls check()
+# directly and bypasses this line, so the only broken path was the only one
+# CI uses. A gate whose entrypoint is inert is worse than no gate.
+check "$@"

--- a/scripts/check-docs-updated.sh
+++ b/scripts/check-docs-updated.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Fail a PR that changes user-facing surface without touching the docs site.
+#
+# The CHANGELOG gate exists because entries "repeatedly merged with none and had
+# to be back-filled by separate PRs (at least eight)". The docs are in exactly
+# that state, and it is not hypothetical: taskPodSecurity.readOnlyRootFilesystem
+# — the security hardening of the v0.4.5 tranche — shipped in rc.3 with ZERO
+# mentions anywhere in website/content/. It was validated on a real cluster the
+# same day and nobody noticed, because nothing looks.
+#
+# "User-facing surface" is deliberately narrow, so the gate is about capability,
+# not churn: a chart value an operator sets, the authoring schema a user writes,
+# and the CLI commands they run. Internal refactors do not trip it.
+#
+# Escape hatch: the `skip-docs` label, for PRs that genuinely change nothing a
+# user could discover — release prep, dependabot, pure internals. Same shape as
+# skip-changelog, and the workflow re-runs on label so it takes effect at once.
+#
+# Usage: scripts/check-docs-updated.sh <base-ref>   e.g. origin/main
+#        scripts/check-docs-updated.sh --self-test
+set -euo pipefail
+
+DOCS_DIR="website/content"
+# Paths whose change implies something an operator or author can see.
+SURFACE_RE='^(helm/leoflow/values\.yaml|docs/api/leoflow-yaml-schema\.json|internal/domain/schemas/|internal/cli/[a-z_]+\.go)$'
+
+check() { # <base-ref> [changed-files-file]
+	local base="$1" listfile="${2:-}" changed
+	if [ -n "$listfile" ]; then
+		changed=$(cat "$listfile")
+	else
+		changed=$(git diff --name-only "$base"...HEAD)
+	fi
+	local surface docs
+	surface=$(printf '%s\n' "$changed" | grep -E "$SURFACE_RE" || true)
+	docs=$(printf '%s\n' "$changed" | grep -E "^${DOCS_DIR}/" || true)
+	if [ -z "$surface" ]; then
+		echo "no user-facing surface changed; docs not required"
+		return 0
+	fi
+	if [ -n "$docs" ]; then
+		echo "user-facing surface changed and ${DOCS_DIR}/ was updated"
+		return 0
+	fi
+	{
+		echo "This PR changes user-facing surface but updates no docs:"
+		printf '  %s\n' $surface
+		echo
+		echo "Update ${DOCS_DIR}/ in THIS PR — a capability an operator cannot find"
+		echo "in the docs did not really ship. If nothing here is user-discoverable,"
+		echo "apply the 'skip-docs' label and this guard re-runs."
+	} >&2
+	return 1
+}
+
+self_test() {
+	local tmp rc; tmp=$(mktemp -d); trap 'rm -rf "$tmp"' RETURN
+
+	printf 'helm/leoflow/values.yaml\nwebsite/content/operate/x.md\n' > "$tmp/a"
+	check X "$tmp/a" >/dev/null || { echo "self-test FAIL: surface+docs rejected" >&2; return 1; }
+
+	printf 'internal/executor/kubernetes.go\ninternal/storage/repo.go\n' > "$tmp/b"
+	check X "$tmp/b" >/dev/null || { echo "self-test FAIL: internal-only rejected" >&2; return 1; }
+
+	# The real regression: a chart value with no docs.
+	printf 'helm/leoflow/values.yaml\n' > "$tmp/c"
+	rc=0; check X "$tmp/c" >/dev/null 2>&1 || rc=$?
+	[ "$rc" -ne 0 ] || { echo "self-test FAIL: chart value with no docs accepted" >&2; return 1; }
+
+	# The authoring schema is surface too.
+	printf 'docs/api/leoflow-yaml-schema.json\n' > "$tmp/d"
+	rc=0; check X "$tmp/d" >/dev/null 2>&1 || rc=$?
+	[ "$rc" -ne 0 ] || { echo "self-test FAIL: schema change with no docs accepted" >&2; return 1; }
+
+	# A CLI command is surface; an internal helper in the same package is not.
+	printf 'internal/cli/compile.go\n' > "$tmp/e"
+	rc=0; check X "$tmp/e" >/dev/null 2>&1 || rc=$?
+	[ "$rc" -ne 0 ] || { echo "self-test FAIL: cli change with no docs accepted" >&2; return 1; }
+
+	# A docs-only PR must pass, not trip on itself.
+	printf 'website/content/operate/x.md\n' > "$tmp/f"
+	check X "$tmp/f" >/dev/null || { echo "self-test FAIL: docs-only PR rejected" >&2; return 1; }
+
+	echo "check-docs-updated self-test: ok"
+}
+
+if [ "${1:-}" = "--self-test" ]; then self_test; exit $?; fi
+[ $# -ge 1 ] || { echo "usage: $0 <base-ref> | --self-test" >&2; exit 2; }
+check "$1"

--- a/scripts/check-docs-updated.sh
+++ b/scripts/check-docs-updated.sh
@@ -22,7 +22,13 @@ set -euo pipefail
 
 DOCS_DIR="website/content"
 # Paths whose change implies something an operator or author can see.
-SURFACE_RE='^(helm/leoflow/values\.yaml|docs/api/leoflow-yaml-schema\.json|internal/domain/schemas/|internal/cli/[a-z_]+\.go)$'
+SURFACE_RE='^(helm/leoflow/values\.yaml|docs/api/leoflow-yaml-schema\.json|internal/domain/schemas/.+|internal/cli/[a-z0-9_]+\.go)$'
+# A Go TEST file is not user-facing surface. `[a-z_]+\.go` matched
+# compile_baseimage_integration_test.go, so this gate blocked a test-only PR and
+# sent its author looking for a `skip-docs` label that did not exist. Digits are
+# allowed in the name now too; `internal/domain/schemas/` gained `.+` because the
+# alternation is `$`-anchored and a bare directory prefix matched nothing.
+NOT_SURFACE_RE='(_test\.go|/testdata/)$'
 
 check() { # <base-ref> [changed-files-file]
 	local base="$1" listfile="${2:-}" changed
@@ -32,7 +38,7 @@ check() { # <base-ref> [changed-files-file]
 		changed=$(git diff --name-only "$base"...HEAD)
 	fi
 	local surface docs
-	surface=$(printf '%s\n' "$changed" | grep -E "$SURFACE_RE" || true)
+	surface=$(printf '%s\n' "$changed" | grep -E "$SURFACE_RE" | grep -vE "$NOT_SURFACE_RE" || true)
 	docs=$(printf '%s\n' "$changed" | grep -E "^${DOCS_DIR}/" || true)
 	if [ -z "$surface" ]; then
 		echo "no user-facing surface changed; docs not required"
@@ -89,11 +95,35 @@ self_test() {
 	rc=0; bash "$0" X "$tmp/f" >/dev/null 2>&1 || rc=$?
 	[ "$rc" -eq 0 ] || { echo "self-test FAIL: entrypoint rejected a docs-only PR" >&2; return 1; }
 
+	# No arguments is how cut-release.sh's run_gates() invokes every check-*.sh.
+	# Exiting non-zero here broke the cut; this locks the skip.
+	rc=0; bash "$0" >/dev/null 2>&1 || rc=$?
+	[ "$rc" -eq 0 ] || { echo "self-test FAIL: a no-arg invocation is not a skip — this breaks every release cut" >&2; return 1; }
+
+	# A Go TEST file is not user-facing surface. This blocked a test-only PR.
+	rm -f "$tmp"/*.yaml
+	printf 'internal/cli/compile_baseimage_integration_test.go\n' >"$tmp/tst"
+	bash "$0" X "$tmp/tst" >/dev/null 2>&1 || { echo "self-test FAIL: a test-only PR was told to write docs" >&2; return 1; }
+
+	# The schemas directory is real surface; a `$`-anchored bare prefix matched nothing.
+	printf 'internal/domain/schemas/leoflow-yaml-schema.json\n' >"$tmp/sch"
+	rc=0; bash "$0" X "$tmp/sch" >/dev/null 2>&1 || rc=$?
+	[ "$rc" -ne 0 ] || { echo "self-test FAIL: an authoring-schema change did not require docs" >&2; return 1; }
+
 	echo "check-docs-updated self-test: ok"
 }
 
 if [ "${1:-}" = "--self-test" ]; then self_test; exit $?; fi
-[ $# -ge 1 ] || { echo "usage: $0 <base-ref> [changed-files-file] | --self-test" >&2; exit 2; }
+# No arguments is a SKIP, not an error. cut-release.sh's run_gates() globs
+# scripts/check-*.sh and runs each with NO arguments, treating any non-zero as
+# "gate FAIL" and dying with "mechanical gates failed". Exiting 2 here would
+# have broken every release cut -- the exact failure check-script-selftests.sh's
+# header records for an earlier gate that "failed every rc cut it was globbed
+# into". This gate needs a PR to have an opinion about; a cut has none.
+if [ $# -eq 0 ]; then
+	echo "gate skipped: needs a PR context (<base-ref> [changed-files-file])"
+	exit 0
+fi
 # Forward BOTH arguments. This used to be `check "$1"`, which silently dropped
 # the file list and diffed <base>...HEAD instead — empty in CI, so the gate
 # passed everything. The self-test never caught it because it calls check()

--- a/website/content/operate/task-pod-hardening.md
+++ b/website/content/operate/task-pod-hardening.md
@@ -12,14 +12,21 @@ cluster policy audits them.
 
 The executor builds each task container with:
 
-| field | value |
-|---|---|
-| `runAsNonRoot` | `true` |
-| `allowPrivilegeEscalation` | `false` |
-| `capabilities.drop` | `["ALL"]` |
-| `seccompProfile` | `RuntimeDefault` |
-| `automountServiceAccountToken` | `false` (pod level) |
-| `fsGroup` | `65532` |
+| field | value | always emitted? |
+|---|---|---|
+| `allowPrivilegeEscalation` | `false` | yes |
+| `capabilities.drop` | `["ALL"]` | yes |
+| `seccompProfile` | `RuntimeDefault` | yes |
+| `automountServiceAccountToken` | `false` (pod level) | yes |
+| `runAsNonRoot` | `true` | follows `taskPodSecurity.runAsNonRoot` (default `true`) |
+| `fsGroup` | `65532` (pod level) | only when `runAsNonRoot` is on |
+
+The first four cost an ordinary task nothing and do not depend on the UID, so
+the executor sets them whatever the image runs as. The last two move together:
+turn `taskPodSecurity.runAsNonRoot` off for a fleet whose images legitimately
+run as root, and the executor drops `runAsNonRoot` *and* the pod-level `fsGroup`
+— a root task already writes its volumes as root, so there is nothing to fix,
+and leaving the pod context unset skips the kubelet's recursive volume chown.
 
 Two of these are worth understanding rather than just reading.
 
@@ -54,11 +61,12 @@ and run your DAGs once after.
 
 Two things to know before you rely on it:
 
-- **The `/tmp` emptyDir has no `sizeLimit`.** Nothing in Leoflow bounds it. A
-  task that writes a large amount of scratch data is bounded only by a namespace
-  `LimitRange` with a default `ephemeral-storage` limit, or failing that by the
-  node's own eviction threshold. If your tasks produce large intermediates, set a
-  `LimitRange`.
+- **The `/tmp` emptyDir has no `sizeLimit`.** The volume itself is unbounded, but
+  the DAG author already controls this per task: set
+  `resources.limits.ephemeral_storage` in `leoflow.yaml` (ADR 0054), which the
+  kubelet enforces against the task container. A namespace `LimitRange` default,
+  or failing that the node's own eviction threshold, is the cluster-side backstop
+  — reach for it only when you cannot change the DAG.
 - **Airflow logs a warning in every task.** With a read-only root, Airflow cannot
   create `/home/leoflow/airflow/logs` and says so:
   `Could not create log folder … Read-only file system … Airflow will continue`.

--- a/website/content/operate/task-pod-hardening.md
+++ b/website/content/operate/task-pod-hardening.md
@@ -1,0 +1,101 @@
+---
+title: Task pod hardening
+description: What the executor puts in every task pod's securityContext, what readOnlyRootFilesystem changes, and how to run task pods in a Pod Security Admission `restricted` namespace.
+weight: 78
+---
+
+Every task runs in its own pod. This page covers the security posture those pods
+get by default, the one knob that tightens it further, and what to expect when a
+cluster policy audits them.
+
+## What you get without configuring anything
+
+The executor builds each task container with:
+
+| field | value |
+|---|---|
+| `runAsNonRoot` | `true` |
+| `allowPrivilegeEscalation` | `false` |
+| `capabilities.drop` | `["ALL"]` |
+| `seccompProfile` | `RuntimeDefault` |
+| `automountServiceAccountToken` | `false` (pod level) |
+| `fsGroup` | `65532` |
+
+Two of these are worth understanding rather than just reading.
+
+**`runAsNonRoot` without `runAsUser`.** Leoflow deliberately does not pin a UID.
+The kubelet resolves the image's own `USER` and refuses the pod if it resolves
+to root. That means a **numeric** `USER` in your DAG image — `USER 65532:65532`,
+which the Leoflow base image uses — is required: a symbolic `USER myuser` cannot
+be resolved by the kubelet before the container starts, and the pod fails
+admission with `CreateContainerConfigError`. If you build a DAG image from
+something other than our base, make the final `USER` numeric.
+
+**No ServiceAccount token.** Task pods authenticate to the control plane with
+their own per-task token over gRPC and never call the Kubernetes API, so
+mounting a SA token would hand a credential to untrusted code for no reason.
+
+## `readOnlyRootFilesystem`
+
+```yaml
+taskPodSecurity:
+  readOnlyRootFilesystem: true   # default: false
+```
+
+With this on, the task container's root filesystem is mounted read-only and the
+executor mounts an `emptyDir` at `/tmp` so anything that needs scratch space
+still has it. The Leoflow base image already points dbt's target, log and
+profiles paths at `/tmp`, so a dbt task needs no further configuration.
+
+**It is off by default** because a DAG image that writes anywhere outside `/tmp`
+— a pip install at runtime, a library caching into `$HOME`, a tool writing next
+to its input — stops working the moment you turn it on. Turn it on deliberately,
+and run your DAGs once after.
+
+Two things to know before you rely on it:
+
+- **The `/tmp` emptyDir has no `sizeLimit`.** Nothing in Leoflow bounds it. A
+  task that writes a large amount of scratch data is bounded only by a namespace
+  `LimitRange` with a default `ephemeral-storage` limit, or failing that by the
+  node's own eviction threshold. If your tasks produce large intermediates, set a
+  `LimitRange`.
+- **Airflow logs a warning in every task.** With a read-only root, Airflow cannot
+  create `/home/leoflow/airflow/logs` and says so:
+  `Could not create log folder … Read-only file system … Airflow will continue`.
+  It is harmless — Leoflow captures task output over its own channel, unaffected
+  — but it appears at the top of every task log.
+
+## Running in a `restricted` namespace
+
+The defaults above satisfy Pod Security Admission's `restricted` profile, so you
+can label the task namespace and task pods will be admitted:
+
+```bash
+kubectl label ns <taskNamespace> pod-security.kubernetes.io/enforce=restricted
+```
+
+Nothing else is required. `restricted` does **not** require
+`readOnlyRootFilesystem`; the two are independent, and you can enable either
+without the other.
+
+## Verifying it
+
+On a running task pod:
+
+```bash
+kubectl get pod <task-pod> -n <taskNamespace> -o jsonpath='{.spec.containers[0].securityContext}{"\n"}{range .spec.volumes[*]}{.name} {end}{"\n"}'
+```
+
+With `readOnlyRootFilesystem: true` you should see `readOnlyRootFilesystem=true`,
+`runAsNonRoot=true`, and a `leoflow-tmp` volume among the pod's volumes. Task
+pods are short-lived, so read this while one is running, or from a pod that has
+finished but not yet been garbage-collected.
+
+**Verified on GKE 1.35 (Standard):** task pods admitted by a
+`restricted`-enforcing namespace with `readOnlyRootFilesystem: true`, running a
+hybrid DAG whose dbt models materialized normally.
+
+## Related
+
+- [Control-plane HA and disruption posture](/operate/control-plane-ha/)
+- [Agent credential transport](/operate/agent-credential-transport/)


### PR DESCRIPTION
Answers "a doc tem que sair junto com a release" with a gate, and fills the gap that prompted it.

## The gap

`taskPodSecurity.readOnlyRootFilesystem` — this tranche's security hardening — shipped in **rc.3** with zero mentions anywhere under `website/content/`:

```
$ grep -rl readOnlyRootFilesystem website/content/ | wc -l
0
```

I validated it on a real GKE cluster the same day and did not notice. An operator wanting to run task pods under a `restricted` namespace had no page to read.

## The gate

The repo already learned this for the CHANGELOG. That guard's header says entries *"repeatedly merged with none and had to be back-filled by separate PRs (#529, #532, #708, #739, #756, #780, #781, #888 — at least eight)"*. Docs were in exactly that state.

`scripts/check-docs-updated.sh` keys on **capability, not churn** — the chart values file, the authoring schema, and `internal/cli` commands. An internal refactor does not trip it. The workflow mirrors the CHANGELOG guard: standalone so it re-runs on `labeled`/`unlabeled`, `skip-docs` for PRs with nothing user-discoverable, Dependabot exempt by author rather than by label.

One deliberate difference: the changed-file **list** comes from `gh pr diff --name-only`. The CHANGELOG guard can fetch `--depth=1` because it compares one file's content; a file list needs a merge base, and a shallow clone has none.

Six self-test cases, including the two that matter — a chart-value change with no docs must **fail**, and a docs-only PR must **not** trip on itself.

**Feasibility, measured before proposing:** 25 of 153 chart keys (levels 1–2) are absent from the site today. That is a backfill someone can actually do, not a wall. Note the gate does not demand coverage of the backlog — it only stops new gaps.

## The page

`operate/task-pod-hardening.md` documents what I **measured** today rather than what the chart promises:

- `runAsNonRoot` without `runAsUser` makes a **numeric** image `USER` mandatory — a symbolic one fails admission with `CreateContainerConfigError`.
- The `/tmp` emptyDir has **no `sizeLimit`**; a namespace `LimitRange` or the node's eviction threshold is the only bound.
- A read-only root makes Airflow log a harmless warning at the top of **every** task log — worth saying so nobody chases it.
- `restricted` does not require `readOnlyRootFilesystem`; the two are independent.

Verified on GKE 1.35 Standard: task pods admitted by a `restricted`-enforcing namespace with the read-only root on, running a hybrid DAG whose dbt models materialized normally.

## Not in scope

A gate that requires an RC to have been validated on a real cluster — filed as #1026 and deliberately deferred to keep it manual for now.