### PR TITLE
fix(dbt): refuse an unusable derived task id by name, and pin id stability (#1114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,14 @@ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **A dbt folder that cannot be a task id is refused by name (#1114).** With
+  `granularity: folder` the folder name becomes the task id verbatim, so a
+  folder like `my folder!` produced an unusable id. It was already caught — but
+  at the end of the compile, as `schema validation: jsonschema validation
+  failed with 'file:///…/dag.json#'`, leaving the author to work out that a dbt
+  folder name was the cause. The compiler knows the folder and the rule, and now
+  says both, along with the models the group holds and the two ways out.
+
 - **The migration Job honours `nodeSelector`, `tolerations` and `affinity`
   (#1056).** It was the one workload in the chart ignoring the pod-placement
   values every other workload respects, and it is the workload that runs

--- a/internal/dbt/group_names_test.go
+++ b/internal/dbt/group_names_test.go
@@ -1,0 +1,65 @@
+package dbt
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGroupIDsDoNotDependOnMemberCount pins a decision taken while fixing
+// #1114 and worth keeping: a grouped task is NOT renamed after its single
+// member.
+//
+// Naming a one-model level `a` reads better than `level_0` — but it makes the
+// task id depend on how many models the group happens to hold, so adding a
+// sibling silently renames the task from `a` back to `level_0`. task_id is what
+// depends_on, run history, retries and URLs are keyed on, and an ordinary edit
+// to a dbt project must not rewrite them. The legibility problem is real and is
+// solved by describing a task, not by renaming it — which needs a TaskSpec field
+// the schema does not have yet.
+func TestGroupIDsDoNotDependOnMemberCount(t *testing.T) {
+	one := []byte(`{"nodes":{
+	  "model.s.a":{"resource_type":"model","name":"a","depends_on":{"nodes":[]},"config":{"materialized":"table"},"fqn":["s","staging","a"]}}}`)
+	two := []byte(`{"nodes":{
+	  "model.s.a":{"resource_type":"model","name":"a","depends_on":{"nodes":[]},"config":{"materialized":"table"},"fqn":["s","staging","a"]},
+	  "model.s.b":{"resource_type":"model","name":"b","depends_on":{"nodes":[]},"config":{"materialized":"table"},"fqn":["s","staging","b"]}}}`)
+	for _, gran := range []Granularity{GranularityFolder, GranularityLevel} {
+		t1, err := Render(one, Options{Granularity: gran})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t2, err := Render(two, Options{Granularity: gran})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(t1) != 1 || len(t2) != 1 {
+			t.Fatalf("%s: expected one group either way, got %d and %d", gran, len(t1), len(t2))
+		}
+		if t1[0].TaskID != t2[0].TaskID {
+			t.Errorf("%s: adding a model renamed the task %q -> %q; ids are what depends_on and history are keyed on",
+				gran, t1[0].TaskID, t2[0].TaskID)
+		}
+	}
+}
+
+// TestDerivedTaskIDIsRefusedByName covers the last item of #1114. A dbt folder
+// name becomes a task id verbatim, and an unusable one — `my folder!` — WAS
+// caught, but only later by DAGSpec.Validate, as a JSON-schema dump naming
+// dag.json. The compiler knows the folder AND the rule, so it should say which
+// folder and why.
+func TestDerivedTaskIDIsRefusedByName(t *testing.T) {
+	bad := []byte(`{"nodes":{
+	  "model.s.x":{"resource_type":"model","name":"x","depends_on":{"nodes":[]},"config":{"materialized":"table"},"fqn":["s","my folder!","x"]},
+	  "model.s.y":{"resource_type":"model","name":"y","depends_on":{"nodes":[]},"config":{"materialized":"table"},"fqn":["s","my folder!","y"]}}}`)
+	_, err := Render(bad, Options{Granularity: GranularityFolder})
+	if err == nil {
+		t.Fatal("expected a refusal naming the folder")
+	}
+	for _, want := range []string{"my folder!", "granularity"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should name the folder and the knob (missing %q)", err, want)
+		}
+	}
+	if strings.Contains(err.Error(), "jsonschema") {
+		t.Errorf("the author should not be reading a schema dump: %v", err)
+	}
+}

--- a/internal/dbt/render.go
+++ b/internal/dbt/render.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -287,6 +288,10 @@ func renderGrouped(nodes map[string]execNode, gran Granularity) ([]domain.TaskSp
 			gran, strings.Join(append(cyc, cyc[0]), " -> "))
 	}
 
+	if verr := checkDerivedTaskIDs(members, gran); verr != nil {
+		return nil, verr
+	}
+
 	tasks := make([]domain.TaskSpec, 0, len(members))
 	for g, mem := range members {
 		sort.Strings(mem)
@@ -408,4 +413,31 @@ func sortedSetKeys[V any](m map[string]V) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// taskIDPattern mirrors the dag schema's task_id rule. It is duplicated here on
+// purpose: the schema is the authority and still rejects a bad id, but it does
+// so at the END of the compile, as a jsonschema failure naming dag.json. A dbt
+// folder becomes a task id verbatim, so this package knows both the offending
+// folder and the rule, and is the only place that can say which folder.
+var taskIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_-]{0,199}$`)
+
+// checkDerivedTaskIDs refuses a group key that cannot be a task id, naming the
+// folder and the knob that produced it (#1114).
+func checkDerivedTaskIDs(members map[string][]string, gran Granularity) error {
+	keys := make([]string, 0, len(members))
+	for g := range members {
+		keys = append(keys, g)
+	}
+	sort.Strings(keys)
+	for _, g := range keys {
+		if taskIDPattern.MatchString(g) {
+			continue
+		}
+		mem := append([]string(nil), members[g]...)
+		sort.Strings(mem)
+		return fmt.Errorf("dbt granularity=%s derives the task id %q from your project, and it is not a usable task id (letters, digits, underscore, then letters/digits/underscore/hyphen, up to 200 chars). It groups %s — rename it in the dbt project, or use granularity=node so each model keeps its own name",
+			gran, g, strings.Join(mem, ", "))
+	}
+	return nil
 }


### PR DESCRIPTION
fix(dbt): refuse an unusable derived task id by name, and pin id stability (#1114)

Two outcomes from measuring the granularity naming complaint, and one of them is
a decision NOT to make a change I had proposed.

**Refused by name.** With granularity=folder the folder name becomes the task id
verbatim, so `my folder!` produces an id the dag schema rejects. It was already
caught — at the END of the compile, as a jsonschema failure naming dag.json —
leaving the author to work out that a dbt folder was the cause. This package
knows both the offending folder and the rule, so it is the only place that can
say which folder. The message names it, the models it groups, and the two ways
out. The schema stays the authority; this is the earlier, specific half.

**Not renamed, and this is the reversal.** I had proposed naming a single-member
group after its model — `a` instead of `level_0`, which reads better. It makes
the task id depend on how many models the group happens to hold: add a sibling
and the task silently renames back to `level_0`. task_id is what depends_on, run
history, retries and URLs are keyed on, and an ordinary edit to a dbt project
must not rewrite them. For folder it is worse — ids are stable there today, so
the change would introduce instability where there is none.

A test pins that rather than a comment: adding a model to a group must not
change the group's id, for both folder and level.

Also corrected in the issue: TaskSpec has NO Description field — the one I saw is
on DAGSpec. So "put the member list in the description it already has" was not
available, and the real fix for a grouped task saying nothing about its contents
is a new field plus the dag schema (additionalProperties: false), the OpenAPI
surface and the UI. That stays open, and stays out of a release week.