### PR TITLE
feat(lite): a way to start clean, and a banner that admits what it inherited (#1104, #1105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`leoflow dev --fresh`, and a banner line for the state you inherited
+  (#1104).** Lite keeps its state under `~/.leoflow/dev` and nothing reset it, so
+  a DAG registered during a spike weeks ago stayed registered: it kept being
+  scheduled, it kept failing, and it failed inside sessions that had nothing to
+  do with it. `--fresh` drops the local database first, announcing what goes with
+  it (registered DAGs, runs and history).
+
+  The banner line is the half that fixes the surprise rather than the state. The
+  leftovers were invisible until one of them broke, and nobody goes looking for a
+  flag to remove something they do not know is there — so the count now arrives
+  unasked, in the block that already carries the URL, the login and the project
+  path. It says nothing when the slate is clean, and nothing when the count could
+  not be read: asserting "0" on a lookup that never ran would be worse than
+  silence.
+
+### Fixed
+
+- **`leoflow lite --help` now says the admin password is shown once, and names
+  the way back (#1105).** It described the UI as being "behind a login (the admin
+  created by `leoflow setup`)" and stopped there. The password is printed once
+  during setup and never again; `leoflow lite reset-password` sets a new one, and
+  it was already listed as a subcommand in the same help output — just never
+  connected to the sentence about the login. Present and unlinked is the same as
+  absent for someone stuck on a login screen.
+
+
 ### Fixed
 
 - **A database outage is reported as an outage, not as the caller's fault

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -120,6 +120,9 @@ const (
 
 // devOptions holds the resolved flags for a dev run.
 type devOptions struct {
+	// fresh drops the Lite dev database before provisioning, so the session
+	// starts with nothing registered (#1104).
+	fresh       bool
 	image       string
 	executor    string
 	host        string
@@ -294,7 +297,15 @@ func warnIfExposed(out io.Writer, host, adminHash string) {
 // URL to open, the login, and the watched project path — so they are not lost
 // above the provisioning output. When the friendly name leoflow.local resolves it
 // is shown too; otherwise a one-line tip explains how to enable it.
-func announceReady(out io.Writer, host string, port int, adminEmail, dir string) {
+//
+// inherited is how many DAGs were already registered in the local database when
+// this session started — leftovers from earlier runs, which keep scheduling and
+// failing inside a session that has nothing to do with them (#1104). It is
+// reported only when there are some: a line that prints every time stops being
+// read, and the clean slate is the common case. A NEGATIVE value means the count
+// could not be determined, and says nothing at all — claiming "0" would assert a
+// clean slate nobody verified.
+func announceReady(out io.Writer, host string, port int, adminEmail, dir string, inherited int) {
 	login := "no-auth (loopback only)"
 	if adminEmail != "" {
 		login = adminEmail
@@ -310,6 +321,13 @@ func announceReady(out io.Writer, host string, port int, adminEmail, dir string)
 	}
 	devPrintf(out, "      login:   %s\n", login)
 	devPrintf(out, "      project: %s\n", project)
+	if inherited > 0 {
+		noun := "DAGs"
+		if inherited == 1 {
+			noun = "DAG"
+		}
+		devPrintf(out, "      state:   %d %s registered by earlier sessions (they still run; --fresh starts empty)\n", inherited, noun)
+	}
 	if !friendlyResolves() {
 		devPrintf(out, "      tip: for %s, add '127.0.0.1 %s' to /etc/hosts (sudo).\n",
 			friendlyHost, friendlyHost)
@@ -426,7 +444,8 @@ func newLiteCommand() *cobra.Command {
 		Long: "lite is the Leoflow Lite edition: it brings up local dependencies and runs the " +
 			"control plane against an isolated local database, registers the DAG, and hot-reloads " +
 			"on every save. The UI is served on a Lite port (default 8088, --port), marked with a " +
-			"LITE badge, and behind a login (the admin created by `leoflow setup`).\n\nExecutor " +
+			("LITE badge, and behind a login (the admin created by `leoflow setup`, which prints the\n" +
+				"generated password ONCE — `leoflow lite reset-password` sets a new one if it is gone).\n\nExecutor ") +
 			"(--executor): 'subprocess' runs tasks unsandboxed on the host with no image build — " +
 			"the fast inner loop, best for local use. 'k8s' runs real pod-per-task on a dedicated, " +
 			"isolated k3d mini-cluster (leoflow-dev) — highest fidelity, best for development; it " +
@@ -449,6 +468,7 @@ func newLiteCommand() *cobra.Command {
 	cmd.Flags().StringVar(&o.serverBin, "server-bin", "", "leoflow-server binary (default: PATH, then ./bin)")
 	cmd.Flags().StringVar(&o.agentBin, "agent-bin", "", "leoflow-agent binary (default: PATH, then ./bin)")
 	cmd.Flags().BoolVar(&o.noUp, "no-up", false, "skip docker compose (Postgres already running); the dev DB + venv are still provisioned")
+	cmd.Flags().BoolVar(&o.fresh, "fresh", false, "drop the local dev database first, so the session starts with nothing registered (DESTRUCTIVE: registered DAGs, runs and history)")
 	cmd.Flags().StringVar(&o.postgres, "postgres", datastoreAuto, "Postgres backend: 'auto' (default; the Docker postgres:16 when Docker is present, else a managed relocatable PG under ~/.leoflow on a Unix socket, no Docker), 'docker', or 'managed' (best on full distros; minimal hosts may lack its system libs)")
 	cmd.AddCommand(newLiteProvisionCommand())
 	cmd.AddCommand(newResetPasswordCommand())
@@ -611,9 +631,15 @@ func runDev(cmd *cobra.Command, dir string, o devOptions) error {
 		return uerr
 	}
 	defer cleanupDeps() // stops managed Postgres on exit; no-op for the Docker path
+	// --fresh drops the local database before it is recreated, so a session
+	// starts with nothing registered. State under ~/.leoflow/dev otherwise
+	// outlives every session: a DAG from an old spike stays registered, keeps
+	// being scheduled, and fails inside a run that has nothing to do with it
+	// (#1104). Destructive by definition, and scoped to the Lite dev database —
+	// it is the same drop `leoflow db reset` performs.
 	// Provision the isolated dev state: own database + own venv (never the
 	// product's database or the system Python).
-	if derr := ensureDevDatabase(ctx, cmd); derr != nil {
+	if derr := provisionDevDatabase(ctx, cmd, out, o.fresh); derr != nil {
 		return derr
 	}
 	if merr := devMigrate(cmd); merr != nil {
@@ -655,7 +681,7 @@ func runDev(cmd *cobra.Command, dir string, o devOptions) error {
 	if werr := waitForReady(ctx, uiURL); werr != nil {
 		return werr
 	}
-	announceReady(out, o.host, o.port, o.adminEmail, ws.Path)
+	announceReady(out, o.host, o.port, o.adminEmail, ws.Path, countRegisteredDags(ctx))
 	// Mint an admin token in-process signed with the dev JWT secret; the control
 	// plane validates it by signature + claims, so no login or seeded user is
 	// needed. Re-minted per operation (signing is cheap) so a Lite left running
@@ -2136,4 +2162,46 @@ func devEnforcedPythonVersion(cmd *cobra.Command, cfg *domain.LeoflowConfig) str
 		return ""
 	}
 	return cfg.PythonVersion
+}
+
+// countRegisteredDags reports how many DAGs the local database already holds.
+// Called before this session registers anything, so the number is exactly what
+// earlier runs left behind (#1104).
+//
+// It reads Postgres directly rather than going through the API: at banner time
+// the admin token has not been minted yet, and a read-only count has no business
+// depending on the auth surface. A failure returns -1 — "unknown", which the
+// banner reports as nothing — because a state line that guesses is worse than no
+// state line: it would assert a clean slate on a lookup that never ran.
+func countRegisteredDags(ctx context.Context) int {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	conn, err := pgx.Connect(ctx, devDSNs().database)
+	if err != nil {
+		return -1
+	}
+	defer func() { _ = conn.Close(ctx) }() //nolint:errcheck // best-effort close of a short-lived read connection
+	var n int
+	if qerr := conn.QueryRow(ctx, "SELECT count(*) FROM dags").Scan(&n); qerr != nil {
+		return -1
+	}
+	return n
+}
+
+// provisionDevDatabase brings the Lite dev database up, dropping it first when
+// fresh is set.
+//
+// State under ~/.leoflow/dev otherwise outlives every session: a DAG registered
+// during an old spike stays registered, keeps being scheduled, and fails inside
+// a run that has nothing to do with it (#1104). The drop is the same one
+// `leoflow db reset` performs, and it is announced before it happens — it takes
+// registered DAGs, runs and history with it.
+func provisionDevDatabase(ctx context.Context, cmd *cobra.Command, out io.Writer, fresh bool) error {
+	if fresh {
+		devPrintln(out, "▸ --fresh: dropping the local dev database (registered DAGs, runs and history go with it)")
+		if err := dropDevDatabase(ctx, cmd); err != nil {
+			return err
+		}
+	}
+	return ensureDevDatabase(ctx, cmd)
 }

--- a/internal/cli/lite_inherited_test.go
+++ b/internal/cli/lite_inherited_test.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestAnnounceReadyInheritedDags covers the visible half of #1104. `leoflow dev`
+// keeps its state under ~/.leoflow/dev and nothing resets it, so a DAG
+// registered during a spike weeks ago is still registered: it schedules, it
+// fires, it fails, and it fails inside a session that has nothing to do with it.
+//
+// The banner is where the fix belongs. The leftovers are invisible until one of
+// them breaks, and someone who does not know they exist will not go looking for
+// a flag to remove them — so the count has to arrive unasked, in the block
+// already carrying the URL, the login and the project path.
+func TestAnnounceReadyInheritedDags(t *testing.T) {
+	t.Run("names the count and the way out when there are leftovers", func(t *testing.T) {
+		var out bytes.Buffer
+		announceReady(&out, "127.0.0.1", 8088, "admin@leoflow.local", "/ws", 3)
+		s := out.String()
+		if !strings.Contains(s, "3") {
+			t.Errorf("banner must state how many were inherited; got %q", s)
+		}
+		if !strings.Contains(s, "--fresh") {
+			t.Errorf("banner must name the way out; got %q", s)
+		}
+	})
+
+	t.Run("says nothing when the slate is clean", func(t *testing.T) {
+		// A line that always prints stops being read. Zero leftovers is the
+		// common case and must add nothing to the block.
+		var out bytes.Buffer
+		announceReady(&out, "127.0.0.1", 8088, "admin@leoflow.local", "/ws", 0)
+		if strings.Contains(out.String(), "--fresh") {
+			t.Errorf("no leftovers means no line; got %q", out.String())
+		}
+	})
+
+	t.Run("stays quiet when the count could not be determined", func(t *testing.T) {
+		// A negative count means the lookup failed. Guessing "0" would claim a
+		// clean slate we did not verify, and guessing any number would be worse.
+		var out bytes.Buffer
+		announceReady(&out, "127.0.0.1", 8088, "admin@leoflow.local", "/ws", -1)
+		if strings.Contains(out.String(), "--fresh") {
+			t.Errorf("an unknown count must not be reported; got %q", out.String())
+		}
+	})
+
+	t.Run("singular reads correctly", func(t *testing.T) {
+		var out bytes.Buffer
+		announceReady(&out, "127.0.0.1", 8088, "admin@leoflow.local", "/ws", 1)
+		s := out.String()
+		if strings.Contains(s, "1 DAGs") {
+			t.Errorf("one leftover should not read as plural; got %q", s)
+		}
+	})
+
+	t.Run("the existing block is unchanged", func(t *testing.T) {
+		// The URL, login and project path are what people actually came for.
+		var out bytes.Buffer
+		announceReady(&out, "127.0.0.1", 8088, "admin@leoflow.local", "/ws", 2)
+		for _, want := range []string{"Leoflow Lite is ready", "login:", "project:"} {
+			if !strings.Contains(out.String(), want) {
+				t.Errorf("banner lost %q: %s", want, out.String())
+			}
+		}
+	})
+}

--- a/website/content/operate/troubleshooting.md
+++ b/website/content/operate/troubleshooting.md
@@ -74,6 +74,7 @@ leoflow-mcp --version
 |---|---|
 | `Invalid credentials` on the login page even with the right password | Disable autofill or type the password manually — some browsers append a trailing space. Usernames are trimmed, passwords are not (per security best practice). |
 | Login rate-limits you out after a few typos | Older builds counted *every* attempt against a 5/min cap; the fix splits successful and failed attempts so a typo does not block recovery. Update to the latest release. |
+| A DAG you deleted weeks ago still runs and fails | Lite's state lives in `~/.leoflow/dev` and outlives sessions, so a DAG registered during an old spike stays registered and keeps being scheduled. The ready banner now reports how many DAGs earlier sessions left (`state: N DAGs registered by earlier sessions`); `leoflow dev --fresh` starts from an empty local database. Deleting the project directory stops it being re-registered, but does not deregister what is already there. |
 | No **Lite** badge on `http://localhost:8088` | You are likely on the **Demo** (production-shaped reference, port `8080`) — Lite runs on `8088` with a silver `Leoflow Lite` badge. See [operating modes](/concepts/editions/). |
 | Copy-logs button silently fails over `http://<lan-ip>:8088` | The Clipboard API requires a secure context, so plain HTTP origins (LAN access from another machine) used to break copy. Recent builds inject a polyfill (`document.execCommand('copy')` fallback) — update. |
 | Task state badge does not refresh after "Mark as failed/success" | Known upstream Airflow bug — see [apache/airflow#67883](https://github.com/apache/airflow/issues/67883). The server-side mutation persists correctly; the SPA cache update is the gap. Hard-refresh the page (Cmd+Shift+R) to see the new state. |
@@ -83,6 +84,7 @@ leoflow-mcp --version
 
 ```bash
 leoflow lite reset-password --user admin@leoflow.local  # generate a fresh admin password (no sudo)
+leoflow dev --fresh                                     # start a session with nothing registered (DESTRUCTIVE)
 leoflow db reset --yes                                  # drop + recreate the Lite database (DESTRUCTIVE)
 leoflow uninstall                                       # remove ~/.leoflow (binaries, managed Python, config)
 leoflow uninstall --purge                               # also remove the workspace (your DAGs!)


### PR DESCRIPTION
feat(lite): a way to start clean, and a banner that admits what it inherited (#1104, #1105)

Two of the three gaps field feedback raised about using Lite as a daily dev
environment. Grouped because they are the same surface: what Lite tells you in
its first second.

**--fresh (#1104).** State under ~/.leoflow/dev outlives every session, and
nothing reset it. A DAG registered during an old spike stays registered, keeps
being scheduled, and fails inside a run that has nothing to do with it. The flag
drops the local database before provisioning — the same drop `leoflow db reset`
performs — and says what goes with it before doing it.

**The banner line, which is the half I would keep if I could only keep one.**
--fresh fixes the state; the line fixes the surprise. Today the leftovers are
invisible until one of them breaks, and someone who does not know they exist
will never go looking for a flag to remove them. The count now arrives unasked,
in the block that already carries the URL, the login and the project path.

Three deliberate silences there, each of which could have been a wrong guess:

  - zero prints nothing. A line that appears every time stops being read, and a
    clean slate is the common case;
  - a failed lookup prints nothing, and is passed as a negative count rather
    than zero. Reporting "0 inherited" on a query that never ran asserts a clean
    slate nobody verified;
  - the count reads Postgres directly instead of the API, because at banner time
    the admin token has not been minted and a read-only count should not depend
    on the auth surface to exist.

It is counted before this session registers anything, so the number is exactly
what earlier runs left — no subtraction, no guessing which are "mine".

**The help text (#1105), the one genuinely documentation item in that
feedback.** `leoflow lite --help` said the UI sits "behind a login (the admin
created by `leoflow setup`)" and stopped. It never said the generated password
is printed ONCE and never again, and it never connected the login sentence to
`leoflow lite reset-password` — which was already in the same help output as a
subcommand. Information that is present and unlinked is absent to anyone reading
under pressure.

provisionDevDatabase exists only to keep runDev under the complexity limit it
was already sitting against; no behaviour change beyond the drop.

Closes #1104. Closes #1105.