### PR TITLE
chore: gate the duplicated version facts, reconcile the Go toolchain (#1036)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1229,7 +1229,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install PyYAML
         run: python3 -m pip install --user pyyaml
       - name: Go toolchain is one fact with one value

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1212,6 +1212,38 @@ jobs:
         run: bash scripts/check-python-runtime-matrix.sh
 
   # ─────────────────────────────────────────────────────────────────────
+  # Duplicated version facts (#1036). A version string written in two places
+  # with nothing between them drifts, and the failure is not a broken build —
+  # it is that somebody reads one copy and reasons correctly from a false
+  # premise. That happened three times in one day: the Go toolchain said 1.26.6,
+  # 1.26.3, 1.26.4 and 1.27 in four files; a job named "Trivy (image scan)" ran
+  # a filesystem scan; and the two Python lists were read as one.
+  #
+  # One job rather than five, because they are one class and each runs in
+  # milliseconds — but one STEP per gate, so the check that went red names
+  # itself in the job summary before anyone opens the log. Each gate prints both
+  # locations and both values.
+  # ─────────────────────────────────────────────────────────────────────
+  version-facts:
+    name: Duplicated version facts agree
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install PyYAML
+        run: python3 -m pip install --user pyyaml
+      - name: Go toolchain is one fact with one value
+        run: bash scripts/check-go-toolchain-pin.sh
+      - name: Host Python interpreters relate correctly to the published matrix
+        run: bash scripts/check-python-host-interpreters.sh
+      - name: golangci-lint pin agrees between make lint and CI
+        run: bash scripts/check-golangci-lint-pin.sh
+      - name: Lite Postgres tag agrees with the container Lite starts
+        run: bash scripts/check-lite-postgres-tag.sh
+      - name: Embedded Airflow UI pin agrees with the committed bundle
+        run: bash scripts/check-airflow-ui-pin.sh
+
+  # ─────────────────────────────────────────────────────────────────────
   stale-deploy-path:
     name: No stale legacy deploy path
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -79,13 +79,22 @@ jobs:
           category: "/language:${{ matrix.language }}"
 
   # ─────────────────────────────────────────────────────────────────────
-  # Trivy: container image scanning (ADR 0014)
+  # Trivy: FILESYSTEM scanning of this repository (ADR 0014)
+  #
+  # This job reads our module graph and lock files. It scans no image, and the
+  # job name says so: it was called "Trivy (image scan)" for many releases with
+  # `scan-type: fs` underneath, and the maintainer drew the wrong conclusion
+  # from that name twice in one day, in both directions (#1036). Container
+  # images are scanned by the `server-image` job below (the blocking half) and
+  # by .github/workflows/image-scan.yaml (the reporting half, #1034); a third
+  # copy here would only duplicate them.
+  #
   # Runs on PRs too (#437): a fixable dependency CVE must fail its own PR check,
   # not slip through and redden main on the post-merge run (as it did in #436 and
   # #439). ignore-unfixed keeps the gate to actionable, fixable findings only.
   # ─────────────────────────────────────────────────────────────────────
   trivy:
-    name: Trivy (image scan)
+    name: Trivy (filesystem scan)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -153,15 +162,18 @@ jobs:
   # — blind to a stdlib CVE that affects the shipped toolchain, and red for one
   # that does not.
   #
-  # `deploy/Dockerfile.server` compiles from source inside `golang:1.27-bookworm`
-  # and is the developer/kind convenience path. GoReleaser publishes
+  # `deploy/Dockerfile.server` compiles from source inside `golang:<toolchain>-
+  # bookworm` and is the developer/kind convenience path. GoReleaser publishes
   # `deploy/Dockerfile.server.release`, which copies in a binary the release
   # workflow builds with GO_VERSION. So this job reproduces the release recipe —
   # same toolchain, same `CGO_ENABLED=0 -trimpath`, same distroless base — and
-  # scans that. GO_VERSION here is the same literal as release.yaml's; the two
-  # must move together.
+  # scans that. GO_VERSION here is the same literal as release.yaml's, go.mod's
+  # `toolchain` line and both Dockerfiles' `ARG GO_VERSION` default;
+  # scripts/check-go-toolchain-pin.sh fails when any of them disagree (#1036).
+  # Before that gate existed, this comment spent two paragraphs arguing for a
+  # base tag one minor ahead of the toolchain go.mod pinned, and nothing noticed.
   #
-  # A floating `golang:1.27-bookworm` would also have quietly broken the fairness
+  # A floating major.minor build tag would also have quietly broken the fairness
   # argument this gate rests on. A stdlib CVE in a floating build tag is closed
   # by a base rebuild, not by a `go get` — it would redden the blocking gate for
   # whoever opened the next unrelated PR, which is exactly the scenario used to

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -85,9 +85,10 @@ jobs:
   # job name says so: it was called "Trivy (image scan)" for many releases with
   # `scan-type: fs` underneath, and the maintainer drew the wrong conclusion
   # from that name twice in one day, in both directions (#1036). Container
-  # images are scanned by the `server-image` job below (the blocking half) and
-  # by .github/workflows/image-scan.yaml (the reporting half, #1034); a third
-  # copy here would only duplicate them.
+  # images are scanned by two blocking jobs below — `server-image` and
+  # `migrate-image` (#1039) — and by .github/workflows/image-scan.yaml, which
+  # covers leoflow-runtime on a schedule (#1034). A third copy here would only
+  # duplicate them.
   #
   # Runs on PRs too (#437): a fixable dependency CVE must fail its own PR check,
   # not slip through and redden main on the post-merge run (as it did in #436 and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,7 +172,7 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   already worked (`check-lite-prepull-matches-compose.sh` and the Task SDK check
   in `ci.yaml`), each with a `--self-test`, all globbed into the release cut's
   pre-flight and run per-PR by the new `Duplicated version facts agree` job:
-  `check-go-toolchain-pin.sh` (ten copies, prose comments included),
+  `check-go-toolchain-pin.sh` (eleven copies, prose comments included),
   `check-python-host-interpreters.sh` (the managed CPython must be a *member* of
   the published matrix and every host probe either published or marked
   `// lite-only` — these are relationships, not equality, see #1031),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,42 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   demo `docker compose` stack builds the same image rather than pulling a
   separately pinned `migrate/migrate:v4.18.1`.
 
+- **The Go toolchain is one fact with one value again, and four more duplicated
+  version facts got a gate (#1036).** Four files declared the Go toolchain and
+  they said three different things: `go.mod` pinned `toolchain go1.26.6`,
+  `runtime/Dockerfile` defaulted `GO_VERSION` to `1.26.3`, the Makefile's chaos
+  image to `1.26.4`, and `deploy/Dockerfile.server` had been carried to
+  `golang:1.27-bookworm` by a Dependabot bump to the one file with a literal
+  tag. Nothing was broken — CI and release both passed their own literal, so the
+  published artifacts were consistent — which is precisely why it survived: the
+  cost of this class is not a red build, it is that somebody reads one copy and
+  reasons correctly from a false premise. All four now resolve to **1.26.6**,
+  `deploy/Dockerfile.server` derives it from an `ARG GO_VERSION` default like
+  `runtime/Dockerfile` already did, and both images were rebuilt to confirm it.
+
+  Five gates now hold the line, each in the ~40-line shape of the two that
+  already worked (`check-lite-prepull-matches-compose.sh` and the Task SDK check
+  in `ci.yaml`), each with a `--self-test`, all globbed into the release cut's
+  pre-flight and run per-PR by the new `Duplicated version facts agree` job:
+  `check-go-toolchain-pin.sh` (ten copies, prose comments included),
+  `check-python-host-interpreters.sh` (the managed CPython must be a *member* of
+  the published matrix and every host probe either published or marked
+  `// lite-only` — these are relationships, not equality, see #1031),
+  `check-golangci-lint-pin.sh` (four copies; `make lint is clean` only predicts
+  CI while they agree), `check-lite-postgres-tag.sh` (what Lite starts vs what
+  Lite *tells you* it started) and `check-airflow-ui-pin.sh` (the pin the
+  Makefile fetches vs the marker committed next to the bundle the binary
+  serves).
+
+- **The `Trivy (image scan)` job is renamed to `Trivy (filesystem scan)`,
+  because that is what it runs (#1036).** It has run `scan-type: fs` under an
+  image-scan name for many releases, behind a comment deferring image scanning
+  until `deploy/Dockerfile.server` existed — it has existed the whole time. The
+  name is the fix rather than the behaviour: container images are already
+  scanned by the `Trivy (leoflow-server image)` gate next to it and by the
+  scheduled `image-scan.yaml` workflow (#1034), and a third copy here would only
+  duplicate them.
+
 - **The task base image moves from Debian 12 (bookworm) to Debian 13 (trixie),
   which takes its OpenSSL from 3.0.x to 3.5.x.** `python:3.x-slim` links CPython's
   `ssl` module against the **system** OpenSSL, so this is the library every TLS

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ chaos-dogfood: ## Pre-Lima gate (#231) — Phase 1: run all suites on the host +
 	@bash scripts/chaos/run.sh
 
 CHAOS_IMAGE          ?= leoflow-chaos:local
-CHAOS_GO_VERSION     ?= 1.26.4
+CHAOS_GO_VERSION     ?= 1.26.6
 CHAOS_LINT_VERSION   ?= v2.12.2
 
 .PHONY: chaos-dogfood-docker

--- a/deploy/Dockerfile.server
+++ b/deploy/Dockerfile.server
@@ -5,7 +5,15 @@
 #   docker build -f deploy/Dockerfile.server -t leoflow-server .
 # Migrations are applied separately (see the migrate service in docker-compose).
 
-FROM golang:1.27-bookworm AS build
+# The toolchain is one fact with one value (#1036): go.mod's `toolchain` line is
+# the source of truth and scripts/check-go-toolchain-pin.sh fails this default
+# when it falls behind. Pinned to a full PATCH release, like runtime/Dockerfile:
+# a floating major.minor tag re-resolves on every build, and this image's
+# stdlib CVE surface is keyed to the toolchain recorded in the binary's build
+# info, so a floating pin means the image the security gate scans and the image
+# the release publishes can differ for reasons no commit explains.
+ARG GO_VERSION=1.26.6
+FROM golang:${GO_VERSION}-bookworm AS build
 WORKDIR /src
 
 # Cache module downloads.

--- a/internal/setup/detect.go
+++ b/internal/setup/detect.go
@@ -83,9 +83,16 @@ type Report struct {
 // shim has been verified against it — the list is the deliberate gate
 // for "we know this version works", not a free-for-all (see follow-up
 // issue tracking the more general fallback via `python3 --version` exec).
+//
+// The `// lite-only` marker is load-bearing, not decoration:
+// scripts/check-python-host-interpreters.sh requires every candidate to be
+// either in the published matrix or marked, so the difference between these
+// two lists is always a recorded decision rather than the unexplained gap
+// #1031 read as drift. Move an entry across the marker in the same change that
+// starts or stops publishing a base image for it.
 var pythonCandidates = []string{
 	"python3.11", "python3.12", "python3.13",
-	"python3.14", "python3.15", "python3.16", "python3.17", "python3.18",
+	"python3.14", "python3.15", "python3.16", "python3.17", "python3.18", // lite-only
 }
 
 // muslLoaders are the dynamic-loader paths that mark a musl-based distro (Alpine).

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -15,7 +15,10 @@
 # python_version enum is, and scripts/check-python-runtime-matrix.sh fails this
 # comment when it falls behind. 3.10 is deprecated (upstream EOL 2026-10-31).
 
-ARG GO_VERSION=1.26.3
+# GO_VERSION is not authoritative here either: go.mod's `toolchain` line is the
+# source of truth for the toolchain, and scripts/check-go-toolchain-pin.sh fails
+# this default when it falls behind (#1036).
+ARG GO_VERSION=1.26.6
 ARG PYTHON_VERSION=3.11
 
 # ── Stage 1: build the static agent binary ───────────────────────────────────

--- a/scripts/chaos/Dockerfile
+++ b/scripts/chaos/Dockerfile
@@ -11,7 +11,7 @@
 # Usage: built via `make chaos-dogfood-docker` (don't `docker build` directly
 #        — the Makefile passes the right build-args).
 
-ARG GO_VERSION=1.26.3
+ARG GO_VERSION=1.26.6
 ARG GOLANGCI_LINT_VERSION=v2.12.2
 
 FROM python:3.12-slim-bookworm AS base

--- a/scripts/check-airflow-ui-pin.sh
+++ b/scripts/check-airflow-ui-pin.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# The Airflow UI bundle is pinned twice, and only one of the two is real.
+#
+#   Makefile AIRFLOW_UI_VERSION   the tag `make fetch-airflow-ui` pulls
+#   internal/ui/assets/VERSION    the marker COMMITTED next to the bundle,
+#                                 which `ui.Version()` returns at runtime
+#
+# The marker is the source of truth: it is a byte in the binary, next to the
+# SPA the binary serves. The Makefile is intent. Bump the Makefile and forget to
+# re-run the target — the most ordinary way this goes wrong, because the target
+# needs Docker and a multi-GB pull — and every declaration in the tree says one
+# version while the server ships another. Nothing fails: the old bundle keeps
+# working, `ui.Version()` keeps answering, and the next person debugging a UI
+# behaviour reads the Makefile and compares against the wrong upstream release.
+#
+# The prose is reconciled too, in the places a reader takes as current truth:
+# the `internal/ui` package godoc (which states the pin three times), README.md,
+# and docker-compose.yml's comment on the server service.
+#
+# Deliberately NOT scanned:
+#   - internal/api/**, where ~20 DTO godocs name the Airflow release whose
+#     response shape they mirror. Those are 20 copies of this same fact, and a
+#     UI bump genuinely should revisit them — but mechanically, the useful check
+#     is that the SHAPE still matches, and a gate that only demanded the string
+#     be rewritten would produce a 20-file sed on every bump for a reviewer to
+#     wave through. That is the rubber-stamp failure this class of gate exists
+#     to avoid, so it stays a human step; this gate's header is where the next
+#     bump reads that it is one.
+#   - website/content/project/** and CHANGELOG.md, which are records of their
+#     own era (ADRs are immutable — CLAUDE.md).
+#   - scripts/connectors-providers*.txt, whose `apache-airflow==` pin happens to
+#     match today but governs the provider package set, not the SPA.
+#
+# Usage: scripts/check-airflow-ui-pin.sh [--self-test]
+#        scripts/check-airflow-ui-pin.sh <repo-root>
+set -euo pipefail
+
+MARKER_REL="internal/ui/assets/VERSION"
+
+check() { # <repo-root>
+	python3 - "$1" "$MARKER_REL" <<'PY'
+import os
+import re
+import sys
+
+root, marker_rel = sys.argv[1:3]
+problems = []
+
+
+def fail(msg):
+	sys.exit("FAIL: " + msg)
+
+
+def read(rel):
+	path = os.path.join(root, rel)
+	if not os.path.exists(path):
+		fail(f"{rel} does not exist — this gate's scan target moved and it would otherwise report OK")
+	with open(path) as fh:
+		text = fh.read()
+	if not text.strip():
+		fail(f"{rel} is empty")
+	return text
+
+
+# ── the source of truth: the marker committed next to the bundle ─────────────
+truth = read(marker_rel).strip()
+if not re.fullmatch(r"\d+\.\d+\.\d+", truth):
+	fail(
+		f"{marker_rel} holds {truth!r}, which is not an `X.Y.Z` upstream tag.\n"
+		"That file is what `ui.Version()` reports; a placeholder there means the bundle was\n"
+		"never fetched, and this gate must not reconcile the tree against a placeholder."
+	)
+
+# ── 1. the Makefile pin that produced it ─────────────────────────────────────
+m = re.search(r"^AIRFLOW_UI_VERSION\s*\?=\s*(\S+)\s*$", read("Makefile"), re.M)
+if not m:
+	fail(
+		"Makefile declares no `AIRFLOW_UI_VERSION ?= <X.Y.Z>` — did `fetch-airflow-ui` get\n"
+		"renamed? A gate that cannot find the pin must not report OK."
+	)
+if m.group(1) != truth:
+	problems.append(
+		f"  Makefile\n"
+		f"    AIRFLOW_UI_VERSION: {m.group(1)}\n"
+		f"    {marker_rel}:      {truth}\n"
+		"    The pin moved but the bundle did not. Run `make fetch-airflow-ui` and commit the\n"
+		"    result, or put the pin back — the server serves the marker's version either way."
+	)
+
+# ── 2. the prose that states it as current truth ─────────────────────────────
+# `Airflow 3.2.x` and other deliberately generalized forms do not match and are
+# always accepted: they cannot go stale on a patch bump.
+VERSION_RE = re.compile(r"(?:Apache Airflow|Airflow|apache/airflow:)\s*(\d+\.\d+\.\d+)")
+
+targets = ["README.md", "docker-compose.yml"]
+uidir = os.path.join(root, "internal", "ui")
+if not os.path.isdir(uidir):
+	fail("internal/ui/ does not exist — the package that owns the bundle moved")
+for name in sorted(os.listdir(uidir)):
+	if name.endswith(".go"):
+		targets.append(f"internal/ui/{name}")
+
+seen = 0
+for rel in targets:
+	for lineno, line in enumerate(read(rel).splitlines(), 1):
+		for m in VERSION_RE.finditer(line):
+			seen += 1
+			if m.group(1) == truth:
+				continue
+			problems.append(
+				f"  {rel}:{lineno}\n"
+				f"    names Airflow {m.group(1)}\n"
+				f"    {marker_rel}: {truth}\n"
+				"    This sentence is read as a statement about the UI the binary actually serves.\n"
+				"    Use the marker's version, or generalize the sentence (`3.2.x`) if the exact\n"
+				"    patch is not what it is about."
+			)
+
+if seen == 0:
+	fail(
+		"no `Airflow <X.Y.Z>` reference found in README.md, docker-compose.yml or the\n"
+		"internal/ui package. Either the prose stopped naming the pin (fine — delete this arm\n"
+		"in that change) or the scan targets moved; an empty scan must not report OK."
+	)
+
+if problems:
+	sys.exit(
+		"FAIL: the embedded Airflow UI pin has drifted.\n"
+		+ "\n".join(problems)
+		+ f"\n\n{marker_rel} is the source of truth: it ships in the binary next to the\n"
+		"bundle it describes, and `ui.Version()` reports it."
+	)
+
+print(f"OK: the embedded Airflow UI pin agrees everywhere ({truth}; {seen} prose reference(s))")
+PY
+}
+
+self_test() {
+	local fail=0 tmp
+	tmp="$(mktemp -d)"
+	trap 'rm -rf "${tmp:-}"' RETURN
+
+	_marker() { printf '%s\n' "$2" >"$1/internal/ui/assets/VERSION"; }
+	_makefile() { printf 'AIRFLOW_UI_VERSION ?= %s\n\nfetch-airflow-ui:\n\t@echo fetch\n' "$2" >"$1/Makefile"; }
+	_embed() { printf '// Package ui embeds the pinned Apache Airflow %s React SPA bundle,\n// extracted from the apache/airflow:%s image.\npackage ui\n' "$2" "$2" >"$1/internal/ui/embed.go"; }
+	_readme() { printf 'The Airflow %s UI ships embedded in the server.\n' "$2" >"$1/README.md"; }
+	_compose() { printf 'services:\n  server:\n    # serves the embedded Airflow %s UI\n    image: leoflow-server\n' "$2" >"$1/docker-compose.yml"; }
+
+	_mkroot() { # <dir>
+		local d="$1"
+		mkdir -p "$d/internal/ui/assets"
+		_marker "$d" 3.2.1
+		_makefile "$d" 3.2.1
+		_embed "$d" 3.2.1
+		_readme "$d" 3.2.1
+		_compose "$d" 3.2.1
+	}
+
+	_case() { # <name> <want-rc> <want-substring> <mutator...>
+		local name="$1" want_rc="$2" want_msg="$3" rc=0 out d
+		shift 3
+		d="$tmp/case"
+		rm -rf "$d"
+		_mkroot "$d"
+		"$@" "$d"
+		out="$(check "$d" 2>&1)" || rc=$?
+		if [ "$rc" != "$want_rc" ]; then
+			printf '  FAIL %s (exit)\n    got:  %s\n    want: %s\n    out: %s\n' "$name" "$rc" "$want_rc" "$out"
+			fail=1
+			return
+		fi
+		case "$out" in
+			*"$want_msg"*) printf '  ok   %s\n' "$name" ;;
+			*) printf '  FAIL %s (message)\n    got: %q\n    want to contain: %q\n' "$name" "$out" "$want_msg"; fail=1 ;;
+		esac
+	}
+
+	_noop() { :; }
+	# The motivating mutation: bump the pin, do not re-run the fetch. Nothing
+	# breaks; the binary just keeps serving the old bundle.
+	_pin_bumped_without_the_bundle() { _makefile "$1" 3.3.0; }
+	_godoc_lags() { _embed "$1" 3.2.0; }
+	_readme_lags() { _readme "$1" 3.1.4; }
+	_compose_comment_lags() { _compose "$1" 3.1.4; }
+	_generalized_prose_is_accepted() { _readme "$1" 3.2.x; }
+	_placeholder_marker() { _marker "$1" unknown; }
+	_missing_marker() { rm -f "$1/internal/ui/assets/VERSION"; }
+	_missing_makefile_pin() { printf 'fetch-airflow-ui:\n\t@echo fetch\n' >"$1/Makefile"; }
+	_nothing_names_the_pin() {
+		printf '// Package ui embeds the pinned Airflow SPA bundle.\npackage ui\n' >"$1/internal/ui/embed.go"
+		_readme "$1" 3.2.x
+		printf 'services:\n  server:\n    image: leoflow-server\n' >"$1/docker-compose.yml"
+	}
+	_a_new_ui_file_is_covered() { printf '// Server serves the embedded Airflow 3.1.4 SPA.\npackage ui\n' >"$1/internal/ui/handler.go"; }
+
+	_case "an agreeing tree passes"                 0 "agrees everywhere (3.2.1" _noop
+	_case "the pin moved but the bundle did not"    1 "AIRFLOW_UI_VERSION: 3.3.0" _pin_bumped_without_the_bundle
+	_case "a lagging package godoc"                 1 "names Airflow 3.2.0" _godoc_lags
+	_case "a lagging README sentence"               1 "README.md:1" _readme_lags
+	_case "a lagging compose comment"               1 "docker-compose.yml:3" _compose_comment_lags
+	_case "generalized prose is accepted"           0 "agrees everywhere" _generalized_prose_is_accepted
+	_case "a placeholder marker is refused"         1 "not an \`X.Y.Z\` upstream tag" _placeholder_marker
+	_case "a missing marker fails, not skips"       1 "does not exist" _missing_marker
+	_case "a dropped Makefile pin fails loudly"     1 "declares no \`AIRFLOW_UI_VERSION" _missing_makefile_pin
+	_case "an empty prose scan fails, not passes"   1 "no \`Airflow <X.Y.Z>\` reference found" _nothing_names_the_pin
+	_case "a new file in internal/ui is covered"    1 "internal/ui/handler.go" _a_new_ui_file_is_covered
+
+	if [ "$fail" -eq 0 ]; then echo "self-test: PASS"; return 0; else echo "self-test: FAIL"; return 1; fi
+}
+
+[ "${1:-}" = "--self-test" ] && { self_test; exit $?; }
+
+cd "$(dirname "$0")/.."
+check "${1:-$PWD}"

--- a/scripts/check-go-toolchain-pin.sh
+++ b/scripts/check-go-toolchain-pin.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
-# The Go toolchain Leoflow builds with is stated in ten places. Until #1036 it
+# Companion gate: scripts/check-migrate-cli-build-tags.sh reconciles
+# deploy/Dockerfile.migrate's pin against security.yaml's GO_VERSION, which this
+# gate in turn reconciles against go.mod. That file is covered here directly too
+# (both its ARG default and its `golang:` literal), so the two overlap rather
+# than depend on each other — but if you change either, read the other.
+#
+# The Go toolchain Leoflow builds with is stated in eleven places. Until #1036 it
 # said three different things: `toolchain go1.26.6` in go.mod, `1.26.3` in
 # runtime/Dockerfile's GO_VERSION default, `1.26.4` in the Makefile's chaos
 # pin, and `golang:1.27-bookworm` in deploy/Dockerfile.server after a Dependabot
@@ -104,8 +110,12 @@ if m.group(1) != truth_minor:
 	note("go.mod", "`go` directive minor", m.group(1))
 
 # ── 2. the website module, installed by go-version-file ──────────────────────
-# website-build.yml and website-deploy.yml both point actions/setup-go at
-# website/go.mod, so this directive IS the toolchain those jobs get.
+# website-build.yml points actions/setup-go at `website/go.mod`, so this
+# directive IS the toolchain that job gets. website-deploy.yml uses
+# `src/website/go.mod` — the same file under its own checkout path, not a
+# second module. Stated precisely because this gate's whole thesis is that an
+# untested sentence in a comment is the bug: the earlier wording claimed both
+# workflows name the same path, and they do not.
 website = read("website/go.mod")
 m = re.search(r"^go (\d+\.\d+(?:\.\d+)?)\s*$", website, re.M)
 if not m:
@@ -165,7 +175,12 @@ if pinned_workflows == 0:
 	)
 
 # ── 4. the Dockerfile ARG defaults ───────────────────────────────────────────
-for rel in ("runtime/Dockerfile", "deploy/Dockerfile.server", "scripts/chaos/Dockerfile"):
+# deploy/Dockerfile.migrate arrived with #1039, after this gate was written, and
+# was covered only by the `golang:` literal scan below — its ARG default could be
+# moved alone and this gate still printed OK. Its pin is ALSO reconciled against
+# security.yaml by scripts/check-migrate-cli-build-tags.sh, so the two gates form
+# a two-hop chain; neither header said so, which is how a seam becomes a hole.
+for rel in ("runtime/Dockerfile", "deploy/Dockerfile.server", "deploy/Dockerfile.migrate", "scripts/chaos/Dockerfile"):
 	text = read(rel)
 	m = re.search(r"^ARG GO_VERSION=(\S+)\s*$", text, re.M)
 	if not m:
@@ -247,10 +262,13 @@ self_test() {
 	_dockerfile() { # <dir> <rel> <arg-default> <from-line>
 		printf 'ARG GO_VERSION=%s\n%s\nRUN go build ./...\n' "$3" "$4" >"$1/$2"
 	}
+	_mut_migrate_arg() { # <dir>
+		printf 'ARG GO_VERSION=1.25.0\nFROM golang:${GO_VERSION}-bookworm AS build\nRUN go build ./...\n' >"$1/deploy/Dockerfile.migrate"
+	}
 	_ci() { printf 'name: CI\nenv:\n  GO_VERSION: "%s"\njobs:\n  build:\n    steps:\n      - uses: actions/setup-go@v7\n        with:\n          go-version: ${{ env.GO_VERSION }}\n' "$2" >"$1/.github/workflows/ci.yaml"; }
 	_release() { printf 'name: Release\nenv:\n  GO_VERSION: "%s"\njobs:\n  release:\n    steps:\n      - run: go build ./...\n' "$2" >"$1/.github/workflows/release.yaml"; }
 
-	# Builds a minimal repo root whose ten copies all say 1.26.6.
+	# Builds a minimal repo root whose copies all say 1.26.6.
 	_mkroot() { # <dir>
 		local d="$1"
 		mkdir -p "$d/website" "$d/.github/workflows" "$d/runtime" "$d/deploy" "$d/scripts/chaos"
@@ -259,6 +277,7 @@ self_test() {
 		_makefile "$d" 1.26.6
 		_dockerfile "$d" runtime/Dockerfile 1.26.6 'FROM golang:${GO_VERSION}-bookworm AS agent-build'
 		_dockerfile "$d" deploy/Dockerfile.server 1.26.6 'FROM golang:${GO_VERSION}-bookworm AS build'
+		_dockerfile "$d" deploy/Dockerfile.migrate 1.26.6 'FROM golang:${GO_VERSION}-bookworm AS build'
 		_dockerfile "$d" scripts/chaos/Dockerfile 1.26.6 'FROM python:3.12-slim'
 		_ci "$d" 1.26.6
 		_release "$d" 1.26.6
@@ -320,6 +339,12 @@ self_test() {
 
 	_case "an agreeing tree passes"                    0 "agrees everywhere (go1.26.6)" _noop
 	_case "a Dependabot bump to one Dockerfile"        1 "golang:1.27-bookworm" _dependabot_bumps_one_dockerfile
+	# The migrate Dockerfile arrived after this gate and was covered only by the
+	# `golang:` literal scan, so its ARG default could move alone and the gate
+	# still said OK. Confirmed on the real tree before this case existed.
+	_case "the migrate Dockerfile's ARG default is covered too" 1 "deploy/Dockerfile.migrate" \
+		_mut_migrate_arg
+
 	_case "a stale runtime ARG default"                1 "ARG GO_VERSION default: 1.26.3" _stale_runtime_arg
 	_case "a floating major.minor ARG"                 1 "Pin a full patch version" _floating_arg
 	_case "a dropped ARG fails loudly"                 1 "declares no \`ARG GO_VERSION" _missing_arg

--- a/scripts/check-go-toolchain-pin.sh
+++ b/scripts/check-go-toolchain-pin.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+# The Go toolchain Leoflow builds with is stated in ten places. Until #1036 it
+# said three different things: `toolchain go1.26.6` in go.mod, `1.26.3` in
+# runtime/Dockerfile's GO_VERSION default, `1.26.4` in the Makefile's chaos
+# pin, and `golang:1.27-bookworm` in deploy/Dockerfile.server after a Dependabot
+# bump touched the one file with a literal tag.
+#
+# Nothing was broken by that, and that is the point. CI and release both pass
+# their own literal, so the published artifacts were consistent; the drift only
+# bit `make runtime-images` and `make chaos-dogfood-docker`, which nobody
+# releases. What it did do is make every one of the four a false premise for the
+# next reader — three people read three different files today and reasoned
+# correctly to three different conclusions about which toolchain ships.
+#
+# Same shape as check-lite-prepull-matches-compose.sh: two copies of a version
+# string with nothing between them. The source of truth here is go.mod's
+# `toolchain` line, because it is the one the `go` command itself honors — every
+# other copy exists to make some other tool agree with it.
+#
+# The prose is reconciled too, not just the declarations. security.yaml's
+# comment argued at length about `golang:1.27-bookworm` being the right pin
+# while go.mod said 1.26.6; a comment that asserts a version the tree does not
+# use outlives every defect, because nothing tests it.
+#
+# Deliberately out of scope: prose in website/ and CHANGELOG.md. A released
+# changelog section naming its own era's toolchain is a record, not drift, and
+# the docs speak in major.minor ("Go 1.26") where this gate reconciles a patch.
+#
+# Usage: scripts/check-go-toolchain-pin.sh [--self-test]
+#        scripts/check-go-toolchain-pin.sh <repo-root>
+set -euo pipefail
+
+check() { # <repo-root>
+	python3 - "$1" <<'PY'
+import os
+import re
+import sys
+
+try:
+	import yaml
+except ImportError:
+	sys.exit("FAIL: PyYAML unavailable; cannot parse the workflows (pip install pyyaml)")
+
+root = sys.argv[1]
+problems = []
+TRUTH_REL = "go.mod"
+
+# Every file that must carry a declaration. A missing one is a FAIL, never a
+# silent pass: a gate that stops gating after a file move still reports OK,
+# which is worse than no gate at all.
+REQUIRED = [
+	"go.mod",
+	"website/go.mod",
+	"Makefile",
+	"runtime/Dockerfile",
+	"deploy/Dockerfile.server",
+	"scripts/chaos/Dockerfile",
+	".github/workflows/ci.yaml",
+	".github/workflows/release.yaml",
+]
+
+PATCH_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def fail(msg):
+	sys.exit("FAIL: " + msg)
+
+
+def read(rel):
+	path = os.path.join(root, rel)
+	if not os.path.exists(path):
+		fail(f"{rel} does not exist — this gate's scan target moved and it would otherwise report OK")
+	with open(path) as fh:
+		return fh.read()
+
+
+def note(rel, what, got):
+	problems.append(f"  {rel}\n    {what}: {got}\n    {TRUTH_REL} toolchain: {truth}")
+
+
+for rel in REQUIRED:
+	read(rel)
+
+# ── the source of truth ──────────────────────────────────────────────────────
+gomod = read("go.mod")
+m = re.search(r"^toolchain go(\d+\.\d+\.\d+)\s*$", gomod, re.M)
+if not m:
+	fail(
+		"go.mod declares no `toolchain go<X.Y.Z>` line. That line is what the `go` command\n"
+		"itself honors, and this gate reconciles every other copy against it. Restore it,\n"
+		"or move the source of truth deliberately and rewrite this gate to match."
+	)
+truth = m.group(1)
+truth_minor = ".".join(truth.split(".")[:2])
+
+# ── 1. go.mod's own language directive ───────────────────────────────────────
+# `go 1.26.0` may legally sit below the toolchain, but then the two lines three
+# rows apart in one file state different minors, which is the drift this gate is
+# for. Equality of the MINOR is the invariant; the patch is free.
+m = re.search(r"^go (\d+\.\d+)(?:\.\d+)?\s*$", gomod, re.M)
+if not m:
+	fail("go.mod declares no `go <X.Y>` directive")
+if m.group(1) != truth_minor:
+	note("go.mod", "`go` directive minor", m.group(1))
+
+# ── 2. the website module, installed by go-version-file ──────────────────────
+# website-build.yml and website-deploy.yml both point actions/setup-go at
+# website/go.mod, so this directive IS the toolchain those jobs get.
+website = read("website/go.mod")
+m = re.search(r"^go (\d+\.\d+(?:\.\d+)?)\s*$", website, re.M)
+if not m:
+	fail("website/go.mod declares no `go <X.Y[.Z]>` directive")
+if m.group(1) != truth:
+	note("website/go.mod", "`go` directive (setup-go reads this via go-version-file)", m.group(1))
+
+# ── 3. every Go version a workflow pins ──────────────────────────────────────
+# Parsed as YAML rather than grepped, so a commented-out env cannot be read as a
+# declaration. `${{ ... }}` expressions are skipped: they resolve to some other
+# copy, which is itself checked here.
+EXPR = re.compile(r"\$\{\{")
+
+
+def walk(node, path, wf_rel, found):
+	if isinstance(node, dict):
+		env = node.get("env")
+		if isinstance(env, dict) and "GO_VERSION" in env:
+			v = str(env["GO_VERSION"])
+			found.append(True)
+			if not EXPR.search(v) and v != truth:
+				note(wf_rel, f"{path}env.GO_VERSION", v)
+		with_ = node.get("with")
+		if isinstance(with_, dict) and "go-version" in with_:
+			v = str(with_["go-version"])
+			found.append(True)
+			if not EXPR.search(v) and v != truth:
+				note(wf_rel, f"{path}with.go-version", v)
+		for k, v in node.items():
+			walk(v, f"{path}{k}.", wf_rel, found)
+	elif isinstance(node, list):
+		for i, v in enumerate(node):
+			walk(v, f"{path}[{i}].", wf_rel, found)
+
+
+wfdir = os.path.join(root, ".github", "workflows")
+if not os.path.isdir(wfdir):
+	fail(".github/workflows/ does not exist — this gate cannot see the CI pins")
+pinned_workflows = 0
+for name in sorted(os.listdir(wfdir)):
+	if not name.endswith((".yaml", ".yml")):
+		continue
+	rel = f".github/workflows/{name}"
+	try:
+		doc = yaml.safe_load(read(rel))
+	except yaml.YAMLError as exc:
+		fail(f"{rel} is not parseable YAML: {exc}")
+	found = []
+	walk(doc, "", rel, found)
+	if found:
+		pinned_workflows += 1
+if pinned_workflows == 0:
+	fail(
+		"no workflow declares a Go version at all (neither `env.GO_VERSION` nor a setup-go\n"
+		"`with.go-version`). Either the keys were renamed or this gate is scanning the wrong\n"
+		"directory; it must not report OK on an empty scan."
+	)
+
+# ── 4. the Dockerfile ARG defaults ───────────────────────────────────────────
+for rel in ("runtime/Dockerfile", "deploy/Dockerfile.server", "scripts/chaos/Dockerfile"):
+	text = read(rel)
+	m = re.search(r"^ARG GO_VERSION=(\S+)\s*$", text, re.M)
+	if not m:
+		fail(
+			f"{rel} declares no `ARG GO_VERSION=<X.Y.Z>` default.\n"
+			"That default is what a plain `docker build` of this file uses, which is the only\n"
+			"path CI does not override — restore it, or drop this file from REQUIRED deliberately."
+		)
+	if not PATCH_RE.match(m.group(1)):
+		problems.append(
+			f"  {rel}\n"
+			f"    ARG GO_VERSION default: {m.group(1)}\n"
+			"    Pin a full patch version. A major.minor tag floats onto whatever upstream last\n"
+			"    pushed, so the image nobody rebuilt is not the image the pin describes."
+		)
+	elif m.group(1) != truth:
+		note(rel, "ARG GO_VERSION default", m.group(1))
+
+# ── 5. the Makefile's chaos pin ──────────────────────────────────────────────
+makefile = read("Makefile")
+m = re.search(r"^CHAOS_GO_VERSION\s*\?=\s*(\S+)\s*$", makefile, re.M)
+if not m:
+	fail("Makefile declares no `CHAOS_GO_VERSION ?= <X.Y.Z>` — did the chaos target get renamed?")
+if m.group(1) != truth:
+	note("Makefile", "CHAOS_GO_VERSION", m.group(1))
+
+# ── 6. every `golang:<version>` literal, comments included ───────────────────
+# Prose counts here, deliberately. security.yaml carried three paragraphs
+# arguing about `golang:1.27-bookworm` while go.mod said 1.26.6; that comment
+# outlived the mismatch because nothing tested it. A suffix-free or
+# deliberately generalized reference (`golang:1.x-bookworm`) does not match and
+# is always accepted — it cannot go stale.
+IMAGE_RE = re.compile(r"golang:(\d+\.\d+(?:\.\d+)?)(?![\w.])(?:-[A-Za-z0-9.]+)?")
+scan = [
+	"runtime/Dockerfile",
+	"deploy/Dockerfile.server",
+	"deploy/Dockerfile.server.release",
+	"deploy/Dockerfile.migrate",
+	"scripts/chaos/Dockerfile",
+	"Makefile",
+]
+scan += [f".github/workflows/{n}" for n in sorted(os.listdir(wfdir)) if n.endswith((".yaml", ".yml"))]
+for rel in scan:
+	if not os.path.exists(os.path.join(root, rel)):
+		continue
+	for lineno, line in enumerate(read(rel).splitlines(), 1):
+		for m in IMAGE_RE.finditer(line):
+			if m.group(1) == truth:
+				continue
+			problems.append(
+				f"  {rel}:{lineno}\n"
+				f"    names {m.group(0)}\n"
+				f"    {TRUTH_REL} toolchain: {truth}\n"
+				f"    Write `golang:{truth}-...`, or drop the version from the literal if the\n"
+				"    sentence is about the base image in general. A version in prose is read as a\n"
+				"    fact and nothing else tests it."
+			)
+
+if problems:
+	sys.exit(
+		"FAIL: the Go toolchain pin has drifted.\n"
+		+ "\n".join(problems)
+		+ f"\n\ngo.mod's `toolchain go{truth}` is the source of truth: it is what the `go`\n"
+		"command itself honors. Change it first, then bring the copies to match."
+	)
+
+print(f"OK: the Go toolchain pin agrees everywhere (go{truth})")
+PY
+}
+
+self_test() {
+	local fail=0 tmp
+	tmp="$(mktemp -d)"
+	trap 'rm -rf "${tmp:-}"' RETURN
+
+	_gomod() { printf 'module github.com/x/y\n\ngo %s\n\ntoolchain go%s\n' "$2" "$3" >"$1/go.mod"; }
+	_website() { printf 'module github.com/x/y/website\n\ngo %s\n' "$2" >"$1/website/go.mod"; }
+	_makefile() { printf 'CHAOS_GO_VERSION ?= %s\n\nbuild:\n\t@echo hi\n' "$2" >"$1/Makefile"; }
+	_dockerfile() { # <dir> <rel> <arg-default> <from-line>
+		printf 'ARG GO_VERSION=%s\n%s\nRUN go build ./...\n' "$3" "$4" >"$1/$2"
+	}
+	_ci() { printf 'name: CI\nenv:\n  GO_VERSION: "%s"\njobs:\n  build:\n    steps:\n      - uses: actions/setup-go@v7\n        with:\n          go-version: ${{ env.GO_VERSION }}\n' "$2" >"$1/.github/workflows/ci.yaml"; }
+	_release() { printf 'name: Release\nenv:\n  GO_VERSION: "%s"\njobs:\n  release:\n    steps:\n      - run: go build ./...\n' "$2" >"$1/.github/workflows/release.yaml"; }
+
+	# Builds a minimal repo root whose ten copies all say 1.26.6.
+	_mkroot() { # <dir>
+		local d="$1"
+		mkdir -p "$d/website" "$d/.github/workflows" "$d/runtime" "$d/deploy" "$d/scripts/chaos"
+		_gomod "$d" 1.26.0 1.26.6
+		_website "$d" 1.26.6
+		_makefile "$d" 1.26.6
+		_dockerfile "$d" runtime/Dockerfile 1.26.6 'FROM golang:${GO_VERSION}-bookworm AS agent-build'
+		_dockerfile "$d" deploy/Dockerfile.server 1.26.6 'FROM golang:${GO_VERSION}-bookworm AS build'
+		_dockerfile "$d" scripts/chaos/Dockerfile 1.26.6 'FROM python:3.12-slim'
+		_ci "$d" 1.26.6
+		_release "$d" 1.26.6
+	}
+
+	_case() { # <name> <want-rc> <want-substring> <mutator...>
+		local name="$1" want_rc="$2" want_msg="$3" rc=0 out d
+		shift 3
+		d="$tmp/case"
+		rm -rf "$d"
+		_mkroot "$d"
+		"$@" "$d"
+		out="$(check "$d" 2>&1)" || rc=$?
+		if [ "$rc" != "$want_rc" ]; then
+			printf '  FAIL %s (exit)\n    got:  %s\n    want: %s\n    out: %s\n' "$name" "$rc" "$want_rc" "$out"
+			fail=1
+			return
+		fi
+		case "$out" in
+			*"$want_msg"*) printf '  ok   %s\n' "$name" ;;
+			*) printf '  FAIL %s (message)\n    got: %q\n    want to contain: %q\n' "$name" "$out" "$want_msg"; fail=1 ;;
+		esac
+	}
+
+	_noop() { :; }
+	_dependabot_bumps_one_dockerfile() { _dockerfile "$1" deploy/Dockerfile.server 1.26.6 'FROM golang:1.27-bookworm AS build'; }
+	_stale_runtime_arg() { _dockerfile "$1" runtime/Dockerfile 1.26.3 'FROM golang:${GO_VERSION}-bookworm AS agent-build'; }
+	_floating_arg() { _dockerfile "$1" runtime/Dockerfile 1.26 'FROM golang:${GO_VERSION}-bookworm AS agent-build'; }
+	_missing_arg() { printf 'FROM golang:1.26.6-bookworm\n' >"$1/runtime/Dockerfile"; }
+	_stale_chaos_make() { _makefile "$1" 1.26.4; }
+	_missing_chaos_make() { printf 'build:\n\t@echo hi\n' >"$1/Makefile"; }
+	_stale_ci_env() { _ci "$1" 1.26.5; }
+	_stale_website_gomod() { _website "$1" 1.26.5; }
+	_language_directive_drifts() { _gomod "$1" 1.25 1.26.6; }
+	_no_toolchain_line() { printf 'module github.com/x/y\n\ngo 1.26.0\n' >"$1/go.mod"; }
+	_missing_release_workflow() { rm -f "$1/.github/workflows/release.yaml"; }
+	# The motivating mutation for the prose arm: every declaration still agrees,
+	# so every case above stays green, while the comment a maintainer reads while
+	# editing the pin names a toolchain the tree has not used since the move.
+	_stale_prose_in_a_comment() {
+		printf '  # The server image compiles inside `golang:1.27-bookworm`, which is the\n  # release toolchain.\n' >>"$1/.github/workflows/release.yaml"
+	}
+	_suffix_free_prose_is_fine() {
+		printf '  # The server image compiles inside `golang:1.x-bookworm`.\n' >>"$1/.github/workflows/release.yaml"
+	}
+	# A commented-out env is not a declaration: YAML drops it, so it must not be
+	# read as a stale pin. Grepping for `GO_VERSION:` would fail this case.
+	_commented_out_env_is_not_a_pin() {
+		printf 'name: Extra\njobs:\n  x:\n    steps:\n      # - GO_VERSION: "1.27.0"\n      - run: true\n' >"$1/.github/workflows/extra.yaml"
+	}
+	_a_new_workflow_pins_its_own() {
+		printf 'name: Extra\njobs:\n  x:\n    steps:\n      - uses: actions/setup-go@v7\n        with:\n          go-version: "1.27.0"\n' >"$1/.github/workflows/extra.yaml"
+	}
+	_no_workflow_pins_anything() {
+		_ci "$1" 1.26.6
+		printf 'name: CI\njobs:\n  build:\n    steps:\n      - run: true\n' >"$1/.github/workflows/ci.yaml"
+		printf 'name: Release\njobs:\n  release:\n    steps:\n      - run: true\n' >"$1/.github/workflows/release.yaml"
+	}
+
+	_case "an agreeing tree passes"                    0 "agrees everywhere (go1.26.6)" _noop
+	_case "a Dependabot bump to one Dockerfile"        1 "golang:1.27-bookworm" _dependabot_bumps_one_dockerfile
+	_case "a stale runtime ARG default"                1 "ARG GO_VERSION default: 1.26.3" _stale_runtime_arg
+	_case "a floating major.minor ARG"                 1 "Pin a full patch version" _floating_arg
+	_case "a dropped ARG fails loudly"                 1 "declares no \`ARG GO_VERSION" _missing_arg
+	_case "a stale chaos pin in the Makefile"          1 "CHAOS_GO_VERSION: 1.26.4" _stale_chaos_make
+	_case "a dropped CHAOS_GO_VERSION"                 1 "did the chaos target get renamed?" _missing_chaos_make
+	_case "a stale workflow env"                       1 "env.GO_VERSION: 1.26.5" _stale_ci_env
+	_case "a stale website/go.mod directive"           1 "go-version-file" _stale_website_gomod
+	_case "the language directive drifts"              1 "\`go\` directive minor: 1.25" _language_directive_drifts
+	_case "no toolchain line fails, not skips"         1 "declares no \`toolchain go" _no_toolchain_line
+	_case "a missing required file fails, not skips"   1 "does not exist" _missing_release_workflow
+	_case "a stale version named only in prose"        1 "names golang:1.27" _stale_prose_in_a_comment
+	_case "version-agnostic prose is accepted"         0 "agrees everywhere" _suffix_free_prose_is_fine
+	_case "a commented-out env is not a pin"           0 "agrees everywhere" _commented_out_env_is_not_a_pin
+	_case "a new workflow pinning its own version"     1 "with.go-version: 1.27.0" _a_new_workflow_pins_its_own
+	_case "an empty scan fails, not passes"            1 "no workflow declares a Go version" _no_workflow_pins_anything
+
+	if [ "$fail" -eq 0 ]; then echo "self-test: PASS"; return 0; else echo "self-test: FAIL"; return 1; fi
+}
+
+[ "${1:-}" = "--self-test" ] && { self_test; exit $?; }
+
+cd "$(dirname "$0")/.."
+check "${1:-$PWD}"

--- a/scripts/check-golangci-lint-pin.sh
+++ b/scripts/check-golangci-lint-pin.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# The golangci-lint version is pinned in four places, and scripts/chaos/Dockerfile
+# already carries the sentence a gate should have carried: "bumping one must bump
+# the other". A comment cannot fail a build.
+#
+#   Makefile GOLANGCI_LINT_VERSION      what `make lint` installs and runs
+#   Makefile CHAOS_LINT_VERSION         what the chaos image is built with
+#   scripts/chaos/Dockerfile ARG        that image's default, for a bare docker build
+#   .github/workflows/*.yaml            what the CI job that decides the grade runs
+#
+# ADR 0012 makes golangci-lint the arbiter of the A+ floor and CLAUDE.md makes
+# "make lint is clean" the precondition for a commit. Both sentences are only
+# true while the two run the same binary. Drift here does not break anything
+# loudly — it makes a clean local run stop predicting CI, in whichever direction
+# the newer version added or dropped a check, and the contributor who hits it
+# has no reason to suspect the pin.
+#
+# The Makefile is the source of truth because it is the copy a contributor runs
+# before pushing; everything else exists to reproduce it.
+#
+# Prose is deliberately NOT scanned here, unlike check-go-toolchain-pin.sh. The
+# chaos Dockerfile records that one specific version's arm64 build had a flaky
+# installer checksum — a statement about that version, still true after a bump,
+# and a gate that demanded it be rewritten would be demanding a lie.
+#
+# Usage: scripts/check-golangci-lint-pin.sh [--self-test]
+#        scripts/check-golangci-lint-pin.sh <repo-root>
+set -euo pipefail
+
+check() { # <repo-root>
+	python3 - "$1" <<'PY'
+import os
+import re
+import sys
+
+try:
+	import yaml
+except ImportError:
+	sys.exit("FAIL: PyYAML unavailable; cannot parse the workflows (pip install pyyaml)")
+
+root = sys.argv[1]
+problems = []
+EXPR = re.compile(r"\$\{\{")
+
+
+def fail(msg):
+	sys.exit("FAIL: " + msg)
+
+
+def read(rel):
+	path = os.path.join(root, rel)
+	if not os.path.exists(path):
+		fail(f"{rel} does not exist — this gate's scan target moved and it would otherwise report OK")
+	with open(path) as fh:
+		return fh.read()
+
+
+def note(rel, what, got):
+	problems.append(f"  {rel}\n    {what}: {got}\n    Makefile GOLANGCI_LINT_VERSION: {truth}")
+
+
+# ── the source of truth ──────────────────────────────────────────────────────
+makefile = read("Makefile")
+m = re.search(r"^GOLANGCI_LINT_VERSION\s*\?=\s*(\S+)\s*$", makefile, re.M)
+if not m:
+	fail(
+		"Makefile declares no `GOLANGCI_LINT_VERSION ?= v<X.Y.Z>`.\n"
+		"That is the pin `make lint` installs, which is the run a contributor is told to make\n"
+		"clean before pushing. Restore it, or move the source of truth deliberately."
+	)
+truth = m.group(1)
+if not re.fullmatch(r"v\d+\.\d+\.\d+", truth):
+	fail(
+		f"Makefile pins GOLANGCI_LINT_VERSION to {truth!r}, which is not a `vX.Y.Z` release.\n"
+		"`latest` or a floating major would make the local run and the CI run disagree by\n"
+		"calendar date rather than by a commit anyone can point at."
+	)
+
+# ── 1. the chaos image's pin, in the Makefile ────────────────────────────────
+m = re.search(r"^CHAOS_LINT_VERSION\s*\?=\s*(\S+)\s*$", makefile, re.M)
+if not m:
+	fail("Makefile declares no `CHAOS_LINT_VERSION ?= ...` — did the chaos target get renamed?")
+if m.group(1) != truth:
+	note("Makefile", "CHAOS_LINT_VERSION", m.group(1))
+
+# ── 2. the chaos image's own default ─────────────────────────────────────────
+rel = "scripts/chaos/Dockerfile"
+m = re.search(r"^ARG GOLANGCI_LINT_VERSION=(\S+)\s*$", read(rel), re.M)
+if not m:
+	fail(
+		f"{rel} declares no `ARG GOLANGCI_LINT_VERSION=...` default.\n"
+		"The Makefile always passes one, so this default only shows up on a bare `docker build`\n"
+		"— which is exactly the path nobody watches."
+	)
+if m.group(1) != truth:
+	note(rel, "ARG GOLANGCI_LINT_VERSION default", m.group(1))
+
+# ── 3. every workflow copy ───────────────────────────────────────────────────
+# Parsed as YAML, so a commented-out env is not read as a declaration, and a
+# `${{ ... }}` reference is skipped because it resolves to a copy checked here.
+ACTION = "golangci/golangci-lint-action"
+
+
+def walk(node, path, rel, found):
+	if isinstance(node, dict):
+		env = node.get("env")
+		if isinstance(env, dict) and "GOLANGCI_LINT_VERSION" in env:
+			v = str(env["GOLANGCI_LINT_VERSION"])
+			found.append(True)
+			if not EXPR.search(v) and v != truth:
+				note(rel, f"{path}env.GOLANGCI_LINT_VERSION", v)
+		uses = node.get("uses")
+		with_ = node.get("with")
+		if isinstance(uses, str) and uses.startswith(ACTION) and isinstance(with_, dict):
+			v = str(with_.get("version", ""))
+			found.append(True)
+			if not v:
+				problems.append(
+					f"  {rel}\n"
+					f"    {path}uses {ACTION} with no `version:`\n"
+					"    An unpinned action installs whatever it defaults to that week, so the run that\n"
+					"    decides the A+ grade stops being the run a contributor can reproduce."
+				)
+			elif not EXPR.search(v) and v != truth:
+				note(rel, f"{path}with.version", v)
+		for k, v in node.items():
+			walk(v, f"{path}{k}.", rel, found)
+	elif isinstance(node, list):
+		for i, v in enumerate(node):
+			walk(v, f"{path}[{i}].", rel, found)
+
+
+wfdir = os.path.join(root, ".github", "workflows")
+if not os.path.isdir(wfdir):
+	fail(".github/workflows/ does not exist — this gate cannot see the CI pin")
+found = []
+for name in sorted(os.listdir(wfdir)):
+	if not name.endswith((".yaml", ".yml")):
+		continue
+	rel = f".github/workflows/{name}"
+	try:
+		doc = yaml.safe_load(read(rel))
+	except yaml.YAMLError as exc:
+		fail(f"{rel} is not parseable YAML: {exc}")
+	walk(doc, "", rel, found)
+if not found:
+	fail(
+		f"no workflow declares a golangci-lint version (neither `env.GOLANGCI_LINT_VERSION` nor\n"
+		f"a `{ACTION}` step). ADR 0012 makes that job the arbiter of the A+ floor; a gate that\n"
+		"finds no CI copy at all must not report OK."
+	)
+
+if problems:
+	sys.exit(
+		"FAIL: the golangci-lint pin has drifted.\n"
+		+ "\n".join(problems)
+		+ f"\n\nThe Makefile's `GOLANGCI_LINT_VERSION ?= {truth}` is the source of truth: it is the\n"
+		"binary `make lint` runs, and 'make lint is clean' only predicts CI while the two match."
+	)
+
+print(f"OK: the golangci-lint pin agrees everywhere ({truth})")
+PY
+}
+
+self_test() {
+	local fail=0 tmp
+	tmp="$(mktemp -d)"
+	trap 'rm -rf "${tmp:-}"' RETURN
+
+	_makefile() { printf 'GOLANGCI_LINT_VERSION ?= %s\nCHAOS_LINT_VERSION   ?= %s\n\nlint:\n\t@echo lint\n' "$2" "$3" >"$1/Makefile"; }
+	_chaos() { printf 'ARG GOLANGCI_LINT_VERSION=%s\nFROM python:3.12-slim\n' "$2" >"$1/scripts/chaos/Dockerfile"; }
+	_ci() { # <dir> <env-value> <action-version>
+		printf 'name: CI\nenv:\n  GOLANGCI_LINT_VERSION: "%s"\njobs:\n  lint:\n    steps:\n      - uses: golangci/golangci-lint-action@abc # v8\n        with:\n          version: %s\n' \
+			"$2" "$3" >"$1/.github/workflows/ci.yaml"
+	}
+
+	_mkroot() { # <dir>
+		local d="$1"
+		mkdir -p "$d/.github/workflows" "$d/scripts/chaos"
+		_makefile "$d" v2.12.2 v2.12.2
+		_chaos "$d" v2.12.2
+		_ci "$d" v2.12.2 '${{ env.GOLANGCI_LINT_VERSION }}'
+	}
+
+	_case() { # <name> <want-rc> <want-substring> <mutator...>
+		local name="$1" want_rc="$2" want_msg="$3" rc=0 out d
+		shift 3
+		d="$tmp/case"
+		rm -rf "$d"
+		_mkroot "$d"
+		"$@" "$d"
+		out="$(check "$d" 2>&1)" || rc=$?
+		if [ "$rc" != "$want_rc" ]; then
+			printf '  FAIL %s (exit)\n    got:  %s\n    want: %s\n    out: %s\n' "$name" "$rc" "$want_rc" "$out"
+			fail=1
+			return
+		fi
+		case "$out" in
+			*"$want_msg"*) printf '  ok   %s\n' "$name" ;;
+			*) printf '  FAIL %s (message)\n    got: %q\n    want to contain: %q\n' "$name" "$out" "$want_msg"; fail=1 ;;
+		esac
+	}
+
+	_noop() { :; }
+	_ci_bumped_alone() { _ci "$1" v2.13.0 '${{ env.GOLANGCI_LINT_VERSION }}'; }
+	_action_pins_its_own() { _ci "$1" v2.12.2 v2.13.0; }
+	_action_pins_nothing() { printf 'name: CI\njobs:\n  lint:\n    steps:\n      - uses: golangci/golangci-lint-action@abc # v8\n        with:\n          install-mode: goinstall\n' >"$1/.github/workflows/ci.yaml"; }
+	_chaos_lags() { _makefile "$1" v2.12.2 v2.11.0; }
+	_chaos_dockerfile_lags() { _chaos "$1" v2.11.0; }
+	_missing_chaos_arg() { printf 'FROM python:3.12-slim\n' >"$1/scripts/chaos/Dockerfile"; }
+	_missing_chaos_make() { printf 'GOLANGCI_LINT_VERSION ?= v2.12.2\n\nlint:\n\t@echo lint\n' >"$1/Makefile"; }
+	_no_makefile_pin() { printf 'lint:\n\t@echo lint\n' >"$1/Makefile"; }
+	_floating_makefile_pin() { _makefile "$1" latest latest; }
+	_no_ci_copy() { printf 'name: CI\njobs:\n  lint:\n    steps:\n      - run: true\n' >"$1/.github/workflows/ci.yaml"; }
+	# A version named in prose is left alone here on purpose: the chaos Dockerfile
+	# records a defect in one specific build, which stays true after a bump.
+	_prose_naming_an_old_version_is_fine() {
+		printf '# The installer checksum was flaky on the v2.11.0 arm64 build.\n' >>"$1/scripts/chaos/Dockerfile"
+	}
+
+	_case "an agreeing tree passes"                 0 "agrees everywhere (v2.12.2)" _noop
+	_case "CI bumped on its own"                    1 "env.GOLANGCI_LINT_VERSION: v2.13.0" _ci_bumped_alone
+	_case "the action pins its own version"         1 "with.version: v2.13.0" _action_pins_its_own
+	_case "the action pins nothing at all"          1 "with no \`version:\`" _action_pins_nothing
+	_case "the chaos make pin lags"                 1 "CHAOS_LINT_VERSION: v2.11.0" _chaos_lags
+	_case "the chaos Dockerfile default lags"       1 "ARG GOLANGCI_LINT_VERSION default: v2.11.0" _chaos_dockerfile_lags
+	_case "a dropped ARG fails, not skips"          1 "declares no \`ARG GOLANGCI_LINT_VERSION" _missing_chaos_arg
+	_case "a dropped CHAOS_LINT_VERSION"            1 "did the chaos target get renamed?" _missing_chaos_make
+	_case "no Makefile pin fails, not skips"        1 "declares no \`GOLANGCI_LINT_VERSION" _no_makefile_pin
+	_case "a floating Makefile pin is refused"      1 "not a \`vX.Y.Z\` release" _floating_makefile_pin
+	_case "an empty CI scan fails, not passes"      1 "no workflow declares a golangci-lint version" _no_ci_copy
+	_case "prose about an old version is fine"      0 "agrees everywhere" _prose_naming_an_old_version_is_fine
+
+	if [ "$fail" -eq 0 ]; then echo "self-test: PASS"; return 0; else echo "self-test: FAIL"; return 1; fi
+}
+
+[ "${1:-}" = "--self-test" ] && { self_test; exit $?; }
+
+cd "$(dirname "$0")/.."
+check "${1:-$PWD}"

--- a/scripts/check-hugo-version-pin.sh
+++ b/scripts/check-hugo-version-pin.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# The Hugo the PR gate builds with must be the Hugo the deploy publishes with.
+#
+# website-build.yml (per-PR) and website-deploy.yml (on merge) each declare their
+# own `HUGO_VERSION` and each interpolates it into the SAME download URL:
+#
+#   https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb
+#
+# Two copies of a version string with nothing between them. If they drift, the
+# PR gate validates a site the deploy never builds — a Docsy shortcode, a
+# template function or a config key that works in one Hugo and not the other
+# passes review and then breaks production, and the diagnostic arrives on `main`
+# rather than on the PR that caused it.
+#
+# #1036 first skipped this on three grounds, and review took all three apart:
+# the copies are in adjacent files but not adjacent lines; hugo.toml's
+# `module.hugoVersion.min` is a FLOOR, a different relation this gate can
+# declare out of scope the same way the Go gate scopes out prose; and "it fails
+# loudly on the next deploy" is the argument the golangci-lint pin gate already
+# rejected, because failing on the deploy is failing in the wrong place.
+#
+# The floor is checked too, but only as a floor: a pin BELOW the minimum the site
+# config demands is a configuration that cannot build, and that is worth catching
+# here rather than in a Hugo error message.
+#
+# Usage:
+#   scripts/check-hugo-version-pin.sh
+#   scripts/check-hugo-version-pin.sh --self-test
+set -euo pipefail
+
+check() { # <root>
+	python3 - "$1" <<'PY'
+import os
+import re
+import sys
+
+root = sys.argv[1]
+
+try:
+	import yaml
+except ImportError:
+	sys.exit("SKIP: PyYAML unavailable; cannot read the workflow HUGO_VERSION values")
+
+
+def fail(msg):
+	sys.exit("FAIL: " + msg)
+
+
+def read(rel):
+	path = os.path.join(root, rel)
+	try:
+		with open(path) as fh:
+			return fh.read()
+	except OSError as exc:
+		fail(f"{rel} does not exist ({exc}) — this gate's scan target moved and it would otherwise report OK")
+
+
+WORKFLOWS = ("website-build.yml", "website-deploy.yml")
+pins = {}
+for name in WORKFLOWS:
+	rel = f".github/workflows/{name}"
+	text = read(rel)
+	# Parsed as YAML, not grepped: a commented-out `# HUGO_VERSION: "0.1.0"` is
+	# the most common way a value gets disabled while debugging, and a grep
+	# happily reads it back as the live value.
+	doc = yaml.safe_load(text) or {}
+	env = doc.get("env") or {}
+	v = env.get("HUGO_VERSION")
+	if v is None:
+		fail(
+			f"{rel} declares no top-level `env.HUGO_VERSION`.\n"
+			"Either it was renamed or moved into a job, or this gate is reading the wrong key;\n"
+			"it must not report OK on a value it could not find."
+		)
+	v = str(v).strip()
+	if not re.fullmatch(r"\d+\.\d+\.\d+", v):
+		fail(f"{rel}'s HUGO_VERSION is {v!r}, not an `X.Y.Z` Hugo release. The download URL interpolates it verbatim.")
+	pins[rel] = v
+	# The pin has to be the one the URL actually uses, not merely present.
+	if "hugo_extended_${HUGO_VERSION}" not in text:
+		fail(
+			f"{rel} declares HUGO_VERSION but no longer interpolates it into the hugo_extended\n"
+			"download URL, so the value this gate reconciles is not the version that gets installed."
+		)
+
+distinct = sorted(set(pins.values()))
+if len(distinct) != 1:
+	detail = "\n".join(f"    {rel}: {v}" for rel, v in sorted(pins.items()))
+	fail(
+		"the two website workflows pin different Hugo versions:\n"
+		f"{detail}\n"
+		"    The per-PR gate would validate the site with one Hugo and the deploy publish it\n"
+		"    with another, so a shortcode or config key that works in one and not the other\n"
+		"    passes review and breaks on main. Set both to the same X.Y.Z."
+	)
+pin = distinct[0]
+
+# The floor in hugo.toml is a different relation — a minimum, not a copy — so it
+# is only checked for consistency in the one direction that is unbuildable.
+floor_rel = "website/hugo.toml"
+floor_text = read(floor_rel)
+fm = re.search(r"\[module\.hugoVersion\][^\[]*?\bmin\s*=\s*\"([0-9.]+)\"", floor_text, re.S)
+if not fm:
+	fail(f"{floor_rel} declares no `[module.hugoVersion] min = \"X.Y.Z\"` — this gate's floor target moved.")
+floor = fm.group(1)
+
+
+def parts(v):
+	return tuple(int(x) for x in v.split("."))
+
+
+if parts(pin) < parts(floor[:]):
+	fail(
+		f"the workflows pin Hugo {pin} but {floor_rel} requires at least {floor}.\n"
+		"    That configuration cannot build; Hugo refuses the module at startup."
+	)
+
+print(f"hugo pin: {pin} in both website workflows (>= the {floor} floor in {floor_rel})")
+PY
+}
+
+self_test() {
+	local fail=0 tmp
+	tmp="$(mktemp -d)"
+	trap 'rm -rf "${tmp:-}"' RETURN
+
+	_wf() { # <dir> <name> <version> [extra]
+		printf 'name: x\nenv:\n  HUGO_VERSION: "%s"\njobs:\n  b:\n    steps:\n      - run: |\n          url="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb"\n' "$3" >"$1/.github/workflows/$2"
+	}
+	_toml() { printf '[module]\n  [module.hugoVersion]\n    extended = true\n    min = "%s"\n' "$2" >"$1/website/hugo.toml"; }
+
+	_mkroot() { # <dir>
+		mkdir -p "$1/.github/workflows" "$1/website"
+		_wf "$1" website-build.yml 0.165.0
+		_wf "$1" website-deploy.yml 0.165.0
+		_toml "$1" 0.110.0
+	}
+
+	_case() { # <name> <want-rc> <want-substr> <mutator...>
+		local name="$1" want="$2" substr="$3" rc=0 out d
+		shift 3
+		d="$tmp/case"; rm -rf "$d"; _mkroot "$d"; "$@" "$d"
+		out="$(check "$d" 2>&1)" || rc=$?
+		if [ "$rc" != "$want" ]; then
+			printf '  FAIL %s — exit %s, wanted %s\n    %s\n' "$name" "$rc" "$want" "$out"; fail=1; return
+		fi
+		case "$out" in *"$substr"*) printf '  ok   %s\n' "$name" ;;
+		*) printf '  FAIL %s — output lacks %q\n    %s\n' "$name" "$substr" "$out"; fail=1 ;; esac
+	}
+
+	_noop() { :; }
+	_drift() { _wf "$1" website-deploy.yml 0.140.0; }
+	_below_floor() { _wf "$1" website-build.yml 0.100.0; _wf "$1" website-deploy.yml 0.100.0; }
+	_commented_out() { printf 'name: x\nenv:\n  # HUGO_VERSION: "0.165.0"\njobs:\n  b:\n    steps:\n      - run: echo hugo_extended_${HUGO_VERSION}\n' >"$1/.github/workflows/website-build.yml"; }
+	_not_semver() { _wf "$1" website-build.yml latest; }
+	_url_no_longer_uses_it() { printf 'name: x\nenv:\n  HUGO_VERSION: "0.165.0"\njobs:\n  b:\n    steps:\n      - run: apt-get install hugo\n' >"$1/.github/workflows/website-deploy.yml"; }
+	_moved() { rm -f "$1/.github/workflows/website-deploy.yml"; }
+
+	_case "an agreeing tree passes"                      0 "0.165.0 in both website workflows" _noop
+	_case "drift between the two workflows is caught"    1 "pin different Hugo versions"        _drift
+	_case "a pin below the hugo.toml floor is caught"    1 "requires at least 0.110.0"          _below_floor
+	_case "a commented-out declaration fails loudly"     1 "declares no top-level"              _commented_out
+	_case "a non-semver pin is refused"                  1 "not an \`X.Y.Z\` Hugo release"      _not_semver
+	_case "a pin the URL stops using is caught"          1 "no longer interpolates it"          _url_no_longer_uses_it
+	_case "a moved workflow fails, not skips"            1 "does not exist"                     _moved
+
+	if [ "$fail" -eq 0 ]; then echo "self-test: PASS"; return 0; fi
+	echo "self-test: FAIL"; return 1
+}
+
+[ "${1:-}" = "--self-test" ] && { self_test; exit $?; }
+
+cd "$(dirname "$0")/.."
+check "$(pwd)"

--- a/scripts/check-lite-postgres-tag.sh
+++ b/scripts/check-lite-postgres-tag.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# Leoflow Lite starts a Postgres container from docker-compose.dev.yaml, and
+# then TELLS the user which one, in prose, from four other places:
+#
+#   internal/cli/... `leoflow lite` flag help and the resolved-backend note
+#   website/content/get-started/quickstart.md
+#   website/content/concepts/editions.md
+#   website/content/contribute/local-dev-loop.md
+#
+# The compose file is the only one of the five that does anything; the rest are
+# a version string with nothing between them and the thing they describe. This
+# is the same shape as check-lite-prepull-matches-compose.sh, which reconciles
+# the SIXTH copy — the pre-pull tag baked into the cold-start release gate. That
+# gate exists because a stale copy there wastes the boot budget. This one exists
+# because a stale copy here tells the user, on their terminal, a fact about
+# their own machine that is not true. They have a container running, we name a
+# different one, and the mismatch shows up when they go looking for the volume
+# or the port and find the wrong thing.
+#
+# Scope is deliberately narrow. Three other Postgres tags in this tree are NOT
+# this fact and must not be dragged into it: docker-compose.yml runs 17-alpine
+# for the Pro stack, the e2e scripts run their own warehouse container for dbt,
+# and helm/leoflow ships an evaluation datastore. Nothing says those should
+# track Lite's, and a gate that forced them to would be inventing a policy
+# rather than catching drift.
+#
+# website/content/project/ is excluded for the same reason
+# check-python-runtime-matrix.sh excludes CHANGELOG.md: an ADR records the
+# decision of its era and is immutable (CLAUDE.md), so "correcting" one would be
+# falsifying history.
+#
+# Usage: scripts/check-lite-postgres-tag.sh [--self-test]
+#        scripts/check-lite-postgres-tag.sh <repo-root>
+set -euo pipefail
+
+COMPOSE_REL="docker-compose.dev.yaml"
+
+check() { # <repo-root>
+	python3 - "$1" "$COMPOSE_REL" <<'PY'
+import os
+import re
+import sys
+
+try:
+	import yaml
+except ImportError:
+	sys.exit("FAIL: PyYAML unavailable; cannot parse the Lite compose file (pip install pyyaml)")
+
+root, compose_rel = sys.argv[1:3]
+problems = []
+
+
+def fail(msg):
+	sys.exit("FAIL: " + msg)
+
+
+def read(rel):
+	path = os.path.join(root, rel)
+	if not os.path.exists(path):
+		fail(f"{rel} does not exist — this gate's scan target moved and it would otherwise report OK")
+	with open(path) as fh:
+		text = fh.read()
+	if not text.strip():
+		fail(f"{rel} is empty")
+	return text
+
+
+# ── the source of truth: the container Lite actually starts ──────────────────
+# Parsed as YAML, not grepped: a commented-out `image:` is not an image, and
+# that fail-open is the one a reviewer reproduced in one line against an earlier
+# version of the sibling gate.
+compose = yaml.safe_load(read(compose_rel)) or {}
+services = compose.get("services") or {}
+if "postgres" not in services:
+	fail(f"{compose_rel} declares no `postgres` service — Lite's datastore moved and this gate is blind")
+image = (services["postgres"] or {}).get("image")
+if not image:
+	fail(f"{compose_rel}'s `postgres` service declares no `image:`")
+image = str(image)
+if not re.fullmatch(r"postgres:[\w.-]+", image):
+	fail(
+		f"{compose_rel}'s postgres image is {image!r}, which this gate cannot read as a\n"
+		"`postgres:<tag>` reference. Widen the gate deliberately rather than letting it pass."
+	)
+truth = image
+
+# ── the copies that only describe it ─────────────────────────────────────────
+# `postgres://` connection strings do not match: the pattern requires a digit
+# after the colon.
+TAG_RE = re.compile(r"postgres:(\d[\w.-]*)")
+
+targets = []
+for base, _, names in os.walk(os.path.join(root, "internal", "cli")):
+	for name in sorted(names):
+		if name.endswith(".go"):
+			targets.append(os.path.relpath(os.path.join(base, name), root))
+if not targets:
+	fail("internal/cli/ holds no .go files — the CLI moved and this gate is scanning nothing")
+
+docs_root = os.path.join(root, "website", "content")
+if not os.path.isdir(docs_root):
+	fail("website/content/ does not exist — this gate cannot see the pages that state the tag")
+doc_targets = []
+for base, dirs, names in os.walk(docs_root):
+	rel_base = os.path.relpath(base, root)
+	# Records, not current truth: ADRs are immutable and the background pages
+	# report what was observed at the time.
+	if rel_base.startswith(os.path.join("website", "content", "project")):
+		dirs[:] = []
+		continue
+	for name in sorted(names):
+		if name.endswith(".md"):
+			doc_targets.append(os.path.relpath(os.path.join(base, name), root))
+targets += doc_targets
+
+seen = 0
+for rel in sorted(targets):
+	for lineno, line in enumerate(read(rel).splitlines(), 1):
+		for m in TAG_RE.finditer(line):
+			seen += 1
+			if m.group(0) == truth:
+				continue
+			problems.append(
+				f"  {rel}:{lineno}\n"
+				f"    names {m.group(0)}\n"
+				f"    {compose_rel} starts: {truth}\n"
+				"    This text is what a Lite user is told about a container running on their own\n"
+				"    machine. Bring it to the compose tag, or move the compose tag first if the\n"
+				"    intent was to change what Lite starts."
+			)
+
+if seen == 0:
+	fail(
+		f"no `postgres:<tag>` reference found in internal/cli/ or website/content/ at all.\n"
+		f"The copies this gate reconciles against {compose_rel} are gone — either the prose\n"
+		"stopped naming the image (fine, delete this gate in that change) or the scan roots\n"
+		"moved. An empty scan must not report OK."
+	)
+
+if problems:
+	sys.exit(
+		"FAIL: the Lite Postgres tag has drifted from the container Lite starts.\n"
+		+ "\n".join(problems)
+		+ f"\n\n{compose_rel} is the source of truth: it is the only one of these copies that\n"
+		"starts anything."
+	)
+
+print(f"OK: every Lite-facing copy of the Postgres tag says {truth} ({seen} reference(s))")
+PY
+}
+
+self_test() {
+	local fail=0 tmp
+	tmp="$(mktemp -d)"
+	trap 'rm -rf "${tmp:-}"' RETURN
+
+	_compose() { # <dir> <yaml-printf-format>
+		# shellcheck disable=SC2059 # $2 IS the format: callers pass literal templates
+		printf "$2" >"$1/docker-compose.dev.yaml"
+	}
+	_compose_default='services:\n  postgres:\n    image: postgres:16\n  redis:\n    image: redis:7\n'
+	_cli() { printf 'package cli\n\n// help mentions the Docker %s container.\nconst help = "using the Docker Postgres (%s)"\n' "$2" "$2" >"$1/internal/cli/dev.go"; }
+	_doc() { printf 'Lite spins up `%s` automatically.\n' "$2" >"$1/website/content/get-started/quickstart.md"; }
+	_adr() { printf 'Lite default datastore is `%s`.\n' "$2" >"$1/website/content/project/adrs/0029-lite.md"; }
+
+	_mkroot() { # <dir>
+		local d="$1"
+		mkdir -p "$d/internal/cli" "$d/website/content/get-started" "$d/website/content/project/adrs"
+		_compose "$d" "$_compose_default"
+		_cli "$d" postgres:16
+		_doc "$d" postgres:16
+		# An ADR naming the tag of its own era must never fail this gate.
+		_adr "$d" postgres:15
+	}
+
+	_case() { # <name> <want-rc> <want-substring> <mutator...>
+		local name="$1" want_rc="$2" want_msg="$3" rc=0 out d
+		shift 3
+		d="$tmp/case"
+		rm -rf "$d"
+		_mkroot "$d"
+		"$@" "$d"
+		out="$(check "$d" 2>&1)" || rc=$?
+		if [ "$rc" != "$want_rc" ]; then
+			printf '  FAIL %s (exit)\n    got:  %s\n    want: %s\n    out: %s\n' "$name" "$rc" "$want_rc" "$out"
+			fail=1
+			return
+		fi
+		case "$out" in
+			*"$want_msg"*) printf '  ok   %s\n' "$name" ;;
+			*) printf '  FAIL %s (message)\n    got: %q\n    want to contain: %q\n' "$name" "$out" "$want_msg"; fail=1 ;;
+		esac
+	}
+
+	_noop() { :; }
+	# The motivating mutation: bump the container Lite starts and leave the
+	# sentences that describe it behind.
+	_compose_bumped_alone() { _compose "$1" 'services:\n  postgres:\n    image: postgres:17-alpine\n'; }
+	_cli_help_lags() { _cli "$1" postgres:15; }
+	_doc_lags() { _doc "$1" postgres:17; }
+	_commented_out_image() { _compose "$1" 'services:\n  postgres:\n    # image: postgres:16\n    restart: always\n'; }
+	_no_postgres_service() { _compose "$1" 'services:\n  redis:\n    image: redis:7\n'; }
+	_missing_compose() { rm -f "$1/docker-compose.dev.yaml"; }
+	_nothing_names_the_tag() {
+		printf 'package cli\n\nconst help = "using the Docker Postgres"\n' >"$1/internal/cli/dev.go"
+		printf 'Lite spins up Postgres automatically.\n' >"$1/website/content/get-started/quickstart.md"
+	}
+	# A connection string is not an image tag.
+	_connection_strings_are_not_tags() {
+		printf 'package cli\n\nconst dsn = "postgres://leoflow:leoflow@localhost:5432/leoflow"\nconst help = "the Docker Postgres (postgres:16)"\n' >"$1/internal/cli/dev.go"
+	}
+	_a_new_doc_page_is_covered() {
+		mkdir -p "$1/website/content/operate"
+		printf 'Lite uses `postgres:15` under the hood.\n' >"$1/website/content/operate/new-page.md"
+	}
+
+	_case "an agreeing tree passes"                  0 "says postgres:16" _noop
+	_case "the compose bump leaves prose behind"     1 "names postgres:16" _compose_bumped_alone
+	_case "the CLI help lags"                        1 "internal/cli/dev.go" _cli_help_lags
+	_case "a docs page lags"                         1 "names postgres:17" _doc_lags
+	_case "a commented-out image is not an image"    1 "declares no \`image:\`" _commented_out_image
+	_case "a renamed service fails, not skips"       1 "declares no \`postgres\` service" _no_postgres_service
+	_case "a missing compose fails, not skips"       1 "does not exist" _missing_compose
+	_case "an empty scan fails, not passes"          1 "no \`postgres:<tag>\` reference found" _nothing_names_the_tag
+	_case "connection strings are not tags"          0 "says postgres:16" _connection_strings_are_not_tags
+	_case "a new docs page is covered by the walk"   1 "operate/new-page.md" _a_new_doc_page_is_covered
+	# The ADR fixture names postgres:15 in every case above and never fails one.
+	_case "ADRs record their own era"                0 "says postgres:16" _noop
+
+	if [ "$fail" -eq 0 ]; then echo "self-test: PASS"; return 0; else echo "self-test: FAIL"; return 1; fi
+}
+
+[ "${1:-}" = "--self-test" ] && { self_test; exit $?; }
+
+cd "$(dirname "$0")/.."
+check "${1:-$PWD}"

--- a/scripts/check-python-host-interpreters.sh
+++ b/scripts/check-python-host-interpreters.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# The CLI states two more Python facts that the published-image matrix does not
+# cover, and they are NOT the same fact as it (#1031, #1036).
+#
+# check-python-runtime-matrix.sh reconciles the copies of one list: the Python
+# lines Leoflow publishes a task base image for. These two answer a different
+# question — which interpreter runs on the DEVELOPER's host, in Lite:
+#
+#   internal/setup/python.go   the managed CPython we download when the host has none
+#   internal/setup/detect.go   the interpreter binary names we probe for on PATH
+#
+# So the assertions here are RELATIONSHIPS, not equality:
+#
+#   1. The managed CPython's minor is a MEMBER of the published matrix. If it is
+#      not, a Lite user who let us install their interpreter develops on a minor
+#      we publish no base image for, and finds out at `leoflow compile` when the
+#      pull 404s — inside their build, naming an image they never typed.
+#   2. Every probe candidate is either in the matrix, or carries an explicit
+#      `// lite-only` marker on its line. The probe list is deliberately WIDER:
+#      it reaches forward to minors that have not shipped yet, because the Lite
+#      parser shim is stdlib-only (ADR 0024) and any of them can parse a dag.py
+#      on this host. A candidate that is neither published nor marked is the
+#      thing #1031 actually got wrong: a version in one list, absent from the
+#      other, and nothing saying whether that was a decision or a mistake.
+#   3. The first (highest-priority) probe candidate is the managed CPython's
+#      minor. detect.go's own comment states this — "3.11 wins when present
+#      because it's the version the managed CPython matches, keeping dev/prod
+#      parity" — and it is the arm most likely to rot, because bumping the
+#      managed interpreter is a one-line change in a different file.
+#
+# The marker is per-line rather than positional on purpose. A gate that assumed
+# "the published ones come first" would silently exempt everything the day
+# somebody reordered the slice for readability.
+#
+# Usage: scripts/check-python-host-interpreters.sh [--self-test]
+#        scripts/check-python-host-interpreters.sh <repo-root>
+set -euo pipefail
+
+SCHEMA_REL="internal/domain/schemas/leoflow-yaml-schema.json"
+MANAGED_REL="internal/setup/python.go"
+DETECT_REL="internal/setup/detect.go"
+
+check() { # <repo-root>
+	python3 - "$1" "$SCHEMA_REL" "$MANAGED_REL" "$DETECT_REL" <<'PY'
+import json
+import os
+import re
+import sys
+
+root, schema_rel, managed_rel, detect_rel = sys.argv[1:5]
+problems = []
+
+
+def fail(msg):
+	sys.exit("FAIL: " + msg)
+
+
+def read(rel):
+	path = os.path.join(root, rel)
+	if not os.path.exists(path):
+		fail(f"{rel} does not exist — this gate's scan target moved and it would otherwise report OK")
+	with open(path) as fh:
+		text = fh.read()
+	if not text.strip():
+		fail(f"{rel} is empty")
+	return text
+
+
+# ── the published matrix (the same source of truth the sibling gate uses) ────
+schema = json.loads(read(schema_rel))
+published = ((schema.get("properties") or {}).get("python_version") or {}).get("enum")
+if not published:
+	fail(f"{schema_rel} declares no python_version enum — the published matrix is gone")
+published = [str(v) for v in published]
+
+# ── 1. the managed CPython ───────────────────────────────────────────────────
+managed_text = read(managed_rel)
+m = re.search(r'^\s*pyVersion\s*=\s*"(\d+\.\d+)\.(\d+)"', managed_text, re.M)
+if not m:
+	fail(
+		f'{managed_rel} declares no `pyVersion = "<X.Y.Z>"` constant.\n'
+		"That constant is the interpreter Lite downloads when the host has none; a gate that\n"
+		"cannot find it must not report OK."
+	)
+managed_minor = m.group(1)
+if managed_minor not in published:
+	problems.append(
+		f"  {managed_rel}\n"
+		f"    managed CPython: {m.group(1)}.{m.group(2)} (minor {managed_minor})\n"
+		f"    published matrix: {', '.join(published)}\n"
+		"    A Lite user who let us install their interpreter would develop on a minor we\n"
+		"    publish no task base image for. They find out at `leoflow compile`, when the pull\n"
+		"    404s inside their own build, naming an image they never typed."
+	)
+
+# ── 2 and 3. the probe list ──────────────────────────────────────────────────
+detect_text = read(detect_rel)
+m = re.search(r"^var pythonCandidates = \[\]string\{\n(.*?)^\}", detect_text, re.M | re.S)
+if not m:
+	fail(
+		f"{detect_rel} declares no `var pythonCandidates = []string{{...}}` literal.\n"
+		"Either it was renamed or its shape changed; this gate cannot reconcile a list it\n"
+		"cannot find, and reporting OK on that is worse than not running at all."
+	)
+
+CANDIDATE_RE = re.compile(r'"python(\d+\.\d+)"')
+ordered = []
+for lineno, line in enumerate(m.group(1).splitlines(), 1):
+	entries = CANDIDATE_RE.findall(line)
+	if not entries:
+		continue
+	# The marker is per LINE: it covers every candidate written on it, which is
+	# how the forward-looking range is grouped in the source.
+	lite_only = re.search(r"//\s*lite-only\b", line) is not None
+	for v in entries:
+		ordered.append(v)
+		if lite_only or v in published:
+			continue
+		problems.append(
+			f"  {detect_rel} (pythonCandidates, line {lineno} of the literal)\n"
+			f"    probes for python{v}\n"
+			f"    published matrix: {', '.join(published)}\n"
+			f"    {v} is neither published nor marked. Add it to the schema enum if we publish a\n"
+			"    base image for it, or append `// lite-only` to its line to record that Lite\n"
+			"    deliberately accepts a host interpreter we ship no image for. An unmarked\n"
+			"    difference between these two lists is what #1031 misread as drift."
+		)
+
+if not ordered:
+	fail(
+		f"{detect_rel}'s pythonCandidates literal contains no `\"python<X.Y>\"` entries.\n"
+		"An empty probe list means Lite finds no host interpreter at all, and an empty scan\n"
+		"must never report OK."
+	)
+
+if ordered[0] != managed_minor:
+	problems.append(
+		f"  {detect_rel}\n"
+		f"    first probe candidate: python{ordered[0]}\n"
+		f"    {managed_rel} managed CPython minor: {managed_minor}\n"
+		"    The list is in priority order and its own comment says the managed minor wins when\n"
+		"    present, so a host that has both gets the same interpreter as a host that has\n"
+		"    neither. Reorder the list or bump the managed pin — but not one without the other."
+	)
+
+if problems:
+	sys.exit(
+		"FAIL: the host-interpreter facts disagree with the published matrix.\n"
+		+ "\n".join(problems)
+		+ f"\n\nThese are relationships, not equality: the probe list is deliberately wider than\n"
+		f"the matrix in {schema_rel}. What must hold is membership and the marker."
+	)
+
+lite = [v for v in ordered if v not in published]
+print(
+	f"OK: managed CPython {managed_minor} is published; {len(ordered)} probe candidate(s), "
+	f"{len(lite)} marked lite-only ({', '.join(lite) or 'none'})"
+)
+PY
+}
+
+self_test() {
+	local fail=0 tmp
+	tmp="$(mktemp -d)"
+	trap 'rm -rf "${tmp:-}"' RETURN
+
+	_schema() { printf '{"properties":{"python_version":{"enum":["3.10","3.11","3.12"],"default":"3.11"}}}\n' >"$1/internal/domain/schemas/leoflow-yaml-schema.json"; }
+	_managed() { printf 'package setup\n\nconst (\n\tpyReleaseTag = "20260510"\n\tpyVersion    = "%s"\n)\n' "$2" >"$1/internal/setup/python.go"; }
+	_detect() { # <dir> <literal-body>
+		{
+			printf 'package setup\n\n// pythonCandidates lists the interpreter binary names Detect probes for.\n'
+			printf 'var pythonCandidates = []string{\n'
+			# shellcheck disable=SC2059 # $2 IS the format: callers pass literal templates
+			printf "$2"
+			printf '}\n'
+		} >"$1/internal/setup/detect.go"
+	}
+
+	# The fixture's published matrix is 3.10/3.11/3.12 and the probe list reaches
+	# to 3.13/3.14, so the happy path exercises the marker arm positively rather
+	# than vacuously: a fixture with nothing to exempt would pass that arm whether
+	# it worked or not.
+	_body_default='\t"python3.11", "python3.12",\n\t"python3.13", "python3.14", // lite-only\n'
+
+	_mkroot() { # <dir>
+		local d="$1"
+		mkdir -p "$d/internal/domain/schemas" "$d/internal/setup"
+		_schema "$d"
+		_managed "$d" 3.11.15
+		_detect "$d" "$_body_default"
+	}
+
+	_case() { # <name> <want-rc> <want-substring> <mutator...>
+		local name="$1" want_rc="$2" want_msg="$3" rc=0 out d
+		shift 3
+		d="$tmp/case"
+		rm -rf "$d"
+		_mkroot "$d"
+		"$@" "$d"
+		out="$(check "$d" 2>&1)" || rc=$?
+		if [ "$rc" != "$want_rc" ]; then
+			printf '  FAIL %s (exit)\n    got:  %s\n    want: %s\n    out: %s\n' "$name" "$rc" "$want_rc" "$out"
+			fail=1
+			return
+		fi
+		case "$out" in
+			*"$want_msg"*) printf '  ok   %s\n' "$name" ;;
+			*) printf '  FAIL %s (message)\n    got: %q\n    want to contain: %q\n' "$name" "$out" "$want_msg"; fail=1 ;;
+		esac
+	}
+
+	_noop() { :; }
+	# The motivating mutation: bump the managed interpreter to a minor nobody
+	# publishes. Every list still looks reasonable in isolation.
+	_managed_off_the_matrix() {
+		_managed "$1" 3.13.2
+		_detect "$1" '\t"python3.13", "python3.11", "python3.12",\n\t"python3.14", // lite-only\n'
+	}
+	_managed_minor_not_first() { _managed "$1" 3.12.9; }
+	_missing_managed_const() { printf 'package setup\n\nconst pyReleaseTag = "20260510"\n' >"$1/internal/setup/python.go"; }
+	_unmarked_future_minor() { _detect "$1" '\t"python3.11", "python3.12",\n\t"python3.13", "python3.14",\n'; }
+	_marker_covers_only_its_line() { _detect "$1" '\t"python3.11", "python3.12",\n\t"python3.13", // lite-only\n\t"python3.14",\n'; }
+	_reordered_list_keeps_its_markers() { _detect "$1" '\t"python3.11",\n\t"python3.14", // lite-only\n\t"python3.12",\n\t"python3.13", // lite-only\n'; }
+	_renamed_literal() { printf 'package setup\n\nvar probes = []string{"python3.11"}\n' >"$1/internal/setup/detect.go"; }
+	_empty_literal() { _detect "$1" '\t// nothing yet\n'; }
+	_missing_schema() { rm -f "$1/internal/domain/schemas/leoflow-yaml-schema.json"; }
+	_empty_enum() { printf '{"properties":{"python_version":{"default":"3.11"}}}\n' >"$1/internal/domain/schemas/leoflow-yaml-schema.json"; }
+	# A line comment that merely mentions Lite is not the marker. The gate looks
+	# for the token, so prose cannot exempt an entry by accident.
+	_prose_is_not_a_marker() { _detect "$1" '\t"python3.11", "python3.12",\n\t"python3.13", "python3.14", // only Lite uses these\n'; }
+
+	_case "an agreeing tree passes"                  0 "2 marked lite-only (3.13, 3.14)" _noop
+	_case "a managed minor nobody publishes"         1 "publish no task base image for" _managed_off_the_matrix
+	_case "the managed minor is not the first probe" 1 "first probe candidate: python3.11" _managed_minor_not_first
+	_case "a dropped pyVersion fails, not skips"     1 "declares no \`pyVersion" _missing_managed_const
+	_case "an unmarked future minor"                 1 "neither published nor marked" _unmarked_future_minor
+	_case "the marker covers only its own line"      1 "probes for python3.14" _marker_covers_only_its_line
+	_case "a reordered list keeps its markers"       0 "2 marked lite-only" _reordered_list_keeps_its_markers
+	_case "a renamed literal fails loudly"           1 "declares no \`var pythonCandidates" _renamed_literal
+	_case "an empty literal fails, not passes"       1 "contains no" _empty_literal
+	_case "a missing schema fails, not skips"        1 "does not exist" _missing_schema
+	_case "an empty enum fails"                      1 "declares no python_version enum" _empty_enum
+	_case "prose is not the marker"                  1 "neither published nor marked" _prose_is_not_a_marker
+
+	if [ "$fail" -eq 0 ]; then echo "self-test: PASS"; return 0; else echo "self-test: FAIL"; return 1; fi
+}
+
+[ "${1:-}" = "--self-test" ] && { self_test; exit $?; }
+
+cd "$(dirname "$0")/.."
+check "${1:-$PWD}"

--- a/scripts/check-python-host-interpreters.sh
+++ b/scripts/check-python-host-interpreters.sh
@@ -16,7 +16,10 @@
 #      we publish no base image for, and finds out at `leoflow compile` when the
 #      pull 404s — inside their build, naming an image they never typed.
 #   2. Every probe candidate is either in the matrix, or carries an explicit
-#      `// lite-only` marker on its line. The probe list is deliberately WIDER:
+#      `// lite-only` marker on its line — an author assertion nothing else
+#      verifies, so this gate checks it BOTH ways and fails a marker on a line
+#      that IS published, rather than letting it become a mute button.
+#      The probe list is deliberately WIDER:
 #      it reaches forward to minors that have not shipped yet, because the Lite
 #      parser shim is stdlib-only (ADR 0024) and any of them can parse a dag.py
 #      on this host. A candidate that is neither published nor marked is the
@@ -114,6 +117,23 @@ for lineno, line in enumerate(m.group(1).splitlines(), 1):
 	lite_only = re.search(r"//\s*lite-only\b", line) is not None
 	for v in entries:
 		ordered.append(v)
+		if lite_only and v in published:
+			# The marker is an author assertion nobody verifies, so it has to be
+			# checked in BOTH directions or it decays into a mute button. The
+			# moment we start publishing a line that carries the marker, the
+			# marker is a false statement sitting in the source — and left
+			# one-way this gate would go on printing OK over it forever, which
+			# is the precise shape of the drift #1036 is about.
+			problems.append(
+				f"  {detect_rel} (pythonCandidates, line {lineno} of the literal)\n"
+				f"    probes for python{v}, marked `// lite-only`\n"
+				f"    published matrix: {', '.join(published)}\n"
+				f"    but {v} IS published now, so the marker is stale. Drop `// lite-only`\n"
+				"    from that line. The marker means \"Lite deliberately accepts a host\n"
+				"    interpreter we ship no image for\"; it is not a way to exempt an entry\n"
+				"    from this gate, and nothing else verifies it."
+			)
+			continue
 		if lite_only or v in published:
 			continue
 		problems.append(
@@ -228,6 +248,12 @@ self_test() {
 	# A line comment that merely mentions Lite is not the marker. The gate looks
 	# for the token, so prose cannot exempt an entry by accident.
 	_prose_is_not_a_marker() { _detect "$1" '\t"python3.11", "python3.12",\n\t"python3.13", "python3.14", // only Lite uses these\n'; }
+
+	# The marker checked the other way: once a marked line IS published, the
+	# marker is a false statement and the gate must say so instead of exempting
+	# it. Left one-way, a marker silences the entry forever.
+	_stale_marker() { _detect "$1" '\t"python3.11", // lite-only\n\t"python3.12", "python3.13",\n'; }
+	_case "a marker on a published line is stale, not an exemption" 1 "marker is stale" _stale_marker
 
 	_case "an agreeing tree passes"                  0 "2 marked lite-only (3.13, 3.14)" _noop
 	_case "a managed minor nobody publishes"         1 "publish no task base image for" _managed_off_the_matrix

--- a/scripts/check-script-selftests.sh
+++ b/scripts/check-script-selftests.sh
@@ -49,8 +49,8 @@ done
 
 # A rename or a lost self_test() would otherwise shrink this gate to nothing
 # while still exiting 0 — the same silent-shrink hole run_gates guards against.
-if [ "$found" -lt "${MIN_SELFTESTS:-15}" ]; then
-	echo "FAIL: found only $found self-test(s), expected at least ${MIN_SELFTESTS:-15} — did a script lose its self_test()?" >&2
+if [ "$found" -lt "${MIN_SELFTESTS:-18}" ]; then
+	echo "FAIL: found only $found self-test(s), expected at least ${MIN_SELFTESTS:-18} — did a script lose its self_test()?" >&2
 	exit 1
 fi
 [ "$failed" -eq 0 ] || exit 1

--- a/scripts/check-script-selftests.sh
+++ b/scripts/check-script-selftests.sh
@@ -49,8 +49,8 @@ done
 
 # A rename or a lost self_test() would otherwise shrink this gate to nothing
 # while still exiting 0 — the same silent-shrink hole run_gates guards against.
-if [ "$found" -lt "${MIN_SELFTESTS:-9}" ]; then
-	echo "FAIL: found only $found self-test(s), expected at least ${MIN_SELFTESTS:-9} — did a script lose its self_test()?" >&2
+if [ "$found" -lt "${MIN_SELFTESTS:-15}" ]; then
+	echo "FAIL: found only $found self-test(s), expected at least ${MIN_SELFTESTS:-15} — did a script lose its self_test()?" >&2
 	exit 1
 fi
 [ "$failed" -eq 0 ] || exit 1

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -748,8 +748,8 @@ run_gates() { # <tag>
   shopt -u nullglob
   # A gate renamed out of check-*.sh silently leaves the cut's gate set with no
   # signal at all, so assert the floor.
-  [ "${#gates[@]}" -ge "${MIN_GATES:-9}" ] || {
-    echo "gate set shrank to ${#gates[@]} (expected >= ${MIN_GATES:-9}) — a check-*.sh was renamed or removed" >&2
+  [ "${#gates[@]}" -ge "${MIN_GATES:-16}" ] || {
+    echo "gate set shrank to ${#gates[@]} (expected >= ${MIN_GATES:-16}) — a check-*.sh was renamed or removed" >&2
     return 1
   }
   for s in "${gates[@]}"; do

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -748,8 +748,8 @@ run_gates() { # <tag>
   shopt -u nullglob
   # A gate renamed out of check-*.sh silently leaves the cut's gate set with no
   # signal at all, so assert the floor.
-  [ "${#gates[@]}" -ge "${MIN_GATES:-16}" ] || {
-    echo "gate set shrank to ${#gates[@]} (expected >= ${MIN_GATES:-16}) — a check-*.sh was renamed or removed" >&2
+  [ "${#gates[@]}" -ge "${MIN_GATES:-19}" ] || {
+    echo "gate set shrank to ${#gates[@]} (expected >= ${MIN_GATES:-19}) — a check-*.sh was renamed or removed" >&2
     return 1
   }
   for s in "${gates[@]}"; do


### PR DESCRIPTION
Closes #1036.

The Go toolchain is one fact with one value again, five gates hold the line on this class, and the mislabeled Trivy job now says what it does.

## What landed

**Go reconciled to 1.26.6.** `runtime/Dockerfile` (`1.26.3`), the Makefile's `CHAOS_GO_VERSION` (`1.26.4`) and `deploy/Dockerfile.server` (`golang:1.27-bookworm`, from Dependabot `76a73fc`) all move to what `go.mod`'s `toolchain`, CI and release already used. `deploy/Dockerfile.server` gains an `ARG GO_VERSION` default and derives its base tag from it, the same shape `runtime/Dockerfile` already had. `security.yaml`'s three paragraphs arguing about `golang:1.27-bookworm` are rewritten — that comment outlived the mismatch because nothing tested it.

Both images rebuilt clean afterwards, exit code read without a pipe:

```
$ docker build -f deploy/Dockerfile.server -t leoflow-server:gate-1036 . >/tmp/build-server.log 2>&1; echo "EXIT=$?"
EXIT=0
$ docker build -f runtime/Dockerfile --build-arg PYTHON_VERSION=3.11 -t leoflow-base:gate-1036 . >/tmp/build-runtime.log 2>&1; echo "EXIT=$?"
EXIT=0
```

**Five gates**, each in the ~40-line shape of the two that already work, each with a `--self-test`, all globbed into `cut-release.sh`'s `run_gates()` and run per-PR by a new `Duplicated version facts agree` job (one job, one step per gate, so the red step names itself before anyone opens the log):

| gate | asserts | self-test cases |
|---|---|---|
| `check-go-toolchain-pin.sh` | `go.mod`'s `toolchain` == the `go` directive's minor, `website/go.mod`, every workflow `GO_VERSION`/`go-version` literal, three `ARG GO_VERSION` defaults, `CHAOS_GO_VERSION`, and every `golang:<version>` literal **including in comments** | 17 |
| `check-python-host-interpreters.sh` | managed CPython ∈ published matrix; every `detect.go` probe published **or** marked `// lite-only`; first probe == managed minor | 12 |
| `check-golangci-lint-pin.sh` | Makefile `GOLANGCI_LINT_VERSION` == `CHAOS_LINT_VERSION` == chaos `ARG` == every workflow copy | 12 |
| `check-lite-postgres-tag.sh` | `docker-compose.dev.yaml`'s postgres tag == every copy in `internal/cli/` and `website/content/` (excl. `project/`) | 11 |
| `check-airflow-ui-pin.sh` | `internal/ui/assets/VERSION` == Makefile `AIRFLOW_UI_VERSION` == the prose in `internal/ui/`, `README.md`, `docker-compose.yml` | 11 |

Every one is a no-op with no arguments (`run_gates()` runs them bare):

```
scripts/check-go-toolchain-pin.sh -> 0
scripts/check-python-host-interpreters.sh -> 0
scripts/check-golangci-lint-pin.sh -> 0
scripts/check-lite-postgres-tag.sh -> 0
scripts/check-airflow-ui-pin.sh -> 0
```

`check-script-selftests.sh` goes 10 → 15 self-tests (+5, exactly the gates added). `MIN_SELFTESTS` 9 → 15 and `MIN_GATES` 9 → 16 to match, so the floors do not go stale the way #1036 records them going stale before.

Each gate FAILS loudly rather than passing on a moved file, a renamed job, a commented-out declaration or an empty scan — a gate that stops gating still reports OK, which is worse than no gate.

**Trivy job renamed** to `Trivy (filesystem scan)`. It runs `scan-type: fs` and has done for many releases; the comment deferring image scanning until `deploy/Dockerfile.server` existed was stale in both directions. Renaming rather than adding a scan, because images are already covered by the `Trivy (leoflow-server image)` gate directly below it and by the scheduled `image-scan.yaml` from #1034 — which **did** land (`8c71818`), so a third copy here would only duplicate it. `main`'s branch protection declares no `required_status_checks`, so the rename breaks no required check.

## Mutation evidence

Every gate broken on a real file, the mutant asserted to have applied (occurrence count before → after), the gate run bare, then reverted. Output trimmed to the failure lines; exit codes verbatim.

<details>
<summary><b>G1.a — <code>runtime/Dockerfile</code>'s ARG falls behind <code>go.mod</code></b></summary>

```
mutant applied to runtime/Dockerfile: occurrences of "ARG GO_VERSION=1.26.6" 1 -> 0
$ bash scripts/check-go-toolchain-pin.sh
FAIL: the Go toolchain pin has drifted.
  runtime/Dockerfile
    ARG GO_VERSION default: 1.26.3
    go.mod toolchain: 1.26.6

go.mod's `toolchain go1.26.6` is the source of truth: it is what the `go`
command itself honors. Change it first, then bring the copies to match.
exit=1
after revert: OK: the Go toolchain pin agrees everywhere (go1.26.6) (exit=0)
```
</details>

<details>
<summary><b>G1.b — the original Dependabot bump, replayed</b></summary>

```
mutant applied to deploy/Dockerfile.server: occurrences of "FROM golang:${GO_VERSION}-bookworm AS build" 1 -> 0
$ bash scripts/check-go-toolchain-pin.sh
FAIL: the Go toolchain pin has drifted.
  deploy/Dockerfile.server:16
    names golang:1.27-bookworm
    go.mod toolchain: 1.26.6
    Write `golang:1.26.6-...`, or drop the version from the literal if the
    sentence is about the base image in general. A version in prose is read as a
    fact and nothing else tests it.
exit=1
after revert: OK: the Go toolchain pin agrees everywhere (go1.26.6) (exit=0)
```
</details>

<details>
<summary><b>G2.a — a probe candidate loses its <code>// lite-only</code> marker</b></summary>

```
mutant applied to internal/setup/detect.go: occurrences of "// lite-only" 2 -> 1
$ bash scripts/check-python-host-interpreters.sh
FAIL: the host-interpreter facts disagree with the published matrix.
  internal/setup/detect.go (pythonCandidates, line 2 of the literal)
    probes for python3.14
    published matrix: 3.10, 3.11, 3.12, 3.13
    3.14 is neither published nor marked. Add it to the schema enum if we publish a
    base image for it, or append `// lite-only` to its line to record that Lite
    deliberately accepts a host interpreter we ship no image for. An unmarked
    difference between these two lists is what #1031 misread as drift.
  [... same for 3.15, 3.16, 3.17, 3.18 ...]
exit=1
after revert: OK: managed CPython 3.11 is published; 8 probe candidate(s), 5 marked lite-only (3.14, 3.15, 3.16, 3.17, 3.18) (exit=0)
```
</details>

<details>
<summary><b>G2.b — the managed CPython leaves the published matrix</b></summary>

```
mutant applied to internal/setup/python.go: occurrences of 'pyVersion    = "3.11.15"' 1 -> 0
$ bash scripts/check-python-host-interpreters.sh
FAIL: the host-interpreter facts disagree with the published matrix.
  internal/setup/python.go
    managed CPython: 3.14.1 (minor 3.14)
    published matrix: 3.10, 3.11, 3.12, 3.13
    A Lite user who let us install their interpreter would develop on a minor we
    publish no task base image for. They find out at `leoflow compile`, when the pull
    404s inside their own build, naming an image they never typed.
  internal/setup/detect.go
    first probe candidate: python3.11
    internal/setup/python.go managed CPython minor: 3.14
    The list is in priority order and its own comment says the managed minor wins when
    present, so a host that has both gets the same interpreter as a host that has
    neither. Reorder the list or bump the managed pin — but not one without the other.
exit=1
after revert: OK: managed CPython 3.11 is published; 8 probe candidate(s), 5 marked lite-only (...) (exit=0)
```
</details>

<details>
<summary><b>G3 — CI bumps golangci-lint without <code>make lint</code></b></summary>

```
mutant applied to .github/workflows/ci.yaml: occurrences of 'GOLANGCI_LINT_VERSION: "v2.12.2"' 1 -> 0
$ bash scripts/check-golangci-lint-pin.sh
FAIL: the golangci-lint pin has drifted.
  .github/workflows/ci.yaml
    env.GOLANGCI_LINT_VERSION: v2.13.0
    Makefile GOLANGCI_LINT_VERSION: v2.12.2

The Makefile's `GOLANGCI_LINT_VERSION ?= v2.12.2` is the source of truth: it is the
binary `make lint` runs, and 'make lint is clean' only predicts CI while the two match.
exit=1
after revert: OK: the golangci-lint pin agrees everywhere (v2.12.2) (exit=0)
```
</details>

<details>
<summary><b>G4 — the Lite compose bumps, the prose does not</b></summary>

```
mutant applied to docker-compose.dev.yaml: occurrences of "image: postgres:16" 1 -> 0
$ bash scripts/check-lite-postgres-tag.sh
FAIL: the Lite Postgres tag has drifted from the container Lite starts.
  internal/cli/dev.go:452
    names postgres:16
    docker-compose.dev.yaml starts: postgres:17
    This text is what a Lite user is told about a container running on their own
    machine. Bring it to the compose tag, or move the compose tag first if the
    intent was to change what Lite starts.
  internal/cli/lite_postgres_default_test.go:10   [same]
  internal/cli/managed_postgres.go:77             [same]
  internal/cli/managed_postgres.go:81             [same]
  website/content/concepts/editions.md:40         [same]
  website/content/concepts/editions.md:96         [same]
  website/content/contribute/local-dev-loop.md:286 [same]
  website/content/get-started/quickstart.md:18    [same]
  website/content/get-started/quickstart.md:65    [same]
  website/content/reference/cli/leoflow_lite.md:36 [same]
exit=1
after revert: OK: every Lite-facing copy of the Postgres tag says postgres:16 (10 reference(s)) (exit=0)
```

Note what stayed silent: the two ADRs that name `postgres:16` as the decision of their era. Correcting those would be falsifying history, so `website/content/project/` is excluded, and a self-test case pins that.
</details>

<details>
<summary><b>G5 — the UI pin moves, the committed bundle does not</b></summary>

```
mutant applied to Makefile: occurrences of "AIRFLOW_UI_VERSION ?= 3.2.1" 1 -> 0
$ bash scripts/check-airflow-ui-pin.sh
FAIL: the embedded Airflow UI pin has drifted.
  Makefile
    AIRFLOW_UI_VERSION: 3.3.0
    internal/ui/assets/VERSION:      3.2.1
    The pin moved but the bundle did not. Run `make fetch-airflow-ui` and commit the
    result, or put the pin back — the server serves the marker's version either way.
exit=1
after revert: OK: the embedded Airflow UI pin agrees everywhere (3.2.1; 5 prose reference(s)) (exit=0)
```
</details>

`git status --short` is empty after the run; nothing was left mutated.

## The inventory

Swept the tree rather than fixing the two we tripped over. Twenty candidates examined.

| # | fact | copies | verdict |
|---|---|---|---|
| 1 | Go toolchain | 12 (`go.mod` ×2, `website/go.mod`, 3 Dockerfile ARGs, `CHAOS_GO_VERSION`, `GO_VERSION` in ci/release/security/image-scan, a literal in secrets-e2e, prose in security.yaml ×2) | **gated + reconciled** |
| 2 | managed CPython ∈ published matrix | 2 | **gated** |
| 3 | `detect.go` probe list vs matrix | 8 entries vs 4 published | **gated** (per-line `// lite-only` marker) |
| 4 | golangci-lint pin | 4 | **gated** |
| 5 | Lite Postgres tag | 11 | **gated** |
| 6 | embedded Airflow UI pin | 7 | **gated** |
| 7 | published Python matrix (schema/release/Makefile/Dockerfile comment/`requires-python`/docs) | 6 | already gated — `check-python-runtime-matrix.sh` |
| 8 | Airflow Task SDK | 2 | already gated — `ci.yaml` |
| 9 | Lite pre-pull tag ↔ compose | 2 | already gated |
| 10 | chart `version`/`appVersion` ↔ tag | 3 | already gated at cut time |
| 11 | `Airflow 3.2.1` in `internal/api/**` DTO godocs | ~20 | **not gated** |
| 12 | Postgres/Redis majors across compose files, CI service containers, e2e, helm examples | ~30 | **not gated** |
| 13 | `cosign-release: v2.4.3` | 5 | **not gated** |
| 14 | `HUGO_VERSION: "0.165.0"` | 2 | **gated** (added in review) |
| 15 | `apache-airflow==3.2.1` in `scripts/connectors-providers*.txt` | 2 | **not gated** |
| 16 | Kubernetes 1.27 floor in prose (`values.yaml`, helm tests, install docs) | 3+ | **not gated** |
| 17 | `Go 1.26` in `website/content/concepts/architecture.md` | 1 | **not gated** |
| 18 | kind/k3d node images vs CI service containers | 0 | named in the issue; **does not exist** — nothing pins a node image, `k3d` is installed at latest by script |
| 19 | `migrate/migrate:v4.19.1` | 1 | single copy, nothing to reconcile |
| 20 | `TRIVY_VERSION: "0.72.0"` | 1 | single copy |

> Rebased onto `main` at `b47961c` after #1027 landed a new `scripts/check-docs-updated.sh`; the floors above account for it (11 → 16 gates, 10 → 15 self-tests). That gate is a no-op for this PR: `internal/setup/detect.go` is not user-facing surface under its `SURFACE_RE`.

### Why the ungated ones are ungated

**11 — `internal/api`'s twenty "Airflow 3.2.1" godocs.** These are twenty copies of the same fact and a UI bump genuinely should revisit them, but the useful check is that the DTO *shape* still matches the spec, and a gate on the string would produce a twenty-file sed on every bump for a reviewer to wave through. That rubber-stamp is the same failure this class of gate exists to avoid, so it stays a human step — and `check-airflow-ui-pin.sh`'s header is where the next bump reads that it is one.

**12 — the Postgres/Redis majors.** They are deliberately *different* facts: `docker-compose.dev.yaml` runs 16 for Lite, `docker-compose.yml` runs 17-alpine for the Pro stack, the CI service containers run 16, the dbt e2e scripts run their own warehouse, and `helm/leoflow/examples` ships an evaluation datastore. Nothing declares that any of these should track another. A gate would be inventing a policy, not catching drift — the one relation that *is* declared (Lite's pre-pull ↔ Lite's compose) already has a gate, and #6's own header says the tree carries two majors on purpose.

**13 — `cosign-release: v2.4.3`, five copies.** Still not gated, but review corrected the reason: "drift is loud" holds for a *nonexistent* version, not for a stale-but-existing one, and stale-but-existing is the likelier drift. The real reason to accept the skip is that the consequence is bounded — `helm-release.yaml` would sign the chart with a different cosign release than `release.yaml` signs the artifacts, and both signatures still verify. Reconsider if a sixth copy appears outside `release.yaml`/`helm-release.yaml`, or if the two cosign majors ever diverge.

**14 — `HUGO_VERSION`, two copies. NOW GATED** (`scripts/check-hugo-version-pin.sh`). This was listed as the closest call, and review took all three reasons for skipping it apart, correctly:

- "eleven lines apart in adjacent files" — they are at `website-build.yml:26` and `website-deploy.yml:77`. Adjacent files, not adjacent lines.
- "`hugo.toml` carries an independent floor that would also need a relation defined" — a floor is a *different* relation and can be declared out of scope, exactly as the Go gate scopes out prose. (The new gate does check it, but only in the one direction that is unbuildable: a pin *below* the floor.)
- "the failure surfaces on the next deploy rather than silently" — that is verbatim the argument the golangci-lint gate rejects, and that one got gated. Failing on the deploy is failing in the wrong place: the per-PR gate would have validated the site with a Hugo the deploy never uses.

Both workflows interpolate their copy into the same `hugo_extended_${HUGO_VERSION}_linux-amd64.deb` URL, so the gate also asserts each pin is still *used* by that URL, not merely declared. Mutation-tested on the real tree: moving `website-deploy.yml` to 0.140.0 exits 1 naming both files and both values.

**15 — `apache-airflow==3.2.1`.** It matches the UI pin today by coincidence of both targeting Airflow 3.2.1, but it governs the provider *package* set the connector generator reads, not the SPA bundle. Binding them would forbid a legitimate divergence.

**16 — the Kubernetes 1.27 floor.** Prose about an external project's support window, stated in three different sentence shapes, none of which we pin. A gate here would be parsing English for no gain.

**17 — "Go 1.26" in `architecture.md`.** Major.minor, deliberately, in a stack table. `check-go-toolchain-pin.sh` reconciles a patch version and does not scan `website/` or `CHANGELOG.md` at all: a released changelog section naming its own era's toolchain is a record, not drift.

## Verification

```
for f in scripts/check-*.sh; do bash "$f" >/dev/null 2>&1 || echo "RED: $f"; done
  RED: scripts/check-chart-version-matches-tag.sh      # pre-existing: needs a tag, special-cased in run_gates()

bash scripts/check-script-selftests.sh   → check-script-selftests: 15 self-test(s) pass   (was 10)
golangci-lint run                        → 0 issues.
go test ./...                            → EXIT=0, no FAIL lines
bash scripts/check-changelog-entry.sh origin/main → OK
python3 -c "yaml.safe_load(...)"         → ci.yaml, security.yaml parse
```

CHANGELOG entry added under `[Unreleased] → Changed`.

