### PR TITLE
release: promote v0.4.5 GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.5] - 2026-09-09
+
 ### Added
 
 - **`auth.secretScoping` is now a chart value, and the security flips are

--- a/helm/leoflow/Chart.yaml
+++ b/helm/leoflow/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version is the chart version; appVersion tracks the leoflow-server image.
 # Both move in lockstep with the release tag (ADR 0028); decouple only if the
 # chart ever needs a cadence of its own for a template-only fix.
-version: 0.4.5-rc.3
-appVersion: "0.4.5-rc.3"
+version: 0.4.5
+appVersion: "0.4.5"
 home: https://github.com/neochaotic/leoflow
 sources:
   - https://github.com/neochaotic/leoflow

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -1,6 +1,6 @@
 # leoflow
 
-![Version: 0.4.5-rc.3](https://img.shields.io/badge/Version-0.4.5--rc.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.5-rc.3](https://img.shields.io/badge/AppVersion-0.4.5--rc.3-informational?style=flat-square)
+![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.5](https://img.shields.io/badge/AppVersion-0.4.5-informational?style=flat-square)
 
 Leoflow control plane — a GitOps-first, container-native workflow orchestrator (Airflow 3.2.x UI/API compatible).
 


### PR DESCRIPTION
CHANGELOG [Unreleased] -> [0.4.5] - 2026-09-09; Chart version/appVersion -> 0.4.5 (ADR 0028 lockstep).