### PR TITLE
release: promote v0.4.6 GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.6] - 2026-09-11
+
 ### Added
 
 - **A `py3.13` task base image, and one list that decides which ones exist

--- a/helm/leoflow/Chart.yaml
+++ b/helm/leoflow/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version is the chart version; appVersion tracks the leoflow-server image.
 # Both move in lockstep with the release tag (ADR 0028); decouple only if the
 # chart ever needs a cadence of its own for a template-only fix.
-version: 0.4.6-rc.1
-appVersion: "0.4.6-rc.1"
+version: 0.4.6
+appVersion: "0.4.6"
 home: https://github.com/neochaotic/leoflow
 sources:
   - https://github.com/neochaotic/leoflow

--- a/helm/leoflow/README.md
+++ b/helm/leoflow/README.md
@@ -1,6 +1,6 @@
 # leoflow
 
-![Version: 0.4.6-rc.1](https://img.shields.io/badge/Version-0.4.6--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.6-rc.1](https://img.shields.io/badge/AppVersion-0.4.6--rc.1-informational?style=flat-square)
+![Version: 0.4.6](https://img.shields.io/badge/Version-0.4.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.6](https://img.shields.io/badge/AppVersion-0.4.6-informational?style=flat-square)
 
 Leoflow control plane — a GitOps-first, container-native workflow orchestrator (Airflow 3.2.x UI/API compatible).
 


### PR DESCRIPTION
CHANGELOG [Unreleased] -> [0.4.6] - 2026-09-11; Chart version/appVersion -> 0.4.6 (ADR 0028 lockstep).