### PR TITLE
fix(agentrpc): stop database errors reaching the task pod, keep them in the log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -510,6 +510,32 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   unknown role, an undeclared variable or connection, a `max_active_runs` cap,
   the undeletable default pool.
 
+- **Database errors no longer reach the task pod either (#1068).** The same
+  disclosure class was open on the agent gRPC transport, where twenty call
+  sites put `%v` of a storage, XCom, log-sink or signing failure into the
+  status message returned to the agent — so a SQLSTATE, a constraint name or a
+  `pgconn` connection string reached the pod. That pod is a trust boundary: it
+  runs the tenant's own image and entrypoint, so it is authenticated,
+  tenant-controlled code execution that can call `GetTaskSpec`,
+  `GetVariables` or `FetchXCom` in a loop. The control plane already treats it
+  as one — a panic in a handler has always been collapsed to a constant for
+  exactly this audience — and that rule now covers the ordinary failures too.
+
+  Every status the agent receives still names the step that failed — `loading
+  task spec`, `storing xcom`, `fetching connections`, `opening log sink` — so a
+  task's own log still says something usable; only the underlying error's text
+  is replaced, and it is written to the control-plane log under a `cause`
+  field carrying the attempt identity (`ti`, `run`, `task`, `try`), which is
+  the join key between the two. No status code changed. One message is passed
+  through deliberately, as a `domain.SafeError`: `task "x" not found in run
+  "y"`, which tells you the pod is running a task its `dag_version` does not
+  declare — a stale image or a mismatched version — rather than that the
+  control plane is broken.
+
+  This also closes a second-order path: the agent puts a failed RPC's text into
+  the state it reports, which is persisted on the task instance and rendered in
+  the UI, so a driver error could reach a browser through the pod.
+
 ### Testing
 
 - **The DAG base-image pin is now verified end to end, for both of its branches

--- a/internal/agentrpc/await_assignment.go
+++ b/internal/agentrpc/await_assignment.go
@@ -114,7 +114,7 @@ func (s *Server) AwaitAssignment(stream agentv1.AgentService_AwaitAssignmentServ
 			if errors.Is(rerr, io.EOF) {
 				return nil
 			}
-			return status.Errorf(codes.Internal, "receiving worker message: %v", rerr)
+			return peerStatus("receiving worker message", rerr, attemptAttrs(id)...)
 		case a := <-worker.send:
 			if serr := stream.Send(a); serr != nil {
 				return serr
@@ -133,7 +133,7 @@ func (s *Server) registerFromStream(stream agentv1.AgentService_AwaitAssignmentS
 		if errors.Is(err, io.EOF) {
 			return nil, status.Error(codes.FailedPrecondition, "stream closed before worker registration")
 		}
-		return nil, status.Errorf(codes.Internal, "receiving worker registration: %v", err)
+		return nil, peerStatus("receiving worker registration", err, "worker", identity)
 	}
 	reg := first.GetRegister()
 	if reg == nil {

--- a/internal/agentrpc/exchange.go
+++ b/internal/agentrpc/exchange.go
@@ -108,15 +108,16 @@ func (s *Server) ExchangeToken(ctx context.Context, _ *agentv1.ExchangeTokenRequ
 	// instance exactly as before. IssueAgentToken mints whichever flavor.
 	id, err := s.podResolver.ResolveAgent(ctx, pod)
 	if err != nil {
-		slog.Warn("agent token exchange: cannot resolve reviewed pod to an agent identity",
-			"namespace", pod.Namespace, "pod", pod.PodName, "pod_uid", pod.PodUID, "error", err)
-		return nil, status.Errorf(codes.Internal, "resolving pod to agent identity: %v", err)
+		// The resolver reads the control plane's own state, so its error can carry
+		// SQLSTATE and schema names. The agent is told which step failed and the
+		// cause stays in the control-plane log (#1068).
+		return nil, internalStatus("resolving pod to agent identity", err,
+			"namespace", pod.Namespace, "pod", pod.PodName, "pod_uid", pod.PodUID)
 	}
 	minted, err := s.tokenMinter.IssueAgentToken(id, s.exchangeTTL)
 	if err != nil {
-		slog.Warn("agent token exchange: minting agent token failed",
-			"scope", id.Scope, "ti", id.TaskInstanceID, "worker", id.WorkerID, "error", err)
-		return nil, status.Errorf(codes.Internal, "minting agent token: %v", err)
+		return nil, internalStatus("minting agent token", err,
+			"scope", id.Scope, "ti", id.TaskInstanceID, "worker", id.WorkerID)
 	}
 	if id.Scope == auth.ScopeWarmWorker {
 		// Log the warm case distinctly (worker/dag_version, never the token): the

--- a/internal/agentrpc/safe_status.go
+++ b/internal/agentrpc/safe_status.go
@@ -81,6 +81,13 @@ func redactedStatus(op string, cause error) error {
 // causeArgs puts the real error first on the log line, ahead of the caller's
 // own fields, under the same cause key the HTTP request log uses (#961).
 func causeArgs(cause error, attrs []any) []any {
+	// Every call site today is inside an `if err != nil`, so this cannot fire —
+	// but this helper is documented as the single sanctioned way to build one of
+	// these statuses, and a future site outside that guard would panic into the
+	// recovery interceptor rather than log.
+	if cause == nil {
+		return attrs
+	}
 	args := make([]any, 0, len(attrs)+2)
 	args = append(args, "cause", cause.Error())
 	return append(args, attrs...)

--- a/internal/agentrpc/safe_status.go
+++ b/internal/agentrpc/safe_status.go
@@ -1,0 +1,100 @@
+package agentrpc
+
+import (
+	"errors"
+	"log/slog"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/domain"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// detailInternal is the phrase an agent receives in place of a control-plane
+// failure's own text.
+//
+// The task pod is a trust boundary. It runs the tenant's own image and
+// entrypoint, so every gRPC status message is text handed to authenticated,
+// tenant-controlled code that can call TaskSpec, GetVariables or GetXCom in a
+// loop. A repository error normally wraps a driver error, and pgconn renders a
+// *pgconn.PgError as "severity: message (SQLSTATE code)" with the constraint,
+// table and column names of our schema inside the message; a *pgconn.ConnectError
+// renders the database user and name. Echoing either into the pod is schema
+// disclosure (CWE-209). RecoveryUnaryInterceptor already collapses a panic to a
+// constant for exactly this audience; this is the same rule applied to the
+// failures the handlers themselves see.
+const detailInternal = "the request could not be completed; see the control-plane logs"
+
+// safeMessage returns the phrase Leoflow composed for this failure, or fallback
+// when the error carries no such phrase.
+//
+// The default is deny. Only a domain.SafeError — an error someone deliberately
+// wrote as client-facing — contributes text to a status message; everything
+// else, including every fmt.Errorf wrap of a driver error, is replaced. A newly
+// introduced storage error therefore cannot leak by omission: it leaks only if
+// someone rewrites it as a SafeError, the one construct whose GoDoc says its
+// message is shown verbatim.
+func safeMessage(err error, fallback string) string {
+	var safe *domain.SafeError
+	if errors.As(err, &safe) && safe.ClientMessage() != "" {
+		return safe.ClientMessage()
+	}
+	return fallback
+}
+
+// internalStatus is the single sanctioned way to turn a failure the agent
+// cannot act on into the status it receives. It returns codes.Internal with op
+// plus a client-safe phrase, and hands the real error to the control-plane log
+// under a cause field, alongside attrs.
+//
+// op is a constant written at the call site, never derived from an error, so
+// the agent's own log — the one an operator reads in the task's output — still
+// says WHICH step failed. Over-redaction is a real regression: a task that
+// fails with no usable reason costs the person debugging the DAG more than the
+// disclosure costs the tenant.
+//
+// The parameter is named cause, not err, because the value is destined for the
+// log and never for the wire; the package's source guard trips on any
+// error-named value reaching a status constructor.
+func internalStatus(op string, cause error, attrs ...any) error {
+	slog.Error(op, causeArgs(cause, attrs)...)
+	return redactedStatus(op, cause)
+}
+
+// peerStatus is internalStatus for a failure the PEER caused rather than the
+// control plane: a stream that broke because the pod went away. The redaction
+// is identical — a transport error is not a database error today, but a status
+// built from any error value is the shape this package no longer allows — while
+// the log stays at warn, so an ordinary pod kill does not manufacture an error
+// line for an operator to chase.
+func peerStatus(op string, cause error, attrs ...any) error {
+	slog.Warn(op, causeArgs(cause, attrs)...)
+	return redactedStatus(op, cause)
+}
+
+// redactedStatus is the message both build: the operation, then either the
+// phrase Leoflow composed for this failure or the constant.
+func redactedStatus(op string, cause error) error {
+	return status.Error(codes.Internal, op+": "+safeMessage(cause, detailInternal))
+}
+
+// causeArgs puts the real error first on the log line, ahead of the caller's
+// own fields, under the same cause key the HTTP request log uses (#961).
+func causeArgs(cause error, attrs []any) []any {
+	args := make([]any, 0, len(attrs)+2)
+	args = append(args, "cause", cause.Error())
+	return append(args, attrs...)
+}
+
+// attemptAttrs are the log fields every redacted agent failure carries. The
+// agent has no request id to echo back, so the attempt identity is the join key
+// between the phrase the task log shows and the cause recorded here.
+func attemptAttrs(id *auth.AgentIdentity) []any {
+	if id == nil {
+		return nil
+	}
+	return []any{
+		"ti", id.TaskInstanceID, "tenant", id.TenantID, "dag", id.DagID,
+		"run", id.RunID, "task", id.TaskID, "try", id.TryNumber,
+	}
+}

--- a/internal/agentrpc/secrets.go
+++ b/internal/agentrpc/secrets.go
@@ -238,13 +238,13 @@ func (s *Server) GetVariables(ctx context.Context, _ *agentv1.GetVariablesReques
 		}
 		vars, verr := s.secrets.SecretVariablesScoped(ctx, id.TenantID, declared)
 		if verr != nil {
-			return nil, status.Errorf(codes.Internal, "fetching variables: %v", verr)
+			return nil, internalStatus("fetching variables", verr, attemptAttrs(id)...)
 		}
 		return &agentv1.GetVariablesResponse{Variables: vars}, nil
 	}
 	vars, err := s.secrets.SecretVariables(ctx, id.TenantID)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "fetching variables: %v", err)
+		return nil, internalStatus("fetching variables", err, attemptAttrs(id)...)
 	}
 	// permissive warns on a narrow declaration; off disables the warn entirely.
 	if s.scopingPolicy() == ScopingPermissive {
@@ -276,13 +276,13 @@ func (s *Server) GetConnections(ctx context.Context, _ *agentv1.GetConnectionsRe
 		}
 		uris, uerr := s.secrets.SecretConnectionURIsScoped(ctx, id.TenantID, declared)
 		if uerr != nil {
-			return nil, status.Errorf(codes.Internal, "fetching connections: %v", uerr)
+			return nil, internalStatus("fetching connections", uerr, attemptAttrs(id)...)
 		}
 		return &agentv1.GetConnectionsResponse{ConnectionUris: uris}, nil
 	}
 	uris, err := s.secrets.SecretConnectionURIs(ctx, id.TenantID)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "fetching connections: %v", err)
+		return nil, internalStatus("fetching connections", err, attemptAttrs(id)...)
 	}
 	// permissive warns on a narrow declaration; off disables the warn entirely.
 	if s.scopingPolicy() == ScopingPermissive {
@@ -300,7 +300,7 @@ func (s *Server) GetConnections(ctx context.Context, _ *agentv1.GetConnectionsRe
 func (s *Server) declaredNames(ctx context.Context, id *auth.AgentIdentity, kind string) ([]string, error) {
 	spec, err := s.store.TaskSpec(ctx, *id)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "loading task spec for scope enforcement: %v", err)
+		return nil, internalStatus("loading task spec for scope enforcement", err, attemptAttrs(id)...)
 	}
 	if kind == "connections" {
 		return spec.DeclaredConnections, nil

--- a/internal/agentrpc/server.go
+++ b/internal/agentrpc/server.go
@@ -255,7 +255,7 @@ func (s *Server) GetTaskSpec(ctx context.Context, _ *agentv1.GetTaskSpecRequest)
 	}
 	spec, err := s.store.TaskSpec(ctx, *id)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "loading task spec: %v", err)
+		return nil, internalStatus("loading task spec", err, attemptAttrs(id)...)
 	}
 	return &agentv1.TaskSpec{
 		TenantId:                id.TenantID,
@@ -299,7 +299,7 @@ func (s *Server) ReportState(ctx context.Context, req *agentv1.ReportStateReques
 	// generic state write (#380).
 	if req.GetState() == agentv1.TaskState_TASK_STATE_UP_FOR_RESCHEDULE {
 		if rerr := s.store.Reschedule(ctx, *id, req.GetRescheduleAt().AsTime()); rerr != nil {
-			return nil, status.Errorf(codes.Internal, "recording reschedule: %v", rerr)
+			return nil, internalStatus("recording reschedule", rerr, attemptAttrs(id)...)
 		}
 		return &agentv1.ReportStateResponse{Acknowledged: true}, nil
 	}
@@ -325,7 +325,7 @@ func (s *Server) ReportState(ctx context.Context, req *agentv1.ReportStateReques
 			// execution is never told to terminate.
 			return &agentv1.ReportStateResponse{Acknowledged: true, ShouldTerminate: true}, nil
 		}
-		return nil, status.Errorf(codes.Internal, "recording state: %v", rerr)
+		return nil, internalStatus("recording state", rerr, attemptAttrs(id)...)
 	}
 	return &agentv1.ReportStateResponse{Acknowledged: true}, nil
 }
@@ -418,7 +418,7 @@ func (s *Server) PushXCom(ctx context.Context, req *agentv1.PushXComRequest) (*a
 	}
 	spec, err := s.store.TaskSpec(ctx, *id)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "loading task spec: %v", err)
+		return nil, internalStatus("loading task spec", err, attemptAttrs(id)...)
 	}
 	key := xcomKey(*id, id.TaskID, req.GetKey())
 	perr := s.xcom.Push(ctx, key, req.GetValue(), req.GetContentType(), spec.XComSchema)
@@ -428,7 +428,7 @@ func (s *Server) PushXCom(ctx context.Context, req *agentv1.PushXComRequest) (*a
 	case errors.Is(perr, xcom.ErrSchemaMismatch):
 		return &agentv1.PushXComResponse{Accepted: false, RejectionReason: "schema_mismatch"}, nil
 	case perr != nil:
-		return nil, status.Errorf(codes.Internal, "storing xcom: %v", perr)
+		return nil, internalStatus("storing xcom", perr, attemptAttrs(id)...)
 	}
 	return &agentv1.PushXComResponse{Accepted: true}, nil
 }
@@ -446,7 +446,7 @@ func (s *Server) FetchXCom(ctx context.Context, req *agentv1.FetchXComRequest) (
 	}
 	spec, err := s.store.TaskSpec(ctx, *id)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "loading task spec: %v", err)
+		return nil, internalStatus("loading task spec", err, attemptAttrs(id)...)
 	}
 	// A task may fetch XCom from an upstream it declared as an xcom input OR from any
 	// of its direct dependencies (depends_on) — the latter powers a captured
@@ -461,7 +461,7 @@ func (s *Server) FetchXCom(ctx context.Context, req *agentv1.FetchXComRequest) (
 		return nil, status.Errorf(codes.NotFound, "no xcom for task %q", req.GetUpstreamTaskId())
 	}
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "reading xcom: %v", err)
+		return nil, internalStatus("reading xcom", err, attemptAttrs(id)...)
 	}
 	return &agentv1.FetchXComResponse{
 		Value:       entry.Value,
@@ -504,11 +504,12 @@ func (s *Server) StreamLogs(stream agentv1.AgentService_StreamLogsServer) (err e
 		TenantID: id.TenantID, DagID: id.DagID, RunID: id.RunID, TaskID: id.TaskID, TryNumber: id.TryNumber,
 	})
 	if oerr != nil {
-		// Surface the cause: without this, a non-writable logs.dir makes the
-		// agent see only a bare stream EOF, with no server-side explanation (#36).
-		slog.Error("opening log sink for task; logs will not be shipped",
-			"dag", id.DagID, "run", id.RunID, "task", id.TaskID, "error", oerr)
-		return status.Errorf(codes.Internal, "opening log sink: %v", oerr)
+		// The agent is told WHICH step failed — without that it sees only a bare
+		// stream EOF, with no server-side explanation (#36) — but not the sink's
+		// own text, which carries host paths, bucket names and credential-adjacent
+		// detail into the tenant's pod. internalStatus records the cause on the
+		// control-plane log, keyed by the attempt (#1068).
+		return internalStatus("opening log sink", oerr, attemptAttrs(id)...)
 	}
 	defer func() {
 		cerr := w.Close()
@@ -516,7 +517,7 @@ func (s *Server) StreamLogs(stream agentv1.AgentService_StreamLogsServer) (err e
 			return
 		}
 		if err == nil {
-			err = status.Errorf(codes.Internal, "flushing logs: %v", cerr)
+			err = internalStatus("flushing logs", cerr, attemptAttrs(id)...)
 			return
 		}
 		// The stream already ended with its own error (the shutdown path returns
@@ -536,7 +537,7 @@ func (s *Server) StreamLogs(stream agentv1.AgentService_StreamLogsServer) (err e
 			}
 		}
 	}
-	return writeLines(s.shutdown, w, stream.Recv, publish)
+	return writeLines(s.shutdown, w, stream.Recv, publish, attemptAttrs(id))
 }
 
 // logLevelString maps the protobuf log level onto the lowercase level name the
@@ -569,7 +570,9 @@ type receivedLine struct {
 // Close (the final flush) runs while the process is still alive. A nil shutdown
 // channel never fires. The receiver goroutine exits once recv returns, which
 // gRPC guarantees after the handler returns and the stream context is canceled.
-func writeLines(shutdown <-chan struct{}, w logs.LogWriter, recv func() (*agentv1.LogLine, error), publish func(string)) error {
+// attrs carries the attempt identity onto the cause log line of a redacted
+// failure (#1068); nil is fine for callers that have none.
+func writeLines(shutdown <-chan struct{}, w logs.LogWriter, recv func() (*agentv1.LogLine, error), publish func(string), attrs []any) error {
 	lines := make(chan receivedLine)
 	done := make(chan struct{})
 	defer close(done)
@@ -597,16 +600,17 @@ func writeLines(shutdown <-chan struct{}, w logs.LogWriter, recv func() (*agentv
 			return nil
 		}
 		if rl.err != nil {
-			return status.Errorf(codes.Internal, "receiving log line: %v", rl.err)
+			return peerStatus("receiving log line", rl.err, attrs...)
 		}
-		if werr := writeLine(w, rl.line, publish); werr != nil {
+		if werr := writeLine(w, rl.line, publish, attrs); werr != nil {
 			return werr
 		}
 	}
 }
 
-// writeLine stores one received line and publishes it for live tailing.
-func writeLine(w logs.LogWriter, line *agentv1.LogLine, publish func(string)) error {
+// writeLine stores one received line and publishes it for live tailing. attrs
+// carries the attempt identity onto the cause log line of a redacted failure.
+func writeLine(w logs.LogWriter, line *agentv1.LogLine, publish func(string), attrs []any) error {
 	msg := line.GetMessage()
 	// The agent derives the wire level from the source stream (stdout=info,
 	// stderr=error), which mis-colors an error printed to stdout or an info
@@ -620,7 +624,7 @@ func writeLine(w logs.LogWriter, line *agentv1.LogLine, publish func(string)) er
 		Message: msg,
 	}
 	if werr := w.WriteEvent(ev); werr != nil {
-		return status.Errorf(codes.Internal, "writing log line: %v", werr)
+		return internalStatus("writing log line", werr, attrs...)
 	}
 	// Publish the full event (level/stream/ts), not just the text, so a live
 	// NDJSON follower can color lines exactly like the stored drill-down.

--- a/internal/agentrpc/server.go
+++ b/internal/agentrpc/server.go
@@ -509,7 +509,7 @@ func (s *Server) StreamLogs(stream agentv1.AgentService_StreamLogsServer) (err e
 		// own text, which carries host paths, bucket names and credential-adjacent
 		// detail into the tenant's pod. internalStatus records the cause on the
 		// control-plane log, keyed by the attempt (#1068).
-		return internalStatus("opening log sink", oerr, attemptAttrs(id)...)
+		return internalStatus("opening log sink for task; logs will not be shipped", oerr, attemptAttrs(id)...)
 	}
 	defer func() {
 		cerr := w.Close()

--- a/internal/agentrpc/server_test.go
+++ b/internal/agentrpc/server_test.go
@@ -393,7 +393,7 @@ func TestWriteLinesDrainsStreamToSink(t *testing.T) {
 	}
 	w := &fakeLogWriter{}
 	var published []string
-	if err := writeLines(nil, w, recv, func(l string) { published = append(published, l) }); err != nil {
+	if err := writeLines(nil, w, recv, func(l string) { published = append(published, l) }, nil); err != nil {
 		t.Fatalf("writeLines: %v", err)
 	}
 	if len(w.lines) != 3 || w.lines[2] != "line three" {
@@ -408,7 +408,7 @@ func TestWriteLinesDrainsStreamToSink(t *testing.T) {
 
 func TestWriteLinesPropagatesRecvError(t *testing.T) {
 	recv := func() (*agentv1.LogLine, error) { return nil, errors.New("stream broke") }
-	if err := writeLines(nil, &fakeLogWriter{}, recv, func(string) {}); err == nil {
+	if err := writeLines(nil, &fakeLogWriter{}, recv, func(string) {}, nil); err == nil {
 		t.Error("a non-EOF receive error should propagate")
 	}
 }

--- a/internal/agentrpc/status_leak_test.go
+++ b/internal/agentrpc/status_leak_test.go
@@ -582,7 +582,7 @@ func TestAgentRPCKeepsTheAttemptIdentityOnTheCauseLine(t *testing.T) {
 // version) rather than that the control plane is broken. domain.SafeError is the
 // opt-in that lets exactly those phrases through.
 //
-// This asserts the FORMATTING layer honours the opt-in. That storage actually
+// This asserts the FORMATTING layer honors the opt-in. That storage actually
 // PRODUCES one is pinned separately, at the layer that produces it — see
 // internal/storage/agent_safe_error_integration_test.go — because this test is
 // satisfied by a fake and would stay green with every Safef reverted.

--- a/internal/agentrpc/status_leak_test.go
+++ b/internal/agentrpc/status_leak_test.go
@@ -1,0 +1,602 @@
+package agentrpc_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/neochaotic/leoflow/internal/agentrpc"
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/domain"
+	"github.com/neochaotic/leoflow/internal/logs"
+	"github.com/neochaotic/leoflow/internal/xcom"
+	agentv1 "github.com/neochaotic/leoflow/proto/agent/v1"
+)
+
+// The task pod is a trust boundary: it runs the tenant's own image and
+// entrypoint, so every gRPC status the agent RPCs return is text handed to
+// authenticated, tenant-controlled code that can call TaskSpec / GetVariables /
+// GetXCom in a loop. recovery.go already collapses a panic to a constant for
+// exactly this audience; these tests extend the same rule to every storage,
+// cache, object-store and signing failure behind the handlers (#1068, the
+// agentrpc half of #961).
+//
+// The assertions are made on the status a REAL gRPC CLIENT receives, not on the
+// value a handler returns, so they hold whichever way the text would have got
+// out: status.Errorf with %v, a bare wrapped error rendered by grpc-go as
+// Unknown, or a future third mechanism.
+
+// pgFixture is a realistic driver error: a foreign-key violation as pgconn
+// renders it, carrying the SQLSTATE, the constraint, the table and the column.
+// Tests drive every seam with THIS value rather than a hand-made clean string,
+// because a clean string cannot fail an assertion that a real one would.
+func pgFixture() *pgconn.PgError {
+	return &pgconn.PgError{
+		Severity:       "ERROR",
+		Code:           "23503",
+		Message:        `insert or update on table "task_instances" violates foreign key constraint "task_instances_dag_run_id_fkey"`,
+		Detail:         `Key (dag_run_id)=(0f8f1a1e-0000-0000-0000-000000000000) is not present in table "dag_runs".`,
+		SchemaName:     "public",
+		TableName:      "task_instances",
+		ColumnName:     "dag_run_id",
+		ConstraintName: "task_instances_dag_run_id_fkey",
+		Routine:        "ri_ReportViolation",
+		File:           "ri_triggers.c",
+	}
+}
+
+// poison is the error the fakes return: the driver error wrapped exactly the
+// way the storage layer wraps it, so the test exercises the real shape
+// (fmt.Errorf("...: %w", pgErr)) and not a bare *pgconn.PgError.
+func poison() error { return fmt.Errorf("loading run: %w", pgFixture()) }
+
+// leakTokens are derived FROM the fixture rather than hand-listed, so widening
+// the fixture automatically widens the scan instead of silently leaving the new
+// field uncovered.
+func leakTokens(pe *pgconn.PgError) []string {
+	return []string{
+		pe.Code, pe.Message, pe.Error(), pe.Severity + ":",
+		pe.ConstraintName, pe.TableName, pe.ColumnName, pe.SchemaName,
+		pe.Routine, pe.File, "SQLSTATE",
+	}
+}
+
+// syncBuffer is an io.Writer safe to write from the server goroutine and read
+// from the test goroutine.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// ---------------------------------------------------------------------------
+// Fakes: one per collaborator seam behind the agent RPCs. Each can be poisoned
+// independently so a case names exactly the seam it drives.
+// ---------------------------------------------------------------------------
+
+type poisonStore struct {
+	spec          agentrpc.TaskSpec
+	specErr       error
+	reportErr     error
+	rescheduleErr error
+	heartbeatErr  error
+	bindErr       error
+}
+
+func (s *poisonStore) TaskSpec(context.Context, auth.AgentIdentity) (agentrpc.TaskSpec, error) {
+	return s.spec, s.specErr
+}
+
+func (s *poisonStore) ReportState(context.Context, auth.AgentIdentity, domain.TaskState, int, string) error {
+	return s.reportErr
+}
+
+func (s *poisonStore) Reschedule(context.Context, auth.AgentIdentity, time.Time) error {
+	return s.rescheduleErr
+}
+
+func (s *poisonStore) RecordHeartbeat(context.Context, auth.AgentIdentity) error {
+	return s.heartbeatErr
+}
+
+func (s *poisonStore) BindWarmAttempt(context.Context, string, string, int, string) error {
+	return s.bindErr
+}
+
+type poisonXCom struct {
+	pushErr  error
+	fetchErr error
+}
+
+func (x *poisonXCom) Push(context.Context, xcom.Key, []byte, string, map[string]any) error {
+	return x.pushErr
+}
+
+func (x *poisonXCom) Fetch(context.Context, xcom.Key) (xcom.Entry, error) {
+	if x.fetchErr != nil {
+		return xcom.Entry{}, x.fetchErr
+	}
+	return xcom.Entry{Value: []byte(`"v"`), ContentType: "application/json"}, nil
+}
+
+type poisonSecrets struct{ err error }
+
+func (s *poisonSecrets) SecretVariables(context.Context, string) (map[string]string, error) {
+	return nil, s.err
+}
+
+func (s *poisonSecrets) SecretConnectionURIs(context.Context, string) (map[string]string, error) {
+	return nil, s.err
+}
+
+func (s *poisonSecrets) SecretVariablesScoped(context.Context, string, []string) (map[string]string, error) {
+	return nil, s.err
+}
+
+func (s *poisonSecrets) SecretConnectionURIsScoped(context.Context, string, []string) (map[string]string, error) {
+	return nil, s.err
+}
+
+type poisonSink struct {
+	openErr  error
+	writeErr error
+	closeErr error
+}
+
+func (s *poisonSink) Open(logs.Ref) (logs.LogWriter, error) {
+	if s.openErr != nil {
+		return nil, s.openErr
+	}
+	return &poisonWriter{writeErr: s.writeErr, closeErr: s.closeErr}, nil
+}
+
+type poisonWriter struct {
+	writeErr error
+	closeErr error
+}
+
+func (w *poisonWriter) WriteEvent(logs.Event) error { return w.writeErr }
+func (w *poisonWriter) Close() error                { return w.closeErr }
+
+type stubReviewer struct{}
+
+func (stubReviewer) ReviewProjectedToken(context.Context, string) (agentrpc.ReviewedPod, error) {
+	return agentrpc.ReviewedPod{Namespace: "tasks", PodName: "etl-extract-1", PodUID: "uid-1"}, nil
+}
+
+type poisonResolver struct{ err error }
+
+func (r *poisonResolver) ResolveTaskInstance(context.Context, agentrpc.ReviewedPod) (auth.AgentIdentity, error) {
+	return auth.AgentIdentity{}, r.err
+}
+
+func (r *poisonResolver) ResolveAgent(context.Context, agentrpc.ReviewedPod) (auth.AgentIdentity, error) {
+	if r.err != nil {
+		return auth.AgentIdentity{}, r.err
+	}
+	return leakIdentity(), nil
+}
+
+type poisonMinter struct{ err error }
+
+func (m *poisonMinter) IssueAgentToken(auth.AgentIdentity, time.Duration) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	return "minted", nil
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+func leakIdentity() auth.AgentIdentity {
+	return auth.AgentIdentity{
+		TaskInstanceID: "ti-1", TenantID: "acme", DagID: "etl",
+		RunID: "run-1", TaskID: "extract", TryNumber: 1,
+	}
+}
+
+// leakFakes holds the poisonable collaborators so a case can reach into the one
+// seam it drives.
+type leakFakes struct {
+	store    *poisonStore
+	xcom     *poisonXCom
+	secrets  *poisonSecrets
+	sink     *poisonSink
+	resolver *poisonResolver
+	minter   *poisonMinter
+	scoping  string
+}
+
+func newLeakFakes() *leakFakes {
+	return &leakFakes{
+		store: &poisonStore{spec: agentrpc.TaskSpec{
+			Operator: "python", Entrypoint: "dag:main", DagVersion: "v1",
+			XComInputMapping:  map[string][]string{"v": {"upstream"}},
+			DeclaredVariables: []string{"region"}, DeclaredConnections: []string{"warehouse"},
+		}},
+		xcom:     &poisonXCom{},
+		secrets:  &poisonSecrets{},
+		sink:     &poisonSink{},
+		resolver: &poisonResolver{},
+		minter:   &poisonMinter{},
+		scoping:  agentrpc.ScopingPermissive,
+	}
+}
+
+// startLeakServer wires a real *agentrpc.Server with the given fakes behind a
+// real gRPC server on a bufconn, exactly as main.go wires it (recovery
+// outermost), and returns a real client plus the captured control-plane log.
+func startLeakServer(t *testing.T, f *leakFakes) (agentv1.AgentServiceClient, context.Context, *syncBuffer) {
+	t.Helper()
+	captured := &syncBuffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(captured, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	authn := auth.NewJWTAuthenticator(nil, "leak-test-secret", time.Hour)
+	srv := agentrpc.NewServer(authn, f.store, f.xcom)
+	srv.SetSecrets(f.secrets, true)
+	srv.SetSecretScoping(f.scoping)
+	srv.SetLogSink(f.sink)
+	srv.SetTokenExchange(stubReviewer{}, f.resolver, f.minter, time.Hour, true)
+
+	lis := bufconn.Listen(1 << 20)
+	grpcSrv := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(agentrpc.RecoveryUnaryInterceptor(slog.Default())),
+		grpc.ChainStreamInterceptor(agentrpc.RecoveryStreamInterceptor(slog.Default())),
+	)
+	agentv1.RegisterAgentServiceServer(grpcSrv, srv)
+	go func() { _ = grpcSrv.Serve(lis) }()
+	t.Cleanup(grpcSrv.Stop)
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) { return lis.DialContext(ctx) }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	token, err := authn.IssueAgentToken(leakIdentity(), time.Hour)
+	if err != nil {
+		t.Fatalf("IssueAgentToken: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
+	return agentv1.NewAgentServiceClient(conn), ctx, captured
+}
+
+// streamLogsErr drives StreamLogs to completion and returns the terminating
+// status the agent sees. It sends one line, then half-closes, so both the
+// per-line write path and the end-of-stream flush path are reachable.
+func streamLogsErr(ctx context.Context, c agentv1.AgentServiceClient) error {
+	stream, err := c.StreamLogs(ctx)
+	if err != nil {
+		return err
+	}
+	if serr := stream.Send(&agentv1.LogLine{Message: "hello", Stream: "stdout"}); serr != nil {
+		// A Send race with a handler that already returned surfaces as EOF; the
+		// real status comes from Recv below.
+		if !errors.Is(serr, io.EOF) {
+			return serr
+		}
+	}
+	if serr := stream.CloseSend(); serr != nil {
+		return serr
+	}
+	for {
+		if _, rerr := stream.Recv(); rerr != nil {
+			if errors.Is(rerr, io.EOF) {
+				return nil
+			}
+			return rerr
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The sweep
+// ---------------------------------------------------------------------------
+
+// TestAgentRPCStatusesCarryNoStorageErrorText drives every agent RPC with a
+// realistic driver error on every collaborator seam behind it and asserts the
+// status a real client receives carries none of that error's text — while the
+// control-plane log still carries all of it under `cause`, and the message
+// still names the operation that failed so the task's own log stays usable.
+func TestAgentRPCStatusesCarryNoStorageErrorText(t *testing.T) {
+	cases := []struct {
+		name     string
+		poison   func(*leakFakes)
+		call     func(context.Context, agentv1.AgentServiceClient) error
+		wantCode codes.Code
+		wantOp   string
+	}{
+		{
+			name:   "GetTaskSpec: the task spec cannot be loaded",
+			poison: func(f *leakFakes) { f.store.specErr = poison() },
+			call: func(ctx context.Context, c agentv1.AgentServiceClient) error {
+				_, err := c.GetTaskSpec(ctx, &agentv1.GetTaskSpecRequest{})
+				return err
+			},
+			wantCode: codes.Internal, wantOp: "loading task spec",
+		},
+		{
+			name:   "ReportState: the state write fails",
+			poison: func(f *leakFakes) { f.store.reportErr = poison() },
+			call: func(ctx context.Context, c agentv1.AgentServiceClient) error {
+				_, err := c.ReportState(ctx, &agentv1.ReportStateRequest{State: agentv1.TaskState_TASK_STATE_SUCCESS})
+				return err
+			},
+			wantCode: codes.Internal, wantOp: "recording state",
+		},
+		{
+			name:   "ReportState: the reschedule write fails",
+			poison: func(f *leakFakes) { f.store.rescheduleErr = poison() },
+			call: func(ctx context.Context, c agentv1.AgentServiceClient) error {
+				_, err := c.ReportState(ctx, &agentv1.ReportStateRequest{State: agentv1.TaskState_TASK_STATE_UP_FOR_RESCHEDULE})
+				return err
+			},
+			wantCode: codes.Internal, wantOp: "recording reschedule",
+		},
+		{
+			name:   "PushXCom: the task spec cannot be loaded",
+			poison: func(f *leakFakes) { f.store.specErr = poison() },
+			call: func(ctx context.Context, c agentv1.AgentServiceClient) error {
+				_, err := c.PushXCom(ctx, &agentv1.PushXComRequest{Key: "return_value", Value: []byte(`"v"`)})
+				return err
+			},
+			wantCode: codes.Internal, wantOp: "loading task spec",
+		},
+		{
+			name:   "PushXCom: the xcom backend rejects the write",
+			poison: func(f *leakFakes) { f.xcom.pushErr = poison() },
+			call: func(ctx context.Context, c agentv1.AgentServiceClient) error {
+				_, err := c.PushXCom(ctx, &agentv1.PushXComRequest{Key: "return_value", Value: []byte(`"v"`)})
+				return err
+			},
+			wantCode: codes.Internal, wantOp: "storing xcom",
+		},
+		{
+			name:   "FetchXCom: the task spec cannot be loaded",
+			poison: func(f *leakFakes) { f.store.specErr = poison() },
+			call: func(ctx context.Context, c agentv1.AgentServiceClient) error {
+				_, err := c.FetchXCom(ctx, &agentv1.FetchXComRequest{UpstreamTaskId: "upstream", Key: "return_value"})
+				return err
+			},
+			wantCode: codes.Internal, wantOp: "loading task spec",
+		},
+		{
+			name:   "FetchXCom: the xcom backend fails the read",
+			poison: func(f *leakFakes) { f.xcom.fetchErr = poison() },
+			call: func(ctx context.Context, c agentv1.AgentServiceClient) error {
+				_, err := c.FetchXCom(ctx, &agentv1.FetchXComRequest{UpstreamTaskId: "upstream", Key: "return_value"})
+				return err
+			},
+			wantCode: codes.Internal, wantOp: "reading xcom",
+		},
+		{
+			name:     "StreamLogs: the sink cannot be opened",
+			poison:   func(f *leakFakes) { f.sink.openErr = poison() },
+			call:     streamLogsErr,
+			wantCode: codes.Internal, wantOp: "opening log sink",
+		},
+		{
+			name:     "StreamLogs: a line cannot be written",
+			poison:   func(f *leakFakes) { f.sink.writeErr = poison() },
+			call:     streamLogsErr,
+			wantCode: codes.Internal, wantOp: "writing log line",
+		},
+		{
+			name:     "StreamLogs: the final flush fails",
+			poison:   func(f *leakFakes) { f.sink.closeErr = poison() },
+			call:     streamLogsErr,
+			wantCode: codes.Internal, wantOp: "flushing logs",
+		},
+		{
+			name:   "GetVariables: the vault read fails (permissive)",
+			poison: func(f *leakFakes) { f.secrets.err = poison() },
+			call: func(ctx context.Context, c agentv1.AgentServiceClient) error {
+				_, err := c.GetVariables(ctx, &agentv1.GetVariablesRequest{})
+				return err
+			},
+			wantCode: codes.Internal, wantOp: "fetching variables",
+		},
+		{
+			name: "GetVariables: the scoped vault read fails (enforce)",
+			poison: func(f *leakFakes) {
+				f.scoping = agentrpc.ScopingEnforce
+				f.secrets.err = poison()
+			},
+			call: func(ctx context.Context, c agentv1.AgentServiceClient) error {
+				_, err := c.GetVariables(ctx, &agentv1.GetVariablesRequest{})
+				return err
+			},
+			wantCode: codes.Internal, wantOp: "fetching variables",
+		},
+		{
+			name: "GetVariables: the declared-set lookup fails (enforce)",
+			poison: func(f *leakFakes) {
+				f.scoping = agentrpc.ScopingEnforce
+				f.store.specErr = poison()
+			},
+			call: func(ctx context.Context, c agentv1.AgentServiceClient) error {
+				_, err := c.GetVariables(ctx, &agentv1.GetVariablesRequest{})
+				return err
+			},
+			wantCode: codes.Internal, wantOp: "loading task spec for scope enforcement",
+		},
+		{
+			name:   "GetConnections: the vault read fails (permissive)",
+			poison: func(f *leakFakes) { f.secrets.err = poison() },
+			call: func(ctx context.Context, c agentv1.AgentServiceClient) error {
+				_, err := c.GetConnections(ctx, &agentv1.GetConnectionsRequest{})
+				return err
+			},
+			wantCode: codes.Internal, wantOp: "fetching connections",
+		},
+		{
+			name: "GetConnections: the scoped vault read fails (enforce)",
+			poison: func(f *leakFakes) {
+				f.scoping = agentrpc.ScopingEnforce
+				f.secrets.err = poison()
+			},
+			call: func(ctx context.Context, c agentv1.AgentServiceClient) error {
+				_, err := c.GetConnections(ctx, &agentv1.GetConnectionsRequest{})
+				return err
+			},
+			wantCode: codes.Internal, wantOp: "fetching connections",
+		},
+		{
+			name: "GetConnections: the declared-set lookup fails (enforce)",
+			poison: func(f *leakFakes) {
+				f.scoping = agentrpc.ScopingEnforce
+				f.store.specErr = poison()
+			},
+			call: func(ctx context.Context, c agentv1.AgentServiceClient) error {
+				_, err := c.GetConnections(ctx, &agentv1.GetConnectionsRequest{})
+				return err
+			},
+			wantCode: codes.Internal, wantOp: "loading task spec for scope enforcement",
+		},
+		{
+			name:   "ExchangeToken: the reviewed pod cannot be resolved",
+			poison: func(f *leakFakes) { f.resolver.err = poison() },
+			call: func(ctx context.Context, c agentv1.AgentServiceClient) error {
+				_, err := c.ExchangeToken(ctx, &agentv1.ExchangeTokenRequest{})
+				return err
+			},
+			wantCode: codes.Internal, wantOp: "resolving pod to agent identity",
+		},
+		{
+			name:   "ExchangeToken: the token cannot be minted",
+			poison: func(f *leakFakes) { f.minter.err = poison() },
+			call: func(ctx context.Context, c agentv1.AgentServiceClient) error {
+				_, err := c.ExchangeToken(ctx, &agentv1.ExchangeTokenRequest{})
+				return err
+			},
+			wantCode: codes.Internal, wantOp: "minting agent token",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newLeakFakes()
+			tc.poison(f)
+			client, ctx, captured := startLeakServer(t, f)
+
+			err := tc.call(ctx, client)
+			if err == nil {
+				t.Fatal("the poisoned seam produced no error; this case no longer drives the path it names")
+			}
+			if got := status.Code(err); got != tc.wantCode {
+				t.Errorf("status code = %v, want %v (%v)", got, tc.wantCode, err)
+			}
+			msg := status.Convert(err).Message()
+			for _, leak := range leakTokens(pgFixture()) {
+				if leak == "" {
+					continue
+				}
+				if strings.Contains(msg, leak) {
+					t.Errorf("the status the task pod receives leaks %q:\n  %s", leak, msg)
+				}
+			}
+			// Over-redaction is a real regression too: a task that fails with no
+			// usable reason in its own log costs the person debugging the DAG.
+			if !strings.Contains(msg, tc.wantOp) {
+				t.Errorf("the status no longer names the operation %q, so the task log says nothing usable:\n  %s", tc.wantOp, msg)
+			}
+			// The operator must lose nothing: the real cause belongs on the
+			// control-plane log line, correlatable with what the caller got.
+			logged := captured.String()
+			if !strings.Contains(logged, `"cause"`) {
+				t.Errorf("the control-plane log has no cause field; the operator lost the diagnosis:\n%s", logged)
+			}
+			for _, want := range []string{pgFixture().Code, pgFixture().ConstraintName} {
+				if !strings.Contains(logged, want) {
+					t.Errorf("the control-plane log lost %q; the operator lost the diagnosis:\n%s", want, logged)
+				}
+			}
+			if !strings.Contains(logged, tc.wantOp) {
+				t.Errorf("the control-plane log does not name %q, so it cannot be correlated with what the agent saw:\n%s", tc.wantOp, logged)
+			}
+		})
+	}
+}
+
+// TestAgentRPCKeepsTheAttemptIdentityOnTheCauseLine pins the correlation handle.
+// The agent has no request id to echo, so the attempt identity IS the join key
+// between the phrase the task log shows and the cause on the control-plane log.
+func TestAgentRPCKeepsTheAttemptIdentityOnTheCauseLine(t *testing.T) {
+	f := newLeakFakes()
+	f.store.specErr = poison()
+	client, ctx, captured := startLeakServer(t, f)
+
+	if _, err := client.GetTaskSpec(ctx, &agentv1.GetTaskSpecRequest{}); err == nil {
+		t.Fatal("GetTaskSpec should have failed")
+	}
+	logged := captured.String()
+	id := leakIdentity()
+	for field, want := range map[string]string{
+		"ti": id.TaskInstanceID, "run": id.RunID, "task": id.TaskID,
+	} {
+		if !strings.Contains(logged, `"`+field+`":"`+want+`"`) {
+			t.Errorf("the cause line has no %s=%s, so it cannot be correlated with the failing attempt:\n%s", field, want, logged)
+		}
+	}
+}
+
+// TestAgentRPCPassesThroughDeliberatelyClientFacingMessages is the other side of
+// the guard. Blanket redaction would take away the one storage message the agent
+// genuinely needs: "task X not found in run Y" tells the operator the pod is
+// running a task its dag_version does not declare (a stale image, a mismatched
+// version) rather than that the control plane is broken. domain.SafeError is the
+// opt-in that lets exactly those phrases through.
+//
+// This asserts the FORMATTING layer honours the opt-in. That storage actually
+// PRODUCES one is pinned separately, at the layer that produces it — see
+// internal/storage/agent_safe_error_integration_test.go — because this test is
+// satisfied by a fake and would stay green with every Safef reverted.
+func TestAgentRPCPassesThroughDeliberatelyClientFacingMessages(t *testing.T) {
+	f := newLeakFakes()
+	f.store.specErr = domain.Safef(domain.ErrNotFound, "task %q not found in run %q", "extract", "run-1")
+	client, ctx, _ := startLeakServer(t, f)
+
+	_, err := client.GetTaskSpec(ctx, &agentv1.GetTaskSpecRequest{})
+	if err == nil {
+		t.Fatal("GetTaskSpec should have failed")
+	}
+	msg := status.Convert(err).Message()
+	if !strings.Contains(msg, `task "extract" not found in run "run-1"`) {
+		t.Errorf("a deliberately client-facing message was redacted; the task fails with no usable reason:\n  %s", msg)
+	}
+}

--- a/internal/agentrpc/status_source_guard_test.go
+++ b/internal/agentrpc/status_source_guard_test.go
@@ -34,9 +34,9 @@ var statusConstructors = map[string]bool{"Error": true, "Errorf": true, "New": t
 // pattern reappears, and it reaches the two AwaitAssignment sites whose error is
 // a transport failure a client cannot force.
 //
-// internalStatus is the single sanctioned way to turn an error into a status
-// here; its parameter is deliberately named cause, not err, because the value
-// it carries is destined for the log and never for the wire.
+// internalStatus and peerStatus are the only sanctioned ways to turn an error
+// into a status here; their parameter is deliberately named cause, not err,
+// because the value it carries is destined for the log and never for the wire.
 func TestNoErrorValueIsInterpolatedIntoAnAgentStatus(t *testing.T) {
 	fset := token.NewFileSet()
 	entries, err := os.ReadDir(".")
@@ -87,7 +87,7 @@ func inspectStatusCalls(t *testing.T, fset *token.FileSet, file *ast.File) int {
 		seen++
 		for _, arg := range call.Args {
 			if name, found := errorishOperand(arg); found {
-				t.Errorf("%s: status.%s interpolates the error value %q into a message the task pod receives; route it through internalStatus so the cause stays in the control-plane log (#1068)",
+				t.Errorf("%s: status.%s interpolates the error value %q into a message the task pod receives; route it through internalStatus/peerStatus so the cause stays in the control-plane log (#1068)",
 					fset.Position(call.Pos()), sel.Sel.Name, name)
 			}
 		}

--- a/internal/agentrpc/status_source_guard_test.go
+++ b/internal/agentrpc/status_source_guard_test.go
@@ -1,0 +1,123 @@
+package agentrpc_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// errorish matches the names Go convention gives error values — err, rerr,
+// verr, perr, cerr, oerr, werr, hbErr, rl.err — a convention golangci's
+// error-naming rule already enforces in this repo. It is deliberately narrow:
+// it matches how errors are NAMED, not how they are used.
+var errorish = regexp.MustCompile(`(?i)^[a-z0-9_]*err(or)?$`)
+
+// statusConstructors are the ways a gRPC status is built. Every one of them
+// puts its message on the wire to the task pod.
+var statusConstructors = map[string]bool{"Error": true, "Errorf": true, "New": true, "Newf": true}
+
+// TestNoErrorValueIsInterpolatedIntoAnAgentStatus is the source-level tripwire
+// for the reintroduction of #1068: a `status.Errorf(codes.Internal, "doing X:
+// %v", err)` anywhere in this package puts a driver error's text — SQLSTATE,
+// constraint, table, column, or a connection string — into a message returned
+// to the tenant's own pod.
+//
+// It complements, and does not replace, TestAgentRPCStatusesCarryNoStorageErrorText:
+// that one asserts on what a real client receives and so catches a leak through
+// any mechanism, including a bare error returned from a handler and rendered by
+// grpc-go as Unknown. This one names the offending file and line the moment the
+// pattern reappears, and it reaches the two AwaitAssignment sites whose error is
+// a transport failure a client cannot force.
+//
+// internalStatus is the single sanctioned way to turn an error into a status
+// here; its parameter is deliberately named cause, not err, because the value
+// it carries is destined for the log and never for the wire.
+func TestNoErrorValueIsInterpolatedIntoAnAgentStatus(t *testing.T) {
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading the package directory: %v", err)
+	}
+	constructors := 0
+	files := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		file, perr := parser.ParseFile(fset, filepath.Join(".", name), nil, 0)
+		if perr != nil {
+			t.Fatalf("parsing %s: %v", name, perr)
+		}
+		files++
+		constructors += inspectStatusCalls(t, fset, file)
+	}
+	if files == 0 {
+		t.Fatal("no non-test sources parsed; this guard would pass vacuously")
+	}
+	if constructors == 0 {
+		t.Fatal("no status constructor found in the package; the guard is not watching anything")
+	}
+}
+
+// inspectStatusCalls reports every error-named value handed to a gRPC status
+// constructor in file, and returns how many constructors it examined so the
+// caller can prove the guard was not vacuous.
+func inspectStatusCalls(t *testing.T, fset *token.FileSet, file *ast.File) int {
+	t.Helper()
+	seen := 0
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		pkgIdent, ok := sel.X.(*ast.Ident)
+		if !ok || pkgIdent.Name != "status" || !statusConstructors[sel.Sel.Name] {
+			return true
+		}
+		seen++
+		for _, arg := range call.Args {
+			if name, found := errorishOperand(arg); found {
+				t.Errorf("%s: status.%s interpolates the error value %q into a message the task pod receives; route it through internalStatus so the cause stays in the control-plane log (#1068)",
+					fset.Position(call.Pos()), sel.Sel.Name, name)
+			}
+		}
+		return true
+	})
+	return seen
+}
+
+// errorishOperand reports the first error-named identifier or field reachable
+// from an argument expression, so both `err` and `rl.err` are caught.
+func errorishOperand(expr ast.Expr) (string, bool) {
+	var name string
+	found := false
+	ast.Inspect(expr, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		switch v := n.(type) {
+		case *ast.SelectorExpr:
+			if errorish.MatchString(v.Sel.Name) {
+				name, found = v.Sel.Name, true
+				return false
+			}
+		case *ast.Ident:
+			if errorish.MatchString(v.Name) {
+				name, found = v.Name, true
+				return false
+			}
+		}
+		return true
+	})
+	return name, found
+}

--- a/internal/agentrpc/streamlogs_level_test.go
+++ b/internal/agentrpc/streamlogs_level_test.go
@@ -34,7 +34,7 @@ func TestWriteLinesRefinesLevelButKeepsStream(t *testing.T) {
 	}
 
 	w := &capLogWriter{}
-	if err := writeLines(nil, w, recv, func(string) {}); err != nil {
+	if err := writeLines(nil, w, recv, func(string) {}, nil); err != nil {
 		t.Fatalf("writeLines: %v", err)
 	}
 	if len(w.events) != 3 {

--- a/internal/agentrpc/streamlogs_shutdown_test.go
+++ b/internal/agentrpc/streamlogs_shutdown_test.go
@@ -34,7 +34,7 @@ func TestWriteLinesReturnsOnShutdown(t *testing.T) {
 	shutdown := make(chan struct{})
 	w := &fakeLogWriter{}
 	errCh := make(chan error, 1)
-	go func() { errCh <- writeLines(shutdown, w, recv, func(string) {}) }()
+	go func() { errCh <- writeLines(shutdown, w, recv, func(string) {}, nil) }()
 
 	select {
 	case err := <-errCh:
@@ -72,7 +72,7 @@ func TestWriteLinesDeliversLinesBeforeShutdown(t *testing.T) {
 	w := &fakeLogWriter{}
 	published := make(chan struct{}, 2) // publish runs after each WriteEvent, on the loop goroutine
 	errCh := make(chan error, 1)
-	go func() { errCh <- writeLines(shutdown, w, recv, func(string) { published <- struct{}{} }) }()
+	go func() { errCh <- writeLines(shutdown, w, recv, func(string) { published <- struct{}{} }, nil) }()
 	for i := 0; i < 2; i++ {
 		select {
 		case <-published:

--- a/internal/storage/agent_safe_error_integration_test.go
+++ b/internal/storage/agent_safe_error_integration_test.go
@@ -1,0 +1,74 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// TestExecutionStoreProducesSafeErrorsForTheAgentFacingMessage closes, for the
+// agent transport, the hole review found in #961's fix and #1068 repeats.
+//
+// agentrpc now sends the task pod a fixed phrase per operation and keeps the
+// real cause in the control-plane log; only a domain.SafeError — an error
+// someone deliberately wrote as client-facing — still contributes text. One
+// message was converted on that basis: "task X not found in run Y", which tells
+// the operator the pod is running a task its dag_version does not declare (a
+// stale image, a mismatched version) rather than that the control plane is
+// broken.
+//
+// Nothing in internal/agentrpc can pin that. Its tests build the SafeError in
+// the test or hand one to a fake, so reverting the Safef here would leave them
+// green while every real unknown-task failure collapsed to "loading task spec:
+// the request could not be completed". The assertion belongs at the layer that
+// PRODUCES the error, which is this one.
+func TestExecutionStoreProducesSafeErrorsForTheAgentFacingMessage(t *testing.T) {
+	repo, sched, exec, ctx := openExec(t)
+	dagID := fmt.Sprintf("agent_safe_error_%d", time.Now().UnixNano())
+	runUUID := seedRunningTask(t, repo, sched, ctx, dagID, "load")
+
+	id := auth.AgentIdentity{
+		TaskInstanceID: "ti-unknown", TenantID: "default", DagID: dagID,
+		RunID: runUUID, TaskID: "no_such_task", TryNumber: 1,
+	}
+	_, err := exec.TaskSpec(ctx, id)
+	if err == nil {
+		t.Fatal("TaskSpec for a task the dag_version does not declare must fail")
+	}
+	var safe *domain.SafeError
+	if !errors.As(err, &safe) {
+		t.Fatalf("the unknown-task error is not a *domain.SafeError, so agentrpc redacts it and the pod is told nothing usable: %v", err)
+	}
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Errorf("the unknown-task error lost its ErrNotFound class: %v", err)
+	}
+	for _, want := range []string{"no_such_task", runUUID} {
+		if !strings.Contains(safe.ClientMessage(), want) {
+			t.Errorf("the message the agent receives lost %q: %q", want, safe.ClientMessage())
+		}
+	}
+}
+
+// TestExecutionStoreLeavesDriverErrorsUnsafe is the other half: converting the
+// one message worth passing through must not turn into wrapping everything in
+// Safef, which would re-open the leak through the sanctioned door. A malformed
+// run id fails inside the driver, and that failure must stay opaque.
+func TestExecutionStoreLeavesDriverErrorsUnsafe(t *testing.T) {
+	_, _, exec, ctx := openExec(t)
+
+	_, err := exec.TaskSpec(ctx, auth.AgentIdentity{RunID: "not-a-uuid", TaskID: "load", TryNumber: 1})
+	if err == nil {
+		t.Fatal("TaskSpec with a malformed run id must fail")
+	}
+	var safe *domain.SafeError
+	if errors.As(err, &safe) {
+		t.Errorf("a driver-level failure was marked client-facing; its text would reach the task pod verbatim: %q", safe.ClientMessage())
+	}
+}

--- a/internal/storage/agent_store.go
+++ b/internal/storage/agent_store.go
@@ -407,7 +407,14 @@ func (s *ExecutionStore) resolve(ctx context.Context, runID, taskID string) (dom
 			return t, spec, ver, run, nil
 		}
 	}
-	return domain.TaskSpec{}, domain.DAGSpec{}, queries.DagVersion{}, queries.DagRun{}, fmt.Errorf("task %q not found in run %q", taskID, runID)
+	// The one failure on this path an agent can act on, so it is composed as a
+	// SafeError and reaches the task pod verbatim while every driver error behind
+	// the same call is redacted. It says the pod is running a task its
+	// dag_version does not declare — a stale image, a mismatched version — rather
+	// than that the control plane is broken, and it names only values the caller
+	// already holds in its own token.
+	return domain.TaskSpec{}, domain.DAGSpec{}, queries.DagVersion{}, queries.DagRun{},
+		domain.Safef(domain.ErrNotFound, "task %q not found in run %q", taskID, runID)
 }
 
 // latestTry returns the highest try_number task instance for the given task.

--- a/website/content/operate/troubleshooting.md
+++ b/website/content/operate/troubleshooting.md
@@ -133,6 +133,37 @@ journalctl -u leoflow-server -o cat | grep '"request_id":"<id>"' | jq '.cause'
 `kubectl logs deploy/leoflow -c leoflow | jq 'select(.cause) | {path, status, cause}'`
 lists every request that failed with a server-side cause.
 
+### "…: the request could not be completed; see the control-plane logs" in a task log
+
+The agent inside a task pod talks to the control plane over gRPC, and the same
+rule applies there for the same reason: the pod runs *your* image and
+entrypoint, so it is not a place to put the database's text. A failed agent RPC
+therefore reads as the step that failed plus a fixed phrase, for example:
+
+```
+fetching task spec: rpc error: code = Internal desc = loading task spec: the request could not be completed; see the control-plane logs
+```
+
+The step name is the diagnostic half and is always there — `loading task spec`,
+`recording state`, `recording reschedule`, `storing xcom`, `reading xcom`,
+`fetching variables`, `fetching connections`, `opening log sink`, `writing log
+line`, `flushing logs`, `minting agent token`. The cause is on the
+control-plane log line of the same name, carrying the attempt identity:
+
+```bash
+kubectl logs deploy/leoflow -c leoflow \
+  | jq 'select(.cause) | select(.run == "<run_id>" and .task == "<task_id>") | {msg, try, cause}'
+# {"msg":"loading task spec","try":1,"cause":"loading run: ERROR: … (SQLSTATE 42P01)"}
+```
+
+Two messages are *not* redacted, because they are Leoflow's own words about
+your DAG rather than an infrastructure failure, and you can act on them:
+
+| What the pod sees | Means |
+|---|---|
+| `loading task spec: task "x" not found in run "y"` | The pod is running a task its `dag_version` does not declare — usually a stale image, or a run created against a different version. |
+| `task "a" may not read xcom from "b" (not a declared input or dependency)` | The task pulled an XCom it never declared as an input or a dependency. |
+
 ## Observability
 
 - **Metrics:** Prometheus at `:9090/metrics` (scheduler, dispatch, inline

--- a/website/content/operate/troubleshooting.md
+++ b/website/content/operate/troubleshooting.md
@@ -144,10 +144,13 @@ therefore reads as the step that failed plus a fixed phrase, for example:
 fetching task spec: rpc error: code = Internal desc = loading task spec: the request could not be completed; see the control-plane logs
 ```
 
-The step name is the diagnostic half and is always there — `loading task spec`,
-`recording state`, `recording reschedule`, `storing xcom`, `reading xcom`,
-`fetching variables`, `fetching connections`, `opening log sink`, `writing log
-line`, `flushing logs`, `minting agent token`. The cause is on the
+The step name is the diagnostic half and is always there. All sixteen:
+`loading task spec`, `loading task spec for scope enforcement`, `recording
+state`, `recording reschedule`, `storing xcom`, `reading xcom`, `fetching
+variables`, `fetching connections`, `resolving pod to agent identity`,
+`minting agent token`, `opening log sink for task; logs will not be shipped`,
+`writing log line`, `flushing logs`, `receiving log line`, `receiving
+assignment request`, `receiving assignment ack`. The cause is on the
 control-plane log line of the same name, carrying the attempt identity:
 
 ```bash
@@ -156,13 +159,23 @@ kubectl logs deploy/leoflow -c leoflow \
 # {"msg":"loading task spec","try":1,"cause":"loading run: ERROR: … (SQLSTATE 42P01)"}
 ```
 
-Two messages are *not* redacted, because they are Leoflow's own words about
+On Lite the same line comes from the service journal rather than a pod — worth
+knowing because `opening log sink` against a filesystem sink is a
+characteristically Lite failure:
+
+```bash
+journalctl -u leoflow -o cat \
+  | jq 'select(.cause) | select(.run == "<run_id>" and .task == "<task_id>") | {msg, try, cause}'
+```
+
+Three messages are *not* redacted, because they are Leoflow's own words about
 your DAG rather than an infrastructure failure, and you can act on them:
 
 | What the pod sees | Means |
 |---|---|
 | `loading task spec: task "x" not found in run "y"` | The pod is running a task its `dag_version` does not declare — usually a stale image, or a run created against a different version. |
 | `task "a" may not read xcom from "b" (not a declared input or dependency)` | The task pulled an XCom it never declared as an input or a dependency. |
+| `no xcom for task "x"` | Nothing was pushed under that key. The agent handles this one by status code rather than by text, so you will normally see its effect rather than the sentence. |
 
 ## Observability
 


### PR DESCRIPTION
Closes #1068. Same disclosure class as #961, second transport, same shape of fix as #1069.

## What was wrong

`internal/agentrpc` put `%v` of a storage, XCom, log-sink or signing failure straight into the gRPC status message returned to the agent. `pgconn` renders a `*PgError` as `severity: message (SQLSTATE code)` with the constraint, table and column names of the schema inside the message, and a `*ConnectError` renders the database user and name — so all of that reached the pod (CWE-209).

The pod is a trust boundary, and this codebase already treats it as one: `RecoveryUnaryInterceptor` collapses a panic to a constant `"internal server error"` for exactly this audience. It runs the tenant's own image and entrypoint, so it is authenticated, tenant-controlled code execution that can call `GetTaskSpec` / `GetVariables` / `FetchXCom` in a loop. Higher exploitability than #961's browser session, not lower.

Two things the issue did not have:

- **A second-order path out of the pod.** The agent puts a failed RPC's text into the state it reports (`runner.go:161` → `failWithReason` → `ReportState.error_message`), storage persists it (`agent_store.go:165`), and `mappers.go:127` maps it to `FailureReason`, which `internal/api/dto.go:255` serves and `logs.go:96` injects into the served log. A driver error could therefore reach a browser *through* the pod, on a route #1069 did not touch because the text does not pass through `handleRepoError`.
- **The count is exactly 20, and the issue's list is exactly right.** The AST guard below, derived independently, names the same 20 sites the issue enumerates (it says "~21").

## The fix

The default is inverted from allow to deny, the same way `safeDetail` did it for the HTTP surface.

- `internalStatus(op, cause, attrs...)` is the single sanctioned way to turn an error into a status. It returns `codes.Internal` with `op` plus a fixed phrase, and only a `domain.SafeError` — an error someone deliberately wrote as client-facing — contributes text. A newly wrapped driver error cannot leak by omission.
- `peerStatus` is its sibling for a failure the **peer's transport** caused (a stream that broke because the pod went away): identical redaction, logged at warn instead of error, so an ordinary pod kill does not manufacture an error line. Those two sites were previously not logged at all, and routing them through `internalStatus` would have been a noise regression.
- **No status code changed.** Every code in the package is byte-identical to before; only messages moved.
- **The operator loses nothing.** The real error goes to the control-plane log under the same `cause` field #1069 introduced, alongside the attempt identity (`ti`, `tenant`, `dag`, `run`, `task`, `try`). The agent has no request id to echo, so the attempt identity *is* the join key. The two `slog.Warn` lines the exchange path already wrote are folded into the helper rather than duplicated, keeping their `namespace`/`pod`/`pod_uid`/`scope` fields.

## The agent's own logs, which operators read in task output

Checked explicitly, because this is where over-redacting costs someone real time. The agent logs and reports the gRPC error (`runner.go:141`, `:197`, `:317`, `:411`, `:421`), so before this change a task's own log carried the driver text and after it carries the operation plus a pointer. `fetching task spec: rpc error: … desc = loading task spec: the request could not be completed; see the control-plane logs`.

That is why the operation name is a **compile-time constant at each call site and stays on the wire** — `loading task spec`, `recording state`, `recording reschedule`, `storing xcom`, `reading xcom`, `fetching variables`, `fetching connections`, `loading task spec for scope enforcement`, `opening log sink`, `writing log line`, `flushing logs`, `receiving log line`, `resolving pod to agent identity`, `minting agent token`, `receiving worker message`, `receiving worker registration`. The step that failed is the half a DAG author can act on; the driver text never was. `TestAgentRPCStatusesCarryNoStorageErrorText` asserts the operation survives in every case, and M7 below is the mutant that proves the assertion bites.

`opening log sink` is the one that needed a decision rather than a rule: it is the only site whose whole point (#36) was to tell the agent *why*, because a failed sink means the task's logs are not being shipped and the agent otherwise sees a bare stream EOF. The step name preserves that; the path, bucket or credential detail behind it moves to the control-plane log, which is where an operator can act on it anyway.

## Which messages stay client-facing

Three, and only one of them is new work:

| Message | Why it passes through |
|---|---|
| `task "x" not found in run "y"` (**new `domain.Safef`**, `storage/agent_store.go`) | The one storage failure on this path an agent can act on: the pod is running a task its `dag_version` does not declare — a stale image, a run created against another version — rather than the control plane being broken. It names only values the caller already holds in its own token. |
| `task "a" may not read xcom from "b" (not a declared input or dependency)` | Not an error render at all: our own sentence about the caller's own request. Unchanged. |
| `no xcom for task "x"` | Same. Unchanged. |

Everything else in the package was already a constant (`warm pools disabled`, `not the scheduler leader`, `invalid agent token`, the two insecure-channel refusals, the scope refusals, the shutdown phrases) and stays one.

Deliberately **not** made safe: `mapState`'s `unsupported task state %v` renders a protobuf enum, not an error; the `499`-equivalent `status.FromContextError(ctx.Err())` can only carry `context canceled` / `deadline exceeded`.

## How the sweep was established

Four derivations, three of them independent of the code I wrote.

**1. Every gRPC status constructor in the package, enumerated and classified.**

```
grep -rn --include='*.go' 'status\.\(Error\|Errorf\|New\|Newf\)(' internal/agentrpc/ | grep -v '_test.go'   # 26
grep -rn --include='*.go' 'status\.Errorf(' internal/agentrpc/ | grep -v '_test.go'                        # 3 after the fix
```

The 3 remaining interpolate `req.GetUpstreamTaskId()`, `id.TaskID` and a protobuf enum — no error value among them. The other 23 take string literals.

**2. Every path by which text can leave a handler, not just `status.Errorf`.** grpc-go renders a bare error returned from a handler as `codes.Unknown` with `err.Error()`, so the grep above is not sufficient on its own. Every `return` of an error value in the package's non-test files was read and classified: `err` from `identify` (constant `Unauthenticated`), `aerr`/`werr` from the scope gates, `gerr` from the two channel guards, `lerr` from `checkLiveness`, `derr` from `declaredNames`, `err` from `mapState` and `registerFromStream`, `ierr` in `StreamLogs`, `serr` from `stream.Send` (a transport status, no control-plane text), and `status.FromContextError`. All are statuses built in this package or by grpc-go itself; no handler returns a bare wrapped error. The other text vectors were checked and are empty: `grep 'SetTrailer\|SetHeader\|SendHeader'` finds nothing, and the only error-derived field on any response payload is `RejectionReason`, whose two values are the constants `payload_too_large` and `schema_mismatch`.

**3. Behavioural, at the client.** `internal/agentrpc/status_leak_test.go` stands up the real `*agentrpc.Server` behind a real `grpc.Server` on a bufconn, wired as `main.go` wires it (recovery outermost), and drives **18 cases across every agent RPC** with a realistic `*pgconn.PgError` (23503, constraint + table + column + routine + file), wrapped the way storage wraps it, on **every collaborator seam**: `Store.TaskSpec` / `ReportState` / `Reschedule`, `XComService.Push` / `Fetch`, all four `SecretsStore` methods in both scoping modes, `LogSink.Open` and the writer's `WriteEvent` and `Close`, `PodTaskResolver` and `AgentTokenMinter`. The assertion is on the status a **real client** receives, so it holds whichever mechanism the text would have escaped through. Scan tokens are derived from the fixture (`Code`, `Message`, `Error()`, severity prefix, constraint / table / column / schema / routine / file), not hand-listed. Each case also asserts the `cause` log line still carries the SQLSTATE and the constraint, and still names the operation.

**4. Source tripwire.** `status_source_guard_test.go` parses the package's non-test files and fails on any error-named value (`err`, `rerr`, `verr`, `perr`, `cerr`, `oerr`, `werr`, `hbErr`, `rl.err` — the convention golangci's `error-naming` rule already enforces here) reaching a status constructor, naming the file and line. It is what reaches the two `AwaitAssignment` sites whose error is a transport failure a client cannot force from outside. Run against `main` it names **exactly the 20 sites the issue lists** — an independent re-derivation of the issue's enumeration, and the reason I am confident 20 is the whole set rather than "about 21". It also refuses to pass vacuously (it fails if it parsed no files or found no constructors).

The blast radius stops at this package: `grep -rln 'google.golang.org/grpc/status'` over non-test sources finds only `internal/agentrpc` (server side) and `internal/agent` (the in-pod client, which reads codes and builds nothing for a peer), and `cmd/leoflow-server/main.go:910` registers exactly one service on the agent listener — no reflection, no health service, no second server.

## Mutation evidence

Each mutant applied by exact-string replacement with the occurrence count asserted (`== 1`) and the file's SHA-256 compared before and after, so a mutant that silently failed to apply is distinguishable from a passing one. Every command run without a pipe and its own exit code read.

```
M1-helper-echoes-the-cause:                        9db13314b87d -> da2369696b09 (applied), exit=1 RED
M2-helper-drops-the-cause-field:                   9db13314b87d -> 86d1835776d9 (applied), exit=1 RED
M3-helper-always-redacts:                          9db13314b87d -> 89d89e5b5bdc (applied), exit=1 RED
M4-storage-stops-producing-a-safe-error:           0f873cafff35 -> 2f4fab146448 (applied), exit=1 RED
M4b-same-mutant-leaves-agentrpc-green:             0f873cafff35 -> 2f4fab146448 (applied), exit=0 GREEN
M5-one-call-site-reverted:                         9b3d3e19a468 -> d101404639df (applied), exit=1 RED
M6-cause-line-loses-the-attempt-identity:          9db13314b87d -> ec9c314bde0d (applied), exit=1 RED
M7-message-loses-the-operation:                    9db13314b87d -> 77dfc5e0975f (applied), exit=1 RED
M8-peer-site-reverted-caught-by-the-source-guard:  9b3d3e19a468 -> 938dda9c6960 (applied), exit=1 RED
post-restore go test ./... exit=0
```

**M4 and M4b are the pair that matter**, because they are the trap review found in #1069's fix. The *same* mutant — reverting the `Safef` in `internal/storage/agent_store.go` to a plain `fmt.Errorf` — turns the storage pin red and leaves the **entire** `internal/agentrpc` suite green, including the test named `TestAgentRPCPassesThroughDeliberatelyClientFacingMessages`. That test builds its `SafeError` in the test, so it can only ever pin the formatting layer. The promise "the message the agent needs still gets through" is therefore asserted where it is *produced*, in `internal/storage/agent_safe_error_integration_test.go`, modelled on `safe_error_integration_test.go` on `main`. Its sibling `TestExecutionStoreLeavesDriverErrorsUnsafe` is the other side: converting one message must not become wrapping everything in `Safef`, which would re-open the leak through the sanctioned door.

M7 is the over-redaction guard: dropping the operation from the client message goes red, so "the task log still says something usable" is not just a claim in this description.

Separately, the first commit (`85032a4`, tests only) is red on its own tree: all 18 leak cases fail, the correlation test fails, and the source guard prints all 20 offending file:line pairs.

## Gates

`go build ./...` clean. `go test -race ./...` clean. `go test -tags integration -race ./...` clean against a migrated Postgres 16 + Redis 7 (the two new storage pins pass; the throwaway containers were removed afterwards). `golangci-lint run ./...` (v2.12.2, the repo's pinned version) reports **0 issues**. Every `scripts/check-*.sh` green except `check-chart-version-matches-tag.sh`, which needs a tag argument.


CHANGELOG under `[Unreleased]` / `Security`, next to #961's entry. Docs: a new section in `website/content/operate/troubleshooting.md` under the one #1069 added, giving the operator the `jq` that pulls a `cause` out by run/task and listing the two messages that are deliberately *not* redacted.

## Deliberately left

- **`internal/api/ide.go`** still returns filesystem errors verbatim. #1069 flagged it, it is a different class with a different audience (the single-user Lite IDE), and it is still unfiled. Say the word and I will file it.
- **`log_reader.go:79`** unchanged, for the reason #1069 gave.
- **The log-only paths keep their `error` field rather than being renamed to `cause`.** `Heartbeat`'s store error is deliberately never returned (ADR 0031 "do no harm"), and the same is true of the best-effort audit writes, the warm-binding persist, the live-tail publish, the rejected token review and the failed-final-flush warning: ten `slog` lines whose error never reaches the wire and so has nothing to redact. `cause` is reserved for "this is the text the caller did *not* get", which is what makes it greppable; renaming those would dilute it.
- **The agent-side wrapping is untouched.** `runner.go` still puts the (now safe) status text into the reported `error_message`. That is the right place for it now that the text is ours, and narrowing it further is #930's territory.
