### PR TITLE
fix(agent): make execution_timeout kill the task's process group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -404,10 +404,18 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   log, so a spawn that silently fails cannot let it pass while covering only the
   easy case.
 
-  One behavior is worth knowing: a task that exits **successfully** while
-  leaving a background process holding the pipe keeps its own exit status rather
-  than being turned into a failure. It loses only the tail of its output once
-  the delay expires, and the agent logs a warning saying so.
+  One behavior is worth knowing, and one boundary on it. A task with **no
+  declared timeout** that exits successfully while leaving a background process
+  holding the pipe keeps its own exit status rather than being turned into a
+  failure; it loses only the tail of its output once the delay expires, and the
+  agent logs a warning saying so. It also now takes an extra 10s to return,
+  where before it hung indefinitely.
+
+  Where a timeout **was** declared and fired, the attempt is reported as
+  `execution_timeout` regardless of what the task's own exit status was — the
+  classification reads the deadline, not the exit code. That is pre-existing
+  and unchanged here; this fix narrows the window in which it can happen but
+  does not close it.
 - **A version floor in `dependencies` was silently dropped, and left junk in the
   image.** `RUN` in a Dockerfile is `/bin/sh -c`, and the specifiers were joined
   into that line unquoted — so `setuptools>=80.9.0` was a *redirection*: pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -371,6 +371,43 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   mode and fails if any Service or PodDisruptionBudget selector is ever again a
   subset of the hook pod's labels
   ([#1055](https://github.com/neochaotic/leoflow/issues/1055)).
+- **`execution_timeout` now applies to the task, not just to its first
+  process.** A task that left a grandchild behind defeated the timeout
+  completely. The agent's cancel SIGKILLed the direct child alone; the surviving
+  grandchild kept the stdout pipe it had inherited open; and because the agent
+  wires stdout to a log writer rather than to a file, the standard library
+  interposes that pipe and blocks `Wait` on its copying goroutine until every
+  writer closes it. So the deadline fired, nothing died, and the agent never
+  reached the branch that reports the timeout or writes the durable outcome
+  record. The attempt ended minutes later on the kubelet's
+  `activeDeadlineSeconds` with the generic container-terminated reason and
+  nothing for the reconciler to recover — the exact state the pod-deadline
+  arithmetic exists to prevent, reached through the front door
+  ([#943](https://github.com/neochaotic/leoflow/issues/943)).
+
+  This is the ordinary task shape, not an exotic one: the bash operator runs its
+  entrypoint under `bash -c`, so any `&&`, pipe, `;` or background job makes the
+  user's real programs grandchildren of the process the agent kills, and the
+  same holds for any Python task that shells out. The agent now starts the task
+  in its **own process group** and the cancel SIGKILLs the **group**, so the
+  whole tree goes with the deadline. A bounded 10-second `WaitDelay` backstops
+  the residue — a descendant that escapes the group by calling `setsid` — so
+  nothing can hold the wait open indefinitely any more. Measured on the
+  regression test: a shell backgrounding a long-running child under a 500 ms
+  deadline returned after 23.5 s before the fix and half a second after it,
+  with the task's process group gone.
+
+  This **supersedes the limitation stated in 0.4.5**, which scoped the
+  `execution_timeout` guarantee to a task whose process tree exits with it. The
+  end-to-end scenario that deliberately avoided the shape now spawns such a
+  grandchild on purpose and asserts the grandchild's own line in the shipped
+  log, so a spawn that silently fails cannot let it pass while covering only the
+  easy case.
+
+  One behavior is worth knowing: a task that exits **successfully** while
+  leaving a background process holding the pipe keeps its own exit status rather
+  than being turned into a failure. It loses only the tail of its output once
+  the delay expires, and the agent logs a warning saying so.
 - **A version floor in `dependencies` was silently dropped, and left junk in the
   image.** `RUN` in a Dockerfile is `/bin/sh -c`, and the specifiers were joined
   into that line unquoted — so `setuptools>=80.9.0` was a *redirection*: pip

--- a/internal/agent/exec.go
+++ b/internal/agent/exec.go
@@ -75,9 +75,16 @@ func (r execRunner) Run(ctx context.Context, argv, env []string, stdout, stderr 
 	cmd.Stderr = stderr
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	// Same signal the default cancel sends, widened to the group: an immediate
-	// SIGKILL. Cancel runs only when the context is done AND the process has not
-	// already been reaped, so cmd.Process is set and its pid cannot have been
-	// recycled by the time the group is addressed.
+	// SIGKILL. cmd.Process is always set here — Start installs the watcher that
+	// calls this only after the process exists — but the process may already
+	// have been REAPED: os/exec's watcher races its result handoff against the
+	// context, so Wait can collect the child and this still run afterwards. That
+	// is wanted rather than guarded against, because a process group outlives
+	// its leader for exactly as long as a descendant is still in it, and that
+	// descendant is what this call exists to kill. The residue is a pid reused
+	// in the microseconds between the reap and this call, which would address
+	// some other group; closing it would need a pidfd, and it costs a pid-space
+	// wraparound inside that window to happen at all.
 	cmd.Cancel = func() error { return killProcessGroup(cmd.Process) }
 	cmd.WaitDelay = r.waitDelay
 

--- a/internal/agent/exec.go
+++ b/internal/agent/exec.go
@@ -5,20 +5,67 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
+	"os"
 	"os/exec"
+	"syscall"
+	"time"
 )
+
+// execWaitDelay bounds how long Wait may spend on the two delays os/exec cannot
+// otherwise escape: a child that has not exited after its context was canceled,
+// and a child that has exited but left its I/O pipes open (#943).
+//
+// It is a BACKSTOP, not the mechanism. The process-group kill below is what
+// normally ends both, and it leaves nothing holding the pipe, so this timer
+// fires only for a descendant that escaped the group — one that called setsid,
+// or was handed to a system service manager. Without it that descendant would
+// hold the wait open for as long as it lives, and the agent's clock would stop
+// being the authority on execution_timeout.
+//
+// The size is set by the pod deadline's shutdown tail: the kubelet must not
+// preempt the agent between its own clock firing and its report landing. That
+// budget is a pod's termination grace, which defaults to 30 seconds
+// (corev1.DefaultTerminationGracePeriodSeconds, the value
+// executor.podDeadlineGraceTerm falls back to), so ten seconds here leaves
+// twenty for the durable outcome record and one report RPC. It is also far more
+// than a healthy drain needs: once every writer is dead the pipe reaches EOF at
+// once and only what is already buffered (a pipe's worth, 64 KiB) is left to
+// copy. A task whose DAG declares a grace SHORTER than this delay can still be
+// preempted by the kubelet in the escaped-descendant case; that corner predates
+// this bound and is not made worse by it.
+const execWaitDelay = 10 * time.Second
 
 // execRunner is the production CommandRunner: it spawns the user task as a child
 // process bound to the supplied context.
-type execRunner struct{}
+//
+// waitDelay is a field rather than the constant so a test can bound a wait
+// without spending the production delay; every caller outside tests goes through
+// NewExecRunner.
+type execRunner struct{ waitDelay time.Duration }
 
 // NewExecRunner returns a CommandRunner that executes tasks as child processes.
-func NewExecRunner() CommandRunner { return execRunner{} }
+func NewExecRunner() CommandRunner { return execRunner{waitDelay: execWaitDelay} }
 
 // Run executes argv with env, streaming output to stdout and stderr. A non-zero
 // process exit is returned as the exit code with a nil error; only failure to
 // start or wait on the process yields an error.
-func (execRunner) Run(ctx context.Context, argv, env []string, stdout, stderr io.Writer) (int, error) {
+//
+// The child leads its OWN process group and the context's cancel kills that
+// group, not just the child (#943). This is what makes execution_timeout apply
+// to a task rather than to its first process. Two properties combine to defeat
+// the default otherwise: the default cancel signals the direct child alone, and
+// stdout here is a log writer rather than an *os.File, so the standard library
+// interposes a pipe whose copying goroutine Wait blocks on until EVERY writer
+// closes it. A surviving grandchild holds that pipe — and the bash operator runs
+// its entrypoint under `bash -c`, so any compound command makes the user's real
+// programs grandchildren — so the deadline would fire, the child would die, and
+// the task would keep running with the agent still blocked in Wait.
+//
+// Unix-only, deliberately without a build-tagged Windows twin: the agent is
+// built for linux and darwin only (.goreleaser.yaml) and runs inside a Linux
+// task container.
+func (r execRunner) Run(ctx context.Context, argv, env []string, stdout, stderr io.Writer) (int, error) {
 	if len(argv) == 0 {
 		return -1, errors.New("empty command")
 	}
@@ -26,14 +73,56 @@ func (execRunner) Run(ctx context.Context, argv, env []string, stdout, stderr io
 	cmd.Env = env
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	// Same signal the default cancel sends, widened to the group: an immediate
+	// SIGKILL. Cancel runs only when the context is done AND the process has not
+	// already been reaped, so cmd.Process is set and its pid cannot have been
+	// recycled by the time the group is addressed.
+	cmd.Cancel = func() error { return killProcessGroup(cmd.Process) }
+	cmd.WaitDelay = r.waitDelay
 
 	err := cmd.Run()
 	var exitErr *exec.ExitError
 	if errors.As(err, &exitErr) {
 		return exitErr.ExitCode(), nil
 	}
+	if errors.Is(err, exec.ErrWaitDelay) {
+		// The process itself exited with a SUCCESSFUL status and the delay expired
+		// with its pipes still held open by something it left behind; os/exec
+		// reports the forced close this way. That is an agent-side I/O outcome,
+		// not the task's verdict, so the task keeps the exit status it chose. The
+		// cost is the tail of its output, which is why this is logged.
+		slog.Warn("task output was truncated: the process exited but left its output pipe open",
+			"wait_delay", r.waitDelay)
+		if cmd.ProcessState != nil {
+			return cmd.ProcessState.ExitCode(), nil
+		}
+		return 0, nil
+	}
 	if err != nil {
 		return -1, fmt.Errorf("running command: %w", err)
 	}
 	return 0, nil
+}
+
+// killProcessGroup SIGKILLs every process in the group led by p, falling back to
+// p alone when no such group exists.
+//
+// A process group is named by its LEADER's pid, so kill(-pid) reaches nothing at
+// all — ESRCH, harming no other group — when the process is not a leader. That
+// is the case whenever the Setpgid above did not take effect, and answering it
+// with "already done" would leave the child running with the cancel reporting
+// success. Falling back to killing the process is what the default cancel does,
+// so the worst case degrades to the old behavior rather than to no behavior.
+// p.Kill reports an already-exited process as os.ErrProcessDone, which os/exec
+// treats as nothing to do rather than as a failure of the run.
+func killProcessGroup(p *os.Process) error {
+	err := syscall.Kill(-p.Pid, syscall.SIGKILL)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, syscall.ESRCH) {
+		return fmt.Errorf("killing process group %d: %w", p.Pid, err)
+	}
+	return p.Kill()
 }

--- a/internal/agent/exec_timeout_test.go
+++ b/internal/agent/exec_timeout_test.go
@@ -1,0 +1,336 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/taskoutcome"
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+)
+
+// grandchildScript is the canonical shape of the task that defeated
+// execution_timeout (#943): a shell that BACKGROUNDS a long-running child and
+// waits. The background subshell inherits the shell's stdout, which — because
+// the agent wires stdout to a log writer rather than to an *os.File — is a pipe
+// the standard library's copying goroutine reads until every writer closes it.
+// Killing the direct shell alone therefore does not end the wait.
+//
+// The loop is self-limiting (400 × 0.05s ≈ 20s) so a regression fails the
+// elapsed-time assertion instead of hanging the package for its whole timeout,
+// and it appends a byte per iteration so a test can see whether the work is
+// still happening AFTER the call returned.
+func grandchildScript(pidFile, marker string) string {
+	return fmt.Sprintf(
+		"echo $$ > %[1]s\n"+
+			"( i=0; while [ $i -lt 400 ]; do printf x >> %[2]s; sleep 0.05; i=$((i+1)); done ) &\n"+
+			"echo started\n"+
+			"wait\n", pidFile, marker)
+}
+
+// readPGID waits for the script above to publish its own pid, which under the
+// fix is also its process-group id (the child leads a new group).
+func readPGID(t *testing.T, pidFile string) int {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		b, err := os.ReadFile(pidFile) //nolint:gosec // test-owned temp path
+		if err == nil {
+			if pid, cerr := strconv.Atoi(strings.TrimSpace(string(b))); cerr == nil && pid > 0 {
+				return pid
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("the task never published its pid to %s", pidFile)
+	return 0
+}
+
+// requireProcessGroupGone polls until no process remains in pgid. Signal 0 only
+// probes for existence; it delivers nothing. Polling (rather than a single
+// check) absorbs the moment in which the killed grandchild is still a zombie
+// awaiting reaping by init, which would otherwise keep the group "alive".
+func requireProcessGroupGone(t *testing.T, pgid int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		err := syscall.Kill(-pgid, 0)
+		if err == syscall.ESRCH { //nolint:errorlint // syscall.Kill returns a bare syscall.Errno
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("process group %d still has live members 5s after the call returned (kill probe: %v) — "+
+				"the timeout returned but the task's work did not stop", pgid, err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// TestExecRunnerTimeoutKillsAGrandchildHoldingStdout is the regression test for
+// #943. Before the fix this shape defeats execution_timeout entirely: the cancel
+// SIGKILLs the direct child only, the surviving grandchild keeps the stdout pipe
+// open, and Wait blocks on the copying goroutine until that grandchild exits on
+// its own — here about twenty seconds after a deadline of half a second.
+//
+// Returning is necessary but not sufficient, so this asserts all three halves:
+// the call returns near the deadline, the process group is gone, and the work
+// the grandchild was doing has actually stopped.
+func TestExecRunnerTimeoutKillsAGrandchildHoldingStdout(t *testing.T) {
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "pid")
+	marker := filepath.Join(dir, "marker")
+
+	const deadline = 500 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), deadline)
+	defer cancel()
+
+	var out bytes.Buffer
+	start := time.Now()
+	// The writers are deliberately NOT *os.File: that is what makes the standard
+	// library interpose a pipe and a copying goroutine, which is half the defect.
+	_, err := NewExecRunner().Run(ctx, []string{"sh", "-c", grandchildScript(pidFile, marker)}, nil, &out, &out)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// 3s is far below the ~20s the grandchild's loop runs for and far above the
+	// 500ms deadline plus any plausible scheduling jitter, so this separates
+	// "the deadline was honored" from "the grandchild was waited out".
+	if elapsed > 3*time.Second {
+		t.Fatalf("Run returned after %v for a %v deadline: the grandchild holding stdout kept the wait open", elapsed, deadline)
+	}
+
+	t.Logf("Run returned %v after a %v deadline", elapsed.Round(time.Millisecond), deadline)
+
+	pgid := readPGID(t, pidFile)
+	requireProcessGroupGone(t, pgid)
+
+	// The grandchild must have run (otherwise this test proves nothing about
+	// killing it) and must have stopped (otherwise the timeout freed the agent
+	// while the task kept burning the pod's resources).
+	before := fileSize(t, marker)
+	if before == 0 {
+		t.Fatal("the grandchild never wrote to its marker file; the test is not exercising the shape it claims")
+	}
+	time.Sleep(500 * time.Millisecond)
+	if after := fileSize(t, marker); after != before {
+		t.Errorf("the grandchild is still working after the timeout returned: marker grew %d -> %d bytes", before, after)
+	}
+}
+
+func fileSize(t *testing.T, path string) int64 {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0
+		}
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return fi.Size()
+}
+
+// slowWriter accepts bytes at a fixed cost per Write, standing in for a log sink
+// streaming to a control plane that is not keeping up.
+type slowWriter struct {
+	mu    sync.Mutex
+	buf   bytes.Buffer
+	delay time.Duration
+}
+
+func (w *slowWriter) Write(p []byte) (int, error) {
+	time.Sleep(w.delay)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(p)
+}
+
+func (w *slowWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
+// TestExecRunnerCapturesEveryLineOfANormalExit guards the fix's own risk. A
+// bounded WaitDelay closes the child's pipes when the delay expires, and the
+// timer starts when Wait observes the child exit — not when the copying finishes
+// — so a delay set too short truncates the tail of a task that exited perfectly
+// well. The writer here consumes deliberately slowly, which puts that drain on
+// the clock the WaitDelay bounds; the assertion is the COMPLETE output, in
+// order, with the exit code the task chose.
+func TestExecRunnerCapturesEveryLineOfANormalExit(t *testing.T) {
+	const lines = 4000
+	var want strings.Builder
+	for i := range lines {
+		fmt.Fprintf(&want, "line-%04d\n", i)
+	}
+
+	out := &slowWriter{delay: 300 * time.Millisecond}
+	var errb bytes.Buffer
+	code, err := NewExecRunner().Run(context.Background(),
+		[]string{"sh", "-c", fmt.Sprintf("i=0; while [ $i -lt %d ]; do printf 'line-%%04d\\n' $i; i=$((i+1)); done", lines)},
+		nil, out, &errb)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	if got := out.String(); got != want.String() {
+		t.Errorf("stdout was not captured whole: got %d bytes / %d lines, want %d bytes / %d lines",
+			len(got), strings.Count(got, "\n"), want.Len(), lines)
+	}
+}
+
+// TestExecRunnerLeakedPipeOnCleanExitKeepsTheTasksVerdict covers the other side
+// of the WaitDelay: a task whose own process exits 0 but leaves a background
+// child holding stdout. No context is canceled here, so nothing kills the group
+// and the agent would otherwise wait for that child for as long as it lives.
+// The delay stops the wait — and the task's verdict must survive that, because
+// the leaked pipe is the agent's I/O problem, not a failure of the user's task.
+// os/exec reports the forced pipe close as ErrWaitDelay in exactly this case
+// (successful exit status), which is why it needs mapping rather than passing
+// through as a run error.
+func TestExecRunnerLeakedPipeOnCleanExitKeepsTheTasksVerdict(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "marker")
+
+	// A short delay keeps the test fast; the production value is exercised by the
+	// timeout test above.
+	runner := execRunner{waitDelay: 300 * time.Millisecond}
+	var out bytes.Buffer
+	start := time.Now()
+	code, err := runner.Run(context.Background(),
+		[]string{"sh", "-c", fmt.Sprintf("( sleep 10; printf x >> %s ) &\necho done\nexit 0\n", marker)},
+		nil, &out, &out)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("a task that exited 0 must not be turned into a failure by a leaked pipe: %v", err)
+	}
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("Run took %v: the wait was not bounded by the WaitDelay", elapsed)
+	}
+	if !strings.Contains(out.String(), "done") {
+		t.Errorf("stdout = %q, want it to contain the output written before the exit", out.String())
+	}
+}
+
+// TestRunnerExecutionTimeoutSurvivesAGrandchild drives the REAL entry point:
+// Runner.Run with the production command runner and a bash task, which is the
+// wiring the leaf test cannot prove. The bash operator runs the entrypoint under
+// `bash -c`, so a task doing anything compound — an `&&`, a pipe, a background
+// job — already makes the user's own programs grandchildren of the process the
+// agent kills.
+//
+// It asserts what #943 says is missing today: the agent's clock is authoritative
+// (the call returns near the deadline), the task's work stops, and the failure
+// is reported AND recorded as a timeout rather than as a generic failure.
+func TestRunnerExecutionTimeoutSurvivesAGrandchild(t *testing.T) {
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "pid")
+	marker := filepath.Join(dir, "marker")
+	logPath := filepath.Join(dir, "termination-log")
+
+	client := &fakeClient{spec: &agentv1.TaskSpec{
+		Operator:                "bash",
+		Entrypoint:              grandchildScript(pidFile, marker),
+		ExecutionTimeoutSeconds: 1,
+	}}
+	r := newRunner(client, nil, &recordingSink{})
+	r.Cmd = NewExecRunner()
+	r.Env = os.Environ() // the task needs a PATH to resolve `sleep`
+	r.TerminationLogPath = logPath
+
+	start := time.Now()
+	err := r.Run(context.Background())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("a task that exceeds its execution_timeout_seconds must fail")
+	}
+	// The grandchild's loop runs ~20s; anything under 10s means the agent's own
+	// clock ended the attempt rather than the task finishing on its own.
+	if elapsed > 10*time.Second {
+		t.Fatalf("Run took %v for a 1s execution_timeout: the timeout did not stop the task", elapsed)
+	}
+	if !strings.Contains(err.Error(), "execution_timeout") {
+		t.Errorf("error = %q, want it to name execution_timeout", err)
+	}
+
+	t.Logf("Run returned %v for a 1s execution_timeout", elapsed.Round(time.Millisecond))
+
+	pgid := readPGID(t, pidFile)
+	requireProcessGroupGone(t, pgid)
+
+	if last := client.states[len(client.states)-1]; last != agentv1.TaskState_TASK_STATE_FAILED {
+		t.Errorf("final reported state = %v, want failed", last)
+	}
+	if n := len(client.reports); n > 0 {
+		if got := client.reports[n-1].GetErrorMessage(); !strings.Contains(got, "execution_timeout") {
+			t.Errorf("reported message = %q, want it to name execution_timeout", got)
+		}
+	}
+	rec := readOutcome(t, logPath)
+	if rec.Outcome != taskoutcome.Failed {
+		t.Errorf("durable outcome = %q, want failed", rec.Outcome)
+	}
+	if !strings.Contains(rec.Reason, "execution_timeout") {
+		t.Errorf("durable reason = %q, want it to name execution_timeout", rec.Reason)
+	}
+	if rec.ExitCode == nil || *rec.ExitCode == 0 {
+		t.Errorf("durable exit_code = %v, want a non-zero code (a killed task never exited 0)", rec.ExitCode)
+	}
+}
+
+// TestKillProcessGroupFallsBackWhenTheChildLeadsNoGroup pins the degrade path.
+// A process group is named by its leader's pid, so kill(-pid) on a process that
+// leads no group reaches NOTHING — it returns ESRCH rather than signaling the
+// group the process happens to belong to (measured, not assumed). Reporting
+// that as "already done" would leave a live child behind while the cancel
+// claimed success, so the fallback kills the process itself.
+func TestKillProcessGroupFallsBackWhenTheChildLeadsNoGroup(t *testing.T) {
+	// The context is deliberately never canceled: this test drives the kill
+	// helper directly, not through the context path.
+	cmd := exec.CommandContext(context.Background(), "sleep", "30") // no SysProcAttr: inherits this group
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting the child: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil {
+		t.Fatalf("Getpgid: %v", err)
+	}
+	// The premise: this child is NOT its own group leader, so the group-kill
+	// below must miss and the fallback must be what ends it.
+	if pgid == cmd.Process.Pid {
+		t.Fatalf("child pid %d already leads its own group; this test cannot exercise the fallback", cmd.Process.Pid)
+	}
+
+	if err := killProcessGroup(cmd.Process); err != nil {
+		t.Fatalf("killProcessGroup: %v", err)
+	}
+	werr := cmd.Wait()
+	var exitErr *exec.ExitError
+	if !errors.As(werr, &exitErr) {
+		t.Fatalf("child did not exit on a signal: %v", werr)
+	}
+	if !exitErr.ProcessState.Sys().(syscall.WaitStatus).Signaled() { //nolint:errcheck,forcetypeassert // unix-only test
+		t.Errorf("child exited %v, want it killed by a signal", exitErr.ProcessState)
+	}
+}

--- a/internal/agent/exec_timeout_test.go
+++ b/internal/agent/exec_timeout_test.go
@@ -32,22 +32,42 @@ import (
 // still happening AFTER the call returned.
 func grandchildScript(pidFile, marker string) string {
 	return fmt.Sprintf(
-		"echo $$ > %[1]s\n"+
+		// Both, and on one line: the premise "the task leads its own group" has
+		// to be checkable AFTER the kill, and Getpgid on a dead leader returns
+		// ESRCH — which is indistinguishable from "the group is gone".
+		"echo \"$$ $(ps -o pgid= -p $$ | tr -d ' ')\" > %[1]s\n"+
 			"( i=0; while [ $i -lt 400 ]; do printf x >> %[2]s; sleep 0.05; i=$((i+1)); done ) &\n"+
 			"echo started\n"+
 			"wait\n", pidFile, marker)
 }
 
-// readPGID waits for the script above to publish its own pid, which under the
-// fix is also its process-group id (the child leads a new group).
+// readPGID waits for the script above to publish its pid and its pgid, and
+// asserts they are equal — i.e. that the task really did lead its own group.
+//
+// That assertion is the premise the kill probe rests on and cannot make for
+// itself: `kill(-pgid, 0)` returns ESRCH both when the group is gone and when
+// it never existed, so without this, dropping Setpgid makes the probe report
+// success having tested nothing. Measured: the wiring test then passed in 1.1s
+// while `ps` still showed the bash tree and its sleep running — the exact
+// "returns on time, work keeps going" shape #943 is about, reproduced inside
+// its own regression test.
 func readPGID(t *testing.T, pidFile string) int {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		b, err := os.ReadFile(pidFile) //nolint:gosec // test-owned temp path
 		if err == nil {
-			if pid, cerr := strconv.Atoi(strings.TrimSpace(string(b))); cerr == nil && pid > 0 {
-				return pid
+			fields := strings.Fields(string(b))
+			if len(fields) == 2 {
+				pid, perr := strconv.Atoi(fields[0])
+				pgid, gerr := strconv.Atoi(fields[1])
+				if perr == nil && gerr == nil && pid > 0 && pgid > 0 {
+					if pid != pgid {
+						t.Fatalf("the task ran in process group %d rather than leading its own (%d): "+
+							"the kill probe would then ESRCH on a group that never existed and report success", pgid, pid)
+					}
+					return pid
+				}
 			}
 		}
 		time.Sleep(10 * time.Millisecond)
@@ -332,5 +352,50 @@ func TestKillProcessGroupFallsBackWhenTheChildLeadsNoGroup(t *testing.T) {
 	}
 	if !exitErr.ProcessState.Sys().(syscall.WaitStatus).Signaled() { //nolint:errcheck,forcetypeassert // unix-only test
 		t.Errorf("child exited %v, want it killed by a signal", exitErr.ProcessState)
+	}
+}
+
+// TestExecRunnerTimeoutKillsATaskThatTrapsSIGTERM pins the signal, which the
+// rest of the suite does not.
+//
+// Swapping SIGKILL for SIGTERM in killProcessGroup leaves every other test in
+// this file green — measured. That is the shape of a plausible future
+// refactor ("let's shut down gracefully"), and it silently re-opens #943 for
+// any task that traps the signal: a `trap ” TERM` shell, a JVM with a
+// shutdown hook that blocks, a Python process with a SIGTERM handler that
+// swallows it. The timeout is the last resort, so it does not negotiate.
+func TestExecRunnerTimeoutKillsATaskThatTrapsSIGTERM(t *testing.T) {
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "pid")
+	marker := filepath.Join(dir, "marker")
+
+	// Ignores TERM entirely, then does the same grandchild-holding-stdout
+	// thing: only an un-trappable signal ends this.
+	script := "trap '' TERM\n" + grandchildScript(pidFile, marker)
+
+	const deadline = 500 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), deadline)
+	defer cancel()
+
+	var out bytes.Buffer
+	start := time.Now()
+	if _, err := NewExecRunner().Run(ctx, []string{"sh", "-c", script}, nil, &out, &out); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("Run returned after %v for a %v deadline against a SIGTERM-trapping task: "+
+			"the timeout is negotiating with something that refuses", elapsed, deadline)
+	}
+	requireProcessGroupGone(t, readPGID(t, pidFile))
+
+	// Same two-sample check the sibling test uses: a marker that never grew
+	// would mean the fixture never ran, not that the kill worked.
+	before := fileSize(t, marker)
+	if before == 0 {
+		t.Fatal("the grandchild never wrote to its marker file; the test is not exercising the shape it claims")
+	}
+	time.Sleep(300 * time.Millisecond)
+	if after := fileSize(t, marker); after != before {
+		t.Errorf("a SIGTERM-trapping task is still working after the timeout returned: marker grew %d -> %d bytes", before, after)
 	}
 }

--- a/internal/executor/kubernetes.go
+++ b/internal/executor/kubernetes.go
@@ -270,9 +270,11 @@ const maxPodActiveDeadline = math.MaxInt32
 // durable outcome record and land one report RPC, and the kubelet must not
 // preempt that. But the tail is not proportional to the declared grace. The
 // agent does not pass the declaration on to the child: internal/agent/exec.go
-// runs it under exec.CommandContext with the default cancel, an immediate
-// SIGKILL whatever the DAG asked for. So what is left after the kill is one
-// record write and one RPC, and a minute covers that on any cluster.
+// SIGKILLs the child's whole process group immediately, whatever the DAG asked
+// for (#943). What is left after that kill is bounded by the agent too — its
+// execWaitDelay (10 s) caps the wait for an output pipe held open by a
+// descendant that escaped the group — so the worst tail is that delay plus one
+// record write and one RPC, and a minute covers it on any cluster.
 const maxDeadlineGraceTerm = 60
 
 // podDeadlineGraceTerm is the shutdown tail the pod deadline budgets for the

--- a/internal/executor/kubernetes_deadline_test.go
+++ b/internal/executor/kubernetes_deadline_test.go
@@ -166,9 +166,9 @@ func TestPodDeadlineLetsTheAgentTimeoutFirst(t *testing.T) {
 // execution_timeout by about two hours. The term is still right to ADD (it
 // budgets the agent's own tail after its clock fires), but it is capped, because
 // that tail is not proportional to the declared grace: internal/agent/exec.go
-// runs the child under exec.CommandContext with the default cancel, so the agent
-// SIGKILLs it immediately no matter what the DAG asked for, and what is left is
-// one outcome-record write and one report RPC.
+// SIGKILLs the child's whole process group immediately no matter what the DAG
+// asked for (#943), and what is left is the agent's own bounded wait for the
+// output pipe, one outcome-record write and one report RPC.
 func TestBuildPodDeadlineCapsTerminationGraceTerm(t *testing.T) {
 	headroom := int64(defaultDispatchLostThreshold / time.Second)
 	const graceCap = int64(maxDeadlineGraceTerm)

--- a/test/e2e/execution-timeout-e2e.sh
+++ b/test/e2e/execution-timeout-e2e.sh
@@ -20,8 +20,19 @@
 # assertion here says anything about what an operator sees on a screen.
 #
 # The scenario declares `execution_timeout_seconds: 10` on a task that sleeps
-# far past it, with the image PRE-LOADED into the cluster so the startup delta
-# is a few seconds and the run stays fast.
+# far past it AND leaves a grandchild holding the agent's stdout pipe (#943),
+# with the image PRE-LOADED into the cluster so the startup delta is a few
+# seconds and the run stays fast.
+#
+# What is red before #943. Assertion 1 is red UNCONDITIONALLY on both halves:
+# the agent killed its direct child alone, the grandchild kept the stdout pipe
+# open, and the agent's Wait therefore blocked for the full 600s the grandchild
+# lives — so the kubelet's 220s deadline always fired first, stamping
+# `status.reason=DeadlineExceeded` and settling the pod with a generic reason
+# and no outcome record. Assertion 2 is red with it, for the same reason: the
+# agent never reaches the branch that writes the record. This is the scenario's
+# only unconditional outcome red; see the #925 note below for why the earlier
+# shape could not offer one.
 #
 # What is red before #925, precisely. Assertion 3 is red UNCONDITIONALLY: the
 # pod deadline was the declared timeout itself, so 10 rather than 220, on any
@@ -36,7 +47,12 @@
 # assertion 3 asserts the arithmetic directly rather than inferring it from the
 # outcome.
 #
-# Four assertions:
+# Five assertions:
+#   0. the sleeper's shipped log carries a line written by its GRANDCHILD, which
+#      is the premise of assertion 1 rather than an assertion in its own right:
+#      it proves the task really did hand the agent's stdout pipe to a process
+#      the agent does not directly own, so a silently failed spawn cannot let
+#      this scenario pass while covering only the easy shape;
 #   1. the timed-out task instance's `failure_reason` names `execution_timeout:`
 #      — the agent won the race — AND the sleeper pod's own `status.reason` is
 #      NOT `DeadlineExceeded`, which names the race winner directly rather than
@@ -275,16 +291,22 @@ tasks:
   sleeper:
     execution_timeout_seconds: ${TASK_TIMEOUT}
 YAML
-# The body sleeps IN-PROCESS rather than shelling out to sleep(1): the agent runs
-# the user process under exec.CommandContext with the default cancel (an
-# immediate SIGKILL to the direct child only), and its Wait also waits for the
-# stdout pipe to close. A shelled-out grandchild would survive the kill holding
-# that pipe, so the agent would block past its own deadline and the kubelet
-# would win the race for a reason that has nothing to do with #925.
+# The body LEAVES A GRANDCHILD holding the agent's stdout, on purpose (#943).
+# This scenario used to sleep strictly in-process to avoid that shape, because
+# the agent SIGKILLed its direct child only and then waited for the stdout pipe
+# to close, so a surviving grandchild blocked the wait past the agent's own
+# deadline and handed the race to the kubelet for a reason unrelated to #925.
+# That is the shape almost every real task has — the bash operator runs its
+# entrypoint under `bash -c`, so any `&&`, pipe or background job makes the
+# user's programs grandchildren — so avoiding it meant the green here did not
+# cover the common case. The agent now puts the child in its own process group
+# and kills the GROUP, so the scenario exercises the path instead of dodging it,
+# and assertion 1 is what proves the agent still wins the race.
 cat >"$PROJ/dag.py" <<'PY'
-"""Locks the execution_timeout race against the kubelet (#925 / #930)."""
+"""Locks the execution_timeout race against the kubelet (#925 / #930 / #943)."""
 from __future__ import annotations
 
+import subprocess
 import time
 
 from airflow.sdk import DAG, task
@@ -295,7 +317,16 @@ def sleeper() -> None:
     # Declares execution_timeout_seconds: 10 (leoflow.yaml) and runs far past it.
     # The agent's own clock must interrupt this, and the timeout must be named
     # on the task instance the API serves.
+    #
+    # The subprocess is a GRANDCHILD of the agent and inherits this process's
+    # stdout, which is the agent's log pipe (#943). Its greeting is asserted in
+    # the shipped log, because it is the premise of everything below: if the
+    # spawn silently failed, this task would be an ordinary in-process sleep and
+    # the scenario would be back to proving the easy case.
     print("sleeper: running past the declared execution_timeout", flush=True)
+    subprocess.Popen(  # noqa: S603,S607 - inheriting stdout is the point
+        ["sh", "-c", "echo 'sleeper: grandchild holding the agent stdout pipe'; sleep 600"],
+    )
     time.sleep(600)
 
 
@@ -440,6 +471,23 @@ while :; do
   [ "$(date +%s)" -lt "$deadline" ] || fail "timeout waiting for 'sleeper' to fail"
   sleep 2
 done
+
+log "Asserting the sleeper really did leave a grandchild on the agent's stdout pipe"
+# The PREMISE of assertion 1, checked rather than assumed. The grandchild writes
+# its greeting to the stdout it inherited from the task process, so seeing that
+# line in the shipped log is proof that the pipe was inherited by a process the
+# agent does not directly own — the shape #943 was about. Without this check a
+# silently failed spawn (no `sh`, no `sleep`, an image change) would quietly turn
+# this scenario back into the in-process sleep it used to be, and it would go on
+# passing while covering nothing.
+GRANDCHILD_LOG=""
+for try in 0 1 2; do
+  body="$(curl -fsS --max-time "$CURL_MAX_TIME" -H "Authorization: Bearer $TOKEN" \
+    "$API/api/v2/dags/$DAG_ID/dagRuns/$RUN_ID/taskInstances/sleeper/logs/$try" 2>/dev/null || true)"
+  case "$body" in *"grandchild holding the agent stdout pipe"*) GRANDCHILD_LOG="$body"; break ;; esac
+done
+[ -n "$GRANDCHILD_LOG" ] \
+  || fail "the sleeper's shipped log never carried the grandchild's line — the task did not spawn a process holding the agent's stdout pipe, so this scenario is not exercising the #943 shape it claims to"
 
 REASON="$(task_field sleeper failure_reason)"
 log "sleeper error_message: ${REASON:-<empty>}"

--- a/test/e2e/execution-timeout-e2e.sh
+++ b/test/e2e/execution-timeout-e2e.sh
@@ -24,15 +24,15 @@
 # with the image PRE-LOADED into the cluster so the startup delta is a few
 # seconds and the run stays fast.
 #
-# What is red before #943. Assertion 1 is red UNCONDITIONALLY on both halves:
-# the agent killed its direct child alone, the grandchild kept the stdout pipe
-# open, and the agent's Wait therefore blocked for the full 600s the grandchild
-# lives — so the kubelet's 220s deadline always fired first, stamping
-# `status.reason=DeadlineExceeded` and settling the pod with a generic reason
-# and no outcome record. Assertion 2 is red with it, for the same reason: the
-# agent never reaches the branch that writes the record. This is the scenario's
-# only unconditional outcome red; see the #925 note below for why the earlier
-# shape could not offer one.
+# What is red before #943. Assertions 1 and 2 are red UNCONDITIONALLY, on every
+# host: the agent killed its direct child alone, the grandchild kept the stdout
+# pipe open, and the agent's Wait would have blocked for the 600s that
+# grandchild lives — so the kubelet's 220s deadline always fired first, stamping
+# `status.reason=DeadlineExceeded` and settling the pod with a generic reason.
+# The agent never reached the branch that names the timeout or writes the
+# durable outcome record, so both halves of assertion 1 and the whole of
+# assertion 2 fail. These are the scenario's only unconditional OUTCOME reds;
+# see the #925 note below for why the earlier, in-process shape had none.
 #
 # What is red before #925, precisely. Assertion 3 is red UNCONDITIONALLY: the
 # pod deadline was the declared timeout itself, so 10 rather than 220, on any

--- a/website/content/operate/scheduler-resilience.md
+++ b/website/content/operate/scheduler-resilience.md
@@ -47,8 +47,30 @@ task served by a **warm pool** has only the agent's: warm pods carry no
 warm worker's attempt watchdog, derived from
 `auth.max_attempt_credential_lifetime` — so everything below about the kubelet
 racing the agent does not apply to them.) The **agent** owns the semantic
-timeout: it interrupts the user process at the declared boundary and reports
-`execution_timeout: task exceeded Ns limit`. The task pod's
+timeout: at the declared boundary it **SIGKILLs the task's whole process
+group**, not just the process it started, and reports
+`execution_timeout: task exceeded Ns limit`.
+
+The group matters. Signalling only the direct child left the timeout
+defeatable by anything that outlived it — a backgrounded daemon, a `nohup`, a
+shell that forks — and worse, a descendant that inherited the task's stdout
+kept the agent's own wait open, so the timeout fired and *nothing died*
+(#943). The group kill is un-trappable on purpose: a task that handles SIGTERM
+and declines to exit would otherwise be exempt from its own declared limit.
+
+Three consequences worth knowing:
+
+- **A descendant that escapes the group** (by calling `setsid`) is not
+  reached. The agent stops waiting for it after a bounded 10s and reports the
+  timeout anyway, rather than hanging. If your pod declares a
+  `terminationGracePeriodSeconds` shorter than that, the kubelet can still win
+  the race and you get the degraded reason described above.
+- **Output written before the kill is kept.** The tail still in flight when
+  the group dies is drained within the same bound; only a descendant holding
+  the pipe past it can cost you the last lines, and that is logged.
+- **A task with no declared timeout that backgrounds a process** now costs an
+  extra 10s at exit while the agent waits out the inherited pipe. Previously
+  that case hung indefinitely. The task pod's
 `activeDeadlineSeconds` is only the **backstop** for an agent that can no
 longer enforce anything (crashed, wedged, partitioned); when the kubelet gets
 there first, the pod is gone and the failure reason degrades to what Kubernetes

--- a/website/content/reference/go/internal-agent.md
+++ b/website/content/reference/go/internal-agent.md
@@ -190,7 +190,7 @@ type CommandRunner interface {
 ```
 
 <a name="NewExecRunner"></a>
-### func [NewExecRunner](<https://github.com/neochaotic/leoflow/blob/main/internal/agent/exec.go#L16>)
+### func [NewExecRunner](<https://github.com/neochaotic/leoflow/blob/main/internal/agent/exec.go#L48>)
 
 ```go
 func NewExecRunner() CommandRunner

--- a/website/content/reference/go/internal-executor.md
+++ b/website/content/reference/go/internal-executor.md
@@ -533,7 +533,7 @@ func ResilienceLadderWarnings(l ResilienceLadder) []LadderWarning
 ResilienceLadderWarnings reports the ladder settings that are valid but remove a resilience backstop, so the server can surface them as boot WARNs. ValidateResilienceLadder deliberately accepts a non\-positive credential ceiling — it is the operator's documented "no ceiling" setting — but that one value disables every wall\-clock bound the ceiling carries: heartbeat renewal of an attempt's bearer becomes unbounded; a dedicated task pod whose DAG declares no execution timeout gets no ActiveDeadlineSeconds floor; and, with warm pools enabled, the per\-attempt watchdog that keeps a wedged attempt from pinning a warm slot is off too \(a warm pod has no pod\-level deadline at all, and the worker lifetime cap drains between attempts, never mid\-attempt\). A task that wedges while still heartbeating then has no bound of its own even with a healthy control plane: the orphan\-run reaper skips a run with a live task instance and agent\-lost never fires on a live agent. None of these losses is an error; all are invisible without this signal. Pure, like the validator: the server calls it once at boot after the logger exists.
 
 <a name="OutcomeReporter"></a>
-## type [OutcomeReporter](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L227-L231>)
+## type [OutcomeReporter](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L234-L238>)
 
 OutcomeReporter records a terminal task\-instance outcome the reconciler recovered from a pod \(its durable outcome record, or its phase\). Every method is guarded by the attempt \(try\_number\) so a stale reconciler acting on a previous attempt's pod never clobbers a live retry, and is idempotent: a settle on an already\-terminal instance is a no\-op, not an error.
 
@@ -546,7 +546,7 @@ type OutcomeReporter interface {
 ```
 
 <a name="PodIdentity"></a>
-## type [PodIdentity](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L326-L333>)
+## type [PodIdentity](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L328-L335>)
 
 PodIdentity is the JSON payload of AgentIdentityAnnotation: the full task\-instance identity the control plane mints the exchanged JWT for.
 
@@ -562,7 +562,7 @@ type PodIdentity struct {
 ```
 
 <a name="ParseAgentIdentity"></a>
-### func [ParseAgentIdentity](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L338>)
+### func [ParseAgentIdentity](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/kubernetes.go#L340>)
 
 ```go
 func ParseAgentIdentity(raw string) (PodIdentity, error)
@@ -829,7 +829,7 @@ type PodSecurity struct {
 ```
 
 <a name="PodSnapshotter"></a>
-## type [PodSnapshotter](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L239-L244>)
+## type [PodSnapshotter](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L246-L251>)
 
 PodSnapshotter supplies the reconciler's task\-pod set from a local cache instead of a live LIST every tick \(PR\-10\). It is safe here without a live confirm: the signal the reconciler acts on is presence of a terminal pod, which is monotonic \(a pod that reached Failed/Succeeded stays terminal\), and every settle is attempt\- and state\-guarded \(ADR 0052\), so at worst cache lag delays a settle by a tick. A nil snapshotter \(Lite/subprocess, or a cold start\) keeps the live LIST.
 
@@ -1000,7 +1000,7 @@ type ReaperStore interface {
 ```
 
 <a name="Reconciler"></a>
-## type [Reconciler](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L262-L277>)
+## type [Reconciler](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L269-L284>)
 
 Reconciler detects task pods whose task instance was never settled by the agent \(a pod killed before or during its report\) and records the true outcome — from the pod's durable outcome record where present, else its phase — so retries and run finalization proceed instead of stranding the task. It also garbage\-collects finished pods once they age out.
 
@@ -1013,7 +1013,7 @@ type Reconciler struct {
 ```
 
 <a name="NewReconciler"></a>
-### func [NewReconciler](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L280>)
+### func [NewReconciler](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L287>)
 
 ```go
 func NewReconciler(clientset kubernetes.Interface, namespace string, reporter OutcomeReporter) *Reconciler
@@ -1022,7 +1022,7 @@ func NewReconciler(clientset kubernetes.Interface, namespace string, reporter Ou
 NewReconciler builds a Reconciler over the given cluster and outcome reporter.
 
 <a name="Reconciler.LastSweepCompletedAt"></a>
-### func \(\*Reconciler\) [LastSweepCompletedAt](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L301>)
+### func \(\*Reconciler\) [LastSweepCompletedAt](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L308>)
 
 ```go
 func (r *Reconciler) LastSweepCompletedAt() time.Time
@@ -1033,7 +1033,7 @@ LastSweepCompletedAt reports when the last COMPLETED sweep finished: the task\-p
 A sweep that could not list pods records nothing. A sweep whose individual settle failed on a DB error still counts: that pod is retried next sweep, and the gate's grace leaves room for the retry before any reaper may act.
 
 <a name="Reconciler.Reconcile"></a>
-### func \(\*Reconciler\) [Reconcile](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L312>)
+### func \(\*Reconciler\) [Reconcile](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L319>)
 
 ```go
 func (r *Reconciler) Reconcile(ctx context.Context) error
@@ -1042,7 +1042,7 @@ func (r *Reconciler) Reconcile(ctx context.Context) error
 Reconcile lists managed task pods, records each terminal one's outcome against its task instance, and garbage\-collects finished pods older than the grace period. A completed sweep is stamped for LastSweepCompletedAt.
 
 <a name="Reconciler.SetPodSnapshotter"></a>
-### func \(\*Reconciler\) [SetPodSnapshotter](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L287>)
+### func \(\*Reconciler\) [SetPodSnapshotter](<https://github.com/neochaotic/leoflow/blob/main/internal/executor/reconcile.go#L294>)
 
 ```go
 func (r *Reconciler) SetPodSnapshotter(s PodSnapshotter)


### PR DESCRIPTION
Closes #943.

`execution_timeout` bounded the agent's first process, not the task. When a task left a grandchild behind, the timeout did nothing at all: the cancel SIGKILLed the direct child alone, the grandchild kept the stdout pipe it had inherited open, and because the agent wires stdout to a log writer rather than to a file, the standard library interposes that pipe and blocks `Wait` on its copying goroutine until every writer closes it. So the deadline fired, nothing died, and the agent never reached the branch that reports the timeout or writes the durable outcome record. The attempt ended minutes later on the kubelet's `activeDeadlineSeconds`, with the generic container-terminated reason and nothing for the reconciler to recover.

This is the ordinary task shape rather than an exotic one. The bash operator runs its entrypoint under `bash -c`, so any `&&`, pipe, `;` or background job makes the user's real programs grandchildren of the process the agent kills, and the same holds for a Python task that shells out.

## The fix

`internal/agent/exec.go` starts the task in its **own process group** and the cancel SIGKILLs the **group**. That is the mechanism: it leaves nothing holding the pipe, so `Wait` returns at the deadline and the whole tree goes with it. A bounded 10-second `WaitDelay` is the **backstop** for the residue — a descendant that escapes the group by calling `setsid` — so nothing can hold the wait open indefinitely any more.

The delay is sized against the pod deadline's shutdown tail: the kubelet must not preempt the agent between its clock firing and its report landing, and that budget is the pod's termination grace, 30s when undeclared. Ten seconds leaves twenty for the outcome record and one report RPC. The godoc on `executor.maxDeadlineGraceTerm`, which asserted the old "immediate SIGKILL, so all that is left is a record write and an RPC", is corrected rather than left to outlive the behaviour it described.

`os/exec` reports a forced pipe close on a **successfully exited** process as `ErrWaitDelay`. That is mapped back to the task's own exit status with a warning, because a leaked pipe is the agent's I/O outcome and not the task's verdict; the cost is the tail of that task's output, and the agent says so in the log.

## The properties, and how each is proved

Every assertion below was mutation-tested — the mutant applied is confirmed by a SHA-256 of the file before and after, not by `sed`'s exit code.

**1 — a timed-out task stops consuming resources, grandchild and all.** `TestExecRunnerTimeoutKillsAGrandchildHoldingStdout` runs the canonical shape (a shell that backgrounds a long-running child and waits) under a 500 ms deadline. Returning is not the assertion, because returning is exactly what the bug lets you do: it also reads the shell's pid, polls until `kill(-pgid, 0)` reports ESRCH, and checks that the file the grandchild was appending to has stopped growing. Measured: **23.5 s before, 501–503 ms after**. `TestRunnerExecutionTimeoutSurvivesAGrandchild` drives the same shape through `Runner.Run` with the production runner and a real bash task — the wiring, not the leaf — and takes **23.4 s → 1.00 s**.

**2 — the normal path is unchanged.** This is the fix's own risk: the `WaitDelay` timer starts when `Wait` observes the child exit, not when the copying finishes, so a delay set too short truncates a task that exited perfectly well. `TestExecRunnerCapturesEveryLineOfANormalExit` writes 4000 lines into a deliberately slow consumer (standing in for a log sink that is not keeping up, which is what puts the drain on the clock the delay bounds) and asserts the **complete** output, byte for byte, with the task's own exit code. Setting `execWaitDelay` to 1 ms takes it from 40000 bytes to 10 — while the pre-existing `TestExecRunnerCapturesOutputAndExitCode` stays green, which is why truncation needed a test of its own.

**3 — a timeout is reported as a timeout.** Kept as it was, and now locked through the real path rather than through a fake command runner. The wiring test asserts the returned error, the last reported state (`FAILED`), the reported message and the **durable outcome record's** reason all name `execution_timeout`, and that the recorded exit code is non-zero (255 — a killed task never exited 0). Before this PR that classification was only ever exercised with a `fakeCmd`; the real path could not reach it at all, which is the point of #943.

**4 — the end-to-end scenario stops routing around the defect.** `test/e2e/execution-timeout-e2e.sh` said in its own comment that its task slept in-process *because* a shelled-out grandchild would hand the race to the kubelet. It now spawns one on purpose. Its premise is checked rather than assumed: a new assertion 0 requires the **grandchild's own line** in the shipped task log, so a spawn that silently fails (no `sh`, an image change) cannot quietly turn the scenario back into the easy case while it goes on passing. The header's red-before analysis is updated too — assertions 1 and 2 are now unconditionally red before this fix, which is the first unconditional *outcome* red this scenario has had; #925's note explains why the earlier shape could offer none.

## Mutation matrix

| Mutant | Test that goes red | Observed |
|---|---|---|
| drop `Setpgid` + group cancel | timeout test | returns at 10.5 s (the `WaitDelay` alone), grandchild alive |
| drop `Setpgid` only | timeout test | 10.5 s — `kill(-pid)` on a non-leader is ESRCH, so the group kill reaches nothing |
| drop the group `Cancel` only | timeout test | 10.5 s — default cancel takes the direct child only |
| drop `WaitDelay` | leaked-pipe test | 10.0 s, unbounded wait |
| `WaitDelay` = 1 ms | full-output test | 40000 bytes → 10 |
| drop the `ErrWaitDelay` mapping | leaked-pipe test | a task that exited 0 is reported as a failure |
| drop the non-leader fallback | `TestKillProcessGroupFallsBack…` | the child survives while the cancel reports success |

One belief was checked and **discarded** rather than shipped as a comment: I expected `kill(-pid)` on a non-leader to hit the *parent's* group, and wrote a standalone program to demonstrate it. It does not — a group is named by its leader's pid, so the call simply ESRCHes and reaches nothing. `killProcessGroup` therefore falls back to killing the process itself on ESRCH, so a future edit that drops the `Setpgid` degrades to the old behaviour instead of to no behaviour at all, and the godoc says the measured thing rather than the assumed one.

## Verified

`go build ./...`, `go test ./...` (33 packages), `go test -race -count=2 ./internal/agent/`, `go vet -tags integration ./...`, `golangci-lint run` → 0 issues, `gofmt -l` empty, `shellcheck -x` and `bash -n` on the e2e script, the generated `dag.py` compiled, and all 19 `scripts/check-*.sh` green except `check-chart-version-matches-tag.sh`, which needs a tag argument. Exit codes were read directly, never through a pipe.

## Found, deliberately not fixed

- **The committed godoc mirror is stale on `main`.** Re-running `website/scripts/gen-go.sh` rewrites `internal-api`, `internal-auth`, `internal-domain` and `internal-storage` for reasons unrelated to this change. Only the two pages this PR actually moves (`internal-agent`, `internal-executor`) are included; the rest is left for a sweep of its own, and CI regenerates before `hugo` regardless.
- **`test/e2e/execution-timeout-e2e.sh` still builds with `--dockerfile`**, the hand-written escape hatch (ADR 0003's "Intermediate" tier) rather than the generated Dockerfile almost every user gets from `leoflow.yaml`. Out of scope here, and changing it would alter what the scenario builds while it is being changed for another reason.
- **The e2e is still not wired into any CI tier** (#939 landed it manual/nightly on purpose). It is now a much stronger test than it was, which strengthens the case for promoting it, but promoting it is a separate decision.
- **A DAG that declares a `terminationGracePeriodSeconds` shorter than the 10s `WaitDelay`** can still be preempted by the kubelet in the escaped-descendant case. That corner predates this bound and is not widened by it; it is noted in the `execWaitDelay` godoc.
