### PR TITLE
docs: publish v0.4.6 at the documentation root

### DIFF
--- a/website/scripts/ci/versions.json
+++ b/website/scripts/ci/versions.json
@@ -4,10 +4,17 @@
   "versions": [
     {
       "id": "latest",
-      "ref": "v0.4.5",
+      "ref": "v0.4.6",
       "subpath": "",
       "label": "latest",
       "archived": false
+    },
+    {
+      "id": "v0.4.5",
+      "ref": "v0.4.5",
+      "subpath": "v0.4.5",
+      "label": "v0.4.5",
+      "archived": true
     },
     {
       "id": "v0.4.1",


### PR DESCRIPTION
Repoints website/scripts/ci/versions.json's `latest` leg at v0.4.6 and archives the one it replaces. Opened by cut-release.sh after the tag was pushed — the deploy checks the tag out, so this cannot ride in the prepare commit.