### PR TITLE
docs: publish v0.4.5 at the documentation root

### DIFF
--- a/website/scripts/ci/versions.json
+++ b/website/scripts/ci/versions.json
@@ -2,9 +2,33 @@
   "_comment": "Single source of truth for the multi-version Pages tree (issue #814). One entry per published leg. `id` names the build's artifact/subdir; `ref` is the git ref to build from (empty string means \"whatever ref triggered the workflow\" — resolved to github.sha by the plan job); `subpath` is where it lands under https://neochaotic.github.io/leoflow/ (empty = site root); `label` is the string shown in the version dropdown and written to params.version; `archived` marks a superseded GA so Docsy renders the archived-version banner.\n\nCutting a new GA release does this automatically: scripts/cut-release.sh calls promote_docs_version() after the tag is pushed, which repoints the `latest` entry's `ref` (NOT its `label` — the dropdown keeps saying \"latest\") and archives the GA it replaces, adding an entry for it if there is not one yet. The cut edits this file; hand-edit it only to recover a promotion the cut skipped, following the recipe in RELEASING.md. Before that was scripted, three GAs shipped with the root still built from v0.4.1: a procedure written in a comment that no script performs is a procedure that does not happen.",
   "root_url": "https://neochaotic.github.io/leoflow/",
   "versions": [
-    { "id": "latest", "ref": "v0.4.1", "subpath": "", "label": "latest", "archived": false },
-    { "id": "v0.4.1", "ref": "v0.4.1", "subpath": "v0.4.1", "label": "v0.4.1", "archived": false },
-    { "id": "v0.4.0", "ref": "v0.4.0", "subpath": "v0.4.0", "label": "v0.4.0", "archived": true },
-    { "id": "dev", "ref": "", "subpath": "dev", "label": "dev", "archived": false }
+    {
+      "id": "latest",
+      "ref": "v0.4.5",
+      "subpath": "",
+      "label": "latest",
+      "archived": false
+    },
+    {
+      "id": "v0.4.1",
+      "ref": "v0.4.1",
+      "subpath": "v0.4.1",
+      "label": "v0.4.1",
+      "archived": true
+    },
+    {
+      "id": "v0.4.0",
+      "ref": "v0.4.0",
+      "subpath": "v0.4.0",
+      "label": "v0.4.0",
+      "archived": true
+    },
+    {
+      "id": "dev",
+      "ref": "",
+      "subpath": "dev",
+      "label": "dev",
+      "archived": false
+    }
   ]
 }


### PR DESCRIPTION
Repoints website/scripts/ci/versions.json's `latest` leg at v0.4.5 and archives the one it replaces. Opened by cut-release.sh after the tag was pushed — the deploy checks the tag out, so this cannot ride in the prepare commit.