### PR TITLE
fix(api): make /readyz assert the schema invariant boot asserts, on every probe (#1023)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,13 +101,40 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   a replica that has not caught up, a migration rolled back out of band, and a
   `database.url` repointed at the wrong database.
 
-  Three properties of the fix are deliberate. The response body stays vague —
-  it names the dependency (`postgres schema not current`) and nothing else,
-  because `/readyz` is unauthenticated and the underlying error can carry a DSN
-  or an internal hostname; the detail goes to the log. **Liveness is
-  unchanged**: restarting a pod does not create a schema, so a crash loop would
-  trade an honestly not-ready pod for one that cannot even be inspected. And
-  the check is bounded at 2s, under the chart's 3s
+  **A migration in flight does not take the control plane out of rotation.**
+  The migrate Job is a `pre-install,pre-upgrade` Helm hook, so on upgrade it runs
+  while the old pods are still live and serving, and golang-migrate marks the
+  schema dirty for the whole execution of each migration body. Every replica
+  reads that same row, so a probe that treated dirty as not-ready would flip all
+  of them at the same instant for any migration longer than 30s
+  (`periodSeconds × failureThreshold`) and drop the Service to zero endpoints —
+  and in the single-Deployment `all` role that Service also carries gRPC, so
+  running task pods would lose the control plane mid-upgrade. Readiness is
+  therefore version-aware where boot is not: a dirty schema **above** the
+  version the running binary embeds is a forward migration that does not concern
+  it, and the pod keeps serving (one log line per episode, not one per probe). A
+  dirty schema at or below that version is a half-applied schema the binary
+  actually depends on, and it goes not-ready. Boot still refuses to *start*
+  against any dirty schema — a process that has not begun serving has nothing to
+  lose by waiting, and that is the one state where the two verdicts are meant to
+  differ.
+
+  **`/api/v2/monitor/health` asserts the same thing.** It reads the same
+  dependency map and was also Ping-only, so in the state above it reported
+  `metadatabase: healthy` at HTTP 200 while `/readyz` was 503 and the pod was out
+  of the Service — the Airflow-compatible surface the UI dashboard renders was
+  the last place still claiming the database was fine.
+
+  Three further properties of the fix are deliberate. The response body stays
+  vague — it names the dependency and nothing else, because `/readyz` is
+  unauthenticated and the underlying error can carry a DSN or an internal
+  hostname; the detail goes to the log. It also distinguishes what it saw:
+  `postgres schema not current` is a schema verdict, `postgres unavailable` is a
+  database that could not be read at all (a timeout, a reset connection, an
+  exhausted pool). Both are 503, but only one of them is a reason to go looking
+  at migrations. **Liveness is unchanged**: restarting a pod does not create a
+  schema, so a crash loop would trade an honestly not-ready pod for one that
+  cannot even be inspected. And the check is bounded at 2s, under the chart's 3s
   `probes.readiness.timeoutSeconds`, so a wedged database makes the probe report
   not-ready rather than report nothing at all. An **ahead** schema still passes,
   as it does at boot — expand-contract migrations keep older code working, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,38 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   **What to do:** set `python_version: "3.11"` (or `"3.12"` / `"3.13"`) in
   `leoflow.yaml` and rebuild — or, if you pinned `base_image`, repoint it to the
   matching `py3.11` tag and rebuild.
+### Fixed
+
+- **`/readyz` no longer reports ready over a database with no schema (#1023).**
+  The readiness probe pinged each dependency and nothing more, and a Postgres
+  `Ping` succeeds whenever the *connection* is healthy — it says nothing about
+  what is behind it. Found on the v0.4.5 RC cluster: a node recycle recreated an
+  ephemeral-storage Postgres **empty**, and the running control plane answered
+  `{"status":"ready"}` HTTP 200 in the same seconds the scheduler was failing
+  every tick on `relation "dag_runs" does not exist` and `/auth/token` was
+  answering 503. Readiness now asserts the same invariant boot does —
+  `schema_migrations` present, clean, and not behind the version this binary
+  embeds — through the same storage-layer code path, so the two verdicts cannot
+  drift. This is the signal Kubernetes routes traffic on and calls a rollout
+  successful on, so the gap let `helm upgrade --wait` report success against a
+  control plane that could not serve one authenticated request, let a rolling
+  update replace working pods with broken ones, and kept a 503-ing pod in
+  Service rotation. It also covers the cases that reach installs with durable
+  storage: a restore from a backup older than the running binary, a failover to
+  a replica that has not caught up, a migration rolled back out of band, and a
+  `database.url` repointed at the wrong database.
+
+  Three properties of the fix are deliberate. The response body stays vague —
+  it names the dependency (`postgres schema not current`) and nothing else,
+  because `/readyz` is unauthenticated and the underlying error can carry a DSN
+  or an internal hostname; the detail goes to the log. **Liveness is
+  unchanged**: restarting a pod does not create a schema, so a crash loop would
+  trade an honestly not-ready pod for one that cannot even be inspected. And
+  the check is bounded at 2s, under the chart's 3s
+  `probes.readiness.timeoutSeconds`, so a wedged database makes the probe report
+  not-ready rather than report nothing at all. An **ahead** schema still passes,
+  as it does at boot — expand-contract migrations keep older code working, and
+  failing it would break `helm rollback`.
 
 ## [0.4.5] - 2026-09-09
 

--- a/cmd/leoflow-server/health_checks_test.go
+++ b/cmd/leoflow-server/health_checks_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/api"
+	"github.com/neochaotic/leoflow/internal/storage"
+)
+
+// pingOnlyChecker stands in for the decorator this test exists to catch — a
+// metrics wrapper, a circuit breaker, a tenant router. It satisfies
+// api.HealthChecker, so healthChecks would still compile with it in the map.
+type pingOnlyChecker struct{ api.HealthChecker }
+
+// TestHealthChecksPostgresCarriesTheSchemaAssertion pins #1023 where it can
+// actually break, which is not where a compile-time interface pin can see it.
+//
+// The readiness handler discovers the schema assertion with a runtime type
+// assertion on the VALUE in the checks map. `var _ api.SchemaChecker =
+// (*storage.Postgres)(nil)` pins the TYPE, so it catches a rename on either
+// side and nothing else: wrap the value in any decorator that implements only
+// Ping and the pin still compiles, every test stays green, and /readyz silently
+// returns to reporting ready over an empty database — the exact regression
+// #1023 was. The value is what the handler sees, so the value is what to assert.
+func TestHealthChecksPostgresCarriesTheSchemaAssertion(t *testing.T) {
+	// A nil Pool is fine: nothing here reaches the database, and constructing
+	// the value is the whole point — it is the map entry that must keep the
+	// capability, not the declared type of the field it came from.
+	pg := &storage.Postgres{}
+
+	checks := healthChecks(pg, nil)
+
+	entry, ok := checks["postgres"]
+	if !ok {
+		t.Fatalf(`no "postgres" entry in the readiness checks: %v`, keys(checks))
+	}
+	if _, ok := entry.(api.SchemaChecker); !ok {
+		t.Fatalf("the postgres readiness check (%T) does not implement api.SchemaChecker, "+
+			"so /readyz and /api/v2/monitor/health silently fall back to Ping-only and report "+
+			"ready over a database with no schema (#1023)", entry)
+	}
+}
+
+// TestHealthChecksDecoratorLosingSchemaIsCaught is the negative control: it
+// proves the assertion above can fail, by building the map shape a Ping-only
+// decorator would produce.
+func TestHealthChecksDecoratorLosingSchemaIsCaught(t *testing.T) {
+	wrapped := api.HealthChecker(pingOnlyChecker{&storage.Postgres{}})
+	if _, ok := wrapped.(api.SchemaChecker); ok {
+		t.Fatal("pingOnlyChecker must NOT satisfy api.SchemaChecker, or the guard above proves nothing")
+	}
+}
+
+// TestHealthChecksOmitsRedisWhenAbsent keeps the map's other contract honest:
+// Redis is schema-less and is registered only when it is the active datastore.
+func TestHealthChecksOmitsRedisWhenAbsent(t *testing.T) {
+	if _, ok := healthChecks(&storage.Postgres{}, nil)["redis"]; ok {
+		t.Error("redis registered as a readiness dependency in the embedded edition")
+	}
+	redis := api.HealthChecker(pingOnlyChecker{})
+	checks := healthChecks(&storage.Postgres{}, redis)
+	if _, ok := checks["redis"]; !ok {
+		t.Error("redis not registered when it is the active datastore")
+	}
+	if _, ok := checks["redis"].(api.SchemaChecker); ok {
+		t.Error("a schema-less dependency must keep the Ping-only contract")
+	}
+}
+
+func keys(m map[string]api.HealthChecker) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -1137,6 +1137,13 @@ func selectDatastore(ctx context.Context, cfg *config.ServerConfig, pg *storage.
 	return xcom.NewRedisBackend(rd.Client), logs.NewRedisTailer(rd.Client), rd, cleanup, nil
 }
 
+// The readiness probe asserts the schema invariant only for dependencies that
+// ALSO implement api.SchemaChecker, and a type assertion that stops matching is
+// silent: /readyz would go back to reporting ready over an empty database with
+// every test still green (#1023). Pin the coupling here so a rename on either
+// side is a build failure.
+var _ api.SchemaChecker = (*storage.Postgres)(nil)
+
 // healthChecks builds the readiness checks, including Redis only when it is the
 // active datastore (redisHealth is nil in the embedded edition).
 func healthChecks(pg *storage.Postgres, redisHealth api.HealthChecker) map[string]api.HealthChecker {

--- a/cmd/leoflow-server/main.go
+++ b/cmd/leoflow-server/main.go
@@ -1137,15 +1137,19 @@ func selectDatastore(ctx context.Context, cfg *config.ServerConfig, pg *storage.
 	return xcom.NewRedisBackend(rd.Client), logs.NewRedisTailer(rd.Client), rd, cleanup, nil
 }
 
-// The readiness probe asserts the schema invariant only for dependencies that
-// ALSO implement api.SchemaChecker, and a type assertion that stops matching is
-// silent: /readyz would go back to reporting ready over an empty database with
-// every test still green (#1023). Pin the coupling here so a rename on either
-// side is a build failure.
-var _ api.SchemaChecker = (*storage.Postgres)(nil)
-
-// healthChecks builds the readiness checks, including Redis only when it is the
-// active datastore (redisHealth is nil in the embedded edition).
+// healthChecks builds the health checks read by /readyz and
+// /api/v2/monitor/health, including Redis only when it is the active datastore
+// (redisHealth is nil in the embedded edition).
+//
+// The "postgres" entry must keep satisfying api.SchemaChecker. Both endpoints
+// discover the schema assertion with a runtime type assertion on the VALUE in
+// this map, and an assertion that stops matching is silent — they would fall
+// back to Ping-only and report ready over an empty database with every test
+// still green, which is #1023. A compile-time `var _ api.SchemaChecker =
+// (*storage.Postgres)(nil)` does not cover that: it pins the TYPE, so wrapping
+// the value in any decorator that implements only Ping (metrics, a circuit
+// breaker, a tenant router) still compiles. The guard is on the value, in
+// TestHealthChecksPostgresCarriesTheSchemaAssertion.
 func healthChecks(pg *storage.Postgres, redisHealth api.HealthChecker) map[string]api.HealthChecker {
 	checks := map[string]api.HealthChecker{"postgres": pg}
 	if redisHealth != nil {

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -13,7 +14,32 @@ type HealthChecker interface {
 	Ping(ctx context.Context) error
 }
 
+// SchemaChecker is an optional capability a HealthChecker may also implement:
+// asserting that the dependency's SCHEMA — not just its connection — is the one
+// this binary requires. *storage.Postgres implements it; Redis and other
+// schema-less dependencies do not, and keep the Ping-only contract.
+//
+// It exists because a Ping is not evidence of a usable database (#1023). The
+// invariant is enforced at boot, where the server refuses to start against a
+// database whose schema_migrations is absent or behind — but a boot check says
+// nothing about a database that changes UNDER a running pod, which is exactly
+// what an ephemeral-volume recycle, a restore from an older backup, a failover
+// to a lagging replica, or a repointed database.url does.
+type SchemaChecker interface {
+	SchemaReady(ctx context.Context) error
+}
+
+// schemaProbeTimeout bounds the schema query so a wedged or slow database cannot
+// hold the handler past the kubelet's own probe timeout (the chart's
+// probes.readiness.timeoutSeconds default is 3s). Overrunning it turns a probe
+// that should report "not ready" into a probe that reports nothing at all.
+const schemaProbeTimeout = 2 * time.Second
+
 func livenessHandler(c *gin.Context) {
+	// Deliberately trivial, and deliberately NOT schema-aware: liveness decides
+	// whether the kubelet RESTARTS the pod, and restarting creates no schema. A
+	// crash loop on a database problem is strictly worse than a pod that is
+	// honestly not-ready and stays available for logs and diagnosis.
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
 
@@ -27,6 +53,22 @@ func readinessHandler(checks map[string]HealthChecker) gin.HandlerFunc {
 				// cause server-side; tell the caller only which dependency is unready.
 				slog.WarnContext(c.Request.Context(), "readiness check failed", "dependency", name, "error", err)
 				AbortProblem(c, http.StatusServiceUnavailable, "not ready", name+" unavailable")
+				return
+			}
+			sc, ok := hc.(SchemaChecker)
+			if !ok {
+				continue
+			}
+			// Ping passed, so the connection is up; ask whether what is behind it is
+			// still the schema this binary requires.
+			ctx, cancel := context.WithTimeout(c.Request.Context(), schemaProbeTimeout)
+			err := sc.SchemaReady(ctx)
+			cancel()
+			if err != nil {
+				// Same audit H2 reasoning as above: the version gap and any connection
+				// detail stay in the log, and the response only names the dependency.
+				slog.WarnContext(c.Request.Context(), "readiness schema check failed", "dependency", name, "error", err)
+				AbortProblem(c, http.StatusServiceUnavailable, "not ready", name+" schema not current")
 				return
 			}
 		}

--- a/internal/api/health.go
+++ b/internal/api/health.go
@@ -2,11 +2,13 @@ package api
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/neochaotic/leoflow/internal/domain"
 )
 
 // HealthChecker reports dependency health for readiness checks.
@@ -43,32 +45,56 @@ func livenessHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }
 
+// checkDependency runs the full health contract for one dependency: Ping first,
+// then — only for a dependency that carries a schema — the schema assertion.
+//
+// Ping first and short-circuiting, because with the connection down there is
+// nothing to learn from a schema query and it would only burn the probe's
+// budget. Shared by /readyz and /api/v2/monitor/health so the two endpoints,
+// which read the same checks map, cannot come to disagree about whether a
+// dependency works — they did, and that was half of #1023's blast radius.
+func checkDependency(ctx context.Context, hc HealthChecker) error {
+	if err := hc.Ping(ctx); err != nil {
+		return err
+	}
+	sc, ok := hc.(SchemaChecker)
+	if !ok {
+		return nil
+	}
+	sctx, cancel := context.WithTimeout(ctx, schemaProbeTimeout)
+	defer cancel()
+	return sc.SchemaReady(sctx)
+}
+
+// unreadyDetail turns a dependency failure into the one phrase the caller is
+// allowed to see, and picks WHICH phrase by the kind of failure.
+//
+// The distinction is operational, not cosmetic. The schema check reports through
+// a single error, but it answers two questions: "the schema is wrong" and "I
+// could not read the schema". A deadline exceeded against the handler's own 2s
+// bound, a reset connection, an exhausted pool — all arrive here as a non-nil
+// error from the schema call, and calling those "schema not current" points
+// whoever is paged at the migration Job for a connectivity problem. The runbook
+// makes that exact string a PASS criterion, so conflating them would also make
+// the release check pass for the wrong reason.
+//
+// Both remain 503, and both remain vague on purpose: /readyz is unauthenticated
+// (probes carry no token) and the raw error can carry a DSN, credentials or an
+// internal hostname (audit H2), so the real cause is logged server-side and the
+// response names only the dependency.
+func unreadyDetail(name string, err error) string {
+	if errors.Is(err, domain.ErrSchemaNotCurrent) {
+		return name + " schema not current"
+	}
+	return name + " unavailable"
+}
+
 func readinessHandler(checks map[string]HealthChecker) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		for name, hc := range checks {
-			if err := hc.Ping(c.Request.Context()); err != nil {
-				// /readyz is unauthenticated (probes carry no token), so the raw
-				// dependency error — which can carry a DSN, credentials, or internal
-				// hostnames — must not go in the response (audit H2). Log the real
-				// cause server-side; tell the caller only which dependency is unready.
+			if err := checkDependency(c.Request.Context(), hc); err != nil {
 				slog.WarnContext(c.Request.Context(), "readiness check failed", "dependency", name, "error", err)
-				AbortProblem(c, http.StatusServiceUnavailable, "not ready", name+" unavailable")
-				return
-			}
-			sc, ok := hc.(SchemaChecker)
-			if !ok {
-				continue
-			}
-			// Ping passed, so the connection is up; ask whether what is behind it is
-			// still the schema this binary requires.
-			ctx, cancel := context.WithTimeout(c.Request.Context(), schemaProbeTimeout)
-			err := sc.SchemaReady(ctx)
-			cancel()
-			if err != nil {
-				// Same audit H2 reasoning as above: the version gap and any connection
-				// detail stay in the log, and the response only names the dependency.
-				slog.WarnContext(c.Request.Context(), "readiness schema check failed", "dependency", name, "error", err)
-				AbortProblem(c, http.StatusServiceUnavailable, "not ready", name+" schema not current")
+				AbortProblem(c, http.StatusServiceUnavailable, "not ready", unreadyDetail(name, err))
 				return
 			}
 		}

--- a/internal/api/health_schema_test.go
+++ b/internal/api/health_schema_test.go
@@ -3,12 +3,14 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/neochaotic/leoflow/internal/domain"
 )
 
 // fakeSchemaHealthCheck implements HealthChecker plus the optional SchemaChecker,
@@ -137,6 +139,71 @@ func TestReadinessHandlerAssertsSchemaInvariant(t *testing.T) {
 		}
 		if pg.schemaCalls != 0 {
 			t.Errorf("schema queried %d times on a dependency that failed Ping, want 0", pg.schemaCalls)
+		}
+	})
+}
+
+// TestReadinessDistinguishesSchemaFromUnavailable pins the classification the
+// detail string makes. The schema check reaches the handler through one return
+// value, but it answers two different questions: "the schema is wrong" and "I
+// could not read the schema". Treating every non-nil return as a schema verdict
+// reports `postgres schema not current` for a database that is merely slow —
+// the 2s bound alone produces it under pool exhaustion or a stalled connection —
+// and sends whoever is on call into migration-land for a connectivity problem.
+//
+// Both stay 503 (a probe that cannot read the schema must not report ready) and
+// both still leak nothing; only the operator-facing detail differs.
+func TestReadinessDistinguishesSchemaFromUnavailable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	readyz := func(t *testing.T, schemaErr error) *httptest.ResponseRecorder {
+		t.Helper()
+		r := gin.New()
+		r.GET("/readyz", readinessHandler(map[string]HealthChecker{
+			"postgres": &fakeSchemaHealthCheck{schemaErr: schemaErr},
+		}))
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", http.NoBody))
+		return rec
+	}
+
+	t.Run("a timed-out schema read reports unavailable, not a schema verdict", func(t *testing.T) {
+		// Exactly what the handler's own 2s bound produces against a slow
+		// database: the storage layer wraps the context error.
+		rec := readyz(t, fmt.Errorf("reading database schema version: %w", context.DeadlineExceeded))
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want 503", rec.Code)
+		}
+		body := rec.Body.String()
+		if strings.Contains(body, "schema not current") {
+			t.Errorf("a slow database was reported as a migration problem: %q", body)
+		}
+		if !strings.Contains(body, "postgres unavailable") {
+			t.Errorf("body = %q, want it to report postgres unavailable", body)
+		}
+	})
+
+	t.Run("a real schema verdict still says schema not current", func(t *testing.T) {
+		rec := readyz(t, fmt.Errorf("%w: schema_migrations is absent", domain.ErrSchemaNotCurrent))
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want 503", rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "postgres schema not current") {
+			t.Errorf("body = %q, want it to name the schema verdict", rec.Body.String())
+		}
+	})
+
+	t.Run("neither classification leaks connection detail", func(t *testing.T) {
+		for _, err := range []error{
+			fmt.Errorf("reading database schema version: dial postgres://leoflow:hunter2@pg.internal.svc:5432/leoflow: %w", context.DeadlineExceeded),
+			fmt.Errorf("%w: schema at v23, want v26 (postgres://leoflow:hunter2@pg.internal.svc:5432/leoflow)", domain.ErrSchemaNotCurrent),
+		} {
+			body := readyz(t, err).Body.String()
+			for _, secret := range []string{"hunter2", "pg.internal.svc", "postgres://", "5432"} {
+				if strings.Contains(body, secret) {
+					t.Errorf("body leaked %q: %q", secret, body)
+				}
+			}
 		}
 	})
 }

--- a/internal/api/health_schema_test.go
+++ b/internal/api/health_schema_test.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// fakeSchemaHealthCheck implements HealthChecker plus the optional SchemaChecker,
+// standing in for *storage.Postgres — the one dependency that carries a schema.
+// schemaErr is whatever the storage-layer check would return (an absent
+// schema_migrations, a version behind the binary, a dirty migration).
+type fakeSchemaHealthCheck struct {
+	pingErr     error
+	schemaErr   error
+	schemaCalls int
+	hadDeadline bool
+}
+
+func (f *fakeSchemaHealthCheck) Ping(context.Context) error { return f.pingErr }
+
+func (f *fakeSchemaHealthCheck) SchemaReady(ctx context.Context) error {
+	f.schemaCalls++
+	_, f.hadDeadline = ctx.Deadline()
+	return f.schemaErr
+}
+
+// TestReadinessHandlerAssertsSchemaInvariant pins the #1023 contract: readiness
+// asserts the same invariant boot does, on every probe, not only once at startup.
+//
+// A Postgres Ping succeeds whenever the *connection* is healthy and says nothing
+// about the schema, so a database emptied, restored from an older backup, failed
+// over to a lagging replica, or simply repointed under a RUNNING pod kept /readyz
+// at 200 while the scheduler could not read dag_runs and /auth/token answered 503.
+// Kubernetes routes traffic on that 200 and calls a rollout successful on it, so
+// the pod has to report itself not-ready instead.
+func TestReadinessHandlerAssertsSchemaInvariant(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// readyz drives the handler over one dependency map and returns the recorder.
+	readyz := func(t *testing.T, checks map[string]HealthChecker) *httptest.ResponseRecorder {
+		t.Helper()
+		r := gin.New()
+		r.GET("/readyz", readinessHandler(checks))
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/readyz", http.NoBody))
+		return rec
+	}
+
+	t.Run("current schema → 200 ready", func(t *testing.T) {
+		pg := &fakeSchemaHealthCheck{}
+		rec := readyz(t, map[string]HealthChecker{"postgres": pg})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+		if pg.schemaCalls != 1 {
+			t.Errorf("schema checked %d times, want exactly 1 per probe", pg.schemaCalls)
+		}
+	})
+
+	t.Run("schema_migrations absent → 503, not ready", func(t *testing.T) {
+		// The exact shape of the boot-time failure (#1023): a healthy connection to
+		// a database where migrations never ran.
+		pg := &fakeSchemaHealthCheck{schemaErr: errors.New(
+			"database schema is not current: schema_migrations is absent — migrations have not run; schema v26 is required")}
+		rec := readyz(t, map[string]HealthChecker{"postgres": pg})
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want 503 — an empty database must never report ready", rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "postgres") {
+			t.Errorf("body must name the unready dependency, got %q", rec.Body.String())
+		}
+	})
+
+	t.Run("schema behind the binary → 503, not ready", func(t *testing.T) {
+		pg := &fakeSchemaHealthCheck{schemaErr: errors.New(
+			"database schema is not current: schema is at v23 but this binary requires v26")}
+		rec := readyz(t, map[string]HealthChecker{"postgres": pg})
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want 503 — a database behind the binary must not report ready", rec.Code)
+		}
+	})
+
+	t.Run("the body leaks no connection detail", func(t *testing.T) {
+		// /readyz is unauthenticated (probes carry no token), so the raw error —
+		// which reaches here from a DSN-aware layer — must not go in the response
+		// (audit H2). It is logged server-side instead.
+		pg := &fakeSchemaHealthCheck{schemaErr: errors.New(
+			"reading database schema version: dial postgres://leoflow:hunter2@pg.internal.svc:5432/leoflow: connection refused")}
+		rec := readyz(t, map[string]HealthChecker{"postgres": pg})
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want 503", rec.Code)
+		}
+		body := rec.Body.String()
+		for _, secret := range []string{"hunter2", "pg.internal.svc", "postgres://", "5432"} {
+			if strings.Contains(body, secret) {
+				t.Errorf("body leaked %q from the raw dependency error: %q", secret, body)
+			}
+		}
+	})
+
+	t.Run("the schema probe is bounded, so a slow database cannot hang it", func(t *testing.T) {
+		// The kubelet allows the probe probes.readiness.timeoutSeconds (3s in the
+		// chart). A query with no deadline of its own leaves the handler blocked on
+		// a wedged database for as long as the query takes.
+		pg := &fakeSchemaHealthCheck{}
+		readyz(t, map[string]HealthChecker{"postgres": pg})
+		if !pg.hadDeadline {
+			t.Error("schema check ran with no deadline; a slow database would hang the probe")
+		}
+	})
+
+	t.Run("a dependency with no schema is unaffected", func(t *testing.T) {
+		// Redis implements HealthChecker only. The schema assertion is an optional
+		// capability, so a non-schema dependency keeps its Ping-only contract.
+		rec := readyz(t, map[string]HealthChecker{
+			"postgres": &fakeSchemaHealthCheck{},
+			"redis":    &fakeHealthCheck{},
+		})
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+	})
+
+	t.Run("an unreachable database is reported without querying it", func(t *testing.T) {
+		// Ping first: with the connection down there is nothing to learn from a
+		// schema query, and it would only burn the probe's budget waiting.
+		pg := &fakeSchemaHealthCheck{pingErr: errors.New("connection refused")}
+		rec := readyz(t, map[string]HealthChecker{"postgres": pg})
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want 503", rec.Code)
+		}
+		if pg.schemaCalls != 0 {
+			t.Errorf("schema queried %d times on a dependency that failed Ping, want 0", pg.schemaCalls)
+		}
+	})
+}

--- a/internal/api/monitor.go
+++ b/internal/api/monitor.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -38,9 +39,16 @@ func componentHealth(hb Heartbeater) (status, heartbeat string) {
 // HealthInfoResponse). The Airflow UI's home dashboard polls it to color the
 // component health widgets (metadatabase, scheduler, triggerer, dag processor).
 //
-// The metadatabase status is a real probe (pings the "postgres" checker) and the
-// scheduler status is a real heartbeat (sched, when wired, reports its last loop
-// tick — a stalled leader goes unhealthy). Leoflow's single Go control plane
+// The metadatabase status is a real probe of the "postgres" checker — the SAME
+// check /readyz runs, connection and schema both. It has to be: this endpoint
+// reads the same checks map, and when it did Ping only, the #1023 state produced
+// a control plane answering `metadatabase: healthy` at HTTP 200 here while
+// /readyz was 503ing, the pod was out of the Service's endpoints and the
+// scheduler was failing every tick. The dashboard a user looks at to find out
+// whether the database is fine must not be the one surface that says it is.
+//
+// The scheduler status is a real heartbeat (sched, when wired, reports its last
+// loop tick — a stalled leader goes unhealthy). Leoflow's single Go control plane
 // subsumes the triggerer and DAG-processor roles (no separate Python daemons):
 // triggering is folded into the scheduler and DAG "processing" is GitOps
 // compile-time, so those mirror the scheduler heartbeat. See docs/ui-compatibility.md.
@@ -48,7 +56,12 @@ func monitorHealthHandler(checks map[string]HealthChecker, sched Heartbeater) gi
 	return func(c *gin.Context) {
 		dbStatus := healthStatusHealthy
 		if hc, ok := checks["postgres"]; ok {
-			if err := hc.Ping(c.Request.Context()); err != nil {
+			if err := checkDependency(c.Request.Context(), hc); err != nil {
+				// Unlike /readyz this endpoint always answers 200 (the Airflow
+				// HealthInfoResponse carries the verdict in the body), so the
+				// error is logged rather than returned — and, as there, never
+				// echoed to the caller.
+				slog.WarnContext(c.Request.Context(), "monitor health check failed", "dependency", "postgres", "error", err)
 				dbStatus = healthStatusUnhealthy
 			}
 		}

--- a/internal/api/monitor_test.go
+++ b/internal/api/monitor_test.go
@@ -1,13 +1,17 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/neochaotic/leoflow/internal/domain"
 )
 
 type fakeHeartbeater struct {
@@ -82,4 +86,61 @@ func TestMonitorHealthReflectsSchedulerHeartbeat(t *testing.T) {
 	if live["scheduler"]["status"] != "healthy" {
 		t.Errorf("live scheduler status = %q, want healthy", live["scheduler"]["status"])
 	}
+}
+
+// TestMonitorHealthAssertsSchemaInvariant closes the adjacent call site with the
+// identical #1023 bug. /api/v2/monitor/health reads the SAME checks map and did
+// Ping-only, so in the exact state the issue describes — empty database, /readyz
+// 503, pod out of the endpoints, scheduler failing every tick — the
+// Airflow-compatible surface the UI's home dashboard renders reported
+// `metadatabase: healthy` at HTTP 200. Two endpoints reading one map must not
+// disagree about whether the database works.
+func TestMonitorHealthAssertsSchemaInvariant(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	status := func(t *testing.T, pg HealthChecker) string {
+		t.Helper()
+		r := gin.New()
+		r.GET("/h", monitorHealthHandler(map[string]HealthChecker{"postgres": pg}, nil))
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/h", http.NoBody))
+		var h map[string]map[string]string
+		if err := json.Unmarshal(rec.Body.Bytes(), &h); err != nil {
+			t.Fatalf("decoding body %q: %v", rec.Body.String(), err)
+		}
+		return h["metadatabase"]["status"]
+	}
+
+	t.Run("a pingable database with no schema is unhealthy", func(t *testing.T) {
+		pg := &fakeSchemaHealthCheck{schemaErr: fmt.Errorf("%w: schema_migrations is absent", domain.ErrSchemaNotCurrent)}
+		if got := status(t, pg); got != healthStatusUnhealthy {
+			t.Errorf("metadatabase = %q, want %q — /readyz 503s on this same state", got, healthStatusUnhealthy)
+		}
+	})
+
+	t.Run("a current schema is healthy", func(t *testing.T) {
+		if got := status(t, &fakeSchemaHealthCheck{}); got != healthStatusHealthy {
+			t.Errorf("metadatabase = %q, want %q", got, healthStatusHealthy)
+		}
+	})
+
+	t.Run("a dependency that fails Ping is never queried for its schema", func(t *testing.T) {
+		pg := &fakeSchemaHealthCheck{pingErr: errors.New("connection refused")}
+		if got := status(t, pg); got != healthStatusUnhealthy {
+			t.Errorf("metadatabase = %q, want %q", got, healthStatusUnhealthy)
+		}
+		if pg.schemaCalls != 0 {
+			t.Errorf("schema queried %d times after a failed Ping, want 0", pg.schemaCalls)
+		}
+	})
+
+	t.Run("the schema call is bounded here too", func(t *testing.T) {
+		// The UI polls this endpoint; an unbounded query against a wedged
+		// database would hold a request goroutine for as long as it takes.
+		pg := &fakeSchemaHealthCheck{}
+		status(t, pg)
+		if !pg.hadDeadline {
+			t.Error("schema check ran with no deadline")
+		}
+	})
 }

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -13,3 +13,12 @@ var ErrConflict = errors.New("resource already exists")
 // caller can fix (e.g. creating a user with a role that does not exist). The API
 // maps it to 400.
 var ErrValidation = errors.New("invalid input")
+
+// ErrSchemaNotCurrent is returned when the database is reachable but its
+// migration state is not one the running binary can serve. It lives here, next
+// to the other cross-cutting sentinels, because two layers need to agree on it:
+// storage produces the verdict, and the health endpoints must tell it apart
+// from "the database could not be read at all". Both answers are a 503, but one
+// sends an operator to the migration Job and the other to the connection pool,
+// and a probe that conflates them costs an on-call hour.
+var ErrSchemaNotCurrent = errors.New("database schema is not current")

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sync/atomic"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -37,6 +38,11 @@ type Postgres struct {
 	// the scheduler read path and the dispatch/agent path so a spec is fetched
 	// and decoded once per version, not once per active run per tick.
 	specs *specCache
+	// dirtyAheadLogged latches the readiness probe's "a migration is in flight"
+	// log line so it is written once per episode rather than once per probe
+	// period for the whole duration of a migration. SchemaReady clears it when
+	// the condition clears, so a later upgrade is reported again.
+	dirtyAheadLogged atomic.Bool
 }
 
 // poolConfig builds a pgxpool.Config from the database section.

--- a/internal/storage/schema_check.go
+++ b/internal/storage/schema_check.go
@@ -63,17 +63,32 @@ func checkSchemaCurrent(dbVersion uint, exists, dirty bool, latest uint) error {
 	}
 }
 
+// SchemaReady reports whether the live database still satisfies the invariant
+// boot asserted: schema_migrations present, clean, and not behind this binary.
+// It is the same verdict as CheckSchemaCurrent from the same code path, minus
+// the boot-only logging — the readiness probe calls it on EVERY probe, so a
+// warning here would repeat once per period for as long as the condition lasts.
+//
+// It exists because a Ping only proves the connection: a database emptied by an
+// ephemeral-volume recycle, restored from an older backup, failed over to a
+// lagging replica, or repointed by a changed database.url stays pingable while
+// serving nothing (#1023). One SELECT against a single-row table, so it is cheap
+// enough to run per probe; the caller bounds it with the probe's own deadline.
+func (p *Postgres) SchemaReady(ctx context.Context) error {
+	version, dirty, exists, latest, err := p.schemaState(ctx)
+	if err != nil {
+		return err
+	}
+	return checkSchemaCurrent(version, exists, dirty, latest)
+}
+
 // CheckSchemaCurrent reads the DB schema version and compares it to the binary's
 // embedded latest, failing fast on a mismatch. Called at boot after the pool is
 // open, before the server serves.
 func (p *Postgres) CheckSchemaCurrent(ctx context.Context) error {
-	latest, err := migrations.Latest()
+	version, dirty, exists, latest, err := p.schemaState(ctx)
 	if err != nil {
-		return fmt.Errorf("reading embedded schema version: %w", err)
-	}
-	version, dirty, exists, err := p.SchemaVersion(ctx)
-	if err != nil {
-		return fmt.Errorf("reading database schema version: %w", err)
+		return err
 	}
 	if exists && !dirty && version > latest {
 		// Ahead schema (see checkSchemaCurrent): boot proceeds — expand-contract
@@ -83,4 +98,19 @@ func (p *Postgres) CheckSchemaCurrent(ctx context.Context) error {
 			"db_version", version, "binary_latest", latest)
 	}
 	return checkSchemaCurrent(version, exists, dirty, latest)
+}
+
+// schemaState gathers both sides of the comparison — what the database says and
+// what this binary embeds — so the boot gate and the readiness probe cannot drift
+// apart on either the query or the required version.
+func (p *Postgres) schemaState(ctx context.Context) (version uint, dirty, exists bool, latest uint, err error) {
+	latest, err = migrations.Latest()
+	if err != nil {
+		return 0, false, false, 0, fmt.Errorf("reading embedded schema version: %w", err)
+	}
+	version, dirty, exists, err = p.SchemaVersion(ctx)
+	if err != nil {
+		return 0, false, false, 0, fmt.Errorf("reading database schema version: %w", err)
+	}
+	return version, dirty, exists, latest, nil
 }

--- a/internal/storage/schema_check.go
+++ b/internal/storage/schema_check.go
@@ -7,12 +7,9 @@ import (
 	"log/slog"
 
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/neochaotic/leoflow/internal/domain"
 	"github.com/neochaotic/leoflow/migrations"
 )
-
-// errSchemaNotCurrent is the sentinel for a boot-time schema mismatch, so callers
-// can recognize it distinctly from a transient DB error.
-var errSchemaNotCurrent = errors.New("database schema is not current")
 
 // SchemaVersion reads the applied migration version from golang-migrate's
 // schema_migrations table. exists is false when the table is absent (migrations
@@ -45,13 +42,13 @@ func checkSchemaCurrent(dbVersion uint, exists, dirty bool, latest uint) error {
 	switch {
 	case !exists:
 		return fmt.Errorf("%w: schema_migrations is absent — migrations have not run (apply them: the Helm pre-upgrade migration Job, or `leoflow db migrate` for Lite); schema v%d is required",
-			errSchemaNotCurrent, latest)
+			domain.ErrSchemaNotCurrent, latest)
 	case dirty:
 		return fmt.Errorf("%w: schema is dirty at v%d — a migration did not complete; resolve it before starting",
-			errSchemaNotCurrent, dbVersion)
+			domain.ErrSchemaNotCurrent, dbVersion)
 	case dbVersion < latest:
 		return fmt.Errorf("%w: schema is at v%d but this binary requires v%d — run the pending migrations (the Helm pre-upgrade migration Job, or `leoflow db migrate` for Lite)",
-			errSchemaNotCurrent, dbVersion, latest)
+			domain.ErrSchemaNotCurrent, dbVersion, latest)
 	default:
 		// dbVersion >= latest. An AHEAD schema (dbVersion > latest) is NOT fatal:
 		// expand-contract migrations are backward-compatible by construction, so
@@ -63,23 +60,102 @@ func checkSchemaCurrent(dbVersion uint, exists, dirty bool, latest uint) error {
 	}
 }
 
-// SchemaReady reports whether the live database still satisfies the invariant
-// boot asserted: schema_migrations present, clean, and not behind this binary.
-// It is the same verdict as CheckSchemaCurrent from the same code path, minus
-// the boot-only logging — the readiness probe calls it on EVERY probe, so a
-// warning here would repeat once per period for as long as the condition lasts.
+// dirtyAhead reports the one dirty state a RUNNING pod must keep serving
+// through: a migration in flight at a version this binary does not need yet.
 //
-// It exists because a Ping only proves the connection: a database emptied by an
+// It is the discriminator that keeps the readiness exemption narrow. Widening it
+// to "dirty is fine" would let a pod serve against a half-applied version of its
+// own required schema; narrowing it to nothing is what empties the Service
+// during an upgrade. Only the strictly-ahead case is both in-flight and
+// irrelevant to this binary.
+func dirtyAhead(dbVersion uint, exists, dirty bool, latest uint) bool {
+	return exists && dirty && dbVersion > latest
+}
+
+// checkSchemaReady is the READINESS gate, and it deliberately differs from
+// checkSchemaCurrent in exactly one state: dirty above this binary's latest.
+//
+// Sharing one function between boot and readiness looks like the safe economy —
+// two verdicts that cannot drift — but they answer different questions, and for
+// `dirty` the answers genuinely differ:
+//
+//   - Boot asks "may this process START against a half-applied schema?" No: it
+//     would run its first query against a table that may be half-migrated.
+//   - Readiness asks "should this pod, which was serving correctly a second ago,
+//     be pulled out of the Service?" A migration in flight is not a reason to.
+//
+// Treating run-time dirty as not-ready is an outage, not a conservatism. The
+// migrate Job is a `pre-upgrade` Helm hook, so it runs while the OLD pods are
+// live and in the Service's endpoints, and golang-migrate commits dirty=true for
+// the whole execution of each migration body. Every old replica reads the same
+// row, so any migration longer than failureThreshold × periodSeconds (3 × 10s in
+// the chart) flips them all NotReady at the same instant and the Service reaches
+// zero endpoints. In the "all" role that Service also carries gRPC, so running
+// task pods lose the control plane mid-upgrade — the agent_lost cascade (#860).
+//
+// A failed migration that leaves dirty=true permanently is the same shape: it
+// degrades the control plane today, and would remove it from rotation entirely.
+//
+// Everything else is the boot verdict. An absent or behind schema is not ready:
+// no amount of waiting makes this pod able to serve, and it is the #1023 state.
+func checkSchemaReady(dbVersion uint, exists, dirty bool, latest uint) error {
+	switch {
+	case !exists:
+		return fmt.Errorf("%w: schema_migrations is absent — migrations have not run (apply them: the Helm pre-upgrade migration Job, or `leoflow db migrate` for Lite); schema v%d is required",
+			domain.ErrSchemaNotCurrent, latest)
+	case dbVersion < latest:
+		// Also covers dirty-and-behind: a migration in flight that has not yet
+		// reached what this binary needs cannot serve it either.
+		return fmt.Errorf("%w: schema is at v%d but this binary requires v%d — run the pending migrations (the Helm pre-upgrade migration Job, or `leoflow db migrate` for Lite)",
+			domain.ErrSchemaNotCurrent, dbVersion, latest)
+	case dirtyAhead(dbVersion, exists, dirty, latest):
+		// The whole divergence, expressed through the one predicate so the gate
+		// and the log line above cannot come to disagree about which state it is.
+		return nil
+	case dirty:
+		// dbVersion == latest and dirty (below and ahead are already handled),
+		// so the half-applied migration is the very one this binary requires.
+		// Its own schema is not usable.
+		return fmt.Errorf("%w: schema is dirty at v%d, the version this binary requires — a migration to it did not complete; resolve it before this pod can serve",
+			domain.ErrSchemaNotCurrent, dbVersion)
+	default:
+		// Clean and at or above latest. See the ahead-schema reasoning in
+		// checkSchemaCurrent: expand-contract keeps older code working.
+		return nil
+	}
+}
+
+// SchemaReady is the readiness probe's entry point: it re-asserts on every probe
+// what boot asserted once, because a boot check says nothing about a database
+// that changes UNDER a running pod.
+//
+// It exists because a Ping only proves the connection. A database emptied by an
 // ephemeral-volume recycle, restored from an older backup, failed over to a
 // lagging replica, or repointed by a changed database.url stays pingable while
 // serving nothing (#1023). One SELECT against a single-row table, so it is cheap
 // enough to run per probe; the caller bounds it with the probe's own deadline.
+//
+// The verdict is checkSchemaReady, NOT the boot gate — see there for the one
+// state where the two must disagree.
 func (p *Postgres) SchemaReady(ctx context.Context) error {
 	version, dirty, exists, latest, err := p.schemaState(ctx)
 	if err != nil {
 		return err
 	}
-	return checkSchemaCurrent(version, exists, dirty, latest)
+	if dirtyAhead(version, exists, dirty, latest) {
+		// Worth one line, because it explains why this pod is serving against a
+		// schema its own boot gate would have refused. Latched rather than
+		// logged per probe: readiness runs every periodSeconds, and a migration
+		// can take minutes. The latch resets when the condition clears, so the
+		// NEXT upgrade logs again instead of going silent for the process's life.
+		if p.dirtyAheadLogged.CompareAndSwap(false, true) {
+			slog.InfoContext(ctx, "a migration is in flight above this binary's schema version; staying ready (expand-contract assumed backward-compatible)",
+				"db_version", version, "binary_latest", latest)
+		}
+	} else {
+		p.dirtyAheadLogged.Store(false)
+	}
+	return checkSchemaReady(version, exists, dirty, latest)
 }
 
 // CheckSchemaCurrent reads the DB schema version and compares it to the binary's

--- a/internal/storage/schema_check_test.go
+++ b/internal/storage/schema_check_test.go
@@ -3,6 +3,8 @@ package storage
 import (
 	"errors"
 	"testing"
+
+	"github.com/neochaotic/leoflow/internal/domain"
 )
 
 // checkSchemaCurrent is the pure boot-time gate: given the DB's schema state and
@@ -51,8 +53,130 @@ func TestCheckSchemaCurrent(t *testing.T) {
 	})
 
 	t.Run("errors are ErrValidation-wrapped for a clean boot message", func(t *testing.T) {
-		if err := checkSchemaCurrent(0, false, false, latest); !errors.Is(err, errSchemaNotCurrent) {
-			t.Errorf("want errSchemaNotCurrent, got %v", err)
+		if err := checkSchemaCurrent(0, false, false, latest); !errors.Is(err, domain.ErrSchemaNotCurrent) {
+			t.Errorf("want domain.ErrSchemaNotCurrent, got %v", err)
 		}
 	})
+}
+
+// TestSchemaReadinessDivergesFromBootOnDirty pins the one state where the boot
+// gate and the readiness probe MUST disagree, and why sharing one function
+// between them was a bug rather than an economy.
+//
+// The migrate Job is a `pre-upgrade` Helm hook, so on `helm upgrade` it runs
+// while the OLD pods are live and in the Service's endpoints. golang-migrate
+// commits dirty=true for the whole execution of each migration body. A readiness
+// probe that treats dirty as not-ready therefore flips EVERY old replica
+// NotReady at the same instant — they all read the same row — for any migration
+// longer than failureThreshold × periodSeconds (3 × 10s), dropping the Service
+// to zero endpoints. In the "all" role that Service also carries gRPC, so
+// running task pods lose the control plane mid-migration.
+//
+// The two verdicts answer different questions:
+//
+//   - boot: "may this process start against a half-applied schema?" — no.
+//   - readiness: "is a migration in flight right now?" — a pod that was serving
+//     correctly a second ago should keep serving.
+//
+// The discriminator is the version. dirty at a version ABOVE this binary's
+// latest is a forward migration past what this binary needs, which is exactly
+// the old-pods-during-upgrade case, and expand-contract keeps this binary
+// working. dirty at or below its latest is a half-applied schema this binary
+// actually depends on.
+func TestSchemaReadinessDivergesFromBootOnDirty(t *testing.T) {
+	const latest = 26
+
+	t.Run("dirty ahead: boot refuses, readiness stays ready", func(t *testing.T) {
+		// An old binary (v26) during an upgrade whose migration Job is applying
+		// v27 right now. This is the case that empties the Service.
+		if err := checkSchemaCurrent(latest+1, true, true, latest); err == nil {
+			t.Error("boot must still refuse to start against a half-applied schema")
+		}
+		if err := checkSchemaReady(latest+1, true, true, latest); err != nil {
+			t.Errorf("a live pod must stay ready while a forward migration is in flight, got: %v", err)
+		}
+	})
+
+	t.Run("dirty at this binary's own version = not ready", func(t *testing.T) {
+		// Not the upgrade case: the migration that is half-applied is the very
+		// one this binary requires, so its own schema is unusable.
+		if err := checkSchemaReady(latest, true, true, latest); err == nil {
+			t.Error("a half-applied migration to this binary's required version must not report ready")
+		}
+	})
+
+	t.Run("dirty and behind = not ready", func(t *testing.T) {
+		// A migration in flight that has not yet reached what this binary needs.
+		if err := checkSchemaReady(latest-1, true, true, latest); err == nil {
+			t.Error("a dirty schema still behind this binary must not report ready")
+		}
+	})
+
+	t.Run("absent = not ready (the #1023 state)", func(t *testing.T) {
+		if err := checkSchemaReady(0, false, false, latest); err == nil {
+			t.Error("an empty database must never report ready")
+		}
+	})
+
+	t.Run("behind = not ready", func(t *testing.T) {
+		if err := checkSchemaReady(latest-3, true, false, latest); err == nil {
+			t.Error("a database behind this binary must not report ready")
+		}
+	})
+
+	t.Run("clean ahead = ready (rollback must be able to converge)", func(t *testing.T) {
+		if err := checkSchemaReady(latest+1, true, false, latest); err != nil {
+			t.Errorf("an ahead schema must be ready, got: %v", err)
+		}
+	})
+
+	t.Run("current = ready", func(t *testing.T) {
+		if err := checkSchemaReady(latest, true, false, latest); err != nil {
+			t.Errorf("a current schema must be ready, got: %v", err)
+		}
+	})
+
+	t.Run("every not-ready verdict is the schema sentinel, not a transient error", func(t *testing.T) {
+		// The probe handler branches on this to decide whether to report
+		// "schema not current" or "unavailable"; a verdict that does not carry
+		// the sentinel would be reported as a connection problem.
+		for _, c := range []struct {
+			name            string
+			version, latest uint
+			exists, dirty   bool
+		}{
+			{"absent", 0, latest, false, false},
+			{"behind", latest - 3, latest, true, false},
+			{"dirty at latest", latest, latest, true, true},
+		} {
+			err := checkSchemaReady(c.version, c.exists, c.dirty, c.latest)
+			if !errors.Is(err, domain.ErrSchemaNotCurrent) {
+				t.Errorf("%s: want domain.ErrSchemaNotCurrent, got %v", c.name, err)
+			}
+		}
+	})
+}
+
+// TestDirtyAheadIsTheOnlyReadyDirtyState guards the discriminator itself: the
+// readiness exemption is scoped to a forward migration past this binary, and
+// must not widen into "dirty is fine".
+func TestDirtyAheadIsTheOnlyReadyDirtyState(t *testing.T) {
+	const latest = 26
+	cases := []struct {
+		name          string
+		version       uint
+		exists, dirty bool
+		want          bool
+	}{
+		{"dirty ahead", latest + 1, true, true, true},
+		{"dirty at latest", latest, true, true, false},
+		{"dirty behind", latest - 1, true, true, false},
+		{"clean ahead", latest + 1, true, false, false},
+		{"absent", 0, false, true, false},
+	}
+	for _, c := range cases {
+		if got := dirtyAhead(c.version, c.exists, c.dirty, latest); got != c.want {
+			t.Errorf("%s: dirtyAhead = %v, want %v", c.name, got, c.want)
+		}
+	}
 }

--- a/internal/storage/schema_ready_integration_test.go
+++ b/internal/storage/schema_ready_integration_test.go
@@ -1,0 +1,123 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/config"
+	"github.com/neochaotic/leoflow/internal/storage"
+)
+
+// TestSchemaReadyAgainstLiveDatabase exercises the readiness schema assertion
+// (#1023) against a real Postgres, which is the only place the query itself can
+// be wrong: the pure gate is unit-tested, but "does SELECT version, dirty FROM
+// schema_migrations actually report an absent table as absent, on this server,
+// through this pool" is not something a fake can answer. It is the same
+// distinction the issue is about — a Ping proving the connection while saying
+// nothing about the schema.
+//
+// Each case connects with search_path pointed at a scratch schema, so a missing
+// or stale schema_migrations is produced WITHOUT touching the migrated one the
+// rest of the suite shares.
+func TestSchemaReadyAgainstLiveDatabase(t *testing.T) {
+	raw := os.Getenv("DATABASE_URL")
+	if raw == "" {
+		t.Skip("DATABASE_URL must point at a migrated database for the schema readiness test")
+	}
+	ctx := context.Background()
+
+	pg, err := storage.NewPostgres(ctx, config.DatabaseSection{URL: raw})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pg.Close()
+
+	t.Run("migrated database → ready", func(t *testing.T) {
+		if err := pg.SchemaReady(ctx); err != nil {
+			t.Errorf("a migrated database must be ready, got: %v", err)
+		}
+	})
+
+	t.Run("schema_migrations absent → not ready", func(t *testing.T) {
+		// The #1023 cluster state: the connection is healthy, the database is empty.
+		other := connectWithSearchPath(ctx, t, pg, raw, "leoflow_probe_empty")
+		defer other.Close()
+		if err := other.Ping(ctx); err != nil {
+			t.Fatalf("precondition: the connection itself must be healthy, got: %v", err)
+		}
+		if err := other.SchemaReady(ctx); err == nil {
+			t.Error("a database with no schema_migrations reported ready")
+		}
+	})
+
+	t.Run("version behind the binary → not ready", func(t *testing.T) {
+		// A restore from a backup older than this binary, or a lagging replica.
+		other := connectWithSearchPath(ctx, t, pg, raw, "leoflow_probe_behind",
+			"CREATE TABLE %[1]s.schema_migrations (version bigint NOT NULL, dirty boolean NOT NULL)",
+			"INSERT INTO %[1]s.schema_migrations (version, dirty) VALUES (1, false)")
+		defer other.Close()
+		if err := other.SchemaReady(ctx); err == nil {
+			t.Error("a database at v1 reported ready against a binary that requires the embedded latest")
+		}
+	})
+
+	t.Run("boot and readiness agree", func(t *testing.T) {
+		// The point of the fix is that the two verdicts cannot drift: whatever boot
+		// refuses to start against, readiness must refuse to be ready against.
+		other := connectWithSearchPath(ctx, t, pg, raw, "leoflow_probe_agree")
+		defer other.Close()
+		bootErr := other.CheckSchemaCurrent(ctx)
+		readyErr := other.SchemaReady(ctx)
+		if bootErr == nil || readyErr == nil {
+			t.Fatalf("both must reject an empty schema: boot=%v readiness=%v", bootErr, readyErr)
+		}
+		if bootErr.Error() != readyErr.Error() {
+			t.Errorf("boot and readiness disagree:\n boot: %v\n ready: %v", bootErr, readyErr)
+		}
+	})
+}
+
+// connectWithSearchPath opens a second pool whose search_path is a scratch schema
+// it (re)creates, optionally seeding it, and registers the drop. Unqualified
+// lookups then resolve inside that schema, so schema_migrations can be absent or
+// stale for this connection while the shared migrated schema is untouched. Each
+// seed statement is a format string whose %[1]s is the scratch schema name (the
+// seeding connection has its own search_path, so the DDL must qualify itself).
+func connectWithSearchPath(ctx context.Context, t *testing.T, admin *storage.Postgres, raw, schema string, seed ...string) *storage.Postgres {
+	t.Helper()
+	if _, err := admin.Pool.Exec(ctx, "DROP SCHEMA IF EXISTS "+schema+" CASCADE"); err != nil {
+		t.Fatalf("dropping stale scratch schema: %v", err)
+	}
+	if _, err := admin.Pool.Exec(ctx, "CREATE SCHEMA "+schema); err != nil {
+		t.Fatalf("creating scratch schema: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := admin.Pool.Exec(ctx, "DROP SCHEMA IF EXISTS "+schema+" CASCADE"); err != nil {
+			t.Errorf("dropping scratch schema %s: %v", schema, err)
+		}
+	})
+	for _, stmt := range seed {
+		if _, err := admin.Pool.Exec(ctx, fmt.Sprintf(stmt, schema)); err != nil {
+			t.Fatalf("seeding scratch schema: %v", err)
+		}
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("DATABASE_URL is not a URL: %v", err)
+	}
+	q := u.Query()
+	q.Set("search_path", schema)
+	u.RawQuery = q.Encode()
+
+	pg, err := storage.NewPostgres(ctx, config.DatabaseSection{URL: u.String()})
+	if err != nil {
+		t.Fatalf("connecting with search_path=%s: %v", schema, err)
+	}
+	return pg
+}

--- a/internal/storage/schema_ready_integration_test.go
+++ b/internal/storage/schema_ready_integration_test.go
@@ -3,14 +3,21 @@
 package storage_test
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/neochaotic/leoflow/internal/config"
+	"github.com/neochaotic/leoflow/internal/domain"
 	"github.com/neochaotic/leoflow/internal/storage"
+	"github.com/neochaotic/leoflow/migrations"
 )
 
 // TestSchemaReadyAgainstLiveDatabase exercises the readiness schema assertion
@@ -24,6 +31,13 @@ import (
 // Each case connects with search_path pointed at a scratch schema, so a missing
 // or stale schema_migrations is produced WITHOUT touching the migrated one the
 // rest of the suite shares.
+//
+// PRIVILEGES: building those scratch schemas needs CREATE on the database, which
+// the read-only role:api identity (ADR 0049) deliberately does not have. CI runs
+// this with the DSN in .github/workflows/ci.yaml — the `leoflow` role the
+// postgres image bootstraps, which owns the database — so a green there is real
+// evidence. Against a least-privilege DSN the test SKIPS with the reason rather
+// than failing, so nobody reads a permission error as a schema regression.
 func TestSchemaReadyAgainstLiveDatabase(t *testing.T) {
 	raw := os.Getenv("DATABASE_URL")
 	if raw == "" {
@@ -66,9 +80,10 @@ func TestSchemaReadyAgainstLiveDatabase(t *testing.T) {
 		}
 	})
 
-	t.Run("boot and readiness agree", func(t *testing.T) {
-		// The point of the fix is that the two verdicts cannot drift: whatever boot
-		// refuses to start against, readiness must refuse to be ready against.
+	t.Run("boot and readiness agree on an empty schema", func(t *testing.T) {
+		// Outside the in-flight-migration case the two verdicts must not drift:
+		// whatever boot refuses to start against, readiness must refuse to be
+		// ready against.
 		other := connectWithSearchPath(ctx, t, pg, raw, "leoflow_probe_agree")
 		defer other.Close()
 		bootErr := other.CheckSchemaCurrent(ctx)
@@ -78,6 +93,68 @@ func TestSchemaReadyAgainstLiveDatabase(t *testing.T) {
 		}
 		if bootErr.Error() != readyErr.Error() {
 			t.Errorf("boot and readiness disagree:\n boot: %v\n ready: %v", bootErr, readyErr)
+		}
+	})
+
+	t.Run("a migration in flight above this binary: boot refuses, readiness stays ready", func(t *testing.T) {
+		// The state that a `pre-upgrade` migration Job puts the database in while
+		// the OLD pods are still live and in the Service's endpoints:
+		// golang-migrate has committed dirty=true at a version this binary does
+		// not need. Treating that as not-ready flips every old replica at once —
+		// they all read this one row — and empties the Service mid-upgrade.
+		//
+		// v9999 stands in for "ahead of whatever this binary embeds", so the case
+		// does not have to track migrations.Latest().
+		other := connectWithSearchPath(ctx, t, pg, raw, "leoflow_probe_dirty_ahead",
+			"CREATE TABLE %[1]s.schema_migrations (version bigint NOT NULL, dirty boolean NOT NULL)",
+			"INSERT INTO %[1]s.schema_migrations (version, dirty) VALUES (9999, true)")
+		defer other.Close()
+
+		if err := other.SchemaReady(ctx); err != nil {
+			t.Errorf("readiness must survive a forward migration in flight, got: %v", err)
+		}
+		if err := other.CheckSchemaCurrent(ctx); err == nil {
+			t.Error("boot must still refuse to START against a half-applied schema")
+		}
+	})
+
+	t.Run("a migration in flight at or below this binary is still not ready", func(t *testing.T) {
+		// The other arm: the half-applied migration is one this binary depends
+		// on, so the exemption must not apply.
+		other := connectWithSearchPath(ctx, t, pg, raw, "leoflow_probe_dirty_behind",
+			"CREATE TABLE %[1]s.schema_migrations (version bigint NOT NULL, dirty boolean NOT NULL)",
+			"INSERT INTO %[1]s.schema_migrations (version, dirty) VALUES (1, true)")
+		defer other.Close()
+		if err := other.SchemaReady(ctx); err == nil {
+			t.Error("a dirty schema behind this binary reported ready")
+		}
+	})
+
+	t.Run("a migration in flight AT this binary's own version is not ready", func(t *testing.T) {
+		// The boundary of the exemption, seeded at the exact version this binary
+		// embeds. Widening dirtyAhead from "strictly above" to "dirty at all"
+		// passes every other case in this file and fails only here.
+		latest, err := migrations.Latest()
+		if err != nil {
+			t.Fatalf("reading the embedded schema version: %v", err)
+		}
+		other := connectWithSearchPath(ctx, t, pg, raw, "leoflow_probe_dirty_at_latest",
+			"CREATE TABLE %[1]s.schema_migrations (version bigint NOT NULL, dirty boolean NOT NULL)",
+			fmt.Sprintf("INSERT INTO %%[1]s.schema_migrations (version, dirty) VALUES (%d, true)", latest))
+		defer other.Close()
+		if err := other.SchemaReady(ctx); err == nil {
+			t.Error("a half-applied migration to this binary's own required version reported ready")
+		}
+	})
+
+	t.Run("every not-ready verdict is the schema sentinel, not a transient error", func(t *testing.T) {
+		// What the health endpoints branch on to say "schema not current" rather
+		// than "unavailable". Asserted here as well as in the unit tests because
+		// only here does the error come back through the real query path.
+		other := connectWithSearchPath(ctx, t, pg, raw, "leoflow_probe_sentinel")
+		defer other.Close()
+		if err := other.SchemaReady(ctx); !errors.Is(err, domain.ErrSchemaNotCurrent) {
+			t.Errorf("want domain.ErrSchemaNotCurrent, got %v", err)
 		}
 	})
 }
@@ -91,10 +168,10 @@ func TestSchemaReadyAgainstLiveDatabase(t *testing.T) {
 func connectWithSearchPath(ctx context.Context, t *testing.T, admin *storage.Postgres, raw, schema string, seed ...string) *storage.Postgres {
 	t.Helper()
 	if _, err := admin.Pool.Exec(ctx, "DROP SCHEMA IF EXISTS "+schema+" CASCADE"); err != nil {
-		t.Fatalf("dropping stale scratch schema: %v", err)
+		skipOrFatal(t, "dropping stale scratch schema", err)
 	}
 	if _, err := admin.Pool.Exec(ctx, "CREATE SCHEMA "+schema); err != nil {
-		t.Fatalf("creating scratch schema: %v", err)
+		skipOrFatal(t, "creating scratch schema", err)
 	}
 	t.Cleanup(func() {
 		if _, err := admin.Pool.Exec(ctx, "DROP SCHEMA IF EXISTS "+schema+" CASCADE"); err != nil {
@@ -120,4 +197,127 @@ func connectWithSearchPath(ctx context.Context, t *testing.T, admin *storage.Pos
 		t.Fatalf("connecting with search_path=%s: %v", schema, err)
 	}
 	return pg
+}
+
+// TestSchemaReadyFollowsTheDatabaseUnderOnePool walks ONE pool through the
+// states a real upgrade puts the database in, in order, without reconnecting.
+//
+// Two things only this shape can show. First, that the verdict tracks the
+// database rather than anything cached at connect time — the whole premise of
+// #1023 is a database that changes UNDER a running pod, so a probe that answered
+// from a memo would reproduce the bug. Second, that the "a migration is in
+// flight" log line is latched per EPISODE: readiness runs every periodSeconds
+// and a migration can take minutes, so logging it per probe would bury the log,
+// while never resetting would silence every later upgrade for the life of the
+// process.
+func TestSchemaReadyFollowsTheDatabaseUnderOnePool(t *testing.T) {
+	raw := os.Getenv("DATABASE_URL")
+	if raw == "" {
+		t.Skip("DATABASE_URL must point at a migrated database for the schema readiness test")
+	}
+	ctx := context.Background()
+
+	admin, err := storage.NewPostgres(ctx, config.DatabaseSection{URL: raw})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	// t.Cleanup, not defer: connectWithSearchPath registers its DROP SCHEMA as a
+	// cleanup too, and cleanups run after the deferred calls. Closing the admin
+	// pool with defer would pull it out from under that drop. Registered first,
+	// so LIFO ordering runs it last.
+	t.Cleanup(admin.Close)
+
+	latest, err := migrations.Latest()
+	if err != nil {
+		t.Fatalf("reading the embedded schema version: %v", err)
+	}
+
+	const scratch = "leoflow_probe_transitions"
+	pg := connectWithSearchPath(ctx, t, admin, raw, scratch,
+		"CREATE TABLE %[1]s.schema_migrations (version bigint NOT NULL, dirty boolean NOT NULL)",
+		"INSERT INTO %[1]s.schema_migrations (version, dirty) VALUES (1, false)")
+	defer pg.Close()
+
+	setRow := func(version uint, dirty bool) {
+		t.Helper()
+		if _, err := admin.Pool.Exec(ctx,
+			fmt.Sprintf("UPDATE %s.schema_migrations SET version = $1, dirty = $2", scratch), int64(version), dirty); err != nil {
+			t.Fatalf("moving the schema row to (v%d, dirty=%v): %v", version, dirty, err)
+		}
+	}
+
+	// SchemaReady logs through the default logger; capture it for the duration.
+	var logged bytes.Buffer
+	restore := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logged, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() { slog.SetDefault(restore) })
+	inFlightLines := func() int {
+		return strings.Count(logged.String(), "a migration is in flight")
+	}
+
+	// Behind: not ready, and nothing to report.
+	if err := pg.SchemaReady(ctx); err == nil {
+		t.Fatal("a schema at v1 reported ready")
+	}
+	if n := inFlightLines(); n != 0 {
+		t.Errorf("in-flight logged %d times before any migration started", n)
+	}
+
+	// A forward migration starts, past what this binary needs: stay ready, say so once.
+	setRow(latest+1, true)
+	if err := pg.SchemaReady(ctx); err != nil {
+		t.Fatalf("readiness must survive a forward migration in flight, got: %v", err)
+	}
+	if n := inFlightLines(); n != 1 {
+		t.Fatalf("in-flight logged %d times on the first probe of the episode, want 1", n)
+	}
+
+	// The kubelet keeps probing for as long as the migration runs. Still ready,
+	// and still one line — not one per period.
+	for range 5 {
+		if err := pg.SchemaReady(ctx); err != nil {
+			t.Fatalf("readiness flipped mid-migration: %v", err)
+		}
+	}
+	if n := inFlightLines(); n != 1 {
+		t.Errorf("in-flight logged %d times across 6 probes of one episode, want 1", n)
+	}
+
+	// The migration lands. The pod stays ready, and the latch clears.
+	setRow(latest+1, false)
+	if err := pg.SchemaReady(ctx); err != nil {
+		t.Fatalf("a clean ahead schema must be ready, got: %v", err)
+	}
+
+	// A LATER upgrade must be reported again rather than swallowed by the latch.
+	setRow(latest+2, true)
+	if err := pg.SchemaReady(ctx); err != nil {
+		t.Fatalf("readiness must survive the second migration too, got: %v", err)
+	}
+	if n := inFlightLines(); n != 2 {
+		t.Errorf("in-flight logged %d times across two separate episodes, want 2", n)
+	}
+
+	// And the database dropping out from under the pool is still caught.
+	if _, err := admin.Pool.Exec(ctx, "DROP TABLE "+scratch+".schema_migrations"); err != nil {
+		t.Fatalf("dropping the fixture table: %v", err)
+	}
+	if err := pg.SchemaReady(ctx); !errors.Is(err, domain.ErrSchemaNotCurrent) {
+		t.Errorf("a schema that vanished under a live pool: want domain.ErrSchemaNotCurrent, got %v", err)
+	}
+}
+
+// skipOrFatal separates "this DSN is not allowed to build the fixture" from a
+// real failure. The scratch schemas need CREATE on the database; a least
+// privilege DSN (the read-only role:api identity of ADR 0049) cannot create
+// them, and reporting that as a FAIL would read as a schema regression. CI uses
+// the owning role, so it takes the Fatalf path and the coverage is real.
+func skipOrFatal(t *testing.T, what string, err error) {
+	t.Helper()
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "42501" { // insufficient_privilege
+		t.Skipf("%s: DATABASE_URL lacks CREATE on the database (%v); "+
+			"this test needs the owning role, not the read-only role:api identity", what, err)
+	}
+	t.Fatalf("%s: %v", what, err)
 }

--- a/test/release/rc-cluster-validation.md
+++ b/test/release/rc-cluster-validation.md
@@ -595,6 +595,9 @@ a restart** — the check is per-probe, so recovery needs no pod churn. Note tha
 `--wait` now blocks on real readiness, which is the #1023 fix seen from the other
 side: before it, `helm upgrade --wait` reported success against this database.
 
+Then drop the forward, or it will outlive the pod it points at and quietly
+mislead the next step: `kill $PF`.
+
 #### §4.6b — a rolling upgrade never drops the Service to zero endpoints
 
 The reason §4.6a is not the whole check. The migrate Job is a
@@ -607,11 +610,13 @@ the `all` role that Service also carries gRPC, so running task pods lose the
 control plane mid-upgrade. Readiness is version-aware on `dirty` precisely to
 avoid this, and the property is not observable in §4.6a.
 
-Needs a migration slow enough to span more than 30s of probing. Simulate it by
-holding the row that every replica reads, in a transaction, while an upgrade runs:
+Staging a genuinely slow migration is awkward and cloud-dependent, and it is not
+what is being tested — the pods only ever see one row. So write that row directly
+into the state golang-migrate leaves it in for the duration of a migration body,
+and hold it there longer than `3 × 10s` of probing:
 
 ```bash
-# terminal 1 — watch the endpoints for the whole upgrade; never let this reach 0
+# terminal 1 — watch the endpoints for the whole window; never let this reach 0
 kubectl get endpoints -n "$NS" leoflow -w
 
 # terminal 2 — park the schema in the state a long migration produces:

--- a/test/release/rc-cluster-validation.md
+++ b/test/release/rc-cluster-validation.md
@@ -495,32 +495,152 @@ built** — the script builds the base image but not those two.
 The v0.4.5 RC found this the expensive way: an ephemeral-storage Postgres came
 back **empty** after a node recycle and the running control plane kept answering
 `/readyz` 200 while the scheduler could not read `dag_runs`. A Ping proves the
-connection, not the schema, so nothing in the probe noticed. It is a two-command
-check and it belongs in every RC from here.
+connection, not the schema, so nothing in the probe noticed.
 
-Do this against a **throwaway** database — it drops the schema:
+It has two halves, and **both** have to be run. The first is the fix. The second
+is the outage the fix can cause if it is built naively, and it is the more
+expensive of the two to discover in production.
+
+#### §4.6a — a schema that vanishes takes the pod out of rotation
+
+Do this against a **throwaway** database — it drops the schema.
+
+**Port-forward to the POD, not the Service.** This is the whole point of the
+check: a correct build leaves the Service's endpoints within ~30s, and a
+port-forward through the Service dies with it. `curl` then prints `000` — a
+connection failure, not an HTTP status — and `000` is not `503`, so the row
+would read FAIL against a build that is working exactly as intended. Forwarding
+to the pod keeps talking to it after it is out of rotation, which is also the
+only way to see the 503 body at all.
 
 ```bash
-API=<control-plane base URL>          # e.g. http://localhost:8080 via port-forward
+NS=<ns>
+POD=$(kubectl get pod -n "$NS" -l app.kubernetes.io/instance=leoflow -o name | head -1)
+kubectl port-forward -n "$NS" "$POD" 8080:8080 &          # 9090 in the scheduler-only role
+PF=$!
+
 psql "$DATABASE_URL" -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public;'
-curl -sS -o /dev/stderr -w '%{http_code}\n' "$API/readyz"       # expect 503
-kubectl get pod -n <ns> -l app.kubernetes.io/instance=leoflow   # READY 0/1, RESTARTS unchanged
 ```
 
-**PASS:** `/readyz` answers **503** within one probe period, the pod goes
-`READY 0/1` and leaves the Service's endpoints, and the 503 body names only the
-dependency (`postgres schema not current`) — **no DSN, credentials or internal
-hostname**, since the endpoint is unauthenticated. The log line carries the
-version detail.
+Readiness is `periodSeconds: 10 × failureThreshold: 3`, so the flip takes up to
+30s. Wait for the condition rather than sampling it — checked instantly, a
+**correctly fixed** build still shows `READY 1/1`, and the row cannot fail:
 
-**Also PASS, and the point of checking it:** the pod is **not restarting**.
-`/healthz` stays 200 and `RESTARTS` does not climb — liveness is deliberately
-schema-blind, because restarting creates no schema and a crash loop would cost
-you the pod you need to diagnose. A `CrashLoopBackOff` here is a FAIL.
+```bash
+kubectl wait --for=condition=Ready=false --timeout=60s -n "$NS" "$POD"
+curl -sS -o /dev/stderr -w '%{http_code}\n' localhost:8080/readyz    # expect 503
+kubectl get endpoints -n "$NS" -l app.kubernetes.io/instance=leoflow  # pod's IP gone
+```
 
-Re-run the migration Job (or restore the database) and confirm `/readyz` returns
-to 200 **without a restart** — the check is per-probe, so recovery needs no pod
-churn.
+**PASS:** `kubectl wait` returns success (it did not time out), `/readyz` answers
+**503**, the pod's IP is no longer in the Service's endpoints, and the 503 body
+names only the dependency — **no DSN, credentials or internal hostname**, since
+the endpoint is unauthenticated. The version detail is in the pod log.
+
+Read the detail string, do not just grep for 503. `postgres schema not current`
+is the schema verdict; `postgres unavailable` is a database that could not be
+**read** — a timeout, a reset connection, an exhausted pool. Both are 503 and
+only the first one is this check. A run that shows `postgres unavailable` here
+has proved something about the pool, not about #1023.
+
+**Liveness must NOT fire, and this is the half that needs patience.** Liveness is
+`periodSeconds: 20 × failureThreshold: 3`, so a restart needs **60s of continuous
+failure**. `RESTARTS` read immediately after the DROP is `0` whether liveness is
+schema-blind or not, so the instant check proves nothing. Hold the broken state
+for ~90s and assert `/healthz` stays 200 the whole time — a positive assertion,
+not the absence of a restart:
+
+```bash
+end=$((SECONDS+90))
+while [ $SECONDS -lt $end ]; do
+  printf '%s ' "$(curl -sS -o /dev/null -w '%{http_code}' localhost:8080/healthz)"
+  sleep 10
+done; echo
+kubectl get pod -n "$NS" "$POD" -o jsonpath='{.status.containerStatuses[0].restartCount}{"\n"}'
+```
+
+**PASS:** every sample is `200` and the restart count is unchanged from before
+the DROP. A `CrashLoopBackOff`, or any 5xx from `/healthz`, is a FAIL — liveness
+is deliberately schema-blind, because restarting creates no schema and a crash
+loop would cost you the pod you need to diagnose.
+
+**Recovery — two traps, both of which have cost time.**
+
+*The Job is not there to re-run.* `migration-job.yaml` carries
+`helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded`, so after a
+successful install the Job object is **deleted**. `kubectl create job
+--from=job/leoflow-migrate` answers `NotFound`. What re-runs the migration is a
+Helm operation that fires the `pre-upgrade` hook:
+
+```bash
+helm upgrade leoflow <chart> -n "$NS" --reuse-values --wait
+```
+
+*`CREATE SCHEMA public` does not restore who may use it.* The recreated schema is
+owned by whichever role ran the `psql`, and every grant that was on the old one
+went with it. If the migrate Job connects as a different role — the usual split,
+and mandatory under the read-only `role:api` identity (ADR 0049) — it fails on
+`permission denied for schema public` and the Job's `backoffLimit: 3` turns that
+into a failed `helm upgrade` several minutes later. Restore ownership first,
+substituting your own roles:
+
+```sql
+ALTER SCHEMA public OWNER TO <migrate role>;
+GRANT USAGE, CREATE ON SCHEMA public TO <migrate role>;
+GRANT USAGE ON SCHEMA public TO <api role>;   -- only if you run the split identity
+```
+
+**PASS:** `/readyz` returns to 200 and the pod re-enters the endpoints **without
+a restart** — the check is per-probe, so recovery needs no pod churn. Note that
+`--wait` now blocks on real readiness, which is the #1023 fix seen from the other
+side: before it, `helm upgrade --wait` reported success against this database.
+
+#### §4.6b — a rolling upgrade never drops the Service to zero endpoints
+
+The reason §4.6a is not the whole check. The migrate Job is a
+`pre-install,pre-upgrade` hook, so on **upgrade** it runs while the OLD pods are
+live and serving, and golang-migrate commits `dirty=true` for the duration of
+each migration body. A readiness probe that treats `dirty` as not-ready flips
+**every** old replica at the same instant — they all read the same one row — for
+any migration longer than `3 × 10s`. The Service reaches zero endpoints, and in
+the `all` role that Service also carries gRPC, so running task pods lose the
+control plane mid-upgrade. Readiness is version-aware on `dirty` precisely to
+avoid this, and the property is not observable in §4.6a.
+
+Needs a migration slow enough to span more than 30s of probing. Simulate it by
+holding the row that every replica reads, in a transaction, while an upgrade runs:
+
+```bash
+# terminal 1 — watch the endpoints for the whole upgrade; never let this reach 0
+kubectl get endpoints -n "$NS" leoflow -w
+
+# terminal 2 — park the schema in the state a long migration produces:
+#   dirty, at a version ABOVE what the running binaries embed
+psql "$DATABASE_URL" -c \
+  'UPDATE schema_migrations SET version = version + 1, dirty = true;'
+sleep 60
+psql "$DATABASE_URL" -c \
+  'UPDATE schema_migrations SET version = version - 1, dirty = false;'
+```
+
+**PASS:** across the whole 60s the endpoints list never empties, `/readyz` on a
+running pod stays **200**, and the pod log carries **one** line about a migration
+being in flight — not one per probe period. If the endpoints drop to zero, or
+`/readyz` goes 503 here, readiness is treating an in-flight forward migration as
+a broken schema and every `helm upgrade` with a slow migration is an outage.
+
+**The other arm, and it must FAIL closed.** The same state at or *below* the
+running binary's own version is a genuinely half-applied schema it depends on,
+and must take the pod out of rotation:
+
+```bash
+psql "$DATABASE_URL" -c 'UPDATE schema_migrations SET dirty = true;'   # same version
+kubectl wait --for=condition=Ready=false --timeout=60s -n "$NS" "$POD"
+psql "$DATABASE_URL" -c 'UPDATE schema_migrations SET dirty = false;'
+```
+
+**PASS:** the pod goes NotReady here. A build that stays ready through **both**
+arms has not fixed #1023, it has disabled the dirty check.
 
 ---
 
@@ -599,6 +719,8 @@ cloud reads as proof, and that is the failure §5 exists to prevent.
 | #729 | managed-PG re-extract (Lite host) | | |
 | — | task pods non-root by default | | |
 | HA | HA-profile upgrade: a PDB exists that nobody asked for (§4.5) | | |
+| #1023 | schema dropped under a running pod: `/readyz` 503, pod leaves endpoints, no restart across 90s (§4.6a) | | |
+| #1023 | in-flight migration above the running binary: endpoints never empty, `/readyz` stays 200; dirty at the same version still goes NotReady (§4.6b) | | |
 | ADR 0052 | `LEOFLOW_CHAOS_ONLY=CD chaos-runtime.sh` — C and D pass (§4.5) | | |
 
 For each FAIL: open an issue on `neochaotic/leoflow` with the root cause and, where

--- a/test/release/rc-cluster-validation.md
+++ b/test/release/rc-cluster-validation.md
@@ -490,6 +490,38 @@ Prerequisites beyond §0: a Linux docker host (a Lima VM on macOS), `k3d`, `jq`,
 a migrated external Postgres, and **`bin/leoflow` + `bin/leoflow-server` already
 built** — the script builds the base image but not those two.
 
+### §4.6 — #1023: readiness fails when the schema disappears under a running pod
+
+The v0.4.5 RC found this the expensive way: an ephemeral-storage Postgres came
+back **empty** after a node recycle and the running control plane kept answering
+`/readyz` 200 while the scheduler could not read `dag_runs`. A Ping proves the
+connection, not the schema, so nothing in the probe noticed. It is a two-command
+check and it belongs in every RC from here.
+
+Do this against a **throwaway** database — it drops the schema:
+
+```bash
+API=<control-plane base URL>          # e.g. http://localhost:8080 via port-forward
+psql "$DATABASE_URL" -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public;'
+curl -sS -o /dev/stderr -w '%{http_code}\n' "$API/readyz"       # expect 503
+kubectl get pod -n <ns> -l app.kubernetes.io/instance=leoflow   # READY 0/1, RESTARTS unchanged
+```
+
+**PASS:** `/readyz` answers **503** within one probe period, the pod goes
+`READY 0/1` and leaves the Service's endpoints, and the 503 body names only the
+dependency (`postgres schema not current`) — **no DSN, credentials or internal
+hostname**, since the endpoint is unauthenticated. The log line carries the
+version detail.
+
+**Also PASS, and the point of checking it:** the pod is **not restarting**.
+`/healthz` stays 200 and `RESTARTS` does not climb — liveness is deliberately
+schema-blind, because restarting creates no schema and a crash loop would cost
+you the pod you need to diagnose. A `CrashLoopBackOff` here is a FAIL.
+
+Re-run the migration Job (or restore the database) and confirm `/readyz` returns
+to 200 **without a restart** — the check is per-probe, so recovery needs no pod
+churn.
+
 ---
 
 ## §5 EKS ↔ GKE deltas (so a GKE pass doesn't give false confidence)

--- a/website/content/project/adrs/0010-observability.md
+++ b/website/content/project/adrs/0010-observability.md
@@ -125,6 +125,20 @@ Every binary exposes:
 
 K8s deployments use these for liveness and readiness probes.
 
+> **Superseded in part by #1023.** "Reachable" turned out to be too weak a bar
+> for the dependency that carries a schema. A Postgres `Ping` succeeds whenever
+> the *connection* is healthy and says nothing about what is behind it, so a
+> database emptied by a node recycle, restored from an older backup, failed over
+> to a lagging replica or repointed by a changed `database.url` kept `/readyz`
+> at 200 while the control plane could not serve one authenticated request.
+> Readiness now also asserts that `schema_migrations` is present and not behind
+> the version the running binary embeds, with one deliberate exemption: a
+> migration in flight *above* that version keeps the pod ready, because the
+> migrate Job is a `pre-upgrade` hook and failing it would empty the Service on
+> every slow upgrade. The decision above is left as written — it is the record
+> of what was decided in 2026-05, and this note is the record of what replaced
+> it.
+
 ## Consequences
 
 - The dependency footprint grows. `client_golang`, `go.opentelemetry.io/otel`, and `slog` are mandatory.


### PR DESCRIPTION
Closes #1023.

## The bug

`/readyz` answered `{"status":"ready"}` HTTP 200 against a database with zero tables, while the scheduler was failing every tick on `relation "dag_runs" does not exist` and `/auth/token` was answering 503. `readinessHandler` called `Ping` on each dependency and nothing else, and a Postgres `Ping` succeeds whenever the *connection* is healthy — it says nothing about the schema.

The invariant was already enforced, but only at boot, where the server refuses to start ("`schema_migrations` is absent — migrations have not run; schema v26 is required"). A boot check cannot see a database that changes under a running pod. Since `/readyz` is what Kubernetes routes traffic on and judges a rollout by, this let `helm upgrade --wait` report success against a control plane that could not serve one authenticated request.

## The fix

Readiness asserts the same invariant, through the same code path:

- `storage.(*Postgres).schemaState` is new and unexported, and is now the single place both the boot gate (`CheckSchemaCurrent`) and the probe read the DB version and the binary's embedded latest. **The version constant is not duplicated** — it stays `migrations.Latest()` — and the two verdicts cannot drift.
- `storage.(*Postgres).SchemaReady` is the probe's entry point. It differs from `CheckSchemaCurrent` in exactly one respect: no ahead-schema warning, which is boot-only reporting and would otherwise repeat once per probe period for as long as the condition lasted. An **ahead** schema still passes, as at boot — expand-contract migrations keep older code working, and failing it would CrashLoopBackOff old pods on `helm rollback`.
- `api.SchemaChecker` is an **optional** capability on `HealthChecker`. Redis and other schema-less dependencies keep the Ping-only contract untouched.
- `var _ api.SchemaChecker = (*storage.Postgres)(nil)` in `main.go`. A type assertion that stops matching is silent — without this pin, a rename on either side returns `/readyz` to reporting ready over an empty database with every test still green.

Three constraints, each with a test that fails without it:

- **The body stays vague.** `/readyz` is unauthenticated and the error can carry a DSN or an internal hostname (audit H2), so the response names the dependency (`postgres schema not current`) and the detail goes to the log — the same split the existing `Ping` path uses.
- **Bounded at 2s**, under the chart's 3s `probes.readiness.timeoutSeconds`. The existing `Ping` path is bounded only by the request context; a schema query with no deadline of its own would turn a probe that should report not-ready into one that reports nothing. `Ping` itself is left as it was — I did not widen the change to it, and it is worth a follow-up decision rather than a silent one here.
- **Ping first, short-circuiting.** With the connection down there is nothing to learn from a schema query, and it would only burn the probe's budget.

## Liveness is unchanged, deliberately

I agree with the issue. Restarting creates no schema, so a crash loop would trade an honestly not-ready pod for one that cannot be inspected — and it would do it to every replica at once, on a condition that is often external and self-healing (a migration Job that has not finished, a replica catching up). The reasoning is now a comment on `livenessHandler` rather than tribal knowledge, and the new runbook row asserts `RESTARTS` does not climb.

## Tests

TDD, and verified as such rather than asserted:

**`internal/api/health_schema_test.go`** (7 subtests): 200 on a current schema; 503 when `schema_migrations` is absent; 503 when the version is behind; the body leaks none of `hunter2` / `pg.internal.svc` / `postgres://` / `5432` out of a DSN-bearing error; the schema call receives a deadline; a Ping-only dependency is unaffected; a dependency that fails Ping is never queried.

Run against the unmodified handler **before** implementing: 5 of the 7 fail. The two that pass are the two asserting *unchanged* behavior (the Ping-only dependency, and no schema call after a failed Ping), which is what they are there for.

**Mutation-tested afterwards**, each restored before the next:

| mutation | result |
| --- | --- |
| `if err != nil` → `if false` on the schema verdict | the 3 status assertions redden |
| drop `context.WithTimeout`, pass the request context | the deadline assertion reddens |
| append `err.Error()` to the problem detail | the leak assertion reddens, naming all 4 secrets |

**`internal/storage/schema_ready_integration_test.go`** (`//go:build integration`): the same states against a real Postgres, because "does this SELECT report an absent table as absent, through this pool" is exactly what a fake cannot answer — which is the shape of the bug being fixed. Each case connects with `search_path` pointed at a scratch schema, so an absent or stale `schema_migrations` is produced **without touching** the migrated schema the rest of the suite shares, and the scratch schemas are dropped in `t.Cleanup`. A fourth case asserts boot and readiness return the *identical* error for the same database — the anti-drift property.

**Honest limitation:** there is no Docker or Postgres on this machine, so the integration file is verified locally only by `go vet -tags integration` and `golangci-lint --build-tags integration` (both clean, and it failed to compile before `SchemaReady` existed). Its first real execution is this PR's `integration` job — please treat a green there as the actual evidence, and I will follow up if it is not.

## Also verified

- `go test ./...` green, `golangci-lint run ./...` **0 issues** (cache cleaned first — a stale cross-worktree cache was reporting findings from other checkouts).
- `scripts/check-changelog-entry.sh`, `check-no-stale-deploy-path.sh`, `check-values-doc-comments.sh`, `check-service-image-registry.sh`, `check-script-selftests.sh` all pass.
- CHANGELOG entry under `## [Unreleased]` (user-facing; `skip-changelog` does not apply).
- RC runbook gains **§4.6**: drop the schema under a running control plane, assert `/readyz` goes 503 and the pod leaves the endpoints, assert it does **not** restart, and assert recovery needs no pod churn.

## Not changed, on purpose

ADR 0010 still says readiness "returns 200 only if dependencies are reachable". It is a record of a decision made then, and this PR supersedes the behavior rather than the history — say the word if the house rule is to amend it.
