### PR TITLE
docs(dbt): say which dbt runs the parse, because it differs by edition

### DIFF
--- a/website/content/author-dags/dbt.md
+++ b/website/content/author-dags/dbt.md
@@ -243,6 +243,23 @@ and the resulting manifest is copied into the DAG image alongside the project.
 Pin a pre-built one with `dbt.manifest` to skip the parse (see
 [No local dbt](#no-local-dbt)).
 
+**Which `dbt` runs the parse is not the same in both editions**, and the
+difference decides whether you need dbt installed on your host at all:
+
+- Under **`leoflow dev`** the per-DAG venv is provisioned from `dependencies:`
+  *before* the project is compiled, and the parse uses **that venv's `dbt`**. So
+  a Lite project that declares `dbt-core` and its adapter in `dependencies:`
+  compiles with no dbt on your `PATH` — the version that parses your models is
+  the same one that will run them.
+- Running **`leoflow compile` by hand** provisions nothing. It falls back to the
+  `dbt` on your `PATH`, and fails with a message naming both ways out if there
+  is none: install dbt-core plus your adapter, or pin `dbt.manifest`.
+
+The practical consequence is the reverse of what people usually assume: you do
+not need to `pip install dbt-core` to develop a dbt DAG in Lite. Declaring it in
+`dependencies:` is enough, and is better, because the host and the task then
+cannot disagree about the dbt version.
+
 dbt's **Slim CI** (`--select state:modified+ --defer --state`) is not offered as a
 turnkey recipe: there is no supported way to export the deployed manifest to diff
 against, and the compiler emits node/level/folder selectors only. If you drive dbt


### PR DESCRIPTION
docs(dbt): say which dbt runs the parse, because it differs by edition

Field feedback: in Lite, compiling a dbt project depends on something a DAG
author does not have to think about, and the page did not say what.

The page said `leoflow compile` "runs `dbt parse` on your machine — both
editions", which reads as uniform and hides the part that matters. It is not the
same dbt. `dbtParseBinAt` prefers the per-DAG venv's binary and only falls back
to the `dbt` on PATH, and `leoflow dev` provisions that venv (line 749) before
it compiles (line 754).

So the ordering IS handled inside the dev loop, and the honest documentation is
the opposite of a warning: a Lite project that declares dbt-core and its adapter
in `dependencies:` compiles with no dbt on the host PATH at all, and the version
that parses the models is the one that will run them. `leoflow compile` invoked
by hand provisions nothing and does need a PATH dbt, or a pinned `dbt.manifest`.

Worth stating because the omission costs work in the wrong direction: people
`pip install dbt-core` on the host to make Lite work, which is unnecessary and
introduces the host/task version disagreement that declaring it avoids.

Not claimed here, because it is not verified: what the first `leoflow dev` of a
dbt project does before any venv exists. The lite-dbt e2e deliberately
pre-parses the manifest "rather than depending on parse-on-save ordering", so
that path has no coverage and no statement is made about it.