### PR TITLE
build(migrate): compile the migrate CLI from our go.mod instead of shipping a third-party image (#1039)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1139,6 +1139,26 @@ jobs:
         run: bash scripts/check-trivyignore-entries.sh
 
   # ─────────────────────────────────────────────────────────────────────
+  # The migrate CLI we ship and the migrate CLI CI scans must be one binary.
+  # `deploy/Dockerfile.migrate` compiles golang-migrate's `cmd/migrate` from the
+  # version in our go.mod (#1039) and security.yaml runs govulncheck over that
+  # package — but golang-migrate registers its database drivers behind BUILD
+  # TAGS, so a tag on one side and not the other means govulncheck reports clean
+  # on a package that is not the one in the image. Same for the Go pin: Trivy
+  # keys stdlib findings to the toolchain in the binary. Both drifts stay green
+  # while the coverage stops meaning anything, which is the shape of the gap
+  # #1039 closed.
+  # ─────────────────────────────────────────────────────────────────────
+  migrate-cli-build-tags:
+    name: Shipped migrate CLI is the one CI scans
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Check the migrate CLI build tags and toolchain pin
+        run: bash scripts/check-migrate-cli-build-tags.sh
+
+  # ─────────────────────────────────────────────────────────────────────
   # Script self-tests. cut-release.sh and the check-* gates hold logic nothing
   # else exercises — the tag normalizers, FLAKE_RE (which decides whether a red
   # run is rerun or stops a release), and the gates' ref comparisons. A defect

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1154,7 +1154,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Check the migrate CLI build tags and toolchain pin
         run: bash scripts/check-migrate-cli-build-tags.sh
 

--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -2,19 +2,22 @@
 #
 # ── Why this is not a PR gate ────────────────────────────────────────────────
 #
-# leoflow-runtime is python:3.x-slim and leoflow-migrate is
-# migrate/migrate (Alpine + a third-party Go binary). Neither package set is
-# ours. A CVE lands in them because a Debian security team published an
-# advisory, not because anyone here pushed a commit — so a blocking gate on them
-# fails whoever opens the next unrelated pull request, and the person who can
-# actually fix it (by rebasing a base image or bumping a pinned third-party tag)
-# is not in that PR. That gate gets switched off within a week, and switched-off
-# is worse than never-installed because it looks like coverage.
+# leoflow-runtime is python:3.x-slim, and that package set is not ours. A CVE
+# lands in it because a Debian security team published an advisory, not because
+# anyone here pushed a commit — so a blocking gate on it fails whoever opens the
+# next unrelated pull request, and the person who can actually fix it (by
+# rebasing a base image) is not in that PR. That gate gets switched off within a
+# week, and switched-off is worse than never-installed because it looks like
+# coverage.
 #
 # So: this workflow never fails the build. It publishes to the Security tab and
 # keeps exactly one tracking issue current. The blocking gate lives in
-# security.yaml and covers leoflow-server, the one image whose every byte comes
-# from our go.mod.
+# security.yaml and covers the images whose every byte comes from our go.mod:
+# leoflow-server, and — since #1039 rebuilt it from `FROM migrate/migrate` into
+# a distroless image holding a binary compiled from our own module graph —
+# leoflow-migrate. It used to be scanned here, and was the largest finding this
+# workflow ever produced (84 fixable, 50 CRITICAL/HIGH); it moved lanes because
+# what the image contains changed, not because the policy softened.
 #
 # ── Why a fixability filter, not just a severity floor ───────────────────────
 #
@@ -47,8 +50,6 @@ on:
     branches: [main]
     paths:
       - "runtime/**"
-      - "deploy/Dockerfile.migrate"
-      - "migrations/**"
       # The python_version enum decides which base images exist, and the first
       # step reconciles it against this workflow's SARIF upload steps.
       - "internal/domain/schemas/**"
@@ -64,8 +65,6 @@ on:
     # by findings that were already there.
     paths:
       - "runtime/**"
-      - "deploy/Dockerfile.migrate"
-      - "migrations/**"
       # The python_version enum decides which base images exist, and the first
       # step reconciles it against this workflow's SARIF upload steps.
       - "internal/domain/schemas/**"
@@ -98,8 +97,8 @@ env:
   ISSUE_TITLE: "Container image CVEs: fixable findings in published images"
 
 jobs:
-  # Named for what it does. This job builds the runtime and migrate images from
-  # the checkout — it does NOT pull a published tag. The two coincide whenever
+  # Named for what it does. This job builds the runtime images from the
+  # checkout — it does NOT pull a published tag. The two coincide whenever
   # HEAD still produces the published image, which is the normal case, but the
   # gap is real and worth stating: a base CVE in an already-published `py3.11`
   # that HEAD no longer produces is invisible here. Scan the tag directly when
@@ -180,9 +179,6 @@ jobs:
               -t "leoflow-runtime:py${py}" .
             echo "::endgroup::"
           done
-          echo "::group::build leoflow-migrate"
-          docker build -f deploy/Dockerfile.migrate -t leoflow-migrate:ci .
-          echo "::endgroup::"
 
       # Scan each image once to JSON (fixable findings, every severity), then
       # derive the SARIF from that report. The file stem names the image in the
@@ -204,7 +200,6 @@ jobs:
           for py in ${PY_LINES}; do
             scan "leoflow-runtime-py${py}" "leoflow-runtime:py${py}"
           done
-          scan leoflow-migrate leoflow-migrate:ci
 
       # The complete picture, including the unfixed findings the policy filters
       # out, so a filter this workflow applies is never the only copy of the data.
@@ -215,7 +210,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p scan-out/unfiltered
-          refs="leoflow-migrate:ci"
+          refs=""
           for py in ${PY_LINES}; do refs="${refs} leoflow-runtime:py${py}"; done
           for ref in ${refs}; do
             name="${ref//[:\/]/-}"
@@ -261,13 +256,6 @@ jobs:
           sarif_file: scan-out/leoflow-runtime-py3.13.sarif
           category: trivy-image-runtime-py313
 
-      - name: Upload SARIF (leoflow-migrate)
-        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
-        if: always() && github.event_name != 'pull_request'
-        with:
-          sarif_file: scan-out/leoflow-migrate.sarif
-          category: trivy-image-migrate
-
       - name: Build report
         id: report
         run: |
@@ -277,7 +265,6 @@ jobs:
           # shellcheck disable=SC2086 # deliberate word splitting over the report list.
           python3 scripts/trivy-report.py \
             ${reports} \
-            scan-out/leoflow-migrate.json \
             --gate-severity "$GATE_SEVERITY" \
             --fingerprint-out scan-out/fingerprint.txt \
             --blocking-count-out scan-out/blocking.txt \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,9 +73,13 @@ jobs:
   # ghcr.io/neochaotic/leoflow-migrate:<tag>; this job publishes that image,
   # multi-arch, on every release tag in parallel with install-smoke.
   #
-  # Dockerfile.migrate is `FROM migrate/migrate + COPY migrations/` — no Go
-  # binary, so GoReleaser's dockers block (which expects a built artifact) is
-  # overkill. docker/build-push-action is the simpler shape here.
+  # Dockerfile.migrate builds golang-migrate's own CLI from the version in our
+  # go.mod (#1039) and copies migrations/ on top. GoReleaser's dockers block
+  # expects a pre-built artifact from a `builds:` entry, and this binary is not
+  # one of ours to stamp — it is a dependency's main package, cross-compiled
+  # inside the Dockerfile from go.mod alone. docker/build-push-action is the
+  # simpler shape, and it builds the same file the blocking Trivy gate in
+  # security.yaml scans on every PR.
   migrate-image:
     name: Build + push leoflow-migrate image
     needs: release

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -36,6 +36,22 @@ jobs:
       - name: Run govulncheck
         run: govulncheck -show verbose ./...
 
+      # `./...` matches packages in THIS module and nothing else, so it does not
+      # reach the second binary we publish: the golang-migrate CLI in
+      # `leoflow-migrate`, which deploy/Dockerfile.migrate compiles from
+      # upstream's own `cmd/migrate` main package at the version pinned in our
+      # go.mod (#1039). That package is inside our module graph but outside
+      # `./...`, which is precisely the gap that let the old third-party image
+      # accumulate 50 fixable CRITICAL/HIGH unseen — naming it here is what
+      # keeps the gap closed rather than merely reset.
+      #
+      # The build tags matter: golang-migrate registers database drivers behind
+      # them, so an untagged analysis would scan a binary with no drivers in it
+      # — not the one that ships. scripts/check-migrate-cli-build-tags.sh fails
+      # CI when these tags and the Dockerfile's disagree.
+      - name: Run govulncheck on the published migrate CLI
+        run: govulncheck -tags postgres,pgx5 -show verbose github.com/golang-migrate/migrate/v4/cmd/migrate
+
   # ─────────────────────────────────────────────────────────────────────
   # CodeQL: GitHub's semantic SAST (ADR 0014)
   # Free for public repos. Catches taint flow / control flow issues.
@@ -112,11 +128,12 @@ jobs:
   # closed by a `go get`. That makes it the only image where a PR-blocking gate
   # is fair — the person who turns it red is the person who can turn it green.
   #
-  # The counterpart images (leoflow-runtime, leoflow-migrate) are NOT gated here.
-  # They inherit Debian and Alpine package sets that acquire CVEs with no commit
-  # of ours, so a blocking gate on them would fail whoever pushes next rather
-  # than whoever can fix it, and would be switched off within a week. They are
-  # scanned on a schedule instead — see .github/workflows/image-scan.yaml.
+  # `leoflow-migrate` is gated by its own job below, on the same criterion, since
+  # #1039 made it true of that image too. `leoflow-runtime` is NOT gated here: it
+  # inherits a Debian package set that acquires CVEs with no commit of ours, so a
+  # blocking gate on it would fail whoever pushes next rather than whoever can fix
+  # it, and would be switched off within a week. It is scanned on a schedule
+  # instead — see .github/workflows/image-scan.yaml.
   #
   # Policy: fixable only, CRITICAL/HIGH blocks. `ignore-unfixed` is what makes
   # this sustainable: severity says how bad a finding is, fixability says whether
@@ -129,9 +146,10 @@ jobs:
   #
   # It has to be, or the gate is theatre. Trivy keys `stdlib` findings to the Go
   # toolchain recorded in the binary's build info, not to the module graph: the
-  # migrate image reports 21 HIGH `stdlib` findings purely because its vendored
-  # binary was built with go1.25.4. Scanning a binary built by a different
-  # toolchain than the release one therefore scans a different vulnerability set
+  # migrate image used to report 21 HIGH `stdlib` findings purely because the
+  # third-party binary it shipped was built with go1.25.4 (#1039). Scanning a
+  # binary built by a different toolchain than the release one scans a different
+  # vulnerability set
   # — blind to a stdlib CVE that affects the shipped toolchain, and red for one
   # that does not.
   #
@@ -228,6 +246,84 @@ jobs:
         with:
           scan-type: image
           image-ref: leoflow-server:ci
+          scanners: vuln
+          ignore-unfixed: true
+          trivyignores: .trivyignore.yaml
+          severity: CRITICAL,HIGH
+          exit-code: 1
+          format: table
+
+  # ─────────────────────────────────────────────────────────────────────
+  # leoflow-migrate image scan — the second half of the BLOCKING gate.
+  #
+  # This image was the strongest argument for the report-only lane: it was
+  # `FROM migrate/migrate` — Alpine plus a third-party Go binary — and the daily
+  # scan found 84 fixable findings in it, 50 of them CRITICAL/HIGH, none of them
+  # produced or closeable by a commit here.
+  #
+  # #1039 changed what the image is, and therefore which lane it belongs in.
+  # `deploy/Dockerfile.migrate` now compiles golang-migrate's own CLI from the
+  # version in our go.mod onto distroless static, so the image is a Go binary we
+  # build plus our SQL files, with no OS package set underneath. Every finding
+  # it can now report is closed by a `go get` or a toolchain bump, which is the
+  # exact criterion the server gate above rests on — "the person who turns it
+  # red is the person who can turn it green".
+  #
+  # Unlike leoflow-server there is no separate release Dockerfile to reproduce:
+  # `deploy/Dockerfile.migrate` IS the file release.yaml builds and pushes, so
+  # building it here scans the published recipe rather than an approximation.
+  # Its pinned GO_VERSION defaults to the same toolchain as this workflow's, and
+  # the build stage cross-compiles, so the amd64 image built here is byte-for-
+  # byte the recipe the release runs.
+  #
+  # Baseline at the time of writing: ZERO findings under this policy (zero
+  # unfiltered, too), so the gate starts green and any red is a real regression.
+  # ─────────────────────────────────────────────────────────────────────
+  migrate-image:
+    name: Trivy (leoflow-migrate image)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # No build-args: the Dockerfile's own GO_VERSION default is the pin, and
+      # scripts/check-migrate-cli-build-tags.sh asserts it equals this
+      # workflow's GO_VERSION. Overriding it here would scan a toolchain the
+      # release does not use.
+      - name: Build leoflow-migrate image (the published Dockerfile)
+        run: docker build -f deploy/Dockerfile.migrate -t leoflow-migrate:ci .
+
+      # Report: every FIXABLE finding at any severity, so the Security tab shows
+      # the MEDIUM/LOW ones the gate deliberately does not block on.
+      - name: Trivy image scan (SARIF report)
+        uses: aquasecurity/trivy-action@d2a0b60797ff03db6132bd4e2b293f9b37081297 # master
+        with:
+          scan-type: image
+          image-ref: leoflow-migrate:ci
+          scanners: vuln
+          ignore-unfixed: true
+          trivyignores: .trivyignore.yaml
+          format: sarif
+          output: trivy-migrate-image.sarif
+
+      # Same rule as every other scan here (#437): gate on every event, upload
+      # only off pull_request so a PR run cannot overwrite the main baseline.
+      - name: Upload Trivy SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        if: always() && github.event_name != 'pull_request'
+        with:
+          sarif_file: trivy-migrate-image.sarif
+          category: trivy-migrate-image
+
+      # Gate: fixable CRITICAL/HIGH only.
+      - name: Trivy image scan (gate)
+        uses: aquasecurity/trivy-action@d2a0b60797ff03db6132bd4e2b293f9b37081297 # master
+        with:
+          scan-type: image
+          image-ref: leoflow-migrate:ci
           scanners: vuln
           ignore-unfixed: true
           trivyignores: .trivyignore.yaml

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -264,10 +264,23 @@ jobs:
   # #1039 changed what the image is, and therefore which lane it belongs in.
   # `deploy/Dockerfile.migrate` now compiles golang-migrate's own CLI from the
   # version in our go.mod onto distroless static, so the image is a Go binary we
-  # build plus our SQL files, with no OS package set underneath. Every finding
-  # it can now report is closed by a `go get` or a toolchain bump, which is the
-  # exact criterion the server gate above rests on — "the person who turns it
-  # red is the person who can turn it green".
+  # build, our SQL files, and the six base packages distroless carries
+  # (base-files, ca-certificates, media-types, netbase, tzdata, tzdata-legacy).
+  # Not zero OS packages — six instead of Alpine's full set. Every finding in the
+  # Go half is closed by a `go get` or a toolchain bump, which is the criterion
+  # the server gate above rests on: "the person who turns it red is the person
+  # who can turn it green".
+  #
+  # The six are the residual, and they are why this gate does not need an off
+  # switch. A fixable finding in one of them is not closeable here — you wait for
+  # Google to rebuild the base — so it gets a dated entry in .trivyignore.yaml,
+  # which enforces a statement, an expiry and a 180-day cap. A reviewed,
+  # self-expiring exception is what keeps a blocking gate from becoming a
+  # disabled one, and it is the same posture leoflow-server already runs under.
+  #
+  # A Go stdlib advisory with no released fix carries no FixedVersion, so
+  # --ignore-unfixed drops it and the gate stays green until the patch ships —
+  # at which point the remedy is an ARG GO_VERSION bump in this repo.
   #
   # Unlike leoflow-server there is no separate release Dockerfile to reproduce:
   # `deploy/Dockerfile.migrate` IS the file release.yaml builds and pushes, so

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -300,7 +300,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # No build-args: the Dockerfile's own GO_VERSION default is the pin, and
       # scripts/check-migrate-cli-build-tags.sh asserts it equals this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,15 +61,20 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `go get`: it is scanned on **every PR and push, and the job goes red**
   (baseline today: zero findings, so it starts green). Whether that red *blocks
   a merge* is a branch-protection setting — a new job is not a required check
-  until somebody adds it. `leoflow-runtime` and `leoflow-migrate` inherit
-  package sets we do not author, where a CVE lands because a distro security
-  team published an advisory and not because anyone pushed anything — blocking
-  those would fail whoever opens the next unrelated PR while the person who can
-  fix it is elsewhere. They are scanned **daily, never block, and maintain a
+  until somebody adds it. `leoflow-runtime` inherits a Debian package set we do
+  not author, where a CVE lands because a distro security team published an
+  advisory and not because anyone pushed anything — blocking it would fail
+  whoever opens the next unrelated PR while the person who can fix it is
+  elsewhere. It is scanned **daily, never blocks, and maintains a
   single self-closing tracking issue** whose body is refreshed each run, which
   comments only when the finding set actually changes, which reopens rather than
   duplicates when findings return, and which leaves the issue alone once a human
   has reopened it.
+
+  `leoflow-migrate` started in that lane and moved to the blocking one in this
+  same release: rebuilding it from our own `go.mod` onto distroless static
+  (below) changed what the image is, so the criterion that put it in the
+  report-only lane stopped describing it.
 
   The server gate scans **the artifact GoReleaser publishes** — the release
   Dockerfile, with a binary built by the release toolchain — not the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,41 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **`leoflow-migrate` is now built from our own `go.mod` instead of `FROM
+  migrate/migrate`, taking it from 50 fixable CRITICAL/HIGH findings to zero
+  (#1039).** The migration image shipped a third-party compiled binary, and
+  that binary ran in the Helm pre-install/pre-upgrade hook Job — the first
+  thing to touch a fresh cluster, holding the database DSN, before the control
+  plane starts. `govulncheck` could not see it. The distinction is narrow and
+  worth stating exactly: `golang-migrate` **is** in our `go.mod` and
+  govulncheck does cover the copy compiled into the Lite path, but the binary
+  inside `migrate/migrate` was built from upstream's dependency set with
+  upstream's toolchain, and nothing here read it. Two migrate binaries, one
+  covered.
+
+  `deploy/Dockerfile.migrate` now compiles golang-migrate's own `cmd/migrate`
+  package — upstream's CLI, not a reimplementation — at the version `go list -m`
+  reports, onto `gcr.io/distroless/static-debian13:nonroot`. Same entrypoint,
+  same flags, same subcommands, so the chart's Job is unchanged; the registered
+  driver list narrows to what Leoflow actually supports (`postgres`,
+  `postgresql`, `pgx5`, and the `file` source) instead of the two dozen the
+  general-purpose image carried. The image runs as UID 65532 in its own right
+  rather than relying on the chart to override a root default, and drops from
+  84 MB to 20 MB.
+
+  Bumping the `FROM` pin would have cleared the same 50 findings, and was
+  rejected for the reason it keeps working: it restores the blind spot on the
+  day the next advisory lands. Instead the binary is now inside the module
+  graph CI reads. `security.yaml` runs `govulncheck` over that package by name
+  (with the build tags the image is built with, or the drivers that actually
+  ship would go unanalysed), the image moves from the daily reporting scan to
+  the **blocking** Trivy gate alongside `leoflow-server` — it now meets the
+  same criterion, that every finding is closed by a commit here — and
+  `scripts/check-migrate-cli-build-tags.sh` fails CI if the build tags or the
+  Go toolchain pin ever stop matching between the Dockerfile and the scan. The
+  demo `docker compose` stack builds the same image rather than pulling a
+  separately pinned `migrate/migrate:v4.18.1`.
+
 - **The task base image moves from Debian 12 (bookworm) to Debian 13 (trixie),
   which takes its OpenSSL from 3.0.x to 3.5.x.** `python:3.x-slim` links CPython's
   `ssl` module against the **system** OpenSSL, so this is the library every TLS

--- a/deploy/Dockerfile.migrate
+++ b/deploy/Dockerfile.migrate
@@ -73,12 +73,23 @@ RUN set -eux; \
 		-ldflags="-s -w -X main.Version=${version}" \
 		-o /out/migrate github.com/golang-migrate/migrate/v4/cmd/migrate
 
-# Distroless static, Debian 13 (trixie) — the same family and posture as
-# leoflow-server, and the suite runtime/Dockerfile moved to in #1038. It carries
-# a CA bundle (needed for `sslmode=verify-full` DSNs), /etc/passwd with the
-# nonroot user, and nothing else: no shell, no package manager, no OS package
-# set to inherit CVEs from. Replaces an Alpine base whose package set was not
-# ours either.
+# Distroless static, Debian 13 (trixie). Same family as leoflow-server, which is
+# still on debian12 — not the same suite, and this is the suite
+# runtime/Dockerfile moved to in #1038.
+#
+# It carries a CA bundle, /etc/passwd with the nonroot user, and six base
+# packages (base-files, ca-certificates, media-types, netbase, tzdata,
+# tzdata-legacy). No shell and no package manager, so nothing an operator can
+# exec into and no application package set — but "no OS packages" would be
+# false, and the difference matters for the blocking gate: a fixable HIGH in
+# ca-certificates or tzdata reddens it and no commit here closes it. That is a
+# six-package exposure instead of Alpine's full set, and .trivyignore.yaml's
+# dated, self-expiring entries are what handle it — see security.yaml.
+#
+# The CA bundle is what makes `sslmode=verify-full` work against a managed
+# Postgres whose CA is in the system store. A DSN with an explicit
+# `sslrootcert=` path needs that file mounted; the migration Job does not mount
+# database.caConfigMap today, which the chart's own recipe assumes.
 FROM gcr.io/distroless/static-debian13:nonroot
 
 LABEL org.opencontainers.image.source="https://github.com/neochaotic/leoflow"
@@ -86,7 +97,12 @@ LABEL org.opencontainers.image.description="golang-migrate CLI plus the Leoflow 
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 COPY --from=build /out/migrate /usr/local/bin/migrate
-COPY migrations/ /migrations/
+# Only the SQL. migrations/ also holds embed.go, latest.go and their tests,
+# which the Go side uses to compute the binary's required schema version;
+# golang-migrate's file source ignores names that do not match its version
+# pattern, so copying them was harmless — but shipping source into a runtime
+# image is not a thing to leave harmless on purpose.
+COPY migrations/*.sql /migrations/
 
 # 65532 numerically, not `nonroot` by name: a PodSecurity `restricted` namespace
 # verifies runAsNonRoot against the image's user and the kubelet can only

--- a/deploy/Dockerfile.migrate
+++ b/deploy/Dockerfile.migrate
@@ -1,4 +1,101 @@
-# Bundles the Leoflow SQL migrations with golang-migrate, for the Helm chart's
-# migration Job (#34/#48). Run as: migrate -path /migrations -database <url> up
-FROM migrate/migrate:v4.19.1
+# Bundles the Leoflow SQL migrations with the golang-migrate CLI, for the Helm
+# chart's migration Job (#34/#48). Run as:
+#   migrate -path /migrations -database <url> up
+#
+# Build from the repository root (go.mod / go.sum must be in context):
+#   docker build -f deploy/Dockerfile.migrate -t leoflow-migrate .
+#
+# ── Why this compiles the CLI instead of `FROM migrate/migrate:<tag>` (#1039) ─
+#
+# It used to be `FROM migrate/migrate:v4.19.1` plus a COPY. That shipped someone
+# else's compiled binary, with its own dependency tree and its own Go toolchain,
+# into a pod that holds the database DSN and runs before anything else on a
+# fresh cluster. `govulncheck` could not see it: golang-migrate IS in our go.mod
+# (the Lite path compiles it into the CLI, internal/cli/dev.go), but the binary
+# inside the third-party image is not in our module graph, so we had two migrate
+# binaries and covered one. The scan added in #1034 measured the difference —
+# 84 fixable findings, 50 of them CRITICAL/HIGH, against zero for leoflow-server.
+#
+# Bumping the pin would have cleared those 50 and restored the same blind spot
+# the day the next advisory landed. Building the CLI from the version already in
+# our go.mod removes the third-party image instead: one migrate binary, resolved
+# by `go list -m`, moved by Dependabot like every other dependency, and inside
+# govulncheck's reach — `govulncheck -tags postgres,pgx5
+# github.com/golang-migrate/migrate/v4/cmd/migrate` analyses exactly the package
+# this stage builds, at exactly the version it builds it at.
+#
+# The CLI surface is upstream's, unmodified: this builds upstream's own
+# `cmd/migrate` main package, not a reimplementation, so every flag and
+# subcommand the Job (or an operator) passes behaves as documented.
+
+# Pinned to the toolchain CI uses (GO_VERSION in .github/workflows/security.yaml
+# and image-scan.yaml). Not cosmetic: Trivy keys `stdlib` findings to the Go
+# toolchain recorded in the binary's build info, so a floating tag here would
+# move this image's reported vulnerability set for reasons unrelated to any
+# commit — the same trap security.yaml documents for leoflow-server.
+ARG GO_VERSION=1.26.6
+
+# Build on the NATIVE platform and cross-compile with GOARCH, rather than
+# letting buildx emulate the build stage under QEMU for the arm64 leg. The
+# output is a CGO-free static binary either way, so nothing from this stage
+# reaches the published image; bookworm vs trixie here changes the build
+# environment only, exactly as runtime/Dockerfile's agent stage explains.
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-bookworm AS build
+WORKDIR /src
+
+# Only the module files are copied: the package being built lives in a
+# dependency module, so none of this repository's own source is an input. That
+# also means the build cache keys on go.mod/go.sum alone and survives every
+# unrelated commit.
+COPY go.mod go.sum ./
+
+ARG TARGETARCH
+# Build tags select which database drivers are registered — golang-migrate
+# registers none by default, and a binary built without them fails at RUNTIME
+# with "unknown driver", not at build time. `postgres` covers the `postgres://`
+# and `postgresql://` schemes the Helm Job's LEOFLOW_DATABASE_URL uses; `pgx5`
+# covers the `pgx5://` scheme the Lite path uses (internal/cli/dev.go), so a DSN
+# that works in one place works in the other. Postgres is the only database
+# Leoflow supports, so no other driver is built in.
+#
+# The version stamped into the binary is READ from the module graph rather than
+# written here, so `migrate -version` cannot drift from the version actually
+# compiled. `-X main.Version=` must use the unqualified `main.` form; a
+# fully-qualified package path silently no-ops.
+#
+# TARGETARCH is filled in by BuildKit; the fallback keeps a build under any
+# front end that leaves it empty from setting GOARCH to the empty string, which
+# is not the same thing as leaving it unset.
+RUN set -eux; \
+	version="$(go list -m -f '{{.Version}}' github.com/golang-migrate/migrate/v4)"; \
+	CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH:-$(go env GOARCH)}" go build -trimpath \
+		-tags 'postgres pgx5' \
+		-ldflags="-s -w -X main.Version=${version}" \
+		-o /out/migrate github.com/golang-migrate/migrate/v4/cmd/migrate
+
+# Distroless static, Debian 13 (trixie) — the same family and posture as
+# leoflow-server, and the suite runtime/Dockerfile moved to in #1038. It carries
+# a CA bundle (needed for `sslmode=verify-full` DSNs), /etc/passwd with the
+# nonroot user, and nothing else: no shell, no package manager, no OS package
+# set to inherit CVEs from. Replaces an Alpine base whose package set was not
+# ours either.
+FROM gcr.io/distroless/static-debian13:nonroot
+
+LABEL org.opencontainers.image.source="https://github.com/neochaotic/leoflow"
+LABEL org.opencontainers.image.description="golang-migrate CLI plus the Leoflow SQL migrations, for the Helm migration Job"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+COPY --from=build /out/migrate /usr/local/bin/migrate
 COPY migrations/ /migrations/
+
+# 65532 numerically, not `nonroot` by name: a PodSecurity `restricted` namespace
+# verifies runAsNonRoot against the image's user and the kubelet can only
+# resolve a numeric UID. This is the UID helm/leoflow/values.yaml pins for the
+# migration Job, and the migrations are world-readable, so the Job's
+# readOnlyRootFilesystem + drop-ALL posture needs no change.
+USER 65532:65532
+
+# Matches the entrypoint the third-party image exposed, so the Helm Job's
+# args-only invocation (`-path=… -database=… up`) is unchanged.
+ENTRYPOINT ["/usr/local/bin/migrate"]
+CMD ["--help"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,9 +50,19 @@ services:
   # then open http://localhost:8080 and log in as admin@leoflow.local / admin.
 
   # One-shot migration runner: applies all up migrations, then exits.
+  #
+  # Built from deploy/Dockerfile.migrate rather than pulled from
+  # `migrate/migrate` (#1039), so the demo stack runs the same migrate binary
+  # the Helm chart does — golang-migrate's CLI compiled from this repository's
+  # go.mod — instead of a separately pinned third-party image that drifted a
+  # minor version behind and pulled from rate-limited Docker Hub. The bind
+  # mount stays: it shadows the copy baked into the image with the live tree,
+  # so editing a .sql file does not need a rebuild.
   migrate:
     profiles: ["demo"]
-    image: migrate/migrate:v4.18.1
+    build:
+      context: .
+      dockerfile: deploy/Dockerfile.migrate
     depends_on:
       postgres:
         condition: service_healthy

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -169,7 +169,10 @@ is required.
 The pre-install/pre-upgrade Job runs `migrate -path <path> -database <url> up`
 using the default image **`ghcr.io/neochaotic/leoflow-migrate`** (built from
 `deploy/Dockerfile.migrate`, published by `.github/workflows/release.yaml` on
-every tag), which bundles the Leoflow `migrations/` at `migrations.path`.
+every tag), which bundles the Leoflow `migrations/` at `migrations.path`. The
+`migrate` binary in it is golang-migrate's own CLI, compiled from the version
+pinned in Leoflow's `go.mod` onto distroless static and running as UID 65532,
+rather than a third-party image pulled at build time (#1039).
 Override `migrations.image` to use your own, or set `migrations.enabled=false`
 to migrate out of band.
 
@@ -427,7 +430,7 @@ differ from what's committed.
 | metrics.serviceMonitor.scrapeTimeout | string | `"10s"` | Prometheus scrape timeout (must be ≤ interval). |
 | migrations.enabled | bool | `true` |  |
 | migrations.image.pullPolicy | string | `"IfNotPresent"` |  |
-| migrations.image.repository | string | `"ghcr.io/neochaotic/leoflow-migrate"` | leoflow-migrate image bundling Leoflow SQL migrations on top of `migrate/migrate`. Published per release by `release.yaml`, signed with cosign, multi-arch (amd64 + arm64). |
+| migrations.image.repository | string | `"ghcr.io/neochaotic/leoflow-migrate"` | leoflow-migrate image: the golang-migrate CLI compiled from the version in our `go.mod`, plus the Leoflow SQL migrations, on distroless static. Published per release by `release.yaml`, signed with cosign, multi-arch (amd64 + arm64). |
 | migrations.image.tag | string | `""` | Migration image tag. Defaults to `.Chart.appVersion` when empty. Pin to the same tag as `image.tag` (both server and migrate publish both `v`-prefix and no-`v` forms — use whichever convention you prefer, they resolve to the same digest): `--set migrations.image.tag=v0.4.0-rc.2`. |
 | migrations.path | string | `"/migrations"` | Path inside the migrate image where the SQL files live. Must match the COPY destination in `deploy/Dockerfile.migrate`. |
 | migrations.podSecurityContext.fsGroup | int | `65532` |  |

--- a/helm/leoflow/README.md.gotmpl
+++ b/helm/leoflow/README.md.gotmpl
@@ -169,7 +169,10 @@ is required.
 The pre-install/pre-upgrade Job runs `migrate -path <path> -database <url> up`
 using the default image **`ghcr.io/neochaotic/leoflow-migrate`** (built from
 `deploy/Dockerfile.migrate`, published by `.github/workflows/release.yaml` on
-every tag), which bundles the Leoflow `migrations/` at `migrations.path`.
+every tag), which bundles the Leoflow `migrations/` at `migrations.path`. The
+`migrate` binary in it is golang-migrate's own CLI, compiled from the version
+pinned in Leoflow's `go.mod` onto distroless static and running as UID 65532,
+rather than a third-party image pulled at build time (#1039).
 Override `migrations.image` to use your own, or set `migrations.enabled=false`
 to migrate out of band.
 

--- a/helm/leoflow/values.yaml
+++ b/helm/leoflow/values.yaml
@@ -323,7 +323,7 @@ bootstrap:
 migrations:
   enabled: true
   image:
-    # -- leoflow-migrate image bundling Leoflow SQL migrations on top of `migrate/migrate`. Published per release by `release.yaml`, signed with cosign, multi-arch (amd64 + arm64).
+    # -- leoflow-migrate image: the golang-migrate CLI compiled from the version in our `go.mod`, plus the Leoflow SQL migrations, on distroless static. Published per release by `release.yaml`, signed with cosign, multi-arch (amd64 + arm64).
     repository: ghcr.io/neochaotic/leoflow-migrate
     # -- Migration image tag. Defaults to `.Chart.appVersion` when empty. Pin to the same tag as `image.tag` (both server and migrate publish both `v`-prefix and no-`v` forms — use whichever convention you prefer, they resolve to the same digest): `--set migrations.image.tag=v0.4.0-rc.2`.
     tag: ""
@@ -336,10 +336,12 @@ migrations:
   # (top-level podSecurityContext); these defaults mirror that posture so
   # restricted-PSA clusters accept the migration Job too.
   #
-  # The migrate/migrate base image runs as root by default, but the binary
-  # is a static Go binary that works fine under any UID — verified locally
-  # via `docker run --rm -u 65532:65532 migrate/migrate -version` and
-  # `ls /migrations` (migrations are world-readable, mode 644).
+  # The image itself already runs as UID 65532 (deploy/Dockerfile.migrate,
+  # #1039) rather than as root the way the old `migrate/migrate` base did, so
+  # these values now agree with the image instead of overriding it. Kept
+  # explicit all the same: a restricted namespace verifies the POD spec, and an
+  # operator overriding `migrations.image` must land on a UID that can read
+  # /migrations (world-readable, mode 644).
   podSecurityContext:
     runAsNonRoot: true
     runAsUser: 65532
@@ -352,8 +354,10 @@ migrations:
     allowPrivilegeEscalation: false
     # migrate is a static Go binary writing only to the DB (advisory lock for
     # migration mutex). No /tmp writes, no log files. Safe to lock the root
-    # FS read-only — tightest restricted-PSA posture. Verified locally with
-    # `docker run --rm --read-only -u 65532:65532 leoflow-migrate -version`.
+    # FS read-only — tightest restricted-PSA posture. Verified against the
+    # image this chart defaults to by applying all 26 migrations with
+    # `docker run --rm --read-only -u 65532:65532 --cap-drop ALL
+    # leoflow-migrate -path=/migrations -database=<dsn> up`.
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 65532

--- a/scripts/check-migrate-cli-build-tags.sh
+++ b/scripts/check-migrate-cli-build-tags.sh
@@ -32,19 +32,66 @@ PKG="github.com/golang-migrate/migrate/v4/cmd/migrate"
 
 # ── Pure parsers, so --self-test can drive them without the real files ───────
 
-# dockerfile_tags reads a Dockerfile on stdin and prints the build tags of the
-# `go build` line, normalised to a sorted, comma-separated set. Accepts the
-# space-separated `-tags 'a b'` spelling the Dockerfile uses.
+# dockerfile_build_line reads a Dockerfile on stdin and prints the LOGICAL line
+# that runs `go build`: comment lines dropped, backslash continuations joined.
+#
+# Everything below parses that string rather than the file, and the difference
+# is the whole point. An earlier version grepped the file, which this same
+# Dockerfile's prose then satisfied on its own: the header explains the build in
+# English, quoting `-tags 'postgres pgx5'`, `go list -m` and the package path, so
+# a reviewer's mutation to the actual RUN line left every assertion green. A gate
+# that its own documentation satisfies is worse than no gate — it is a green
+# check that means nothing, which is the exact failure #1039 was about.
+dockerfile_build_line() {
+	sed '/^[[:space:]]*#/d' | awk '
+		{ if (buf != "") { buf = buf " " $0 } else { buf = $0 } }
+		buf ~ /\\[[:space:]]*$/ { sub(/\\[[:space:]]*$/, "", buf); next }
+		{ print buf; buf = "" }
+		END { if (buf != "") print buf }
+	' | grep -F 'go build' | head -1
+}
+
+# dockerfile_tags prints the build tags of the `go build` line, normalised to a
+# sorted, comma-separated set. Accepts the space-separated `-tags 'a b'`
+# spelling the Dockerfile uses.
 dockerfile_tags() {
-	sed -n "s/.*-tags[ =]*'\([^']*\)'.*/\1/p" | head -1 | tr ' ,' '\n' |
+	dockerfile_build_line | sed -n "s/.*-tags[ =]*'\([^']*\)'.*/\1/p" | tr ' ,' '\n' |
 		sed '/^$/d' | LC_ALL=C sort -u | paste -sd, -
+}
+
+# dockerfile_builds_pkg exits 0 when the build line's output package is $1.
+# Scoped to the build line for the same reason as the tags.
+dockerfile_builds_pkg() { # <pkg>
+	dockerfile_build_line | grep -qF -- "$1"
+}
+
+# dockerfile_reads_version exits 0 when the build line derives the stamped
+# version from the module graph rather than carrying a literal.
+dockerfile_reads_version() {
+	dockerfile_build_line | grep -qF 'go list -m'
 }
 
 # workflow_tags reads a workflow on stdin and prints the tags passed to
 # govulncheck, normalised the same way. Accepts `-tags a,b` and `-tags=a,b`.
 workflow_tags() {
-	grep -o 'govulncheck[^|]*-tags[ =][^ ]*' | sed -n 's/.*-tags[ =]\([^ ]*\).*/\1/p' |
+	sed '/^[[:space:]]*#/d' | grep -o 'govulncheck[^|]*-tags[ =][^ ]*' |
+		sed -n 's/.*-tags[ =]\([^ ]*\).*/\1/p' |
 		head -1 | tr ' ,' '\n' | sed '/^$/d' | LC_ALL=C sort -u | paste -sd, -
+}
+
+# workflow_scans_migrate_image exits 0 when the workflow still contains a Trivy
+# step whose image-ref is the migrate image, built from the migrate Dockerfile.
+#
+# This is the assertion with the most at stake and it was the one missing.
+# image-scan.yaml no longer covers leoflow-migrate at all — #1039 moved it out of
+# the report-only lane — so the job in security.yaml is the ONLY scan of this
+# image anywhere. Deleting it leaves every other gate here green and the image
+# that holds the database DSN completely unscanned: the same "coverage deleted
+# while claiming to strengthen it" shape the move was meant to avoid.
+workflow_scans_migrate_image() {
+	local body; body=$(sed '/^[[:space:]]*#/d')
+	printf '%s' "$body" | grep -qE 'image-ref:[[:space:]]*leoflow-migrate' &&
+		printf '%s' "$body" | grep -qF 'deploy/Dockerfile.migrate'
 }
 
 # dockerfile_go_version reads a Dockerfile on stdin and prints the default of
@@ -94,6 +141,52 @@ self_test() {
 	# hard failure, and this pins that it can tell the difference.
 	_eq "$(printf 'FROM scratch\n' | dockerfile_tags)" "" "no -tags yields empty"
 
+	# ── The reviewer's mutations, as fixtures ────────────────────────────
+	# Every case below was green against the first version of this gate, which
+	# grepped whole files. The Dockerfile's own header quotes `-tags 'postgres
+	# pgx5'`, `go list -m` and the package path in prose, so the documentation
+	# satisfied the checks and the mutations could not fail.
+
+	# A comment line quoting the tags must not out-vote the real build line.
+	local decoy
+	decoy=$'# example: -tags \'postgres pgx5\'\nRUN set -eux; \\\n\tgo build -tags \'pgx5\' -o /out/migrate '"$PKG"'\n'
+	_eq "$(printf '%s' "$decoy" | dockerfile_tags)" "pgx5" "a decoy -tags comment does not out-vote the build line"
+
+	# Prose naming the package must not satisfy the build-target assertion.
+	local prose
+	prose=$'# builds '"$PKG"$'\nRUN go build -o /out/migrate github.com/golang-migrate/migrate/v4/internal/cli\n'
+	if printf '%s' "$prose" | dockerfile_builds_pkg "$PKG"; then
+		printf '  FAIL %s\n' "a comment naming the package satisfies the build-target check"; fail=1
+	else
+		printf '  ok   %s\n' "prose naming the package does not satisfy the build-target check"
+	fi
+
+	# Prose quoting `go list -m` must not satisfy the version-derivation check.
+	local hardcoded
+	hardcoded=$'# the version is read with go list -m\nRUN version="v4.19.1"; go build -o /out/migrate x\n'
+	if printf '%s' "$hardcoded" | dockerfile_reads_version; then
+		printf '  FAIL %s\n' "a comment quoting 'go list -m' satisfies the version check"; fail=1
+	else
+		printf '  ok   %s\n' "prose quoting 'go list -m' does not satisfy the version check"
+	fi
+	# shellcheck disable=SC2016 # the fixture is a literal Dockerfile line; $( ) must NOT expand here.
+	_eq "$(printf 'RUN v="$(go list -m x)"; go build -o /o/m x\n' | dockerfile_build_line | grep -c 'go list -m')" "1" "a real 'go list -m' on the build line is found"
+
+	# The migrate image scan must be asserted to EXIST, not merely to agree.
+	local wf_ok wf_gone
+	wf_ok=$'      - uses: aquasecurity/trivy-action@v0\n        with:\n          image-ref: leoflow-migrate:ci\n      - run: docker build -f deploy/Dockerfile.migrate -t leoflow-migrate:ci .\n'
+	wf_gone=$'      - run: echo nothing scans the migrate image any more\n'
+	if printf '%s' "$wf_ok" | workflow_scans_migrate_image; then
+		printf '  ok   %s\n' "a present migrate image scan is recognised"
+	else
+		printf '  FAIL %s\n' "a present migrate image scan is not recognised"; fail=1
+	fi
+	if printf '%s' "$wf_gone" | workflow_scans_migrate_image; then
+		printf '  FAIL %s\n' "a deleted migrate image scan passes — the image would ship unscanned"; fail=1
+	else
+		printf '  ok   %s\n' "a deleted migrate image scan is caught"
+	fi
+
 	[ "$fail" -eq 0 ] && echo "self-test: all passed"
 	return "$fail"
 }
@@ -120,18 +213,21 @@ note() {
 if grep -qE '^\s*FROM\s+migrate/migrate' "$DOCKERFILE"; then
 	note "$DOCKERFILE is back on the third-party migrate/migrate image (#1039). The migrate binary must be compiled from the version in our go.mod so govulncheck can see it."
 fi
-if ! grep -qF "$PKG" "$DOCKERFILE"; then
-	note "$DOCKERFILE does not build $PKG."
+if ! dockerfile_builds_pkg "$PKG" <"$DOCKERFILE"; then
+	note "$DOCKERFILE's go build line does not build $PKG."
 fi
 if ! grep -qF "$PKG" "$WORKFLOW"; then
 	note "$WORKFLOW does not run govulncheck over $PKG, so the shipped migrate binary is outside CI's module graph again (#1039)."
+fi
+if ! workflow_scans_migrate_image <"$WORKFLOW"; then
+	note "$WORKFLOW no longer builds deploy/Dockerfile.migrate and scans it as leoflow-migrate. image-scan.yaml does not cover this image any more, so that job is the only scan of the container that holds the database DSN — without it the image ships unscanned and every other check here still passes."
 fi
 
 # 2. The version stamped into the binary must be READ from the module graph, not
 #    written by hand — a hardcoded `-X main.Version=v4.19.1` survives a go.mod
 #    bump and makes `migrate -version` lie about what is actually compiled.
-if ! grep -qF 'go list -m' "$DOCKERFILE"; then
-	note "$DOCKERFILE no longer derives the stamped version with 'go list -m'; a hardcoded version drifts from go.mod silently."
+if ! dockerfile_reads_version <"$DOCKERFILE"; then
+	note "$DOCKERFILE's go build line no longer derives the stamped version with 'go list -m'; a hardcoded version drifts from go.mod silently."
 fi
 
 # 3. Build tags: same set on both ends.
@@ -144,6 +240,17 @@ elif [ -z "$wf_tags" ]; then
 elif [ "$df_tags" != "$wf_tags" ]; then
 	note "build tags disagree: $DOCKERFILE builds with [$df_tags], $WORKFLOW scans with [$wf_tags]. govulncheck would be analysing a different binary than the one in the image."
 fi
+
+# 3b. Consistency is not correctness. Dropping `postgres` from BOTH ends
+#     satisfies the comparison above and produces a binary with no driver for
+#     the only database Leoflow supports — `unknown driver postgres (forgotten
+#     import?)` at Job runtime. helm-ci's kind install would catch it, several
+#     minutes and one cluster later; this catches it in seconds. Leoflow is
+#     Postgres-only, so this is a fact about the product, not a preference.
+case ",$df_tags," in
+*,postgres,*) ;;
+*) note "the build tags [$df_tags] do not include 'postgres'. golang-migrate registers its drivers behind build tags, so this binary would fail at runtime with \"unknown driver postgres\" — the migration Job would not start, and the tag comparison above cannot see it because both ends agree." ;;
+esac
 
 # 4. Go toolchain: same pin on both ends.
 df_go="$(dockerfile_go_version <"$DOCKERFILE")"

--- a/scripts/check-migrate-cli-build-tags.sh
+++ b/scripts/check-migrate-cli-build-tags.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# Keep the migrate CLI we SHIP and the migrate CLI we SCAN the same binary.
+#
+# `deploy/Dockerfile.migrate` compiles golang-migrate's own `cmd/migrate` from
+# the version in our go.mod (#1039), and `.github/workflows/security.yaml` runs
+# `govulncheck` over that same package so the binary is inside the module graph
+# CI actually reads. Both ends of that chain are needed, and neither proves the
+# other:
+#
+#   - golang-migrate registers database drivers behind BUILD TAGS. A binary
+#     built with `-tags 'postgres pgx5'` and analysed with no tags is analysed
+#     without the drivers it ships — govulncheck reports clean on a package that
+#     is not the one in the image, and reports it in a green check. The reverse
+#     drift (a tag added to the scan and not to the build) is quieter still.
+#   - Trivy keys `stdlib` findings to the Go toolchain recorded in the binary's
+#     build info. If the Dockerfile's GO_VERSION and the workflow's diverge, the
+#     blocking image gate scans a toolchain the release never builds with.
+#
+# The failure mode both share is silence: everything stays green while the
+# coverage stops meaning anything. That is the exact shape of the gap #1039
+# closed — a migrate binary nobody was watching — so it gets a gate rather than
+# a comment asking the next reader to keep two files in sync.
+#
+# Usage:
+#   scripts/check-migrate-cli-build-tags.sh
+#   scripts/check-migrate-cli-build-tags.sh --self-test
+set -euo pipefail
+
+DOCKERFILE="deploy/Dockerfile.migrate"
+WORKFLOW=".github/workflows/security.yaml"
+PKG="github.com/golang-migrate/migrate/v4/cmd/migrate"
+
+# ── Pure parsers, so --self-test can drive them without the real files ───────
+
+# dockerfile_tags reads a Dockerfile on stdin and prints the build tags of the
+# `go build` line, normalised to a sorted, comma-separated set. Accepts the
+# space-separated `-tags 'a b'` spelling the Dockerfile uses.
+dockerfile_tags() {
+	sed -n "s/.*-tags[ =]*'\([^']*\)'.*/\1/p" | head -1 | tr ' ,' '\n' |
+		sed '/^$/d' | LC_ALL=C sort -u | paste -sd, -
+}
+
+# workflow_tags reads a workflow on stdin and prints the tags passed to
+# govulncheck, normalised the same way. Accepts `-tags a,b` and `-tags=a,b`.
+workflow_tags() {
+	grep -o 'govulncheck[^|]*-tags[ =][^ ]*' | sed -n 's/.*-tags[ =]\([^ ]*\).*/\1/p' |
+		head -1 | tr ' ,' '\n' | sed '/^$/d' | LC_ALL=C sort -u | paste -sd, -
+}
+
+# dockerfile_go_version reads a Dockerfile on stdin and prints the default of
+# its `ARG GO_VERSION=`.
+dockerfile_go_version() {
+	sed -n 's/^ARG GO_VERSION=\(.*\)$/\1/p' | head -1 | tr -d "\"'"
+}
+
+# workflow_go_version reads a workflow on stdin and prints its top-level
+# `GO_VERSION:` env value.
+workflow_go_version() {
+	sed -n 's/^  GO_VERSION: *"\{0,1\}\([0-9.]*\)"\{0,1\} *$/\1/p' | head -1
+}
+
+self_test() {
+	local fail=0
+	_eq() { # <got> <want> <name>
+		if [ "$1" = "$2" ]; then printf '  ok   %s\n' "$3"; else
+			printf '  FAIL %s\n    got:  %q\n    want: %q\n' "$3" "$1" "$2"
+			fail=1
+		fi
+	}
+
+	local df
+	df=$'ARG GO_VERSION=1.26.6\nFROM golang:${GO_VERSION}-bookworm AS build\nRUN go build -trimpath \\\n\t\t-tags '"'"'postgres pgx5'"'"' \\\n\t\t-o /out/migrate '"$PKG"'\n'
+	_eq "$(printf '%s' "$df" | dockerfile_tags)" "pgx5,postgres" "Dockerfile tags parse and sort"
+	_eq "$(printf '%s' "$df" | dockerfile_go_version)" "1.26.6" "Dockerfile GO_VERSION parses"
+
+	local wf
+	wf=$'env:\n  GO_VERSION: "1.26.6"\njobs:\n  x:\n    steps:\n      - run: govulncheck -tags postgres,pgx5 -show verbose '"$PKG"'\n'
+	_eq "$(printf '%s' "$wf" | workflow_tags)" "pgx5,postgres" "workflow tags parse and sort"
+	_eq "$(printf '%s' "$wf" | workflow_go_version)" "1.26.6" "workflow GO_VERSION parses"
+
+	# `-tags=a,b` is the other spelling govulncheck accepts; a gate that only
+	# understood one would pass by reading nothing.
+	local wf2
+	wf2=$'      - run: govulncheck -tags=pgx5,postgres '"$PKG"'\n'
+	_eq "$(printf '%s' "$wf2" | workflow_tags)" "pgx5,postgres" "workflow -tags=a,b spelling"
+
+	# Order must not matter: the sets are compared, not the strings.
+	local df2
+	df2=$'RUN go build -tags '"'"'pgx5 postgres'"'"' -o /out/migrate x\n'
+	_eq "$(printf '%s' "$df2" | dockerfile_tags)" "$(printf '%s' "$df" | dockerfile_tags)" "tag order is irrelevant"
+
+	# A Dockerfile with no -tags at all must yield the empty string rather than
+	# silently matching an empty workflow parse — the caller treats empty as a
+	# hard failure, and this pins that it can tell the difference.
+	_eq "$(printf 'FROM scratch\n' | dockerfile_tags)" "" "no -tags yields empty"
+
+	[ "$fail" -eq 0 ] && echo "self-test: all passed"
+	return "$fail"
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+	self_test
+	exit $?
+fi
+
+cd "$(dirname "$0")/.."
+
+fail=0
+note() {
+	echo "FAIL: $*" >&2
+	fail=1
+}
+
+[ -f "$DOCKERFILE" ] || { echo "FAIL: $DOCKERFILE not found" >&2; exit 1; }
+[ -f "$WORKFLOW" ] || { echo "FAIL: $WORKFLOW not found" >&2; exit 1; }
+
+# 1. The image must still build OUR binary. A `FROM migrate/migrate` would put
+#    a third-party compiled binary back in the pod that holds the DSN, and every
+#    other assertion here would go on passing while meaning nothing.
+if grep -qE '^\s*FROM\s+migrate/migrate' "$DOCKERFILE"; then
+	note "$DOCKERFILE is back on the third-party migrate/migrate image (#1039). The migrate binary must be compiled from the version in our go.mod so govulncheck can see it."
+fi
+if ! grep -qF "$PKG" "$DOCKERFILE"; then
+	note "$DOCKERFILE does not build $PKG."
+fi
+if ! grep -qF "$PKG" "$WORKFLOW"; then
+	note "$WORKFLOW does not run govulncheck over $PKG, so the shipped migrate binary is outside CI's module graph again (#1039)."
+fi
+
+# 2. The version stamped into the binary must be READ from the module graph, not
+#    written by hand — a hardcoded `-X main.Version=v4.19.1` survives a go.mod
+#    bump and makes `migrate -version` lie about what is actually compiled.
+if ! grep -qF 'go list -m' "$DOCKERFILE"; then
+	note "$DOCKERFILE no longer derives the stamped version with 'go list -m'; a hardcoded version drifts from go.mod silently."
+fi
+
+# 3. Build tags: same set on both ends.
+df_tags="$(dockerfile_tags <"$DOCKERFILE")"
+wf_tags="$(workflow_tags <"$WORKFLOW")"
+if [ -z "$df_tags" ]; then
+	note "could not read build tags from $DOCKERFILE. golang-migrate registers no database driver without one, so a tagless build fails at RUNTIME with 'unknown driver'."
+elif [ -z "$wf_tags" ]; then
+	note "could not read -tags from the govulncheck invocation in $WORKFLOW. Without them govulncheck analyses a driverless package, not the binary we ship."
+elif [ "$df_tags" != "$wf_tags" ]; then
+	note "build tags disagree: $DOCKERFILE builds with [$df_tags], $WORKFLOW scans with [$wf_tags]. govulncheck would be analysing a different binary than the one in the image."
+fi
+
+# 4. Go toolchain: same pin on both ends.
+df_go="$(dockerfile_go_version <"$DOCKERFILE")"
+wf_go="$(workflow_go_version <"$WORKFLOW")"
+if [ -z "$df_go" ]; then
+	note "$DOCKERFILE has no 'ARG GO_VERSION=' default. An unpinned toolchain moves this image's reported stdlib findings with no commit of ours."
+elif [ -z "$wf_go" ]; then
+	note "could not read GO_VERSION from $WORKFLOW."
+elif [ "$df_go" != "$wf_go" ]; then
+	note "Go toolchain pins disagree: $DOCKERFILE builds with $df_go, $WORKFLOW uses $wf_go. Trivy keys stdlib findings to the toolchain in the binary, so the gate would scan a build the release never produces."
+fi
+
+if [ "$fail" -ne 0 ]; then
+	exit 1
+fi
+
+echo "OK: the shipped migrate CLI ($PKG, tags [$df_tags], go $df_go) is the one govulncheck and the image gate scan"

--- a/website/content/contribute/image-vulnerability-scanning.md
+++ b/website/content/contribute/image-vulnerability-scanning.md
@@ -6,19 +6,28 @@ description: "Where container CVE findings appear, what blocks a build and what 
 ---
 
 `govulncheck` reads our Go module graph. It says nothing about the Debian
-packages in `python:3.x-slim`, or about a third-party Go binary baked
-into someone else's image. Those are scanned separately, by
+packages in `python:3.x-slim`, and it says nothing about a compiled Go binary
+that came from somebody else's build. Those are scanned separately, by
 [Trivy](https://trivy.dev/), under the policy on this page.
 
-The second gap is the easier one to misread, so state it precisely. Take
-`golang-migrate`: it **is** in our `go.mod` and govulncheck does see it, resolved
-against **our** MVS versions and **our** toolchain. What govulncheck cannot see
-is what upstream vendored into the release binary shipped inside
-`migrate/migrate` — a different dependency set, frozen at their build. That is
-where 48 of the 50 fixable CRITICAL/HIGH findings in `leoflow-migrate` live
-(`usr/local/bin/migrate`). A dependency being covered by govulncheck therefore
-says nothing about the third-party *binary* of the same name in an image we
-pull, and the Lite path that runs that image is covered here, not there.
+The second gap is the easier one to misread, so state it precisely — and it is
+worth stating even though the repository no longer has an instance of it,
+because it is the trap that reopens the moment someone adds a `FROM
+<vendor>/<tool>` to a Dockerfile. `leoflow-migrate` used to be `FROM
+migrate/migrate`. `golang-migrate` **is** in our `go.mod` and govulncheck does
+see it, resolved against **our** MVS versions and **our** toolchain — but what
+govulncheck could not see was what upstream had vendored into the release
+binary inside that image: a different dependency set, frozen at their build.
+That was where 48 of the 50 fixable CRITICAL/HIGH findings in `leoflow-migrate`
+lived (`usr/local/bin/migrate`). A dependency being covered by govulncheck says
+nothing about a third-party *binary* of the same name in an image we pull.
+
+`deploy/Dockerfile.migrate` now compiles that CLI itself, from the version in
+our `go.mod`, so there is one migrate binary instead of two and govulncheck
+covers it by name (see [the govulncheck
+step](https://github.com/neochaotic/leoflow/blob/main/.github/workflows/security.yaml)).
+The image went from 84 fixable findings — 50 of them CRITICAL/HIGH — to zero,
+and moved from the reporting lane to the blocking one.
 
 ## What gets scanned, and what happens when it finds something
 
@@ -26,12 +35,13 @@ pull, and the Lite path that runs that image is covered here, not there.
 |---|---|---|---|
 | `leoflow-server` | `deploy/Dockerfile.server.release` | Every PR and push, in [`security.yaml`](https://github.com/neochaotic/leoflow/blob/main/.github/workflows/security.yaml) | **Yes** |
 | `leoflow-runtime` (one leg per published Python line) | `runtime/Dockerfile` | Daily, in [`image-scan.yaml`](https://github.com/neochaotic/leoflow/blob/main/.github/workflows/image-scan.yaml) | No — opens an issue |
-| `leoflow-migrate` | `deploy/Dockerfile.migrate` | Daily, in `image-scan.yaml` | No — opens an issue |
+| `leoflow-migrate` | `deploy/Dockerfile.migrate` | Every PR and push, in `security.yaml` | **Yes** |
 
 "Fails a build" means the job goes red. Whether that *blocks a merge* is a
 branch-protection setting: a new job is not a required check by default, so the
-`Trivy (leoflow-server image)` check has to be added to the protected-branch
-rules before it can stop anything from merging.
+`Trivy (leoflow-server image)` and `Trivy (leoflow-migrate image)` checks have
+to be added to the protected-branch rules before they can stop anything from
+merging.
 
 The split is deliberate, and it is about **who can fix the finding**.
 
@@ -39,6 +49,12 @@ The split is deliberate, and it is about **who can fix the finding**.
 from this repository. There is no inherited OS package set, so a finding there
 was introduced by a commit and is closed by a `go get`. Blocking the PR that
 introduced it puts the work in front of the person who can do it.
+
+`leoflow-migrate` is the same shape and is gated on the same criterion:
+distroless static on Debian 13, a Go binary cross-compiled from our `go.mod`,
+and our SQL files. Nothing about it is inherited, so every finding it can report
+is closed by a `go get` or a toolchain bump. It is scanned by its own job so a
+red check names which image is red.
 
 That argument only holds if the gate scans the artifact we publish, so it does.
 `deploy/Dockerfile.server` — which compiles from source inside a floating
@@ -52,20 +68,30 @@ gate compiling with a different toolchain reports a different vulnerability set
 rather than by a `go get`, reddening the blocking gate for whoever opened the
 next unrelated PR.
 
+`leoflow-migrate` needs none of that reproduction: `deploy/Dockerfile.migrate`
+*is* the file the release builds and pushes, so the gate builds the published
+recipe directly. Its Go toolchain is pinned in the Dockerfile itself, and
+`scripts/check-migrate-cli-build-tags.sh` fails CI if that pin, or the
+golang-migrate build tags, stop matching what govulncheck is given.
+
 The gate still builds **HEAD's** binary rather than pulling a published tag, and
-the daily scan likewise builds the runtime and migrate images from the checkout.
+the daily scan likewise builds the runtime images from the checkout.
 So a CVE in an already-published image that HEAD no longer produces does not
 appear in either. Scan the tag directly when that is the question — Trivy reads
 a remote reference with no local build.
 
-The other two inherit package sets we do not author — Debian for the task
-runtime, Alpine plus a pinned third-party binary for the migrator. A CVE lands
-in them because a distro security team published an advisory, on a day when
-nobody here pushed anything. A blocking gate on those fails whoever opens the
-next unrelated PR, and the person who can actually fix it (by rebasing a base
-image or bumping a pin) is not in that PR. That gate gets switched off within a
-week — and switched off is worse than never installed, because it still looks
-like coverage. So they are reported instead, loudly and on a schedule.
+`leoflow-runtime` inherits a package set we do not author: Debian, underneath
+`python:3.x-slim`. A CVE lands in it because a distro security team published an
+advisory, on a day when nobody here pushed anything. A blocking gate on that
+fails whoever opens the next unrelated PR, and the person who can actually fix
+it (by rebasing a base image) is not in that PR. That gate gets switched off
+within a week — and switched off is worse than never installed, because it still
+looks like coverage. So it is reported instead, loudly and on a schedule.
+
+Note what decided the lane, because it is not seniority or noisiness: it is
+whether a finding is closed by a commit here. `leoflow-migrate` moved from the
+reporting lane to the blocking one when what the image *contains* changed, not
+because the policy was tightened.
 
 ## The two filters, and why fixability comes first
 
@@ -83,7 +109,8 @@ Both scans apply the same policy:
    blocking decision only.
 
 Everything fixable is **reported** at every severity; only fixable CRITICAL/HIGH
-**blocks** (on `leoflow-server`) or **is tracked in the issue** (on the others).
+**blocks** (on `leoflow-server` and `leoflow-migrate`) or **is tracked in the
+issue** (on `leoflow-runtime`).
 
 Unfixed findings are left out of the Security tab as well as the gate. An alert
 nobody can ever close is not visibility — it is noise that teaches people to
@@ -93,32 +120,33 @@ stop opening the tab. The complete unfiltered scan is attached to every
 ## Where findings appear
 
 - **Security tab → Code scanning.** Every fixable finding, at every severity,
-  under one category per image: `trivy-server-image`, one
-  `trivy-image-runtime-pyXYZ` per published Python line, and
-  `trivy-image-migrate`. Uploaded from `main` and from scheduled runs only — a
-  PR upload would overwrite the branch baseline.
-- **The failing check**, for `leoflow-server`: the job prints the table of
-  fixable CRITICAL/HIGH findings that failed it.
+  under one category per image: `trivy-server-image`, `trivy-migrate-image`, and
+  one `trivy-image-runtime-pyXYZ` per published Python line. Uploaded from
+  `main` and from scheduled runs only — a PR upload would overwrite the branch
+  baseline.
+- **The failing check**, for `leoflow-server` and `leoflow-migrate`: the job
+  prints the table of fixable CRITICAL/HIGH findings that failed it.
 - **A single tracking issue**, titled *Container image CVEs: fixable findings in
-  published images*, for the runtime and migrate images. The daily scan
+  published images*, for the runtime images. The daily scan
   refreshes its body, comments only when the set of findings actually changes,
   closes it when the list empties, and **reopens that same issue** — rather than
   filing a second one — if the findings come back. One issue, always current.
   If you reopen it yourself, the scan leaves it alone: it checks who performed
   the last reopen and will not close a human's out from under them.
 - **The job summary** of any `image-scan` run, including on a PR that touches
-  `runtime/**`, `deploy/Dockerfile.migrate`, `migrations/**`, `go.mod`, or the
-  authoring schema. On a PR it reports and stays green, so you can see what your
+  `runtime/**`, `go.mod`, or the authoring schema. On a PR it reports and stays
+  green, so you can see what your
   change did to the image without being blocked by what was already there.
 
 ## Triaging a finding
 
 **Fix it, if the fix is ours.** A Go dependency in `leoflow-server` is a
 `go get`. A Python package in the task runtime is a pin in
-`runtime/python/pyproject.toml`. A CVE in the Alpine or Go layers of
-`leoflow-migrate` is a bump of the `FROM migrate/migrate:` pin in
-`deploy/Dockerfile.migrate`. This is the expected outcome for most findings, and
-Dependabot already opens PRs for the base images weekly.
+`runtime/python/pyproject.toml`. A dependency finding in `leoflow-migrate` is a
+`go get` too — it is built from the same `go.mod` — and a `stdlib` finding there
+is a bump of `ARG GO_VERSION` in `deploy/Dockerfile.migrate`, kept in step with
+CI's by `scripts/check-migrate-cli-build-tags.sh`. This is the expected outcome
+for most findings, and Dependabot already opens PRs for the base images weekly.
 
 **Wait for it, if the fix is upstream's.** An unfixed Debian CVE needs no action
 and will not be reported — that is what the fixability filter is for. If it
@@ -218,6 +246,21 @@ trivy image --scanners vuln --ignore-unfixed \
   --ignorefile .trivyignore.yaml \
   --severity CRITICAL,HIGH --exit-code 1 leoflow-server:local
 ```
+
+The migration image is published from the same Dockerfile CI gates, so there is
+nothing to reproduce — build it and scan it:
+
+```bash
+docker build -f deploy/Dockerfile.migrate -t leoflow-migrate:local .
+
+trivy image --scanners vuln --ignore-unfixed \
+  --ignorefile .trivyignore.yaml \
+  --severity CRITICAL,HIGH --exit-code 1 leoflow-migrate:local
+```
+
+Do not pass `--build-arg GO_VERSION` there: unlike `runtime/Dockerfile`, this
+one pins the toolchain CI uses as its own default, and overriding it scans a
+build the release never produces.
 
 Trivy scans a remote reference too, so a published image needs no local build,
 and this is the only way to see what an *already-published* tag carries:

--- a/website/content/contribute/image-vulnerability-scanning.md
+++ b/website/content/contribute/image-vulnerability-scanning.md
@@ -52,9 +52,19 @@ introduced it puts the work in front of the person who can do it.
 
 `leoflow-migrate` is the same shape and is gated on the same criterion:
 distroless static on Debian 13, a Go binary cross-compiled from our `go.mod`,
-and our SQL files. Nothing about it is inherited, so every finding it can report
-is closed by a `go get` or a toolchain bump. It is scanned by its own job so a
-red check names which image is red.
+and our SQL files. Its Go half is entirely ours, so a finding there is closed by
+a `go get` or a toolchain bump. It is scanned by its own job so a red check
+names which image is red.
+
+Distroless is not zero packages — it carries six (`base-files`,
+`ca-certificates`, `media-types`, `netbase`, `tzdata`, `tzdata-legacy`), and a
+fixable finding in one of those is not closeable by a commit here. That residual
+is handled the same way `leoflow-server`'s is: a dated entry in
+`.trivyignore.yaml`, which requires a statement and an expiry and caps it at 180
+days. A reviewed exception that expires on its own is what keeps a blocking gate
+from turning into a disabled one — which is the failure the report-only lane
+exists to prevent, and the reason six packages belong in the blocking lane while
+`leoflow-runtime`'s full Debian set does not.
 
 That argument only holds if the gate scans the artifact we publish, so it does.
 `deploy/Dockerfile.server` — which compiles from source inside a floating


### PR DESCRIPTION
Closes #1039.

`deploy/Dockerfile.migrate` was `FROM migrate/migrate:v4.19.1` plus a `COPY migrations/`. We shipped somebody else's compiled binary — their dependency set, their toolchain — into the Helm pre-install/pre-upgrade hook Job, which holds the database DSN and runs before the control plane on a fresh cluster.

**Option taken: 2** (build from our own `go.mod`), as the issue leaned. Nothing turned up that argued for the pin bump: the CLI is upstream's own `cmd/migrate` main package, not a reimplementation, so the surface is identical; the postgres driver is a build tag, not a licensing or CGO problem; and the image got smaller and starts the same.

---

## 1. The binary comes from our `go.mod`

```
$ grep golang-migrate go.mod
	github.com/golang-migrate/migrate/v4 v4.19.1

$ docker run --rm leoflow-migrate:after -version
v4.19.1
```

The stamped version is *read* from the module graph inside the build (`go list -m -f '{{.Version}}'`), not written into the Dockerfile, so `migrate -version` cannot drift from what is compiled. Build info confirms it:

```
$ go version -m ./migrate | head -3
./migrate: go1.26.6
	path	github.com/golang-migrate/migrate/v4/cmd/migrate
	mod	github.com/golang-migrate/migrate/v4	v4.19.1
```

## 2. govulncheck covers it

Source mode, over exactly the package the Dockerfile builds, with exactly the build tags it builds with:

```
$ govulncheck -tags postgres,pgx5 -show verbose github.com/golang-migrate/migrate/v4/cmd/migrate
The package pattern matched the following root package:
  github.com/golang-migrate/migrate/v4/cmd/migrate
Govulncheck scanned the following 9 modules and the go1.26.6 standard library:
  github.com/golang-migrate/migrate/v4@v4.19.1
  github.com/jackc/pgerrcode@v0.0.0-20220416144525-469b46aa5efa
  github.com/jackc/pgpassfile@v1.0.0
  github.com/jackc/pgservicefile@v0.0.0-20240606120523-5a60cdf6a761
  github.com/jackc/pgx/v5@v5.10.0
  github.com/jackc/puddle/v2@v2.2.2
  github.com/lib/pq@v1.10.9
  golang.org/x/sync@v0.22.0
  golang.org/x/text@v0.41.0

No vulnerabilities found.
```

And binary mode, against the binary actually extracted from the built image:

```
$ govulncheck -mode=binary ./migrate
No vulnerabilities found.
```

The source-mode invocation is now a step in `security.yaml`'s govulncheck job. `./...` matches packages in this module only, which is why the old binary was invisible even though `golang-migrate` was already a dependency — naming the package is what closes the gap rather than resetting it.

**The tags are load-bearing.** golang-migrate registers database drivers behind build tags, so an untagged govulncheck would analyse a driverless package — clean result, wrong binary. `scripts/check-migrate-cli-build-tags.sh` (new, with a self-test, wired into `ci.yaml`) fails when the Dockerfile's tags and the scan's diverge, when the Go pins diverge, when the version stops being read from `go list -m`, or when a `FROM migrate/migrate` comes back. Each of those four was mutation-tested to red and back.

## 3. Trivy, `--ignore-unfixed`

Same invocation the repo's own scans use (`trivy image --scanners vuln --ignore-unfixed --ignorefile .trivyignore.yaml`, Trivy 0.72):

| | total fixable | CRITICAL | HIGH | **fixable CRITICAL/HIGH** |
|---|---:|---:|---:|---:|
| **before** (`migrate/migrate:v4.19.1`) | 84 | 5 | 45 | **50** |
| **after** | 0 | 0 | 0 | **0** |

The before numbers reproduce #1039's table exactly. After is zero *unfiltered* too, not just zero under the policy — there is no OS package set left to inherit from. Confirmed on both `linux/arm64` and the `linux/amd64` leg the CI gate scans.

## 4. The Helm Job works — against a real Postgres

The Job passes `-path=…`, `-database=…`, `up` to an args-only container, so the entrypoint stays `migrate`. The driver question is the one that fails at runtime rather than at build: `-tags 'postgres pgx5'` registers `postgres`, `postgresql` and `pgx5`, which covers the chart's `LEOFLOW_DATABASE_URL` and the Lite path's DSN.

Run under the chart's own security posture (`--read-only -u 65532:65532 --cap-drop ALL`) against a throwaway `postgres:17-alpine`:

```
$ docker run --rm --network … --read-only -u 65532:65532 --cap-drop ALL \
    leoflow-migrate:after -path=/migrations -database=postgres://…/leoflow?sslmode=disable up
1/u init_tenants_and_rbac (8.874792ms)
…
26/u task_instance_warm_worker (16.510792ms)

$ psql -c "SELECT version, dirty FROM schema_migrations;"
 version | dirty
---------+-------
      26 | f

$ … up          # what pre-upgrade re-runs
no change
$ … version
26
```

24 tables in `public`. `postgresql://` resolves too. `helm unittest` is 218/218 green, and `helm-ci`'s kind job exercises the real chart install with this image on this PR.

The CLI surface is otherwise byte-identical — `diff` of `-help` between old and new images shows only the registered-driver line, which narrows from two dozen databases and nine sources to `postgres, postgresql, pgx5, stub` and `file`. Nothing in Leoflow used the rest.

## 5. Non-root, minimal

`gcr.io/distroless/static-debian13:nonroot` — consistent with #1038's move to trixie and with `leoflow-server`'s distroless posture. `USER 65532:65532` numerically, because a restricted-PSA kubelet cannot resolve a name. The old image ran as **root** and depended on the chart to override it; this one does not. 84 MB → 20 MB.

`values.yaml`'s `readOnlyRootFilesystem: true` comment previously cited a `-version` smoke run; it now cites the full 26-migration apply above, since "the binary starts" was never evidence that "the Job works".

## 6. CI

- `release.yaml` builds the same file, multi-arch. Verified with `docker buildx build --platform linux/amd64,linux/arm64` (exit 0) and by extracting the amd64 leg: `ELF 64-bit LSB executable, x86-64, statically linked`, `go1.26.6`, `v4.19.1`. The build stage runs on `$BUILDPLATFORM` and cross-compiles via `TARGETARCH`, so the arm64 leg no longer needs QEMU emulation.
- `helm-ci.yaml` and `pro-netpol-rwx` build it into kind, unchanged.
- **Lane change:** `leoflow-migrate` moves from `image-scan.yaml` (daily, report-only) to `security.yaml` (every PR/push, blocking), beside `leoflow-server`. That workflow's policy is written around one criterion — is a finding closed by a commit here — and the image now meets it. Both headers say why, and say it moved because the image's contents changed, not because the policy softened. It starts green at zero.
- `deploy/Dockerfile.migrate` pins `ARG GO_VERSION=1.26.6`, matching CI's. Trivy keys `stdlib` findings to the toolchain in the binary, so a floating tag would move this image's reported vulnerability set with no commit of ours — the same trap `security.yaml` already documents for the server gate. The new check script asserts the two pins stay equal.

## Also

- The demo `docker compose` stack built `migrate/migrate:v4.18.1` — a *different, older* third-party pin, from rate-limited Docker Hub. It now builds `deploy/Dockerfile.migrate`, so there is one migrate binary in the repository.
- Docs updated: `website/content/contribute/image-vulnerability-scanning.md` (the table, the lane rationale, the SARIF categories, the triage advice, and a local-scan recipe), the chart README via `README.md.gotmpl` + `helm-docs`, and `CHANGELOG.md` under `[Unreleased]`.

`for f in scripts/check-*.sh` is clean (only `check-chart-version-matches-tag.sh`, which needs a tag argument), `actionlint` clean, `shellcheck` clean.

---

## Correction (post-review)

The claim above that the gate's four assertions were mutation-tested red→green **was true of an earlier draft of `check-migrate-cli-build-tags.sh`, not of the file as first submitted.** Review re-ran them: four of five stayed green, because every assertion grepped the whole file and this PR's own Dockerfile header quotes `-tags 'postgres pgx5'`, `go list -m` and the package path in prose. The documentation satisfied the gate.

Fixed by anchoring every parser to the extracted logical `go build` line, plus two assertions that were missing:

- **the migrate Trivy job must still exist** — `image-scan.yaml` no longer covers this image, so `security.yaml`'s job is the only scan of the container holding the DSN, and deleting it left every gate green
- **`postgres` must be present in the tag set**, not merely consistent across both ends — dropping it from both satisfied the comparison and produced a binary that dies at Job runtime with `unknown driver postgres`

All five are now self-test fixtures, and all five were re-run against the real tree with each mutation's application verified before reading the exit code.

Also corrected: distroless static is **not** zero OS packages. It carries six (`base-files`, `ca-certificates`, `media-types`, `netbase`, `tzdata`, `tzdata-legacy`), so "no OS package set underneath" was false in three places. The replacement text names them and gives the argument the false claim was standing in for — `.trivyignore.yaml`'s dated, self-expiring entries are what keep a blocking gate from becoming a disabled one.

