### PR TITLE
feat(runtime): publish a py3.13 task base, deprecate py3.10, and make the published-Python list singular

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1152,6 +1152,25 @@ jobs:
         run: bash scripts/check-lite-prepull-matches-compose.sh
 
   # ─────────────────────────────────────────────────────────────────────
+  # Which Python lines we publish a task base image for is stated in five
+  # files, and only the schema enum is enforced by anything (the CLI's
+  # Validate() rejects everything else). By #1031 they had already drifted in
+  # both directions. Both directions fail in the user's build, minutes in: a
+  # selectable version with no published leg is a `docker pull` 404, a
+  # published leg outside the enum is a compile that refuses a good image.
+  # ─────────────────────────────────────────────────────────────────────
+  python-runtime-matrix:
+    name: Published Python matrix agrees everywhere
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install PyYAML
+        run: python3 -m pip install --user pyyaml
+      - name: Check the published Python matrix against the schema enum
+        run: bash scripts/check-python-runtime-matrix.sh
+
+  # ─────────────────────────────────────────────────────────────────────
   stale-deploy-path:
     name: No stale legacy deploy path
     runs-on: ubuntu-latest
@@ -1168,6 +1187,11 @@ jobs:
   # detector promises compatibility we never verified, which is exactly
   # the silent-regression risk #220 (F2) flagged. Only 3.11/3.12/3.13 are
   # generally available today; bump as 3.14+ ship and stabilise.
+  #
+  # This is the HOST interpreter that parses a dag.py, not the interpreter
+  # inside the published task base image — a different list on purpose, checked
+  # by a different thing (the base-image list is the schema enum, gated by
+  # scripts/check-python-runtime-matrix.sh). #1031 read the two as one.
   python-parser:
     name: Python parser tests (py${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -156,6 +156,19 @@ jobs:
   # testing Pro without the repo (#318). One leg per supported Python so an author
   # picks the interpreter via `python_version`. Multi-arch + keyless cosign mirror
   # leoflow-server/leoflow-migrate.
+  #
+  # The matrix below is a COPY. The source of truth is the `python_version` enum
+  # in internal/domain/schemas/leoflow-yaml-schema.json — the list the CLI's
+  # Validate() actually enforces — and scripts/check-python-runtime-matrix.sh
+  # fails when the two disagree. Publishing a leg nobody can select, or letting an
+  # author select a leg nobody publishes, both surface as a `docker pull` 404
+  # inside the user's own build, which is the furthest point from the cause (#1031).
+  #
+  # py3.10 is DEPRECATED: Python 3.10 goes EOL 2026-10-31 and docker-library/python
+  # stops rebuilding an EOL line the day after, so the base freezes with whatever
+  # OS CVEs it has. The leg keeps being published until then because `base_image`
+  # pins make a silent drop a broken build for somebody else; the schema carries
+  # the removal date and `leoflow compile` warns the author.
   runtime-image:
     name: Build + push leoflow-runtime base (py${{ matrix.python }})
     needs: release
@@ -164,7 +177,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.10", "3.11", "3.12"]
+        python: ["3.10", "3.11", "3.12", "3.13"]
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -132,3 +132,61 @@ jobs:
           [ "$ok" = 1 ] || { echo "::error::could not download gitleaks v${GITLEAKS_VERSION} after 3 attempts"; exit 1; }
           tar -xzf /tmp/gitleaks.tgz -C /tmp gitleaks
           /tmp/gitleaks dir . --no-banner --redact --exit-code 1
+
+  # ─────────────────────────────────────────────────────────────────────
+  # Python EOL watch (#1031)
+  # Every other signal in this workflow reacts to a CVE that already exists.
+  # A base image that stops being rebuilt produces the opposite: the CVEs
+  # accumulate and the image never changes, because docker-library/python
+  # stops rebuilding an EOL line the day after it goes EOL. So this one asks
+  # the calendar (endoflife.date) instead, and it runs here because this is
+  # where the schedule already lives.
+  #
+  # It does not block anything on a date: the script exits 0 for every finding
+  # and non-zero only when it cannot do its own job (feed down, feed reshaped).
+  # A finding opens an issue instead, deduplicated by the python-eol label, so
+  # it reaches a person rather than an annotation on a scheduled run nobody
+  # opens. Issue-opening is limited to the schedule — a PR must not file one.
+  # ─────────────────────────────────────────────────────────────────────
+  python-eol:
+    name: Python EOL watch
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # A PR must not go red because endoflife.date is down. The findings still
+    # appear as annotations on the PR run — a contributor editing the enum sees
+    # them — but only push and schedule treat the watchdog's own failure as red,
+    # where a rerun is the whole remedy and nobody is blocked meanwhile.
+    continue-on-error: ${{ github.event_name == 'pull_request' }}
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Check every published Python line against endoflife.date
+        id: eol
+        run: |
+          # pipefail explicitly: the Actions default shell does not set it, and
+          # `tee` would otherwise swallow the script's own failure exit.
+          set -euo pipefail
+          bash scripts/python-eol-warn.sh | tee "$RUNNER_TEMP/python-eol.md"
+
+      - name: Open a tracking issue
+        if: github.event_name == 'schedule' && steps.eol.outputs.alert == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: ${{ steps.eol.outputs.title }}
+        run: |
+          set -euo pipefail
+          # The label is both the filing category and the dedupe key, so create
+          # it if it is missing rather than failing the run on its absence.
+          gh label create python-eol --color FBCA04 \
+            --description "A published Python runtime base is approaching or past upstream EOL" \
+            2>/dev/null || true
+          existing="$(gh issue list --state open --label python-eol --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            echo "python-eol issue #${existing} is already open; commenting instead of filing a duplicate"
+            gh issue comment "$existing" --body-file "$RUNNER_TEMP/python-eol.md"
+            exit 0
+          fi
+          gh issue create --title "$TITLE" --label python-eol --body-file "$RUNNER_TEMP/python-eol.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   in *your* build — a selectable version with no published leg is a
   `docker pull` 404 minutes into a compile, naming an image you never typed.
 
+  The gate reconciles the deprecation *status and dates* as well as the list, so
+  the support table in the configuration reference — the only place you can read
+  when a line stops being published — cannot say one thing while the CLI warns
+  another.
+
 - **A weekly Python end-of-life watch.** Every other supply-chain signal in the
   repo (Dependabot, Trivy, govulncheck) reacts to a CVE that already exists. A
   base image whose Python line has gone EOL produces the opposite signal: it
@@ -54,15 +59,27 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   every release until then, and images you have already built keep running. This
   is announced rather than dropped silently because a DAG image is built `FROM`
   the base and many projects pin `base_image`, so our choice becomes yours until
-  you rebuild. `leoflow compile` now prints a warning when your project resolves
-  to a deprecated line — including when you pin one of our published `py3.10`
-  tags through `base_image` — naming the removal date and the replacement. The
-  warning is at compile, not at task boot: the author choosing the interpreter is
-  the only person who can change it, and a per-task-pod warning would reach the
-  operator instead and repeat on every run until people filtered it out.
+  you rebuild. `leoflow validate`, `leoflow compile` and `leoflow deploy` now
+  print a warning when your project resolves to a deprecated line, naming the
+  removal date and the fix. The warning is at authoring time, not at task boot:
+  the author choosing the interpreter is the only person who can change it, and
+  a per-task-pod warning would reach the operator instead and repeat on every
+  run until people filtered it out. With `--build` it is repeated in one line
+  after the image is built, because minutes of builder output otherwise scroll
+  it off the top of the terminal.
+
+  **The warning names the field you actually set, and its fix works on that
+  field.** Setting `python_version: "3.10"` is told to change `python_version`.
+  Pinning one of our published `py3.10` tags through `base_image` — including a
+  digest pin such as `…:py3.10-v0.4.5@sha256:…` — is told to repoint
+  `base_image`, and is given the exact replacement tag with its suffix
+  preserved. The two are separated because `base_image` is used verbatim: an
+  author who pins it and is told to change `python_version` can follow that
+  advice, rebuild, and get the identical warning back.
 
   **What to do:** set `python_version: "3.11"` (or `"3.12"` / `"3.13"`) in
-  `leoflow.yaml` and rebuild.
+  `leoflow.yaml` and rebuild — or, if you pinned `base_image`, repoint it to the
+  matching `py3.11` tag and rebuild.
 
 ## [0.4.5] - 2026-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,64 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **A `py3.13` task base image, and one list that decides which ones exist
+  (#1031).** `ghcr.io/neochaotic/leoflow-runtime:py3.13` is now published
+  alongside `py3.10`/`py3.11`/`py3.12` — multi-arch and cosign-signed like its
+  siblings — so `python_version: "3.13"` works in `leoflow.yaml`. **3.13 is the
+  ceiling, and it is set by the dbt adapters, not by Airflow:** `dbt-core` and
+  `dbt-postgres` publish for 3.14, but `dbt-snowflake`, `dbt-bigquery`,
+  `dbt-databricks` and `dbt-duckdb` all stop at 3.13. A `py3.14` base would give
+  you an image where `dbt-postgres` installs and `dbt-snowflake` does not,
+  discovered inside your build rather than ours, so it is not published.
+
+  The set of published lines was stated in five places and only one of them was
+  enforced, so they had already drifted in both directions — the release
+  published a `py3.10` the CLI's host detector would never select, and the
+  detector probed for a 3.13 nobody published. There is now one list: the
+  `python_version` enum in the authoring schema, which is what
+  `leoflow compile` already validates against. `scripts/check-python-runtime-matrix.sh`
+  fails CI when the release matrix, `make runtime-images`, the
+  `runtime/Dockerfile` comment, the runtime helper's `requires-python` floor or
+  this reference disagree with it. Both directions of that drift used to surface
+  in *your* build — a selectable version with no published leg is a
+  `docker pull` 404 minutes into a compile, naming an image you never typed.
+
+- **A weekly Python end-of-life watch.** Every other supply-chain signal in the
+  repo (Dependabot, Trivy, govulncheck) reacts to a CVE that already exists. A
+  base image whose Python line has gone EOL produces the opposite signal: it
+  stops changing, because `docker-library/python` stops rebuilding an EOL line
+  the day after, while the CVEs underneath it keep accumulating. The scheduled
+  security workflow now asks endoflife.date instead, and opens a tracking issue
+  when a line we still call supported comes within 270 days of EOL, or when a
+  line we already deprecated is still being published past its own removal date.
+  It never fails a build on a date.
+
+### Deprecated
+
+- **`python_version: "3.10"` — the `py3.10` base image stops being published
+  after 2026-10-31.** Python 3.10 reaches upstream end-of-life on that date, and
+  `docker-library/python` stops rebuilding an EOL line the day after
+  (`python:3.9-slim` was last rebuilt 2025-11-01, one day after 3.9 went EOL).
+  From November, `python:3.10-slim-bookworm` — and therefore
+  `ghcr.io/neochaotic/leoflow-runtime:py3.10` — receives no further OS security
+  updates and accumulates unfixed CVEs indefinitely.
+
+  **Nothing breaks today.** The `py3.10` leg keeps being built and pushed on
+  every release until then, and images you have already built keep running. This
+  is announced rather than dropped silently because a DAG image is built `FROM`
+  the base and many projects pin `base_image`, so our choice becomes yours until
+  you rebuild. `leoflow compile` now prints a warning when your project resolves
+  to a deprecated line — including when you pin one of our published `py3.10`
+  tags through `base_image` — naming the removal date and the replacement. The
+  warning is at compile, not at task boot: the author choosing the interpreter is
+  the only person who can change it, and a per-task-pod warning would reach the
+  operator instead and repeat on every run until people filtered it out.
+
+  **What to do:** set `python_version: "3.11"` (or `"3.12"` / `"3.13"`) in
+  `leoflow.yaml` and rebuild.
+
 ## [0.4.5] - 2026-09-09
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ e2e-lite-selfheal: ## Lite boot self-heal gate (#404); needs local Postgres (DES
 
 .PHONY: runtime-images
 runtime-images: ## Build the task base images for each supported Python version
-	for v in 3.10 3.11 3.12; do \
+	for v in 3.10 3.11 3.12 3.13; do \
 		docker build -f runtime/Dockerfile --build-arg PYTHON_VERSION=$$v -t leoflow-base:py$$v . ; \
 	done
 

--- a/docs/api/leoflow-yaml-schema.json
+++ b/docs/api/leoflow-yaml-schema.json
@@ -39,7 +39,7 @@
     },
     "base_image": {
       "type": "string",
-      "description": "Override the default leoflow/python-runtime base image."
+      "description": "Override the image the DAG is built FROM. Default: the published Leoflow task base for python_version (ghcr.io/neochaotic/leoflow-runtime:py<python_version>, pinned to the CLI's release tag). Setting this makes python_version unused for the FROM, so a pin to a deprecated py<line> tag is not fixed by changing python_version — repoint this field. Pinning also freezes the interpreter and OS packages at whatever the base carried the day you pinned it (ADR 0003)."
     },
     "dependencies": {
       "type": "array",

--- a/docs/api/leoflow-yaml-schema.json
+++ b/docs/api/leoflow-yaml-schema.json
@@ -25,8 +25,17 @@
 
     "python_version": {
       "type": "string",
-      "enum": ["3.10", "3.11", "3.12"],
-      "default": "3.11"
+      "description": "Python line of the published task base image (ghcr.io/neochaotic/leoflow-runtime:py<version>). This enum is the single source of truth for which base images the release publishes; scripts/check-python-runtime-matrix.sh fails when the release matrix, the Makefile, runtime/Dockerfile or the configuration reference disagree with it. 3.10 is deprecated and stops being published after its 2026-10-31 upstream EOL.",
+      "enum": ["3.10", "3.11", "3.12", "3.13"],
+      "default": "3.11",
+      "x-leoflow-python-deprecations": {
+        "3.10": {
+          "eol": "2026-10-31",
+          "remove_after": "2026-10-31",
+          "replacement": "3.11",
+          "reason": "Python 3.10 reaches upstream end-of-life on 2026-10-31. docker-library/python stops rebuilding an EOL line the day after (python:3.9-slim was last rebuilt 2025-11-01, one day after 3.9 went EOL), so python:3.10-slim-bookworm — and therefore leoflow-runtime:py3.10 — stops receiving OS security updates and accumulates unfixed CVEs indefinitely."
+        }
+      }
     },
     "base_image": {
       "type": "string",

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -73,6 +73,25 @@ func newCompileCommand() *cobra.Command {
 	return cmd
 }
 
+// checkProjectPreconditions runs the checks that apply to every compile before
+// the dag.py and dbt paths diverge: the leoflow.yaml must validate, it must not
+// declare a dbt: block alongside a dag.py (#1015), and a deprecated Python line
+// earns a warning the author can still act on.
+//
+// Grouped rather than inlined so both compile paths get all three by
+// construction: warnDeprecatedPython landing on only the dag.py branch would
+// leave every dbt project silently on a base image that stops being rebuilt.
+func checkProjectPreconditions(cmd *cobra.Command, dir string, cfg *domain.LeoflowConfig) error {
+	if verr := cfg.Validate(); verr != nil {
+		return fmt.Errorf("invalid %s: %w", projectConfigPath(dir), verr)
+	}
+	if derr := errDbtBlockWithDagSource(dir, cfg); derr != nil {
+		return derr
+	}
+	// Stderr, not stdout: the compile summary and any piped output stay clean.
+	return warnDeprecatedPython(cmd.ErrOrStderr(), cfg)
+}
+
 // runCompile resolves the project config, runs the parser, validates the output,
 // and optionally builds the DAG image.
 func runCompile(cmd *cobra.Command, dir string, o compileOptions) error {
@@ -80,11 +99,8 @@ func runCompile(cmd *cobra.Command, dir string, o compileOptions) error {
 	if err != nil {
 		return err
 	}
-	if verr := cfg.Validate(); verr != nil {
-		return fmt.Errorf("invalid %s: %w", projectConfigPath(dir), verr)
-	}
-	if derr := errDbtBlockWithDagSource(dir, cfg); derr != nil {
-		return derr
+	if perr := checkProjectPreconditions(cmd, dir, cfg); perr != nil {
+		return perr
 	}
 	// Self-heal the extracted parser sources before running the parser, so a binary
 	// upgrade (new features like dbt vs a stale ~/.leoflow/pysrc) never surfaces as

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -73,14 +73,18 @@ func newCompileCommand() *cobra.Command {
 	return cmd
 }
 
-// checkProjectPreconditions runs the checks that apply to every compile before
+// checkProjectPreconditions runs the checks that apply to every project before
 // the dag.py and dbt paths diverge: the leoflow.yaml must validate, it must not
 // declare a dbt: block alongside a dag.py (#1015), and a deprecated Python line
 // earns a warning the author can still act on.
 //
-// Grouped rather than inlined so both compile paths get all three by
-// construction: warnDeprecatedPython landing on only the dag.py branch would
-// leave every dbt project silently on a base image that stops being rebuilt.
+// Grouped rather than inlined so every entry point gets all three by
+// construction. warnDeprecatedPython landing on only the dag.py branch would
+// leave every dbt project silently on a base image that stops being rebuilt,
+// and `leoflow validate` open-coding the first two checks is how it spent this
+// PR's first round never warning at all — validate is the sub-second command an
+// author runs in a loop with leoflow.yaml open, which is the exact moment the
+// warning is worth something.
 func checkProjectPreconditions(cmd *cobra.Command, dir string, cfg *domain.LeoflowConfig) error {
 	if verr := cfg.Validate(); verr != nil {
 		return fmt.Errorf("invalid %s: %w", projectConfigPath(dir), verr)
@@ -89,7 +93,9 @@ func checkProjectPreconditions(cmd *cobra.Command, dir string, cfg *domain.Leofl
 		return derr
 	}
 	// Stderr, not stdout: the compile summary and any piped output stay clean.
-	return warnDeprecatedPython(cmd.ErrOrStderr(), cfg)
+	// Advisory only — a write failure here must not fail an otherwise good run.
+	warnDeprecatedPython(cmd.ErrOrStderr(), cfg)
+	return nil
 }
 
 // runCompile resolves the project config, runs the parser, validates the output,
@@ -152,6 +158,9 @@ func runCompile(cmd *cobra.Command, dir string, o compileOptions) error {
 	if berr := buildAndPush(cmd, dir, o, cfg, image); berr != nil {
 		return berr
 	}
+	if o.build {
+		remindDeprecatedPythonAfterBuild(cmd.ErrOrStderr(), cfg)
+	}
 	_, werr := fmt.Fprint(cmd.OutOrStdout(), compileSummary(dagSourcePath(dir, cfg), o.output, image, o.dagVersion))
 	return werr
 }
@@ -213,6 +222,9 @@ func runDbtCompile(cmd *cobra.Command, dir string, o compileOptions, cfg *domain
 	}
 	if berr := buildAndPush(cmd, dir, o, cfg, image); berr != nil {
 		return berr
+	}
+	if o.build {
+		remindDeprecatedPythonAfterBuild(cmd.ErrOrStderr(), cfg)
 	}
 	_, werr := fmt.Fprint(cmd.OutOrStdout(), compileSummary(filepath.Join(dir, cfg.Dbt.Project), o.output, image, o.dagVersion))
 	return werr

--- a/internal/cli/compile_python_deprecation.go
+++ b/internal/cli/compile_python_deprecation.go
@@ -8,10 +8,48 @@ import (
 	"github.com/neochaotic/leoflow/internal/domain"
 )
 
-// deprecationWrapCols is where the reason paragraph is folded. Narrow enough to
-// stay readable in a split terminal, wide enough that the sentence structure of
-// the reason survives.
+// deprecationWrapCols is the widest RENDERED line the warning emits, indent
+// included. Narrow enough to stay readable in a split terminal, wide enough
+// that the sentence structure of the reason survives. Body lines carry a
+// two-space indent, so they are folded at deprecationWrapCols-len(bodyIndent);
+// folding them at deprecationWrapCols and then indenting is how the `Fix:` line
+// came out at 91 columns against a declared 78.
 const deprecationWrapCols = 78
+
+// bodyIndent prefixes every line of the warning after the headline.
+const bodyIndent = "  "
+
+// The two leoflow.yaml fields that can put a compile on a deprecated Python
+// line. They are spelled exactly as the author writes them, because the warning
+// names the field it wants changed and a name that does not match the file is a
+// name the reader has to translate.
+const (
+	fieldPythonVersion = "python_version"
+	fieldBaseImage     = "base_image"
+)
+
+// pythonDeprecationHit is a compile that resolves to a deprecated Python line,
+// and — the part that matters — WHICH field put it there.
+//
+// The two sources need different remedies, and a remedy that does not apply is
+// worse than none. `resolveBaseImage` returns cfg.BaseImage verbatim, so telling
+// an author who pinned base_image to change python_version is an instruction
+// they can follow, rebuild, and watch produce the identical warning. At that
+// point the honest conclusion is that the tool is broken, and the message gets
+// filtered — which is precisely the fate this warning exists to avoid.
+type pythonDeprecationHit struct {
+	// version is the deprecated Python line, e.g. "3.10".
+	version string
+	// field is the leoflow.yaml key that selected it: fieldPythonVersion or
+	// fieldBaseImage.
+	field string
+	// ref is the base_image value as written, empty on the python_version path.
+	ref string
+	// tag is ref's tag ("py3.10-v0.4.5"), empty on the python_version path.
+	tag string
+	// digest is ref's digest ("sha256:…") when the pin carries one.
+	digest string
+}
 
 // warnDeprecatedPython prints a one-time warning when the base image this
 // compile will build FROM is a Python line that is on its way out.
@@ -26,11 +64,14 @@ const deprecationWrapCols = 78
 // it only fires for people who build the base from a source checkout, which is
 // nobody on the path this deprecation is about (they pull the published tag).
 //
-// Nothing here fails the compile. The line is still published, still pulls, and
-// still works; the point is to reach the author months before it stops being
-// rebuilt, not to break them today.
+// Nothing here fails the compile — not even a failed write to w. The line is
+// still published, still pulls, and still works; the point is to reach the
+// author months before it stops being rebuilt, not to break them today. A
+// compile that produced a correct dag.json must not exit non-zero because a
+// closed pipe swallowed an advisory.
 //
-// Two populations get the warning:
+// Two populations get the warning, and each gets its own headline and its own
+// remedy:
 //   - the default path, where base_image is unset and the FROM is derived from
 //     python_version;
 //   - an explicit base_image that pins one of OUR published deprecated tags,
@@ -40,45 +81,155 @@ const deprecationWrapCols = 78
 // An explicit base_image pointing anywhere else is somebody else's image and
 // gets no warning, even when python_version is set: the field is unused for the
 // FROM in that case, and nagging about it would train people to ignore this.
-func warnDeprecatedPython(w io.Writer, cfg *domain.LeoflowConfig) error {
-	version, ok := deprecatedPythonForBuild(cfg)
+func warnDeprecatedPython(w io.Writer, cfg *domain.LeoflowConfig) {
+	hit, ok := deprecatedPythonForBuild(cfg)
 	if !ok {
-		return nil
+		return
 	}
-	d, ok := domain.DeprecatedPythonVersion(version)
+	d, ok := domain.DeprecatedPythonVersion(hit.version)
 	if !ok {
-		return nil
+		return
 	}
 	var b strings.Builder
-	fmt.Fprintf(&b, "warning: python_version %s is deprecated; %s:py%s stops being published after %s.\n",
-		d.Version, publishedBaseRepo, d.Version, d.RemoveAfter)
-	for _, line := range wrapWords(d.Reason, deprecationWrapCols) {
-		fmt.Fprintf(&b, "  %s\n", line)
-	}
-	fmt.Fprintf(&b, "  Fix: set python_version: \"%s\" in leoflow.yaml and rebuild. "+
-		"Existing images keep running.\n", d.Replacement)
-	_, err := io.WriteString(w, b.String())
-	return err
+	writeWrapped(&b, deprecationHeadline(hit, d), false)
+	writeWrapped(&b, d.Reason, true)
+	writeWrapped(&b, deprecationRemedy(hit, d), true)
+	// Deliberately unchecked: a warning that can abort the compile is not a
+	// warning. A closed pipe (`leoflow compile | head`) must not turn a correct
+	// dag.json into a non-zero exit.
+	_, _ = io.WriteString(w, b.String()) //nolint:errcheck // advisory output; a write failure must not fail the compile
 }
 
-// deprecatedPythonForBuild returns the Python line whose deprecation applies to
-// this config's build, and whether one does at all. See warnDeprecatedPython for
-// why an unrelated base_image opts out.
-func deprecatedPythonForBuild(cfg *domain.LeoflowConfig) (string, bool) {
+// writeWrapped folds text to deprecationWrapCols and appends it to b.
+//
+// Body paragraphs are indented on every line; the headline hangs, so it starts
+// at column 0 and its continuations line up with the body. Everything is folded
+// at deprecationWrapCols-len(bodyIndent) and indented afterwards, which is the
+// arithmetic the previous version got backwards — folding at the declared width
+// and THEN adding the indent is how a message that declares 78 columns rendered
+// at 91, and the headline, folded at no width at all, at 189.
+func writeWrapped(b *strings.Builder, text string, indentFirst bool) {
+	for i, line := range wrapWords(text, deprecationWrapCols-len(bodyIndent)) {
+		if i > 0 || indentFirst {
+			b.WriteString(bodyIndent)
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+}
+
+// remindDeprecatedPythonAfterBuild re-states the deprecation in one line after
+// the image is built.
+//
+// `--build` shells out to a container builder, and the minutes of layer output
+// that follow scroll the warning off the top of the terminal. Authors read the
+// last screen of a long command, not the first, so the finding has to appear
+// where the eye lands. One line, not the full argument: the argument is above,
+// and repeating it in full is how a warning becomes wallpaper.
+func remindDeprecatedPythonAfterBuild(w io.Writer, cfg *domain.LeoflowConfig) {
+	hit, ok := deprecatedPythonForBuild(cfg)
+	if !ok {
+		return
+	}
+	d, ok := domain.DeprecatedPythonVersion(hit.version)
+	if !ok {
+		return
+	}
+	var b strings.Builder
+	writeWrapped(&b, fmt.Sprintf(
+		"warning: built on the deprecated Python %s line, selected by %s; %s:py%s stops being published after %s — see the warning above this build for the fix.",
+		d.Version, hit.field, publishedBaseRepo, d.Version, d.RemoveAfter), false)
+	_, _ = io.WriteString(w, b.String()) //nolint:errcheck // advisory output; a write failure must not fail the compile
+}
+
+// deprecationHeadline names the deprecated line AND the field that selected it.
+// Reporting `python_version 3.10` to an author whose file says
+// `python_version: "3.12"` next to a py3.10 base_image pin is a message about
+// somebody else's project.
+func deprecationHeadline(hit pythonDeprecationHit, d domain.PythonDeprecation) string {
+	if hit.field == fieldBaseImage {
+		return fmt.Sprintf("warning: base_image %s pins Python %s, which is deprecated; %s:py%s stops being published after %s.",
+			hit.ref, d.Version, publishedBaseRepo, d.Version, d.RemoveAfter)
+	}
+	return fmt.Sprintf("warning: python_version %s is deprecated; %s:py%s stops being published after %s.",
+		d.Version, publishedBaseRepo, d.Version, d.RemoveAfter)
+}
+
+// deprecationRemedy renders the `Fix:` line for the field that actually
+// controls the FROM.
+//
+// On the base_image path it names the replacement tag in full rather than the
+// line, because the author pinned a specific tag shape (`py3.10`,
+// `py3.10-v0.4.5`, `py3.10-v0.4.5-rc.1`) and the useful instruction is the
+// string that replaces theirs, suffix preserved. python_version is deliberately
+// not mentioned there: it is unused for the FROM, so changing it does nothing.
+func deprecationRemedy(hit pythonDeprecationHit, d domain.PythonDeprecation) string {
+	if hit.field != fieldBaseImage {
+		return fmt.Sprintf("Fix: set python_version: %q in leoflow.yaml and rebuild. Existing images keep running.", d.Replacement)
+	}
+	replacement := publishedBaseRepo + ":py" + d.Replacement + strings.TrimPrefix(hit.tag, "py"+hit.version)
+	if hit.digest != "" {
+		// The pinned digest names a py3.10 manifest; carrying it over would pull
+		// the deprecated image back in under a 3.11 tag.
+		return fmt.Sprintf("Fix: repoint base_image to %s in leoflow.yaml, re-pinning its digest, and rebuild. Existing images keep running.", replacement)
+	}
+	return fmt.Sprintf("Fix: repoint base_image to %s in leoflow.yaml and rebuild. Existing images keep running.", replacement)
+}
+
+// deprecatedPythonForBuild returns the deprecation-relevant facts about this
+// config's build, and whether a deprecated line is involved at all. See
+// warnDeprecatedPython for why an unrelated base_image opts out.
+func deprecatedPythonForBuild(cfg *domain.LeoflowConfig) (pythonDeprecationHit, bool) {
 	if cfg == nil {
-		return "", false
+		return pythonDeprecationHit{}, false
 	}
 	if cfg.BaseImage == "" {
-		return cfg.PythonVersion, cfg.PythonVersion != ""
+		if cfg.PythonVersion == "" {
+			return pythonDeprecationHit{}, false
+		}
+		return pythonDeprecationHit{version: cfg.PythonVersion, field: fieldPythonVersion}, true
 	}
-	repo, tag, found := strings.Cut(cfg.BaseImage, ":")
-	if !found || repo != publishedBaseRepo || !strings.HasPrefix(tag, "py") {
-		return "", false
+	repo, tag, digest := splitImageRef(cfg.BaseImage)
+	if repo != publishedBaseRepo || !strings.HasPrefix(tag, "py") {
+		// A digest-only pin (repo@sha256:…) lands here with an empty tag. The
+		// reference names a manifest, not a line, and resolving it would mean a
+		// registry round-trip inside a command that must stay offline-safe — so it
+		// stays silent rather than guessing.
+		return pythonDeprecationHit{}, false
 	}
 	// Both published tag shapes name the line first: the moving `py3.10` and the
 	// immutable per-release `py3.10-v0.4.5`.
 	line, _, _ := strings.Cut(strings.TrimPrefix(tag, "py"), "-")
-	return line, line != ""
+	if line == "" {
+		return pythonDeprecationHit{}, false
+	}
+	return pythonDeprecationHit{
+		version: line,
+		field:   fieldBaseImage,
+		ref:     cfg.BaseImage,
+		tag:     tag,
+		digest:  digest,
+	}, true
+}
+
+// splitImageRef splits an OCI reference into repository, tag and digest.
+//
+// A plain strings.Cut on ":" gets both real-world shapes wrong. A digest pin —
+// `repo:py3.10@sha256:…`, which is what a supply-chain-conscious author writes,
+// and exactly the author most likely to be pinned to an old base — yields the
+// tag "py3.10@sha256" and stops matching anything, so the population this
+// warning is for is the population it silently skips. A registry port
+// (`registry:5000/team/img`) is misread as a tag for the same reason.
+func splitImageRef(ref string) (repo, tag, digest string) {
+	if before, after, found := strings.Cut(ref, "@"); found {
+		ref, digest = before, after
+	}
+	// The tag separator is the last ":" that comes after the last "/"; anything
+	// earlier belongs to the registry host's port.
+	if colon := strings.LastIndex(ref, ":"); colon > strings.LastIndex(ref, "/") {
+		return ref[:colon], ref[colon+1:], digest
+	}
+	return ref, "", digest
 }
 
 // wrapWords folds s onto lines of at most cols runes, breaking only at spaces. A

--- a/internal/cli/compile_python_deprecation.go
+++ b/internal/cli/compile_python_deprecation.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// deprecationWrapCols is where the reason paragraph is folded. Narrow enough to
+// stay readable in a split terminal, wide enough that the sentence structure of
+// the reason survives.
+const deprecationWrapCols = 78
+
+// warnDeprecatedPython prints a one-time warning when the base image this
+// compile will build FROM is a Python line that is on its way out.
+//
+// It runs at compile, not at task boot. The choice matters: the author picking
+// `python_version` is the only person who can change it, and compile is the
+// moment they make the choice, with the file open. A warning from the agent in
+// the task pod would reach the operator instead — who cannot edit the DAG's
+// leoflow.yaml — and would repeat on every task of every run of every DAG,
+// which is how a real warning becomes log noise people filter out. A build-time
+// warning inside runtime/Dockerfile was the third option and is weaker still:
+// it only fires for people who build the base from a source checkout, which is
+// nobody on the path this deprecation is about (they pull the published tag).
+//
+// Nothing here fails the compile. The line is still published, still pulls, and
+// still works; the point is to reach the author months before it stops being
+// rebuilt, not to break them today.
+//
+// Two populations get the warning:
+//   - the default path, where base_image is unset and the FROM is derived from
+//     python_version;
+//   - an explicit base_image that pins one of OUR published deprecated tags,
+//     which is the population the deprecation is actually about — a pin is what
+//     keeps a user on a frozen base after we stop publishing it.
+//
+// An explicit base_image pointing anywhere else is somebody else's image and
+// gets no warning, even when python_version is set: the field is unused for the
+// FROM in that case, and nagging about it would train people to ignore this.
+func warnDeprecatedPython(w io.Writer, cfg *domain.LeoflowConfig) error {
+	version, ok := deprecatedPythonForBuild(cfg)
+	if !ok {
+		return nil
+	}
+	d, ok := domain.DeprecatedPythonVersion(version)
+	if !ok {
+		return nil
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "warning: python_version %s is deprecated; %s:py%s stops being published after %s.\n",
+		d.Version, publishedBaseRepo, d.Version, d.RemoveAfter)
+	for _, line := range wrapWords(d.Reason, deprecationWrapCols) {
+		fmt.Fprintf(&b, "  %s\n", line)
+	}
+	fmt.Fprintf(&b, "  Fix: set python_version: \"%s\" in leoflow.yaml and rebuild. "+
+		"Existing images keep running.\n", d.Replacement)
+	_, err := io.WriteString(w, b.String())
+	return err
+}
+
+// deprecatedPythonForBuild returns the Python line whose deprecation applies to
+// this config's build, and whether one does at all. See warnDeprecatedPython for
+// why an unrelated base_image opts out.
+func deprecatedPythonForBuild(cfg *domain.LeoflowConfig) (string, bool) {
+	if cfg == nil {
+		return "", false
+	}
+	if cfg.BaseImage == "" {
+		return cfg.PythonVersion, cfg.PythonVersion != ""
+	}
+	repo, tag, found := strings.Cut(cfg.BaseImage, ":")
+	if !found || repo != publishedBaseRepo || !strings.HasPrefix(tag, "py") {
+		return "", false
+	}
+	// Both published tag shapes name the line first: the moving `py3.10` and the
+	// immutable per-release `py3.10-v0.4.5`.
+	line, _, _ := strings.Cut(strings.TrimPrefix(tag, "py"), "-")
+	return line, line != ""
+}
+
+// wrapWords folds s onto lines of at most cols runes, breaking only at spaces. A
+// single word longer than cols is left over-long rather than cut, because the
+// long tokens in these messages are image references and URLs, and a broken one
+// cannot be copied.
+func wrapWords(s string, cols int) []string {
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return nil
+	}
+	lines := []string{fields[0]}
+	for _, word := range fields[1:] {
+		last := len(lines) - 1
+		if len([]rune(lines[last]))+1+len([]rune(word)) <= cols {
+			lines[last] += " " + word
+			continue
+		}
+		lines = append(lines, word)
+	}
+	return lines
+}

--- a/internal/cli/compile_python_deprecation_test.go
+++ b/internal/cli/compile_python_deprecation_test.go
@@ -1,6 +1,10 @@
 package cli
 
 import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -42,33 +46,163 @@ func supportedPythonLine(t *testing.T) string {
 	return ""
 }
 
+// warn runs the warning and returns what a terminal would show.
+func warn(cfg *domain.LeoflowConfig) string {
+	var out strings.Builder
+	warnDeprecatedPython(&out, cfg)
+	return out.String()
+}
+
+// flatten collapses the word wrapping so a phrase assertion is about the words
+// the reader gets, not about where the folding happened to land. Line breaks are
+// the subject of exactly one test (the width one), which reads the raw output.
+func flatten(s string) string { return strings.Join(strings.Fields(s), " ") }
+
+// mustContainAll asserts on the RENDERED text, not on "a warning fired".
+// Asserting only that output is non-empty is what let the base_image path ship
+// with the python_version path's message: both produced bytes, and the bytes
+// were wrong.
+func mustContainAll(t *testing.T, got string, want ...string) {
+	t.Helper()
+	flat := flatten(got)
+	for _, w := range want {
+		if !strings.Contains(flat, flatten(w)) {
+			t.Errorf("warning does not contain %q:\n%s", w, got)
+		}
+	}
+}
+
+func mustContainNone(t *testing.T, got string, unwanted ...string) {
+	t.Helper()
+	flat := flatten(got)
+	for _, u := range unwanted {
+		if strings.Contains(flat, flatten(u)) {
+			t.Errorf("warning must not contain %q:\n%s", u, got)
+		}
+	}
+}
+
 func TestWarnDeprecatedPythonDefaultPath(t *testing.T) {
 	d := deprecatedPythonLine(t)
-	var out strings.Builder
-	if err := warnDeprecatedPython(&out, &domain.LeoflowConfig{PythonVersion: d.Version}); err != nil {
-		t.Fatalf("warnDeprecatedPython: %v", err)
-	}
-	got := out.String()
-	for _, want := range []string{
+	got := warn(&domain.LeoflowConfig{PythonVersion: d.Version})
+	mustContainAll(t, got,
 		"warning:",
-		"python_version " + d.Version,
-		publishedBaseRepo + ":py" + d.Version,
+		"python_version "+d.Version+" is deprecated",
+		publishedBaseRepo+":py"+d.Version,
 		d.RemoveAfter,
-		`python_version: "` + d.Replacement + `"`,
+		`Fix: set python_version: "`+d.Replacement+`" in leoflow.yaml and rebuild.`,
+	)
+	// The remedy for the field the author actually set must not be the other
+	// field's remedy.
+	mustContainNone(t, got, "repoint base_image")
+}
+
+// The property the whole warning rests on: following the Fix must make the
+// warning stop. A base_image pin is used verbatim by resolveBaseImage, so a
+// remedy naming python_version is one the author can follow, rebuild, and watch
+// reproduce the identical warning — at which point they filter the message and
+// the deprecation reaches nobody.
+//
+// This is the case the original test could not see: it built the config with
+// PythonVersion empty and asserted only that a warning fired.
+func TestWarnDeprecatedPythonPinnedBaseImageNamesBaseImage(t *testing.T) {
+	d := deprecatedPythonLine(t)
+	supported := supportedPythonLine(t)
+	for name, tc := range map[string]struct{ pinned, wantFixRef string }{
+		"moving line tag": {
+			publishedBaseRepo + ":py" + d.Version,
+			publishedBaseRepo + ":py" + d.Replacement,
+		},
+		"per-release pin": {
+			publishedBaseRepo + ":py" + d.Version + "-v0.4.5",
+			publishedBaseRepo + ":py" + d.Replacement + "-v0.4.5",
+		},
+		"per-release rc": {
+			publishedBaseRepo + ":py" + d.Version + "-v0.4.5-rc.1",
+			publishedBaseRepo + ":py" + d.Replacement + "-v0.4.5-rc.1",
+		},
 	} {
-		if !strings.Contains(got, want) {
-			t.Errorf("warning does not mention %q:\n%s", want, got)
+		t.Run(name, func(t *testing.T) {
+			// python_version is set to a SUPPORTED line, as it is in a real file
+			// that pins base_image: reporting "python_version 3.10 is deprecated"
+			// to this author describes a file they do not have.
+			got := warn(&domain.LeoflowConfig{PythonVersion: supported, BaseImage: tc.pinned})
+			mustContainAll(t, got,
+				"warning: base_image "+tc.pinned+" pins Python "+d.Version,
+				d.RemoveAfter,
+				"Fix: repoint base_image to "+tc.wantFixRef+" in leoflow.yaml and rebuild.",
+			)
+			// The headline must not blame a field whose value is not deprecated,
+			// and the remedy must not send the author to a field that is unused.
+			mustContainNone(t, got,
+				"python_version "+d.Version+" is deprecated",
+				"python_version "+supported+" is deprecated",
+				`Fix: set python_version`,
+			)
+		})
+	}
+}
+
+// A digest pin is what a supply-chain-conscious author writes, and it is the
+// author most likely to still be sitting on an old base. `strings.Cut(ref, ":")`
+// read the tag as "py3.10@sha256" and skipped exactly that population.
+func TestWarnDeprecatedPythonDigestPinnedBase(t *testing.T) {
+	d := deprecatedPythonLine(t)
+	const digest = "@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	pinned := publishedBaseRepo + ":py" + d.Version + "-v0.4.5" + digest
+	got := warn(&domain.LeoflowConfig{BaseImage: pinned})
+	mustContainAll(t, got,
+		"warning: base_image "+pinned+" pins Python "+d.Version,
+		"Fix: repoint base_image to "+publishedBaseRepo+":py"+d.Replacement+"-v0.4.5",
+		// Carrying the old digest over under a new tag would pull the deprecated
+		// manifest right back in, so the remedy has to say so.
+		"re-pinning its digest",
+	)
+	// The digest must not leak into the suggested replacement reference.
+	mustContainNone(t, got, publishedBaseRepo+":py"+d.Replacement+"-v0.4.5"+digest)
+}
+
+// A digest-ONLY pin names a manifest, not a line. Resolving it needs a registry
+// round-trip, so the warning stays silent rather than guessing.
+func TestWarnDeprecatedPythonSilentOnDigestOnlyPin(t *testing.T) {
+	d := deprecatedPythonLine(t)
+	ref := publishedBaseRepo + "@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	if got := warn(&domain.LeoflowConfig{PythonVersion: d.Version, BaseImage: ref}); got != "" {
+		t.Fatalf("a digest-only pin produced a warning:\n%s", got)
+	}
+}
+
+// A registry port puts a ":" in the reference that is not the tag separator.
+func TestWarnDeprecatedPythonSilentOnPortedForeignRegistry(t *testing.T) {
+	d := deprecatedPythonLine(t)
+	ref := "registry.example.com:5000/team/base:py" + d.Version
+	if got := warn(&domain.LeoflowConfig{BaseImage: ref}); got != "" {
+		t.Fatalf("a foreign registry with a port produced a warning:\n%s", got)
+	}
+}
+
+func TestSplitImageRef(t *testing.T) {
+	const dig = "sha256:abc"
+	cases := []struct{ in, repo, tag, digest string }{
+		{"ghcr.io/o/r:py3.10", "ghcr.io/o/r", "py3.10", ""},
+		{"ghcr.io/o/r:py3.10@" + dig, "ghcr.io/o/r", "py3.10", dig},
+		{"ghcr.io/o/r@" + dig, "ghcr.io/o/r", "", dig},
+		{"ghcr.io/o/r", "ghcr.io/o/r", "", ""},
+		{"registry:5000/o/r", "registry:5000/o/r", "", ""},
+		{"registry:5000/o/r:py3.10", "registry:5000/o/r", "py3.10", ""},
+	}
+	for _, tc := range cases {
+		repo, tag, digest := splitImageRef(tc.in)
+		if repo != tc.repo || tag != tc.tag || digest != tc.digest {
+			t.Errorf("splitImageRef(%q) = (%q, %q, %q), want (%q, %q, %q)",
+				tc.in, repo, tag, digest, tc.repo, tc.tag, tc.digest)
 		}
 	}
 }
 
 func TestWarnDeprecatedPythonSilentOnSupported(t *testing.T) {
-	var out strings.Builder
-	if err := warnDeprecatedPython(&out, &domain.LeoflowConfig{PythonVersion: supportedPythonLine(t)}); err != nil {
-		t.Fatalf("warnDeprecatedPython: %v", err)
-	}
-	if out.String() != "" {
-		t.Fatalf("a supported python_version produced a warning:\n%s", out.String())
+	if got := warn(&domain.LeoflowConfig{PythonVersion: supportedPythonLine(t)}); got != "" {
+		t.Fatalf("a supported python_version produced a warning:\n%s", got)
 	}
 }
 
@@ -77,57 +211,105 @@ func TestWarnDeprecatedPythonSilentOnSupported(t *testing.T) {
 // train the author to filter this message out.
 func TestWarnDeprecatedPythonSilentOnForeignBaseImage(t *testing.T) {
 	d := deprecatedPythonLine(t)
-	var out strings.Builder
 	cfg := &domain.LeoflowConfig{PythonVersion: d.Version, BaseImage: "registry.example.com/team/base:2026-09"}
-	if err := warnDeprecatedPython(&out, cfg); err != nil {
-		t.Fatalf("warnDeprecatedPython: %v", err)
-	}
-	if out.String() != "" {
-		t.Fatalf("an unrelated base_image produced a warning:\n%s", out.String())
-	}
-}
-
-// The population the deprecation is actually about: a pin to our own published
-// tag is what keeps a user on a base after we stop rebuilding it. Both published
-// tag shapes must be recognized.
-func TestWarnDeprecatedPythonPinnedPublishedBase(t *testing.T) {
-	d := deprecatedPythonLine(t)
-	for name, ref := range map[string]string{
-		"moving line tag": publishedBaseRepo + ":py" + d.Version,
-		"per-release pin": publishedBaseRepo + ":py" + d.Version + "-v0.4.5",
-		"per-release rc":  publishedBaseRepo + ":py" + d.Version + "-v0.4.5-rc.1",
-	} {
-		var out strings.Builder
-		if err := warnDeprecatedPython(&out, &domain.LeoflowConfig{BaseImage: ref}); err != nil {
-			t.Fatalf("%s: warnDeprecatedPython: %v", name, err)
-		}
-		if !strings.Contains(out.String(), "python_version "+d.Version) {
-			t.Errorf("%s (%s) produced no warning:\n%s", name, ref, out.String())
-		}
+	if got := warn(cfg); got != "" {
+		t.Fatalf("an unrelated base_image produced a warning:\n%s", got)
 	}
 }
 
 func TestWarnDeprecatedPythonSilentOnSupportedPin(t *testing.T) {
 	ref := publishedBaseRepo + ":py" + supportedPythonLine(t)
-	var out strings.Builder
-	if err := warnDeprecatedPython(&out, &domain.LeoflowConfig{BaseImage: ref}); err != nil {
-		t.Fatalf("warnDeprecatedPython: %v", err)
-	}
-	if out.String() != "" {
-		t.Fatalf("a pin to a supported line produced a warning:\n%s", out.String())
+	if got := warn(&domain.LeoflowConfig{BaseImage: ref}); got != "" {
+		t.Fatalf("a pin to a supported line produced a warning:\n%s", got)
 	}
 }
 
 func TestWarnDeprecatedPythonNilAndEmpty(t *testing.T) {
+	if got := warn(nil) + warn(&domain.LeoflowConfig{}); got != "" {
+		t.Fatalf("nil/empty config produced a warning:\n%s", got)
+	}
+}
+
+// The warning declares a width. The `Fix:` line was folded at that width and
+// THEN indented, so it rendered two columns over on the default path and much
+// wider on the base_image path, where the replacement reference is longer.
+func TestWarnDeprecatedPythonRespectsItsDeclaredWidth(t *testing.T) {
+	d := deprecatedPythonLine(t)
+	for name, cfg := range map[string]*domain.LeoflowConfig{
+		"python_version": {PythonVersion: d.Version},
+		"base_image":     {BaseImage: publishedBaseRepo + ":py" + d.Version + "-v0.4.5"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			// The post-build reminder is held to the same width: it is emitted by
+			// the same code path and read on the same terminal.
+			var after strings.Builder
+			remindDeprecatedPythonAfterBuild(&after, cfg)
+			for _, line := range strings.Split(strings.TrimRight(warn(cfg)+after.String(), "\n"), "\n") {
+				// An unbreakable token (an image reference) is allowed to overhang:
+				// a wrapped reference cannot be copied, which is the only thing the
+				// reader wants to do with it. Everything else must fit.
+				if len([]rune(line)) > deprecationWrapCols && len(strings.Fields(line)) > 1 {
+					longest := 0
+					for _, f := range strings.Fields(line) {
+						longest = max(longest, len([]rune(f)))
+					}
+					if longest+len(bodyIndent) <= deprecationWrapCols {
+						t.Errorf("line is %d cols, declared max is %d, and nothing on it is unbreakable:\n%s",
+							len([]rune(line)), deprecationWrapCols, line)
+					}
+				}
+			}
+		})
+	}
+}
+
+// errWriter fails every write, standing in for a closed pipe (`leoflow compile
+// | head`) or a full disk.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) { return 0, errors.New("broken pipe") }
+
+// The warning is advisory, and the assertion has to be made where the damage
+// was: checkProjectPreconditions used to `return warnDeprecatedPython(...)`, so
+// a closed stderr aborted a compile that would otherwise have succeeded. The
+// renderer alone cannot show this — a caller is free to discard a returned
+// error — so the test drives the precondition gate the commands actually call.
+func TestDeprecationWarningIsNotFatalOnAFailingWriter(t *testing.T) {
+	d := deprecatedPythonLine(t)
+	dir := writeProject(t, "schema_version: \"1.0\"\ndag_id: sales\npython_version: \""+d.Version+"\"\n")
+	cfg, err := loadProjectConfig(dir)
+	if err != nil {
+		t.Fatalf("loadProjectConfig: %v", err)
+	}
+	cmd := newValidateCommand()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(errWriter{})
+	if perr := checkProjectPreconditions(cmd, dir, cfg); perr != nil {
+		t.Fatalf("a stderr write failure failed the command: %v", perr)
+	}
+	// The post-build reminder is on the same footing.
+	remindDeprecatedPythonAfterBuild(errWriter{}, cfg)
+}
+
+// `--build` shells out to a container builder; the layer output that follows
+// scrolls the warning off the top. The reminder puts it back where the eye
+// lands, and it must still name the field that has to change.
+func TestRemindDeprecatedPythonAfterBuild(t *testing.T) {
+	d := deprecatedPythonLine(t)
 	var out strings.Builder
-	if err := warnDeprecatedPython(&out, nil); err != nil {
-		t.Fatalf("nil config: %v", err)
-	}
-	if err := warnDeprecatedPython(&out, &domain.LeoflowConfig{}); err != nil {
-		t.Fatalf("empty config: %v", err)
-	}
+	remindDeprecatedPythonAfterBuild(&out, &domain.LeoflowConfig{PythonVersion: d.Version})
+	mustContainAll(t, out.String(), "warning:", d.Version, fieldPythonVersion, d.RemoveAfter)
+
+	out.Reset()
+	pinned := publishedBaseRepo + ":py" + d.Version + "-v0.4.5"
+	remindDeprecatedPythonAfterBuild(&out, &domain.LeoflowConfig{PythonVersion: supportedPythonLine(t), BaseImage: pinned})
+	mustContainAll(t, out.String(), "warning:", d.Version, fieldBaseImage, d.RemoveAfter)
+	mustContainNone(t, out.String(), fieldPythonVersion)
+
+	out.Reset()
+	remindDeprecatedPythonAfterBuild(&out, &domain.LeoflowConfig{PythonVersion: supportedPythonLine(t)})
 	if out.String() != "" {
-		t.Fatalf("nil/empty config produced a warning:\n%s", out.String())
+		t.Fatalf("a supported line produced a post-build reminder:\n%s", out.String())
 	}
 }
 
@@ -164,5 +346,46 @@ func TestWrapWords(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// `leoflow validate` is the sub-second command an author runs in a loop with
+// leoflow.yaml open — the exact moment this warning is worth something, and the
+// one entry point that open-coded its preconditions and so never warned at all.
+// Driving the real cobra command rather than calling the helper is the point:
+// the bug was in the wiring, not in the renderer.
+func TestValidateWarnsAboutADeprecatedPythonLine(t *testing.T) {
+	d := deprecatedPythonLine(t)
+	dir := writeProject(t, "schema_version: \"1.0\"\ndag_id: sales\npython_version: \""+d.Version+"\"\n")
+	if err := os.WriteFile(filepath.Join(dir, "dag.py"), []byte("dag = None\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stderr strings.Builder
+	cmd := newValidateCommand()
+	cmd.SetArgs([]string{dir})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(&stderr)
+	// The dag.py syntax check may fail or be skipped depending on the host's
+	// interpreter; the warning is emitted before it either way, and asserting on
+	// the command's error would make this a test of the local Python install.
+	_ = cmd.Execute()
+	mustContainAll(t, stderr.String(), "warning:", "python_version "+d.Version+" is deprecated")
+}
+
+// A supported line must leave `validate` silent, or the warning is noise on
+// every run of the command an author runs most.
+func TestValidateSilentOnASupportedPythonLine(t *testing.T) {
+	dir := writeProject(t, "schema_version: \"1.0\"\ndag_id: sales\npython_version: \""+supportedPythonLine(t)+"\"\n")
+	if err := os.WriteFile(filepath.Join(dir, "dag.py"), []byte("dag = None\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stderr strings.Builder
+	cmd := newValidateCommand()
+	cmd.SetArgs([]string{dir})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(&stderr)
+	_ = cmd.Execute()
+	if strings.Contains(stderr.String(), "is deprecated") {
+		t.Fatalf("validate warned about a supported line:\n%s", stderr.String())
 	}
 }

--- a/internal/cli/compile_python_deprecation_test.go
+++ b/internal/cli/compile_python_deprecation_test.go
@@ -1,0 +1,168 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// deprecatedPythonLine returns a python_version the schema marks deprecated, or
+// skips the test. Hard-coding "3.10" here would turn every case below into a
+// failure on the day the line is finally dropped, which is the one day nobody
+// wants to be debugging the test suite.
+func deprecatedPythonLine(t *testing.T) domain.PythonDeprecation {
+	t.Helper()
+	versions, err := domain.SupportedPythonVersions()
+	if err != nil {
+		t.Fatalf("SupportedPythonVersions: %v", err)
+	}
+	for _, v := range versions {
+		if d, ok := domain.DeprecatedPythonVersion(v); ok {
+			return d
+		}
+	}
+	t.Skip("no python_version is currently deprecated")
+	return domain.PythonDeprecation{}
+}
+
+// supportedPythonLine returns a python_version with no deprecation note.
+func supportedPythonLine(t *testing.T) string {
+	t.Helper()
+	versions, err := domain.SupportedPythonVersions()
+	if err != nil {
+		t.Fatalf("SupportedPythonVersions: %v", err)
+	}
+	for _, v := range versions {
+		if _, ok := domain.DeprecatedPythonVersion(v); !ok {
+			return v
+		}
+	}
+	t.Fatal("every supported python_version is deprecated")
+	return ""
+}
+
+func TestWarnDeprecatedPythonDefaultPath(t *testing.T) {
+	d := deprecatedPythonLine(t)
+	var out strings.Builder
+	if err := warnDeprecatedPython(&out, &domain.LeoflowConfig{PythonVersion: d.Version}); err != nil {
+		t.Fatalf("warnDeprecatedPython: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"warning:",
+		"python_version " + d.Version,
+		publishedBaseRepo + ":py" + d.Version,
+		d.RemoveAfter,
+		`python_version: "` + d.Replacement + `"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("warning does not mention %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestWarnDeprecatedPythonSilentOnSupported(t *testing.T) {
+	var out strings.Builder
+	if err := warnDeprecatedPython(&out, &domain.LeoflowConfig{PythonVersion: supportedPythonLine(t)}); err != nil {
+		t.Fatalf("warnDeprecatedPython: %v", err)
+	}
+	if out.String() != "" {
+		t.Fatalf("a supported python_version produced a warning:\n%s", out.String())
+	}
+}
+
+// A base_image pointing at somebody else's registry means python_version is not
+// what the FROM is built from, so warning about it would be wrong and would
+// train the author to filter this message out.
+func TestWarnDeprecatedPythonSilentOnForeignBaseImage(t *testing.T) {
+	d := deprecatedPythonLine(t)
+	var out strings.Builder
+	cfg := &domain.LeoflowConfig{PythonVersion: d.Version, BaseImage: "registry.example.com/team/base:2026-09"}
+	if err := warnDeprecatedPython(&out, cfg); err != nil {
+		t.Fatalf("warnDeprecatedPython: %v", err)
+	}
+	if out.String() != "" {
+		t.Fatalf("an unrelated base_image produced a warning:\n%s", out.String())
+	}
+}
+
+// The population the deprecation is actually about: a pin to our own published
+// tag is what keeps a user on a base after we stop rebuilding it. Both published
+// tag shapes must be recognized.
+func TestWarnDeprecatedPythonPinnedPublishedBase(t *testing.T) {
+	d := deprecatedPythonLine(t)
+	for name, ref := range map[string]string{
+		"moving line tag": publishedBaseRepo + ":py" + d.Version,
+		"per-release pin": publishedBaseRepo + ":py" + d.Version + "-v0.4.5",
+		"per-release rc":  publishedBaseRepo + ":py" + d.Version + "-v0.4.5-rc.1",
+	} {
+		var out strings.Builder
+		if err := warnDeprecatedPython(&out, &domain.LeoflowConfig{BaseImage: ref}); err != nil {
+			t.Fatalf("%s: warnDeprecatedPython: %v", name, err)
+		}
+		if !strings.Contains(out.String(), "python_version "+d.Version) {
+			t.Errorf("%s (%s) produced no warning:\n%s", name, ref, out.String())
+		}
+	}
+}
+
+func TestWarnDeprecatedPythonSilentOnSupportedPin(t *testing.T) {
+	ref := publishedBaseRepo + ":py" + supportedPythonLine(t)
+	var out strings.Builder
+	if err := warnDeprecatedPython(&out, &domain.LeoflowConfig{BaseImage: ref}); err != nil {
+		t.Fatalf("warnDeprecatedPython: %v", err)
+	}
+	if out.String() != "" {
+		t.Fatalf("a pin to a supported line produced a warning:\n%s", out.String())
+	}
+}
+
+func TestWarnDeprecatedPythonNilAndEmpty(t *testing.T) {
+	var out strings.Builder
+	if err := warnDeprecatedPython(&out, nil); err != nil {
+		t.Fatalf("nil config: %v", err)
+	}
+	if err := warnDeprecatedPython(&out, &domain.LeoflowConfig{}); err != nil {
+		t.Fatalf("empty config: %v", err)
+	}
+	if out.String() != "" {
+		t.Fatalf("nil/empty config produced a warning:\n%s", out.String())
+	}
+}
+
+func TestWrapWords(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		cols int
+		want []string
+	}{
+		{"empty", "   ", 10, nil},
+		{"fits on one line", "a b c", 10, []string{"a b c"}},
+		{"folds at the boundary", "aaaa bbbb cccc", 9, []string{"aaaa bbbb", "cccc"}},
+		{"collapses runs of whitespace", "a \n  b", 10, []string{"a b"}},
+		{
+			// An image reference longer than the column budget must survive intact:
+			// a wrapped one cannot be copy-pasted, which is the only thing the
+			// reader wants to do with it.
+			"an over-long token is not cut",
+			"pull ghcr.io/neochaotic/leoflow-runtime:py3.10-v0.4.5 now",
+			20,
+			[]string{"pull", "ghcr.io/neochaotic/leoflow-runtime:py3.10-v0.4.5", "now"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := wrapWords(tc.in, tc.cols)
+			if len(got) != len(tc.want) {
+				t.Fatalf("wrapWords(%q, %d) = %q, want %q", tc.in, tc.cols, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("wrapWords(%q, %d) = %q, want %q", tc.in, tc.cols, got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -24,16 +24,21 @@ func newValidateCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if verr := cfg.Validate(); verr != nil {
-				return fmt.Errorf("invalid %s: %w", projectConfigPath(dir), verr)
-			}
+			// Shared with `compile`/`deploy` rather than open-coded, which is
+			// what this was: schema validation, the dbt-block-with-dag.py
+			// conflict (#1015), and the deprecated-Python warning. Open-coding
+			// the first two meant `validate` silently skipped the third — and
+			// `validate` is the sub-second command an author runs in a loop
+			// with leoflow.yaml open, so it is where a warning about a field
+			// in that file has the best chance of being acted on.
+			//
 			// A pure-dbt project has no dag.py: the dbt project IS the DAG
 			// (ADR 0042). Stat'ing the source unconditionally made the whole
 			// mode unvalidatable — the command that exists to say "this is
 			// fine" always said it was not (#996). The check is scoped, not
-			// removed: a dag.py DAG with a missing source still fails here.
-			if derr := errDbtBlockWithDagSource(dir, cfg); derr != nil {
-				return derr
+			// removed: a dag.py DAG with a missing source still fails below.
+			if perr := checkProjectPreconditions(cmd, dir, cfg); perr != nil {
+				return perr
 			}
 			if cfg.Dbt != nil {
 				// Scoping the dag.py check to a dag.py DAG left the dbt lane with

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -212,8 +212,10 @@ func highestPythonVersion(projects []Project) string {
 // "3.11". Components are compared numerically (so "3.10" > "3.9", which naive
 // string comparison gets wrong since '1' < '9'). Non-numeric or malformed
 // components fall back to string compare so the function never panics on
-// bad input — caller filters to the schema-allowed set ("3.10|3.11|3.12|3.13"
-// today) before relying on the result.
+// bad input — caller filters to the schema-allowed set (the python_version enum
+// in internal/domain/schemas/leoflow-yaml-schema.json, reachable as
+// domain.SupportedPythonVersions) before relying on the result. Naming the
+// versions here was a fourth copy of that list and had already gone stale.
 func pythonVersionLess(a, b string) bool {
 	aParts := strings.Split(a, ".")
 	bParts := strings.Split(b, ".")

--- a/internal/domain/python.go
+++ b/internal/domain/python.go
@@ -1,0 +1,119 @@
+package domain
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"sync"
+	"time"
+)
+
+// PythonDeprecation records why a published Python line is on its way out and
+// when it stops being published. It is read from the authoring schema rather
+// than declared in Go so that the enum and the deprecation notes cannot drift
+// apart: they are two fields of the same object.
+type PythonDeprecation struct {
+	// Version is the deprecated python_version value, e.g. "3.10".
+	Version string `json:"-"`
+	// EOL is the upstream CPython end-of-life date (YYYY-MM-DD). After it,
+	// docker-library/python stops rebuilding the line and the base image stops
+	// receiving OS security updates.
+	EOL string `json:"eol"`
+	// RemoveAfter is the date after which the release stops publishing a base
+	// image for this line (YYYY-MM-DD).
+	RemoveAfter string `json:"remove_after"`
+	// Replacement is the version an author should move to.
+	Replacement string `json:"replacement"`
+	// Reason is the human-readable justification, quoted verbatim in the CLI
+	// warning so the author gets the argument and not just a verdict.
+	Reason string `json:"reason"`
+}
+
+// pythonVersionSchema is the shape of the schema's python_version subschema that
+// this package cares about. Everything else in it (type, description) is the
+// validator's business.
+type pythonVersionSchema struct {
+	Enum    []string `json:"enum"`
+	Default string   `json:"default"`
+	// The key is spelled by the JSON Schema document, not by us: `x-` is the
+	// conventional prefix for a vendor extension keyword, and a validator must be
+	// free to ignore it.
+	Deprecations map[string]PythonDeprecation `json:"x-leoflow-python-deprecations"` //nolint:tagliatelle // JSON Schema vendor-extension keyword; the name is fixed by the schema document
+}
+
+// pythonSupport is parsed once. A malformed schema is a build-time defect, not a
+// runtime condition, so the error is carried and surfaced by the accessors'
+// callers rather than swallowed.
+var pythonSupport = sync.OnceValues(loadPythonSupport)
+
+func loadPythonSupport() (pythonVersionSchema, error) {
+	var doc struct {
+		Properties struct {
+			PythonVersion pythonVersionSchema `json:"python_version"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal(leoflowSchemaJSON, &doc); err != nil {
+		return pythonVersionSchema{}, fmt.Errorf("parsing leoflow.yaml schema: %w", err)
+	}
+	p := doc.Properties.PythonVersion
+	if len(p.Enum) == 0 {
+		return pythonVersionSchema{}, fmt.Errorf("leoflow.yaml schema declares no python_version enum")
+	}
+	// A default that is not selectable, or one that is on its way out, would hand
+	// every author who writes no python_version at all the version we are asking
+	// them to leave. ApplyDefaults hard-codes the same string; the two are tied
+	// together by TestApplyDefaultsPythonVersionIsSupported.
+	if !slices.Contains(p.Enum, p.Default) {
+		return pythonVersionSchema{}, fmt.Errorf(
+			"leoflow.yaml schema: python_version default %q is not in the enum %v", p.Default, p.Enum)
+	}
+	if _, deprecated := p.Deprecations[p.Default]; deprecated {
+		return pythonVersionSchema{}, fmt.Errorf(
+			"leoflow.yaml schema: python_version default %q is deprecated — "+
+				"move the default to a supported line before deprecating it", p.Default)
+	}
+	for v, d := range p.Deprecations {
+		if !slices.Contains(p.Enum, v) {
+			return pythonVersionSchema{}, fmt.Errorf(
+				"leoflow.yaml schema deprecates python_version %q, which is not in the enum %v — "+
+					"a deprecation note for a version nobody can select is a note nobody will read", v, p.Enum)
+		}
+		if _, err := time.Parse(time.DateOnly, d.RemoveAfter); err != nil {
+			return pythonVersionSchema{}, fmt.Errorf(
+				"leoflow.yaml schema: python_version %q has remove_after %q, want YYYY-MM-DD", v, d.RemoveAfter)
+		}
+	}
+	return p, nil
+}
+
+// SupportedPythonVersions returns the python_version values the project
+// publishes a task base image for, in schema order (ascending). The slice is a
+// copy: callers may sort or filter it.
+//
+// This is the one list. scripts/check-python-runtime-matrix.sh asserts that the
+// release matrix, the Makefile target, the runtime Dockerfile and the
+// configuration reference all agree with it, because a published image nobody
+// can select — and a selectable version nobody publishes — both surface as a
+// `docker pull` 404 inside the user's own build.
+func SupportedPythonVersions() ([]string, error) {
+	p, err := pythonSupport()
+	if err != nil {
+		return nil, err
+	}
+	return append([]string(nil), p.Enum...), nil
+}
+
+// DeprecatedPythonVersion reports the deprecation record for v, if the schema
+// carries one. The second result is false for a version that is fine.
+func DeprecatedPythonVersion(v string) (PythonDeprecation, bool) {
+	p, err := pythonSupport()
+	if err != nil {
+		return PythonDeprecation{}, false
+	}
+	d, ok := p.Deprecations[v]
+	if !ok {
+		return PythonDeprecation{}, false
+	}
+	d.Version = v
+	return d, true
+}

--- a/internal/domain/python_test.go
+++ b/internal/domain/python_test.go
@@ -1,0 +1,151 @@
+package domain
+
+import (
+	"encoding/json"
+	"slices"
+	"testing"
+	"time"
+)
+
+// TestSupportedPythonVersionsMatchesSchemaEnum pins the accessor to the schema
+// the validator actually enforces. If the two ever came from different places a
+// `python_version` could pass Validate() and still have no published base image
+// — the failure would then surface as a `docker pull` 404 inside the user's
+// build, which is the furthest possible point from the cause.
+func TestSupportedPythonVersionsMatchesSchemaEnum(t *testing.T) {
+	got, err := SupportedPythonVersions()
+	if err != nil {
+		t.Fatalf("SupportedPythonVersions: %v", err)
+	}
+
+	var doc struct {
+		Properties struct {
+			PythonVersion struct {
+				Enum []string `json:"enum"`
+			} `json:"python_version"`
+		} `json:"properties"`
+	}
+	if uerr := json.Unmarshal(leoflowSchemaJSON, &doc); uerr != nil {
+		t.Fatalf("unmarshal schema: %v", uerr)
+	}
+	if !slices.Equal(got, doc.Properties.PythonVersion.Enum) {
+		t.Fatalf("SupportedPythonVersions() = %v, schema enum = %v", got, doc.Properties.PythonVersion.Enum)
+	}
+	if len(got) == 0 {
+		t.Fatal("no supported Python versions — the schema enum must never be empty")
+	}
+}
+
+// TestSupportedPythonVersionsIsACopy guards the accessor from handing callers a
+// window into the parsed-once schema. A caller that sorts or appends to the
+// result must not mutate what every later caller sees.
+func TestSupportedPythonVersionsIsACopy(t *testing.T) {
+	first, err := SupportedPythonVersions()
+	if err != nil {
+		t.Fatalf("SupportedPythonVersions: %v", err)
+	}
+	original := slices.Clone(first)
+	for i := range first {
+		first[i] = "mutated"
+	}
+	second, err := SupportedPythonVersions()
+	if err != nil {
+		t.Fatalf("SupportedPythonVersions: %v", err)
+	}
+	if !slices.Equal(second, original) {
+		t.Fatalf("mutating the returned slice changed a later call: got %v, want %v", second, original)
+	}
+}
+
+// TestDeprecatedPythonVersionIsSelectableAndDated asserts every deprecation note
+// describes a version an author can actually write, and carries the two dates
+// the CLI warning quotes. A note for a version that is not in the enum is a note
+// nobody will ever be shown.
+func TestDeprecatedPythonVersionIsSelectableAndDated(t *testing.T) {
+	versions, err := SupportedPythonVersions()
+	if err != nil {
+		t.Fatalf("SupportedPythonVersions: %v", err)
+	}
+	deprecated := 0
+	for _, v := range versions {
+		d, ok := DeprecatedPythonVersion(v)
+		if !ok {
+			continue
+		}
+		deprecated++
+		if d.Version != v {
+			t.Errorf("DeprecatedPythonVersion(%q).Version = %q", v, d.Version)
+		}
+		for name, date := range map[string]string{"eol": d.EOL, "remove_after": d.RemoveAfter} {
+			if _, perr := time.Parse(time.DateOnly, date); perr != nil {
+				t.Errorf("python %s: %s = %q, want YYYY-MM-DD", v, name, date)
+			}
+		}
+		if d.Reason == "" {
+			t.Errorf("python %s: deprecation carries no reason — the warning would state a verdict with no argument", v)
+		}
+		if !slices.Contains(versions, d.Replacement) {
+			t.Errorf("python %s: replacement %q is not itself a supported version", v, d.Replacement)
+		}
+		if _, alsoDeprecated := DeprecatedPythonVersion(d.Replacement); alsoDeprecated {
+			t.Errorf("python %s: replacement %q is itself deprecated", v, d.Replacement)
+		}
+	}
+	if deprecated == len(versions) {
+		t.Fatal("every published Python line is deprecated — there is nowhere to send an author")
+	}
+}
+
+// TestDeprecatedPythonVersionUnknown keeps the negative path honest: a version
+// with no note, and a string that is not a version at all, both report false
+// rather than a zero-valued record that reads as "deprecated with no details".
+func TestDeprecatedPythonVersionUnknown(t *testing.T) {
+	for _, v := range []string{"", "3.99", "not-a-version"} {
+		if d, ok := DeprecatedPythonVersion(v); ok {
+			t.Errorf("DeprecatedPythonVersion(%q) = %+v, true; want false", v, d)
+		}
+	}
+}
+
+// TestApplyDefaultsPythonVersionIsSupported ties the hard-coded default in
+// ApplyDefaults to the schema. They are two statements of one fact and the
+// schema is the one that is enforced.
+func TestApplyDefaultsPythonVersionIsSupported(t *testing.T) {
+	c := &LeoflowConfig{DagID: "d"}
+	c.ApplyDefaults()
+	versions, err := SupportedPythonVersions()
+	if err != nil {
+		t.Fatalf("SupportedPythonVersions: %v", err)
+	}
+	if !slices.Contains(versions, c.PythonVersion) {
+		t.Fatalf("ApplyDefaults set python_version %q, not in the schema enum %v", c.PythonVersion, versions)
+	}
+	if d, ok := DeprecatedPythonVersion(c.PythonVersion); ok {
+		t.Fatalf("ApplyDefaults defaults to the deprecated python_version %q (%s); move the default first",
+			c.PythonVersion, d.Reason)
+	}
+}
+
+// TestValidateAcceptsEverySupportedPythonVersion closes the loop from the other
+// side: the enum this package exports must be exactly what Validate() lets
+// through, so a version the release publishes can never be rejected by the CLI.
+func TestValidateAcceptsEverySupportedPythonVersion(t *testing.T) {
+	versions, err := SupportedPythonVersions()
+	if err != nil {
+		t.Fatalf("SupportedPythonVersions: %v", err)
+	}
+	for _, v := range versions {
+		c := &LeoflowConfig{DagID: "d", PythonVersion: v}
+		c.ApplyDefaults()
+		c.PythonVersion = v
+		if verr := c.Validate(); verr != nil {
+			t.Errorf("python_version %q is published but Validate() rejects it: %v", v, verr)
+		}
+	}
+	c := &LeoflowConfig{DagID: "d", PythonVersion: "3.9"}
+	c.ApplyDefaults()
+	c.PythonVersion = "3.9"
+	if verr := c.Validate(); verr == nil {
+		t.Error("Validate() accepted python_version 3.9, for which no base image is published")
+	}
+}

--- a/internal/domain/schemas/leoflow-yaml-schema.json
+++ b/internal/domain/schemas/leoflow-yaml-schema.json
@@ -39,7 +39,7 @@
     },
     "base_image": {
       "type": "string",
-      "description": "Override the default leoflow/python-runtime base image."
+      "description": "Override the image the DAG is built FROM. Default: the published Leoflow task base for python_version (ghcr.io/neochaotic/leoflow-runtime:py<python_version>, pinned to the CLI's release tag). Setting this makes python_version unused for the FROM, so a pin to a deprecated py<line> tag is not fixed by changing python_version — repoint this field. Pinning also freezes the interpreter and OS packages at whatever the base carried the day you pinned it (ADR 0003)."
     },
     "dependencies": {
       "type": "array",

--- a/internal/domain/schemas/leoflow-yaml-schema.json
+++ b/internal/domain/schemas/leoflow-yaml-schema.json
@@ -25,8 +25,17 @@
 
     "python_version": {
       "type": "string",
-      "enum": ["3.10", "3.11", "3.12"],
-      "default": "3.11"
+      "description": "Python line of the published task base image (ghcr.io/neochaotic/leoflow-runtime:py<version>). This enum is the single source of truth for which base images the release publishes; scripts/check-python-runtime-matrix.sh fails when the release matrix, the Makefile, runtime/Dockerfile or the configuration reference disagree with it. 3.10 is deprecated and stops being published after its 2026-10-31 upstream EOL.",
+      "enum": ["3.10", "3.11", "3.12", "3.13"],
+      "default": "3.11",
+      "x-leoflow-python-deprecations": {
+        "3.10": {
+          "eol": "2026-10-31",
+          "remove_after": "2026-10-31",
+          "replacement": "3.11",
+          "reason": "Python 3.10 reaches upstream end-of-life on 2026-10-31. docker-library/python stops rebuilding an EOL line the day after (python:3.9-slim was last rebuilt 2025-11-01, one day after 3.9 went EOL), so python:3.10-slim-bookworm — and therefore leoflow-runtime:py3.10 — stops receiving OS security updates and accumulates unfixed CVEs indefinitely."
+        }
+      }
     },
     "base_image": {
       "type": "string",

--- a/internal/setup/detect.go
+++ b/internal/setup/detect.go
@@ -67,6 +67,16 @@ type Report struct {
 // present because it's the version the managed CPython matches, keeping
 // dev/prod parity for users on the documented path.
 //
+// This is NOT the list of Python lines Leoflow publishes a task base image for,
+// and it deliberately differs from it. That list is the python_version enum in
+// internal/domain/schemas/leoflow-yaml-schema.json (see
+// domain.SupportedPythonVersions), and it answers a different question: which
+// interpreter runs INSIDE the DAG image, on a machine that is not this one.
+// This list answers which interpreter on THIS host can parse a dag.py. #1031
+// read the two as one list that had drifted; they are two lists that agree
+// about nothing in particular, and the overlap is a coincidence of both being
+// Python.
+//
 // The forward-looking range (3.14–3.18) covers minors that haven't shipped
 // yet so users with a future system Python still skip the managed-CPython
 // download. Bump the upper bound when a new minor lands AND the parser

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -10,7 +10,10 @@
 #   docker build -f runtime/Dockerfile \
 #     --build-arg PYTHON_VERSION=3.11 -t leoflow-base:py3.11 .
 #
-# PYTHON_VERSION selects the interpreter (3.10 / 3.11 / 3.12).
+# PYTHON_VERSION selects the interpreter (3.10 / 3.11 / 3.12 / 3.13). The list
+# is not authoritative here: internal/domain/schemas/leoflow-yaml-schema.json's
+# python_version enum is, and scripts/check-python-runtime-matrix.sh fails this
+# comment when it falls behind. 3.10 is deprecated (upstream EOL 2026-10-31).
 
 ARG GO_VERSION=1.26.3
 ARG PYTHON_VERSION=3.11

--- a/scripts/check-python-runtime-matrix.sh
+++ b/scripts/check-python-runtime-matrix.sh
@@ -33,6 +33,17 @@
 # published line makes that leg unbuildable, and one below it advertises support
 # for an interpreter we ship no image for.
 #
+# The gate reconciles the deprecation STATUS AND DATES as well as the list, and
+# that second half is not optional. Reconciling only the set of versions leaves
+# the half a user acts on unguarded: move a deprecation from 3.10 to 3.11 in the
+# schema and every version still appears in every file, so the list arms stay
+# green while the support table in the configuration reference — the only place
+# a user learns the date — says the exact opposite of what the CLI enforces and
+# what the weekly watchdog asserts. The same date is hardcoded in release.yaml's
+# comment above the matrix, which is the copy a maintainer reads while editing
+# the matrix that publishes the leg, so it is reconciled too. A wrong date is
+# worse than a missing one: it answers the question the reader came with.
+#
 # Usage: scripts/check-python-runtime-matrix.sh [--self-test]
 #        scripts/check-python-runtime-matrix.sh <repo-root>
 set -euo pipefail
@@ -213,6 +224,134 @@ got = [VERSION_RE.search(ln).group(0) for ln in status_rows]
 if set(got) != wantset:
 	note(docs_rel, "Python version support table", got, want)
 
+# ── 6. the deprecation STATUS and DATES, not just the list ───────────────────
+# Reconciling only the set of versions left the half that a user actually acts
+# on unguarded: move the deprecation from 3.10 to 3.11 in the schema and this
+# table keeps saying `3.11 | Supported (default)` / `3.10 | Deprecated` with a
+# green gate. The table is the only place a user learns the date, so a stale one
+# is worse than a missing one — it answers the question, wrongly.
+
+
+def cells(row):
+	"""Split a markdown table row into its cells, markdown emphasis stripped."""
+	parts = [c.strip() for c in row.strip().strip("|").split("|")]
+	return [re.sub(r"[`*_]", "", c).strip() for c in parts]
+
+
+header = None
+for ln in docs_text.splitlines():
+	if not ln.startswith("|"):
+		continue
+	c = cells(ln)
+	if len(c) >= 4 and c[0] == "Line" and c[1] == "Status":
+		header = c
+		break
+if header is None:
+	fail(
+		f"{docs_rel} has no Python-support table header of the shape\n"
+		"`| Line | Status | Upstream EOL | Published until |` — the status/date arm of this\n"
+		"gate cannot locate its columns and must not report OK."
+	)
+# Index by name rather than position: a reordered column would otherwise be
+# compared against the wrong schema field and pass for the wrong reason.
+for required in ("Upstream EOL", "Published until"):
+	if required not in header:
+		fail(f"{docs_rel}'s Python-support table has no {required!r} column (header: {header})")
+eol_col = header.index("Upstream EOL")
+until_col = header.index("Published until")
+
+for row in status_rows:
+	c = cells(row)
+	version = VERSION_RE.search(c[0]).group(0)
+	if len(c) <= max(eol_col, until_col):
+		problems.append(f"  {docs_rel}\n    status row for {version} has {len(c)} cells, header declares {len(header)}")
+		continue
+	dep = deprecations.get(version)
+	says_deprecated = "deprecated" in c[1].lower()
+	if dep is None:
+		if says_deprecated:
+			problems.append(
+				f"  {docs_rel}\n"
+				f"    status row for {version}: {c[1]!r}\n"
+				f"    schema:  {version} carries no x-leoflow-python-deprecations entry\n"
+				"    A line the docs call deprecated and the schema does not is a line the CLI\n"
+				"    will never warn about — the user is told to move off something nothing enforces."
+			)
+		if re.search(r"\d{4}-\d{2}-\d{2}", c[until_col]):
+			problems.append(
+				f"  {docs_rel}\n"
+				f"    status row for {version} declares a removal date ({c[until_col]}) but the schema\n"
+				"    marks the line supported. Record it in x-leoflow-python-deprecations or drop it."
+			)
+		continue
+	if not says_deprecated:
+		problems.append(
+			f"  {docs_rel}\n"
+			f"    status row for {version}: {c[1]!r}\n"
+			f"    schema:  deprecated (eol {dep.get('eol')}, remove_after {dep.get('remove_after')})\n"
+			"    This table is where a user learns a line is going away."
+		)
+	for label, col, key in (("Upstream EOL", eol_col, "eol"), ("Published until", until_col, "remove_after")):
+		expected = dep.get(key)
+		if not expected:
+			fail(f"{schema_rel}'s deprecation of {version} declares no {key!r}")
+		if c[col] != expected:
+			problems.append(
+				f"  {docs_rel}\n"
+				f"    status row for {version}, {label}: {c[col]!r}\n"
+				f"    schema {key}: {expected}\n"
+				"    The date in the docs is the one the user plans around; the one in the schema is\n"
+				"    the one the CLI prints and the watchdog asserts. They cannot be two dates."
+			)
+
+# The prose paragraph beneath the table repeats the argument and the dates. It
+# is what a user reads after the table tells them there is something to read.
+for version, dep in deprecations.items():
+	marker = f"`{version}` is deprecated"
+	if marker not in docs_text:
+		problems.append(
+			f"  {docs_rel}\n"
+			f"    no prose paragraph saying {marker!r}\n"
+			f"    schema:  {version} is deprecated, remove_after {dep.get('remove_after')}\n"
+			"    The table states the verdict; the paragraph is where the reason and the fix live."
+		)
+		continue
+	para = docs_text.split(marker, 1)[1][:1600]
+	for key in ("eol", "remove_after", "replacement"):
+		if dep[key] not in para:
+			problems.append(
+				f"  {docs_rel}\n"
+				f"    the {version} deprecation paragraph never mentions {key} = {dep[key]!r}"
+			)
+
+# ── 7. the release workflow's own prose about the deprecation ────────────────
+# release.yaml hardcodes the EOL date in the comment above the matrix. It is the
+# copy a maintainer reads while editing the matrix, so it is the copy most likely
+# to be trusted and least likely to be revisited.
+workflow_text = read(workflow_rel)
+for version in want:
+	dep = deprecations.get(version)
+	found = re.search(rf"py{re.escape(version)} is DEPRECATED", workflow_text, re.I)
+	if dep and not found:
+		problems.append(
+			f"  {workflow_rel}\n"
+			f"    no `py{version} is DEPRECATED` note above the matrix\n"
+			f"    schema:  {version} is deprecated, remove_after {dep.get('remove_after')}\n"
+			"    This is the comment a maintainer reads while editing the matrix that publishes it."
+		)
+	elif dep is None and found:
+		problems.append(
+			f"  {workflow_rel}\n"
+			f"    calls py{version} DEPRECATED, but the schema does not"
+		)
+	elif dep and found:
+		tail = workflow_text[found.start():found.start() + 700]
+		if dep["eol"] not in tail:
+			problems.append(
+				f"  {workflow_rel}\n"
+				f"    the py{version} deprecation note never states its EOL date ({dep['eol']})"
+			)
+
 if problems:
 	sys.exit(
 		"FAIL: the published-Python list has drifted from the schema enum.\n"
@@ -231,27 +370,56 @@ self_test() {
 	tmp="$(mktemp -d)"
 	trap 'rm -rf "${tmp:-}"' RETURN
 
-	# Builds a minimal repo root whose five copies all agree on 3.10/3.11.
+	# The fixture deliberately gives 3.10 an `eol` (2026-10-31) DIFFERENT from its
+	# `remove_after` (2026-12-31). In the real repo the two happen to be the same
+	# date, which would let a gate that compares the wrong column against the wrong
+	# schema field pass every case below for the wrong reason.
+	_dep_json='{"3.10":{"eol":"2026-10-31","remove_after":"2026-12-31","replacement":"3.11"}}'
+	_schema() { # <dir> <deprecations-json>
+		printf '{"properties":{"python_version":{"enum":["3.10","3.11"],"default":"3.11",\n "x-leoflow-python-deprecations":%s}}}\n' \
+			"$2" >"$1/internal/domain/schemas/leoflow-yaml-schema.json"
+	}
+
+	# release.yaml carries both the matrix and the prose note about the deprecated
+	# leg, so a mutator that rewrites one must restate the other or it is changing
+	# two things at once and the case proves nothing about either.
+	_matrix_both='jobs:\n  runtime-image:\n    strategy:\n      matrix:\n        python: ["3.10", "3.11"]\n'
+	_note_default='py3.10 is DEPRECATED: Python 3.10 goes EOL 2026-10-31.'
+	_release() { # <dir> <matrix-yaml-printf-format> <deprecation-note>
+		{
+			printf '# %s\n' "$3"
+			# shellcheck disable=SC2059 # $2 IS the format: callers pass literal templates
+			printf "$2"
+		} >"$1/.github/workflows/release.yaml"
+	}
+
+	_rows_default='| `3.10` | **Deprecated** | 2026-10-31 | 2026-12-31 |\n| `3.11` | Supported *(default)* | 2027-10-31 | — |\n'
+	_prose_default='**`3.10` is deprecated.** Upstream EOL 2026-10-31; published until 2026-12-31. Set `python_version` to `3.11`.\n'
+	_docs() { # <dir> <status-rows-printf-format> <prose-printf-format>
+		{
+			printf '| `python_version` | `3.10`\\|`3.11` | Base image Python. |\n'
+			printf '| `python_version` | `"3.11"` | Pick `3.10` or `3.11`. |\n\n'
+			printf '| Line | Status | Upstream EOL | Published until |\n|---|---|---|---|\n'
+			# shellcheck disable=SC2059 # $2 IS the format: callers pass literal templates
+			printf "$2"
+			printf '\n'
+			# shellcheck disable=SC2059 # $3 IS the format: callers pass literal templates
+			printf "$3"
+		} >"$1/website/content/reference/configuration.md"
+	}
+
+	# Builds a minimal repo root whose copies all agree on 3.10/3.11.
 	_mkroot() { # <dir>
 		local d="$1"
 		mkdir -p "$d/internal/domain/schemas" "$d/.github/workflows" "$d/runtime/python" \
 			"$d/website/content/reference"
-		cat >"$d/internal/domain/schemas/leoflow-yaml-schema.json" <<'JSON'
-{"properties":{"python_version":{"enum":["3.10","3.11"],"default":"3.11",
- "x-leoflow-python-deprecations":{"3.10":{"eol":"2026-10-31"}}}}}
-JSON
-		printf 'jobs:\n  runtime-image:\n    strategy:\n      matrix:\n        python: ["3.10", "3.11"]\n' \
-			>"$d/.github/workflows/release.yaml"
+		_schema "$d" "$_dep_json"
+		_release "$d" "$_matrix_both" "$_note_default"
 		printf 'runtime-images:\n\tfor v in 3.10 3.11; do \\\n\t\tdocker build . ; \\\n\tdone\n' >"$d/Makefile"
 		printf '# PYTHON_VERSION selects the interpreter (3.10 / 3.11).\nARG PYTHON_VERSION=3.11\n' \
 			>"$d/runtime/Dockerfile"
 		printf '[project]\nrequires-python = ">=3.10"\n' >"$d/runtime/python/pyproject.toml"
-		{
-			printf '| `python_version` | `3.10`\\|`3.11` | Base image Python. |\n'
-			printf '| `python_version` | `"3.11"` | Pick `3.10` or `3.11`. |\n'
-			printf '| Line | Status |\n|---|---|\n'
-			printf '| `3.10` | Deprecated |\n| `3.11` | Supported |\n'
-		} >"$d/website/content/reference/configuration.md"
+		_docs "$d" "$_rows_default" "$_prose_default"
 	}
 
 	_case() { # <name> <want-rc> <want-substring> <mutator...>
@@ -274,23 +442,54 @@ JSON
 	}
 
 	_noop() { :; }
-	_drop_from_matrix() { printf 'jobs:\n  runtime-image:\n    strategy:\n      matrix:\n        python: ["3.10"]\n' >"$1/.github/workflows/release.yaml"; }
-	_comment_out_matrix() { printf 'jobs:\n  runtime-image:\n    strategy:\n      matrix:\n        # python: ["3.10", "3.11"]\n        os: [ubuntu-latest]\n' >"$1/.github/workflows/release.yaml"; }
-	_rename_job() { printf 'jobs:\n  runtime-base:\n    strategy:\n      matrix:\n        python: ["3.10", "3.11"]\n' >"$1/.github/workflows/release.yaml"; }
-	_unquoted_matrix() { printf 'jobs:\n  runtime-image:\n    strategy:\n      matrix:\n        python: [3.10, 3.11]\n' >"$1/.github/workflows/release.yaml"; }
+	_drop_from_matrix() { _release "$1" 'jobs:\n  runtime-image:\n    strategy:\n      matrix:\n        python: ["3.10"]\n' "$_note_default"; }
+	_comment_out_matrix() { _release "$1" 'jobs:\n  runtime-image:\n    strategy:\n      matrix:\n        # python: ["3.10", "3.11"]\n        os: [ubuntu-latest]\n' "$_note_default"; }
+	_rename_job() { _release "$1" 'jobs:\n  runtime-base:\n    strategy:\n      matrix:\n        python: ["3.10", "3.11"]\n' "$_note_default"; }
+	_unquoted_matrix() { _release "$1" 'jobs:\n  runtime-image:\n    strategy:\n      matrix:\n        python: [3.10, 3.11]\n' "$_note_default"; }
 	_stale_makefile() { printf 'runtime-images:\n\tfor v in 3.10; do \\\n\t\tdocker build . ; \\\n\tdone\n' >"$1/Makefile"; }
 	_commented_makefile_loop() { printf 'runtime-images:\n\t# for v in 3.10 3.11; do \\\n\t@echo skip\n' >"$1/Makefile"; }
 	_other_target_loop() { printf 'other-images:\n\tfor v in 3.10 3.11; do \\\n\tdone\n\nruntime-images:\n\t@echo nothing\n' >"$1/Makefile"; }
 	_stale_dockerfile() { printf '# PYTHON_VERSION selects the interpreter (3.10 / 3.11 / 3.12).\n' >"$1/runtime/Dockerfile"; }
 	_dropped_dockerfile_comment() { printf 'ARG PYTHON_VERSION=3.11\n' >"$1/runtime/Dockerfile"; }
 	_raised_floor() { printf '[project]\nrequires-python = ">=3.11"\n' >"$1/runtime/python/pyproject.toml"; }
-	_stale_docs_row() { printf '| `python_version` | `3.10`\\|`3.11`\\|`3.12` | x |\n| `3.10` | Deprecated |\n| `3.11` | Supported |\n' >"$1/website/content/reference/configuration.md"; }
-	_stale_status_table() { printf '| `python_version` | `3.10`\\|`3.11` | x |\n| `3.10` | Deprecated |\n' >"$1/website/content/reference/configuration.md"; }
+	_stale_docs_row() {
+		_docs "$1" "$_rows_default" "$_prose_default"
+		printf '| `python_version` | `3.10`\\|`3.11`\\|`3.12` | drifted |\n' >>"$1/website/content/reference/configuration.md"
+	}
+	_stale_status_table() { _docs "$1" '| `3.10` | **Deprecated** | 2026-10-31 | 2026-12-31 |\n' "$_prose_default"; }
 	_missing_schema() { rm -f "$1/internal/domain/schemas/leoflow-yaml-schema.json"; }
 	_empty_enum() { printf '{"properties":{"python_version":{"default":"3.11"}}}\n' >"$1/internal/domain/schemas/leoflow-yaml-schema.json"; }
-	_unlisted_deprecation() { printf '{"properties":{"python_version":{"enum":["3.10","3.11"],"default":"3.11","x-leoflow-python-deprecations":{"3.9":{}}}}}\n' >"$1/internal/domain/schemas/leoflow-yaml-schema.json"; }
+	_unlisted_deprecation() { _schema "$1" '{"3.9":{}}'; }
 	_deprecated_default() { printf '{"properties":{"python_version":{"enum":["3.10","3.11"],"default":"3.10","x-leoflow-python-deprecations":{"3.10":{}}}}}\n' >"$1/internal/domain/schemas/leoflow-yaml-schema.json"; }
 	_unsorted_enum() { printf '{"properties":{"python_version":{"enum":["3.11","3.10"],"default":"3.11"}}}\n' >"$1/internal/domain/schemas/leoflow-yaml-schema.json"; }
+
+	# ── the status/date arm: the half the list check cannot see ─────────────────
+	# The motivating mutation is _deprecation_moves_in_schema_only: move the
+	# deprecation from 3.10 to 3.11 in the schema and the list of versions is
+	# still identical everywhere, so every case above stays green while the table
+	# the user reads now says the exact opposite of what the CLI enforces.
+	_deprecation_moves_in_schema_only() {
+		_schema "$1" '{"3.11":{"eol":"2027-10-31","remove_after":"2027-12-31","replacement":"3.12"}}'
+		# Keep the default off the newly deprecated line so this case fails on the
+		# docs disagreement and not on the deprecated-default rule.
+		sed -i.bak 's/"default":"3.11"/"default":"3.10"/' "$1/internal/domain/schemas/leoflow-yaml-schema.json"
+		rm -f "$1/internal/domain/schemas/leoflow-yaml-schema.json.bak"
+	}
+	_docs_call_it_supported() { _docs "$1" '| `3.10` | Supported | 2026-10-31 | 2026-12-31 |\n| `3.11` | Supported *(default)* | 2027-10-31 | — |\n' "$_prose_default"; }
+	_docs_deprecate_a_supported_line() { _docs "$1" '| `3.10` | **Deprecated** | 2026-10-31 | 2026-12-31 |\n| `3.11` | **Deprecated** | 2027-10-31 | — |\n' "$_prose_default"; }
+	_docs_stale_eol() { _docs "$1" '| `3.10` | **Deprecated** | 2025-10-31 | 2026-12-31 |\n| `3.11` | Supported *(default)* | 2027-10-31 | — |\n' "$_prose_default"; }
+	_docs_stale_removal_date() { _docs "$1" '| `3.10` | **Deprecated** | 2026-10-31 | 2027-06-30 |\n| `3.11` | Supported *(default)* | 2027-10-31 | — |\n' "$_prose_default"; }
+	_docs_removal_date_on_supported_line() { _docs "$1" '| `3.10` | **Deprecated** | 2026-10-31 | 2026-12-31 |\n| `3.11` | Supported *(default)* | 2027-10-31 | 2028-01-01 |\n' "$_prose_default"; }
+	_docs_no_status_header() {
+		_docs "$1" "$_rows_default" "$_prose_default"
+		sed -i.bak 's/^| Line | Status .*/| Version | State |/' "$1/website/content/reference/configuration.md"
+		rm -f "$1/website/content/reference/configuration.md.bak"
+	}
+	_docs_no_prose() { _docs "$1" "$_rows_default" 'The table above is the whole story.\n'; }
+	_docs_prose_omits_removal_date() { _docs "$1" "$_rows_default" '**`3.10` is deprecated.** Upstream EOL 2026-10-31. Set `python_version` to `3.11`.\n'; }
+	_release_drops_deprecation_note() { _release "$1" "$_matrix_both" 'One leg per supported Python.'; }
+	_release_deprecates_a_supported_line() { _release "$1" "$_matrix_both" 'py3.11 is DEPRECATED: EOL 2027-10-31. Also py3.10 is DEPRECATED: Python 3.10 goes EOL 2026-10-31.'; }
+	_release_note_omits_eol() { _release "$1" "$_matrix_both" 'py3.10 is DEPRECATED: it goes away at some point.'; }
 
 	_case "an agreeing tree passes"                  0 "agrees everywhere (3.10, 3.11; deprecated: 3.10)" _noop
 	_case "a leg missing from the release matrix"    1 "matrix.python" _drop_from_matrix
@@ -311,6 +510,18 @@ JSON
 	_case "a deprecation outside the enum"           1 "is not in the enum" _unlisted_deprecation
 	_case "a deprecated default"                     1 "also marks deprecated" _deprecated_default
 	_case "an out-of-order enum"                     1 "not in ascending order" _unsorted_enum
+	_case "the deprecation moves in the schema only" 1 "status row for 3.11" _deprecation_moves_in_schema_only
+	_case "the docs call a deprecated line supported" 1 "This table is where a user learns" _docs_call_it_supported
+	_case "the docs deprecate a supported line"      1 "carries no x-leoflow-python-deprecations entry" _docs_deprecate_a_supported_line
+	_case "a stale Upstream EOL cell"                1 "schema eol: 2026-10-31" _docs_stale_eol
+	_case "a stale Published until cell"             1 "schema remove_after: 2026-12-31" _docs_stale_removal_date
+	_case "a removal date on a supported line"       1 "declares a removal date" _docs_removal_date_on_supported_line
+	_case "a renamed status table header"            1 "has no Python-support table header" _docs_no_status_header
+	_case "no deprecation prose at all"              1 "no prose paragraph saying" _docs_no_prose
+	_case "prose that omits the removal date"        1 "never mentions remove_after" _docs_prose_omits_removal_date
+	_case "release.yaml drops the deprecation note"  1 "no \`py3.10 is DEPRECATED\` note" _release_drops_deprecation_note
+	_case "release.yaml deprecates a supported leg"  1 "calls py3.11 DEPRECATED" _release_deprecates_a_supported_line
+	_case "a release note with no EOL date"          1 "never states its EOL date" _release_note_omits_eol
 
 	if [ "$fail" -eq 0 ]; then echo "self-test: PASS"; return 0; else echo "self-test: FAIL"; return 1; fi
 }

--- a/scripts/check-python-runtime-matrix.sh
+++ b/scripts/check-python-runtime-matrix.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# The set of Python lines Leoflow publishes a task base image for is stated in
+# five files, and only one of them is enforced by anything.
+#
+# The enforced one is the `python_version` enum in
+# internal/domain/schemas/leoflow-yaml-schema.json: it is embedded into the CLI
+# and `LeoflowConfig.Validate()` rejects anything else. (docs/api/ carries the
+# byte-equal canonical mirror of the same file; TestEmbeddedSchemasMatchDocs
+# already binds the two, so this gate reads the copy that actually ships in the
+# binary.) The other four are the
+# release matrix that actually pushes the images, the Makefile target that
+# builds them locally, the comment in runtime/Dockerfile, and the configuration
+# reference the user reads. Nothing reconciled them, and by #1031 they had
+# already drifted in both directions: the release published py3.10 while the
+# host detector probed for a 3.13 nobody published.
+#
+# Both directions of drift fail in the same expensive place. A version in the
+# enum with no published leg is a `docker pull ... 404` inside the USER's build,
+# minutes after their compile started, naming an image they never typed. A
+# published leg missing from the enum is a `leoflow compile` that refuses a
+# perfectly good image with "value must be one of" — and the user cannot fix
+# either one, because both live in our repo.
+#
+# This is the same "two copies of a fact with nothing between them" shape as
+# check-lite-prepull-matches-compose.sh, and it takes the same two lessons from
+# it. The workflow is parsed as YAML, not grepped, so a commented-out matrix
+# cannot keep the gate green. And a missing file, a renamed job or an
+# unrecognized declaration is a FAIL, never a silent pass — a gate that stops
+# gating after a file move is worse than no gate, because it still reports OK.
+#
+# The floor in runtime/python/pyproject.toml is checked too: the runtime helper
+# is pip-installed INTO the base image, so a `requires-python` above the oldest
+# published line makes that leg unbuildable, and one below it advertises support
+# for an interpreter we ship no image for.
+#
+# Usage: scripts/check-python-runtime-matrix.sh [--self-test]
+#        scripts/check-python-runtime-matrix.sh <repo-root>
+set -euo pipefail
+
+SCHEMA_REL="internal/domain/schemas/leoflow-yaml-schema.json"
+WORKFLOW_REL=".github/workflows/release.yaml"
+MAKEFILE_REL="Makefile"
+DOCKERFILE_REL="runtime/Dockerfile"
+PYPROJECT_REL="runtime/python/pyproject.toml"
+DOCS_REL="website/content/reference/configuration.md"
+JOB="runtime-image"
+
+check() { # <repo-root>
+	python3 - "$1" "$SCHEMA_REL" "$WORKFLOW_REL" "$MAKEFILE_REL" "$DOCKERFILE_REL" "$PYPROJECT_REL" "$DOCS_REL" "$JOB" <<'PY'
+import json
+import os
+import re
+import sys
+
+try:
+	import yaml
+except ImportError:
+	sys.exit("FAIL: PyYAML unavailable; cannot parse the release workflow (pip install pyyaml)")
+
+root, schema_rel, workflow_rel, makefile_rel, dockerfile_rel, pyproject_rel, docs_rel, job_name = sys.argv[1:9]
+
+problems = []
+VERSION_RE = re.compile(r"3\.\d+")
+
+
+def fail(msg):
+	sys.exit("FAIL: " + msg)
+
+
+def read(rel):
+	path = os.path.join(root, rel)
+	if not os.path.exists(path):
+		fail(f"{rel} does not exist — this gate's scan target moved and it would otherwise report OK")
+	with open(path) as fh:
+		text = fh.read()
+	if not text.strip():
+		fail(f"{rel} is empty")
+	return text
+
+
+def note(rel, what, got, want):
+	problems.append(f"  {rel}\n    {what}: {got}\n    schema enum:  {want}")
+
+
+# ── the source of truth ──────────────────────────────────────────────────────
+schema = json.loads(read(schema_rel))
+py = ((schema.get("properties") or {}).get("python_version") or {})
+want = py.get("enum")
+if not want:
+	fail(f"{schema_rel} declares no python_version enum — the source of truth is gone")
+if sorted(set(want)) != sorted(want) or len(want) != len(set(want)):
+	fail(f"{schema_rel}'s python_version enum repeats a value: {want}")
+for v in want:
+	if not VERSION_RE.fullmatch(v):
+		fail(f"{schema_rel}'s python_version enum contains {v!r}, which is not a 3.<minor> line")
+
+default = py.get("default")
+if default not in want:
+	fail(f"{schema_rel}'s python_version default {default!r} is not in its own enum {want}")
+
+deprecations = py.get("x-leoflow-python-deprecations") or {}
+for v in deprecations:
+	if v not in want:
+		fail(
+			f"{schema_rel} deprecates python_version {v!r}, which is not in the enum {want}.\n"
+			"A deprecation note for a version nobody can select is a note nobody reads;\n"
+			"drop the note in the same change that drops the leg."
+		)
+if default in deprecations:
+	fail(f"{schema_rel} defaults python_version to {default!r}, which it also marks deprecated")
+
+wantset = set(want)
+sorted_want = sorted(want, key=lambda v: [int(p) for p in v.split(".")])
+if want != sorted_want:
+	fail(f"{schema_rel}'s python_version enum is not in ascending order: {want}")
+
+# ── 1. the release matrix that pushes the images ─────────────────────────────
+workflow = yaml.safe_load(read(workflow_rel)) or {}
+jobs = workflow.get("jobs") or {}
+if job_name not in jobs:
+	fail(f"{workflow_rel} has no `{job_name}` job — did it get renamed?")
+matrix = (((jobs[job_name].get("strategy") or {}).get("matrix")) or {}).get("python")
+if not matrix:
+	fail(
+		f"{workflow_rel}'s `{job_name}` job declares no `strategy.matrix.python`.\n"
+		"Without it no base image is published at all, and every `leoflow compile`\n"
+		"that does not override base_image fails on the pull."
+	)
+# YAML reads an unquoted 3.10 as the float 3.1, which is the exact typo this
+# gate exists to catch; compare as written, not as parsed.
+got = [str(v) for v in matrix]
+if set(got) != wantset:
+	note(workflow_rel, f"`{job_name}` matrix.python", got, want)
+
+# ── 2. the Makefile target that builds them locally ──────────────────────────
+make_text = read(makefile_rel)
+recipe = None
+in_target = False
+for line in make_text.splitlines():
+	if re.match(r"^runtime-images\s*:", line):
+		in_target = True
+		continue
+	if in_target:
+		# A recipe line is TAB-indented; the first line that is not ends the recipe.
+		if not line.startswith("\t"):
+			if line.strip() == "" or line.startswith("#"):
+				continue
+			break
+		if line.lstrip().startswith("#"):
+			continue
+		if "for v in" in line:
+			recipe = line
+			break
+if recipe is None:
+	fail(
+		f"{makefile_rel} has no `runtime-images` recipe with a `for v in ...` loop — did it get renamed?\n"
+		"`make runtime-images` is how the base images are built outside CI; a gate that\n"
+		"cannot find it must not report OK."
+	)
+loop = recipe.split("for v in", 1)[1].split(";", 1)[0]
+got = VERSION_RE.findall(loop)
+if set(got) != wantset:
+	note(makefile_rel, "`runtime-images` loop", got, want)
+
+# ── 3. the runtime Dockerfile's own statement of the list ────────────────────
+dockerfile_text = read(dockerfile_rel)
+marker = "PYTHON_VERSION selects the interpreter"
+lines = [ln for ln in dockerfile_text.splitlines() if marker in ln]
+if not lines:
+	fail(
+		f"{dockerfile_rel} no longer carries the `{marker} (...)` comment.\n"
+		"It is the list a reader of the Dockerfile sees; either restore it or delete\n"
+		"this arm of the gate deliberately."
+	)
+got = VERSION_RE.findall(lines[0])
+if set(got) != wantset:
+	note(dockerfile_rel, f"`{marker}` comment", got, want)
+
+# ── 4. the runtime helper's floor ────────────────────────────────────────────
+pyproject_text = read(pyproject_rel)
+m = re.search(r"^\s*requires-python\s*=\s*[\"']>=\s*(3\.\d+)", pyproject_text, re.M)
+if not m:
+	fail(f"{pyproject_rel} declares no `requires-python = \">=3.<minor>\"` — did the key change shape?")
+floor = m.group(1)
+oldest = sorted_want[0]
+if floor != oldest:
+	problems.append(
+		f"  {pyproject_rel}\n"
+		f"    requires-python floor: >={floor}\n"
+		f"    oldest published leg:  {oldest}\n"
+		"    The runtime helper is pip-installed into the base image: a floor above the\n"
+		"    oldest published line makes that leg unbuildable; one below it advertises an\n"
+		"    interpreter no base image exists for."
+	)
+
+# ── 5. the configuration reference the user reads ────────────────────────────
+docs_text = read(docs_rel)
+rows = [ln for ln in docs_text.splitlines() if ln.startswith("|") and "`python_version`" in ln]
+if not rows:
+	fail(f"{docs_rel} has no table row naming `python_version` — did the reference move?")
+for row in rows:
+	got = VERSION_RE.findall(row)
+	if set(got) != wantset:
+		note(docs_rel, f"row {row.strip()[:60]!r}", got, want)
+
+status_rows = [ln for ln in docs_text.splitlines() if re.match(r"^\|\s*`3\.\d+`\s*\|", ln)]
+if not status_rows:
+	fail(
+		f"{docs_rel} has no Python-support status table (rows of the shape `| \\`3.11\\` | ... |`).\n"
+		"That table is where a user learns which lines are deprecated and until when."
+	)
+got = [VERSION_RE.search(ln).group(0) for ln in status_rows]
+if set(got) != wantset:
+	note(docs_rel, "Python version support table", got, want)
+
+if problems:
+	sys.exit(
+		"FAIL: the published-Python list has drifted from the schema enum.\n"
+		+ "\n".join(problems)
+		+ f"\n\nThe schema ({schema_rel}) is the source of truth: it is what the CLI\n"
+		"enforces. Change it first, then bring the copies to match."
+	)
+
+deprecated = ", ".join(sorted(deprecations)) or "none"
+print(f"OK: published Python matrix agrees everywhere ({', '.join(want)}; deprecated: {deprecated})")
+PY
+}
+
+self_test() {
+	local fail=0 tmp
+	tmp="$(mktemp -d)"
+	trap 'rm -rf "${tmp:-}"' RETURN
+
+	# Builds a minimal repo root whose five copies all agree on 3.10/3.11.
+	_mkroot() { # <dir>
+		local d="$1"
+		mkdir -p "$d/internal/domain/schemas" "$d/.github/workflows" "$d/runtime/python" \
+			"$d/website/content/reference"
+		cat >"$d/internal/domain/schemas/leoflow-yaml-schema.json" <<'JSON'
+{"properties":{"python_version":{"enum":["3.10","3.11"],"default":"3.11",
+ "x-leoflow-python-deprecations":{"3.10":{"eol":"2026-10-31"}}}}}
+JSON
+		printf 'jobs:\n  runtime-image:\n    strategy:\n      matrix:\n        python: ["3.10", "3.11"]\n' \
+			>"$d/.github/workflows/release.yaml"
+		printf 'runtime-images:\n\tfor v in 3.10 3.11; do \\\n\t\tdocker build . ; \\\n\tdone\n' >"$d/Makefile"
+		printf '# PYTHON_VERSION selects the interpreter (3.10 / 3.11).\nARG PYTHON_VERSION=3.11\n' \
+			>"$d/runtime/Dockerfile"
+		printf '[project]\nrequires-python = ">=3.10"\n' >"$d/runtime/python/pyproject.toml"
+		{
+			printf '| `python_version` | `3.10`\\|`3.11` | Base image Python. |\n'
+			printf '| `python_version` | `"3.11"` | Pick `3.10` or `3.11`. |\n'
+			printf '| Line | Status |\n|---|---|\n'
+			printf '| `3.10` | Deprecated |\n| `3.11` | Supported |\n'
+		} >"$d/website/content/reference/configuration.md"
+	}
+
+	_case() { # <name> <want-rc> <want-substring> <mutator...>
+		local name="$1" want_rc="$2" want_msg="$3" rc=0 out d
+		shift 3
+		d="$tmp/case"
+		rm -rf "$d"
+		_mkroot "$d"
+		"$@" "$d"
+		out="$(check "$d" 2>&1)" || rc=$?
+		if [ "$rc" != "$want_rc" ]; then
+			printf '  FAIL %s (exit)\n    got:  %s\n    want: %s\n    out: %s\n' "$name" "$rc" "$want_rc" "$out"
+			fail=1
+			return
+		fi
+		case "$out" in
+			*"$want_msg"*) printf '  ok   %s\n' "$name" ;;
+			*) printf '  FAIL %s (message)\n    got: %q\n    want to contain: %q\n' "$name" "$out" "$want_msg"; fail=1 ;;
+		esac
+	}
+
+	_noop() { :; }
+	_drop_from_matrix() { printf 'jobs:\n  runtime-image:\n    strategy:\n      matrix:\n        python: ["3.10"]\n' >"$1/.github/workflows/release.yaml"; }
+	_comment_out_matrix() { printf 'jobs:\n  runtime-image:\n    strategy:\n      matrix:\n        # python: ["3.10", "3.11"]\n        os: [ubuntu-latest]\n' >"$1/.github/workflows/release.yaml"; }
+	_rename_job() { printf 'jobs:\n  runtime-base:\n    strategy:\n      matrix:\n        python: ["3.10", "3.11"]\n' >"$1/.github/workflows/release.yaml"; }
+	_unquoted_matrix() { printf 'jobs:\n  runtime-image:\n    strategy:\n      matrix:\n        python: [3.10, 3.11]\n' >"$1/.github/workflows/release.yaml"; }
+	_stale_makefile() { printf 'runtime-images:\n\tfor v in 3.10; do \\\n\t\tdocker build . ; \\\n\tdone\n' >"$1/Makefile"; }
+	_commented_makefile_loop() { printf 'runtime-images:\n\t# for v in 3.10 3.11; do \\\n\t@echo skip\n' >"$1/Makefile"; }
+	_other_target_loop() { printf 'other-images:\n\tfor v in 3.10 3.11; do \\\n\tdone\n\nruntime-images:\n\t@echo nothing\n' >"$1/Makefile"; }
+	_stale_dockerfile() { printf '# PYTHON_VERSION selects the interpreter (3.10 / 3.11 / 3.12).\n' >"$1/runtime/Dockerfile"; }
+	_dropped_dockerfile_comment() { printf 'ARG PYTHON_VERSION=3.11\n' >"$1/runtime/Dockerfile"; }
+	_raised_floor() { printf '[project]\nrequires-python = ">=3.11"\n' >"$1/runtime/python/pyproject.toml"; }
+	_stale_docs_row() { printf '| `python_version` | `3.10`\\|`3.11`\\|`3.12` | x |\n| `3.10` | Deprecated |\n| `3.11` | Supported |\n' >"$1/website/content/reference/configuration.md"; }
+	_stale_status_table() { printf '| `python_version` | `3.10`\\|`3.11` | x |\n| `3.10` | Deprecated |\n' >"$1/website/content/reference/configuration.md"; }
+	_missing_schema() { rm -f "$1/internal/domain/schemas/leoflow-yaml-schema.json"; }
+	_empty_enum() { printf '{"properties":{"python_version":{"default":"3.11"}}}\n' >"$1/internal/domain/schemas/leoflow-yaml-schema.json"; }
+	_unlisted_deprecation() { printf '{"properties":{"python_version":{"enum":["3.10","3.11"],"default":"3.11","x-leoflow-python-deprecations":{"3.9":{}}}}}\n' >"$1/internal/domain/schemas/leoflow-yaml-schema.json"; }
+	_deprecated_default() { printf '{"properties":{"python_version":{"enum":["3.10","3.11"],"default":"3.10","x-leoflow-python-deprecations":{"3.10":{}}}}}\n' >"$1/internal/domain/schemas/leoflow-yaml-schema.json"; }
+	_unsorted_enum() { printf '{"properties":{"python_version":{"enum":["3.11","3.10"],"default":"3.11"}}}\n' >"$1/internal/domain/schemas/leoflow-yaml-schema.json"; }
+
+	_case "an agreeing tree passes"                  0 "agrees everywhere (3.10, 3.11; deprecated: 3.10)" _noop
+	_case "a leg missing from the release matrix"    1 "matrix.python" _drop_from_matrix
+	_case "a commented-out matrix is not a matrix"   1 "declares no \`strategy.matrix.python\`" _comment_out_matrix
+	_case "a renamed job fails loudly"               1 "did it get renamed?" _rename_job
+	# YAML turns an unquoted 3.10 into the float 3.1 — the typo this gate is for.
+	_case "an unquoted 3.10 is caught"               1 "matrix.python" _unquoted_matrix
+	_case "a stale Makefile loop"                    1 "runtime-images\` loop" _stale_makefile
+	_case "a commented-out Makefile loop"            1 "did it get renamed?" _commented_makefile_loop
+	_case "another target's loop does not count"     1 "did it get renamed?" _other_target_loop
+	_case "a stale Dockerfile comment"               1 "selects the interpreter\` comment" _stale_dockerfile
+	_case "a dropped Dockerfile comment"             1 "no longer carries the" _dropped_dockerfile_comment
+	_case "a raised requires-python floor"           1 "oldest published leg" _raised_floor
+	_case "a stale docs row"                         1 "configuration.md" _stale_docs_row
+	_case "a stale docs status table"                1 "Python version support table" _stale_status_table
+	_case "a missing schema fails, not skips"        1 "does not exist" _missing_schema
+	_case "an empty enum fails"                      1 "declares no python_version enum" _empty_enum
+	_case "a deprecation outside the enum"           1 "is not in the enum" _unlisted_deprecation
+	_case "a deprecated default"                     1 "also marks deprecated" _deprecated_default
+	_case "an out-of-order enum"                     1 "not in ascending order" _unsorted_enum
+
+	if [ "$fail" -eq 0 ]; then echo "self-test: PASS"; return 0; else echo "self-test: FAIL"; return 1; fi
+}
+
+[ "${1:-}" = "--self-test" ] && { self_test; exit $?; }
+
+cd "$(dirname "$0")/.."
+check "${1:-$PWD}"

--- a/scripts/check-script-selftests.sh
+++ b/scripts/check-script-selftests.sh
@@ -33,8 +33,8 @@ done
 
 # A rename or a lost self_test() would otherwise shrink this gate to nothing
 # while still exiting 0 — the same silent-shrink hole run_gates guards against.
-if [ "$found" -lt "${MIN_SELFTESTS:-5}" ]; then
-	echo "FAIL: found only $found self-test(s), expected at least ${MIN_SELFTESTS:-5} — did a script lose its self_test()?" >&2
+if [ "$found" -lt "${MIN_SELFTESTS:-7}" ]; then
+	echo "FAIL: found only $found self-test(s), expected at least ${MIN_SELFTESTS:-7} — did a script lose its self_test()?" >&2
 	exit 1
 fi
 [ "$failed" -eq 0 ] || exit 1

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -748,8 +748,8 @@ run_gates() { # <tag>
   shopt -u nullglob
   # A gate renamed out of check-*.sh silently leaves the cut's gate set with no
   # signal at all, so assert the floor.
-  [ "${#gates[@]}" -ge "${MIN_GATES:-8}" ] || {
-    echo "gate set shrank to ${#gates[@]} (expected >= ${MIN_GATES:-8}) — a check-*.sh was renamed or removed" >&2
+  [ "${#gates[@]}" -ge "${MIN_GATES:-9}" ] || {
+    echo "gate set shrank to ${#gates[@]} (expected >= ${MIN_GATES:-9}) — a check-*.sh was renamed or removed" >&2
     return 1
   }
   for s in "${gates[@]}"; do

--- a/scripts/python-eol-warn.sh
+++ b/scripts/python-eol-warn.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# Weekly watch on the Python lines we publish a base image for.
+#
+# #1031 was found by hand, seven weeks before python:3.10-slim stops being
+# rebuilt. Nothing in the repo would have found it at all: an EOL is a date, and
+# a date passes without any commit, any CI run and any diff. Every other supply
+# chain signal we have (Dependabot, Trivy, govulncheck) reacts to a CVE that
+# already exists, which for a frozen base image is precisely the signal that
+# stops arriving — docker-library/python stops rebuilding an EOL line the day
+# after it goes EOL (python:3.9-slim was last rebuilt 2025-11-01, one day after
+# 3.9's EOL), so the image simply stops changing while the CVEs accumulate under
+# it.
+#
+# So this asks the calendar instead, weekly, from the scheduled security
+# workflow, and it does not gate anything. It is deliberately NOT named
+# check-*.sh: cut-release.sh's run_gates() globs that prefix, and a release must
+# never be blocked because a date is approaching or because a third-party JSON
+# endpoint is down. The one thing it does exit non-zero for is its OWN failure
+# (no network, unparseable feed) — a watchdog that cannot tell you it is broken
+# is worse than no watchdog, and it is on a path where red costs nothing.
+#
+# Two findings are worth a human:
+#   1. a line we still call supported is within EOL_WARN_DAYS of upstream EOL —
+#      the one that would have raised #1031 in January instead of September;
+#   2. a line the schema already marked deprecated is still in the enum after
+#      its own remove_after date — the deprecation that quietly never happened.
+# An already-deprecated line inside its window is a notice, not an alert: we
+# know, the date is recorded, and repeating it weekly is how a real alert gets
+# filtered out.
+#
+# Usage: scripts/python-eol-warn.sh [--self-test]
+#        scripts/python-eol-warn.sh [<eol-json>] [<today YYYY-MM-DD>]
+#
+# Env: EOL_WARN_DAYS (default 270) — how far out a supported line raises.
+set -euo pipefail
+
+EOL_API="https://endoflife.date/api/python.json"
+SCHEMA_REL="internal/domain/schemas/leoflow-yaml-schema.json"
+
+# report <root> <eol-json> <today>
+# Writes the markdown report to stdout, GitHub annotations to stderr, and
+# `alert=true|false` to $GITHUB_OUTPUT when running in Actions.
+report() {
+	python3 - "$1" "$SCHEMA_REL" "$2" "${3:-}" "${EOL_WARN_DAYS:-270}" <<'PY'
+import json
+import os
+import sys
+from datetime import date, datetime
+
+root, schema_rel, eol_path, today_arg, warn_days = sys.argv[1:6]
+warn_days = int(warn_days)
+
+
+def die(msg):
+	sys.exit("ERROR: " + msg)
+
+
+def parse_day(s, what):
+	try:
+		return datetime.strptime(s, "%Y-%m-%d").date()
+	except (TypeError, ValueError):
+		die(f"{what}: {s!r} is not a YYYY-MM-DD date")
+
+
+today = parse_day(today_arg, "today") if today_arg else date.today()
+
+with open(os.path.join(root, schema_rel)) as fh:
+	py = ((json.load(fh).get("properties") or {}).get("python_version") or {})
+published = py.get("enum") or die(f"{schema_rel} declares no python_version enum")
+deprecations = py.get("x-leoflow-python-deprecations") or {}
+
+try:
+	with open(eol_path) as fh:
+		cycles = json.load(fh)
+except (OSError, ValueError) as e:
+	die(f"cannot read the endoflife.date feed ({eol_path}): {e}")
+if not isinstance(cycles, list) or not cycles:
+	die("the endoflife.date feed is not a non-empty list — did the API shape change?")
+
+eol_by_cycle = {}
+for c in cycles:
+	if isinstance(c, dict) and isinstance(c.get("cycle"), str):
+		eol_by_cycle[c["cycle"]] = c.get("eol")
+
+alerts, notices = [], []
+
+for v in published:
+	raw = eol_by_cycle.get(v)
+	if raw is None:
+		alerts.append(
+			f"- **python {v}** — endoflife.date has no `{v}` cycle. We publish a base image for a "
+			"line upstream does not list; either the version is wrong or the feed changed shape."
+		)
+		continue
+	if raw is False:
+		notices.append(f"- python {v} — no EOL announced upstream.")
+		continue
+	eol = parse_day(raw, f"endoflife.date eol for python {v}")
+	days = (eol - today).days
+	dep = deprecations.get(v)
+
+	if dep is None:
+		if days <= warn_days:
+			when = f"in {days} day(s)" if days >= 0 else f"{-days} day(s) ago"
+			alerts.append(
+				f"- **python {v} reaches upstream EOL on {eol} ({when})** and is still listed as "
+				f"supported in `{schema_rel}`.\n"
+				f"  `docker-library/python` stops rebuilding the line the day after, so "
+				f"`ghcr.io/neochaotic/leoflow-runtime:py{v}` freezes and accumulates unfixed OS CVEs. "
+				f"Users pin `base_image`, so our choice becomes theirs.\n"
+				f"  Decide now: add `x-leoflow-python-deprecations` for `{v}` with a removal date, "
+				f"announce it in the CHANGELOG, and keep publishing until then."
+			)
+		continue
+
+	# Already deprecated: only the deprecation that never happened is an alert.
+	recorded = dep.get("eol")
+	if recorded and recorded != str(eol):
+		alerts.append(
+			f"- **python {v}** — the schema records eol `{recorded}`, endoflife.date says `{eol}`. "
+			"One of the two is wrong and the CHANGELOG quotes ours."
+		)
+	remove_after = dep.get("remove_after")
+	if remove_after and parse_day(remove_after, f"remove_after for python {v}") < today:
+		alerts.append(
+			f"- **python {v} is past its own removal date ({remove_after}) and is still in the "
+			f"`python_version` enum.** The base has not been rebuilt since {eol}; drop the leg from "
+			"the enum and from the release matrix."
+		)
+	else:
+		notices.append(f"- python {v} — deprecated, EOL {eol}, published until {remove_after or 'unset'}.")
+
+for line in notices:
+	print(f"::notice::{line.lstrip('- ')}", file=sys.stderr)
+for line in alerts:
+	print(f"::warning::{line.splitlines()[0].lstrip('- ')}", file=sys.stderr)
+
+title = "Python EOL watch: a published runtime base needs a decision"
+body = [
+	f"`scripts/python-eol-warn.sh` ran on {today} against {', '.join(published)} "
+	f"(threshold: {warn_days} days).",
+	"",
+]
+body += alerts if alerts else ["No published Python line needs a decision."]
+if notices:
+	body += ["", "<details><summary>Already handled</summary>", ""] + notices + ["", "</details>"]
+body += ["", "Source of truth: `" + schema_rel + "`. Feed: <https://endoflife.date/api/python.json>."]
+print("\n".join(body))
+
+if out := os.environ.get("GITHUB_OUTPUT"):
+	with open(out, "a") as fh:
+		fh.write(f"alert={'true' if alerts else 'false'}\n")
+		fh.write(f"title={title}\n")
+PY
+}
+
+fetch_feed() { # <dest>
+	local i
+	for i in 1 2 3; do
+		if curl -fsSL --max-time 30 "$EOL_API" -o "$1"; then return 0; fi
+		echo "::warning::endoflife.date fetch attempt ${i} failed; retrying in 5s" >&2
+		sleep 5
+	done
+	echo "::error::could not fetch ${EOL_API} after 3 attempts" >&2
+	return 1
+}
+
+self_test() {
+	local fail=0 tmp
+	tmp="$(mktemp -d)"
+	trap 'rm -rf "${tmp:-}"' RETURN
+
+	mkdir -p "$tmp/root/internal/domain/schemas"
+	local schema="$tmp/root/internal/domain/schemas/leoflow-yaml-schema.json"
+
+	_schema() { # <json>
+		printf '%s' "$1" >"$schema"
+	}
+	_feed() { # <json>
+		printf '%s' "$1" >"$tmp/feed.json"
+	}
+
+	_case() { # <name> <want-rc> <want-substring> <today>
+		local name="$1" want_rc="$2" want_msg="$3" today="$4" rc=0 out
+		out="$(report "$tmp/root" "$tmp/feed.json" "$today" 2>&1)" || rc=$?
+		if [ "$rc" != "$want_rc" ]; then
+			printf '  FAIL %s (exit)\n    got:  %s\n    want: %s\n    out: %s\n' "$name" "$rc" "$want_rc" "$out"
+			fail=1
+			return
+		fi
+		case "$out" in
+			*"$want_msg"*) printf '  ok   %s\n' "$name" ;;
+			*) printf '  FAIL %s (message)\n    got: %q\n    want to contain: %q\n' "$name" "$out" "$want_msg"; fail=1 ;;
+		esac
+	}
+
+	_case_absent() { # <name> <unwanted-substring> <today>
+		local name="$1" unwanted="$2" today="$3" out
+		out="$(report "$tmp/root" "$tmp/feed.json" "$today" 2>&1)" || {
+			printf '  FAIL %s (unexpected non-zero exit)\n    out: %s\n' "$name" "$out"; fail=1; return
+		}
+		case "$out" in
+			*"$unwanted"*) printf '  FAIL %s\n    out must NOT contain: %q\n    got: %q\n' "$name" "$unwanted" "$out"; fail=1 ;;
+			*) printf '  ok   %s\n' "$name" ;;
+		esac
+	}
+
+	_feed '[{"cycle":"3.13","eol":"2029-10-31"},{"cycle":"3.12","eol":"2028-10-31"},{"cycle":"3.11","eol":"2027-10-31"},{"cycle":"3.10","eol":"2026-10-31"}]'
+
+	# A supported line far from EOL is silent.
+	_schema '{"properties":{"python_version":{"enum":["3.12","3.13"]}}}'
+	_case "a healthy matrix reports nothing to decide" 0 "No published Python line needs a decision" "2026-09-09"
+
+	# The finding that would have raised #1031 in March instead of September.
+	_schema '{"properties":{"python_version":{"enum":["3.10","3.11"]}}}'
+	_case "an undeprecated line inside the window raises" 0 "python 3.10 reaches upstream EOL on 2026-10-31" "2026-03-01"
+	_case_absent "and a far-off line does not" "python 3.11 reaches upstream EOL" "2026-03-01"
+
+	# The threshold is the whole mechanism; a small one must go quiet again.
+	EOL_WARN_DAYS=10
+	_case "outside the threshold it stays quiet" 0 "No published Python line needs a decision" "2026-03-01"
+	unset EOL_WARN_DAYS
+
+	# The deprecation block belongs UNDER python_version. One a level up is a
+	# no-op that must not be mistaken for a handled deprecation.
+	_schema '{"properties":{"python_version":{"enum":["3.10","3.11"]},"x-leoflow-python-deprecations":{"3.10":{"eol":"2026-10-31","remove_after":"2026-10-31"}}}}'
+	_case "a misplaced deprecation block still alerts" 0 "python 3.10 reaches upstream EOL" "2026-09-09"
+
+	_schema '{"properties":{"python_version":{"enum":["3.10","3.11"],"x-leoflow-python-deprecations":{"3.10":{"eol":"2026-10-31","remove_after":"2026-10-31"}}}}}'
+	_case "a correctly deprecated line is only a notice" 0 "No published Python line needs a decision" "2026-09-09"
+	_case "the deprecation that never happened alerts" 0 "past its own removal date" "2026-12-01"
+
+	# A recorded EOL that disagrees with upstream means the CHANGELOG is wrong.
+	_schema '{"properties":{"python_version":{"enum":["3.10","3.11"],"x-leoflow-python-deprecations":{"3.10":{"eol":"2026-11-30","remove_after":"2026-11-30"}}}}}'
+	_case "a schema/upstream EOL mismatch alerts" 0 "the schema records eol" "2026-09-09"
+
+	# We publish a line upstream has never heard of.
+	_schema '{"properties":{"python_version":{"enum":["3.99"]}}}'
+	_case "a version upstream does not list alerts" 0 "endoflife.date has no \`3.99\` cycle" "2026-09-09"
+
+	# Its own failures are loud: this is the watchdog telling you it is blind.
+	_schema '{"properties":{"python_version":{"enum":["3.11"]}}}'
+	_feed '{"not":"a list"}'
+	_case "a reshaped feed exits non-zero" 1 "did the API shape change?" "2026-09-09"
+	_feed 'not json at all'
+	_case "an unparseable feed exits non-zero" 1 "cannot read the endoflife.date feed" "2026-09-09"
+	_feed '[{"cycle":"3.11","eol":"soon"}]'
+	_case "a non-date eol exits non-zero" 1 "is not a YYYY-MM-DD date" "2026-09-09"
+	_feed '[{"cycle":"3.11","eol":"2027-10-31"}]'
+	_schema '{"properties":{}}'
+	_case "an enum-less schema exits non-zero" 1 "declares no python_version enum" "2026-09-09"
+
+	if [ "$fail" -eq 0 ]; then echo "self-test: PASS"; return 0; else echo "self-test: FAIL"; return 1; fi
+}
+
+[ "${1:-}" = "--self-test" ] && { self_test; exit $?; }
+
+cd "$(dirname "$0")/.."
+feed="${1:-}"
+if [ -z "$feed" ]; then
+	feed="$(mktemp)"
+	trap 'rm -f "${feed:-}"' EXIT
+	fetch_feed "$feed"
+fi
+report "$PWD" "$feed" "${2:-}"

--- a/website/content/project/adrs/0003-dag-as-image.md
+++ b/website/content/project/adrs/0003-dag-as-image.md
@@ -77,6 +77,16 @@ To serve different audiences, Leoflow supports three progressive levels:
 
 ## Official Base Images
 
+> **Note (2026-09, #1031).** The list below is the decision as taken in 2026-05
+> and is no longer current — neither the repository name nor the set of Python
+> lines. The live list is the `python_version` enum in
+> `internal/domain/schemas/leoflow-yaml-schema.json`, published as
+> `ghcr.io/neochaotic/leoflow-runtime:py<version>` and rendered in the
+> [configuration reference](/reference/configuration/#python-version-support).
+> `scripts/check-python-runtime-matrix.sh` keeps every copy of it honest; this
+> ADR is deliberately not one of them, because a decision record states what was
+> decided, not what is true today.
+
 The project maintains three base images from day one:
 
 - `leoflow/python-runtime:3.10`

--- a/website/content/project/adrs/0014-supply-chain-security.md
+++ b/website/content/project/adrs/0014-supply-chain-security.md
@@ -80,6 +80,17 @@ Standard GitHub feature. Configured to:
 
 ### cosign for release signing
 
+> **Note (2026-09, #1031).** `leoflow/python-runtime:*` below is the repository
+> name as decided in 2026-05 and it no longer exists. The task base images are
+> published as `ghcr.io/neochaotic/leoflow-runtime:py<version>`, one leg per
+> entry in the `python_version` enum of
+> `internal/domain/schemas/leoflow-yaml-schema.json`, and rendered in the
+> [configuration reference](/reference/configuration/#python-version-support).
+> The signing decision itself is unchanged: every published leg is signed
+> keylessly on every release. This ADR is deliberately not one of the copies
+> `scripts/check-python-runtime-matrix.sh` reconciles, because a decision record
+> states what was decided, not what is true today.
+
 Every tagged release (`v0.1.0`, `v0.1.1`, etc.) signs:
 
 1. All published binaries (`leoflow`, `leoflow-server`, `leoflow-agent`)

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -24,7 +24,7 @@ chart's own values (image, replicas, ingress, Postgres/Redis wiring), see the
 |---|---|---|
 | `dag_id` *(required)* | string | Unique DAG id (`^[A-Za-z0-9_][A-Za-z0-9_-]{0,199}$`). |
 | `description`, `owner`, `tags` | string / string / list | Metadata. |
-| `python_version` | `3.10`\|`3.11`\|`3.12` | Base image Python (default 3.11). |
+| `python_version` | `3.10`\|`3.11`\|`3.12`\|`3.13` | Base image Python (default 3.11). `3.10` is **deprecated** — see [Python version support](#python-version-support). |
 | `base_image` | string | Override the runtime base image. |
 | `dependencies` | list | pip specifiers baked into the image. |
 | `connectors` | list | Short connector names (`postgres`, `http`, …) expanded at compile to their `apache-airflow-providers-*` packages. Sugar over `dependencies` — see [Installing a connector's provider](/connections/#installing-a-connectors-provider). |
@@ -36,6 +36,39 @@ chart's own values (image, replicas, ingress, Postgres/Redis wiring), see the
 | `tasks.<task_id>` | object | Per-task overrides (ADR 0023): `retries`, `retry_delay_seconds`, `execution_timeout_seconds`, `env`, `resources`, `execution`. |
 
 See [DAG authoring](/author-dags/dag-authoring/) for the override layers.
+
+### Python version support
+
+Every value the schema accepts has a published, multi-arch, cosign-signed base
+image at `ghcr.io/neochaotic/leoflow-runtime:py<version>`. Nothing else does —
+if a version is not in the table above, no base image exists for it and the
+build fails on the pull.
+
+| Line | Status | Upstream EOL | Published until |
+|---|---|---|---|
+| `3.10` | **Deprecated** | 2026-10-31 | the last release before 2026-11-01 |
+| `3.11` | Supported *(default)* | 2027-10-31 | — |
+| `3.12` | Supported | 2028-10-31 | — |
+| `3.13` | Supported | 2029-10-31 | — |
+
+`3.13` is the current ceiling, and it is set by the dbt adapters rather than by
+Airflow: `dbt-core` and `dbt-postgres` publish for 3.14, but `dbt-snowflake`,
+`dbt-bigquery`, `dbt-databricks` and `dbt-duckdb` stop at 3.13. A `py3.14` base
+would give you an image where `dbt-postgres` installs and `dbt-snowflake` does
+not — discovered inside your build, not ours — so it is not published.
+
+**`3.10` is deprecated.** Python 3.10 reaches upstream end-of-life on
+2026-10-31, and `docker-library/python` stops rebuilding an EOL line the day
+after (`python:3.9-slim` was last rebuilt 2025-11-01, one day after 3.9 went
+EOL). From that point `python:3.10-slim-bookworm` — and so
+`leoflow-runtime:py3.10` — receives no further OS security updates and
+accumulates unfixed CVEs indefinitely. The `py3.10` leg keeps being published
+until then, so nothing breaks today; `leoflow compile` warns when your project
+resolves to it. Set `python_version: "3.11"` (or later) and rebuild.
+
+This matters more than for most images because it is inherited: a DAG image is
+built `FROM` this base, so pinning `base_image` freezes your DAG on whatever the
+base was on the day you pinned it.
 
 ### Defaults
 
@@ -49,7 +82,7 @@ roadmap item.
 |---|---|---|
 | `schema_version` | `"1.0"` | Stamps every artifact for forward-compat. |
 | `dag_id` | *subdir basename* | If `leoflow.yaml` is absent, the parent directory name is used. Two subdirs resolving to the same `dag_id` is a hard error — see [Discovery rules](/author-dags/dag-authoring/#discovery-rules). |
-| `python_version` | `"3.11"` | Pick `3.10`, `3.11`, or `3.12`. |
+| `python_version` | `"3.11"` | Pick `3.10`, `3.11`, `3.12`, or `3.13`. |
 | `dag_source` | `"dag.py"` | DAG file relative to the project. |
 | `dependencies` | `[]` | pip specifiers baked into the image. |
 | `connectors` | `[]` | Short connector names expanded to provider packages at compile (ADR 0038). |

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -46,10 +46,19 @@ build fails on the pull.
 
 | Line | Status | Upstream EOL | Published until |
 |---|---|---|---|
-| `3.10` | **Deprecated** | 2026-10-31 | the last release before 2026-11-01 |
+| `3.10` | **Deprecated** | 2026-10-31 | 2026-10-31 |
 | `3.11` | Supported *(default)* | 2027-10-31 | — |
 | `3.12` | Supported | 2028-10-31 | — |
 | `3.13` | Supported | 2029-10-31 | — |
+
+**Published until** is the last date on which a release publishes that leg; a
+release cut after it ships no `py<line>` image. A `—` means the line is
+supported with no removal date set. The Status and Published-until cells are
+generated from nothing — they are written by hand — but
+`scripts/check-python-runtime-matrix.sh` reconciles them against the
+`x-leoflow-python-deprecations` block in the authoring schema, so a deprecation
+that moves in the schema and not here fails the build rather than leaving this
+table quietly telling you the opposite.
 
 `3.13` is the current ceiling, and it is set by the dbt adapters rather than by
 Airflow: `dbt-core` and `dbt-postgres` publish for 3.14, but `dbt-snowflake`,
@@ -63,8 +72,19 @@ after (`python:3.9-slim` was last rebuilt 2025-11-01, one day after 3.9 went
 EOL). From that point `python:3.10-slim-bookworm` — and so
 `leoflow-runtime:py3.10` — receives no further OS security updates and
 accumulates unfixed CVEs indefinitely. The `py3.10` leg keeps being published
-until then, so nothing breaks today; `leoflow compile` warns when your project
-resolves to it. Set `python_version: "3.11"` (or later) and rebuild.
+until 2026-10-31, so nothing breaks today; `leoflow validate`, `leoflow
+compile` and `leoflow deploy` warn when your project resolves to it.
+
+There are two ways to resolve to it, and they have different fixes:
+
+- **You set `python_version: "3.10"`.** Set `python_version: "3.11"` (or later)
+  and rebuild.
+- **You pinned `base_image` to a published `py3.10` tag** (`…:py3.10`,
+  `…:py3.10-v0.4.5`). Repoint `base_image` to the matching `py3.11` tag and
+  rebuild. Changing `python_version` here does nothing: when `base_image` is
+  set it is used verbatim and `python_version` is not consulted for the `FROM`.
+
+Existing images keep running either way; the rebuild is what moves you.
 
 This matters more than for most images because it is inherited: a DAG image is
 built `FROM` this base, so pinning `base_image` freezes your DAG on whatever the


### PR DESCRIPTION
Closes #1031.

Adds a `py3.13` task base, deprecates `py3.10` with a date instead of dropping it, replaces five copies of "which Python lines do we publish" with one enforced list, and puts a calendar on it so the next one surfaces months out.

## What changed

| | before | after |
|---|---|---|
| Published legs | 3.10, 3.11, 3.12 | 3.10 *(deprecated)*, 3.11, 3.12, **3.13** |
| Source of truth | none — 5 copies, 1 enforced | the `python_version` enum in the authoring schema |
| Copies gated | 0 | 5, by `scripts/check-python-runtime-matrix.sh` |
| EOL signal | a person reading a calendar | weekly, from the scheduled security workflow |

## Why `3.13` and not `3.14`

The ceiling is set by the dbt adapters, not by Airflow. Read from PyPI classifiers on each package's current release:

| package | version | max Python |
|---|---|---|
| `dbt-core` | 1.12.4 | 3.14 |
| `dbt-postgres` | 1.11.0 | 3.14 |
| `apache-airflow-task-sdk` | 1.3.1 | 3.14 |
| `dbt-snowflake` | 1.12.0 | **3.13** |
| `dbt-bigquery` | 1.12.0 | **3.13** |
| `dbt-databricks` | 1.12.5 | **3.13** |
| `dbt-duckdb` | 1.11.0 | **3.13** |

A `py3.14` base would give a user an image where `dbt-postgres` installs and `dbt-snowflake` does not, discovered inside *their* build rather than ours.

The Debian suite is untouched — `bookworm` → `trixie` is a separate decision in flight, and mixing them makes both harder to review and to roll back.

## Why `py3.10` gets a warning at compile, and not at boot or build

The issue asked for the argument, so: three places could carry it.

- **`leoflow compile` (chosen).** The author picking `python_version` is the only person who can change it, and compile is the moment they make the choice, with the file open. Stderr, once per compile, non-fatal.
- **Task boot (agent, in the pod).** Reaches the *operator*, who cannot edit somebody else's `leoflow.yaml`, and repeats on every task of every run of every DAG. That is how a real warning becomes noise people filter out.
- **Build time, inside `runtime/Dockerfile`.** Only fires for people who build the base from a source checkout — nobody in the population this deprecation is about, since they pull the published tag.

The warning also fires for an explicit `base_image` pinning one of *our* published `py3.10` tags (both shapes: `py3.10` and `py3.10-v0.4.5`), because a pin is precisely what keeps someone on a base after we stop rebuilding it. A `base_image` pointing anywhere else stays silent — `python_version` is unused for the `FROM` then, and nagging would train people to ignore the message.

Nothing is dropped in this PR. The `py3.10` leg keeps being built and pushed on every release until 2026-10-31; the removal date is recorded in the schema, announced in the CHANGELOG, and asserted weekly.

## Making the list singular

The schema enum was already the only *enforced* statement — it is embedded in the CLI and `LeoflowConfig.Validate()` rejects everything else. It is now the source of truth in fact too: `domain.SupportedPythonVersions()` / `DeprecatedPythonVersion()` read it, so Go never restates it, and the deprecation metadata lives beside the enum as a `x-leoflow-python-deprecations` vendor keyword rather than in a comment.

`scripts/check-python-runtime-matrix.sh` fails when any copy disagrees:

1. `.github/workflows/release.yaml` — the `runtime-image` matrix that actually pushes
2. `Makefile` — `make runtime-images`
3. `runtime/Dockerfile` — the `PYTHON_VERSION selects the interpreter (…)` comment
4. `runtime/python/pyproject.toml` — `requires-python` floor must equal the *oldest* published leg (the helper is pip-installed **into** the base image: a floor above it makes that leg unbuildable, one below advertises an interpreter we ship no image for)
5. `website/content/reference/configuration.md` — the reference table and the new support table

Following `check-lite-prepull-matches-compose.sh`, including both lessons its header records: the workflow is parsed as YAML rather than grepped, so a commented-out matrix cannot keep the gate green and an unquoted `3.10` (which YAML reads as the float `3.1`) is caught; and a missing file, renamed job or unrecognized declaration is a **FAIL**, never a silent pass.

## The calendar

`scripts/python-eol-warn.sh`, weekly, from the existing `security.yaml` schedule. It is deliberately **not** named `check-*.sh` — `cut-release.sh`'s `run_gates()` globs that prefix, and a release must never be blocked because a date is approaching. It exits 0 for every finding and non-zero only when it cannot do its own job (feed unreachable, feed reshaped, enum gone); a PR run is `continue-on-error` so a third-party outage cannot block a merge.

Findings reach a person as a labelled, deduplicated issue rather than an annotation on a scheduled run nobody opens. Two are worth one:

- a line we still call **supported** within 270 days of upstream EOL — the finding that would have raised #1031 in March instead of September;
- a line we already deprecated still being published past its own `remove_after` — the deprecation that quietly never happened.

An already-deprecated line inside its window is a notice, not an alert. Live run against the real feed today:

```
::notice::python 3.10 — deprecated, EOL 2026-10-31, published until 2026-10-31.
No published Python line needs a decision.
```

## `detect.go` is a different list, not a disagreeing one

The issue reads `internal/setup/detect.go`'s `pythonCandidates` (3.11, 3.12, 3.13, plus a forward-looking 3.14–3.18) as the same list drifted. It is not. That list answers *which interpreter on this host can parse a `dag.py`*; the schema enum answers *which interpreter runs inside the DAG image, on a machine that is not this one*. They overlap only because both are Python — `py3.10` being published while the detector starts at 3.11 is not a contradiction. Both `pythonCandidates` and `ci.yaml`'s `python-parser` matrix now say so in a comment, instead of implying a relationship a reader would try to reconcile.

## Fifth and sixth copies found

- **`docs/api/leoflow-yaml-schema.json`** — the repo-designated canonical mirror of the embedded schema. Already byte-equality-enforced by `TestEmbeddedSchemasMatchDocs` (which is how it was found: the suite went red), so it needed updating but no new gate.
- **`website/content/project/adrs/0003-dag-as-image.md`** — lists three base images under a repository name (`leoflow/python-runtime`) that no longer exists. Given a dated pointer to the live list rather than an edit: a decision record states what was decided, not what is true today.

Also stale and fixed: `internal/cli/workspace.go`'s comment claimed the schema-allowed set was already `3.10|3.11|3.12|3.13`, which it was not.

`articles/2026-06-leoflow-v0-0-2-deploy-devto.md` names the three published tags too, but it is a dated published article; left alone on purpose.

## Verified, not assumed

- `python:3.13-slim-bookworm` **exists and is current** — last rebuilt 2026-09-01, Python 3.13.15.
- The full `runtime/Dockerfile` **builds** at `PYTHON_VERSION=3.13`; the resulting image imports `leoflow_runtime` and `airflow.sdk`, and `leoflow-agent` runs as its entrypoint (`leoflow dev (commit none, built unknown, go1.26.3)`).
- `apache-airflow-task-sdk==1.3.1` installs and imports on 3.13.
- Every dbt ceiling in the table above, from PyPI.
- Python 3.10's EOL date from endoflife.date matches the date recorded in the schema — and the watchdog now re-asserts that agreement weekly.
- **The gate can fail.** Each of the five real copies was broken in the working tree in turn, confirmed red with a message naming the file, and restored. Disabling the gate's single comparison line turns 6 of its 18 self-test cases red; disabling the watchdog's threshold turns 3 of its 13 red. Both restored and green.

## Gates run locally

`go test ./...` green · `golangci-lint run ./...` 0 issues · `actionlint` clean (all workflows) · all 9 `scripts/check-*.sh` pass · `check-script-selftests.sh` → 7/7 · `sync-example-dockerfiles.sh --check` clean.

`MIN_GATES` 8→9 and `MIN_SELFTESTS` 5→7 for the two added scripts — they are `-ge` floors, so leaving them stale breaks nothing today, it just lets the invariant they protect tolerate the loss of one (as happened in #1018).


---

## Review round 1 — what changed

### D1 (blocking) — the warning gave a no-op instruction to the population it exists for

One message was rendered regardless of which field produced the deprecated
version, so `python_version: "3.12"` + `base_image: …:py3.10-v0.4.5` printed
`warning: python_version 3.10 is deprecated` (a version their file does not
contain) and `Fix: set python_version: "3.11" … and rebuild` — inert, because
`resolveBaseImage` returns `cfg.BaseImage` verbatim. Following it and rebuilding
reproduced the identical warning.

Headline and remedy now both branch on the source field:

```
warning: base_image ghcr.io/neochaotic/leoflow-runtime:py3.10-v0.4.5 pins
  Python 3.10, which is deprecated; ghcr.io/neochaotic/leoflow-runtime:py3.10
  stops being published after 2026-10-31.
  Python 3.10 reaches upstream end-of-life on 2026-10-31. …
  Fix: repoint base_image to ghcr.io/neochaotic/leoflow-runtime:py3.11-v0.4.5
  in leoflow.yaml and rebuild. Existing images keep running.
```

The tag suffix is preserved (`py3.10` → `py3.11`, `py3.10-v0.4.5` →
`py3.11-v0.4.5`, `…-rc.1` likewise), so the remedy is the literal string that
replaces theirs. `python_version` is not mentioned on that path, because
changing it does nothing.

Every assertion now reads the **rendered text** on both paths, and each path
asserts the *absence* of the other's message. The old test built the config with
`PythonVersion` empty and asserted only that a warning fired.

### D2 — the gate reconciles status and dates, not just the list

For each `x-leoflow-python-deprecations` entry the gate now asserts the docs
status row says Deprecated and carries the matching `eol`/`remove_after`, that a
non-deprecated row says neither (and declares no removal date), that the prose
paragraph exists and repeats both dates plus the replacement, and that
`release.yaml`'s hardcoded comment names the leg as deprecated with its EOL
date. Columns are located by header name, so a reordered table fails loudly.

The docs `Published until` cell is now the literal `remove_after` date instead
of prose, so it can be reconciled at all.

The self-test fixture deliberately gives 3.10 an `eol` (2026-10-31) **different**
from its `remove_after` (2026-12-31) — in the real repo they coincide, which
would let a gate comparing the wrong column pass every case for the wrong
reason. 12 new cases, **30 total**; disabling the single `deprecations` lookup
turns 11 of them red.

The review's exact scenario now fails:

```
$ # move the deprecation from 3.10 to 3.11 in the schema
FAIL: the published-Python list has drifted from the schema enum.
  website/content/reference/configuration.md
    status row for 3.11: 'Supported (default)'
    schema:  deprecated (eol 2026-10-31, remove_after 2026-10-31)
    This table is where a user learns a line is going away.
  …
```

### D3 — the stale repository name

`base_image`'s description in both schema mirrors now names the real default,
says that setting it makes `python_version` unused for the `FROM`, and says that
pinning freezes the interpreter and OS packages. ADR 0014 gets the same dated
pointer ADR 0003 already had.

### D4 — `leoflow validate` warns

`validate` open-coded `cfg.Validate()` + `errDbtBlockWithDagSource` instead of
calling `checkProjectPreconditions`, so the one command an author runs in a loop
was the one that never warned. It now shares the gate, which also removes the
duplication. Two tests drive the real cobra command.

### Folded in

- **D7** — the warning was **fatal** on a stderr write error. There is no error
  in the signature any more. The test asserts through
  `checkProjectPreconditions`, not the renderer: a renderer returning an error a
  caller may discard cannot demonstrate the property, and the first version of
  this test passed against the mutation for exactly that reason.
- **D6** — digest pins. `strings.Cut(ref, ":")` read `…:py3.10-v0.4.5@sha256:…`
  as the tag `py3.10-v0.4.5@sha256` and matched nothing. `splitImageRef` strips
  the digest first and takes the tag at the last `:` after the last `/`, which
  also stops a registry port being read as a tag. The remedy tells a digest
  pinner to re-pin, since carrying the old digest under a new tag would pull the
  deprecated manifest straight back in. A digest-**only** pin stays silent on
  purpose: it names a manifest, not a line, and resolving it needs a registry
  round-trip in a command that must work offline.
- **D8** — width. Body text was folded at 78 and *then* indented by two (91
  columns), and the headline was not folded at all (189 on the `base_image`
  path). Folding now happens at `78-len(indent)`. A test walks the raw output of
  both paths and fails any over-long line that is not a single unbreakable token
  — an image reference must stay copy-pasteable, so it is allowed to overhang.
- **D5** — on `--build` the warning is re-emitted as one wrapped line after the
  image is built, on both the dag.py and dbt paths.

### Mutations verified

| mutation | caught by |
|---|---|
| headline stops branching on the source field | `…PinnedBaseImageNamesBaseImage` (×3), `…DigestPinnedBase` |
| remedy stops branching (everyone gets `set python_version`) | `…PinnedBaseImageNamesBaseImage` (×3), `…DigestPinnedBase` |
| digest stripping removed from `splitImageRef` | `TestSplitImageRef`, `…DigestPinnedBase` |
| revert to `strings.Cut(ref, ":")` | `TestSplitImageRef`, `…DigestPinnedBase` |
| fold at the declared width, then indent | `…RespectsItsDeclaredWidth` (both paths) |
| warning returns the io error **and** the gate propagates it | `TestDeprecationWarningIsNotFatalOnAFailingWriter` |
| `validate` back to open-coding `cfg.Validate()` | `TestValidateWarnsAboutADeprecatedPythonLine` |
| post-build reminder disabled | `TestRemindDeprecatedPythonAfterBuild` |
| deprecation moved 3.10 → 3.11 in the real schema | gate: 6 findings across the docs table, prose and `release.yaml` |
| docs `Published until` drifts from `remove_after` | gate, naming both dates |
| `release.yaml`'s hardcoded EOL date drifts | gate, naming the date |
| the status/date arm disabled in the gate | 11 of 30 self-test cases |

One mutation did **not** fail and is recorded as a limitation: reverting
`splitImageRef` to the original `strings.Cut` leaves
`TestWarnDeprecatedPythonSilentOnPortedForeignRegistry` green, because a
port-bearing foreign registry ends up silent either way — for the wrong reason
under the old parse. The digest cases cover the parser.

`go test ./...` green · `golangci-lint run ./...` 0 issues · `actionlint` clean ·
all `scripts/check-*.sh` green · `check-script-selftests.sh` 7/7 ·
`check-python-runtime-matrix.sh --self-test` 30/30.

## Cross-PR — noted, deliberately not fixed here

**D9 / #1038.** The deprecation `reason` in the schema names
`python:3.10-slim-bookworm` and is printed **verbatim to users** (CLI warning)
and rendered into `configuration.md`. #1038 moves the suite to trixie and
nothing gates that prose. **Whoever merges second updates the `reason` string**
in `internal/domain/schemas/leoflow-yaml-schema.json` and its `docs/api/`
byte-mirror; the docs paragraph in
`website/content/reference/configuration.md` quotes the same sentence.

**#1034.** Expect a textual conflict on the `MIN_SELFTESTS` line in
`scripts/check-script-selftests.sh` and in `.github/workflows/security.yaml`.

**#1043 (filed).** After #1027 and #1034 land, `MIN_GATES`/`MIN_SELFTESTS` at
9/7 face actuals of 11/8 — they would tolerate losing two gates and one
self-test, reintroducing the #1018 slack this PR argues against. #1043 proposes
deriving the floor from a committed manifest and failing on any difference,
rather than a hardcoded integer somebody has to remember to bump. Blocked on
#1027 and #1034 to avoid resolving the same conflict twice.
