### PR TITLE
fix(api): stop database errors reaching tenants, keep them in the log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -421,6 +421,29 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   not-ready rather than report nothing at all. An **ahead** schema still passes,
   as it does at boot — expand-contract migrations keep older code working, and
   failing it would break `helm rollback`.
+
+### Security
+
+- **Database errors no longer reach API clients (#961).** A repository failure
+  used to be rendered into the problem-detail body verbatim, and Postgres
+  errors render themselves as `severity: message (SQLSTATE code)` — with the
+  constraint, table and column names of the schema inside the message. Only
+  SQLSTATE `23505` was translated (to a 409), so every other code — a `23503`
+  foreign-key violation, `23502` not-null, `42P01` on a database whose
+  migration is behind, `40001`, `53300` — was disclosed to any authenticated
+  tenant of a multi-tenant control plane (CWE-209). A `pgconn` connect failure
+  additionally carries the database user and name, and reached the 499 branch
+  the same way because it satisfies `errors.Is(err, context.DeadlineExceeded)`.
+
+  Responses now carry a fixed phrase per condition — a 404 still reads as
+  missing, a 409 as a conflict, a 400 as rejected input — and the real error
+  goes to the request log under a new `cause` field, so nothing an operator
+  needs is lost. The default is deny rather than allow: only a message Leoflow
+  composed itself (`domain.Safef`) is echoed, so a newly wrapped driver error
+  cannot leak by omission. The messages worth reading survive unchanged — an
+  unknown role, an undeclared variable or connection, a `max_active_runs` cap,
+  the undeletable default pool.
+
 ### Testing
 
 - **The DAG base-image pin is now verified end to end, for both of its branches

--- a/internal/api/leakscan_scrub_test.go
+++ b/internal/api/leakscan_scrub_test.go
@@ -6,8 +6,12 @@ import (
 	"testing"
 )
 
-// pgLeaks are the database internals no error body may carry to a client.
-var pgLeaks = []string{"23505", "dag_versions_unique", "SQLSTATE"}
+// pgLeaks are the database internals no error body may carry to a client. The
+// severity prefixes are here because the disclosure class is wider than the one
+// SQLSTATE #746 hardened: pgconn renders EVERY server error as
+// "severity: message (SQLSTATE code)", so "ERROR:" catches an unmapped code
+// whose number nobody thought to list (#961).
+var pgLeaks = []string{"23505", "dag_versions_unique", "SQLSTATE", "ERROR:", "FATAL:"}
 
 func TestLeakScanTargetIgnoresTheEchoedIdentifier(t *testing.T) {
 	// The dag id and body from the observed failure, where the timestamp
@@ -50,7 +54,7 @@ func TestLeakScanTargetStillSeesARealLeak(t *testing.T) {
 // token from pgLeaks makes every test above easier and silently weakens the
 // integration assertion that consumes it, so the floor is pinned here.
 func TestPgLeaksCoversTheKnownPgInternals(t *testing.T) {
-	for _, want := range []string{"23505", "dag_versions_unique", "SQLSTATE"} {
+	for _, want := range []string{"23505", "dag_versions_unique", "SQLSTATE", "ERROR:", "FATAL:"} {
 		if !slices.Contains(pgLeaks, want) {
 			t.Errorf("pgLeaks no longer covers %q; the 409 leak scan is weaker than it was", want)
 		}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -20,7 +20,11 @@ const (
 	// can surface WHY a 4xx/5xx happened — otherwise a failing request is logged
 	// only as a status code, with no cause (an observability blind spot).
 	contextKeyProblemDetail = "leoflow.problem_detail"
-	headerRequestID         = "X-Request-Id"
+	// contextKeyProblemCause carries the real error behind a redacted detail.
+	// The response says "the request could not be completed"; this says which
+	// SQLSTATE, on which operation, so the operator is not left guessing.
+	contextKeyProblemCause = "leoflow.problem_cause"
+	headerRequestID        = "X-Request-Id"
 )
 
 // RequestID assigns a request id (honoring an inbound X-Request-Id) and echoes it.
@@ -68,6 +72,12 @@ func StructuredLogger(logger *slog.Logger) gin.HandlerFunc {
 		// request (WARN). Below 400 stays INFO.
 		if detail := c.GetString(contextKeyProblemDetail); detail != "" {
 			attrs = append(attrs, "detail", detail)
+		}
+		// The detail is what the CLIENT was told, which for a storage failure is
+		// a deliberately vague phrase. The cause is the error itself; without it
+		// the log would say only that something went wrong.
+		if cause := c.GetString(contextKeyProblemCause); cause != "" {
+			attrs = append(attrs, "cause", cause)
 		}
 		switch {
 		case status >= 500:

--- a/internal/api/problem.go
+++ b/internal/api/problem.go
@@ -12,7 +12,30 @@ type Problem struct {
 	Instance string `json:"instance,omitempty"`
 }
 
+// AbortProblemCause writes an RFC 7807 problem whose detail is safe to show the
+// caller, while handing the real error to the request log.
+//
+// It exists because the two audiences need different text. A storage failure
+// carries the driver's own message — for Postgres, "severity: message (SQLSTATE
+// code)" with our constraint, table and column names inside — and a tenant of a
+// multi-tenant control plane must not receive that (CWE-209). The operator, on
+// the other hand, cannot diagnose the failure without it. Redacting the
+// response and dropping the cause would trade one defect for another, so cause
+// is logged verbatim under its own field.
+//
+// cause may be nil, which makes this identical to AbortProblem.
+func AbortProblemCause(c *gin.Context, status int, title, detail string, cause error) {
+	if cause != nil {
+		c.Set(contextKeyProblemCause, cause.Error())
+	}
+	AbortProblem(c, status, title, detail)
+}
+
 // AbortProblem writes an RFC 7807 problem response and stops the handler chain.
+//
+// detail is sent to the client as-is, so it must never carry a driver,
+// filesystem, or network error's text. Where the real cause must stay
+// server-side, use AbortProblemCause.
 func AbortProblem(c *gin.Context, status int, title, detail string) {
 	// Record the cause so StructuredLogger can log WHY this failed (4xx/5xx are
 	// otherwise logged as a bare status code).

--- a/internal/api/repo_error_leak_test.go
+++ b/internal/api/repo_error_leak_test.go
@@ -1,0 +1,335 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// The fixtures below are the error VALUES the driver hands us, not hand-written
+// strings: a *pgconn.PgError renders itself as
+// "severity: message (SQLSTATE code)", and its message carries the constraint,
+// table and column names of our schema. A test built on a hand-made string
+// would only prove that a clean string stays clean.
+
+func pgForeignKeyViolation() *pgconn.PgError {
+	return &pgconn.PgError{
+		Severity:            "ERROR",
+		SeverityUnlocalized: "ERROR",
+		Code:                "23503",
+		Message:             `insert or update on table "dag_versions" violates foreign key constraint "dag_versions_dag_id_fkey"`,
+		Detail:              `Key (dag_id)=(6f1c0f2e-0c3f-4a1d-9a3e-2c9a0f4b7d11) is not present in table "dags".`,
+		SchemaName:          "leoflow",
+		TableName:           "dag_versions",
+		ConstraintName:      "dag_versions_dag_id_fkey",
+		File:                "ri_triggers.c",
+		Line:                2528,
+		Routine:             "ri_ReportViolation",
+	}
+}
+
+func pgNotNullViolation() *pgconn.PgError {
+	return &pgconn.PgError{
+		Severity:            "ERROR",
+		SeverityUnlocalized: "ERROR",
+		Code:                "23502",
+		Message:             `null value in column "spec_hash" of relation "dag_versions" violates not-null constraint`,
+		SchemaName:          "leoflow",
+		TableName:           "dag_versions",
+		ColumnName:          "spec_hash",
+		File:                "execMain.c",
+		Routine:             "ExecConstraints",
+	}
+}
+
+func pgUndefinedTable() *pgconn.PgError {
+	return &pgconn.PgError{
+		Severity:            "ERROR",
+		SeverityUnlocalized: "ERROR",
+		Code:                "42P01",
+		Message:             `relation "dag_versions" does not exist`,
+		Position:            13,
+		File:                "parse_relation.c",
+		Routine:             "parserOpenTable",
+	}
+}
+
+func pgTooManyConnections() *pgconn.PgError {
+	return &pgconn.PgError{
+		Severity:            "FATAL",
+		SeverityUnlocalized: "FATAL",
+		Code:                "53300",
+		Message:             "sorry, too many clients already",
+		File:                "proc.c",
+		Routine:             "InitProcess",
+	}
+}
+
+// pgLeakTokens are the substrings that must never appear in a response body for
+// pe: the SQLSTATE marker and code, the server's message (which carries the
+// constraint name), and every schema identifier the driver attached.
+func pgLeakTokens(pe *pgconn.PgError) []string {
+	tokens := []string{"SQLSTATE", pe.Code, pe.Message, pe.Error(), pe.Severity + ":"}
+	for _, id := range []string{pe.ConstraintName, pe.TableName, pe.ColumnName, pe.SchemaName, pe.Routine, pe.File} {
+		if id != "" {
+			tokens = append(tokens, id)
+		}
+	}
+	return tokens
+}
+
+func assertNoPgLeak(t *testing.T, where, body string, pe *pgconn.PgError, echoed ...string) {
+	t.Helper()
+	scanned := leakScanTarget(body, echoed...)
+	for _, leak := range pgLeakTokens(pe) {
+		if strings.Contains(scanned, leak) {
+			t.Errorf("%s: response body leaks database internals (%q): %s", where, leak, scanned)
+		}
+	}
+}
+
+// TestHandleRepoErrorNeverLeaksDriverTextToTheClient is the regression guard for
+// #961. Every branch of the repository-error funnel is driven with a real
+// *pgconn.PgError riding along, because that is how the leak reappears: a new
+// SQLSTATE that mapConflict does not translate, or an existing sentinel joined
+// with the driver error that produced it. The status classes must survive
+// unchanged (a conflict stays a 409, a missing row stays a 404) while the body
+// carries none of the driver's text — and the server log must still carry all
+// of it, or we have traded a disclosure bug for a blindness bug.
+func TestHandleRepoErrorNeverLeaksDriverTextToTheClient(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	fk := pgForeignKeyViolation()
+	notNull := pgNotNullViolation()
+	undefined := pgUndefinedTable()
+	tooMany := pgTooManyConnections()
+
+	cases := []struct {
+		name   string
+		err    error
+		pgErr  *pgconn.PgError
+		status int
+	}{
+		{
+			name:   "unmapped SQLSTATE falls through to 500",
+			err:    fmt.Errorf("upserting dag: %w", fk),
+			pgErr:  fk,
+			status: http.StatusInternalServerError,
+		},
+		{
+			name:   "undefined table (migration behind) is a 500",
+			err:    fmt.Errorf("checking existing version: %w", undefined),
+			pgErr:  undefined,
+			status: http.StatusInternalServerError,
+		},
+		{
+			name:   "connection exhaustion is a 500",
+			err:    fmt.Errorf("listing dags: %w", tooMany),
+			pgErr:  tooMany,
+			status: http.StatusInternalServerError,
+		},
+		{
+			name:   "driver error joined to a not-found stays a 404",
+			err:    errors.Join(domain.ErrNotFound, notNull),
+			pgErr:  notNull,
+			status: http.StatusNotFound,
+		},
+		{
+			name:   "driver error joined to a conflict stays a 409",
+			err:    errors.Join(domain.ErrConflict, fk),
+			pgErr:  fk,
+			status: http.StatusConflict,
+		},
+		{
+			name:   "driver error joined to a validation failure stays a 400",
+			err:    errors.Join(domain.ErrValidation, fk),
+			pgErr:  fk,
+			status: http.StatusBadRequest,
+		},
+		{
+			name:   "driver error joined to a client cancel stays a 499",
+			err:    errors.Join(context.Canceled, fk),
+			pgErr:  fk,
+			status: statusClientClosedRequest,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			r := gin.New()
+			r.Use(StructuredLogger(logger))
+			r.GET("/x", func(c *gin.Context) { handleRepoError(c, tc.err) })
+
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", http.NoBody))
+
+			if rec.Code != tc.status {
+				t.Errorf("status = %d, want %d (%s)", rec.Code, tc.status, rec.Body.String())
+			}
+			assertNoPgLeak(t, "handleRepoError", rec.Body.String(), tc.pgErr)
+
+			// The operator keeps everything the tenant lost: the SQLSTATE, the
+			// server's message (constraint name included) and the operation the
+			// repository was performing.
+			var logLine map[string]any
+			if err := json.Unmarshal(logBuf.Bytes(), &logLine); err != nil {
+				t.Fatalf("log line is not JSON: %q", logBuf.String())
+			}
+			cause, _ := logLine["cause"].(string)
+			for _, want := range []string{tc.pgErr.Code, tc.pgErr.Message, tc.pgErr.Error()} {
+				if !strings.Contains(cause, want) {
+					t.Errorf("server log lost %q, so the failure is no longer diagnosable: %v", want, logLine)
+				}
+			}
+		})
+	}
+}
+
+// TestHandleRepoErrorRedactsAConnectionStringOnTheCancelBranch covers the case
+// no PgError fixture can: a pgconn.ConnectError renders the database user and
+// name, and a connect TIMEOUT satisfies errors.Is(err, context.DeadlineExceeded)
+// — so before #961 it took the 499 branch and echoed the DSN identity there,
+// nowhere near the 500 the issue was written about. The error is produced by
+// dialing, not hand-built, because ConnectError's inner error is unexported.
+func TestHandleRepoErrorRedactsAConnectionStringOnTheCancelBranch(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	// TEST-NET-3 is routable nowhere, so the dial runs into the deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	_, connErr := pgconn.Connect(ctx,
+		"postgres://leoflow_app:s3cr3t@203.0.113.1:5432/leoflow_meta?sslmode=disable&connect_timeout=1")
+	if connErr == nil {
+		t.Skip("the dial unexpectedly succeeded; no connect error to redact")
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", http.NoBody)
+	handleRepoError(c, fmt.Errorf("listing dags: %w", connErr))
+
+	// Whichever branch it lands on (499 when the deadline is what surfaced, 500
+	// otherwise), the identity of the database must not be in the body.
+	body := rec.Body.String()
+	for _, leak := range []string{"leoflow_app", "leoflow_meta", "203.0.113.1", "failed to connect", connErr.Error()} {
+		if strings.Contains(body, leak) {
+			t.Errorf("response body leaks the connection string (%q): %s", leak, body)
+		}
+	}
+}
+
+// TestRegisterVersionUnmappedDriverErrorIsOpaque drives the real route the issue
+// was found on. mapConflict translates only 23505; a 23503 reaches the handler
+// unchanged, and before #961 the constraint name and SQLSTATE went straight into
+// the 500 body.
+func TestRegisterVersionUnmappedDriverErrorIsOpaque(t *testing.T) {
+	fk := pgForeignKeyViolation()
+	repo := &fakeVersionRepo{err: fmt.Errorf("upserting dag: %w", fk)}
+	rec := authGet(versionServer(repo), http.MethodPost, "/api/v2/dags/etl/versions", validSpecJSON)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("unmapped driver error = %d, want 500 (%s)", rec.Code, rec.Body.String())
+	}
+	assertNoPgLeak(t, "POST /versions", rec.Body.String(), fk, "etl")
+}
+
+// TestTriggerDagRunSpecReadDriverErrorIsOpaque covers the second unguarded call
+// site: applyDeclaredParams concatenated the spec-read error into its own 500
+// detail, bypassing the funnel entirely.
+func TestTriggerDagRunSpecReadDriverErrorIsOpaque(t *testing.T) {
+	fk := pgForeignKeyViolation()
+	srv := NewServer(Dependencies{
+		Logger:        discardLogger(),
+		Authenticator: &fakeAuthn{user: &auth.User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}},
+		RateLimiter:   auth.NewRateLimiter(100, time.Minute),
+		CORSOrigins:   []string{"*"},
+		DagRuns:       &fakeRunRepo{},
+		Specs:         &fakeSpecReader{err: fmt.Errorf("loading current spec: %w", fk)},
+	})
+	rec := authGet(srv, http.MethodPost, "/api/v2/dags/etl/dagRuns", `{"dag_run_id":"manual__1","conf":{"limit":5}}`)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("spec read failure = %d, want 500 (%s)", rec.Code, rec.Body.String())
+	}
+	assertNoPgLeak(t, "POST /dagRuns", rec.Body.String(), fk, "etl")
+}
+
+// TestSafeErrorMessagesStillReachTheClient is the other half of the contract.
+// Redacting everything would be easy and useless: the messages Leoflow composes
+// itself — an unknown role, a max_active_runs cap — are the ones a caller can
+// act on, so they must survive the redaction that removes the driver's.
+func TestSafeErrorMessagesStillReachTheClient(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cases := []struct {
+		name   string
+		err    error
+		status int
+		want   string
+	}{
+		{
+			name:   "validation message survives",
+			err:    domain.Safef(domain.ErrValidation, "unknown role %q", "analyst"),
+			status: http.StatusBadRequest,
+			want:   `unknown role "analyst"`,
+		},
+		{
+			name:   "conflict message survives",
+			err:    fmt.Errorf("creating dag run: %w", domain.Safef(domain.ErrConflict, "dag %q is at max_active_runs cap of %d", "etl", 3)),
+			status: http.StatusConflict,
+			want:   `dag "etl" is at max_active_runs cap of 3`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", http.NoBody)
+			handleRepoError(c, tc.err)
+			if rec.Code != tc.status {
+				t.Fatalf("status = %d, want %d (%s)", rec.Code, tc.status, rec.Body.String())
+			}
+			var p Problem
+			if err := json.Unmarshal(rec.Body.Bytes(), &p); err != nil {
+				t.Fatalf("body is not a problem document: %v (%s)", err, rec.Body.String())
+			}
+			if !strings.Contains(p.Detail, tc.want) {
+				t.Errorf("detail = %q, want it to carry %q", p.Detail, tc.want)
+			}
+		})
+	}
+}
+
+// TestSafeErrorDoesNotCarryDriverTextThrough guards the one way the allowlist
+// could be defeated: a Safef message is returned verbatim, so interpolating a
+// driver error into one would reopen the hole. Nothing in the tree does it, and
+// this pins that a Safef built around a sentinel alone stays clean.
+func TestSafeErrorDoesNotCarryDriverTextThrough(t *testing.T) {
+	fk := pgForeignKeyViolation()
+	err := errors.Join(domain.Safef(domain.ErrConflict, "the default pool cannot be deleted"), fk)
+
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", http.NoBody)
+	handleRepoError(c, err)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 (%s)", rec.Code, rec.Body.String())
+	}
+	assertNoPgLeak(t, "safe conflict beside a driver error", rec.Body.String(), fk)
+	if !strings.Contains(rec.Body.String(), "the default pool cannot be deleted") {
+		t.Errorf("the composed message was dropped: %s", rec.Body.String())
+	}
+}

--- a/internal/api/resources.go
+++ b/internal/api/resources.go
@@ -115,32 +115,71 @@ func tenantOf(c *gin.Context) string {
 // aborted before the server finished — not a server fault.
 const statusClientClosedRequest = 499
 
+// Client-facing details for a repository failure whose cause must stay
+// server-side. They are constants because a repository error normally wraps a
+// driver error, and pgconn renders a *pgconn.PgError as "severity: message
+// (SQLSTATE code)" with our constraint, table and column names inside the
+// message — schema disclosure to any authenticated tenant (CWE-209, #961).
+//
+// One phrase per condition, not one phrase overall: the split is the same one
+// unreadyDetail makes in health.go. "Does not exist", "conflicts", "was
+// rejected" and "could not be completed" send a caller to four different
+// places, and collapsing them into a single opaque message would cost real
+// diagnosability to buy no extra privacy.
+const (
+	detailNotFound     = "the requested resource does not exist"
+	detailConflict     = "the request conflicts with the current state of the resource"
+	detailClientClosed = "the client closed the request before it completed"
+	detailInvalidInput = "the request was rejected by a validation rule"
+	detailInternal     = "the request could not be completed; see the server logs"
+)
+
+// safeDetail returns the phrase Leoflow composed for this failure, or fallback
+// when the error carries no such phrase.
+//
+// The default is deny. Only a domain.SafeError — an error someone deliberately
+// wrote as client-facing — contributes text to a response body; everything
+// else, including every fmt.Errorf wrap of a driver error, is replaced. That
+// way a newly introduced storage error cannot leak by omission: it leaks only
+// if someone rewrites it as a SafeError, which is the one construct whose
+// GoDoc says its message is shown to clients.
+func safeDetail(err error, fallback string) string {
+	var safe *domain.SafeError
+	if errors.As(err, &safe) && safe.ClientMessage() != "" {
+		return safe.ClientMessage()
+	}
+	return fallback
+}
+
+// handleRepoError maps a repository failure to a status and a client-safe
+// detail, and hands the real error to the request log (see AbortProblemCause).
+// It is the single funnel for storage errors in this package; a handler that
+// renders a repository error any other way must apply the same redaction.
 func handleRepoError(c *gin.Context, err error) {
-	if errors.Is(err, ErrNotFound) {
-		AbortProblem(c, http.StatusNotFound, "not found", err.Error())
-		return
-	}
-	if errors.Is(err, domain.ErrConflict) {
-		AbortProblem(c, http.StatusConflict, "conflict", err.Error())
-		return
-	}
+	switch {
+	case errors.Is(err, ErrNotFound):
+		AbortProblemCause(c, http.StatusNotFound, "not found", safeDetail(err, detailNotFound), err)
+	case errors.Is(err, domain.ErrConflict):
+		AbortProblemCause(c, http.StatusConflict, "conflict", safeDetail(err, detailConflict), err)
 	// A canceled/timed-out context means the client went away (the UI routinely
 	// supersedes in-flight grid requests). That is NOT a server error — mapping it
 	// to 500 produced spurious ti_summaries 500s under rapid refresh. Report 499 so
-	// it logs as a client-side 4xx, not a server fault.
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		AbortProblem(c, statusClientClosedRequest, "client closed request", err.Error())
-		return
-	}
+	// it logs as a client-side 4xx, not a server fault. The detail is fixed rather
+	// than composed: pgconn reports a connect timeout as a ConnectError whose text
+	// carries the database user and name, and that error satisfies
+	// errors.Is(err, context.DeadlineExceeded).
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		AbortProblemCause(c, statusClientClosedRequest, "client closed request", detailClientClosed, err)
 	// A business-rule input failure (unknown role, undeclared variable/connection)
-	// is the client's to fix, not a server fault. Every domain.ErrValidation wrap
-	// site is client-supplied input, so map the whole class to 400 — otherwise it
-	// reads as a server error and points users at the logs instead of their request.
-	if errors.Is(err, domain.ErrValidation) {
-		AbortProblem(c, http.StatusBadRequest, "invalid request", err.Error())
-		return
+	// is the client's to fix, not a server fault, so the whole class maps to 400 —
+	// otherwise it reads as a server error and points users at the logs instead of
+	// their request. The rule that rejected it is stated only when the storage
+	// layer composed the phrase itself with domain.Safef.
+	case errors.Is(err, domain.ErrValidation):
+		AbortProblemCause(c, http.StatusBadRequest, "invalid request", safeDetail(err, detailInvalidInput), err)
+	default:
+		AbortProblemCause(c, http.StatusInternalServerError, "internal error", detailInternal, err)
 	}
-	AbortProblem(c, http.StatusInternalServerError, "internal error", err.Error())
 }
 
 func listDagsHandler(repo DagRepository) gin.HandlerFunc {
@@ -365,7 +404,9 @@ func applyDeclaredParams(c *gin.Context, specs DagSpecReader, dagID string, conf
 	if err != nil {
 		// A real spec-read failure must NOT silently skip param validation on a
 		// DAG that may declare typed params — fail loud instead of fail open.
-		AbortProblem(c, http.StatusInternalServerError, "internal error", "loading DAG params: "+err.Error())
+		// The read goes to storage, so the error is redacted like any other
+		// (#961) and the cause is logged.
+		AbortProblemCause(c, http.StatusInternalServerError, "internal error", detailInternal, err)
 		return nil, false
 	}
 	if len(spec.Params) == 0 {
@@ -377,7 +418,7 @@ func applyDeclaredParams(c *gin.Context, specs DagSpecReader, dagID string, conf
 	}
 	out, merr := json.Marshal(merged)
 	if merr != nil {
-		AbortProblem(c, http.StatusInternalServerError, "internal error", "encoding merged conf: "+merr.Error())
+		AbortProblemCause(c, http.StatusInternalServerError, "internal error", detailInternal, merr)
 		return nil, false
 	}
 	return out, true

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -183,7 +183,9 @@ func recordUserCreatedAudit(c *gin.Context, audit UserAuditWriter, u domain.User
 // handleRepoError (duplicate email -> 409, cancellation -> 499, else 500).
 func handleUserWriteError(c *gin.Context, err error) {
 	if errors.Is(err, domain.ErrValidation) {
-		AbortProblem(c, http.StatusBadRequest, "bad request", err.Error())
+		// Same redaction as the funnel: only a phrase the storage layer composed
+		// with domain.Safef reaches the caller (#961).
+		AbortProblemCause(c, http.StatusBadRequest, "bad request", safeDetail(err, detailInvalidInput), err)
 		return
 	}
 	handleRepoError(c, err)

--- a/internal/api/versions.go
+++ b/internal/api/versions.go
@@ -41,7 +41,11 @@ func registerVersionHandler(repo DagVersionRepository) gin.HandlerFunc {
 		}
 		hash, err := spec.CanonicalHash()
 		if err != nil {
-			AbortProblem(c, http.StatusInternalServerError, "internal error", err.Error())
+			// Hashing touches no storage, so this error carries nothing from the
+			// database — but a 500 detail is a constant here for the same reason
+			// it is everywhere else: nobody re-audits a call site when the error
+			// source behind it changes.
+			AbortProblemCause(c, http.StatusInternalServerError, "internal error", detailInternal, err)
 			return
 		}
 		created, err := repo.RegisterDagVersion(c.Request.Context(), tenantOf(c), spec, hash)

--- a/internal/api/versions_leak_integration_test.go
+++ b/internal/api/versions_leak_integration_test.go
@@ -1,0 +1,71 @@
+//go:build integration
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/config"
+	"github.com/neochaotic/leoflow/internal/storage"
+)
+
+// TestRegisterVersionUnmappedSQLSTATEIsOpaqueIntegration is the other half of
+// TestRegisterVersionDuplicateReturns409. That test proves the ONE SQLSTATE
+// mapConflict translates (23505) comes back clean; this one proves an
+// untranslated SQLSTATE does too, driven by a real Postgres against the real
+// Repository so the error value is the driver's, not a fixture's.
+//
+// A NUL byte in the DAG description is the cheapest way to make the server
+// itself raise an error mapConflict has never heard of: Postgres refuses it
+// with 22021 (invalid byte sequence for encoding "UTF8") on the UpsertDag
+// write. Before #961 that reached the tenant as
+// "upserting dag: ERROR: ... (SQLSTATE 22021)".
+func TestRegisterVersionUnmappedSQLSTATEIsOpaqueIntegration(t *testing.T) {
+	url := os.Getenv("DATABASE_URL")
+	if url == "" {
+		t.Skip("DATABASE_URL must point at a migrated database for integration tests")
+	}
+	ctx := context.Background()
+	pg, err := storage.NewPostgres(ctx, config.DatabaseSection{URL: url})
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pg.Close)
+
+	srv := NewServer(Dependencies{
+		Logger:        discardLogger(),
+		Authenticator: &fakeAuthn{user: &auth.User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}},
+		RateLimiter:   auth.NewRateLimiter(100, time.Minute),
+		CORSOrigins:   []string{"*"},
+		TokenTTLSecs:  3600,
+		Versions:      storage.NewRepository(pg),
+	})
+
+	dagID := fmt.Sprintf("api_leak_%d", time.Now().UnixNano())
+	path := "/api/v2/dags/" + dagID + "/versions"
+	// The \u0000 escape survives JSON decoding into the Go string and is
+	// rejected by Postgres, not by our own validation - exactly the shape
+	// needed: a driver error raised inside a repository write.
+	spec := fmt.Sprintf(`{"schema_version":"1.0","dag_id":%q,"dag_version":"dev","image":"img:dev",`+
+		`"description":"nul\u0000byte","tasks":[{"task_id":"a","type":"python","entrypoint":"dag:a"}]}`, dagID)
+
+	rec := authGet(srv, http.MethodPost, path, spec)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("NUL in description = %d, want 500 (%s)", rec.Code, rec.Body.String())
+	}
+	// Scan what the server composed, not the dag id it echoes back — see
+	// leakScanTarget.
+	body := leakScanTarget(rec.Body.String(), dagID)
+	for _, leak := range append(pgLeaks, "22021", "ERROR:", "encoding") {
+		if strings.Contains(body, leak) {
+			t.Errorf("500 body leaks raw pg internals (%q): %s", leak, body)
+		}
+	}
+}

--- a/internal/api/versions_test.go
+++ b/internal/api/versions_test.go
@@ -3,8 +3,8 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -88,12 +88,17 @@ func TestRegisterVersionRejectsRemovedHTTPAPIType(t *testing.T) {
 // the handleRepoError ErrValidation branch it fell through to 500, which sent
 // users to server logs instead of to their own DAG (#724).
 func TestRegisterVersionUnknownConnectionReturns400(t *testing.T) {
-	repo := &fakeVersionRepo{err: fmt.Errorf(
-		"dag %q declares unknown connection(s) %s; define them (leoflow connections set) or remove them from the DAG's connections: declaration: %w",
-		"etl", "warehouse", domain.ErrValidation)}
+	repo := &fakeVersionRepo{err: domain.Safef(domain.ErrValidation,
+		"dag %q declares unknown connection(s) %s; define them (leoflow connections set) or remove them from the DAG's connections: declaration",
+		"etl", "warehouse")}
 	rec := authGet(versionServer(repo), http.MethodPost, "/api/v2/dags/etl/versions", validSpecJSON)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("unknown connection = %d, want 400 (%s)", rec.Code, rec.Body.String())
+	}
+	// The phrase names what to fix. Redacting storage errors (#961) must not
+	// take it away, or the 400 sends the author to the logs after all.
+	if !strings.Contains(rec.Body.String(), "warehouse") {
+		t.Errorf("400 body no longer names the undeclared connection: %s", rec.Body.String())
 	}
 }
 

--- a/internal/domain/safe_error.go
+++ b/internal/domain/safe_error.go
@@ -1,0 +1,55 @@
+package domain
+
+import "fmt"
+
+// SafeError carries a message Leoflow composed itself, attached to one of the
+// sentinel classes above. It exists so the API boundary can tell "a phrase we
+// wrote for the caller" apart from "whatever text the failure happened to
+// carry".
+//
+// The distinction is a security boundary, not a style choice. A repository
+// error usually wraps a driver error, and a *pgconn.PgError renders itself as
+// "severity: message (SQLSTATE code)" with the constraint, table and column
+// names of our schema inside the message. Echoing that to an authenticated
+// tenant of a multi-tenant control plane is schema disclosure (CWE-209). The
+// API therefore returns Message verbatim and replaces everything else with a
+// constant phrase, logging the real error instead.
+//
+// That inverts the safe/unsafe default: a new error is opaque to clients until
+// someone deliberately writes it as a SafeError, so a newly wrapped driver
+// error cannot leak by omission.
+//
+// Message is returned to API clients verbatim. Never interpolate a driver,
+// filesystem, or network error into it — pass the caller-facing facts (a role
+// name, a declared variable, a configured cap) and let the underlying error
+// reach the log through the wrap chain.
+type SafeError struct {
+	// Message is the client-facing phrase, without the class's own wording.
+	Message string
+	// Class is the sentinel this failure belongs to (ErrValidation,
+	// ErrConflict, ErrNotFound, ...). errors.Is sees it through Unwrap.
+	Class error
+}
+
+// Error renders "<message>: <class>", identical to what
+// fmt.Errorf("<message>: %w", class) produced before, so logs and error strings
+// are unchanged.
+func (e *SafeError) Error() string {
+	if e.Message == "" {
+		return e.Class.Error()
+	}
+	return e.Message + ": " + e.Class.Error()
+}
+
+// Unwrap returns the sentinel class so errors.Is keeps working.
+func (e *SafeError) Unwrap() error { return e.Class }
+
+// ClientMessage returns the phrase that may be shown to an API client.
+func (e *SafeError) ClientMessage() string { return e.Message }
+
+// Safef builds a SafeError in class with the formatted message. The message is
+// shown to API clients verbatim, so it must contain only facts the caller
+// supplied or Leoflow chose — never a driver, filesystem, or network error.
+func Safef(class error, format string, a ...any) error {
+	return &SafeError{Message: fmt.Sprintf(format, a...), Class: class}
+}

--- a/internal/domain/safe_error_test.go
+++ b/internal/domain/safe_error_test.go
@@ -1,0 +1,48 @@
+package domain
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// TestSafefKeepsTheSentinelClass pins the property every caller relies on: a
+// Safef error is still the sentinel it was built from, so the API's status
+// mapping is unchanged by the switch away from fmt.Errorf.
+func TestSafefKeepsTheSentinelClass(t *testing.T) {
+	err := Safef(ErrValidation, "unknown role %q", "analyst")
+	if !errors.Is(err, ErrValidation) {
+		t.Fatalf("Safef(ErrValidation, ...) is not ErrValidation: %v", err)
+	}
+	if errors.Is(err, ErrConflict) {
+		t.Error("Safef must not match a class it was not built with")
+	}
+	// Wrapping is the normal shape at the call sites, so it must survive one.
+	wrapped := fmt.Errorf("creating user: %w", err)
+	if !errors.Is(wrapped, ErrValidation) {
+		t.Error("wrapping a Safef loses its class")
+	}
+}
+
+// TestSafefErrorTextMatchesTheOldWrapping keeps logs and existing string
+// assertions stable: "<message>: <class>" is exactly what
+// fmt.Errorf("<message>: %w", class) produced.
+func TestSafefErrorTextMatchesTheOldWrapping(t *testing.T) {
+	got := Safef(ErrValidation, "unknown role %q", "analyst").Error()
+	want := fmt.Errorf("unknown role %q: %w", "analyst", ErrValidation).Error()
+	if got != want {
+		t.Errorf("Safef text = %q, want %q", got, want)
+	}
+}
+
+// TestClientMessageIsTheComposedTextOnly is what the API boundary reads: the
+// message Leoflow composed, without the sentinel's own wording appended.
+func TestClientMessageIsTheComposedTextOnly(t *testing.T) {
+	var se *SafeError
+	if !errors.As(Safef(ErrConflict, "dag %q is at max_active_runs cap of %d", "etl", 3), &se) {
+		t.Fatal("Safef must be reachable with errors.As(*SafeError)")
+	}
+	if se.ClientMessage() != `dag "etl" is at max_active_runs cap of 3` {
+		t.Errorf("ClientMessage = %q", se.ClientMessage())
+	}
+}

--- a/internal/storage/pool_store.go
+++ b/internal/storage/pool_store.go
@@ -79,7 +79,7 @@ func (r *Repository) DeletePool(ctx context.Context, tenant, name string) error 
 		// missing pool or an attempt to delete the default. Disambiguate for a
 		// clear status without leaking the guard into the query's row count.
 		if p, gerr := r.GetPool(ctx, tenant, name); gerr == nil && p.IsDefault {
-			return fmt.Errorf("the default pool cannot be deleted: %w", domain.ErrConflict)
+			return domain.Safef(domain.ErrConflict, "the default pool cannot be deleted")
 		}
 		return domain.ErrNotFound
 	}

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -86,7 +86,10 @@ const pgUniqueViolation = "23505"
 // mapConflict translates a Postgres unique-constraint violation into
 // domain.ErrConflict (which the API maps to 409), leaving other errors as is — so
 // a duplicate write (e.g. a second dag run for the same logical date) surfaces as
-// a clean conflict rather than a raw 500.
+// a clean conflict rather than a 500. What is at stake is the STATUS, not the
+// body: since #961 an untranslated error no longer discloses its SQLSTATE to
+// the caller either way, but a 500 for an ordinary duplicate would still send
+// the caller (and the on-call) hunting a server fault that never happened.
 func mapConflict(err error) error {
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) && pgErr.Code == pgUniqueViolation {
@@ -217,7 +220,7 @@ func (r *Repository) CreateOIDCUser(ctx context.Context, tenant, email, provider
 		roleID, rerr := r.q.GetRoleByName(ctx, queries.GetRoleByNameParams{TenantID: tid, Name: role})
 		if rerr != nil {
 			if errors.Is(rerr, pgx.ErrNoRows) {
-				return nil, fmt.Errorf("unknown role %q: %w", role, domain.ErrValidation)
+				return nil, domain.Safef(domain.ErrValidation, "unknown role %q", role)
 			}
 			return nil, fmt.Errorf("looking up role: %w", rerr)
 		}
@@ -293,7 +296,7 @@ func (r *Repository) ReconcileUserRoles(ctx context.Context, userID string, role
 		roleID, rerr := qtx.GetRoleIDForUserTenant(ctx, queries.GetRoleIDForUserTenantParams{ID: uid, Name: name})
 		if rerr != nil {
 			if errors.Is(rerr, pgx.ErrNoRows) {
-				return fmt.Errorf("unknown role %q: %w", name, domain.ErrValidation)
+				return domain.Safef(domain.ErrValidation, "unknown role %q", name)
 			}
 			return fmt.Errorf("looking up role: %w", rerr)
 		}
@@ -444,7 +447,7 @@ func (r *Repository) CreateDagRun(ctx context.Context, tenant, dagID string, run
 			return domain.DagRun{}, fmt.Errorf("counting active runs: %w", countErr)
 		}
 		if int(active) >= maxActive {
-			return domain.DagRun{}, fmt.Errorf("dag %q is at max_active_runs cap of %d: %w", dagID, maxActive, domain.ErrConflict)
+			return domain.DagRun{}, domain.Safef(domain.ErrConflict, "dag %q is at max_active_runs cap of %d", dagID, maxActive)
 		}
 	}
 	// Persist an explicit empty object when the run carries no conf (or an
@@ -994,8 +997,9 @@ func (r *Repository) RegisterDagVersion(ctx context.Context, tenant string, spec
 		// version string was pushed with different content — the hash dedup above
 		// only short-circuits identical re-pushes. Versions are immutable, so this
 		// is a genuine conflict, not an overwrite: map it to domain.ErrConflict
-		// (API 409) instead of leaking the raw pg 23505 through a 500 (#746). Bump
-		// --dag-version to push new content.
+		// so the API answers 409 instead of 500 (#746 — where it also leaked the
+		// raw 23505, which #961 closed for every code). Bump --dag-version to
+		// push new content.
 		return false, fmt.Errorf("inserting version: %w", mapConflict(err))
 	}
 	if err := r.q.SetCurrentDagVersion(ctx, queries.SetCurrentDagVersionParams{ID: dag.ID, CurrentVersionID: version.ID}); err != nil {
@@ -1039,9 +1043,9 @@ func (r *Repository) validateDeclaredSecrets(ctx context.Context, tid pgtype.UUI
 			return fmt.Errorf("checking declared variables: %w", err)
 		}
 		if unknown := unknownDeclaredNames(varNames, existing, coveredVar); len(unknown) > 0 {
-			return fmt.Errorf(
-				"dag %q declares unknown variable(s) %s; define them (leoflow variables set) or remove them from the DAG's variables: declaration: %w",
-				spec.DagID, strings.Join(unknown, ", "), domain.ErrValidation)
+			return domain.Safef(domain.ErrValidation,
+				"dag %q declares unknown variable(s) %s; define them (leoflow variables set) or remove them from the DAG's variables: declaration",
+				spec.DagID, strings.Join(unknown, ", "))
 		}
 	}
 	connNames := declaredSecretNames(spec.Connections, spec.Tasks, func(t domain.TaskSpec) []string { return t.Connections })
@@ -1051,9 +1055,9 @@ func (r *Repository) validateDeclaredSecrets(ctx context.Context, tid pgtype.UUI
 			return fmt.Errorf("checking declared connections: %w", err)
 		}
 		if unknown := unknownDeclaredNames(connNames, existing, coveredConn); len(unknown) > 0 {
-			return fmt.Errorf(
-				"dag %q declares unknown connection(s) %s; define them (leoflow connections set) or remove them from the DAG's connections: declaration: %w",
-				spec.DagID, strings.Join(unknown, ", "), domain.ErrValidation)
+			return domain.Safef(domain.ErrValidation,
+				"dag %q declares unknown connection(s) %s; define them (leoflow connections set) or remove them from the DAG's connections: declaration",
+				spec.DagID, strings.Join(unknown, ", "))
 		}
 	}
 	return nil
@@ -1156,7 +1160,7 @@ func (r *Repository) CreateUser(ctx context.Context, tenant, email, password str
 		roleID, rerr := r.q.GetRoleByName(ctx, queries.GetRoleByNameParams{TenantID: tid, Name: role})
 		if rerr != nil {
 			if errors.Is(rerr, pgx.ErrNoRows) {
-				return domain.User{}, fmt.Errorf("unknown role %q: %w", role, domain.ErrValidation)
+				return domain.User{}, domain.Safef(domain.ErrValidation, "unknown role %q", role)
 			}
 			return domain.User{}, fmt.Errorf("looking up role: %w", rerr)
 		}

--- a/internal/storage/safe_error_integration_test.go
+++ b/internal/storage/safe_error_integration_test.go
@@ -1,0 +1,105 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// TestStorageProducesSafeErrorsForClientFacingMessages closes the hole review
+// found in #961's fix.
+//
+// The fix inverts the default from allow to deny: a 4xx/5xx detail is a fixed
+// phrase unless the error is a domain.SafeError someone deliberately wrote as
+// client-facing. Seven messages were converted to Safef on that basis — the
+// ones a tenant needs in order to fix their own input.
+//
+// Nothing pinned them. Reverting all seven to their pre-fix fmt.Errorf form
+// left the whole suite green, because the tests that look client-facing build
+// their SafeError values in the test or hand one to a fake repo. They pin
+// handleRepoError; they do not pin that any storage call site produces one.
+//
+// So the promise "the messages worth reading survive" was true on the day and
+// unpinned the day after: a refactor could turn a self-service 400 into "the
+// request was rejected by a validation rule" with CI green, and the first
+// report would be a support ticket. These assertions are at the storage layer
+// because that is where the property lives — an API-level test can be satisfied
+// by a fake.
+func TestStorageProducesSafeErrorsForClientFacingMessages(t *testing.T) {
+	repo, _, ctx := openRepo(t)
+
+	assertSafe := func(t *testing.T, err error, class error, want string) {
+		t.Helper()
+		if err == nil {
+			t.Fatal("no error; this call is supposed to be refused")
+		}
+		var safe *domain.SafeError
+		if !errors.As(err, &safe) {
+			t.Fatalf("error is not a *domain.SafeError, so its text is redacted from the client: %v", err)
+		}
+		if !errors.Is(err, class) {
+			t.Errorf("error class is not %v: %v", class, err)
+		}
+		if !strings.Contains(safe.Error(), want) {
+			t.Errorf("the message a tenant sees lost %q: %q", want, safe.Error())
+		}
+	}
+
+	t.Run("unknown role on CreateUser", func(t *testing.T) {
+		_, err := repo.CreateUser(ctx, "default", "safe-probe@leoflow.local", "pw-123456", []string{"not-a-real-role"})
+		assertSafe(t, err, domain.ErrValidation, "not-a-real-role")
+	})
+
+	t.Run("unknown role on CreateOIDCUser", func(t *testing.T) {
+		_, err := repo.CreateOIDCUser(ctx, "default", "safe-oidc@leoflow.local", "prov", "subj-1", []string{"not-a-real-role"})
+		assertSafe(t, err, domain.ErrValidation, "not-a-real-role")
+	})
+
+	t.Run("the default pool cannot be deleted", func(t *testing.T) {
+		err := repo.DeletePool(ctx, "default", "default_pool")
+		assertSafe(t, err, domain.ErrConflict, "default pool cannot be deleted")
+	})
+
+	// The two that matter most: they name the thing to create and the command
+	// that creates it. Generalising these turns a self-service fix into a
+	// support ticket, which is the cost of erring the other way.
+	t.Run("a spec declaring an unknown variable says which, and how to define it", func(t *testing.T) {
+		spec := domain.DAGSpec{
+			SchemaVersion: "1.0", DagID: "safe_probe_var", DagVersion: "v1", Image: "img:v1",
+			Variables: []string{"no_such_variable_here"},
+			Tasks:     []domain.TaskSpec{{TaskID: "t", Type: "python"}},
+		}
+		hash, herr := spec.CanonicalHash()
+		if herr != nil {
+			t.Fatal(herr)
+		}
+		_, err := repo.RegisterDagVersion(ctx, "default", spec, hash)
+		assertSafe(t, err, domain.ErrValidation, "no_such_variable_here")
+		var safe *domain.SafeError
+		if errors.As(err, &safe) && !strings.Contains(safe.Error(), "leoflow variables set") {
+			t.Errorf("the message no longer tells the author how to fix it: %q", safe.Error())
+		}
+	})
+
+	t.Run("a spec declaring an unknown connection says which, and how to define it", func(t *testing.T) {
+		spec := domain.DAGSpec{
+			SchemaVersion: "1.0", DagID: "safe_probe_conn", DagVersion: "v1", Image: "img:v1",
+			Connections: []string{"no_such_connection_here"},
+			Tasks:       []domain.TaskSpec{{TaskID: "t", Type: "python"}},
+		}
+		hash, herr := spec.CanonicalHash()
+		if herr != nil {
+			t.Fatal(herr)
+		}
+		_, err := repo.RegisterDagVersion(ctx, "default", spec, hash)
+		assertSafe(t, err, domain.ErrValidation, "no_such_connection_here")
+		var safe *domain.SafeError
+		if errors.As(err, &safe) && !strings.Contains(safe.Error(), "leoflow connections set") {
+			t.Errorf("the message no longer tells the author how to fix it: %q", safe.Error())
+		}
+	})
+}

--- a/website/content/operate/troubleshooting.md
+++ b/website/content/operate/troubleshooting.md
@@ -106,6 +106,33 @@ Control-plane logs are structured `slog` (JSON by default), one line per HTTP
 request with a request id — `grep <request_id>` correlates a UI click to its
 backend trace.
 
+### "the request could not be completed; see the server logs"
+
+API error bodies never carry the underlying failure. A storage error carries
+the database's own text — for Postgres, `severity: message (SQLSTATE code)`,
+with the constraint, table and column names of the schema inside the message —
+and Leoflow is multi-tenant, so that text stays server-side (CWE-209). The
+response says only which *kind* of failure it was:
+
+| Status | Body detail | Means |
+|---|---|---|
+| 400 | `the request was rejected by a validation rule` | Input a caller can fix. Rules Leoflow states itself (an unknown role, an undeclared variable or connection) name the offending value instead. |
+| 404 | `the requested resource does not exist` | No such DAG, run, task instance, variable, connection or pool for this tenant. |
+| 409 | `the request conflicts with the current state of the resource` | A duplicate write, or a rule such as the `max_active_runs` cap, which names itself. |
+| 499 | `the client closed the request before it completed` | The caller went away (the UI supersedes in-flight grid requests routinely). Not a server fault. |
+| 500 | `the request could not be completed; see the server logs` | A server-side failure. The cause is in the log line for that request. |
+
+The cause is on the control-plane's request log line, under `cause`, alongside
+the `request_id` the response header `X-Request-Id` carries:
+
+```bash
+journalctl -u leoflow-server -o cat | grep '"request_id":"<id>"' | jq '.cause'
+# "upserting dag: ERROR: ... violates foreign key constraint \"dag_versions_dag_id_fkey\" (SQLSTATE 23503)"
+```
+
+`kubectl logs deploy/leoflow -c leoflow | jq 'select(.cause) | {path, status, cause}'`
+lists every request that failed with a server-side cause.
+
 ## Observability
 
 - **Metrics:** Prometheus at `:9090/metrics` (scheduler, dispatch, inline


### PR DESCRIPTION
Closes #961.

## What was wrong

`handleRepoError` rendered every repository failure into the problem-detail body verbatim. `pgconn` renders a `*PgError` as `severity: message (SQLSTATE code)`, and `Message` for a constraint violation carries the constraint name, so any authenticated tenant of a multi-tenant control plane got the schema back (CWE-209). `mapConflict` translates only SQLSTATE `23505`; every other code went through untouched.

Two things the issue did not have:

- **The 499 branch leaked too, and worse.** A `pgconn.ConnectError` renders ``failed to connect to `user=… database=…` ``, and a connect *timeout* satisfies `errors.Is(err, context.DeadlineExceeded)` — so it took the client-cancel branch and disclosed the database identity there. Verified empirically, not assumed: dialing TEST-NET-3 with a 150 ms deadline gives `*pgconn.ConnectError`, text ``failed to connect to `user=leoflow_app database=leoflow_meta`: … timeout: context deadline exceeded``, and `errors.Is(err, context.DeadlineExceeded) == true`. That is now a test (`TestHandleRepoErrorRedactsAConnectionStringOnTheCancelBranch`).
- **`versions.go:44` is not a database path.** The issue lists it; `spec.CanonicalHash()` is `json.Marshal` + SHA-256 (`internal/domain/hash.go:13`) and touches no storage. It is hardened anyway (a constant costs nothing, and nobody re-audits a call site when the error source behind it changes), but the PR should not claim it was a leak.

## The fix

The default is inverted from allow to deny.

- `handleRepoError` sends a **fixed phrase per condition**, and only a `domain.SafeError` — an error someone deliberately wrote as client-facing, via `domain.Safef` — contributes text to a body. A newly wrapped driver error therefore cannot leak by omission: it leaks only if someone rewrites it as a `SafeError`, whose GoDoc says its message is shown to clients verbatim.
- One phrase per condition, not one overall — the same split `unreadyDetail` makes in `health.go`. A 404 still reads as missing, a 409 as a conflict, a 400 as rejected input, a 499 as a client abort. No status class changed.
- **The operator loses nothing.** `AbortProblemCause` records the real error and `StructuredLogger` logs it under a new `cause` field, on the same line as the `request_id` the response already echoes in `X-Request-Id`. Operation, SQLSTATE and driver text are all still there, one grep from the failing request.
- The messages worth reading survive: unknown role, undeclared variable/connection, the `max_active_runs` cap, the undeletable default pool — rebuilt with `domain.Safef` (7 sites). `Safef(class, msg)` renders exactly what `fmt.Errorf("msg: %w", class)` did, so logs and `errors.Is` are unchanged.

## How the sweep was established

Text can only enter a response body in `internal/api` through `AbortProblem`, `c.JSON`, `c.String`, `c.Data`, `c.SSEvent`, `c.Writer.Write*` or `http.Error`. Each was enumerated and each non-constant argument classified:

```
grep -rn --include='*.go' 'AbortProblem' internal/ cmd/ | grep -v '_test.go'
grep -rn --include='*.go' 'c\.JSON(\|c\.String(\|c\.Data(\|c\.SSEvent(\|Writer\.Write\|http.Error(' internal/ cmd/ | grep -v '_test.go'
grep -rn --include='*.go' 'ListenAndServe\|http.HandleFunc\|mux.Handle' internal/ cmd/ | grep -v '_test.go'
```

Result, across all 95 `AbortProblem` sites:

- **Repository errors — all 69 reach `handleRepoError`.** `grep -c 'handleRepoError('` over non-test files in `internal/api` is 69, and the `AbortProblem` enumeration above shows no repository call site rendering its error any other way. `handleUserWriteError` is a thin pre-filter that ends there; it gets the same `safeDetail` treatment.
- **Two repository errors bypassed the funnel**, both now closed: `applyDeclaredParams` concatenated the spec-read error into its own 500 detail (`resources.go:368`), and its sibling `json.Marshal` failure at `:380`.
- **Every remaining non-constant detail was read and is not a storage path**: `ShouldBindJSON` / `json.Unmarshal` of the request body (`users.go:138`, `auth_handler.go:102`, `ui_connections.go:337,378`, `ui_variables.go:137,182`, `ui_pools.go:110,136`, `resources.go:180,275,465,474,611,778`, `versions.go:31`), spec and JSON-Schema validation (`versions.go:39`, `resources.go:427`), `domain.ValidateRunID` (`resources.go:502`), the embedded static OpenAPI document (`docs.go:45,50`), and `unreadyDetail` (`health.go:201`), which is already the house pattern.
- **`c.JSON` / `c.String` / `Writer.Write` carry no error text.** `logs.go` writes log lines and a recorded failure reason; `docs.go` writes the embedded spec. `tailLogs` (`logs.go:149`, `ui_logs.go:111`) discards its error, and `classifyLogReadError`'s embedded sink text lands on the 200 no-logs path — and is redacted anyway now that a 404 detail is a constant.
- **Second listener**: the observability handler serves only `/healthz`, `/readyz` (`unreadyDetail`) and `/metrics`.
- **`internal/mcp`** reads through the generated HTTP API client and never echoes a response body (`"control plane returned %d …"`), so it inherits the fix rather than needing one.
- **`internal/ui`** serves static assets.

## Mutation evidence

Each mutant was applied by exact-string replacement with the occurrence count asserted (`== 1`) and the file's SHA-256 compared before and after, so a mutant that silently failed to apply is distinguishable from a passing one. Every test was run without a pipe and its own exit code read.

```
M1-500-branch-echoes-error:      bd9bede06f63 -> 5add48175bc1 (applied), exit=1 RED
M2-404-branch-echoes-error:      bd9bede06f63 -> 7aa75c2aaec1 (applied), exit=1 RED
M3-409-branch-echoes-error:      bd9bede06f63 -> 974c5146fb27 (applied), exit=1 RED
M4-400-branch-echoes-error:      bd9bede06f63 -> 7342e628545c (applied), exit=1 RED
M5-499-branch-echoes-error:      bd9bede06f63 -> 2af342072311 (applied), exit=1 RED
M6-params-path-echoes-error:     bd9bede06f63 -> 62cb5f4dba3c (applied), exit=1 RED
M7-log-drops-the-cause:          6cca0309f07e -> c21a5af10543 (applied), exit=1 RED
M8-safe-message-suppressed:      bd9bede06f63 -> f49fecc48ac7 (applied), exit=1 RED
M9-integration-500-echoes-error: bd9bede06f63 -> 5add48175bc1 (applied), exit=1 RED
```

M7 and M8 are the two-sided guards: M7 removes the `cause` log field and the tests go red for *losing diagnosability*; M8 makes `safeDetail` always redact and they go red for *over-redacting* (`TestSafeErrorMessagesStillReachTheClient`, `TestRegisterVersionUnknownConnectionReturns400`).

Separately, the first commit (`a004550`, tests only) is red on its own tree — 53 leak assertions fire in the unit suite and 4 in the integration one:

```
--- FAIL: TestRegisterVersionUnmappedSQLSTATEIsOpaqueIntegration
    500 body leaks raw pg internals ("SQLSTATE"):
    {"title":"internal error","status":500,
     "detail":"upserting dag: ERROR: invalid byte sequence for encoding \"UTF8\": 0x00 (SQLSTATE 22021)", …}
```

## Tests

- `internal/api/repo_error_leak_test.go` — every funnel branch driven with a real `*pgconn.PgError` (23503 FK with constraint name, 23502 not-null with column name, 42P01 undefined table, 53300 too-many-clients), each also joined to a sentinel so the 404/409/400/499 branches are covered, not just the 500. Scan tokens are derived from the fixture (`Code`, `Message`, `Error()`, severity prefix, constraint/table/column/schema/routine/file), not hand-listed. Each case also asserts the `cause` log field still carries the SQLSTATE and the message. Two cases drive the real routes end to end.
- `internal/api/versions_leak_integration_test.go` — the RC-pass the issue asked for, and it needs no doctored migration: a NUL byte (a JSON `\u0000` escape) in the DAG description makes a real Postgres raise 22021 inside `UpsertDag`. Passes against the CI Postgres service.
- `pgLeaks` widened with `ERROR:` / `FATAL:` — the severity prefix catches an unmapped code whose number nobody thought to list — and the floor test that pins the list widened with it.
- `TestRegisterVersionUnknownConnectionReturns400`'s fixture rebuilt with `domain.Safef` so it matches what the repository now returns, plus an assertion that the 400 still names the undeclared connection.

## Deliberately not fixed

- **`internal/agentrpc` — filed as #1068.** About 20 sites put `%v` of a storage error into the gRPC status returned to the task pod (`server.go:258` and friends, via `ExecutionStore.TaskSpec`). Confirmed real in code, not inferred. Left out because the audience (the agent in the tenant's own pod) and the trade-off differ: the agent surfaces these strings in the task log operators read, so a blanket redaction would remove text people rely on today. It wants its own decision per site.
- **`internal/api/ide.go`** returns filesystem errors verbatim (`ide_error`, `invalid_path`, `not_found`), disclosing host paths from the Lite workspace. A different class with a different audience (the single-user Lite IDE), not a database leak. Not filed — say the word and I will.
- **`log_reader.go:79`** still builds `fmt.Errorf("%w: %s", domain.ErrNotFound, err.Error())`, embedding the object-sink error text into an error chain. It is unreachable as a response body today (`serveLogs` routes it to the 200 no-logs view) and the constant 404 detail closes it even if that changes, so it was left alone rather than churned.

## Gates

`go build ./...` clean; `go test ./...` clean; `go test -tags integration ./...` clean against a migrated Postgres 16; `golangci-lint run` (v2.12.2) reports 0 issues; all `scripts/check-*.sh` green except `check-chart-version-matches-tag.sh`, which needs a tag argument.

CHANGELOG under `[Unreleased] / Security`. Docs: a new "the request could not be completed; see the server logs" section in `website/content/operate/troubleshooting.md` mapping each status to what it means and showing how to pull the `cause` out of the request log — the behaviour change is operator-visible even though the docs gate's surface list does not cover it.
