### PR TITLE
ci: scan container images for CVEs, with a policy that can stay on

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1118,6 +1118,27 @@ jobs:
         run: bash scripts/check-service-image-registry.sh
 
   # ─────────────────────────────────────────────────────────────────────
+  # Container-scan ignore list. Every finding we accept must say why and carry
+  # an expiry date, and the file holding them must actually be passed to a scan.
+  # Trivy honours `expired_at` — a lapsed entry stops suppressing, so neglect
+  # makes a finding come back rather than stay hidden — but nothing in Trivy
+  # requires an entry to have an expiry or a rationale at all, which makes the
+  # permanent unexplained entry the easiest one to write. The other half is
+  # wiring: a renamed ignore file, or a dropped `--ignorefile` flag, leaves
+  # entries that look accepted and suppress nothing. Both ends are checked.
+  # ─────────────────────────────────────────────────────────────────────
+  trivyignore-entries:
+    name: Container-scan ignore list is reviewable
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install PyYAML
+        run: python3 -m pip install --user pyyaml
+      - name: Check every accepted finding has a reason and an expiry
+        run: bash scripts/check-trivyignore-entries.sh
+
+  # ─────────────────────────────────────────────────────────────────────
   # Script self-tests. cut-release.sh and the check-* gates hold logic nothing
   # else exercises — the tag normalizers, FLAKE_RE (which decides whether a red
   # run is rerun or stops a release), and the gates' ref comparisons. A defect

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -1,0 +1,289 @@
+# Scheduled container image scan — the REPORTING half of the container policy.
+#
+# ── Why this is not a PR gate ────────────────────────────────────────────────
+#
+# leoflow-runtime is python:3.x-slim-bookworm and leoflow-migrate is
+# migrate/migrate (Alpine + a third-party Go binary). Neither package set is
+# ours. A CVE lands in them because a Debian security team published an
+# advisory, not because anyone here pushed a commit — so a blocking gate on them
+# fails whoever opens the next unrelated pull request, and the person who can
+# actually fix it (by rebasing a base image or bumping a pinned third-party tag)
+# is not in that PR. That gate gets switched off within a week, and switched-off
+# is worse than never-installed because it looks like coverage.
+#
+# So: this workflow never fails the build. It publishes to the Security tab and
+# keeps exactly one tracking issue current. The blocking gate lives in
+# security.yaml and covers leoflow-server, the one image whose every byte comes
+# from our go.mod.
+#
+# ── Why a fixability filter, not just a severity floor ───────────────────────
+#
+# Debian stable always carries CVEs that are unfixed there and never will be
+# fixed there. At the time of writing leoflow-runtime:py3.11 reports 273
+# findings, of which 5 are CRITICAL and every one of those 5 is unfixed upstream
+# (`will_not_fix`, `fix_deferred`, `affected`). `--ignore-unfixed` takes that
+# 273 down to 14 — the ones a human could act on today. Severity says how bad a
+# finding is; fixability says whether anyone can do anything about it. Only the
+# second is a sane gate criterion, and a policy that cannot be satisfied is a
+# policy that gets deleted.
+#
+# Unfixed findings are excluded from the SARIF upload too. A code-scanning alert
+# that can never be closed is not visibility — it is noise that teaches people
+# to stop opening the tab. The complete unfiltered inventory is kept as a build
+# artifact on every run for anyone who needs it.
+
+name: Image scan
+
+on:
+  schedule:
+    # Daily. Base-image CVEs appear on the distro's clock, not ours, so a weekly
+    # cadence means up to seven days between a fix landing upstream and anyone
+    # here knowing. Offset from security.yaml's 06:00 Monday run.
+    - cron: "20 6 * * *"
+  workflow_dispatch:
+  # The two path lists below are duplicated on purpose: GitHub Actions does not
+  # support YAML anchors, so an alias here would not expand. Keep them in sync.
+  push:
+    branches: [main]
+    paths:
+      - "runtime/**"
+      - "deploy/Dockerfile.migrate"
+      - "migrations/**"
+      - "go.mod"
+      - "go.sum"
+      - ".trivyignore.yaml"
+      - "scripts/trivy-report.py"
+      - ".github/workflows/image-scan.yaml"
+  pull_request:
+    branches: [main]
+    # Same inputs. On a PR this reports into the job summary and stays green —
+    # the author sees what their change does to the image without being blocked
+    # by findings that were already there.
+    paths:
+      - "runtime/**"
+      - "deploy/Dockerfile.migrate"
+      - "migrations/**"
+      - "go.mod"
+      - "go.sum"
+      - ".trivyignore.yaml"
+      - "scripts/trivy-report.py"
+      - ".github/workflows/image-scan.yaml"
+
+permissions:
+  contents: read
+
+env:
+  # Pinned: the scanner version decides what is reported, so an unpinned bump
+  # can move the tracking issue overnight for reasons unrelated to our images.
+  TRIVY_VERSION: "0.72.0"
+  # Matches ci.yaml, so the agent baked into the scanned runtime image is built
+  # with the toolchain that ships.
+  GO_VERSION: "1.26.6"
+  GATE_SEVERITY: "CRITICAL,HIGH"
+  ISSUE_TITLE: "Container image CVEs: fixable findings in published images"
+
+jobs:
+  scan:
+    name: Scan published image bases
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      security-events: write   # SARIF upload to the Security tab
+      issues: write            # create/update the single tracking issue
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # Pinned release tarball rather than an action or a Docker Hub pull: the
+      # same reasoning as the gitleaks step in security.yaml. GitHub release
+      # downloads are reliable from Actions and rate-limited by nothing we share.
+      - name: Install Trivy
+        run: |
+          set -euo pipefail
+          url="https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+          ok=0
+          for i in 1 2 3; do
+            if curl -fsSL "$url" -o /tmp/trivy.tgz; then ok=1; break; fi
+            echo "::warning::trivy download attempt ${i} failed; retrying in 5s"; sleep 5
+          done
+          [ "$ok" = 1 ] || { echo "::error::could not download trivy v${TRIVY_VERSION} after 3 attempts"; exit 1; }
+          tar -xzf /tmp/trivy.tgz -C /tmp trivy
+          sudo install -m 0755 /tmp/trivy /usr/local/bin/trivy
+          trivy --version
+
+      # One DB pull for every scan below.
+      - name: Warm the vulnerability database
+        run: trivy image --download-db-only
+
+      - name: Build images
+        run: |
+          set -euo pipefail
+          for py in 3.10 3.11 3.12; do
+            echo "::group::build leoflow-runtime py${py}"
+            docker build -f runtime/Dockerfile \
+              --build-arg "PYTHON_VERSION=${py}" \
+              --build-arg "GO_VERSION=${GO_VERSION}" \
+              -t "leoflow-runtime:py${py}" .
+            echo "::endgroup::"
+          done
+          echo "::group::build leoflow-migrate"
+          docker build -f deploy/Dockerfile.migrate -t leoflow-migrate:ci .
+          echo "::endgroup::"
+
+      # Scan each image once to JSON (fixable findings, every severity), then
+      # derive the SARIF from that report. The file stem names the image in the
+      # summary, so keep it readable.
+      - name: Scan images
+        run: |
+          set -euo pipefail
+          mkdir -p scan-out
+          scan() { # <report-name> <image-ref>
+            echo "::group::scan $2"
+            trivy image --quiet --scanners vuln \
+              --ignore-unfixed \
+              --ignorefile .trivyignore.yaml \
+              --format json --output "scan-out/$1.json" "$2"
+            trivy convert --quiet \
+              --format sarif --output "scan-out/$1.sarif" "scan-out/$1.json"
+            echo "::endgroup::"
+          }
+          scan leoflow-runtime-py3.10 leoflow-runtime:py3.10
+          scan leoflow-runtime-py3.11 leoflow-runtime:py3.11
+          scan leoflow-runtime-py3.12 leoflow-runtime:py3.12
+          scan leoflow-migrate       leoflow-migrate:ci
+
+      # The complete picture, including the unfixed findings the policy filters
+      # out, so a filter this workflow applies is never the only copy of the data.
+      - name: Full unfiltered inventory
+        run: |
+          set -euo pipefail
+          mkdir -p scan-out/unfiltered
+          for ref in leoflow-runtime:py3.10 leoflow-runtime:py3.11 leoflow-runtime:py3.12 leoflow-migrate:ci; do
+            name="${ref//[:\/]/-}"
+            trivy image --quiet --scanners vuln \
+              --format json --output "scan-out/unfiltered/${name}.json" "$ref"
+          done
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: trivy-image-reports
+          path: scan-out/
+          retention-days: 30
+
+      # One category per image so the uploads do not overwrite each other. Not
+      # on pull_request: a PR run would collide with the main-branch baseline
+      # under a shared category, the same trap security.yaml documents (#437).
+      - name: Upload SARIF (leoflow-runtime py3.10)
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        if: always() && github.event_name != 'pull_request'
+        with:
+          sarif_file: scan-out/leoflow-runtime-py3.10.sarif
+          category: trivy-image-runtime-py310
+
+      - name: Upload SARIF (leoflow-runtime py3.11)
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        if: always() && github.event_name != 'pull_request'
+        with:
+          sarif_file: scan-out/leoflow-runtime-py3.11.sarif
+          category: trivy-image-runtime-py311
+
+      - name: Upload SARIF (leoflow-runtime py3.12)
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        if: always() && github.event_name != 'pull_request'
+        with:
+          sarif_file: scan-out/leoflow-runtime-py3.12.sarif
+          category: trivy-image-runtime-py312
+
+      - name: Upload SARIF (leoflow-migrate)
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        if: always() && github.event_name != 'pull_request'
+        with:
+          sarif_file: scan-out/leoflow-migrate.sarif
+          category: trivy-image-migrate
+
+      - name: Build report
+        id: report
+        run: |
+          set -euo pipefail
+          python3 scripts/trivy-report.py \
+            scan-out/leoflow-runtime-py3.10.json \
+            scan-out/leoflow-runtime-py3.11.json \
+            scan-out/leoflow-runtime-py3.12.json \
+            scan-out/leoflow-migrate.json \
+            --gate-severity "$GATE_SEVERITY" \
+            --fingerprint-out scan-out/fingerprint.txt \
+            --blocking-count-out scan-out/blocking.txt \
+            > scan-out/report.md
+          {
+            echo "fingerprint=$(cat scan-out/fingerprint.txt)"
+            echo "blocking=$(cat scan-out/blocking.txt)"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "## Container image scan"
+            echo
+            echo "Fixable findings only. Severity floor for the \"would block\" column: \`$GATE_SEVERITY\`."
+            echo
+            cat scan-out/report.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # One issue, kept current — not one issue per run, and not a comment a day.
+      # A daily scan that notifies on every run is a daily scan nobody reads, so
+      # the body is refreshed silently and a comment is posted only when the set
+      # of would-block findings actually changes.
+      - name: Update the tracking issue
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BLOCKING: ${{ steps.report.outputs.blocking }}
+          FINGERPRINT: ${{ steps.report.outputs.fingerprint }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          # Anchored on the exact title rather than a label, so the workflow does
+          # not depend on a label existing in the repository.
+          number="$(gh issue list --state open --limit 100 \
+            --json number,title,body \
+            --jq "[.[] | select(.title == env.ISSUE_TITLE)][0].number // empty")"
+
+          if [ "$BLOCKING" -eq 0 ]; then
+            if [ -n "$number" ]; then
+              gh issue comment "$number" --body \
+                "All previously reported fixable ${GATE_SEVERITY} findings are gone as of [this run](${RUN_URL}). Closing."
+              gh issue close "$number"
+            fi
+            echo "no fixable ${GATE_SEVERITY} findings; nothing to track"
+            exit 0
+          fi
+
+          {
+            echo "Fixable **${GATE_SEVERITY}** findings in images we publish, from the daily"
+            echo "[image scan](${RUN_URL}). Unfixed findings are excluded — see"
+            echo "\`.github/workflows/image-scan.yaml\` for why."
+            echo
+            echo "This issue is maintained by the scan: the body is refreshed on every run and"
+            echo "the issue closes itself when the list empties. Triage guidance is in"
+            echo "[Image vulnerability scanning](https://leoflow.dev/contribute/image-vulnerability-scanning/)."
+            echo
+            cat scan-out/report.md
+            echo
+            echo "<!-- image-scan-fingerprint: ${FINGERPRINT} -->"
+          } > scan-out/issue-body.md
+
+          if [ -z "$number" ]; then
+            gh issue create --title "$ISSUE_TITLE" --body-file scan-out/issue-body.md
+            echo "opened tracking issue"
+            exit 0
+          fi
+
+          previous="$(gh issue view "$number" --json body --jq '.body' \
+            | sed -n 's/.*<!-- image-scan-fingerprint: \([0-9a-f]*\) -->.*/\1/p')"
+          gh issue edit "$number" --body-file scan-out/issue-body.md
+          if [ "$previous" != "$FINGERPRINT" ]; then
+            gh issue comment "$number" --body \
+              "The set of fixable ${GATE_SEVERITY} findings changed as of [this run](${RUN_URL}). Updated above."
+            echo "updated issue #${number} (finding set changed)"
+          else
+            echo "updated issue #${number} (no change to the finding set; stayed quiet)"
+          fi

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -49,6 +49,9 @@ on:
       - "runtime/**"
       - "deploy/Dockerfile.migrate"
       - "migrations/**"
+      # The python_version enum decides which base images exist, and the first
+      # step reconciles it against this workflow's SARIF upload steps.
+      - "internal/domain/schemas/**"
       - "go.mod"
       - "go.sum"
       - ".trivyignore.yaml"
@@ -63,6 +66,9 @@ on:
       - "runtime/**"
       - "deploy/Dockerfile.migrate"
       - "migrations/**"
+      # The python_version enum decides which base images exist, and the first
+      # step reconciles it against this workflow's SARIF upload steps.
+      - "internal/domain/schemas/**"
       - "go.mod"
       - "go.sum"
       - ".trivyignore.yaml"
@@ -71,6 +77,15 @@ on:
 
 permissions:
   contents: read
+
+# The tracking issue is a single shared object, so two runs of this workflow must
+# not be in flight at once: a push landing while the 06:20 cron is mid-scan gives
+# two runs that both look up the issue, both find none, and both create one. Main
+# and the schedule share `refs/heads/main`, so grouping by ref serialises exactly
+# that pair. PR runs touch no issue and supersede each other, so those cancel.
+concurrency:
+  group: image-scan-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   # Pinned: the scanner version decides what is reported, so an unpinned bump
@@ -83,16 +98,55 @@ env:
   ISSUE_TITLE: "Container image CVEs: fixable findings in published images"
 
 jobs:
+  # Named for what it does. This job builds the runtime and migrate images from
+  # the checkout — it does NOT pull a published tag. The two coincide whenever
+  # HEAD still produces the published image, which is the normal case, but the
+  # gap is real and worth stating: a base CVE in an already-published `py3.11`
+  # that HEAD no longer produces is invisible here. Scan the tag directly when
+  # that is the question — `trivy image ghcr.io/neochaotic/leoflow-runtime:py3.11`
+  # needs no build.
   scan:
-    name: Scan published image bases
+    name: Scan the images HEAD builds
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
       contents: read
       security-events: write   # SARIF upload to the Security tab
+      # There is ONE job, so this is held on schedule, push and pull_request
+      # alike — `permissions:` takes no expression, and only the STEPS are
+      # guarded by `github.event_name != 'pull_request'`. Splitting the issue
+      # update into its own job to narrow the grant would mean shipping the scan
+      # output between jobs as an artifact; not worth it for a token that, on a
+      # pull_request from a fork, is read-only anyway.
       issues: write            # create/update the single tracking issue
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # Which Python lines we publish is decided in ONE place (#1031): the
+      # `python_version` enum in the authoring schema. A base image we publish
+      # and do not scan is the exact blind spot this workflow exists to close, so
+      # the loop below reads that enum rather than repeating the list.
+      #
+      # The SARIF uploads cannot be a loop — each needs its own code-scanning
+      # category — so they stay one step per line, and this step fails when that
+      # set and the enum disagree. Runs first, in seconds, before anything is
+      # built. `internal/domain/schemas/**` is in the paths filters above so the
+      # PR that adds a line is the run that catches it.
+      - name: Resolve the published Python lines
+        env:
+          # One step per line exists below. Keep in sync with the enum.
+          UPLOADED: "3.10 3.11 3.12 3.13"
+        run: |
+          set -euo pipefail
+          lines="$(python3 -c "import json,sys; \
+            print(' '.join(json.load(open(sys.argv[1]))['properties']['python_version']['enum']))" \
+            internal/domain/schemas/leoflow-yaml-schema.json)"
+          echo "schema enum: ${lines}"
+          if [ "$lines" != "$UPLOADED" ]; then
+            echo "::error::the published Python lines (${lines}) and the SARIF upload steps in this workflow (${UPLOADED}) disagree. Add or remove an 'Upload SARIF (leoflow-runtime pyX.Y)' step and update UPLOADED."
+            exit 1
+          fi
+          echo "PY_LINES=${lines}" >> "$GITHUB_ENV"
 
       # Pinned release tarball rather than an action or a Docker Hub pull: the
       # same reasoning as the gitleaks step in security.yaml. GitHub release
@@ -118,7 +172,7 @@ jobs:
       - name: Build images
         run: |
           set -euo pipefail
-          for py in 3.10 3.11 3.12; do
+          for py in ${PY_LINES}; do
             echo "::group::build leoflow-runtime py${py}"
             docker build -f runtime/Dockerfile \
               --build-arg "PYTHON_VERSION=${py}" \
@@ -147,18 +201,23 @@ jobs:
               --format sarif --output "scan-out/$1.sarif" "scan-out/$1.json"
             echo "::endgroup::"
           }
-          scan leoflow-runtime-py3.10 leoflow-runtime:py3.10
-          scan leoflow-runtime-py3.11 leoflow-runtime:py3.11
-          scan leoflow-runtime-py3.12 leoflow-runtime:py3.12
-          scan leoflow-migrate       leoflow-migrate:ci
+          for py in ${PY_LINES}; do
+            scan "leoflow-runtime-py${py}" "leoflow-runtime:py${py}"
+          done
+          scan leoflow-migrate leoflow-migrate:ci
 
       # The complete picture, including the unfixed findings the policy filters
       # out, so a filter this workflow applies is never the only copy of the data.
+      # trivy-ignorefile-exempt: this is the unsuppressed copy of record — applying
+      # .trivyignore.yaml here would make the accepted findings unrecoverable from
+      # the artifact, which is the one thing this step exists to prevent.
       - name: Full unfiltered inventory
         run: |
           set -euo pipefail
           mkdir -p scan-out/unfiltered
-          for ref in leoflow-runtime:py3.10 leoflow-runtime:py3.11 leoflow-runtime:py3.12 leoflow-migrate:ci; do
+          refs="leoflow-migrate:ci"
+          for py in ${PY_LINES}; do refs="${refs} leoflow-runtime:py${py}"; done
+          for ref in ${refs}; do
             name="${ref//[:\/]/-}"
             trivy image --quiet --scanners vuln \
               --format json --output "scan-out/unfiltered/${name}.json" "$ref"
@@ -195,6 +254,13 @@ jobs:
           sarif_file: scan-out/leoflow-runtime-py3.12.sarif
           category: trivy-image-runtime-py312
 
+      - name: Upload SARIF (leoflow-runtime py3.13)
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        if: always() && github.event_name != 'pull_request'
+        with:
+          sarif_file: scan-out/leoflow-runtime-py3.13.sarif
+          category: trivy-image-runtime-py313
+
       - name: Upload SARIF (leoflow-migrate)
         uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         if: always() && github.event_name != 'pull_request'
@@ -206,10 +272,11 @@ jobs:
         id: report
         run: |
           set -euo pipefail
+          reports=""
+          for py in ${PY_LINES}; do reports="${reports} scan-out/leoflow-runtime-py${py}.json"; done
+          # shellcheck disable=SC2086 # deliberate word splitting over the report list.
           python3 scripts/trivy-report.py \
-            scan-out/leoflow-runtime-py3.10.json \
-            scan-out/leoflow-runtime-py3.11.json \
-            scan-out/leoflow-runtime-py3.12.json \
+            ${reports} \
             scan-out/leoflow-migrate.json \
             --gate-severity "$GATE_SEVERITY" \
             --fingerprint-out scan-out/fingerprint.txt \
@@ -231,24 +298,55 @@ jobs:
       # A daily scan that notifies on every run is a daily scan nobody reads, so
       # the body is refreshed silently and a comment is posted only when the set
       # of would-block findings actually changes.
+      #
+      # continue-on-error, because the header of this file promises the workflow
+      # never fails the build and `issues: write` is not guaranteed: on a fork, or
+      # under an org policy that restricts the default token, every `gh issue`
+      # call 403s and `set -euo pipefail` would turn the daily job red for a
+      # reason that has nothing to do with any image. The scan results are in the
+      # job summary, the artifact and the Security tab regardless; the trap makes
+      # the failure visible as a warning instead of as a silent success.
       - name: Update the tracking issue
         if: github.event_name != 'pull_request'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           BLOCKING: ${{ steps.report.outputs.blocking }}
           FINGERPRINT: ${{ steps.report.outputs.fingerprint }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BOT_LOGIN: "github-actions"
         run: |
           set -euo pipefail
+          trap 'echo "::warning::could not update the tracking issue (does this token carry issues: write?). The findings are in the job summary, the trivy-image-reports artifact and the Security tab."' ERR
 
-          # Anchored on the exact title rather than a label, so the workflow does
-          # not depend on a label existing in the repository.
-          number="$(gh issue list --state open --limit 100 \
-            --json number,title,body \
-            --jq "[.[] | select(.title == env.ISSUE_TITLE)][0].number // empty")"
+          # Search by title across EVERY state, not `--state open --limit 100`.
+          # That listing is newest-first over 130+ open issues, so it stops about
+          # a month back: past that window the lookup returns nothing, a SECOND
+          # tracking issue opens and the first is abandoned open with a frozen
+          # body. `in:title` asks the server the question instead of paging, and
+          # `--state all` means a closed one is reopened rather than duplicated.
+          # Still anchored on the exact title rather than a label, so nothing
+          # depends on a label existing in the repository; the search is a
+          # prefilter and the exact match below is what decides.
+          found="$(gh issue list --state all --limit 100 \
+            --search "in:title ${ISSUE_TITLE}" \
+            --json number,title,state \
+            --jq "[.[] | select(.title == env.ISSUE_TITLE)][0] // empty")"
+          number="$(printf '%s' "$found" | jq -r '.number // empty')"
+          state="$(printf '%s' "$found" | jq -r '.state // empty')"
 
           if [ "$BLOCKING" -eq 0 ]; then
-            if [ -n "$number" ]; then
+            if [ -n "$number" ] && [ "$state" = "OPEN" ]; then
+              # Do not fight a human. If the last reopen came from a person
+              # rather than from this workflow, they reopened it deliberately —
+              # to track the migrate bump, say — and closing it again every
+              # morning, with a comment, is the behaviour that gets a bot muted.
+              reopener="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${number}/timeline" \
+                --paginate --jq '[.[] | select(.event == "reopened")] | last | .actor.login // empty')"
+              if [ -n "$reopener" ] && [ "${reopener%\[bot\]}" != "$BOT_LOGIN" ]; then
+                echo "issue #${number} was reopened by @${reopener}; leaving it to them"
+                exit 0
+              fi
               gh issue comment "$number" --body \
                 "All previously reported fixable ${GATE_SEVERITY} findings are gone as of [this run](${RUN_URL}). Closing."
               gh issue close "$number"
@@ -280,7 +378,16 @@ jobs:
           previous="$(gh issue view "$number" --json body --jq '.body' \
             | sed -n 's/.*<!-- image-scan-fingerprint: \([0-9a-f]*\) -->.*/\1/p')"
           gh issue edit "$number" --body-file scan-out/issue-body.md
-          if [ "$previous" != "$FINGERPRINT" ]; then
+
+          # Findings came back after the issue was closed. Reopening the one that
+          # already carries the history is right; opening a second one every day
+          # until somebody notices is what `--state open` used to do.
+          if [ "$state" = "CLOSED" ]; then
+            gh issue reopen "$number"
+            gh issue comment "$number" --body \
+              "Fixable ${GATE_SEVERITY} findings are back as of [this run](${RUN_URL}). Reopened; the list is above."
+            echo "reopened issue #${number} (findings returned)"
+          elif [ "$previous" != "$FINGERPRINT" ]; then
             gh issue comment "$number" --body \
               "The set of fixable ${GATE_SEVERITY} findings changed as of [this run](${RUN_URL}). Updated above."
             echo "updated issue #${number} (finding set changed)"

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -76,8 +76,11 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Filesystem scan of the repo (dependencies + committed secrets).
-      # Container image scanning returns once deploy/Dockerfile.server exists
-      # (Phase 6 deploy artifacts).
+      # trivy-ignorefile-exempt: .trivyignore.yaml holds accepted CONTAINER IMAGE
+      # findings — OS and vendored-binary CVEs in bases we do not author. This scan
+      # reads our own module graph and lock files, a different population with a
+      # different owner, and wiring the image list in here would let one accepted
+      # base-image finding silently suppress the same CVE in code we wrote.
       - name: Trivy filesystem scan
         uses: aquasecurity/trivy-action@d2a0b60797ff03db6132bd4e2b293f9b37081297 # master
         with:
@@ -121,6 +124,43 @@ jobs:
   # Baseline at the time of writing: leoflow-server reports ZERO findings under
   # this policy (1 total finding, nothing CRITICAL/HIGH, nothing fixable), so the
   # gate starts green and any red is a real regression.
+  #
+  # ── The image built here is the one we publish ───────────────────────
+  #
+  # It has to be, or the gate is theatre. Trivy keys `stdlib` findings to the Go
+  # toolchain recorded in the binary's build info, not to the module graph: the
+  # migrate image reports 21 HIGH `stdlib` findings purely because its vendored
+  # binary was built with go1.25.4. Scanning a binary built by a different
+  # toolchain than the release one therefore scans a different vulnerability set
+  # — blind to a stdlib CVE that affects the shipped toolchain, and red for one
+  # that does not.
+  #
+  # `deploy/Dockerfile.server` compiles from source inside `golang:1.27-bookworm`
+  # and is the developer/kind convenience path. GoReleaser publishes
+  # `deploy/Dockerfile.server.release`, which copies in a binary the release
+  # workflow builds with GO_VERSION. So this job reproduces the release recipe —
+  # same toolchain, same `CGO_ENABLED=0 -trimpath`, same distroless base — and
+  # scans that. GO_VERSION here is the same literal as release.yaml's; the two
+  # must move together.
+  #
+  # A floating `golang:1.27-bookworm` would also have quietly broken the fairness
+  # argument this gate rests on. A stdlib CVE in a floating build tag is closed
+  # by a base rebuild, not by a `go get` — it would redden the blocking gate for
+  # whoever opened the next unrelated PR, which is exactly the scenario used to
+  # justify NOT gating runtime and migrate. Pinning to the release toolchain
+  # keeps "a finding here is closed by a commit" true.
+  #
+  # Residual gap, stated rather than papered over: this builds HEAD's binary, not
+  # a published tag. A CVE in an already-published `leoflow-server` that HEAD no
+  # longer produces is not visible here — the daily scan and the Security tab
+  # baseline from `main` are where that shows up.
+  #
+  # Cost: compiling with actions/setup-go (module + build cache across runs) and
+  # then a COPY into distroless is minutes, where `docker build` of the
+  # from-source Dockerfile re-downloaded and recompiled everything on every run.
+  # The job stays on every event deliberately — it is meant to be a required
+  # check, and a `paths:`-skipped required check never reports and blocks the PR
+  # forever.
   # ─────────────────────────────────────────────────────────────────────
   server-image:
     name: Trivy (leoflow-server image)
@@ -131,11 +171,31 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
-      # Build the image this PR would produce, not a published tag: the point is
-      # to catch the dependency before it ships, not after.
-      - name: Build leoflow-server image
-        run: docker build -f deploy/Dockerfile.server -t leoflow-server:ci .
+      # The GoReleaser recipe for the `leoflow-server` binary (.goreleaser.yaml,
+      # builds id: leoflow-server): CGO-free, -trimpath, version metadata in
+      # ldflags. The ldflag VALUES do not affect what Trivy reports — it reads
+      # the module list and toolchain from the build info — but the toolchain and
+      # the build mode do, so those match exactly.
+      - name: Build the release binary (the GoReleaser recipe)
+        run: |
+          set -euo pipefail
+          mkdir -p dist/image-scan-context
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath \
+            -ldflags="-s -w \
+              -X github.com/neochaotic/leoflow/internal/version.version=ci \
+              -X github.com/neochaotic/leoflow/internal/version.gitCommit=${GITHUB_SHA}" \
+            -o dist/image-scan-context/leoflow-server ./cmd/leoflow-server
+          go version -m dist/image-scan-context/leoflow-server | head -3
+
+      # deploy/Dockerfile.server.release is the file .goreleaser.yaml points at
+      # for both published arches. It COPYs `leoflow-server` from the build
+      # context, so the context is the staging directory holding it.
+      - name: Build leoflow-server image (the published Dockerfile)
+        run: docker build -f deploy/Dockerfile.server.release -t leoflow-server:ci dist/image-scan-context
 
       # Report: every FIXABLE finding at any severity, so the Security tab shows
       # the MEDIUM/LOW ones the gate deliberately does not block on. Unfixed

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -101,6 +101,81 @@ jobs:
           category: trivy-fs
 
   # ─────────────────────────────────────────────────────────────────────
+  # leoflow-server image scan — the BLOCKING half of the container policy.
+  #
+  # This is the one image whose contents are entirely ours: distroless static
+  # plus a Go binary built from this repository's go.mod. There is no OS package
+  # set to inherit CVEs from, so every finding here is caused by a commit and
+  # closed by a `go get`. That makes it the only image where a PR-blocking gate
+  # is fair — the person who turns it red is the person who can turn it green.
+  #
+  # The counterpart images (leoflow-runtime, leoflow-migrate) are NOT gated here.
+  # They inherit Debian and Alpine package sets that acquire CVEs with no commit
+  # of ours, so a blocking gate on them would fail whoever pushes next rather
+  # than whoever can fix it, and would be switched off within a week. They are
+  # scanned on a schedule instead — see .github/workflows/image-scan.yaml.
+  #
+  # Policy: fixable only, CRITICAL/HIGH blocks. `ignore-unfixed` is what makes
+  # this sustainable: severity says how bad a finding is, fixability says whether
+  # anyone can do anything about it, and only the second is a gate criterion.
+  # Baseline at the time of writing: leoflow-server reports ZERO findings under
+  # this policy (1 total finding, nothing CRITICAL/HIGH, nothing fixable), so the
+  # gate starts green and any red is a real regression.
+  # ─────────────────────────────────────────────────────────────────────
+  server-image:
+    name: Trivy (leoflow-server image)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # Build the image this PR would produce, not a published tag: the point is
+      # to catch the dependency before it ships, not after.
+      - name: Build leoflow-server image
+        run: docker build -f deploy/Dockerfile.server -t leoflow-server:ci .
+
+      # Report: every FIXABLE finding at any severity, so the Security tab shows
+      # the MEDIUM/LOW ones the gate deliberately does not block on. Unfixed
+      # findings are excluded here too — an alert nobody can ever close is not
+      # visibility, it is noise that teaches people to ignore the tab.
+      - name: Trivy image scan (SARIF report)
+        uses: aquasecurity/trivy-action@d2a0b60797ff03db6132bd4e2b293f9b37081297 # master
+        with:
+          scan-type: image
+          image-ref: leoflow-server:ci
+          scanners: vuln
+          ignore-unfixed: true
+          trivyignores: .trivyignore.yaml
+          format: sarif
+          output: trivy-server-image.sarif
+
+      # Same rule as the filesystem scan above (#437): gate on every event, but
+      # upload only off pull_request, so a PR run cannot overwrite the main
+      # branch baseline under a shared category.
+      - name: Upload Trivy SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        if: always() && github.event_name != 'pull_request'
+        with:
+          sarif_file: trivy-server-image.sarif
+          category: trivy-server-image
+
+      # Gate: fixable CRITICAL/HIGH only.
+      - name: Trivy image scan (gate)
+        uses: aquasecurity/trivy-action@d2a0b60797ff03db6132bd4e2b293f9b37081297 # master
+        with:
+          scan-type: image
+          image-ref: leoflow-server:ci
+          scanners: vuln
+          ignore-unfixed: true
+          trivyignores: .trivyignore.yaml
+          severity: CRITICAL,HIGH
+          exit-code: 1
+          format: table
+
+  # ─────────────────────────────────────────────────────────────────────
   # Gitleaks: secret scanning
   # ─────────────────────────────────────────────────────────────────────
   gitleaks:

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,56 @@
+# Accepted container-image vulnerability findings.
+#
+# Every entry here is a finding that a scan WOULD report and that we have
+# decided, deliberately and with a date on it, not to act on yet. Nothing is
+# suppressed by being old, noisy, or inconvenient — only by an entry in this
+# file, reviewed in the PR that adds it.
+#
+# ── Why this file exists in this shape ───────────────────────────────────────
+#
+# An ignore list is the part of a scanning policy that rots. The failure mode is
+# never "we added a bad entry"; it is "we added a reasonable entry in a hurry and
+# nobody ever looked at it again", and three years later the list is the reason
+# the scanner reports clean. So an entry cannot be written here without saying
+# WHY it is accepted and WHEN that acceptance lapses.
+#
+# `expired_at` is enforced by Trivy itself, not by convention: once the date
+# passes, Trivy stops honouring the entry and the finding comes back into the
+# scan. Verified against Trivy 0.72 — a future-dated entry suppresses, a lapsed
+# one does not. That makes the default outcome of neglect "the finding returns",
+# which is the only default that is safe.
+#
+# `scripts/check-trivyignore-entries.sh` (a CI gate) additionally refuses:
+#   - an entry with no `statement`, or a placeholder one
+#   - an entry with no `expired_at`
+#   - an entry whose `expired_at` has already lapsed (dead weight: renew it
+#     deliberately or delete it — do not leave it for the next reader to decode)
+#   - an entry parked more than 180 days out, so "accepted" cannot mean "forever"
+#   - a top-level section name Trivy does not know, which would otherwise
+#     silently suppress nothing while looking like it suppresses something
+#
+# ── How to add an entry ──────────────────────────────────────────────────────
+#
+#   vulnerabilities:
+#     - id: CVE-2023-45853
+#       # What the finding is, why it does not apply to us or cannot be acted on
+#       # yet, and what would change that. Write it for someone who finds this
+#       # line in eighteen months with no other context.
+#       statement: >-
+#         zlib1g in Debian bookworm; upstream marked will_not_fix. Reachable only
+#         through MiniZip, which nothing in the task runtime links against.
+#         Re-evaluate when the base moves off bookworm (#NNN).
+#       expired_at: 2026-12-31
+#
+# Scope note: this file is applied to the container image scans. Go module
+# vulnerabilities are govulncheck's job and are not suppressed here.
+#
+# ── Current state ────────────────────────────────────────────────────────────
+#
+# Empty, and that is the real state rather than an omission. The blocking gate
+# (leoflow-server) reports zero findings under the policy, so nothing needs
+# accepting; the runtime and migrate images are reported, not gated, so their
+# findings are tracked in an issue rather than suppressed here. The mechanism is
+# in place BEFORE the first exception, which is the only time it can be designed
+# calmly instead of under a red build.
+
+vulnerabilities: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,23 +50,35 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the Debian packages inside `python:3.x-slim-bookworm`, or about a third-party
   Go binary baked into someone else's image — so OS-level and vendored-binary
   CVEs in the images we publish reached a human before they reached CI. Trivy
-  now scans all three (`leoflow-server`, `leoflow-runtime` ×3 Python lines,
-  `leoflow-migrate`), publishing to the Security tab under one code-scanning
-  category per image.
+  now scans all three (`leoflow-server`, `leoflow-runtime` on every published
+  Python line, `leoflow-migrate`), publishing to the Security tab under one
+  code-scanning category per image.
 
   The policy is split by **who can fix the finding**, because a naive
   "fail on any HIGH" is unsatisfiable on a Debian base and gets disabled within
   a week. `leoflow-server` is distroless plus a binary built from our own
   `go.mod`, so every finding there is caused by a commit and closed by a
-  `go get`: it is scanned on **every PR and push, and it blocks** (baseline
-  today: zero findings, so the gate starts green). `leoflow-runtime` and
-  `leoflow-migrate` inherit package sets we do not author, where a CVE lands
-  because a distro security team published an advisory and not because anyone
-  pushed anything — blocking those would fail whoever opens the next unrelated
-  PR while the person who can fix it is elsewhere. They are scanned **daily,
-  never block, and maintain a single self-closing tracking issue** whose body is
-  refreshed each run and which comments only when the finding set actually
-  changes.
+  `go get`: it is scanned on **every PR and push, and the job goes red**
+  (baseline today: zero findings, so it starts green). Whether that red *blocks
+  a merge* is a branch-protection setting — a new job is not a required check
+  until somebody adds it. `leoflow-runtime` and `leoflow-migrate` inherit
+  package sets we do not author, where a CVE lands because a distro security
+  team published an advisory and not because anyone pushed anything — blocking
+  those would fail whoever opens the next unrelated PR while the person who can
+  fix it is elsewhere. They are scanned **daily, never block, and maintain a
+  single self-closing tracking issue** whose body is refreshed each run, which
+  comments only when the finding set actually changes, which reopens rather than
+  duplicates when findings return, and which leaves the issue alone once a human
+  has reopened it.
+
+  The server gate scans **the artifact GoReleaser publishes** — the release
+  Dockerfile, with a binary built by the release toolchain — not the
+  build-from-source Dockerfile used for local and kind runs. Trivy keys `stdlib`
+  findings to the toolchain recorded in the binary, so the two are different
+  scans; and the from-source path builds on a floating `golang:1.x` tag, where a
+  stdlib CVE is closed by a base rebuild rather than by a `go get`, which is
+  precisely the unfairness this policy refuses to inflict on runtime and
+  migrate.
 
   Both scans gate on **fixability first, severity second**: severity says how
   bad a finding is, fixability says whether anyone can act on it today, and only
@@ -84,8 +96,10 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (`scripts/check-trivyignore-entries.sh`, with a `--self-test`) rejects a
   missing or placeholder rationale, a missing, lapsed, or beyond-180-day expiry,
   and a section name Trivy would silently ignore — and checks the other end of
-  the chain too, that a workflow actually passes the file to `--ignorefile`, so
-  a rename cannot leave entries that look accepted and suppress nothing.
+  the chain too, **per scan**: every step that runs trivy must pass the file, so
+  a flag dropped from one workflow cannot hide behind another workflow that
+  still has it. A scan that must apply no suppressions declares itself with a
+  reason the gate length-checks.
   `scripts/check-script-selftests.sh` now discovers Python self-tests alongside
   shell ones, so `scripts/trivy-report.py` is covered by the same gate.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,56 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   line we already deprecated is still being published past its own removal date.
   It never fails a build on a date.
 
+- **Container image vulnerability scanning, with a policy designed to stay
+  switched on.** `govulncheck` reads our Go module graph and says nothing about
+  the Debian packages inside `python:3.x-slim-bookworm`, or about a third-party
+  Go binary baked into someone else's image — so OS-level and vendored-binary
+  CVEs in the images we publish reached a human before they reached CI. Trivy
+  now scans all three (`leoflow-server`, `leoflow-runtime` ×3 Python lines,
+  `leoflow-migrate`), publishing to the Security tab under one code-scanning
+  category per image.
+
+  The policy is split by **who can fix the finding**, because a naive
+  "fail on any HIGH" is unsatisfiable on a Debian base and gets disabled within
+  a week. `leoflow-server` is distroless plus a binary built from our own
+  `go.mod`, so every finding there is caused by a commit and closed by a
+  `go get`: it is scanned on **every PR and push, and it blocks** (baseline
+  today: zero findings, so the gate starts green). `leoflow-runtime` and
+  `leoflow-migrate` inherit package sets we do not author, where a CVE lands
+  because a distro security team published an advisory and not because anyone
+  pushed anything — blocking those would fail whoever opens the next unrelated
+  PR while the person who can fix it is elsewhere. They are scanned **daily,
+  never block, and maintain a single self-closing tracking issue** whose body is
+  refreshed each run and which comments only when the finding set actually
+  changes.
+
+  Both scans gate on **fixability first, severity second**: severity says how
+  bad a finding is, fixability says whether anyone can act on it today, and only
+  the second works as a gate criterion. On `leoflow-runtime:py3.11` that takes
+  273 findings down to 14, removing all five CRITICALs — every one of which is
+  `will_not_fix`, `fix_deferred`, or `affected` upstream in bookworm. Unfixed
+  findings are kept out of the Security tab too: an alert nobody can ever close
+  is not visibility, it is noise that teaches people to stop opening the tab.
+  The full unfiltered inventory is retained as a build artifact.
+
+  Accepted findings live in `.trivyignore.yaml` and cannot silently become
+  permanent. Each entry must carry a `statement` saying why and an `expired_at`
+  saying when the acceptance lapses; Trivy enforces the date itself, so neglect
+  makes a finding *come back* rather than stay hidden. A new CI gate
+  (`scripts/check-trivyignore-entries.sh`, with a `--self-test`) rejects a
+  missing or placeholder rationale, a missing, lapsed, or beyond-180-day expiry,
+  and a section name Trivy would silently ignore — and checks the other end of
+  the chain too, that a workflow actually passes the file to `--ignorefile`, so
+  a rename cannot leave entries that look accepted and suppress nothing.
+  `scripts/check-script-selftests.sh` now discovers Python self-tests alongside
+  shell ones, so `scripts/trivy-report.py` is covered by the same gate.
+
+  **No base image changed in this work** — it is detection only; which base
+  `leoflow-runtime` ships is an authoring-surface decision users inherit through
+  `base_image` and is argued separately. Findings, filters and triage steps are
+  documented in [Image
+  scanning](https://leoflow.dev/contribute/image-vulnerability-scanning/).
+
 ### Deprecated
 
 - **`python_version: "3.10"` — the `py3.10` base image stops being published

--- a/scripts/check-script-selftests.sh
+++ b/scripts/check-script-selftests.sh
@@ -31,6 +31,22 @@ for f in "$ROOT"/scripts/*.sh; do
 	fi
 done
 
+# Python helpers under scripts/ get the same treatment, by the same
+# discovery-by-existence rule. Not every script here is shell, and a report
+# generator whose filter silently returns nothing fails exactly as quietly as a
+# gate that always passes. Scripts without a self_test are skipped, as above.
+for f in "$ROOT"/scripts/*.py; do
+	[ -f "$f" ] || continue
+	grep -qE '^def self_test\(' "$f" || continue
+	found=$((found + 1))
+	if out="$(python3 "$f" --self-test 2>&1)"; then
+		echo "OK: $(basename "$f") --self-test"
+	else
+		printf 'FAIL: %s --self-test\n%s\n' "$(basename "$f")" "$out" >&2
+		failed=$((failed + 1))
+	fi
+done
+
 # A rename or a lost self_test() would otherwise shrink this gate to nothing
 # while still exiting 0 — the same silent-shrink hole run_gates guards against.
 if [ "$found" -lt "${MIN_SELFTESTS:-7}" ]; then

--- a/scripts/check-script-selftests.sh
+++ b/scripts/check-script-selftests.sh
@@ -49,8 +49,8 @@ done
 
 # A rename or a lost self_test() would otherwise shrink this gate to nothing
 # while still exiting 0 — the same silent-shrink hole run_gates guards against.
-if [ "$found" -lt "${MIN_SELFTESTS:-7}" ]; then
-	echo "FAIL: found only $found self-test(s), expected at least ${MIN_SELFTESTS:-7} — did a script lose its self_test()?" >&2
+if [ "$found" -lt "${MIN_SELFTESTS:-9}" ]; then
+	echo "FAIL: found only $found self-test(s), expected at least ${MIN_SELFTESTS:-9} — did a script lose its self_test()?" >&2
 	exit 1
 fi
 [ "$failed" -eq 0 ] || exit 1

--- a/scripts/check-trivyignore-entries.sh
+++ b/scripts/check-trivyignore-entries.sh
@@ -21,11 +21,36 @@
 # workflows must reference an ignore file, and the file they reference must be
 # the one that exists.
 #
+# The wiring assertion is PER INVOCATION, not per repository. An earlier version
+# asked only whether SOME workflow somewhere passed an ignore file, which is a
+# question the repository answers "yes" to for as long as any one scan still
+# carries the flag: deleting `trivyignores:` from the BLOCKING gate on its own
+# left this gate green, because the daily reporting scan still had it. That is
+# the one mutation that mattered and the only one the old shape could not see.
+# So every step that runs a trivy SCAN must carry an ignore-file reference of
+# its own — `--ignorefile` on the command line, the action's `trivyignores:` /
+# `ignorefile:` input, or `TRIVY_IGNOREFILE` in the environment.
+#
+# A scan that must run with no suppressions (the unfiltered inventory keeps the
+# complete picture precisely so that no filter this policy applies is the only
+# copy of the data) declares itself, in the step or in the comment above it:
+#
+#   # trivy-ignorefile-exempt: <why this scan must apply no suppressions>
+#
+# The reason is mandatory and length-checked, so an exemption is an argument
+# somebody wrote, not a flag somebody dropped. The declaration is per step.
+#
 # The tree is PARSED, not grepped. `--ignorefile` lives inside a `run:` block, so
 # the raw text also contains it in shell comments and in this script's own
 # documentation; a grep would count those as wiring and pass a workflow that has
 # none. Shell-comment lines inside the parsed `run:` scripts are dropped for the
-# same reason.
+# same reason, `\`-continuations are joined before the line is read, and `trivy`
+# counts as an invocation only in command position — `install /tmp/trivy
+# /usr/local/bin/trivy` installs the binary, it does not scan anything.
+#
+# Classification fails CLOSED: a trivy subcommand this script does not recognise
+# is an error, not a pass. A gate that silently ignores what it cannot parse is
+# the failure mode this whole file exists to prevent.
 #
 # Usage: scripts/check-trivyignore-entries.sh [--self-test]
 #        scripts/check-trivyignore-entries.sh <workflow-dir> <ignore-file>
@@ -65,46 +90,163 @@ KNOWN_SECTIONS = {"vulnerabilities", "misconfigurations", "secrets", "licenses"}
 PLACEHOLDERS = {"todo", "tbd", "fixme", "xxx", "n/a", "na", "none", "wip",
                 "accepted", "temporary", "later", "see above", "-"}
 
-# ── 1. The ignore file must be wired to at least one scan ────────────────────
+# ── 1. Every trivy scan must be wired to the ignore file ─────────────────────
 FLAG = re.compile(r"--ignorefile[=\s]+(\S+)")
+EXEMPT = re.compile(r"trivy-ignorefile-exempt:\s*(\S.*)")
+
+# Subcommands that read an image/filesystem/repository and report findings —
+# the ones an ignore file applies to.
+SCAN_SUBCOMMANDS = {"image", "i", "fs", "filesystem", "rootfs", "repo",
+                    "repository", "config", "conf", "k8s", "vm", "sbom", "aws"}
+# Subcommands that do not scan anything, so an ignore file is meaningless.
+# `convert` re-renders a report that was already filtered when it was produced.
+NON_SCAN_SUBCOMMANDS = {"version", "convert", "clean", "module", "plugin",
+                        "server", "completion", "registry", "help"}
+NON_SCAN_FLAGS = {"--version", "-v", "--help", "-h"}
+# `trivy image --download-db-only` warms the vulnerability database. It names a
+# scan subcommand and scans nothing.
+MAINTENANCE_FLAGS = ("--download-db-only", "--download-java-db-only", "--reset",
+                     "--clear-cache", "--generate-default-trivy-yaml")
+# Words that may precede the real command word without changing what it is.
+WRAPPERS = {"sudo", "env", "command", "exec", "time", "nice", "then", "do",
+            "else", "!"}
+ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+# Splits a shell line into the segments a command can start in.
+SEGMENT = re.compile(r"\|\||&&|[|;&()]")
 
 
-def run_scripts(doc):
-    """Yield text in which a `--ignorefile <path>` reference may appear.
+def logical_lines(script):
+    """Yield each shell line of `script` with `\\`-continuations joined.
 
-    Two shapes wire an ignore file, and both must be seen or the gate reports a
-    file as unwired when it is not (or, worse, passes a workflow that dropped
-    the flag):
-
-      * a `run:` shell script passing `--ignorefile <path>` to the trivy binary;
-      * an action step whose `with:` carries the file as a dedicated input.
-
-    `args` is scanned for the flag rather than treated as a path — it is a free
-    -form command line, and other actions in this repository use `args` for
-    entirely unrelated things.
+    A `--ignorefile` two lines below the `trivy` that consumes it is the same
+    invocation, and the real workflows are written that way. Reading raw lines
+    would report the flag as missing on the command and as orphaned on its own.
+    Shell comments are dropped: an invocation someone commented out is not one.
     """
-    for job in (doc.get("jobs") or {}).values():
-        if not isinstance(job, dict):
+    buf = ""
+    for raw in script.splitlines():
+        stripped = raw.strip()
+        if not buf:
+            if not stripped or stripped.startswith("#"):
+                continue
+            buf = stripped
+        else:
+            buf += " " + stripped
+        if buf.endswith("\\"):
+            buf = buf[:-1].rstrip()
             continue
-        for step in (job.get("steps") or []):
-            if not isinstance(step, dict):
-                continue
-            if isinstance(step.get("run"), str):
-                yield step["run"]
-            with_ = step.get("with")
-            if not isinstance(with_, dict):
-                continue
-            if isinstance(with_.get("args"), str):
-                yield with_["args"]
-            # aquasecurity/trivy-action names it `trivyignores`, and accepts a
-            # comma-separated list.
-            for key in ("trivyignores", "ignorefile"):
-                val = with_.get(key)
-                if isinstance(val, str):
-                    for part in val.split(","):
-                        if part.strip():
-                            yield f"--ignorefile {part.strip()}"
+        yield buf
+        buf = ""
+    if buf:
+        yield buf
 
+
+def trivy_invocations(line):
+    """Yield each segment of `line` in which trivy is the command being run.
+
+    Command position matters. `install -m 0755 /tmp/trivy /usr/local/bin/trivy`
+    mentions trivy twice and runs it zero times; treating either mention as an
+    invocation would demand an ignore file from the step that installs the
+    scanner.
+    """
+    for segment in SEGMENT.split(line):
+        toks = segment.split()
+        while toks and (toks[0] in WRAPPERS or ASSIGNMENT.match(toks[0])):
+            toks.pop(0)
+        if not toks:
+            continue
+        if pathlib.PurePosixPath(toks[0].strip("\"'")).name != "trivy":
+            continue
+        yield segment, toks[1:]
+
+
+def classify(args):
+    """Return "scan", "other", or None when the subcommand is unrecognised."""
+    for tok in args:
+        if tok in MAINTENANCE_FLAGS or tok.split("=", 1)[0] in MAINTENANCE_FLAGS:
+            return "other"
+    for tok in args:
+        bare = tok.strip("\"'")
+        if bare in NON_SCAN_FLAGS:
+            return "other"
+        if bare.startswith("-"):
+            continue
+        if bare in SCAN_SUBCOMMANDS:
+            return "scan"
+        if bare in NON_SCAN_SUBCOMMANDS:
+            return "other"
+        # A bare word that is not a subcommand we know about. Fail closed.
+        return None
+    # `trivy` with no subcommand at all (a bare path, or `trivy` alone).
+    return "other"
+
+
+def step_span(lines, step):
+    """Raw workflow lines covering a step, plus the comment block above it.
+
+    An exemption is an argument a human wrote next to the scan it excuses, and
+    the natural place to write it for an action step — which has no `run:` body
+    — is the comment immediately above. YAML comments are gone by the time the
+    document is parsed, so the raw text is read back over the step's own range.
+    """
+    start = step.get("__line__")
+    end = step.get("__endline__")
+    if not isinstance(start, int) or not isinstance(end, int):
+        return []
+    first = lines[start - 1]
+    indent = len(first) - len(first.lstrip())
+    # A block mapping's end mark sits on the FIRST TOKEN AFTER it, so the raw
+    # range runs into the next step. Stop at the first line that dedents back to
+    # the step's own level, or an exemption written for one step would excuse
+    # the step above it.
+    stop = end
+    for j in range(start, min(end, len(lines))):
+        line = lines[j]
+        if line.strip() and (len(line) - len(line.lstrip())) <= indent:
+            stop = j
+            break
+    i = start - 1  # 0-based index of the step's first line
+    while i - 1 >= 0 and lines[i - 1].lstrip().startswith("#"):
+        i -= 1
+    return lines[i:stop]
+
+
+def wiring_refs(step, job, doc):
+    """Ignore-file paths this step's scans would actually use, minus the CLI flag."""
+    refs = []
+    for scope in (doc, job, step):
+        env = scope.get("env") if isinstance(scope, dict) else None
+        if isinstance(env, dict) and isinstance(env.get("TRIVY_IGNOREFILE"), str):
+            refs.append(env["TRIVY_IGNOREFILE"].strip("\"'"))
+    with_ = step.get("with")
+    if isinstance(with_, dict):
+        # aquasecurity/trivy-action names it `trivyignores`, and accepts a
+        # comma-separated list. `args` is a free-form command line — other
+        # actions in this repository use it for entirely unrelated things — so
+        # it is scanned for the flag rather than read as a path.
+        for key in ("trivyignores", "ignorefile"):
+            val = with_.get(key)
+            if isinstance(val, str):
+                refs += [p.strip().strip("\"'") for p in val.split(",") if p.strip()]
+        if isinstance(with_.get("args"), str):
+            refs += [m.group(1).strip("\"'") for m in FLAG.finditer(with_["args"])]
+    return refs
+
+
+class LineLoader(yaml.SafeLoader):
+    """SafeLoader that records where each mapping started and ended."""
+
+
+def _mapping_with_lines(loader, node, deep=False):
+    mapping = yaml.SafeLoader.construct_mapping(loader, node, deep=deep)
+    mapping["__line__"] = node.start_mark.line + 1
+    mapping["__endline__"] = node.end_mark.line + 1
+    return mapping
+
+
+LineLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _mapping_with_lines
+)
 
 if not wf_dir.is_dir():
     sys.exit(f"FAIL: {wf_dir} is not a directory — the scan target moved, refusing to report clean")
@@ -114,24 +256,75 @@ if not wf_files:
     sys.exit(f"FAIL: no workflow files under {wf_dir} — refusing to report clean")
 
 referenced = set()
+scans_seen = 0
 for f in wf_files:
+    text = f.read_text()
+    lines = text.splitlines()
     try:
-        doc = yaml.safe_load(f.read_text()) or {}
+        doc = yaml.load(text, Loader=LineLoader) or {}
     except yaml.YAMLError:
         continue
     if not isinstance(doc, dict):
         continue
-    for script in run_scripts(doc):
-        for line in script.splitlines():
-            # A shell comment inside a run: block is documentation, not wiring.
-            if line.lstrip().startswith("#"):
+    for job_id, job in (doc.get("jobs") or {}).items():
+        if not isinstance(job, dict):
+            continue
+        for step in (job.get("steps") or []):
+            if not isinstance(step, dict):
                 continue
-            for m in FLAG.finditer(line):
-                referenced.add(m.group(1).strip("\"'"))
+            where = f"{f.name}: job '{job_id}', step '{step.get('name') or step.get('uses') or step.get('id') or '?'}'"
 
-if not referenced:
+            # What this step would pass to trivy without the CLI flag.
+            step_refs = wiring_refs(step, job, doc)
+            invocations = []          # (label, refs-for-this-invocation)
+            uses = step.get("uses")
+            if isinstance(uses, str) and re.search(r"trivy", uses, re.I):
+                invocations.append(("the trivy action", list(step_refs)))
+            if isinstance(step.get("run"), str):
+                for line in logical_lines(step["run"]):
+                    for segment, args in trivy_invocations(line):
+                        kind = classify(args)
+                        if kind is None:
+                            fail.append(
+                                f"{where}: cannot tell whether `{segment.strip()}` scans anything. "
+                                "Teach this gate the subcommand rather than letting it guess."
+                            )
+                            continue
+                        if kind != "scan":
+                            continue
+                        cli = [m.group(1).strip("\"'") for m in FLAG.finditer(segment)]
+                        invocations.append((f"`{segment.strip()}`", step_refs + cli))
+
+            if not invocations:
+                continue
+            exemption = None
+            for raw in step_span(lines, step):
+                m = EXEMPT.search(raw)
+                if m:
+                    exemption = " ".join(m.group(1).split()).rstrip("\"'")
+                    break
+
+            for label, refs in invocations:
+                scans_seen += 1
+                if refs:
+                    referenced.update(refs)
+                    continue
+                if exemption is None:
+                    fail.append(
+                        f"{where}: {label} runs a scan with no ignore file.\n"
+                        f"      Pass --ignorefile {ignore_path.name} (or the action's `trivyignores:` input),\n"
+                        "      or declare why this scan must apply no suppressions with a\n"
+                        "      `# trivy-ignorefile-exempt: <reason>` comment on the step."
+                    )
+                elif len(exemption) < min_statement:
+                    fail.append(
+                        f"{where}: 'trivy-ignorefile-exempt' reason is {len(exemption)} chars, "
+                        f"need >= {min_statement}. Say why this scan must see every finding."
+                    )
+
+if scans_seen == 0:
     fail.append(
-        f"no workflow under {wf_dir} passes --ignorefile, so {ignore_path} is read by nothing.\n"
+        f"no workflow under {wf_dir} runs a trivy scan, so {ignore_path} is read by nothing.\n"
         "      Entries in it would look accepted and suppress nothing."
     )
 
@@ -141,7 +334,12 @@ for ref in sorted(referenced):
     if not (root / ref).is_file() and not pathlib.Path(ref).is_file():
         fail.append(f"a workflow passes --ignorefile {ref}, but no such file exists.")
 
-if referenced and ignore_path.name not in {pathlib.Path(r).name for r in referenced}:
+if scans_seen and not referenced:
+    fail.append(
+        f"every trivy scan under {wf_dir} is exempt from the ignore file, so {ignore_path} "
+        "is read by nothing."
+    )
+elif referenced and ignore_path.name not in {pathlib.Path(r).name for r in referenced}:
     fail.append(
         f"{ignore_path} exists but no workflow references it "
         f"(workflows reference: {', '.join(sorted(referenced))})."
@@ -239,7 +437,10 @@ if fail:
     print("lapses (expired_at), so the list cannot silently become permanent.", file=sys.stderr)
     sys.exit(1)
 
-print(f"trivyignore ok ({entries} accepted finding(s), {len(wf_files)} workflow file(s) scanned)")
+print(
+    f"trivyignore ok ({entries} accepted finding(s), {scans_seen} trivy scan(s) wired, "
+    f"{len(wf_files)} workflow file(s) scanned)"
+)
 PY
 }
 
@@ -352,10 +553,106 @@ self_test() {
 	# ── Wiring. Both ends, because neither proves the chain alone. ───────
 	printf 'vulnerabilities: []\n' >"$tmp/.trivyignore.yaml"
 
+	wok() { # <label> — the workflow dir as currently written must pass
+		check "$tmp/wf" "$tmp/.trivyignore.yaml" >/dev/null 2>&1 ||
+			{ echo "self-test FAIL: rejected $1" >&2; return 1; }
+	}
+	wbad() { # <label> — the workflow dir as currently written must fail
+		rc=0; check "$tmp/wf" "$tmp/.trivyignore.yaml" >/dev/null 2>&1 || rc=$?
+		[ "$rc" -ne 0 ] || { echo "self-test FAIL: accepted $1" >&2; return 1; }
+	}
+
 	# No workflow passes --ignorefile: the file is read by nothing.
 	printf 'jobs:\n  scan:\n    steps:\n      - run: trivy image alpine\n' >"$tmp/wf/scan.yaml"
-	rc=0; check "$tmp/wf" "$tmp/.trivyignore.yaml" >/dev/null 2>&1 || rc=$?
-	[ "$rc" -ne 0 ] || { echo "self-test FAIL: accepted an ignore file no workflow reads" >&2; return 1; }
+	wbad "an ignore file no workflow reads" || return 1
+
+	# ── The mutation the repository-wide check could not see ────────────
+	# Two workflows, both scanning; the flag is dropped from ONE. The old shape
+	# asked "does SOME workflow pass --ignorefile" and answered yes, so deleting
+	# the flag from the BLOCKING gate alone left this gate green. Every scan must
+	# now carry its own reference.
+	printf 'jobs:\n  daily:\n    steps:\n      - run: |\n          trivy image --ignorefile .trivyignore.yaml alpine\n' \
+		>"$tmp/wf/daily.yaml"
+	printf 'jobs:\n  gate:\n    steps:\n      - run: |\n          trivy image --ignorefile .trivyignore.yaml --exit-code 1 alpine\n' \
+		>"$tmp/wf/scan.yaml"
+	wok "two workflows that both wire the ignore file" || return 1
+	printf 'jobs:\n  gate:\n    steps:\n      - run: |\n          trivy image --exit-code 1 alpine\n' \
+		>"$tmp/wf/scan.yaml"
+	wbad "the blocking gate dropping --ignorefile while another workflow keeps it" || return 1
+	rm -f "$tmp/wf/daily.yaml"
+
+	# Same failure one level down: two steps in ONE job, only one wired.
+	printf 'jobs:\n  scan:\n    steps:\n      - name: report\n        run: |\n          trivy image --ignorefile .trivyignore.yaml --format sarif alpine\n      - name: gate\n        run: |\n          trivy image --exit-code 1 alpine\n' \
+		>"$tmp/wf/scan.yaml"
+	wbad "an unwired scan step alongside a wired one in the same job" || return 1
+
+	# The action shape has the same per-step rule: two trivy-action steps, one
+	# missing `trivyignores:`. This is the literal mutation reviewed on #1034.
+	printf 'jobs:\n  scan:\n    steps:\n      - name: report\n        uses: aquasecurity/trivy-action@abc\n        with:\n          trivyignores: .trivyignore.yaml\n      - name: gate\n        uses: aquasecurity/trivy-action@abc\n        with:\n          exit-code: 1\n' \
+		>"$tmp/wf/scan.yaml"
+	wbad "a trivy-action gate step with no trivyignores: input" || return 1
+
+	# ── Declared exemptions ─────────────────────────────────────────────
+	# A scan that must apply no suppressions says so, with a reason. The shape is
+	# the real one: a wired gate plus an exempt unfiltered inventory beside it.
+	local wired_step='      - name: gate\n        run: |\n          trivy image --ignorefile .trivyignore.yaml alpine\n'
+	# shellcheck disable=SC2059 # the format string is built above, on purpose.
+	printf "jobs:\n  scan:\n    steps:\n${wired_step}      # trivy-ignorefile-exempt: the unfiltered inventory is the copy of record and must show every finding\n      - name: inventory\n        run: |\n          trivy image --format json alpine\n" \
+		>"$tmp/wf/scan.yaml"
+	wok "a scan with a declared, argued exemption" || return 1
+
+	# ...but the reason is mandatory and length-checked, or the marker becomes a
+	# one-word way to switch the gate off.
+	# shellcheck disable=SC2059
+	printf "jobs:\n  scan:\n    steps:\n${wired_step}      # trivy-ignorefile-exempt: later\n      - name: inventory\n        run: |\n          trivy image --format json alpine\n" \
+		>"$tmp/wf/scan.yaml"
+	wbad "an exemption with no real reason" || return 1
+
+	# An exemption on one step must not excuse the step ABOVE it. The end mark of
+	# a YAML block mapping lands on the following step's first line, so a span
+	# read naively leaks the marker upwards. A wired step is kept in the file so
+	# that the "every scan is exempt" rule cannot fail this case for the wrong
+	# reason and hide a leak.
+	# shellcheck disable=SC2059
+	printf "jobs:\n  scan:\n    steps:\n${wired_step}      - name: unwired\n        run: |\n          trivy image --exit-code 1 alpine\n      # trivy-ignorefile-exempt: the unfiltered inventory is the copy of record and must show every finding\n      - name: inventory\n        run: |\n          trivy image --format json alpine\n" \
+		>"$tmp/wf/scan.yaml"
+	wbad "an unwired scan sitting above another step's exemption" || return 1
+
+	# Every scan exempt means the ignore file is still read by nothing.
+	printf 'jobs:\n  scan:\n    steps:\n      # trivy-ignorefile-exempt: the unfiltered inventory is the copy of record and must show every finding\n      - name: inventory\n        run: |\n          trivy image --format json alpine\n' \
+		>"$tmp/wf/scan.yaml"
+	printf 'vulnerabilities:\n  - id: CVE-2023-45853\n    statement: "%s"\n    expired_at: %s\n' "$good_stmt" "$future" \
+		>"$tmp/.trivyignore.yaml"
+	wbad "entries in an ignore file whose every scan is exempt" || return 1
+	printf 'vulnerabilities: []\n' >"$tmp/.trivyignore.yaml"
+
+	# ── Classification ──────────────────────────────────────────────────
+	# Installing, warming the database, printing the version and re-rendering a
+	# report are not scans, and must not demand an ignore file. All four appear
+	# in the real image-scan workflow.
+	printf 'jobs:\n  scan:\n    steps:\n      - name: setup\n        run: |\n          tar -xzf /tmp/trivy.tgz -C /tmp trivy\n          sudo install -m 0755 /tmp/trivy /usr/local/bin/trivy\n          trivy --version\n          trivy image --download-db-only\n          trivy convert --format sarif --output out.sarif out.json\n      - name: gate\n        run: |\n          trivy image --ignorefile .trivyignore.yaml alpine\n' \
+		>"$tmp/wf/scan.yaml"
+	wok "install, --version, --download-db-only and convert as non-scans" || return 1
+
+	# A `\`-continuation is one invocation: the flag two lines below the command
+	# still wires it. Every real scan in this repository is written that way.
+	printf 'jobs:\n  scan:\n    steps:\n      - run: |\n          trivy image --quiet \\\n            --ignore-unfixed \\\n            --ignorefile .trivyignore.yaml \\\n            alpine\n' \
+		>"$tmp/wf/scan.yaml"
+	wok "an invocation split across continuation lines" || return 1
+
+	# An unrecognised subcommand is an error, not a pass. A gate that shrugs at
+	# what it cannot parse is the failure mode this file exists to prevent. The
+	# wired step beside it keeps the "no trivy scan anywhere" rule from failing
+	# this case for the wrong reason.
+	# shellcheck disable=SC2059
+	printf "jobs:\n  scan:\n    steps:\n${wired_step}      - name: future\n        run: |\n          trivy futurecmd --ignorefile .trivyignore.yaml alpine\n" \
+		>"$tmp/wf/scan.yaml"
+	wbad "a trivy subcommand the gate cannot classify" || return 1
+
+	# TRIVY_IGNOREFILE in the environment wires a scan just as the flag does.
+	printf 'jobs:\n  scan:\n    steps:\n      - env:\n          TRIVY_IGNOREFILE: .trivyignore.yaml\n        run: |\n          trivy image alpine\n' \
+		>"$tmp/wf/scan.yaml"
+	wok "an ignore file passed through TRIVY_IGNOREFILE" || return 1
 
 	# Only a SHELL COMMENT mentions the flag — that is documentation, not wiring.
 	printf 'jobs:\n  scan:\n    steps:\n      - run: |\n          # we used to pass --ignorefile .trivyignore.yaml here\n          trivy image alpine\n' \
@@ -386,8 +683,8 @@ self_test() {
 	check "$tmp/wf" "$tmp/.trivyignore.yaml" >/dev/null 2>&1 ||
 		{ echo "self-test FAIL: an unrelated action's args: was misread as an ignore-file path" >&2; return 1; }
 
-	# ...but a flag genuinely inside `args:` DOES count.
-	printf 'jobs:\n  a:\n    steps:\n      - uses: some/action@abc\n        with:\n          args: image --ignorefile .trivyignore.yaml alpine\n' \
+	# ...but a flag genuinely inside a TRIVY action's `args:` DOES count.
+	printf 'jobs:\n  a:\n    steps:\n      - uses: aquasecurity/trivy-action@abc\n        with:\n          args: image --ignorefile .trivyignore.yaml alpine\n' \
 		>"$tmp/wf/scan.yaml"
 	check "$tmp/wf" "$tmp/.trivyignore.yaml" >/dev/null 2>&1 ||
 		{ echo "self-test FAIL: --ignorefile inside args: did not count as wiring" >&2; return 1; }

--- a/scripts/check-trivyignore-entries.sh
+++ b/scripts/check-trivyignore-entries.sh
@@ -1,0 +1,421 @@
+#!/usr/bin/env bash
+# Every accepted container-scan finding must say why it is accepted and when
+# that acceptance lapses — and the file holding them must actually be wired to a
+# scan.
+#
+# An ignore list is where a scanning policy goes to die. Not through a bad entry:
+# through a reasonable entry added in a hurry that nobody revisits, until the
+# list is the reason the scanner reports clean. Trivy gives us half the cure —
+# it honours `expired_at` and stops suppressing once the date passes, so neglect
+# makes a finding COME BACK rather than stay hidden. It does not give us the
+# other half: nothing in Trivy requires an entry to carry an `expired_at` at all,
+# or a rationale, so the easiest entry to write is the permanent, unexplained one.
+# This gate makes that entry impossible to commit.
+#
+# The wiring check is the part that is easy to leave out and the most likely to
+# fail open. A renamed ignore file, or a `--ignorefile` flag dropped from a
+# workflow during an edit, leaves this gate happily validating a file that no
+# scan reads — entries look accepted and suppress nothing, or worse, a scan runs
+# with no suppressions and someone "fixes" the noise by disabling the scan.
+# Neither end proves the chain on its own, so both ends are checked here: the
+# workflows must reference an ignore file, and the file they reference must be
+# the one that exists.
+#
+# The tree is PARSED, not grepped. `--ignorefile` lives inside a `run:` block, so
+# the raw text also contains it in shell comments and in this script's own
+# documentation; a grep would count those as wiring and pass a workflow that has
+# none. Shell-comment lines inside the parsed `run:` scripts are dropped for the
+# same reason.
+#
+# Usage: scripts/check-trivyignore-entries.sh [--self-test]
+#        scripts/check-trivyignore-entries.sh <workflow-dir> <ignore-file>
+set -euo pipefail
+
+# Longest an acceptance may be parked before it must be re-argued. Six months is
+# two release trains: long enough that a real "wait for upstream" is not busywork,
+# short enough that nobody can park a finding past the memory of why.
+MAX_DAYS="${MAX_DAYS:-180}"
+# A rationale shorter than this is not one. Tuned to reject "not exploitable"
+# while accepting a genuine one-sentence explanation.
+MIN_STATEMENT="${MIN_STATEMENT:-40}"
+
+check() { # <workflow-dir> <ignore-file>
+	MAX_DAYS="$MAX_DAYS" MIN_STATEMENT="$MIN_STATEMENT" python3 - "$@" <<'PY'
+import datetime
+import os
+import pathlib
+import re
+import sys
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("PyYAML is required (pip install pyyaml)")
+
+wf_dir, ignore_path = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+max_days = int(os.environ["MAX_DAYS"])
+min_statement = int(os.environ["MIN_STATEMENT"])
+today = datetime.date.today()
+fail = []
+
+# Trivy's known ignore sections. A typo like `vulnerability:` parses fine and
+# suppresses nothing, so an unknown key is a silent no-op, not a style nit.
+KNOWN_SECTIONS = {"vulnerabilities", "misconfigurations", "secrets", "licenses"}
+
+PLACEHOLDERS = {"todo", "tbd", "fixme", "xxx", "n/a", "na", "none", "wip",
+                "accepted", "temporary", "later", "see above", "-"}
+
+# ── 1. The ignore file must be wired to at least one scan ────────────────────
+FLAG = re.compile(r"--ignorefile[=\s]+(\S+)")
+
+
+def run_scripts(doc):
+    """Yield text in which a `--ignorefile <path>` reference may appear.
+
+    Two shapes wire an ignore file, and both must be seen or the gate reports a
+    file as unwired when it is not (or, worse, passes a workflow that dropped
+    the flag):
+
+      * a `run:` shell script passing `--ignorefile <path>` to the trivy binary;
+      * an action step whose `with:` carries the file as a dedicated input.
+
+    `args` is scanned for the flag rather than treated as a path — it is a free
+    -form command line, and other actions in this repository use `args` for
+    entirely unrelated things.
+    """
+    for job in (doc.get("jobs") or {}).values():
+        if not isinstance(job, dict):
+            continue
+        for step in (job.get("steps") or []):
+            if not isinstance(step, dict):
+                continue
+            if isinstance(step.get("run"), str):
+                yield step["run"]
+            with_ = step.get("with")
+            if not isinstance(with_, dict):
+                continue
+            if isinstance(with_.get("args"), str):
+                yield with_["args"]
+            # aquasecurity/trivy-action names it `trivyignores`, and accepts a
+            # comma-separated list.
+            for key in ("trivyignores", "ignorefile"):
+                val = with_.get(key)
+                if isinstance(val, str):
+                    for part in val.split(","):
+                        if part.strip():
+                            yield f"--ignorefile {part.strip()}"
+
+
+if not wf_dir.is_dir():
+    sys.exit(f"FAIL: {wf_dir} is not a directory — the scan target moved, refusing to report clean")
+
+wf_files = sorted(list(wf_dir.glob("*.yaml")) + list(wf_dir.glob("*.yml")))
+if not wf_files:
+    sys.exit(f"FAIL: no workflow files under {wf_dir} — refusing to report clean")
+
+referenced = set()
+for f in wf_files:
+    try:
+        doc = yaml.safe_load(f.read_text()) or {}
+    except yaml.YAMLError:
+        continue
+    if not isinstance(doc, dict):
+        continue
+    for script in run_scripts(doc):
+        for line in script.splitlines():
+            # A shell comment inside a run: block is documentation, not wiring.
+            if line.lstrip().startswith("#"):
+                continue
+            for m in FLAG.finditer(line):
+                referenced.add(m.group(1).strip("\"'"))
+
+if not referenced:
+    fail.append(
+        f"no workflow under {wf_dir} passes --ignorefile, so {ignore_path} is read by nothing.\n"
+        "      Entries in it would look accepted and suppress nothing."
+    )
+
+root = ignore_path.parent if str(ignore_path.parent) != "" else pathlib.Path(".")
+for ref in sorted(referenced):
+    # Workflow paths are repo-root-relative; resolve against the ignore file's root.
+    if not (root / ref).is_file() and not pathlib.Path(ref).is_file():
+        fail.append(f"a workflow passes --ignorefile {ref}, but no such file exists.")
+
+if referenced and ignore_path.name not in {pathlib.Path(r).name for r in referenced}:
+    fail.append(
+        f"{ignore_path} exists but no workflow references it "
+        f"(workflows reference: {', '.join(sorted(referenced))})."
+    )
+
+# ── 2. The ignore file itself ────────────────────────────────────────────────
+if not ignore_path.is_file():
+    fail.append(f"{ignore_path} does not exist, but a workflow passes it to --ignorefile.")
+    doc = {}
+else:
+    try:
+        doc = yaml.safe_load(ignore_path.read_text()) or {}
+    except yaml.YAMLError as e:
+        fail.append(f"{ignore_path} is not valid YAML: {e}")
+        doc = {}
+
+if not isinstance(doc, dict):
+    fail.append(f"{ignore_path} must be a mapping of section -> entries.")
+    doc = {}
+
+for key in doc:
+    if key not in KNOWN_SECTIONS:
+        fail.append(
+            f"{ignore_path}: unknown section '{key}'. Trivy ignores it silently, so every "
+            f"entry under it suppresses nothing. Known: {', '.join(sorted(KNOWN_SECTIONS))}."
+        )
+
+entries = 0
+for section in sorted(KNOWN_SECTIONS & set(doc)):
+    items = doc.get(section) or []
+    if not isinstance(items, list):
+        fail.append(f"{ignore_path}: section '{section}' must be a list.")
+        continue
+    for i, e in enumerate(items):
+        where = f"{ignore_path}: {section}[{i}]"
+        if not isinstance(e, dict):
+            fail.append(f"{where}: each entry must be a mapping with id/statement/expired_at.")
+            continue
+        entries += 1
+        vid = e.get("id")
+        if not isinstance(vid, str) or not vid.strip():
+            fail.append(f"{where}: missing 'id'.")
+            vid = f"<entry {i}>"
+
+        stmt = e.get("statement")
+        if not isinstance(stmt, str) or not stmt.strip():
+            fail.append(f"{where} ({vid}): missing 'statement' — say why this is accepted.")
+        else:
+            s = " ".join(stmt.split())
+            low = s.lower().rstrip(".")
+            if low in PLACEHOLDERS or re.match(r"^(todo|tbd|fixme|xxx)\b", low):
+                fail.append(f"{where} ({vid}): 'statement' is a placeholder ({s!r}).")
+            elif len(s) < min_statement:
+                fail.append(
+                    f"{where} ({vid}): 'statement' is {len(s)} chars, need >= {min_statement}. "
+                    "Say what the finding is, why it is accepted, and what would change that."
+                )
+
+        exp = e.get("expired_at")
+        if exp is None:
+            fail.append(
+                f"{where} ({vid}): missing 'expired_at' — an acceptance with no end date "
+                "is a permanent one."
+            )
+            continue
+        if isinstance(exp, datetime.datetime):
+            exp = exp.date()
+        elif isinstance(exp, str):
+            try:
+                exp = datetime.date.fromisoformat(exp.strip())
+            except ValueError:
+                fail.append(f"{where} ({vid}): 'expired_at' {exp!r} is not an ISO date (YYYY-MM-DD).")
+                continue
+        elif not isinstance(exp, datetime.date):
+            fail.append(f"{where} ({vid}): 'expired_at' must be a YYYY-MM-DD date, got {exp!r}.")
+            continue
+
+        if exp < today:
+            fail.append(
+                f"{where} ({vid}): 'expired_at' {exp} has lapsed. Trivy already stopped "
+                "honouring it, so the entry is dead weight — renew it deliberately or delete it."
+            )
+        elif (exp - today).days > max_days:
+            fail.append(
+                f"{where} ({vid}): 'expired_at' {exp} is {(exp - today).days} days out, "
+                f"limit is {max_days}. 'Accepted' must not mean 'forever'."
+            )
+
+if fail:
+    print("Container-scan ignore list is not reviewable:", file=sys.stderr)
+    for f_ in fail:
+        print(f"  - {f_}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print("Every accepted finding must say why (statement) and when the acceptance", file=sys.stderr)
+    print("lapses (expired_at), so the list cannot silently become permanent.", file=sys.stderr)
+    sys.exit(1)
+
+print(f"trivyignore ok ({entries} accepted finding(s), {len(wf_files)} workflow file(s) scanned)")
+PY
+}
+
+self_test() {
+	local tmp rc
+	tmp=$(mktemp -d)
+	trap 'rm -rf "$tmp"' RETURN
+	mkdir -p "$tmp/wf"
+	local future past far
+	future=$(python3 -c 'import datetime;print(datetime.date.today()+datetime.timedelta(days=30))')
+	past=$(python3 -c 'import datetime;print(datetime.date.today()-datetime.timedelta(days=1))')
+	far=$(python3 -c 'import datetime;print(datetime.date.today()+datetime.timedelta(days=400))')
+
+	# A workflow that wires the ignore file, in the shape the real ones use.
+	printf 'jobs:\n  scan:\n    steps:\n      - run: |\n          trivy image --ignorefile .trivyignore.yaml alpine\n' \
+		>"$tmp/wf/scan.yaml"
+
+	ok() { # <yaml-body> <label>
+		printf '%s' "$1" >"$tmp/.trivyignore.yaml"
+		check "$tmp/wf" "$tmp/.trivyignore.yaml" >/dev/null 2>&1 ||
+			{ echo "self-test FAIL: rejected $2" >&2; return 1; }
+	}
+	bad() { # <yaml-body> <label>
+		printf '%s' "$1" >"$tmp/.trivyignore.yaml"
+		rc=0; check "$tmp/wf" "$tmp/.trivyignore.yaml" >/dev/null 2>&1 || rc=$?
+		[ "$rc" -ne 0 ] || { echo "self-test FAIL: accepted $2" >&2; return 1; }
+	}
+
+	local good_stmt="Debian marks this will_not_fix; the affected code path is not linked in."
+
+	# ── Accepted shapes ──────────────────────────────────────────────────
+	ok "vulnerabilities: []
+" "an empty list (no exceptions is a valid state)" || return 1
+
+	ok "vulnerabilities:
+  - id: CVE-2023-45853
+    statement: \"$good_stmt\"
+    expired_at: $future
+" "a well-formed entry" || return 1
+
+	# Trivy accepts a quoted date too; both must pass.
+	ok "vulnerabilities:
+  - id: CVE-2023-45853
+    statement: \"$good_stmt\"
+    expired_at: \"$future\"
+" "a quoted ISO date" || return 1
+
+	# ── Rejected shapes. Each must fail ON ITS OWN, or one catch masks the rest.
+	bad "vulnerabilities:
+  - id: CVE-2023-45853
+    expired_at: $future
+" "an entry with no statement" || return 1
+
+	# Long enough to clear the length floor, so ONLY the placeholder rule can
+	# catch it. A short "TODO" would be rejected by the length check instead, and
+	# this case would pass while the placeholder rule was broken.
+	bad "vulnerabilities:
+  - id: CVE-2023-45853
+    statement: \"TODO: work out whether this one actually reaches us, sometime\"
+    expired_at: $future
+" "a placeholder statement long enough to clear the length floor" || return 1
+
+	bad "vulnerabilities:
+  - id: CVE-2023-45853
+    statement: accepted
+    expired_at: $future
+" "a bare placeholder statement" || return 1
+
+	bad "vulnerabilities:
+  - id: CVE-2023-45853
+    statement: not exploitable
+    expired_at: $future
+" "a statement below the length floor" || return 1
+
+	bad "vulnerabilities:
+  - id: CVE-2023-45853
+    statement: \"$good_stmt\"
+" "an entry with no expired_at" || return 1
+
+	bad "vulnerabilities:
+  - id: CVE-2023-45853
+    statement: \"$good_stmt\"
+    expired_at: $past
+" "a lapsed expired_at" || return 1
+
+	bad "vulnerabilities:
+  - id: CVE-2023-45853
+    statement: \"$good_stmt\"
+    expired_at: $far
+" "an expired_at parked beyond the limit" || return 1
+
+	bad "vulnerabilities:
+  - id: CVE-2023-45853
+    statement: \"$good_stmt\"
+    expired_at: someday
+" "an unparseable expired_at" || return 1
+
+	bad "vulnerabilities:
+  - statement: \"$good_stmt\"
+    expired_at: $future
+" "an entry with no id" || return 1
+
+	# A typo'd section suppresses nothing while looking configured.
+	bad "vulnerability:
+  - id: CVE-2023-45853
+    statement: \"$good_stmt\"
+    expired_at: $future
+" "an unknown top-level section" || return 1
+
+	# ── Wiring. Both ends, because neither proves the chain alone. ───────
+	printf 'vulnerabilities: []\n' >"$tmp/.trivyignore.yaml"
+
+	# No workflow passes --ignorefile: the file is read by nothing.
+	printf 'jobs:\n  scan:\n    steps:\n      - run: trivy image alpine\n' >"$tmp/wf/scan.yaml"
+	rc=0; check "$tmp/wf" "$tmp/.trivyignore.yaml" >/dev/null 2>&1 || rc=$?
+	[ "$rc" -ne 0 ] || { echo "self-test FAIL: accepted an ignore file no workflow reads" >&2; return 1; }
+
+	# Only a SHELL COMMENT mentions the flag — that is documentation, not wiring.
+	printf 'jobs:\n  scan:\n    steps:\n      - run: |\n          # we used to pass --ignorefile .trivyignore.yaml here\n          trivy image alpine\n' \
+		>"$tmp/wf/scan.yaml"
+	rc=0; check "$tmp/wf" "$tmp/.trivyignore.yaml" >/dev/null 2>&1 || rc=$?
+	[ "$rc" -ne 0 ] || { echo "self-test FAIL: a commented-out --ignorefile counted as wiring" >&2; return 1; }
+
+	# The action-input shape (aquasecurity/trivy-action `trivyignores:`) counts as
+	# wiring, including as one entry of a comma-separated list.
+	printf 'jobs:\n  scan:\n    steps:\n      - uses: aquasecurity/trivy-action@abc\n        with:\n          trivyignores: .trivyignore.yaml\n' \
+		>"$tmp/wf/scan.yaml"
+	check "$tmp/wf" "$tmp/.trivyignore.yaml" >/dev/null 2>&1 ||
+		{ echo "self-test FAIL: a trivyignores: action input did not count as wiring" >&2; return 1; }
+	printf 'jobs:\n  scan:\n    steps:\n      - uses: aquasecurity/trivy-action@abc\n        with:\n          trivyignores: "other.yaml,.trivyignore.yaml"\n' \
+		>"$tmp/wf/scan.yaml"
+	printf 'x\n' >"$tmp/other.yaml"
+	check "$tmp/wf" "$tmp/.trivyignore.yaml" >/dev/null 2>&1 ||
+		{ echo "self-test FAIL: a comma-separated trivyignores list did not count as wiring" >&2; return 1; }
+	rm -f "$tmp/other.yaml"
+
+	# An unrelated action's `args:` is a free-form command line, NOT a path. An
+	# earlier version treated the whole value as an ignore-file path and failed
+	# against the real repository, where other actions use `args` for their own
+	# purposes. It must be scanned for the flag, and count as wiring only if the
+	# flag is actually in it.
+	printf 'jobs:\n  a:\n    steps:\n      - uses: some/action@abc\n        with:\n          args: --config release\n      - run: |\n          trivy image --ignorefile .trivyignore.yaml alpine\n' \
+		>"$tmp/wf/scan.yaml"
+	check "$tmp/wf" "$tmp/.trivyignore.yaml" >/dev/null 2>&1 ||
+		{ echo "self-test FAIL: an unrelated action's args: was misread as an ignore-file path" >&2; return 1; }
+
+	# ...but a flag genuinely inside `args:` DOES count.
+	printf 'jobs:\n  a:\n    steps:\n      - uses: some/action@abc\n        with:\n          args: image --ignorefile .trivyignore.yaml alpine\n' \
+		>"$tmp/wf/scan.yaml"
+	check "$tmp/wf" "$tmp/.trivyignore.yaml" >/dev/null 2>&1 ||
+		{ echo "self-test FAIL: --ignorefile inside args: did not count as wiring" >&2; return 1; }
+
+	# The workflow points at a file that does not exist (a rename on either end).
+	printf 'jobs:\n  scan:\n    steps:\n      - run: |\n          trivy image --ignorefile .trivyignore-renamed.yaml alpine\n' \
+		>"$tmp/wf/scan.yaml"
+	rc=0; check "$tmp/wf" "$tmp/.trivyignore.yaml" >/dev/null 2>&1 || rc=$?
+	[ "$rc" -ne 0 ] || { echo "self-test FAIL: accepted a --ignorefile path that does not exist" >&2; return 1; }
+
+	# A missing or empty workflow dir must NOT report clean.
+	printf 'jobs:\n  scan:\n    steps:\n      - run: |\n          trivy image --ignorefile .trivyignore.yaml alpine\n' \
+		>"$tmp/wf/scan.yaml"
+	rc=0; check "$tmp/gone" "$tmp/.trivyignore.yaml" >/dev/null 2>&1 || rc=$?
+	[ "$rc" -ne 0 ] || { echo "self-test FAIL: a missing workflow directory reported clean" >&2; return 1; }
+	mkdir -p "$tmp/empty"
+	rc=0; check "$tmp/empty" "$tmp/.trivyignore.yaml" >/dev/null 2>&1 || rc=$?
+	[ "$rc" -ne 0 ] || { echo "self-test FAIL: an empty workflow directory reported clean" >&2; return 1; }
+
+	# A wired workflow with the ignore file deleted.
+	rm -f "$tmp/.trivyignore.yaml"
+	rc=0; check "$tmp/wf" "$tmp/.trivyignore.yaml" >/dev/null 2>&1 || rc=$?
+	[ "$rc" -ne 0 ] || { echo "self-test FAIL: a wired but missing ignore file reported clean" >&2; return 1; }
+
+	echo "check-trivyignore-entries self-test: ok"
+}
+
+if [ "${1:-}" = "--self-test" ]; then self_test; exit $?; fi
+if [ "$#" -eq 2 ]; then check "$1" "$2"; exit $?; fi
+cd "$(dirname "$0")/.."
+check ".github/workflows" ".trivyignore.yaml"

--- a/scripts/trivy-report.py
+++ b/scripts/trivy-report.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Turn Trivy JSON image reports into a review-ready Markdown summary.
+
+Used by .github/workflows/image-scan.yaml to build the job summary and the body
+of the container-CVE tracking issue.
+
+Two numbers matter and they are not the same number, which is the whole reason
+this exists rather than a `trivy --format table`:
+
+  * **Reported** — every finding with a fix available, at any severity. This is
+    what the scan publishes to the Security tab.
+  * **Would block** — the subset at or above the gate severity floor. This is
+    what a blocking gate WOULD fail on, shown for images that are deliberately
+    not gated, so "we chose not to gate this" stays a visible, revisitable
+    decision instead of a silent one.
+
+A finding with no fix available never appears in either. Trivy is invoked with
+--ignore-unfixed upstream of this script, so the input JSON already excludes
+them; the counts here are of what someone could actually act on today.
+
+The fingerprint is the sorted set of (image, vulnerability, package) triples that
+would block. The workflow compares it against the one recorded in the open issue
+so a daily re-run stays silent when nothing changed, and speaks up when the set
+moves. Without it a scheduled scan either spams a comment a day or goes unread.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+import sys
+
+SEVERITY_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN"]
+
+
+def load(path: pathlib.Path) -> list[dict]:
+    """Flatten a Trivy JSON report into a list of finding dicts."""
+    doc = json.loads(path.read_text())
+    out = []
+    for result in doc.get("Results") or []:
+        for v in result.get("Vulnerabilities") or []:
+            out.append(
+                {
+                    "id": v.get("VulnerabilityID", "?"),
+                    "pkg": v.get("PkgName", "?"),
+                    "severity": v.get("Severity", "UNKNOWN"),
+                    "installed": v.get("InstalledVersion", ""),
+                    "fixed": v.get("FixedVersion", ""),
+                    "type": result.get("Type", "?"),
+                }
+            )
+    return out
+
+
+def render(images: dict[str, list[dict]], floor: list[str]) -> tuple[str, str, int]:
+    """Return (markdown, fingerprint, blocking count) for an image -> findings map."""
+    lines: list[str] = []
+    blocking_all: list[tuple[str, str, str]] = []
+
+    lines.append("| Image | Reported (fixable) | Would block |")
+    lines.append("|---|---:|---:|")
+    for image in sorted(images):
+        findings = images[image]
+        blocking = [f for f in findings if f["severity"] in floor]
+        blocking_all += [(image, f["id"], f["pkg"]) for f in blocking]
+        lines.append(f"| `{image}` | {len(findings)} | {len(blocking)} |")
+    lines.append("")
+
+    for image in sorted(images):
+        blocking = [f for f in images[image] if f["severity"] in floor]
+        if not blocking:
+            continue
+        lines.append(f"### `{image}`")
+        lines.append("")
+        lines.append("| Severity | ID | Package | Installed | Fixed in |")
+        lines.append("|---|---|---|---|---|")
+        blocking.sort(key=lambda f: (SEVERITY_ORDER.index(f["severity"])
+                                     if f["severity"] in SEVERITY_ORDER else 99, f["id"]))
+        for f in blocking:
+            lines.append(
+                f"| {f['severity']} | {f['id']} | `{f['pkg']}` | "
+                f"`{f['installed']}` | `{f['fixed']}` |"
+            )
+        lines.append("")
+
+    fp = hashlib.sha256(
+        "\n".join(f"{i}|{v}|{p}" for i, v, p in sorted(set(blocking_all))).encode()
+    ).hexdigest()[:16]
+    return "\n".join(lines), fp, len(blocking_all)
+
+
+def self_test() -> int:
+    """Cases that must hold, each isolating one behaviour."""
+    import tempfile
+
+    def report(vulns):
+        return {"Results": [{"Type": "debian", "Vulnerabilities": vulns}]}
+
+    def v(vid, sev, pkg="p", fixed="1.1"):
+        return {"VulnerabilityID": vid, "Severity": sev, "PkgName": pkg,
+                "InstalledVersion": "1.0", "FixedVersion": fixed}
+
+    failures = []
+
+    def check(cond, msg):
+        if not cond:
+            failures.append(msg)
+
+    with tempfile.TemporaryDirectory() as td:
+        p = pathlib.Path(td) / "img.json"
+
+        # Severity floor selects the blocking subset, not the whole report.
+        p.write_text(json.dumps(report([v("CVE-1", "CRITICAL"), v("CVE-2", "MEDIUM")])))
+        md, fp1, n1 = render({"img": load(p)}, ["CRITICAL", "HIGH"])
+        check("| 2 | 1 |" in md, f"floor must report 2 and block 1, got:\n{md}")
+        check(n1 == 1, f"blocking count must be 1, got {n1}")
+        check("CVE-1" in md, "blocking finding must be listed")
+        check("CVE-2" not in md.split("###")[-1], "non-blocking finding must not be in the detail table")
+
+        # An empty report is clean, and its fingerprint is stable.
+        p.write_text(json.dumps({"Results": []}))
+        md_empty, fp_empty, n_empty = render({"img": load(p)}, ["CRITICAL", "HIGH"])
+        check("| 0 | 0 |" in md_empty, "an empty report must render zeroes")
+        check(n_empty == 0, f"empty blocking count must be 0, got {n_empty}")
+        _, fp_empty2, _ = render({"img": []}, ["CRITICAL", "HIGH"])
+        check(fp_empty == fp_empty2, "empty fingerprint must be stable")
+
+        # Fingerprint changes when the blocking set changes...
+        p.write_text(json.dumps(report([v("CVE-1", "CRITICAL"), v("CVE-3", "HIGH")])))
+        _, fp2, _ = render({"img": load(p)}, ["CRITICAL", "HIGH"])
+        check(fp1 != fp2, "fingerprint must change when the blocking set changes")
+
+        # ...and NOT when only a non-blocking finding changes. This is the
+        # property that keeps a daily scan from commenting every morning.
+        p.write_text(json.dumps(report([v("CVE-1", "CRITICAL"), v("CVE-9", "LOW")])))
+        _, fp3, _ = render({"img": load(p)}, ["CRITICAL", "HIGH"])
+        p.write_text(json.dumps(report([v("CVE-1", "CRITICAL"), v("CVE-8", "LOW")])))
+        _, fp4, _ = render({"img": load(p)}, ["CRITICAL", "HIGH"])
+        check(fp3 == fp4, "fingerprint must ignore findings below the floor")
+
+        # Ordering of Trivy's output must not move the fingerprint.
+        p.write_text(json.dumps(report([v("CVE-3", "HIGH"), v("CVE-1", "CRITICAL")])))
+        _, fp5, _ = render({"img": load(p)}, ["CRITICAL", "HIGH"])
+        check(fp2 == fp5, "fingerprint must be order-independent")
+
+        # Multiple results sections in one report are all read. A Trivy image
+        # report has one section per package type; reading only the first would
+        # silently drop every language-package finding.
+        p.write_text(json.dumps({"Results": [
+            {"Type": "debian", "Vulnerabilities": [v("CVE-1", "CRITICAL")]},
+            {"Type": "python-pkg", "Vulnerabilities": [v("CVE-4", "HIGH")]},
+        ]}))
+        md_multi, _, n_multi = render({"img": load(p)}, ["CRITICAL", "HIGH"])
+        check("| 2 | 2 |" in md_multi, f"both result sections must be read, got:\n{md_multi}")
+        check(n_multi == 2, f"both sections must count toward blocking, got {n_multi}")
+
+        # A section with a null Vulnerabilities list is normal for a clean type.
+        p.write_text(json.dumps({"Results": [{"Type": "debian", "Vulnerabilities": None}]}))
+        check(load(p) == [], "a null Vulnerabilities list must read as no findings")
+
+    if failures:
+        for f in failures:
+            print(f"self-test FAIL: {f}", file=sys.stderr)
+        return 1
+    print("trivy-report self-test: ok")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("reports", nargs="*", type=pathlib.Path,
+                    help="Trivy JSON reports; the file stem names the image.")
+    ap.add_argument("--gate-severity", default="CRITICAL,HIGH",
+                    help="Severity floor a blocking gate would use.")
+    ap.add_argument("--fingerprint-out", type=pathlib.Path,
+                    help="Write the blocking-set fingerprint here.")
+    ap.add_argument("--blocking-count-out", type=pathlib.Path,
+                    help="Write the number of would-block findings here.")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.reports:
+        ap.error("no reports given")
+
+    floor = [s.strip().upper() for s in args.gate_severity.split(",") if s.strip()]
+    images = {}
+    for path in args.reports:
+        if not path.is_file():
+            print(f"missing report: {path} — refusing to report clean", file=sys.stderr)
+            return 1
+        images[path.stem] = load(path)
+
+    md, fp, blocking = render(images, floor)
+    if args.fingerprint_out:
+        args.fingerprint_out.write_text(fp)
+    if args.blocking_count_out:
+        args.blocking_count_out.write_text(str(blocking))
+    print(md)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/website/content/contribute/_index.md
+++ b/website/content/contribute/_index.md
@@ -37,4 +37,10 @@ How to work on Leoflow itself.
     <span class="lf-card__desc">The two rules — private locality and masked-on-read — every feature that touches a credential must follow (<a href="/project/adrs/0061-secret-locality/">ADR 0061</a>).</span>
     <span class="lf-card__more">Read the rules →</span>
   </a>
+  <a class="lf-card" href="/contribute/image-vulnerability-scanning/">
+    <span class="lf-card__icon"><i class="fa-solid fa-shield-halved"></i></span>
+    <span class="lf-card__title">Image scanning</span>
+    <span class="lf-card__desc">Where container CVE findings appear, what blocks a build and what only opens an issue, and how to triage either one.</span>
+    <span class="lf-card__more">Read the policy →</span>
+  </a>
 </div>

--- a/website/content/contribute/image-vulnerability-scanning.md
+++ b/website/content/contribute/image-vulnerability-scanning.md
@@ -10,13 +10,28 @@ packages in `python:3.x-slim-bookworm`, or about a third-party Go binary baked
 into someone else's image. Those are scanned separately, by
 [Trivy](https://trivy.dev/), under the policy on this page.
 
+The second gap is the easier one to misread, so state it precisely. Take
+`golang-migrate`: it **is** in our `go.mod` and govulncheck does see it, resolved
+against **our** MVS versions and **our** toolchain. What govulncheck cannot see
+is what upstream vendored into the release binary shipped inside
+`migrate/migrate` — a different dependency set, frozen at their build. That is
+where 48 of the 50 fixable CRITICAL/HIGH findings in `leoflow-migrate` live
+(`usr/local/bin/migrate`). A dependency being covered by govulncheck therefore
+says nothing about the third-party *binary* of the same name in an image we
+pull, and the Lite path that runs that image is covered here, not there.
+
 ## What gets scanned, and what happens when it finds something
 
 | Image | Built from | Scan | Fails a build? |
 |---|---|---|---|
-| `leoflow-server` | `deploy/Dockerfile.server` | Every PR and push, in [`security.yaml`](https://github.com/neochaotic/leoflow/blob/main/.github/workflows/security.yaml) | **Yes** |
-| `leoflow-runtime` (py3.10/3.11/3.12) | `runtime/Dockerfile` | Daily, in [`image-scan.yaml`](https://github.com/neochaotic/leoflow/blob/main/.github/workflows/image-scan.yaml) | No — opens an issue |
+| `leoflow-server` | `deploy/Dockerfile.server.release` | Every PR and push, in [`security.yaml`](https://github.com/neochaotic/leoflow/blob/main/.github/workflows/security.yaml) | **Yes** |
+| `leoflow-runtime` (one leg per published Python line) | `runtime/Dockerfile` | Daily, in [`image-scan.yaml`](https://github.com/neochaotic/leoflow/blob/main/.github/workflows/image-scan.yaml) | No — opens an issue |
 | `leoflow-migrate` | `deploy/Dockerfile.migrate` | Daily, in `image-scan.yaml` | No — opens an issue |
+
+"Fails a build" means the job goes red. Whether that *blocks a merge* is a
+branch-protection setting: a new job is not a required check by default, so the
+`Trivy (leoflow-server image)` check has to be added to the protected-branch
+rules before it can stop anything from merging.
 
 The split is deliberate, and it is about **who can fix the finding**.
 
@@ -24,6 +39,24 @@ The split is deliberate, and it is about **who can fix the finding**.
 from this repository. There is no inherited OS package set, so a finding there
 was introduced by a commit and is closed by a `go get`. Blocking the PR that
 introduced it puts the work in front of the person who can do it.
+
+That argument only holds if the gate scans the artifact we publish, so it does.
+`deploy/Dockerfile.server` — which compiles from source inside a floating
+`golang:1.x-bookworm` — is the developer and kind-cluster convenience path;
+GoReleaser publishes `deploy/Dockerfile.server.release`, which copies in a binary
+built by the release workflow's pinned `GO_VERSION`. The gate reproduces that
+recipe and scans the result. This matters more than it looks: Trivy keys
+`stdlib` findings to the Go toolchain recorded in the binary's build info, so a
+gate compiling with a different toolchain reports a different vulnerability set
+— and a floating build tag would also mean a stdlib CVE closed by a base rebuild
+rather than by a `go get`, reddening the blocking gate for whoever opened the
+next unrelated PR.
+
+The gate still builds **HEAD's** binary rather than pulling a published tag, and
+the daily scan likewise builds the runtime and migrate images from the checkout.
+So a CVE in an already-published image that HEAD no longer produces does not
+appear in either. Scan the tag directly when that is the question — Trivy reads
+a remote reference with no local build.
 
 The other two inherit package sets we do not author — Debian for the task
 runtime, Alpine plus a pinned third-party binary for the migrator. A CVE lands
@@ -60,20 +93,23 @@ stop opening the tab. The complete unfiltered scan is attached to every
 ## Where findings appear
 
 - **Security tab → Code scanning.** Every fixable finding, at every severity,
-  under one category per image: `trivy-server-image`, `trivy-image-runtime-py310`
-  / `-py311` / `-py312`, `trivy-image-migrate`. Uploaded from `main` and from
-  scheduled runs only — a PR upload would overwrite the branch baseline.
+  under one category per image: `trivy-server-image`, one
+  `trivy-image-runtime-pyXYZ` per published Python line, and
+  `trivy-image-migrate`. Uploaded from `main` and from scheduled runs only — a
+  PR upload would overwrite the branch baseline.
 - **The failing check**, for `leoflow-server`: the job prints the table of
   fixable CRITICAL/HIGH findings that failed it.
 - **A single tracking issue**, titled *Container image CVEs: fixable findings in
   published images*, for the runtime and migrate images. The daily scan
   refreshes its body, comments only when the set of findings actually changes,
-  and closes it when the list empties. One issue, always current — not one issue
-  per run, and not a comment a day.
+  closes it when the list empties, and **reopens that same issue** — rather than
+  filing a second one — if the findings come back. One issue, always current.
+  If you reopen it yourself, the scan leaves it alone: it checks who performed
+  the last reopen and will not close a human's out from under them.
 - **The job summary** of any `image-scan` run, including on a PR that touches
-  `runtime/**`, `deploy/Dockerfile.migrate`, `migrations/**`, or `go.mod`. On a
-  PR it reports and stays green, so you can see what your change did to the
-  image without being blocked by what was already there.
+  `runtime/**`, `deploy/Dockerfile.migrate`, `migrations/**`, `go.mod`, or the
+  authoring schema. On a PR it reports and stays green, so you can see what your
+  change did to the image without being blocked by what was already there.
 
 ## Triaging a finding
 
@@ -114,9 +150,26 @@ Both fields are mandatory and CI enforces them
   rejects an already-lapsed entry, so dead weight is renewed deliberately or
   deleted rather than left for the next reader to decode.
 
-The same gate checks the other end of the chain: that a workflow actually passes
-the file to `--ignorefile`. A renamed ignore file or a dropped flag would
-otherwise leave entries that look accepted and suppress nothing.
+The same gate checks the other end of the chain, per scan: **every** step that
+runs a trivy scan must pass the file, through `--ignorefile`, the action's
+`trivyignores:` input, or `TRIVY_IGNOREFILE`. A renamed ignore file or a flag
+dropped from one workflow would otherwise leave entries that look accepted and
+suppress nothing, and asking only whether *some* workflow still passes it is a
+question the repository keeps answering "yes" to while the gate that matters has
+gone unfiltered.
+
+A scan that must apply no suppressions says so where it runs, with a reason the
+gate length-checks:
+
+```yaml
+# trivy-ignorefile-exempt: this is the unsuppressed copy of record — applying
+# .trivyignore.yaml here would make the accepted findings unrecoverable.
+- name: Full unfiltered inventory
+```
+
+Two scans are exempt today: that inventory, and the repository `trivy fs` scan,
+whose findings come from our own module graph rather than from a base image
+nobody here authored.
 
 ## Changing a base image
 
@@ -128,9 +181,18 @@ problem; it does not tell you which base to move to.
 
 ## Running a scan locally
 
+`GO_VERSION` is not optional in either recipe below. `runtime/Dockerfile`
+defaults it to an older line than CI uses, and the agent binary baked into the
+image carries the toolchain it was built with — which is exactly what Trivy keys
+`stdlib` findings to. Omit the build arg and you scan a binary CI never builds.
+Take the value from `env.GO_VERSION` in
+[`.github/workflows/image-scan.yaml`](https://github.com/neochaotic/leoflow/blob/main/.github/workflows/image-scan.yaml)
+(`1.26.6` at the time of writing).
+
 ```bash
 # Build and scan the task runtime base as CI does.
-docker build -f runtime/Dockerfile --build-arg PYTHON_VERSION=3.11 \
+docker build -f runtime/Dockerfile \
+  --build-arg PYTHON_VERSION=3.11 --build-arg GO_VERSION=1.26.6 \
   -t leoflow-runtime:py3.11 .
 
 trivy image --scanners vuln --ignore-unfixed \
@@ -142,5 +204,21 @@ trivy image --scanners vuln --ignore-unfixed \
   --severity CRITICAL,HIGH --exit-code 1 leoflow-runtime:py3.11
 ```
 
-Trivy scans a remote reference too, so a published image needs no local build:
+The control-plane image is the one the release publishes, so reproduce the
+GoReleaser recipe rather than building `deploy/Dockerfile.server`:
+
+```bash
+mkdir -p dist/image-scan-context
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" \
+  -o dist/image-scan-context/leoflow-server ./cmd/leoflow-server
+docker build -f deploy/Dockerfile.server.release \
+  -t leoflow-server:local dist/image-scan-context
+
+trivy image --scanners vuln --ignore-unfixed \
+  --ignorefile .trivyignore.yaml \
+  --severity CRITICAL,HIGH --exit-code 1 leoflow-server:local
+```
+
+Trivy scans a remote reference too, so a published image needs no local build,
+and this is the only way to see what an *already-published* tag carries:
 `trivy image ghcr.io/neochaotic/leoflow-runtime:py3.11`.

--- a/website/content/contribute/image-vulnerability-scanning.md
+++ b/website/content/contribute/image-vulnerability-scanning.md
@@ -1,0 +1,146 @@
+---
+title: "Container image vulnerability scanning"
+linkTitle: "Image scanning"
+weight: 50
+description: "Where container CVE findings appear, what blocks a build and what only opens an issue, and how to triage either one."
+---
+
+`govulncheck` reads our Go module graph. It says nothing about the Debian
+packages in `python:3.x-slim-bookworm`, or about a third-party Go binary baked
+into someone else's image. Those are scanned separately, by
+[Trivy](https://trivy.dev/), under the policy on this page.
+
+## What gets scanned, and what happens when it finds something
+
+| Image | Built from | Scan | Fails a build? |
+|---|---|---|---|
+| `leoflow-server` | `deploy/Dockerfile.server` | Every PR and push, in [`security.yaml`](https://github.com/neochaotic/leoflow/blob/main/.github/workflows/security.yaml) | **Yes** |
+| `leoflow-runtime` (py3.10/3.11/3.12) | `runtime/Dockerfile` | Daily, in [`image-scan.yaml`](https://github.com/neochaotic/leoflow/blob/main/.github/workflows/image-scan.yaml) | No — opens an issue |
+| `leoflow-migrate` | `deploy/Dockerfile.migrate` | Daily, in `image-scan.yaml` | No — opens an issue |
+
+The split is deliberate, and it is about **who can fix the finding**.
+
+`leoflow-server` is `gcr.io/distroless/static-debian12` plus a Go binary built
+from this repository. There is no inherited OS package set, so a finding there
+was introduced by a commit and is closed by a `go get`. Blocking the PR that
+introduced it puts the work in front of the person who can do it.
+
+The other two inherit package sets we do not author — Debian for the task
+runtime, Alpine plus a pinned third-party binary for the migrator. A CVE lands
+in them because a distro security team published an advisory, on a day when
+nobody here pushed anything. A blocking gate on those fails whoever opens the
+next unrelated PR, and the person who can actually fix it (by rebasing a base
+image or bumping a pin) is not in that PR. That gate gets switched off within a
+week — and switched off is worse than never installed, because it still looks
+like coverage. So they are reported instead, loudly and on a schedule.
+
+## The two filters, and why fixability comes first
+
+Both scans apply the same policy:
+
+1. **Fixable only** (`--ignore-unfixed`). Debian stable permanently carries CVEs
+   that are not fixed there and never will be. Severity tells you how bad a
+   finding is; fixability tells you whether anyone can do anything about it
+   today. Only the second works as a gate criterion, because a policy that
+   cannot be satisfied is a policy that gets deleted. On
+   `leoflow-runtime:py3.11` this filter takes 273 findings down to 14 — and
+   removes all five CRITICALs, every one of which is marked `will_not_fix`,
+   `fix_deferred`, or `affected` upstream.
+2. **A severity floor of CRITICAL/HIGH**, applied *after* fixability, for the
+   blocking decision only.
+
+Everything fixable is **reported** at every severity; only fixable CRITICAL/HIGH
+**blocks** (on `leoflow-server`) or **is tracked in the issue** (on the others).
+
+Unfixed findings are left out of the Security tab as well as the gate. An alert
+nobody can ever close is not visibility — it is noise that teaches people to
+stop opening the tab. The complete unfiltered scan is attached to every
+`image-scan` run as the `trivy-image-reports` artifact, kept 30 days.
+
+## Where findings appear
+
+- **Security tab → Code scanning.** Every fixable finding, at every severity,
+  under one category per image: `trivy-server-image`, `trivy-image-runtime-py310`
+  / `-py311` / `-py312`, `trivy-image-migrate`. Uploaded from `main` and from
+  scheduled runs only — a PR upload would overwrite the branch baseline.
+- **The failing check**, for `leoflow-server`: the job prints the table of
+  fixable CRITICAL/HIGH findings that failed it.
+- **A single tracking issue**, titled *Container image CVEs: fixable findings in
+  published images*, for the runtime and migrate images. The daily scan
+  refreshes its body, comments only when the set of findings actually changes,
+  and closes it when the list empties. One issue, always current — not one issue
+  per run, and not a comment a day.
+- **The job summary** of any `image-scan` run, including on a PR that touches
+  `runtime/**`, `deploy/Dockerfile.migrate`, `migrations/**`, or `go.mod`. On a
+  PR it reports and stays green, so you can see what your change did to the
+  image without being blocked by what was already there.
+
+## Triaging a finding
+
+**Fix it, if the fix is ours.** A Go dependency in `leoflow-server` is a
+`go get`. A Python package in the task runtime is a pin in
+`runtime/python/pyproject.toml`. A CVE in the Alpine or Go layers of
+`leoflow-migrate` is a bump of the `FROM migrate/migrate:` pin in
+`deploy/Dockerfile.migrate`. This is the expected outcome for most findings, and
+Dependabot already opens PRs for the base images weekly.
+
+**Wait for it, if the fix is upstream's.** An unfixed Debian CVE needs no action
+and will not be reported — that is what the fixability filter is for. If it
+later becomes fixable, it appears on the next daily run.
+
+**Accept it, if it genuinely does not apply.** Add an entry to
+`.trivyignore.yaml` in the PR that argues for it:
+
+```yaml
+vulnerabilities:
+  - id: CVE-2023-45853
+    statement: >-
+      zlib1g in Debian bookworm; upstream marked will_not_fix. Reachable only
+      through MiniZip, which nothing in the task runtime links against.
+      Re-evaluate when the base moves off bookworm (#NNN).
+    expired_at: 2026-12-31
+```
+
+Both fields are mandatory and CI enforces them
+(`scripts/check-trivyignore-entries.sh`):
+
+- **`statement`** must be a real explanation, not `TODO`. Say what the finding
+  is, why it is accepted, and what would change that — for someone who finds the
+  line in eighteen months with no other context.
+- **`expired_at`** must be a future date no more than 180 days out. Trivy
+  enforces it itself: once the date passes it stops honouring the entry and the
+  finding comes back. That makes the result of neglect *the finding returns*,
+  which is the only safe default for an ignore list. The gate additionally
+  rejects an already-lapsed entry, so dead weight is renewed deliberately or
+  deleted rather than left for the next reader to decode.
+
+The same gate checks the other end of the chain: that a workflow actually passes
+the file to `--ignorefile`. A renamed ignore file or a dropped flag would
+otherwise leave entries that look accepted and suppress nothing.
+
+## Changing a base image
+
+Not from this policy, and not from a scan result alone. Which base
+`leoflow-runtime` ships is an authoring-surface decision — users pin it through
+`base_image` in `leoflow.yaml`, so our choice becomes theirs for years. It is
+argued separately, on its own evidence. Detection tells you a base has a
+problem; it does not tell you which base to move to.
+
+## Running a scan locally
+
+```bash
+# Build and scan the task runtime base as CI does.
+docker build -f runtime/Dockerfile --build-arg PYTHON_VERSION=3.11 \
+  -t leoflow-runtime:py3.11 .
+
+trivy image --scanners vuln --ignore-unfixed \
+  --ignorefile .trivyignore.yaml leoflow-runtime:py3.11
+
+# Just what a blocking gate would fail on.
+trivy image --scanners vuln --ignore-unfixed \
+  --ignorefile .trivyignore.yaml \
+  --severity CRITICAL,HIGH --exit-code 1 leoflow-runtime:py3.11
+```
+
+Trivy scans a remote reference too, so a published image needs no local build:
+`trivy image ghcr.io/neochaotic/leoflow-runtime:py3.11`.


### PR DESCRIPTION
`govulncheck` reads our Go module graph. It says nothing about the Debian packages inside `python:3.x-slim-bookworm`, nor about a third-party Go binary baked into someone else's image. That is the gap that let a class of vulnerability reach a human before it reached CI.

This PR is **detection only**. No base image changes.

> **Review round 2.** Rebased onto `main` after #1037; the CHANGELOG entry sits in the new `[Unreleased]`, not the cut `[0.4.5]`. Both blockers fixed — the gate now builds the Dockerfile GoReleaser publishes with the release toolchain (B1), and the ignore-file wiring is asserted **per trivy invocation** rather than per repository (B2). Also in: the tracking issue is looked up by title across every state (it used to duplicate itself monthly) and stands down when a human reopens it; `image-scan.yaml` gets a `concurrency:` group; the daily scan reads the published Python lines from the schema enum, so `py3.13` is no longer unscanned; `MIN_SELFTESTS` raised to 9; the local-run recipe passes `--build-arg GO_VERSION`. Claim corrections are folded into the text below.

## The policy, and why it is shaped this way

A Debian base permanently carries CVEs that are unfixed in stable and never will be fixed there. A naive "fail on any HIGH" is unsatisfiable on day one, so it gets disabled within a week — and disabled is worse than absent, because it still looks like coverage. Two filters and one split make it survivable.

**1. Fixability before severity.** Severity says how bad a finding is; fixability says whether anyone can act on it today. Only the second works as a gate criterion. On `leoflow-runtime:py3.11`, `--ignore-unfixed` takes **273 findings → 14**, and removes **all five CRITICALs** — every one marked `will_not_fix`, `fix_deferred` or `affected` upstream in bookworm. That is the entire argument in one number.

**2. A severity floor of CRITICAL/HIGH**, applied *after* fixability, for the blocking decision only. Everything fixable is still reported at every severity.

**3. Blocking is split by who can fix the finding**, not by how bad it is:

| Image | Base | When | Blocks? |
|---|---|---|---|
| `leoflow-server` | distroless + our `go.mod` binary | every PR + push | **Yes** — job goes red |
| `leoflow-runtime` (one leg per published Python line) | `python:3.x-slim-bookworm` | daily | No — tracking issue |
| `leoflow-migrate` | `migrate/migrate` (Alpine + vendored Go) | daily | No — tracking issue |

`leoflow-server` has no inherited OS package set: every finding is caused by a commit and closed by a `go get`, so blocking puts the work in front of the person who can do it. **That only holds if the gate scans the artifact we publish**, so it does: it reproduces the GoReleaser recipe — the pinned release toolchain, `CGO_ENABLED=0 -trimpath` — and builds `deploy/Dockerfile.server.release`, the Dockerfile `.goreleaser.yaml` points at. Building `deploy/Dockerfile.server` instead would compile inside a floating `golang:1.x-bookworm` (`go1.27.1` today against the release's `go1.26.6`), and Trivy keys `stdlib` findings to the toolchain in the binary's build info — so it would scan a different vulnerability set, and a stdlib CVE there would be closed by a base rebuild rather than a `go get`, reddening the blocking gate for whoever opened the next unrelated PR. **"Blocks" here means the job goes red**; making it stop a merge needs the check added to the branch-protection rules, which a new job is not by default. The other two inherit package sets we do not author — a CVE lands because a distro security team published an advisory, on a day nobody here pushed anything. Blocking those fails whoever opens the next unrelated PR while the person who can fix it is elsewhere. They get a **daily scan, a SARIF upload, and one self-closing tracking issue** whose body refreshes each run and which comments only when the finding set actually changes (a daily scan that notifies daily is a daily scan nobody reads). That issue is found by title across every state, so a closed one is reopened rather than duplicated, and the scan checks who performed the last reopen before closing — it will not close an issue a maintainer reopened out from under them. The step is `continue-on-error` with an `ERR` trap, so a token without `issues: write` warns instead of reddening a workflow whose header promises it never fails the build.

The daily job builds those images **from the checkout**; it pulls no published tag, and is named for that. A base CVE in an already-published `py3.11` that HEAD no longer produces is invisible to it — `trivy image ghcr.io/…:py3.11` answers that question directly, with no build. Which Python lines it scans comes from the `python_version` enum, the single source of truth since #1031, and a first step fails the run if that enum and the per-line SARIF upload steps disagree.

**Visibility over blocking:** every fixable finding goes to the Security tab, one code-scanning category per image. Unfixed findings are excluded from SARIF too — an alert nobody can ever close is not visibility, it is noise that teaches people to stop opening the tab. The full unfiltered inventory is kept as a 30-day build artifact so no filter here is the only copy of the data.

## Scanner choice: Trivy

The repo already runs `aquasecurity/trivy-action` for the filesystem scan, and `security.yaml` carried a `Container image scanning returns once deploy/Dockerfile.server exists` TODO — that file exists now, and the TODO is retired with this change. Beyond continuity: Trivy resolves Debian's `will_not_fix` / `fix_deferred` status (which is what makes `--ignore-unfixed` trustworthy here rather than a guess), reads OS packages, language packages **and Go binaries** in one pass — the last of which is what surfaced the migrate finding below, and which a pure OS scanner would have missed entirely — emits SARIF natively, and supports a native `expired_at` on ignore entries. Grype is a reasonable scanner but has no equivalent self-expiring ignore mechanic, which is the load-bearing piece of the policy below.

## The ignore list cannot silently become permanent

`.trivyignore.yaml` ships with **zero entries** — the honest state, since the blocking gate is green and the reported images are not suppressed. The mechanism is in place *before* the first exception, which is the only time it can be designed calmly instead of under a red build.

Trivy enforces `expired_at` itself: once the date passes it stops honouring the entry and the finding returns. **Verified against Trivy 0.72** — future-dated suppresses, lapsed does not. That makes the result of neglect *the finding comes back*.

Trivy does not require an entry to have an expiry or a rationale at all, which makes the permanent unexplained entry the easiest one to write. `scripts/check-trivyignore-entries.sh` (new CI gate, with `--self-test`) rejects:

- a missing or placeholder `statement`, or one below a length floor
- a missing, unparseable, already-lapsed, or beyond-180-day `expired_at`
- a top-level section name Trivy would silently ignore (a typo'd `vulnerability:` suppresses nothing while looking configured)
- **and the other end of the chain, per scan** — that **every** step running a trivy scan passes the file, through `--ignorefile`, the action's `trivyignores:` input, or `TRIVY_IGNOREFILE`. Asking only whether *some* workflow still references it is a question a repository keeps answering "yes" to while the gate that matters has quietly gone unfiltered: dropping `trivyignores:` from the blocking gate alone used to give rc=0, because the daily scan still had it. Proving one end does not prove the chain, and proving one link does not prove the others.

Shell lines are read with `\`-continuations joined and comments dropped, and `trivy` counts only in command position — `install /tmp/trivy /usr/local/bin/trivy` installs the scanner, `trivy image --download-db-only` warms a database, `trivy convert` re-renders an already-filtered report, and none of the three is a scan. An unrecognised subcommand **fails closed**: a gate that shrugs at what it cannot parse is the failure mode the file exists to prevent.

A scan that must apply no suppressions declares itself where it runs, with a length-checked reason:

```yaml
# trivy-ignorefile-exempt: this is the unsuppressed copy of record — applying
# .trivyignore.yaml here would make the accepted findings unrecoverable.
- name: Full unfiltered inventory
```

Two scans are exempt: that inventory, and the repository `trivy fs` gate, whose findings come from our own module graph rather than a base image nobody here authored.

That wiring check found a real defect in its own first draft: it read any action's free-form `args:` input as an ignore-file path and failed against the real repo. Fixed, and the shape is now a self-test case.

The self-test is **mutation-tested**: nine guards disabled one at a time, **nine go red**. Three of them survived the first pass and were not accepted as redundant — each turned out to be masked by a *different* rule firing (`len(None)` raising, or "no trivy scan anywhere" catching a case the test meant to attribute elsewhere), so the fixtures were rewritten until each case fails for the reason it claims. The nine cover the per-invocation assertion, the exemption reason floor, the YAML end-mark bleed that would let one step's exemption excuse the step above it, fail-closed classification, continuation joining, command position, database-warming flags, `TRIVY_IGNOREFILE`, and "every scan exempt means the file is read by nothing".

`scripts/check-script-selftests.sh` now discovers Python self-tests alongside shell ones, by the same discovery-by-existence rule it already documents, so `scripts/trivy-report.py` is covered by the gate that already covers the `check-*` scripts. It reports **9 self-tests passing**, and the `MIN_SELFTESTS` floor was raised to 9 to match.

## What the scanner says about our images TODAY

Real scans of the published `v0.4.5` images, fixable findings only:

| Image | Total findings | Fixable | **Would block (fixable C/H)** |
|---|---:|---:|---:|
| `leoflow-server:v0.4.5` | 1 | 0 | **0** |
| `leoflow-runtime:py3.10` | 274 | 15 | **2** |
| `leoflow-runtime:py3.11` | 273 | 14 | **2** |
| `leoflow-runtime:py3.12` | 270 | 11 | **0** |
| `leoflow-migrate:v0.4.5` | 87 | 84 | **50** |

**The blocking gate is green on day one.** `leoflow-server` reports nothing under the policy, so it starts clean and any red is a real regression.

**The runtime base is boring, which is the point.** 5 CRITICALs on every leg, all unfixed Debian (`zlib1g` `will_not_fix`, `perl-base` ×3, `libsqlite3-0`). Nothing to do, and the policy correctly says nothing. What *is* actionable is small: `jaraco.context` 5.3.0→6.1.0 and `wheel` 0.45.1→0.46.2 on py3.10/3.11 — both pip packages, both absent from py3.12, so the matrix legs have drifted. Also fixable but below the floor: `pip` 24.0 (5 MEDIUM), `setuptools`, and `libpcre2-8-0` 10.42-1→10.42-1+deb12u1, an OS package that is fixable and would clear on a rebuild — `runtime/Dockerfile` never runs `apt-get upgrade`, so it inherits whatever the base shipped with.

**The unexpected result — and the reason this was worth doing:** `leoflow-migrate` has **50 fixable CRITICAL/HIGH**, and none of it is Debian noise. It is the third-party Go binary inside `migrate/migrate:v4.19.1`, built with Go 1.25.4:

- **CRITICAL** — `pgx/v5` v5.5.4 (×2), `golang.org/x/crypto` v0.45.0, `google.golang.org/grpc` v1.74.2, Go `stdlib` v1.25.4
- **HIGH ×45** — 20 more `stdlib`, 9 `x/crypto`, 5 `x/net`, 4 `grpc`, 3 `otel`, `go-jose`, `x/text`, plus 2 Alpine `musl`

`govulncheck` structurally cannot see any of this — and the precise reason matters, because the loose version of it is wrong. `golang-migrate` **is** in our `go.mod` and govulncheck does see it, resolved against **our** MVS versions and toolchain. What it cannot see is what upstream vendored into their release binary: 48 of the 50 findings sit in `usr/local/bin/migrate`. The Lite path that runs that image is covered here, not there. The image nobody was worried about is the one on fire, and the fix is ours to make — bump the `FROM migrate/migrate:` pin in `deploy/Dockerfile.migrate`, or build the migrator on our own base. **That is out of scope here** (this PR is detection), and it is exactly what the tracking issue is for: the first scheduled run will open it with this table.

So the honest day-one summary: **the gate that blocks is green, and the scan that reports immediately finds a real, fixable, previously-invisible problem.** That is the shape a scanner should have on the day you install it.

## Conventions

- Pinned action SHAs with version comments; reuses the SHAs already in the tree.
- Job-level minimal `permissions`; `security-events: write` only where SARIF is uploaded. `issues: write` is held by `image-scan.yaml`'s single job on **schedule, push and pull_request alike** — `permissions:` takes no expression, so only the steps are guarded by `github.event_name != 'pull_request'`.
- `timeout-minutes` on every job.
- SARIF upload is skipped on `pull_request`, matching the `#437` note in `security.yaml` about PR runs overwriting the main-branch baseline under a shared category.
- Trivy is installed from a pinned GitHub release tarball with retries in the new workflow, mirroring the `gitleaks` step's reasoning (no Docker Hub, no shared-IP rate limit). `scripts/check-service-image-registry.sh` passes.
- No YAML anchors — `actionlint` resolves them but GitHub Actions does not support them; the duplicated `paths:` lists are commented as deliberate.

## Verification

- `actionlint` (with `shellcheck`) clean on every workflow; `shellcheck` clean on the new script.
- All repo `check-*.sh` gates pass; `check-script-selftests.sh` reports 9/9 and its floor was raised to match.
- Scan → `trivy convert` → SARIF → report pipeline dry-run end-to-end against the real published images with the real ignorefile; SARIF validated as 2.1.0.
- The server gate's new build path run locally: the image embeds `go1.26.6` (the release toolchain), and Trivy 0.72 reports **1 total finding, 0 fixable, 0 would-block** on it — the same numbers as the published `v0.4.5` image, so the gate stays green after the change.
- `check-trivyignore-entries.sh`'s per-scan assertion mutation-tested: nine guards disabled one at a time, **nine go red**, including the literal review mutation (drop `trivyignores:` from the blocking gate while the daily scan keeps it), which the previous shape passed.
- The tracking-issue script driven against a stubbed `gh` over all eight paths — create, quiet update, changed-fingerprint comment, reopen-instead-of-duplicate, close, and the human-reopen case where it now stands down.

