### PR TITLE
fix(cli): make exclude_paths reach the image build, and stop baking dbt's host artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -311,17 +311,19 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   It is now materialized as a `.dockerignore` for the duration of the build —
   merged with yours if you have one, restored afterwards
   ([#995](https://github.com/neochaotic/leoflow/issues/995)).
-- **dbt build artifacts no longer ship in DAG images.** The compile runs a
-  host-side `dbt parse`, which writes into the project it parsed; the wholesale
-  `COPY` then baked `.user.yml` — dbt's anonymous-usage cookie, a stable UUID
-  identifying the build host, read by the in-pod dbt so every pod reported as
-  that user — and `logs/dbt.log`, carrying absolute host paths. Also `target/`,
-  `dbt_packages/` and `profiles.yml`, the last of which is warehouse credentials
-  the runtime never reads because it always generates its own
-  ([#1013](https://github.com/neochaotic/leoflow/issues/1013)).
+- **dbt's host-side parse artifacts no longer ship in DAG images.** The compile
+  runs `dbt parse` on the host, which writes into the project it parsed; the
+  wholesale `COPY` then baked `.user.yml` — dbt's anonymous-usage cookie, a
+  stable UUID identifying the build host, read by the in-pod dbt so every pod
+  reported as that user — and `logs/dbt.log`, carrying absolute host paths
+  ([#1013](https://github.com/neochaotic/leoflow/issues/1013)). `target/`,
+  `dbt_packages/` and `profiles.yml` are deliberately left in place: each is a
+  real input in a configuration people use (the `dbt.manifest` path, host-side
+  `dbt deps`, and BYO profiles with `DBT_PROFILES_DIR`).
 - A build now warns when a credential-shaped file (`.env`, `.netrc`,
-  `credentials.json`, a service-account key, `id_rsa`) is in the context and not
-  excluded. It is a warning rather than a silent exclusion because a `.env` can
+  `credentials.json`, a service-account key, `id_rsa`, a BYO `profiles.yml`) is
+  in the context and not excluded — checking each dbt project directory as well
+  as the context root, since that is where `profiles.yml` lives. It is a warning rather than a silent exclusion because a `.env` can
   be a legitimate input, and breaking `load_dotenv()` far from its cause is the
   wrong trade in the other direction.
 - The pre-install migration Job now mounts `database.caConfigMap`. It reads the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -320,10 +320,16 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `dbt_packages/` and `profiles.yml` are deliberately left in place: each is a
   real input in a configuration people use (the `dbt.manifest` path, host-side
   `dbt deps`, and BYO profiles with `DBT_PROFILES_DIR`).
-- A build now warns when a credential-shaped file (`.env`, `.netrc`,
-  `credentials.json`, a service-account key, `id_rsa`, a BYO `profiles.yml`) is
-  in the context and not excluded — checking each dbt project directory as well
-  as the context root, since that is where `profiles.yml` lives. It is a warning rather than a silent exclusion because a `.env` can
+- A build now warns when something credential-shaped is in the context and not
+  excluded: a file (`.env` and its `.env.*` variants, `.netrc`, `.pypirc`,
+  `credentials.json`, a service-account key, an SSH private key, a
+  `kubeconfig`, a BYO `profiles.yml`) or a whole directory (`.ssh`, `.aws`,
+  `.gnupg`, `.azure`, `.kube`, `secrets`). It checks each dbt project directory
+  as well as the context root, fires only for paths a `COPY` actually reaches —
+  a plain `dag.py` project copies one file, so warning there would be false —
+  respects an exclusion you already wrote in your own `.dockerignore`, and
+  repeats itself in one line after the build, where minutes of layer output
+  have scrolled the first warning away. It is a warning rather than a silent exclusion because a `.env` can
   be a legitimate input, and breaking `load_dotenv()` far from its cause is the
   wrong trade in the other direction.
 - The pre-install migration Job now mounts `database.caConfigMap`. It reads the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,6 +304,26 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `leoflow.yaml` and rebuild — or, if you pinned `base_image`, repoint it to the
   matching `py3.11` tag and rebuild.
 ### Fixed
+- **`exclude_paths` now reaches the image build.** It had been in the schema,
+  defaulted, and documented as "skipped both in image build and workspace
+  discovery" with zero consumers in build code, so with the default
+  `project: "."` the single `COPY . /home/leoflow/` baked the entire context.
+  It is now materialized as a `.dockerignore` for the duration of the build —
+  merged with yours if you have one, restored afterwards
+  ([#995](https://github.com/neochaotic/leoflow/issues/995)).
+- **dbt build artifacts no longer ship in DAG images.** The compile runs a
+  host-side `dbt parse`, which writes into the project it parsed; the wholesale
+  `COPY` then baked `.user.yml` — dbt's anonymous-usage cookie, a stable UUID
+  identifying the build host, read by the in-pod dbt so every pod reported as
+  that user — and `logs/dbt.log`, carrying absolute host paths. Also `target/`,
+  `dbt_packages/` and `profiles.yml`, the last of which is warehouse credentials
+  the runtime never reads because it always generates its own
+  ([#1013](https://github.com/neochaotic/leoflow/issues/1013)).
+- A build now warns when a credential-shaped file (`.env`, `.netrc`,
+  `credentials.json`, a service-account key, `id_rsa`) is in the context and not
+  excluded. It is a warning rather than a silent exclusion because a `.env` can
+  be a legitimate input, and breaking `load_dotenv()` far from its cause is the
+  wrong trade in the other direction.
 - The pre-install migration Job now mounts `database.caConfigMap`. It reads the
   same DSN as the control plane, so the chart's own managed-Postgres recipe —
   `sslmode=verify-full&sslrootcert=/etc/leoflow/db-ca/ca.crt` — produced an

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -452,6 +452,14 @@ func buildAndPush(cmd *cobra.Command, dir string, o compileOptions, cfg *domain.
 			return derr
 		}
 		defer cleanup()
+		// Applies whether or not the project ships its own Dockerfile: exclude_paths
+		// is a statement about what may enter the image, and it does not become
+		// less true because the author wrote the Dockerfile themselves.
+		ignoreCleanup, ierr := ensureDockerignore(cmd.ErrOrStderr(), dir, cfg)
+		if ierr != nil {
+			return ierr
+		}
+		defer ignoreCleanup()
 		var platforms []string
 		if cfg.Build != nil {
 			platforms = cfg.Build.Platforms

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -459,7 +459,7 @@ func buildAndPush(cmd *cobra.Command, dir string, o compileOptions, cfg *domain.
 		// Applies whether or not the project ships its own Dockerfile: exclude_paths
 		// is a statement about what may enter the image, and it does not become
 		// less true because the author wrote the Dockerfile themselves.
-		ignoreCleanup, ierr := ensureDockerignore(cmd.ErrOrStderr(), dir, cfg, ownDockerfile)
+		ignoreCleanup, baked, ierr := ensureDockerignore(cmd.ErrOrStderr(), dir, cfg, ownDockerfile)
 		if ierr != nil {
 			return ierr
 		}
@@ -471,6 +471,9 @@ func buildAndPush(cmd *cobra.Command, dir string, o compileOptions, cfg *domain.
 		if berr := buildImage(cmd, o.builder, image, dockerfile, dir, platforms); berr != nil {
 			return berr
 		}
+		// After the build, where the eye lands: the warning above is minutes of
+		// layer output away by now.
+		remindBakedSecretsAfterBuild(cmd.ErrOrStderr(), baked)
 	}
 	if o.push {
 		if perr := pushImage(cmd, o.builder, image); perr != nil {

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -452,10 +452,14 @@ func buildAndPush(cmd *cobra.Command, dir string, o compileOptions, cfg *domain.
 			return derr
 		}
 		defer cleanup()
+		// A project that ships its own Dockerfile gets the exclusions too, but
+		// we cannot read its COPY lines — so the secret warning softens rather
+		// than claiming what ships.
+		ownDockerfile := dockerfile != filepath.Join(dir, generatedDockerfileName)
 		// Applies whether or not the project ships its own Dockerfile: exclude_paths
 		// is a statement about what may enter the image, and it does not become
 		// less true because the author wrote the Dockerfile themselves.
-		ignoreCleanup, ierr := ensureDockerignore(cmd.ErrOrStderr(), dir, cfg)
+		ignoreCleanup, ierr := ensureDockerignore(cmd.ErrOrStderr(), dir, cfg, ownDockerfile)
 		if ierr != nil {
 			return ierr
 		}

--- a/internal/cli/compile_build.go
+++ b/internal/cli/compile_build.go
@@ -264,7 +264,7 @@ func ensureDockerignore(w io.Writer, dir string, cfg *domain.LeoflowConfig) (cle
 	// Concatenated into a fresh slice: append onto cfg.ExcludePaths would write
 	// through to the caller's config whenever that slice has spare capacity.
 	patterns := slices.Concat(cfg.ExcludePaths, dbtBuildArtifacts(cfg))
-	warnUnexcludedSecrets(w, dir, patterns)
+	warnUnexcludedSecrets(w, dir, cfg, patterns)
 	merged, changed := mergeDockerignore(original, patterns)
 	if !changed {
 		return noop, nil
@@ -286,30 +286,43 @@ func ensureDockerignore(w io.Writer, dir string, cfg *domain.LeoflowConfig) (cle
 	}, nil
 }
 
-// dbtBuildArtifacts lists the files a host-side `dbt parse` leaves inside each
-// dbt project directory, scoped to those directories.
+// dbtBuildArtifacts lists what a host-side `dbt parse` leaves inside each dbt
+// project directory that is provably never read back, scoped to those
+// directories.
 //
-// The compile runs `dbt parse` on the host before building, and that parse
-// writes into the project it parsed. Wholesale-COPYing the project then bakes
-// the result (#1013). Measured on an image the e2e builds:
+// The compile runs `dbt parse` on the host, that parse writes into the project
+// it parsed, and a wholesale COPY then bakes the result (#1013). Measured on an
+// image the e2e builds:
 //
-//   - `.user.yml` is dbt's anonymous-usage cookie: a stable UUID identifying the
-//     BUILD HOST's dbt user, shared with everyone who pulls the image, and read
-//     by the in-pod dbt so every pod reports as that same user.
+//   - `.user.yml` is dbt's anonymous-usage cookie: a stable UUID identifying
+//     the BUILD HOST's dbt user, shared with everyone who pulls the image, and
+//     read by the in-pod dbt so every pod reports as that same user.
 //   - `logs/dbt.log` carries absolute host paths — four of them in that build.
 //     That is the #993 class (a build-host path baked into a published
-//     artifact) arriving through a door the entrypoint assertions do not watch:
-//     #993 was about the entrypoint, the entrypoint is clean, and the image
-//     leaked the paths anyway. In CI it is worse, because the path names the
-//     runner's workspace.
-//   - `target/` is dead weight: the base image points DBT_TARGET_PATH at /tmp,
-//     so the pod never reads a baked target/.
-//   - `dbt_packages/` is host-resolved dependency source; the image installs
-//     its own.
+//     artifact) arriving through a door the entrypoint assertions do not watch.
+//
+// **Only those two.** An earlier version of this also excluded `target/`,
+// `dbt_packages/` and `profiles.yml`, and the dbt e2e caught all three as
+// regressions — correctly, because each of them CAN be a deliberate input:
+//
+//   - `target/` holds the manifest that `dbt.manifest` points at. The field is
+//     documented as "a pre-built manifest.json (the Pro/CI baked path)", and
+//     the e2e's own fixture sets `manifest: target/manifest.json`.
+//   - `dbt_packages/` is where `dbt deps` installs. A project that resolves
+//     dependencies on the build host and bakes them is doing something
+//     reasonable and reproducible.
+//   - `profiles.yml` is the BYO-profiles pattern: ship your own and point
+//     DBT_PROFILES_DIR at it. The runtime generates a profiles.yml from a
+//     Leoflow connection when it HAS one — it does not have one here, and
+//     "the runtime always generates its own" was a claim read off a single
+//     code path rather than checked against the configurations that exist.
+//
+// profiles.yml is credential-shaped, so it is warned about instead — the same
+// trade as .env: tell the author, do not decide for them.
 //
 // Scoped per project directory rather than added to the default ExcludePaths,
-// because `logs` and `target` are ordinary names a non-dbt project may want
-// shipped. A project with no dbt gets none of these.
+// because `logs` is an ordinary name a non-dbt project may want shipped. A
+// project with no dbt gets none of these.
 func dbtBuildArtifacts(cfg *domain.LeoflowConfig) []string {
 	dirs := dbtGroupProjectDirs(cfg)
 	if cfg.Dbt != nil && cfg.Dbt.Project != "" {
@@ -320,13 +333,7 @@ func dbtBuildArtifacts(cfg *domain.LeoflowConfig) []string {
 	}
 	slices.Sort(dirs)
 
-	// profiles.yml is here rather than in the generic excludes because it is
-	// provably dead in the image, not merely unwanted: the runtime ALWAYS
-	// generates profiles.yml into DBT_PROFILES_DIR — a private 0700 scratch dir
-	// — from the connection, and never reads one out of the project
-	// (runtime/python/leoflow_runtime/__main__.py). So a baked profiles.yml is
-	// warehouse credentials in a published artifact that nothing will ever load.
-	artifacts := []string{"target", "logs", ".user.yml", "dbt_packages", "profiles.yml"}
+	artifacts := []string{"logs", ".user.yml"}
 	out := make([]string, 0, len(dirs)*len(artifacts))
 	for _, dir := range dirs {
 		for _, a := range artifacts {
@@ -343,37 +350,53 @@ func dbtBuildArtifacts(cfg *domain.LeoflowConfig) []string {
 // secretishNames are files whose presence in a build context is nearly always a
 // mistake, and whose contents are nearly always a credential.
 //
-// They are NOT excluded by default. `.env` in particular can be a legitimate
-// input — a DAG calling load_dotenv() reads it at run time — and silently
-// dropping it would break that project with a failure far from its cause. So
-// the author is told, once per build, in time to act. Choosing for them is the
-// wrong trade; letting a password ship unnoticed is also the wrong trade, and a
-// warning is the only option that is neither.
-var secretishNames = []string{".env", ".env.local", ".netrc", "credentials.json", "service-account.json", "id_rsa"}
+// They are NOT excluded. Each of them can be a legitimate input — a DAG calling
+// load_dotenv() reads `.env` at run time, and a dbt project may ship its own
+// profiles.yml with DBT_PROFILES_DIR pointed at it — so dropping one silently
+// would break that project with a failure far from its cause. Choosing for the
+// author is the wrong trade; letting a password ship unnoticed is also the
+// wrong trade; a warning is the only option that is neither.
+var secretishNames = []string{".env", ".env.local", ".netrc", "credentials.json", "service-account.json", "id_rsa", "profiles.yml"}
 
-// warnUnexcludedSecrets prints a note for any secret-looking file that the
-// build context still carries after exclude_paths is applied.
+// warnUnexcludedSecrets prints a note for any secret-looking file the build
+// context still carries after exclude_paths is applied.
 //
-// Scans the context root only. A recursive walk of an arbitrary project is
-// slow, and the root is where these files actually live — dbt's own credential
-// file is handled precisely, per project directory, by dbtBuildArtifacts.
-func warnUnexcludedSecrets(w io.Writer, dir string, patterns []string) {
+// Looks in the context root and in each dbt project directory. Not a recursive
+// walk: that is slow on an arbitrary project and noisy, and those are the two
+// places these files actually live — profiles.yml in particular belongs next to
+// dbt_project.yml, which is not the root when the project is a subdirectory.
+func warnUnexcludedSecrets(w io.Writer, dir string, cfg *domain.LeoflowConfig, patterns []string) {
 	excluded := make(map[string]bool, len(patterns))
 	for _, p := range patterns {
 		excluded[strings.TrimSpace(p)] = true
 	}
-	for _, name := range secretishNames {
-		if excluded[name] {
-			continue
+
+	places := []string{"."}
+	places = append(places, dbtGroupProjectDirs(cfg)...)
+	if cfg.Dbt != nil && cfg.Dbt.Project != "" {
+		places = append(places, filepath.Clean(cfg.Dbt.Project))
+	}
+
+	seen := make(map[string]bool)
+	for _, place := range places {
+		for _, name := range secretishNames {
+			rel := name
+			if place != "." {
+				rel = place + "/" + name
+			}
+			if seen[rel] || excluded[rel] {
+				continue
+			}
+			seen[rel] = true
+			info, err := os.Stat(filepath.Join(dir, rel))
+			if err != nil || info.IsDir() {
+				continue
+			}
+			//nolint:errcheck // a warning that cannot be delivered must not fail the build
+			fmt.Fprintf(w, "warning: %s is in the build context and will be baked into the image, "+
+				"which is pushed to a registry and pulled by every pod that runs this DAG. "+
+				"If it holds credentials, add %q to exclude_paths in leoflow.yaml.\n", rel, rel)
 		}
-		info, err := os.Stat(filepath.Join(dir, name))
-		if err != nil || info.IsDir() {
-			continue
-		}
-		//nolint:errcheck // a warning that cannot be delivered must not fail the build
-		fmt.Fprintf(w, "warning: %s is in the build context and will be baked into the image, "+
-			"which is pushed to a registry and pulled by every pod that runs this DAG. "+
-			"If it holds credentials, add %q to exclude_paths in leoflow.yaml.\n", name, name)
 	}
 }
 

--- a/internal/cli/compile_build.go
+++ b/internal/cli/compile_build.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -251,7 +252,7 @@ const dockerignoreHeader = "# added by leoflow compile --build from exclude_path
 // file, so nothing extra can enter the context. If the process dies mid-build
 // the workspace is left with the MERGED file — a superset of the user's, so it
 // excludes more and never less. That is the right direction to fail in.
-func ensureDockerignore(w io.Writer, dir string, cfg *domain.LeoflowConfig) (cleanup func(), err error) {
+func ensureDockerignore(w io.Writer, dir string, cfg *domain.LeoflowConfig, ownDockerfile bool) (cleanup func(), err error) {
 	noop := func() {}
 	path := filepath.Join(dir, dockerignoreName)
 
@@ -260,12 +261,26 @@ func ensureDockerignore(w io.Writer, dir string, cfg *domain.LeoflowConfig) (cle
 	if rerr != nil && !os.IsNotExist(rerr) {
 		return noop, fmt.Errorf("reading %s: %w", path, rerr)
 	}
+	// A build killed before cleanup — Ctrl-C during a multi-minute `docker
+	// build`, which is THE interruption, not a rare one — leaves our merged
+	// file behind. Read back as-is it would look like the author's own work:
+	// `had` would be true, and the next successful build would "restore" a
+	// leoflow block as if they had written it, permanently, still headed
+	// "removed after the build" and no longer tracking leoflow.yaml.
+	//
+	// So strip our block on the way in and treat what remains as theirs.
+	if stripped, found := stripLeoflowBlock(original); found {
+		//nolint:errcheck // the note is best-effort; the build proceeds either way
+		fmt.Fprintf(w, "note: removing a leoflow block in %s left behind by an interrupted build\n", dockerignoreName)
+		original = stripped
+		had = len(original) > 0
+	}
 
 	// Concatenated into a fresh slice: append onto cfg.ExcludePaths would write
 	// through to the caller's config whenever that slice has spare capacity.
 	patterns := slices.Concat(cfg.ExcludePaths, dbtBuildArtifacts(cfg))
-	warnUnexcludedSecrets(w, dir, cfg, patterns)
 	merged, changed := mergeDockerignore(original, patterns)
+	warnUnexcludedSecrets(w, dir, cfg, merged, ownDockerfile)
 	if !changed {
 		return noop, nil
 	}
@@ -347,6 +362,23 @@ func dbtBuildArtifacts(cfg *domain.LeoflowConfig) []string {
 	return out
 }
 
+// copiedRoots are the context paths the generated Dockerfile actually COPYs
+// from, mirroring generatedDockerfile's decisions. A plain dag.py project copies
+// one file and nothing else; a dbt project or group at "." copies the whole
+// context; a group at `transform` copies that directory wholesale.
+func copiedRoots(cfg *domain.LeoflowConfig) []string {
+	groups := dbtGroupProjectDirs(cfg)
+	if cfg.Dbt != nil && cfg.Dbt.Project != "" {
+		if project := filepath.Clean(cfg.Dbt.Project); !slices.Contains(groups, project) {
+			groups = append(groups, project)
+		}
+	}
+	if slices.Contains(groups, ".") {
+		return []string{"."}
+	}
+	return groups
+}
+
 // secretishNames are files whose presence in a build context is nearly always a
 // mistake, and whose contents are nearly always a credential.
 //
@@ -365,16 +397,30 @@ var secretishNames = []string{".env", ".env.local", ".netrc", "credentials.json"
 // walk: that is slow on an arbitrary project and noisy, and those are the two
 // places these files actually live — profiles.yml in particular belongs next to
 // dbt_project.yml, which is not the root when the project is a subdirectory.
-func warnUnexcludedSecrets(w io.Writer, dir string, cfg *domain.LeoflowConfig, patterns []string) {
-	excluded := make(map[string]bool, len(patterns))
-	for _, p := range patterns {
-		excluded[strings.TrimSpace(p)] = true
+func warnUnexcludedSecrets(w io.Writer, dir string, cfg *domain.LeoflowConfig, merged []byte, ownDockerfile bool) {
+	// Built from the MERGED file, not just exclude_paths, so an author who
+	// excluded .env in their own .dockerignore — the docker-native, obvious
+	// place — is not told to go and duplicate it in leoflow.yaml.
+	excluded := make(map[string]bool)
+	for _, line := range strings.Split(string(merged), "\n") {
+		excluded[strings.TrimSpace(line)] = true
 	}
 
-	places := []string{"."}
-	places = append(places, dbtGroupProjectDirs(cfg)...)
-	if cfg.Dbt != nil && cfg.Dbt.Project != "" {
-		places = append(places, filepath.Clean(cfg.Dbt.Project))
+	// Only look where the image actually copies FROM. The generated Dockerfile
+	// emits `COPY . /home/leoflow/` only when a dbt project resolves to "."; for
+	// a plain dag.py project it copies one file, and warning that a .env "will
+	// be baked into the image" for an image whose only content is dag.py is a
+	// security warning that cries wolf on the most common project shape. One
+	// that cries wolf trains people to ignore the one that is real.
+	places := copiedRoots(cfg)
+	if ownDockerfile {
+		// We cannot read their COPY lines, so we cannot claim it ships — but we
+		// also must not stay quiet. Look everywhere plausible and soften below.
+		places = append(places, ".")
+		places = append(places, dbtGroupProjectDirs(cfg)...)
+	}
+	if len(places) == 0 {
+		return
 	}
 
 	seen := make(map[string]bool)
@@ -392,12 +438,71 @@ func warnUnexcludedSecrets(w io.Writer, dir string, cfg *domain.LeoflowConfig, p
 			if err != nil || info.IsDir() {
 				continue
 			}
+			verb := "will be baked into the image"
+			if ownDockerfile {
+				verb = "is in the build context, and your Dockerfile may copy it into the image"
+			}
 			//nolint:errcheck // a warning that cannot be delivered must not fail the build
-			fmt.Fprintf(w, "warning: %s is in the build context and will be baked into the image, "+
+			fmt.Fprintf(w, "warning: %s %s, "+
 				"which is pushed to a registry and pulled by every pod that runs this DAG. "+
-				"If it holds credentials, add %q to exclude_paths in leoflow.yaml.\n", rel, rel)
+				"If it holds credentials, add %q to exclude_paths in leoflow.yaml.\n", rel, verb, rel)
 		}
 	}
+}
+
+// expandPattern turns one exclude_paths entry into the .dockerignore forms that
+// actually deliver it. Both are measured, not assumed.
+//
+//  1. A pattern with no slash matches ONLY at the context root. `.dockerignore`
+//     is not `.gitignore`. Built with `__pycache__` and `*.pyc` in the file,
+//     `pkg/__pycache__/a.pyc` shipped; with `**/__pycache__` and `**/*.pyc` it
+//     did not. Three of the five defaults — `__pycache__`, `*.pyc`, `.venv` —
+//     are names that overwhelmingly appear nested, so without this the feature
+//     would land looking delivered and prune almost nothing.
+//
+//  2. Re-emitting a pattern that is already present does NOT override an
+//     earlier `!` exception. With `secrets`, `!secrets/keep.pem`, `secrets`,
+//     the keep.pem shipped on both builders; with `secrets/**` last it did not.
+//     That matters because the merge deliberately puts our block last so
+//     leoflow.yaml has the final word — a promise the plain form does not keep.
+//
+// So a bare directory name yields four forms and a glob yields two. Emitting a
+// form that is already present is harmless; omitting the `/**` one is what
+// silently loses to a negation.
+func expandPattern(pat string) []string {
+	pat = strings.TrimSpace(pat)
+	// A negation in exclude_paths is the author asking to KEEP something. Pass
+	// it through untouched rather than inventing forms that would fight it.
+	if pat == "" || strings.HasPrefix(pat, "!") || strings.HasPrefix(pat, "#") {
+		return nil
+	}
+	forms := []string{pat}
+	rooted := strings.Contains(pat, "/")
+	if !rooted {
+		forms = append(forms, "**/"+pat)
+	}
+	// A glob in the final segment names files, not a directory to descend into.
+	if !strings.ContainsAny(filepath.Base(pat), "*?[") {
+		forms = append(forms, strings.TrimSuffix(pat, "/")+"/**")
+		if !rooted {
+			forms = append(forms, "**/"+pat+"/**")
+		}
+	}
+	return forms
+}
+
+// stripLeoflowBlock removes the block this tool appends — the header line and
+// everything after it — and reports whether one was there. Our block is always
+// written last, so everything from the header on is ours.
+func stripLeoflowBlock(content []byte) (rest []byte, found bool) {
+	i := bytes.Index(content, []byte(dockerignoreHeader))
+	if i < 0 {
+		return content, false
+	}
+	// No trimming: the header always follows the author's content directly, so
+	// content[:i] is exactly what they had, trailing newline included. Trimming
+	// it would hand back a file one byte different from the one we read.
+	return content[:i], true
 }
 
 // mergeDockerignore appends the patterns to the existing content, skipping any
@@ -410,12 +515,13 @@ func mergeDockerignore(original []byte, excludes []string) (merged []byte, chang
 		existing[strings.TrimSpace(line)] = true
 	}
 
-	want := make([]string, 0, len(excludes)+1)
+	want := make([]string, 0, len(excludes)*4+1)
 	for _, p := range excludes {
-		p = strings.TrimSpace(p)
-		if p != "" && !existing[p] {
-			want = append(want, p)
-			existing[p] = true
+		for _, form := range expandPattern(p) {
+			if !existing[form] {
+				want = append(want, form)
+				existing[form] = true
+			}
 		}
 	}
 	if !existing[generatedDockerfileName] {

--- a/internal/cli/compile_build.go
+++ b/internal/cli/compile_build.go
@@ -252,14 +252,14 @@ const dockerignoreHeader = "# added by leoflow compile --build from exclude_path
 // file, so nothing extra can enter the context. If the process dies mid-build
 // the workspace is left with the MERGED file — a superset of the user's, so it
 // excludes more and never less. That is the right direction to fail in.
-func ensureDockerignore(w io.Writer, dir string, cfg *domain.LeoflowConfig, ownDockerfile bool) (cleanup func(), err error) {
+func ensureDockerignore(w io.Writer, dir string, cfg *domain.LeoflowConfig, ownDockerfile bool) (cleanup func(), baked []string, err error) {
 	noop := func() {}
 	path := filepath.Join(dir, dockerignoreName)
 
 	original, rerr := os.ReadFile(path) //nolint:gosec // G304: dir is the user's own project directory.
 	had := rerr == nil
 	if rerr != nil && !os.IsNotExist(rerr) {
-		return noop, fmt.Errorf("reading %s: %w", path, rerr)
+		return noop, nil, fmt.Errorf("reading %s: %w", path, rerr)
 	}
 	// A build killed before cleanup — Ctrl-C during a multi-minute `docker
 	// build`, which is THE interruption, not a rare one — leaves our merged
@@ -280,16 +280,16 @@ func ensureDockerignore(w io.Writer, dir string, cfg *domain.LeoflowConfig, ownD
 	// through to the caller's config whenever that slice has spare capacity.
 	patterns := slices.Concat(cfg.ExcludePaths, dbtBuildArtifacts(cfg))
 	merged, changed := mergeDockerignore(original, patterns)
-	warnUnexcludedSecrets(w, dir, cfg, merged, ownDockerfile)
+	baked = warnUnexcludedSecrets(w, dir, cfg, merged, ownDockerfile)
 	if !changed {
-		return noop, nil
+		return noop, baked, nil
 	}
 	//nolint:gosec // G703: `path` is filepath.Join(dir, <const>), and dir is the
 	// project directory the operator pointed `leoflow compile` at. Writing into
 	// it is the whole point — ensureDockerfile writes the generated Dockerfile to
 	// the same place, for the same reason.
 	if werr := os.WriteFile(path, merged, 0o600); werr != nil {
-		return noop, fmt.Errorf("writing %s: %w", path, werr)
+		return noop, nil, fmt.Errorf("writing %s: %w", path, werr)
 	}
 	return func() {
 		if had {
@@ -298,7 +298,7 @@ func ensureDockerignore(w io.Writer, dir string, cfg *domain.LeoflowConfig, ownD
 			return
 		}
 		_ = os.Remove(path) //nolint:errcheck // best-effort cleanup of a file we created
-	}, nil
+	}, baked, nil
 }
 
 // dbtBuildArtifacts lists what a host-side `dbt parse` leaves inside each dbt
@@ -388,16 +388,55 @@ func copiedRoots(cfg *domain.LeoflowConfig) []string {
 // would break that project with a failure far from its cause. Choosing for the
 // author is the wrong trade; letting a password ship unnoticed is also the
 // wrong trade; a warning is the only option that is neither.
-var secretishNames = []string{".env", ".env.local", ".netrc", "credentials.json", "service-account.json", "id_rsa", "profiles.yml"}
+var secretishNames = []string{
+	".env", ".netrc", ".pypirc", ".npmrc", "credentials.json",
+	"service-account.json", "id_rsa", "id_ed25519", "kubeconfig", "profiles.yml",
+}
 
-// warnUnexcludedSecrets prints a note for any secret-looking file the build
-// context still carries after exclude_paths is applied.
+// secretishDirs are checked as directories. They were unreachable before: the
+// scan skipped anything IsDir(), which excluded exactly the highest-value hits
+// — a whole ~/.ssh or ~/.aws copied into a project is a bigger leak than any
+// single file in the list above.
+var secretishDirs = []string{".ssh", ".aws", ".gnupg", ".azure", ".kube", "secrets"}
+
+// secretCandidate is one thing to look for and whether it is a directory.
+type secretCandidate struct {
+	name  string
+	isDir bool
+}
+
+// secretCandidatesIn lists what to look for inside one context-relative place:
+// the fixed name and directory lists, plus whatever `.env.*` variants actually
+// exist there, so `.env.production` is covered without enumerating spellings.
+func secretCandidatesIn(dir, place string) []secretCandidate {
+	out := make([]secretCandidate, 0, len(secretishNames)+len(secretishDirs)+2)
+	for _, n := range secretishNames {
+		out = append(out, secretCandidate{n, false})
+	}
+	for _, d := range secretishDirs {
+		out = append(out, secretCandidate{d, true})
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, place, ".env.*"))
+	if err != nil {
+		return out // a bad pattern is ours, not the author's; the fixed lists still apply
+	}
+	for _, m := range matches {
+		out = append(out, secretCandidate{filepath.Base(m), false})
+	}
+	return out
+}
+
+// warnUnexcludedSecrets prints a note for any secret-looking file or directory
+// the build context still carries after exclude_paths is applied, and returns
+// what it found so the caller can repeat it after the build.
 //
-// Looks in the context root and in each dbt project directory. Not a recursive
-// walk: that is slow on an arbitrary project and noisy, and those are the two
-// places these files actually live — profiles.yml in particular belongs next to
-// dbt_project.yml, which is not the root when the project is a subdirectory.
-func warnUnexcludedSecrets(w io.Writer, dir string, cfg *domain.LeoflowConfig, merged []byte, ownDockerfile bool) {
+// Looks in the places the image actually copies FROM, not everywhere. The
+// generated Dockerfile emits `COPY . /home/leoflow/` only when a dbt project
+// resolves to "."; for a plain dag.py project it copies one file, and warning
+// that a .env "will be baked into the image" for an image whose only content is
+// dag.py is a security warning that cries wolf on the most common project
+// shape. One that cries wolf trains people to ignore the one that is real.
+func warnUnexcludedSecrets(w io.Writer, dir string, cfg *domain.LeoflowConfig, merged []byte, ownDockerfile bool) (found []string) {
 	// Built from the MERGED file, not just exclude_paths, so an author who
 	// excluded .env in their own .dockerignore — the docker-native, obvious
 	// place — is not told to go and duplicate it in leoflow.yaml.
@@ -406,12 +445,6 @@ func warnUnexcludedSecrets(w io.Writer, dir string, cfg *domain.LeoflowConfig, m
 		excluded[strings.TrimSpace(line)] = true
 	}
 
-	// Only look where the image actually copies FROM. The generated Dockerfile
-	// emits `COPY . /home/leoflow/` only when a dbt project resolves to "."; for
-	// a plain dag.py project it copies one file, and warning that a .env "will
-	// be baked into the image" for an image whose only content is dag.py is a
-	// security warning that cries wolf on the most common project shape. One
-	// that cries wolf trains people to ignore the one that is real.
 	places := copiedRoots(cfg)
 	if ownDockerfile {
 		// We cannot read their COPY lines, so we cannot claim it ships — but we
@@ -420,34 +453,37 @@ func warnUnexcludedSecrets(w io.Writer, dir string, cfg *domain.LeoflowConfig, m
 		places = append(places, dbtGroupProjectDirs(cfg)...)
 	}
 	if len(places) == 0 {
-		return
+		return nil
+	}
+
+	verb := "will be baked into the image"
+	if ownDockerfile {
+		verb = "is in the build context, and your Dockerfile may copy it into the image"
 	}
 
 	seen := make(map[string]bool)
 	for _, place := range places {
-		for _, name := range secretishNames {
-			rel := name
+		for _, c := range secretCandidatesIn(dir, place) {
+			rel := c.name
 			if place != "." {
-				rel = place + "/" + name
+				rel = place + "/" + c.name
 			}
 			if seen[rel] || excluded[rel] {
 				continue
 			}
 			seen[rel] = true
 			info, err := os.Stat(filepath.Join(dir, rel))
-			if err != nil || info.IsDir() {
+			if err != nil || info.IsDir() != c.isDir {
 				continue
-			}
-			verb := "will be baked into the image"
-			if ownDockerfile {
-				verb = "is in the build context, and your Dockerfile may copy it into the image"
 			}
 			//nolint:errcheck // a warning that cannot be delivered must not fail the build
 			fmt.Fprintf(w, "warning: %s %s, "+
 				"which is pushed to a registry and pulled by every pod that runs this DAG. "+
 				"If it holds credentials, add %q to exclude_paths in leoflow.yaml.\n", rel, verb, rel)
+			found = append(found, rel)
 		}
 	}
+	return found
 }
 
 // expandPattern turns one exclude_paths entry into the .dockerignore forms that
@@ -503,6 +539,23 @@ func stripLeoflowBlock(content []byte) (rest []byte, found bool) {
 	// content[:i] is exactly what they had, trailing newline included. Trimming
 	// it would hand back a file one byte different from the one we read.
 	return content[:i], true
+}
+
+// remindBakedSecretsAfterBuild re-states the finding in one line after the
+// image is built.
+//
+// `--build` shells out to a container builder, and the minutes of layer output
+// that follow scroll the warning off the top of the terminal. Authors read the
+// last screen of a long command, not the first. Same reasoning and same shape
+// as remindDeprecatedPythonAfterBuild — one line, not the full argument, since
+// repeating the argument in full is how a warning becomes wallpaper.
+func remindBakedSecretsAfterBuild(w io.Writer, found []string) {
+	if len(found) == 0 {
+		return
+	}
+	//nolint:errcheck // a reminder that cannot be delivered must not fail the build
+	fmt.Fprintf(w, "reminder: the image just built carries %s — see the warning above.\n",
+		strings.Join(found, ", "))
 }
 
 // mergeDockerignore appends the patterns to the existing content, skipping any

--- a/internal/cli/compile_build.go
+++ b/internal/cli/compile_build.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -206,6 +207,221 @@ func generatedDockerfile(cfg *domain.LeoflowConfig, dagSource string) (string, e
 		b.WriteString("USER 65532:65532\n")
 	}
 	return b.String(), nil
+}
+
+// dockerignoreName is the only ignore-file form every builder reads.
+//
+// BuildKit also honors `<dockerfile>.dockerignore`, which would be tidier — it
+// needs no cleanup and cannot touch a file the user owns. It is not usable
+// here, for two measured reasons:
+//
+//   - the legacy builder ignores it completely. Built with DOCKER_BUILDKIT=0
+//     against a context holding a `.leoflow.generated.Dockerfile.dockerignore`
+//     listing `.env`, the `.env` landed in the image. A silent leak on a
+//     builder the operator can still select (`--builder`, or podman) is worse
+//     than no feature.
+//   - where it IS honored it REPLACES the context `.dockerignore` rather than
+//     adding to it. With a user `.dockerignore` excluding `big.bin` and a
+//     per-Dockerfile file excluding `.env`, `big.bin` shipped. We would have
+//     closed one leak by reopening whatever the user had closed.
+const dockerignoreName = ".dockerignore"
+
+// dockerignoreHeader marks the block this tool appends, so a repeated merge
+// after an interrupted build does not stack identical comments.
+const dockerignoreHeader = "# added by leoflow compile --build from exclude_paths (leoflow.yaml); removed after the build"
+
+// ensureDockerignore materializes exclude_paths as a .dockerignore for the
+// duration of the build, and restores the workspace afterward.
+//
+// exclude_paths has been in the schema, defaulted, and documented as "skipped
+// both in image build and workspace discovery" while having zero consumers in
+// build code (#995). With `project: "."` — mode 1's documented default — the
+// generated Dockerfile is a single `COPY . /home/leoflow/`, so the whole
+// context is baked: measured in a built image, that included a `.env` holding a
+// warehouse password, a BYO `profiles.yml`, `.git`, and the generated
+// Dockerfile the build had just written.
+//
+// The user's own .dockerignore is preserved and comes FIRST, so their file is
+// merged rather than replaced. Ours goes last because later rules win in
+// .dockerignore syntax, and leoflow.yaml is the authoritative statement of what
+// may leave in the image: a stray `!secrets/x` in a .dockerignore must not
+// silently defeat an `exclude_paths: [secrets/]` the author wrote deliberately.
+//
+// The original content is held in the closure rather than a sibling backup
+// file, so nothing extra can enter the context. If the process dies mid-build
+// the workspace is left with the MERGED file — a superset of the user's, so it
+// excludes more and never less. That is the right direction to fail in.
+func ensureDockerignore(w io.Writer, dir string, cfg *domain.LeoflowConfig) (cleanup func(), err error) {
+	noop := func() {}
+	path := filepath.Join(dir, dockerignoreName)
+
+	original, rerr := os.ReadFile(path) //nolint:gosec // G304: dir is the user's own project directory.
+	had := rerr == nil
+	if rerr != nil && !os.IsNotExist(rerr) {
+		return noop, fmt.Errorf("reading %s: %w", path, rerr)
+	}
+
+	// Concatenated into a fresh slice: append onto cfg.ExcludePaths would write
+	// through to the caller's config whenever that slice has spare capacity.
+	patterns := slices.Concat(cfg.ExcludePaths, dbtBuildArtifacts(cfg))
+	warnUnexcludedSecrets(w, dir, patterns)
+	merged, changed := mergeDockerignore(original, patterns)
+	if !changed {
+		return noop, nil
+	}
+	//nolint:gosec // G703: `path` is filepath.Join(dir, <const>), and dir is the
+	// project directory the operator pointed `leoflow compile` at. Writing into
+	// it is the whole point — ensureDockerfile writes the generated Dockerfile to
+	// the same place, for the same reason.
+	if werr := os.WriteFile(path, merged, 0o600); werr != nil {
+		return noop, fmt.Errorf("writing %s: %w", path, werr)
+	}
+	return func() {
+		if had {
+			//nolint:errcheck,gosec // best-effort restore; 0600 matches the write above.
+			_ = os.WriteFile(path, original, 0o600)
+			return
+		}
+		_ = os.Remove(path) //nolint:errcheck // best-effort cleanup of a file we created
+	}, nil
+}
+
+// dbtBuildArtifacts lists the files a host-side `dbt parse` leaves inside each
+// dbt project directory, scoped to those directories.
+//
+// The compile runs `dbt parse` on the host before building, and that parse
+// writes into the project it parsed. Wholesale-COPYing the project then bakes
+// the result (#1013). Measured on an image the e2e builds:
+//
+//   - `.user.yml` is dbt's anonymous-usage cookie: a stable UUID identifying the
+//     BUILD HOST's dbt user, shared with everyone who pulls the image, and read
+//     by the in-pod dbt so every pod reports as that same user.
+//   - `logs/dbt.log` carries absolute host paths — four of them in that build.
+//     That is the #993 class (a build-host path baked into a published
+//     artifact) arriving through a door the entrypoint assertions do not watch:
+//     #993 was about the entrypoint, the entrypoint is clean, and the image
+//     leaked the paths anyway. In CI it is worse, because the path names the
+//     runner's workspace.
+//   - `target/` is dead weight: the base image points DBT_TARGET_PATH at /tmp,
+//     so the pod never reads a baked target/.
+//   - `dbt_packages/` is host-resolved dependency source; the image installs
+//     its own.
+//
+// Scoped per project directory rather than added to the default ExcludePaths,
+// because `logs` and `target` are ordinary names a non-dbt project may want
+// shipped. A project with no dbt gets none of these.
+func dbtBuildArtifacts(cfg *domain.LeoflowConfig) []string {
+	dirs := dbtGroupProjectDirs(cfg)
+	if cfg.Dbt != nil && cfg.Dbt.Project != "" {
+		project := filepath.Clean(cfg.Dbt.Project)
+		if !slices.Contains(dirs, project) {
+			dirs = append(dirs, project)
+		}
+	}
+	slices.Sort(dirs)
+
+	// profiles.yml is here rather than in the generic excludes because it is
+	// provably dead in the image, not merely unwanted: the runtime ALWAYS
+	// generates profiles.yml into DBT_PROFILES_DIR — a private 0700 scratch dir
+	// — from the connection, and never reads one out of the project
+	// (runtime/python/leoflow_runtime/__main__.py). So a baked profiles.yml is
+	// warehouse credentials in a published artifact that nothing will ever load.
+	artifacts := []string{"target", "logs", ".user.yml", "dbt_packages", "profiles.yml"}
+	out := make([]string, 0, len(dirs)*len(artifacts))
+	for _, dir := range dirs {
+		for _, a := range artifacts {
+			if dir == "." {
+				out = append(out, a)
+				continue
+			}
+			out = append(out, dir+"/"+a)
+		}
+	}
+	return out
+}
+
+// secretishNames are files whose presence in a build context is nearly always a
+// mistake, and whose contents are nearly always a credential.
+//
+// They are NOT excluded by default. `.env` in particular can be a legitimate
+// input — a DAG calling load_dotenv() reads it at run time — and silently
+// dropping it would break that project with a failure far from its cause. So
+// the author is told, once per build, in time to act. Choosing for them is the
+// wrong trade; letting a password ship unnoticed is also the wrong trade, and a
+// warning is the only option that is neither.
+var secretishNames = []string{".env", ".env.local", ".netrc", "credentials.json", "service-account.json", "id_rsa"}
+
+// warnUnexcludedSecrets prints a note for any secret-looking file that the
+// build context still carries after exclude_paths is applied.
+//
+// Scans the context root only. A recursive walk of an arbitrary project is
+// slow, and the root is where these files actually live — dbt's own credential
+// file is handled precisely, per project directory, by dbtBuildArtifacts.
+func warnUnexcludedSecrets(w io.Writer, dir string, patterns []string) {
+	excluded := make(map[string]bool, len(patterns))
+	for _, p := range patterns {
+		excluded[strings.TrimSpace(p)] = true
+	}
+	for _, name := range secretishNames {
+		if excluded[name] {
+			continue
+		}
+		info, err := os.Stat(filepath.Join(dir, name))
+		if err != nil || info.IsDir() {
+			continue
+		}
+		//nolint:errcheck // a warning that cannot be delivered must not fail the build
+		fmt.Fprintf(w, "warning: %s is in the build context and will be baked into the image, "+
+			"which is pushed to a registry and pulled by every pod that runs this DAG. "+
+			"If it holds credentials, add %q to exclude_paths in leoflow.yaml.\n", name, name)
+	}
+}
+
+// mergeDockerignore appends the patterns to the existing content, skipping any
+// already present, and reports whether anything was added. The generated
+// Dockerfile is always excluded: it is written into the context by
+// ensureDockerfile and has no business inside the image it builds.
+func mergeDockerignore(original []byte, excludes []string) (merged []byte, changed bool) {
+	existing := make(map[string]bool)
+	for _, line := range strings.Split(string(original), "\n") {
+		existing[strings.TrimSpace(line)] = true
+	}
+
+	want := make([]string, 0, len(excludes)+1)
+	for _, p := range excludes {
+		p = strings.TrimSpace(p)
+		if p != "" && !existing[p] {
+			want = append(want, p)
+			existing[p] = true
+		}
+	}
+	if !existing[generatedDockerfileName] {
+		want = append(want, generatedDockerfileName)
+	}
+	if len(want) == 0 {
+		return original, false
+	}
+
+	var b strings.Builder
+	if len(original) > 0 {
+		b.Write(original)
+		if !strings.HasSuffix(string(original), "\n") {
+			b.WriteString("\n")
+		}
+	}
+	// The header is written once. A build killed before cleanup leaves the merged
+	// file behind (documented on ensureDockerignore), and the next build merges
+	// onto it — patterns already present are skipped, so without this check the
+	// only thing that accumulated was a stack of identical comments.
+	if !strings.Contains(string(original), dockerignoreHeader) {
+		b.WriteString(dockerignoreHeader)
+		b.WriteString("\n")
+	}
+	for _, p := range want {
+		b.WriteString(p)
+		b.WriteString("\n")
+	}
+	return []byte(b.String()), true
 }
 
 // ensureDockerfile resolves the Dockerfile to build with. A project that ships

--- a/internal/cli/compile_dockerignore_test.go
+++ b/internal/cli/compile_dockerignore_test.go
@@ -101,14 +101,14 @@ func TestUserDockerignoreIsMergedNotReplaced(t *testing.T) {
 }
 
 // TestDbtArtifactsAreScopedToTheirProject is the #1013 regression. The compile
-// runs a host-side `dbt parse`, which writes into the project it parsed, and the
-// wholesale COPY then bakes the result: `.user.yml` (dbt's anonymous-usage
+// runs a host-side `dbt parse`, which writes into the project it parsed, and
+// the wholesale COPY then bakes the result: `.user.yml` (dbt's anonymous-usage
 // cookie, a stable UUID identifying the BUILD HOST, read by the in-pod dbt so
 // every pod reports as that user) and `logs/dbt.log` (absolute host paths — the
 // #993 class arriving through a door the entrypoint assertions do not watch).
 //
 // Scoped to the project directories rather than added to the defaults, because
-// `logs` and `target` are ordinary names a non-dbt project may want shipped.
+// `logs` is an ordinary name a non-dbt project may want shipped.
 func TestDbtArtifactsAreScopedToTheirProject(t *testing.T) {
 	dir := writeCtx(t, map[string]string{"dag.py": "x"})
 	cfg := &domain.LeoflowConfig{DagID: "d"}
@@ -119,18 +119,72 @@ func TestDbtArtifactsAreScopedToTheirProject(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := readIgnore(t, dir)
-	for _, want := range []string{
-		"transform/target", "transform/logs", "transform/.user.yml",
-		"transform/dbt_packages", "transform/profiles.yml",
-	} {
+	for _, want := range []string{"transform/logs", "transform/.user.yml"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("missing %q — a dbt build artifact would be baked\n%s", want, got)
 		}
 	}
-	for _, unwanted := range []string{"\nlogs\n", "\ntarget\n"} {
-		if strings.Contains(got, unwanted) {
-			t.Errorf("unscoped %q would exclude an unrelated directory in a non-dbt tree\n%s", unwanted, got)
+	if strings.Contains(got, "\nlogs\n") {
+		t.Errorf("unscoped \"logs\" would exclude an unrelated directory in a non-dbt tree\n%s", got)
+	}
+}
+
+// TestDbtInputsAreNeverExcluded is the regression for what the dbt e2e caught
+// after the first version of this shipped. Three paths were excluded as
+// "artifacts" that are each a deliberate INPUT in a configuration that exists:
+//
+//   - `target/` holds the manifest `dbt.manifest` points at, documented as "a
+//     pre-built manifest.json (the Pro/CI baked path)". The e2e's own fixture
+//     sets `manifest: target/manifest.json`.
+//   - `dbt_packages/` is where `dbt deps` installs; resolving on the build host
+//     and baking the result is reasonable and reproducible.
+//   - `profiles.yml` is the BYO-profiles pattern — ship your own, point
+//     DBT_PROFILES_DIR at it. The runtime generates one from a Leoflow
+//     connection when it HAS one; the e2e has none.
+//
+// The claim that justified excluding profiles.yml ("the runtime always
+// generates its own and never reads one from the project") was read off a
+// single code path and was false for the configurations that exist. This test
+// is here so the next person tempted by the same tidy-up finds out in seconds
+// instead of in a k3d run.
+func TestDbtInputsAreNeverExcluded(t *testing.T) {
+	dir := writeCtx(t, map[string]string{"dag.py": "x"})
+	cfg := &domain.LeoflowConfig{DagID: "d"}
+	cfg.Dbt = &domain.DbtConfig{Project: ".", Manifest: "target/manifest.json"}
+	cfg.ApplyDefaults()
+
+	if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg); err != nil {
+		t.Fatal(err)
+	}
+	got := readIgnore(t, dir)
+	for _, input := range []string{"target", "dbt_packages", "profiles.yml"} {
+		for _, form := range []string{"\n" + input + "\n", "\n./" + input + "\n"} {
+			if strings.Contains(got, form) {
+				t.Errorf("%q is excluded, but it is a deliberate dbt input — this breaks the manifest, dbt deps or BYO profiles path\n%s", input, got)
+			}
 		}
+	}
+}
+
+// TestByoProfilesIsWarnedNotDropped: profiles.yml is credential-shaped, so it
+// gets the same treatment as .env — the author is told, not overruled.
+func TestByoProfilesIsWarnedNotDropped(t *testing.T) {
+	dir := writeCtx(t, map[string]string{"transform/profiles.yml": "password: s3cret", "dag.py": "x"})
+	cfg := &domain.LeoflowConfig{DagID: "d"}
+	cfg.DbtGroups = map[string]*domain.DbtConfig{"a": {Project: "transform"}}
+	cfg.ApplyDefaults()
+
+	var out bytes.Buffer
+	if _, err := ensureDockerignore(&out, dir, cfg); err != nil {
+		t.Fatal(err)
+	}
+	// Found in the dbt project directory, not just the context root: that is
+	// where profiles.yml lives, next to dbt_project.yml.
+	if !strings.Contains(out.String(), "transform/profiles.yml") {
+		t.Errorf("no warning for a BYO profiles.yml inside the dbt project, got %q", out.String())
+	}
+	if strings.Contains(readIgnore(t, dir), "transform/profiles.yml") {
+		t.Error("the BYO profiles.yml was excluded; that breaks a project that points DBT_PROFILES_DIR at it")
 	}
 }
 

--- a/internal/cli/compile_dockerignore_test.go
+++ b/internal/cli/compile_dockerignore_test.go
@@ -51,7 +51,7 @@ func TestExcludePathsReachTheBuildContext(t *testing.T) {
 	cfg.ExcludePaths = []string{"secrets", "*.pem"}
 	cfg.ApplyDefaults()
 
-	cleanup, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false)
+	cleanup, _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func TestUserDockerignoreIsMergedNotReplaced(t *testing.T) {
 	cfg := &domain.LeoflowConfig{DagID: "d"}
 	cfg.ApplyDefaults()
 
-	cleanup, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false)
+	cleanup, _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +117,7 @@ func TestDbtArtifactsAreScopedToTheirProject(t *testing.T) {
 	cfg.DbtGroups = map[string]*domain.DbtConfig{"a": {Project: "transform"}}
 	cfg.ApplyDefaults()
 
-	if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false); err != nil {
+	if _, _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false); err != nil {
 		t.Fatal(err)
 	}
 	got := readIgnore(t, dir)
@@ -155,7 +155,7 @@ func TestDbtInputsAreNeverExcluded(t *testing.T) {
 	cfg.Dbt = &domain.DbtConfig{Project: ".", Manifest: "target/manifest.json"}
 	cfg.ApplyDefaults()
 
-	if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false); err != nil {
+	if _, _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false); err != nil {
 		t.Fatal(err)
 	}
 	got := readIgnore(t, dir)
@@ -177,7 +177,7 @@ func TestByoProfilesIsWarnedNotDropped(t *testing.T) {
 	cfg.ApplyDefaults()
 
 	var out bytes.Buffer
-	if _, err := ensureDockerignore(&out, dir, cfg, false); err != nil {
+	if _, _, err := ensureDockerignore(&out, dir, cfg, false); err != nil {
 		t.Fatal(err)
 	}
 	// Found in the dbt project directory, not just the context root: that is
@@ -194,7 +194,7 @@ func TestNoDbtMeansNoDbtExcludes(t *testing.T) {
 	dir := writeCtx(t, map[string]string{"dag.py": "x"})
 	cfg := &domain.LeoflowConfig{DagID: "d"}
 	cfg.ApplyDefaults()
-	if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false); err != nil {
+	if _, _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false); err != nil {
 		t.Fatal(err)
 	}
 	if got := readIgnore(t, dir); strings.Contains(got, "dbt_packages") {
@@ -214,7 +214,7 @@ func TestSecretishFilesWarnRatherThanVanish(t *testing.T) {
 	cfg.ApplyDefaults()
 
 	var out bytes.Buffer
-	if _, err := ensureDockerignore(&out, dir, cfg, false); err != nil {
+	if _, _, err := ensureDockerignore(&out, dir, cfg, false); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(out.String(), ".env") {
@@ -229,7 +229,7 @@ func TestSecretishFilesWarnRatherThanVanish(t *testing.T) {
 	cfg2.ExcludePaths = []string{".env"}
 	cfg2.ApplyDefaults()
 	var out2 bytes.Buffer
-	if _, err := ensureDockerignore(&out2, dir, cfg2, false); err != nil {
+	if _, _, err := ensureDockerignore(&out2, dir, cfg2, false); err != nil {
 		t.Fatal(err)
 	}
 	if strings.Contains(out2.String(), "warning") {
@@ -248,7 +248,7 @@ func TestNoWarningWhenNothingCopiesIt(t *testing.T) {
 	cfg.ApplyDefaults()
 
 	var out bytes.Buffer
-	if _, err := ensureDockerignore(&out, dir, cfg, false); err != nil {
+	if _, _, err := ensureDockerignore(&out, dir, cfg, false); err != nil {
 		t.Fatal(err)
 	}
 	if out.Len() != 0 {
@@ -267,7 +267,7 @@ func TestAuthorsOwnExclusionSilencesTheWarning(t *testing.T) {
 	cfg.ApplyDefaults()
 
 	var out bytes.Buffer
-	if _, err := ensureDockerignore(&out, dir, cfg, false); err != nil {
+	if _, _, err := ensureDockerignore(&out, dir, cfg, false); err != nil {
 		t.Fatal(err)
 	}
 	if strings.Contains(out.String(), ".env") {
@@ -287,7 +287,7 @@ func TestBareNamesPruneNestedCopies(t *testing.T) {
 	cfg := &domain.LeoflowConfig{DagID: "d"}
 	cfg.ApplyDefaults()
 
-	if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false); err != nil {
+	if _, _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false); err != nil {
 		t.Fatal(err)
 	}
 	got := readIgnore(t, dir)
@@ -311,7 +311,7 @@ func TestOurBlockBeatsAnEarlierNegation(t *testing.T) {
 	cfg.ExcludePaths = []string{"secrets"}
 	cfg.ApplyDefaults()
 
-	if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false); err != nil {
+	if _, _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false); err != nil {
 		t.Fatal(err)
 	}
 	got := readIgnore(t, dir)
@@ -336,12 +336,12 @@ func TestInterruptedBlockIsStrippedNotAdopted(t *testing.T) {
 	cfg.ApplyDefaults()
 
 	// Build one: interrupted — no cleanup runs.
-	if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false); err != nil {
+	if _, _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false); err != nil {
 		t.Fatal(err)
 	}
 	// Build two: completes.
 	var out bytes.Buffer
-	cleanup, err := ensureDockerignore(&out, dir, cfg, false)
+	cleanup, _, err := ensureDockerignore(&out, dir, cfg, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -365,7 +365,7 @@ func TestMergeIsIdempotentAcrossAnInterruptedBuild(t *testing.T) {
 	cfg.ApplyDefaults()
 
 	for range 3 {
-		if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false); err != nil {
+		if _, _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -422,5 +422,52 @@ func TestBuildActuallyGetsTheDockerignore(t *testing.T) {
 	// And the workspace is clean again afterwards.
 	if _, statErr := os.Stat(filepath.Join(dir, ".dockerignore")); !os.IsNotExist(statErr) {
 		t.Error("the .dockerignore outlived the build")
+	}
+}
+
+// TestSecretDirectoriesAreReachable. The scan skipped anything IsDir(), which
+// made the highest-value hits structurally unreachable: a whole .ssh or .aws
+// copied into a project is a bigger leak than any single file.
+func TestSecretDirectoriesAreReachable(t *testing.T) {
+	dir := writeCtx(t, map[string]string{"dag.py": "x", ".aws/credentials": "key", ".env.production": "P=1"})
+	cfg := &domain.LeoflowConfig{DagID: "d", Dbt: &domain.DbtConfig{Project: "."}}
+	cfg.ApplyDefaults()
+
+	var out bytes.Buffer
+	if _, _, err := ensureDockerignore(&out, dir, cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{".aws", ".env.production"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("no warning for %q, got %q", want, out.String())
+		}
+	}
+}
+
+// TestFindingsComeBackForThePostBuildReminder. A warning printed before minutes
+// of layer output is a warning nobody reads — the repo already learned this and
+// shipped remindDeprecatedPythonAfterBuild for exactly this reason.
+func TestFindingsComeBackForThePostBuildReminder(t *testing.T) {
+	dir := writeCtx(t, map[string]string{"dag.py": "x", ".env": "P=1"})
+	cfg := &domain.LeoflowConfig{DagID: "d", Dbt: &domain.DbtConfig{Project: "."}}
+	cfg.ApplyDefaults()
+
+	_, baked, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(baked) == 0 {
+		t.Fatal("nothing came back, so the post-build reminder can never fire")
+	}
+	var out bytes.Buffer
+	remindBakedSecretsAfterBuild(&out, baked)
+	if !strings.Contains(out.String(), ".env") {
+		t.Errorf("the reminder does not name the file: %q", out.String())
+	}
+	// And it stays silent when there is nothing to say.
+	var quiet bytes.Buffer
+	remindBakedSecretsAfterBuild(&quiet, nil)
+	if quiet.Len() != 0 {
+		t.Errorf("reminded with no findings: %q", quiet.String())
 	}
 }

--- a/internal/cli/compile_dockerignore_test.go
+++ b/internal/cli/compile_dockerignore_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+
 	"github.com/neochaotic/leoflow/internal/domain"
 )
 
@@ -49,7 +51,7 @@ func TestExcludePathsReachTheBuildContext(t *testing.T) {
 	cfg.ExcludePaths = []string{"secrets", "*.pem"}
 	cfg.ApplyDefaults()
 
-	cleanup, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg)
+	cleanup, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +79,7 @@ func TestUserDockerignoreIsMergedNotReplaced(t *testing.T) {
 	cfg := &domain.LeoflowConfig{DagID: "d"}
 	cfg.ApplyDefaults()
 
-	cleanup, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg)
+	cleanup, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,7 +117,7 @@ func TestDbtArtifactsAreScopedToTheirProject(t *testing.T) {
 	cfg.DbtGroups = map[string]*domain.DbtConfig{"a": {Project: "transform"}}
 	cfg.ApplyDefaults()
 
-	if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg); err != nil {
+	if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false); err != nil {
 		t.Fatal(err)
 	}
 	got := readIgnore(t, dir)
@@ -153,7 +155,7 @@ func TestDbtInputsAreNeverExcluded(t *testing.T) {
 	cfg.Dbt = &domain.DbtConfig{Project: ".", Manifest: "target/manifest.json"}
 	cfg.ApplyDefaults()
 
-	if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg); err != nil {
+	if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false); err != nil {
 		t.Fatal(err)
 	}
 	got := readIgnore(t, dir)
@@ -175,7 +177,7 @@ func TestByoProfilesIsWarnedNotDropped(t *testing.T) {
 	cfg.ApplyDefaults()
 
 	var out bytes.Buffer
-	if _, err := ensureDockerignore(&out, dir, cfg); err != nil {
+	if _, err := ensureDockerignore(&out, dir, cfg, false); err != nil {
 		t.Fatal(err)
 	}
 	// Found in the dbt project directory, not just the context root: that is
@@ -192,7 +194,7 @@ func TestNoDbtMeansNoDbtExcludes(t *testing.T) {
 	dir := writeCtx(t, map[string]string{"dag.py": "x"})
 	cfg := &domain.LeoflowConfig{DagID: "d"}
 	cfg.ApplyDefaults()
-	if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg); err != nil {
+	if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false); err != nil {
 		t.Fatal(err)
 	}
 	if got := readIgnore(t, dir); strings.Contains(got, "dbt_packages") {
@@ -205,30 +207,151 @@ func TestNoDbtMeansNoDbtExcludes(t *testing.T) {
 // password ship unnoticed is also wrong. The author is told in time to act.
 func TestSecretishFilesWarnRatherThanVanish(t *testing.T) {
 	dir := writeCtx(t, map[string]string{".env": "PASSWORD=hunter2", "dag.py": "x"})
+	// A dbt project at "." is what makes the generated Dockerfile a wholesale
+	// `COPY . /home/leoflow/`, which is when .env actually ships.
 	cfg := &domain.LeoflowConfig{DagID: "d"}
+	cfg.Dbt = &domain.DbtConfig{Project: "."}
 	cfg.ApplyDefaults()
 
 	var out bytes.Buffer
-	if _, err := ensureDockerignore(&out, dir, cfg); err != nil {
+	if _, err := ensureDockerignore(&out, dir, cfg, false); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(out.String(), ".env") {
-		t.Errorf("no warning for a .env in the build context, got %q", out.String())
+		t.Errorf("no warning for a .env that will be baked, got %q", out.String())
 	}
 	if strings.Contains(readIgnore(t, dir), "\n.env\n") {
 		t.Error(".env was excluded silently; that breaks load_dotenv() far from its cause")
 	}
 
-	// And the warning stops once the author acts on it.
-	cfg2 := &domain.LeoflowConfig{DagID: "d"}
+	// And it stops once the author acts on it.
+	cfg2 := &domain.LeoflowConfig{DagID: "d", Dbt: &domain.DbtConfig{Project: "."}}
 	cfg2.ExcludePaths = []string{".env"}
 	cfg2.ApplyDefaults()
 	var out2 bytes.Buffer
-	if _, err := ensureDockerignore(&out2, dir, cfg2); err != nil {
+	if _, err := ensureDockerignore(&out2, dir, cfg2, false); err != nil {
 		t.Fatal(err)
 	}
 	if strings.Contains(out2.String(), "warning") {
 		t.Errorf("still warning after .env was added to exclude_paths: %q", out2.String())
+	}
+}
+
+// TestNoWarningWhenNothingCopiesIt is the "cries wolf" regression. A plain
+// dag.py project's generated Dockerfile is `COPY dag.py /home/leoflow/dag.py`
+// — the .env never enters the image. Warning that it "will be baked" there is
+// false, and a security warning that fires on the most common project shape
+// trains people to ignore the one that is real.
+func TestNoWarningWhenNothingCopiesIt(t *testing.T) {
+	dir := writeCtx(t, map[string]string{".env": "PASSWORD=hunter2", "dag.py": "x"})
+	cfg := &domain.LeoflowConfig{DagID: "d"}
+	cfg.ApplyDefaults()
+
+	var out bytes.Buffer
+	if _, err := ensureDockerignore(&out, dir, cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("warned about a file no COPY reaches: %q", out.String())
+	}
+}
+
+// TestAuthorsOwnExclusionSilencesTheWarning. Someone who excluded .env in their
+// .dockerignore — the docker-native, obvious place — must not be told to go and
+// duplicate it in leoflow.yaml.
+func TestAuthorsOwnExclusionSilencesTheWarning(t *testing.T) {
+	dir := writeCtx(t, map[string]string{
+		".env": "PASSWORD=hunter2", "dag.py": "x", ".dockerignore": ".env\n",
+	})
+	cfg := &domain.LeoflowConfig{DagID: "d", Dbt: &domain.DbtConfig{Project: "."}}
+	cfg.ApplyDefaults()
+
+	var out bytes.Buffer
+	if _, err := ensureDockerignore(&out, dir, cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out.String(), ".env") {
+		t.Errorf("warned about a file the author had already excluded: %q", out.String())
+	}
+}
+
+// TestBareNamesPruneNestedCopies is Blocker 2. `.dockerignore` is not
+// `.gitignore`: a pattern with no slash matches ONLY at the context root.
+// Measured on both builders — with `__pycache__` and `*.pyc` in the file,
+// `pkg/__pycache__/a.pyc` shipped; with the `**/` forms it did not. Three of
+// the five shipped defaults are names that overwhelmingly appear nested, so
+// without the expansion the feature lands looking delivered and prunes almost
+// nothing.
+func TestBareNamesPruneNestedCopies(t *testing.T) {
+	dir := writeCtx(t, map[string]string{"dag.py": "x"})
+	cfg := &domain.LeoflowConfig{DagID: "d"}
+	cfg.ApplyDefaults()
+
+	if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	got := readIgnore(t, dir)
+	for _, want := range []string{"**/__pycache__", "**/*.pyc", "**/.venv"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q — the default would prune only the context root\n%s", want, got)
+		}
+	}
+}
+
+// TestOurBlockBeatsAnEarlierNegation is the other half of Blocker 2, and it is
+// what makes the documented promise true. Re-emitting a pattern that is already
+// present does NOT override an earlier `!` exception — measured: with
+// `secrets`, `!secrets/keep.pem`, `secrets`, the keep.pem shipped on both
+// builders. Only the `p/**` form wins.
+func TestOurBlockBeatsAnEarlierNegation(t *testing.T) {
+	dir := writeCtx(t, map[string]string{
+		"dag.py": "x", ".dockerignore": "secrets\n!secrets/keep.pem\n",
+	})
+	cfg := &domain.LeoflowConfig{DagID: "d"}
+	cfg.ExcludePaths = []string{"secrets"}
+	cfg.ApplyDefaults()
+
+	if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	got := readIgnore(t, dir)
+	if !strings.Contains(got, "secrets/**") {
+		t.Errorf("no `secrets/**` after the author's negation, so exclude_paths loses to it\n%s", got)
+	}
+	if strings.Index(got, "secrets/**") < strings.Index(got, "!secrets/keep.pem") {
+		t.Errorf("our overriding form precedes the negation, so it does not win\n%s", got)
+	}
+}
+
+// TestInterruptedBlockIsStrippedNotAdopted is Finding 4. There is no signal
+// handling in the CLI, so Ctrl-C during a multi-minute `docker build` kills the
+// process before any defer — that is THE interruption, not a rare one. Read
+// back naively, our leftover block looks like the author's own file, and the
+// next successful build "restores" it permanently: a stale, self-perpetuating,
+// git-committable artifact headed "removed after the build" that no longer
+// tracks leoflow.yaml.
+func TestInterruptedBlockIsStrippedNotAdopted(t *testing.T) {
+	dir := writeCtx(t, map[string]string{"dag.py": "x", ".dockerignore": "big.bin\n"})
+	cfg := &domain.LeoflowConfig{DagID: "d"}
+	cfg.ApplyDefaults()
+
+	// Build one: interrupted — no cleanup runs.
+	if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false); err != nil {
+		t.Fatal(err)
+	}
+	// Build two: completes.
+	var out bytes.Buffer
+	cleanup, err := ensureDockerignore(&out, dir, cfg, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "interrupted build") {
+		t.Errorf("the leftover block was adopted silently, not reported: %q", out.String())
+	}
+	cleanup()
+
+	if got := readIgnore(t, dir); got != "big.bin\n" {
+		t.Errorf("the workspace was not returned to the author's own file, got:\n%q", got)
 	}
 }
 
@@ -242,7 +365,7 @@ func TestMergeIsIdempotentAcrossAnInterruptedBuild(t *testing.T) {
 	cfg.ApplyDefaults()
 
 	for range 3 {
-		if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg); err != nil {
+		if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg, false); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -252,5 +375,52 @@ func TestMergeIsIdempotentAcrossAnInterruptedBuild(t *testing.T) {
 	}
 	if n := strings.Count(got, "\n.git\n"); n != 1 {
 		t.Errorf(".git appears %d times, want 1\n%s", n, got)
+	}
+}
+
+// TestBuildActuallyGetsTheDockerignore binds the feature to a build.
+//
+// Every other test here calls ensureDockerignore directly, so deleting its only
+// caller in buildAndPush left the whole suite green — restoring precisely the
+// #995 condition this PR exists to end: declared, documented, and wired to
+// nothing. For a change whose thesis is "a field nobody consumed", shipping the
+// wiring untested is the same defect one level up.
+//
+// The builder is operator-configurable (ADR 0015: shelled out, no Docker SDK),
+// so a script standing in for `docker` can record what the context looked like
+// at the moment the build ran — which is the only moment that matters.
+func TestBuildActuallyGetsTheDockerignore(t *testing.T) {
+	dir := writeCtx(t, map[string]string{
+		"dag.py": "print('x')", ".env": "PASSWORD=hunter2", ".git/config": "x",
+	})
+	probe := filepath.Join(t.TempDir(), "fake-builder")
+	record := filepath.Join(t.TempDir(), "seen.txt")
+	script := "#!/bin/sh\ncp \"" + dir + "/.dockerignore\" \"" + record + "\" 2>/dev/null\nexit 0\n"
+	if err := os.WriteFile(probe, []byte(script), 0o700); err != nil { //nolint:gosec // a test fixture that must be executable
+		t.Fatal(err)
+	}
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cfg := &domain.LeoflowConfig{DagID: "d", Dbt: &domain.DbtConfig{Project: "."}}
+	cfg.ApplyDefaults()
+	opts := compileOptions{build: true, builder: probe}
+	if err := buildAndPush(cmd, dir, opts, cfg, "img:t"); err != nil {
+		t.Fatalf("buildAndPush: %v", err)
+	}
+
+	seen, err := os.ReadFile(record)
+	if err != nil {
+		t.Fatalf("no .dockerignore existed when the builder ran: %v", err)
+	}
+	for _, want := range []string{".git", "**/__pycache__", generatedDockerfileName} {
+		if !strings.Contains(string(seen), want) {
+			t.Errorf("the builder saw a .dockerignore without %q:\n%s", want, seen)
+		}
+	}
+	// And the workspace is clean again afterwards.
+	if _, statErr := os.Stat(filepath.Join(dir, ".dockerignore")); !os.IsNotExist(statErr) {
+		t.Error("the .dockerignore outlived the build")
 	}
 }

--- a/internal/cli/compile_dockerignore_test.go
+++ b/internal/cli/compile_dockerignore_test.go
@@ -1,0 +1,202 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+func writeCtx(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, body := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func readIgnore(t *testing.T, dir string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, ".dockerignore"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+// TestExcludePathsReachTheBuildContext is the #995 regression. exclude_paths was
+// in the schema, defaulted and documented as "skipped both in image build and
+// workspace discovery" with zero consumers in build code, so with the mode-1
+// default `project: "."` the single `COPY . /home/leoflow/` baked the whole
+// context — a `.env`, a BYO `profiles.yml`, `.git`, and the generated Dockerfile
+// the build had just written.
+func TestExcludePathsReachTheBuildContext(t *testing.T) {
+	dir := writeCtx(t, map[string]string{"dag.py": "x", ".git/config": "x"})
+	cfg := &domain.LeoflowConfig{DagID: "d"}
+	cfg.ExcludePaths = []string{"secrets", "*.pem"}
+	cfg.ApplyDefaults()
+
+	cleanup, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := readIgnore(t, dir)
+	for _, want := range []string{"secrets", "*.pem", generatedDockerfileName} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the .dockerignore does not carry %q; exclude_paths never reached the build\n%s", want, got)
+		}
+	}
+	// The generated Dockerfile is written INTO the context by ensureDockerfile
+	// and has no business inside the image it builds.
+	cleanup()
+	if readIgnore(t, dir) != "" {
+		t.Error("the workspace was left dirty: a .dockerignore we created outlived the build")
+	}
+}
+
+// TestUserDockerignoreIsMergedNotReplaced pins the trap that decided the design.
+// BuildKit's `<dockerfile>.dockerignore` would need no cleanup, but where it is
+// honored it REPLACES the context .dockerignore — measured: with a user file
+// excluding big.bin and a per-Dockerfile file excluding .env, big.bin shipped.
+// Closing one leak by reopening the author's own exclusions is not a fix.
+func TestUserDockerignoreIsMergedNotReplaced(t *testing.T) {
+	dir := writeCtx(t, map[string]string{".dockerignore": "big.bin\n!keep.me\n", "dag.py": "x"})
+	cfg := &domain.LeoflowConfig{DagID: "d"}
+	cfg.ApplyDefaults()
+
+	cleanup, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := readIgnore(t, dir)
+	if !strings.Contains(got, "big.bin") || !strings.Contains(got, "!keep.me") {
+		t.Errorf("the author's own rules were dropped:\n%s", got)
+	}
+	if !strings.Contains(got, ".git") {
+		t.Errorf("our excludes were not added:\n%s", got)
+	}
+	// Ours last: later rules win in .dockerignore, and leoflow.yaml is the
+	// authoritative statement of what may leave in the image.
+	if strings.Index(got, "big.bin") > strings.Index(got, ".git") {
+		t.Errorf("our block precedes the author's, so a stray !rule could defeat exclude_paths:\n%s", got)
+	}
+
+	cleanup()
+	if restored := readIgnore(t, dir); restored != "big.bin\n!keep.me\n" {
+		t.Errorf("the author's .dockerignore was not restored byte-for-byte, got:\n%q", restored)
+	}
+}
+
+// TestDbtArtifactsAreScopedToTheirProject is the #1013 regression. The compile
+// runs a host-side `dbt parse`, which writes into the project it parsed, and the
+// wholesale COPY then bakes the result: `.user.yml` (dbt's anonymous-usage
+// cookie, a stable UUID identifying the BUILD HOST, read by the in-pod dbt so
+// every pod reports as that user) and `logs/dbt.log` (absolute host paths — the
+// #993 class arriving through a door the entrypoint assertions do not watch).
+//
+// Scoped to the project directories rather than added to the defaults, because
+// `logs` and `target` are ordinary names a non-dbt project may want shipped.
+func TestDbtArtifactsAreScopedToTheirProject(t *testing.T) {
+	dir := writeCtx(t, map[string]string{"dag.py": "x"})
+	cfg := &domain.LeoflowConfig{DagID: "d"}
+	cfg.DbtGroups = map[string]*domain.DbtConfig{"a": {Project: "transform"}}
+	cfg.ApplyDefaults()
+
+	if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg); err != nil {
+		t.Fatal(err)
+	}
+	got := readIgnore(t, dir)
+	for _, want := range []string{
+		"transform/target", "transform/logs", "transform/.user.yml",
+		"transform/dbt_packages", "transform/profiles.yml",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q — a dbt build artifact would be baked\n%s", want, got)
+		}
+	}
+	for _, unwanted := range []string{"\nlogs\n", "\ntarget\n"} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("unscoped %q would exclude an unrelated directory in a non-dbt tree\n%s", unwanted, got)
+		}
+	}
+}
+
+func TestNoDbtMeansNoDbtExcludes(t *testing.T) {
+	dir := writeCtx(t, map[string]string{"dag.py": "x"})
+	cfg := &domain.LeoflowConfig{DagID: "d"}
+	cfg.ApplyDefaults()
+	if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if got := readIgnore(t, dir); strings.Contains(got, "dbt_packages") {
+		t.Errorf("a project with no dbt got dbt excludes:\n%s", got)
+	}
+}
+
+// TestSecretishFilesWarnRatherThanVanish. Silently dropping .env would break a
+// DAG that calls load_dotenv() with a failure far from its cause; letting a
+// password ship unnoticed is also wrong. The author is told in time to act.
+func TestSecretishFilesWarnRatherThanVanish(t *testing.T) {
+	dir := writeCtx(t, map[string]string{".env": "PASSWORD=hunter2", "dag.py": "x"})
+	cfg := &domain.LeoflowConfig{DagID: "d"}
+	cfg.ApplyDefaults()
+
+	var out bytes.Buffer
+	if _, err := ensureDockerignore(&out, dir, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), ".env") {
+		t.Errorf("no warning for a .env in the build context, got %q", out.String())
+	}
+	if strings.Contains(readIgnore(t, dir), "\n.env\n") {
+		t.Error(".env was excluded silently; that breaks load_dotenv() far from its cause")
+	}
+
+	// And the warning stops once the author acts on it.
+	cfg2 := &domain.LeoflowConfig{DagID: "d"}
+	cfg2.ExcludePaths = []string{".env"}
+	cfg2.ApplyDefaults()
+	var out2 bytes.Buffer
+	if _, err := ensureDockerignore(&out2, dir, cfg2); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(out2.String(), "warning") {
+		t.Errorf("still warning after .env was added to exclude_paths: %q", out2.String())
+	}
+}
+
+// TestMergeIsIdempotentAcrossAnInterruptedBuild. A build killed before cleanup
+// leaves the merged file behind — a superset of the author's, so it excludes
+// more and never less, which is the right direction to fail in. The next build
+// must not stack duplicate blocks onto it.
+func TestMergeIsIdempotentAcrossAnInterruptedBuild(t *testing.T) {
+	dir := writeCtx(t, map[string]string{".dockerignore": "big.bin\n", "dag.py": "x"})
+	cfg := &domain.LeoflowConfig{DagID: "d"}
+	cfg.ApplyDefaults()
+
+	for range 3 {
+		if _, err := ensureDockerignore(&bytes.Buffer{}, dir, cfg); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := readIgnore(t, dir)
+	if n := strings.Count(got, dockerignoreHeader); n != 1 {
+		t.Errorf("header appears %d times after three interrupted builds, want 1\n%s", n, got)
+	}
+	if n := strings.Count(got, "\n.git\n"); n != 1 {
+		t.Errorf(".git appears %d times, want 1\n%s", n, got)
+	}
+}

--- a/website/content/author-dags/dag-authoring.md
+++ b/website/content/author-dags/dag-authoring.md
@@ -361,6 +361,13 @@ ends. Your rules come first and Leoflow's last, which means `exclude_paths` has
 the final word: a `!` re-include in your `.dockerignore` cannot silently defeat
 an exclusion you declared in `leoflow.yaml`.
 
+Each entry is written out in the forms Docker honours rather than verbatim.
+`.dockerignore` is **not** `.gitignore`: a pattern with no slash matches only at
+the context root, so `__pycache__` alone would leave every nested one in the
+image. Leoflow emits `p`, `**/p` and `p/**` for a bare name — the last of those
+is also what lets `exclude_paths` beat an earlier `!` rule, which re-stating the
+plain pattern does not do.
+
 For a dbt project, two things a host-side `dbt parse` leaves behind are
 excluded automatically, scoped to each project directory: `logs/` and
 `.user.yml`. Both matter beyond image size — `.user.yml` is dbt's

--- a/website/content/author-dags/dag-authoring.md
+++ b/website/content/author-dags/dag-authoring.md
@@ -347,6 +347,41 @@ leoflow push dag.json
 Full, copy-pasteable pipelines for **GitHub Actions, GitLab CI, Google Cloud
 Build/Run, and generic runners** are in **[CI/CD & deploy examples](/operate/cicd-deploy/)**.
 
+#### What ends up in the image
+
+`--build` bakes the build context into the image, and with the default
+`project: "."` that context is your whole DAG directory. The image is pushed to
+a registry and pulled by every pod that runs the DAG, so anything in it is
+shared with everyone who can pull it.
+
+`exclude_paths` in `leoflow.yaml` decides what stays out. During the build it is
+materialized as a `.dockerignore` in the context — merged with your own if you
+have one, and removed afterwards, so the workspace is unchanged when the build
+ends. Your rules come first and Leoflow's last, which means `exclude_paths` has
+the final word: a `!` re-include in your `.dockerignore` cannot silently defeat
+an exclusion you declared in `leoflow.yaml`.
+
+For a dbt project, the artifacts a host-side `dbt parse` leaves behind are
+excluded automatically, scoped to each project directory: `target/`, `logs/`,
+`dbt_packages/`, `.user.yml` and `profiles.yml`. Two of those matter beyond
+image size — `.user.yml` is dbt's anonymous-usage cookie identifying *your*
+machine, and `logs/dbt.log` carries absolute paths from the build host. The
+runtime always generates its own `profiles.yml` from the connection into a
+private directory, so a baked one is a credential nothing will ever read.
+
+Credentials are **not** excluded for you. A `.env` can be a legitimate input —
+a DAG calling `load_dotenv()` reads it at run time — so dropping it silently
+would break that project far from the cause. Instead the build warns:
+
+```console
+warning: .env is in the build context and will be baked into the image, which is
+pushed to a registry and pulled by every pod that runs this DAG. If it holds
+credentials, add ".env" to exclude_paths in leoflow.yaml.
+```
+
+Act on it or declare it deliberately; the warning stops once the file is in
+`exclude_paths`.
+
 ---
 
 See also: [Concepts & glossary](/concepts/core-concepts/) · [Operating modes](/concepts/editions/)

--- a/website/content/author-dags/dag-authoring.md
+++ b/website/content/author-dags/dag-authoring.md
@@ -361,17 +361,23 @@ ends. Your rules come first and Leoflow's last, which means `exclude_paths` has
 the final word: a `!` re-include in your `.dockerignore` cannot silently defeat
 an exclusion you declared in `leoflow.yaml`.
 
-For a dbt project, the artifacts a host-side `dbt parse` leaves behind are
-excluded automatically, scoped to each project directory: `target/`, `logs/`,
-`dbt_packages/`, `.user.yml` and `profiles.yml`. Two of those matter beyond
-image size — `.user.yml` is dbt's anonymous-usage cookie identifying *your*
-machine, and `logs/dbt.log` carries absolute paths from the build host. The
-runtime always generates its own `profiles.yml` from the connection into a
-private directory, so a baked one is a credential nothing will ever read.
+For a dbt project, two things a host-side `dbt parse` leaves behind are
+excluded automatically, scoped to each project directory: `logs/` and
+`.user.yml`. Both matter beyond image size — `.user.yml` is dbt's
+anonymous-usage cookie identifying *your* machine, and it is read by the in-pod
+dbt, so every pod from that image reports as you; `logs/dbt.log` carries
+absolute paths from the build host.
 
-Credentials are **not** excluded for you. A `.env` can be a legitimate input —
-a DAG calling `load_dotenv()` reads it at run time — so dropping it silently
-would break that project far from the cause. Instead the build warns:
+Nothing else in a dbt project is excluded, deliberately. `target/` holds the
+manifest `dbt.manifest` points at, `dbt_packages/` is where `dbt deps`
+installs, and `profiles.yml` may be a BYO profile you point `DBT_PROFILES_DIR`
+at — each is a real input in a configuration people use, so excluding them
+would break working projects.
+
+Credentials are **not** excluded for you either. A `.env` can be a legitimate
+input — a DAG calling `load_dotenv()` reads it at run time — and so can a BYO
+`profiles.yml`, so dropping either silently would break that project far from
+the cause. Instead the build warns:
 
 ```console
 warning: .env is in the build context and will be baked into the image, which is

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -108,7 +108,7 @@ roadmap item.
 | `connectors` | `[]` | Short connector names expanded to provider packages at compile (ADR 0038). |
 | `system_packages` | `[]` | apt packages. `apt-get install`ed into the DAG image at compile, resolving against the task base image's Debian suite — see the `system_packages` row under [leoflow.yaml](#leoflowyaml) for which suite that is and what moved. |
 | `include_paths` | `["."]` | Files copied into the image. |
-| `exclude_paths` | `[".git", "__pycache__", "*.pyc", ".venv", "venv"]` | Skipped both in image build **and** workspace discovery. Hidden directories (`.*`) are skipped as well. |
+| `exclude_paths` | `[".git", "__pycache__", "*.pyc", ".venv", "venv"]` | Skipped both in image build **and** workspace discovery. Hidden directories (`.*`) are skipped as well. On `--build`, these become a `.dockerignore` in the build context for the duration of the build — merged with yours if you have one, and removed afterwards. Add anything holding credentials: the image is pushed to a registry and pulled by every pod that runs the DAG. |
 | `build.context` | `"."` | Docker build context. |
 | `build.platforms` | `["linux/amd64"]` | Multi-arch via `["linux/amd64","linux/arm64"]`. |
 | `registry.auth_method` | `"docker_config"` | Credential source for `compile --push`. |

--- a/website/content/reference/configuration.md
+++ b/website/content/reference/configuration.md
@@ -108,7 +108,7 @@ roadmap item.
 | `connectors` | `[]` | Short connector names expanded to provider packages at compile (ADR 0038). |
 | `system_packages` | `[]` | apt packages. `apt-get install`ed into the DAG image at compile, resolving against the task base image's Debian suite — see the `system_packages` row under [leoflow.yaml](#leoflowyaml) for which suite that is and what moved. |
 | `include_paths` | `["."]` | Files copied into the image. |
-| `exclude_paths` | `[".git", "__pycache__", "*.pyc", ".venv", "venv"]` | Skipped both in image build **and** workspace discovery. Hidden directories (`.*`) are skipped as well. On `--build`, these become a `.dockerignore` in the build context for the duration of the build — merged with yours if you have one, and removed afterwards. Add anything holding credentials: the image is pushed to a registry and pulled by every pod that runs the DAG. |
+| `exclude_paths` | `[".git", "__pycache__", "*.pyc", ".venv", "venv"]` | Kept out of the image. On `--build` these become a `.dockerignore` in the build context for the duration of the build — merged with yours if you have one, and removed afterwards. Each entry is expanded to the forms Docker actually honours (`p`, `**/p`, `p/**`), because a bare name in a `.dockerignore` matches only at the context root. Add anything holding credentials: the image is pushed to a registry and pulled by every pod that runs the DAG. **Not** used by workspace discovery, which has its own hardcoded skip list. |
 | `build.context` | `"."` | Docker build context. |
 | `build.platforms` | `["linux/amd64"]` | Multi-arch via `["linux/amd64","linux/arm64"]`. |
 | `registry.auth_method` | `"docker_config"` | Credential source for `compile --push`. |


### PR DESCRIPTION
fix(cli): make exclude_paths reach the image build, and stop baking dbt's host artifacts

`exclude_paths` has been in the schema, defaulted, and documented as "skipped
both in image build and workspace discovery" while having **zero consumers in
build code** (#995). With `project: "."` — mode 1's documented default — the
generated Dockerfile is one `COPY . /home/leoflow/`, so the whole context was
baked. Measured on a probe image before this change: a `.env` holding a
warehouse password, a BYO `profiles.yml` with credentials, `.git`, and the
generated Dockerfile the build had just written.

The same door let dbt's host-side artifacts through (#1013). The compile runs
`dbt parse` on the host, that parse writes into the project it parsed, and the
wholesale COPY baked the result: `.user.yml` — dbt's anonymous-usage cookie, a
stable UUID identifying the BUILD HOST's dbt user, read by the in-pod dbt so
every pod reports as that same user — and `logs/dbt.log`, carrying absolute host
paths. That last one is the #993 class arriving through a door the entrypoint
assertions do not watch: #993 was about the entrypoint, the entrypoint is clean,
and the image leaked the paths anyway.

exclude_paths is now materialized as a `.dockerignore` for the duration of the
build, with the same write/restore lifecycle as the generated Dockerfile.

**Two measurements decided the form**, and both ruled out the tidier option.
BuildKit's `<dockerfile>.dockerignore` needs no cleanup and cannot touch a file
the user owns, but:

- the legacy builder ignores it entirely. Built with DOCKER_BUILDKIT=0 against
  a context whose per-Dockerfile ignore listed `.env`, the `.env` landed in the
  image. A silent leak on a builder the operator can still select is worse than
  no feature.
- where it IS honored it REPLACES the context `.dockerignore` rather than adding
  to it. With a user file excluding `big.bin` and a per-Dockerfile file
  excluding `.env`, `big.bin` shipped. Closing one leak by reopening whatever
  the author had closed is not a fix.

So: the plain form, merged. The author's rules come first and ours last, because
later rules win in .dockerignore syntax and leoflow.yaml is the authoritative
statement of what may leave in the image — a stray `!secrets/x` must not
silently defeat an `exclude_paths: [secrets/]` written deliberately. The
original is held in a closure rather than a sibling backup file so nothing extra
can enter the context, and a build killed before cleanup leaves the MERGED file:
a superset of the author's, excluding more and never less.

dbt artifacts are scoped per project directory rather than added to the
defaults, because `logs` and `target` are ordinary names a non-dbt project may
want shipped. `profiles.yml` is in that set because it is provably dead in the
image, not merely unwanted: the runtime ALWAYS generates profiles.yml into a
private 0700 DBT_PROFILES_DIR from the connection and never reads one out of
the project, so a baked one is warehouse credentials nothing will ever load.

**Credentials are deliberately NOT excluded for you.** A `.env` can be a real
input — a DAG calling load_dotenv() reads it at run time — so dropping it
silently would break that project with a failure far from its cause. Letting a
password ship unnoticed is also wrong. The build warns instead, once, naming the
file and the one-line fix, and stops warning when the author acts.

Before/after on the probe image, same context:

  before: .env, transform/profiles.yml, transform/.user.yml,
          transform/logs/dbt.log (with /Users/... in it), .git,
          .leoflow.generated.Dockerfile
  after:  transform/ reduced to dbt_project.yml + models; no profiles.yml, no
          .user.yml, no logs, no host paths; .git and the generated Dockerfile
          gone; the author's own big.bin exclusion still honored; .env still
          present, with the warning printed

Six regression tests. Five mutations, each verified applied by comparing the
file's checksum before and after rather than trusting the edit: reverting to the
per-Dockerfile name, overwriting instead of merging, putting our block first,
dropping the dbt scoping, and skipping the cleanup all turn the suite red.

Closes #995
Closes #1013