### PR TITLE
fix(api): stop reporting a database outage as the caller's fault (#1087, #1071)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (#1087, #1071).** Two surfaces answered a dependency failure with a statement
   about the client, and both were wrong in the same way.
 
-  `leoflow validate`-style token checks aside, **any authenticated request during
-  a database outage returned `401 invalid token`**. `Authenticate` joined
+  **Any authenticated request during a database outage returned
+  `401 invalid token`**. `Authenticate` joined
   `ErrInvalidToken` onto every store failure, so a dead database and a forged
   token were the same value, and the middleware — which inspected only
   `err == nil` — answered 401. Measured against a real stopped Postgres: 401
@@ -42,8 +42,14 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   stays: the UI supersedes in-flight grid requests constantly, and mapping those
   to 500 is the regression it was added for.
 
-
-### Fixed
+  `POST /api/v2/auth/token/renew` carried the same conflation and is fixed with
+  it. Renewal re-proves the principal against the user store, so it fails for
+  the same two unrelated reasons — and both mapped to `401 token cannot be
+  renewed; log in again`, with no cause recorded at all, so an outage was
+  invisible on that route. A store failure there is now 503 as well, and the
+  driver detail reaches the log. A token that was judged and rejected, and a
+  session past `max_lifetime`, are still 401. Renewal still fails closed either
+  way: any error refuses the re-mint.
 
 - **`leoflow dev` builds each venv on the interpreter the project declares, not
   always on the managed CPython 3.11 (#1092).** `python_version` selects the task

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **A database outage is reported as an outage, not as the caller's fault
+  (#1087, #1071).** Two surfaces answered a dependency failure with a statement
+  about the client, and both were wrong in the same way.
+
+  `leoflow validate`-style token checks aside, **any authenticated request during
+  a database outage returned `401 invalid token`**. `Authenticate` joined
+  `ErrInvalidToken` onto every store failure, so a dead database and a forged
+  token were the same value, and the middleware — which inspected only
+  `err == nil` — answered 401. Measured against a real stopped Postgres: 401
+  after **76 seconds**, on a token minted seconds earlier. Signature
+  verification is local and takes about a millisecond, so the duration alone
+  says it was never about the token. It is now **503 "authentication temporarily
+  unavailable"**, the same answer the login path has given for the same cause
+  since #843, with the driver detail kept in the log and out of the body. A
+  token that was actually judged and rejected is still 401.
+
+  That mattered beyond the status code: a well-behaved client reads 401 as
+  "re-authenticate" and retries against `/auth/token`, which needs the same
+  database — turning a read outage into a retry storm against the dependency
+  that is already down. And a wall of 401s reads to whoever is on call as an
+  authentication incident, sending them to rotate credentials during a database
+  outage.
+
+  Separately, **an unreachable database was reported as `499 client closed
+  request`**. `handleRepoError` routed on `errors.Is(err, context.DeadlineExceeded)`,
+  and a `pgconn` connect timeout satisfies that while the caller is still
+  perfectly connected. So the tenant was told they had hung up, the request
+  logged at WARN because 499 is below 500, and **a 5xx-rate alert missed a
+  database outage entirely** — the one incident it exists to catch. The 499
+  branch now asks the request's own context, which is done for a caller who
+  really went away and healthy for one whose database died. The branch itself
+  stays: the UI supersedes in-flight grid requests constantly, and mapping those
+  to 500 is the regression it was added for.
+
+
+### Fixed
+
 - **`leoflow dev` builds each venv on the interpreter the project declares, not
   always on the managed CPython 3.11 (#1092).** `python_version` selects the task
   base image, and since #1031 that image really can be 3.13 — but the dev venv

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -173,7 +173,20 @@ func renewTokenHandler(renewer TokenRenewer, ttlSeconds, maxLifetimeSeconds int)
 		}
 		renewed, ok, err := renewer.RenewUserToken(c.Request.Context(), token, ttl, maxLifetime)
 		if err != nil {
-			AbortProblem(c, http.StatusUnauthorized, "unauthorized", "token cannot be renewed; log in again")
+			// Renewal re-proves the principal against the user store, so it fails for
+			// two unrelated reasons: the token was judged and rejected, or the store
+			// could not be reached to judge it. Only the first is a statement about
+			// the caller. Answering 401 for the second sends the client to log in
+			// against the database that is already down and reads to whoever is on
+			// call as an auth incident — the same conflation JWTAuth carried (#1087).
+			// Either way the renewal is refused; the cause goes to the log, never to
+			// the body.
+			if !errors.Is(err, auth.ErrInvalidToken) {
+				AbortProblemCause(c, http.StatusServiceUnavailable, "service unavailable",
+					"authentication temporarily unavailable", err)
+				return
+			}
+			AbortProblemCause(c, http.StatusUnauthorized, "unauthorized", "token cannot be renewed; log in again", err)
 			return
 		}
 		if !ok {

--- a/internal/api/auth_outage_status_test.go
+++ b/internal/api/auth_outage_status_test.go
@@ -1,0 +1,104 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/neochaotic/leoflow/internal/auth"
+)
+
+// TestAuthOutageIsNot401 is the regression for #1087.
+//
+// JWTAuth inspected only `err == nil` and answered 401 "invalid token" for every
+// failure, so a database the control plane could not reach was reported as a
+// statement about the caller's credentials. Measured against a real stopped
+// Postgres during the v0.4.6 validation: 401 after 76 seconds, on a token minted
+// seconds earlier. Signature verification is local and takes about a
+// millisecond, so the duration alone proves it was not the token.
+//
+// 401 is not merely the wrong number. A well-behaved client reads it as
+// "re-authenticate", so it retries against /auth/token — which needs the same
+// database — turning a read outage into a retry storm on the dependency that is
+// already down. And a wall of 401s reads to whoever is on call as an auth
+// incident, sending them to rotate credentials during a database outage.
+func TestAuthOutageIsNot401(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	dbDown := errors.New("failed to connect to `user=leoflow database=leoflow`: dial tcp 10.0.0.1:5432: i/o timeout")
+
+	run := func(t *testing.T, authErr error) (*httptest.ResponseRecorder, string) {
+		t.Helper()
+		var logBuf bytes.Buffer
+		r := gin.New()
+		r.Use(StructuredLogger(slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))))
+		r.Use(JWTAuth(&fakeAuthn{authErr: authErr}))
+		r.GET("/api/v2/dags", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{}) })
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v2/dags", http.NoBody)
+		req.Header.Set("Authorization", "Bearer whatever")
+		r.ServeHTTP(rec, req)
+		return rec, logBuf.String()
+	}
+
+	t.Run("a backend failure is 503, not 401", func(t *testing.T) {
+		rec, _ := run(t, dbDown)
+		if rec.Code != http.StatusServiceUnavailable {
+			t.Errorf("status = %d, want 503 — the token was never judged, the store was unreachable", rec.Code)
+		}
+		if strings.Contains(rec.Body.String(), "invalid token") {
+			t.Errorf("body blames the caller's token for an outage: %s", rec.Body.String())
+		}
+	})
+
+	t.Run("the body stays clean and the log keeps the cause", func(t *testing.T) {
+		rec, logs := run(t, dbDown)
+		// #961's split: the tenant learns nothing about the driver; the operator
+		// keeps everything, correlatable by request_id.
+		for _, leak := range []string{"dial tcp", "10.0.0.1", "user=leoflow", "i/o timeout"} {
+			if strings.Contains(rec.Body.String(), leak) {
+				t.Errorf("body leaks %q: %s", leak, rec.Body.String())
+			}
+		}
+		if !strings.Contains(logs, "dial tcp") {
+			t.Errorf("the log must carry the cause the body withheld; got %s", logs)
+		}
+		var body map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Fatalf("body is not problem+json: %v", err)
+		}
+		if body["status"].(float64) != http.StatusServiceUnavailable {
+			t.Errorf("problem body status = %v, want 503", body["status"])
+		}
+	})
+
+	t.Run("a genuinely invalid token is still 401", func(t *testing.T) {
+		// The 401 path must survive: narrowing it to real rejections is the fix,
+		// removing it would be a different bug.
+		rec, _ := run(t, auth.ErrInvalidToken)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401 for a token that was judged and rejected", rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "invalid token") {
+			t.Errorf("body = %s, want the invalid-token detail", rec.Body.String())
+		}
+	})
+
+	t.Run("a missing token is still 401 and never 503", func(t *testing.T) {
+		r := gin.New()
+		r.Use(JWTAuth(&fakeAuthn{authErr: dbDown}))
+		r.GET("/api/v2/dags", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{}) })
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/api/v2/dags", http.NoBody))
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401 — no credential was presented, so nothing needed the store", rec.Code)
+		}
+	})
+}

--- a/internal/api/auth_renew_test.go
+++ b/internal/api/auth_renew_test.go
@@ -1,10 +1,14 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -104,5 +108,44 @@ func TestRenewTokenPastMaxLifetimeIsUnauthorized(t *testing.T) {
 	rec := postRenew(renewServer(r), "aged-token")
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("renew past max_lifetime = %d, want 401", rec.Code)
+	}
+}
+
+// TestRenewTokenDuringAnOutageIsNot401 is the renew route's half of #1087.
+//
+// The route re-proves the principal against the user store, so it fails for the
+// same two unrelated reasons every other authenticated route does: the token was
+// judged and rejected, or the store could not be reached to judge it. Collapsing
+// both to 401 "log in again" during a database outage points the client and
+// whoever is on call at the credential instead of the incident, and — because
+// the handler used AbortProblem rather than AbortProblemCause — dropped the
+// driver's error entirely, leaving the outage invisible on this route.
+func TestRenewTokenDuringAnOutageIsNot401(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	dbDown := errors.New("failed to connect to `user=leoflow database=leoflow`: dial tcp 10.0.0.1:5432: i/o timeout")
+
+	var logBuf bytes.Buffer
+	srv := NewServer(Dependencies{
+		Logger:               slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		Authenticator:        &fakeAuthn{user: &auth.User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}},
+		RateLimiter:          auth.NewRateLimiter(5, time.Minute),
+		HealthChecks:         map[string]HealthChecker{},
+		CORSOrigins:          []string{"*"},
+		TokenTTLSecs:         3600,
+		TokenRenewer:         &fakeRenewer{err: dbDown},
+		TokenMaxLifetimeSecs: 86400,
+	})
+	rec := postRenew(srv, "still-valid-token")
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503 — the token was never judged, the store was unreachable", rec.Code)
+	}
+	for _, leak := range []string{"dial tcp", "10.0.0.1", "user=leoflow", "log in again"} {
+		if strings.Contains(rec.Body.String(), leak) {
+			t.Errorf("body leaks or misattributes %q: %s", leak, rec.Body.String())
+		}
+	}
+	if !strings.Contains(logBuf.String(), "dial tcp") {
+		t.Errorf("the log must carry the cause the body withheld; got %s", logBuf.String())
 	}
 }

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -3,6 +3,7 @@ package api
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -174,12 +175,31 @@ func JWTAuth(authn auth.Authenticator) gin.HandlerFunc {
 		// on a full-page refresh the Airflow UI loses its in-memory token and may
 		// send a stale/empty bearer, but a valid _token cookie still authenticates
 		// — otherwise the invalid bearer 401s and the UI bounces to login.
+		// unavailable holds a backend failure seen while checking a candidate. A
+		// later candidate may still authenticate, so it only decides the answer
+		// once every candidate has been tried.
+		var unavailable error
 		for _, token := range tokens {
-			if user, err := authn.Authenticate(c.Request.Context(), token); err == nil {
+			user, err := authn.Authenticate(c.Request.Context(), token)
+			if err == nil {
 				c.Set(contextKeyUser, user)
 				c.Next()
 				return
 			}
+			if !errors.Is(err, auth.ErrInvalidToken) {
+				unavailable = err
+			}
+		}
+		if unavailable != nil {
+			// We could not DETERMINE whether the token is valid — the store was
+			// unreachable. Answering 401 says something false about the caller and
+			// is actively harmful: a well-behaved client reads 401 as "re-authenticate",
+			// so it hammers /auth/token against the same dead database, and a wall of
+			// 401s reads to whoever is on call as an auth incident rather than the
+			// outage it is. 503 is the same answer the login path already gives for
+			// the same cause (#843), and the cause stays in the log (#1087).
+			AbortProblemCause(c, http.StatusServiceUnavailable, "service unavailable", "authentication temporarily unavailable", unavailable)
+			return
 		}
 		AbortProblem(c, http.StatusUnauthorized, "unauthorized", "invalid token")
 	}

--- a/internal/api/repo_error_leak_test.go
+++ b/internal/api/repo_error_leak_test.go
@@ -217,44 +217,90 @@ func TestHandleRepoErrorNeverLeaksDriverTextToTheClient(t *testing.T) {
 	}
 }
 
-// TestHandleRepoErrorRedactsAConnectionString covers the case
-// no PgError fixture can: a pgconn.ConnectError renders the database user and
-// name, and a connect TIMEOUT satisfies errors.Is(err, context.DeadlineExceeded)
-// — so before #961 it took the 499 branch and echoed the DSN identity there,
-// nowhere near the 500 the issue was written about. The error is produced by
-// dialing, not hand-built, because ConnectError's inner error is unexported.
+// TestHandleRepoErrorRedactsAConnectionString covers the case no PgError fixture
+// can: a pgconn.ConnectError renders the database user and name, and a connect
+// TIMEOUT also satisfies errors.Is(err, context.DeadlineExceeded) — so before
+// #961 it took the 499 branch and echoed the DSN identity there, nowhere near
+// the 500 the issue was written about. The error is produced by dialing, not
+// hand-built, because ConnectError's inner error is unexported.
+//
+// The dial is to a refused port rather than to a black-holed address so the
+// fixture is deterministic and costs no network wait. That makes it a real
+// driver error but NOT a deadline one, so the deadline chain — the whole of
+// #1071 — is composed onto it explicitly below rather than left to whether a
+// runner's dial happened to time out. The earlier version dialed TEST-NET-3 with
+// a 250ms budget and accepted EITHER status, so it asserted nothing about which
+// branch ran.
 func TestHandleRepoErrorRedactsAConnectionString(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	// Port 1 on loopback refuses immediately: a real *pgconn.ConnectError, whose
-	// text is what this test exists to keep out of the body, with no network
-	// round trip and no timing dependency. It used to dial TEST-NET-3 with a
-	// 250ms deadline and then accept EITHER branch — so on a runner where the
-	// dial failed fast it silently exercised the 500 path while being named for
-	// the cancel one, and it cost a network wait inside a unit suite (#1071).
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	_, connErr := pgconn.Connect(ctx,
+	// text is what this test exists to keep out of the body.
+	dialCtx, cancelDial := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelDial()
+	_, connErr := pgconn.Connect(dialCtx,
 		"postgres://leoflow_app:s3cr3t@127.0.0.1:1/leoflow_meta?sslmode=disable")
 	if connErr == nil {
 		t.Skip("the dial unexpectedly succeeded; no connect error to redact")
 	}
-
-	rec := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(rec)
-	c.Request = httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", http.NoBody)
-	handleRepoError(c, fmt.Errorf("listing dags: %w", connErr))
-
-	// The caller is still connected, so an unreachable database is a server
-	// fault — deterministically, whatever the driver put in the error's chain.
-	if rec.Code != http.StatusInternalServerError {
-		t.Errorf("status = %d, want 500 for an unreachable database with a live caller", rec.Code)
+	if !strings.Contains(connErr.Error(), "leoflow_app") {
+		t.Fatalf("the driver no longer renders the DSN identity, so this test would pass vacuously: %v", connErr)
 	}
-	// And the identity of the database must not be in the body.
-	body := rec.Body.String()
-	for _, leak := range []string{"leoflow_app", "leoflow_meta", "203.0.113.1", "failed to connect", connErr.Error()} {
-		if strings.Contains(body, leak) {
-			t.Errorf("response body leaks the connection string (%q): %s", leak, body)
-		}
+
+	cases := []struct {
+		name   string
+		err    error
+		gone   bool // the caller hung up: its request context is done
+		status int
+	}{
+		{
+			// The shape #1071 was filed about, with the real driver error: an
+			// unreachable database, a caller still on the other end. The deadline in
+			// the chain must not make it the tenant's fault.
+			name:   "unreachable database, live caller",
+			err:    fmt.Errorf("listing dags: %w", errors.Join(context.DeadlineExceeded, connErr)),
+			status: http.StatusInternalServerError,
+		},
+		{
+			// The same driver text on the branch #961 was about: the caller really
+			// did hang up, so 499 is right — and the DSN must stay out of the body
+			// there too, which is the branch that used to echo it.
+			name:   "same driver error, caller gone",
+			err:    fmt.Errorf("listing dags: %w", errors.Join(context.Canceled, connErr)),
+			gone:   true,
+			status: statusClientClosedRequest,
+		},
+		{
+			// No cancellation anywhere in the chain: the plain 500.
+			name:   "connect refused, no cancellation in the chain",
+			err:    fmt.Errorf("listing dags: %w", connErr),
+			status: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tc.gone {
+				cancel()
+			}
+			c.Request = httptest.NewRequestWithContext(ctx, http.MethodGet, "/x", http.NoBody)
+			handleRepoError(c, tc.err)
+
+			if rec.Code != tc.status {
+				t.Errorf("status = %d, want %d (%s)", rec.Code, tc.status, rec.Body.String())
+			}
+			// Whichever branch it lands on, the identity of the database must not
+			// be in the body.
+			body := rec.Body.String()
+			for _, leak := range []string{"leoflow_app", "leoflow_meta", "127.0.0.1", "failed to connect", connErr.Error()} {
+				if strings.Contains(body, leak) {
+					t.Errorf("response body leaks the connection string (%q): %s", leak, body)
+				}
+			}
+		})
 	}
 }
 

--- a/internal/api/repo_error_leak_test.go
+++ b/internal/api/repo_error_leak_test.go
@@ -121,6 +121,7 @@ func TestHandleRepoErrorNeverLeaksDriverTextToTheClient(t *testing.T) {
 		name   string
 		err    error
 		pgErr  *pgconn.PgError
+		gone   bool // the caller hung up: its request context is done
 		status int
 	}{
 		{
@@ -163,7 +164,17 @@ func TestHandleRepoErrorNeverLeaksDriverTextToTheClient(t *testing.T) {
 			name:   "driver error joined to a client cancel stays a 499",
 			err:    errors.Join(context.Canceled, fk),
 			pgErr:  fk,
+			gone:   true,
 			status: statusClientClosedRequest,
+		},
+		{
+			// Same shape, caller still connected: a pgconn connect timeout carries
+			// context.DeadlineExceeded in its chain, and routing on that alone
+			// reported an outage as the tenant hanging up (#1071).
+			name:   "a connect timeout with a live caller is a 500, and still leaks nothing",
+			err:    fmt.Errorf("listing dags: %w", errors.Join(context.DeadlineExceeded, fk)),
+			pgErr:  fk,
+			status: http.StatusInternalServerError,
 		},
 	}
 
@@ -176,7 +187,13 @@ func TestHandleRepoErrorNeverLeaksDriverTextToTheClient(t *testing.T) {
 			r.GET("/x", func(c *gin.Context) { handleRepoError(c, tc.err) })
 
 			rec := httptest.NewRecorder()
-			r.ServeHTTP(rec, httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", http.NoBody))
+			ctx, cancel := context.WithCancel(context.Background())
+			if tc.gone {
+				cancel()
+			} else {
+				defer cancel()
+			}
+			r.ServeHTTP(rec, httptest.NewRequestWithContext(ctx, http.MethodGet, "/x", http.NoBody))
 
 			if rec.Code != tc.status {
 				t.Errorf("status = %d, want %d (%s)", rec.Code, tc.status, rec.Body.String())
@@ -200,19 +217,24 @@ func TestHandleRepoErrorNeverLeaksDriverTextToTheClient(t *testing.T) {
 	}
 }
 
-// TestHandleRepoErrorRedactsAConnectionStringOnTheCancelBranch covers the case
+// TestHandleRepoErrorRedactsAConnectionString covers the case
 // no PgError fixture can: a pgconn.ConnectError renders the database user and
 // name, and a connect TIMEOUT satisfies errors.Is(err, context.DeadlineExceeded)
 // — so before #961 it took the 499 branch and echoed the DSN identity there,
 // nowhere near the 500 the issue was written about. The error is produced by
 // dialing, not hand-built, because ConnectError's inner error is unexported.
-func TestHandleRepoErrorRedactsAConnectionStringOnTheCancelBranch(t *testing.T) {
+func TestHandleRepoErrorRedactsAConnectionString(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	// TEST-NET-3 is routable nowhere, so the dial runs into the deadline.
-	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	// Port 1 on loopback refuses immediately: a real *pgconn.ConnectError, whose
+	// text is what this test exists to keep out of the body, with no network
+	// round trip and no timing dependency. It used to dial TEST-NET-3 with a
+	// 250ms deadline and then accept EITHER branch — so on a runner where the
+	// dial failed fast it silently exercised the 500 path while being named for
+	// the cancel one, and it cost a network wait inside a unit suite (#1071).
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	_, connErr := pgconn.Connect(ctx,
-		"postgres://leoflow_app:s3cr3t@203.0.113.1:5432/leoflow_meta?sslmode=disable&connect_timeout=1")
+		"postgres://leoflow_app:s3cr3t@127.0.0.1:1/leoflow_meta?sslmode=disable")
 	if connErr == nil {
 		t.Skip("the dial unexpectedly succeeded; no connect error to redact")
 	}
@@ -222,8 +244,12 @@ func TestHandleRepoErrorRedactsAConnectionStringOnTheCancelBranch(t *testing.T) 
 	c.Request = httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", http.NoBody)
 	handleRepoError(c, fmt.Errorf("listing dags: %w", connErr))
 
-	// Whichever branch it lands on (499 when the deadline is what surfaced, 500
-	// otherwise), the identity of the database must not be in the body.
+	// The caller is still connected, so an unreachable database is a server
+	// fault — deterministically, whatever the driver put in the error's chain.
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500 for an unreachable database with a live caller", rec.Code)
+	}
+	// And the identity of the database must not be in the body.
 	body := rec.Body.String()
 	for _, leak := range []string{"leoflow_app", "leoflow_meta", "203.0.113.1", "failed to connect", connErr.Error()} {
 		if strings.Contains(body, leak) {

--- a/internal/api/resources.go
+++ b/internal/api/resources.go
@@ -168,7 +168,15 @@ func handleRepoError(c *gin.Context, err error) {
 	// than composed: pgconn reports a connect timeout as a ConnectError whose text
 	// carries the database user and name, and that error satisfies
 	// errors.Is(err, context.DeadlineExceeded).
-	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+	//
+	// Gate on the REQUEST's context, not on the error's chain. A pgconn connect
+	// timeout satisfies errors.Is(err, context.DeadlineExceeded) while the caller
+	// is still perfectly connected, so chain-matching alone reported a database
+	// outage as the tenant hanging up: WARN instead of ERROR, a 4xx instead of a
+	// 5xx, and a 5xx-rate alert that misses the one incident it exists to catch
+	// (#1071). A caller who went away has a done context; a dead database does not.
+	case c.Request != nil && c.Request.Context().Err() != nil &&
+		(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)):
 		AbortProblemCause(c, statusClientClosedRequest, "client closed request", detailClientClosed, err)
 	// A business-rule input failure (unknown role, undeclared variable/connection)
 	// is the client's to fix, not a server fault, so the whole class maps to 400 —

--- a/internal/api/resources_test.go
+++ b/internal/api/resources_test.go
@@ -666,28 +666,45 @@ func TestTaskInstanceActionMapIndexSubresources(t *testing.T) {
 }
 
 // TestHandleRepoErrorClientCancel guards the ti_summaries 500 regression: a
-// canceled/timed-out context means the client aborted (the UI supersedes in-flight
-// grid requests), which must map to 499 (client closed), not a 500 server fault.
+// client that aborted (the UI supersedes in-flight grid requests) must map to 499
+// (client closed), not a 500 server fault.
+//
+// `gone` is what distinguishes the scenario from the mechanism, and the
+// distinction is the whole of #1071. These cases used to run with a healthy
+// request context and assert 499 purely from the error's chain — which is also
+// what a pgconn connect timeout looks like, so a database outage was reported to
+// the tenant as their own disconnect. A client that went away has a done
+// context; a dead database does not.
 func TestHandleRepoErrorClientCancel(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	cases := []struct {
 		name string
 		err  error
+		gone bool // the caller really did hang up: its request context is done
 		want int
 	}{
-		{"client canceled", context.Canceled, statusClientClosedRequest},
-		{"deadline exceeded", context.DeadlineExceeded, statusClientClosedRequest},
-		{"wrapped cancel", errors.Join(errors.New("task instances for runs"), context.Canceled), statusClientClosedRequest},
-		{"not found", ErrNotFound, http.StatusNotFound},
-		{"conflict (duplicate run)", domain.ErrConflict, http.StatusConflict},
-		{"wrapped conflict", fmt.Errorf("creating dag run: %w", domain.ErrConflict), http.StatusConflict},
-		{"real server error", errors.New("db exploded"), http.StatusInternalServerError},
+		{"client canceled", context.Canceled, true, statusClientClosedRequest},
+		{"deadline exceeded", context.DeadlineExceeded, true, statusClientClosedRequest},
+		{"wrapped cancel", errors.Join(errors.New("task instances for runs"), context.Canceled), true, statusClientClosedRequest},
+		// The same error values with the caller still connected: a database that
+		// cannot be reached, which is a server fault and must alert as one.
+		{"unreachable database (client still there)", context.DeadlineExceeded, false, http.StatusInternalServerError},
+		{"connect timeout wrapped by the driver", fmt.Errorf("failed to connect to `user=leoflow database=leoflow`: timeout: %w", context.DeadlineExceeded), false, http.StatusInternalServerError},
+		{"not found", ErrNotFound, false, http.StatusNotFound},
+		{"conflict (duplicate run)", domain.ErrConflict, false, http.StatusConflict},
+		{"wrapped conflict", fmt.Errorf("creating dag run: %w", domain.ErrConflict), false, http.StatusConflict},
+		{"real server error", errors.New("db exploded"), false, http.StatusInternalServerError},
 	}
 	for _, tc := range cases {
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
-		c.Request = httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", http.NoBody)
+		ctx, cancel := context.WithCancel(context.Background())
+		if tc.gone {
+			cancel()
+		}
+		c.Request = httptest.NewRequestWithContext(ctx, http.MethodGet, "/x", http.NoBody)
 		handleRepoError(c, tc.err)
+		cancel()
 		if w.Code != tc.want {
 			t.Errorf("%s: got %d, want %d", tc.name, w.Code, tc.want)
 		}

--- a/internal/api/ui_test.go
+++ b/internal/api/ui_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -314,5 +315,33 @@ func TestUIServesStaticAndIndexShell(t *testing.T) {
 	}
 	if cc := rec.Header().Get("Cache-Control"); cc == "" {
 		t.Errorf("/static response missing Cache-Control")
+	}
+}
+
+// TestShellGateDeniesOnABackendError pins the SECOND caller of
+// auth.Authenticate. #1087 changed what Authenticate returns for a store
+// failure — a raw backend error instead of a joined ErrInvalidToken — and
+// nothing outside internal/auth switches on that sentinel, so the shell gate
+// must keep deciding on `err == nil` alone. If it ever grew a "not
+// ErrInvalidToken, so let it through" branch, an unreachable user store would
+// serve the authenticated SPA shell to anyone holding any string.
+func TestShellGateDeniesOnABackendError(t *testing.T) {
+	srv := NewServer(Dependencies{
+		Logger:        discardLogger(),
+		Authenticator: &fakeAuthn{authErr: errors.New("dial tcp 10.0.0.1:5432: i/o timeout")},
+		RateLimiter:   auth.NewRateLimiter(100, time.Minute),
+		CORSOrigins:   []string{"*"},
+		UI:            ui.New(),
+	})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/dags/etl/grid", http.NoBody)
+	req.AddCookie(&http.Cookie{Name: authTokenCookie, Value: "whatever"})
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Errorf("shell GET with an unreachable store = %d, want 302 to login — a store we could not read must never authenticate", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "<div id=\"root\"") {
+		t.Error("the authenticated SPA shell was served while the user store was unreachable")
 	}
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -163,12 +163,32 @@ func TestAuthenticateFailsClosedOnStoreError(t *testing.T) {
 	// A DB failure during the reload must reject the request, never fall through
 	// to the token claims (which would let a failing store silently disable
 	// revocation) and never panic.
+	//
+	// The assertion used to be `errors.Is(err, ErrInvalidToken)`, which encoded
+	// the CLASSIFICATION rather than the security property and made a database
+	// outage indistinguishable from a forged token (#1087). Fail-closed does not
+	// depend on the error's identity: both callers of Authenticate allow on
+	// `err == nil` and deny on anything else, and nothing outside this package
+	// references ErrInvalidToken. So the property is "an error, and no user" —
+	// which is what this now asserts, plus the new requirement that a backend
+	// failure is not labeled invalid.
 	const secret = "dberr-secret"
 	tok, _ := MintUserToken(secret, time.Hour, User{ID: "u1", TenantID: "default", Roles: []string{"admin"}})
-	store := &fakeStore{byIDErr: errors.New("connection refused")}
+	dbErr := errors.New("connection refused")
+	store := &fakeStore{byIDErr: dbErr}
 	a := NewJWTAuthenticator(store, secret, time.Hour)
-	if _, err := a.Authenticate(context.Background(), tok); !errors.Is(err, ErrInvalidToken) {
-		t.Errorf("a store error must fail closed as ErrInvalidToken, got %v", err)
+	user, err := a.Authenticate(context.Background(), tok)
+	if err == nil {
+		t.Fatal("a store error must reject the request; got err = nil")
+	}
+	if user != nil {
+		t.Errorf("a store error must not return a user (that would disable revocation); got %+v", user)
+	}
+	if !errors.Is(err, dbErr) {
+		t.Errorf("the cause must survive for the log; got %v", err)
+	}
+	if errors.Is(err, ErrInvalidToken) {
+		t.Error("a backend failure must not be labeled an invalid token — the caller maps that to 401 and tells the client to re-authenticate against the database that is down")
 	}
 }
 

--- a/internal/auth/authenticate_backend_error_test.go
+++ b/internal/auth/authenticate_backend_error_test.go
@@ -1,0 +1,68 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// #843 established the rule for IssueToken: a backend (DB) error must PROPAGATE
+// rather than be reported as a credential failure, because a database outage
+// reported as "wrong password" masks the incident. Authenticate — the sibling
+// that validates an already-issued token — did the opposite: it joined
+// ErrInvalidToken onto EVERY store error, so a dead database and a forged token
+// were the same value to every caller.
+//
+// Measured against a real stopped Postgres during the v0.4.6 validation: the API
+// answered 401 "invalid token" after 76 seconds, on a token minted seconds
+// earlier (#1087). Signature verification is local and takes about a
+// millisecond; the 76 seconds were the store timing out.
+func TestAuthenticatePropagatesBackendError(t *testing.T) {
+	dbErr := errors.New("dial tcp 10.0.0.1:5432: i/o timeout")
+	// Mint with a healthy store, validate against a dead one, same secret — the
+	// shape of a control plane whose database fails after a user logged in.
+	minter := NewJWTAuthenticator(
+		&fakeStore{user: &User{ID: "u1", TenantID: "default"}, hash: must(HashPassword("pw"))},
+		"secret", time.Hour)
+	tok, err := minter.IssueToken(context.Background(), Credentials{Tenant: "default", Username: "a@b.c", Password: "pw"})
+	if err != nil {
+		t.Fatalf("minting a token: %v", err)
+	}
+
+	down := NewJWTAuthenticator(&fakeStore{byIDErr: dbErr}, "secret", time.Hour)
+	if _, aerr := down.Authenticate(context.Background(), tok); !errors.Is(aerr, dbErr) {
+		t.Errorf("a backend error must propagate unchanged; got %v", aerr)
+	} else if errors.Is(aerr, ErrInvalidToken) {
+		t.Error("a backend error must NOT be reported as an invalid token — that conflation is #1087")
+	}
+}
+
+// The fail-closed behavior the conflation was protecting must survive: a token
+// whose subject has no user row is still invalid, so deleting a user revokes
+// immediately instead of leaving claimed roles alive until the token expires.
+func TestAuthenticateKeepsFailClosedOnMissingUser(t *testing.T) {
+	minter := NewJWTAuthenticator(
+		&fakeStore{user: &User{ID: "u1", TenantID: "default"}, hash: must(HashPassword("pw"))},
+		"secret", time.Hour)
+	tok, err := minter.IssueToken(context.Background(), Credentials{Tenant: "default", Username: "a@b.c", Password: "pw"})
+	if err != nil {
+		t.Fatalf("minting a token: %v", err)
+	}
+
+	gone := NewJWTAuthenticator(&fakeStore{byIDErr: ErrUserNotFound}, "secret", time.Hour)
+	if _, aerr := gone.Authenticate(context.Background(), tok); !errors.Is(aerr, ErrInvalidToken) {
+		t.Errorf("a deleted user must still be ErrInvalidToken (fail closed); got %v", aerr)
+	}
+}
+
+// A malformed token never reaches the store, so it must stay invalid even when
+// the store is down — otherwise an outage would turn every forged token into a
+// 503 and hide the rejection.
+func TestAuthenticateMalformedTokenStaysInvalidDuringAnOutage(t *testing.T) {
+	down := NewJWTAuthenticator(&fakeStore{byIDErr: errors.New("dial tcp: i/o timeout")}, "secret", time.Hour)
+	_, aerr := down.Authenticate(context.Background(), "not-a-jwt")
+	if !errors.Is(aerr, ErrInvalidToken) {
+		t.Errorf("a malformed token must be ErrInvalidToken; got %v", aerr)
+	}
+}

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -114,14 +114,24 @@ func (a *JWTAuthenticator) Authenticate(ctx context.Context, token string) (*Use
 	}
 	user, active, err := a.store.FindUserByID(ctx, c.Subject)
 	if err != nil {
-		// A subject with no user row is trusted from its signed claims ONLY for the
-		// in-process dev token (which has no DB row by design); any other missing
-		// subject fails closed, so a hard-deleted user cannot keep claimed roles
-		// until the token expires — deletion revokes at once, like is_active=false.
-		if errors.Is(err, ErrUserNotFound) && c.Subject == DevTokenSubject {
-			return claimed, nil
+		if errors.Is(err, ErrUserNotFound) {
+			// A subject with no user row is trusted from its signed claims ONLY for
+			// the in-process dev token (which has no DB row by design); any other
+			// missing subject fails closed, so a hard-deleted user cannot keep
+			// claimed roles until the token expires — deletion revokes at once, like
+			// is_active=false.
+			if c.Subject == DevTokenSubject {
+				return claimed, nil
+			}
+			return nil, errors.Join(ErrInvalidToken, err)
 		}
-		return nil, errors.Join(ErrInvalidToken, err)
+		// Any OTHER store failure means we could not DETERMINE whether this token
+		// is valid — not that it is invalid. Propagating it unchanged is the rule
+		// #843 set for IssueToken, and it applies here for the same reason: a
+		// database outage answered as "invalid token" tells every client to
+		// re-authenticate against the database that is already down, and tells
+		// whoever is on call that they have an auth incident (#1087).
+		return nil, err
 	}
 	if !active {
 		return nil, ErrInvalidToken

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -238,7 +238,8 @@ func (a *JWTAuthenticator) RenewUserToken(ctx context.Context, token string, ttl
 // obey the same revocation rule as request authentication, and it mirrors
 // Authenticate's branches one for one — nil store and the dev-token subject fall
 // back to the signed claims, an inactive or otherwise-missing user is refused,
-// and any other store error fails closed.
+// and any other store error fails closed (propagated unchanged, so the handler
+// can tell "rejected" apart from "could not be determined").
 func (a *JWTAuthenticator) reloadForRenewal(ctx context.Context, c *jwtClaims) (*User, error) {
 	claimed := &User{ID: c.Subject, TenantID: c.TenantID, Email: c.Email, Roles: c.Roles}
 	if a.store == nil {
@@ -246,10 +247,18 @@ func (a *JWTAuthenticator) reloadForRenewal(ctx context.Context, c *jwtClaims) (
 	}
 	user, active, err := a.store.FindUserByID(ctx, c.Subject)
 	if err != nil {
-		if errors.Is(err, ErrUserNotFound) && c.Subject == DevTokenSubject {
-			return claimed, nil
+		if errors.Is(err, ErrUserNotFound) {
+			if c.Subject == DevTokenSubject {
+				return claimed, nil
+			}
+			return nil, errors.Join(ErrInvalidToken, err)
 		}
-		return nil, errors.Join(ErrInvalidToken, err)
+		// Same split Authenticate makes, for the same reason: a store we could not
+		// reach did not tell us the token is invalid, only that we cannot say. The
+		// renewal is still refused — the caller denies on any error — but the
+		// handler can now answer 503 instead of sending the client to log in
+		// against the database that is already down.
+		return nil, err
 	}
 	if !active {
 		return nil, ErrInvalidToken

--- a/internal/auth/user_token_renewal_test.go
+++ b/internal/auth/user_token_renewal_test.go
@@ -312,3 +312,34 @@ func TestRenewUserTokenAllowsNilStore(t *testing.T) {
 		t.Fatalf("a nil store must still renew; got ok=%v err=%v", ok, rerr)
 	}
 }
+
+// TestRenewUserTokenPropagatesBackendError is the renewal half of #1087.
+//
+// Authenticate and reloadForRenewal read the SAME store for the SAME reason, so
+// they must classify its failures the same way. reloadForRenewal kept joining
+// ErrInvalidToken onto every store error, and renewTokenHandler maps any error
+// to 401 "log in again" — so during a database outage the renew route still
+// answered with a statement about the caller's credential, and the cause never
+// reached the log at all (AbortProblem carries no cause). Fail-closed is
+// unchanged: the renewal is still refused, it is just no longer mislabeled.
+func TestRenewUserTokenPropagatesBackendError(t *testing.T) {
+	dbErr := errors.New("dial tcp 10.0.0.1:5432: i/o timeout")
+	a := NewJWTAuthenticator(&fakeStore{byIDErr: dbErr}, "secret", time.Hour)
+	t0 := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	a.now = func() time.Time { return t0 }
+	issued, err := a.mintUserToken(&User{ID: "u1", TenantID: "default", Roles: []string{"admin"}}, time.Hour, t0)
+	if err != nil {
+		t.Fatalf("mintUserToken: %v", err)
+	}
+
+	renewed, ok, rerr := a.RenewUserToken(context.Background(), issued, time.Hour, 24*time.Hour)
+	if ok || renewed != "" {
+		t.Fatalf("a store error must still fail closed; got ok=%v renewed=%q", ok, renewed)
+	}
+	if !errors.Is(rerr, dbErr) {
+		t.Errorf("the cause must survive for the log; got %v", rerr)
+	}
+	if errors.Is(rerr, ErrInvalidToken) {
+		t.Error("a backend failure must not be labeled an invalid token — the handler maps that to 401 and sends the client to log in against the database that is down")
+	}
+}


### PR DESCRIPTION
fix(api): stop reporting a database outage as the caller's fault (#1087, #1071)

Two surfaces answered a dependency failure with a statement about the client.
Different code, same mistake, and the same fix already existed in the repo for a
third surface.

**401 invalid token during an outage (#1087).** Authenticate joined
ErrInvalidToken onto every store failure, so "the database is unreachable" and
"this token is forged" were the same value, and JWTAuth — which inspected only
`err == nil` — answered 401. Measured against a real stopped Postgres during the
v0.4.6 cluster validation: 401 after 76 seconds, on a token minted seconds
earlier. Signature verification is local and takes about a millisecond, so the
duration alone proves the verdict was never about the token.

#843 already settled this for IssueToken: a backend error propagates rather than
being reported as a credential failure, and the login handler maps it to 503,
because an outage reported as "wrong password" masks the incident. Authenticate
is the sibling that validates an already-issued token and it did the opposite.
This applies the existing rule rather than inventing one — hence no new sentinel:
ErrInvalidToken keeps its meaning, everything else propagates, and the caller
decides the status the same way the login path does.

Fail-closed survives untouched, and I checked rather than assumed: both callers
of Authenticate allow on `err == nil` and deny on anything else, and nothing
outside internal/auth references ErrInvalidToken. Denial depends on there BEING
an error, not on its identity. The test that guarded the property asserted the
classification instead, so it now asserts the property — an error, no user, the
cause preserved — plus the new requirement that a backend failure is not
labeled invalid.

Why the status matters beyond correctness: a well-behaved client reads 401 as
"re-authenticate" and retries against /auth/token, which needs the same
database, turning a read outage into a retry storm against the dependency that
is already down. And a wall of 401s reads to whoever is on call as an auth
incident, sending them to rotate credentials during a database outage.

**499 client closed request during an outage (#1071).** handleRepoError routed
on errors.Is(err, context.DeadlineExceeded), which a pgconn connect timeout
satisfies while the caller is still connected. The tenant was told they hung up,
the request logged at WARN because 499 is under 500, and a 5xx-rate alert missed
a database outage — the one incident it exists to catch. The branch now asks the
REQUEST's context: done for a caller who left, healthy for one whose database
died. The 499 itself stays; the UI supersedes in-flight grid requests constantly
and mapping those to 500 is the regression it was added for.

The existing tests for that branch passed a healthy context and asserted 499
from the error's chain alone — the mechanism, not the scenario, which is why the
bug survived them. They now carry a `gone` flag and the symmetric cases: the
same error value with and without the caller present, expecting 499 and 500.

Also fixed the test #1071 called out: it accepted EITHER branch ("whichever
branch it lands on") and dialled TEST-NET-3 with a 250ms deadline, so on a
runner where the dial failed fast it silently exercised the branch it was not
named for. It now dials a refused loopback port, asserts one branch, runs in
0.00s, and is renamed for what it actually checks.

Closes #1087. Closes #1071.