### PR TITLE
ci: run the readiness-budget and Hugo gates per PR, not only at the release cut

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1242,6 +1242,17 @@ jobs:
         run: bash scripts/check-lite-postgres-tag.sh
       - name: Embedded Airflow UI pin agrees with the committed bundle
         run: bash scripts/check-airflow-ui-pin.sh
+      # Both of these landed with a self-test wired into `Script self-tests` and
+      # their REAL check reachable only through cut-release.sh's run_gates().
+      # That is too late to be useful: a PR lowering api.probeBudget under the
+      # chart's floor, or drifting HUGO_VERSION between the two website
+      # workflows, stayed green all the way to the release cut, where the
+      # failure lands on whoever is cutting rather than whoever caused it. Same
+      # argument that put the golangci-lint pin in this job.
+      - name: Readiness probe budget sits under the chart's floor
+        run: bash scripts/check-readiness-probe-budget.sh
+      - name: Hugo pin agrees between the website build and deploy
+        run: bash scripts/check-hugo-version-pin.sh
 
   # ─────────────────────────────────────────────────────────────────────
   stale-deploy-path:


### PR DESCRIPTION
ci: run the readiness-budget and Hugo gates per PR, not only at the release cut

Both gates shipped with a `--self-test` wired into `Script self-tests` and their
REAL check reachable only through `cut-release.sh`'s `run_gates()`. The
self-test proves the parser works; nothing was asking it about the tree.

So a PR lowering `api.probeBudget` under the chart's floor, or drifting
`HUGO_VERSION` between the website build and deploy workflows, stayed green
through review and landed on main. The failure then surfaced at the release
cut, in front of whoever was cutting rather than whoever caused it — which is
the same argument that put the golangci-lint pin in this job, and the same
"failing in the wrong place" reasoning that got HUGO_VERSION gated at all.

Raised in the review of #1046, where I said I would fold it in once #1047's
`Duplicated version facts agree` job existed rather than open a second job in
ci.yaml and guarantee a conflict. It exists now. Then I added the Hugo gate in
#1047 and left it with the identical gap, so both go in together.

Verified each step can fail rather than assuming it: `probeBudget` 2s -> 4s
exits 1, `website-deploy.yml` 0.165.0 -> 0.140.0 exits 1, each with the diff
confirmed before reading the exit code and the tree clean afterwards.