### PR TITLE
fix(helm): keep the migration hook's pod out of the control-plane selector

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -23,6 +23,7 @@ on:
       - "scripts/helm-template-checks.sh"
       - "scripts/rbac-covers-executor.sh"
       - "scripts/check-values-doc-comments.sh"
+      - "scripts/check-migrate-pod-selection.sh"
       - ".github/workflows/helm-ci.yaml"
       - ".github/ci/kind-datastores.yaml"
       - "deploy/Dockerfile.server"
@@ -107,6 +108,17 @@ jobs:
       # a configuration key without updating the chart side.
       - name: helm-template-checks (contract)
         run: bash scripts/helm-template-checks.sh
+
+      # Cross-document contract: the pre-install/pre-upgrade migration hook's pod
+      # must not be selectable by any control-plane Service or PodDisruptionBudget,
+      # in any deployment mode (#1055). Selection is a SUBSET relation between two
+      # documents, and helm-unittest asserts one document at a time — which is how
+      # a Job pod carrying the exact control-plane selector survived ~230 cases.
+      # This renders the chart in every mode and compares the real label maps.
+      - name: Install PyYAML (the gate compares rendered label maps)
+        run: python3 -m pip install --user pyyaml
+      - name: check-migrate-pod-selection (migrate hook pod is not a control-plane endpoint)
+        run: bash scripts/check-migrate-pod-selection.sh
 
       # Contract test in the other direction: the Role must permit every
       # Kubernetes call the executor makes. Nothing else compares the two — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -328,6 +328,46 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   install, naming neither value the operator set. Refused at render time now,
   along with a minimum below 1, which Kubernetes rejects without the
   `HPAScaleToZero` gate ([#947](https://github.com/neochaotic/leoflow/issues/947)).
+- **The migration hook's pod no longer answers for the control plane on
+  `helm upgrade`.** A Service selector matches every pod whose labels *contain*
+  it, and for the default (non-split) install the control-plane Service's
+  selector is exactly the label set the migrate Job's pod template carried — so
+  the pre-upgrade hook pod was selected by the Service and by the
+  PodDisruptionBudget for the whole migration window, `Ready` from its first
+  instant because a Job pod has no readiness probe. `helm install` was never
+  affected (no Service exists yet when the pre-install hook runs) and neither was
+  `split.enabled` (api and scheduler carry a component label the Job lacked).
+
+  The measurable loss was disruption accounting, not traffic. Held open on k3s
+  v1.33.6, an integer `minAvailable` budget reported `currentHealthy: 2` over one
+  real replica — the hook pod padded the count, so the budget allowed one more
+  simultaneous eviction than it was sized for — and a percentage-valued budget
+  failed outright (`DisruptionAllowed=False`, *"jobs.batch does not implement the
+  scale subresource"*), pinning `disruptionsAllowed` at 0 and stalling every
+  voluntary eviction until the hook exited. Requests were *not* black-holed, for
+  a reason that is accidental rather than designed: all three Service ports use
+  **named** `targetPort`s and the hook pod declares no container port, so its
+  endpoint landed in a slice with `ports: null` and kube-proxy programmed nothing
+  for it. Change one of those to a numeric `targetPort` and the same cluster
+  black-holed 19 of 40 requests; consumers that resolve ports themselves (AWS
+  Load Balancer Controller in IP-target mode, service meshes, Gateway API) were
+  never covered by the accident at all.
+
+  The hook's pod now runs under its own application name
+  (`app.kubernetes.io/name: <name>-migrate`, `component: migrate`). Adding a
+  distinguishing label while keeping the shared pair would have changed nothing —
+  a superset still matches a selector — so the pod differs on a key the selector
+  *carries*. It is also the truer label: this is a different image with a
+  different lifetime, not a replica of the control plane. One consequence worth
+  knowing: with `networkPolicy.enabled`, the control-plane policy used to govern
+  the hook pod on upgrade but not on install; now it governs it in neither, which
+  is at least symmetric. Egress is allow-all by default, so nothing changes for a
+  default install — but in a namespace with a default-deny policy the migrate pod
+  needs its own allowance to reach Postgres, on upgrade as well as on install.
+  `scripts/check-migrate-pod-selection.sh` renders the chart in every deployment
+  mode and fails if any Service or PodDisruptionBudget selector is ever again a
+  subset of the hook pod's labels
+  ([#1055](https://github.com/neochaotic/leoflow/issues/1055)).
 - **A version floor in `dependencies` was silently dropped, and left junk in the
   image.** `RUN` in a Dockerfile is `/bin/sh -c`, and the specifiers were joined
   into that line unquoted — so `setuptools>=80.9.0` was a *redirection*: pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -333,15 +333,18 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   it, and for the default (non-split) install the control-plane Service's
   selector is exactly the label set the migrate Job's pod template carried — so
   the pre-upgrade hook pod was selected by the Service and by the
-  PodDisruptionBudget for the whole migration window, `Ready` from its first
+  PodDisruptionBudget (on the HA profile, where one renders) for the whole
+  migration window, `Ready` from its first
   instant because a Job pod has no readiness probe. `helm install` was never
   affected (no Service exists yet when the pre-install hook runs) and neither was
   `split.enabled` (api and scheduler carry a component label the Job lacked).
 
   The measurable loss was disruption accounting, not traffic. Held open on k3s
   v1.33.6, an integer `minAvailable` budget reported `currentHealthy: 2` over one
-  real replica — the hook pod padded the count, so the budget allowed one more
-  simultaneous eviction than it was sized for — and a percentage-valued budget
+  real replica — the hook pod padded the count, so at the default
+  `minAvailable: 1` the hook pod **alone satisfied the budget** and every real
+  replica became evictable for the migration window, not one extra — and a
+  percentage-valued budget
   failed outright (`DisruptionAllowed=False`, *"jobs.batch does not implement the
   scale subresource"*), pinning `disruptionsAllowed` at 0 and stalling every
   voluntary eviction until the hook exited. Requests were *not* black-holed, for

--- a/helm/leoflow/templates/_helpers.tpl
+++ b/helm/leoflow/templates/_helpers.tpl
@@ -73,6 +73,71 @@ suffix so the two Deployments, Services, SAs, etc. do not collide. Takes {ctx, r
 {{- include "leoflow.suffixRole" (dict "base" (include "leoflow.fullname" .ctx) "role" .role) -}}
 {{- end -}}
 
+{{/*
+Application name of the migration hook's pod: the chart name with a "-migrate"
+suffix. It is deliberately NOT leoflow.name.
+
+A Service selector matches every pod whose labels CONTAIN its map, so the migrate
+Job's pod template used to be selected by the control-plane Service and by the
+PodDisruptionBudget: for the default "all" role, leoflow.roleSelectorLabels is
+exactly leoflow.selectorLabels, and the Job carried that same pair. A Job pod has
+no readinessProbe, so it is Ready the instant its container starts. `helm install`
+never showed it (no Service exists yet when the pre-install hook runs) and split
+mode never showed it either (api and scheduler add a component label the Job
+lacks), which left `helm upgrade` on the default install as the one exposed path
+(#1055).
+
+What that cost, measured on k3s v1.33.6 (k3d) against the pre-fix chart with the hook pod
+held open:
+
+  - Disruption accounting was wrong for the whole migration window. An integer
+    minAvailable budget reported currentHealthy=2 over ONE real replica — the
+    hook pod padded the count — so the budget permitted one more simultaneous
+    eviction than it was sized for. A percentage-valued budget failed outright:
+    DisruptionAllowed=False, "jobs.batch does not implement the scale
+    subresource", disruptionsAllowed pinned at 0, every voluntary eviction
+    stalled until the hook pod exited.
+  - Traffic was NOT lost, and the reason is worth writing down because it is
+    accidental. The pod joined the Service's EndpointSlice (ready=true) but in a
+    slice with `ports: null`: all three Service ports use NAMED targetPorts and
+    this pod declares no containerPort, so the EndpointSlice controller could
+    resolve nothing and kube-proxy programmed nothing. Give any of those ports a
+    NUMERIC targetPort and the protection is gone — the same cluster then
+    black-holed 19 of 40 requests to the Service. Consumers that read
+    EndpointSlices and resolve ports themselves (AWS Load Balancer Controller in
+    IP-target mode, service meshes, Gateway API implementations) are not covered
+    by it either, and no in-cluster CI here can settle that.
+
+Adding a component label alongside the shared pair does NOT fix this — a superset
+still matches the selector. The pod has to differ on a key the selector CARRIES,
+which is why the name changes rather than being decorated. It is also the honest
+label: this pod runs a different image (leoflow-migrate) with a different
+lifetime, not a replica of the control plane.
+
+Suffixed through leoflow.suffixRole so a long nameOverride cannot produce a label
+value over the 63-char limit — this is a pre-install hook, so an invalid label is
+a failed install, not a degraded one.
+*/}}
+{{- define "leoflow.migrateName" -}}
+{{- include "leoflow.suffixRole" (dict "base" (include "leoflow.name" .) "role" "migrate") -}}
+{{- end -}}
+
+{{/*
+Pod-template labels for the migration hook Job. Kept whole and in one place so
+the set that must NOT be a superset of any control-plane selector has a single
+definition. instance is retained on purpose: `kubectl -n <ns> get pods -l
+app.kubernetes.io/instance=<release>` is how an operator finds a wedged migration,
+and it is not a key any control-plane selector can match alone.
+
+scripts/check-migrate-pod-selection.sh renders the chart and asserts no
+Service/PDB selector is a subset of this map, in every mode.
+*/}}
+{{- define "leoflow.migratePodLabels" -}}
+app.kubernetes.io/name: {{ include "leoflow.migrateName" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: migrate
+{{- end -}}
+
 {{- define "leoflow.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
 {{- default (include "leoflow.fullname" .) .Values.serviceAccount.name -}}

--- a/helm/leoflow/templates/migration-job.yaml
+++ b/helm/leoflow/templates/migration-job.yaml
@@ -22,8 +22,17 @@ spec:
   backoffLimit: 3
   template:
     metadata:
+      # NOT leoflow.selectorLabels (#1055). A Service selector matches every pod
+      # whose labels CONTAIN it, and for the default "all" role the control-plane
+      # Service's selector IS that set — so on `helm upgrade`, where the Service
+      # is already live when the pre-upgrade hook runs, this pod joined the
+      # Service's EndpointSlice and the PodDisruptionBudget's healthy count,
+      # Ready from the first instant because a Job pod has no readinessProbe. A
+      # distinguishing label alone would not help: a superset still matches. What
+      # that cost, and why the traffic half stayed invisible, is written out on
+      # leoflow.migrateName.
       labels:
-        {{- include "leoflow.selectorLabels" . | nindent 8 }}
+        {{- include "leoflow.migratePodLabels" . | nindent 8 }}
     spec:
       restartPolicy: Never
       # The migrate binary talks only to Postgres via LEOFLOW_DATABASE_URL and

--- a/helm/leoflow/tests/migrate_pod_selection_test.yaml
+++ b/helm/leoflow/tests/migrate_pod_selection_test.yaml
@@ -1,0 +1,138 @@
+# #1055 — the migration hook pod must not be an endpoint of the control plane.
+#
+# The defect was one of SELECTION, and selection is a relationship between two
+# documents: a Service selector matches a pod when the pod's labels are a
+# superset of the selector's map. Every other suite here asserts one document at
+# a time, which is why the collision survived ~246 cases — the Job's labels were
+# "correct" and the Service's selector was "correct", and nothing compared them.
+#
+# So each case below pins BOTH maps, whole, side by side. Whole, because
+# asserting that the Job carries one distinguishing label stays green when
+# someone re-adds the shared selector set beside it — a superset still matches,
+# and that is exactly how the bug would come back. Side by side, because the
+# invariant is between them: reading one assertion without the other tells you
+# nothing about whether the pod is an endpoint.
+#
+# helm-unittest cannot compute the subset relation across documents, so the
+# property itself ("no control-plane Service selector is a subset of the migrate
+# pod's labels, in any mode") is enforced by scripts/check-migrate-pod-selection.sh,
+# which renders the chart and compares the real maps. These cases are the shape;
+# that script is the property.
+suite: "#1055 — the migrate Job's pod is not selected by the control plane"
+release:
+  name: leoflow
+templates:
+  - migration-job.yaml
+  - service.yaml
+  - pdb.yaml
+set:
+  database.url: postgres://h/d
+  redis.url: redis://h/0
+  auth.jwtSecret: jwt
+tests:
+  # The default install, and the only mode where the collision existed: the "all"
+  # role's selector is byte-identical to leoflow.selectorLabels (ADR 0049 keeps it
+  # that way so the Deployment's immutable selector survives an upgrade from a
+  # pre-split install), so anything carrying that pair is an endpoint.
+  - it: "non-split: the Service selector is not a subset of the migrate pod's labels"
+    asserts:
+      - equal:
+          path: spec.selector
+          value:
+            app.kubernetes.io/name: leoflow
+            app.kubernetes.io/instance: leoflow
+        template: service.yaml
+      - equal:
+          path: spec.template.metadata.labels
+          value:
+            app.kubernetes.io/name: leoflow-migrate
+            app.kubernetes.io/instance: leoflow
+            app.kubernetes.io/component: migrate
+        template: migration-job.yaml
+      # No PodDisruptionBudget at the default replica floor of one.
+      - hasDocuments:
+          count: 0
+        template: pdb.yaml
+
+  # The PodDisruptionBudget selects on the same role labels and renders once the
+  # guaranteed replica floor is above one, so an HA install also had a budget
+  # covering the migrate pod. Measured on k3s v1.33.6 (k3d) against the pre-fix chart, with the
+  # hook pod running: an integer `minAvailable` budget reported currentHealthy=2
+  # over ONE real replica — the hook pod padded the count, so the budget allowed
+  # one more simultaneous eviction than it was sized for. A percentage-valued
+  # budget failed outright, DisruptionAllowed=False with
+  # "jobs.batch does not implement the scale subresource", which pins
+  # disruptionsAllowed at 0 and stalls every voluntary eviction until the hook
+  # pod goes away. Both are gone once the selector cannot reach the pod.
+  - it: "replicaCount > 1: neither the Service nor the PodDisruptionBudget selects the migrate pod"
+    set:
+      replicaCount: 3
+      logs.persistence.enabled: false
+      logs.sink.provider: s3
+      logs.sink.bucket: leoflow-logs
+    asserts:
+      - equal:
+          path: spec.selector
+          value:
+            app.kubernetes.io/name: leoflow
+            app.kubernetes.io/instance: leoflow
+        template: service.yaml
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: leoflow
+            app.kubernetes.io/instance: leoflow
+        template: pdb.yaml
+      - equal:
+          path: spec.template.metadata.labels
+          value:
+            app.kubernetes.io/name: leoflow-migrate
+            app.kubernetes.io/instance: leoflow
+            app.kubernetes.io/component: migrate
+        template: migration-job.yaml
+
+  # Split mode never had the collision — api and scheduler each add a component
+  # label the Job lacked — and it must not acquire one. The migrate pod's own
+  # component is `migrate`, so it cannot match either role even if the shared
+  # name/instance pair were restored.
+  - it: "split mode: neither role's Service selector matches the migrate pod"
+    set:
+      split.enabled: true
+      logs.persistence.enabled: false
+      logs.sink.provider: s3
+      logs.sink.bucket: leoflow-logs
+    asserts:
+      - equal:
+          path: spec.selector
+          value:
+            app.kubernetes.io/name: leoflow
+            app.kubernetes.io/instance: leoflow
+            app.kubernetes.io/component: api
+        template: service.yaml
+        documentSelector:
+          path: metadata.name
+          value: leoflow-api
+      - equal:
+          path: spec.selector
+          value:
+            app.kubernetes.io/name: leoflow
+            app.kubernetes.io/instance: leoflow
+            app.kubernetes.io/component: scheduler
+        template: service.yaml
+        documentSelector:
+          path: metadata.name
+          value: leoflow-scheduler
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: leoflow
+            app.kubernetes.io/instance: leoflow
+            app.kubernetes.io/component: api
+        template: pdb.yaml
+      - equal:
+          path: spec.template.metadata.labels
+          value:
+            app.kubernetes.io/name: leoflow-migrate
+            app.kubernetes.io/instance: leoflow
+            app.kubernetes.io/component: migrate
+        template: migration-job.yaml

--- a/helm/leoflow/tests/migration_job_test.yaml
+++ b/helm/leoflow/tests/migration_job_test.yaml
@@ -192,3 +192,49 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.memory
           value: 512Mi
+
+  # #1055 — the migrate hook pod must not be selectable by the control-plane
+  # Service. `leoflow.roleSelectorLabels` for the default "all" role is EXACTLY
+  # `leoflow.selectorLabels`, and a Service selector matches every pod whose
+  # labels are a SUPERSET of it. This pod template carried that same set, so on
+  # `helm upgrade` — the one path where the Service already exists while the
+  # pre-upgrade hook runs — the migrate pod joined the Service's EndpointSlice
+  # and the PodDisruptionBudget's healthy count. A Job pod has no readinessProbe,
+  # so it is Ready the instant its container starts. The disruption-accounting
+  # half is a measured loss; the traffic half is only latent today, for a reason
+  # that has nothing to do with this chart's intent — see leoflow.migrateName.
+  #
+  # Adding a component label alongside the shared set does NOT fix it: a superset
+  # still matches. The pod has to differ on a key the selector CARRIES, so the
+  # Job runs under its own application name — it is its own image
+  # (leoflow-migrate), not a replica of the control plane.
+  #
+  # The map is pinned WHOLE. Asserting that one label is present would stay green
+  # if someone re-added the shared selector set beside it, which is the exact
+  # regression. The cross-document property in every deployment mode is asserted
+  # in tests/migrate_pod_selection_test.yaml and enforced against the real
+  # rendered maps by scripts/check-migrate-pod-selection.sh.
+  - it: "issue #1055 — the migrate pod carries its own app name, not the control plane's selector labels"
+    set:
+      database.url: postgres://h/d
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels
+          value:
+            app.kubernetes.io/name: leoflow-migrate
+            app.kubernetes.io/instance: leoflow
+            app.kubernetes.io/component: migrate
+
+  # The suffix is applied to the chart NAME, so a nameOverride carries through and
+  # the value still fits the 63-char label limit (leoflow.suffixRole truncates the
+  # base to 53 first). Without that truncation a long nameOverride would produce a
+  # label value the apiserver rejects — and this is a pre-install hook, so that is
+  # a failed `helm install`, not a degraded one.
+  - it: "issue #1055 — the migrate pod's app name follows nameOverride and stays within 63 chars"
+    set:
+      database.url: postgres://h/d
+      nameOverride: aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffggg
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeefff-migrate

--- a/scripts/check-migrate-pod-selection.sh
+++ b/scripts/check-migrate-pod-selection.sh
@@ -84,6 +84,7 @@ if not selectors:
 	sys.exit(f"FAIL: {mode}: nothing selects control-plane pods in this render — the comparison had no left-hand side, which is a broken gate, not a pass.")
 
 problems = []
+compared = 0
 for job in jobs:
 	jname = (job.get("metadata") or {}).get("name", "<unnamed>")
 	pod = ((job.get("spec") or {}).get("template") or {}).get("metadata") or {}
@@ -92,11 +93,27 @@ for job in jobs:
 		sys.exit(f"FAIL: {mode}: Job/{jname} pod template has no labels at all — that is unselectable by accident, not by design; give it its own label set.")
 	for kind, name, sel in selectors:
 		if not sel:
+			# An empty selector means opposite things per kind, and skipping both
+			# was the hole: for a Service it is correct (no selector, so the
+			# endpoints controller does nothing), but a PodDisruptionBudget with
+			# `selector: {}` matches EVERY pod in the namespace — including this
+			# one. Skipping it meant the gate could report OK having performed
+			# zero comparisons, which is the "passes while measuring nothing"
+			# shape this repo has shipped twice.
+			if kind == "PodDisruptionBudget":
+				problems.append(
+					f"  {kind}/{name} has an empty selector, which matches every pod in the namespace, so it selects Job/{jname}"
+				)
+				compared += 1
 			continue
+		compared += 1
 		if all(labels.get(k) == v for k, v in sel.items()):
 			problems.append(
 				f"  {kind}/{name} selector {sel} is a SUBSET of Job/{jname} pod labels {labels}"
 			)
+
+if compared == 0:
+	sys.exit(f"FAIL: {mode}: zero selector/pod comparisons were performed, so an OK here would mean nothing was measured.")
 
 if problems:
 	sys.exit(
@@ -303,6 +320,41 @@ metadata: {name: leoflow-migrate}
 spec:
   template:
     metadata: {}
+'
+
+	# An empty selector means opposite things per kind, and skipping both was a
+	# hole: for a Service it is correct, but a PodDisruptionBudget with
+	# `selector: {}` matches EVERY pod in the namespace. Skipping it let the
+	# gate report OK having compared nothing — the "passes while measuring
+	# nothing" shape this repo has shipped twice.
+	_case "an empty PDB selector matches everything, and is caught" 1 "matches every pod" '
+kind: PodDisruptionBudget
+metadata: {name: leoflow}
+spec:
+  selector: {}
+---
+kind: Job
+metadata: {name: leoflow-migrate}
+spec:
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: leoflow-migrate}
+'
+
+	# A Service with no selector is legitimately skipped — but then nothing was
+	# compared, and an OK would mean nothing was measured.
+	_case "zero comparisons is a failure, not a pass" 1 "zero selector/pod comparisons" '
+kind: Service
+metadata: {name: leoflow}
+spec:
+  selector: {}
+---
+kind: Job
+metadata: {name: leoflow-migrate}
+spec:
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: leoflow-migrate}
 '
 
 	if [ "$fail" -eq 0 ]; then

--- a/scripts/check-migrate-pod-selection.sh
+++ b/scripts/check-migrate-pod-selection.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+# The migration hook pod must not be selectable by any control-plane Service or
+# PodDisruptionBudget, in any deployment mode (#1055).
+#
+# Selection in Kubernetes is a SUBSET relation: a Service sends traffic to every
+# pod whose labels contain all of the selector's key/value pairs. Extra labels on
+# the pod do not exclude it. `leoflow.roleSelectorLabels` for the default "all"
+# role is exactly `leoflow.selectorLabels` (ADR 0049 keeps it that way so the
+# Deployment's immutable selector survives an upgrade from a pre-split install),
+# so the migrate Job's pod template carrying that same set made the pod an
+# endpoint of the control-plane Service. A Job pod has no readinessProbe, so it
+# is Ready the instant its container starts: on `helm upgrade`, where the Service
+# already exists while the pre-upgrade hook runs, the hook pod was an endpoint of
+# the control plane and a healthy member of its PodDisruptionBudget. `helm install`
+# was unaffected — no Service exists yet.
+#
+# The disruption half was the measured loss (a percentage-valued budget fails
+# outright with "jobs.batch does not implement the scale subresource"). The
+# traffic half is latent rather than active, and only by accident: every Service
+# port here uses a NAMED targetPort and the hook pod declares no containerPort, so
+# the endpoint lands in a slice with `ports: null` and kube-proxy programs nothing.
+# One numeric targetPort removes that, and consumers that resolve ports themselves
+# never had it. Both are reasons to fix the selection, not to rely on the accident.
+#
+# Why this is a script and not a helm-unittest case: the invariant lives BETWEEN
+# two rendered documents, and helm-unittest asserts one document at a time. Both
+# maps were individually "correct" for ~246 cases while their relationship was
+# wrong. This renders the chart and compares the real maps, so a future edit to
+# EITHER side — the Job's pod labels or any control-plane selector — is caught by
+# the same gate. helm/leoflow/tests/migrate_pod_selection_test.yaml pins the
+# shapes; this asserts the property.
+#
+# Usage: scripts/check-migrate-pod-selection.sh [--self-test]
+#        scripts/check-migrate-pod-selection.sh <rendered.yaml> [<mode-label>]
+set -euo pipefail
+
+CHART="helm/leoflow"
+# The chart refuses to render without these; they are fixtures, not credentials.
+BASE_VALUES=(
+	--set 'database.url=postgres://leoflow:p@db:5432/leoflow?sslmode=disable'
+	--set 'redis.url=redis://r:6379/0'
+	--set 'auth.jwtSecret=migrate-pod-selection-check-fixture'
+)
+
+# compare <rendered-manifest-file> <mode-label>
+# Exits non-zero when any Service / PodDisruptionBudget selector in the file is a
+# subset of any Job pod template's labels.
+compare() {
+	python3 - "$1" "$2" <<'PY'
+import sys
+
+try:
+	import yaml
+except ImportError:
+	sys.exit(
+		"FAIL: PyYAML is required to compare the rendered label maps. "
+		"Install it (python3 -m pip install --user pyyaml) — this gate deliberately "
+		"does not skip, because a selection bug that renders clean is invisible "
+		"everywhere else."
+	)
+
+path, mode = sys.argv[1], sys.argv[2]
+with open(path) as fh:
+	docs = [d for d in yaml.safe_load_all(fh) if isinstance(d, dict)]
+
+jobs = [d for d in docs if d.get("kind") == "Job"]
+if not jobs:
+	sys.exit(f"FAIL: {mode}: no Job rendered — the migrate hook is what this gate exists to check, so an empty set is a failure, not a pass.")
+
+# (kind, name, selector-map) for everything that selects control-plane pods.
+selectors = []
+for d in docs:
+	kind = d.get("kind")
+	name = (d.get("metadata") or {}).get("name", "<unnamed>")
+	spec = d.get("spec") or {}
+	if kind == "Service":
+		selectors.append((kind, name, spec.get("selector") or {}))
+	elif kind == "PodDisruptionBudget":
+		sel = spec.get("selector") or {}
+		if sel.get("matchExpressions"):
+			sys.exit(f"FAIL: {mode}: PodDisruptionBudget/{name} uses matchExpressions, which this gate does not evaluate — teach it the expression semantics rather than leave the case unchecked.")
+		selectors.append((kind, name, sel.get("matchLabels") or {}))
+if not selectors:
+	sys.exit(f"FAIL: {mode}: nothing selects control-plane pods in this render — the comparison had no left-hand side, which is a broken gate, not a pass.")
+
+problems = []
+for job in jobs:
+	jname = (job.get("metadata") or {}).get("name", "<unnamed>")
+	pod = ((job.get("spec") or {}).get("template") or {}).get("metadata") or {}
+	labels = pod.get("labels") or {}
+	if not labels:
+		sys.exit(f"FAIL: {mode}: Job/{jname} pod template has no labels at all — that is unselectable by accident, not by design; give it its own label set.")
+	for kind, name, sel in selectors:
+		if not sel:
+			continue
+		if all(labels.get(k) == v for k, v in sel.items()):
+			problems.append(
+				f"  {kind}/{name} selector {sel} is a SUBSET of Job/{jname} pod labels {labels}"
+			)
+
+if problems:
+	sys.exit(
+		f"FAIL: {mode}: the migrate hook pod is selected by the control plane:\n"
+		+ "\n".join(problems)
+		+ "\n  A selector matches every pod whose labels CONTAIN it, so adding a label to the"
+		"\n  pod does not exclude it — the pod must differ on a key the selector carries."
+		"\n  On `helm upgrade` this puts a container with no listener into the Service's"
+		"\n  EndpointSlice for the whole migration window (#1055)."
+	)
+
+print(f"OK:   {mode}: no Service/PDB selector is a subset of the migrate pod's labels")
+PY
+}
+
+# render <mode-label> <extra helm --set args...>
+render_and_compare() {
+	local mode="$1"
+	shift
+	local rendered
+	rendered="$(mktemp)"
+	# Rendered to a FILE, and helm's exit status read on its own line: piping
+	# helm into python would report python's status and a failed render would
+	# read as a pass.
+	if ! helm template leoflow-selection-check "$CHART" "${BASE_VALUES[@]}" "$@" >"$rendered" 2>"$rendered.err"; then
+		echo "FAIL: $mode: helm template failed" >&2
+		cat "$rendered.err" >&2
+		rm -f "$rendered" "$rendered.err"
+		return 1
+	fi
+	local rc=0
+	compare "$rendered" "$mode" || rc=$?
+	rm -f "$rendered" "$rendered.err"
+	return "$rc"
+}
+
+check() {
+	command -v helm >/dev/null 2>&1 || {
+		echo "FAIL: helm is not installed; this gate renders the chart and cannot be skipped silently" >&2
+		return 2
+	}
+	[ -f "$CHART/Chart.yaml" ] || {
+		echo "FAIL: $CHART not found; run from the repo root" >&2
+		return 2
+	}
+	local fail=0
+	# Every mode the chart renders a control-plane Service in. Split and the
+	# multi-replica shapes need the logs PVC off: the chart refuses more than one
+	# mounter on a ReadWriteOnce volume.
+	local -a ha=(--set logs.persistence.enabled=false --set logs.sink.provider=s3 --set logs.sink.bucket=leoflow-logs)
+	render_and_compare "default (non-split, replicaCount=1)" || fail=1
+	render_and_compare "replicaCount=3" --set replicaCount=3 "${ha[@]}" || fail=1
+	render_and_compare "autoscaling (HPA floor 2)" --set autoscaling.enabled=true "${ha[@]}" || fail=1
+	render_and_compare "split mode (api + scheduler)" --set split.enabled=true "${ha[@]}" || fail=1
+	# The PodDisruptionBudget is tri-state and can be forced on at one replica;
+	# that is the shape where a budget covers the hook pod on a single-replica
+	# install, so render it too.
+	render_and_compare "podDisruptionBudget forced on at one replica" --set podDisruptionBudget.enabled=true || fail=1
+	return "$fail"
+}
+
+self_test() {
+	local fail=0 tmp
+	tmp=$(mktemp -d)
+	trap 'rm -rf "$tmp"' RETURN
+
+	_case() { # <name> <want-exit> <want-substr> <manifest>
+		local name=$1 want=$2 substr=$3 manifest=$4 out rc
+		printf '%s' "$manifest" >"$tmp/m.yaml"
+		out=$(compare "$tmp/m.yaml" "self-test" 2>&1) && rc=0 || rc=$?
+		if [ "$rc" -ne "$want" ]; then
+			echo "self-test FAIL: $name — exit $rc, wanted $want"
+			echo "  $out"
+			fail=1
+			return
+		fi
+		case "$out" in
+		*"$substr"*) ;;
+		*)
+			echo "self-test FAIL: $name — output lacks \"$substr\""
+			echo "  $out"
+			fail=1
+			;;
+		esac
+	}
+
+	# The shape #1055 shipped: identical maps.
+	_case "identical maps are caught" 1 "is a SUBSET of" '
+kind: Service
+metadata: {name: leoflow}
+spec:
+  selector: {app.kubernetes.io/name: leoflow, app.kubernetes.io/instance: rel}
+---
+kind: Job
+metadata: {name: leoflow-migrate}
+spec:
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: leoflow, app.kubernetes.io/instance: rel}
+'
+
+	# The fix proposed on the issue — add a distinguishing label and keep the
+	# shared set — does NOT work, and this gate has to say so. A selector matches
+	# a SUPERSET. If this case ever passes, the comparison has been weakened into
+	# equality and the gate no longer means anything.
+	_case "a merely-extra label does not save it" 1 "is a SUBSET of" '
+kind: Service
+metadata: {name: leoflow}
+spec:
+  selector: {app.kubernetes.io/name: leoflow, app.kubernetes.io/instance: rel}
+---
+kind: Job
+metadata: {name: leoflow-migrate}
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: leoflow
+        app.kubernetes.io/instance: rel
+        app.kubernetes.io/component: migrate
+'
+
+	# Differing on a key the selector carries is what actually excludes the pod.
+	_case "differing on a selector key passes" 0 "no Service/PDB selector is a subset" '
+kind: Service
+metadata: {name: leoflow}
+spec:
+  selector: {app.kubernetes.io/name: leoflow, app.kubernetes.io/instance: rel}
+---
+kind: Job
+metadata: {name: leoflow-migrate}
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: leoflow-migrate
+        app.kubernetes.io/instance: rel
+        app.kubernetes.io/component: migrate
+'
+
+	# A PodDisruptionBudget selects pods the same way; a budget over a hook pod
+	# refuses evictions on behalf of a container that serves nothing.
+	_case "a PodDisruptionBudget selector is checked too" 1 "PodDisruptionBudget/leoflow" '
+kind: PodDisruptionBudget
+metadata: {name: leoflow}
+spec:
+  selector:
+    matchLabels: {app.kubernetes.io/name: leoflow, app.kubernetes.io/instance: rel}
+---
+kind: Job
+metadata: {name: leoflow-migrate}
+spec:
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: leoflow, app.kubernetes.io/instance: rel}
+'
+
+	# A different role's selector must not raise a false positive: split-mode
+	# api/scheduler selectors carry a component the Job never has.
+	_case "a component-scoped selector is not a false positive" 0 "no Service/PDB selector is a subset" '
+kind: Service
+metadata: {name: leoflow-api}
+spec:
+  selector:
+    app.kubernetes.io/name: leoflow
+    app.kubernetes.io/instance: rel
+    app.kubernetes.io/component: api
+---
+kind: Job
+metadata: {name: leoflow-migrate}
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: leoflow-migrate
+        app.kubernetes.io/instance: rel
+        app.kubernetes.io/component: migrate
+'
+
+	# The three ways this gate could pass by measuring nothing. Each must FAIL
+	# loudly instead: an empty filter output is not a pass.
+	_case "no Job at all is a failure, not a pass" 1 "no Job rendered" '
+kind: Service
+metadata: {name: leoflow}
+spec:
+  selector: {app.kubernetes.io/name: leoflow}
+'
+	_case "nothing selecting is a failure, not a pass" 1 "no left-hand side" '
+kind: Job
+metadata: {name: leoflow-migrate}
+spec:
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: leoflow-migrate}
+'
+	_case "an unlabelled hook pod is a failure, not a pass" 1 "no labels at all" '
+kind: Service
+metadata: {name: leoflow}
+spec:
+  selector: {app.kubernetes.io/name: leoflow}
+---
+kind: Job
+metadata: {name: leoflow-migrate}
+spec:
+  template:
+    metadata: {}
+'
+
+	if [ "$fail" -eq 0 ]; then
+		echo "check-migrate-pod-selection self-test: ok"
+		return 0
+	fi
+	return 1
+}
+
+[ "${1:-}" = "--self-test" ] && {
+	self_test
+	exit $?
+}
+
+cd "$(dirname "$0")/.."
+if [ $# -ge 1 ]; then
+	compare "$1" "${2:-$1}"
+	exit $?
+fi
+check

--- a/scripts/check-script-selftests.sh
+++ b/scripts/check-script-selftests.sh
@@ -49,8 +49,8 @@ done
 
 # A rename or a lost self_test() would otherwise shrink this gate to nothing
 # while still exiting 0 — the same silent-shrink hole run_gates guards against.
-if [ "$found" -lt "${MIN_SELFTESTS:-18}" ]; then
-	echo "FAIL: found only $found self-test(s), expected at least ${MIN_SELFTESTS:-18} — did a script lose its self_test()?" >&2
+if [ "$found" -lt "${MIN_SELFTESTS:-19}" ]; then
+	echo "FAIL: found only $found self-test(s), expected at least ${MIN_SELFTESTS:-19} — did a script lose its self_test()?" >&2
 	exit 1
 fi
 [ "$failed" -eq 0 ] || exit 1

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -803,7 +803,13 @@ main() {
   local tag cv logf; tag="$(normalize_tag "$version")"; cv="$(chart_version "$version")"
   logf="$ROOT/.release-$tag.log"
 
-  for t in gh jq git helm-docs; do command -v "$t" >/dev/null || die "missing tool: $t"; done
+  # helm and PyYAML are here because run_gates globs scripts/check-*.sh, and
+  # check-migrate-pod-selection.sh renders the chart to compare selectors
+  # against the migrate hook's pod labels. Without them the cut fails
+  # mid-flight as "gate FAIL check-migrate-pod-selection.sh" rather than as a
+  # named missing tool, which is the wrong place to learn it.
+  for t in gh jq git helm-docs helm; do command -v "$t" >/dev/null || die "missing tool: $t"; done
+  python3 -c 'import yaml' 2>/dev/null || die "missing python module: PyYAML (pip install pyyaml) — several scripts/check-*.sh parse YAML"
 
   log "cutting $tag (chart $cv, $(is_rc "$version" && echo prerelease || echo GA))"
   # --tags explicitly: `git fetch origin main` does not follow tags, so a local

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -748,8 +748,8 @@ run_gates() { # <tag>
   shopt -u nullglob
   # A gate renamed out of check-*.sh silently leaves the cut's gate set with no
   # signal at all, so assert the floor.
-  [ "${#gates[@]}" -ge "${MIN_GATES:-19}" ] || {
-    echo "gate set shrank to ${#gates[@]} (expected >= ${MIN_GATES:-19}) — a check-*.sh was renamed or removed" >&2
+  [ "${#gates[@]}" -ge "${MIN_GATES:-20}" ] || {
+    echo "gate set shrank to ${#gates[@]} (expected >= ${MIN_GATES:-20}) — a check-*.sh was renamed or removed" >&2
     return 1
   }
   for s in "${gates[@]}"; do

--- a/test/release/rc-cluster-validation.md
+++ b/test/release/rc-cluster-validation.md
@@ -647,6 +647,68 @@ psql "$DATABASE_URL" -c 'UPDATE schema_migrations SET dirty = false;'
 **PASS:** the pod goes NotReady here. A build that stays ready through **both**
 arms has not fixed #1023, it has disabled the dirty check.
 
+#### §4.6c — #1055: the migration hook pod is not part of the control plane
+
+`helm upgrade` runs the migrate Job as a `pre-upgrade` hook while the Service and
+the PodDisruptionBudget are already live. Its pod used to carry the exact
+control-plane selector labels, and a Job pod has no readiness probe, so it was
+`Ready` — and therefore selected — from its first instant. The fix gives it its
+own application name; these checks confirm that on a real cluster, in the window
+where it matters.
+
+The window is short on a fast migration, so hold it open. `pause` ignores the
+Job's args and never exits, which is a hook that stays running until you delete
+it — the upgrade will fail at its timeout, which is fine, this run is the
+measurement, not the release:
+
+```bash
+helm upgrade leoflow ... --set migrations.image.repository=registry.k8s.io/pause \
+                         --set migrations.image.tag=3.9 --timeout 150s &
+```
+
+**Selection PASS.** Ask the apiserver, not the chart — it is the component that
+evaluates the selector:
+
+```bash
+kubectl -n "$NS" get pods -l app.kubernetes.io/name=leoflow,app.kubernetes.io/instance=leoflow
+# PASS = only the control-plane pod(s). A leoflow-migrate-* row here is the bug.
+kubectl -n "$NS" get endpointslice -l kubernetes.io/service-name=leoflow \
+  -o jsonpath='{range .items[*].endpoints[*]}{.addresses[0]}{" "}{.targetRef.name}{"\n"}{end}'
+# PASS = no leoflow-migrate-* target.
+```
+
+**Disruption PASS.** This was the half that actually cost something, and it needs
+a budget present, so force one on (`--set podDisruptionBudget.enabled=true`) or
+run the HA profile:
+
+```bash
+kubectl -n "$NS" get pdb -o custom-columns=\
+'NAME:.metadata.name,ALLOWED:.status.disruptionsAllowed,CURRENT:.status.currentHealthy,REASON:.status.conditions[0].reason'
+```
+
+PASS = `currentHealthy` equals the number of *control-plane* replicas, and the
+reason is never `SyncFailed`. On the pre-fix chart this reported one pod too many,
+and with a percentage-valued `minAvailable` it reported
+`jobs.batch does not implement the scale subresource` and pinned
+`disruptionsAllowed` at 0 — a stalled drain for the length of the migration.
+
+**The part k3d cannot settle, and EKS must.** No request was lost on k3s even
+before the fix, and only by accident: every Service port here uses a *named*
+`targetPort` and the hook pod declares no container port, so the endpoint landed
+in a slice with `ports: null` and kube-proxy programmed nothing. Anything that
+reads EndpointSlices and resolves ports for itself never had that protection. On
+the EKS RC, with the **AWS Load Balancer Controller in IP-target mode** in front
+of the api Service, re-run the hold-open upgrade and watch the target group:
+
+```bash
+aws elbv2 describe-target-health --target-group-arn <arn>
+```
+
+PASS = the migrate pod's IP is never registered. Record **NOT VERIFIED (cloud)**
+for this row on any run that is not EKS with an IP-mode ALB/NLB — a k3d pass says
+nothing about it. Same for a service mesh: an Istio/Linkerd sidecar reads the
+EndpointSlice directly.
+
 ---
 
 ## §5 EKS ↔ GKE deltas (so a GKE pass doesn't give false confidence)

--- a/website/content/operate/upgrades.md
+++ b/website/content/operate/upgrades.md
@@ -107,6 +107,36 @@ against a database a newer binary already migrated. Use `--version <VERSION>`
 with the chart version — the [latest release](https://github.com/neochaotic/leoflow/releases)
 tag with the leading `v` stripped.
 
+### The migration Job's pod is not part of the control plane
+
+The hook pod runs under its own application name —
+`app.kubernetes.io/name: <chart name>-migrate`, with
+`app.kubernetes.io/component: migrate` — deliberately *not* the control plane's
+`app.kubernetes.io/name`. A Service selector matches every pod whose labels
+contain it, so a hook pod carrying the control plane's own selector labels is
+selected by the control-plane Service and PodDisruptionBudget for as long as it
+runs, and a Job pod has no readiness probe: it counts as `Ready` from the instant
+its container starts. On `helm upgrade` — the one path where those objects
+already exist while the hook runs — that put a pod that serves nothing into the
+control plane's endpoint set and into its disruption budget's healthy count.
+
+Two consequences for your own tooling:
+
+- **Do not select control-plane pods by `app.kubernetes.io/instance` alone.**
+  That label is still on the hook pod on purpose, so
+  `kubectl -n <ns> get pods -l app.kubernetes.io/instance=<release>` finds a
+  wedged migration. Add `app.kubernetes.io/name=<chart name>` (or, in
+  `split.enabled` installs, `app.kubernetes.io/component=api|scheduler`) when you
+  mean the control plane.
+- **With `networkPolicy.enabled`, the hook pod is governed by no policy** — on
+  `helm install` and on `helm upgrade` alike. Egress is allow-all by default, so
+  a default install is unaffected. If your namespace carries a default-deny
+  policy from a platform team, give the migration pod its own egress allowance to
+  Postgres (match on `app.kubernetes.io/component: migrate`), and create it
+  outside the release or as a hook with a negative `helm.sh/hook-weight` — a
+  policy the chart creates normally does not exist yet when the *pre-install*
+  hook runs.
+
 ## Related issues
 
 - #136 — this contract.


### PR DESCRIPTION
Closes #1055.

## What was wrong

`migration-job.yaml` gave its pod template `leoflow.selectorLabels`. For the
default non-split `all` role that set is byte-identical to
`leoflow.roleSelectorLabels` — ADR 0049 keeps it that way so the Deployment's
immutable selector survives an upgrade from a pre-split install — and a
Kubernetes selector matches every pod whose labels **contain** it. So the
control-plane Service and the PodDisruptionBudget both selected the migration
hook's pod, which has no readiness probe and is therefore `Ready` from the
instant its container starts.

`helm install` was never affected (no Service exists yet when the pre-install
hook runs). `split.enabled` was never affected (api and scheduler carry a
component label the Job lacked). `helm upgrade` on a default install was the one
exposed path — exactly as the issue says.

## Two corrections to the issue, both measured

**1. The suggested one-line fix does not work.** "Add a distinguishing label
(e.g. `app.kubernetes.io/component: migrate`)" leaves the shared pair in place,
and a *superset* still matches a selector. Rendered with that change applied:

```
Job pod labels: {component: migrate, instance: rel, name: leoflow}
  Service rel-leoflow selector {instance: rel, name: leoflow} -> selects job pod: True
```

The pod has to differ on a key the selector **carries**.

**2. The traffic loss is latent, not active — and the harm that *is* active is
the PodDisruptionBudget.** Held open on k3s v1.33.6 (k3d) with a `pause` image
as the migrate container, against the pre-fix chart:

- The pod joins the Service's EndpointSlice, `ready: true`. But it lands in a
  **separate slice with `ports: null`**, because all three Service ports use
  *named* `targetPort`s and this pod declares no container port, so the
  EndpointSlice controller can resolve nothing and kube-proxy programs nothing.
  Measured from a client pod: **40/40 requests succeeded**. Flip one port to a
  numeric `targetPort` on the same cluster and it becomes **21 ok / 19 failed**.
  The protection is accidental, one edit away from gone, and absent entirely for
  consumers that resolve ports themselves (AWS Load Balancer Controller in
  IP-target mode, service meshes, Gateway API).
- The PDB half is a real, unconditional loss. With the hook pod running:

  | budget | disruptionsAllowed | currentHealthy | condition |
  |---|---|---|---|
  | `minAvailable: 1` | 1 | **2** (one real replica) | — |
  | `minAvailable: 50%` | **0** | 0 | `DisruptionAllowed=False`, *"jobs.batch does not implement the scale subresource"* |

  The integer budget over-counts, so it permits one more simultaneous eviction
  than it was sized for. The percentage budget fails outright and **stalls every
  voluntary eviction** for the length of the migration. Both recover the moment
  the hook pod is gone, which is the causality check.

## The fix

The hook's pod runs under its own application name — `leoflow.migrateName`
(`<chart name>-migrate`, suffixed through the existing `leoflow.suffixRole` so a
long `nameOverride` cannot exceed the 63-char label limit) — plus
`app.kubernetes.io/component: migrate`. `app.kubernetes.io/instance` stays, on
purpose: `-l app.kubernetes.io/instance=<release>` is how an operator finds a
wedged migration, and instance alone is not a selector any control-plane object
uses.

Nothing else moves. Full-render diff against `origin/main`, default and split,
with the non-deterministic auto-gen TLS material filtered: the only change is
those three labels. The Deployment's immutable selector, the Services, the PDB
and the NetworkPolicy are untouched. `values.yaml` is untouched.

## Property 1 — rendered evidence, not reasoning

Both maps parsed out of `helm template` and compared as maps.

**Before:**

```
### default (non-split, replicaCount=1)
  Job pod labels: {instance: rel, name: leoflow}
    Service rel-leoflow selector {instance: rel, name: leoflow} -> selects job pod: True
### split mode
    Service rel-leoflow-api       {component: api, instance: rel, name: leoflow}       -> False
    Service rel-leoflow-scheduler {component: scheduler, instance: rel, name: leoflow} -> False
    PDB     rel-leoflow-api       {component: api, instance: rel, name: leoflow}       -> False
### replicaCount=3
    Service rel-leoflow selector {instance: rel, name: leoflow} -> selects job pod: True
    PDB     rel-leoflow selector {instance: rel, name: leoflow} -> selects job pod: True
```

**After:**

```
### default (non-split, replicaCount=1)
  Job pod labels: {component: migrate, instance: rel, name: leoflow-migrate}
    Service rel-leoflow selector {instance: rel, name: leoflow} -> selects job pod: False
### split mode
    Service rel-leoflow-api / rel-leoflow-scheduler / PDB rel-leoflow-api -> False
### replicaCount=3
    Service rel-leoflow -> False
    PDB     rel-leoflow -> False
```

## Property 2 — what else selects on those labels

| Object | Selects the hook pod before | after | note |
|---|---|---|---|
| control-plane `Service` | **yes** (all role) | no | the defect |
| `PodDisruptionBudget` | **yes** (all role) | no | the measured harm |
| control-plane `NetworkPolicy` `podSelector` | **yes**, on upgrade only | no | see below |
| task-pod `NetworkPolicy` egress `to.podSelector` | yes | no | task pods never dial the migrate pod, and it is gone before any task pod exists |
| `ServiceMonitor` | n/a | n/a | selects **Services**, not pods; Service labels unchanged |

On the NetworkPolicy: today the control-plane policy governs the hook pod on
`helm upgrade` but not on `helm install`, because the policy is not a hook and
so does not exist yet when the pre-install hook runs. This PR makes it govern the
pod in **neither** case — asymmetry replaced by consistency. Default egress is
allow-all, so no default install changes behaviour. The case that does change is
a namespace carrying a platform-team default-deny: there, the hook pod was
rescued on upgrade by inheriting the control plane's allow-all egress and was
*already* failing on install. Now it fails on both, consistently, and needs its
own egress allowance to Postgres. `website/content/operate/upgrades.md` says so,
including that such a policy must itself be a negative-weight hook to exist
before the pre-install Job.

## Property 3 — the Job still works, on a real cluster

Not asserted. k3d/k3s v1.33.6, bare Postgres + Redis, published `0.4.5` images:

1. `helm install` with the chart at `origin/main` → `Install complete`.
2. one `helm upgrade` onto this branch → **exit 0**, revision 2 `deployed`,
   `SuccessfulCreate` → `Started container migrate` → **`Job completed`**.
3. no immutability error — a Job's `spec.selector` is controller-generated, and
   the hook carries `before-hook-creation` regardless.
4. the Service's EndpointSlice holds only the control-plane pod throughout.

## Property 4 — a test fails if it comes back

- `helm/leoflow/tests/migrate_pod_selection_test.yaml` (new suite, 3 cases):
  pins the Service selector, the PDB selector and the Job's pod labels **whole
  and side by side**, in default / `replicaCount: 3` / split. Whole, because
  asserting one distinguishing label stays green when someone re-adds the shared
  set beside it — which is exactly how the bug returns.
- two more cases in `migration_job_test.yaml`, where a future editor of the Job
  actually looks, including the 63-char `nameOverride` truncation.
- `scripts/check-migrate-pod-selection.sh` carries the property helm-unittest
  cannot express: it renders five modes and fails if **any** Service or PDB
  selector is a subset of **any** Job pod's labels. Wired into the Helm CI lint
  job (and its `paths:` trigger), and globbed by the release cut's `run_gates`
  (`MIN_GATES` 19 → 20, `MIN_SELFTESTS` 18 → 19). It refuses to pass on an empty
  measurement: no Job, nothing selecting, or an unlabelled pod are each a `FAIL`.

**Mutation-tested, mutants checksum-verified before reading any exit code:**

| mutant | applied | `helm unittest` | `check-migrate-pod-selection.sh` |
|---|---|---|---|
| template calls `leoflow.selectorLabels` again (helper left defined) | md5 changed | **exit 1** | **exit 1** |
| restored | md5 back to original | exit 0 | exit 0 |
| gate's subset test weakened to equality | md5 changed | — | `--self-test` **exit 1** ("a merely-extra label does not save it") |

## Gates

`helm lint` 0 · `helm unittest` 230/230 (23 suites) · `helm-docs -c helm/leoflow`
no diff (`values.yaml` untouched) · `helm-template-checks.sh` 0 ·
`rbac-covers-executor.sh` 0 · `check-script-selftests.sh` 19/19 ·
every `scripts/check-*.sh` 0 except `check-chart-version-matches-tag.sh`, which
requires a tag argument and is only invoked with one by the cut.

## Reported, deliberately not fixed here

- **No other label collision in the chart.** `leoflow.selectorLabels` has three
  remaining consumers and all three are correct: the ServiceMonitor selects
  Services, the task-pod policy's egress rule intends the superset of both
  control-plane roles, and `roleSelectorLabels` is the definition itself. The
  migrate Job was the only pod template outside the control-plane Deployment.
- **The NetworkPolicy asymmetry deserves its own issue** — for the *forward*
  half, not the one that is now resolved. What is still missing is a policy the
  migrate pod can be governed by at all in a default-deny namespace, and it has
  a real design constraint: it must be a hook with a `hook-weight` below the
  Job's `0`, or it does not exist when the pre-install hook runs. Needs the AWS
  VPC CNI with its network-policy agent (or GKE Dataplane V2) to observe;
  kindnet enforces nothing, so CI can never show it.
- **The named-`targetPort` accident should be written down as an invariant.**
  Today it is the only thing standing between a mis-selected pod and a real
  black hole, and nothing tests it. A gate asserting every control-plane Service
  port uses a named `targetPort` would make that explicit.
