### PR TITLE
build: move the DAG task base image to Debian 13 (trixie)

### DIFF
--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -2,7 +2,7 @@
 #
 # ── Why this is not a PR gate ────────────────────────────────────────────────
 #
-# leoflow-runtime is python:3.x-slim-bookworm and leoflow-migrate is
+# leoflow-runtime is python:3.x-slim and leoflow-migrate is
 # migrate/migrate (Alpine + a third-party Go binary). Neither package set is
 # ours. A CVE lands in them because a Debian security team published an
 # advisory, not because anyone here pushed a commit — so a blocking gate on them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **Container image vulnerability scanning, with a policy designed to stay
   switched on.** `govulncheck` reads our Go module graph and says nothing about
-  the Debian packages inside `python:3.x-slim-bookworm`, or about a third-party
+  the Debian packages inside `python:3.x-slim`, or about a third-party
   Go binary baked into someone else's image — so OS-level and vendored-binary
   CVEs in the images we publish reached a human before they reached CI. Trivy
   now scans all three (`leoflow-server`, `leoflow-runtime` on every published
@@ -120,9 +120,10 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   **2030-04-08**. The suite itself is on the same trajectory: Debian 12 left
   regular security support on 2026-06-11 and is now oldstable under the LTS
   team's narrower, best-effort scope, while Debian 13 has full Security Team
-  support to 2028-08-09 and LTS to 2030-06-30. Verified on all three interpreter
-  variants (3.10 / 3.11 / 3.12): `openssl 3.5.7-1~deb13u2`, and the image still
-  ends on numeric UID `65532` with `import leoflow, leoflow_runtime` working.
+  support to 2028-08-09 and LTS to 2030-06-30. Verified on all four interpreter
+  variants (3.10 / 3.11 / 3.12 / 3.13): `openssl 3.5.7-1~deb13u2`, and the image
+  still ends on numeric UID `65532` with `import leoflow, leoflow_runtime`
+  working.
 
   **This changes what your `system_packages:` resolves to.** That key emits
   `apt-get install` into the generated DAG image, and apt now resolves against
@@ -137,6 +138,29 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   watch, since `sqv` is stricter than `gpgv` about legacy key material. Such a
   repository fails loudly at build time rather than silently, but it can fail.
 
+  **Your outbound TLS handshake changes shape, and this is the one to read if
+  your tasks talk to anything behind a corporate proxy.** OpenSSL 3.5 enables
+  the hybrid post-quantum group `X25519MLKEM768` by default and puts its key
+  share in the first flight, which takes the ClientHello from **517 to 1525
+  bytes** (measured, same `ssl.create_default_context()`, bookworm vs trixie).
+  Middleboxes, TLS-inspecting proxies and a few load balancers are known to
+  mishandle a first flight that no longer fits one segment; the symptom is a
+  handshake that hangs or resets **at task runtime in a pod, after a green
+  build** — against one endpoint, from inside your network, which is the hardest
+  shape of failure to attribute. If you hit it, restore the classical group list
+  by pointing `OPENSSL_CONF` at a file containing
+  `[system_default_sect]` / `Groups = x25519:secp256r1:x448:secp521r1:secp384r1`
+  (verified: that puts the ClientHello back to 517 bytes) and tell us, so the
+  base can carry the setting if it turns out to be common.
+
+  **What did NOT change is the certificate floor**, which is worth stating
+  because it is the thing people expect an OpenSSL major bump to break. Both
+  suites already run at security level 2. Measured on four probes against a
+  local TLS server, bookworm's 3.0.20 and trixie's 3.5.7 behave identically: an
+  RSA-1024 leaf, an RSA-1024 CA and a SHA-1-signed leaf are refused on both, and
+  TLS 1.1 is refused on both. If a legacy vendor certificate worked before this
+  release, it still works.
+
   One silent behavior change is pinned rather than inherited: Debian's `passwd`
   went 1:4.13 → 1:4.17.4 and the `HOME_MODE` default tightened with it, so the
   unchanged `useradd` line produced `0755` on bookworm and `0700` on trixie.
@@ -146,13 +170,31 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   agent build stage stays on `golang:*-bookworm` deliberately; see the comment in
   `runtime/Dockerfile` for why (nothing from it reaches a task pod).
 
+  **Rolling back is not symmetric across Python lines.** Pinning `base_image`
+  to a `v0.4.5` tag gets you the bookworm base again — for `py3.10`, `py3.11`
+  and `py3.12`. There is no `py3.13-v0.4.5`: that leg is published for the first
+  time in this release, so it only ever existed on trixie. A project on
+  `python_version: "3.13"` that needs bookworm has to move to `"3.12"` as well
+  as pin the older base.
+
+  **This path now has CI behind it.** Nothing in the repository built a DAG
+  image with `system_packages:` set, so the apt half of this change was
+  certified by a hand-run build and nothing re-certified it after merge. The
+  k3d operator E2E now compiles a project through the **generated** Dockerfile
+  (no hand-written one, which would have skipped the apt layer entirely),
+  asserts the package landed, and makes one real outbound HTTPS request from
+  inside the task pod. The same run asserts the base image's own properties —
+  the Debian suite (read out of `runtime/Dockerfile` rather than hardcoded), the
+  `65532:65532 0700` home dir, and the numeric final `USER` — each of which was
+  previously guarded by a comment and by nothing else.
+
 ### Deprecated
 
 - **`python_version: "3.10"` — the `py3.10` base image stops being published
   after 2026-10-31.** Python 3.10 reaches upstream end-of-life on that date, and
   `docker-library/python` stops rebuilding an EOL line the day after
   (`python:3.9-slim` was last rebuilt 2025-11-01, one day after 3.9 went EOL).
-  From November, `python:3.10-slim-bookworm` — and therefore
+  From November, `python:3.10-slim` — and therefore
   `ghcr.io/neochaotic/leoflow-runtime:py3.10` — receives no further OS security
   updates and accumulates unfixed CVEs indefinitely.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,43 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   documented in [Image
   scanning](https://leoflow.dev/contribute/image-vulnerability-scanning/).
 
+### Changed
+
+- **The task base image moves from Debian 12 (bookworm) to Debian 13 (trixie),
+  which takes its OpenSSL from 3.0.x to 3.5.x.** `python:3.x-slim` links CPython's
+  `ssl` module against the **system** OpenSSL, so this is the library every TLS
+  call made from inside a task terminates in — every provider hitting an API,
+  every `requests` call, every warehouse driver. bookworm ships OpenSSL 3.0.x,
+  whose **upstream support ended 2026-09-07**; trixie ships 3.5.x, supported to
+  **2030-04-08**. The suite itself is on the same trajectory: Debian 12 left
+  regular security support on 2026-06-11 and is now oldstable under the LTS
+  team's narrower, best-effort scope, while Debian 13 has full Security Team
+  support to 2028-08-09 and LTS to 2030-06-30. Verified on all three interpreter
+  variants (3.10 / 3.11 / 3.12): `openssl 3.5.7-1~deb13u2`, and the image still
+  ends on numeric UID `65532` with `import leoflow, leoflow_runtime` working.
+
+  **This changes what your `system_packages:` resolves to.** That key emits
+  `apt-get install` into the generated DAG image, and apt now resolves against
+  trixie rather than bookworm — so package versions move, and a name or version
+  pin that only existed in bookworm has to be re-pinned. apt itself goes 2.6.1 →
+  3.0.3 and repository signature verification moves from GnuPG's `gpgv` to
+  Sequoia's `sqv` (the slim image now ships **no `gpgv` at all**); a
+  `system_packages:` install of `curl git libpq-dev ca-certificates` was compiled
+  and built end-to-end against the new base to confirm the path still works.
+  Debian's own repositories were exercised and verify cleanly; a **third-party**
+  apt repository added by a custom Dockerfile layer was not, and is the case to
+  watch, since `sqv` is stricter than `gpgv` about legacy key material. Such a
+  repository fails loudly at build time rather than silently, but it can fail.
+
+  One silent behavior change is pinned rather than inherited: Debian's `passwd`
+  went 1:4.13 → 1:4.17.4 and the `HOME_MODE` default tightened with it, so the
+  unchanged `useradd` line produced `0755` on bookworm and `0700` on trixie.
+  `0700` is kept — a task pod runs as this very UID, so the owner traverses its
+  own home and no supported path breaks — but `runtime/Dockerfile` now sets the
+  mode explicitly, so it no longer moves when a distro default does. The
+  agent build stage stays on `golang:*-bookworm` deliberately; see the comment in
+  `runtime/Dockerfile` for why (nothing from it reaches a task pod).
+
 ### Deprecated
 
 - **`python_version: "3.10"` — the `py3.10` base image stops being published

--- a/docs/api/leoflow-yaml-schema.json
+++ b/docs/api/leoflow-yaml-schema.json
@@ -33,7 +33,7 @@
           "eol": "2026-10-31",
           "remove_after": "2026-10-31",
           "replacement": "3.11",
-          "reason": "Python 3.10 reaches upstream end-of-life on 2026-10-31. docker-library/python stops rebuilding an EOL line the day after (python:3.9-slim was last rebuilt 2025-11-01, one day after 3.9 went EOL), so python:3.10-slim-bookworm — and therefore leoflow-runtime:py3.10 — stops receiving OS security updates and accumulates unfixed CVEs indefinitely."
+          "reason": "Python 3.10 reaches upstream end-of-life on 2026-10-31. docker-library/python stops rebuilding an EOL line the day after (python:3.9-slim was last rebuilt 2025-11-01, one day after 3.9 went EOL), so python:3.10-slim — and therefore leoflow-runtime:py3.10 — stops receiving OS security updates and accumulates unfixed CVEs indefinitely."
         }
       }
     },

--- a/internal/domain/schemas/leoflow-yaml-schema.json
+++ b/internal/domain/schemas/leoflow-yaml-schema.json
@@ -33,7 +33,7 @@
           "eol": "2026-10-31",
           "remove_after": "2026-10-31",
           "replacement": "3.11",
-          "reason": "Python 3.10 reaches upstream end-of-life on 2026-10-31. docker-library/python stops rebuilding an EOL line the day after (python:3.9-slim was last rebuilt 2025-11-01, one day after 3.9 went EOL), so python:3.10-slim-bookworm — and therefore leoflow-runtime:py3.10 — stops receiving OS security updates and accumulates unfixed CVEs indefinitely."
+          "reason": "Python 3.10 reaches upstream end-of-life on 2026-10-31. docker-library/python stops rebuilding an EOL line the day after (python:3.9-slim was last rebuilt 2025-11-01, one day after 3.9 went EOL), so python:3.10-slim — and therefore leoflow-runtime:py3.10 — stops receiving OS security updates and accumulates unfixed CVEs indefinitely."
         }
       }
     },

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -23,11 +23,19 @@ ARG PYTHON_VERSION=3.11
 # inconsistency without re-reading this. Nothing from this stage reaches a task
 # pod: the only thing copied out is /out/leoflow-agent, built CGO_ENABLED=0, so
 # it links no glibc and no OpenSSL from here. Go does not use OpenSSL at all
-# (crypto/tls is pure Go), and the module download's trust anchors come from
-# this image's ca-certificates, which Debian 12 LTS still ships. So this stage's
-# suite changes the build environment only, never what a user runs — a different
-# risk class from stage 2, and a change worth making on its own evidence rather
-# than as a rider on a user-facing one.
+# (crypto/tls is pure Go), and crypto/x509 reads the FINAL image's trust store,
+# not this one's. So this stage's suite changes the build environment only,
+# never what a user runs — a different risk class from stage 2, and a change
+# worth making on its own evidence rather than as a rider on a user-facing one.
+#
+# What keeps it current is the Go pin, not Debian's support calendar. GO_VERSION
+# is pinned to a PATCH release, so this image is whatever docker-library/golang
+# published for that exact tag: a Debian security update never reaches it in
+# place, and Debian 12's remaining LTS window buys it nothing. Every bump of
+# GO_VERSION pulls a freshly built image with a current package set — that is
+# the whole refresh mechanism, and it runs on the Go release cadence. The move
+# off bookworm therefore becomes forced, not optional, on the first GO_VERSION
+# bump after upstream stops publishing a `-bookworm` variant.
 FROM golang:${GO_VERSION}-bookworm AS agent-build
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -19,6 +19,15 @@ ARG GO_VERSION=1.26.3
 ARG PYTHON_VERSION=3.11
 
 # ── Stage 1: build the static agent binary ───────────────────────────────────
+# Deliberately still bookworm while stage 2 is trixie — do not "fix" the
+# inconsistency without re-reading this. Nothing from this stage reaches a task
+# pod: the only thing copied out is /out/leoflow-agent, built CGO_ENABLED=0, so
+# it links no glibc and no OpenSSL from here. Go does not use OpenSSL at all
+# (crypto/tls is pure Go), and the module download's trust anchors come from
+# this image's ca-certificates, which Debian 12 LTS still ships. So this stage's
+# suite changes the build environment only, never what a user runs — a different
+# risk class from stage 2, and a change worth making on its own evidence rather
+# than as a rider on a user-facing one.
 FROM golang:${GO_VERSION}-bookworm AS agent-build
 WORKDIR /src
 COPY go.mod go.sum ./
@@ -37,7 +46,25 @@ RUN CGO_ENABLED=0 go build -trimpath \
 	-o /out/leoflow-agent ./cmd/leoflow-agent
 
 # ── Stage 2: runtime base ─────────────────────────────────────────────────────
-FROM python:${PYTHON_VERSION}-slim-bookworm
+# Debian 13 (trixie). The suite is pinned explicitly rather than left implicit
+# so a base-image move is a reviewable diff, not a silent consequence of
+# upstream retagging.
+#
+# The reason it is trixie and not bookworm is OpenSSL, not the Debian release
+# calendar on its own. `python:3.x-slim` links CPython's `ssl` module against
+# the SYSTEM OpenSSL, so every TLS call a task makes — every provider hitting an
+# API, every `requests` call, every warehouse driver — terminates in this
+# image's libssl. bookworm ships OpenSSL 3.0.x, whose UPSTREAM support ended
+# 2026-09-07; trixie ships 3.5.x, supported to 2030-04-08. Debian 12 also left
+# regular security support on 2026-06-11 and is now oldstable under the LTS
+# team's narrower, best-effort scope, while Debian 13 has full Security Team
+# support to 2028-08-09.
+#
+# Note that this suite is also what a user's `system_packages:` resolves
+# against: the compiler emits `apt-get install` into the generated DAG image
+# (internal/cli/compile_build.go), so the package versions a DAG gets move with
+# this line. That makes it a user-visible change, not an internal one.
+FROM python:${PYTHON_VERSION}-slim-trixie
 
 LABEL org.opencontainers.image.source="https://github.com/neochaotic/leoflow"
 LABEL org.opencontainers.image.description="Leoflow task base image (agent + Python runtime)"
@@ -51,8 +78,20 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 # the UID the Helm chart pins for the control-plane and migration pods. The home
 # dir is created and owned by this UID so runtime writes to it (e.g. __pycache__)
 # succeed; the staging PVC is made group-writable at the pod level via fsGroup.
+#
+# The trailing chmod pins the home-dir mode instead of inheriting it from
+# /etc/login.defs. Debian's `passwd` went 1:4.13 (bookworm) → 1:4.17.4 (trixie)
+# and the HOME_MODE default tightened with it: the identical `useradd` line
+# produced 0755 on bookworm and produces 0700 on trixie. Nothing supported
+# breaks at 0700 — a task pod runs as this very UID (buildSecurityContext sets
+# runAsNonRoot with no runAsUser, so the kubelet uses the image's 65532) and the
+# owner traverses its own home regardless — so the tighter mode is kept. What is
+# not kept is the silence: a filesystem permission that moves because a distro
+# default moved is the kind of drift that surfaces as an unexplained EACCES
+# three releases later, so it is now stated here and independent of the suite.
 RUN groupadd --gid 65532 leoflow \
- && useradd --create-home --home-dir /home/leoflow --uid 65532 --gid 65532 leoflow
+ && useradd --create-home --home-dir /home/leoflow --uid 65532 --gid 65532 leoflow \
+ && chmod 0700 /home/leoflow
 
 COPY --from=agent-build /out/leoflow-agent /usr/local/bin/leoflow-agent
 COPY runtime/python /opt/leoflow-runtime

--- a/scripts/check-python-runtime-matrix.sh
+++ b/scripts/check-python-runtime-matrix.sh
@@ -44,6 +44,19 @@
 # the matrix that publishes the leg, so it is reconciled too. A wrong date is
 # worse than a missing one: it answers the question the reader came with.
 #
+# The same argument runs one step further, and that is the last arm. The
+# deprecation `reason` is printed VERBATIM to the user on compile, validate and
+# deploy, and it named a full base-image tag including the Debian suite. Move
+# the task base from one Debian release to the next and every arm above stays
+# green — the versions and the dates did not change — while that sentence now
+# describes an image nobody builds. A reader checks the Dockerfile the compiler
+# generated, sees a different suite, and dismisses the warning as stale tooling,
+# which retires the one mechanism there is for reaching them before the leg
+# stops being published. So the suite named in the schema and in the
+# configuration reference is reconciled against runtime/Dockerfile's stage-2
+# FROM — and the fix that failure recommends is to stop naming a suite at all,
+# because `python:3.10-slim` is correct on every one of them.
+#
 # Usage: scripts/check-python-runtime-matrix.sh [--self-test]
 #        scripts/check-python-runtime-matrix.sh <repo-root>
 set -euo pipefail
@@ -352,6 +365,67 @@ for version in want:
 				f"    the py{version} deprecation note never states its EOL date ({dep['eol']})"
 			)
 
+# ── 8. the Debian suite named in prose vs the one stage 2 is built on ────────
+# The list arms above are blind to the suite: move the base image from one
+# Debian release to the next and every version still appears in every file, so
+# they all stay green while the schema's deprecation `reason` — which the CLI
+# prints VERBATIM on compile, validate and deploy — keeps naming the old one.
+# That is worse than a stale doc. A py3.10 author reads the warning, checks the
+# Dockerfile the compiler generated, finds a different suite, and files the
+# whole warning under stale tooling — which retires the one mechanism we have
+# for reaching them before the leg stops being published.
+#
+# The fix a suite move should make is to stop naming a suite: `python:3.10-slim`
+# is literally correct on every suite, because that tag has always resolved to
+# whatever the current one is. So this arm does not demand the CURRENT suite
+# anywhere; it only refuses a literal that names one stage 2 does not use. A
+# suffix-free reference is always accepted.
+#
+# Only the two files a user reads as CURRENT truth are scanned. The docs/api
+# mirror of the schema needs no arm of its own: TestEmbeddedSchemasMatchDocs
+# binds it byte-for-byte to the copy embedded in the binary, which is the copy
+# read here. CHANGELOG.md is deliberately excluded — a released section naming
+# the suite of its own era is a record, and correcting it would be falsifying
+# history rather than fixing drift.
+dockerfile_from = None
+for line in dockerfile_text.splitlines():
+	m = re.match(r"\s*FROM\s+python:(?:\$\{PYTHON_VERSION\}|3\.\d+)-slim(-[A-Za-z0-9.]+)?\s*(?:AS\s+\S+)?\s*$", line)
+	if m:
+		dockerfile_from = (line.strip(), m.group(1))
+		break
+if dockerfile_from is None:
+	fail(
+		f"{dockerfile_rel} has no `FROM python:...-slim...` line — this gate cannot tell which\n"
+		"Debian suite the task base is built on, so it cannot reconcile the suite named in the\n"
+		"schema's deprecation reason against it. Either restore the line or delete this arm\n"
+		"deliberately; a gate that stops gating after a refactor is worse than no gate."
+	)
+from_line, from_suffix = dockerfile_from
+if not from_suffix:
+	fail(
+		f"{dockerfile_rel}'s stage-2 base `{from_line}` pins no Debian suite.\n"
+		"The suffix is carried deliberately (see the comment above that FROM): with it, moving\n"
+		"the task base to a new Debian release is a reviewable one-line diff; without it the\n"
+		"move happens the day upstream retags, in someone else's build, with nothing in our\n"
+		"history to point at. Pin it, or remove this arm in the change that decides otherwise."
+	)
+suite = from_suffix.lstrip("-")
+# `3.x` as well as `3.10`: prose generalizes over the lines, and a generalized
+# literal goes stale exactly the same way a specific one does.
+IMAGE_SUITE_RE = re.compile(r"python:3\.(?:\d+|x)-slim-([A-Za-z0-9.]+)")
+for rel, text in ((schema_rel, read(schema_rel)), (docs_rel, docs_text)):
+	for m in IMAGE_SUITE_RE.finditer(text):
+		if m.group(1) == suite:
+			continue
+		problems.append(
+			f"  {rel}\n"
+			f"    names {m.group(0)}\n"
+			f"    {dockerfile_rel} stage 2: {from_line}\n"
+			f"    Drop the suite from the literal ({m.group(0).rsplit('-', 1)[0]}) rather than\n"
+			f"    swapping it for {suite!r}: the suffix-free tag is correct on every suite, so it\n"
+			"    cannot go stale on the next move. This text is printed to users verbatim."
+		)
+
 if problems:
 	sys.exit(
 		"FAIL: the published-Python list has drifted from the schema enum.\n"
@@ -374,7 +448,11 @@ self_test() {
 	# `remove_after` (2026-12-31). In the real repo the two happen to be the same
 	# date, which would let a gate that compares the wrong column against the wrong
 	# schema field pass every case below for the wrong reason.
-	_dep_json='{"3.10":{"eol":"2026-10-31","remove_after":"2026-12-31","replacement":"3.11"}}'
+	#
+	# The `reason` carries a `python:3.10-slim-trixie` literal so the happy path
+	# exercises the suite arm positively rather than only vacuously: a fixture
+	# with no image literal at all would pass that arm whether it worked or not.
+	_dep_json='{"3.10":{"eol":"2026-10-31","remove_after":"2026-12-31","replacement":"3.11","reason":"docker-library stops rebuilding python:3.10-slim-trixie after its EOL."}}'
 	_schema() { # <dir> <deprecations-json>
 		printf '{"properties":{"python_version":{"enum":["3.10","3.11"],"default":"3.11",\n "x-leoflow-python-deprecations":%s}}}\n' \
 			"$2" >"$1/internal/domain/schemas/leoflow-yaml-schema.json"
@@ -408,6 +486,18 @@ self_test() {
 		} >"$1/website/content/reference/configuration.md"
 	}
 
+	# The Dockerfile fixture carries a stage-1 `golang:*-bookworm` alongside the
+	# stage-2 `python:*-slim-trixie`, because the real one does and because that
+	# is the pair the suite arm has to tell apart: an arm that grepped the file
+	# for a suite name would read the builder's and reconcile against the wrong
+	# stage, passing every case below for the wrong reason.
+	_dfcomment_default='# PYTHON_VERSION selects the interpreter (3.10 / 3.11).'
+	_dffrom_default='FROM python:${PYTHON_VERSION}-slim-trixie'
+	_dockerfile() { # <dir> <comment-line> <stage-2-FROM-line>
+		printf '%s\nARG PYTHON_VERSION=3.11\nFROM golang:1.26.3-bookworm AS agent-build\n%s\n' \
+			"$2" "$3" >"$1/runtime/Dockerfile"
+	}
+
 	# Builds a minimal repo root whose copies all agree on 3.10/3.11.
 	_mkroot() { # <dir>
 		local d="$1"
@@ -416,8 +506,7 @@ self_test() {
 		_schema "$d" "$_dep_json"
 		_release "$d" "$_matrix_both" "$_note_default"
 		printf 'runtime-images:\n\tfor v in 3.10 3.11; do \\\n\t\tdocker build . ; \\\n\tdone\n' >"$d/Makefile"
-		printf '# PYTHON_VERSION selects the interpreter (3.10 / 3.11).\nARG PYTHON_VERSION=3.11\n' \
-			>"$d/runtime/Dockerfile"
+		_dockerfile "$d" "$_dfcomment_default" "$_dffrom_default"
 		printf '[project]\nrequires-python = ">=3.10"\n' >"$d/runtime/python/pyproject.toml"
 		_docs "$d" "$_rows_default" "$_prose_default"
 	}
@@ -449,8 +538,8 @@ self_test() {
 	_stale_makefile() { printf 'runtime-images:\n\tfor v in 3.10; do \\\n\t\tdocker build . ; \\\n\tdone\n' >"$1/Makefile"; }
 	_commented_makefile_loop() { printf 'runtime-images:\n\t# for v in 3.10 3.11; do \\\n\t@echo skip\n' >"$1/Makefile"; }
 	_other_target_loop() { printf 'other-images:\n\tfor v in 3.10 3.11; do \\\n\tdone\n\nruntime-images:\n\t@echo nothing\n' >"$1/Makefile"; }
-	_stale_dockerfile() { printf '# PYTHON_VERSION selects the interpreter (3.10 / 3.11 / 3.12).\n' >"$1/runtime/Dockerfile"; }
-	_dropped_dockerfile_comment() { printf 'ARG PYTHON_VERSION=3.11\n' >"$1/runtime/Dockerfile"; }
+	_stale_dockerfile() { _dockerfile "$1" '# PYTHON_VERSION selects the interpreter (3.10 / 3.11 / 3.12).' "$_dffrom_default"; }
+	_dropped_dockerfile_comment() { _dockerfile "$1" '# nothing to see here' "$_dffrom_default"; }
 	_raised_floor() { printf '[project]\nrequires-python = ">=3.11"\n' >"$1/runtime/python/pyproject.toml"; }
 	_stale_docs_row() {
 		_docs "$1" "$_rows_default" "$_prose_default"
@@ -491,6 +580,25 @@ self_test() {
 	_release_deprecates_a_supported_line() { _release "$1" "$_matrix_both" 'py3.11 is DEPRECATED: EOL 2027-10-31. Also py3.10 is DEPRECATED: Python 3.10 goes EOL 2026-10-31.'; }
 	_release_note_omits_eol() { _release "$1" "$_matrix_both" 'py3.10 is DEPRECATED: it goes away at some point.'; }
 
+	# ── the Debian-suite arm ───────────────────────────────────────────────────
+	# The motivating mutation is _schema_names_a_stale_suite: every version still
+	# appears in every file, every date still agrees, so every case above stays
+	# green — while the `reason` the CLI prints VERBATIM on compile/validate/deploy
+	# names a suite the base image has not been built on since the move. A reader
+	# checks their generated Dockerfile, sees a different suite, and files the
+	# whole warning under stale tooling.
+	_dep_with_reason() { # <dir> <reason>
+		_schema "$1" "{\"3.10\":{\"eol\":\"2026-10-31\",\"remove_after\":\"2026-12-31\",\"replacement\":\"3.11\",\"reason\":\"$2\"}}"
+	}
+	_schema_names_a_stale_suite() { _dep_with_reason "$1" 'docker-library stops rebuilding python:3.10-slim-bookworm after its EOL.'; }
+	_schema_is_suite_agnostic() { _dep_with_reason "$1" 'docker-library stops rebuilding python:3.10-slim after its EOL.'; }
+	_docs_name_a_stale_suite() {
+		_docs "$1" "$_rows_default" \
+			'**`3.10` is deprecated.** Upstream EOL 2026-10-31; published until 2026-12-31. From then `python:3.10-slim-bookworm` receives no updates. Set `python_version` to `3.11`.\n'
+	}
+	_dockerfile_from_omits_the_suite() { _dockerfile "$1" "$_dfcomment_default" 'FROM python:${PYTHON_VERSION}-slim'; }
+	_dockerfile_has_no_python_from() { _dockerfile "$1" "$_dfcomment_default" 'FROM scratch'; }
+
 	_case "an agreeing tree passes"                  0 "agrees everywhere (3.10, 3.11; deprecated: 3.10)" _noop
 	_case "a leg missing from the release matrix"    1 "matrix.python" _drop_from_matrix
 	_case "a commented-out matrix is not a matrix"   1 "declares no \`strategy.matrix.python\`" _comment_out_matrix
@@ -522,6 +630,11 @@ self_test() {
 	_case "release.yaml drops the deprecation note"  1 "no \`py3.10 is DEPRECATED\` note" _release_drops_deprecation_note
 	_case "release.yaml deprecates a supported leg"  1 "calls py3.11 DEPRECATED" _release_deprecates_a_supported_line
 	_case "a release note with no EOL date"          1 "never states its EOL date" _release_note_omits_eol
+	_case "the schema names a stale Debian suite"    1 "python:3.10-slim-bookworm" _schema_names_a_stale_suite
+	_case "the docs name a stale Debian suite"       1 "python:3.10-slim-bookworm" _docs_name_a_stale_suite
+	_case "a suite-agnostic reason passes"           0 "agrees everywhere" _schema_is_suite_agnostic
+	_case "a stage-2 FROM with no suite"             1 "pins no Debian suite" _dockerfile_from_omits_the_suite
+	_case "no stage-2 python FROM at all"            1 "no \`FROM python:" _dockerfile_has_no_python_from
 
 	if [ "$fail" -eq 0 ]; then echo "self-test: PASS"; return 0; else echo "self-test: FAIL"; return 1; fi
 }

--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -195,6 +195,46 @@ DOCKER
 log "Building base and DAG images"
 docker build --provenance=false -f "$ROOT/runtime/Dockerfile" --build-arg "PYTHON_VERSION=${PY_VERSION}" -t "$BASE_IMAGE" "$ROOT"
 
+# ─────────────────────────────────────────────────────────────────────────────
+# The base image's own properties. Every one of these was, until now, asserted
+# by a comment in runtime/Dockerfile and by nothing else — so each moved once
+# already without a red run: the Debian suite when the FROM was edited, and the
+# home-dir mode when Debian's `passwd` changed its HOME_MODE default under an
+# unchanged `useradd` line. Three `docker` invocations against an image this
+# script has just built anyway.
+#
+# The expected suite is read out of runtime/Dockerfile rather than written here.
+# A hardcoded "trixie" would be a fourth copy of the same fact, green on the day
+# it was typed and wrong on the day of the next move — which is the failure this
+# whole block exists to stop.
+log "Asserting the task base image's own properties (suite, home-dir mode, final USER)"
+WANT_SUITE="$(sed -n 's/^FROM python:\${PYTHON_VERSION}-slim-\([A-Za-z0-9.]*\).*/\1/p' "$ROOT/runtime/Dockerfile")"
+[ -n "$WANT_SUITE" ] \
+  || fail "runtime/Dockerfile's stage-2 FROM pins no Debian suite; this assertion has nothing to compare against"
+GOT_SUITE="$(docker run --rm --entrypoint sh "$BASE_IMAGE" -c '. /etc/os-release; printf %s "$VERSION_CODENAME"')"
+[ "$GOT_SUITE" = "$WANT_SUITE" ] \
+  || fail "base image is Debian '$GOT_SUITE' but runtime/Dockerfile's stage-2 FROM pins '$WANT_SUITE'"
+log "base suite: $GOT_SUITE (matches runtime/Dockerfile)"
+
+# 65532:65532 and 0700. The mode is pinned by an explicit chmod because the
+# distro default moved under us; the ownership is what makes 0700 survivable,
+# since a task pod runs as exactly this UID (buildSecurityContext sets
+# runAsNonRoot with no runAsUser, so the kubelet resolves the image's user) and
+# an owner traverses its own home whatever the mode. Assert the pair together:
+# 0700 with the wrong owner is an unreadable home, and that is the regression.
+GOT_HOME="$(docker run --rm --entrypoint stat "$BASE_IMAGE" -c '%u:%g %a' /home/leoflow)"
+[ "$GOT_HOME" = "65532:65532 700" ] \
+  || fail "/home/leoflow is '$GOT_HOME', want '65532:65532 700' (owner+mode pair, see runtime/Dockerfile)"
+log "home dir: $GOT_HOME"
+
+# A NUMERIC non-root user, not the name `leoflow`: PodSecurity `restricted`
+# verifies runAsNonRoot against the image's user and the kubelet can only
+# resolve a numeric UID, so a name here is a rejected container.
+GOT_USER="$(docker image inspect -f '{{.Config.User}}' "$BASE_IMAGE")"
+[ "$GOT_USER" = "65532:65532" ] \
+  || fail "base image final USER is '$GOT_USER', want numeric '65532:65532'"
+log "final USER: $GOT_USER"
+
 log "Creating k3d cluster '$CLUSTER'"
 k3d cluster create "$CLUSTER" --wait
 
@@ -487,5 +527,158 @@ done
 echo "$cblog" | grep -q "running on_failure_callback" \
   || fail "runtime did not log the on_failure_callback lifecycle in the pod (#424)"
 log "callback pod-path OK: on_failure_callback ran in the pod on terminal failure (#424)"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# system_packages: on the GENERATED Dockerfile path, and one real TLS handshake
+# from inside a task pod.
+#
+# Both halves were uncovered. `grep -rn system_packages test/ .github/ examples/`
+# returned nothing: no fixture anywhere built a DAG image with the key set, so
+# the `apt-get install` the compiler emits into every such image was certified
+# by whoever last ran a build by hand. That matters more than an unused key
+# normally would, because the suite the base is built on is what those package
+# names and version pins resolve against — the apt version and its signature
+# verifier move with the base image, and this is the only place we would find
+# out.
+#
+# This leg deliberately ships NO Dockerfile. Every other project in this script
+# hand-writes one, which is the documented escape hatch and not the path almost
+# every user takes; a `system_packages:` bolted onto a project with its own
+# Dockerfile would be silently ignored (ensureDockerfile honours the file on
+# disk), and the leg would pass while testing nothing. `base_image` points at
+# the base built above rather than the published one, so what is exercised is
+# the base in this diff, not the last release's.
+#
+# The TLS half answers the question a version string cannot. python:*-slim
+# links CPython's `ssl` against the system OpenSSL, so a base-image move
+# relocates every outbound handshake a task makes onto a different libssl, and
+# whatever that library refuses is refused at task runtime in a pod, against
+# one endpoint, long after a green build. `ssl.OPENSSL_VERSION` cannot see any
+# of that; only a handshake can, which is why this is here and not a printed
+# version.
+#
+# Do not read this as guarding a specific policy difference. The certificate
+# floor was measured across the bookworm→trixie move and did not move with it:
+# both suites already run at security level 2, and an RSA-1024 leaf, an
+# RSA-1024 CA, a SHA-1-signed leaf and TLS 1.1 are refused on both. What did
+# change is the first flight's size (OpenSSL 3.5 offers a hybrid post-quantum
+# group by default, 517 → 1525 bytes), which is the kind of thing no assertion
+# can predict in advance and a completed handshake covers generically.
+#
+# pypi.org is the peer because this leg's own image build already had to reach
+# it — if it is unreachable the build failed first, so this adds no external
+# dependency the leg did not already have.
+log "system_packages + in-pod TLS (generated Dockerfile path)"
+SPID="sysdag"
+mkdir -p "$WORKDIR/$SPID"
+cat > "$WORKDIR/$SPID/leoflow.yaml" <<YAML
+schema_version: "1.0"
+dag_id: ${SPID}
+base_image: ${BASE_IMAGE}
+system_packages:
+  - curl
+  - ca-certificates
+build:
+  platforms:
+    - ${HOST_PLATFORM}
+YAML
+cat > "$WORKDIR/$SPID/dag.py" <<'PY'
+"""sysdag — system_packages install + one real outbound TLS handshake, in a pod."""
+from __future__ import annotations
+
+from airflow.sdk import DAG, task
+
+
+@task
+def apt_and_tls() -> None:
+    import shutil
+    import ssl
+    import urllib.error
+    import urllib.request
+
+    # The apt half: a binary that is NOT in python:*-slim and can only have
+    # arrived through the generated Dockerfile's `apt-get install`. If apt or
+    # its repository signature verification broke on the current suite, the
+    # image build fails before this ever runs; this catches the subtler case
+    # where the build succeeded and installed nothing usable.
+    curl = shutil.which("curl")
+    assert curl, "system_packages did not put curl on PATH (generated apt layer did not land)"
+    print("E2E_SYSPKG curl=" + curl, flush=True)
+
+    # The TLS half. Report the version for the log, then actually shake hands.
+    print("E2E_OPENSSL " + ssl.OPENSSL_VERSION, flush=True)
+    ctx = ssl.create_default_context()
+    try:
+        with urllib.request.urlopen(
+            "https://pypi.org/simple/pip/", timeout=60, context=ctx
+        ) as resp:
+            assert resp.status == 200, f"unexpected HTTPS status {resp.status}"
+    except urllib.error.URLError as err:
+        # urlopen wraps the TLS failure in URLError and puts the ssl exception in
+        # .reason, so an `except ssl.SSLCertVerificationError` here would never
+        # fire and every TLS failure would be reported as a network one.
+        # Classify off the wrapped cause instead: an ssl.SSLError is the
+        # algorithm-policy regression this assertion exists for, and anything
+        # else is the network, which is a rerun rather than a bug in the base.
+        cause = getattr(err, "reason", None)
+        if isinstance(cause, ssl.SSLError):
+            raise AssertionError(
+                f"outbound TLS failed under {ssl.OPENSSL_VERSION} — algorithm policy, "
+                f"not reachability: {cause}"
+            ) from err
+        raise AssertionError(f"outbound HTTPS could not be attempted (network, not TLS): {err}") from err
+    print("E2E_TLS_OK", flush=True)
+
+
+with DAG("sysdag", schedule=None, tags=["e2e"]):
+    apt_and_tls()
+PY
+[ -e "$WORKDIR/$SPID/Dockerfile" ] \
+  && fail "sysdag must not ship a Dockerfile: the hand-written one would win and system_packages would never be installed"
+SP_IMAGE="leoflow-e2e-sysdag:local"
+# A unique version per run, as deploy-e2e.sh does and for the same reason: a
+# DAG version is immutable, so against the shared dev database a re-run whose
+# body changed is rejected 409 — and one whose body did not is accepted while
+# quietly running the version already stored. The second is the dangerous half
+# and it looks like a pass. CI gets a fresh Postgres per run and never sees
+# either; a developer editing this leg locally sees both.
+"$ROOT/bin/leoflow" compile "$WORKDIR/$SPID" --image "$SP_IMAGE" \
+  --build --dag-version "e2e-$(date +%s)" -o "$WORKDIR/$SPID/dag.json"
+# The generated Dockerfile installs as root and drops back to the numeric UID as
+# its LAST instruction (#852). A root-final image is a CreateContainerConfigError
+# under runAsNonRoot, discovered in the user's cluster; assert it here instead.
+SP_USER="$(docker image inspect -f '{{.Config.User}}' "$SP_IMAGE")"
+[ "$SP_USER" = "65532:65532" ] \
+  || fail "the generated system_packages image ends on USER '$SP_USER', want numeric '65532:65532'"
+log "generated DAG image final USER: $SP_USER"
+k3d_import "$CLUSTER" "$SP_IMAGE"
+"$ROOT/bin/leoflow" push "$WORKDIR/$SPID/dag.json" --server "$API" --token "$TOKEN"
+SP_RUN="$(curl -fsS -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  -d '{}' "$API/api/v2/dags/$SPID/dagRuns" | jq -r '.dag_run_id')"
+[ -n "$SP_RUN" ] && [ "$SP_RUN" != "null" ] || fail "no sysdag dag_run_id returned"
+log "sysdag run = $SP_RUN"
+sp_deadline=$(( $(date +%s) + 300 ))
+while :; do
+  sp_state="$(curl -fsS -H "Authorization: Bearer $TOKEN" \
+    "$API/api/v2/dags/$SPID/dagRuns/$SP_RUN/taskInstances" \
+    | jq -r '.task_instances[] | select(.task_id=="apt_and_tls") | .state')"
+  [ "$sp_state" = "success" ] && break
+  echo "${sp_state:-}" | grep -qE 'failed|upstream_failed' && fail "sysdag apt_and_tls failed (state=$sp_state)"
+  [ "$(date +%s)" -gt "$sp_deadline" ] && fail "sysdag apt_and_tls did not succeed (state=${sp_state:-<none>})"
+  sleep 3
+done
+splog=""
+for try in 0 1 2; do
+  body="$(curl -fsS -H "Authorization: Bearer $TOKEN" \
+    "$API/api/v2/dags/$SPID/dagRuns/$SP_RUN/taskInstances/apt_and_tls/logs/$try" 2>/dev/null || true)"
+  if echo "$body" | grep -q "E2E_SYSPKG"; then splog="$body"; break; fi
+done
+[ -n "$splog" ] || fail "no sysdag log shipped: cannot confirm the apt install or the TLS handshake"
+echo "$splog" | grep -q "E2E_SYSPKG curl=" \
+  || fail "system_packages did not install curl into the generated DAG image"
+echo "$splog" | grep -q "E2E_TLS_OK" \
+  || fail "no outbound TLS handshake completed from the task pod (OpenSSL security level?)"
+log "system_packages installed and one real HTTPS handshake completed inside a task pod"
+echo "$splog" | grep "E2E_OPENSSL" || true
 
 log "E2E passed"

--- a/website/content/contribute/image-vulnerability-scanning.md
+++ b/website/content/contribute/image-vulnerability-scanning.md
@@ -6,7 +6,7 @@ description: "Where container CVE findings appear, what blocks a build and what 
 ---
 
 `govulncheck` reads our Go module graph. It says nothing about the Debian
-packages in `python:3.x-slim-bookworm`, or about a third-party Go binary baked
+packages in `python:3.x-slim`, or about a third-party Go binary baked
 into someone else's image. Those are scanned separately, by
 [Trivy](https://trivy.dev/), under the policy on this page.
 

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -69,7 +69,7 @@ not — discovered inside your build, not ours — so it is not published.
 **`3.10` is deprecated.** Python 3.10 reaches upstream end-of-life on
 2026-10-31, and `docker-library/python` stops rebuilding an EOL line the day
 after (`python:3.9-slim` was last rebuilt 2025-11-01, one day after 3.9 went
-EOL). From that point `python:3.10-slim-bookworm` — and so
+EOL). From that point `python:3.10-slim` — and so
 `leoflow-runtime:py3.10` — receives no further OS security updates and
 accumulates unfixed CVEs indefinitely. The `py3.10` leg keeps being published
 until 2026-10-31, so nothing breaks today; `leoflow validate`, `leoflow
@@ -106,7 +106,7 @@ roadmap item.
 | `dag_source` | `"dag.py"` | DAG file relative to the project. |
 | `dependencies` | `[]` | pip specifiers baked into the image. |
 | `connectors` | `[]` | Short connector names expanded to provider packages at compile (ADR 0038). |
-| `system_packages` | `[]` | apt packages. |
+| `system_packages` | `[]` | apt packages. `apt-get install`ed into the DAG image at compile, resolving against the task base image's Debian suite — see the `system_packages` row under [leoflow.yaml](#leoflowyaml) for which suite that is and what moved. |
 | `include_paths` | `["."]` | Files copied into the image. |
 | `exclude_paths` | `[".git", "__pycache__", "*.pyc", ".venv", "venv"]` | Skipped both in image build **and** workspace discovery. Hidden directories (`.*`) are skipped as well. |
 | `build.context` | `"."` | Docker build context. |

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -28,7 +28,7 @@ chart's own values (image, replicas, ingress, Postgres/Redis wiring), see the
 | `base_image` | string | Override the runtime base image. |
 | `dependencies` | list | pip specifiers baked into the image. |
 | `connectors` | list | Short connector names (`postgres`, `http`, …) expanded at compile to their `apache-airflow-providers-*` packages. Sugar over `dependencies` — see [Installing a connector's provider](/connections/#installing-a-connectors-provider). |
-| `system_packages` | list | apt packages. |
+| `system_packages` | list | apt packages, installed into the DAG image at compile. Resolved against the task base image's Debian suite, now **Debian 13 (trixie)** — it was Debian 12 (bookworm) through v0.4.5, so a package name or version pin that only existed in bookworm has to be re-pinned. |
 | `dag_source` | string | DAG file (default `dag.py`). |
 | `build`, `registry` | object | Image build + push settings. |
 | `defaults` | object | DAG-level `retries`, `retry_delay_seconds`, `execution_timeout_seconds`, `resources`. |


### PR DESCRIPTION
## What & why

Moves the **DAG task base image** from Debian 12 (bookworm) to Debian 13 (trixie) — `runtime/Dockerfile` stage 2.

The reason is **OpenSSL**, not the Debian release calendar on its own.

`python:3.x-slim` links CPython's `ssl` module against the **system** OpenSSL, so that library is where every TLS call made from inside a task terminates: every provider hitting an API, every `requests` call, every warehouse driver. bookworm ships OpenSSL 3.0.x, whose **upstream support ended 2026-09-07**. That is the load-bearing date — Debian LTS will keep backporting into 3.0 for a while, but the flow of upstream fixes it backports *from* has stopped, so the gap between a CVE existing and a patch reaching a task pod widens from here. trixie ships 3.5.x, supported to **2030-04-08**.

The suite is on the same trajectory: Debian 12 left regular security support **2026-06-11** and is oldstable under the LTS team's narrower, best-effort scope; Debian 13 has full Security Team support to **2028-08-09**, LTS to **2030-06-30**.

Upstream has already moved — `python:3.11-slim` and `python:3.11-slim-trixie` resolve to the identical index digest, children annotated `org.opencontainers.image.base.name: debian:trixie-slim`. So `-slim-bookworm` is no longer "the default", it is an explicit opt-in to the old suite. The new line pins `-slim-trixie` rather than dropping the suffix, so a future base-image move stays a reviewable diff instead of a silent consequence of upstream retagging — and that pin is now **enforced**, see below.

---

# Review round 2

Rebased onto `main` (picks up #1037 py3.13/deprecation-gate and #1034 image scanning). The CHANGELOG conflict is resolved into the **new** `[Unreleased]`, with `### Changed` placed ahead of `### Deprecated` per Keep-a-Changelog ordering. Verified the entry did not land in the cut `[0.4.5]` section.

## B1 — the false sentence, and a gate for it

#1037 records the py3.10 deprecation in the authoring schema, and the CLI prints its `reason` **verbatim** on compile, validate and deploy. That reason named a full tag: `python:3.10-slim-bookworm`. After this move it describes an image nobody builds — and the reader it is aimed at is exactly the one who will check, find trixie in the generated Dockerfile, and file the whole warning under stale tooling.

**Not fixed by `s/bookworm/trixie/`.** That is right today and wrong again on the next move, silently. The suite is **dropped**: `python:3.10-slim` is literally correct on every suite, since that tag has always resolved to the current one. Same edit applied to the configuration reference's prose, the CHANGELOG's #1037 and #1034 entries, the image-scanning page and `image-scan.yaml`'s header, so the release notes do not name two different suites for one base.

**New arm 8 in `scripts/check-python-runtime-matrix.sh`.** Reads the suite off `runtime/Dockerfile`'s stage-2 `FROM` and refuses any `python:3.x-slim-<suite>` literal in the schema or the configuration reference naming a different one. A suffix-free reference always passes, and the failure message recommends dropping the suite rather than swapping it. It also refuses a stage-2 `FROM` with **no** suite, which turns the Dockerfile's own argument for the explicit `-trixie` into something enforced.

Scope is deliberate: `docs/api/`'s mirror needs no arm (`TestEmbeddedSchemasMatchDocs` binds it byte-for-byte to the copy this gate reads); `CHANGELOG.md` is excluded, because a released section naming the suite of its own era is a record, not drift. The self-test fixture grew a stage-1 `golang:*-bookworm` line so the cases prove something — an arm that grepped for a suite name would read the builder's.

## B2 — CI for the headline surface

`grep -rn system_packages test/ .github/ examples/` returned nothing. The k3d operator E2E now carries a leg that ships **no Dockerfile**, which is load-bearing: `ensureDockerfile` honours a file on disk, so `system_packages:` bolted onto any existing fixture would have been silently ignored and the leg would have passed while testing nothing (the same shape that hid four defects in one dbt fixture). `base_image` points at the base built moments earlier in the same run, not the published one.

The same run asserts the base image's own properties, each previously guarded by a comment and nothing else: the **Debian suite** (read out of `runtime/Dockerfile`, not hardcoded — a literal `"trixie"` would be one more copy of the fact this PR is about), the **`65532:65532 0700`** home dir, and the **numeric final `USER`** on both the base and the generated `system_packages` image.

**py3.13 on trixie, built.** It had never been built by anyone; the first build would have been in `runtime-image` (`needs: release`), after the tag. Built locally on this change: Debian 13, `openssl`/`libssl3t64` `3.5.7-1~deb13u2`, `apt 3.0.3`, `passwd 1:4.17.4-2`, Python 3.13.15, `/home/leoflow` = `65532:65532 700`, final `USER 65532:65532`, `import leoflow, leoflow_runtime` and `from airflow.sdk import DAG, task` both fine, bookworm-built agent runs in it.

## The TLS regression class — corrected by measurement

The review expected OpenSSL 3.5 to raise the certificate floor and bite a user with a legacy vendor certificate. **Measured, it does not.** Four probes against a local TLS server, bookworm 3.0.20 vs trixie 3.5.7, identical on all four: RSA-1024 leaf refused on both, RSA-1024 CA refused on both, SHA-1-signed leaf refused on both, TLS 1.1 refused on both. Both suites already run at security level 2. A certificate that worked before this release still works.

**What did change is the first flight's size.** OpenSSL 3.5 enables the hybrid post-quantum group `X25519MLKEM768` by default and sends its key share in the ClientHello: **517 → 1525 bytes** for the same `ssl.create_default_context()`. That is the size at which known-broken middleboxes and TLS-inspecting proxies stop working, and it fails exactly the way the review described — a hang or reset at task runtime in a pod, against one endpoint, after a green build. The CHANGELOG names it and gives the workaround, verified rather than repeated: pointing `OPENSSL_CONF` at a file setting `Groups` to the classical list puts the ClientHello back to 517 bytes.

The in-pod HTTPS assertion is in the E2E regardless. A generic completed handshake is the only thing that covers a class like this, which no assertion could have predicted in advance.

## Should-fix items

- `configuration.md:109` — the second `system_packages` row (Defaults table) updated.
- **Rollback caveat** in the CHANGELOG: a `v0.4.5` `base_image` pin gets bookworm back for py3.10/3.11/3.12, but there is no `py3.13-v0.4.5`, so a 3.13 project must also move to `"3.12"`.
- **Stage-1 comment fixed.** "bookworm is fine because Debian 12 LTS still ships ca-certificates" argued the wrong axis and was doubly wrong: `GO_VERSION` is pinned by patch, so a Debian security update never reaches that image in place and its refresh mechanism is the Go bump; and `crypto/x509` reads the **final** image's trust store, not the builder's. The comment now says both, and names the condition that forces the move (the first `GO_VERSION` bump after upstream stops publishing a `-bookworm` variant).

## Confirmed correct, unchanged

`0700`; the stage-1 split; `cut-release.sh:109`'s FLAKE_RE fixture (matches on `failed to solve`, never on the suite, verbatim record of an observed failure); `cicd-deploy.md:140` (the user's own CI runner).

**#1034 is not reddened.** Its blocking gate covers `leoflow-server` — distroless-debian12 plus a binary from our `go.mod` — untouched here. `leoflow-runtime` changes suite under the **daily, non-blocking** scan, and `.trivyignore.yaml` is empty, so no suppression can go stale against the new package set.

## Verification

`go test ./...` green. `make lint` 0 issues. `actionlint` clean. All `scripts/check-*.sh` green (`check-chart-version-matches-tag.sh` is release-only and needs a tag argument). `shellcheck -S warning` clean. `check-script-selftests.sh`: 9/9, `check-python-runtime-matrix.sh --self-test` 35/35.

**Full `test/e2e/e2e.sh` run locally on k3d, green end to end**, including both new sections. **CI: 49/49 green.**

One rerun, disclosed rather than hidden: `E2E split (k3d two-process api/scheduler)` failed first time on `ErrImagePull` — the k3d import flake `test/e2e/lib.sh` exists to paper over, where `k3d image import` reports success and leaves the node without the image. It is not this change: every other k3d job on the same commit passed on the first attempt, including `E2E operators` (which imports one *more* image than before) and `E2E deploy`, and a trixie image that had actually pulled could not fail as a missing image. Green on rerun, no code touched.

Mutations — each applied and asserted to have applied, red confirmed, restored:

| # | Mutation | Caught by |
|---|---|---|
| M1 | schema `reason` says `python:3.10-slim-bookworm` again | gate arm 8: *"names python:3.10-slim-bookworm / stage 2: FROM …-slim-trixie"* |
| M2 | stage-2 `FROM` drops `-trixie` | gate arm 8: *"pins no Debian suite"* |
| M3 | `chmod 0755 /home/leoflow` | E2E: *"/home/leoflow is '65532:65532 755', want '65532:65532 700'"* |
| M4 | base built on bookworm while the Dockerfile says trixie | E2E: *"base image is Debian 'bookworm' but … pins 'trixie'"* |
| M5 | final `USER leoflow` instead of the numeric pair | E2E: *"final USER is 'leoflow', want numeric '65532:65532'"* |
| M6 | `system_packages:` removed from the leg's `leoflow.yaml` | E2E task: *"system_packages did not put curl on PATH"* |
| M7 | trust store emptied, forcing a TLS verification failure | *found a bug in my own assertion* — see below |

M3/M4/M5 were driven by extracting the **shipped** assertion block out of `e2e.sh` by marker and `eval`ing it against mutant images, with the extraction itself asserted so a mutant that failed to apply cannot look like a pass. M6 was driven through the real CLI (`leoflow compile --build`) and the shipped task body.

**A second finding came out of re-running the E2E rather than reasoning about it.** The leg pushed under the default `git describe` version, so the first local re-run after editing the DAG body died on a 409 against the shared dev database. The dangerous half of that is the case where the body did *not* change: the push is accepted and the run silently exercises the stored version — a pass that proves nothing, which is how the chaos harness spent a stretch of time testing nothing. The leg now stamps a unique `--dag-version` per run, as `deploy-e2e.sh` already does. CI never sees either case (fresh Postgres per run); whoever edits this leg next would have seen both.

**M7 earned its keep.** `urllib.request.urlopen` wraps the TLS error in `URLError` and puts the `ssl` exception in `.reason`, so my `except ssl.SSLCertVerificationError` branch was unreachable and every TLS failure would have been reported as *"network, not TLS"* — a diagnostic that actively misleads, in the one place someone would be reading it under pressure. Fixed to classify off `err.reason`; all three branches re-verified (success, TLS-refused, no-egress) and the E2E re-run clean afterwards.

## Not verified

- The **third-party apt repository** case (`sqv` stricter than `gpgv` about legacy key material). Debian's own repositories are exercised by the new E2E leg; a custom repo added in a user's Dockerfile layer is not, and remains the case to watch. It fails loudly at build time.
- The **ClientHello size** finding is measured on this host's images, not against a real middlebox — no proxy of that kind is available to test against.
- py3.13 is built and inspected locally, **not** exercised by an E2E: every E2E still pins `PY_VERSION=3.11`.
