### PR TITLE
fix(chart): the migration Job was the only workload ignoring pod placement (#1056)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,21 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **The migration Job honours `nodeSelector`, `tolerations` and `affinity`
+  (#1056).** It was the one workload in the chart ignoring the pod-placement
+  values every other workload respects, and it is the workload that runs
+  **first**. On a cluster with a tainted or dedicated node pool — where the
+  operator set `tolerations` precisely so Leoflow lands there — the pre-install
+  hook was unschedulable: the pod sat `Pending`, Helm waited out the hook
+  timeout, and `helm install` failed with a message that never mentioned
+  scheduling.
+
+  The values are inherited from the top level rather than given their own
+  `migrations.*` knobs. Someone who set `tolerations` said "Leoflow runs on this
+  pool", and the migration Job is Leoflow; a Job-specific pool is surface nobody
+  has asked for. Nothing is rendered when nothing is set, so an existing release
+  sees no diff.
+
 - **`leoflow lite --help` now says the admin password is shown once, and names
   the way back (#1105).** It described the UI as being "behind a login (the admin
   created by `leoflow setup`)" and stopped there. The password is printed once

--- a/helm/leoflow/templates/migration-job.yaml
+++ b/helm/leoflow/templates/migration-job.yaml
@@ -43,6 +43,30 @@ spec:
       automountServiceAccountToken: false
       securityContext:
         {{- toYaml .Values.migrations.podSecurityContext | nindent 8 }}
+      # Pod placement is INHERITED from the top-level values rather than given
+      # its own knobs (#1056). An operator who set `tolerations` said "Leoflow
+      # runs on this pool", and the migration Job is Leoflow — it was the one
+      # workload in the chart ignoring the values every other workload honours,
+      # and it is the workload that runs FIRST. On a tainted or dedicated pool
+      # the hook was unschedulable: the pod sat Pending, Helm waited out the hook
+      # timeout, and the install failed with a message that never mentioned
+      # scheduling.
+      #
+      # No `migrations.nodeSelector` etc.: a Job-specific pool is surface nobody
+      # has asked for, and this chart is busy removing values that are declared
+      # and unread rather than adding more.
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: migrate
           image: "{{ .Values.migrations.image.repository }}:{{ $migrateTag }}"

--- a/helm/leoflow/tests/migration_job_test.yaml
+++ b/helm/leoflow/tests/migration_job_test.yaml
@@ -238,3 +238,55 @@ tests:
       - equal:
           path: spec.template.metadata.labels["app.kubernetes.io/name"]
           value: aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeefff-migrate
+
+  # #1056: the Job is the FIRST workload the chart runs and was the only one
+  # ignoring the pod-placement values every other workload honours. On a cluster
+  # with a tainted or dedicated pool — the operator set `tolerations` precisely
+  # so Leoflow lands there — the pre-install hook is unschedulable: the pod sits
+  # Pending, Helm waits out the hook timeout, and the install fails with a
+  # message that says nothing about scheduling.
+  - it: inherits nodeSelector, tolerations and affinity from the top-level values
+    set:
+      database.url: postgres://h/d
+      nodeSelector:
+        workload: leoflow
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: leoflow
+          effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/zone
+                    operator: In
+                    values: [eu-west-1a]
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.workload
+          value: leoflow
+      - equal:
+          path: spec.template.spec.tolerations[0].key
+          value: dedicated
+      - equal:
+          path: spec.template.spec.tolerations[0].effect
+          value: NoSchedule
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: topology.kubernetes.io/zone
+
+  # Absent values must render nothing at all: an empty `nodeSelector: {}` in the
+  # pod spec is not harmless noise — it is a diff against every existing
+  # release, and on some admission stacks an empty affinity block is rejected.
+  - it: renders no placement keys when none are set
+    set:
+      database.url: postgres://h/d
+    asserts:
+      - notExists:
+          path: spec.template.spec.nodeSelector
+      - notExists:
+          path: spec.template.spec.tolerations
+      - notExists:
+          path: spec.template.spec.affinity


### PR DESCRIPTION
fix(chart): the migration Job was the only workload ignoring pod placement (#1056)

The chart renders nodeSelector, tolerations and affinity on the control-plane
Deployment (_controlplane-deployment.tpl) and rendered none of them on the
pre-install migration Job. On a cluster with a tainted or dedicated node pool the
hook is then unschedulable, and the way that surfaces is the problem: the pod
sits Pending, Helm waits out the hook timeout, and `helm install` fails with a
message that never mentions scheduling. The operator set `tolerations` precisely
so Leoflow would land there, and the first thing the chart runs ignored it.

Inherited from the top level rather than given `migrations.nodeSelector` and
friends. Someone who sets `tolerations` is saying "Leoflow runs on this pool",
and the migration Job is Leoflow; a Job-specific pool is surface nobody has asked
for, and this chart is busy removing values that are declared and unread rather
than adding more. If a real case for splitting them appears it can be added then,
with the case to justify it.

priorityClassName is deliberately NOT added. The issue raised it as worth
considering — a migration that must finish before anything else starts is a
plausible candidate — but there is no top-level priorityClassName today, so it
would be a brand-new value with no reported need. That is the same "declared and
unread" shape being removed elsewhere in this release.

The tests pin both directions, and the second is the one that protects existing
releases: placement renders when set, and NOTHING renders when unset. An empty
`nodeSelector: {}` in the pod spec is not harmless noise — it is a diff against
every deployed release, and some admission stacks reject an empty affinity block.

Closes #1056.