### PR TITLE
feat(lite): seed a declared connection the environment already carries (#1103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   not be read: asserting "0" on a lookup that never ran would be worse than
   silence.
 
+
 ### Fixed
 
 - **`leoflow lite --help` now says the admin password is shown once, and names
@@ -32,9 +33,6 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   it was already listed as a subcommand in the same help output — just never
   connected to the sentence about the login. Present and unlinked is the same as
   absent for someone stuck on a login screen.
-
-
-### Fixed
 
 - **A 401 now says when your saved token belongs to a different server
   (#1102).** `~/.leoflow/config.yaml` holds a `server_url` and a `token`, written
@@ -57,8 +55,26 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   of the same line, and now share one. Holding more than one server's token at a
   time is the structural answer and is still open.
 
+- **Lite seeds a declared connection your environment already carries (#1103).**
+  Registration is fail-closed against the vault: a DAG declaring a connection the
+  vault does not hold is refused, with a message naming the fix. In Lite that
+  meant declaring the same value twice — once as `AIRFLOW_CONN_<ID>` for the task
+  (the subprocess executor inherits the environment, which is how tasks read
+  connections) and once in the vault so registration would pass. The first
+  `leoflow dev` of a project now works without the second declaration.
 
-### Fixed
+  Four constraints, because taking a secret from ambient environment is only
+  defensible under them: only connections the DAG **declares** are considered, so
+  unrelated `AIRFLOW_CONN_*` exports are never copied out of your shell; a
+  connection the vault already holds is **never** replaced, so a stale export
+  cannot shadow a value you set deliberately; a URI that does not parse is
+  reported by name and not stored, because a broken connection that exists is
+  worse than one that is missing; and every seeded connection is announced by
+  name — never by value — so a secret store never fills itself silently.
+
+  If the vault cannot be read at all, nothing is seeded: "already set" is then
+  unknown, and the one thing this must never do is overwrite. Seeding is best
+  effort throughout and never fails a reload.
 
 - **A database outage is reported as an outage, not as the caller's fault
   (#1087, #1071).** Two surfaces answered a dependency failure with a statement
@@ -134,7 +150,6 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   differently. `leoflow validate`'s syntax check still resolves the older
   managed-first/`python3` precedence and does not yet honour `python_version` —
   tracked separately.
-
 
 ## [0.4.6] - 2026-09-11
 

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -775,6 +775,11 @@ func devSubprocessSetup(ctx context.Context, cmd *cobra.Command, ws *WorkspaceSp
 			if _, perr := ensureWorkspaceDagVenvs(ctx, cmd, curWs, home, runtimeSrc); perr != nil {
 				return perr
 			}
+			// Seed declared connections the environment already carries, BEFORE
+			// registration reads the vault — registration is fail-closed, and in
+			// Lite the value is usually already exported for the task to consume
+			// (#1103).
+			seedDeclaredConnections(ctx, cmd, curWs, token, devURL(o.port))
 			// local: this is the subprocess run mode, so tasks execute on this
 			// host and dbt needs the absolute workspace path (#993).
 			return devCompileAndRegisterAll(ctx, cmd, curWs, compileOptions{image: o.image, local: true}, token, nil, devURL(o.port))

--- a/internal/cli/lite_seed_connections.go
+++ b/internal/cli/lite_seed_connections.go
@@ -1,0 +1,169 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	apiclient "github.com/neochaotic/leoflow/pkg/client"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// connectionsToSeed decides which of a DAG's declared connections Lite may take
+// from the environment, and reports the ones it refused and why (#1103).
+//
+// Registration is fail-closed against the vault: a DAG declaring a connection
+// the vault does not hold is rejected, with a message naming the fix. In Lite
+// that produces a second declaration of the same value, because the subprocess
+// executor inherits the environment and connections reach tasks as
+// AIRFLOW_CONN_<ID> — so the developer has already exported the connection for
+// the task to consume, and must then write it again for registration to pass.
+//
+// Taking a secret from ambient environment is only defensible under conditions,
+// and they are the reason this is a separate, testable decision rather than a
+// loop inlined at the call site:
+//
+//   - DECLARED ONLY. Anything AIRFLOW_CONN_* that the DAG did not declare is
+//     ignored. Seeding whatever happens to be exported would copy unrelated
+//     credentials out of a developer's shell into a database.
+//   - THE VAULT WINS. A connection already stored is never replaced, so a stale
+//     export cannot shadow a value somebody set deliberately.
+//   - UNUSABLE IS REPORTED, NOT STORED. A URI that does not parse is skipped
+//     with its name, never its value: storing garbage would replace "this
+//     connection is missing", which registration says clearly, with a
+//     connection that exists and fails inside the task.
+//   - LITE ONLY. Enforced by the caller — this runs from `leoflow dev`, which
+//     is the unsandboxed dev loop, and has no path into a Pro control plane.
+//
+// lookup is the environment accessor (os.Getenv in production), injected so the
+// decision is testable without mutating the process environment.
+func connectionsToSeed(declared []string, existing map[string]bool, lookup func(string) string) (seed []domain.Connection, skipped []string) {
+	for _, id := range declared {
+		if existing[id] {
+			continue
+		}
+		uri := lookup("AIRFLOW_CONN_" + strings.ToUpper(id))
+		if uri == "" {
+			continue
+		}
+		// The stored id keeps the DAG's spelling; only the env lookup is
+		// upper-cased, because that is the convention for the variable name and
+		// not for the connection.
+		c, err := domain.ParseConnectionURI(id, uri)
+		if err != nil {
+			// Never the URI, and never the parser's echo of it: the value is a
+			// secret, the reason it was rejected is not.
+			skipped = append(skipped, fmt.Sprintf("%s (its AIRFLOW_CONN_%s is not a usable connection URI)", id, strings.ToUpper(id)))
+			continue
+		}
+		seed = append(seed, c)
+	}
+	sort.Slice(seed, func(i, j int) bool { return seed[i].ConnID < seed[j].ConnID })
+	sort.Strings(skipped)
+	return seed, skipped
+}
+
+// seedDeclaredConnections writes, into the Lite vault, the declared connections
+// this machine's environment already carries — so the first `leoflow dev` of a
+// project works without declaring the same value twice (#1103).
+//
+// It is deliberately BEST EFFORT and never fails the reload: registration
+// already reports a missing connection with a message naming the fix, and that
+// message is a better failure than a boot that dies because seeding could not
+// reach the API. Everything it does is announced by name, never by value —
+// a secret store that fills itself without saying so is a surprise waiting to
+// happen, and the point here is to remove a step the developer knows about, not
+// to hide one.
+//
+// Lite only: this is reachable from `leoflow dev`, the unsandboxed local loop.
+// Nothing calls it from a path that can reach a Pro control plane.
+func seedDeclaredConnections(ctx context.Context, cmd *cobra.Command, ws *WorkspaceSpec, token, serverURL string) {
+	if ws == nil {
+		return
+	}
+	names := declaredConnectionNames(ws)
+	if len(names) == 0 {
+		return
+	}
+	c, err := apiclient.New(serverURL, token)
+	if err != nil {
+		return
+	}
+	existing := map[string]bool{}
+	if resp, lerr := c.ListConnectionsWithResponse(ctx, nil); lerr == nil &&
+		resp.JSON200 != nil && resp.JSON200.Connections != nil {
+		for _, conn := range *resp.JSON200.Connections {
+			existing[conn.ConnectionId] = true
+		}
+	} else {
+		// The vault could not be read, so "already set" is unknown. Seeding now
+		// could overwrite a stored secret, which is the one thing this must
+		// never do — so do nothing and let registration speak.
+		return
+	}
+
+	seed, skipped := connectionsToSeed(names, existing, os.Getenv)
+	for _, conn := range seed {
+		resp, cerr := c.CreateConnectionWithResponse(ctx, connectionBody(conn))
+		if cerr != nil || resp.StatusCode() >= 300 {
+			devPrintf(cmd.OutOrStdout(), "  (warning) could not seed connection %q from the environment; define it with `leoflow connections set %s`\n", conn.ConnID, conn.ConnID)
+			continue
+		}
+		devPrintf(cmd.OutOrStdout(), "▸ seeded connection %q from AIRFLOW_CONN_%s (value not shown; `leoflow connections set` overrides it)\n",
+			conn.ConnID, strings.ToUpper(conn.ConnID))
+	}
+	for _, s := range skipped {
+		devPrintf(cmd.OutOrStdout(), "  (warning) not seeding %s\n", s)
+	}
+}
+
+// declaredConnectionNames collects every connection id the workspace declares,
+// at the DAG level and per task, sorted so the seeding output is stable.
+func declaredConnectionNames(ws *WorkspaceSpec) []string {
+	declared := map[string]bool{}
+	for _, p := range ws.Projects {
+		if p.Config == nil {
+			continue
+		}
+		for _, id := range p.Config.Connections {
+			declared[id] = true
+		}
+		for _, t := range p.Config.Tasks {
+			for _, id := range t.Connections {
+				declared[id] = true
+			}
+		}
+	}
+	names := make([]string, 0, len(declared))
+	for id := range declared {
+		names = append(names, id)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// connectionBody converts a parsed Connection into the API's create body. Empty
+// optional fields are left absent rather than sent as empty strings, so seeding
+// writes exactly what the URI carried.
+func connectionBody(conn domain.Connection) apiclient.ConnectionBody {
+	body := apiclient.ConnectionBody{ConnType: conn.ConnType, Port: conn.Port}
+	id := conn.ConnID
+	body.ConnectionId = &id
+	set := func(dst **string, v string) {
+		if v != "" {
+			s := v
+			*dst = &s
+		}
+	}
+	set(&body.Host, conn.Host)
+	set(&body.Login, conn.Login)
+	set(&body.Password, conn.Password)
+	set(&body.Schema, conn.Schema)
+	set(&body.Extra, conn.Extra)
+	return body
+}

--- a/internal/cli/lite_seed_connections_test.go
+++ b/internal/cli/lite_seed_connections_test.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+// TestConnectionsToSeed covers the decision half of #1103: WHICH declared
+// connections Lite takes from the environment. The write itself is the API's
+// existing path; what is new — and what needs pinning — is the judgment about
+// when taking a secret from ambient environment is acceptable.
+func TestConnectionsToSeed(t *testing.T) {
+	env := func(kv ...string) func(string) string {
+		m := map[string]string{}
+		for i := 0; i+1 < len(kv); i += 2 {
+			m[kv[i]] = kv[i+1]
+		}
+		return func(k string) string { return m[k] }
+	}
+
+	t.Run("takes a declared connection present in the environment", func(t *testing.T) {
+		got, skipped := connectionsToSeed([]string{"my_db"}, nil,
+			env("AIRFLOW_CONN_MY_DB", "postgres://u:p@h:5432/app"))
+		if len(got) != 1 || got[0].ConnID != "my_db" {
+			t.Fatalf("got %+v, want one connection my_db", got)
+		}
+		if got[0].ConnType != "postgres" || got[0].Host != "h" {
+			t.Errorf("parsed wrong: %+v", got[0])
+		}
+		if len(skipped) != 0 {
+			t.Errorf("nothing should be skipped: %v", skipped)
+		}
+	})
+
+	t.Run("never overwrites a connection the vault already has", func(t *testing.T) {
+		// A stale export must not shadow a value somebody set deliberately —
+		// and silently replacing a stored secret from ambient environment is
+		// the exact shape this feature must not have.
+		got, _ := connectionsToSeed([]string{"my_db"}, map[string]bool{"my_db": true},
+			env("AIRFLOW_CONN_MY_DB", "postgres://u:p@h:5432/app"))
+		if len(got) != 0 {
+			t.Errorf("the vault must win; got %+v", got)
+		}
+	})
+
+	t.Run("ignores environment variables the DAG did not declare", func(t *testing.T) {
+		// Seeding whatever AIRFLOW_CONN_* happens to be exported would copy
+		// unrelated credentials from the developer's shell into a database.
+		got, _ := connectionsToSeed([]string{"my_db"}, nil,
+			env("AIRFLOW_CONN_MY_DB", "postgres://u:p@h:5432/app",
+				"AIRFLOW_CONN_SOMEONE_ELSES_PROD", "postgres://root:hunter2@prod:5432/x"))
+		if len(got) != 1 || got[0].ConnID != "my_db" {
+			t.Errorf("only declared connections may be seeded; got %+v", got)
+		}
+	})
+
+	t.Run("a declared connection absent from the environment is left alone", func(t *testing.T) {
+		got, skipped := connectionsToSeed([]string{"my_db", "other"}, nil,
+			env("AIRFLOW_CONN_MY_DB", "postgres://u:p@h:5432/app"))
+		if len(got) != 1 {
+			t.Errorf("got %+v", got)
+		}
+		if len(skipped) != 0 {
+			t.Errorf("absent is not an error, just nothing to do: %v", skipped)
+		}
+	})
+
+	t.Run("an unusable URI is reported, not stored", func(t *testing.T) {
+		// Storing garbage would replace "the connection is missing" — which
+		// registration reports clearly — with a connection that exists and
+		// fails inside the task.
+		got, skipped := connectionsToSeed([]string{"broken"}, nil,
+			env("AIRFLOW_CONN_BROKEN", "h:5432/db"))
+		if len(got) != 0 {
+			t.Errorf("nothing usable should be stored; got %+v", got)
+		}
+		if len(skipped) != 1 || !strings.Contains(skipped[0], "broken") {
+			t.Errorf("the skip must name the connection; got %v", skipped)
+		}
+	})
+
+	t.Run("the reported skip never carries the URI", func(t *testing.T) {
+		// The value is a secret; the reason it was rejected is not.
+		_, skipped := connectionsToSeed([]string{"broken"}, nil,
+			env("AIRFLOW_CONN_BROKEN", "postgres://user:hunter2@h:5432/db?x"))
+		for _, s := range skipped {
+			if strings.Contains(s, "hunter2") {
+				t.Errorf("a skip message leaked the secret: %q", s)
+			}
+		}
+	})
+
+	t.Run("the id is upper-cased for the lookup, not for storage", func(t *testing.T) {
+		got, _ := connectionsToSeed([]string{"Mixed_Case"}, nil,
+			env("AIRFLOW_CONN_MIXED_CASE", "postgres://u:p@h:5432/app"))
+		if len(got) != 1 || got[0].ConnID != "Mixed_Case" {
+			t.Errorf("the stored id must keep the DAG's spelling; got %+v", got)
+		}
+	})
+}
+
+var _ = domain.Connection{}

--- a/internal/domain/conn_uri_parse.go
+++ b/internal/domain/conn_uri_parse.go
@@ -1,0 +1,84 @@
+package domain
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// ParseConnectionURI reads an Airflow connection URI — the AIRFLOW_CONN_<ID>
+// form a task consumes — back into a Connection.
+//
+// It is the inverse of the URI the control plane delivers to tasks, and it
+// follows Airflow's own from_uri semantics wherever the two could differ,
+// because the value being parsed is one the user wrote for Airflow to read:
+//
+//   - the scheme carries `-` where the conn_type has `_` (google_cloud_platform
+//     and friends are not legal URI schemes), so it is reversed here exactly as
+//     the emitter applies it;
+//   - userinfo is percent-decoded into login and password;
+//   - the path becomes the schema with ONE leading slash removed, which is what
+//     Airflow does — note this is lossy for an absolute path like sqlite's
+//     `sqlite:///tmp/db`, whose schema comes back as `tmp/db`. Matching Airflow
+//     is the right loss to take: the task resolves the connection through
+//     Airflow, so Airflow's reading is the meaning;
+//   - `__extra__` carries the JSON blob, as the emitter writes it.
+//
+// No error returned here ever contains the URI: the value is a credential, and
+// an error is the most likely thing to be logged, wrapped or printed. Errors
+// name the connection and the problem.
+//
+// An empty conn_type is refused. A connection with no type cannot be delivered
+// to a task in a form Airflow will accept, so storing one would replace a
+// missing connection with a broken one.
+func ParseConnectionURI(connID, uri string) (Connection, error) {
+	if strings.TrimSpace(uri) == "" {
+		return Connection{}, fmt.Errorf("connection %q: empty URI", connID)
+	}
+	u, err := url.Parse(uri)
+	if err != nil {
+		// url.Parse echoes the input it rejected, and the input is a credential.
+		// Name the connection and the problem; never the value.
+		return Connection{}, fmt.Errorf("connection %q: not a valid URI", connID)
+	}
+	if u.Scheme == "" {
+		return Connection{}, fmt.Errorf("connection %q: URI has no scheme (expected e.g. postgres://user:pass@host:5432/db)", connID)
+	}
+	// `host:5432/db` parses "successfully": url.Parse reads `host` as the scheme
+	// and the rest as an OPAQUE body, which would store conn_type="host" and
+	// deliver a connection no task can use. An Airflow connection URI is always
+	// hierarchical, so an opaque one is a typo, not a connection.
+	if u.Opaque != "" {
+		return Connection{}, fmt.Errorf("connection %q: URI is missing `//` after the scheme (expected e.g. postgres://user:pass@host:5432/db)", connID)
+	}
+	// The degenerate form the emitter produces for a connection carrying only a
+	// type (and possibly extra) has no `//` and no host or path; anything else
+	// without `//` lost its authority somewhere.
+	if !strings.Contains(uri, "://") && (u.Host != "" || u.Path != "") {
+		return Connection{}, fmt.Errorf("connection %q: URI is missing `//` after the scheme", connID)
+	}
+	c := Connection{
+		ConnID:   connID,
+		ConnType: strings.ReplaceAll(u.Scheme, "-", "_"),
+		Host:     u.Hostname(),
+	}
+	if u.User != nil {
+		c.Login = u.User.Username()
+		if pw, ok := u.User.Password(); ok {
+			c.Password = pw
+		}
+	}
+	if p := u.Port(); p != "" {
+		n, perr := strconv.Atoi(p)
+		if perr != nil {
+			return Connection{}, fmt.Errorf("connection %q: port %q is not a number", connID, p)
+		}
+		c.Port = &n
+	}
+	c.Schema = strings.TrimPrefix(u.Path, "/")
+	if extra := u.Query().Get("__extra__"); extra != "" {
+		c.Extra = extra
+	}
+	return c, nil
+}

--- a/internal/storage/conn_uri_roundtrip_test.go
+++ b/internal/storage/conn_uri_roundtrip_test.go
@@ -1,0 +1,98 @@
+package storage
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/neochaotic/leoflow/internal/domain"
+)
+
+func intp(n int) *int { return &n }
+
+// TestConnURIRoundTrip is the guard that makes seeding a connection from the
+// environment safe (#1103). Lite reads AIRFLOW_CONN_<ID> and stores it as a
+// Connection; the control plane then delivers that Connection back to tasks as a
+// URI. If the parser is not the emitter's inverse, a connection is silently
+// mangled between the value the developer exported and the value their task
+// receives — and the failure surfaces inside the task, far from the cause.
+//
+// The property asserted is the one that matters: what a task RECEIVES is
+// unchanged. Comparing parsed structs instead would fail on representations
+// that are equivalent in the URI (Airflow's from_uri is lossy for an absolute
+// path, deliberately), so the round trip is anchored on the delivered form.
+func TestConnURIRoundTrip(t *testing.T) {
+	for _, c := range []domain.Connection{
+		{ConnID: "pg", ConnType: "postgres", Host: "db.internal", Login: "app", Password: "s3cr3t", Port: intp(5432), Schema: "leoflow"},
+		{ConnID: "nopass", ConnType: "postgres", Host: "db", Login: "readonly", Port: intp(5432)},
+		{ConnID: "noport", ConnType: "mysql", Host: "mysql.local", Login: "u", Password: "p", Schema: "app"},
+		{ConnID: "hostonly", ConnType: "http", Host: "api.example.com"},
+		// conn_type with underscores: not a legal URI scheme, rewritten to `-`
+		// by the emitter and back by the parser. Getting this wrong turns
+		// google_cloud_platform into google-cloud-platform in the vault.
+		{ConnID: "gcp", ConnType: "google_cloud_platform", Host: "unused"},
+		{ConnID: "spark", ConnType: "spark_sql", Host: "spark", Port: intp(10000)},
+		// extra travels as __extra__; losing it drops sslmode and friends.
+		{ConnID: "withextra", ConnType: "postgres", Host: "db", Port: intp(5432), Schema: "app", Extra: `{"sslmode":"require"}`},
+		// Credentials needing percent-encoding: a naive parser splits on the
+		// wrong ':' or '@' and silently truncates the password.
+		{ConnID: "weird", ConnType: "postgres", Host: "db", Login: "user@corp", Password: "p@ss:w/rd", Port: intp(5432)},
+		{ConnID: "sqlite", ConnType: "sqlite", Schema: "/tmp/leoflow.db"},
+		{ConnID: "relsqlite", ConnType: "sqlite", Schema: "local.db"},
+		// The degenerate form: a type and nothing else. The emitter produces
+		// `scheme:` with no `//`, so the parser's "missing //" refusal must not
+		// reject what we ourselves deliver.
+		{ConnID: "typeonly", ConnType: "fs"},
+		{ConnID: "extraonly", ConnType: "fs", Extra: `{"path":"/data"}`},
+	} {
+		t.Run(c.ConnID, func(t *testing.T) {
+			delivered := airflowConnURI(c)
+			parsed, err := domain.ParseConnectionURI(c.ConnID, delivered)
+			if err != nil {
+				t.Fatalf("parsing %q: %v", delivered, err)
+			}
+			if again := airflowConnURI(parsed); again != delivered {
+				t.Errorf("a task would receive a different connection after a round trip\n  emitted: %s\n  after:   %s", delivered, again)
+			}
+		})
+	}
+}
+
+// TestParseConnectionURIRefusesUnusable pins the inputs that must NOT become a
+// stored connection. Storing a typed-less or empty connection would replace
+// "the connection is missing" — which registration reports clearly — with a
+// connection that exists and fails inside the task.
+func TestParseConnectionURIRefusesUnusable(t *testing.T) {
+	for _, tc := range []struct{ name, uri string }{
+		{"empty", ""},
+		{"blank", "   "},
+		{"no scheme", "db.internal:5432/app"},
+		{"non-numeric port", "postgres://db:not-a-port/app"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := domain.ParseConnectionURI("x", tc.uri); err == nil {
+				t.Errorf("ParseConnectionURI(%q) = nil error, want a refusal", tc.uri)
+			}
+		})
+	}
+}
+
+// TestParseConnectionURIErrorsNeverEchoTheValue is a security property, not a
+// style preference: the input is a credential, and an error is the single most
+// likely thing to be logged, wrapped into another error, or printed to a
+// terminal someone screenshots.
+func TestParseConnectionURIErrorsNeverEchoTheValue(t *testing.T) {
+	const secret = "hunter2"
+	for _, uri := range []string{
+		"postgres://user:" + secret + "@h:5432/db\x7f",
+		"h:5432/db?p=" + secret,
+		"postgres://db:" + secret + "/app",
+	} {
+		_, err := domain.ParseConnectionURI("c", uri)
+		if err == nil {
+			continue // parsed fine; nothing to leak
+		}
+		if strings.Contains(err.Error(), secret) {
+			t.Errorf("error leaks the connection value: %v", err)
+		}
+	}
+}

--- a/website/content/operate/troubleshooting.md
+++ b/website/content/operate/troubleshooting.md
@@ -58,6 +58,7 @@ leoflow-mcp --version
 
 | Symptom | Cause / fix |
 |---|---|
+| `declares unknown connection(s)` on the first `leoflow dev` of a project | Lite seeds a declared connection from `AIRFLOW_CONN_<ID>` when your environment already carries it, so this usually means the variable is absent or misspelled — the lookup upper-cases the id, so `my_db` reads `AIRFLOW_CONN_MY_DB`. Only connections the DAG **declares** are considered, a connection already in the vault is never replaced by the environment (use `leoflow connections set` to change one), and a URI that cannot be parsed is reported by name and not stored. |
 | `leoflow compile` dumps a Python traceback with internal parser paths first | Recent builds lead the failure with the user-facing line (e.g. `SyntaxError: ...`) and put the parser paths in the bounded tail. If you still see the internal-first dump, you are on an older release — update. |
 | `leoflow compile` rejects a sensor / Jinja template / branching operator | This is **intentional** — Leoflow accepts a closed set of task types (`python`, `bash`, `airflow_operator`). See [DAG authoring → Not supported](/author-dags/dag-authoring/#not-supported--leoflow-compile-rejects-these) for the full list and workarounds (`@task` + poll loop for sensors; build values from `airflow.sdk` context for Jinja). |
 | `Compiled .../dag.py -> dag.json (image , version dev)` (dangling comma) | Older build — update. Recent versions render `(no image, version dev)` when `--image` is unset. |


### PR DESCRIPTION
feat(lite): seed a declared connection the environment already carries (#1103)

The third gap from field feedback on using Lite as a daily dev environment, and
the one where the information was provably already in the process.

Registration is fail-closed against the vault: a DAG declaring a connection the
vault does not hold is refused, with a message naming the fix. Good message,
wrong level — in Lite the subprocess executor inherits the environment
(subprocess.go: cmd.Env = append(os.Environ(), ...)) and connections reach tasks
as AIRFLOW_CONN_<ID>, so the developer has ALREADY exported the value for the
task to consume and must then write it a second time, in a second format, for
registration to pass. The report that prompted this had a Makefile target
keeping the two in sync.

Seeding is mechanical precisely because the naming is fixed: the variable
exported for the task IS the lookup key.

Four constraints, and they are the feature rather than decoration, because
taking a secret from ambient environment is only defensible under them:

  - DECLARED ONLY. An AIRFLOW_CONN_* the DAG did not declare is ignored;
    otherwise an unrelated production credential in a developer's shell gets
    copied into a database.
  - THE VAULT WINS. A stored connection is never replaced, so a stale export
    cannot shadow a value somebody set deliberately.
  - UNUSABLE IS REPORTED, NOT STORED. A URI that does not parse is skipped by
    name. A broken connection that EXISTS is worse than a missing one:
    registration's clear refusal becomes a failure inside the task.
  - ANNOUNCED, NEVER SILENT, and never by value. The point is removing a step
    the developer knows about, not hiding one.

And one the issue did not anticipate: if the vault cannot be READ, nothing is
seeded. "Already set" is then unknown, and acting on unknown risks the overwrite
this must never do.

Seeding needed an inverse the repository did not have. airflowConnURI composes
Connection -> URI for delivery; nothing parsed the other way. domain.
ParseConnectionURI is that inverse, and is tested as one: a round trip through
the emitter over twelve shapes, asserting what a TASK RECEIVES is unchanged
rather than comparing structs — Airflow's from_uri is deliberately lossy for an
absolute path (sqlite:///tmp/db), so the delivered form is the honest anchor.
The shapes include google_cloud_platform (underscores are not legal URI schemes,
so the emitter rewrites them and the parser must reverse it), credentials
containing @ and :, __extra__, and the degenerate `scheme:` with no authority
that the emitter itself produces and that an over-strict parser would reject.

Two refusals worth naming. `db.internal:5432/app` PARSES in Go — url.Parse reads
`db.internal` as the scheme and the rest as an opaque body — and without a guard
would store conn_type="db.internal". And no error from the parser echoes the
URI: url.Parse repeats the input it rejected, the input is a credential, and an
error is the most likely thing to be logged or wrapped. Both are tested.

Closes #1103.